### PR TITLE
Record game histories. Compute user stats and show them in the client.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ Mage.Client/serverlist.txt
 /target/
 
 client_secrets.json
+
+dependency-reduced-pom.xml

--- a/Mage.Client/src/main/java/mage/client/table/PlayersChatPanel.java
+++ b/Mage.Client/src/main/java/mage/client/table/PlayersChatPanel.java
@@ -128,7 +128,7 @@ public class PlayersChatPanel extends javax.swing.JPanel {
             TableColumnModel tcm = th.getColumnModel();
 
             tcm.getColumn(jTablePlayers.convertColumnIndexToView(1)).setHeaderValue("Players (" + this.players.length + ")");
-            tcm.getColumn(jTablePlayers.convertColumnIndexToView(3)).setHeaderValue(
+            tcm.getColumn(jTablePlayers.convertColumnIndexToView(4)).setHeaderValue(
                     "Games " + roomUserInfo.getNumberActiveGames()
                     + (roomUserInfo.getNumberActiveGames() != roomUserInfo.getNumberGameThreads() ? " (T:" + roomUserInfo.getNumberGameThreads() : " (")
                     + " limit: " + roomUserInfo.getNumberMaxGames() + ")");

--- a/Mage.Client/src/main/java/mage/client/table/PlayersChatPanel.java
+++ b/Mage.Client/src/main/java/mage/client/table/PlayersChatPanel.java
@@ -61,7 +61,7 @@ public class PlayersChatPanel extends javax.swing.JPanel {
 
     private final List<String> players = new ArrayList<>();
     private final UserTableModel userTableModel;
-    private static final int[] defaultColumnsWidth = {20, 100, 100, 80, 80};
+    private static final int[] defaultColumnsWidth = {20, 100, 100, 100, 80, 80};
 
 
     /*
@@ -118,7 +118,7 @@ public class PlayersChatPanel extends javax.swing.JPanel {
 
     class UserTableModel extends AbstractTableModel {
 
-        private final String[] columnNames = new String[]{"Loc", "Players", "Info", "Games", "Connection"};
+        private final String[] columnNames = new String[]{"Loc", "Players", "History", "Info", "Games", "Connection"};
         private UsersView[] players = new UsersView[0];
 
         public void loadData(Collection<RoomUsersView> roomUserInfoList) throws MageRemoteException {
@@ -154,10 +154,12 @@ public class PlayersChatPanel extends javax.swing.JPanel {
                 case 1:
                     return players[arg0].getUserName();
                 case 2:
-                    return players[arg0].getInfoState();
+                    return players[arg0].getHistory();
                 case 3:
-                    return players[arg0].getInfoGames();
+                    return players[arg0].getInfoState();
                 case 4:
+                    return players[arg0].getInfoGames();
+                case 5:
                     return players[arg0].getInfoPing();
             }
             return "";

--- a/Mage.Common/src/mage/view/UsersView.java
+++ b/Mage.Common/src/mage/view/UsersView.java
@@ -39,12 +39,14 @@ public class UsersView implements Serializable {
 
     private final String flagName;
     private final String userName;
+    private final String history;
     private final String infoState;
     private final String infoGames;
     private final String infoPing;
 
-    public UsersView(String flagName, String userName, String infoState, String infoGames, String infoPing) {
+    public UsersView(String flagName, String userName, String history, String infoState, String infoGames, String infoPing) {
         this.flagName = flagName;
+        this.history = history;
         this.userName = userName;
         this.infoState = infoState;
         this.infoGames = infoGames;
@@ -57,6 +59,10 @@ public class UsersView implements Serializable {
 
     public String getUserName() {
         return userName;
+    }
+
+    public String getHistory() {
+        return history;
     }
 
     public String getInfoState() {

--- a/Mage.Server/pom.xml
+++ b/Mage.Server/pom.xml
@@ -199,6 +199,11 @@
             <artifactId>jersey-multipart</artifactId>
             <version>1.19</version>
         </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.7.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Mage.Server/src/main/java/mage/server/MageServerImpl.java
+++ b/Mage.Server/src/main/java/mage/server/MageServerImpl.java
@@ -438,7 +438,7 @@ public class MageServerImpl implements MageServer {
 //    }
     @Override
     public boolean startMatch(final String sessionId, final UUID roomId, final UUID tableId) throws MageException {
-        if (!TableManager.getInstance().getController(tableId).changeTableState(TableState.STARTING)) {
+        if (!TableManager.getInstance().getController(tableId).changeTableStateToStarting()) {
             return false;
         }
         execute("startMatch", sessionId, new Action() {
@@ -463,7 +463,7 @@ public class MageServerImpl implements MageServer {
 //    }
     @Override
     public boolean startTournament(final String sessionId, final UUID roomId, final UUID tableId) throws MageException {
-        if (!TableManager.getInstance().getController(tableId).changeTableState(TableState.STARTING)) {
+        if (!TableManager.getInstance().getController(tableId).changeTableStateToStarting()) {
             return false;
         }
         execute("startTournament", sessionId, new Action() {

--- a/Mage.Server/src/main/java/mage/server/record/TableRecord.java
+++ b/Mage.Server/src/main/java/mage/server/record/TableRecord.java
@@ -1,0 +1,37 @@
+package mage.server.record;
+
+import com.j256.ormlite.field.DataType;
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.table.DatabaseTable;
+import mage.game.result.ResultProtos.TableProto;
+import org.mage.mage.shaded.protobuf.InvalidProtocolBufferException;
+import org.apache.log4j.Logger;
+
+@DatabaseTable(tableName = "table_history")
+public class TableRecord {
+
+    private static final Logger logger = Logger.getLogger(TableRecord.class);
+
+    @DatabaseField(dataType = DataType.BYTE_ARRAY, indexName = "proto_index", unique = true)
+    protected byte[] proto;
+
+    @DatabaseField(indexName = "end_time_ms")
+    protected long endTimeMs;
+
+    public TableRecord() {
+    }
+
+    public TableRecord(TableProto proto, long endTimeMs) {
+        this.proto = proto.toByteArray();
+        this.endTimeMs = endTimeMs;
+    }
+
+    public TableProto getProto() {
+        try {
+            return TableProto.parseFrom(this.proto);
+        } catch (InvalidProtocolBufferException ex) {
+            logger.error("Failed to parse serialized proto", ex);
+        }
+        return null;
+    }
+}

--- a/Mage.Server/src/main/java/mage/server/record/TableRecordRepository.java
+++ b/Mage.Server/src/main/java/mage/server/record/TableRecordRepository.java
@@ -1,0 +1,77 @@
+package mage.server.record;
+
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.dao.DaoManager;
+import com.j256.ormlite.jdbc.JdbcConnectionSource;
+import com.j256.ormlite.stmt.QueryBuilder;
+import com.j256.ormlite.support.ConnectionSource;
+import com.j256.ormlite.support.DatabaseConnection;
+import com.j256.ormlite.table.TableUtils;
+import java.io.File;
+import java.sql.SQLException;
+import java.util.List;
+import mage.cards.repository.RepositoryUtil;
+import org.apache.log4j.Logger;
+
+public enum TableRecordRepository {
+
+    instance;
+
+    private static final String JDBC_URL = "jdbc:sqlite:./db/table_record.db";
+    private static final String VERSION_ENTITY_NAME = "table_record";
+    // raise this if db structure was changed
+    private static final long DB_VERSION = 0;
+
+    private Dao<TableRecord, Object> dao;
+
+    private TableRecordRepository() {
+        File file = new File("db");
+        if (!file.exists()) {
+            file.mkdirs();
+        }
+        try {
+            ConnectionSource connectionSource = new JdbcConnectionSource(JDBC_URL);
+            boolean obsolete = RepositoryUtil.isDatabaseObsolete(connectionSource, VERSION_ENTITY_NAME, DB_VERSION);
+
+            if (obsolete) {
+                TableUtils.dropTable(connectionSource, TableRecord.class, true);
+            }
+
+            TableUtils.createTableIfNotExists(connectionSource, TableRecord.class);
+            dao = DaoManager.createDao(connectionSource, TableRecord.class);
+        } catch (SQLException ex) {
+            Logger.getLogger(TableRecordRepository.class).error("Error creating table_record repository - ", ex);
+        }
+    }
+
+    public void add(TableRecord tableHistory) {
+        try {
+            dao.create(tableHistory);
+        } catch (SQLException ex) {
+            Logger.getLogger(TableRecordRepository.class).error("Error adding a table_record to DB - ", ex);
+        }
+    }
+
+    public List<TableRecord> getAfter(long endTimeMs) {
+        try {
+            QueryBuilder<TableRecord, Object> qb = dao.queryBuilder();
+            qb.where().gt("endTimeMs", endTimeMs);
+            qb.orderBy("endTimeMs", true);
+            return dao.query(qb.prepare());
+        } catch (SQLException ex) {
+            Logger.getLogger(TableRecordRepository.class).error("Error getting table_records from DB - ", ex);
+        }
+        return null;
+    }
+
+    public void closeDB() {
+        try {
+            if (dao != null && dao.getConnectionSource() != null) {
+                DatabaseConnection conn = dao.getConnectionSource().getReadWriteConnection();
+                conn.executeStatement("shutdown compact", 0);
+            }
+        } catch (SQLException ex) {
+            Logger.getLogger(TableRecordRepository.class).error("Error closing table_record repository - ", ex);
+        }
+    }
+}

--- a/Mage.Server/src/main/java/mage/server/record/TableRecorderImpl.java
+++ b/Mage.Server/src/main/java/mage/server/record/TableRecorderImpl.java
@@ -16,7 +16,6 @@ public class TableRecorderImpl implements TableRecorder {
 
     public void record(Table table) {
         TableProto proto = table.toProto();
-        logger.info("Adding record:\n" + proto.toString());
         TableRecordRepository.instance.add(new TableRecord(proto, proto.getEndTimeMs()));
     }
 }

--- a/Mage.Server/src/main/java/mage/server/record/TableRecorderImpl.java
+++ b/Mage.Server/src/main/java/mage/server/record/TableRecorderImpl.java
@@ -1,0 +1,22 @@
+package mage.server.record;
+
+import mage.game.Table;
+import mage.game.Table.TableRecorder;
+import mage.game.result.ResultProtos.TableProto;
+import org.apache.log4j.Logger;
+
+public class TableRecorderImpl implements TableRecorder {
+
+    private static TableRecorderImpl INSTANCE = new TableRecorderImpl();
+    private static final Logger logger = Logger.getLogger(TableRecorderImpl.class);
+
+    public static TableRecorderImpl getInstance() {
+        return INSTANCE;
+    }
+
+    public void record(Table table) {
+        TableProto proto = table.toProto();
+        logger.info("Adding record:\n" + proto.toString());
+        TableRecordRepository.instance.add(new TableRecord(proto, proto.getEndTimeMs()));
+    }
+}

--- a/Mage.Server/src/main/java/mage/server/record/UserStats.java
+++ b/Mage.Server/src/main/java/mage/server/record/UserStats.java
@@ -1,0 +1,45 @@
+package mage.server.record;
+
+import com.j256.ormlite.field.DataType;
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.table.DatabaseTable;
+import mage.game.result.ResultProtos.UserStatsProto;
+import org.mage.mage.shaded.protobuf.InvalidProtocolBufferException;
+import org.apache.log4j.Logger;
+
+@DatabaseTable(tableName = "user_stats")
+public class UserStats {
+
+    private static final Logger logger = Logger.getLogger(TableRecord.class);
+
+    @DatabaseField(indexName = "user_name_index", unique = true, id = true)
+    protected String userName;
+
+    @DatabaseField(dataType = DataType.BYTE_ARRAY)
+    protected byte[] proto;
+
+    @DatabaseField(indexName = "end_time_ms_index")
+    protected long endTimeMs;
+
+    public UserStats() {
+    }
+
+    public UserStats(UserStatsProto proto, long endTimeMs) {
+        this.userName = proto.getName();
+        this.proto = proto.toByteArray();
+        this.endTimeMs = endTimeMs;
+    }
+
+    public UserStatsProto getProto() {
+        try {
+            return UserStatsProto.parseFrom(this.proto);
+        } catch (InvalidProtocolBufferException ex) {
+            logger.error("Failed to parse serialized proto", ex);
+        }
+        return null;
+    }
+
+    public long getEndTimeMs() {
+        return this.endTimeMs;
+    }
+}

--- a/Mage.Server/src/main/java/mage/server/record/UserStatsRepository.java
+++ b/Mage.Server/src/main/java/mage/server/record/UserStatsRepository.java
@@ -1,0 +1,111 @@
+package mage.server.record;
+
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.dao.DaoManager;
+import com.j256.ormlite.jdbc.JdbcConnectionSource;
+import com.j256.ormlite.stmt.QueryBuilder;
+import com.j256.ormlite.support.ConnectionSource;
+import com.j256.ormlite.support.DatabaseConnection;
+import com.j256.ormlite.table.TableUtils;
+import java.io.File;
+import java.sql.SQLException;
+import java.util.List;
+import mage.cards.repository.RepositoryUtil;
+import org.apache.log4j.Logger;
+
+public enum UserStatsRepository {
+
+    instance;
+
+    private static final String JDBC_URL = "jdbc:sqlite:./db/user_stats.db";
+    private static final String VERSION_ENTITY_NAME = "user_stats";
+    // raise this if db structure was changed
+    private static final long DB_VERSION = 0;
+
+    private Dao<UserStats, Object> dao;
+
+    private UserStatsRepository() {
+        File file = new File("db");
+        if (!file.exists()) {
+            file.mkdirs();
+        }
+        try {
+            ConnectionSource connectionSource = new JdbcConnectionSource(JDBC_URL);
+            boolean obsolete = RepositoryUtil.isDatabaseObsolete(connectionSource, VERSION_ENTITY_NAME, DB_VERSION);
+
+            if (obsolete) {
+                TableUtils.dropTable(connectionSource, UserStats.class, true);
+            }
+
+            TableUtils.createTableIfNotExists(connectionSource, UserStats.class);
+            dao = DaoManager.createDao(connectionSource, UserStats.class);
+        } catch (SQLException ex) {
+            Logger.getLogger(UserStatsRepository.class).error("Error creating user_stats repository - ", ex);
+        }
+    }
+
+    public void add(UserStats userStats) {
+        try {
+            dao.create(userStats);
+        } catch (SQLException ex) {
+            Logger.getLogger(UserStatsRepository.class).error("Error adding a user_stats to DB - ", ex);
+        }
+    }
+
+    public void update(UserStats userStats) {
+        try {
+            dao.update(userStats);
+        } catch (SQLException ex) {
+            Logger.getLogger(UserStatsRepository.class).error("Error updating a user_stats in DB - ", ex);
+        }
+    }
+
+    public UserStats getUser(String userName) {
+        try {
+            QueryBuilder<UserStats, Object> qb = dao.queryBuilder();
+            qb.where().eq("userName", userName);
+            List<UserStats> users = dao.query(qb.prepare());
+            if (users.size() == 1) {
+                return users.get(0);
+            }
+        } catch (SQLException ex) {
+            Logger.getLogger(UserStatsRepository.class).error("Error getting a user from DB - ", ex);
+        }
+        return null;
+    }
+
+    public List<UserStats> getAllUsers() {
+        try {
+            QueryBuilder<UserStats, Object> qb = dao.queryBuilder();
+            return dao.query(qb.prepare());
+        } catch (SQLException ex) {
+            Logger.getLogger(UserStatsRepository.class).error("Error getting all users from DB - ", ex);
+        }
+        return null;
+    }
+
+    public long getLatestEndTimeMs() {
+        try {
+          QueryBuilder<UserStats, Object> qb = dao.queryBuilder();
+          qb.orderBy("endTimeMs", false).limit(1);
+          List<UserStats> users = dao.query(qb.prepare());
+          if (users.size() == 1) {
+              return users.get(0).getEndTimeMs();
+          }
+        } catch (SQLException ex) {
+            Logger.getLogger(UserStatsRepository.class).error("Error getting the latest end time from DB - ", ex);
+        }
+        return 0;
+    }
+
+    public void closeDB() {
+        try {
+            if (dao != null && dao.getConnectionSource() != null) {
+                DatabaseConnection conn = dao.getConnectionSource().getReadWriteConnection();
+                conn.executeStatement("shutdown compact", 0);
+            }
+        } catch (SQLException ex) {
+            Logger.getLogger(UserStatsRepository.class).error("Error closing user_stats repository - ", ex);
+        }
+    }
+}

--- a/Mage/pom.xml
+++ b/Mage/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>junit</artifactId>
             <version>4.12</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -51,11 +56,141 @@
                 </configuration>
             </plugin>
 
+            <!-- http://vlkan.com/blog/post/2015/11/27/maven-protobuf/ -->
+            <!-- copy protoc binary into build directory -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-protoc</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.google.protobuf</groupId>
+                                    <artifactId>protoc</artifactId>
+                                    <version>${protobuf.version}</version>
+                                    <classifier>${os.detected.classifier}</classifier>
+                                    <type>exe</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- compile proto buffer files using copied protoc binary -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${maven-antrun-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>exec-protoc</id>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <target>
+                                <property name="protoc.filename" value="protoc-${protobuf.version}-${os.detected.classifier}.exe"/>
+                                <property name="protoc.filepath" value="${project.build.directory}/${protoc.filename}"/>
+                                <chmod file="${protoc.filepath}" perm="ugo+rx"/>
+                                <mkdir dir="${protobuf.output.directory}" />
+                                <path id="protobuf.input.filepaths.path">
+                                    <fileset dir="${protobuf.input.directory}">
+                                        <include name="**/*.proto"/>
+                                    </fileset>
+                                </path>
+                                <pathconvert pathsep=" " property="protobuf.input.filepaths" refid="protobuf.input.filepaths.path"/>
+                                <exec executable="${protoc.filepath}" failonerror="true">
+                                    <arg value="-I"/>
+                                    <arg value="${protobuf.input.directory}"/>
+                                    <arg value="--java_out"/>
+                                    <arg value="${protobuf.output.directory}"/>
+                                    <arg line="${protobuf.input.filepaths}"/>
+                                </exec>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- add generated proto buffer classes into the package -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${build-helper-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>add-classes</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${protobuf.output.directory}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--  shade protobuf to avoid version conflicts -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.protobuf</pattern>
+                                    <shadedPattern>${project.groupId}.${project.artifactId}.shaded.protobuf</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <finalName>mage</finalName>
+
+        <!-- http://vlkan.com/blog/post/2015/11/27/maven-protobuf/ -->
+        <extensions>
+            <!-- provides os.detected.classifier (i.e. linux-x86_64, osx-x86_64) property -->
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${os-maven-plugin.version}</version>
+            </extension>
+        </extensions>
     </build>
 
-    <properties/>
+    <!-- http://vlkan.com/blog/post/2015/11/27/maven-protobuf/ -->
+    <properties>
+        <!-- protobuf paths -->
+        <protobuf.input.directory>${project.basedir}/src/main/proto</protobuf.input.directory>
+        <protobuf.output.directory>${project.build.directory}/generated-sources</protobuf.output.directory>
+
+        <!-- library versions -->
+        <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
+        <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
+        <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
+        <maven-shade-plugin.version>2.4.2</maven-shade-plugin.version>
+        <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
+        <protobuf.version>3.0.0-beta-1</protobuf.version>
+    </properties>
 
 </project>

--- a/Mage/pom.xml
+++ b/Mage/pom.xml
@@ -56,7 +56,7 @@
                 </configuration>
             </plugin>
 
-            <!-- http://vlkan.com/blog/post/2015/11/27/maven-protobuf/ -->
+            <!-- The plugins below are added by following http://vlkan.com/blog/post/2015/11/27/maven-protobuf/ -->
             <!-- copy protoc binary into build directory -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -167,7 +167,7 @@
 
         <finalName>mage</finalName>
 
-        <!-- http://vlkan.com/blog/post/2015/11/27/maven-protobuf/ -->
+        <!-- The extension below is added added by following http://vlkan.com/blog/post/2015/11/27/maven-protobuf/ -->
         <extensions>
             <!-- provides os.detected.classifier (i.e. linux-x86_64, osx-x86_64) property -->
             <extension>
@@ -178,7 +178,7 @@
         </extensions>
     </build>
 
-    <!-- http://vlkan.com/blog/post/2015/11/27/maven-protobuf/ -->
+    <!-- The properties below are added added by following http://vlkan.com/blog/post/2015/11/27/maven-protobuf/ -->
     <properties>
         <!-- protobuf paths -->
         <protobuf.input.directory>${project.basedir}/src/main/proto</protobuf.input.directory>

--- a/Mage/src/main/java/mage/game/match/Match.java
+++ b/Mage/src/main/java/mage/game/match/Match.java
@@ -39,6 +39,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import mage.game.GameInfo;
+import mage.game.result.ResultProtos.MatchProto;
 
 /**
  *
@@ -111,4 +112,6 @@ public interface Match {
 
     void setTableId(UUID tableId);
     void setTournamentRound(int round);
+
+    MatchProto toProto();
 }

--- a/Mage/src/main/java/mage/game/match/MatchImpl.java
+++ b/Mage/src/main/java/mage/game/match/MatchImpl.java
@@ -41,6 +41,8 @@ import mage.game.events.Listener;
 import mage.game.events.TableEvent;
 import mage.game.events.TableEvent.EventType;
 import mage.game.events.TableEventSource;
+import mage.game.result.ResultProtos.MatchProto;
+import mage.game.result.ResultProtos.MatchQuitStatus;
 import mage.players.Player;
 import mage.util.DateFormat;
 import org.apache.log4j.Logger;
@@ -486,6 +488,27 @@ public abstract class MatchImpl implements Match {
             matchPlayer.cleanUpOnMatchEnd();
         }
         this.getGames().clear();
+    }
+
+    @Override
+    public MatchProto toProto() {
+        MatchProto.Builder builder = MatchProto.newBuilder()
+                .setName(this.getName())
+                .setGameType(this.getOptions().getGameType())
+                .setDeckType(this.getOptions().getDeckType())
+                .setGames(this.getNumGames())
+                .setDraws(this.getDraws());
+        for (MatchPlayer matchPlayer : this.getPlayers()) {
+            MatchQuitStatus status = !matchPlayer.hasQuit() ? MatchQuitStatus.NO_MATCH_QUIT :
+                    matchPlayer.getPlayer().hasTimerTimeout() ? MatchQuitStatus.TIMER_TIMEOUT :
+                    matchPlayer.getPlayer().hasIdleTimeout() ? MatchQuitStatus.IDLE_TIMEOUT :
+                    MatchQuitStatus.QUIT;
+            builder.addPlayersBuilder()
+                    .setName(matchPlayer.getName())
+                    .setQuit(status)
+                    .setWins(matchPlayer.getWins());
+        }
+        return builder.build();
     }
 
 }

--- a/Mage/src/main/java/mage/game/tournament/Tournament.java
+++ b/Mage/src/main/java/mage/game/tournament/Tournament.java
@@ -38,6 +38,7 @@ import mage.game.draft.Draft;
 import mage.game.events.Listener;
 import mage.game.events.PlayerQueryEvent;
 import mage.game.events.TableEvent;
+import mage.game.result.ResultProtos.TourneyProto;
 import mage.players.Player;
 
 /**
@@ -98,4 +99,6 @@ public interface Tournament {
 
     void clearDraft();
     Draft getDraft();
+
+    TourneyProto toProto();
 }

--- a/Mage/src/main/java/mage/game/tournament/TournamentPlayer.java
+++ b/Mage/src/main/java/mage/game/tournament/TournamentPlayer.java
@@ -31,6 +31,8 @@ package mage.game.tournament;
 import java.util.Set;
 import mage.cards.decks.Deck;
 import mage.constants.TournamentPlayerState;
+import mage.game.result.ResultProtos.TourneyPlayerProto;
+import mage.game.result.ResultProtos.TourneyQuitStatus;
 import mage.players.Player;
 import mage.util.TournamentUtil;
 
@@ -52,6 +54,8 @@ public class TournamentPlayer {
     protected boolean quit = false;
     protected boolean doneConstructing;
     protected boolean joined = false;
+    protected TourneyQuitStatus quitStatus = TourneyQuitStatus.NO_TOURNEY_QUIT;
+    protected TournamentPlayer replacedTournamentPlayer;
 
     public TournamentPlayer(Player player, String playerType) {
         this.player = player;
@@ -60,7 +64,6 @@ public class TournamentPlayer {
         this.stateInfo = "";
         this.disconnectInfo = "";
         this.results = "";
-
     }
 
     public Player getPlayer() {
@@ -185,12 +188,13 @@ public class TournamentPlayer {
         return quit;
     }
 
-    public void setQuit(String info) {
+    public void setQuit(String info, TourneyQuitStatus status) {
         setEliminated();
         this.setState(TournamentPlayerState.CANCELED);
         this.setStateInfo(info);
         this.quit = true;
         this.doneConstructing = true;
+        this.quitStatus = status;
     }
 
     /**
@@ -215,6 +219,24 @@ public class TournamentPlayer {
         return !this.getState().equals(TournamentPlayerState.CANCELED)
                 && !this.getState().equals(TournamentPlayerState.ELIMINATED)
                 && !this.getState().equals(TournamentPlayerState.FINISHED);
+    }
+
+    public TournamentPlayer getReplacedTournamentPlayer() {
+        return this.replacedTournamentPlayer;
+    }
+
+    public void setReplacedTournamentPlayer(TournamentPlayer player) {
+        this.replacedTournamentPlayer = player;
+    }
+
+    public TourneyPlayerProto toProto() {
+        return TourneyPlayerProto.newBuilder()
+                .setName(this.player.getName())
+                .setPlayerType(this.playerType)
+                .setStateInfo(this.stateInfo)
+                .setDisconnectInfo(this.disconnectInfo)
+                .setQuit(this.quitStatus)
+                .build();
     }
 }
 

--- a/Mage/src/main/java/mage/game/tournament/TournamentPlayer.java
+++ b/Mage/src/main/java/mage/game/tournament/TournamentPlayer.java
@@ -233,8 +233,6 @@ public class TournamentPlayer {
         return TourneyPlayerProto.newBuilder()
                 .setName(this.player.getName())
                 .setPlayerType(this.playerType)
-                .setStateInfo(this.stateInfo)
-                .setDisconnectInfo(this.disconnectInfo)
                 .setQuit(this.quitStatus)
                 .build();
     }

--- a/Mage/src/main/proto/result.proto
+++ b/Mage/src/main/proto/result.proto
@@ -46,9 +46,7 @@ message TourneyPlayerProto {
   optional string name = 1;
   optional string player_type = 2;
   optional string replaced_player_name = 3;
-  optional string state_info = 4;
-  optional string disconnect_info = 5;
-  optional TourneyQuitStatus quit = 6;
+  optional TourneyQuitStatus quit = 4;
 }
 
 enum TourneyQuitStatus {

--- a/Mage/src/main/proto/result.proto
+++ b/Mage/src/main/proto/result.proto
@@ -1,0 +1,79 @@
+package mage.game.result;
+
+option java_outer_classname = "ResultProtos";
+
+message TableProto {
+  optional MatchProto match = 1;
+  optional TourneyProto tourney = 2;
+  optional string game_type = 3;
+  optional string deck_type = 4;
+  optional string name = 5;
+  optional string controller_name = 6;
+  optional int64 start_time_ms = 7;
+  optional int64 end_time_ms = 8;
+}
+
+message MatchProto {
+  optional string name = 1;
+  optional string game_type = 2;
+  optional string deck_type = 3;
+  optional int32 games = 4;
+  optional int32 draws = 5;
+  repeated MatchPlayerProto players = 6;
+}
+
+message MatchPlayerProto {
+  optional string name = 1;
+  optional int32 wins = 2;
+  optional MatchQuitStatus quit = 3;
+  optional bool bye = 4;
+}
+
+enum MatchQuitStatus {
+  NO_MATCH_QUIT = 0;
+  IDLE_TIMEOUT = 1;  // I
+  TIMER_TIMEOUT = 2;  // T
+  QUIT = 3;  // Q
+}
+
+message TourneyProto {
+  optional string booster_info = 1;
+  repeated TourneyPlayerProto players = 2;
+  repeated TourneyRoundProto rounds = 3;
+}
+
+message TourneyPlayerProto {
+  optional string name = 1;
+  optional string player_type = 2;
+  optional string replaced_player_name = 3;
+  optional string state_info = 4;
+  optional string disconnect_info = 5;
+  optional TourneyQuitStatus quit = 6;
+}
+
+enum TourneyQuitStatus {
+  NO_TOURNEY_QUIT = 0;
+  DURING_ROUND = 1;
+  DURING_DRAFTING = 2;
+  DURING_CONSTRUCTION = 3;
+}
+
+message TourneyRoundProto {
+  optional int32 round = 1;
+  repeated MatchProto matches = 2;
+  repeated string byes = 3;
+}
+
+message UserStatsProto {
+  optional string name = 1;
+
+  optional int32 tourneys = 2;
+  optional int32 tourneys_quit_during_round = 3;
+  optional int32 tourneys_quit_during_drafting = 4;
+  optional int32 tourneys_quit_during_construction = 5;
+
+  optional int32 matches = 6;
+  optional int32 matches_idle_timeout = 7;
+  optional int32 matches_timer_timeout = 8;
+  optional int32 matches_quit = 9;
+}


### PR DESCRIPTION
* Used protobuf as a serialization format for game histories and user stats. There's a fairly large change to pom.xml so that protobuf compiler can be invoked as part of the build process. Otherwise we need to check in ~6K lines of generated java code.
* Added 2 DBs for match histories and user stats. I used SQLite as the backend, because from my personal experience H2 grew unexpectedly in size when I kept inserted match histories. There're several articles online mentioning the issue (some garbage collection can't run whie DB is open).
