### PR TITLE
Fix the problematic behavior on version up introduced by my previous commit.

### DIFF
--- a/Mage.Common/src/mage/interfaces/MageServer.java
+++ b/Mage.Common/src/mage/interfaces/MageServer.java
@@ -56,7 +56,11 @@ import mage.view.UserView;
 public interface MageServer {
 
     // connection methods
-    boolean registerClient(String userName, String password, String sessionId, MageVersion version) throws MageException;
+    // DEPRECATED - Use registerClientWithPassword instead. This is kept for older clients.
+    // This can be deleted once users transitioned to newer clients (1.4.6v1 and later).
+    boolean registerClient(String userName, String sessionId, MageVersion version) throws MageException;
+
+    boolean registerClientWithPassword(String userName, String password, String sessionId, MageVersion version) throws MageException;
 
     boolean registerAdmin(String password, String sessionId, MageVersion version) throws MageException;
 // Not used

--- a/Mage.Server/src/main/java/mage/server/MageServerImpl.java
+++ b/Mage.Server/src/main/java/mage/server/MageServerImpl.java
@@ -106,7 +106,15 @@ public class MageServerImpl implements MageServer {
     }
 
     @Override
-    public boolean registerClient(String userName, String password, String sessionId, MageVersion version) throws MageException {
+    public boolean registerClient(String userName, String sessionId, MageVersion version) throws MageException {
+        // This method is deprecated, so just inform the server version.
+        logger.info("MageVersionException: userName=" + userName + ", version=" + version);
+        LogServiceImpl.instance.log(LogKeys.KEY_WRONG_VERSION, userName, version.toString(), Main.getVersion().toString(), sessionId);
+        throw new MageVersionException(version, Main.getVersion());
+    }
+
+    @Override
+    public boolean registerClientWithPassword(String userName, String password, String sessionId, MageVersion version) throws MageException {
         try {
             if (version.compareTo(Main.getVersion()) != 0) {
                 logger.info("MageVersionException: userName=" + userName + ", version=" + version);


### PR DESCRIPTION
My previous commit results in an uninformative error message on incompatible server <-> client version. This commit fixes it.

* Keep registerClient for older clients, which just throws an MageVersionException.
* Rename the new version to registerClientWithPassword.
* Add an error message on NoSuchMethodException so that this kind of version incompatibility can be handled and informed to user.

I checked the following two scenarios work:
* Server: 1.4.6v1, Client: 1.4.6v0
* Server: 1.4.6v0, Client: 1.4.6v1