### PR TITLE
Fixes #1728

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/soi/TheGitrogMonsterTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/soi/TheGitrogMonsterTest.java
@@ -16,31 +16,31 @@ import org.mage.test.serverside.base.CardTestPlayerBase;
 
     You may play an additional land on each of your turns.
 
-    Whenever one or more land cards are put into your graveyard from anywhere, draw a card. 
+    Whenever one or more land cards are put into your graveyard from anywhere, draw a card.
  *
  * @author escplan9 (Derek Monturo - dmontur1 at gmail dot com)
  */
 public class TheGitrogMonsterTest extends CardTestPlayerBase  {
-    
+
     /**
      * Basic sacrifice test when no lands are present
      */
     @Test
     public void noLandsSacrificeGitrog() {
-         
+
         addCard(Zone.HAND, playerA, "The Gitrog Monster", 1);
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
         addCard(Zone.BATTLEFIELD, playerA, "Forest", 2);
-                
+
         addCard(Zone.HAND, playerB, "Armageddon", 1); // destroy all lands
         addCard(Zone.BATTLEFIELD, playerB, "Plains", 4);
-        
+
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "The Gitrog Monster");
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Armageddon");
 
         setStopAt(3, PhaseStep.DRAW);
         execute();
-        
+
         Set<Card> hand = playerA.getHand().getCards(currentGame);
         assertGraveyardCount(playerA, "Swamp", 3);
         assertGraveyardCount(playerA, "Forest", 2);
@@ -48,27 +48,27 @@ public class TheGitrogMonsterTest extends CardTestPlayerBase  {
         assertGraveyardCount(playerB, "Plains", 4);
         assertGraveyardCount(playerB, "Armageddon", 1);
         assertPermanentCount(playerA, "The Gitrog Monster", 0);
-        assertHandCount(playerA, 6); // 1 for turn, 5 more for lands that hit the grave
+        assertHandCount(playerA, 2); // 1 for turn, 1 for one or more for lands that hit the grave
     }
-    
+
     /**
      * Basic sacrifice test when there is a land
      */
     @Test
     public void hasLandsSacrificeLand() {
-         
+
         addCard(Zone.HAND, playerA, "The Gitrog Monster", 1);
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
         addCard(Zone.BATTLEFIELD, playerA, "Forest", 2);
-                        
+
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "The Gitrog Monster");
-        
+
         // on 3rd turn during upkeep opt to sacrifice a land
         setChoice(playerA, "Yes");
         addTarget(playerA, "Swamp");
         setStopAt(3, PhaseStep.DRAW);
         execute();
-        
+
         Set<Card> hand = playerA.getHand().getCards(currentGame);
         assertGraveyardCount(playerA, "Swamp", 1);
         assertPermanentCount(playerA, "The Gitrog Monster", 1);

--- a/Mage/src/main/java/mage/abilities/effects/AuraReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/AuraReplacementEffect.java
@@ -208,6 +208,7 @@ public class AuraReplacementEffect extends ReplacementEffectImpl {
             Card card = game.getCard(event.getTargetId());
             if (card != null && (card.getCardType().contains(CardType.ENCHANTMENT) && card.hasSubtype("Aura") ||
                     (game.getState().getValue(TransformAbility.VALUE_KEY_ENTER_TRANSFORMED + card.getId()) != null &&
+                    card.getSecondCardFace() != null &&
                     card.getSecondCardFace().getCardType().contains(CardType.ENCHANTMENT) &&
                     card.getSecondCardFace().hasSubtype("Aura")))) {
                 return true;

--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -32,8 +32,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Abilities;
@@ -59,6 +63,8 @@ import mage.game.combat.CombatGroup;
 import mage.game.command.Command;
 import mage.game.command.CommandObject;
 import mage.game.events.GameEvent;
+import mage.game.events.ZoneChangeEvent;
+import mage.game.events.ZoneChangeGroupEvent;
 import mage.game.permanent.Battlefield;
 import mage.game.permanent.Permanent;
 import mage.game.stack.SpellStack;
@@ -647,6 +653,70 @@ public class GameState implements Serializable, Copyable<GameState> {
         zones.put(id, zone);
     }
 
+    public List<GameEvent> createEventGroups(List<GameEvent> events, Game game) {
+        class ZoneChangeData {
+            private Zone fromZone;
+            private Zone toZone;
+            private UUID sourceId;
+            private UUID playerId;
+            public ZoneChangeData(UUID sourceId, UUID playerId, Zone fromZone, Zone toZone) {
+                this.sourceId = sourceId;
+                this.playerId = playerId;
+                this.fromZone = fromZone;
+                this.toZone = toZone;
+            }
+            @Override
+            public int hashCode() {
+                return (this.fromZone.ordinal() + 1) * 1 +
+                        (this.toZone.ordinal() + 1) * 10 +
+                        (this.sourceId != null ? this.sourceId.hashCode(): 0) +
+                        (this.playerId != null ? this.playerId.hashCode(): 0);
+            }
+            @Override
+            public boolean equals(Object obj) {
+                if (obj instanceof ZoneChangeData) {
+                    ZoneChangeData data = (ZoneChangeData) obj;
+                    return this.fromZone == data.fromZone &&
+                            this.toZone == data.toZone &&
+                            this.sourceId == data.sourceId &&
+                            this.playerId == data.playerId;
+                }
+                return false;
+            }
+        }
+        Map<ZoneChangeData, List<GameEvent>> eventsByKey = new HashMap<>();
+        List<GameEvent> groupEvents = new LinkedList<>();
+        for(GameEvent event: events) {
+            if(event instanceof ZoneChangeEvent) {
+                ZoneChangeEvent castEvent = (ZoneChangeEvent) event;
+                ZoneChangeData key = new ZoneChangeData(castEvent.getSourceId(), castEvent.getPlayerId(), castEvent.getFromZone(), castEvent.getToZone());
+                if(eventsByKey.containsKey(key)) {
+                    eventsByKey.get(key).add(event);
+                } else {
+                    List<GameEvent> list = new LinkedList<>();
+                    list.add(event);
+                    eventsByKey.put(key, list);
+                }
+            }
+        }
+        for(Map.Entry<ZoneChangeData, List<GameEvent>> entry: eventsByKey.entrySet()) {
+            Set<Card> movedCards = new LinkedHashSet<>();
+            for (Iterator<GameEvent> it = entry.getValue().iterator(); it.hasNext();) {
+                GameEvent event = it.next();
+                ZoneChangeEvent castEvent = (ZoneChangeEvent) event;
+                UUID targetId = castEvent.getTargetId();
+                Card card = game.getCard(targetId);
+                movedCards.add(card);
+            }
+            ZoneChangeData eventData = entry.getKey();
+            if (!movedCards.isEmpty()) {
+                ZoneChangeGroupEvent event = new ZoneChangeGroupEvent(movedCards, eventData.sourceId, eventData.playerId, eventData.fromZone, eventData.toZone);
+                groupEvents.add(event);
+            }
+        }
+        return groupEvents;
+    }
+
     public void addSimultaneousEvent(GameEvent event, Game game) {
         simultaneousEvents.add(event);
     }
@@ -655,7 +725,9 @@ public class GameState implements Serializable, Copyable<GameState> {
         if (!simultaneousEvents.isEmpty() && !getTurn().isEndTurnRequested()) {
             // it can happen, that the events add new simultaneous events, so copy the list before
             List<GameEvent> eventsToHandle = new ArrayList<>();
+            List<GameEvent> eventGroups = createEventGroups(simultaneousEvents, game);
             eventsToHandle.addAll(simultaneousEvents);
+            eventsToHandle.addAll(eventGroups);
             simultaneousEvents.clear();
             for (GameEvent event : eventsToHandle) {
                 this.handleEvent(event, game);

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -3249,9 +3249,6 @@ public abstract class PlayerImpl implements Player, Serializable {
             default:
                 throw new UnsupportedOperationException("to Zone" + toZone.toString() + " not supported yet");
         }
-        if (!successfulMovedCards.isEmpty()) {
-            game.fireEvent(new ZoneChangeGroupEvent(successfulMovedCards, source == null ? null : source.getSourceId(), this.getId(), fromZone, toZone));
-        }
         return successfulMovedCards.size() > 0;
     }
 
@@ -3267,7 +3264,6 @@ public abstract class PlayerImpl implements Player, Serializable {
         if (cards.isEmpty()) {
             return true;
         }
-        game.fireEvent(new ZoneChangeGroupEvent(cards, source == null ? null : source.getSourceId(), this.getId(), null, Zone.EXILED));
         boolean result = false;
         for (Card card : cards) {
             Zone fromZone = game.getState().getZone(card.getId());
@@ -3368,7 +3364,6 @@ public abstract class PlayerImpl implements Player, Serializable {
                 }
             }
         }
-        game.fireEvent(new ZoneChangeGroupEvent(movedCards, source == null ? null : source.getSourceId(), this.getId(), fromZone, Zone.GRAVEYARD));
         return movedCards;
     }
 


### PR DESCRIPTION
Firstly, this contains a fixed test case from clever impersonator that I think I broke previously.

But now for the meat and potatoes: This code changes how ZoneChangeGroupEvent's are created. I found that the concept of the events is useful and necessary but that certain effects made it impossible to predict when they would occur. For example if you cast wrath of god, indestructible creatures aren't destroyed. Instead, each non-indestructible creature is destroyed individually. No group event is ever created.

Because of situations like the wrath of god situation, it's more correct to retro-actively group zone changes. This way you can defer until you have all the information about the individual events.

I removed any "top-down" calls to ZoneChangeGroupEvent because they will only ever be inconsistent at best. Instead they are created "bottom-up" inside the game-state processing of events.

The Gitrog tests pass and also the Sidisi Brood Tyrant + Dredge tests pass. I manually tested Sidisi + Gitrog + Dredge... fun.