### PR TITLE
Fix wording of Magus of the Future ability tooltip

### DIFF
--- a/Mage.Sets/src/mage/sets/futuresight/MagusOfTheFuture.java
+++ b/Mage.Sets/src/mage/sets/futuresight/MagusOfTheFuture.java
@@ -55,9 +55,9 @@ public class MagusOfTheFuture extends CardImpl {
 
         // Play with the top card of your library revealed.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PlayWithTheTopCardRevealedEffect()));
-        
+
         // You may play the top card of your library.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PlayTheTopCardEffect(new FilterCard())));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PlayTheTopCardEffect()));
     }
 
     public MagusOfTheFuture(final MagusOfTheFuture card) {


### PR DESCRIPTION
It used to say “if it's a card”. Removing the filter argument leads to equivalent logic but with the correct tooltip text.