### PR TITLE
Small fixes to constants, added header and standardised spelling

### DIFF
--- a/Mage.Client/src/main/java/mage/client/deck/generator/DeckGenerator.java
+++ b/Mage.Client/src/main/java/mage/client/deck/generator/DeckGenerator.java
@@ -244,10 +244,10 @@ public class DeckGenerator {
         // Store the nonbasic lands (if any) we'll add
         List<Card> deckLands = new ArrayList<>();
 
-        // Calculates the percentage of coloured mana symbols over all spells in the deck
-        Map<String, Double> percentage = genPool.calculateSpellColourPercentages();
+        // Calculates the percentage of colored mana symbols over all spells in the deck
+        Map<String, Double> percentage = genPool.calculateSpellColorPercentages();
 
-        // Only dual/tri colour lands are generated for now, and not non-basic lands that only produce colourless mana.
+        // Only dual/tri color lands are generated for now, and not non-basic lands that only produce colorless mana.
         if (!genPool.isMonoColoredDeck() && genDialog.useNonBasicLand()) {
             List<Card> landCards = genPool.filterLands(CardRepository.instance.findCards(criteria));
             int allCount = landCards.size();
@@ -270,7 +270,7 @@ public class DeckGenerator {
                 }
             }
         }
-        // Calculate the amount of coloured mana already can be produced by the non-basic lands
+        // Calculate the amount of colored mana already can be produced by the non-basic lands
         Map<String, Integer> count = genPool.countManaProduced(deckLands);
         // Fill up the rest of the land quota with basic lands adjusted to fit the deck's mana costs
         addBasicLands(landsCount - countNonBasic, percentage, count, basicLands);
@@ -345,7 +345,7 @@ public class DeckGenerator {
      */
     private static void addBasicLands(int landsNeeded, Map<String, Double> percentage, Map<String, Integer> count, Map<String, List<CardInfo>> basicLands) {
         int colorTotal = 0;
-        ColoredManaSymbol colourToAdd = null;
+        ColoredManaSymbol colorToAdd = null;
 
         // Add up the totals for all colors, to keep track of the percentage a color is.
         for (Map.Entry<String, Integer> c : count.entrySet()) {
@@ -360,25 +360,25 @@ public class DeckGenerator {
             for (ColoredManaSymbol color : ColoredManaSymbol.values()) {
                 // What percentage of this color is requested
                 double neededPercentage = percentage.get(color.toString());
-                // If there is a 0% need for basic lands of this colour, skip it
+                // If there is a 0% need for basic lands of this color, skip it
                 if (neededPercentage <= 0) {
                     continue;
                 }
                 int currentCount = count.get(color.toString());
                 double thisPercentage = 0.0;
-                // Calculate the percentage of lands so far that produce this colour
+                // Calculate the percentage of lands so far that produce this color
                 if (currentCount > 0)
                     thisPercentage = (currentCount / (double) colorTotal) * 100.0;
                 // Check if the color is the most "needed" (highest percentage) we have seen so far
                 if (neededPercentage - thisPercentage > minPercentage) {
                     // Put this color land forward to be added
-                    colourToAdd = color;
+                    colorToAdd = color;
                     minPercentage = (neededPercentage - thisPercentage);
                 }
             }
-            if(colourToAdd != null) {
-                genPool.addCard(getBasicLand(colourToAdd, basicLands));
-                count.put(colourToAdd.toString(), count.get(colourToAdd.toString()) + 1);
+            if(colorToAdd != null) {
+                genPool.addCard(getBasicLand(colorToAdd, basicLands));
+                count.put(colorToAdd.toString(), count.get(colorToAdd.toString()) + 1);
                 colorTotal++;
                 landsNeeded--;
             }

--- a/Mage.Client/src/main/java/mage/client/deck/generator/DeckGeneratorCMC.java
+++ b/Mage.Client/src/main/java/mage/client/deck/generator/DeckGeneratorCMC.java
@@ -1,3 +1,30 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
 package mage.client.deck.generator;
 
 /**

--- a/Mage.Client/src/main/java/mage/client/deck/generator/DeckGeneratorPool.java
+++ b/Mage.Client/src/main/java/mage/client/deck/generator/DeckGeneratorPool.java
@@ -60,7 +60,7 @@ public class DeckGeneratorPool
 
     // Count how many copies of the card exists in the deck to check we don't go over 4 copies (or 1 for singleton)
     private Map<String, Integer> cardCounts = new HashMap<>();
-    // If there is only a single colour selected to generate a deck
+    // If there is only a single color selected to generate a deck
     private boolean monoColored = false;
     // List of cards so far in the deck
     private List<Card> deckCards = new ArrayList<>();
@@ -84,7 +84,7 @@ public class DeckGeneratorPool
                 add(new DeckGeneratorCMC(0, 2, 0.20f));
                 add(new DeckGeneratorCMC(3, 5, 0.50f));
                 add(new DeckGeneratorCMC(6, 7, 0.25f));
-                add(new DeckGeneratorCMC(8, 100, 0.5f));
+                add(new DeckGeneratorCMC(8, 100, 0.05f));
             }};
 
         }
@@ -96,7 +96,7 @@ public class DeckGeneratorPool
                 add(new DeckGeneratorCMC(0, 2, 0.30f));
                 add(new DeckGeneratorCMC(3, 4, 0.45f));
                 add(new DeckGeneratorCMC(5, 6, 0.20f));
-                add(new DeckGeneratorCMC(7, 100, 0.5f));
+                add(new DeckGeneratorCMC(7, 100, 0.05f));
             }};
         }
 
@@ -216,7 +216,7 @@ public class DeckGeneratorPool
      * cards mana costs.
      * @return a list of colored mana symbols and the percentage of symbols seen in cards mana costs.
      */
-    public Map<String, Double> calculateSpellColourPercentages() {
+    public Map<String, Double> calculateSpellColorPercentages() {
 
         final Map<String, Integer> colorCount = new HashMap<>();
         for (final ColoredManaSymbol color : ColoredManaSymbol.values()) {
@@ -245,7 +245,7 @@ public class DeckGeneratorPool
         for(Map.Entry<String, Integer> singleCount: colorCount.entrySet()) {
             String color = singleCount.getKey();
             int count = singleCount.getValue();
-            // Calculate the percentage this colour has out of the total colour counts
+            // Calculate the percentage this color has out of the total color counts
             double percentage = (count / (double) totalCount) * 100;
             percentages.put(color, percentage);
         }
@@ -293,7 +293,7 @@ public class DeckGeneratorPool
     }
 
     /**
-     * Returns the card name that represents the basic land for this colour.
+     * Returns the card name that represents the basic land for this color.
      * @param symbolString the colored mana symbol.
      * @return the name of a basic land card.
      */


### PR DESCRIPTION
* Fixed deck generation constants (Thanks to emerald000 for spotting it)
* Added missing header copyright to DeckGeneratorCMC
* Standardised spelling of "colour" vs "color" to fit in with the rest of the code.