### PR TITLE
spjspj - Lands are ok from top of library

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/PlayTheTopCardEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/PlayTheTopCardEffect.java
@@ -32,6 +32,7 @@ import mage.abilities.Ability;
 import mage.abilities.effects.AsThoughEffectImpl;
 import mage.cards.Card;
 import mage.constants.AsThoughEffectType;
+import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.filter.FilterCard;
@@ -77,7 +78,7 @@ public class PlayTheTopCardEffect extends AsThoughEffectImpl {
         if (cardOnTop != null
                 && affectedControllerId.equals(source.getControllerId())
                 && cardOnTop.getOwnerId().equals(source.getControllerId())
-                && !cardOnTop.getManaCost().isEmpty()
+                && (!cardOnTop.getManaCost().isEmpty() || cardOnTop.getCardType().contains(CardType.LAND))
                 && filter.match(cardOnTop, game)) {
             Player player = game.getPlayer(cardOnTop.getOwnerId());
             if (player != null && cardOnTop.equals(player.getLibrary().getFromTop(game))) {


### PR DESCRIPTION
Suspend cards are uncastable from top of library but lands are ok