### PR TITLE
Implement 6 Cards

### DIFF
--- a/Mage.Client/release/sample-decks/Duel Decks/Phyrexia vs. Coalition/Phyrexia.dck
+++ b/Mage.Client/release/sample-decks/Duel Decks/Phyrexia vs. Coalition/Phyrexia.dck
@@ -1,0 +1,35 @@
+1 [DDE:9] Sanguine Guard
+1 [DDE:8] Phyrexian Broodlings
+2 [DDE:7] Priest of Gix
+1 [DDE:6] Phyrexian Ghoul
+1 [DDE:5] Bone Shredder
+1 [DDE:4] Phyrexian Denouncer
+1 [DDE:3] Phyrexian Battleflies
+1 [DDE:2] Carrion Feeder
+1 [DDE:29] Phyrexian Processor
+1 [DDE:1] Phyrexian Negator
+1 [DDE:27] Phyrexian Arena
+1 [DDE:28] Hornet Cannon
+1 [DDE:25] Slay
+1 [DDE:26] Hideous End
+1 [DDE:23] Whispersilk Cloak
+1 [DDE:24] Worn Powerstone
+1 [DDE:21] Phyrexian Vault
+2 [DDE:22] Puppet Strings
+1 [DDE:20] Phyrexian Totem
+2 [DDE:18] Dark Ritual
+1 [DDE:19] Lightning Greaves
+1 [DDE:16] Phyrexian Colossus
+1 [DDE:17] Voltaic Key
+1 [DDE:14] Phyrexian Hulk
+1 [DDE:15] Phyrexian Gargantua
+6 [DDE:34] Swamp
+1 [DDE:12] Phyrexian Defiler
+6 [DDE:35] Swamp
+1 [DDE:13] Phyrexian Plaguelord
+7 [DDE:32] Swamp
+1 [DDE:10] Phyrexian Debaser
+6 [DDE:33] Swamp
+1 [DDE:11] Order of Yawgmoth
+2 [DDE:30] Tendrils of Corruption
+1 [DDE:31] Living Death

--- a/Mage.Sets/src/mage/sets/eighthedition/PhyrexianColossus.java
+++ b/Mage.Sets/src/mage/sets/eighthedition/PhyrexianColossus.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.eighthedition;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.common.PayLifeCost;
+import mage.abilities.effects.common.DoIfCostPaid;
+import mage.abilities.effects.common.DontUntapInControllersUntapStepSourceEffect;
+import mage.abilities.effects.common.UntapSourceEffect;
+import mage.abilities.effects.common.combat.CantBeBlockedByOneEffect;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+
+/**
+ *
+ * @author FenrisulfrX
+ */
+public class PhyrexianColossus extends CardImpl {
+
+    public PhyrexianColossus(UUID ownerId) {
+        super(ownerId, 309, "Phyrexian Colossus", Rarity.RARE, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{7}");
+        this.expansionSetCode = "8ED";
+        this.subtype.add("Golem");
+        this.power = new MageInt(8);
+        this.toughness = new MageInt(8);
+
+        // {this} doesn't untap during your untap step.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new DontUntapInControllersUntapStepSourceEffect()));
+        // Pay 8 life: Untap {this}.
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD,
+                new UntapSourceEffect(), new PayLifeCost(8)));
+        // {this} can't be blocked except by three or more creatures.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new CantBeBlockedByOneEffect(3)));
+        
+    }
+
+    public PhyrexianColossus(final PhyrexianColossus card) {
+        super(card);
+    }
+
+    @Override
+    public PhyrexianColossus copy() {
+        return new PhyrexianColossus(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/invasion/PhyrexianBattleflies.java
+++ b/Mage.Sets/src/mage/sets/invasion/PhyrexianBattleflies.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.invasion;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author anonymous
+ */
+public class PhyrexianBattleflies extends mage.sets.phyrexiavsthecoalition.PhyrexianBattleflies {
+
+    public PhyrexianBattleflies(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 114;
+        this.expansionSetCode = "INV";
+    }
+
+    public PhyrexianBattleflies(final PhyrexianBattleflies card) {
+        super(card);
+    }
+
+    @Override
+    public PhyrexianBattleflies copy() {
+        return new PhyrexianBattleflies(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/HornetCannon.java
+++ b/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/HornetCannon.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.phyrexiavsthecoalition;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.DelayedTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DestroyTargetEffect;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.permanent.token.HornetToken;
+import mage.game.permanent.token.Token;
+import mage.target.targetpointer.FixedTarget;
+
+/**
+ *
+ * @author FenrisulfrX
+ */
+public class HornetCannon extends CardImpl {
+
+    public HornetCannon(UUID ownerId) {
+        super(ownerId, 28, "Hornet Cannon", Rarity.UNCOMMON, new CardType[]{CardType.ARTIFACT}, "{4}");
+        this.expansionSetCode = "DDE";
+
+        // {3}, {tap}: Put a 1/1 colorless Insect artifact creature token with flying and haste named Hornet onto the battlefield. Destroy it at the beginning of the next end step.
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new HornetCannonEffect(), new GenericManaCost(3));
+        ability.addCost(new TapSourceCost());
+        this.addAbility(ability);
+    }
+
+    public HornetCannon(final HornetCannon card) {
+        super(card);
+    }
+
+    @Override
+    public HornetCannon copy() {
+        return new HornetCannon(this);
+    }
+}
+
+class HornetCannonEffect extends OneShotEffect {
+    
+    public HornetCannonEffect() {
+        super(Outcome.PutCreatureInPlay);
+        staticText = "Put a 1/1 colorless Insect artifact creature token with flying and haste named Hornet onto the battlefield. Destroy it at the beginning of the next end step.";
+    }
+    
+    public HornetCannonEffect(final HornetCannonEffect effect) {
+        super(effect);
+    }
+    
+    @Override
+    public HornetCannonEffect copy() {
+        return new HornetCannonEffect(this);
+    }
+    
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Token hornetToken = new HornetToken();
+        hornetToken.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId());
+        
+        DestroyTargetEffect destroyEffect = new DestroyTargetEffect("destroy the token.");
+        destroyEffect.setTargetPointer(new FixedTarget(hornetToken.getLastAddedToken()));
+        DelayedTriggeredAbility delayedAbility = new AtTheBeginOfNextEndStepDelayedTriggeredAbility(destroyEffect);
+        delayedAbility.setSourceId(source.getSourceId());
+        delayedAbility.setControllerId(source.getControllerId());
+        delayedAbility.setSourceObject(source.getSourceObject(game));
+        game.addDelayedTriggeredAbility(delayedAbility);
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/PhyrexianBattleflies.java
+++ b/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/PhyrexianBattleflies.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.phyrexiavsthecoalition;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.LimitedTimesPerTurnActivatedAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.continuous.BoostSourceEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+
+/**
+ *
+ * @author FenrisulfrX
+ */
+public class PhyrexianBattleflies extends CardImpl {
+
+    public PhyrexianBattleflies(UUID ownerId) {
+        super(ownerId, 3, "Phyrexian Battleflies", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{B}");
+        this.expansionSetCode = "DDE";
+        this.subtype.add("Insect");
+        this.power = new MageInt(0);
+        this.toughness = new MageInt(1);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+        // {B}: {this} gets +1/+0 until end of turn. Activate this ability no more than twice each turn.
+        this.addAbility(new LimitedTimesPerTurnActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1,0,Duration.EndOfTurn), new ManaCostsImpl("{B}"), 2));
+    }
+
+    public PhyrexianBattleflies(final PhyrexianBattleflies card) {
+        super(card);
+    }
+
+    @Override
+    public PhyrexianBattleflies copy() {
+        return new PhyrexianBattleflies(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/PhyrexianColossus.java
+++ b/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/PhyrexianColossus.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.phyrexiavsthecoalition;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author anonymous
+ */
+public class PhyrexianColossus extends mage.sets.eighthedition.PhyrexianColossus {
+
+    public PhyrexianColossus(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 16;
+        this.expansionSetCode = "DDE";
+    }
+
+    public PhyrexianColossus(final PhyrexianColossus card) {
+        super(card);
+    }
+
+    @Override
+    public PhyrexianColossus copy() {
+        return new PhyrexianColossus(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/PhyrexianProcessor.java
+++ b/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/PhyrexianProcessor.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.phyrexiavsthecoalition;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author anonymous
+ */
+public class PhyrexianProcessor extends mage.sets.urzassaga.PhyrexianProcessor {
+
+    public PhyrexianProcessor(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 29;
+        this.expansionSetCode = "DDE";
+    }
+
+    public PhyrexianProcessor(final PhyrexianProcessor card) {
+        super(card);
+    }
+
+    @Override
+    public PhyrexianProcessor copy() {
+        return new PhyrexianProcessor(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/PhyrexianTotem.java
+++ b/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/PhyrexianTotem.java
@@ -1,0 +1,131 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.phyrexiavsthecoalition;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.common.StaticValue;
+import mage.abilities.effects.common.SacrificeEffect;
+import mage.abilities.effects.common.continuous.BecomesCreatureSourceEffect;
+import mage.abilities.keyword.TrampleAbility;
+import mage.abilities.mana.BlackManaAbility;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.filter.common.FilterControlledPermanent;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.token.Token;
+import mage.players.Player;
+import mage.target.targetpointer.FixedTarget;
+
+/**
+ *
+ * @author FenrisulfrX
+ */
+public class PhyrexianTotem extends CardImpl {
+
+    public PhyrexianTotem(UUID ownerId) {
+        super(ownerId, 20, "Phyrexian Totem", Rarity.UNCOMMON, new CardType[]{CardType.ARTIFACT}, "{3}");
+        this.expansionSetCode = "DDE";
+
+        // {tap}: Add {B} to your mana pool.
+        this.addAbility(new BlackManaAbility());
+        // {2}{B}: {this} becomes a 5/5 black Horror artifact creature with trample until end of turn.
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(
+                new PhyrexianTotemToken(), "", Duration.EndOfTurn), new ManaCostsImpl("{2}{B}")));
+        // Whenever {this} is dealt damage, if it's a creature, sacrifice that many permanents.
+        this.addAbility(new PhyrexianTotemTriggeredAbility());
+    }
+
+    public PhyrexianTotem(final PhyrexianTotem card) {
+        super(card);
+    }
+
+    @Override
+    public PhyrexianTotem copy() {
+        return new PhyrexianTotem(this);
+    }
+    
+    private class PhyrexianTotemToken extends Token {
+        PhyrexianTotemToken() {
+            super("", "a 5/5 black Horror artifact creature with trample");
+            cardType.add(CardType.ARTIFACT);
+            cardType.add(CardType.CREATURE);
+            color.setBlack(true);
+            this.subtype.add("Horror");
+            power = new MageInt(5);
+            toughness = new MageInt(5);
+            this.addAbility(TrampleAbility.getInstance());
+        }
+    }
+}
+
+class PhyrexianTotemTriggeredAbility extends TriggeredAbilityImpl {
+    
+    public PhyrexianTotemTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new SacrificeEffect(new FilterControlledPermanent(), 0,""));
+    }
+    
+    public PhyrexianTotemTriggeredAbility(final PhyrexianTotemTriggeredAbility ability) {
+        super(ability);
+    }
+    
+    @Override
+    public PhyrexianTotemTriggeredAbility copy() {
+        return new PhyrexianTotemTriggeredAbility(this);
+    }
+    
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        if(event.getType() == GameEvent.EventType.DAMAGED_CREATURE && event.getTargetId().equals(this.sourceId)) {
+            UUID controller = game.getControllerId(event.getTargetId());
+            if(controller != null) {
+                Player player = game.getPlayer(controller);
+                Card card = game.getCard(event.getSourceId());
+                if(player != null && card.getCardType().contains(CardType.CREATURE)) {
+                    getEffects().get(0).setTargetPointer(new FixedTarget(player.getId()));
+                    ((SacrificeEffect) getEffects().get(0)).setAmount(new StaticValue(event.getAmount()));
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    
+    @Override
+    public String getRule() {
+        return "Whenever {this} is dealt damage, if it's a creature, sacrifice that many permanents.";
+    }
+}

--- a/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/SanguineGuard.java
+++ b/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/SanguineGuard.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.phyrexiavsthecoalition;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author Backfir3
+ */
+public class SanguineGuard extends mage.sets.urzassaga.SanguineGuard {
+    
+    public SanguineGuard(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 9;
+        this.expansionSetCode = "DDE";
+    }
+    
+    public SanguineGuard(final SanguineGuard card) {
+        super(card);
+    }
+    
+    @Override
+    public SanguineGuard copy() {
+        return new SanguineGuard(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/seventhedition/PhyrexianColossus.java
+++ b/Mage.Sets/src/mage/sets/seventhedition/PhyrexianColossus.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.seventhedition;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author anonymous
+ */
+public class PhyrexianColossus extends mage.sets.eighthedition.PhyrexianColossus {
+
+    public PhyrexianColossus(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 311;
+        this.expansionSetCode = "7ED";
+    }
+
+    public PhyrexianColossus(final PhyrexianColossus card) {
+        super(card);
+    }
+
+    @Override
+    public PhyrexianColossus copy() {
+        return new PhyrexianColossus(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/stronghold/HornetCannon.java
+++ b/Mage.Sets/src/mage/sets/stronghold/HornetCannon.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.stronghold;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author anonymous
+ */
+public class HornetCannon extends mage.sets.phyrexiavsthecoalition.HornetCannon {
+
+    public HornetCannon(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 130;
+        this.expansionSetCode = "STH";
+    }
+
+    public HornetCannon(final HornetCannon card) {
+        super(card);
+    }
+
+    @Override
+    public HornetCannon copy() {
+        return new HornetCannon(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/timespiral/PhyrexianTotem.java
+++ b/Mage.Sets/src/mage/sets/timespiral/PhyrexianTotem.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.timespiral;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author anonymous
+ */
+public class PhyrexianTotem extends mage.sets.phyrexiavsthecoalition.PhyrexianTotem {
+
+    public PhyrexianTotem(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 261;
+        this.expansionSetCode = "TSP";
+    }
+
+    public PhyrexianTotem(final PhyrexianTotem card) {
+        super(card);
+    }
+
+    @Override
+    public PhyrexianTotem copy() {
+        return new PhyrexianTotem(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/urzassaga/PhyrexianColossus.java
+++ b/Mage.Sets/src/mage/sets/urzassaga/PhyrexianColossus.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.urzassaga;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author anonymous
+ */
+public class PhyrexianColossus extends mage.sets.eighthedition.PhyrexianColossus {
+
+    public PhyrexianColossus(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 306;
+        this.expansionSetCode = "USG";
+    }
+
+    public PhyrexianColossus(final PhyrexianColossus card) {
+        super(card);
+    }
+
+    @Override
+    public PhyrexianColossus copy() {
+        return new PhyrexianColossus(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/urzassaga/PhyrexianProcessor.java
+++ b/Mage.Sets/src/mage/sets/urzassaga/PhyrexianProcessor.java
@@ -1,0 +1,139 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.urzassaga;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.permanent.token.MinionToken;
+import mage.players.Player;
+import mage.util.CardUtil;
+
+/**
+ *
+ * @author FenrisulfrX
+ */
+public class PhyrexianProcessor extends CardImpl {
+
+    public PhyrexianProcessor(UUID ownerId) {
+        super(ownerId, 306, "Phyrexian Processor", Rarity.RARE, new CardType[]{CardType.ARTIFACT}, "{4}");
+        this.expansionSetCode = "USG";
+
+        // As {this} enters the battlefield, pay any amount of life.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new PhyrexianProcessorEffect()));
+        // {4}, {tap}: Put an X/X black Minion creature token onto the battlefield, where X is the life paid as {this} entered the battlefield.
+        SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new PhyrexianProcessorCreateTokenEffect(), new ManaCostsImpl("{4}"));
+        ability.addCost(new TapSourceCost());
+        this.addAbility(ability);
+    }
+
+    public PhyrexianProcessor(final PhyrexianProcessor card) {
+        super(card);
+    }
+
+    @Override
+    public PhyrexianProcessor copy() {
+        return new PhyrexianProcessor(this);
+    }
+}
+
+class PhyrexianProcessorEffect extends OneShotEffect {
+
+    public PhyrexianProcessorEffect() {
+        super(Outcome.LoseLife);
+        staticText = "Pay any amount of life.";
+    }
+
+    public PhyrexianProcessorEffect(final PhyrexianProcessorEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public PhyrexianProcessorEffect copy() {
+        return new PhyrexianProcessorEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if(controller != null) {
+            Card sourceCard = game.getCard(source.getSourceId());
+            int payAmount = controller.getAmount(0, controller.getLife(), staticText, game);
+            controller.loseLife(payAmount, game);
+            game.informPlayers(new StringBuilder(sourceCard.getName()).append(": ").append(controller.getName())
+                .append(" pays ").append(payAmount).append(" life.").toString());
+            String key = CardUtil.getCardZoneString("lifePaid", source.getSourceId(), game);
+            game.getState().setValue(key, payAmount);
+            return true;
+        }
+        return false;
+    }
+}
+
+class PhyrexianProcessorCreateTokenEffect extends OneShotEffect {
+    
+    public PhyrexianProcessorCreateTokenEffect() {
+        super(Outcome.PutCreatureInPlay);
+        staticText = "Put an X/X black Minion creature token onto the battlefield";
+    }
+
+    public PhyrexianProcessorCreateTokenEffect(PhyrexianProcessorCreateTokenEffect ability) {
+        super(ability);
+    }
+    
+    @Override
+    public PhyrexianProcessorCreateTokenEffect copy() {
+        return new PhyrexianProcessorCreateTokenEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        String key = CardUtil.getCardZoneString("lifePaid", source.getSourceId(), game);
+        Object object = game.getState().getValue(key);
+        if(object != null && object instanceof Integer) {
+            int lifePaid = (int) object;
+            MinionToken token = new MinionToken();
+            token.getPower().initValue(lifePaid);
+            token.getToughness().initValue(lifePaid);
+            token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId());
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage/src/mage/game/permanent/token/HornetToken.java
+++ b/Mage/src/mage/game/permanent/token/HornetToken.java
@@ -1,0 +1,57 @@
+/*
+* Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification, are
+* permitted provided that the following conditions are met:
+*
+*    1. Redistributions of source code must retain the above copyright notice, this list of
+*       conditions and the following disclaimer.
+*
+*    2. Redistributions in binary form must reproduce the above copyright notice, this list
+*       of conditions and the following disclaimer in the documentation and/or other materials
+*       provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+* FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+* ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The views and conclusions contained in the software and documentation are those of the
+* authors and should not be interpreted as representing official policies, either expressed
+* or implied, of BetaSteward_at_googlemail.com.
+*/
+
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.HasteAbility;
+import mage.constants.CardType;
+
+/**
+ *
+ * @author FenrisulfrX
+ */
+public class HornetToken extends Token {
+    
+    public HornetToken() {
+        this("DDE");
+    }
+    
+    public HornetToken(String setCode) {
+        super("Hornet", "1/1 colorless Insect artifact creature token with flying and haste");
+        this.setOriginalExpansionSetCode(setCode);
+        cardType.add(CardType.ARTIFACT);
+        cardType.add(CardType.CREATURE);
+        subtype.add("Insect");
+        power = new MageInt(1);
+        toughness = new MageInt(1);
+        addAbility(FlyingAbility.getInstance());
+        addAbility(HasteAbility.getInstance());
+    }    
+}

--- a/Mage/src/mage/game/permanent/token/MinionToken.java
+++ b/Mage/src/mage/game/permanent/token/MinionToken.java
@@ -1,0 +1,53 @@
+/*
+* Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification, are
+* permitted provided that the following conditions are met:
+*
+*    1. Redistributions of source code must retain the above copyright notice, this list of
+*       conditions and the following disclaimer.
+*
+*    2. Redistributions in binary form must reproduce the above copyright notice, this list
+*       of conditions and the following disclaimer in the documentation and/or other materials
+*       provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+* FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+* ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* The views and conclusions contained in the software and documentation are those of the
+* authors and should not be interpreted as representing official policies, either expressed
+* or implied, of BetaSteward_at_googlemail.com.
+*/
+
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+
+/**
+ *
+ * @author FenrisulfrX
+ */
+public class MinionToken extends Token {
+    
+    public MinionToken() {
+        this("DDE");
+    }
+    
+    public MinionToken(String setCode) {
+        super("Minion", "X/X black Minion creature token");
+        this.setOriginalExpansionSetCode(setCode);
+        cardType.add(CardType.CREATURE);
+        subtype.add("Minion");
+        color.setBlack(true);
+        power = new MageInt(0);
+        toughness = new MageInt(0);
+    }
+}


### PR DESCRIPTION
Implemented 6 cards needed to add the Phyrexian deck from Phyrexia vs
coalition Duel Decks.
Cards Implemented:
* Hornet Cannon
* Phyrexian Battleflies
* Phyrexian Colossus
* Phyrexian Processor
* Phyrexian Totem
* Sanguine Guard