### PR TITLE
Remove most "has been deprecated" and "unchecked conversion" errors

### DIFF
--- a/Mage.Sets/src/mage/sets/avacynrestored/DarkImpostor.java
+++ b/Mage.Sets/src/mage/sets/avacynrestored/DarkImpostor.java
@@ -105,7 +105,7 @@ class DarkImpostorContinuousEffect extends ContinuousEffectImpl {
                 if (card != null) {
                     for (Ability ability: card.getAbilities()) {
                         if (ability instanceof ActivatedAbility) {
-                            perm.addAbility(ability, game);
+                            perm.addAbility(ability, source.getSourceId(), game);
                         }
                     }
                 }

--- a/Mage.Sets/src/mage/sets/avacynrestored/RidersOfGavony.java
+++ b/Mage.Sets/src/mage/sets/avacynrestored/RidersOfGavony.java
@@ -110,7 +110,7 @@ class RidersOfGavonyEffect extends OneShotEffect {
             if (typeChoice.getChoice() != null) {
                 game.informPlayers(permanent.getName() + ": " + player.getLogName() + " has chosen " + typeChoice.getChoice());
                 game.getState().setValue(permanent.getId() + "_type", typeChoice.getChoice());
-                permanent.addInfo("chosen type", "<i>Chosen type: " + typeChoice.getChoice().toString() + "</i>", game);
+                permanent.addInfo("chosen type", "<i>Chosen type: " + typeChoice.getChoice() + "</i>", game);
             }
         }
         return false;
@@ -162,7 +162,7 @@ class RidersOfGavonyGainAbilityControlledEffect extends ContinuousEffectImpl {
         }
         if (protectionFilter != null) {
             for (Permanent perm: game.getBattlefield().getAllActivePermanents(filter, source.getControllerId(), game)) {
-                perm.addAbility(new ProtectionAbility(protectionFilter), game);
+                perm.addAbility(new ProtectionAbility(protectionFilter), source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/sets/betrayersofkamigawa/SkullmaneBaku.java
+++ b/Mage.Sets/src/mage/sets/betrayersofkamigawa/SkullmaneBaku.java
@@ -110,7 +110,7 @@ public class SkullmaneBaku extends CardImpl {
             }
             Permanent creature = game.getPermanent(targetPointer.getFirst(game, source));
             if (creature != null && numberToUnboost != 0) {
-                creature.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostSourceEffect(numberToUnboost, numberToUnboost, Duration.EndOfTurn)), game);
+                creature.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostSourceEffect(numberToUnboost, numberToUnboost, Duration.EndOfTurn)), source.getSourceId(), game, false);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/sets/commander2013/CurseOfChaos.java
+++ b/Mage.Sets/src/mage/sets/commander2013/CurseOfChaos.java
@@ -140,7 +140,7 @@ class CurseOfChaosEffect extends OneShotEffect {
         Player attacker = game.getPlayer(this.getTargetPointer().getFirst(game, source));
         if (attacker != null) {
             if (attacker.getHand().size() > 0 && attacker.chooseUse(outcome, "Discard a card and draw a card?", game)){
-                attacker.discard(1, source, game);
+                attacker.discard(1, false, source, game);
                 attacker.drawCards(1, game);
             }
             return true;

--- a/Mage.Sets/src/mage/sets/conflux/KnightOfTheReliquary.java
+++ b/Mage.Sets/src/mage/sets/conflux/KnightOfTheReliquary.java
@@ -36,6 +36,7 @@ import mage.constants.Zone;
 import mage.MageInt;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.Cost;
 import mage.abilities.costs.Costs;
 import mage.abilities.costs.CostsImpl;
 import mage.abilities.costs.common.SacrificeTargetCost;
@@ -81,7 +82,7 @@ public class KnightOfTheReliquary extends CardImpl {
 
         // {T}, Sacrifice a Forest or Plains: Search your library for a land card, put it onto the battlefield, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(new FilterLandCard());
-        Costs costs = new CostsImpl();
+        Costs<Cost> costs = new CostsImpl<>();
         costs.add(new TapSourceCost());
         costs.add(new SacrificeTargetCost(new TargetControlledPermanent(1, 1, filter, false)));
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, false, Outcome.PutLandInPlay), costs));

--- a/Mage.Sets/src/mage/sets/dragonsmaze/BloodBaronOfVizkopa.java
+++ b/Mage.Sets/src/mage/sets/dragonsmaze/BloodBaronOfVizkopa.java
@@ -126,7 +126,7 @@ class BloodBaronOfVizkopaEffect extends ContinuousEffectImpl {
                             break;
                         case AbilityAddingRemovingEffects_6:
                             if (sublayer == SubLayer.NA) {
-                                creature.addAbility(FlyingAbility.getInstance(), game);
+                                creature.addAbility(FlyingAbility.getInstance(), source.getSourceId(), game);
                             }
                             break;
                         default:

--- a/Mage.Sets/src/mage/sets/eventide/NeedleSpecter.java
+++ b/Mage.Sets/src/mage/sets/eventide/NeedleSpecter.java
@@ -98,7 +98,7 @@ class NeedleSpecterEffect extends OneShotEffect {
             Player targetPlayer = game.getPlayer(targetPointer.getFirst(game, source));
             if (targetPlayer != null) {
                 int damage = (Integer)getValue("damage");
-                targetPlayer.discard(damage, source, game);
+                targetPlayer.discard(damage, false, source, game);
                 game.informPlayers(targetPlayer.getLogName() + "discards " + damage + " card(s)");
                 return true;
             }

--- a/Mage.Sets/src/mage/sets/eventide/RiseOfTheHobgoblins.java
+++ b/Mage.Sets/src/mage/sets/eventide/RiseOfTheHobgoblins.java
@@ -34,6 +34,7 @@ import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.costs.mana.ManaCost;
 import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
@@ -116,7 +117,7 @@ class RiseOfTheHobgoblinsEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player you = game.getPlayer(source.getControllerId());
-        ManaCosts cost = new ManaCostsImpl("{X}");
+        ManaCosts<ManaCost> cost = new ManaCostsImpl<>("{X}");
         if (you != null && you.chooseUse(Outcome.Neutral, "Do you want to to pay {X}?", game)) {
             int costX = you.announceXMana(0, Integer.MAX_VALUE, "Announce the value for {X}", game, source);
             cost.add(new GenericManaCost(costX));

--- a/Mage.Sets/src/mage/sets/fallenempires/Derelor.java
+++ b/Mage.Sets/src/mage/sets/fallenempires/Derelor.java
@@ -62,7 +62,7 @@ public class Derelor extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Black spells you cast cost {B} more to cast.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SpellsCostIncreasementControllerEffect(filter, new ManaCostsImpl("B"))));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SpellsCostIncreasementControllerEffect(filter, new ManaCostsImpl<>("{B}"))));
     }
 
     public Derelor(final Derelor card) {

--- a/Mage.Sets/src/mage/sets/fifthedition/Recall.java
+++ b/Mage.Sets/src/mage/sets/fifthedition/Recall.java
@@ -93,7 +93,7 @@ class RecallEffect extends OneShotEffect {
             // Discard X cards
             int amount = source.getManaCostsToPay().getX();
             int discarded = Math.min(amount, player.getHand().size());
-            player.discard(amount, source, game);
+            player.discard(amount, false, source, game);
             
             // then return a card from your graveyard to your hand for each card discarded this way
             TargetCardInYourGraveyard target = new TargetCardInYourGraveyard(discarded, new FilterCard());

--- a/Mage.Sets/src/mage/sets/innistrad/FrightfulDelusion.java
+++ b/Mage.Sets/src/mage/sets/innistrad/FrightfulDelusion.java
@@ -94,7 +94,7 @@ class FrightfulDelusionEffect extends OneShotEffect {
             if (player != null) {
                 cost.clearPaid();
                 game.getPlayer(spell.getControllerId()).discard(
-                        1, source, game);
+                        1, false, source, game);
                 if (!cost.pay(source, game, spell.getControllerId(),
                         spell.getControllerId(), false)) {
                     return game.getStack().counter(source.getFirstTarget(),

--- a/Mage.Sets/src/mage/sets/journeyintonyx/TormentedThoughts.java
+++ b/Mage.Sets/src/mage/sets/journeyintonyx/TormentedThoughts.java
@@ -105,7 +105,7 @@ class TormentedThoughtsDiscardEffect extends OneShotEffect {
                 }
             }
             if (power > 0) {
-                targetPlayer.discard(power, source, game);
+                targetPlayer.discard(power, false, source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/sets/khansoftarkir/KinTreeInvocation.java
+++ b/Mage.Sets/src/mage/sets/khansoftarkir/KinTreeInvocation.java
@@ -102,7 +102,7 @@ class KinTreeInvocationCreateTokenEffect extends OneShotEffect {
         objectColor.setBlack(true);
         objectColor.setGreen(true);
         Token token = new Token("Spirit Warrior", "X/X black and green Spirit Warrior creature token onto the battlefield, where X is the greatest toughness among creatures you control",
-                objectColor, list, value, value, new AbilitiesImpl());
+                objectColor, list, value, value, new AbilitiesImpl<>());
         token.getAbilities().newId(); // neccessary if token has ability like DevourAbility()
         token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId());
         return true;

--- a/Mage.Sets/src/mage/sets/legends/ChainsOfMephistopheles.java
+++ b/Mage.Sets/src/mage/sets/legends/ChainsOfMephistopheles.java
@@ -103,7 +103,7 @@ class ChainsOfMephistophelesReplacementEffect extends ReplacementEffectImpl {
                 return true;
             } else  {
                 // discards a card instead. If the player discards a card this way, he or she draws a card.
-                player.discard(1, source, game);
+                player.discard(1, false, source, game);
                 return false; // because player draws a card, the draw event is kept
             }
         }

--- a/Mage.Sets/src/mage/sets/magic2011/DryadsFavor.java
+++ b/Mage.Sets/src/mage/sets/magic2011/DryadsFavor.java
@@ -1,16 +1,16 @@
 /*
  *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
- * 
+ *
  *  Redistribution and use in source and binary forms, with or without modification, are
  *  permitted provided that the following conditions are met:
- * 
+ *
  *     1. Redistributions of source code must retain the above copyright notice, this list of
  *        conditions and the following disclaimer.
- * 
+ *
  *     2. Redistributions in binary form must reproduce the above copyright notice, this list
  *        of conditions and the following disclaimer in the documentation and/or other materials
  *        provided with the distribution.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
  *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
@@ -20,7 +20,7 @@
  *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *  The views and conclusions contained in the software and documentation are those of the
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
@@ -29,13 +29,6 @@
 package mage.sets.magic2011;
 
 import java.util.UUID;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Layer;
-import mage.constants.Outcome;
-import mage.constants.Rarity;
-import mage.constants.SubLayer;
-import mage.constants.Zone;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
@@ -43,6 +36,13 @@ import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.keyword.EnchantAbility;
 import mage.abilities.keyword.ForestwalkAbility;
 import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Layer;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.SubLayer;
+import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
@@ -57,16 +57,16 @@ public class DryadsFavor extends CardImpl {
     public DryadsFavor(UUID ownerId) {
         super(ownerId, 169, "Dryad's Favor", Rarity.COMMON, new CardType[]{CardType.ENCHANTMENT}, "{G}");
         this.expansionSetCode = "M11";
-        this.color.setGreen(true);
         this.subtype.add("Aura");
 
+        // Enchant creature
         TargetPermanent auraTarget = new TargetCreaturePermanent();
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.Benefit));
         Ability ability = new EnchantAbility(auraTarget.getTargetName());
         this.addAbility(ability);
+        // Enchanted creature has forestwalk.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new DryadsFavorEffect()));
-
     }
 
     public DryadsFavor(final DryadsFavor card) {
@@ -104,7 +104,7 @@ class DryadsFavorEffect extends ContinuousEffectImpl {
                 switch (layer) {
                     case AbilityAddingRemovingEffects_6:
                         if (sublayer == SubLayer.NA) {
-                            creature.addAbility(new ForestwalkAbility(), game);
+                            creature.addAbility(new ForestwalkAbility(), source.getSourceId(), game);
                         }
                         break;
                 }
@@ -123,5 +123,5 @@ class DryadsFavorEffect extends ContinuousEffectImpl {
     public boolean hasLayer(Layer layer) {
         return layer == Layer.AbilityAddingRemovingEffects_6;
     }
-
+    
 }

--- a/Mage.Sets/src/mage/sets/magic2011/VolcanicStrength.java
+++ b/Mage.Sets/src/mage/sets/magic2011/VolcanicStrength.java
@@ -1,16 +1,16 @@
 /*
  *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
- * 
+ *
  *  Redistribution and use in source and binary forms, with or without modification, are
  *  permitted provided that the following conditions are met:
- * 
+ *
  *     1. Redistributions of source code must retain the above copyright notice, this list of
  *        conditions and the following disclaimer.
- * 
+ *
  *     2. Redistributions in binary form must reproduce the above copyright notice, this list
  *        of conditions and the following disclaimer in the documentation and/or other materials
  *        provided with the distribution.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
  *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
@@ -20,22 +20,14 @@
  *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  *  The views and conclusions contained in the software and documentation are those of the
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-
 package mage.sets.magic2011;
 
 import java.util.UUID;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Layer;
-import mage.constants.Outcome;
-import mage.constants.Rarity;
-import mage.constants.SubLayer;
-import mage.constants.Zone;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
@@ -43,6 +35,13 @@ import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.keyword.EnchantAbility;
 import mage.abilities.keyword.MountainwalkAbility;
 import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Layer;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.SubLayer;
+import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
@@ -57,16 +56,16 @@ public class VolcanicStrength extends CardImpl {
     public VolcanicStrength(UUID ownerId) {
         super(ownerId, 158, "Volcanic Strength", Rarity.COMMON, new CardType[]{CardType.ENCHANTMENT}, "{1}{R}");
         this.expansionSetCode = "M11";
-        this.color.setRed(true);
         this.subtype.add("Aura");
 
+        // Enchant creature
         TargetPermanent auraTarget = new TargetCreaturePermanent();
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.BoostCreature));
         Ability ability = new EnchantAbility(auraTarget.getTargetName());
+        // Enchanted creature gets +2/+2 and has mountainwalk.
         this.addAbility(ability);
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new VolcanicStrengthEffect()));
-
     }
 
     public VolcanicStrength(final VolcanicStrength card) {
@@ -127,7 +126,7 @@ class VolcanicStrengthEffect extends ContinuousEffectImpl {
 
     @Override
     public boolean hasLayer(Layer layer) {
-        return layer == Layer.AbilityAddingRemovingEffects_6 || layer == layer.PTChangingEffects_7;
+        return layer == Layer.AbilityAddingRemovingEffects_6 || layer == Layer.PTChangingEffects_7;
     }
 
 }

--- a/Mage.Sets/src/mage/sets/magic2013/VolcanicStrength.java
+++ b/Mage.Sets/src/mage/sets/magic2013/VolcanicStrength.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 /**
  *
- * @author North
+ * @author anonymous
  */
 public class VolcanicStrength extends mage.sets.magic2011.VolcanicStrength {
 

--- a/Mage.Sets/src/mage/sets/odyssey/LaquatussCreativity.java
+++ b/Mage.Sets/src/mage/sets/odyssey/LaquatussCreativity.java
@@ -87,7 +87,7 @@ class LaquatussCreativityEffect extends OneShotEffect {
         Player player = game.getPlayer(source.getFirstTarget());
         int handCount = player.getHand().count(new FilterCard(), game);
         player.drawCards(handCount, game);
-        player.discard(handCount, source, game);
+        player.discard(handCount, false, source, game);
         return false;
     }
 }

--- a/Mage.Sets/src/mage/sets/odyssey/TestamentOfFaith.java
+++ b/Mage.Sets/src/mage/sets/odyssey/TestamentOfFaith.java
@@ -137,7 +137,7 @@ class TestamentOfFaithBecomesCreatureSourceEffect extends ContinuousEffectImpl i
                     if (sublayer == SubLayer.NA) {
                         if (token.getAbilities().size() > 0) {
                             for (Ability ability: token.getAbilities()) {
-                                permanent.addAbility(ability, game);
+                                permanent.addAbility(ability, source.getSourceId(), game, false);
                             }
                         }
                     }

--- a/Mage.Sets/src/mage/sets/planechase2012/LastStand.java
+++ b/Mage.Sets/src/mage/sets/planechase2012/LastStand.java
@@ -135,7 +135,7 @@ class LastStandEffect extends OneShotEffect {
             int islands = game.getBattlefield().count(filterIsland, source.getSourceId(), source.getControllerId(), game);
             if (islands > 0) {
                 controller.drawCards(islands, game);
-                controller.discard(islands, source, game);
+                controller.discard(islands, false, source, game);
             }
 
         }

--- a/Mage.Sets/src/mage/sets/ravnica/CompulsiveResearch.java
+++ b/Mage.Sets/src/mage/sets/ravnica/CompulsiveResearch.java
@@ -94,7 +94,7 @@ class CompulsiveResearchDiscardEffect extends OneShotEffect {
             if (card != null) {
                 targetPlayer.discard(card, source, game);
                 if (!card.getCardType().contains(CardType.LAND) && !targetPlayer.getHand().isEmpty()) {
-                    targetPlayer.discard(1, source, game);
+                    targetPlayer.discard(1, false, source, game);
                 }
                 return true;
             }            

--- a/Mage.Sets/src/mage/sets/returntoravnica/AssassinsStrike.java
+++ b/Mage.Sets/src/mage/sets/returntoravnica/AssassinsStrike.java
@@ -92,7 +92,7 @@ class AssassinsStrikeEffect extends OneShotEffect {
         if (permanent != null) {
             Player player = game.getPlayer(permanent.getControllerId());
             if (player != null) {
-                player.discard(1, source, game);
+                player.discard(1, false, source, game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/sets/returntoravnica/StreetSweeper.java
+++ b/Mage.Sets/src/mage/sets/returntoravnica/StreetSweeper.java
@@ -104,7 +104,7 @@ class StreetSweeperDestroyEffect extends OneShotEffect {
         Permanent permanent = game.getPermanent(source.getFirstTarget());
         if(permanent != null)
         {
-            LinkedList<UUID> attachments = new LinkedList();
+            LinkedList<UUID> attachments = new LinkedList<>();
             attachments.addAll(permanent.getAttachments());
             for(UUID uuid : attachments)
             {

--- a/Mage.Sets/src/mage/sets/riseoftheeldrazi/InduceDespair.java
+++ b/Mage.Sets/src/mage/sets/riseoftheeldrazi/InduceDespair.java
@@ -91,7 +91,7 @@ class InduceDespairEffect extends OneShotEffect {
         if (cost != null) {
             int CMC = -1 * cost.convertedManaCosts;
             if (creature != null) {
-                creature.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostSourceEffect(CMC, CMC, Duration.EndOfTurn)), game);
+                creature.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostSourceEffect(CMC, CMC, Duration.EndOfTurn)), source.getSourceId(), game, false);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/sets/riseoftheeldrazi/ThoughtGorger.java
+++ b/Mage.Sets/src/mage/sets/riseoftheeldrazi/ThoughtGorger.java
@@ -104,7 +104,7 @@ class ThoughtGorgerEffectEnters extends OneShotEffect {
         if (player != null && player.getHand().size() > 0 && thoughtGorger != null ) {
             int cardsInHand = player.getHand().size();
             thoughtGorger.addCounters(CounterType.P1P1.createInstance(cardsInHand), game);
-            player.discard(cardsInHand, source, game);
+            player.discard(cardsInHand, false, source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/sets/scarsofmirrodin/TrigonOfMending.java
+++ b/Mage.Sets/src/mage/sets/scarsofmirrodin/TrigonOfMending.java
@@ -45,6 +45,7 @@ import mage.counters.CounterType;
 
 import java.util.UUID;
 import mage.abilities.Ability;
+import mage.abilities.costs.Cost;
 import mage.abilities.costs.mana.GenericManaCost;
 
 /**
@@ -58,7 +59,7 @@ public class TrigonOfMending extends CardImpl {
 
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.CHARGE.createInstance(3)), ""));
 
-        Costs costs = new CostsImpl();
+        Costs<Cost> costs = new CostsImpl<>();
         costs.add(new RemoveCountersSourceCost(CounterType.CHARGE.createInstance()));
         costs.add(new TapSourceCost());
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(3), costs);

--- a/Mage.Sets/src/mage/sets/shadowmoor/Gloomlance.java
+++ b/Mage.Sets/src/mage/sets/shadowmoor/Gloomlance.java
@@ -93,7 +93,7 @@ class GloomlanceEffect extends OneShotEffect {
             Permanent destroyedCreature = game.getPermanentOrLKIBattlefield(source.getFirstTarget());
             if (destroyedCreature.getColor().isGreen()
                     || destroyedCreature.getColor().isWhite()) {
-                targetController.discard(1, source, game);
+                targetController.discard(1, false, source, game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/sets/shardsofalara/OozeGarden.java
+++ b/Mage.Sets/src/mage/sets/shardsofalara/OozeGarden.java
@@ -108,7 +108,7 @@ class OozeGardenCreateTokenEffect extends OneShotEffect {
         }
         ArrayList<String> list = new ArrayList<>();
         list.add("Ooze");
-        Token token = new Token("Ooze", "X/X green Ooze creature token onto the battlefield, where X is the sacrificed creature's power", ObjectColor.GREEN, list, value, value, new AbilitiesImpl()) {
+        Token token = new Token("Ooze", "X/X green Ooze creature token onto the battlefield, where X is the sacrificed creature's power", ObjectColor.GREEN, list, value, value, new AbilitiesImpl<>()) {
            
       
         };

--- a/Mage.Sets/src/mage/sets/torment/DeepAnalysis.java
+++ b/Mage.Sets/src/mage/sets/torment/DeepAnalysis.java
@@ -59,7 +59,7 @@ public class DeepAnalysis extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPlayer());
 
         // Flashback-{1}{U}, Pay 3 life.
-        CostsImpl costs = new CostsImpl();
+        Costs<Cost> costs = new CostsImpl<>();
         costs.add(new ManaCostsImpl("{1}{U}"));
         costs.add(new PayLifeCost(3));
         this.addAbility(new FlashbackAbility(costs, TimingRule.SORCERY));

--- a/Mage.Sets/src/mage/sets/urzaslegacy/MemoryJar.java
+++ b/Mage.Sets/src/mage/sets/urzaslegacy/MemoryJar.java
@@ -167,7 +167,7 @@ class MemoryJarDelayedEffect extends OneShotEffect {
                 Player player = game.getPlayer(playerId);
                 if (player != null)
                 {
-                    player.discard(player.getHand().size(), source, game);
+                    player.discard(player.getHand().size(), false, source, game);
                 }
             }
             //Return to hand

--- a/Mage.Sets/src/mage/sets/urzassaga/NoRestForTheWicked.java
+++ b/Mage.Sets/src/mage/sets/urzassaga/NoRestForTheWicked.java
@@ -120,12 +120,12 @@ class NoRestForTheWickedWatcher extends Watcher {
 
     public NoRestForTheWickedWatcher() {
         super("NoRestForTheWickedWatcher", WatcherScope.GAME);
-        this.cards = new ArrayList();
+        this.cards = new ArrayList<>();
     }
 
     public NoRestForTheWickedWatcher(final NoRestForTheWickedWatcher watcher) {
         super(watcher);
-        this.cards = new ArrayList();
+        this.cards = new ArrayList<>();
         this.cards.addAll(watcher.cards);
     }
 

--- a/Mage.Sets/src/mage/sets/vintagemasters/DacksDuplicate.java
+++ b/Mage.Sets/src/mage/sets/vintagemasters/DacksDuplicate.java
@@ -53,17 +53,15 @@ public class DacksDuplicate extends CardImpl {
         this.expansionSetCode = "VMA";
         this.subtype.add("Shapeshifter");
 
-        this.color.setRed(true);
-        this.color.setBlue(true);
         this.power = new MageInt(0);
         this.toughness = new MageInt(0);
 
         // You may have Dack's Duplicate enter the battlefield as a copy of any creature on the battlefield except it gains haste and dethrone.
         this.addAbility(new SimpleStaticAbility(
-            Zone.BATTLEFIELD,
-            new EntersBattlefieldEffect(new CopyPermanentEffect(new DacksDuplicateApplyToPermanent()),
-            "You may have {this} enter the battlefield as a copy of any creature on the battlefield except it gains haste and dethrone",
-            true)));
+                Zone.BATTLEFIELD,
+                new EntersBattlefieldEffect(new CopyPermanentEffect(new DacksDuplicateApplyToPermanent()),
+                        "You may have {this} enter the battlefield as a copy of any creature on the battlefield except it gains haste and dethrone",
+                        true)));
     }
 
     public DacksDuplicate(final DacksDuplicate card) {
@@ -77,8 +75,13 @@ public class DacksDuplicate extends CardImpl {
 }
 
 class DacksDuplicateApplyToPermanent extends ApplyToPermanent {
+
     @Override
     public Boolean apply(Game game, Permanent permanent) {
+        /**
+         * 29/05/2014	The ability of Dack’s Duplicate doesn’t target the
+         * creature.
+         */
         permanent.addAbility(new DethroneAbility(), game);
         permanent.addAbility(HasteAbility.getInstance(), game);
         return true;

--- a/Mage.Sets/src/mage/sets/visions/AnvilOfBogardan.java
+++ b/Mage.Sets/src/mage/sets/visions/AnvilOfBogardan.java
@@ -90,7 +90,7 @@ class AnvilOfBogardanEffect extends OneShotEffect {
         Player targetPlayer = game.getPlayer(targetPointer.getFirst(game, source));
         if (targetPlayer != null) {
             targetPlayer.drawCards(1, game);
-            targetPlayer.discard(1, source, game);
+            targetPlayer.discard(1, false, source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/sets/worldwake/PermafrostTrap.java
+++ b/Mage.Sets/src/mage/sets/worldwake/PermafrostTrap.java
@@ -34,6 +34,7 @@ import mage.constants.Rarity;
 import mage.ObjectColor;
 import mage.abilities.Ability;
 import mage.abilities.costs.AlternativeCostImpl;
+import mage.abilities.costs.Cost;
 import mage.abilities.costs.mana.ColoredManaCost;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DontUntapInControllersNextUntapStepTargetEffect;
@@ -115,7 +116,7 @@ class PermafrostTrapWatcher extends Watcher {
     }
 }
 
-class PermafrostTrapAlternativeCost extends AlternativeCostImpl {
+class PermafrostTrapAlternativeCost extends AlternativeCostImpl<Cost> {
 
     public PermafrostTrapAlternativeCost() {
         super("you may pay {U} rather than pay Permafrost Trap's mana cost");

--- a/Mage.Sets/src/mage/sets/worldwake/RicochetTrap.java
+++ b/Mage.Sets/src/mage/sets/worldwake/RicochetTrap.java
@@ -34,6 +34,7 @@ import mage.constants.Rarity;
 import mage.constants.WatcherScope;
 import mage.abilities.Ability;
 import mage.abilities.costs.AlternativeCostImpl;
+import mage.abilities.costs.Cost;
 import mage.abilities.costs.mana.ColoredManaCost;
 import mage.abilities.effects.common.ChooseNewTargetsTargetEffect;
 import mage.cards.CardImpl;
@@ -123,7 +124,7 @@ class RicochetTrapWatcher extends Watcher {
     }
 }
 
-class RicochetTrapAlternativeCost extends AlternativeCostImpl {
+class RicochetTrapAlternativeCost extends AlternativeCostImpl<Cost> {
 
     public RicochetTrapAlternativeCost() {
         super("You may pay {R} rather than pay Ricochet Trap's mana cost");

--- a/Mage.Sets/src/mage/sets/worldwake/SlingbowTrap.java
+++ b/Mage.Sets/src/mage/sets/worldwake/SlingbowTrap.java
@@ -33,6 +33,7 @@ import mage.constants.CardType;
 import mage.constants.Rarity;
 import mage.abilities.Ability;
 import mage.abilities.costs.AlternativeCostImpl;
+import mage.abilities.costs.Cost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.DestroyTargetEffect;
 import mage.abilities.keyword.FlyingAbility;
@@ -80,7 +81,7 @@ public class SlingbowTrap extends CardImpl {
     }
 }
 
-class SlingbowTrapAlternativeCost extends AlternativeCostImpl {
+class SlingbowTrapAlternativeCost extends AlternativeCostImpl<Cost> {
 
     public SlingbowTrapAlternativeCost() {
         super("you may pay {G} rather than pay {this}'s mana cost");

--- a/Mage.Sets/src/mage/sets/zendikar/CobraTrap.java
+++ b/Mage.Sets/src/mage/sets/zendikar/CobraTrap.java
@@ -35,6 +35,7 @@ import mage.constants.WatcherScope;
 import mage.constants.Zone;
 import mage.abilities.Ability;
 import mage.abilities.costs.AlternativeCostImpl;
+import mage.abilities.costs.Cost;
 import mage.abilities.costs.mana.ColoredManaCost;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.cards.CardImpl;
@@ -113,7 +114,7 @@ class CobraTrapWatcher extends Watcher {
     }
 }
 
-class CobraTrapAlternativeCost extends AlternativeCostImpl {
+class CobraTrapAlternativeCost extends AlternativeCostImpl<Cost> {
 
     public CobraTrapAlternativeCost() {
         super("you may pay {G} rather than pay Cobra Trap's mana cost");

--- a/Mage.Sets/src/mage/sets/zendikar/LavaballTrap.java
+++ b/Mage.Sets/src/mage/sets/zendikar/LavaballTrap.java
@@ -35,6 +35,7 @@ import mage.constants.CardType;
 import mage.constants.Rarity;
 import mage.abilities.Ability;
 import mage.abilities.costs.AlternativeCostImpl;
+import mage.abilities.costs.Cost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.DamageAllEffect;
 import mage.abilities.effects.common.DestroyTargetEffect;
@@ -83,7 +84,7 @@ public class LavaballTrap extends CardImpl {
 
 class LavaballTrapWatcher extends Watcher {
 
-    private Map<UUID, Integer> amountOfLandsPlayedThisTurn = new HashMap<UUID, Integer>();
+    private Map<UUID, Integer> amountOfLandsPlayedThisTurn = new HashMap<>();
 
     public LavaballTrapWatcher() {
         super("LavaballTrapWatcher", WatcherScope.GAME);
@@ -108,7 +109,7 @@ class LavaballTrapWatcher extends Watcher {
             if (perm.getCardType().contains(CardType.LAND)) {
                 Integer amount = amountOfLandsPlayedThisTurn.get(perm.getControllerId());
                 if (amount == null) {
-                    amount = Integer.valueOf(1);
+                    amount = 1;
                 } else {
                     ++amount;
                 }
@@ -121,8 +122,8 @@ class LavaballTrapWatcher extends Watcher {
         int maxLands = 0;
         for (UUID opponentId : game.getOpponents(playerId)) {
             Integer amount = amountOfLandsPlayedThisTurn.get(opponentId);
-            if (amount != null && amount.intValue() > maxLands) {
-                maxLands = amount.intValue();
+            if (amount != null && amount > maxLands) {
+                maxLands = amount;
             }
         }
         return maxLands;
@@ -135,7 +136,7 @@ class LavaballTrapWatcher extends Watcher {
     }
 }
 
-class LavaballTrapAlternativeCost extends AlternativeCostImpl {
+class LavaballTrapAlternativeCost extends AlternativeCostImpl<Cost> {
 
     public LavaballTrapAlternativeCost() {
         super("you may pay {3}{R}{R} rather than pay Lavaball Trap's mana cost");

--- a/Mage.Sets/src/mage/sets/zendikar/LethargyTrap.java
+++ b/Mage.Sets/src/mage/sets/zendikar/LethargyTrap.java
@@ -33,6 +33,7 @@ import mage.constants.CardType;
 import mage.constants.Rarity;
 import mage.abilities.Ability;
 import mage.abilities.costs.AlternativeCostImpl;
+import mage.abilities.costs.Cost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.continuous.BoostAllEffect;
 import mage.cards.CardImpl;
@@ -78,7 +79,7 @@ public class LethargyTrap extends CardImpl {
     }
 }
 
-class LethargyTrapAlternativeCost extends AlternativeCostImpl {
+class LethargyTrapAlternativeCost extends AlternativeCostImpl<Cost> {
 
     public LethargyTrapAlternativeCost() {
         super("you may pay {U} rather than pay Lethargy Trap's mana cost");

--- a/Mage.Sets/src/mage/sets/zendikar/RuneflareTrap.java
+++ b/Mage.Sets/src/mage/sets/zendikar/RuneflareTrap.java
@@ -44,6 +44,7 @@ import mage.target.TargetPlayer;
 import mage.watchers.Watcher;
 
 import java.util.UUID;
+import mage.abilities.costs.Cost;
 
 /**
  *
@@ -142,7 +143,7 @@ class CardsDrawnOpponentWatcher extends Watcher {
     }
 }
 
-class RuneflareTrapAlternativeCost extends AlternativeCostImpl {
+class RuneflareTrapAlternativeCost extends AlternativeCostImpl<Cost> {
 
     public RuneflareTrapAlternativeCost() {
         super("you may pay {R} rather than pay Runeflare Trap's mana cost");

--- a/Mage.Sets/src/mage/sets/zendikar/SummoningTrap.java
+++ b/Mage.Sets/src/mage/sets/zendikar/SummoningTrap.java
@@ -36,6 +36,7 @@ import mage.constants.WatcherScope;
 import mage.constants.Zone;
 import mage.abilities.Ability;
 import mage.abilities.costs.AlternativeCostImpl;
+import mage.abilities.costs.Cost;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
@@ -126,7 +127,7 @@ class SummoningTrapWatcher extends Watcher {
     }
 }
 
-class SummoningTrapAlternativeCost extends AlternativeCostImpl {
+class SummoningTrapAlternativeCost extends AlternativeCostImpl<Cost> {
 
     public SummoningTrapAlternativeCost() {
         super("you may pay {0} rather than pay Summoning Trap's mana cost");

--- a/Mage.Sets/src/mage/sets/zendikar/SunspringExpedition.java
+++ b/Mage.Sets/src/mage/sets/zendikar/SunspringExpedition.java
@@ -35,6 +35,7 @@ import mage.constants.Zone;
 import mage.abilities.ActivatedAbility;
 import mage.abilities.common.LandfallAbility;
 import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.Cost;
 import mage.abilities.costs.Costs;
 import mage.abilities.costs.CostsImpl;
 import mage.abilities.costs.common.RemoveCountersSourceCost;
@@ -56,7 +57,7 @@ public class SunspringExpedition extends CardImpl {
         this.color.setWhite(true);
 
         this.addAbility(new LandfallAbility(new AddCountersSourceEffect(CounterType.QUEST.createInstance()), true));
-        Costs costs = new CostsImpl();
+        Costs<Cost> costs = new CostsImpl<>();
         costs.add(new RemoveCountersSourceCost(CounterType.QUEST.createInstance(3)));
         costs.add(new SacrificeSourceCost());
         ActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(8), costs);

--- a/Mage/src/mage/abilities/costs/AlternativeCostImpl.java
+++ b/Mage/src/mage/abilities/costs/AlternativeCostImpl.java
@@ -3,7 +3,7 @@ package mage.abilities.costs;
 import mage.abilities.Ability;
 import mage.game.Game;
 
-public class AlternativeCostImpl extends CostsImpl implements AlternativeCost {
+public class AlternativeCostImpl<T extends Cost> extends CostsImpl<T> implements AlternativeCost {
 
     protected String name;
 
@@ -13,7 +13,7 @@ public class AlternativeCostImpl extends CostsImpl implements AlternativeCost {
 
     public AlternativeCostImpl(String name, Cost cost) {
         this.name = name;
-        this.add(cost);
+        this.add((T)cost);
     }
 
     public AlternativeCostImpl(final AlternativeCostImpl cost) {


### PR DESCRIPTION
```log
--- maven-compiler-plugin:3.2:compile (default-compile) @ mage-sets ---
Compiling 20425 source files to D:\Documents\mage\Mage.Sets\target\classes
(X) mage/sets/betrayersofkamigawa/SkullmaneBaku.java:[113,25] addAbility(mage.abilities.Ability,mage.game.Game) in mage.game.permanent.Permanent has been deprecated
(X) mage/sets/eventide/RiseOfTheHobgoblins.java:[122,21] unchecked call to add(E) as a member of the raw type java.util.List
(X) mage/sets/odyssey/LaquatussCreativity.java:[90,15] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(X) mage/sets/riseoftheeldrazi/ThoughtGorger.java:[107,19] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(N) mage/sets/ravnica/Farseek.java:[51,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/iceage/Jokulhaups.java:[48,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/visions/AnvilOfBogardan.java:[93,25] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(X) mage/sets/zendikar/SunspringExpedition.java:[60,18] unchecked call to add(E) as a member of the raw type java.util.List
(X) mage/sets/zendikar/SunspringExpedition.java:[61,18] unchecked call to add(E) as a member of the raw type java.util.List
(X) mage/sets/zendikar/SunspringExpedition.java:[62,36] unchecked method invocation: constructor <init> in class mage.abilities.common.SimpleActivatedAbility is applied to given types
  required: mage.constants.Zone,mage.abilities.effects.Effect,mage.abilities.costs.Costs<mage.abilities.costs.Cost>
  found: mage.constants.Zone,mage.abilities.effects.common.GainLifeEffect,mage.abilities.costs.Costs
(X) mage/sets/zendikar/SunspringExpedition.java:[62,104] unchecked conversion
  required: mage.abilities.costs.Costs<mage.abilities.costs.Cost>
  found:    mage.abilities.costs.Costs
(X) mage/sets/torment/DeepAnalysis.java:[63,18] unchecked call to add(E) as a member of the raw type java.util.ArrayList
(X) mage/sets/torment/DeepAnalysis.java:[64,18] unchecked call to add(E) as a member of the raw type java.util.ArrayList
(N) mage/sets/fifthedition/NevinyrralsDisk.java:[56,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/unlimitededition/Twiddle.java:[49,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/magic2010/UndeadSlayer.java:[57,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/riseoftheeldrazi/InduceDespair.java:[94,25] addAbility(mage.abilities.Ability,mage.game.Game) in mage.game.permanent.Permanent has been deprecated
(N) mage/sets/planarchaos/FrozenAEther.java:[82,19] setTapped(boolean) in mage.game.permanent.Permanent has been deprecated
(X) mage/sets/ravnica/CompulsiveResearch.java:[97,33] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(X) mage/sets/fifthedition/Recall.java:[96,19] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(N) mage/sets/shardsofalara/EsperPanorama.java:[61,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/worldwake/SlingbowTrap.java:[87,17] unchecked call to add(E) as a member of the raw type java.util.ArrayList
(X) mage/sets/journeyintonyx/TormentedThoughts.java:[108,29] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(X) mage/sets/zendikar/CobraTrap.java:[120,17] unchecked call to add(E) as a member of the raw type java.util.ArrayList
(N) mage/sets/shardsofalara/JundPanorama.java:[62,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/shardsofalara/OozeGarden.java:[111,23] unchecked method invocation: constructor <init> in class <anonymous mage.sets.shardsofalara.OozeGardenCreateTokenEffect$1> is applied to given types
  required: java.lang.String,java.lang.String,mage.ObjectColor,java.util.List<java.lang.String>,int,int,mage.abilities.Abilities<mage.abilities.Ability>
  found: java.lang.String,java.lang.String,mage.ObjectColor,java.util.ArrayList<java.lang.String>,int,int,mage.abilities.AbilitiesImpl
(X) mage/sets/shardsofalara/OozeGarden.java:[111,178] unchecked conversion
  required: mage.abilities.Abilities<mage.abilities.Ability>
  found:    mage.abilities.AbilitiesImpl
(N) mage/sets/bornofthegods/WhelmingWave.java:[49,30] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/urzaslegacy/RingOfGix.java:[55,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/iceage/ElderDruid.java:[55,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/tempest/Aftershock.java:[50,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/darksteel/ShieldOfKaldra.java:[60,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/tenthedition/IcyManipulator.java:[55,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/scarsofmirrodin/TrigonOfMending.java:[62,18] unchecked call to add(E) as a member of the raw type java.util.List
(X) mage/sets/scarsofmirrodin/TrigonOfMending.java:[63,18] unchecked call to add(E) as a member of the raw type java.util.List
(X) mage/sets/scarsofmirrodin/TrigonOfMending.java:[64,27] unchecked method invocation: constructor <init> in class mage.abilities.common.SimpleActivatedAbility is applied to given types
  required: mage.constants.Zone,mage.abilities.effects.Effect,mage.abilities.costs.Costs<mage.abilities.costs.Cost>
  found: mage.constants.Zone,mage.abilities.effects.common.GainLifeEffect,mage.abilities.costs.Costs
(X) mage/sets/scarsofmirrodin/TrigonOfMending.java:[64,95] unchecked conversion
  required: mage.abilities.costs.Costs<mage.abilities.costs.Cost>
  found:    mage.abilities.costs.Costs
(N) mage/sets/vintagemasters/DacksDuplicate.java:[82,18] addAbility(mage.abilities.Ability,mage.game.Game) in mage.game.permanent.Permanent has been deprecated
(N) mage/sets/vintagemasters/DacksDuplicate.java:[83,18] addAbility(mage.abilities.Ability,mage.game.Game) in mage.game.permanent.Permanent has been deprecated
(N) mage/sets/mirage/AmberPrison.java:[63,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/legends/ChainsOfMephistopheles.java:[106,23] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(X) mage/sets/magic2011/VolcanicStrength.java:[113,37] addAbility(mage.abilities.Ability,mage.game.Game) in mage.game.permanent.Permanent has been deprecated
(N) mage/sets/apocalypse/PerniciousDeed.java:[107,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/shadowmoor/Gloomlance.java:[96,33] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(N) mage/sets/scourge/DecreeOfAnnihilation.java:[86,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/tenthedition/CreepingMold.java:[49,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/magic2011/DryadsFavor.java:[107,37] addAbility(mage.abilities.Ability,mage.game.Game) in mage.game.permanent.Permanent has been deprecated
(N) mage/sets/theros/PyxisOfPandemonium.java:[106,48] unchecked cast
  required: java.util.Map<java.lang.String,java.util.UUID>
  found:    java.lang.Object
(N) mage/sets/theros/PyxisOfPandemonium.java:[162,48] unchecked cast
  required: java.util.Map<java.lang.String,java.util.UUID>
  found:    java.lang.Object
(N) mage/sets/innistrad/SlayerOfTheWicked.java:[52,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/returntoravnica/StreetSweeper.java:[107,44] unchecked conversion
  required: java.util.LinkedList<java.util.UUID>
  found:    java.util.LinkedList
(N) mage/sets/magic2010/AcidicSlime.java:[55,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/newphyrexia/UrabraskTheHidden.java:[90,19] setTapped(boolean) in mage.game.permanent.Permanent has been deprecated
(X) mage/sets/commander2013/CurseOfChaos.java:[143,25] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(N) mage/sets/newphyrexia/DueRespect.java:[91,22] setTapped(boolean) in mage.game.permanent.Permanent has been deprecated
(X) mage/sets/zendikar/SummoningTrap.java:[133,17] unchecked call to add(E) as a member of the raw type java.util.ArrayList
(N) mage/sets/fatereforged/Soulflayer.java:[130,79] unchecked cast
  required: java.util.List<mage.cards.Card>
  found:    java.lang.Object
(N) mage/sets/dragonsmaze/VorelOfTheHullClade.java:[59,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/khansoftarkir/KinTreeInvocation.java:[104,23] unchecked method invocation: constructor <init> in class mage.game.permanent.token.Token is applied to given types
  required: java.lang.String,java.lang.String,mage.ObjectColor,java.util.List<java.lang.String>,int,int,mage.abilities.Abilities<mage.abilities.Ability>
  found: java.lang.String,java.lang.String,mage.ObjectColor,java.util.ArrayList<java.lang.String>,int,int,mage.abilities.AbilitiesImpl
(X) mage/sets/khansoftarkir/KinTreeInvocation.java:[105,50] unchecked conversion
  required: mage.abilities.Abilities<mage.abilities.Ability>
  found:    mage.abilities.AbilitiesImpl
(X) mage/sets/conflux/KnightOfTheReliquary.java:[85,18] unchecked call to add(E) as a member of the raw type java.util.List
(X) mage/sets/conflux/KnightOfTheReliquary.java:[86,18] unchecked call to add(E) as a member of the raw type java.util.List
(X) mage/sets/conflux/KnightOfTheReliquary.java:[87,25] unchecked method invocation: constructor <init> in class mage.abilities.common.SimpleActivatedAbility is applied to given types
  required: mage.constants.Zone,mage.abilities.effects.Effect,mage.abilities.costs.Costs<mage.abilities.costs.Cost>
  found: mage.constants.Zone,mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect,mage.abilities.costs.Costs
(X) mage/sets/conflux/KnightOfTheReliquary.java:[87,142] unchecked conversion
  required: mage.abilities.costs.Costs<mage.abilities.costs.Cost>
  found:    mage.abilities.costs.Costs
(N) mage/sets/shadowmoor/OversoulOfDusk.java:[50,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/weatherlight/MaraxusOfKeld.java:[56,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/avacynrestored/DarkImpostor.java:[108,33] addAbility(mage.abilities.Ability,mage.game.Game) in mage.game.permanent.Permanent has been deprecated
(X) mage/sets/worldwake/PermafrostTrap.java:[122,17] unchecked call to add(E) as a member of the raw type java.util.ArrayList
(N) mage/sets/zendikar/ExplorersScope.java:[107,38] setTapped(boolean) in mage.game.permanent.Permanent has been deprecated
(X) mage/sets/planechase2012/LastStand.java:[138,27] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(N) mage/sets/magic2013/MwonvuliBeastTracker.java:[57,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/magic2013/BoundlessRealms.java:[111,38] setTapped(boolean) in mage.game.permanent.Permanent has been deprecated
(N) mage/sets/darksteel/PristineAngel.java:[62,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/zendikar/RuneflareTrap.java:[149,17] unchecked call to add(E) as a member of the raw type java.util.ArrayList
(N) mage/sets/worldwake/Twitch.java:[50,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/zendikar/LethargyTrap.java:[85,17] unchecked call to add(E) as a member of the raw type java.util.ArrayList
(N) mage/sets/commander2013/Flickerform.java:[192,45] unchecked call to match(E,mage.game.Game) as a member of the raw type mage.filter.Filter
(X) mage/sets/fallenempires/Derelor.java:[65,67] unchecked method invocation: constructor <init> in class mage.abilities.effects.common.cost.SpellsCostIncreasementControllerEffect is applied to given types
  required: mage.filter.FilterCard,mage.abilities.costs.mana.ManaCosts<mage.abilities.costs.mana.ManaCost>
  found: mage.filter.FilterCard,mage.abilities.costs.mana.ManaCostsImpl
(X) mage/sets/fallenempires/Derelor.java:[65,118] unchecked conversion
  required: mage.abilities.costs.mana.ManaCosts<mage.abilities.costs.mana.ManaCost>
  found:    mage.abilities.costs.mana.ManaCostsImpl
(N) mage/sets/seventhedition/Opposition.java:[57,49] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/innistrad/FrightfulDelusion.java:[96,56] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(X) mage/sets/odyssey/TestamentOfFaith.java:[140,42] addAbility(mage.abilities.Ability,mage.game.Game) in mage.game.permanent.Permanent has been deprecated
(N) mage/sets/urzassaga/ShowAndTell.java:[80,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/commander/KaaliaOfTheVast.java:[124,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/eventide/NeedleSpecter.java:[101,29] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(N) mage/sets/commander2013/SpoilsOfVictory.java:[49,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/gatecrash/BlindObedience.java:[89,19] setTapped(boolean) in mage.game.permanent.Permanent has been deprecated
(N) mage/sets/timespiral/MagusOfTheDisk.java:[55,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/avacynrestored/RidersOfGavony.java:[165,21] addAbility(mage.abilities.Ability,mage.game.Game) in mage.game.permanent.Permanent has been deprecated
(N) mage/sets/gatecrash/TreasuryThrull.java:[52,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/stronghold/HermitDruid.java:[118,37] unchecked call to match(E,mage.game.Game) as a member of the raw type mage.filter.Filter
(N) mage/sets/stronghold/HermitDruid.java:[124,73] unchecked call to match(E,mage.game.Game) as a member of the raw type mage.filter.Filter
(N) mage/sets/scarsofmirrodin/GethLordOfTheVault.java:[126,34] setTapped(boolean) in mage.game.permanent.Permanent has been deprecated
(X) mage/sets/returntoravnica/AssassinsStrike.java:[95,23] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(N) mage/sets/theros/SwanSong.java:[55,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(N) mage/sets/zendikar/LavaballTrap.java:[142,17] unchecked call to add(E) as a member of the raw type java.util.ArrayList
(N) mage/sets/shardsofalara/ClarionUltimatum.java:[136,26] setTapped(boolean) in mage.game.permanent.Permanent has been deprecated
(X) mage/sets/worldwake/RicochetTrap.java:[130,17] unchecked call to add(E) as a member of the raw type java.util.ArrayList
(X) mage/sets/urzaslegacy/MemoryJar.java:[170,27] discard(int,mage.abilities.Ability,mage.game.Game) in mage.players.Player has been deprecated
(N) mage/sets/shardsofalara/KeeperOfProgenitus.java:[51,33] unchecked generic array creation for varargs parameter of type mage.filter.predicate.Predicate<? super mage.MageObject>[]
(X) mage/sets/dragonsmaze/BloodBaronOfVizkopa.java:[129,41] addAbility(mage.abilities.Ability,mage.game.Game) in mage.game.permanent.Permanent has been deprecated
(X) mage/sets/urzassaga/NoRestForTheWicked.java:[123,22] unchecked conversion
  required: java.util.ArrayList<java.util.UUID>
  found:    java.util.ArrayList
(X) mage/sets/urzassaga/NoRestForTheWicked.java:[128,22] unchecked conversion
  required: java.util.ArrayList<java.util.UUID>
  found:    java.util.ArrayList
```
(N): means this could not be covered, because I either don't get how to or because there is an intention behind the usage of the function e.g. setTapped, or because e.g. Predicates, it's an intended warning from Java (see https://stackoverflow.com/questions/21132692/java-unchecked-unchecked-generic-array-creation-for-varargs-parameter)
(X) means covered.