### PR TITLE
Fixes Phyrexian Totem

### DIFF
--- a/Mage.Sets/src/mage/sets/invasion/PhyrexianBattleflies.java
+++ b/Mage.Sets/src/mage/sets/invasion/PhyrexianBattleflies.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 /**
  *
- * @author anonymous
+ * @author FenrisulfrX
  */
 public class PhyrexianBattleflies extends mage.sets.phyrexiavsthecoalition.PhyrexianBattleflies {
 

--- a/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/PhyrexianColossus.java
+++ b/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/PhyrexianColossus.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 /**
  *
- * @author anonymous
+ * @author FenrisulfrX
  */
 public class PhyrexianColossus extends mage.sets.eighthedition.PhyrexianColossus {
 

--- a/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/PhyrexianProcessor.java
+++ b/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/PhyrexianProcessor.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 /**
  *
- * @author anonymous
+ * @author FenrisulfrX
  */
 public class PhyrexianProcessor extends mage.sets.urzassaga.PhyrexianProcessor {
 

--- a/Mage.Sets/src/mage/sets/seventhedition/PhyrexianColossus.java
+++ b/Mage.Sets/src/mage/sets/seventhedition/PhyrexianColossus.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 /**
  *
- * @author anonymous
+ * @author FenrisulfrX
  */
 public class PhyrexianColossus extends mage.sets.eighthedition.PhyrexianColossus {
 

--- a/Mage.Sets/src/mage/sets/stronghold/HornetCannon.java
+++ b/Mage.Sets/src/mage/sets/stronghold/HornetCannon.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 /**
  *
- * @author anonymous
+ * @author FenrisulfrX
  */
 public class HornetCannon extends mage.sets.phyrexiavsthecoalition.HornetCannon {
 

--- a/Mage.Sets/src/mage/sets/timespiral/PhyrexianTotem.java
+++ b/Mage.Sets/src/mage/sets/timespiral/PhyrexianTotem.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 /**
  *
- * @author anonymous
+ * @author FenrisulfrX
  */
 public class PhyrexianTotem extends mage.sets.phyrexiavsthecoalition.PhyrexianTotem {
 

--- a/Mage.Sets/src/mage/sets/urzassaga/PhyrexianColossus.java
+++ b/Mage.Sets/src/mage/sets/urzassaga/PhyrexianColossus.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 /**
  *
- * @author anonymous
+ * @author FenrisulfrX
  */
 public class PhyrexianColossus extends mage.sets.eighthedition.PhyrexianColossus {
 


### PR DESCRIPTION
I thought phyrexian totem's ability should only trigger if what dealt
damage to it was a creature however that's not the case, it should
trigger only if Phyrexian Totem itself is a creature when it's dealt
damage to. Also fix it to use checkInterveningIfClause() (please review
this if it was done correctly) so it checks on resolution as well.

Also fixes to wrongly credited cards.