### PR TITLE
Disrupting Shoal tests for fuse cards (reported bug)

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/counterspell/DisruptingShoalTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/counterspell/DisruptingShoalTest.java
@@ -75,8 +75,112 @@ public class DisruptingShoalTest extends CardTestPlayerBase {
         assertHandCount(playerA, "Spell Snare", 1);     // Can't be cast -> no valid target
         
         assertGraveyardCount(playerA, "Pillarfield Ox", 1);
-
-        
-        
     }
+    
+    /**
+     * Test that Disrupting Shoal can be played with alternate casting costs
+     * And the X Value can be equal to either half of a fuse card.
+     * 
+     * Reported bug: "Casting Disrupting Shoal pitching Far // Away does not counter spells with converted mana cost 2 or 3, 
+     * which it should. Instead it does counter spells with converted mana cost 5, which it shouldn't".
+     */
+    @Test
+    public void testWithFuseCardCounterCMCTwo() {
+                        
+        // CMC 2 and CMC 3
+        addCard(Zone.HAND, playerA, "Grizzly Bears"); // 2/2 {1}{G}
+        
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 2);
+        
+        /**
+         * Far {1}{U} Instant Return target creature to its owner's hand. Away
+         * {2}{B} Instant Target player sacrifices a creature. Fuse (You may
+         * cast one or both halves of this card from your hand.)
+         */        
+        addCard(Zone.HAND, playerB, "Disrupting Shoal", 1);
+        addCard(Zone.HAND, playerB, "Far // Away", 1);      
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Grizzly Bears");
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Disrupting Shoal", "Grizzly Bears", "Grizzly Bears");
+        playerB.addChoice("Yes"); // use alternate costs = 2 CMC = Far
+        
+        setStopAt(1, PhaseStep.CLEANUP);
+        execute();        
+        
+        assertExileCount(playerB, 1); // Far // Away should be exiled as part of Disrupting alternative cost      
+        assertGraveyardCount(playerB,"Disrupting Shoal", 1);    
+        assertPermanentCount(playerA, "Grizzly Bears", 0); // should have been countered by Shoal
+        assertGraveyardCount(playerA, "Grizzly Bears", 1);         
+    } 
+    
+    /**
+     * Test that Disrupting Shoal can be played with alternate casting costs
+     * And the X Value can be equal to either half of a fuse card.
+     * 
+     * Reported bug: "Casting Disrupting Shoal pitching Far // Away does not counter spells with converted mana cost 2 or 3, 
+     * which it should. Instead it does counter spells with converted mana cost 5, which it shouldn't".
+     */
+    @Test
+    public void testWithFuseCardCounterCMCThree() {
+                        
+        addCard(Zone.HAND, playerA, "Centaur Courser"); // 3/3 {2}{G}        
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 3);
+        
+        /**
+         * Far {1}{U} Instant Return target creature to its owner's hand. Away
+         * {2}{B} Instant Target player sacrifices a creature. Fuse (You may
+         * cast one or both halves of this card from your hand.)
+         */        
+        addCard(Zone.HAND, playerB, "Disrupting Shoal", 1);
+        addCard(Zone.HAND, playerB, "Far // Away", 1);      
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Centaur Courser");
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Disrupting Shoal", "Centaur Courser", "Centaur Courser");
+        playerB.addChoice("Yes"); // use alternate costs = 3 CMC = Away
+        
+        setStopAt(1, PhaseStep.CLEANUP);
+        execute();        
+        
+        assertExileCount(playerB, 1); // Far // Away should be exiled as part of Disrupting alternative cost      
+        assertGraveyardCount(playerB,"Disrupting Shoal", 1);    
+        assertPermanentCount(playerA, "Centaur Courser", 0); // should have been countered by Shoal
+        assertGraveyardCount(playerA, "Centaur Courser", 1);         
+    } 
+    
+    /**
+     * Test that Disrupting Shoal can be played with alternate casting costs
+     * And the X Value can be equal to either half of a fuse card. Not the combined cost of both.
+     * 
+     * Reported bug: "Casting Disrupting Shoal pitching Far // Away does not counter spells with converted mana cost 2 or 3, 
+     * which it should. Instead it does counter spells with converted mana cost 5, which it shouldn't".
+     */
+    @Test
+    public void testWithFuseCardShouldNotCounterCMCFive() {
+                        
+        addCard(Zone.HAND, playerA, "Air Elemental"); // 4/4 Flying {3}{U}{U}         
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
+        
+        /**
+         * Far {1}{U} Instant Return target creature to its owner's hand. Away
+         * {2}{B} Instant Target player sacrifices a creature. Fuse (You may
+         * cast one or both halves of this card from your hand.)
+         */        
+        addCard(Zone.HAND, playerB, "Disrupting Shoal", 1);
+        addCard(Zone.HAND, playerB, "Far // Away", 1);      
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Air Elemental");
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Disrupting Shoal", "Air Elemental", "Air Elemental");
+        playerB.addChoice("Yes"); // use alternate costs = 3 CMC = Away
+        
+        setStopAt(1, PhaseStep.CLEANUP);
+        execute();        
+        
+        assertExileCount(playerB, 1); // Far // Away should be exiled as part of Disrupting alternative cost      
+        assertGraveyardCount(playerB,"Disrupting Shoal", 1);    
+        assertPermanentCount(playerA, "Air Elemental", 0); // should have been countered by Shoal
+        assertGraveyardCount(playerA, "Air Elemental", 1);         
+    } 
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/counterspell/DisruptingShoalTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/counterspell/DisruptingShoalTest.java
@@ -173,14 +173,14 @@ public class DisruptingShoalTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Air Elemental");
         
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Disrupting Shoal", "Air Elemental", "Air Elemental");
-        playerB.addChoice("Yes"); // use alternate costs = 3 CMC = Away
+        playerB.addChoice("Yes"); // use alternate costs = 2 or 3 CMC = Far // Away, not the combined cost!
         
         setStopAt(1, PhaseStep.CLEANUP);
         execute();        
         
         assertExileCount(playerB, 1); // Far // Away should be exiled as part of Disrupting alternative cost      
         assertGraveyardCount(playerB,"Disrupting Shoal", 1);    
-        assertPermanentCount(playerA, "Air Elemental", 0); // should have been countered by Shoal
-        assertGraveyardCount(playerA, "Air Elemental", 1);         
+        assertPermanentCount(playerA, "Air Elemental", 1); // should NOT have been countered by Shoal
+        assertGraveyardCount(playerA, "Air Elemental", 0);         
     } 
 }


### PR DESCRIPTION
Reported bug: http://www.slightlymagic.net/forum/viewtopic.php?p=193489#p193489

The tests for countering 2 CMC or 3 CMC fail with Disrupting Shoal exiling Far // Away when they should be countered. Additionally, Disrupting Shoal exiling Far // Away is countering a 5 CMC (combination of the fuse card CMC) spell, which it should not.