### PR TITLE
Vanishing card implemented

### DIFF
--- a/Mage.Sets/src/mage/sets/ravnica/PariahsShield.java
+++ b/Mage.Sets/src/mage/sets/ravnica/PariahsShield.java
@@ -1,0 +1,118 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.ravnica;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.keyword.EquipAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.DamagePlayerEvent;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+
+/**
+ *
+ * @author escplan9 (Derek Monturo - dmontur1 at gmail dot com)
+ */
+public class PariahsShield extends CardImpl {
+
+    public PariahsShield(UUID ownerId) {
+        super(ownerId, 267, "Pariah's Shield", Rarity.RARE, new CardType[]{CardType.ARTIFACT}, "{5}");
+        this.expansionSetCode = "RAV";
+        this.subtype.add("Equipment");
+
+        // All damage that would be dealt to you is dealt to equipped creature instead.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PariahEffect()));
+        
+        // Equip {3}
+        this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(3)));
+    }
+
+    public PariahsShield(final PariahsShield card) {
+        super(card);
+    }
+
+    @Override
+    public PariahsShield copy() {
+        return new PariahsShield(this);
+    }
+}
+
+class PariahEffect extends ReplacementEffectImpl {
+    PariahEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.RedirectDamage);
+        staticText = "All damage that would be dealt to you is dealt to equipped creature instead";
+    }
+
+    PariahEffect(final PariahEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        DamagePlayerEvent damageEvent = (DamagePlayerEvent) event;
+        Permanent equipment = game.getPermanent(source.getSourceId());
+        if (equipment != null) {
+            Permanent p = game.getPermanent(equipment.getAttachedTo());
+            if (p != null) {
+                p.damage(damageEvent.getAmount(), event.getSourceId(), game, damageEvent.isCombatDamage(), damageEvent.isPreventable());
+                return true;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DAMAGE_PLAYER;
+    }
+    
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        return event.getPlayerId().equals(source.getControllerId());
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return true;
+    }
+
+    @Override
+    public PariahEffect copy() {
+        return new PariahEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/visions/Vanishing.java
+++ b/Mage.Sets/src/mage/sets/visions/Vanishing.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.visions;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.effects.common.PhaseOutAttachedEffect;
+import mage.abilities.keyword.EnchantAbility;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author escplan9 (Derek Monturo - dmontur1 at gmail dot com)
+ */
+public class Vanishing extends CardImpl {
+
+    public Vanishing(UUID ownerId) {
+        super(ownerId, 39, "Vanishing", Rarity.COMMON, new CardType[]{CardType.ENCHANTMENT}, "{U}");
+        this.expansionSetCode = "VIS";
+        this.subtype.add("Aura");
+
+        // Enchant creature
+        TargetPermanent auraTarget = new TargetCreaturePermanent();
+        this.getSpellAbility().addTarget(auraTarget);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.Detriment));
+        Ability ability = new EnchantAbility(auraTarget.getTargetName());
+        this.addAbility(ability);
+        
+        // {U}{U}: Enchanted creature phases out.
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new PhaseOutAttachedEffect(), new ManaCostsImpl("{U}{U}")));
+    }
+
+    public Vanishing(final Vanishing card) {
+        super(card);
+    }
+
+    @Override
+    public Vanishing copy() {
+        return new Vanishing(this);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/PhaseOutAttachedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/PhaseOutAttachedEffect.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.abilities.effects.common;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.constants.Outcome;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+/**
+ *
+ * @author escplan9 (Derek Monturo - dmontur1 at gmail dot com)
+ */
+public class PhaseOutAttachedEffect extends OneShotEffect {
+
+    public PhaseOutAttachedEffect() {
+        super(Outcome.Detriment);
+        this.staticText = "Enchanted creature phases out";
+    }
+
+    public PhaseOutAttachedEffect(final PhaseOutAttachedEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public PhaseOutAttachedEffect copy() {
+        return new PhaseOutAttachedEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent enchantment = game.getPermanentOrLKIBattlefield(source.getSourceId());
+        if(enchantment != null) {
+            Permanent enchanted = game.getPermanent(enchantment.getAttachedTo());
+            if(enchanted != null) {
+                return enchanted.phaseOut(game);
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Not 100% sure on the behavior for the card. When the enchanted creature is phased out, the Vanishing enchantment just sort of "lingers" where the creature used to be until the creature phases back in, and then this enchantment is reattached to it. Looking at the rulings from here:

http://www.mtgsalvation.com/forums/magic-fundamentals/magic-rulings/magic-rulings-archives/279819-phase-out-more-specifically-vanishing

" Enchantments attached to the creature will "phase out indirectly," and stay attached to it, even though it is phased out." and "Enchantments and equipment phase in/out with the permanents they are associated with."

So I believe this card also needs to have the Enchantment itself phase out, and when both the creature and enchantment phase back in, the enchantment phases back in with it attached to the phased in creature? Not sure if I need to program the handling for this into the card itself, the PhaseOutAttachedEffect, or if the handling for phasing needs to be adjusted for this? Or nothing and the card is good as is...