### PR TITLE
* Talent of the Telepath - Bugfix

### DIFF
--- a/Mage.Sets/src/mage/sets/magicorigins/TalentOfTheTelepath.java
+++ b/Mage.Sets/src/mage/sets/magicorigins/TalentOfTheTelepath.java
@@ -136,9 +136,9 @@ class TalentOfTheTelepathEffect extends OneShotEffect {
                         target.clearChosen();
                     }
                 }
-
-                targetOpponent.moveCards(allCards, Zone.LIBRARY, Zone.GRAVEYARD, source, game);
             }
+
+            targetOpponent.moveCards(allCards, Zone.LIBRARY, Zone.GRAVEYARD, source, game);
             return true;
         }
         return false;


### PR DESCRIPTION
This commit ensures that cards go to the opponents graveyard
even if no calid cards are revealed.