### PR TITLE
random draft bug fix and random draft ui improvements

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.form
@@ -169,7 +169,7 @@
                   <Group type="102" attributes="0">
                       <Component id="pnlPacks" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="pnlRandomPacks" min="-2" max="-2" attributes="0"/>
+                      <Component id="pnlRandomPacks" max="32767" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="1" max="-2" attributes="0">
                           <Group type="103" alignment="1" groupAlignment="3" attributes="0">
@@ -521,10 +521,8 @@
         <Property name="toolTipText" type="java.lang.String" value=""/>
       </Properties>
 
-      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridLayout">
-        <Property name="columns" type="int" value="1"/>
-        <Property name="horizontalGap" type="int" value="2"/>
-        <Property name="rows" type="int" value="0"/>
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
+        <Property name="axis" type="int" value="1"/>
       </Layout>
     </Container>
   </SubComponents>

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
@@ -34,8 +34,10 @@
 
 package mage.client.dialog;
 
+import java.awt.Component;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import javax.swing.ComboBoxModel;
@@ -122,8 +124,8 @@ public class NewTournamentDialog extends MageDialog {
             cbAllowSpectators.setSelected(true);
             setTournamentSettingsFromPrefs();
             this.setModal(true);
-            this.setLocation(150, 100);            
-        }        
+            this.setLocation(150, 100);
+        }
         this.setVisible(true);
     }
 
@@ -341,7 +343,7 @@ public class NewTournamentDialog extends MageDialog {
 
         pnlRandomPacks.setBorder(javax.swing.BorderFactory.createEtchedBorder());
         pnlRandomPacks.setToolTipText("");
-        pnlRandomPacks.setLayout(new java.awt.GridLayout(0, 1, 2, 0));
+        pnlRandomPacks.setLayout(new javax.swing.BoxLayout(pnlRandomPacks, javax.swing.BoxLayout.Y_AXIS));
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
@@ -468,7 +470,7 @@ public class NewTournamentDialog extends MageDialog {
                     .addGroup(layout.createSequentialGroup()
                         .addComponent(pnlPacks, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(pnlRandomPacks, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addComponent(pnlRandomPacks, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
                             .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
@@ -477,7 +479,7 @@ public class NewTournamentDialog extends MageDialog {
                                 .addComponent(lblNumRounds))
                             .addComponent(lblNbrPlayers, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addComponent(spnNumPlayers)
-                            .addComponent(pnlDraftOptions, javax.swing.GroupLayout.DEFAULT_SIZE, 0, Short.MAX_VALUE))
+                            .addComponent(pnlDraftOptions, javax.swing.GroupLayout.PREFERRED_SIZE, 0, Short.MAX_VALUE))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(lblPlayer1, javax.swing.GroupLayout.PREFERRED_SIZE, 25, javax.swing.GroupLayout.PREFERRED_SIZE))
                     .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
@@ -533,7 +535,18 @@ public class NewTournamentDialog extends MageDialog {
                 tOptions.getLimitedOptions().setDraftCubeName(this.cbDraftCube.getSelectedItem().toString());
             } else if (tournamentType.isRandom()) {
                 tOptions.getLimitedOptions().getSetCodes().clear();
-                tOptions.getLimitedOptions().getSetCodes().addAll(randomPackSelector.getSelectedPacks());
+                ArrayList<String> selected = randomPackSelector.getSelectedPacks();
+                int maxPacks = 3 * (players.size() + 1);
+                if (selected.size() > maxPacks ){
+                    StringBuilder infoString = new StringBuilder("More sets were selected than needed. ");
+                    infoString.append(maxPacks);
+                    infoString.append(" sets will be randomly chosen.");
+                    JOptionPane.showMessageDialog(MageFrame.getDesktop(), infoString, "Information", JOptionPane.INFORMATION_MESSAGE);
+                    Collections.shuffle(selected);
+                    tOptions.getLimitedOptions().getSetCodes().addAll(selected.subList(0, maxPacks));
+                }else{
+                     tOptions.getLimitedOptions().getSetCodes().addAll(selected);
+                }
             } else {
                 for (JComboBox pack: packs) {
                     tOptions.getLimitedOptions().getSetCodes().add(((ExpansionInfo) pack.getSelectedItem()).getCode());
@@ -717,6 +730,7 @@ public class NewTournamentDialog extends MageDialog {
         if (pnlRandomPacks.getComponentCount() == 0) {
             if (randomPackSelector == null) {
                 randomPackSelector = new RandomPacksSelectorDialog();
+                randomPackSelector.setLocationRelativeTo(this);
             }
             txtRandomPacks = new JTextArea();
             txtRandomPacks.setEnabled(false);
@@ -736,9 +750,10 @@ public class NewTournamentDialog extends MageDialog {
                 }
                 txtRandomPacks.setText(packList.toString());
             }
-
+            txtRandomPacks.setAlignmentX(Component.LEFT_ALIGNMENT);
             pnlRandomPacks.add(txtRandomPacks);
             JButton btnSelectRandomPacks = new JButton();
+            btnSelectRandomPacks.setAlignmentX(Component.LEFT_ALIGNMENT);
             btnSelectRandomPacks.setText("Select packs to be included in the pool");
             btnSelectRandomPacks.setToolTipText(RandomPacksSelectorDialog.randomDraftDescription);
             btnSelectRandomPacks.addActionListener(new java.awt.event.ActionListener() {
@@ -749,11 +764,11 @@ public class NewTournamentDialog extends MageDialog {
                 }
             });
             pnlRandomPacks.add(btnSelectRandomPacks);
-                }
+        }
         this.pack();
         this.revalidate();
         this.repaint();
-            }
+    }
 
     private void showRandomPackSelectorDialog() {
         randomPackSelector.showDialog();

--- a/Mage.Client/src/main/java/mage/client/dialog/RandomPacksSelectorDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/RandomPacksSelectorDialog.form
@@ -2,6 +2,7 @@
 
 <Form version="1.3" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JDialogFormInfo">
   <Properties>
+    <Property name="defaultCloseOperation" type="int" value="0"/>
     <Property name="title" type="java.lang.String" value="Random Booster Draft Packs Selector"/>
     <Property name="modal" type="boolean" value="true"/>
     <Property name="modalExclusionType" type="java.awt.Dialog$ModalExclusionType" editor="org.netbeans.modules.form.editors.EnumEditor">
@@ -16,6 +17,9 @@
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
     <SyntheticProperty name="generateCenter" type="boolean" value="false"/>
   </SyntheticProperties>
+  <Events>
+    <EventHandler event="windowClosing" listener="java.awt.event.WindowListener" parameters="java.awt.event.WindowEvent" handler="formWindowClosing"/>
+  </Events>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>

--- a/Mage.Client/src/main/java/mage/client/dialog/RandomPacksSelectorDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/RandomPacksSelectorDialog.java
@@ -8,6 +8,7 @@ package mage.client.dialog;
 import java.awt.Component;
 import java.util.ArrayList;
 import javax.swing.JCheckBox;
+import javax.swing.JOptionPane;
 import mage.cards.repository.ExpansionInfo;
 import mage.cards.repository.ExpansionRepository;
 
@@ -101,11 +102,17 @@ public class RandomPacksSelectorDialog extends javax.swing.JDialog {
         pnlApply = new javax.swing.JPanel();
         btnApply = new javax.swing.JButton();
 
+        setDefaultCloseOperation(javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE);
         setTitle("Random Booster Draft Packs Selector");
         setModal(true);
         setModalExclusionType(java.awt.Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
         setPreferredSize(new java.awt.Dimension(600, 450));
         setResizable(false);
+        addWindowListener(new java.awt.event.WindowAdapter() {
+            public void windowClosing(java.awt.event.WindowEvent evt) {
+                formWindowClosing(evt);
+            }
+        });
 
         pnlPacks.setLayout(new java.awt.GridLayout(11, 12));
 
@@ -174,13 +181,21 @@ public class RandomPacksSelectorDialog extends javax.swing.JDialog {
     }//GEN-LAST:event_btnNoneActionPerformed
 
     private void btnApplyActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnApplyActionPerformed
+        this.doApply();
+    }//GEN-LAST:event_btnApplyActionPerformed
+
+    private void formWindowClosing(java.awt.event.WindowEvent evt) {//GEN-FIRST:event_formWindowClosing
+        this.doApply();
+    }//GEN-LAST:event_formWindowClosing
+
+    public void doApply() {
         if (getSelectedPacks().size() < 2) {
-            // at least 2 packs must be selected.
+            JOptionPane.showMessageDialog(this, "At least 2 sets must be selected", "Error", JOptionPane.ERROR_MESSAGE);
         } else {
             this.setVisible(false);
         }
-    }//GEN-LAST:event_btnApplyActionPerformed
-
+    }
+    
     private void setAllCheckBoxes(boolean value) {
         for (Component pack : pnlPacks.getComponents()) {
             JCheckBox thePack = (JCheckBox) pack;

--- a/Mage.Server/src/main/java/mage/server/tournament/TournamentFactory.java
+++ b/Mage.Server/src/main/java/mage/server/tournament/TournamentFactory.java
@@ -80,6 +80,13 @@ public class TournamentFactory {
                 if (tournament.getTournamentType().isCubeBooster()) {
                     tournament.getOptions().getLimitedOptions().setDraftCube(CubeFactory.getInstance().createDraftCube(tournament.getOptions().getLimitedOptions().getDraftCubeName()));
                     tournament.setBoosterInfo(tournament.getOptions().getLimitedOptions().getDraftCubeName());
+                } else if (tournament.getTournamentType().isRandom()) {
+                    StringBuilder rv = new StringBuilder( "Random Draft using sets: ");
+                    for (Map.Entry<String, Integer> entry: setInfo.entrySet()){
+                        rv.append(entry.getKey());
+                        rv.append(";");
+                    }
+                    tournament.setBoosterInfo(rv.toString());
                 } else {
                     StringBuilder sb = new StringBuilder();
                     for (Map.Entry<String,Integer> entry:setInfo.entrySet()) {

--- a/Mage/src/mage/cards/ExpansionSet.java
+++ b/Mage/src/mage/cards/ExpansionSet.java
@@ -112,6 +112,26 @@ public abstract class ExpansionSet implements Serializable {
         return name;
     }
 
+    public List<Card> create15CardBooster() {
+        // Forces 15 card booster packs. 
+        // if the packs are too small, it adds commons to fill it out.
+        // if the packs are too big, it removes the first cards.
+        // since it adds lands then commons before uncommons
+        // and rares this should be the least disruptive.
+
+        List<Card> theBooster = this.createBooster();
+        List<CardInfo> commons = getCardsByRarity(Rarity.COMMON);
+        while (15 > theBooster.size()) {
+            addToBooster(theBooster, commons);
+        }
+
+        while (theBooster.size() > 15) {
+            theBooster.remove(0);
+        }
+
+        return theBooster;
+    }
+
     public List<Card> createBooster() {
         List<Card> booster = new ArrayList<>();
         if (!hasBoosters) {

--- a/Mage/src/mage/game/draft/RandomBoosterDraft.java
+++ b/Mage/src/mage/game/draft/RandomBoosterDraft.java
@@ -51,27 +51,10 @@ public class RandomBoosterDraft extends BoosterDraft {
     }
 
     @Override
-    public void start() {
-        while (!isAbort() && boosterNum < numberBoosters) {
-            openBooster();
-            while (!isAbort() && pickCards()) {
-                if (boosterNum % 2 == 1) {
-                    passLeft();
-                } else {
-                    passRight();
-                }
-                fireUpdatePlayersEvent();
-            }
-        }
-        resetBufferedCards();
-        this.fireEndDraftEvent();
-    }
-
-    @Override
     protected void openBooster() {
         if (boosterNum < numberBoosters) {
             for (DraftPlayer player: players.values()) {
-                player.setBooster(getNextBooster().createBooster());
+                player.setBooster(getNextBooster().create15CardBooster());
             }
         }
         boosterNum++;


### PR DESCRIPTION
random draft bug fix: packs are forced to be 15 cards; weirdness occurs if the packs are uneven sizes including the draft ending early.
Random draft ui improvements: 
only the sets that will be used are displayed in the lobby, and the number of characters is large but still greatly reduced.
the pack selector ui will prevent you from chosing fewer than 2 packs.
button to launch pack selector dialog is a normal looking size now:

![image](https://cloud.githubusercontent.com/assets/6047523/8691592/c20c14ce-2a79-11e5-90a2-4531788bb5a0.png)

the info text is still long, but it is managable: I couldn't figure out a good way to have it piped into the chat box, so I left it in the info text area.
![image](https://cloud.githubusercontent.com/assets/6047523/8691620/fa690f98-2a79-11e5-9bb0-c4d0aefb2543.png)
