### PR TITLE
Deck Editor: Fix redraw after missing image

### DIFF
--- a/Mage.Client/src/main/java/mage/client/cards/BigCard.java
+++ b/Mage.Client/src/main/java/mage/client/cards/BigCard.java
@@ -161,6 +161,7 @@ public class BigCard extends JComponent {
     }
 
     public void addJXPanel(UUID cardId, JXPanel jxPanel) {
+        this.cardId = cardId;
         bigImage = null;
         synchronized (this) {
             if (this.panel != null) { remove(this.panel); }


### PR DESCRIPTION
Switching back and forth between a card with an image and a card without an image would fail to update the `BigCard`, leaving the text of the card without an image showing.