### PR TITLE
Be able to build Mage.Stats from the reactor

### DIFF
--- a/Mage.Stats/pom.xml
+++ b/Mage.Stats/pom.xml
@@ -138,7 +138,7 @@
                 <configuration>
                     <sources>
                         <source>
-                            <basedir>src/main/java</basedir>
+                            <basedir>${project.basedir}/src/main/java</basedir>
                         </source>
                     </sources>
                     <complianceLevel>1.6</complianceLevel>


### PR DESCRIPTION
Now, the Mage build fails from the main pom (using reactor) on Mage.Stats module as the aspectj plugin doesn't find the src/main/java folder.
This PR fixes that and allow to build all in a row.