### PR TITLE
fix for Exhaustion on things that entered after resolution

### DIFF
--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanel.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanel.java
@@ -880,7 +880,7 @@ public class CardPanel extends MagePermanent implements MouseListener, MouseMoti
             updateImage();
             if (card.canTransform()) {
                 BufferedImage transformIcon;
-                if (transformed) {
+                if (transformed || card.isTransformed()) {
                     transformIcon = ImageManagerImpl.getInstance().getNightImage();
                 } else {
                     transformIcon = ImageManagerImpl.getInstance().getDayImage();

--- a/Mage.Sets/src/mage/sets/betrayersofkamigawa/FinalJudgment.java
+++ b/Mage.Sets/src/mage/sets/betrayersofkamigawa/FinalJudgment.java
@@ -27,18 +27,12 @@
  */
 package mage.sets.betrayersofkamigawa;
 
+import java.util.UUID;
+import mage.abilities.effects.common.ExileAllEffect;
+import mage.cards.CardImpl;
 import mage.constants.CardType;
 import mage.constants.Rarity;
-import mage.abilities.Ability;
-import mage.abilities.effects.OneShotEffect;
-import mage.cards.CardImpl;
-import mage.constants.Outcome;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.mageobject.CardTypePredicate;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-
-import java.util.UUID;
+import mage.filter.common.FilterCreaturePermanent;
 
 /**
  *
@@ -51,8 +45,7 @@ public class FinalJudgment extends CardImpl {
         this.expansionSetCode = "BOK";
 
         // Exile all creatures.
-        this.getSpellAbility().addEffect(new FinalJudgmentEffect());
-
+        this.getSpellAbility().addEffect(new ExileAllEffect(new FilterCreaturePermanent()));
     }
 
     public FinalJudgment(final FinalJudgment card) {
@@ -63,36 +56,4 @@ public class FinalJudgment extends CardImpl {
     public FinalJudgment copy() {
         return new FinalJudgment(this);
     }
-}
-
-class FinalJudgmentEffect extends OneShotEffect {
-
-    private static final FilterPermanent filter = new FilterPermanent("");
-
-    static {
-        filter.add(new CardTypePredicate(CardType.CREATURE));
-    }
-
-    public FinalJudgmentEffect() {
-        super(Outcome.Exile);
-        staticText = "Exile all creatures";
-    }
-
-    public FinalJudgmentEffect(final FinalJudgmentEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source.getSourceId(), game)) {
-            permanent.moveToExile(null, null,source.getSourceId(), game);
-        }
-        return true;
-    }
-
-    @Override
-    public FinalJudgmentEffect copy() {
-        return new FinalJudgmentEffect(this);
-    }
-
 }

--- a/Mage.Sets/src/mage/sets/darksteel/ScreamsFromWithin.java
+++ b/Mage.Sets/src/mage/sets/darksteel/ScreamsFromWithin.java
@@ -42,8 +42,11 @@ import mage.cards.Card;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.Zone;
+import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
+import mage.game.permanent.Permanent;
 import mage.players.Player;
+import mage.target.Target;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -86,7 +89,7 @@ class ScreamsFromWithinEffect extends OneShotEffect {
 
     public ScreamsFromWithinEffect() {
         super(Outcome.PutCardInPlay);
-        staticText = "return Screams from Within from your graveyard to the battlefield";
+        staticText = "return {this} from your graveyard to the battlefield";
     }
 
     public ScreamsFromWithinEffect(final ScreamsFromWithinEffect effect) {
@@ -95,10 +98,16 @@ class ScreamsFromWithinEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Card sourceEnchantmentCard = game.getCard(source.getSourceId());
+        Card aura = game.getCard(source.getSourceId());
         Player player = game.getPlayer(source.getControllerId());
-        if (sourceEnchantmentCard != null && player != null) {
-            return player.moveCards(sourceEnchantmentCard, Zone.BATTLEFIELD, source, game);
+        if (aura != null && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD && player != null && player.getGraveyard().contains(source.getSourceId())) {
+            for (Permanent creaturePermanent : game.getBattlefield().getAllActivePermanents(new FilterCreaturePermanent(), game)) {
+                for (Target target : aura.getSpellAbility().getTargets()) {
+                    if (target.canTarget(creaturePermanent.getId(), game)) {
+                        return player.moveCards(aura, Zone.BATTLEFIELD, source, game);
+                    }
+                }
+            }
         }
         return false;
     }

--- a/Mage.Sets/src/mage/sets/gameday/AnguishedUnmaking.java
+++ b/Mage.Sets/src/mage/sets/gameday/AnguishedUnmaking.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.gameday;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class AnguishedUnmaking extends mage.sets.shadowsoverinnistrad.AnguishedUnmaking {
+
+    public AnguishedUnmaking(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 52;
+        this.expansionSetCode = "MGDC";
+    }
+
+    public AnguishedUnmaking(final AnguishedUnmaking card) {
+        super(card);
+    }
+
+    @Override
+    public AnguishedUnmaking copy() {
+        return new AnguishedUnmaking(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/legends/ClergyOfTheHolyNimbus.java
+++ b/Mage.Sets/src/mage/sets/legends/ClergyOfTheHolyNimbus.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.legends;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.ActivateOnlyByOpponentActivatedAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.common.CantBeRegeneratedSourceEffect;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+
+/**
+ *
+ * @author escplan9 (Derek Monturo - dmontur1 at gmail dot com)
+ */
+public class ClergyOfTheHolyNimbus extends CardImpl {
+
+    public ClergyOfTheHolyNimbus(UUID ownerId) {
+        super(ownerId, 175, "Clergy of the Holy Nimbus", Rarity.COMMON, new CardType[]{CardType.CREATURE}, "{W}");
+        this.expansionSetCode = "LEG";
+        this.subtype.add("Human");
+        this.subtype.add("Cleric");
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(1);
+
+        // If Clergy of the Holy Nimbus would be destroyed, regenerate it.   
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new ClergyOfTheHolyNimbusReplacementEffect()));
+                
+        // {1}: Clergy of the Holy Nimbus can't be regenerated this turn. Only any opponent may activate this ability.
+        this.addAbility(new ActivateOnlyByOpponentActivatedAbility(Zone.BATTLEFIELD, new CantBeRegeneratedSourceEffect(Duration.EndOfTurn), new ManaCostsImpl("{1}")));
+    }
+
+    public ClergyOfTheHolyNimbus(final ClergyOfTheHolyNimbus card) {
+        super(card);
+    }
+
+    @Override
+    public ClergyOfTheHolyNimbus copy() {
+        return new ClergyOfTheHolyNimbus(this);
+    }
+}
+
+class ClergyOfTheHolyNimbusReplacementEffect extends ReplacementEffectImpl {
+
+    ClergyOfTheHolyNimbusReplacementEffect() {
+        super(Duration.Custom, Outcome.Regenerate);
+        staticText = "If {this} would be destroyed, regenerate it";
+    }
+
+    ClergyOfTheHolyNimbusReplacementEffect(ClergyOfTheHolyNimbusReplacementEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        Permanent ClergyOfTheHolyNimbus = game.getPermanent(event.getTargetId());
+        if (ClergyOfTheHolyNimbus != null 
+                && event.getAmount() == 0) { // 1=noRegen
+            if (ClergyOfTheHolyNimbus.regenerate(source.getSourceId(), game)) {
+                game.informPlayers(source.getSourceObject(game).getName() + " has been regenerated.");
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DESTROY_PERMANENT;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        return event.getTargetId() != null
+                && event.getTargetId().equals(source.getSourceId());
+    }
+
+    @Override
+    public ClergyOfTheHolyNimbusReplacementEffect copy() {
+        return new ClergyOfTheHolyNimbusReplacementEffect(this);
+    }
+
+}

--- a/Mage.Sets/src/mage/sets/mercadianmasques/Misstep.java
+++ b/Mage.Sets/src/mage/sets/mercadianmasques/Misstep.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.mercadianmasques;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.abilities.effects.common.DontUntapInControllersNextUntapStepTargetEffect;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.TargetPlayer;
+import mage.target.targetpointer.FixedTargets;
+
+/**
+ *
+ * @author djbrez
+ */
+public class Misstep extends CardImpl {
+    
+    public Misstep(UUID ownerId) {
+        super(ownerId, 88, "Misstep", Rarity.COMMON, new CardType[]{CardType.SORCERY}, "{1}{U}");
+        this.expansionSetCode = "MMQ";
+
+        // Creatures target player controls don't untap during that player's next untap step.
+        this.getSpellAbility().addEffect(new MisstepEffect());
+        this.getSpellAbility().addTarget(new TargetPlayer());
+    }
+
+    public Misstep(final Misstep card) {
+        super(card);
+    }
+
+    @Override
+    public Misstep copy() {
+        return new Misstep(this);
+    }
+}
+
+class MisstepEffect extends OneShotEffect {
+    
+    MisstepEffect() {
+        super(Outcome.Detriment);
+        this.staticText = "Creatures target player controls don't untap during his or her next untap step";
+    }
+    
+    MisstepEffect(final MisstepEffect effect) {
+        super(effect);
+    }
+    
+    @Override
+    public MisstepEffect copy() {
+        return new MisstepEffect(this);
+    }
+    
+    @Override
+    public boolean apply(Game game, Ability source) {
+    Player player = game.getPlayer(source.getFirstTarget());
+         if (player != null) {
+         List<Permanent> doNotUntapNextUntapStep = new ArrayList<>();
+         for (Permanent creature : game.getBattlefield().getAllActivePermanents(new FilterCreaturePermanent(), player.getId(), game)) {
+           doNotUntapNextUntapStep.add(creature); 
+        }
+        if (!doNotUntapNextUntapStep.isEmpty()) {
+                ContinuousEffect effect = new DontUntapInControllersNextUntapStepTargetEffect("", player.getId());
+                effect.setText("those creatures don't untap during that player's next untap step");
+                effect.setTargetPointer(new FixedTargets(doNotUntapNextUntapStep, game));
+                game.addEffect(effect, source);
+             }
+             return true;
+         }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/portalthreekingdoms/Exhaustion.java
+++ b/Mage.Sets/src/mage/sets/portalthreekingdoms/Exhaustion.java
@@ -33,7 +33,7 @@ import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.DontUntapInControllersNextUntapStepTargetEffect;
+import mage.abilities.effects.common.DontUntapInOpponentsNextUntapStepAllEffect;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
 import mage.constants.Outcome;
@@ -42,7 +42,6 @@ import mage.filter.FilterPermanent;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.CardTypePredicate;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetOpponent;
 import mage.target.targetpointer.FixedTargets;
@@ -97,16 +96,11 @@ class ExhaustionEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getFirstTarget());
+   
         if (player != null) {
-            List<Permanent> doNotUntapNextUntapStep = new ArrayList<>();
-            for (Permanent permanent : game.getBattlefield().getAllActivePermanents(filter, player.getId(), game)) {
-                doNotUntapNextUntapStep.add(permanent);
-            }
-            if (!doNotUntapNextUntapStep.isEmpty()) {
-                ContinuousEffect effect = new DontUntapInControllersNextUntapStepTargetEffect("This creature");
-                effect.setTargetPointer(new FixedTargets(doNotUntapNextUntapStep, game));
-                game.addEffect(effect, source);
-            }
+            ContinuousEffect effect = new DontUntapInOpponentsNextUntapStepAllEffect(filter);
+            effect.setTargetPointer(new FixedTarget(player.getId()));
+            game.addEffect(effect, source);                      
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/AngelOfDeliverance.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/AngelOfDeliverance.java
@@ -1,0 +1,126 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.condition.common.DeliriumCondition;
+import mage.abilities.decorator.ConditionalTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Rarity;
+import mage.constants.TargetController;
+import mage.constants.Zone;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.permanent.ControllerPredicate;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.events.GameEvent.EventType;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class AngelOfDeliverance extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
+
+    static {
+        filter.add(new ControllerPredicate(TargetController.OPPONENT));
+    }
+
+    public AngelOfDeliverance(UUID ownerId) {
+        super(ownerId, 2, "Angel of Deliverance", Rarity.RARE, new CardType[]{CardType.CREATURE}, "{6}{W}{W}");
+        this.expansionSetCode = "SOI";
+        this.subtype.add("Angel");
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // <i>Delirium</i> &mdash; Whenever Angel of Deliverance deals damage, if there are four or more card types among cards in your graveyard,
+        // exile target creature an opponent controls.
+        Ability ability = new ConditionalTriggeredAbility(
+                new AngelOfDeliveranceDealsDamageTriggeredAbility(),
+                new DeliriumCondition(),
+                "<i>Delirium</i> &mdash; Whenever {this} deals damage, if there are four or more card types among cards in your graveyard, exile target creature an opponent controls"
+        );
+        ability.addTarget(new TargetCreaturePermanent(filter));
+        this.addAbility(ability);
+    }
+
+    public AngelOfDeliverance(final AngelOfDeliverance card) {
+        super(card);
+    }
+
+    @Override
+    public AngelOfDeliverance copy() {
+        return new AngelOfDeliverance(this);
+    }
+}
+
+class AngelOfDeliveranceDealsDamageTriggeredAbility extends TriggeredAbilityImpl {
+
+    public AngelOfDeliveranceDealsDamageTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new ExileTargetEffect(), false);
+    }
+
+    public AngelOfDeliveranceDealsDamageTriggeredAbility(final AngelOfDeliveranceDealsDamageTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public AngelOfDeliveranceDealsDamageTriggeredAbility copy() {
+        return new AngelOfDeliveranceDealsDamageTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == EventType.DAMAGED_PLAYER
+                || event.getType() == EventType.DAMAGED_CREATURE
+                || event.getType() == EventType.DAMAGED_PLANESWALKER;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        if (event.getSourceId().equals(this.getSourceId())) {
+            for (Effect effect : this.getEffects()) {
+                effect.setValue("damage", event.getAmount());
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/AnguishedUnmaking.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/AnguishedUnmaking.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.LoseLifeSourceControllerEffect;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Rarity;
+import mage.target.common.TargetNonlandPermanent;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class AnguishedUnmaking extends CardImpl {
+
+    public AnguishedUnmaking(UUID ownerId) {
+        super(ownerId, 242, "Anguished Unmaking", Rarity.RARE, new CardType[]{CardType.INSTANT}, "{1}{W}{B}");
+        this.expansionSetCode = "SOI";
+
+        // Exile target nonland permanent. You lose 3 life.
+        getSpellAbility().addEffect(new ExileTargetEffect());
+        getSpellAbility().addTarget(new TargetNonlandPermanent());
+        getSpellAbility().addEffect(new LoseLifeSourceControllerEffect(3));
+    }
+
+    public AnguishedUnmaking(final AnguishedUnmaking card) {
+        super(card);
+    }
+
+    @Override
+    public AnguishedUnmaking copy() {
+        return new AnguishedUnmaking(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/ArlinnEmbracedByTheMoon.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/ArlinnEmbracedByTheMoon.java
@@ -1,0 +1,121 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.LoyaltyAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.dynamicvalue.common.SourcePermanentPowerCount;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.effects.common.GetEmblemEffect;
+import mage.abilities.effects.common.TransformSourceEffect;
+import mage.abilities.effects.common.continuous.BoostControlledEffect;
+import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
+import mage.abilities.keyword.HasteAbility;
+import mage.abilities.keyword.TrampleAbility;
+import mage.abilities.keyword.TransformAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.command.Emblem;
+import mage.target.common.TargetCreatureOrPlayer;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class ArlinnEmbracedByTheMoon extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Creatures you control");
+
+    public ArlinnEmbracedByTheMoon(UUID ownerId) {
+        super(ownerId, 243, "Arlinn, Embraced by the Moon", Rarity.MYTHIC, new CardType[]{CardType.PLANESWALKER}, "");
+        this.expansionSetCode = "SOI";
+        this.subtype.add("Arlinn");
+
+        this.nightCard = true;
+        this.canTransform = true;
+
+        // +1: Creatures you control get +1/+1 and gain trample until end of turn.
+        Effect effect = new BoostControlledEffect(1, 1, Duration.EndOfTurn, filter);
+        effect.setText("Creatures you control get +1/+1");
+        LoyaltyAbility ability = new LoyaltyAbility(effect, 1);
+        effect = new GainAbilityControlledEffect(TrampleAbility.getInstance(), Duration.EndOfTurn, filter);
+        effect.setText("and gain trample until end of turn");
+        ability.addEffect(effect);
+        this.addAbility(ability);
+
+        // -1: Arlinn, Embraced by the Moon deals 3 damage to target creature or player. Transform Arlinn, Embraced by the Moon.
+        this.addAbility(new TransformAbility());
+        ability = new LoyaltyAbility(new DamageTargetEffect(3), -1);
+        ability.addTarget(new TargetCreatureOrPlayer());
+        ability.addEffect(new TransformSourceEffect(false));
+        this.addAbility(ability);
+
+        // -6: You get an emblem with "Creatures you control have haste and '{T}: This creature deals damage equal to its power to target creature or player.'"
+        this.addAbility(new LoyaltyAbility(new GetEmblemEffect(new ArlinnEmbracedByTheMoonEmblem()), -6));
+    }
+
+    public ArlinnEmbracedByTheMoon(final ArlinnEmbracedByTheMoon card) {
+        super(card);
+    }
+
+    @Override
+    public ArlinnEmbracedByTheMoon copy() {
+        return new ArlinnEmbracedByTheMoon(this);
+    }
+}
+
+class ArlinnEmbracedByTheMoonEmblem extends Emblem {
+
+    // "Creatures you control have haste and '{T}: This creature deals damage equal to its power to target creature or player.'"
+    public ArlinnEmbracedByTheMoonEmblem() {
+        this.setName("EMBLEM: Arlinn, Embraced by the Moon");
+        FilterPermanent filter = new FilterControlledCreaturePermanent("Creatures");
+        GainAbilityControlledEffect effect = new GainAbilityControlledEffect(HasteAbility.getInstance(), Duration.EndOfGame, filter);
+        effect.setText("Creatures you control have haste");
+        Ability ability = new SimpleStaticAbility(Zone.COMMAND, effect);
+        Effect effect2 = new DamageTargetEffect(new SourcePermanentPowerCount());
+        effect2.setText("This creature deals damage equal to its power to target creature or player");
+        Ability ability2 = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect2, new TapSourceCost());
+        ability2.addTarget(new TargetCreatureOrPlayer());
+        effect = new GainAbilityControlledEffect(ability2, Duration.EndOfGame, filter);
+        effect.setText("and '{T}: This creature deals damage equal to its power to target creature or player");
+        ability.addEffect(effect);
+        this.getAbilities().add(ability);
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/ArlinnKord.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/ArlinnKord.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.abilities.LoyaltyAbility;
+import mage.abilities.common.PlanswalkerEntersWithLoyalityCountersAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.TransformSourceEffect;
+import mage.abilities.effects.common.continuous.BoostTargetEffect;
+import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
+import mage.abilities.keyword.HasteAbility;
+import mage.abilities.keyword.TransformAbility;
+import mage.abilities.keyword.VigilanceAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Rarity;
+import mage.game.permanent.token.WolfToken;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class ArlinnKord extends CardImpl {
+
+    public ArlinnKord(UUID ownerId) {
+        super(ownerId, 243, "Arlinn Kord", Rarity.MYTHIC, new CardType[]{CardType.PLANESWALKER}, "{2}{R}{G}");
+        this.expansionSetCode = "SOI";
+        this.subtype.add("Arlinn");
+
+        this.canTransform = true;
+        this.secondSideCard = new ArlinnEmbracedByTheMoon(ownerId);
+
+        this.addAbility(new PlanswalkerEntersWithLoyalityCountersAbility(3));
+
+        // +1: Until end of turn, up to one target creature gets +2/+2 and gains vigilance and haste.
+        Effect effect = new BoostTargetEffect(2, 2, Duration.EndOfTurn);
+        effect.setText("Until end of turn, up to one target creature gets +2/+2");
+        LoyaltyAbility ability = new LoyaltyAbility(effect, 1);
+        effect = new GainAbilityTargetEffect(VigilanceAbility.getInstance(), Duration.EndOfTurn);
+        effect.setText("and gains vigilance");
+        ability.addEffect(effect);
+        effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);
+        effect.setText("and haste");
+        ability.addEffect(effect);
+        ability.addTarget(new TargetCreaturePermanent(0, 1));
+        this.addAbility(ability);
+
+        // 0: Put a 2/2 green Wolf creature token onto the battlefield. Transform Arlinn Kord.
+        this.addAbility(new TransformAbility());
+        ability = new LoyaltyAbility(new CreateTokenEffect(new WolfToken()), 0);
+        ability.addEffect(new TransformSourceEffect(true));
+        this.addAbility(ability);
+    }
+
+    public ArlinnKord(final ArlinnKord card) {
+        super(card);
+    }
+
+    @Override
+    public ArlinnKord copy() {
+        return new ArlinnKord(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/AvacynThePurifier.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/AvacynThePurifier.java
@@ -42,8 +42,8 @@ import mage.constants.Zone;
  * @author fireshoes
  */
 public class AvacynThePurifier extends CardImpl {
-    
-    private static final String rule = "Whenever this creature transforms into Avacyn, the Purifier, it deals 3 damage to each other creature and each opponent";
+
+    private static final String rule = "Whenever this creature transforms into {this}, it deals 3 damage to each other creature and each opponent";
 
     public AvacynThePurifier(UUID ownerId) {
         super(ownerId, 5, "Avacyn, the Purifier", Rarity.MYTHIC, new CardType[]{CardType.CREATURE}, "");
@@ -52,6 +52,7 @@ public class AvacynThePurifier extends CardImpl {
         this.subtype.add("Angel");
         this.power = new MageInt(6);
         this.toughness = new MageInt(5);
+        this.color.setRed(true);
 
         // this card is the second face of double-faced card
         this.nightCard = true;

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/DescendUponTheSinful.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/DescendUponTheSinful.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.abilities.condition.common.DeliriumCondition;
+import mage.abilities.decorator.ConditionalOneShotEffect;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.ExileAllEffect;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Rarity;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.AngelToken;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class DescendUponTheSinful extends CardImpl {
+
+    public DescendUponTheSinful(UUID ownerId) {
+        super(ownerId, 13, "Descend upon the Sinful", Rarity.MYTHIC, new CardType[]{CardType.SORCERY}, "{4}{W}{W}");
+        this.expansionSetCode = "SOI";
+
+        // Exile all creatures
+        this.getSpellAbility().addEffect(new ExileAllEffect(new FilterCreaturePermanent()));
+
+        // <i>Delirium</i> &mdash; Put a 4/4 white Angel creature token with flying onto the battlefield if there are four or more card types among cards in your graveyard.
+        Effect effect = new ConditionalOneShotEffect(new CreateTokenEffect(new AngelToken()), DeliriumCondition.getInstance());
+        effect.setText("<br/><i>Delirium</i> &mdash; Put a 4/4 white Angel creature token with flying onto the battlefield if there are four or more card types among cards in your graveyard");
+        this.getSpellAbility().addEffect(effect);
+    }
+
+    public DescendUponTheSinful(final DescendUponTheSinful card) {
+        super(card);
+    }
+
+    @Override
+    public DescendUponTheSinful copy() {
+        return new DescendUponTheSinful(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/DrogskolCavalry.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/DrogskolCavalry.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.GainLifeEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.mageobject.SubtypePredicate;
+import mage.filter.predicate.permanent.AnotherPredicate;
+import mage.game.permanent.token.SpiritWhiteToken;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class DrogskolCavalry extends CardImpl {
+
+    private static final FilterPermanent filter = new FilterPermanent("another Spirit");
+
+    static {
+        filter.add(new AnotherPredicate());
+        filter.add(new SubtypePredicate("Spirit"));
+    }
+
+    public DrogskolCavalry(UUID ownerId) {
+        super(ownerId, 15, "Drogskol Cavalry", Rarity.RARE, new CardType[]{CardType.CREATURE}, "{5}{W}{W}");
+        this.expansionSetCode = "SOI";
+        this.subtype.add("Spirit");
+        this.subtype.add("Knight");
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(4);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Whenever another Spirit enters the battlefield under your control, you gain 2 life.
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new GainLifeEffect(2), filter));
+
+        // {3}{W}: Put a 1/1 white Spirit creature token with flying onto the battlefield.
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new CreateTokenEffect(new SpiritWhiteToken()), new ManaCostsImpl("{3}{W}")));
+    }
+
+    public DrogskolCavalry(final DrogskolCavalry card) {
+        super(card);
+    }
+
+    @Override
+    public DrogskolCavalry copy() {
+        return new DrogskolCavalry(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/FlamebladeAngel.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/FlamebladeAngel.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.DamageEvent;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.target.targetpointer.FixedTarget;
+
+/**
+ *
+ * @author LevelX2
+ */
+public class FlamebladeAngel extends CardImpl {
+
+    public FlamebladeAngel(UUID ownerId) {
+        super(ownerId, 157, "Flameblade Angel", Rarity.RARE, new CardType[]{CardType.CREATURE}, "{4}{R}{R}");
+        this.expansionSetCode = "SOI";
+        this.subtype.add("Angel");
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(4);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+        // Whenever a source an opponent controls deals damage to you or a permanent you control, you may have Flameblade Angel deal 1 damage to that source's controller.
+        this.addAbility(new FlamebladeAngelTriggeredAbility());
+
+    }
+
+    public FlamebladeAngel(final FlamebladeAngel card) {
+        super(card);
+    }
+
+    @Override
+    public FlamebladeAngel copy() {
+        return new FlamebladeAngel(this);
+    }
+}
+
+class FlamebladeAngelTriggeredAbility extends TriggeredAbilityImpl {
+
+    public FlamebladeAngelTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new DamageTargetEffect(1), true);
+    }
+
+    public FlamebladeAngelTriggeredAbility(final FlamebladeAngelTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @java.lang.Override
+    public FlamebladeAngelTriggeredAbility copy() {
+        return new FlamebladeAngelTriggeredAbility(this);
+    }
+
+    @java.lang.Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event instanceof DamageEvent;
+    }
+
+    @java.lang.Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        boolean result = false;
+        UUID sourceControllerId = game.getControllerId(event.getSourceId());
+        if (sourceControllerId != null && game.getOpponents(getControllerId()).contains(sourceControllerId)) {
+
+            if (event.getTargetId().equals(getControllerId())) {
+                result = true;
+            } else {
+                Permanent permanent = game.getPermanentOrLKIBattlefield(event.getTargetId());
+                if (permanent != null && getControllerId().equals(permanent.getControllerId())) {
+                    result = true;
+                }
+            }
+            if (result) {
+                for (Effect effect : getEffects()) {
+                    effect.setTargetPointer(new FixedTarget(sourceControllerId));
+                }
+            }
+        }
+        return result;
+    }
+
+    @java.lang.Override
+    public String getRule() {
+        return "Whenever a source an opponent controls deals damage to you or a permanent you control, you may have {this} deal 1 damage to that source's controller.";
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/MacabreWaltz.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/MacabreWaltz.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class MacabreWaltz extends mage.sets.magicorigins.MacabreWaltz {
+
+    public MacabreWaltz(UUID ownerId) {
+        super(ownerId);
+        this.cardNumber = 121;
+        this.expansionSetCode = "SOI";
+    }
+
+    public MacabreWaltz(final MacabreWaltz card) {
+        super(card);
+    }
+
+    @Override
+    public MacabreWaltz copy() {
+        return new MacabreWaltz(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/NahiriTheHarbinger.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/NahiriTheHarbinger.java
@@ -1,0 +1,159 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.DelayedTriggeredAbility;
+import mage.abilities.LoyaltyAbility;
+import mage.abilities.common.PlanswalkerEntersWithLoyalityCountersAbility;
+import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
+import mage.abilities.costs.common.DiscardCardCost;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.SearchEffect;
+import mage.abilities.effects.common.DoIfCostPaid;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.ReturnToHandTargetEffect;
+import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
+import mage.abilities.keyword.HasteAbility;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.filter.FilterCard;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.CardTypePredicate;
+import mage.filter.predicate.permanent.TappedPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetCardInLibrary;
+import mage.target.targetpointer.FixedTarget;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class NahiriTheHarbinger extends CardImpl {
+
+    private static final FilterPermanent filter = new FilterPermanent("enchantment, tapped artifact, or tapped creature");
+
+    static {
+        filter.add(Predicates.or(new CardTypePredicate(CardType.ENCHANTMENT),
+                (Predicates.and(new CardTypePredicate(CardType.ARTIFACT),
+                    new TappedPredicate())),
+                (Predicates.and(new CardTypePredicate(CardType.CREATURE),
+                    new TappedPredicate()))));
+    }
+
+    public NahiriTheHarbinger(UUID ownerId) {
+        super(ownerId, 247, "Nahiri, the Harbinger", Rarity.MYTHIC, new CardType[]{CardType.PLANESWALKER}, "{2}{R}{W}");
+        this.expansionSetCode = "SOI";
+        this.subtype.add("Nahiri");
+
+        this.addAbility(new PlanswalkerEntersWithLoyalityCountersAbility(4));
+
+        // +2: You may discard a card. If you do, draw a card.
+        this.addAbility(new LoyaltyAbility(new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new DiscardCardCost()), 2));
+
+        // -2: Exile target enchantment, tapped artifact, or tapped creature.
+        LoyaltyAbility ability = new LoyaltyAbility(new ExileTargetEffect(), -2);
+        ability.addTarget(new TargetPermanent(filter));
+        this.addAbility(ability);
+
+        // -8: Search your library for an artifact or creature card, put it onto the battlefield, then shuffle your library. It gains haste.
+        // Return it to your hand at the beginning of the next end step.
+        this.addAbility(new LoyaltyAbility(new NahiriTheHarbingerEffect(), -8));
+    }
+
+    public NahiriTheHarbinger(final NahiriTheHarbinger card) {
+        super(card);
+    }
+
+    @Override
+    public NahiriTheHarbinger copy() {
+        return new NahiriTheHarbinger(this);
+    }
+}
+
+class NahiriTheHarbingerEffect extends SearchEffect {
+
+    private static final FilterCard filterCard = new FilterCard("artifact or creature card");
+
+    static {
+        filterCard.add(Predicates.or(new CardTypePredicate(CardType.ARTIFACT),
+                new CardTypePredicate(CardType.CREATURE)));
+    }
+
+    NahiriTheHarbingerEffect() {
+        super(new TargetCardInLibrary(0, 1, filterCard), Outcome.PutCardInPlay);
+        this.staticText = "Search your library for an artifact or creature card, put it onto the battlefield, then shuffle your library. It gains haste. Return it to your hand at the beginning of the next end step";
+    }
+
+    NahiriTheHarbingerEffect(final NahiriTheHarbingerEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public NahiriTheHarbingerEffect copy() {
+        return new NahiriTheHarbingerEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            if (controller.searchLibrary(target, game)) {
+                if (target.getTargets().size() > 0) {
+                    Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
+                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+                    Permanent permanent = game.getPermanent(card.getId());
+                    if (permanent != null) {
+                        ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);
+                        effect.setTargetPointer(new FixedTarget(permanent.getId(), permanent.getZoneChangeCounter(game)));
+                        game.addEffect(effect, source);
+                        Effect effect2 = new ReturnToHandTargetEffect();
+                        effect2.setTargetPointer(new FixedTarget(permanent.getId(), permanent.getZoneChangeCounter(game)));
+                        DelayedTriggeredAbility delayedAbility = new AtTheBeginOfNextEndStepDelayedTriggeredAbility(effect2);
+                        game.addDelayedTriggeredAbility(delayedAbility, source);
+                    }
+                }
+                controller.shuffleLibrary(source, game);
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/NephaliaMoondrakes.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/NephaliaMoondrakes.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.ExileSourceFromGraveCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
+import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class NephaliaMoondrakes extends CardImpl {
+    
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Creatures you control");
+
+    public NephaliaMoondrakes(UUID ownerId) {
+        super(ownerId, 75, "Nephalia Moondrakes", Rarity.RARE, new CardType[]{CardType.CREATURE}, "{5}{U}{U}");
+        this.expansionSetCode = "SOI";
+        this.subtype.add("Drake");
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(5);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // When Nephalia Moondrakes enters the battlefield, target creature gains flying until end of turn.
+        Ability ability = new EntersBattlefieldTriggeredAbility(new GainAbilityTargetEffect(FlyingAbility.getInstance(), Duration.EndOfTurn), false);
+        ability.addTarget(new TargetCreaturePermanent());
+        this.addAbility(ability);
+
+        // {4}{U}{U}, Exile Nephalia Moondrakes from your graveyard: Creatures you control gain flying until end of turn.
+        ability = new SimpleActivatedAbility(Zone.GRAVEYARD, new GainAbilityControlledEffect(FlyingAbility.getInstance(), Duration.EndOfTurn, filter), new ManaCostsImpl("{4}{U}{U}"));
+        ability.addCost(new ExileSourceFromGraveCost());
+        this.addAbility(ability);
+    }
+
+    public NephaliaMoondrakes(final NephaliaMoondrakes card) {
+        super(card);
+    }
+
+    @Override
+    public NephaliaMoondrakes copy() {
+        return new NephaliaMoondrakes(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/PiousEvangel.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/PiousEvangel.java
@@ -41,13 +41,11 @@ import mage.abilities.keyword.TransformAbility;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
 import mage.constants.Rarity;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.permanent.AnotherPredicate;
-import mage.filter.predicate.permanent.ControllerPredicate;
 import mage.target.common.TargetControlledPermanent;
 
 /**
@@ -60,7 +58,6 @@ public class PiousEvangel extends CardImpl {
     private static final FilterControlledPermanent filter2 = new FilterControlledPermanent("another permanent");
 
     static {
-        filter.add(new ControllerPredicate(TargetController.YOU));
         filter2.add(new AnotherPredicate());
     }
 

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/Rattlechains.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/Rattlechains.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.continuous.CastAsThoughItHadFlashAllEffect;
+import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
+import mage.abilities.keyword.FlashAbility;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.HexproofAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.filter.FilterCard;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.mageobject.SubtypePredicate;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class Rattlechains extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("spirit");
+    private static final FilterCard filterCard = new FilterCard("spirit cards");
+
+    static {
+        filter.add(new SubtypePredicate("Spirit"));
+        filterCard.add(new SubtypePredicate("Spirit"));
+    }
+
+    public Rattlechains(UUID ownerId) {
+        super(ownerId, 81, "Rattlechains", Rarity.RARE, new CardType[]{CardType.CREATURE}, "{1}{U}");
+        this.expansionSetCode = "SOI";
+        this.subtype.add("Spirit");
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(1);
+
+        // Flash
+        this.addAbility(FlashAbility.getInstance());
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // When Rattlechains enters the battlefield, target spirit gains hexproof until end of turn.
+        Ability ability = new EntersBattlefieldTriggeredAbility(new GainAbilityTargetEffect(HexproofAbility.getInstance(), Duration.EndOfTurn), false);
+        ability.addTarget(new TargetCreaturePermanent(filter));
+        this.addAbility(ability);
+
+        // You may cast spirit cards as though they had flash.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new CastAsThoughItHadFlashAllEffect(Duration.WhileOnBattlefield, filterCard, false)));
+    }
+
+    public Rattlechains(final Rattlechains card) {
+        super(card);
+    }
+
+    @Override
+    public Rattlechains copy() {
+        return new Rattlechains(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/RelentlessDead.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/RelentlessDead.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DiesTriggeredAbility;
+import mage.abilities.costs.Cost;
+import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DoIfCostPaid;
+import mage.abilities.effects.common.ReturnToHandSourceEffect;
+import mage.abilities.keyword.MenaceAbility;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.filter.Filter;
+import mage.filter.FilterCard;
+import mage.filter.predicate.mageobject.ConvertedManaCostPredicate;
+import mage.filter.predicate.mageobject.SubtypePredicate;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.common.TargetCardInYourGraveyard;
+
+/**
+ *
+ * @author LevelX2
+ */
+public class RelentlessDead extends CardImpl {
+
+    public RelentlessDead(UUID ownerId) {
+        super(ownerId, 131, "Relentless Dead", Rarity.MYTHIC, new CardType[]{CardType.CREATURE}, "{B}{B}");
+        this.expansionSetCode = "SOI";
+        this.subtype.add("Zombie");
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(2);
+
+        // Menace
+        this.addAbility(new MenaceAbility());
+
+        // When Relentless Dead dies, you may pay {B}. If you do, return it to its owner's hand.
+        this.addAbility(new DiesTriggeredAbility(new DoIfCostPaid(new ReturnToHandSourceEffect(), new ManaCostsImpl("{B}"))));
+
+        // When Relentless Dead dies, you may pay {X}. If you do, return another target Zombie creature card with converted mana cost X from your graveyard to the battlefield.
+        this.addAbility(new DiesTriggeredAbility(new RelentlessDeadEffect()));
+    }
+
+    public RelentlessDead(final RelentlessDead card) {
+        super(card);
+    }
+
+    @Override
+    public RelentlessDead copy() {
+        return new RelentlessDead(this);
+    }
+}
+
+class RelentlessDeadEffect extends OneShotEffect {
+
+    public RelentlessDeadEffect() {
+        super(Outcome.PutCardInPlay);
+        this.staticText = "you may pay {X}. If you do, return another target Zombie creature card with converted mana cost X from your graveyard to the battlefield";
+    }
+
+    public RelentlessDeadEffect(final RelentlessDeadEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public RelentlessDeadEffect copy() {
+        return new RelentlessDeadEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            if (controller.chooseUse(Outcome.BoostCreature, "Do you want to to pay {X}?", source, game)) {
+                int costX = controller.announceXMana(0, Integer.MAX_VALUE, "Announce the value for {X}", game, source);
+                Cost cost = new GenericManaCost(costX);
+                if (cost.pay(source, game, source.getSourceId(), source.getControllerId(), false, null)) {
+                    FilterCard filter = new FilterCard("Zombie card with converted mana cost " + costX);
+                    filter.add(new SubtypePredicate("Zombie"));
+                    filter.add(new ConvertedManaCostPredicate(Filter.ComparisonType.Equal, costX));
+                    TargetCardInYourGraveyard target = new TargetCardInYourGraveyard(filter);
+                    if (controller.chooseTarget(outcome, target, source, game)) {
+                        Card card = game.getCard(target.getFirstTarget());
+                        if (card != null) {
+                            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+        return false;
+
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/SageOfAncientLore.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/SageOfAncientLore.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.TriggeredAbility;
+import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.common.NoSpellsWereCastLastTurnCondition;
+import mage.abilities.decorator.ConditionalTriggeredAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.CardsInControllerHandCount;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.TransformSourceEffect;
+import mage.abilities.effects.common.continuous.SetPowerToughnessSourceEffect;
+import mage.abilities.keyword.TransformAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Rarity;
+import mage.constants.TargetController;
+import mage.constants.Zone;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class SageOfAncientLore extends CardImpl {
+
+    public SageOfAncientLore(UUID ownerId) {
+        super(ownerId, 225, "Sage of Ancient Lore", Rarity.RARE, new CardType[]{CardType.CREATURE}, "{4}{G}");
+        this.expansionSetCode = "SOI";
+        this.subtype.add("Human");
+        this.subtype.add("Shaman");
+        this.subtype.add("Werewolf");
+        this.power = new MageInt(0);
+        this.toughness = new MageInt(0);
+
+        this.canTransform = true;
+        this.secondSideCard = new WerewolfOfAncientHunger(ownerId);
+
+        // Sage of Ancient Lore's power and toughness are each equal to the number of cards in your hand.
+        DynamicValue xValue= new CardsInControllerHandCount();
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetPowerToughnessSourceEffect(xValue, Duration.EndOfGame)));
+
+        // When Sage of Ancient Lore enters the battlefield, draw a card.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new DrawCardSourceControllerEffect(1), false));
+
+        // At the beginning of each upkeep, if no spells were cast last turn, transform Sage of Ancient Lore.
+        this.addAbility(new TransformAbility());
+        TriggeredAbility ability = new BeginningOfUpkeepTriggeredAbility(new TransformSourceEffect(true), TargetController.ANY, false);
+        this.addAbility(new ConditionalTriggeredAbility(ability, NoSpellsWereCastLastTurnCondition.getInstance(), TransformAbility.NO_SPELLS_TRANSFORM_RULE));
+    }
+
+    public SageOfAncientLore(final SageOfAncientLore card) {
+        super(card);
+    }
+
+    @Override
+    public SageOfAncientLore copy() {
+        return new SageOfAncientLore(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/SinisterConcoction.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/SinisterConcoction.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.DiscardCardCost;
+import mage.abilities.costs.common.PayLifeCost;
+import mage.abilities.costs.common.PutTopCardOfYourLibraryToGraveyardCost;
+import mage.abilities.costs.common.SacrificeSourceCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.DestroyTargetEffect;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class SinisterConcoction extends CardImpl {
+
+    public SinisterConcoction(UUID ownerId) {
+        super(ownerId, 135, "Sinister Concoction", Rarity.UNCOMMON, new CardType[]{CardType.ENCHANTMENT}, "{B}");
+        this.expansionSetCode = "SOI";
+
+        // {B}, Pay 1 life, Put the top card of your library into your graveyard, Discard a card, Sacrifice Sinister Concoction: Destroy target creature.
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DestroyTargetEffect(), new ManaCostsImpl("{B}"));
+        ability.addCost(new PayLifeCost(1));
+        ability.addCost(new PutTopCardOfYourLibraryToGraveyardCost());
+        ability.addCost(new DiscardCardCost());
+        ability.addCost(new SacrificeSourceCost());
+        ability.addTarget(new TargetCreaturePermanent());
+        this.addAbility(ability);
+    }
+
+    public SinisterConcoction(final SinisterConcoction card) {
+        super(card);
+    }
+
+    @Override
+    public SinisterConcoction copy() {
+        return new SinisterConcoction(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/ToTheSlaughter.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/ToTheSlaughter.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.abilities.condition.InvertCondition;
+import mage.abilities.condition.common.DeliriumCondition;
+import mage.abilities.decorator.ConditionalOneShotEffect;
+import mage.abilities.effects.common.SacrificeEffect;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Rarity;
+import mage.filter.common.FilterCreatureOrPlaneswalkerPermanent;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.common.FilterPlaneswalkerPermanent;
+import mage.target.TargetPlayer;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class ToTheSlaughter extends CardImpl {
+
+    public ToTheSlaughter(UUID ownerId) {
+        super(ownerId, 139, "To the Slaughter", Rarity.RARE, new CardType[]{CardType.INSTANT}, "{2}{B}");
+        this.expansionSetCode = "SOI";
+
+        // Target player sacrifices a creature or planeswalker.
+        this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
+                new SacrificeEffect(new FilterCreatureOrPlaneswalkerPermanent(), 1, "Target player"),
+                new InvertCondition(DeliriumCondition.getInstance()),
+                "Target player sacrifices a creature or planeswalker."));
+
+        // <i>Delirium</i> &mdash; If there are four or more card types among cards in your graveyard, instead that player sacrifices a creature and a planeswalker.
+        this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
+                new SacrificeEffect(new FilterCreaturePermanent(), 1, "Target player"),
+                DeliriumCondition.getInstance(),
+                "<br><i>Delirium</i> &mdash; If there are four or more card types among cards in your graveyard, instead that player sacrifices a creature"));
+        this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
+                new SacrificeEffect(new FilterPlaneswalkerPermanent(), 1, "Target player"),
+                DeliriumCondition.getInstance(), "and a planeswalker."));
+        this.getSpellAbility().addTarget(new TargetPlayer());
+    }
+
+    public ToTheSlaughter(final ToTheSlaughter card) {
+        super(card);
+    }
+
+    @Override
+    public ToTheSlaughter copy() {
+        return new ToTheSlaughter(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/WerewolfOfAncientHunger.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/WerewolfOfAncientHunger.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.TriggeredAbility;
+import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.common.TwoOrMoreSpellsWereCastLastTurnCondition;
+import mage.abilities.decorator.ConditionalTriggeredAbility;
+import mage.abilities.dynamicvalue.common.CardsInAllHandsCount;
+import mage.abilities.effects.common.TransformSourceEffect;
+import mage.abilities.effects.common.continuous.SetPowerToughnessSourceEffect;
+import mage.abilities.keyword.TrampleAbility;
+import mage.abilities.keyword.TransformAbility;
+import mage.abilities.keyword.VigilanceAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Rarity;
+import mage.constants.TargetController;
+import mage.constants.Zone;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class WerewolfOfAncientHunger extends CardImpl {
+
+    public WerewolfOfAncientHunger(UUID ownerId) {
+        super(ownerId, 225, "Werewolf of Ancient Hunger", Rarity.RARE, new CardType[]{CardType.CREATURE}, "");
+        this.expansionSetCode = "SOI";
+        this.subtype.add("Werewolf");
+        this.power = new MageInt(0);
+        this.toughness = new MageInt(0);
+
+        this.nightCard = true;
+        this.canTransform = true;
+
+        // Vigilance
+        this.addAbility(VigilanceAbility.getInstance());
+
+        // Trample
+        this.addAbility(TrampleAbility.getInstance());
+
+        // Werewolf of Ancient Hunger's power and toughness are each equal to the total number of cards in all players' hands.
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetPowerToughnessSourceEffect(new CardsInAllHandsCount(), Duration.EndOfGame)));
+
+        // At the beginning of each upkeep, if a player cast two or more spells last turn, transform Werewolf of Ancient Hunger.
+        TriggeredAbility ability = new BeginningOfUpkeepTriggeredAbility(new TransformSourceEffect(false), TargetController.ANY, false);
+        this.addAbility(new ConditionalTriggeredAbility(ability, TwoOrMoreSpellsWereCastLastTurnCondition.getInstance(), TransformAbility.TWO_OR_MORE_SPELLS_TRANSFORM_RULE));
+    }
+
+    public WerewolfOfAncientHunger(final WerewolfOfAncientHunger card) {
+        super(card);
+    }
+
+    @Override
+    public WerewolfOfAncientHunger copy() {
+        return new WerewolfOfAncientHunger(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/WolfOfDevilsBreach.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/WolfOfDevilsBreach.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.shadowsoverinnistrad;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.AttacksTriggeredAbility;
+import mage.abilities.costs.common.DiscardCardCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.common.DiscardCostCardConvertedMana;
+import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.effects.common.DoIfCostPaid;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Rarity;
+import mage.target.common.TargetCreatureOrPlaneswalker;
+
+/**
+ *
+ * @author fireshoes
+ */
+public class WolfOfDevilsBreach extends CardImpl {
+
+    public WolfOfDevilsBreach(UUID ownerId) {
+        super(ownerId, 192, "Wolf of Devil's Breach", Rarity.MYTHIC, new CardType[]{CardType.CREATURE}, "{3}{R}{R}");
+        this.expansionSetCode = "SOI";
+        this.subtype.add("Elemental");
+        this.subtype.add("Wolf");
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(5);
+
+        // Whenever Wolf of Devil's Breach attacks, you may pay {1}{R} and discard a card. If you do, Wolf of Devil's Breach deals 
+        // damage to target creature or planeswalker equal to the discarded card's converted mana cost.
+        Ability ability = new AttacksTriggeredAbility(new DoIfCostPaid(new DamageTargetEffect(new DiscardCostCardConvertedMana()), new ManaCostsImpl("{1}{R}")), false,
+                "Whenever {this} attacks you may pay {1}{R} and discard a card. If you do, {this} deals damage to target creature or planeswalker "
+                        + "equal to the discarded card's converted mana cost.");
+        ability.addCost(new DiscardCardCost());
+        ability.addTarget(new TargetCreatureOrPlaneswalker());
+        this.addAbility(ability);
+    }
+
+    public WolfOfDevilsBreach(final WolfOfDevilsBreach card) {
+        super(card);
+    }
+
+    @Override
+    public WolfOfDevilsBreach copy() {
+        return new WolfOfDevilsBreach(this);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/commander/CommanderColorIdentityTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/commander/CommanderColorIdentityTest.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package org.mage.test.commander;
+
+import mage.cards.Card;
+import mage.cards.repository.CardInfo;
+import mage.cards.repository.CardRepository;
+import mage.filter.FilterMana;
+import mage.util.CardUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestCommander3PlayersFFA;
+
+/**
+ *
+ * @author LevelX2
+ */
+public class CommanderColorIdentityTest extends CardTestCommander3PlayersFFA {
+
+    @Test
+    public void TestColors() {
+        // Basic Colors
+        Assert.assertEquals("{B}", getColorIdentityString("Sengir Vampire"));
+        Assert.assertEquals("{G}", getColorIdentityString("Elvish Visionary"));
+        Assert.assertEquals("{R}", getColorIdentityString("Demolish"));
+        Assert.assertEquals("{U}", getColorIdentityString("Negate"));
+        Assert.assertEquals("{W}", getColorIdentityString("Silvercoat Lion"));
+
+        // Multicolor
+        Assert.assertEquals("{G}{W}", getColorIdentityString("Veteran Warleader"));
+        Assert.assertEquals("{B}{R}", getColorIdentityString("Forerunner of Slaughter"));
+        Assert.assertEquals("{R}{U}", getColorIdentityString("Brutal Expulsion"));
+        Assert.assertEquals("{B}{G}", getColorIdentityString("Catacomb Sifter"));
+        Assert.assertEquals("{B}{U}", getColorIdentityString("Fathom Feeder"));
+
+        Assert.assertEquals("{R}{W}", getColorIdentityString("Angelic Captain"));
+        Assert.assertEquals("{G}{U}", getColorIdentityString("Bring to Light"));
+        Assert.assertEquals("{B}{W}", getColorIdentityString("Drana's Emissary"));
+        Assert.assertEquals("{G}{R}", getColorIdentityString("Grove Rumbler"));
+        Assert.assertEquals("{U}{W}", getColorIdentityString("Roil Spout"));
+
+        // Cards with colors in the rule text
+        Assert.assertEquals("{B}{R}", getColorIdentityString("Fires of Undeath"));
+
+        // Cards without casting costs
+        Assert.assertEquals("{B}", getColorIdentityString("Living End"));
+        Assert.assertEquals("{G}", getColorIdentityString("Hypergenesis"));
+
+        // Phyrexian Mana
+        Assert.assertEquals("{B}", getColorIdentityString("Dismember"));
+
+        // Hybrid mana
+        Assert.assertEquals("{G}{W}", getColorIdentityString("Kitchen Finks"));
+
+        // Lands with colored activation costs
+        Assert.assertEquals("{G}", getColorIdentityString("Treetop Village"));
+
+        // Cards with extort don't use extort to determine color identity
+        Assert.assertEquals("{W}", getColorIdentityString("Knight of Obligation"));
+
+        // Two face cards
+        Assert.assertEquals("{G}{R}", getColorIdentityString("Daybreak Ranger"));
+        Assert.assertEquals("{R}{W}", getColorIdentityString("Archangel Avacyn"));
+        Assert.assertEquals("{R}{U}", getColorIdentityString("Civilized Scholar"));
+
+    }
+
+    private String getColorIdentityString(String cardName) {
+        CardInfo cardInfo = CardRepository.instance.findCard(cardName);
+        if (cardInfo == null) {
+            throw new IllegalArgumentException("Couldn't find the card " + cardName + " in the DB.");
+        }
+        Card card = cardInfo.getCard();
+        FilterMana filterMana = CardUtil.getColorIdentity(card);
+        return filterMana.toString();
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/DontUntapInOpponentsNextUntapStepAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DontUntapInOpponentsNextUntapStepAllEffect.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.abilities.effects.common;
+
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.Mode;
+import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.PhaseStep;
+import mage.constants.TargetController;
+import mage.filter.FilterPermanent;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.events.GameEvent.EventType;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+
+/**
+ * @author okuRaku
+ */
+public class DontUntapInOpponentsNextUntapStepAllEffect extends ContinuousRuleModifyingEffectImpl {
+
+    private int validForTurnNum;
+    //private String targetName;
+    TargetController targetController;
+    FilterPermanent filter;
+
+    /**
+     * Attention: This effect won't work with targets controlled by different
+     * controllers If this is needed, the validForTurnNum has to be saved per
+     * controller.
+     */
+    public DontUntapInOpponentsNextUntapStepAllEffect(FilterPermanent filter) {
+        super(Duration.Custom, Outcome.Detriment, false, true);
+        this.filter = filter; 
+    }
+
+    public DontUntapInOpponentsNextUntapStepAllEffect(final DontUntapInOpponentsNextUntapStepAllEffect effect) {
+        super(effect);
+        this.validForTurnNum = effect.validForTurnNum;
+        this.targetController = effect.targetController;
+        this.filter = effect.filter;
+
+    }
+
+    @Override
+    public DontUntapInOpponentsNextUntapStepAllEffect copy() {
+        return new DontUntapInOpponentsNextUntapStepAllEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return false;
+    }
+
+    @Override
+    public String getInfoMessage(Ability source, GameEvent event, Game game) {
+        MageObject mageObject = game.getObject(source.getSourceId());
+        Permanent permanentToUntap = game.getPermanent((event.getTargetId()));
+        if (permanentToUntap != null && mageObject != null) {
+            return permanentToUntap.getLogName() + " doesn't untap (" + mageObject.getLogName() + ")";
+        }
+        return null;
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == EventType.UNTAP_STEP || event.getType() == EventType.UNTAP;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        // the check for turn number is needed if multiple effects are added to prevent untap in next untap step of controller
+        // if we don't check for turn number, every untap step of a turn only one effect would be used instead of correctly only one time
+        // to skip the untap effect.
+
+        // Discard effect if it's related to a previous turn
+        if (validForTurnNum > 0 && validForTurnNum < game.getTurnNum()) {
+            discard();
+            return false;
+        }
+        // remember the turn of the untap step the effect has to be applied
+        if (GameEvent.EventType.UNTAP_STEP.equals(event.getType())) {
+            if (game.getActivePlayerId().equals(getTargetPointer().getFirst(game, source))) {
+                if (validForTurnNum == game.getTurnNum()) { // the turn has a second untap step but the effect is already related to the first untap step
+                    discard();
+                    return false;
+                }
+                validForTurnNum = game.getTurnNum();
+            }
+        }
+
+        if (game.getTurn().getStepType() == PhaseStep.UNTAP && event.getType() == EventType.UNTAP) {
+            Permanent permanent = game.getPermanent(event.getTargetId());
+            if (permanent != null) {
+                Player controller = game.getPlayer(source.getControllerId());
+                if (controller != null && !game.isOpponent(controller, permanent.getControllerId())) {
+                    return false;
+                }
+                if (game.getActivePlayerId().equals(permanent.getControllerId()) && // controller's untap step
+                        filter.match(permanent, source.getSourceId(), source.getControllerId(), game)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String getText(Mode mode) {
+        if (!staticText.isEmpty()) {
+            return staticText;
+        }
+        return filter.getMessage() + " target opponent controls don't untap during his or her next untap step.";
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/DontUntapInOpponentsNextUntapStepAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DontUntapInOpponentsNextUntapStepAllEffect.java
@@ -121,6 +121,9 @@ public class DontUntapInOpponentsNextUntapStepAllEffect extends ContinuousRuleMo
             Permanent permanent = game.getPermanent(event.getTargetId());
             if (permanent != null) {
                 Player controller = game.getPlayer(source.getControllerId());
+                if (!permanent.getControllerId().equals(getTargetPointer().getFirst(game, source))) {
+                    return false;
+                }
                 if (controller != null && !game.isOpponent(controller, permanent.getControllerId())) {
                     return false;
                 }

--- a/Mage/src/main/java/mage/filter/FilterMana.java
+++ b/Mage/src/main/java/mage/filter/FilterMana.java
@@ -114,4 +114,14 @@ public class FilterMana implements Serializable {
     public FilterMana copy() {
         return new FilterMana(this);
     }
+
+    @Override
+    public String toString() {
+        return (black ? "{B}" : "")
+                + (green ? "{G}" : "")
+                + (red ? "{R}" : "")
+                + (blue ? "{U}" : "")
+                + (white ? "{W}" : "");
+    }
+
 }

--- a/Mage/src/main/java/mage/game/permanent/token/AngelToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/AngelToken.java
@@ -12,7 +12,7 @@ public class AngelToken extends Token {
     final static private List<String> tokenImageSets = new ArrayList<>();
 
     static {
-        tokenImageSets.addAll(Arrays.asList("AVR", "C14", "CFX", "GTC", "ISD", "M14", "ORI", "ZEN"));
+        tokenImageSets.addAll(Arrays.asList("AVR", "C14", "CFX", "GTC", "ISD", "M14", "ORI", "SOI", "ZEN"));
     }
 
     public AngelToken() {

--- a/Mage/src/main/java/mage/game/permanent/token/SpiritWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/SpiritWhiteToken.java
@@ -42,7 +42,7 @@ public class SpiritWhiteToken extends Token {
     final static private List<String> tokenImageSets = new ArrayList<>();
 
     static {
-        tokenImageSets.addAll(Arrays.asList("AVR", "C14", "CNS", "DDC", "DDK", "FRF", "ISD", "KTK", "M15", "MM2", "SHM"));
+        tokenImageSets.addAll(Arrays.asList("AVR", "C14", "CNS", "DDC", "DDK", "FRF", "ISD", "KTK", "M15", "MM2", "SHM", "SOI"));
     }
 
     public SpiritWhiteToken() {

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.UUID;
 import mage.MageObject;
 import mage.Mana;
+import mage.ObjectColor;
 import mage.abilities.Ability;
 import mage.abilities.ActivatedAbility;
 import mage.abilities.SpellAbility;
@@ -623,22 +624,50 @@ public class CardUtil {
 
         for (String rule : card.getRules()) {
             rule = rule.replaceAll("(?i)<i.*?</i>", ""); // Ignoring reminder text in italic
-            if (rule.matches(regexBlack)) {
+            if (!mana.isBlack() && rule.matches(regexBlack)) {
                 mana.setBlack(true);
             }
-            if (rule.matches(regexBlue)) {
+            if (!mana.isBlue() && rule.matches(regexBlue)) {
                 mana.setBlue(true);
             }
-            if (rule.matches(regexGreen)) {
+            if (!mana.isGreen() && rule.matches(regexGreen)) {
                 mana.setGreen(true);
             }
-            if (rule.matches(regexRed)) {
+            if (!mana.isRed() && rule.matches(regexRed)) {
                 mana.setRed(true);
             }
-            if (rule.matches(regexWhite)) {
+            if (!mana.isWhite() && rule.matches(regexWhite)) {
                 mana.setWhite(true);
             }
         }
+        if (card.canTransform()) {
+            Card secondCard = card.getSecondCardFace();
+            ObjectColor color = secondCard.getColor(null);
+            mana.setBlack(mana.isBlack() || color.isBlack());
+            mana.setGreen(mana.isGreen() || color.isGreen());
+            mana.setRed(mana.isRed() || color.isRed());
+            mana.setBlue(mana.isBlue() || color.isBlue());
+            mana.setWhite(mana.isWhite() || color.isWhite());
+            for (String rule : secondCard.getRules()) {
+                rule = rule.replaceAll("(?i)<i.*?</i>", ""); // Ignoring reminder text in italic
+                if (!mana.isBlack() && rule.matches(regexBlack)) {
+                    mana.setBlack(true);
+                }
+                if (!mana.isBlue() && rule.matches(regexBlue)) {
+                    mana.setBlue(true);
+                }
+                if (!mana.isGreen() && rule.matches(regexGreen)) {
+                    mana.setGreen(true);
+                }
+                if (!mana.isRed() && rule.matches(regexRed)) {
+                    mana.setRed(true);
+                }
+                if (!mana.isWhite() && rule.matches(regexWhite)) {
+                    mana.setWhite(true);
+                }
+            }
+        }
+
         return mana;
     }
 


### PR DESCRIPTION
I noticed that the card Exhaustion wasn't working correctly - if a creature or land came into the battlefield after Exhaustion was resolved, and then subsequently tapped (via Gigadrowse), they would untap during opponent's next untap.   Per the rulings this is not correct:

10/1/2009: No creatures or lands controlled by the player will untap during his or her next untap step. This includes those which entered the battlefield after Exhaustion resolved.