### PR TITLE
Fixed some gatherer image loading.

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/WizardCardsImageSource.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/WizardCardsImageSource.java
@@ -69,11 +69,11 @@ public class WizardCardsImageSource implements CardImageSource {
         setsAliases.put("BRB", "Battle Royale Box Set");
         setsAliases.put("BTD", "Beatdown Box Set");
         setsAliases.put("C13", "Commander 2013 Edition");
-        setsAliases.put("C14", "Commander 2014 Edition");
+        setsAliases.put("C14", "Commander 2014");
         setsAliases.put("CHK", "Champions of Kamigawa");
         setsAliases.put("CHR", "Chronicles");
         setsAliases.put("CMD", "Magic: The Gathering-Commander");
-        setsAliases.put("CNS", "Magic: The Gathering-Conspiracy");
+        setsAliases.put("CNS", "Magic: The Gathering—Conspiracy");
         setsAliases.put("CON", "Conflux");
         setsAliases.put("CSP", "Coldsnap");
         setsAliases.put("DD2", "Duel Decks: Jace vs. Chandra");
@@ -179,7 +179,7 @@ public class WizardCardsImageSource implements CardImageSource {
         setsAliases.put("TMP", "Tempest");
         setsAliases.put("TOR", "Torment");
         setsAliases.put("TPR", "Tempest Remastered");
-        setsAliases.put("TSB", "Time Spiral 'Timeshifted'");
+        setsAliases.put("TSB", "Time Spiral \"Timeshifted\"");
         setsAliases.put("TSP", "Time Spiral");
         setsAliases.put("UDS", "Urza's Destiny");
         setsAliases.put("UGL", "Unglued");
@@ -250,17 +250,21 @@ public class WizardCardsImageSource implements CardImageSource {
                         String cardName = normalizeName(cardsImages.get(i).attr("alt"));
                         if (cardName != null && !cardName.isEmpty()) {
                             if (cardName.equals("Forest") || cardName.equals("Swamp") || cardName.equals("Mountain") || cardName.equals("Island") || cardName.equals("Plains")) {
-                                Integer multiverseId = Integer.parseInt(cardsImages.get(i).attr("src").replaceAll("[^\\d]", ""));
-                                String urlLandDocument = "http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=" + multiverseId;
-                                Document landDoc = Jsoup.connect(urlLandDocument).get();
-                                Elements variations = landDoc.select("a.variationlink");
-                                int landNumber = 1;
-                                for (Element variation : variations) {
-                                    Integer landMultiverseId = Integer.parseInt(variation.attr("onclick").replaceAll("[^\\d]", ""));
-                                     // ""
-                                    setLinks.put((cardName + landNumber).toLowerCase(), "/Handlers/Image.ashx?multiverseid=" +landMultiverseId + "&type=card");
-                                    landNumber++;
-                                }
+                            	Integer multiverseId = Integer.parseInt(cardsImages.get(i).attr("src").replaceAll("[^\\d]", ""));
+                            	String urlLandDocument = "http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=" + multiverseId;
+                            	Document landDoc = Jsoup.connect(urlLandDocument).get();
+                            	Elements variations = landDoc.select("a.variationlink");
+                            	if(!variations.isEmpty()) {
+                            		int landNumber = 1;
+                            		for (Element variation : variations) {
+                            			Integer landMultiverseId = Integer.parseInt(variation.attr("onclick").replaceAll("[^\\d]", ""));
+                            			// ""
+                            			setLinks.put((cardName + landNumber).toLowerCase(), "/Handlers/Image.ashx?multiverseid=" +landMultiverseId + "&type=card");
+                            			landNumber++;
+                            		}
+                            	} else {
+                            		setLinks.put(cardName.toLowerCase(), cardsImages.get(i).attr("src").substring(5));
+                            	}
                             } else {
                                 setLinks.put(cardName.toLowerCase(), cardsImages.get(i).attr("src").substring(5));
                             }
@@ -276,6 +280,14 @@ public class WizardCardsImageSource implements CardImageSource {
     }
 
     private String normalizeName(String name) {
+    	//Split card
+    	if(name.contains("//")) {
+    		name = name.substring(0, name.indexOf("(") - 1);
+    	}
+    	//Special timeshifted name
+    	if(name.startsWith("XX")) {
+    		name = name.substring(name.indexOf("(") + 1, name.length() - 1);
+    	}
         return name.replace("\u2014", "-").replace("\u2019", "'")
                 .replace("\u00C6", "AE").replace("\u00E6", "ae")
                 .replace("\u00C3\u2020", "AE")                

--- a/Mage.Sets/src/mage/sets/ajanivsnicolbolas/Island.java
+++ b/Mage.Sets/src/mage/sets/ajanivsnicolbolas/Island.java
@@ -35,19 +35,19 @@ import java.util.UUID;
  */
 
 
-public class Plains1 extends mage.cards.basiclands.Plains {
+public class Island extends mage.cards.basiclands.Island {
 
-    public Plains1(UUID ownerId) {
-        super(ownerId, 40);
+    public Island(UUID ownerId) {
+        super(ownerId, 79);
         this.expansionSetCode = "DDH";
     }
 
-    public Plains1(final Plains1 card) {
+    public Island(final Island card) {
         super(card);
     }
 
     @Override
-    public Plains1 copy() {
-        return new Plains1(this);
+    public Island copy() {
+        return new Island(this);
     }
 }

--- a/Mage.Sets/src/mage/sets/ajanivsnicolbolas/Plains.java
+++ b/Mage.Sets/src/mage/sets/ajanivsnicolbolas/Plains.java
@@ -25,7 +25,7 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.sets.phyrexiavsthecoalition;
+package mage.sets.ajanivsnicolbolas;
 
 import java.util.UUID;
 
@@ -33,19 +33,21 @@ import java.util.UUID;
  *
  * @author LevelX2
  */
-public class Island1 extends mage.cards.basiclands.Island {
 
-    public Island1(UUID ownerId) {
-        super(ownerId, 68);
-        this.expansionSetCode = "DDE";
+
+public class Plains extends mage.cards.basiclands.Plains {
+
+    public Plains(UUID ownerId) {
+        super(ownerId, 40);
+        this.expansionSetCode = "DDH";
     }
 
-    public Island1(final Island1 card) {
+    public Plains(final Plains card) {
         super(card);
     }
 
     @Override
-    public Island1 copy() {
-        return new Island1(this);
+    public Plains copy() {
+        return new Plains(this);
     }
 }

--- a/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/Island.java
+++ b/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/Island.java
@@ -25,7 +25,7 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.sets.ajanivsnicolbolas;
+package mage.sets.phyrexiavsthecoalition;
 
 import java.util.UUID;
 
@@ -33,21 +33,19 @@ import java.util.UUID;
  *
  * @author LevelX2
  */
+public class Island extends mage.cards.basiclands.Island {
 
-
-public class Island1 extends mage.cards.basiclands.Island {
-
-    public Island1(UUID ownerId) {
-        super(ownerId, 79);
-        this.expansionSetCode = "DDH";
+    public Island(UUID ownerId) {
+        super(ownerId, 68);
+        this.expansionSetCode = "DDE";
     }
 
-    public Island1(final Island1 card) {
+    public Island(final Island card) {
         super(card);
     }
 
     @Override
-    public Island1 copy() {
-        return new Island1(this);
+    public Island copy() {
+        return new Island(this);
     }
 }

--- a/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/Mountain.java
+++ b/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/Mountain.java
@@ -33,19 +33,19 @@ import java.util.UUID;
  *
  * @author LevelX2
  */
-public class Plains1 extends mage.cards.basiclands.Plains {
+public class Mountain extends mage.cards.basiclands.Mountain {
 
-    public Plains1(UUID ownerId) {
-        super(ownerId, 67);
+    public Mountain(UUID ownerId) {
+        super(ownerId, 69);
         this.expansionSetCode = "DDE";
     }
 
-    public Plains1(final Plains1 card) {
+    public Mountain(final Mountain card) {
         super(card);
     }
 
     @Override
-    public Plains1 copy() {
-        return new Plains1(this);
+    public Mountain copy() {
+        return new Mountain(this);
     }
 }

--- a/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/Plains.java
+++ b/Mage.Sets/src/mage/sets/phyrexiavsthecoalition/Plains.java
@@ -33,19 +33,19 @@ import java.util.UUID;
  *
  * @author LevelX2
  */
-public class Mountain1 extends mage.cards.basiclands.Mountain {
+public class Plains extends mage.cards.basiclands.Plains {
 
-    public Mountain1(UUID ownerId) {
-        super(ownerId, 69);
+    public Plains(UUID ownerId) {
+        super(ownerId, 67);
         this.expansionSetCode = "DDE";
     }
 
-    public Mountain1(final Mountain1 card) {
+    public Plains(final Plains card) {
         super(card);
     }
 
     @Override
-    public Mountain1 copy() {
-        return new Mountain1(this);
+    public Plains copy() {
+        return new Plains(this);
     }
 }


### PR DESCRIPTION
The lookup names for Conspiracy, Time Spiral "Timeshifted", and Commander 2014 were incorrect, causing the image lookup for them to fail.

I also fixed the loading of split cards.

I also made it so that some very specific Timeshifted cards that gatherer marked with an XX to start their name also load correctly.

I also modified the basic land loading somewhat: If there are no variations, the land is just land instead of land1 (example: Island instead of Island1). This fixes loading for both Unhinged lands and some dual deck lands.

All cards that exist on gatherer should now be downloaded correctly. (The notable exception is the bottom of flip cards, whose flip side isn't actually registered correctly in gatherer)