### PR TITLE
Use dependency management to use common versions of log4j and junit

### DIFF
--- a/Mage.Client/pom.xml
+++ b/Mage.Client/pom.xml
@@ -33,7 +33,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
         </dependency>
         <dependency>
             <groupId>net.sf.trove4j</groupId>
@@ -73,7 +72,6 @@
        <dependency>
            <groupId>junit</groupId>
            <artifactId>junit</artifactId>
-           <version>4.11</version>
            <type>jar</type>
            <scope>test</scope>
        </dependency>

--- a/Mage.Plugins/Mage.Counter.Plugin/pom.xml
+++ b/Mage.Plugins/Mage.Counter.Plugin/pom.xml
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.9</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/Mage.Plugins/Mage.Theme.Plugin/pom.xml
+++ b/Mage.Plugins/Mage.Theme.Plugin/pom.xml
@@ -29,7 +29,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.9</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/Mage.Server.Console/pom.xml
+++ b/Mage.Server.Console/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+           <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/Mage.Server.Plugins/Mage.Player.AI/pom.xml
+++ b/Mage.Server.Plugins/Mage.Player.AI/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.14</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/Mage.Server.Plugins/Mage.Player.AIMCTS/pom.xml
+++ b/Mage.Server.Plugins/Mage.Player.AIMCTS/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.14</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/Mage.Server.Plugins/Mage.Player.AIMinimax/pom.xml
+++ b/Mage.Server.Plugins/Mage.Player.AIMinimax/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.14</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/Mage.Server.Plugins/Mage.Player.Human/pom.xml
+++ b/Mage.Server.Plugins/Mage.Player.Human/pom.xml
@@ -28,7 +28,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.14</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/Mage.Server/pom.xml
+++ b/Mage.Server/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
@@ -42,7 +42,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/Mage.Sets/pom.xml
+++ b/Mage.Sets/pom.xml
@@ -25,14 +25,13 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.14</version>
             <type>jar</type>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/Mage.Tests/pom.xml
+++ b/Mage.Tests/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -55,7 +55,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.14</version>
             <type>jar</type>
         </dependency>
     </dependencies>
@@ -67,6 +66,9 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <version>2.16</version>
+                <configuration>
+                  <argLine>-XX:MaxPermSize=512m</argLine>
+                </configuration>
             </plugin>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>

--- a/Mage/pom.xml
+++ b/Mage/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
             <type>jar</type>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,4 +78,19 @@
         <mage-version>1.3.0</mage-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.8.2</version>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>1.2.17</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>


### PR DESCRIPTION
Use a common version of junit and log4j in all projects.
