### PR TITLE
Added Media Promos set and implemented selected cards

### DIFF
--- a/Mage.Sets/src/mage/sets/MediaInserts.java
+++ b/Mage.Sets/src/mage/sets/MediaInserts.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.SetType;
+
+import java.util.GregorianCalendar;
+
+public class MediaInserts extends ExpansionSet {
+    private static final MediaInserts fINSTANCE = new MediaInserts();
+
+    public static MediaInserts getInstance() {
+        return fINSTANCE;
+    }
+
+    private MediaInserts() {
+        super("Media Inserts", "MBP", "mage.sets.mediainserts", new GregorianCalendar(1990, 1, 1).getTime(), SetType.EXPANSION);
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/Acquire.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/Acquire.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class Acquire extends mage.sets.fifthdawn.Acquire {
+    
+    public Acquire(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 83;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public Acquire(final Acquire card) {
+        super(card);
+    }
+    
+    @Override
+    public Acquire copy() {
+        return new Acquire(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/AjaniCallerOfThePride.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/AjaniCallerOfThePride.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class AjaniCallerOfThePride extends mage.sets.magic2013.AjaniCallerOfThePride {
+    
+    public AjaniCallerOfThePride(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 72;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public AjaniCallerOfThePride(final AjaniCallerOfThePride card) {
+        super(card);
+    }
+    
+    @Override
+    public AjaniCallerOfThePride copy() {
+        return new AjaniCallerOfThePride(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/AjaniSteadfast.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/AjaniSteadfast.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class AjaniSteadfast extends mage.sets.magic2015.AjaniSteadfast {
+    
+    public AjaniSteadfast(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 99;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public AjaniSteadfast(final AjaniSteadfast card) {
+        super(card);
+    }
+    
+    @Override
+    public AjaniSteadfast copy() {
+        return new AjaniSteadfast(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/AngelOfGlorysRise.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/AngelOfGlorysRise.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class AngelOfGlorysRise extends mage.sets.avacynrestored.AngelOfGlorysRise {
+    
+    public AngelOfGlorysRise(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 59;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public AngelOfGlorysRise(final AngelOfGlorysRise card) {
+        super(card);
+    }
+    
+    @Override
+    public AngelOfGlorysRise copy() {
+        return new AngelOfGlorysRise(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/AngelicSkirmisher.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/AngelicSkirmisher.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class AngelicSkirmisher extends mage.sets.gatecrash.AngelicSkirmisher {
+    
+    public AngelicSkirmisher(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 90;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public AngelicSkirmisher(final AngelicSkirmisher card) {
+        super(card);
+    }
+    
+    @Override
+    public AngelicSkirmisher copy() {
+        return new AngelicSkirmisher(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/AnkleShanker.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/AnkleShanker.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class AnkleShanker extends mage.sets.khansoftarkir.AnkleShanker {
+    
+    public AnkleShanker(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 93;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public AnkleShanker(final AnkleShanker card) {
+        super(card);
+    }
+    
+    @Override
+    public AnkleShanker copy() {
+        return new AnkleShanker(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/Arena.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/Arena.java
@@ -1,0 +1,48 @@
+/*
+* Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification, are
+* permitted provided that the following conditions are met:
+*
+*    1. Redistributions of source code must retain the above copyright notice, this list of
+*       conditions and the following disclaimer.
+*
+*    2. Redistributions in binary form must reproduce the above copyright notice, this list
+*       of conditions and the following disclaimer in the documentation and/or other materials
+*       provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+* FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+* ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The views and conclusions contained in the software and documentation are those of the
+* authors and should not be interpreted as representing official policies, either expressed
+* or implied, of BetaSteward_at_googlemail.com.
+*/
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class Arena extends mage.sets.timeshifted.Arena {
+    
+    public Arena(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 1;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public Arena(final Arena card) {
+        super(card);
+    }
+    
+    @Override
+    public Arena copy() {
+        return new Arena(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/Arrest.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/Arrest.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class Arrest extends mage.sets.mirrodin.Arrest {
+    
+    public Arrest(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 53;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public Arrest(final Arrest card) {
+        super(card);
+    }
+    
+    @Override
+    public Arrest copy() {
+        return new Arrest(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/AvalancheTusker.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/AvalancheTusker.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class AvalancheTusker extends mage.sets.khansoftarkir.AvalancheTusker {
+    
+    public AvalancheTusker(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 94;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public AvalancheTusker(final AvalancheTusker card) {
+        super(card);
+    }
+    
+    @Override
+    public AvalancheTusker copy() {
+        return new AvalancheTusker(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/BirdsOfParadise.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/BirdsOfParadise.java
@@ -1,0 +1,66 @@
+/*
+* Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification, are
+* permitted provided that the following conditions are met:
+*
+*    1. Redistributions of source code must retain the above copyright notice, this list of
+*       conditions and the following disclaimer.
+*
+*    2. Redistributions in binary form must reproduce the above copyright notice, this list
+*       of conditions and the following disclaimer in the documentation and/or other materials
+*       provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+* FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+* ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The views and conclusions contained in the software and documentation are those of the
+* authors and should not be interpreted as representing official policies, either expressed
+* or implied, of BetaSteward_at_googlemail.com.
+*/
+
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class BirdsOfParadise extends mage.sets.ravnika.BirdsOfParadise {
+    
+    public BirdsOfParadise(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 26;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public BirdsOfParadise(final BirdsOfParadise card) {
+        super(card);
+    }
+    
+    @Override
+    public BirdsOfParadise copy() {
+        return new BirdsOfParadise(this);
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Mage.Sets/src/mage/sets/mediainserts/BirdsOfParadise.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/BirdsOfParadise.java
@@ -34,7 +34,7 @@ public class BirdsOfParadise extends mage.sets.ravnika.BirdsOfParadise {
     
     public BirdsOfParadise(UUID ownerId) {
         super(ownerId);
-        this.cardNumber = 26;
+        this.cardNumber = 28;
         this.expansionSetCode = "MBP";
     }
     

--- a/Mage.Sets/src/mage/sets/mediainserts/BloodthroneVampire.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/BloodthroneVampire.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class BloodthroneVampire extends mage.sets.riseoftheeldrazi.BloodthroneVampire {
+    
+    public BloodthroneVampire(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 31;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public BloodthroneVampire(final BloodthroneVampire card) {
+        super(card);
+    }
+    
+    @Override
+    public BloodthroneVampire copy() {
+        return new BloodthroneVampire(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/BlueElementalBlast.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/BlueElementalBlast.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class BlueElementalBlast extends mage.sets.limitedalpha.BlueElementalBlast {
+    
+    public BlueElementalBlast(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 5;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public BlueElementalBlast(final BlueElementalBlast card) {
+        super(card);
+    }
+    
+    @Override
+    public BlueElementalBlast copy() {
+        return new BlueElementalBlast(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/BonescytheSliver.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/BonescytheSliver.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class BonescytheSliver extends mage.sets.magic2014.BonescytheSliver {
+    
+    public BonescytheSliver(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 68;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public BonescytheSliver(final BonescytheSliver card) {
+        super(card);
+    }
+    
+    @Override
+    public BonescytheSliver copy() {
+        return new BonescytheSliver(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/BreathOfMalfegor.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/BreathOfMalfegor.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class BreathOfMalfegor extends mage.sets.alarareborn.BreathOfMalfegor {
+    
+    public BreathOfMalfegor(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 58;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public BreathOfMalfegor(final BreathOfMalfegor card) {
+        super(card);
+    }
+    
+    @Override
+    public BreathOfMalfegor copy() {
+        return new BreathOfMalfegor(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/BrionStoutarm.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/BrionStoutarm.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class BrionStoutarm extends mage.sets.lorwyn.BrionStoutarm {
+    
+    public BrionStoutarm(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 17;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public BrionStoutarm(final BrionStoutarm card) {
+        super(card);
+    }
+    
+    @Override
+    public BrionStoutarm copy() {
+        return new BrionStoutarm(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/BroodmateDragon.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/BroodmateDragon.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class BroodmateDragon extends mage.sets.shardsofalara.BroodmateDragon {
+    
+    public BroodmateDragon(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 19;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public BroodmateDragon(final BroodmateDragon card) {
+        super(card);
+    }
+    
+    @Override
+    public BroodmateDragon copy() {
+        return new BroodmateDragon(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/CathedralOfWar.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/CathedralOfWar.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class CathedralOfWar extends mage.sets.magic2013.CathedralOfWar {
+    
+    public CathedralOfWar(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 51;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public CathedralOfWar(final CathedralOfWar card) {
+        super(card);
+    }
+    
+    @Override
+    public CathedralOfWar copy() {
+        return new CathedralOfWar(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/ChandraPyromaster.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/ChandraPyromaster.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class ChandraPyromaster extends mage.sets.magic2015.ChandraPyromaster {
+    
+    public ChandraPyromaster(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 75;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public ChandraPyromaster(final ChandraPyromaster card) {
+        super(card);
+    }
+    
+    @Override
+    public ChandraPyromaster copy() {
+        return new ChandraPyromaster(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/ChandraPyromaster2.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/ChandraPyromaster2.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class ChandraPyromaster2 extends mage.sets.magic2015.ChandraPyromaster {
+    
+    public ChandraPyromaster2(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 102;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public ChandraPyromaster2(final ChandraPyromaster2 card) {
+        super(card);
+    }
+    
+    @Override
+    public ChandraPyromaster2 copy() {
+        return new ChandraPyromaster2(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/ChandrasFury.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/ChandrasFury.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class ChandrasFury extends mage.sets.magic2013.ChandrasFury {
+    
+    public ChandrasFury(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 65;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public ChandrasFury(final ChandrasFury card) {
+        super(card);
+    }
+    
+    @Override
+    public ChandrasFury copy() {
+        return new ChandrasFury(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/ChandrasPhoenix.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/ChandrasPhoenix.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class ChandrasPhoenix extends mage.sets.magic2012.ChandrasPhoenix {
+    
+    public ChandrasPhoenix(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 37;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public ChandrasPhoenix(final ChandrasPhoenix card) {
+        super(card);
+    }
+    
+    @Override
+    public ChandrasPhoenix copy() {
+        return new ChandrasPhoenix(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/ConsumeSpirit.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/ConsumeSpirit.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class ConsumeSpirit extends mage.sets.planechase.ConsumeSpirit {
+    
+    public ConsumeSpirit(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 54;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public ConsumeSpirit(final ConsumeSpirit card) {
+        super(card);
+    }
+    
+    @Override
+    public ConsumeSpirit copy() {
+        return new ConsumeSpirit(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/Corrupt.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/Corrupt.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class Corrupt extends mage.sets.magic2014.Corrupt {
+    
+    public Corrupt(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 64;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public Corrupt(final Corrupt card) {
+        super(card);
+    }
+    
+    @Override
+    public Corrupt copy() {
+        return new Corrupt(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/DayOfJudgment.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/DayOfJudgment.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class DayOfJudgment extends mage.sets.zendikar.DayOfJudgment {
+    
+    public DayOfJudgment(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 22;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public DayOfJudgment(final DayOfJudgment card) {
+        super(card);
+    }
+    
+    @Override
+    public DayOfJudgment copy() {
+        return new DayOfJudgment(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/DevilsPlay.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/DevilsPlay.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class DevilsPlay extends mage.sets.innistrad.DevilsPlay {
+    
+    public DevilsPlay(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 40;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public DevilsPlay(final DevilsPlay card) {
+        super(card);
+    }
+    
+    @Override
+    public DevilsPlay copy() {
+        return new DevilsPlay(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/DregMangler.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/DregMangler.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class DregMangler extends mage.sets.returntoravnica.DregMangler {
+    
+    public DregMangler(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 55;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public DregMangler(final DregMangler card) {
+        super(card);
+    }
+    
+    @Override
+    public DregMangler copy() {
+        return new DregMangler(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/EidolonOfBlossoms.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/EidolonOfBlossoms.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class EidolonOfBlossoms extends mage.sets.journeyintonyx.EidolonOfBlossoms {
+    
+    public EidolonOfBlossoms(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 85;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public EidolonOfBlossoms(final EidolonOfBlossoms card) {
+        super(card);
+    }
+    
+    @Override
+    public EidolonOfBlossoms copy() {
+        return new EidolonOfBlossoms(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/Electrolyze.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/Electrolyze.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class Electrolyze extends mage.sets.guildpact.Electrolyze {
+    
+    public Electrolyze(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 42;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public Electrolyze(final Electrolyze card) {
+        super(card);
+    }
+    
+    @Override
+    public Electrolyze copy() {
+        return new Electrolyze(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/FaithlessLooting.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/FaithlessLooting.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class FaithlessLooting extends mage.sets.darkascension.FaithlessLooting {
+    
+    public FaithlessLooting(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 39;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public FaithlessLooting(final FaithlessLooting card) {
+        super(card);
+    }
+    
+    @Override
+    public FaithlessLooting copy() {
+        return new FaithlessLooting(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/FatedConflagration.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/FatedConflagration.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class FatedConflagration extends mage.sets.bornofthegods.FatedConflagration {
+    
+    public FatedConflagration(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 79;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public FatedConflagration(final FatedConflagration card) {
+        super(card);
+    }
+    
+    @Override
+    public FatedConflagration copy() {
+        return new FatedConflagration(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/FeastOfBlood.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/FeastOfBlood.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class FeastOfBlood extends mage.sets.zendikar.FeastOfBlood {
+    
+    public FeastOfBlood(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 43;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public FeastOfBlood(final FeastOfBlood card) {
+        super(card);
+    }
+    
+    @Override
+    public FeastOfBlood copy() {
+        return new FeastOfBlood(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/Fireball.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/Fireball.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class Fireball extends mage.sets.limitedalpha.Fireball {
+    
+    public Fireball(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 4;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public Fireball(final Fireball card) {
+        super(card);
+    }
+    
+    @Override
+    public Fireball copy() {
+        return new Fireball(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/FrostTitan.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/FrostTitan.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class FrostTitan extends mage.sets.magic2011.FrostTitan {
+    
+    public FrostTitan(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 34;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public FrostTitan(final FrostTitan card) {
+        super(card);
+    }
+    
+    @Override
+    public FrostTitan copy() {
+        return new FrostTitan(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/GarrukApexPredator.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/GarrukApexPredator.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class GarrukApexPredator extends mage.sets.magic2015.GarrukApexPredator {
+    
+    public GarrukApexPredator(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 104;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public GarrukApexPredator(final GarrukApexPredator card) {
+        super(card);
+    }
+    
+    @Override
+    public GarrukApexPredator copy() {
+        return new GarrukApexPredator(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/GarrukCallerOfBeasts.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/GarrukCallerOfBeasts.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class GarrukCallerOfBeasts extends mage.sets.magic2014.GarrukCallerOfBeasts {
+    
+    public GarrukCallerOfBeasts(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 76;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public GarrukCallerOfBeasts(final GarrukCallerOfBeasts card) {
+        super(card);
+    }
+    
+    @Override
+    public GarrukCallerOfBeasts copy() {
+        return new GarrukCallerOfBeasts(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/GarrukWildspeaker.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/GarrukWildspeaker.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class GarrukWildspeaker extends mage.sets.lorwyn.GarrukWildspeaker {
+    
+    public GarrukWildspeaker(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 16;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public GarrukWildspeaker(final GarrukWildspeaker card) {
+        super(card);
+    }
+    
+    @Override
+    public GarrukWildspeaker copy() {
+        return new GarrukWildspeaker(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/GazeOfGranite.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/GazeOfGranite.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class GazeOfGranite extends mage.sets.dragonsmaze.GazeOfGranite {
+    
+    public GazeOfGranite(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 81;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public GazeOfGranite(final GazeOfGranite card) {
+        super(card);
+    }
+    
+    @Override
+    public GazeOfGranite copy() {
+        return new GazeOfGranite(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/GoblinRabblemaster.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/GoblinRabblemaster.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class GoblinRabblemaster extends mage.sets.magic2015.GoblinRabblemaster {
+    
+    public GoblinRabblemaster(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 98;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public GoblinRabblemaster(final GoblinRabblemaster card) {
+        super(card);
+    }
+    
+    @Override
+    public GoblinRabblemaster copy() {
+        return new GoblinRabblemaster(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/GraveTitan.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/GraveTitan.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class GraveTitan extends mage.sets.magic2011.GraveTitan {
+    
+    public GraveTitan(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 35;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public GraveTitan(final GraveTitan card) {
+        super(card);
+    }
+    
+    @Override
+    public GraveTitan copy() {
+        return new GraveTitan(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/Gravecrawler.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/Gravecrawler.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class Gravecrawler extends mage.sets.darkascension.Gravecrawler {
+    
+    public Gravecrawler(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 41;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public Gravecrawler(final Gravecrawler card) {
+        super(card);
+    }
+    
+    @Override
+    public Gravecrawler copy() {
+        return new Gravecrawler(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/GuulDrazAssassin.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/GuulDrazAssassin.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class GuulDrazAssassin extends mage.sets.riseoftheeldrazi.GuulDrazAssassin {
+    
+    public GuulDrazAssassin(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 26;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public GuulDrazAssassin(final GuulDrazAssassin card) {
+        super(card);
+    }
+    
+    @Override
+    public GuulDrazAssassin copy() {
+        return new GuulDrazAssassin(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/HamletbackGoliath.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/HamletbackGoliath.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class HamletbackGoliath extends mage.sets.lorwyn.HamletbackGoliath {
+    
+    public HamletbackGoliath(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 71;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public HamletbackGoliath(final HamletbackGoliath card) {
+        super(card);
+    }
+    
+    @Override
+    public HamletbackGoliath copy() {
+        return new HamletbackGoliath(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/HighTide.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/HighTide.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class HighTide extends mage.sets.fallenempires.HighTide {
+    
+    public HighTide(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 80;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public HighTide(final HighTide card) {
+        super(card);
+    }
+    
+    @Override
+    public HighTide copy() {
+        return new HighTide(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/HonorOfThePure.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/HonorOfThePure.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class HonorOfThePure extends mage.sets.magic2010.HonorOfThePure {
+    
+    public HonorOfThePure(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 20;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public HonorOfThePure(final HonorOfThePure card) {
+        super(card);
+    }
+    
+    @Override
+    public HonorOfThePure copy() {
+        return new HonorOfThePure(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/InfernoTitan.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/InfernoTitan.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class InfernoTitan extends mage.sets.magic2011.InfernoTitan {
+    
+    public InfernoTitan(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 36;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public InfernoTitan(final InfernoTitan card) {
+        super(card);
+    }
+    
+    @Override
+    public InfernoTitan copy() {
+        return new InfernoTitan(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/IvorytuskFortress.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/IvorytuskFortress.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class IvorytuskFortress extends mage.sets.khansoftarkir.IvorytuskFortress {
+    
+    public IvorytuskFortress(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 95;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public IvorytuskFortress(final IvorytuskFortress card) {
+        super(card);
+    }
+    
+    @Override
+    public IvorytuskFortress copy() {
+        return new IvorytuskFortress(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/JaceBeleren.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/JaceBeleren.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class JaceBeleren extends mage.sets.lorwyn.JaceBeleren {
+    
+    public JaceBeleren(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 15;
+        this.expansionSetCode = "MPB";
+    }
+    
+    public JaceBeleren(final JaceBeleren card) {
+        super(card);
+    }
+    
+    @Override
+    public JaceBeleren copy() {
+        return new JaceBeleren(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/JaceMemoryAdept.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/JaceMemoryAdept.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class JaceMemoryAdept extends mage.sets.magic2012.JaceMemoryAdept {
+    
+    public JaceMemoryAdept(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 73;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public JaceMemoryAdept(final JaceMemoryAdept card) {
+        super(card);
+    }
+    
+    @Override
+    public JaceMemoryAdept copy() {
+        return new JaceMemoryAdept(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/JaceTheLivingGuildpact.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/JaceTheLivingGuildpact.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class JaceTheLivingGuildpact extends mage.sets.magic2015.JaceTheLivingGuildpact {
+    
+    public JaceTheLivingGuildpact(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 100;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public JaceTheLivingGuildpact(final JaceTheLivingGuildpact card) {
+        super(card);
+    }
+    
+    @Override
+    public JaceTheLivingGuildpact copy() {
+        return new JaceTheLivingGuildpact(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/JayaBallardTaskMage.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/JayaBallardTaskMage.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class JayaBallardTaskMage extends mage.sets.timespiral.JayaBallardTaskMage {
+    
+    public JayaBallardTaskMage(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 18;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public JayaBallardTaskMage(final JayaBallardTaskMage card) {
+        super(card);
+    }
+    
+    @Override
+    public JayaBallardTaskMage copy() {
+        return new JayaBallardTaskMage(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/KarametrasAcolyte.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/KarametrasAcolyte.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class KarametrasAcolyte extends mage.sets.theros.KarametrasAcolyte {
+    
+    public KarametrasAcolyte(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 78;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public KarametrasAcolyte(final KarametrasAcolyte card) {
+        super(card);
+    }
+    
+    @Override
+    public KarametrasAcolyte copy() {
+        return new KarametrasAcolyte(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/KnightExemplar.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/KnightExemplar.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class KnightExemplar extends mage.sets.magic2011.KnightExemplar {
+    
+    public KnightExemplar(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 46;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public KnightExemplar(final KnightExemplar card) {
+        super(card);
+    }
+    
+    @Override
+    public KnightExemplar copy() {
+        return new KnightExemplar(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/KorSkyfisher.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/KorSkyfisher.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class KorSkyfisher extends mage.sets.zendikar.KorSkyfisher {
+    
+    public KorSkyfisher(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 25;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public KorSkyfisher(final KorSkyfisher card) {
+        super(card);
+    }
+    
+    @Override
+    public KorSkyfisher copy() {
+        return new KorSkyfisher(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/LilianaOfTheDarkRealms.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/LilianaOfTheDarkRealms.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class LilianaOfTheDarkRealms extends mage.sets.magic2014.LilianaOfTheDarkRealms {
+    
+    public LilianaOfTheDarkRealms(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 74;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public LilianaOfTheDarkRealms(final LilianaOfTheDarkRealms card) {
+        super(card);
+    }
+    
+    @Override
+    public LilianaOfTheDarkRealms copy() {
+        return new LilianaOfTheDarkRealms(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/LilianaVess.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/LilianaVess.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class LilianaVess extends mage.sets.lorwyn.LilianaVess {
+    
+    public LilianaVess(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 30;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public LilianaVess(final LilianaVess card) {
+        super(card);
+    }
+    
+    @Override
+    public LilianaVess copy() {
+        return new LilianaVess(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/LilianaVess2.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/LilianaVess2.java
@@ -1,0 +1,22 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+
+public class LilianaVess2 extends mage.sets.magic2011.LilianaVess {
+    
+    public LilianaVess2(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 101;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public LilianaVess2(final LilianaVess2 card) {
+        super(card);
+    }
+    
+    @Override
+    public LilianaVess2 copy() {
+        return new LilianaVess2(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/ManaCrypt.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/ManaCrypt.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class ManaCrypt extends mage.sets.judgepromo.ManaCrypt {
+    
+    public ManaCrypt(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 6;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public ManaCrypt(final ManaCrypt card) {
+        super(card);
+    }
+    
+    @Override
+    public ManaCrypt copy() {
+        return new ManaCrypt(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/Memoricide.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/Memoricide.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class Memoricide extends mage.sets.scarsofmirrodin.Memoricide {
+    
+    public Memoricide(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 29;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public Memoricide(final Memoricide card) {
+        super(card);
+    }
+    
+    @Override
+    public Memoricide copy() {
+        return new Memoricide(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/MerfolkMesmerist.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/MerfolkMesmerist.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class MerfolkMesmerist extends mage.sets.magic2012.MerfolkMesmerist {
+    
+    public MerfolkMesmerist(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 45;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public MerfolkMesmerist(final MerfolkMesmerist card) {
+        super(card);
+    }
+    
+    @Override
+    public MerfolkMesmerist copy() {
+        return new MerfolkMesmerist(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/MirranCrusader.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/MirranCrusader.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class MirranCrusader extends mage.sets.mirrodinbesieged.MirranCrusader {
+    
+    public MirranCrusader(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 32;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public MirranCrusader(final MirranCrusader card) {
+        super(card);
+    }
+    
+    @Override
+    public MirranCrusader copy() {
+        return new MirranCrusader(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/NightveilSpecter.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/NightveilSpecter.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class NightveilSpecter extends mage.sets.gatecrash.NightveilSpecter {
+    
+    public NightveilSpecter(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 61;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public NightveilSpecter(final NightveilSpecter card) {
+        super(card);
+    }
+    
+    @Override
+    public NightveilSpecter copy() {
+        return new NightveilSpecter(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/NissaRevane.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/NissaRevane.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class NissaRevane extends mage.sets.zendikar.NissaRevane {
+    
+    public NissaRevane(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 27;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public NissaRevane(final NissaRevane card) {
+        super(card);
+    }
+    
+    @Override
+    public NissaRevane copy() {
+        return new NissaRevane(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/NissaWorldwaker.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/NissaWorldwaker.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class NissaWorldwaker extends mage.sets.magic2015.NissaWorldwaker {
+    
+    public NissaWorldwaker(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 103;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public NissaWorldwaker(final NissaWorldwaker card) {
+        super(card);
+    }
+    
+    @Override
+    public NissaWorldwaker copy() {
+        return new NissaWorldwaker(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/OgreBattledriver.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/OgreBattledriver.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class OgreBattledriver extends mage.sets.magic2014.OgreBattledriver {
+    
+    public OgreBattledriver(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 69;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public OgreBattledriver(final OgreBattledriver card) {
+        super(card);
+    }
+    
+    @Override
+    public OgreBattledriver copy() {
+        return new OgreBattledriver(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/PhyrexianRager.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/PhyrexianRager.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class PhyrexianRager extends mage.sets.mirrodinbesieged.PhyrexianRager {
+    
+    public PhyrexianRager(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 14;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public PhyrexianRager(final PhyrexianRager card) {
+        super(card);
+    }
+    
+    @Override
+    public PhyrexianRager copy() {
+        return new PhyrexianRager(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/PrimordialHydra.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/PrimordialHydra.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class PrimordialHydra extends mage.sets.magic2012.PrimordialHydra {
+    
+    public PrimordialHydra(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 49;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public PrimordialHydra(final PrimordialHydra card) {
+        super(card);
+    }
+    
+    @Override
+    public PrimordialHydra copy() {
+        return new PrimordialHydra(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/RakshasaVizier.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/RakshasaVizier.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class RakshasaVizier extends mage.sets.khansoftarkir.RakshasaVizier {
+    
+    public RakshasaVizier(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 96;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public RakshasaVizier(final RakshasaVizier card) {
+        super(card);
+    }
+    
+    @Override
+    public RakshasaVizier copy() {
+        return new RakshasaVizier(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/RatchetBomb.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/RatchetBomb.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class RatchetBomb extends mage.sets.magic2014.RatchetBomb {
+    
+    public RatchetBomb(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 67;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public RatchetBomb(final RatchetBomb card) {
+        super(card);
+    }
+    
+    @Override
+    public RatchetBomb copy() {
+        return new RatchetBomb(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/RattleclawMystic.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/RattleclawMystic.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class RattleclawMystic extends mage.sets.khansoftarkir.RattleclawMystic {
+    
+    public RattleclawMystic(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 92;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public RattleclawMystic(final RattleclawMystic card) {
+        super(card);
+    }
+    
+    @Override
+    public RattleclawMystic copy() {
+        return new RattleclawMystic(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/RenderSilent.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/RenderSilent.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class RenderSilent extends mage.sets.dragonsmaze.RenderSilent {
+    
+    public RenderSilent(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 66;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public RenderSilent(final RenderSilent card) {
+        super(card);
+    }
+    
+    @Override
+    public RenderSilent copy() {
+        return new RenderSilent(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/RetaliatorGriffin.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/RetaliatorGriffin.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class RetaliatorGriffin extends mage.sets.alarareborn.RetaliatorGriffin {
+    
+    public RetaliatorGriffin(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 24;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public RetaliatorGriffin(final RetaliatorGriffin card) {
+        super(card);
+    }
+    
+    @Override
+    public RetaliatorGriffin copy() {
+        return new RetaliatorGriffin(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/SageOfTheInwardEye.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/SageOfTheInwardEye.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class SageOfTheInwardEye extends mage.sets.khansoftarkir.SageOfTheInwardEye {
+    
+    public SageOfTheInwardEye(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 97;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public SageOfTheInwardEye(final SageOfTheInwardEye card) {
+        super(card);
+    }
+    
+    @Override
+    public SageOfTheInwardEye copy() {
+        return new SageOfTheInwardEye(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/ScavengingOoze.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/ScavengingOoze.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class ScavengingOoze extends mage.sets.commander.ScavengingOoze {
+    
+    public ScavengingOoze(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 70;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public ScavengingOoze(final ScavengingOoze card) {
+        super(card);
+    }
+    
+    @Override
+    public ScavengingOoze copy() {
+        return new ScavengingOoze(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/SerraAvatar.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/SerraAvatar.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class SerraAvatar extends mage.sets.magic2013.SerraAvatar {
+    
+    public SerraAvatar(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 48;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public SerraAvatar(final SerraAvatar card) {
+        super(card);
+    }
+    
+    @Override
+    public SerraAvatar copy() {
+        return new SerraAvatar(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/SilverbladePaladin.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/SilverbladePaladin.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class SilverbladePaladin extends mage.sets.commander2014.SilverbladePaladin {
+    
+    public SilverbladePaladin(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 44;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public SilverbladePaladin(final SilverbladePaladin card) {
+        super(card);
+    }
+    
+    @Override
+    public SilverbladePaladin copy() {
+        return new SilverbladePaladin(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/SoulOfRavnica.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/SoulOfRavnica.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class SoulOfRavnica extends mage.sets.magic2015.SoulOfRavnica {
+    
+    public SoulOfRavnica(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 87;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public SoulOfRavnica(final SoulOfRavnica card) {
+        super(card);
+    }
+    
+    @Override
+    public SoulOfRavnica copy() {
+        return new SoulOfRavnica(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/SoulOfZendikar.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/SoulOfZendikar.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class SoulOfZendikar extends mage.sets.magic2015.SoulOfZendikar {
+    
+    public SoulOfZendikar(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 88;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public SoulOfZendikar(final SoulOfZendikar card) {
+        super(card);
+    }
+    
+    @Override
+    public SoulOfZendikar copy() {
+        return new SoulOfZendikar(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/Standstill.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/Standstill.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class Standstill extends mage.sets.odyssey.Standstill {
+    
+    public Standstill(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 57;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public Standstill(final Standstill card) {
+        super(card);
+    }
+    
+    @Override
+    public Standstill copy() {
+        return new Standstill(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/StealerOfSecrets.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/StealerOfSecrets.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class StealerOfSecrets extends mage.sets.returntoravnica.StealerOfSecrets {
+    
+    public StealerOfSecrets(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 89;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public StealerOfSecrets(final StealerOfSecrets card) {
+        super(card);
+    }
+    
+    @Override
+    public StealerOfSecrets copy() {
+        return new StealerOfSecrets(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/StewardOfValeron.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/StewardOfValeron.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class StewardOfValeron extends mage.sets.shardsofalara.StewardOfValeron {
+    
+    public StewardOfValeron(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 21;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public StewardOfValeron(final StewardOfValeron card) {
+        super(card);
+    }
+    
+    @Override
+    public StewardOfValeron copy() {
+        return new StewardOfValeron(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/SunblastAngel.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/SunblastAngel.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class SunblastAngel extends mage.sets.scarsofmirrodin.SunblastAngel {
+    
+    public SunblastAngel(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 47;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public SunblastAngel(final SunblastAngel card) {
+        super(card);
+    }
+    
+    @Override
+    public SunblastAngel copy() {
+        return new SunblastAngel(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/SupremeVerdict.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/SupremeVerdict.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class SupremeVerdict extends mage.sets.returntoravnica.SupremeVerdict {
+    
+    public SupremeVerdict(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 56;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public SupremeVerdict(final SupremeVerdict card) {
+        super(card);
+    }
+    
+    @Override
+    public SupremeVerdict copy() {
+        return new SupremeVerdict(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/SurgicalExtraction.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/SurgicalExtraction.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class SurgicalExtraction extends mage.sets.newphyrexia.SurgicalExtraction {
+    
+    public SurgicalExtraction(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 33;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public SurgicalExtraction(final SurgicalExtraction card) {
+        super(card);
+    }
+    
+    @Override
+    public SurgicalExtraction copy() {
+        return new SurgicalExtraction(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/SylvanCaryatid.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/SylvanCaryatid.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class SylvanCaryatid extends mage.sets.theros.SylvanCaryatid {
+    
+    public SylvanCaryatid(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 77;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public SylvanCaryatid(final SylvanCaryatid card) {
+        super(card);
+    }
+    
+    @Override
+    public SylvanCaryatid copy() {
+        return new SylvanCaryatid(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/Terastodon.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/Terastodon.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class Terastodon extends mage.sets.worldwake.Terastodon {
+    
+    public Terastodon(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 52;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public Terastodon(final Terastodon card) {
+        super(card);
+    }
+    
+    @Override
+    public Terastodon copy() {
+        return new Terastodon(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/TreasureHunt.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/TreasureHunt.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class TreasureHunt extends mage.sets.worldwake.TreasureHunt {
+    
+    public TreasureHunt(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 38;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public TreasureHunt(final TreasureHunt card) {
+        super(card);
+    }
+    
+    @Override
+    public TreasureHunt copy() {
+        return new TreasureHunt(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/Turnabout.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/Turnabout.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class Turnabout extends mage.sets.urzassaga.Turnabout {
+    
+    public Turnabout(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 60;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public Turnabout(final Turnabout card) {
+        super(card);
+    }
+    
+    @Override
+    public Turnabout copy() {
+        return new Turnabout(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/VampireNocturnus.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/VampireNocturnus.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class VampireNocturnus extends mage.sets.magic2010.VampireNocturnus {
+    
+    public VampireNocturnus(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 50;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public VampireNocturnus(final VampireNocturnus card) {
+        super(card);
+    }
+    
+    @Override
+    public VampireNocturnus copy() {
+        return new VampireNocturnus(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/mediainserts/WashOut.java
+++ b/Mage.Sets/src/mage/sets/mediainserts/WashOut.java
@@ -1,0 +1,21 @@
+package mage.sets.mediainserts;
+
+import java.util.UUID;
+
+public class WashOut extends mage.sets.invasion.WashOut {
+    
+    public WashOut(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 82;
+        this.expansionSetCode = "MBP";
+    }
+    
+    public WashOut(final WashOut card) {
+        super(card);
+    }
+    
+    @Override
+    public WashOut copy() {
+        return new WashOut(this);
+    }
+}


### PR DESCRIPTION
Media Inserts are the set that contains unique-art Buy-a-Box promos and promos from novels, comic books, and events. It is very similar to Judge promos.

Added the set and implemented 15 of the 104 cards in it. The images can be downloaded from magiccards.info but are not on Gatherer. 
![supreme verdict full](https://cloud.githubusercontent.com/assets/10366239/5607986/c3514efa-9436-11e4-9838-acd7a839fab8.jpg)
