### PR TITLE
Fix activated ability of Canopy Crawler

### DIFF
--- a/Mage.Sets/src/mage/sets/legions/CanopyCrawler.java
+++ b/Mage.Sets/src/mage/sets/legions/CanopyCrawler.java
@@ -61,7 +61,7 @@ public class CanopyCrawler extends CardImpl {
         this.addAbility(new AmplifyAbility(AmplifyEffect.AmplifyFactor.Amplify1));
         // {tap}: Target creature gets +1/+1 until end of turn for each +1/+1 counter on Canopy Crawler.
         CountersCount count = new CountersCount(CounterType.P1P1);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(count, count, Duration.EndOfTurn), new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(count, count, Duration.EndOfTurn, true), new TapSourceCost());
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }


### PR DESCRIPTION
This fixes the effect on Canopy Crawler to only check the number of counters once, upon resolution of the activated ability, instead of dynamically changing the P/T boost while the effect is active. The ruling on this card supports this change.

**Note:** Due to build problems (I'm new to maven and have no idea how to fix them), I have not been able to test this change. Please do so before merging.