### PR TITLE
Fixes #1755

### DIFF
--- a/Mage.Client/src/main/java/mage/client/cards/DraftGrid.java
+++ b/Mage.Client/src/main/java/mage/client/cards/DraftGrid.java
@@ -183,19 +183,22 @@ public class DraftGrid extends javax.swing.JPanel implements MouseListener {
 
     @Override
     public void mouseClicked(MouseEvent e) {
+        if (e.getClickCount() == 2) {
+            if (e.getButton() == MouseEvent.BUTTON1) {
+                Object obj = e.getSource();
+                if (obj instanceof MageCard) {
+                    this.cardEventSource.doubleClick(((MageCard)obj).getOriginal(), "pick-a-card");
+                    this.hidePopup();
+                    AudioManager.playOnDraftSelect();
+                }
+            }
+        }
+
     }
 
     @Override
     public void mousePressed(MouseEvent e) {
-        if (e.getButton() == MouseEvent.BUTTON1) { // only left click select
-            Object obj = e.getSource();
-            if (obj instanceof MageCard) {
-                this.cardEventSource.doubleClick(((MageCard)obj).getOriginal(), "pick-a-card");
-                this.hidePopup();
-                AudioManager.playOnDraftSelect();
-            }
-        }
-        if (e.getButton() == MouseEvent.BUTTON3) { // only right click mark
+        if (e.getButton() == MouseEvent.BUTTON1 || e.getButton() == MouseEvent.BUTTON3) { // left or right click
             Object obj = e.getSource();
             if (obj instanceof MageCard) {
                 if (this.markedCard != null) {


### PR DESCRIPTION
This makes the draft pick window more similar to MTGO. It keeps the old right-click to reserve feature and changes the left-click from confirm to reserve. Double-click makes the pick immediately. I tested locally and this feels a lot better and should give people a better draft experience.

I also looked into the issue of the draft pick timer not representing the actual time you have remaining. My research shows that this stems from the fact that the server has its own timer that starts without acknowledging the client has received the new draft pick. Most of the time the latency is negligible but under some circumstances there could be significant difference. Fixing this can be done in a separate issue if people think it is a serious problem.