### PR TITLE
Removed mutable public static mana

### DIFF
--- a/Mage.Sets/src/mage/sets/alliances/AgentOfStromgald1.java
+++ b/Mage.Sets/src/mage/sets/alliances/AgentOfStromgald1.java
@@ -52,7 +52,7 @@ public class AgentOfStromgald1 extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {R}: Add {B} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new ManaCostsImpl("{R}")));
+        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new ManaCostsImpl("{R}")));
     }
 
     public AgentOfStromgald1(final AgentOfStromgald1 card) {

--- a/Mage.Sets/src/mage/sets/alliances/ElvishSpiritGuide.java
+++ b/Mage.Sets/src/mage/sets/alliances/ElvishSpiritGuide.java
@@ -58,7 +58,7 @@ public class ElvishSpiritGuide extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Exile Elvish Spirit Guide from your hand: Add {G} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.HAND, new BasicManaEffect(Mana.GreenMana), new ExileSourceFromHandCost()));
+        this.addAbility(new SimpleManaAbility(Zone.HAND, new BasicManaEffect(Mana.GreenMana(1)), new ExileSourceFromHandCost()));
     }
 
     public ElvishSpiritGuide(final ElvishSpiritGuide card) {

--- a/Mage.Sets/src/mage/sets/alliances/SoldeviAdnate1.java
+++ b/Mage.Sets/src/mage/sets/alliances/SoldeviAdnate1.java
@@ -66,7 +66,7 @@ public class SoldeviAdnate1 extends CardImpl {
         this.toughness = new MageInt(2);
 
         // {T}, Sacrifice a black or artifact creature: Add to your mana pool an amount of {B} equal to the sacrificed creature's converted mana cost.
-        Ability ability = new DynamicManaAbility(Mana.BlackMana, new SacrificeCostConvertedMana("creature"),
+        Ability ability = new DynamicManaAbility(Mana.BlackMana(1), new SacrificeCostConvertedMana("creature"),
             new TapSourceCost(), "add to your mana pool an amount of {B} equal to the sacrificed creature's converted mana cost");
         ability.addCost(new SacrificeTargetCost(new TargetControlledPermanent(filter)));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/sets/antiquities/PriestOfYawgmoth.java
+++ b/Mage.Sets/src/mage/sets/antiquities/PriestOfYawgmoth.java
@@ -56,7 +56,7 @@ public class PriestOfYawgmoth extends CardImpl {
         this.toughness = new MageInt(2);
 
         // {T}, Sacrifice an artifact: Add to your mana pool an amount of {B} equal to the sacrificed artifact's converted mana cost.
-        Ability ability = new DynamicManaAbility(Mana.BlackMana, new SacrificeCostConvertedMana("artifact"),
+        Ability ability = new DynamicManaAbility(Mana.BlackMana(1), new SacrificeCostConvertedMana("artifact"),
             new TapSourceCost(), "add to your mana pool an amount of {B} equal to the sacrificed artifact's converted mana cost");
         ability.addCost(new SacrificeTargetCost(new TargetControlledPermanent(new FilterControlledArtifactPermanent())));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/sets/apocalypse/BattlefieldForge.java
+++ b/Mage.Sets/src/mage/sets/apocalypse/BattlefieldForge.java
@@ -53,10 +53,10 @@ public class BattlefieldForge extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
 
         // Tap: Add Red or White to your mana pool. Battlefield Forge deals 1 damage to you.
-        Ability redManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new TapSourceCost());
+        Ability redManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new TapSourceCost());
         redManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(redManaAbility);
-        Ability whiteManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana, new TapSourceCost());
+        Ability whiteManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana(1), new TapSourceCost());
         whiteManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(whiteManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/apocalypse/CavesOfKoilos.java
+++ b/Mage.Sets/src/mage/sets/apocalypse/CavesOfKoilos.java
@@ -54,10 +54,10 @@ public class CavesOfKoilos extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
 
         // Tap: Add White or Black to your mana pool. Caves of Koilos deals 1 damage to you.
-        Ability whiteManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana, new TapSourceCost());
+        Ability whiteManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana(1), new TapSourceCost());
         whiteManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(whiteManaAbility);
-        Ability blackManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new TapSourceCost());
+        Ability blackManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new TapSourceCost());
         blackManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(blackManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/apocalypse/LlanowarWastes.java
+++ b/Mage.Sets/src/mage/sets/apocalypse/LlanowarWastes.java
@@ -53,10 +53,10 @@ public class LlanowarWastes extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
 
         // Tap: Add Black or Green to your mana pool. Llanowar Wastes deals 1 damage to you.
-        Ability blackManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new TapSourceCost());
+        Ability blackManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new TapSourceCost());
         blackManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(blackManaAbility);
-        Ability greenManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana, new TapSourceCost());
+        Ability greenManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana(1), new TapSourceCost());
         greenManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(greenManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/apocalypse/ShivanReef.java
+++ b/Mage.Sets/src/mage/sets/apocalypse/ShivanReef.java
@@ -53,10 +53,10 @@ public class ShivanReef extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
 
         //Tap: Add Blue or Red to your mana pool. Shivan Reef deals 1 damage to you.
-        Ability blueManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana, new TapSourceCost());
+        Ability blueManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana(1), new TapSourceCost());
         blueManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(blueManaAbility);
-        Ability redManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new TapSourceCost());
+        Ability redManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new TapSourceCost());
         redManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(redManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/apocalypse/YavimayaCoast.java
+++ b/Mage.Sets/src/mage/sets/apocalypse/YavimayaCoast.java
@@ -53,10 +53,10 @@ public class YavimayaCoast extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
 
         // Tap: Add Green or Blue to your mana pool. Yavimaya Coast deals 1 damage to you.
-        Ability greenManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana, new TapSourceCost());
+        Ability greenManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana(1), new TapSourceCost());
         greenManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(greenManaAbility);
-        Ability blueManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana, new TapSourceCost());
+        Ability blueManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana(1), new TapSourceCost());
         blueManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(blueManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/avacynrestored/BattleHymn.java
+++ b/Mage.Sets/src/mage/sets/avacynrestored/BattleHymn.java
@@ -48,7 +48,7 @@ public class BattleHymn extends CardImpl {
 
 
         // Add {R} to your mana pool for each creature you control.
-        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.RedMana, new PermanentsOnBattlefieldCount(new FilterControlledCreaturePermanent())));
+        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.RedMana(1), new PermanentsOnBattlefieldCount(new FilterControlledCreaturePermanent())));
     }
 
     public BattleHymn(final BattleHymn card) {

--- a/Mage.Sets/src/mage/sets/betrayersofkamigawa/SakuraTribeSpringcaller.java
+++ b/Mage.Sets/src/mage/sets/betrayersofkamigawa/SakuraTribeSpringcaller.java
@@ -55,7 +55,7 @@ public class SakuraTribeSpringcaller extends CardImpl {
         this.toughness = new MageInt(4);
 
         // At the beginning of your upkeep, add {G} to your mana pool. Until end of turn, this mana doesn't empty from your mana pool as steps and phases end.
-        Effect effect = new AddManaToManaPoolTargetControllerEffect(new Mana(Mana.GreenMana), "your", true);
+        Effect effect = new AddManaToManaPoolTargetControllerEffect(new Mana(Mana.GreenMana(1)), "your", true);
         effect.setText("add {G} to your mana pool. Until end of turn, this mana doesn't empty from your mana pool as steps and phases end");        
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, effect, TargetController.YOU, false));
     }

--- a/Mage.Sets/src/mage/sets/championsofkamigawa/HallOfTheBanditLord.java
+++ b/Mage.Sets/src/mage/sets/championsofkamigawa/HallOfTheBanditLord.java
@@ -71,7 +71,7 @@ public class HallOfTheBanditLord extends CardImpl {
         this.addAbility(new EntersBattlefieldTappedAbility());
 
         // {T}, Pay 3 life: Add {1} to your mana pool. If that mana is spent on a creature spell, it gains haste.
-        Mana mana = Mana.ColorlessMana;
+        Mana mana = Mana.ColorlessMana(1);
         mana.setFlag(true);
         ManaEffect effect = new BasicManaEffect(mana);
         effect.setText("Add {1} to your mana pool. If that mana is spent on a creature spell, it gains haste");

--- a/Mage.Sets/src/mage/sets/coldsnap/BraidOfFire.java
+++ b/Mage.Sets/src/mage/sets/coldsnap/BraidOfFire.java
@@ -75,7 +75,7 @@ class BraidOfFireCost extends CostImpl {
     @Override
     public boolean pay(Ability ability, Game game, UUID sourceId, UUID controllerId, boolean noMana) {
         Player player = game.getPlayer(controllerId);
-        player.getManaPool().addMana(Mana.RedMana, game, ability);
+        player.getManaPool().addMana(Mana.RedMana(1), game, ability);
         paid = true;
         return true;
     }

--- a/Mage.Sets/src/mage/sets/commander/MagusOfTheVineyard.java
+++ b/Mage.Sets/src/mage/sets/commander/MagusOfTheVineyard.java
@@ -29,7 +29,7 @@ package mage.sets.commander;
 
 import java.util.UUID;
 import mage.MageInt;
-import static mage.Mana.GreenMana;
+import mage.Mana;
 import mage.abilities.common.BeginningOfPreCombatMainTriggeredAbility;
 import mage.abilities.effects.common.AddManaToManaPoolTargetControllerEffect;
 import mage.cards.CardImpl;
@@ -55,7 +55,7 @@ public class MagusOfTheVineyard extends CardImpl {
 
         // At the beginning of each player's precombat main phase, add {G}{G} to that player's mana pool.
         this.addAbility(new BeginningOfPreCombatMainTriggeredAbility(
-                Zone.BATTLEFIELD, new AddManaToManaPoolTargetControllerEffect(GreenMana(2), "that player's"), TargetController.ANY, false, true));        
+                Zone.BATTLEFIELD, new AddManaToManaPoolTargetControllerEffect(Mana.GreenMana(2), "that player's"), TargetController.ANY, false, true));
     }
 
     public MagusOfTheVineyard(final MagusOfTheVineyard card) {

--- a/Mage.Sets/src/mage/sets/commander2014/MagusOfTheCoffers.java
+++ b/Mage.Sets/src/mage/sets/commander2014/MagusOfTheCoffers.java
@@ -63,7 +63,7 @@ public class MagusOfTheCoffers extends CardImpl {
         this.toughness = new MageInt(4);
 
         // {2}, {T}: Add {B} to your mana pool for each Swamp you control.
-        Ability ability = new DynamicManaAbility(Mana.BlackMana, new PermanentsOnBattlefieldCount(filter), new GenericManaCost(2));
+        Ability ability = new DynamicManaAbility(Mana.BlackMana(1), new PermanentsOnBattlefieldCount(filter), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/sets/conspiracy/ManaGeyser.java
+++ b/Mage.Sets/src/mage/sets/conspiracy/ManaGeyser.java
@@ -56,7 +56,7 @@ public class ManaGeyser extends CardImpl {
 
 
         // Add {R} to your mana pool for each tapped land your opponents control.
-        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.RedMana, new PermanentsOnBattlefieldCount(filter)));
+        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.RedMana(1), new PermanentsOnBattlefieldCount(filter)));
     }
 
     public ManaGeyser(final ManaGeyser card) {

--- a/Mage.Sets/src/mage/sets/fallenempires/BottomlessVault.java
+++ b/Mage.Sets/src/mage/sets/fallenempires/BottomlessVault.java
@@ -70,7 +70,7 @@ public class BottomlessVault extends CardImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, effect, TargetController.YOU, false));
         // {tap}, Remove any number of storage counters from Bottomless Vault: Add {B} to your mana pool for each storage counter removed this way.
         Ability ability = new DynamicManaAbility(
-                Mana.BlackMana,
+                Mana.BlackMana(1),
                 new RemovedCountersForCostValue(),
                 new TapSourceCost(),
                 "Add {B} to your mana pool for each storage counter removed this way",

--- a/Mage.Sets/src/mage/sets/fallenempires/HollowTrees.java
+++ b/Mage.Sets/src/mage/sets/fallenempires/HollowTrees.java
@@ -70,7 +70,7 @@ public class HollowTrees extends CardImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, effect, TargetController.YOU, false));
         // {tap}, Remove any number of storage counters from Hollow Trees: Add {G} to your mana pool for each storage counter removed this way.
         Ability ability = new DynamicManaAbility(
-                Mana.GreenMana,
+                Mana.GreenMana(1),
                 new RemovedCountersForCostValue(),
                 new TapSourceCost(),
                 "Add {G} to your mana pool for each storage counter removed this way",

--- a/Mage.Sets/src/mage/sets/fallenempires/IcatianStore.java
+++ b/Mage.Sets/src/mage/sets/fallenempires/IcatianStore.java
@@ -70,7 +70,7 @@ public class IcatianStore extends CardImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, effect, TargetController.YOU, false));
         // {tap}, Remove any number of storage counters from Icatian Store: Add {W} to your mana pool for each storage counter removed this way.
         Ability ability = new DynamicManaAbility(
-                Mana.WhiteMana,
+                Mana.WhiteMana(1),
                 new RemovedCountersForCostValue(),
                 new TapSourceCost(),
                 "Add {W} to your mana pool for each storage counter removed this way",

--- a/Mage.Sets/src/mage/sets/fatereforged/Dragonrage.java
+++ b/Mage.Sets/src/mage/sets/fatereforged/Dragonrage.java
@@ -63,7 +63,7 @@ public class Dragonrage extends CardImpl {
         this.expansionSetCode = "FRF";
 
         // Add {R} to your mana pool for each attacking creature you control. 
-        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.RedMana, 
+        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.RedMana(1),
                 new PermanentsOnBattlefieldCount(filter)));
         
         // Until end of turn, attacking creatures you control gain "{R}: This creature gets +1/+0 until end of turn."

--- a/Mage.Sets/src/mage/sets/fifthedition/DwarvenHold.java
+++ b/Mage.Sets/src/mage/sets/fifthedition/DwarvenHold.java
@@ -70,7 +70,7 @@ public class DwarvenHold extends CardImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, effect, TargetController.YOU, false));
         // {tap}, Remove any number of storage counters from Dwarven Hold: Add {R} to your mana pool for each storage counter removed this way.
         Ability ability = new DynamicManaAbility(
-                Mana.RedMana,
+                Mana.RedMana(1),
                 new RemovedCountersForCostValue(),
                 new TapSourceCost(),
                 "Add {R} to your mana pool for each storage counter removed this way",

--- a/Mage.Sets/src/mage/sets/fifthedition/SandSilos.java
+++ b/Mage.Sets/src/mage/sets/fifthedition/SandSilos.java
@@ -70,7 +70,7 @@ public class SandSilos extends CardImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, effect, TargetController.YOU, false));
         // {tap}, Remove any number of storage counters from Sand Silos: Add {U} to your mana pool for each storage counter removed this way.
         Ability ability = new DynamicManaAbility(
-                Mana.BlueMana,
+                Mana.BlueMana(1),
                 new RemovedCountersForCostValue(),
                 new TapSourceCost(),
                 "Add {U} to your mana pool for each storage counter removed this way",

--- a/Mage.Sets/src/mage/sets/fifthedition/UrzasMine.java
+++ b/Mage.Sets/src/mage/sets/fifthedition/UrzasMine.java
@@ -48,7 +48,7 @@ public class UrzasMine extends CardImpl {
         this.expansionSetCode = "5ED";
 
         // {T}: Add {1} to your mana pool. If you control an Urza's Power-Plant and an Urza's Tower, add {2} to your mana pool instead.
-        Ability urzaManaAbility = new DynamicManaAbility(Mana.ColorlessMana, new UrzaTerrainValue(2),
+        Ability urzaManaAbility = new DynamicManaAbility(Mana.ColorlessMana(1), new UrzaTerrainValue(2),
                 "Add {1} to your mana pool. If you control an Urza's Power-Plant and an Urza's Tower, add {2} to your mana pool instead");
         this.addAbility(urzaManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/fifthedition/UrzasPowerPlant.java
+++ b/Mage.Sets/src/mage/sets/fifthedition/UrzasPowerPlant.java
@@ -48,7 +48,7 @@ public class UrzasPowerPlant extends CardImpl {
         this.expansionSetCode = "5ED";
 
         // {T}: Add {1} to your mana pool. If you control an Urza's Mine and an Urza's Tower, add {2} to your mana pool instead.
-        Ability urzaManaAbility = new DynamicManaAbility(Mana.ColorlessMana, new UrzaTerrainValue(2),
+        Ability urzaManaAbility = new DynamicManaAbility(Mana.ColorlessMana(1), new UrzaTerrainValue(2),
                 "Add {1} to your mana pool. If you control an Urza's Mine and an Urza's Tower, add {2} to your mana pool instead");
         this.addAbility(urzaManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/fifthedition/UrzasTower.java
+++ b/Mage.Sets/src/mage/sets/fifthedition/UrzasTower.java
@@ -48,7 +48,7 @@ public class UrzasTower extends CardImpl {
         this.expansionSetCode = "5ED";
 
         // {T}: Add {1} to your mana pool. If you control an Urza's Mine and an Urza's Power-Plant, add {3} to your mana pool instead.
-        Ability urzaManaAbility = new DynamicManaAbility(Mana.ColorlessMana, new UrzaTerrainValue(3),
+        Ability urzaManaAbility = new DynamicManaAbility(Mana.ColorlessMana(1), new UrzaTerrainValue(3),
                 "Add {1} to your mana pool. If you control an Urza's Mine and an Urza's Power-Plant, add {3} to your mana pool instead");
         this.addAbility(urzaManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/futuresight/NimbusMaze.java
+++ b/Mage.Sets/src/mage/sets/futuresight/NimbusMaze.java
@@ -68,13 +68,13 @@ public class NimbusMaze extends CardImpl {
         // {tap}: Add {W} to your mana pool. Activate this ability only if you control an Island.
         this.addAbility(new ActivateIfConditionManaAbility(
                 Zone.BATTLEFIELD,
-                new BasicManaEffect(Mana.WhiteMana),
+                new BasicManaEffect(Mana.WhiteMana(1)),
                 new TapSourceCost(),
                 new PermanentsOnTheBattlefieldCondition(controlIsland)));
         // {tap}: Add {U} to your mana pool. Activate this ability only if you control a Plains.
         this.addAbility(new ActivateIfConditionManaAbility(
                 Zone.BATTLEFIELD,
-                new BasicManaEffect(Mana.BlueMana),
+                new BasicManaEffect(Mana.BlueMana(1)),
                 new TapSourceCost(),
                 new PermanentsOnTheBattlefieldCondition(controlPlains)));
     }

--- a/Mage.Sets/src/mage/sets/futuresight/RiverOfTears.java
+++ b/Mage.Sets/src/mage/sets/futuresight/RiverOfTears.java
@@ -52,8 +52,8 @@ public class RiverOfTears extends CardImpl {
 
         // {T}: Add {U} to your mana pool. If you played a land this turn, add {B} to your mana pool instead.
         this.addAbility(new ConditionalManaAbility(Zone.BATTLEFIELD, new ConditionalManaEffect(
-                new BasicManaEffect(Mana.BlackMana),
-                new BasicManaEffect(Mana.BlueMana),
+                new BasicManaEffect(Mana.BlackMana(1)),
+                new BasicManaEffect(Mana.BlueMana(1)),
                 LandfallCondition.getInstance(),
                 "Add {U} to your mana pool. If you played a land this turn, add {B} to your mana pool instead"),
             new TapSourceCost()), 

--- a/Mage.Sets/src/mage/sets/gatecrash/CryptGhast.java
+++ b/Mage.Sets/src/mage/sets/gatecrash/CryptGhast.java
@@ -83,7 +83,7 @@ class CryptGhastTriggeredAbility extends TriggeredManaAbility {
     }
 
     public CryptGhastTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new BasicManaEffect(Mana.BlackMana), false);
+        super(Zone.BATTLEFIELD, new BasicManaEffect(Mana.BlackMana(1)), false);
         this.usesStack = false;
     }
 

--- a/Mage.Sets/src/mage/sets/gatecrash/GyreSage.java
+++ b/Mage.Sets/src/mage/sets/gatecrash/GyreSage.java
@@ -59,7 +59,7 @@ public class GyreSage extends CardImpl {
         this.addAbility(new EvolveAbility());
         
         //{T} : Add {G} to your mana pool for each +1/+1 counter on Gyre Sage.
-        this.addAbility(new DynamicManaAbility(Mana.GreenMana, new CountersCount(CounterType.P1P1)));
+        this.addAbility(new DynamicManaAbility(Mana.GreenMana(1), new CountersCount(CounterType.P1P1)));
     }
 
     public GyreSage(final GyreSage card) {

--- a/Mage.Sets/src/mage/sets/homelands/AnHavvaTownship.java
+++ b/Mage.Sets/src/mage/sets/homelands/AnHavvaTownship.java
@@ -52,14 +52,14 @@ public class AnHavvaTownship extends CardImpl {
         // {tap}: Add {1} to your mana pool.
         this.addAbility(new ColorlessManaAbility());
         // {1}, {tap}: Add {G} to your mana pool.
-        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana, new GenericManaCost(1));
+        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana(1), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
         // {2}, {tap}: Add {R} or {W} to your mana pool.
-        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new GenericManaCost(2));
+        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
-        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana, new GenericManaCost(2));
+        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana(1), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/sets/homelands/AysenAbbey.java
+++ b/Mage.Sets/src/mage/sets/homelands/AysenAbbey.java
@@ -52,14 +52,14 @@ public class AysenAbbey extends CardImpl {
         // {tap}: Add {1} to your mana pool.
         this.addAbility(new ColorlessManaAbility());
         // {1}, {tap}: Add {W} to your mana pool.
-        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana, new GenericManaCost(1));
+        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana(1), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
         // {2}, {tap}: Add {G} or {U} to your mana pool.
-        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana, new GenericManaCost(2));
+        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana(1), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
-        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana, new GenericManaCost(2));
+        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana(1), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/sets/homelands/CastleSengir.java
+++ b/Mage.Sets/src/mage/sets/homelands/CastleSengir.java
@@ -52,14 +52,14 @@ public class CastleSengir extends CardImpl {
         // {tap}: Add {1} to your mana pool.
         this.addAbility(new ColorlessManaAbility());
         // {1}, {tap}: Add {B} to your mana pool.
-        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new GenericManaCost(1));
+        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
         // {2}, {tap}: Add {U} or {R} to your mana pool.
-        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana, new GenericManaCost(2));
+        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana(1), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
-        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new GenericManaCost(2));
+        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/sets/homelands/KoskunKeep.java
+++ b/Mage.Sets/src/mage/sets/homelands/KoskunKeep.java
@@ -52,14 +52,14 @@ public class KoskunKeep extends CardImpl {
         // {tap}: Add {1} to your mana pool.
         this.addAbility(new ColorlessManaAbility());
         // {1}, {tap}: Add {R} to your mana pool.
-        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new GenericManaCost(1));
+        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
         // {2}, {tap}: Add {B} or {G} to your mana pool.
-        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new GenericManaCost(2));
+        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
-        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana, new GenericManaCost(2));
+        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana(1), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/sets/homelands/WizardsSchool.java
+++ b/Mage.Sets/src/mage/sets/homelands/WizardsSchool.java
@@ -52,14 +52,14 @@ public class WizardsSchool extends CardImpl {
         // {tap}: Add {1} to your mana pool.
         this.addAbility(new ColorlessManaAbility());
         // {1}, {tap}: Add {U} to your mana pool.
-        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana, new GenericManaCost(1));
+        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana(1), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
         // {2}, {tap}: Add {W} or {B} to your mana pool.
-        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana, new GenericManaCost(2));
+        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana(1), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
-        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new GenericManaCost(2));
+        ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/sets/iceage/LandCap.java
+++ b/Mage.Sets/src/mage/sets/iceage/LandCap.java
@@ -67,10 +67,10 @@ public class LandCap extends CardImpl {
         Ability ability2 = new BeginningOfUpkeepTriggeredAbility(new RemoveCounterSourceEffect(CounterType.DEPLETION.createInstance()), TargetController.YOU, false);
         this.addAbility(ability2);
         // {T}: Add {W} or {U} to your mana pool. Put a depletion counter on Land Cap.
-        Ability ability3 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana, new TapSourceCost());
+        Ability ability3 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana(1), new TapSourceCost());
         ability3.addEffect(new AddCountersSourceEffect(CounterType.DEPLETION.createInstance()));
         this.addAbility(ability3);
-        Ability ability4 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana, new TapSourceCost());
+        Ability ability4 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana(1), new TapSourceCost());
         ability4.addEffect(new AddCountersSourceEffect(CounterType.DEPLETION.createInstance()));
         this.addAbility(ability4);
     }

--- a/Mage.Sets/src/mage/sets/iceage/LavaTubes.java
+++ b/Mage.Sets/src/mage/sets/iceage/LavaTubes.java
@@ -67,10 +67,10 @@ public class LavaTubes extends CardImpl {
         Ability ability2 = new BeginningOfUpkeepTriggeredAbility(new RemoveCounterSourceEffect(CounterType.DEPLETION.createInstance()), TargetController.YOU, false);
         this.addAbility(ability2);
         // {tap}: Add {B} or {R} to your mana pool. Put a depletion counter on Lava Tubes.
-        Ability ability3 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new TapSourceCost());
+        Ability ability3 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new TapSourceCost());
         ability3.addEffect(new AddCountersSourceEffect(CounterType.DEPLETION.createInstance()));
         this.addAbility(ability3);
-        Ability ability4 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new TapSourceCost());
+        Ability ability4 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new TapSourceCost());
         ability4.addEffect(new AddCountersSourceEffect(CounterType.DEPLETION.createInstance()));
         this.addAbility(ability4);
     }

--- a/Mage.Sets/src/mage/sets/iceage/RiverDelta.java
+++ b/Mage.Sets/src/mage/sets/iceage/RiverDelta.java
@@ -67,10 +67,10 @@ public class RiverDelta extends CardImpl {
         Ability ability2 = new BeginningOfUpkeepTriggeredAbility(new RemoveCounterSourceEffect(CounterType.DEPLETION.createInstance()), TargetController.YOU, false);
         this.addAbility(ability2);
         // {tap}: Add {U} or {B} to your mana pool. Put a depletion counter on River Delta.
-        Ability ability3 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana, new TapSourceCost());
+        Ability ability3 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana(1), new TapSourceCost());
         ability3.addEffect(new AddCountersSourceEffect(CounterType.DEPLETION.createInstance()));
         this.addAbility(ability3);
-        Ability ability4 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new TapSourceCost());
+        Ability ability4 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new TapSourceCost());
         ability4.addEffect(new AddCountersSourceEffect(CounterType.DEPLETION.createInstance()));
         this.addAbility(ability4);
     }

--- a/Mage.Sets/src/mage/sets/iceage/SongsOfTheDamned.java
+++ b/Mage.Sets/src/mage/sets/iceage/SongsOfTheDamned.java
@@ -47,7 +47,7 @@ public class SongsOfTheDamned extends CardImpl {
         this.expansionSetCode = "ICE";
 
         // Add {B} to your mana pool for each creature card in your graveyard.
-        DynamicManaEffect effect = new DynamicManaEffect(Mana.BlackMana, new CardsInControllerGraveyardCount(new FilterCreatureCard()));
+        DynamicManaEffect effect = new DynamicManaEffect(Mana.BlackMana(1), new CardsInControllerGraveyardCount(new FilterCreatureCard()));
         this.getSpellAbility().addEffect(effect);
     }
 

--- a/Mage.Sets/src/mage/sets/iceage/TimberlineRidge.java
+++ b/Mage.Sets/src/mage/sets/iceage/TimberlineRidge.java
@@ -67,10 +67,10 @@ public class TimberlineRidge extends CardImpl {
         Ability ability2 = new BeginningOfUpkeepTriggeredAbility(new RemoveCounterSourceEffect(CounterType.DEPLETION.createInstance()), TargetController.YOU, false);
         this.addAbility(ability2);
         // {tap}: Add {R} or {G} to your mana pool. Put a depletion counter on Timberline Ridge.
-        Ability ability3 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new TapSourceCost());
+        Ability ability3 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new TapSourceCost());
         ability3.addEffect(new AddCountersSourceEffect(CounterType.DEPLETION.createInstance()));
         this.addAbility(ability3);
-        Ability ability4 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana, new TapSourceCost());
+        Ability ability4 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana(1), new TapSourceCost());
         ability4.addEffect(new AddCountersSourceEffect(CounterType.DEPLETION.createInstance()));
         this.addAbility(ability4);
     }

--- a/Mage.Sets/src/mage/sets/iceage/Veldt.java
+++ b/Mage.Sets/src/mage/sets/iceage/Veldt.java
@@ -67,10 +67,10 @@ public class Veldt extends CardImpl {
         Ability ability2 = new BeginningOfUpkeepTriggeredAbility(new RemoveCounterSourceEffect(CounterType.DEPLETION.createInstance()), TargetController.YOU, false);
         this.addAbility(ability2);
         // {tap}: Add {G} or {W} to your mana pool. Put a depletion counter on Veldt.
-        Ability ability3 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana, new TapSourceCost());
+        Ability ability3 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana(1), new TapSourceCost());
         ability3.addEffect(new AddCountersSourceEffect(CounterType.DEPLETION.createInstance()));
         this.addAbility(ability3);
-        Ability ability4 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana, new TapSourceCost());
+        Ability ability4 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana(1), new TapSourceCost());
         ability4.addEffect(new AddCountersSourceEffect(CounterType.DEPLETION.createInstance()));
         this.addAbility(ability4);
     }

--- a/Mage.Sets/src/mage/sets/invasion/BogInitiate.java
+++ b/Mage.Sets/src/mage/sets/invasion/BogInitiate.java
@@ -53,7 +53,7 @@ public class BogInitiate extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {1}: Add {B} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new ManaCostsImpl("{1}")));
+        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new ManaCostsImpl("{1}")));
     }
 
     public BogInitiate(final BogInitiate card) {

--- a/Mage.Sets/src/mage/sets/magic2010/ElvishArchdruid.java
+++ b/Mage.Sets/src/mage/sets/magic2010/ElvishArchdruid.java
@@ -71,7 +71,7 @@ public class ElvishArchdruid extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostControlledEffect(1, 1, Duration.WhileOnBattlefield, filter, true)));
         
         // {T}: Add {G} to your mana pool for each Elf you control.
-        this.addAbility(new DynamicManaAbility(Mana.GreenMana, new PermanentsOnBattlefieldCount(filterCount)));
+        this.addAbility(new DynamicManaAbility(Mana.GreenMana(1), new PermanentsOnBattlefieldCount(filterCount)));
     }
 
     public ElvishArchdruid(final ElvishArchdruid card) {

--- a/Mage.Sets/src/mage/sets/magicorigins/MageRingNetwork.java
+++ b/Mage.Sets/src/mage/sets/magicorigins/MageRingNetwork.java
@@ -65,7 +65,7 @@ public class MageRingNetwork extends CardImpl {
         this.addAbility(ability);
         // {T}, Remove X storage counters from Mage-Ring Network: Add {x} to your mana pool.
         ability = new DynamicManaAbility(
-                Mana.ColorlessMana,
+                Mana.ColorlessMana(1),
                 new RemovedCountersForCostValue(),
                 new TapSourceCost(),
                 "Add {X} to your mana pool",

--- a/Mage.Sets/src/mage/sets/masterseditioniii/FireSprites.java
+++ b/Mage.Sets/src/mage/sets/masterseditioniii/FireSprites.java
@@ -58,7 +58,7 @@ public class FireSprites extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // {G}, {tap}: Add {R} to your mana pool.
-        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new ManaCostsImpl("{G}"));
+        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new ManaCostsImpl("{G}"));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/sets/mercadianmasques/EyeOfRamos.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/EyeOfRamos.java
@@ -51,7 +51,7 @@ public class EyeOfRamos extends CardImpl {
         this.addAbility(new BlueManaAbility());
         
         // Sacrifice Eye of Ramos: Add {U} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana, new SacrificeSourceCost()));
+        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana(1), new SacrificeSourceCost()));
     }
 
     public EyeOfRamos(final EyeOfRamos card) {

--- a/Mage.Sets/src/mage/sets/mercadianmasques/FountainOfCho.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/FountainOfCho.java
@@ -60,7 +60,7 @@ public class FountainOfCho extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.STORAGE.createInstance()), new TapSourceCost()));
         // {T}, Remove any number of storage counters from Fountain of Cho: Add {W} to your mana pool for each storage counter removed this way.
         Ability ability = new DynamicManaAbility(
-                Mana.WhiteMana,
+                Mana.WhiteMana(1),
                 new RemovedCountersForCostValue(),
                 new TapSourceCost(),
                 "Add {W} to your mana pool for each storage counter removed this way",

--- a/Mage.Sets/src/mage/sets/mercadianmasques/HeartOfRamos.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/HeartOfRamos.java
@@ -51,7 +51,7 @@ public class HeartOfRamos extends CardImpl {
         this.addAbility(new RedManaAbility());
         
         // Sacrifice Heart of Ramos: Add {R} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new SacrificeSourceCost()));
+        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new SacrificeSourceCost()));
     }
 
     public HeartOfRamos(final HeartOfRamos card) {

--- a/Mage.Sets/src/mage/sets/mercadianmasques/HornOfRamos.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/HornOfRamos.java
@@ -51,7 +51,7 @@ public class HornOfRamos extends CardImpl {
         this.addAbility(new GreenManaAbility());
         
         // Sacrifice Horn of Ramos: Add {G} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana, new SacrificeSourceCost()));
+        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana(1), new SacrificeSourceCost()));
     }
 
     public HornOfRamos(final HornOfRamos card) {

--- a/Mage.Sets/src/mage/sets/mercadianmasques/MercadianBazaar.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/MercadianBazaar.java
@@ -60,7 +60,7 @@ public class MercadianBazaar extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.STORAGE.createInstance()), new TapSourceCost()));
         // {tap}, Remove any number of storage counters from Mercadian Bazaar: Add {R} to your mana pool for each storage counter removed this way.
         Ability ability = new DynamicManaAbility(
-                Mana.RedMana,
+                Mana.RedMana(1),
                 new RemovedCountersForCostValue(),
                 new TapSourceCost(),
                 "Add {R} to your mana pool for each storage counter removed this way",

--- a/Mage.Sets/src/mage/sets/mercadianmasques/RushwoodGrove.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/RushwoodGrove.java
@@ -60,7 +60,7 @@ public class RushwoodGrove extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.STORAGE.createInstance()), new TapSourceCost()));
         // {T}, Remove any number of storage counters from Rushwood Grove: Add {G} to your mana pool for each storage counter removed this way.
         Ability ability = new DynamicManaAbility(
-                Mana.GreenMana,
+                Mana.GreenMana(1),
                 new RemovedCountersForCostValue(),
                 new TapSourceCost(),
                 "Add {G} to your mana pool for each storage counter removed this way",

--- a/Mage.Sets/src/mage/sets/mercadianmasques/SaprazzanCove.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/SaprazzanCove.java
@@ -60,7 +60,7 @@ public class SaprazzanCove extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.STORAGE.createInstance()), new TapSourceCost()));
         // {tap}, Remove any number of storage counters from Saprazzan Cove: Add {U} to your mana pool for each storage counter removed this way.
         Ability ability = new DynamicManaAbility(
-                Mana.BlueMana,
+                Mana.BlueMana(1),
                 new RemovedCountersForCostValue(),
                 new TapSourceCost(),
                 "Add {U} to your mana pool for each storage counter removed this way",

--- a/Mage.Sets/src/mage/sets/mercadianmasques/SkullOfRamos.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/SkullOfRamos.java
@@ -51,7 +51,7 @@ public class SkullOfRamos extends CardImpl {
         this.addAbility(new BlackManaAbility());
         
         // Sacrifice Skull of Ramos: Add {B} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new SacrificeSourceCost()));
+        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new SacrificeSourceCost()));
     }
 
     public SkullOfRamos(final SkullOfRamos card) {

--- a/Mage.Sets/src/mage/sets/mercadianmasques/SubterraneanHangar.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/SubterraneanHangar.java
@@ -60,7 +60,7 @@ public class SubterraneanHangar extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.STORAGE.createInstance()), new TapSourceCost()));
         // {tap}, Remove any number of storage counters from Subterranean Hangar: Add {B} to your mana pool for each storage counter removed this way.
         Ability ability = new DynamicManaAbility(
-                Mana.BlackMana,
+                Mana.BlackMana(1),
                 new RemovedCountersForCostValue(),
                 new TapSourceCost(),
                 "Add {B} to your mana pool for each storage counter removed this way",

--- a/Mage.Sets/src/mage/sets/mercadianmasques/ToothOfRamos.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/ToothOfRamos.java
@@ -51,7 +51,7 @@ public class ToothOfRamos extends CardImpl {
         this.addAbility(new WhiteManaAbility());
         
         // Sacrifice Tooth of Ramos: Add {W} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana, new SacrificeSourceCost()));
+        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana(1), new SacrificeSourceCost()));
     }
 
     public ToothOfRamos(final ToothOfRamos card) {

--- a/Mage.Sets/src/mage/sets/mirage/JunglePatrol.java
+++ b/Mage.Sets/src/mage/sets/mirage/JunglePatrol.java
@@ -76,7 +76,7 @@ public class JunglePatrol extends CardImpl {
         
         // Sacrifice a token named Wood: Add {R} to your mana pool.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, 
-                new BasicManaEffect(Mana.RedMana),
+                new BasicManaEffect(Mana.RedMana(1)),
                 new SacrificeTargetCost(new TargetControlledPermanent(1, 1, filter, true))));
     }
 

--- a/Mage.Sets/src/mage/sets/mirage/SeaScryer.java
+++ b/Mage.Sets/src/mage/sets/mirage/SeaScryer.java
@@ -59,7 +59,7 @@ public class SeaScryer extends CardImpl {
         // {tap}: Add {1} to your mana pool.
         this.addAbility(new ColorlessManaAbility());
         // {1}, {tap}: Add {U} to your mana pool.
-        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, new BasicManaEffect(Mana.BlueMana), new GenericManaCost(1));
+        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, new BasicManaEffect(Mana.BlueMana(1)), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/sets/mirrodin/ChromeMox.java
+++ b/Mage.Sets/src/mage/sets/mirrodin/ChromeMox.java
@@ -185,17 +185,17 @@ class ChromeMoxManaEffect extends ManaEffect {
                             player.choose(outcome, choice, game);
                         }
                         if (choice.getChoice().equals("Black")) {
-                            player.getManaPool().addMana(Mana.BlackMana, game, source);
+                            player.getManaPool().addMana(Mana.BlackMana(1), game, source);
                         } else if (choice.getChoice().equals("Blue")) {
-                            player.getManaPool().addMana(Mana.BlueMana, game, source);
+                            player.getManaPool().addMana(Mana.BlueMana(1), game, source);
                         } else if (choice.getChoice().equals("Red")) {
-                            player.getManaPool().addMana(Mana.RedMana, game, source);
+                            player.getManaPool().addMana(Mana.RedMana(1), game, source);
                         } else if (choice.getChoice().equals("Green")) {
-                            player.getManaPool().addMana(Mana.GreenMana, game, source);
+                            player.getManaPool().addMana(Mana.GreenMana(1), game, source);
                         } else if (choice.getChoice().equals("White")) {
-                            player.getManaPool().addMana(Mana.WhiteMana, game, source);
+                            player.getManaPool().addMana(Mana.WhiteMana(1), game, source);
                         } else if (choice.getChoice().equals("Colorless")) {
-                            player.getManaPool().addMana(Mana.ColorlessMana, game, source);
+                            player.getManaPool().addMana(Mana.ColorlessMana(1), game, source);
                         }
                         checkToFirePossibleEvents(mana, game, source);
                         player.getManaPool().addMana(mana, game, source);

--- a/Mage.Sets/src/mage/sets/mirrodin/Cloudpost.java
+++ b/Mage.Sets/src/mage/sets/mirrodin/Cloudpost.java
@@ -58,7 +58,7 @@ public class Cloudpost extends CardImpl {
         // Cloudpost enters the battlefield tapped.
         this.addAbility(new EntersBattlefieldTappedAbility());
         // {tap}: Add {1} to your mana pool for each Locus on the battlefield.
-        this.addAbility(new DynamicManaAbility(Mana.ColorlessMana, new PermanentsOnBattlefieldCount(filter)));
+        this.addAbility(new DynamicManaAbility(Mana.ColorlessMana(1), new PermanentsOnBattlefieldCount(filter)));
     }
 
     public Cloudpost(final Cloudpost card) {

--- a/Mage.Sets/src/mage/sets/mirrodin/ViridianJoiner.java
+++ b/Mage.Sets/src/mage/sets/mirrodin/ViridianJoiner.java
@@ -52,7 +52,7 @@ public class ViridianJoiner extends CardImpl {
         this.toughness = new MageInt(2);
 
         // {tap}: Add to your mana pool an amount of {G} equal to Viridian Joiner's power.
-        this.addAbility(new DynamicManaAbility(Mana.GreenMana, new SourcePermanentPowerCount()));
+        this.addAbility(new DynamicManaAbility(Mana.GreenMana(1), new SourcePermanentPowerCount()));
     }
 
     public ViridianJoiner(final ViridianJoiner card) {

--- a/Mage.Sets/src/mage/sets/newphyrexia/ChancellorOfTheTangle.java
+++ b/Mage.Sets/src/mage/sets/newphyrexia/ChancellorOfTheTangle.java
@@ -79,7 +79,7 @@ public class ChancellorOfTheTangle extends CardImpl {
 class ChancellorOfTheTangleDelayedTriggeredAbility extends DelayedTriggeredAbility {
 
     ChancellorOfTheTangleDelayedTriggeredAbility () {
-        super(new BasicManaEffect(Mana.GreenMana));
+        super(new BasicManaEffect(Mana.GreenMana(1)));
     }
 
     ChancellorOfTheTangleDelayedTriggeredAbility(ChancellorOfTheTangleDelayedTriggeredAbility ability) {

--- a/Mage.Sets/src/mage/sets/newphyrexia/ShrineOfBoundlessGrowth.java
+++ b/Mage.Sets/src/mage/sets/newphyrexia/ShrineOfBoundlessGrowth.java
@@ -68,7 +68,7 @@ public class ShrineOfBoundlessGrowth extends CardImpl {
         this.addAbility(new SpellCastControllerTriggeredAbility(new AddCountersSourceEffect(CounterType.CHARGE.createInstance()), filter, false));
 
         // {T}, Sacrifice Shrine of Boundless Growth: Add {1} to your mana pool for each charge counter on Shrine of Boundless Growth.
-        Ability ability = new DynamicManaAbility(Mana.ColorlessMana, new CountersCount(CounterType.CHARGE), new TapSourceCost());
+        Ability ability = new DynamicManaAbility(Mana.ColorlessMana(1), new CountersCount(CounterType.CHARGE), new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/sets/odyssey/SetonKrosanProtector.java
+++ b/Mage.Sets/src/mage/sets/odyssey/SetonKrosanProtector.java
@@ -68,7 +68,7 @@ public class SetonKrosanProtector extends CardImpl {
 
         // Tap an untapped Druid you control: Add {G} to your mana pool.
         this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, 
-                                                  new BasicManaEffect(Mana.GreenMana), 
+                                                  new BasicManaEffect(Mana.GreenMana(1)),
                                                   new TapTargetCost(new TargetControlledCreaturePermanent(1, 1, filter, true))));
     }
 

--- a/Mage.Sets/src/mage/sets/odyssey/TarnishedCitadel.java
+++ b/Mage.Sets/src/mage/sets/odyssey/TarnishedCitadel.java
@@ -50,7 +50,7 @@ public class TarnishedCitadel extends CardImpl {
         this.expansionSetCode = "ODY";
 
         // {tap}: Add {1} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.ColorlessMana, new TapSourceCost()));
+        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.ColorlessMana(1), new TapSourceCost()));
         // {tap}: Add one mana of any color to your mana pool. Tarnished Citadel deals 3 damage to you.
         ManaAbility ability = new AnyColorManaAbility(new TapSourceCost());
         ability.addEffect(new DamageControllerEffect(3));

--- a/Mage.Sets/src/mage/sets/onslaught/BrightstoneRitual.java
+++ b/Mage.Sets/src/mage/sets/onslaught/BrightstoneRitual.java
@@ -55,7 +55,7 @@ public class BrightstoneRitual extends CardImpl {
         this.expansionSetCode = "ONS";
 
         // Add {R} to your mana pool for each Goblin on the battlefield.
-        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.RedMana, new PermanentsOnBattlefieldCount(filter)));
+        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.RedMana(1), new PermanentsOnBattlefieldCount(filter)));
     }
 
     public BrightstoneRitual(final BrightstoneRitual card) {

--- a/Mage.Sets/src/mage/sets/onslaught/SkirkProspector.java
+++ b/Mage.Sets/src/mage/sets/onslaught/SkirkProspector.java
@@ -63,7 +63,7 @@ public class SkirkProspector extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Sacrifice a Goblin: Add {R} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new SacrificeTargetCost(new TargetControlledCreaturePermanent(1,1,filter,true))));
+        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new SacrificeTargetCost(new TargetControlledCreaturePermanent(1,1,filter,true))));
     }
 
     public SkirkProspector(final SkirkProspector card) {

--- a/Mage.Sets/src/mage/sets/planarchaos/SimianSpiritGuide.java
+++ b/Mage.Sets/src/mage/sets/planarchaos/SimianSpiritGuide.java
@@ -59,7 +59,7 @@ public class SimianSpiritGuide extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Exile Simian Spirit Guide from your hand: Add {R} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.HAND, new BasicManaEffect(Mana.RedMana), new ExileSourceFromHandCost()));
+        this.addAbility(new SimpleManaAbility(Zone.HAND, new BasicManaEffect(Mana.RedMana(1)), new ExileSourceFromHandCost()));
     }
 
     public SimianSpiritGuide(final SimianSpiritGuide card) {

--- a/Mage.Sets/src/mage/sets/planechase/CabalCoffers.java
+++ b/Mage.Sets/src/mage/sets/planechase/CabalCoffers.java
@@ -57,7 +57,7 @@ public class CabalCoffers extends CardImpl {
         this.expansionSetCode = "HOP";
 
         // {2}, {tap}: Add {B} to your mana pool for each Swamp you control.
-        Ability ability = new DynamicManaAbility(Mana.BlackMana, new PermanentsOnBattlefieldCount(filter), new GenericManaCost(2));
+        Ability ability = new DynamicManaAbility(Mana.BlackMana(1), new PermanentsOnBattlefieldCount(filter), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/sets/planechase2012/TaintedIsle.java
+++ b/Mage.Sets/src/mage/sets/planechase2012/TaintedIsle.java
@@ -62,12 +62,12 @@ public class TaintedIsle extends CardImpl {
         // {tap}: Add {U} or {B} to your mana pool. Activate this ability only if you control a Swamp.
         this.addAbility(new ActivateIfConditionManaAbility(
                 Zone.BATTLEFIELD,
-                new BasicManaEffect(Mana.BlueMana),
+                new BasicManaEffect(Mana.BlueMana(1)),
                 new TapSourceCost(),
                 new PermanentsOnTheBattlefieldCondition(filter, PermanentsOnTheBattlefieldCondition.CountType.MORE_THAN, 0)));
         this.addAbility(new ActivateIfConditionManaAbility(
                 Zone.BATTLEFIELD,
-                new BasicManaEffect(Mana.BlackMana),
+                new BasicManaEffect(Mana.BlackMana(1)),
                 new TapSourceCost(),
                 new PermanentsOnTheBattlefieldCondition(filter, PermanentsOnTheBattlefieldCondition.CountType.MORE_THAN, 0)));
 

--- a/Mage.Sets/src/mage/sets/planeshift/MeteorCrater.java
+++ b/Mage.Sets/src/mage/sets/planeshift/MeteorCrater.java
@@ -180,19 +180,19 @@ class MeteorCraterEffect extends ManaEffect {
         for (Permanent permanent : controlledPermanents) {
             ObjectColor color = permanent.getColor(game);
             if (color.isBlack()) {
-                types.add(Mana.BlackMana);
+                types.add(Mana.BlackMana(1));
             }
             if (color.isBlue()) {
-                types.add(Mana.BlueMana);
+                types.add(Mana.BlueMana(1));
             }
             if (color.isGreen()) {
-                types.add(Mana.GreenMana);
+                types.add(Mana.GreenMana(1));
             }
             if(color.isRed()) {
-                types.add(Mana.RedMana);
+                types.add(Mana.RedMana(1));
             }
             if(color.isWhite()) {
-                types.add(Mana.WhiteMana);
+                types.add(Mana.WhiteMana(1));
             }
         }
         return types;

--- a/Mage.Sets/src/mage/sets/ravnica/ElvesOfDeepShadow.java
+++ b/Mage.Sets/src/mage/sets/ravnica/ElvesOfDeepShadow.java
@@ -56,7 +56,7 @@ public class ElvesOfDeepShadow extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {tap}: Add {B} to your mana pool. Elves of Deep Shadow deals 1 damage to you.
-        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new TapSourceCost());
+        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new TapSourceCost());
         ability.addEffect(new DamageControllerEffect(1));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/sets/revisededition/Channel.java
+++ b/Mage.Sets/src/mage/sets/revisededition/Channel.java
@@ -103,7 +103,7 @@ class ChannelSpecialAction extends SpecialAction {
     ChannelSpecialAction() {
         super();
         this.addCost(new PayLifeCost(1));
-        this.addEffect(new BasicManaEffect(Mana.ColorlessMana));
+        this.addEffect(new BasicManaEffect(Mana.ColorlessMana(1)));
     }
 
     ChannelSpecialAction(final ChannelSpecialAction ability) {

--- a/Mage.Sets/src/mage/sets/riseoftheeldrazi/NirkanaRevenant.java
+++ b/Mage.Sets/src/mage/sets/riseoftheeldrazi/NirkanaRevenant.java
@@ -87,7 +87,7 @@ class NirkanaRevenantTriggeredAbility extends TriggeredManaAbility {
     }
 
     public NirkanaRevenantTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new BasicManaEffect(Mana.BlackMana), false);
+        super(Zone.BATTLEFIELD, new BasicManaEffect(Mana.BlackMana(1)), false);
         this.usesStack = false;
     }
 

--- a/Mage.Sets/src/mage/sets/riseoftheeldrazi/OvergrownBattlement.java
+++ b/Mage.Sets/src/mage/sets/riseoftheeldrazi/OvergrownBattlement.java
@@ -60,7 +60,7 @@ public class OvergrownBattlement extends CardImpl {
         this.toughness = new MageInt(4);
 
         this.addAbility(DefenderAbility.getInstance());
-        this.addAbility(new DynamicManaAbility(Mana.GreenMana, new PermanentsOnBattlefieldCount(filter)));
+        this.addAbility(new DynamicManaAbility(Mana.GreenMana(1), new PermanentsOnBattlefieldCount(filter)));
     }
 
     public OvergrownBattlement(final OvergrownBattlement card) {

--- a/Mage.Sets/src/mage/sets/saviorsofkamigawa/InnerFire.java
+++ b/Mage.Sets/src/mage/sets/saviorsofkamigawa/InnerFire.java
@@ -47,7 +47,7 @@ public class InnerFire extends CardImpl {
 
 
         // Add {R} to your mana pool for each card in your hand.
-        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.RedMana, new CardsInControllerHandCount()));
+        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.RedMana(1), new CardsInControllerHandCount()));
     }
 
     public InnerFire(final InnerFire card) {

--- a/Mage.Sets/src/mage/sets/scarsofmirrodin/KothOfTheHammer.java
+++ b/Mage.Sets/src/mage/sets/scarsofmirrodin/KothOfTheHammer.java
@@ -92,7 +92,7 @@ public class KothOfTheHammer extends CardImpl {
         this.addAbility(ability);
 
         // -2: Add {R} to your mana pool for each Mountain you control.
-        this.addAbility(new LoyaltyAbility(new DynamicManaEffect(Mana.RedMana, new PermanentsOnBattlefieldCount(filterCount)), -2));
+        this.addAbility(new LoyaltyAbility(new DynamicManaEffect(Mana.RedMana(1), new PermanentsOnBattlefieldCount(filterCount)), -2));
 
         // -5: You get an emblem with "Mountains you control have '{T}: This land deals 1 damage to target creature or player.'
         this.addAbility(new LoyaltyAbility(new GetEmblemEffect(new KothOfTheHammerEmblem()), -5));

--- a/Mage.Sets/src/mage/sets/shadowmoor/LeechriddenSwamp.java
+++ b/Mage.Sets/src/mage/sets/shadowmoor/LeechriddenSwamp.java
@@ -68,7 +68,7 @@ public class LeechriddenSwamp extends CardImpl {
         this.subtype.add("Swamp");
 
         // ({tap}: Add {B} to your mana pool.)
-        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new TapSourceCost()));
+        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new TapSourceCost()));
 
         // Leechridden Swamp enters the battlefield tapped.
         this.addAbility(new EntersBattlefieldTappedAbility());

--- a/Mage.Sets/src/mage/sets/tempest/BloodPet.java
+++ b/Mage.Sets/src/mage/sets/tempest/BloodPet.java
@@ -53,7 +53,7 @@ public class BloodPet extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Sacrifice Blood Pet: Add {B} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new SacrificeSourceCost()));
+        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new SacrificeSourceCost()));
     }
 
     public BloodPet(final BloodPet card) {

--- a/Mage.Sets/src/mage/sets/tempest/EladamrisVineyard.java
+++ b/Mage.Sets/src/mage/sets/tempest/EladamrisVineyard.java
@@ -28,7 +28,8 @@
 package mage.sets.tempest;
 
 import java.util.UUID;
-import static mage.Mana.GreenMana;
+
+import mage.Mana;
 import mage.abilities.common.BeginningOfPreCombatMainTriggeredAbility;
 import mage.abilities.effects.common.AddManaToManaPoolTargetControllerEffect;
 import mage.cards.CardImpl;
@@ -50,7 +51,7 @@ public class EladamrisVineyard extends CardImpl {
 
         // At the beginning of each player's precombat main phase, add {G}{G} to that player's mana pool.
         this.addAbility(new BeginningOfPreCombatMainTriggeredAbility(
-                Zone.BATTLEFIELD, new AddManaToManaPoolTargetControllerEffect(GreenMana(2), "that player's"), TargetController.ANY, false, true));          
+                Zone.BATTLEFIELD, new AddManaToManaPoolTargetControllerEffect(Mana.GreenMana(2), "that player's"), TargetController.ANY, false, true));
     }
 
     public EladamrisVineyard(final EladamrisVineyard card) {

--- a/Mage.Sets/src/mage/sets/tempest/SkyshroudElf.java
+++ b/Mage.Sets/src/mage/sets/tempest/SkyshroudElf.java
@@ -59,9 +59,9 @@ public class SkyshroudElf extends CardImpl {
         this.addAbility(new GreenManaAbility());
 
         // {1}: Add {R} or {W} to your mana pool.
-        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new ManaCostsImpl("{1}"));
+        Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new ManaCostsImpl("{1}"));
         this.addAbility(ability);
-        Ability ability2 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana, new ManaCostsImpl("{1}"));
+        Ability ability2 = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana(1), new ManaCostsImpl("{1}"));
         this.addAbility(ability2);
     }
 

--- a/Mage.Sets/src/mage/sets/tenthedition/AdarkarWastes.java
+++ b/Mage.Sets/src/mage/sets/tenthedition/AdarkarWastes.java
@@ -51,10 +51,10 @@ public class AdarkarWastes extends CardImpl {
 
         this.addAbility(new ColorlessManaAbility());
 
-        Ability whiteManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana, new TapSourceCost());
+        Ability whiteManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana(1), new TapSourceCost());
         whiteManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(whiteManaAbility);
-        Ability blueManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana, new TapSourceCost());
+        Ability blueManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana(1), new TapSourceCost());
         blueManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(blueManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/tenthedition/Brushland.java
+++ b/Mage.Sets/src/mage/sets/tenthedition/Brushland.java
@@ -50,10 +50,10 @@ public class Brushland extends CardImpl {
         this.expansionSetCode = "10E";
         this.addAbility(new ColorlessManaAbility());
 
-        Ability greenManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana, new TapSourceCost());
+        Ability greenManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana(1), new TapSourceCost());
         greenManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(greenManaAbility);
-        Ability whiteManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana, new TapSourceCost());
+        Ability whiteManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.WhiteMana(1), new TapSourceCost());
         whiteManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(whiteManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/tenthedition/KarplusanForest.java
+++ b/Mage.Sets/src/mage/sets/tenthedition/KarplusanForest.java
@@ -51,10 +51,10 @@ public class KarplusanForest extends CardImpl {
         
         this.addAbility(new ColorlessManaAbility());
 
-        Ability redManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new TapSourceCost());
+        Ability redManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new TapSourceCost());
         redManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(redManaAbility);
-        Ability greenManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana, new TapSourceCost());
+        Ability greenManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.GreenMana(1), new TapSourceCost());
         greenManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(greenManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/tenthedition/SulfurousSprings.java
+++ b/Mage.Sets/src/mage/sets/tenthedition/SulfurousSprings.java
@@ -51,10 +51,10 @@ public class SulfurousSprings extends CardImpl {
 
         this.addAbility(new ColorlessManaAbility());
 
-        Ability blackManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new TapSourceCost());
+        Ability blackManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new TapSourceCost());
         blackManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(blackManaAbility);
-        Ability redManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana, new TapSourceCost());
+        Ability redManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.RedMana(1), new TapSourceCost());
         redManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(redManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/tenthedition/UndergroundRiver.java
+++ b/Mage.Sets/src/mage/sets/tenthedition/UndergroundRiver.java
@@ -51,10 +51,10 @@ public class UndergroundRiver extends CardImpl {
 
         this.addAbility(new ColorlessManaAbility());
 
-        Ability blueManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana, new TapSourceCost());
+        Ability blueManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlueMana(1), new TapSourceCost());
         blueManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(blueManaAbility);
-        Ability blackManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new TapSourceCost());
+        Ability blackManaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new TapSourceCost());
         blackManaAbility.addEffect(new DamageControllerEffect(1));
         this.addAbility(blackManaAbility);
     }

--- a/Mage.Sets/src/mage/sets/thedark/CityOfShadows.java
+++ b/Mage.Sets/src/mage/sets/thedark/CityOfShadows.java
@@ -59,7 +59,7 @@ public class CityOfShadows extends CardImpl {
         this.addAbility(ability);
 
         // {T}: Add {X} to your mana pool, where X is the number of storage counters on City of Shadows.
-        ability = new DynamicManaAbility(Mana.ColorlessMana, new CountersCount(CounterType.STORAGE),
+        ability = new DynamicManaAbility(Mana.ColorlessMana(1), new CountersCount(CounterType.STORAGE),
                 "Add {X} to your mana pool, where X is the number of storage counters on {this}");
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/sets/theros/KarametrasAcolyte.java
+++ b/Mage.Sets/src/mage/sets/theros/KarametrasAcolyte.java
@@ -53,7 +53,7 @@ public class KarametrasAcolyte extends CardImpl {
         this.toughness = new MageInt(4);
 
         // {T}: Add an amount of {G} to your mana pool equal to your devotion to green.
-        this.addAbility(new DynamicManaAbility(Mana.GreenMana, new DevotionCount(ColoredManaSymbol.G),
+        this.addAbility(new DynamicManaAbility(Mana.GreenMana(1), new DevotionCount(ColoredManaSymbol.G),
                 "Add an amount of {G} to your mana pool equal to your devotion to green. (Each {G} in the mana costs of permanents you control counts towards your devotion to green.)"));
     }
 

--- a/Mage.Sets/src/mage/sets/timeshifted/WallOfRoots.java
+++ b/Mage.Sets/src/mage/sets/timeshifted/WallOfRoots.java
@@ -61,7 +61,7 @@ public class WallOfRoots extends CardImpl {
         // Defender
         this.addAbility(DefenderAbility.getInstance());
         // Put a -0/-1 counter on Wall of Roots: Add {G} to your mana pool. Activate this ability only once each turn.
-        this.addAbility(new ActivateOncePerTurnManaAbility(Zone.BATTLEFIELD, new BasicManaEffect(Mana.GreenMana), new WallOfRootsCost()));
+        this.addAbility(new ActivateOncePerTurnManaAbility(Zone.BATTLEFIELD, new BasicManaEffect(Mana.GreenMana(1)), new WallOfRootsCost()));
     }
 
     public WallOfRoots(final WallOfRoots card) {

--- a/Mage.Sets/src/mage/sets/timespiral/GemstoneCaverns.java
+++ b/Mage.Sets/src/mage/sets/timespiral/GemstoneCaverns.java
@@ -61,7 +61,7 @@ public class GemstoneCaverns extends CardImpl {
         Ability ability = new ConditionalManaAbility(Zone.BATTLEFIELD,
                 new ConditionalManaEffect(
                     new AddManaOfAnyColorEffect(),
-                    new BasicManaEffect(Mana.ColorlessMana),    
+                    new BasicManaEffect(Mana.ColorlessMana(1)),
                     new SourceHasCounterCondition(CounterType.LUCK), 
                     "Add {1} to your mana pool. If {this} has a luck counter on it, instead add one mana of any color to your mana pool."),
                 new TapSourceCost());        

--- a/Mage.Sets/src/mage/sets/torment/TaintedField.java
+++ b/Mage.Sets/src/mage/sets/torment/TaintedField.java
@@ -63,12 +63,12 @@ public class TaintedField extends CardImpl {
         // {tap}: Add {W} or {B} to your mana pool. Activate this ability only if you control a Swamp.
         this.addAbility(new ActivateIfConditionManaAbility(
                 Zone.BATTLEFIELD,
-                new BasicManaEffect(Mana.WhiteMana),
+                new BasicManaEffect(Mana.WhiteMana(1)),
                 new TapSourceCost(),
                 new PermanentsOnTheBattlefieldCondition(filter, PermanentsOnTheBattlefieldCondition.CountType.MORE_THAN, 0)));
         this.addAbility(new ActivateIfConditionManaAbility(
                 Zone.BATTLEFIELD,
-                new BasicManaEffect(Mana.BlackMana),
+                new BasicManaEffect(Mana.BlackMana(1)),
                 new TapSourceCost(),
                 new PermanentsOnTheBattlefieldCondition(filter, PermanentsOnTheBattlefieldCondition.CountType.MORE_THAN, 0)));
     }

--- a/Mage.Sets/src/mage/sets/torment/TaintedPeak.java
+++ b/Mage.Sets/src/mage/sets/torment/TaintedPeak.java
@@ -63,12 +63,12 @@ public class TaintedPeak extends CardImpl {
         // {tap}: Add {B} or {R} to your mana pool. Activate this ability only if you control a Swamp.
         this.addAbility(new ActivateIfConditionManaAbility(
                 Zone.BATTLEFIELD,
-                new BasicManaEffect(Mana.BlackMana),
+                new BasicManaEffect(Mana.BlackMana(1)),
                 new TapSourceCost(),
                 new PermanentsOnTheBattlefieldCondition(filter, PermanentsOnTheBattlefieldCondition.CountType.MORE_THAN, 0)));
         this.addAbility(new ActivateIfConditionManaAbility(
                 Zone.BATTLEFIELD,
-                new BasicManaEffect(Mana.RedMana),
+                new BasicManaEffect(Mana.RedMana(1)),
                 new TapSourceCost(),
                 new PermanentsOnTheBattlefieldCondition(filter, PermanentsOnTheBattlefieldCondition.CountType.MORE_THAN, 0)));
 

--- a/Mage.Sets/src/mage/sets/torment/TaintedWood.java
+++ b/Mage.Sets/src/mage/sets/torment/TaintedWood.java
@@ -63,12 +63,12 @@ public class TaintedWood extends CardImpl {
         // {tap}: Add {B} or {G} to your mana pool. Activate this ability only if you control a Swamp.
         this.addAbility(new ActivateIfConditionManaAbility(
                 Zone.BATTLEFIELD,
-                new BasicManaEffect(Mana.BlackMana),
+                new BasicManaEffect(Mana.BlackMana(1)),
                 new TapSourceCost(),
                 new PermanentsOnTheBattlefieldCondition(filter, PermanentsOnTheBattlefieldCondition.CountType.MORE_THAN, 0)));
         this.addAbility(new ActivateIfConditionManaAbility(
                 Zone.BATTLEFIELD,
-                new BasicManaEffect(Mana.GreenMana),
+                new BasicManaEffect(Mana.GreenMana(1)),
                 new TapSourceCost(),
                 new PermanentsOnTheBattlefieldCondition(filter, PermanentsOnTheBattlefieldCondition.CountType.MORE_THAN, 0)));
     }

--- a/Mage.Sets/src/mage/sets/unlimitededition/Sacrifice.java
+++ b/Mage.Sets/src/mage/sets/unlimitededition/Sacrifice.java
@@ -50,7 +50,7 @@ public class Sacrifice extends CardImpl {
         // As an additional cost to cast Sacrifice, sacrifice a creature.
         this.getSpellAbility().addCost(new SacrificeTargetCost(new TargetControlledCreaturePermanent()));
         // Add to your mana pool an amount of {B} equal to the sacrificed creature's converted mana cost.
-        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.BlackMana, new SacrificeCostConvertedMana("creature"),
+        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.BlackMana(1), new SacrificeCostConvertedMana("creature"),
             "add to your mana pool an amount of {B} equal to the sacrificed creature's converted mana cost"));
     }
 

--- a/Mage.Sets/src/mage/sets/urzasdestiny/RofellosLlanowarEmissary.java
+++ b/Mage.Sets/src/mage/sets/urzasdestiny/RofellosLlanowarEmissary.java
@@ -62,7 +62,7 @@ public class RofellosLlanowarEmissary extends CardImpl {
         this.toughness = new MageInt(1);
 		
         // {tap}: Add {G} to your mana pool for each Forest you control.
-		this.addAbility(new DynamicManaAbility(Mana.GreenMana, new PermanentsOnBattlefieldCount(filter)));
+		this.addAbility(new DynamicManaAbility(Mana.GreenMana(1), new PermanentsOnBattlefieldCount(filter)));
     }
 
     public RofellosLlanowarEmissary(final RofellosLlanowarEmissary card) {

--- a/Mage.Sets/src/mage/sets/urzassaga/Contamination.java
+++ b/Mage.Sets/src/mage/sets/urzassaga/Contamination.java
@@ -102,7 +102,7 @@ class ContaminationReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ManaEvent manaEvent = (ManaEvent) event;
         Mana mana = manaEvent.getMana();
-        mana.setToMana(Mana.BlackMana);
+        mana.setToMana(Mana.BlackMana(1));
         return false;
     }
     

--- a/Mage.Sets/src/mage/sets/urzassaga/GaeasCradle.java
+++ b/Mage.Sets/src/mage/sets/urzassaga/GaeasCradle.java
@@ -56,7 +56,7 @@ public class GaeasCradle extends CardImpl {
         this.expansionSetCode = "USG";
         this.supertype.add("Legendary");
 
-        DynamicManaAbility ability = new DynamicManaAbility(Mana.GreenMana, new PermanentsOnBattlefieldCount(filter));
+        DynamicManaAbility ability = new DynamicManaAbility(Mana.GreenMana(1), new PermanentsOnBattlefieldCount(filter));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/sets/urzassaga/PriestOfTitania.java
+++ b/Mage.Sets/src/mage/sets/urzassaga/PriestOfTitania.java
@@ -61,7 +61,7 @@ public class PriestOfTitania extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {T}: Add {G} to your mana pool for each Elf on the battlefield.
-        this.addAbility(new DynamicManaAbility(Mana.GreenMana, new PermanentsOnBattlefieldCount(filter)));
+        this.addAbility(new DynamicManaAbility(Mana.GreenMana(1), new PermanentsOnBattlefieldCount(filter)));
     }
 
     public PriestOfTitania(final PriestOfTitania card) {

--- a/Mage.Sets/src/mage/sets/urzassaga/RainOfFilth.java
+++ b/Mage.Sets/src/mage/sets/urzassaga/RainOfFilth.java
@@ -53,7 +53,7 @@ public class RainOfFilth extends CardImpl {
 
 
         // Until end of turn, lands you control gain "Sacrifice this land: Add {B} to your mana pool."
-        ManaAbility ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new SacrificeSourceCost());
+        ManaAbility ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new SacrificeSourceCost());
         this.getSpellAbility().addEffect(new GainAbilityAllEffect(ability, Duration.EndOfTurn, new FilterControlledLandPermanent()));
     }
 

--- a/Mage.Sets/src/mage/sets/urzassaga/SerrasSanctum.java
+++ b/Mage.Sets/src/mage/sets/urzassaga/SerrasSanctum.java
@@ -56,7 +56,7 @@ public class SerrasSanctum extends CardImpl {
         this.expansionSetCode = "USG";
         this.supertype.add("Legendary");
 
-        DynamicManaAbility ability = new DynamicManaAbility(Mana.WhiteMana, new PermanentsOnBattlefieldCount(filter));
+        DynamicManaAbility ability = new DynamicManaAbility(Mana.WhiteMana(1), new PermanentsOnBattlefieldCount(filter));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/sets/urzassaga/TolarianAcademy.java
+++ b/Mage.Sets/src/mage/sets/urzassaga/TolarianAcademy.java
@@ -56,7 +56,7 @@ public class TolarianAcademy extends CardImpl {
         this.supertype.add("Legendary");
         this.expansionSetCode = "USG";
 
-        DynamicManaAbility ability = new DynamicManaAbility(Mana.BlueMana, new PermanentsOnBattlefieldCount(filter));
+        DynamicManaAbility ability = new DynamicManaAbility(Mana.BlueMana(1), new PermanentsOnBattlefieldCount(filter));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/sets/vintagemasters/SkirgeFamiliar.java
+++ b/Mage.Sets/src/mage/sets/vintagemasters/SkirgeFamiliar.java
@@ -55,7 +55,7 @@ public class SkirgeFamiliar extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         
         // Discard a card: Add {B} to your mana pool.
-        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana, new DiscardCardCost(false)));
+        this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(1), new DiscardCardCost(false)));
     }
 
     public SkirgeFamiliar(final SkirgeFamiliar card) {

--- a/Mage.Sets/src/mage/sets/worldwake/EverflowingChalice.java
+++ b/Mage.Sets/src/mage/sets/worldwake/EverflowingChalice.java
@@ -64,7 +64,7 @@ public class EverflowingChalice extends CardImpl {
                 "with a charge counter on it for each time it was kicked"));
 
         // {T}: Add {1} to your mana pool for each charge counter on Everflowing Chalice.
-        this.addAbility(new DynamicManaAbility(Mana.ColorlessMana, new CountersCount(CounterType.CHARGE)));
+        this.addAbility(new DynamicManaAbility(Mana.ColorlessMana(1), new CountersCount(CounterType.CHARGE)));
     }
 
     public EverflowingChalice(final EverflowingChalice card) {

--- a/Mage.Sets/src/mage/sets/zendikar/CryptOfAgadeem.java
+++ b/Mage.Sets/src/mage/sets/zendikar/CryptOfAgadeem.java
@@ -63,7 +63,7 @@ public class CryptOfAgadeem extends CardImpl {
         // {T}: Add {B} to your mana pool.
         this.addAbility(new BlackManaAbility());
         // {2}, {T}: Add {B} to your mana pool for each black creature card in your graveyard.
-        DynamicManaAbility ability = new DynamicManaAbility(Mana.BlackMana, new CardsInControllerGraveyardCount(filter), new GenericManaCost(2));
+        DynamicManaAbility ability = new DynamicManaAbility(Mana.BlackMana(1), new CardsInControllerGraveyardCount(filter), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
     }

--- a/Mage/src/mage/Mana.java
+++ b/Mage/src/mage/Mana.java
@@ -56,13 +56,6 @@ public class Mana implements Comparable<Mana>, Serializable, Copyable<Mana> {
     protected int any;
     protected boolean flag;
 
-    //TODO  These are unsafe and mutable
-    public static final Mana RedMana = RedMana(1);
-    public static final Mana GreenMana = GreenMana(1);
-    public static final Mana BlueMana = BlueMana(1);
-    public static final Mana WhiteMana = WhiteMana(1);
-    public static final Mana BlackMana = BlackMana(1);
-    public static final Mana ColorlessMana = ColorlessMana(1);
 
 
     /**

--- a/Mage/src/mage/abilities/costs/mana/ManaCostImpl.java
+++ b/Mage/src/mage/abilities/costs/mana/ManaCostImpl.java
@@ -242,19 +242,19 @@ public abstract class ManaCostImpl extends CostImpl implements ManaCost {
     protected void addColoredOption(ColoredManaSymbol symbol) {
         switch (symbol) {
             case B:
-                this.options.add(Mana.BlackMana);
+                this.options.add(Mana.BlackMana(1));
                 break;
             case U:
-                this.options.add(Mana.BlueMana);
+                this.options.add(Mana.BlueMana(1));
                 break;
             case W:
-                this.options.add(Mana.WhiteMana);
+                this.options.add(Mana.WhiteMana(1));
                 break;
             case R:
-                this.options.add(Mana.RedMana);
+                this.options.add(Mana.RedMana(1));
                 break;
             case G:
-                this.options.add(Mana.GreenMana);
+                this.options.add(Mana.GreenMana(1));
                 break;
         }
     }

--- a/Mage/src/mage/abilities/keyword/ConvokeAbility.java
+++ b/Mage/src/mage/abilities/keyword/ConvokeAbility.java
@@ -222,32 +222,32 @@ class ConvokeEffect extends OneShotEffect {
                             chooseManaType.setChoice(chooseManaType.getChoices().iterator().next());
                         }
                         if (chooseManaType.getChoice().equals("Black")) {
-                            manaPool.addMana(Mana.BlackMana, game, source);
+                            manaPool.addMana(Mana.BlackMana(1), game, source);
                             manaPool.unlockManaType(ManaType.BLACK);
                         }
                         if (chooseManaType.getChoice().equals("Blue")) {
-                            manaPool.addMana(Mana.BlueMana, game, source);
+                            manaPool.addMana(Mana.BlueMana(1), game, source);
                             manaPool.unlockManaType(ManaType.BLUE);
                         }
                         if (chooseManaType.getChoice().equals("Green")) {
-                            manaPool.addMana(Mana.GreenMana, game, source);
+                            manaPool.addMana(Mana.GreenMana(1), game, source);
                             manaPool.unlockManaType(ManaType.GREEN);
                         }
                         if (chooseManaType.getChoice().equals("White")) {
-                            manaPool.addMana(Mana.WhiteMana, game, source);
+                            manaPool.addMana(Mana.WhiteMana(1), game, source);
                             manaPool.unlockManaType(ManaType.WHITE);
                         }
                         if (chooseManaType.getChoice().equals("Red")) {
-                            manaPool.addMana(Mana.RedMana, game, source);
+                            manaPool.addMana(Mana.RedMana(1), game, source);
                             manaPool.unlockManaType(ManaType.RED);
                         }
                         if (chooseManaType.getChoice().equals("Colorless")) {
-                            manaPool.addMana(Mana.ColorlessMana, game, source);
+                            manaPool.addMana(Mana.ColorlessMana(1), game, source);
                             manaPool.unlockManaType(ManaType.COLORLESS);
                         }
                         manaName = chooseManaType.getChoice().toLowerCase();
                     } else {
-                        manaPool.addMana(Mana.ColorlessMana, game, source);
+                        manaPool.addMana(Mana.ColorlessMana(1), game, source);
                         manaPool.unlockManaType(ManaType.COLORLESS);
                         manaName = "colorless";
                     }

--- a/Mage/src/mage/abilities/mana/BlackManaAbility.java
+++ b/Mage/src/mage/abilities/mana/BlackManaAbility.java
@@ -39,7 +39,7 @@ import mage.constants.ColoredManaSymbol;
 public class BlackManaAbility extends BasicManaAbility {
 
     public BlackManaAbility() {
-        super(new BasicManaEffect(Mana.BlackMana));
+        super(new BasicManaEffect(Mana.BlackMana(1)));
         this.netMana.add(new Mana(ColoredManaSymbol.B));
     }
 

--- a/Mage/src/mage/abilities/mana/BlueManaAbility.java
+++ b/Mage/src/mage/abilities/mana/BlueManaAbility.java
@@ -39,7 +39,7 @@ import mage.constants.ColoredManaSymbol;
 public class BlueManaAbility extends BasicManaAbility {
 
     public BlueManaAbility() {
-        super(new BasicManaEffect(Mana.BlueMana));
+        super(new BasicManaEffect(Mana.BlueMana(1)));
         this.netMana.add(new Mana(ColoredManaSymbol.U));
     }
 

--- a/Mage/src/mage/abilities/mana/ColorlessManaAbility.java
+++ b/Mage/src/mage/abilities/mana/ColorlessManaAbility.java
@@ -38,7 +38,7 @@ import mage.abilities.effects.common.BasicManaEffect;
 public class ColorlessManaAbility extends BasicManaAbility {
 
     public ColorlessManaAbility() {
-        super(new BasicManaEffect(Mana.ColorlessMana));
+        super(new BasicManaEffect(Mana.ColorlessMana(1)));
         this.netMana.add(new Mana(0,0,0,0,0,1,0));
     }
 

--- a/Mage/src/mage/abilities/mana/GreenManaAbility.java
+++ b/Mage/src/mage/abilities/mana/GreenManaAbility.java
@@ -39,7 +39,7 @@ import mage.constants.ColoredManaSymbol;
 public class GreenManaAbility extends BasicManaAbility {
 
     public GreenManaAbility() {
-        super(new BasicManaEffect(Mana.GreenMana));
+        super(new BasicManaEffect(Mana.GreenMana(1)));
         this.netMana.add(new Mana(ColoredManaSymbol.G));
     }
 

--- a/Mage/src/mage/abilities/mana/ManaOptions.java
+++ b/Mage/src/mage/abilities/mana/ManaOptions.java
@@ -296,25 +296,25 @@ public class ManaOptions extends ArrayList<Mana> {
                 for (Mana existingMana : existingManas) {
                     Mana manaToPay = manaAvailable.copy();
                     manaToPay.subtract(existingMana);
-                    if (manaToPay.getBlack() > 0 && !payCombinationsStrings.contains(existingMana.toString() + Mana.BlackMana.toString())) {
-                        manaToPay.subtract(Mana.BlackMana);
-                        addManaCombination(Mana.BlackMana, existingMana, payCombinations, payCombinationsStrings);
+                    if (manaToPay.getBlack() > 0 && !payCombinationsStrings.contains(existingMana.toString() + Mana.BlackMana(1).toString())) {
+                        manaToPay.subtract(Mana.BlackMana(1));
+                        addManaCombination(Mana.BlackMana(1), existingMana, payCombinations, payCombinationsStrings);
                     }
-                    if (manaToPay.getBlue() > 0 && !payCombinationsStrings.contains(existingMana.toString() + Mana.BlueMana.toString())) {
-                        manaToPay.subtract(Mana.BlueMana);
-                        addManaCombination(Mana.BlueMana, existingMana, payCombinations, payCombinationsStrings);
+                    if (manaToPay.getBlue() > 0 && !payCombinationsStrings.contains(existingMana.toString() + Mana.BlueMana(1).toString())) {
+                        manaToPay.subtract(Mana.BlueMana(1));
+                        addManaCombination(Mana.BlueMana(1), existingMana, payCombinations, payCombinationsStrings);
                     }
-                    if (manaToPay.getGreen() > 0 && !payCombinationsStrings.contains(existingMana.toString() + Mana.GreenMana.toString())) {
-                        manaToPay.subtract(Mana.GreenMana);
-                        addManaCombination(Mana.GreenMana, existingMana, payCombinations, payCombinationsStrings);
+                    if (manaToPay.getGreen() > 0 && !payCombinationsStrings.contains(existingMana.toString() + Mana.GreenMana(1).toString())) {
+                        manaToPay.subtract(Mana.GreenMana(1));
+                        addManaCombination(Mana.GreenMana(1), existingMana, payCombinations, payCombinationsStrings);
                     }
-                    if (manaToPay.getRed() > 0 && !payCombinationsStrings.contains(existingMana.toString() + Mana.RedMana.toString())) {
-                        manaToPay.subtract(Mana.RedMana);
-                        addManaCombination(Mana.RedMana, existingMana, payCombinations, payCombinationsStrings);
+                    if (manaToPay.getRed() > 0 && !payCombinationsStrings.contains(existingMana.toString() + Mana.RedMana(1).toString())) {
+                        manaToPay.subtract(Mana.RedMana(1));
+                        addManaCombination(Mana.RedMana(1), existingMana, payCombinations, payCombinationsStrings);
                     }
-                    if (manaToPay.getWhite() > 0 && !payCombinationsStrings.contains(existingMana.toString() + Mana.WhiteMana.toString())) {
-                        manaToPay.subtract(Mana.WhiteMana);
-                        addManaCombination(Mana.WhiteMana, existingMana, payCombinations, payCombinationsStrings);
+                    if (manaToPay.getWhite() > 0 && !payCombinationsStrings.contains(existingMana.toString() + Mana.WhiteMana(1).toString())) {
+                        manaToPay.subtract(Mana.WhiteMana(1));
+                        addManaCombination(Mana.WhiteMana(1), existingMana, payCombinations, payCombinationsStrings);
                     }
                 }
             }

--- a/Mage/src/mage/abilities/mana/RedManaAbility.java
+++ b/Mage/src/mage/abilities/mana/RedManaAbility.java
@@ -39,7 +39,7 @@ import mage.constants.ColoredManaSymbol;
 public class RedManaAbility extends BasicManaAbility {
 
     public RedManaAbility() {
-        super(new BasicManaEffect(Mana.RedMana));
+        super(new BasicManaEffect(Mana.RedMana(1)));
         this.netMana.add(new Mana(ColoredManaSymbol.R));
     }
 

--- a/Mage/src/mage/abilities/mana/WhiteManaAbility.java
+++ b/Mage/src/mage/abilities/mana/WhiteManaAbility.java
@@ -39,7 +39,7 @@ import mage.constants.ColoredManaSymbol;
 public class WhiteManaAbility extends BasicManaAbility {
 
     public WhiteManaAbility() {
-        super(new BasicManaEffect(Mana.WhiteMana));
+        super(new BasicManaEffect(Mana.WhiteMana(1)));
         this.netMana.add(new Mana(ColoredManaSymbol.W));
     }
 

--- a/Mage/src/mage/game/permanent/token/EldraziScionToken.java
+++ b/Mage/src/mage/game/permanent/token/EldraziScionToken.java
@@ -48,7 +48,7 @@ public class EldraziScionToken extends Token {
         subtype.add("Scion");
         power = new MageInt(1);
         toughness = new MageInt(1);
-        addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.ColorlessMana, new SacrificeSourceCost()));
+        addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.ColorlessMana(1), new SacrificeSourceCost()));
         setOriginalExpansionSetCode("BFZ");
 
     }

--- a/Mage/src/mage/game/permanent/token/EldraziSpawnToken.java
+++ b/Mage/src/mage/game/permanent/token/EldraziSpawnToken.java
@@ -58,7 +58,7 @@ public class EldraziSpawnToken extends Token {
         subtype.add("Spawn");
         power = new MageInt(0);
         toughness = new MageInt(1);
-        addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.ColorlessMana, new SacrificeSourceCost()));
+        addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, Mana.ColorlessMana(1), new SacrificeSourceCost()));
 
         availableImageSetCodes = tokenImageSets;
         // Get one of the three possible token images

--- a/Mage/src/mage/util/ManaUtil.java
+++ b/Mage/src/mage/util/ManaUtil.java
@@ -351,23 +351,23 @@ public class ManaUtil {
         int countColorless = 0;
         ManaAbility chosenManaAbility = null;
         for (ManaAbility ability : useableAbilities.values()) {
-            if (ability instanceof RedManaAbility && mana.contains(Mana.RedMana)) {
+            if (ability instanceof RedManaAbility && mana.contains(Mana.RedMana(1))) {
                 chosenManaAbility = ability;
                 countColorfull++;
             }
-            if (ability instanceof BlackManaAbility && mana.contains(Mana.BlackMana)) {
+            if (ability instanceof BlackManaAbility && mana.contains(Mana.BlackMana(1))) {
                 chosenManaAbility = ability;
                 countColorfull++;
             }
-            if (ability instanceof BlueManaAbility && mana.contains(Mana.BlueMana)) {
+            if (ability instanceof BlueManaAbility && mana.contains(Mana.BlueMana(1))) {
                 chosenManaAbility = ability;
                 countColorfull++;
             }
-            if (ability instanceof WhiteManaAbility && mana.contains(Mana.WhiteMana)) {
+            if (ability instanceof WhiteManaAbility && mana.contains(Mana.WhiteMana(1))) {
                 chosenManaAbility = ability;
                 countColorfull++;
             }
-            if (ability instanceof GreenManaAbility && mana.contains(Mana.GreenMana)) {
+            if (ability instanceof GreenManaAbility && mana.contains(Mana.GreenMana(1))) {
                 chosenManaAbility = ability;
                 countColorfull++;
             }


### PR DESCRIPTION
Previously the Mana class contained public static "singletons" of each color.
This is unsafe, as anyone can mutate the instance.

Now we use the public static method `ColorMana(1)` which will return a new instance of the same value. This returned value can be mutated if needed. There might be a performance hit now, as we are moving from a single instance, to multiple. There will be a lot more object creation.