### PR TITLE
Fix serendib djinn island damage

### DIFF
--- a/Mage.Sets/src/mage/sets/masterseditioniv/SerendibDjinn.java
+++ b/Mage.Sets/src/mage/sets/masterseditioniv/SerendibDjinn.java
@@ -121,10 +121,10 @@ class SerendibDjinnEffect extends OneShotEffect {
             player.choose(Outcome.Sacrifice, target, source.getSourceId(), game);
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
-                permanent.sacrifice(source.getSourceId(), game);
                 if (permanent.hasSubtype("Island")) {
                     player.damage(3, source.getSourceId(), game, false, true);
                 }
+                permanent.sacrifice(source.getSourceId(), game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/sets/masterseditioniv/SerendibDjinn.java
+++ b/Mage.Sets/src/mage/sets/masterseditioniv/SerendibDjinn.java
@@ -122,12 +122,11 @@ class SerendibDjinnEffect extends OneShotEffect {
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
                 permanent.sacrifice(source.getSourceId(), game);
+                if (permanent.hasSubtype("Island")) {
+                    player.damage(3, source.getSourceId(), game, false, true);
+                }
                 return true;
             }
-           if (permanent.hasSubtype("Island")){
-            player.damage(3, source.getSourceId(), game, false, true);
-            return true;
-           }
         }
         return false;
     }


### PR DESCRIPTION
Currently, the land sacrifice effect happens without ever checking to see if the land is an Island.  This fixes the effect to check the permanent type after sacrificing it to see if it was an Island, and to deal damage to the player if it was.

For whoever checks this: I'm assuming it's okay to refer to the `permanent` variable in this context, even after the call to `permanent.sacrifice(...)`