### PR TITLE
Fix to mana cost of Goblin Dynamo's 2nd ability

### DIFF
--- a/Mage.Sets/src/mage/sets/legions/GoblinDynamo.java
+++ b/Mage.Sets/src/mage/sets/legions/GoblinDynamo.java
@@ -61,7 +61,7 @@ public class GoblinDynamo extends CardImpl {
         this.addAbility(ability);
         
         //{X}{R}, {T}, Sacrifice Goblin Dynamo: Goblin Dynamo deals X damage to target creature or player.
-        ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,new DamageTargetEffect(new ManacostVariableValue()), new ManaCostsImpl("{X}"));
+        ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,new DamageTargetEffect(new ManacostVariableValue()), new ManaCostsImpl("{X}{R}"));
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetCreatureOrPlayer());
         this.addAbility(ability);


### PR DESCRIPTION
Goblin Dynamo's second ability was incorrectly costed as {X}, instead of {X}{R}.  Implemented the correct cost.