### PR TITLE
Ixidron no longer turns double-faced cards face-down, as per MCR 711.6

### DIFF
--- a/Mage/src/mage/abilities/effects/common/continious/BecomesFaceDownCreatureAllEffect.java
+++ b/Mage/src/mage/abilities/effects/common/continious/BecomesFaceDownCreatureAllEffect.java
@@ -85,7 +85,7 @@ public class BecomesFaceDownCreatureAllEffect extends ContinuousEffectImpl imple
     public void init(Ability source, Game game) {
         super.init(source, game);
         for (Permanent perm: game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source.getSourceId(), game)) {
-            if (!perm.isFaceDown()) {
+            if (!perm.isFaceDown() && !perm.canTransform()) {
                 affectedObjectList.add(new MageObjectReference(perm));
                 perm.setFaceDown(true);
                 // check for Morph


### PR DESCRIPTION
 711.6: A double-faced permanent always has the status "face up" (see rule 110.6). Double-faced permanents can‘t be turned face down. If a spell or ability tries to turn a double-faced permanent face down, nothing happens.