### PR TITLE
Razorverge Thicket should enter untapped only if you control two or less lands.

### DIFF
--- a/Mage.Sets/src/mage/sets/scarsofmirrodin/RazorvergeThicket.java
+++ b/Mage.Sets/src/mage/sets/scarsofmirrodin/RazorvergeThicket.java
@@ -54,7 +54,7 @@ public class RazorvergeThicket extends CardImpl {
         super(ownerId, 228, "Razorverge Thicket", Rarity.RARE, new CardType[]{CardType.LAND}, null);
         this.expansionSetCode = "SOM";
 
-        Condition controls = new InvertCondition(new PermanentsOnTheBattlefieldCondition(filter, PermanentsOnTheBattlefieldCondition.CountType.FEWER_THAN, 4));
+        Condition controls = new InvertCondition(new PermanentsOnTheBattlefieldCondition(filter, PermanentsOnTheBattlefieldCondition.CountType.FEWER_THAN, 3));
         String abilityText = "tap it unless you control fewer than 3 lands";
         this.addAbility(new EntersBattlefieldAbility(new ConditionalOneShotEffect(new TapSourceEffect(), controls, abilityText), abilityText));
         this.addAbility(new GreenManaAbility());

--- a/Mage.Tests/src/test/java/org/mage/test/cards/conditional/RazorvergeThicketTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/conditional/RazorvergeThicketTest.java
@@ -1,0 +1,39 @@
+package org.mage.test.cards.conditional;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author tobz
+ */
+public class RazorvergeThicketTest extends CardTestPlayerBase {
+
+    @Test
+    public void testEntersTappedForThreeLands() {
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
+        addCard(Zone.HAND, playerA, "Razorverge Thicket");
+
+        playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Razorverge Thicket");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertTapped("Razorverge Thicket", true);
+    }
+
+    @Test
+    public void testEntersUntappedForTwoLands() {
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.HAND, playerA, "Razorverge Thicket");
+
+        playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Razorverge Thicket");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertTapped("Razorverge Thicket", false);
+    }
+
+}


### PR DESCRIPTION
This fixes #1339 and also adds a unit test for the fix.