### PR TITLE
Sacred Ground implemented.  Re-ordered logic in GameImpl to handle simul...

### DIFF
--- a/Mage.Sets/src/mage/sets/eighthedition/SacredGround.java
+++ b/Mage.Sets/src/mage/sets/eighthedition/SacredGround.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.eighthedition;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author dustinconrad
+ */
+public class SacredGround extends mage.sets.stronghold.SacredGround {
+
+    public SacredGround(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 39;
+        this.expansionSetCode = "8ED";
+    }
+
+    public SacredGround(final SacredGround card) {
+        super(card);
+    }
+
+    @Override
+    public SacredGround copy() {
+        return new SacredGround(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/ninthedition/SacredGround.java
+++ b/Mage.Sets/src/mage/sets/ninthedition/SacredGround.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.ninthedition;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author dustinconrad
+ */
+public class SacredGround extends mage.sets.stronghold.SacredGround {
+
+    public SacredGround(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 37;
+        this.expansionSetCode = "9ED";
+    }
+
+    public SacredGround(final SacredGround card) {
+        super(card);
+    }
+
+    @Override
+    public SacredGround copy() {
+        return new SacredGround(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/seventhedition/SacredGround.java
+++ b/Mage.Sets/src/mage/sets/seventhedition/SacredGround.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.seventhedition;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author dustinconrad
+ */
+public class SacredGround extends mage.sets.stronghold.SacredGround {
+
+    public SacredGround(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 36;
+        this.expansionSetCode = "7ED";
+    }
+
+    public SacredGround(final SacredGround card) {
+        super(card);
+    }
+
+    @Override
+    public SacredGround copy() {
+        return new SacredGround(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/stronghold/SacredGround.java
+++ b/Mage.Sets/src/mage/sets/stronghold/SacredGround.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.stronghold;
+
+import java.util.UUID;
+
+import mage.MageObject;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.effects.common.ReturnSourceFromGraveyardToBattlefieldEffect;
+import mage.abilities.effects.common.ReturnToBattlefieldUnderYourControlTargetEffect;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.events.ZoneChangeEvent;
+import mage.game.permanent.Permanent;
+import mage.game.stack.StackObject;
+import mage.target.targetpointer.FixedTarget;
+
+/**
+ *
+ * @author dustinconrad
+ */
+public class SacredGround extends CardImpl {
+
+    public SacredGround(UUID ownerId) {
+        super(ownerId, 112, "Sacred Ground", Rarity.RARE, new CardType[]{CardType.ENCHANTMENT}, "{1}{W}");
+        this.expansionSetCode = "STH";
+
+        this.color.setWhite(true);
+
+        // Whenever a spell or ability an opponent controls causes a land to be put into your graveyard from the battlefield, return that card to the battlefield.
+        this.addAbility(new SacredGroundTriggeredAbility());
+    }
+
+    public SacredGround(final SacredGround card) {
+        super(card);
+    }
+
+    @Override
+    public SacredGround copy() {
+        return new SacredGround(this);
+    }
+}
+
+class SacredGroundTriggeredAbility extends TriggeredAbilityImpl {
+
+    SacredGroundTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new ReturnToBattlefieldUnderYourControlTargetEffect());
+    }
+
+    SacredGroundTriggeredAbility(final SacredGroundTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public SacredGroundTriggeredAbility copy() {
+        return new SacredGroundTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        if (GameEvent.EventType.ZONE_CHANGE.equals(event.getType()) &&
+                game.getObject(event.getSourceId()) instanceof StackObject &&
+                game.getOpponents(this.getControllerId()).contains(game.getControllerId(event.getSourceId()))) {
+            ZoneChangeEvent zce = (ZoneChangeEvent) event;
+            if (Zone.BATTLEFIELD.equals(zce.getFromZone()) && Zone.GRAVEYARD.equals(zce.getToZone())) {
+                Permanent targetCard = zce.getTarget();
+                getEffects().get(0).setTargetPointer(new FixedTarget(targetCard.getId()));
+                return targetCard.getCardType().contains(CardType.LAND) && targetCard.getControllerId().equals(getControllerId());
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String getRule() {
+        return "Whenever a spell or ability an opponent controls causes a land to be put into your graveyard from the battlefield, " + super.getRule();
+    }
+}

--- a/Mage/src/mage/game/GameImpl.java
+++ b/Mage/src/mage/game/GameImpl.java
@@ -1113,13 +1113,13 @@ public abstract class GameImpl implements Game, Serializable {
             top.resolve(this);
         } finally {
             if (top != null) {
-                state.getStack().remove(top);
                 if (!getTurn().isEndTurnRequested()) {
                     while (state.hasSimultaneousEvents()) {
                         state.handleSimultaneousEvent(this);
                         checkTriggered();                    
                     }
                 }
+                state.getStack().remove(top);
             }
         }
     }


### PR DESCRIPTION
Re-ordered logic in GameImpl to handle simultaneous events before removing top of the stack.  Please verify if this is ok.

Long Story:
So I noticed that when the Destroy event was processed, the source was till a StackObject.  However, when processing the simultaneous events generated, specifically the ZoneChanged event, the source was not a StackObject anymore.  This was interfering with the check if the source was a spell or ability.
