### PR TITLE
Create MagePreferences class for managing preferences. We should move…

### DIFF
--- a/Mage.Client/src/main/java/mage/client/MageFrame.java
+++ b/Mage.Client/src/main/java/mage/client/MageFrame.java
@@ -107,6 +107,7 @@ import mage.client.draft.DraftPanel;
 import mage.client.game.GamePane;
 import mage.client.game.GamePanel;
 import mage.client.plugins.impl.Plugins;
+import mage.client.preference.MagePreferences;
 import mage.client.remote.CallbackClientImpl;
 import mage.client.table.TablesPane;
 import mage.client.tournament.TournamentPane;
@@ -745,13 +746,10 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
     }
 
     private boolean performConnect() {
-        // TODO: Create MagePreference class to consolidate duplicated preference code in
-        // MageFrame, ConnectDialog and PreferencesDialog.
-        String server = prefs.get("serverAddress", "");
-        int port = Integer.parseInt(prefs.get("serverPort", ""));
-        // For userName and password we save preference per server.
-        String userName = prefs.get(server + "/userName", "");
-        String password = prefs.get(server + "/password", "");
+        String server = MagePreferences.getServerAddress();
+        int port = MagePreferences.getServerPort();
+        String userName = MagePreferences.getUserName(server);
+        String password = MagePreferences.getPassword(server);
         String proxyServer = prefs.get("proxyAddress", "");
         int proxyPort = Integer.parseInt(prefs.get("proxyPort", "0"));
         ProxyType proxyType = ProxyType.valueByText(prefs.get("proxyType", "None"));

--- a/Mage.Client/src/main/java/mage/client/dialog/ConnectDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/ConnectDialog.java
@@ -63,6 +63,7 @@ import mage.client.MageFrame;
 import static mage.client.dialog.PreferencesDialog.KEY_CONNECTION_URL_SERVER_LIST;
 import static mage.client.dialog.PreferencesDialog.KEY_CONNECT_AUTO_CONNECT;
 import static mage.client.dialog.PreferencesDialog.KEY_CONNECT_FLAG;
+import mage.client.preference.MagePreferences;
 import mage.client.util.Config;
 import mage.client.util.gui.countryBox.CountryItemEditor;
 import mage.remote.Connection;
@@ -105,14 +106,11 @@ public class ConnectDialog extends MageDialog {
     }
 
     public void showDialog() {
-        // TODO: Create MagePreference class to consolidate duplicated preference code in
-        // MageFrame, ConnectDialog and PreferencesDialog.
-        String serverAddress = MageFrame.getPreferences().get("serverAddress", Config.serverName);
+        String serverAddress = MagePreferences.getServerAddressWithDefault(Config.serverName);
         this.txtServer.setText(serverAddress);
-        this.txtPort.setText(MageFrame.getPreferences().get("serverPort", Integer.toString(Config.port)));
-        // For userName and password we save preference per server.
-        this.txtUserName.setText(MageFrame.getPreferences().get(serverAddress + "/userName", ""));
-        this.txtPassword.setText(MageFrame.getPreferences().get(serverAddress + "/password", ""));
+        this.txtPort.setText(Integer.toString(MagePreferences.getServerPortWithDefault(Config.port)));
+        this.txtUserName.setText(MagePreferences.getUserName(serverAddress));
+        this.txtPassword.setText(MagePreferences.getPassword(serverAddress));
         this.chkAutoConnect.setSelected(Boolean.parseBoolean(MageFrame.getPreferences().get(KEY_CONNECT_AUTO_CONNECT, "false")));
         this.chkForceUpdateDB.setSelected(false); // has always to be set manually to force comparison
 
@@ -131,14 +129,11 @@ public class ConnectDialog extends MageDialog {
     }
 
     private void saveSettings() {
-        // TODO: Create MagePreference class to consolidate duplicated preference code in
-        // MageFrame, ConnectDialog and PreferencesDialog.
         String serverAddress = txtServer.getText().trim();
-        MageFrame.getPreferences().put("serverAddress", serverAddress);
-        MageFrame.getPreferences().put("serverPort", txtPort.getText().trim());
-        // For userName and password we save preference per server.
-        MageFrame.getPreferences().put(serverAddress + "/userName", txtUserName.getText().trim());
-        MageFrame.getPreferences().put(serverAddress + "/password", txtPassword.getText().trim());
+        MagePreferences.setServerAddress(serverAddress);
+        MagePreferences.setServerPort(Integer.parseInt(txtPort.getText().trim()));
+        MagePreferences.setUserName(serverAddress, txtUserName.getText().trim());
+        MagePreferences.setPassword(serverAddress, txtPassword.getText().trim());
         MageFrame.getPreferences().put(KEY_CONNECT_AUTO_CONNECT, Boolean.toString(chkAutoConnect.isSelected()));
     }
 
@@ -374,7 +369,7 @@ public class ConnectDialog extends MageDialog {
         // txtPassword is not checked here, because authentication might be disabled by the server config.
         if (Integer.valueOf(txtPort.getText()) < 1 || Integer.valueOf(txtPort.getText()) > 65535) {
             JOptionPane.showMessageDialog(rootPane, "Invalid port number");
-            txtPort.setText(MageFrame.getPreferences().get("serverPort", Integer.toString(Config.port)));
+            txtPort.setText(Integer.toString(MagePreferences.getServerPortWithDefault(Config.port)));
             return;
         }
 
@@ -556,8 +551,8 @@ public class ConnectDialog extends MageDialog {
                     this.txtServer.setText(serverAddress);
                     this.txtPort.setText(params[2]);
                     // Update userName and password according to the chosen server.
-                    this.txtUserName.setText(MageFrame.getPreferences().get(serverAddress + "/userName", ""));
-                    this.txtPassword.setText(MageFrame.getPreferences().get(serverAddress + "/password", ""));
+                    this.txtUserName.setText(MagePreferences.getUserName(serverAddress));
+                    this.txtPassword.setText(MagePreferences.getPassword(serverAddress));
                 } else {
                     JOptionPane.showMessageDialog(null, "Wrong server data format.");
                 }

--- a/Mage.Client/src/main/java/mage/client/dialog/RegisterUserDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/RegisterUserDialog.java
@@ -4,10 +4,9 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.prefs.Preferences;
 import javax.swing.SwingWorker;
 import mage.client.MageFrame;
-import mage.client.util.Config;
+import mage.client.preference.MagePreferences;
 import mage.remote.Connection;
 import mage.remote.Session;
 import mage.remote.SessionImpl;
@@ -237,18 +236,15 @@ public class RegisterUserDialog extends MageDialog {
             try {
                 get(CONNECTION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 if (result) {
+                    // Save settings.
+                    MagePreferences.setServerAddress(connection.getHost());
+                    MagePreferences.setServerPort(connection.getPort());
+                    MagePreferences.setUserName(connection.getHost(), connection.getUsername());
+                    MagePreferences.setPassword(connection.getHost(), connection.getPassword());
+                    MagePreferences.setEmail(connection.getHost(), connection.getEmail());
+
                     String message = "Registration succeeded";
                     lblStatus.setText(message);
-
-                    // Save settings.
-                    Preferences prefs = MageFrame.getPreferences();
-                    prefs.put("serverAddress", connection.getHost());
-                    prefs.put("serverPort", Integer.toString(connection.getPort()));
-                    // For userName and password we save preference per server.
-                    prefs.put(connection.getHost() + "/userName", connection.getUsername());
-                    prefs.put(connection.getHost() + "/password", connection.getPassword());
-                    prefs.put(connection.getHost() + "/email", connection.getEmail());
-
                     MageFrame.getInstance().showMessage(message);
                     hideDialog();
                 } else {

--- a/Mage.Client/src/main/java/mage/client/dialog/ResetPasswordDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/ResetPasswordDialog.java
@@ -4,10 +4,9 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.prefs.Preferences;
 import javax.swing.SwingWorker;
 import mage.client.MageFrame;
-import mage.client.util.Config;
+import mage.client.preference.MagePreferences;
 import mage.remote.Connection;
 import mage.remote.Session;
 import mage.remote.SessionImpl;
@@ -34,7 +33,7 @@ public class ResetPasswordDialog extends MageDialog {
         String serverAddress = this.connectDialog.getServer();
         this.txtServer.setText(serverAddress);
         this.txtPort.setText(this.connectDialog.getPort());
-        this.txtEmail.setText(MageFrame.getPreferences().get(serverAddress + "/email", ""));
+        this.txtEmail.setText(MagePreferences.getEmail(serverAddress));
         this.lblStatus.setText("");
 
         this.setModal(true);
@@ -340,8 +339,7 @@ public class ResetPasswordDialog extends MageDialog {
                 get(CONNECTION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 if (result) {
                     // Save settings.
-                    Preferences prefs = MageFrame.getPreferences();
-                    prefs.put(connection.getHost() + "/email", connection.getEmail());
+                    MagePreferences.setEmail(connection.getHost(), connection.getEmail());
 
                     String message = "Auth token is emailed. Please check your inbox.";
                     lblStatus.setText(message);
@@ -383,13 +381,11 @@ public class ResetPasswordDialog extends MageDialog {
             try {
                 get(CONNECTION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 if (result) {
+                    // Save settings.
+                    MagePreferences.setPassword(connection.getHost(), connection.getPassword());
+
                     String message = "Password is reset successfully.";
                     lblStatus.setText(message);
-
-                    // Save settings.
-                    Preferences prefs = MageFrame.getPreferences();
-                    prefs.put(connection.getHost() + "/password", connection.getPassword());
-
                     MageFrame.getInstance().showMessage(message);
                     hideDialog();
                 } else {

--- a/Mage.Client/src/main/java/mage/client/preference/MagePreferences.java
+++ b/Mage.Client/src/main/java/mage/client/preference/MagePreferences.java
@@ -1,0 +1,85 @@
+package mage.client.preference;
+
+import java.util.prefs.Preferences;
+import mage.client.MageFrame;
+
+// TODO: Move all preference related logic from MageFrame and PreferencesDialog to this class.
+public class MagePreferences {
+
+    private static final String KEY_SERVER_ADDRESS = "serverAddress";
+    private static final String KEY_SERVER_PORT = "serverPort";
+    private static final String KEY_USER_NAME = "userName";
+    private static final String KEY_PASSWORD = "password";
+    private static final String KEY_EMAIL = "email";
+    private static final String KEY_AUTO_CONNECT = "autoConnect";
+
+    private static Preferences prefs() {
+        // TODO: Move MageFrame.prefs to this class.
+        return MageFrame.getPreferences();
+    }
+
+    public static String getServerAddress() {
+        return prefs().get(KEY_SERVER_ADDRESS, "");
+    }
+
+    public static String getServerAddressWithDefault(String defaultValue) {
+        return prefs().get(KEY_SERVER_ADDRESS, defaultValue);
+    }
+
+    public static void setServerAddress(String serverAddress) {
+        prefs().put(KEY_SERVER_ADDRESS, serverAddress);
+    }
+
+    public static int getServerPort() {
+        return prefs().getInt(KEY_SERVER_PORT, 0);
+    }
+
+    public static int getServerPortWithDefault(int defaultValue) {
+        return prefs().getInt(KEY_SERVER_PORT, defaultValue);
+    }
+
+    public static void setServerPort(int port) {
+        prefs().putInt(KEY_SERVER_PORT, port);
+    }
+
+    private static String prefixedKey(String prefix, String key) {
+        return prefix + "/" + key;
+    }
+
+    public static String getUserName(String serverAddress) {
+        String userName = prefs().get(prefixedKey(serverAddress, KEY_USER_NAME), "");
+        if (!userName.isEmpty()) {
+            return userName;
+        }
+        // For clients older than 1.4.7, userName is stored without a serverAddress prefix.
+        return prefs().get(KEY_USER_NAME, "");
+    }
+
+    public static void setUserName(String serverAddress, String userName) {
+        prefs().put(prefixedKey(serverAddress, KEY_USER_NAME), userName);
+    }
+
+    public static String getPassword(String serverAddress) {
+        return prefs().get(prefixedKey(serverAddress, KEY_PASSWORD), "");
+    }
+
+    public static void setPassword(String serverAddress, String password) {
+        prefs().put(prefixedKey(serverAddress, KEY_PASSWORD), password);
+    }
+
+    public static String getEmail(String serverAddress) {
+        return prefs().get(prefixedKey(serverAddress, KEY_EMAIL), "");
+    }
+
+    public static void setEmail(String serverAddress, String userName) {
+        prefs().put(prefixedKey(serverAddress, KEY_EMAIL), userName);
+    }
+
+    public static boolean getAutoConnect() {
+        return prefs().getBoolean(KEY_AUTO_CONNECT, false);
+    }
+
+    public static void setAutoConnect(boolean autoConnect) {
+        prefs().putBoolean(KEY_AUTO_CONNECT, autoConnect);
+    }
+}


### PR DESCRIPTION
… preference related code from MageFrame and PreferencesDialog to the class. Push all raw string preference key manipulations for serverAddress, serverPort, userName, password and email into the class.

% for K in serverAddress serverPort userName password email; do echo Checking for $K; grep -r \"$K\" Mage.Client; done
Checking for serverAddress
Mage.Client/src/main/java/mage/client/preference/MagePreferences.java:    private static final String KEY_SERVER_ADDRESS = "serverAddress";
Checking for serverPort
Mage.Client/src/main/java/mage/client/preference/MagePreferences.java:    private static final String KEY_SERVER_PORT = "serverPort";
Checking for userName
Mage.Client/src/main/java/mage/client/preference/MagePreferences.java:    private static final String KEY_USER_NAME = "userName";
Checking for password
Mage.Client/src/main/java/mage/client/dialog/JoinTableDialog.form:        <Property name="text" type="java.lang.String" value="password"/>
Mage.Client/src/main/java/mage/client/dialog/JoinTableDialog.java:        txtPassword.setText("password");
Mage.Client/src/main/java/mage/client/preference/MagePreferences.java:    private static final String KEY_PASSWORD = "password";
Checking for email
Mage.Client/src/main/java/mage/client/preference/MagePreferences.java:    private static final String KEY_EMAIL = "email";