### PR TITLE
Default color

### DIFF
--- a/Mage/src/mage/cards/CardImpl.java
+++ b/Mage/src/mage/cards/CardImpl.java
@@ -104,6 +104,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
         this.cardNumber = cardNumber;
         this.cardType.addAll(Arrays.asList(cardTypes));
         this.manaCost.load(costs);
+        setDefaultColor();
         if (cardType.contains(CardType.LAND)) {
             Ability ability = new PlayLandAbility(name);
             ability.setSourceId(this.getId());


### PR DESCRIPTION
Cards have a color based on their mana cost as per rule 202.2 in the comprehensive rules. This does not account for color indicator. This rule applies to all card types including artifacts (see rule 301.4) and land (land never has mana cost which is why it is always colorless).

The reason for this change is that any card that uses this can be created with less code and is less error prone. Note that these are only the default colors and can be changed at any time even in the card's constructor.

I don't have maven and didn't bother trying to get this project to run so my only concern is that you will need to test it to confirm that it works for hybrid and other mana symbols.
