### PR TITLE
Fix issues with brand new installation, add Generate button to Deck Editor, show card tooltips in logs

### DIFF
--- a/Mage.Client/src/main/java/mage/client/components/ability/AbilityPicker.java
+++ b/Mage.Client/src/main/java/mage/client/components/ability/AbilityPicker.java
@@ -14,6 +14,7 @@ import org.apache.log4j.Logger;
 import org.jdesktop.layout.GroupLayout;
 import org.jdesktop.layout.LayoutStyle;
 import org.jdesktop.swingx.JXPanel;
+import org.jsoup.Jsoup;
 import org.mage.card.arcane.ManaSymbols;
 import org.mage.card.arcane.UI;
 
@@ -434,6 +435,7 @@ public class AbilityPicker extends JXPanel implements MouseWheelListener {
             if (choice == null || choice.isEmpty()) {
                 return choice;
             }
+            choice = Jsoup.parse(choice).text(); // decode HTML entities and strip tags
             return choice.substring(0, 1).toUpperCase() + choice.substring(1);
         }
 

--- a/Mage.Client/src/main/java/mage/client/deck/generator/DeckGenerator.java
+++ b/Mage.Client/src/main/java/mage/client/deck/generator/DeckGenerator.java
@@ -54,6 +54,14 @@ import mage.util.TournamentUtil;
  */
 public class DeckGenerator {
 
+    public static class DeckGeneratorException extends RuntimeException {
+
+        public DeckGeneratorException(String message) {
+            super(message);
+        }
+
+    }
+
     private static final int MAX_TRIES = 8196;
     private static DeckGeneratorDialog genDialog;
     private static DeckGeneratorPool genPool;
@@ -82,6 +90,9 @@ public class DeckGenerator {
         String format = genDialog.getSelectedFormat();
 
         List<String> setsToUse = ConstructedFormats.getSetsByFormat(format);
+        if (setsToUse == null) {
+            throw new DeckGeneratorException("Deck sets aren't initialized; please connect to a server to update the database.");
+        }
         if (setsToUse.isEmpty()) {
             // Default to using all sets
             setsToUse = ExpansionRepository.instance.getSetCodes();

--- a/Mage.Client/src/main/java/mage/client/deckeditor/DeckEditorPanel.form
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/DeckEditorPanel.form
@@ -83,6 +83,8 @@
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="btnImport" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
+                          <Component id="btnGenDeck" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
                           <Component id="btnAddLand" min="-2" max="-2" attributes="0"/>   
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="btnSubmit" min="-2" max="-2" attributes="0"/>                                                    
@@ -110,6 +112,7 @@
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="btnImport" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="btnGenDeck" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="btnAddLand" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="btnSubmit" alignment="3" min="-2" max="-2" attributes="0"/>                      
                   </Group>

--- a/Mage.Client/src/main/java/mage/client/deckeditor/DeckEditorPanel.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/DeckEditorPanel.java
@@ -60,9 +60,9 @@ import mage.client.MageFrame;
 import mage.client.cards.BigCard;
 import mage.client.cards.ICardGrid;
 import mage.client.constants.Constants.DeckEditorMode;
-import static mage.client.constants.Constants.DeckEditorMode.FREE_BUILDING;
-import static mage.client.constants.Constants.DeckEditorMode.LIMITED_BUILDING;
-import static mage.client.constants.Constants.DeckEditorMode.SIDEBOARDING;
+import mage.client.deck.generator.DeckGenerator;
+import mage.client.deck.generator.DeckGenerator.DeckGeneratorException;
+
 import mage.client.dialog.AddLandDialog;
 import mage.client.plugins.impl.Plugins;
 import mage.client.util.Event;
@@ -173,6 +173,7 @@ public class DeckEditorPanel extends javax.swing.JPanel {
                 this.cardSelector.switchToGrid();
                 this.btnExit.setVisible(false);
                 this.btnImport.setVisible(false);
+                this.btnGenDeck.setVisible(false);
                 if (!MageFrame.getSession().isTestMode()) {
                     this.btnLoad.setVisible(false);
                 }
@@ -195,6 +196,7 @@ public class DeckEditorPanel extends javax.swing.JPanel {
                 //this.cardTableSelector.loadCards(this.bigCard);
                 this.btnExit.setVisible(true);
                 this.btnImport.setVisible(true);
+                this.btnGenDeck.setVisible(true);
                 if (!MageFrame.getSession().isTestMode()) {
                     this.btnLoad.setVisible(true);
                 }
@@ -504,6 +506,7 @@ public class DeckEditorPanel extends javax.swing.JPanel {
         btnImport = new javax.swing.JButton();
         btnSubmit = new javax.swing.JButton();
         btnAddLand = new javax.swing.JButton();
+        btnGenDeck = new javax.swing.JButton();
         txtTimeRemaining = new javax.swing.JTextField();
 
         jSplitPane1.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);
@@ -591,6 +594,15 @@ public class DeckEditorPanel extends javax.swing.JPanel {
                 btnAddLandActionPerformed(evt);
             }
         });
+        
+        btnGenDeck.setText("Generate");
+        btnGenDeck.setName("btnGenDeck");
+        btnGenDeck.addActionListener(new java.awt.event.ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnGenDeckActionPerformed(evt);
+            }
+        });
 
         txtTimeRemaining.setEditable(false);
         txtTimeRemaining.setForeground(java.awt.Color.red);
@@ -626,6 +638,8 @@ public class DeckEditorPanel extends javax.swing.JPanel {
                                         .addContainerGap()
                                         .addComponent(btnImport)
                                         .addContainerGap()
+                                        .addComponent(btnGenDeck)
+                                        .addContainerGap()
                                         .addComponent(btnAddLand)
                                         .addContainerGap()
                                         .addComponent(btnSubmit))
@@ -650,6 +664,7 @@ public class DeckEditorPanel extends javax.swing.JPanel {
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                                 .addComponent(btnImport)
+                                .addComponent(btnGenDeck)
                                 .addComponent(btnAddLand)
                                 .addComponent(btnSubmit))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -801,6 +816,21 @@ public class DeckEditorPanel extends javax.swing.JPanel {
         refreshDeck();
     }//GEN-LAST:event_btnAddLandActionPerformed
 
+    private void btnGenDeckActionPerformed(ActionEvent evt) {
+        try {
+            setCursor(new Cursor(Cursor.WAIT_CURSOR));
+            String path = DeckGenerator.generateDeck();
+            deck = Deck.load(DeckImporterUtil.importDeck(path), true, true);
+        } catch (GameException ex) {
+            JOptionPane.showMessageDialog(MageFrame.getDesktop(), ex.getMessage(), "Error loading generated deck", JOptionPane.ERROR_MESSAGE);
+        }catch (DeckGeneratorException ex) {
+            JOptionPane.showMessageDialog(MageFrame.getDesktop(), ex.getMessage(), "Generator error", JOptionPane.ERROR_MESSAGE);
+        } finally {
+            setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
+        }
+        refreshDeck();
+    }
+    
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private mage.client.cards.BigCard bigCard;
     private javax.swing.JButton btnExit;
@@ -816,6 +846,7 @@ public class DeckEditorPanel extends javax.swing.JPanel {
     private javax.swing.JTextField txtDeckName;
     private javax.swing.JButton btnSubmit;
     private javax.swing.JButton btnAddLand;
+    private javax.swing.JButton btnGenDeck;
     private JComponent cardInfoPane;
     private javax.swing.JTextField txtTimeRemaining;
     // End of variables declaration//GEN-END:variables

--- a/Mage.Client/src/main/java/mage/client/dialog/ConnectDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/ConnectDialog.java
@@ -66,6 +66,7 @@ import static mage.client.dialog.PreferencesDialog.KEY_CONNECT_FLAG;
 import mage.client.preference.MagePreferences;
 import mage.client.util.Config;
 import mage.client.util.gui.countryBox.CountryItemEditor;
+import mage.client.util.sets.ConstructedFormats;
 import mage.remote.Connection;
 import org.apache.log4j.Logger;
 
@@ -442,6 +443,7 @@ public class ConnectDialog extends MageDialog {
     private void connected() {
         this.saveSettings();
         this.hideDialog();
+        ConstructedFormats.ensureLists();
     }
 
     private void keyTyped(java.awt.event.KeyEvent evt) {//GEN-FIRST:event_keyTyped

--- a/Mage.Client/src/main/java/mage/client/util/sets/ConstructedFormats.java
+++ b/Mage.Client/src/main/java/mage/client/util/sets/ConstructedFormats.java
@@ -50,6 +50,12 @@ public class ConstructedFormats {
 
     }
 
+    public static void ensureLists() {
+        if (getSetsByFormat(ConstructedFormats.STANDARD) == null) {
+            buildLists();
+        }
+    }
+    
     private static void buildLists() {
         GregorianCalendar cutoff;
         // month is zero based so January = 0
@@ -60,6 +66,7 @@ public class ConstructedFormats {
             cutoff = new GregorianCalendar(calendar.get(Calendar.YEAR) - 2, Calendar.SEPTEMBER, 1);
         }
         final Map<String, ExpansionInfo> expansionInfo = new HashMap<>();
+        formats.clear(); // prevent NPE on sorting if this is not the first try
         for (ExpansionInfo set : ExpansionRepository.instance.getAll()) {
         	expansionInfo.put(set.getName(), set);
         	formats.add(set.getName());
@@ -207,10 +214,11 @@ public class ConstructedFormats {
 			}
         	
 		});
-
-        formats.add(0, MODERN);
-        formats.add(0, EXTENDED);
-        formats.add(0, STANDARD);
+        if (!formats.isEmpty()) {
+            formats.add(0, MODERN);
+            formats.add(0, EXTENDED);
+            formats.add(0, STANDARD);
+        }
         formats.add(0, ALL);
     }
     

--- a/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
@@ -31,6 +31,7 @@ import net.xeoh.plugins.base.annotations.meta.Author;
 import org.apache.log4j.Logger;
 import org.mage.card.arcane.Animation;
 import org.mage.card.arcane.CardPanel;
+import org.mage.card.arcane.ManaSymbols;
 import org.mage.plugins.card.dl.DownloadGui;
 import org.mage.plugins.card.dl.DownloadJob;
 import org.mage.plugins.card.dl.Downloader;
@@ -540,6 +541,7 @@ public class CardPluginImpl implements CardPlugin {
             @Override
             public void windowClosing(WindowEvent e) {
                 g.getDownloader().dispose();
+                ManaSymbols.loadImages();
             }
         });
         d.setLayout(new BorderLayout());


### PR DESCRIPTION
Ok, this one is a little bigger than I expected. I wanted to solve some issues with a brand new installation, i.e. when the client database doesn't exist and images aren't downloaded. For example, in the current version these steps lead to nasty NPEs:
1) get a new clean installation;
2) don't connect to any server, open the Deck Editor instead;
3) select any set (Standard, Extended, Modern);
4) enjoy getting an NPE;
5) moreover, Deck Editor and Generator are broken from now on (until you restart the game completely) even though the sets are received.

Why? Static initialization, one of the things I'm personally very opposed to. It's very unpredictable and leads to situations like this one. The problem is that ConstructedFormats are referenced in CardSelector which is referenced in DeckEditorPanel. Hence this chain leads to calling ConstructedFormats.buildLists() prematurely, when the database is empty. I fixed it, added a special exception for that case to generator and also added a small method to ensure that lists are updated, it's called after connecting to a server. buildLists() is only called from there if the described case actually happened. It would be better to get rid of that static { ] block completely but I'm not sure it won't break anything.

Another issue I fixed is symbols. After they're downloaded, user have to restart the game to get them shown. I added loading of them on closing that progress window, this should provide a bit better user experience.

I also cleaned up HTML for the Ability Picker. Until then I saw some ugly entities like &mdash; and tags like <i> </i> right in the ability choice. Fortunately, Jsoup is already included as a dependency so fixing this was a bliss. I saw another renderer that supports images (ImageRenderer2) but it looks glitchy and unfinished. Until it's done, I suppose my solution is good enough.

One of the things I missed is the ability to generate a deck right in the Deck Editor. It feels natural to be able to do so and I added the Generate button there. It shows the same dialog as the Generate button on the match start. The only downside is that if you press Cancel, it will reload the last used deck. I didn't change this behavior.

And the biggest and most useful (I believe) part is showing info about cards from the log window. It's often hard to understand or remember what happened on the battlefield and I had to resort to browsing exiles and graveyards just to read cards descriptions and understand what's going on. Now I can just point to a card name and a tooltip appears with all the needed information. It's not good enough, unfortunately, the card is selected randomly as there's not enough info to get *that exact card* that was played. Because of that you can see different set symbols each time the tooltip appears. Also, the card gets found by its name, I'm not 100% sure it's absolutely accurate. Maybe in some sets some card may have different params than in another set. I couldn't find another way to extract the info I needed without hacking the server so don't rely on it too much.