### PR TITLE
Fix counterspells not working when Rest in Peace is in play.

### DIFF
--- a/Mage/src/mage/cards/CardImpl.java
+++ b/Mage/src/mage/cards/CardImpl.java
@@ -492,6 +492,11 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
                         game.getExile().removeCard(this, game);
                         break;
                     case STACK:
+                        StackObject stackObject = game.getStack().getSpell(getId());
+                        if (stackObject != null) {
+                            game.getStack().remove(stackObject);
+                        }
+                        break;
                     case PICK:
                         // nothing to do
                         break;


### PR DESCRIPTION
Stuff can now be moved from the stack to exile. 

On a related note, is there any particular reason that there are multiple fromZone switches that do the same thing? And wouldn't it make sense to have a single moveToZone method the handles all the from-to cases? I'd be happy to do the refactoring if unifying them is ok.