### PR TITLE
Added Morningtide. Abstracted out "Exile All Graveyards" effect

### DIFF
--- a/Mage.Sets/src/mage/sets/returntoravnica/RestInPeace.java
+++ b/Mage.Sets/src/mage/sets/returntoravnica/RestInPeace.java
@@ -31,8 +31,8 @@ import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.common.ExileGraveyardAllPlayersEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
@@ -72,9 +72,8 @@ public class RestInPeace extends CardImpl {
         super(ownerId, 18, "Rest in Peace", Rarity.RARE, new CardType[]{CardType.ENCHANTMENT}, "{1}{W}");
         this.expansionSetCode = "RTR";
 
-
         // When Rest in Peace enters the battlefield, exile all cards from all graveyards.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new RestInPeaceExileAllEffect()));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new ExileGraveyardAllPlayersEffect()));
 
         // If a card or token would be put into a graveyard from anywhere, exile it instead.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new RestInPeaceReplacementEffect()));
@@ -87,43 +86,6 @@ public class RestInPeace extends CardImpl {
     @Override
     public RestInPeace copy() {
         return new RestInPeace(this);
-    }
-}
-
-class RestInPeaceExileAllEffect extends OneShotEffect {
-
-    public RestInPeaceExileAllEffect() {
-        super(Outcome.Detriment);
-        staticText = "exile all cards from all graveyards";
-    }
-
-    public RestInPeaceExileAllEffect(final RestInPeaceExileAllEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public RestInPeaceExileAllEffect copy() {
-        return new RestInPeaceExileAllEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null) {
-            for (UUID playerId : controller.getInRange()) {
-                Player player = game.getPlayer(playerId);
-                if (player != null) {
-                    for (UUID cid : player.getGraveyard().copy()) {
-                        Card card = game.getCard(cid);
-                        if (card != null) {
-                            controller.moveCardToExileWithInfo(card, null, "", source.getSourceId(), game, Zone.GRAVEYARD, true);
-                        }
-                    }
-                }
-            }
-            return true;
-        }
-        return false;
     }
 }
 
@@ -173,5 +135,4 @@ class RestInPeaceReplacementEffect extends ReplacementEffectImpl {
     public boolean applies(GameEvent event, Ability source, Game game) {
         return ((ZoneChangeEvent)event).getToZone() == Zone.GRAVEYARD;
     }
-
 }

--- a/Mage.Sets/src/mage/sets/shardsofalara/RelicOfProgenitus.java
+++ b/Mage.Sets/src/mage/sets/shardsofalara/RelicOfProgenitus.java
@@ -35,6 +35,7 @@ import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.ExileGraveyardAllPlayersEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
@@ -63,11 +64,10 @@ public class RelicOfProgenitus extends CardImpl {
         firstAbility.addTarget(new TargetPlayer());
         this.addAbility(firstAbility);
         // {1}, Exile Relic of Progenitus: Exile all cards from all graveyards. Draw a card.
-        Ability secondAbility = new SimpleActivatedAbility(Zone.BATTLEFIELD, new RelicOfProgenitusEffect2(),new GenericManaCost(1));
+        Ability secondAbility = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ExileGraveyardAllPlayersEffect(),new GenericManaCost(1));
         secondAbility.addCost(new ExileSourceCost());
         secondAbility.addEffect(new DrawCardSourceControllerEffect(1));
         this.addAbility(secondAbility);
-
     }
 
     public RelicOfProgenitus(final RelicOfProgenitus card) {
@@ -112,43 +112,5 @@ class RelicOfProgenitusEffect extends OneShotEffect {
             }
         }
         return false;
-    }
-}
-
-class RelicOfProgenitusEffect2 extends OneShotEffect {
-
-    public RelicOfProgenitusEffect2() {
-        super(Outcome.Detriment);
-        staticText = "Exile all cards from all graveyards";
-    }
-
-    public RelicOfProgenitusEffect2(final RelicOfProgenitusEffect2 effect) {
-        super(effect);
-    }
-
-    @Override
-    public RelicOfProgenitusEffect2 copy() {
-        return new RelicOfProgenitusEffect2(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        if (controller == null) {
-            return false;
-        }
-
-        for (UUID playerId : controller.getInRange()) {
-            Player player = game.getPlayer(playerId);
-            if (player != null) {
-                for (UUID cid : player.getGraveyard().copy()) {
-                    Card card = game.getCard(cid);
-                    if (card != null) {
-                        controller.moveCardToExileWithInfo(card, null, "", source.getSourceId(), game, Zone.GRAVEYARD, true);
-                    }
-                }
-            }
-        }
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/sets/torment/Morningtide.java
+++ b/Mage.Sets/src/mage/sets/torment/Morningtide.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.torment;
+
+import java.util.UUID;
+import mage.abilities.effects.common.ExileGraveyardAllPlayersEffect;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Rarity;
+
+/**
+ *
+ * @author Jgod
+ */
+public class Morningtide extends CardImpl {
+
+    public Morningtide(UUID ownerId) {
+        super(ownerId, 10, "Morningtide", Rarity.RARE, new CardType[]{CardType.SORCERY}, "{1}{W}");
+        this.expansionSetCode = "TOR";
+
+        // Exile all cards from all graveyards.
+        this.getSpellAbility().addEffect(new ExileGraveyardAllPlayersEffect());
+    }
+
+    public Morningtide(final Morningtide card) {
+        super(card);
+    }
+
+    @Override
+    public Morningtide copy() {
+        return new Morningtide(this);
+    }
+}

--- a/Mage/src/mage/abilities/effects/common/ExileGraveyardAllPlayersEffect.java
+++ b/Mage/src/mage/abilities/effects/common/ExileGraveyardAllPlayersEffect.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.abilities.effects.common;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.Card;
+import mage.constants.Outcome;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.players.Player;
+
+/**
+ *
+ * @author Jgod
+ */
+public class ExileGraveyardAllPlayersEffect extends OneShotEffect {
+    public ExileGraveyardAllPlayersEffect() {
+        super(Outcome.Detriment);
+        staticText = "exile all cards from all graveyards";
+    }
+    
+    @Override
+    public ExileGraveyardAllPlayersEffect copy() {
+        return new ExileGraveyardAllPlayersEffect();
+    }
+    
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null) {
+            return false;
+        }
+
+        for (UUID playerId : controller.getInRange()) {
+            Player player = game.getPlayer(playerId);
+            if (player != null) {
+                for (UUID cid : player.getGraveyard().copy()) {
+                    Card card = game.getCard(cid);
+                    if (card != null) {
+                        controller.moveCardToExileWithInfo(card, null, "", source.getSourceId(), game, Zone.GRAVEYARD, true);
+                    }
+                }
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Trying my hand at slight refactoring. I'm thinking that since graveyard exiling, etc. is such a common effect, it can be abstracted in a way that's even better than this (like accepting filters) to reduce code duplication across similar cards.
Didn't do extensive testing, but everything seems to work ok.