### PR TITLE
User requested condense trigger ability text for Tuktuk Scrapper

### DIFF
--- a/Mage.Sets/src/mage/sets/worldwake/TuktukScrapper.java
+++ b/Mage.Sets/src/mage/sets/worldwake/TuktukScrapper.java
@@ -113,7 +113,12 @@ class TuktukScrapperTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public String getRule() {
-        return "Whenever {this} or another Ally enters the battlefield under your control, you may destroy target artifact. If that artifact is put into a graveyard this way, {this} deals damage to that artifact's controller equal to the number of Allies you control.";
+        
+        // originally returned fullText, user reported that because the trigger text is so lengthy, they cannot click Yes/No buttons
+        //String fullText = "Whenever {this} or another Ally enters the battlefield under your control, you may destroy target artifact. If that artifact is put into a graveyard this way, {this} deals damage to that artifact's controller equal to the number of Allies you control.";
+        String condensedText = "Whenever {this} or another Ally you enters the battlefield under your control, you may destroy target artifact. If you do, {this} deals damage to that controller equal to the number of Allies you control.";
+        
+        return condensedText;
     }
 }
 


### PR DESCRIPTION
User mtg13579 mentions the issue here where the triggered text was so lengthy he could not accurately click the Yes/No buttons: www.slightlymagic.net/forum/viewtopic.php?p=193530

Proposed change is to the last sentence:

"If that artifact is put into a graveyard this way, TukTuk Scrapper deals damage to that artifact's controller equal to the number of Allies you control." 

to

"If you do, TukTuk Scrapper deals damage to that controller equal to the number of Allies you control."

This would save 51 characters and for me also makes it so the text does not even overlap with the [Yes] [No] buttons. I feel it is close enough to conveying the same message.