### PR TITLE
Tests for Thought-Knot Seer reported bug

### DIFF
--- a/Mage.Sets/src/mage/sets/scourge/DragonFangs.java
+++ b/Mage.Sets/src/mage/sets/scourge/DragonFangs.java
@@ -1,0 +1,130 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.scourge;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
+import mage.abilities.keyword.EnchantAbility;
+import mage.abilities.keyword.TrampleAbility;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.constants.AttachmentType;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.SetTargetPointer;
+import mage.constants.Zone;
+import mage.filter.Filter;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.mageobject.ConvertedManaCostPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author escplan9 (Derek Monturo - dmontur1 at gmail dot com)
+ */
+public class DragonFangs extends CardImpl {
+    
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with converted mana cost 6 or greater");
+    static {
+        filter.add(new ConvertedManaCostPredicate(Filter.ComparisonType.GreaterThan, 5));
+    }
+
+    public DragonFangs(UUID ownerId) {
+        super(ownerId, 117, "Dragon Fangs", Rarity.COMMON, new CardType[]{CardType.ENCHANTMENT}, "{1}{G}");
+        this.expansionSetCode = "SCG";
+        this.subtype.add("Aura");
+
+        // Enchant creature
+        TargetPermanent auraTarget = new TargetCreaturePermanent();
+        this.getSpellAbility().addTarget(auraTarget);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.AddAbility));
+        Ability ability = new EnchantAbility(auraTarget.getTargetName());
+        this.addAbility(ability);
+        
+        // Enchanted creature gets +1/+1 and has trample.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(1, 1, Duration.WhileOnBattlefield)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(TrampleAbility.getInstance(), AttachmentType.AURA)));
+               
+        // When a creature with converted mana cost 6 or greater enters the battlefield, you may return Dragon Fangs from your graveyard to the battlefield attached to that creature.
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonFangsEffect(), filter, true, SetTargetPointer.PERMANENT, null));
+    }
+
+    public DragonFangs(final DragonFangs card) {
+        super(card);
+    }
+
+    @Override
+    public DragonFangs copy() {
+        return new DragonFangs(this);
+    }
+}
+
+class DragonFangsEffect extends OneShotEffect {
+    
+    DragonFangsEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "return {this} from your graveyard to the battlefield attached to that creature";
+    }
+    
+    DragonFangsEffect(final DragonFangsEffect effect) {
+        super(effect);
+    }
+    
+    @Override
+    public DragonFangsEffect copy() {
+        return new DragonFangsEffect(this);
+    }
+    
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Card sourceCard = (Card) source.getSourceObjectIfItStillExists(game);
+        Permanent permanent = game.getPermanent(this.getTargetPointer().getFirst(game, source));
+        Player controller = game.getPlayer(source.getControllerId());
+        if (sourceCard != null && permanent != null && controller != null) {
+            game.getState().setValue("attachTo:" + sourceCard.getId(), permanent);
+            if (controller.moveCards(sourceCard, Zone.BATTLEFIELD, source, game)) {
+                permanent.addAttachment(sourceCard.getId(), game);
+            }
+            return true;
+        }
+        return false;
+    }
+}
+

--- a/Mage.Sets/src/mage/sets/scourge/DragonScales.java
+++ b/Mage.Sets/src/mage/sets/scourge/DragonScales.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.scourge;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
+import mage.abilities.keyword.EnchantAbility;
+import mage.abilities.keyword.VigilanceAbility;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.constants.AttachmentType;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.SetTargetPointer;
+import mage.constants.Zone;
+import mage.filter.Filter;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.mageobject.ConvertedManaCostPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author escplan9 (Derek Monturo - dmontur1 at gmail dot com)
+ */
+public class DragonScales extends CardImpl {
+    
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with converted mana cost 6 or greater");
+    static {
+        filter.add(new ConvertedManaCostPredicate(Filter.ComparisonType.GreaterThan, 5));
+    }
+
+    public DragonScales(UUID ownerId) {
+        super(ownerId, 10, "Dragon Scales", Rarity.COMMON, new CardType[]{CardType.ENCHANTMENT}, "{1}{W}");
+        this.expansionSetCode = "SCG";
+        this.subtype.add("Aura");
+
+        // Enchant creature
+        TargetPermanent auraTarget = new TargetCreaturePermanent();
+        this.getSpellAbility().addTarget(auraTarget);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.AddAbility));
+        Ability ability = new EnchantAbility(auraTarget.getTargetName());
+        this.addAbility(ability);
+                
+        // Enchanted creature gets +1/+2 and has vigilance.        
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(1, 2, Duration.WhileOnBattlefield)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(VigilanceAbility.getInstance(), AttachmentType.AURA)));
+        
+        // When a creature with converted mana cost 6 or greater enters the battlefield, you may return Dragon Scales from your graveyard to the battlefield attached to that creature.
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonScalesEffect(), filter, true, SetTargetPointer.PERMANENT, null));
+    }
+
+    public DragonScales(final DragonScales card) {
+        super(card);
+    }
+
+    @Override
+    public DragonScales copy() {
+        return new DragonScales(this);
+    }
+}
+
+class DragonScalesEffect extends OneShotEffect {
+    
+    DragonScalesEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "return {this} from your graveyard to the battlefield attached to that creature";
+    }
+    
+    DragonScalesEffect(final DragonScalesEffect effect) {
+        super(effect);
+    }
+    
+    @Override
+    public DragonScalesEffect copy() {
+        return new DragonScalesEffect(this);
+    }
+    
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Card sourceCard = (Card) source.getSourceObjectIfItStillExists(game);
+        Permanent permanent = game.getPermanent(this.getTargetPointer().getFirst(game, source));
+        Player controller = game.getPlayer(source.getControllerId());
+        if (sourceCard != null && permanent != null && controller != null) {
+            game.getState().setValue("attachTo:" + sourceCard.getId(), permanent);
+            if (controller.moveCards(sourceCard, Zone.BATTLEFIELD, source, game)) {
+                permanent.addAttachment(sourceCard.getId(), game);
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/scourge/DragonShadow.java
+++ b/Mage.Sets/src/mage/sets/scourge/DragonShadow.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.scourge;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
+import mage.abilities.keyword.EnchantAbility;
+import mage.abilities.keyword.FearAbility;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.constants.AttachmentType;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.SetTargetPointer;
+import mage.constants.Zone;
+import mage.filter.Filter;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.mageobject.ConvertedManaCostPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author escplan9 (Derek Monturo - dmontur1 at gmail dot com)
+ */
+public class DragonShadow extends CardImpl {
+    
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with converted mana cost 6 or greater");
+    static {
+        filter.add(new ConvertedManaCostPredicate(Filter.ComparisonType.GreaterThan, 5));
+    }
+
+    public DragonShadow(UUID ownerId) {
+        super(ownerId, 65, "Dragon Shadow", Rarity.COMMON, new CardType[]{CardType.ENCHANTMENT}, "{1}{B}");
+        this.expansionSetCode = "SCG";
+        this.subtype.add("Aura");
+
+        // Enchant creature
+        TargetPermanent auraTarget = new TargetCreaturePermanent();
+        this.getSpellAbility().addTarget(auraTarget);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.AddAbility));
+        Ability ability = new EnchantAbility(auraTarget.getTargetName());
+        this.addAbility(ability);
+                
+        // Enchanted creature gets +1/+0 and has fear.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(1, 0, Duration.WhileOnBattlefield)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(FearAbility.getInstance(), AttachmentType.AURA)));
+               
+         // When a creature with converted mana cost 6 or greater enters the battlefield, you may return Dragon Breath from your graveyard to the battlefield attached to that creature.
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonShadowEffect(), filter, true, SetTargetPointer.PERMANENT, null));
+    }
+
+    public DragonShadow(final DragonShadow card) {
+        super(card);
+    }
+
+    @Override
+    public DragonShadow copy() {
+        return new DragonShadow(this);
+    }
+}
+
+class DragonShadowEffect extends OneShotEffect {
+    
+    DragonShadowEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "return {this} from your graveyard to the battlefield attached to that creature";
+    }
+    
+    DragonShadowEffect(final DragonShadowEffect effect) {
+        super(effect);
+    }
+    
+    @Override
+    public DragonShadowEffect copy() {
+        return new DragonShadowEffect(this);
+    }
+    
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Card sourceCard = (Card) source.getSourceObjectIfItStillExists(game);
+        Permanent permanent = game.getPermanent(this.getTargetPointer().getFirst(game, source));
+        Player controller = game.getPlayer(source.getControllerId());
+        if (sourceCard != null && permanent != null && controller != null) {
+            game.getState().setValue("attachTo:" + sourceCard.getId(), permanent);
+            if (controller.moveCards(sourceCard, Zone.BATTLEFIELD, source, game)) {
+                permanent.addAttachment(sourceCard.getId(), game);
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/scourge/DragonWings.java
+++ b/Mage.Sets/src/mage/sets/scourge/DragonWings.java
@@ -1,0 +1,131 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.scourge;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
+import mage.abilities.keyword.CyclingAbility;
+import mage.abilities.keyword.EnchantAbility;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.constants.AttachmentType;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.SetTargetPointer;
+import mage.constants.Zone;
+import mage.filter.Filter;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.mageobject.ConvertedManaCostPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author escplan9 (Derek Monturo - dmontur1 at gmail dot com)
+ */
+public class DragonWings extends CardImpl {
+    
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with converted mana cost 6 or greater");
+    static {
+        filter.add(new ConvertedManaCostPredicate(Filter.ComparisonType.GreaterThan, 5));
+    }
+
+    public DragonWings(UUID ownerId) {
+        super(ownerId, 34, "Dragon Wings", Rarity.COMMON, new CardType[]{CardType.ENCHANTMENT}, "{1}{U}");
+        this.expansionSetCode = "SCG";
+        this.subtype.add("Aura");
+
+        // Enchant creature
+        TargetPermanent auraTarget = new TargetCreaturePermanent();
+        this.getSpellAbility().addTarget(auraTarget);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.AddAbility));
+        Ability ability = new EnchantAbility(auraTarget.getTargetName());
+        this.addAbility(ability);
+        
+        // Enchanted creature has flying.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(FlyingAbility.getInstance(), AttachmentType.AURA)));
+        // Cycling {1}{U}
+        this.addAbility(new CyclingAbility(new ManaCostsImpl("{1}{U}")));
+        
+        // When a creature with converted mana cost 6 or greater enters the battlefield, you may return Dragon Breath from your graveyard to the battlefield attached to that creature.
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonWingsEffect(), filter, true, SetTargetPointer.PERMANENT, null));
+    }
+
+    public DragonWings(final DragonWings card) {
+        super(card);
+    }
+
+    @Override
+    public DragonWings copy() {
+        return new DragonWings(this);
+    }
+}
+
+class DragonWingsEffect extends OneShotEffect {
+    
+    DragonWingsEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "return {this} from your graveyard to the battlefield attached to that creature";
+    }
+    
+    DragonWingsEffect(final DragonWingsEffect effect) {
+        super(effect);
+    }
+    
+    @Override
+    public DragonWingsEffect copy() {
+        return new DragonWingsEffect(this);
+    }
+    
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Card sourceCard = (Card) source.getSourceObjectIfItStillExists(game);
+        Permanent permanent = game.getPermanent(this.getTargetPointer().getFirst(game, source));
+        Player controller = game.getPlayer(source.getControllerId());
+        if (sourceCard != null && permanent != null && controller != null) {
+            game.getState().setValue("attachTo:" + sourceCard.getId(), permanent);
+            if (controller.moveCards(sourceCard, Zone.BATTLEFIELD, source, game)) {
+                permanent.addAttachment(sourceCard.getId(), game);
+            }
+            return true;
+        }
+        return false;
+    }
+}
+

--- a/Mage.Tests/src/test/java/org/mage/test/cards/requirement/BlockRequirementTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/requirement/BlockRequirementTest.java
@@ -156,7 +156,7 @@ public class BlockRequirementTest extends CardTestPlayerBase {
         assertLife(playerB, 18);
     }
 
-      /**
+    /**
      * Okk is red creature that can't block unless a creature with greater power also blocks.
      */
     @Test

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ogw/ThoughtKnotSeerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ogw/ThoughtKnotSeerTest.java
@@ -12,7 +12,7 @@ import mage.constants.Zone;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
-public class ThoughtKnotSeerTests extends CardTestPlayerBase {
+public class ThoughtKnotSeerTest extends CardTestPlayerBase {
     
     /**
      * Reported bug

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ogw/ThoughtKnotSeerTests.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ogw/ThoughtKnotSeerTests.java
@@ -1,0 +1,130 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.mage.test.cards.single.ogw;
+
+import java.util.Set;
+import mage.cards.Card;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class ThoughtKnotSeerTests extends CardTestPlayerBase {
+    
+    /**
+     * Reported bug
+     * I bounced a Thought-Knot Seer my opponent controlled with enter the battlefield ability of a Reflector Mage.
+     * I should have drawn a card since the Thought-Knot Seer left the battlefield but I didn't.
+     */
+    @Test
+    public void testThoughtKnotSeerBouncedReflectorMage() {
+
+        // {1}{W}{U} When Reflector Mage enters the battlefield, return target creature an opponent controls to its owner's hand. 
+        // That creature's owner can't cast spells with the same name as that creature until your next turn.
+        addCard(Zone.HAND, playerA, "Reflector Mage"); // 2/3   
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2); 
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2); 
+        
+        // {3}{<>} 4/4
+        // When Thought-Knot Seer enters the battlefield, target opponent reveals his or her hand. You choose a nonland card from it and exile that card.
+        // When Thought-Knot Seer leaves the battlefield, target opponent draws a card.
+        addCard(Zone.BATTLEFIELD, playerB, "Thought-Knot Seer");
+        addCard(Zone.BATTLEFIELD, playerB, "Wastes", 4);
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Reflector Mage");
+        addTarget(playerA, "Thought-Knot Seer");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertHandCount(playerB, "Thought-Knot Seer", 1);     
+        Set<Card> hand = playerA.getHand().getCards(currentGame);
+        assertHandCount(playerA, 1); // should have drawn a card from Thought-Knot Seer leaving
+    }
+    
+    /**
+     * Simple bounce test on Thought-Knot Seer to differentiate between this and Reflector Mage issue
+     */
+    @Test
+    public void testThoughtKnotSeerBouncedUnsummon() {
+
+        // {U} Return target creature to its owner's hand.
+        addCard(Zone.HAND, playerA, "Unsummon");
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2); 
+        
+        // {3}{<>} 4/4
+        // When Thought-Knot Seer enters the battlefield, target opponent reveals his or her hand. You choose a nonland card from it and exile that card.
+        // When Thought-Knot Seer leaves the battlefield, target opponent draws a card.
+        addCard(Zone.BATTLEFIELD, playerB, "Thought-Knot Seer");
+        addCard(Zone.BATTLEFIELD, playerB, "Wastes", 4);
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unsummon");
+        addTarget(playerA, "Thought-Knot Seer");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerA, "Unsummon", 1);
+        assertHandCount(playerB, "Thought-Knot Seer", 1);     
+        Set<Card> hand = playerA.getHand().getCards(currentGame);
+        assertHandCount(playerA, 1); // should have drawn a card from Thought-Knot Seer leaving
+    }
+    
+    /**
+     * 
+     */
+    @Test
+    public void testThoughtKnotSeerDestroyed() {
+
+        // {1}{B} Destroy target nonblack creature.
+        addCard(Zone.HAND, playerA, "Doom Blade"); 
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2); 
+        
+        // {3}{<>} 4/4
+        // When Thought-Knot Seer enters the battlefield, target opponent reveals his or her hand. You choose a nonland card from it and exile that card.
+        // When Thought-Knot Seer leaves the battlefield, target opponent draws a card.
+        addCard(Zone.BATTLEFIELD, playerB, "Thought-Knot Seer");
+        addCard(Zone.BATTLEFIELD, playerB, "Wastes", 4);
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Doom Blade");
+        addTarget(playerA, "Thought-Knot Seer");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerB, "Thought-Knot Seer", 1);     
+        Set<Card> hand = playerA.getHand().getCards(currentGame);
+        assertHandCount(playerA, 1); // should have drawn a card from Thought-Knot Seer leaving
+    }
+    
+    /**
+     * 
+     */
+    @Test
+    public void testThoughtKnotSeerExiled() {
+
+        // {W} Exile target creature. Its controller may search his or her library for a basic land card, put that card onto the battlefield tapped, then shuffle his or her library.
+        addCard(Zone.HAND, playerA, "Path to Exile"); 
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 1); 
+        
+        // {3}{<>} 4/4
+        // When Thought-Knot Seer enters the battlefield, target opponent reveals his or her hand. You choose a nonland card from it and exile that card.
+        // When Thought-Knot Seer leaves the battlefield, target opponent draws a card.
+        addCard(Zone.BATTLEFIELD, playerB, "Thought-Knot Seer");
+        addCard(Zone.BATTLEFIELD, playerB, "Wastes", 4);
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Path to Exile");
+        addTarget(playerA, "Thought-Knot Seer");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertExileCount(playerB, 1);
+        assertExileCount("Thought-Knot Seer", 1);
+        Set<Card> hand = playerA.getHand().getCards(currentGame);
+        assertHandCount(playerA, 1); // should have drawn a card from Thought-Knot Seer leaving
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/EnterLeaveBattlefieldExileTargetTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/EnterLeaveBattlefieldExileTargetTest.java
@@ -94,6 +94,5 @@ public class EnterLeaveBattlefieldExileTargetTest extends CardTestPlayerBase {
         assertHandCount(playerB, "Silvercoat Lion", 1);
         assertHandCount(playerB, "Pillarfield Ox", 1);
         assertExileCount(playerB, 0);
-
     }
 }


### PR DESCRIPTION
Only test that fails is the Reflector Mage one. Unsummon test passes so card is still drawn from bouncing TKS from non-Reflector Mage spells.