### PR TITLE
Fixed: Garruk Apex Predator was using the wrong image for the beast t…

### DIFF
--- a/Mage.Sets/src/mage/sets/magic2015/GarrukApexPredator.java
+++ b/Mage.Sets/src/mage/sets/magic2015/GarrukApexPredator.java
@@ -148,7 +148,7 @@ class GarrukApexPredatorBeastToken extends Token {
     public GarrukApexPredatorBeastToken() {
         super("Beast", "3/3 black Beast creature token with deathtouch");
         setOriginalExpansionSetCode("M15");
-        setTokenType(2);
+        setTokenType(1);
         cardType.add(CardType.CREATURE);
         color.setBlack(true);
         subtype.add("Beast");


### PR DESCRIPTION
Fixed: Garruk Apex Predator was using the wrong image for the beast tokens. They are correctly implemented as 3/3 deathtouch black beasts, but the tokens it showed are 3/3 beasts with no abilities.