### PR TITLE
Update card count in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/magefree/mage](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/magefree/mage?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-XMage allows you to play Magic against one or more online players or computer opponents. It includes full rules enforcement for over **10,000** unique cards (nearly 20,000 counting all cards from different editions). Starting with Eventide, all regular sets have nearly all the cards implemented ([detailed overview](http://ct-magefree.rhcloud.com/stats)).
+XMage allows you to play Magic against one or more online players or computer opponents. It includes full rules enforcement for over **13,000** unique cards (26,000 counting all cards from different editions). Starting with Shadowmoor, all regular sets have nearly all the cards implemented ([detailed overview](http://ct-magefree.rhcloud.com/stats)).
 
 There are public servers where you can play XMage against other players. You can also host your own server to play against the AI and/or your friends.
 


### PR DESCRIPTION
I counted the unique cards using [http://ct-magefree.rhcloud.com/cards](http://ct-magefree.rhcloud.com/cards) and the total cards by counting the files in subdirectories of Mage.Sets. The exact numbers are 15699 and 26000 respectively.

Shadowmoor, the regular set that immediately preceded Eventide, is 100% implemented according to the tracking tool, so I changed the relevant part of the readme.