### PR TITLE
fixed Ali from Cairo

### DIFF
--- a/Mage.Sets/src/mage/sets/arabiannights/AliFromCairo.java
+++ b/Mage.Sets/src/mage/sets/arabiannights/AliFromCairo.java
@@ -97,11 +97,7 @@ class AliFromCairoReplacementEffect extends ReplacementEffectImpl {
                     && (controller.getLife() > 0) &&(controller.getLife() - event.getAmount()) < 1
                     && event.getPlayerId().equals(controller.getId())
                     ) {
-                return true;
-                //unsure how to make this comply with
-                // 10/1/2008: The ability doesn't change how much damage is dealt;
-                // it just changes how much life that damage makes you lose.
-                // An effect such as Spirit Link will see the full amount of damage being dealt.
+                return true;                
             }
         }
         return false;
@@ -110,10 +106,17 @@ class AliFromCairoReplacementEffect extends ReplacementEffectImpl {
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
+        
+        // 10/1/2008: The ability doesn't change how much damage is dealt;
+        // it just changes how much life that damage makes you lose.
+        // An effect such as Spirit Link will see the full amount of damage being dealt.      
+        game.fireEvent(event);                 
+        
         if (controller != null) {
-            event.setAmount(controller.getLife() - 1);
+            controller.setLife(1, game);
         }
-        return false;
+        
+        return true;
     }
 
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/AliFromCairoTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/AliFromCairoTest.java
@@ -1,0 +1,40 @@
+package org.mage.test.cards.single;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author BetaSteward
+ */
+public class AliFromCairoTest extends CardTestPlayerBase {
+
+    @Test
+    public void testCard() {
+        addCard(Zone.BATTLEFIELD, playerA, "Ali from Cairo", 1);       
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 12);
+        addCard(Zone.BATTLEFIELD, playerB, "Soulfire Grand Master", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain", 12);
+        addCard(Zone.HAND, playerA, "Lightning Bolt", 7);
+        addCard(Zone.HAND, playerB, "Lightning Bolt", 7);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerA);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerA);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerA);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerA);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerA);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerA);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerA);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerA);        
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Lightning Bolt", playerA);        
+        
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertLife(playerA, 1);
+        assertLife(playerB, 23);       
+    }
+}


### PR DESCRIPTION
The previous implementation did reduce the amount of damage that is being dealt, so that it does not reduce life below one.
That is not what the card's replacement effect says. It doesn't reduce the damage just reduces the amount of life loss so that it won't go below 1.
Now the damage is untouched but the affected player's life total is set to 1 if the damage would otherwise reduce it below 1.

I also added a small unit test that checks ali's replacement effect. One player has a soulfire grandmaster in play and tries to kill the enemy with ali in play at 1 life with a lightningt bolt. The enemy should not die, but the caster of the bolt should gain 3 life out of the bolt which did not work with the previous implementation.