### PR TITLE
Fix DiesCreatureTriggeredAbility tooltip text

### DIFF
--- a/Mage/src/main/java/mage/abilities/common/DiesCreatureTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DiesCreatureTriggeredAbility.java
@@ -23,12 +23,12 @@ public class DiesCreatureTriggeredAbility extends TriggeredAbilityImpl {
     }
 
     public DiesCreatureTriggeredAbility(Effect effect, boolean optional, boolean another) {
-        this(effect, optional, new FilterCreaturePermanent("another creature"));
+        this(effect, optional, new FilterCreaturePermanent(optional ? "another creature" : "a creature"));
         filter.add(new AnotherPredicate());
     }
 
     public DiesCreatureTriggeredAbility(Effect effect, boolean optional, boolean another, boolean setTargetPointer) {
-        this(effect, optional, new FilterCreaturePermanent("another creature"));
+        this(effect, optional, new FilterCreaturePermanent(optional ? "another creature" : "a creature"));
         filter.add(new AnotherPredicate());
         this.setTargetPointer = setTargetPointer;
     }


### PR DESCRIPTION
Fecundity says “Whenever another creature dies” instead of “whenever a creature dies” even though the `other` flag of the trigger is off. This should fix the tooltip.