### PR TITLE
Fix first card tooltip show.

### DIFF
--- a/Mage.Client/src/main/java/mage/client/plugins/adapters/MageActionCallback.java
+++ b/Mage.Client/src/main/java/mage/client/plugins/adapters/MageActionCallback.java
@@ -189,26 +189,30 @@ public class MageActionCallback implements ActionCallback {
                     Point location = new Point((int) data.locationOnScreen.getX() + data.popupOffsetX - 40, (int) data.locationOnScreen.getY() + data.popupOffsetY - 40);
                     location = GuiDisplayUtil.keepComponentInsideParent(location, parentPoint, popup2, parentComponent);
                     location.translate(-parentPoint.x, -parentPoint.y);
-                    popupContainer.setLocation(location);
 
                     ThreadUtils.sleep(200);
 
-                    final Component c = MageFrame.getUI().getComponent(MageComponents.DESKTOP_PANE);
-                    SwingUtilities.invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            if (!popupTextWindowOpen || !enlargedWindowState.equals(EnlargedWindowState.CLOSED)) {
-                                return;
-                            }
-                            popupContainer.setVisible(true);
-                            c.repaint();
-                        }
-                    }
-                    );
+                    showPopup(popupContainer, location);
 
                 } catch (InterruptedException e) {
                     LOGGER.warn(e.getMessage());
                 }
+            }
+
+            public void showPopup(final Component popupContainer, final Point location) throws InterruptedException {
+                final Component c = MageFrame.getUI().getComponent(MageComponents.DESKTOP_PANE);
+                SwingUtilities.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (!popupTextWindowOpen || !enlargedWindowState.equals(EnlargedWindowState.CLOSED)) {
+                            return;
+                        }
+                        popupContainer.setLocation(location);
+                        popupContainer.setVisible(true);
+                        c.repaint();
+                    }
+                }
+                );
             }
         });
     }

--- a/Mage.Client/src/main/java/org/mage/plugins/card/info/CardInfoPaneImpl.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/info/CardInfoPaneImpl.java
@@ -59,33 +59,28 @@ public class CardInfoPaneImpl extends JEditorPane implements CardInfoPane {
         }
         currentCard = card;
 
-        ThreadUtils.threadPool.submit(new Runnable() {
-            @Override
-            public void run() {
-                try {
+        try {
+            if (!card.equals(currentCard)) {
+                return;
+            }
+
+            SwingUtilities.invokeLater(new Runnable() {
+                @Override
+                public void run() {
                     if (!card.equals(currentCard)) {
                         return;
                     }
-
-                    SwingUtilities.invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            if (!card.equals(currentCard)) {
-                                return;
-                            }
-                            TextLines textLines = GuiDisplayUtil.getTextLinesfromCardView(card);
-                            StringBuilder buffer = GuiDisplayUtil.getRulefromCardView(card, textLines);
-                            resizeTooltipIfNeeded(container, textLines.basicTextLength, textLines.lines.size());
-                            setText(buffer.toString());
-                            setCaretPosition(0);
-                        }
-                    });
-
-                } catch (Exception e) {
-                    e.printStackTrace();
+                    TextLines textLines = GuiDisplayUtil.getTextLinesfromCardView(card);
+                    StringBuilder buffer = GuiDisplayUtil.getRulefromCardView(card, textLines);
+                    resizeTooltipIfNeeded(container, textLines.basicTextLength, textLines.lines.size());
+                    setText(buffer.toString());
+                    setCaretPosition(0);
                 }
-            }
-        });
+            });
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     private void resizeTooltipIfNeeded(Component container, int ruleLength, int rules) {


### PR DESCRIPTION
Should fix #1574 and also the same (but hidden) issue when the first time you point to a card, the tooltip doesn't show up. It happens because of a race condition of sorts and the exception is swallowed inside the thread pool (actually, it's incapsulated in a Future object). The tooltip size is set in the CardInfoPaneImpl.setCard() method. For some reason it's done inside the thread pool where the only meaningful action happening is running SwingUtilities.invokeLater(). The problem is that showing the tooltip happens in ThreadUtils.threadPool2 and resizing in ThreadUtils.threadPool so there's a smelly ThreadUtils.sleep(200); but it doesn't seem to help. To untangle this mess I made resizing synchronous to the point of SwingUtilities.invokeLater() invokation and moved popupContainer.setLocation() to the EDT (it's an AWT method but still I think it's bad to call it from another thread). I also moved my own hyperlink popup to the thread pool so that the UI callbacks order is the same.

Now I don't see any exceptions and the tooltip appears the first time you point to a card.