### PR TITLE
Fixes for GlintHawk, FaerieImpostor. New card implementation DrakeFamiliar

### DIFF
--- a/Mage.Sets/src/mage/sets/magic2015/Quickling.java
+++ b/Mage.Sets/src/mage/sets/magic2015/Quickling.java
@@ -109,7 +109,7 @@ class QuicklingEffect extends OneShotEffect {
                 Permanent permanent = game.getPermanent(target.getFirstTarget());
                 if (permanent != null) {
                     targetChosen = true;
-                    controller.moveCards(permanent, null, Zone.HAND, source, game);
+                    permanent.moveToZone(Zone.HAND, this.getId(), game, false);
                 }
             }
 

--- a/Mage.Sets/src/mage/sets/ravnica/DrakeFamiliar.java
+++ b/Mage.Sets/src/mage/sets/ravnica/DrakeFamiliar.java
@@ -1,0 +1,121 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.ravnica;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.SacrificeSourceEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.filter.common.FilterEnchantmentPermanent;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+
+/**
+ *
+ * @author escplan9 (Derek Monturo - dmontur1 at gmail dot com)
+ */
+public class DrakeFamiliar extends CardImpl {
+    
+    private static final FilterEnchantmentPermanent filter = new FilterEnchantmentPermanent();
+
+    public DrakeFamiliar(UUID ownerId) {
+        super(ownerId, 44, "Drake Familiar", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{1}{U}");
+        this.expansionSetCode = "RAV";
+        this.subtype.add("Drake");
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(1);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+        
+        // When Drake Familiar enters the battlefield, sacrifice it unless you return an enchantment to its owner's hand.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new DrakeFamiliarEffect()));
+    }
+
+    public DrakeFamiliar(final DrakeFamiliar card) {
+        super(card);
+    }
+
+    @Override
+    public DrakeFamiliar copy() {
+        return new DrakeFamiliar(this);
+    }
+}
+
+class DrakeFamiliarEffect extends OneShotEffect {
+
+    private static final FilterEnchantmentPermanent filter = new FilterEnchantmentPermanent();
+    private static final String effectText = "sacrifice it unless you return an enchantment to its owner's hand.";
+
+    DrakeFamiliarEffect () {
+        super(Outcome.Sacrifice);
+        staticText = effectText;
+    }
+
+    DrakeFamiliarEffect (DrakeFamiliarEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            boolean targetChosen = false;
+            TargetPermanent target = new TargetPermanent(1, 1, filter, true);
+            if (target.canChoose(controller.getId(), game) && controller.chooseUse(outcome, "Return an enchantment to its owner's hand?", source, game)) {
+                controller.chooseTarget(Outcome.Sacrifice, target, source, game);
+                Permanent permanent = game.getPermanent(target.getFirstTarget());
+                if (permanent != null) {
+                    targetChosen = true;
+                    permanent.moveToZone(Zone.HAND, this.getId(), game, false);
+                }
+            }
+
+            if (!targetChosen) {
+                new SacrificeSourceEffect().apply(game, source);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public DrakeFamiliarEffect copy() {
+        return new DrakeFamiliarEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/returntoravnica/FaerieImpostor.java
+++ b/Mage.Sets/src/mage/sets/returntoravnica/FaerieImpostor.java
@@ -101,15 +101,13 @@ class FaerieImpostorEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             boolean targetChosen = false;
-            TargetPermanent target = new TargetPermanent(1, 1, filter, false);
-
-            if (target.canChoose(controller.getId(), game)) {
-                controller.choose(Outcome.ReturnToHand, target, source.getSourceId(), game);
+            TargetPermanent target = new TargetPermanent(1, 1, filter, true);
+            if (target.canChoose(controller.getId(), game) && controller.chooseUse(outcome, "Return another creature you control to its owner's hand?", source, game)) {
+                controller.chooseTarget(Outcome.ReturnToHand, target, source, game);
                 Permanent permanent = game.getPermanent(target.getFirstTarget());
-
                 if (permanent != null) {
                     targetChosen = true;
-                    controller.moveCards(permanent, null, Zone.HAND, source, game);
+                    permanent.moveToZone(Zone.HAND, this.getId(), game, false);
                 }
             }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/sacrifice/OptionalSacrificeTests.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/sacrifice/OptionalSacrificeTests.java
@@ -1,0 +1,185 @@
+package org.mage.test.cards.cost.sacrifice;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author escplan9 (Derek Monturo - dmontur1 at gmail dot com)
+ */
+public class OptionalSacrificeTests extends CardTestPlayerBase {
+
+    /**
+     * Glint Hawk - Flying 2/2 - {W}
+     * When Glint Hawk enters the battlefield, sacrifice it unless you return an artifact you control to its owner's hand.
+     * 
+     * Test returning controlled artifact.
+     */
+    @Test
+    public void testGlintHawkChooseArtifact() {
+        
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+        addCard(Zone.HAND, playerA, "Glint Hawk");
+        addCard(Zone.BATTLEFIELD, playerA, "Relic of Progenitus");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Glint Hawk");
+        setChoice(playerA, "Yes");
+        addTarget(playerA, "Relic of Progenitus");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Glint Hawk", 1);
+        assertGraveyardCount(playerA, "Glint Hawk", 0);
+        assertHandCount(playerA, "Relic of Progenitus", 1);
+        assertPermanentCount(playerA, "Relic of Progenitus", 0);
+    }
+    
+    /**
+     * Glint Hawk - Flying 2/2 - {W}
+     * When Glint Hawk enters the battlefield, sacrifice it unless you return an artifact you control to its owner's hand.
+     * 
+     * Test opting not to choose an artifact controlled to sacrifice Glint Hawk.
+     */
+    @Test
+    public void testGlintHawkDoNotChooseArtifactControlled() {
+        
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+        addCard(Zone.HAND, playerA, "Glint Hawk");
+        addCard(Zone.BATTLEFIELD, playerA, "Relic of Progenitus");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Glint Hawk");
+        setChoice(playerA, "No");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Glint Hawk", 0);
+        assertGraveyardCount(playerA, "Glint Hawk", 1);
+        assertHandCount(playerA, "Relic of Progenitus", 0);
+        assertPermanentCount(playerA, "Relic of Progenitus", 1);
+    }
+    
+    /**
+     * Glint Hawk - Flying 2/2 - {W}
+     * When Glint Hawk enters the battlefield, sacrifice it unless you return an artifact you control to its owner's hand.
+     * 
+     * Test no artifacts to target - so Glint Hawk is sacrificed.
+     */
+    @Test
+    public void testGlintHawkNoArtifactControlled() {
+        
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+        addCard(Zone.HAND, playerA, "Glint Hawk");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Glint Hawk");
+        setChoice(playerA, "No");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Glint Hawk", 0);
+        assertGraveyardCount(playerA, "Glint Hawk", 1);
+    } 
+
+    /**
+     * Drake Familiar - Flying 2/1 - {1}{U}
+     * When Drake Familiar enters the battlefield, sacrifice it unless you return an enchantment to its owner's hand.
+     * 
+     * Test returning own enchantment so not sacrificed.
+     */
+    @Test
+    public void testDrakeFamiliarOwnEnchantment() {
+        
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.HAND, playerA, "Drake Familiar");
+        addCard(Zone.BATTLEFIELD, playerA, "Moat");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Drake Familiar");
+        setChoice(playerA, "Yes");
+        addTarget(playerA, "Moat");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Drake Familiar", 1);        
+        assertGraveyardCount(playerA, "Drake Familiar", 0);        
+        assertHandCount(playerA, "Moat", 1);
+        assertPermanentCount(playerA, "Moat", 0);
+    }
+    
+    /**
+     * Drake Familiar - Flying 2/1 - {1}{U}
+     * When Drake Familiar enters the battlefield, sacrifice it unless you return an enchantment to its owner's hand.
+     * 
+     * Test returning opponent's enchantment so not sacrificed.
+     */
+    @Test
+    public void testDrakeFamiliarOpposingEnchantment() {
+        
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.HAND, playerA, "Drake Familiar");
+        addCard(Zone.BATTLEFIELD, playerB, "Propaganda");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Drake Familiar");
+        setChoice(playerA, "Yes");
+        addTarget(playerA, "Propaganda");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Drake Familiar", 1);        
+        assertGraveyardCount(playerA, "Drake Familiar", 0);        
+        assertHandCount(playerB, "Propaganda", 1);
+        assertPermanentCount(playerB, "Propaganda", 0);
+    }
+    
+    /**
+     * Drake Familiar - Flying 2/1 - {1}{U}
+     * When Drake Familiar enters the battlefield, sacrifice it unless you return an enchantment to its owner's hand.
+     * 
+     * Test when no enchantments are on battlefield, Drake is sacrificed.
+     */
+    @Test
+    public void testDrakeFamiliarNoEnchantmentControlled() {
+        
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.HAND, playerA, "Drake Familiar");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Drake Familiar");
+        setChoice(playerA, "No");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Drake Familiar", 0);    
+        assertGraveyardCount(playerA, "Drake Familiar", 1);
+    }
+    
+    /**
+     * Drake Familiar - Flying 2/1 - {1}{U}
+     * When Drake Familiar enters the battlefield, sacrifice it unless you return an enchantment to its owner's hand.
+     * 
+     * Test when no enchantments are on battlefield, Drake is sacrificed.
+     */
+    @Test
+    public void testDrakeFamiliarDoNotChooseEnchantment() {
+        
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.HAND, playerA, "Drake Familiar");
+        addCard(Zone.BATTLEFIELD, playerB, "Propaganda");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Drake Familiar");
+        setChoice(playerA, "No");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Drake Familiar", 0);    
+        assertGraveyardCount(playerA, "Drake Familiar", 1);
+        assertHandCount(playerB, "Propaganda", 0);
+        assertPermanentCount(playerB, "Propaganda", 1);
+    }  
+}


### PR DESCRIPTION
Glint Hawk and Faerie Impostor had a bug not allowing an option to simply sacrifice the creature instead of pay the ETB additional cost. Quickling was using a deprecated method. Implemented new card Drake Familiar.