### PR TITLE
Correction: Set the color of all cards with color indicators

### DIFF
--- a/Mage.Sets/src/mage/sets/darkascension/ArchdemonOfGreed.java
+++ b/Mage.Sets/src/mage/sets/darkascension/ArchdemonOfGreed.java
@@ -66,6 +66,7 @@ public class ArchdemonOfGreed extends CardImpl {
         super(ownerId, 71, "Archdemon of Greed", Rarity.RARE, new CardType[]{CardType.CREATURE}, "");
         this.expansionSetCode = "DKA";
         this.subtype.add("Demon");
+        this.color.setBlack(true);
 
         this.nightCard = true;
         this.canTransform = true;

--- a/Mage.Sets/src/mage/sets/darkascension/GhastlyHaunting.java
+++ b/Mage.Sets/src/mage/sets/darkascension/GhastlyHaunting.java
@@ -48,6 +48,7 @@ public class GhastlyHaunting extends CardImpl {
         super(ownerId, 50, "Ghastly Haunting", Rarity.UNCOMMON, new CardType[]{CardType.ENCHANTMENT}, "");
         this.expansionSetCode = "DKA";
         this.subtype.add("Aura");
+        this.color.setBlue(true);
 
         // this card is the second face of double-faced card
         this.nightCard = true;

--- a/Mage.Sets/src/mage/sets/darkascension/HinterlandScourge.java
+++ b/Mage.Sets/src/mage/sets/darkascension/HinterlandScourge.java
@@ -54,6 +54,7 @@ public class HinterlandScourge extends CardImpl {
         super(ownerId, 94, "Hinterland Scourge", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "");
         this.expansionSetCode = "DKA";
         this.subtype.add("Werewolf");
+        this.color.setRed(true);
 
         // this card is the second face of double-faced card of Hinterland Hermit
         this.nightCard = true;

--- a/Mage.Sets/src/mage/sets/darkascension/KrallenhordeKiller.java
+++ b/Mage.Sets/src/mage/sets/darkascension/KrallenhordeKiller.java
@@ -52,6 +52,7 @@ public class KrallenhordeKiller extends CardImpl {
         super(ownerId, 133, "Krallenhorde Killer", Rarity.RARE, new CardType[]{CardType.CREATURE}, "");
         this.expansionSetCode = "DKA";
         this.subtype.add("Werewolf");
+        this.color.setGreen(true);
 
         this.power = new MageInt(2);
         this.toughness = new MageInt(2);

--- a/Mage.Sets/src/mage/sets/darkascension/MarkovsServant.java
+++ b/Mage.Sets/src/mage/sets/darkascension/MarkovsServant.java
@@ -43,6 +43,7 @@ public class MarkovsServant extends CardImpl {
         super(ownerId, 55, "Markov's Servant", Rarity.COMMON, new CardType[]{CardType.CREATURE}, null);
         this.expansionSetCode = "DKA";
         this.subtype.add("Vampire");
+        this.color.setBlack(true);
 
         this.power = new MageInt(4);
         this.toughness = new MageInt(4);

--- a/Mage.Sets/src/mage/sets/darkascension/RavagerOfTheFells.java
+++ b/Mage.Sets/src/mage/sets/darkascension/RavagerOfTheFells.java
@@ -57,6 +57,8 @@ public class RavagerOfTheFells extends CardImpl {
         super(ownerId, 140, "Ravager of the Fells", Rarity.MYTHIC, new CardType[]{CardType.CREATURE}, "");
         this.expansionSetCode = "DKA";
         this.subtype.add("Werewolf");
+        this.color.setRed(true);
+        this.color.setGreen(true);
 
         // this card is the second face of double-faced card
         this.nightCard = true;

--- a/Mage.Sets/src/mage/sets/darkascension/SilverpeltWerewolf.java
+++ b/Mage.Sets/src/mage/sets/darkascension/SilverpeltWerewolf.java
@@ -53,6 +53,7 @@ public class SilverpeltWerewolf extends CardImpl {
         super(ownerId, 122, "Silverpelt Werewolf", Rarity.UNCOMMON, new CardType[]{CardType.CREATURE}, null);
         this.expansionSetCode = "DKA";
         this.subtype.add("Werewolf");
+        this.color.setGreen(true);
 
         this.power = new MageInt(4);
         this.toughness = new MageInt(5);

--- a/Mage.Sets/src/mage/sets/darkascension/UnhallowedCathar.java
+++ b/Mage.Sets/src/mage/sets/darkascension/UnhallowedCathar.java
@@ -45,6 +45,7 @@ public class UnhallowedCathar extends CardImpl {
         this.expansionSetCode = "DKA";
         this.subtype.add("Zombie");
         this.subtype.add("Soldier");
+        this.color.setBlack(true);
 
         // this card is the second face of double-faced card
         this.nightCard = true;

--- a/Mage.Sets/src/mage/sets/darkascension/WerewolfRansacker.java
+++ b/Mage.Sets/src/mage/sets/darkascension/WerewolfRansacker.java
@@ -62,6 +62,7 @@ public class WerewolfRansacker extends CardImpl {
         super(ownerId, 81, "Werewolf Ransacker", Rarity.UNCOMMON, new CardType[]{CardType.CREATURE}, "");
         this.expansionSetCode = "DKA";
         this.subtype.add("Werewolf");
+        this.color.setRed(true);
 
         // this card is the second face of double-faced card
         this.nightCard = true;

--- a/Mage.Sets/src/mage/sets/darkascension/WithengarUnbound.java
+++ b/Mage.Sets/src/mage/sets/darkascension/WithengarUnbound.java
@@ -54,6 +54,7 @@ public class WithengarUnbound extends CardImpl {
         this.expansionSetCode = "DKA";
         this.supertype.add("Legendary");
         this.subtype.add("Demon");
+        this.color.setBlack(true);
 
         // this card is the second face of double-faced card
         this.nightCard = true;

--- a/Mage.Sets/src/mage/sets/innistrad/LudevicsAbomination.java
+++ b/Mage.Sets/src/mage/sets/innistrad/LudevicsAbomination.java
@@ -45,6 +45,7 @@ public class LudevicsAbomination extends CardImpl {
         this.expansionSetCode = "ISD";
         this.subtype.add("Lizard");
         this.subtype.add("Horror");
+        this.color.setBlue(true);
 
         // this card is the second face of double-faced card
         this.nightCard = true;

--- a/Mage.Sets/src/mage/sets/legends/CrimsonKobolds.java
+++ b/Mage.Sets/src/mage/sets/legends/CrimsonKobolds.java
@@ -42,6 +42,7 @@ public class CrimsonKobolds extends CardImpl {
     public CrimsonKobolds(UUID ownerId) {
         super(ownerId, 219, "Crimson Kobolds", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{0}");
         this.expansionSetCode = "LEG";
+        this.color.setRed(true);
         this.subtype.add("Kobold");
         this.power = new MageInt(0);
         this.toughness = new MageInt(1);

--- a/Mage.Sets/src/mage/sets/legends/CrookshankKobolds.java
+++ b/Mage.Sets/src/mage/sets/legends/CrookshankKobolds.java
@@ -42,6 +42,7 @@ public class CrookshankKobolds extends CardImpl {
     public CrookshankKobolds(UUID ownerId) {
         super(ownerId, 220, "Crookshank Kobolds", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{0}");
         this.expansionSetCode = "LEG";
+        this.color.setRed(true);
         this.subtype.add("Kobold");
         this.power = new MageInt(0);
         this.toughness = new MageInt(1);

--- a/Mage.Sets/src/mage/sets/legends/KoboldsOfKherKeep.java
+++ b/Mage.Sets/src/mage/sets/legends/KoboldsOfKherKeep.java
@@ -42,6 +42,7 @@ public class KoboldsOfKherKeep extends CardImpl {
     public KoboldsOfKherKeep(UUID ownerId) {
         super(ownerId, 226, "Kobolds of Kher Keep", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{0}");
         this.expansionSetCode = "LEG";
+        this.color.setRed(true);
         this.subtype.add("Kobold");
         this.power = new MageInt(0);
         this.toughness = new MageInt(1);

--- a/Mage.Sets/src/mage/sets/timespiral/LivingEnd.java
+++ b/Mage.Sets/src/mage/sets/timespiral/LivingEnd.java
@@ -56,7 +56,7 @@ public class LivingEnd extends CardImpl {
         super(ownerId, 115, "Living End", Rarity.RARE, new CardType[]{CardType.SORCERY}, "");
         this.expansionSetCode = "TSP";
 
-        this.color.isBlack();
+        this.color.setBlack(true);
 
         // Suspend 3-{2}{B}{B}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl("{2}{B}{B}"), this));

--- a/Mage.Sets/src/mage/sets/timespiral/RestoreBalance.java
+++ b/Mage.Sets/src/mage/sets/timespiral/RestoreBalance.java
@@ -60,6 +60,8 @@ public class RestoreBalance extends CardImpl {
         super(ownerId, 38, "Restore Balance", Rarity.RARE, new CardType[]{CardType.SORCERY}, "");
         this.expansionSetCode = "TSP";
 
+        this.color.setWhite(true);
+
         // Suspend 6-{W}
         this.addAbility(new SuspendAbility(6, new ColoredManaCost(ColoredManaSymbol.W), this));
         // Each player chooses a number of lands he or she controls equal to the number of lands controlled by the player who controls the fewest, then sacrifices the rest. Players sacrifice creatures and discard cards the same way.

--- a/Mage.Sets/src/mage/sets/timespiral/WheelOfFate.java
+++ b/Mage.Sets/src/mage/sets/timespiral/WheelOfFate.java
@@ -47,6 +47,8 @@ public class WheelOfFate extends CardImpl {
         super(ownerId, 187, "Wheel of Fate", Rarity.RARE, new CardType[]{CardType.SORCERY}, "");
         this.expansionSetCode = "TSP";
 
+        this.color.setRed(true);
+
         // Suspend 4-{1}{R}
         this.addAbility(new SuspendAbility(4, new ManaCostsImpl("{1}{R}"), this));
         // Each player discards his or her hand, then draws seven cards.


### PR DESCRIPTION
There are a total of 47 cards with color indicators:
http://gatherer.wizards.com/Pages/Search/Default.aspx?cmc=+=[0]&color=|[W]|[U]|[B]|[R]|[G]
