### PR TITLE
new cards

### DIFF
--- a/Mage.Sets/src/mage/sets/dissension/SproutingPhytohydra.java
+++ b/Mage.Sets/src/mage/sets/dissension/SproutingPhytohydra.java
@@ -25,48 +25,44 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.sets.theros;
+package mage.sets.dissension;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.Ability;
-import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.effects.common.UntapTargetEffect;
+import mage.abilities.common.DealtDamageToSourceTriggeredAbility;
+import mage.abilities.effects.common.PutTokenOntoBattlefieldCopySource;
+import mage.abilities.keyword.DefenderAbility;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
 import mage.constants.Rarity;
 import mage.constants.Zone;
-import mage.target.Target;
-import mage.target.common.TargetLandPermanent;
 
 /**
  *
- * @author LevelX2
+ * @author markedagain
  */
-public class VoyagingSatyr extends CardImpl {
+public class SproutingPhytohydra extends CardImpl {
 
-    public VoyagingSatyr(UUID ownerId) {
-        super(ownerId, 182, "Voyaging Satyr", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{1}{G}");
-        this.expansionSetCode = "THS";
-        this.subtype.add("Satyr");
-        this.subtype.add("Druid");
-
-        this.power = new MageInt(1);
+    public SproutingPhytohydra(UUID ownerId) {
+        super(ownerId, 95, "Sprouting Phytohydra", Rarity.RARE, new CardType[]{CardType.CREATURE}, "{4}{G}");
+        this.expansionSetCode = "DIS";
+        this.subtype.add("Plant");
+        this.subtype.add("Hydra");
+        this.power = new MageInt(0);
         this.toughness = new MageInt(2);
 
-        // {T}: Untap target land.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new UntapTargetEffect(), new TapSourceCost());
-        ability.addTarget(new TargetLandPermanent());
-        this.addAbility(ability);
+        // Defender
+        this.addAbility(DefenderAbility.getInstance());
+        // Whenever Sprouting Phytohydra is dealt damage, you may put a token that's a copy of Sprouting Phytohydra onto the battlefield.
+        this.addAbility(new DealtDamageToSourceTriggeredAbility(Zone.BATTLEFIELD, new PutTokenOntoBattlefieldCopySource(), false));
     }
 
-    public VoyagingSatyr(final VoyagingSatyr card) {
+    public SproutingPhytohydra(final SproutingPhytohydra card) {
         super(card);
     }
 
     @Override
-    public VoyagingSatyr copy() {
-        return new VoyagingSatyr(this);
+    public SproutingPhytohydra copy() {
+        return new SproutingPhytohydra(this);
     }
 }

--- a/Mage.Sets/src/mage/sets/izzetvsgolgari/GolgariGermination.java
+++ b/Mage.Sets/src/mage/sets/izzetvsgolgari/GolgariGermination.java
@@ -25,48 +25,46 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.sets.theros;
+package mage.sets.izzetvsgolgari;
 
 import java.util.UUID;
-import mage.MageInt;
-import mage.abilities.Ability;
-import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.effects.common.UntapTargetEffect;
+import mage.abilities.common.DiesCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
 import mage.constants.Rarity;
-import mage.constants.Zone;
-import mage.target.Target;
-import mage.target.common.TargetLandPermanent;
+import mage.constants.TargetController;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.permanent.ControllerPredicate;
+import mage.filter.predicate.permanent.TokenPredicate;
+import mage.game.permanent.token.SaprolingToken;
 
 /**
  *
- * @author LevelX2
+ * @author markedagain
  */
-public class VoyagingSatyr extends CardImpl {
+public class GolgariGermination extends CardImpl {
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("nontoken creature you control");
 
-    public VoyagingSatyr(UUID ownerId) {
-        super(ownerId, 182, "Voyaging Satyr", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{1}{G}");
-        this.expansionSetCode = "THS";
-        this.subtype.add("Satyr");
-        this.subtype.add("Druid");
+    static {
+        filter.add(new ControllerPredicate(TargetController.YOU));
+        filter.add(Predicates.not(new TokenPredicate()));
+    }
+    public GolgariGermination(UUID ownerId) {
+        super(ownerId, 70, "Golgari Germination", Rarity.UNCOMMON, new CardType[]{CardType.ENCHANTMENT}, "{1}{B}{G}");
+        this.expansionSetCode = "DDJ";
 
-        this.power = new MageInt(1);
-        this.toughness = new MageInt(2);
-
-        // {T}: Untap target land.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new UntapTargetEffect(), new TapSourceCost());
-        ability.addTarget(new TargetLandPermanent());
-        this.addAbility(ability);
+        // Whenever a nontoken creature you control dies, put a 1/1 green Saproling creature token onto the battlefield.
+        this.addAbility(new DiesCreatureTriggeredAbility(new CreateTokenEffect(new SaprolingToken()),false,filter));
     }
 
-    public VoyagingSatyr(final VoyagingSatyr card) {
+    public GolgariGermination(final GolgariGermination card) {
         super(card);
     }
 
     @Override
-    public VoyagingSatyr copy() {
-        return new VoyagingSatyr(this);
+    public GolgariGermination copy() {
+        return new GolgariGermination(this);
     }
 }

--- a/Mage.Sets/src/mage/sets/mercadianmasques/BlackMarket.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/BlackMarket.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.mercadianmasques;
+
+import java.util.UUID;
+import mage.Mana;
+import mage.abilities.Ability;
+import mage.abilities.common.BeginningOfPreCombatMainTriggeredAbility;
+import mage.abilities.common.DiesCreatureTriggeredAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.TargetController;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+
+/**
+ *
+ * @author markedagain
+ */
+public class BlackMarket extends CardImpl {
+
+    public BlackMarket(UUID ownerId) {
+        super(ownerId, 116, "Black Market", Rarity.RARE, new CardType[]{CardType.ENCHANTMENT}, "{3}{B}{B}");
+        this.expansionSetCode = "MMQ";
+
+        // Whenever a creature dies, put a charge counter on Black Market.
+        this.addAbility(new DiesCreatureTriggeredAbility(new AddCountersSourceEffect(CounterType.CHARGE.createInstance()),false ));
+        // At the beginning of your precombat main phase, add {B} to your mana pool for each charge counter on Black Market.
+        this.addAbility(new BeginningOfPreCombatMainTriggeredAbility(new BlackMarketEffect(), TargetController.YOU, false));
+        
+    }
+
+    public BlackMarket(final BlackMarket card) {
+        super(card);
+    }
+
+    @Override
+    public BlackMarket copy() {
+        return new BlackMarket(this);
+    }
+}
+class BlackMarketEffect extends OneShotEffect {
+
+    public BlackMarketEffect() {
+        super(Outcome.PutManaInPool);
+        this.staticText = "add {B} to your mana pool for each charge counter on Black Market";
+    }
+
+    public BlackMarketEffect(final BlackMarketEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public BlackMarketEffect copy() {
+        return new BlackMarketEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent sourcePermanent = game.getPermanent(source.getSourceId());
+        Player player = game.getPlayer(source.getControllerId());
+        if (sourcePermanent != null && player != null) {
+            int chargeCounters = sourcePermanent.getCounters().getCount(CounterType.CHARGE);
+            if (chargeCounters > 0){
+                player.getManaPool().addMana(Mana.BlackMana(chargeCounters), game, source);
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/mercadianmasques/Hoodwink.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/Hoodwink.java
@@ -25,48 +25,47 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.sets.theros;
+package mage.sets.mercadianmasques;
 
 import java.util.UUID;
-import mage.MageInt;
-import mage.abilities.Ability;
-import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.effects.common.UntapTargetEffect;
+import mage.abilities.effects.common.ReturnToHandTargetEffect;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
 import mage.constants.Rarity;
-import mage.constants.Zone;
-import mage.target.Target;
-import mage.target.common.TargetLandPermanent;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.CardTypePredicate;
+import mage.target.TargetPermanent;
 
 /**
  *
- * @author LevelX2
+ * @author markedagain
  */
-public class VoyagingSatyr extends CardImpl {
+public class Hoodwink extends CardImpl {
 
-    public VoyagingSatyr(UUID ownerId) {
-        super(ownerId, 182, "Voyaging Satyr", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{1}{G}");
-        this.expansionSetCode = "THS";
-        this.subtype.add("Satyr");
-        this.subtype.add("Druid");
+    private static final FilterPermanent filter = new FilterPermanent("artifact, enchantment, or land");
+    
+    static {
+        filter.add(Predicates.or(
+                new CardTypePredicate(CardType.ARTIFACT),
+                new CardTypePredicate(CardType.ENCHANTMENT),
+                new CardTypePredicate(CardType.LAND)));
+    }
+    public Hoodwink(UUID ownerId) {
+        super(ownerId, 84, "Hoodwink", Rarity.COMMON, new CardType[]{CardType.INSTANT}, "{1}{U}");
+        this.expansionSetCode = "MMQ";
 
-        this.power = new MageInt(1);
-        this.toughness = new MageInt(2);
-
-        // {T}: Untap target land.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new UntapTargetEffect(), new TapSourceCost());
-        ability.addTarget(new TargetLandPermanent());
-        this.addAbility(ability);
+        // Return target artifact, enchantment, or land to its owner's hand.
+        this.getSpellAbility().addEffect(new ReturnToHandTargetEffect());
+        this.getSpellAbility().addTarget(new TargetPermanent(filter));
     }
 
-    public VoyagingSatyr(final VoyagingSatyr card) {
+    public Hoodwink(final Hoodwink card) {
         super(card);
     }
 
     @Override
-    public VoyagingSatyr copy() {
-        return new VoyagingSatyr(this);
+    public Hoodwink copy() {
+        return new Hoodwink(this);
     }
 }

--- a/Mage.Sets/src/mage/sets/mercadianmasques/Thwart.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/Thwart.java
@@ -25,48 +25,49 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.sets.theros;
+package mage.sets.mercadianmasques;
 
 import java.util.UUID;
-import mage.MageInt;
-import mage.abilities.Ability;
-import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.effects.common.UntapTargetEffect;
+import mage.abilities.costs.AlternativeCostSourceAbility;
+import mage.abilities.costs.common.ReturnToHandTargetPermanentCost;
+import mage.abilities.effects.common.CounterTargetEffect;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
 import mage.constants.Rarity;
-import mage.constants.Zone;
-import mage.target.Target;
-import mage.target.common.TargetLandPermanent;
+import mage.filter.common.FilterControlledLandPermanent;
+import mage.filter.predicate.mageobject.SubtypePredicate;
+import mage.target.TargetSpell;
+import mage.target.common.TargetControlledPermanent;
 
 /**
  *
- * @author LevelX2
+ * @author markedagain
  */
-public class VoyagingSatyr extends CardImpl {
+public class Thwart extends CardImpl {
+    private static final FilterControlledLandPermanent filter = new FilterControlledLandPermanent("Island");
+    static{
+        filter.add(new SubtypePredicate("Island"));
+    }
+    public Thwart(UUID ownerId) {
+        super(ownerId, 108, "Thwart", Rarity.UNCOMMON, new CardType[]{CardType.INSTANT}, "{2}{U}{U}");
+        this.expansionSetCode = "MMQ";
 
-    public VoyagingSatyr(UUID ownerId) {
-        super(ownerId, 182, "Voyaging Satyr", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{1}{G}");
-        this.expansionSetCode = "THS";
-        this.subtype.add("Satyr");
-        this.subtype.add("Druid");
-
-        this.power = new MageInt(1);
-        this.toughness = new MageInt(2);
-
-        // {T}: Untap target land.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new UntapTargetEffect(), new TapSourceCost());
-        ability.addTarget(new TargetLandPermanent());
+        // You may return three Islands you control to their owner's hand rather than pay Thwart's mana cost.
+        AlternativeCostSourceAbility ability;   
+        ability = new AlternativeCostSourceAbility(new ReturnToHandTargetPermanentCost(new TargetControlledPermanent(3, 3, filter, true)));
         this.addAbility(ability);
+        
+        // Counter target spell.
+        this.getSpellAbility().addEffect(new CounterTargetEffect());
+        this.getSpellAbility().addTarget(new TargetSpell());
     }
 
-    public VoyagingSatyr(final VoyagingSatyr card) {
+    public Thwart(final Thwart card) {
         super(card);
     }
 
     @Override
-    public VoyagingSatyr copy() {
-        return new VoyagingSatyr(this);
+    public Thwart copy() {
+        return new Thwart(this);
     }
 }

--- a/Mage.Sets/src/mage/sets/scourge/Carbonize.java
+++ b/Mage.Sets/src/mage/sets/scourge/Carbonize.java
@@ -25,48 +25,47 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.sets.theros;
+package mage.sets.scourge;
 
 import java.util.UUID;
-import mage.MageInt;
-import mage.abilities.Ability;
-import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.effects.common.UntapTargetEffect;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.effects.common.replacement.DealtDamageToCreatureBySourceDies;
+import mage.abilities.effects.common.ruleModifying.CantRegenerateTargetEffect;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
+import mage.constants.Duration;
 import mage.constants.Rarity;
-import mage.constants.Zone;
-import mage.target.Target;
-import mage.target.common.TargetLandPermanent;
+import mage.target.common.TargetCreatureOrPlayer;
+import mage.watchers.common.DamagedByWatcher;
 
 /**
  *
- * @author LevelX2
+ * @author markedagain
  */
-public class VoyagingSatyr extends CardImpl {
+public class Carbonize extends CardImpl {
 
-    public VoyagingSatyr(UUID ownerId) {
-        super(ownerId, 182, "Voyaging Satyr", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{1}{G}");
-        this.expansionSetCode = "THS";
-        this.subtype.add("Satyr");
-        this.subtype.add("Druid");
+    public Carbonize(UUID ownerId) {
+        super(ownerId, 83, "Carbonize", Rarity.UNCOMMON, new CardType[]{CardType.INSTANT}, "{2}{R}");
+        this.expansionSetCode = "SCG";
 
-        this.power = new MageInt(1);
-        this.toughness = new MageInt(2);
-
-        // {T}: Untap target land.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new UntapTargetEffect(), new TapSourceCost());
-        ability.addTarget(new TargetLandPermanent());
-        this.addAbility(ability);
+        // Carbonize deals 3 damage to target creature or player. That creature can't be regenerated this turn. If the creature would die this turn, exile it instead.
+        this.getSpellAbility().addEffect(new DamageTargetEffect(3));
+        this.getSpellAbility().addEffect(new CantRegenerateTargetEffect(Duration.EndOfTurn, "That creature"));
+        Effect effect = new DealtDamageToCreatureBySourceDies(this, Duration.EndOfTurn);
+        effect.setText("If the creature would die this turn, exile it instead");
+        this.getSpellAbility().addEffect(effect);
+        this.getSpellAbility().addTarget(new TargetCreatureOrPlayer());
+        this.getSpellAbility().addWatcher(new DamagedByWatcher());
+        
     }
 
-    public VoyagingSatyr(final VoyagingSatyr card) {
+    public Carbonize(final Carbonize card) {
         super(card);
     }
 
     @Override
-    public VoyagingSatyr copy() {
-        return new VoyagingSatyr(this);
+    public Carbonize copy() {
+        return new Carbonize(this);
     }
 }

--- a/Mage.Sets/src/mage/sets/scourge/WipeClean.java
+++ b/Mage.Sets/src/mage/sets/scourge/WipeClean.java
@@ -25,48 +25,46 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.sets.theros;
+package mage.sets.scourge;
 
 import java.util.UUID;
-import mage.MageInt;
-import mage.abilities.Ability;
-import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.effects.common.UntapTargetEffect;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.keyword.CyclingAbility;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
 import mage.constants.Rarity;
-import mage.constants.Zone;
-import mage.target.Target;
-import mage.target.common.TargetLandPermanent;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.mageobject.CardTypePredicate;
+import mage.target.TargetPermanent;
 
 /**
  *
- * @author LevelX2
+ * @author markedagain
  */
-public class VoyagingSatyr extends CardImpl {
+public class WipeClean extends CardImpl {
+    private static final FilterPermanent filter = new FilterPermanent("enchantment");
 
-    public VoyagingSatyr(UUID ownerId) {
-        super(ownerId, 182, "Voyaging Satyr", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{1}{G}");
-        this.expansionSetCode = "THS";
-        this.subtype.add("Satyr");
-        this.subtype.add("Druid");
+    static {
+        filter.add(new CardTypePredicate(CardType.ENCHANTMENT));
+    }
+    public WipeClean(UUID ownerId) {
+        super(ownerId, 26, "Wipe Clean", Rarity.COMMON, new CardType[]{CardType.INSTANT}, "{1}{W}");
+        this.expansionSetCode = "SCG";
 
-        this.power = new MageInt(1);
-        this.toughness = new MageInt(2);
-
-        // {T}: Untap target land.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new UntapTargetEffect(), new TapSourceCost());
-        ability.addTarget(new TargetLandPermanent());
-        this.addAbility(ability);
+        // Exile target enchantment.
+        this.getSpellAbility().addTarget(new TargetPermanent(filter)); 
+        this.getSpellAbility().addEffect(new ExileTargetEffect());
+        // Cycling {3}
+        this.addAbility(new CyclingAbility(new ManaCostsImpl("{3}")));
     }
 
-    public VoyagingSatyr(final VoyagingSatyr card) {
+    public WipeClean(final WipeClean card) {
         super(card);
     }
 
     @Override
-    public VoyagingSatyr copy() {
-        return new VoyagingSatyr(this);
+    public WipeClean copy() {
+        return new WipeClean(this);
     }
 }

--- a/Mage.Sets/src/mage/sets/torment/CabalSurgeon.java
+++ b/Mage.Sets/src/mage/sets/torment/CabalSurgeon.java
@@ -25,48 +25,54 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.sets.theros;
+package mage.sets.torment;
 
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.ExileFromGraveCost;
 import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.effects.common.UntapTargetEffect;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.ReturnToHandTargetEffect;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
 import mage.constants.Rarity;
 import mage.constants.Zone;
-import mage.target.Target;
-import mage.target.common.TargetLandPermanent;
+import mage.filter.FilterCard;
+import mage.filter.common.FilterCreatureCard;
+import mage.target.common.TargetCardInYourGraveyard;
 
 /**
  *
- * @author LevelX2
+ * @author markedagain
  */
-public class VoyagingSatyr extends CardImpl {
+public class CabalSurgeon extends CardImpl {
 
-    public VoyagingSatyr(UUID ownerId) {
-        super(ownerId, 182, "Voyaging Satyr", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{1}{G}");
-        this.expansionSetCode = "THS";
-        this.subtype.add("Satyr");
-        this.subtype.add("Druid");
+    private static final FilterCreatureCard filter = new FilterCreatureCard("creature card from your graveyard");
+    
+    public CabalSurgeon(UUID ownerId) {
+        super(ownerId, 52, "Cabal Surgeon", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{2}{B}{B}");
+        this.expansionSetCode = "TOR";
+        this.subtype.add("Human");
+        this.subtype.add("Minion");
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(1);
 
-        this.power = new MageInt(1);
-        this.toughness = new MageInt(2);
-
-        // {T}: Untap target land.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new UntapTargetEffect(), new TapSourceCost());
-        ability.addTarget(new TargetLandPermanent());
-        this.addAbility(ability);
+        // {2}{B}{B}, {tap}, Exile two cards from your graveyard: Return target creature card from your graveyard to your hand.
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ReturnToHandTargetEffect(),new ManaCostsImpl("{2}{B}{B}"));
+        ability.addTarget(new TargetCardInYourGraveyard(filter));
+        ability.addCost(new TapSourceCost());
+        ability.addCost(new ExileFromGraveCost(new TargetCardInYourGraveyard(2, new FilterCard("cards from your graveyard"))));
+        this.addAbility(ability);    
     }
 
-    public VoyagingSatyr(final VoyagingSatyr card) {
+    public CabalSurgeon(final CabalSurgeon card) {
         super(card);
     }
 
     @Override
-    public VoyagingSatyr copy() {
-        return new VoyagingSatyr(this);
+    public CabalSurgeon copy() {
+        return new CabalSurgeon(this);
     }
 }

--- a/Mage.Sets/src/mage/sets/weatherlight/HauntingMisery.java
+++ b/Mage.Sets/src/mage/sets/weatherlight/HauntingMisery.java
@@ -25,48 +25,41 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.sets.theros;
+package mage.sets.weatherlight;
 
 import java.util.UUID;
-import mage.MageInt;
-import mage.abilities.Ability;
-import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.effects.common.UntapTargetEffect;
+import mage.abilities.costs.common.ExileXFromYourGraveCost;
+import mage.abilities.dynamicvalue.common.GetXValue;
+import mage.abilities.effects.common.DamageTargetEffect;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
 import mage.constants.Rarity;
-import mage.constants.Zone;
-import mage.target.Target;
-import mage.target.common.TargetLandPermanent;
+import mage.filter.common.FilterCreatureCard;
+import mage.target.TargetPlayer;
 
 /**
  *
- * @author LevelX2
+ * @author markedagain
  */
-public class VoyagingSatyr extends CardImpl {
+public class HauntingMisery extends CardImpl {
 
-    public VoyagingSatyr(UUID ownerId) {
-        super(ownerId, 182, "Voyaging Satyr", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{1}{G}");
-        this.expansionSetCode = "THS";
-        this.subtype.add("Satyr");
-        this.subtype.add("Druid");
+    public HauntingMisery(UUID ownerId) {
+        super(ownerId, 13, "Haunting Misery", Rarity.COMMON, new CardType[]{CardType.SORCERY}, "{1}{B}{B}");
+        this.expansionSetCode = "WTH";
 
-        this.power = new MageInt(1);
-        this.toughness = new MageInt(2);
-
-        // {T}: Untap target land.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new UntapTargetEffect(), new TapSourceCost());
-        ability.addTarget(new TargetLandPermanent());
-        this.addAbility(ability);
+        // As an additional cost to cast Haunting Misery, exile X creature cards from your graveyard.
+        this.getSpellAbility().addCost(new ExileXFromYourGraveCost(new FilterCreatureCard()));
+        // Haunting Misery deals X damage to target player.
+        this.getSpellAbility().addTarget(new TargetPlayer());
+        this.getSpellAbility().addEffect(new DamageTargetEffect(new GetXValue()));
     }
 
-    public VoyagingSatyr(final VoyagingSatyr card) {
+    public HauntingMisery(final HauntingMisery card) {
         super(card);
     }
 
     @Override
-    public VoyagingSatyr copy() {
-        return new VoyagingSatyr(this);
+    public HauntingMisery copy() {
+        return new HauntingMisery(this);
     }
 }


### PR DESCRIPTION
sprouting phytohydra, golgari germination, black market, hoodwink, thwart,carbonize, wipe clean, cabal surgeon, haunting misery
clean up: voyagin satyr

i want to mention the replacement effect dies/exile implementation "DealtDamageToCreatureBySourceDies" is not specific in the namespace that it exiles as a replacement
should maybe be called "ExileOnDealtDamageToCreatureBySourceDies"

also i noticed i capitalized text again in Carbonize, maybe edit that before merging it in sorry