### PR TITLE
spjspj - 'Use first Mana ability' fixes

### DIFF
--- a/Mage.Client/src/main/java/mage/client/game/GamePanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/GamePanel.java
@@ -596,7 +596,7 @@ public final class GamePanel extends javax.swing.JPanel {
         setMenuStates(
                 PreferencesDialog.getCachedValue(KEY_GAME_MANA_AUTOPAYMENT, "true").equals("true"),
                 PreferencesDialog.getCachedValue(KEY_GAME_MANA_AUTOPAYMENT_ONLY_ONE, "true").equals("true"),
-                PreferencesDialog.getCachedValue(PreferencesDialog.KEY_USE_FIRST_MANA_ABILITY, "true").equals("true")
+                false
         );
 
         updateGame(game);

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -1255,10 +1255,11 @@ public class HumanPlayer extends PlayerImpl {
             if (ability instanceof ManaAbility) {
                 activateAbility(ability, game);
                 return;
-            }         
-        } else {       
-            game.fireGetChoiceEvent(playerId, name, object, new ArrayList<>(abilities.values()));
-        }
+            }
+        } 
+        
+        game.fireGetChoiceEvent(playerId, name, object, new ArrayList<>(abilities.values()));
+        
         waitForResponse(game);
         if (response.getUUID() != null && isInGame()) {
             if (abilities.containsKey(response.getUUID())) {


### PR DESCRIPTION
1) If first ability is not mana and they've tapped on a land, panic and then default to popup option
    (relevant for fetch lands and probably other lands as Plopman pointed out)
2) Ensure that the default is for it to not be on.