### PR TITLE
[SOI] Neglected Heirloom

### DIFF
--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/NeglectedHeirloom.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/NeglectedHeirloom.java
@@ -28,54 +28,89 @@
 package mage.sets.shadowsoverinnistrad;
 
 import java.util.UUID;
-import mage.abilities.Ability;
+import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.TransformSourceEffect;
 import mage.abilities.effects.common.continuous.BoostEquippedEffect;
-import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
 import mage.abilities.keyword.EquipAbility;
-import mage.abilities.keyword.FirstStrikeAbility;
+import mage.abilities.keyword.TransformAbility;
 import mage.cards.CardImpl;
-import mage.constants.AttachmentType;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.Rarity;
 import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.GameEvent;
 
 /**
  *
- * @author fireshoes
+ * @author halljared
  */
-public class AshmouthBlade extends CardImpl {
+public class NeglectedHeirloom extends CardImpl {
 
-    public AshmouthBlade(UUID ownerId) {
-        super(ownerId, 260, "Ashmouth Blade", Rarity.UNCOMMON, new CardType[]{CardType.ARTIFACT}, "");
+    public NeglectedHeirloom(UUID ownerId) {
+        super(ownerId, 260, "Neglected Heirloom", Rarity.UNCOMMON, new CardType[]{CardType.ARTIFACT}, "{1}");
         this.expansionSetCode = "SOI";
         this.subtype.add("Equipment");
 
-        // this card is the second face of double-faced card
-        this.nightCard = true;
+        this.canTransform = true;
+        this.secondSideCard = new AshmouthBlade(ownerId);
 
-        // Equipped creature gets +3/+3
-        Ability ability = new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEquippedEffect(3, 3));
-        this.addAbility(ability);
+        // Equipped creature gets +1/+1.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEquippedEffect(1, 1)));
+        // Equip {1}
+        this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(1)));
 
-        // and has first strike.
-        Effect effect = new GainAbilityAttachedEffect(FirstStrikeAbility.getInstance(), AttachmentType.EQUIPMENT);
-        effect.setText("and has first strike");
-        ability.addEffect(effect);
+        // When equipped creature transforms, transform Neglected Heirloom.
+        this.addAbility(new TransformAbility());
+        this.addAbility(new NeglectedHeirloomTriggeredAbility());
 
-        // Equip {3}
-        this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(3)));
     }
 
-    public AshmouthBlade(final AshmouthBlade card) {
+    public NeglectedHeirloom(final NeglectedHeirloom card) {
         super(card);
     }
 
     @Override
-    public AshmouthBlade copy() {
-        return new AshmouthBlade(this);
+    public NeglectedHeirloom copy() {
+        return new NeglectedHeirloom(this);
+    }
+
+}
+
+class NeglectedHeirloomTriggeredAbility extends TriggeredAbilityImpl {
+
+    public NeglectedHeirloomTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new TransformSourceEffect(true), false);
+    }
+
+    public NeglectedHeirloomTriggeredAbility(final NeglectedHeirloomTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.TRANSFORMED;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        if (event.getType() == GameEvent.EventType.TRANSFORMED) {
+            if (game.getPermanent(event.getTargetId()).getAttachments().contains(this.getSourceId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public NeglectedHeirloomTriggeredAbility copy() {
+        return new NeglectedHeirloomTriggeredAbility(this);
+    }
+
+    @Override
+    public String getRule() {
+        return "When equipped creature transforms, transform Neglected Heirloom.";
     }
 }


### PR DESCRIPTION
Implemented neglected heirloom. I didn't write tests but I tested in-game functionality.

If the blade trigger is on the stack, killing the transformed creature doesn't matter, the blade still transforms. If you kill the transforming creature WITH the creature's transform trigger on the stack, the blade doesn't trigger at all because its creature didn't actually transform. I think this is how it should work per the rules of the game but there is no gatherer page yet to verify.