### PR TITLE
Fixed issue with Dredge rules text where it always read "three cards"

### DIFF
--- a/Mage/src/mage/abilities/keyword/DredgeAbility.java
+++ b/Mage/src/mage/abilities/keyword/DredgeAbility.java
@@ -71,7 +71,7 @@ class DredgeEffect extends ReplacementEffectImpl {
         super(Duration.WhileInGraveyard, Outcome.ReturnToHand);
         this.amount = value;
         this.staticText = new StringBuilder("Dredge ").append(Integer.toString(value))
-                .append(" <i>(If you would draw a card, instead you may put exactly three cards from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)</i>").toString();
+                .append(" <i>(If you would draw a card, instead you may put exactly " + value + " card(s) from the top of your library into your graveyard. If you do, return this card from your graveyard to your hand. Otherwise, draw a card.)</i>").toString();
     }
 
     public DredgeEffect(final DredgeEffect effect) {


### PR DESCRIPTION
Fixes https://github.com/magefree/mage/issues/1278