### PR TITLE
Add tracking for quantity of artifacts in card lists. Add tracking for quantity of card types in graveyard.

### DIFF
--- a/Mage.Client/src/main/java/mage/client/cards/CardsList.form
+++ b/Mage.Client/src/main/java/mage/client/cards/CardsList.form
@@ -37,7 +37,7 @@
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace min="-2" pref="1" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="panelControl" max="32767" attributes="0"/>
+                  <Component id="panelControl" pref="703" max="32767" attributes="0"/>
                   <Component id="panelCardArea" max="32767" attributes="0"/>
               </Group>
           </Group>
@@ -48,7 +48,7 @@
           <Group type="102" alignment="0" attributes="0">
               <Component id="panelControl" min="-2" pref="25" max="-2" attributes="0"/>
               <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
-              <Component id="panelCardArea" pref="330" max="32767" attributes="0"/>
+              <Component id="panelCardArea" pref="86" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -68,6 +68,9 @@
         </Property>
         <Property name="requestFocusEnabled" type="boolean" value="false"/>
       </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_SerializeTo" type="java.lang.String" value="CardsList_panelControl"/>
+      </AuxValues>
 
       <Layout>
         <DimensionLayout dim="0">
@@ -84,7 +87,9 @@
                   <Component id="lblInstantCount" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="lblEnchantmentCount" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                  <EmptySpace min="-2" pref="4" max="-2" attributes="0"/>
+                  <Component id="lblArtifactCount" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
                   <Component id="chkPiles" min="-2" max="-2" attributes="0"/>
                   <EmptySpace type="unrelated" max="-2" attributes="0"/>
                   <Component id="cbSortBy" min="-2" max="-2" attributes="0"/>
@@ -92,7 +97,7 @@
                   <Component id="jToggleListView" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="jToggleCardView" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                  <EmptySpace min="0" pref="62" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -108,6 +113,7 @@
                           <Component id="lblInstantCount" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="lblEnchantmentCount" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="chkPiles" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="lblArtifactCount" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
                       <Component id="cbSortBy" alignment="0" min="-2" max="-2" attributes="0"/>
                       <Component id="jToggleListView" min="-2" max="-2" attributes="0"/>
@@ -127,7 +133,7 @@
             <Property name="text" type="java.lang.String" value="999"/>
             <Property name="toolTipText" type="java.lang.String" value="Number of all cards in this area."/>
             <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
-              <Color id="Standardcursor"/>
+              <Color id="Default Cursor"/>
             </Property>
             <Property name="focusable" type="boolean" value="false"/>
             <Property name="inheritsPopupMenu" type="boolean" value="false"/>
@@ -145,7 +151,7 @@
             <Property name="toolTipText" type="java.lang.String" value="Number of lands."/>
             <Property name="verticalAlignment" type="int" value="1"/>
             <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
-              <Color id="Standardcursor"/>
+              <Color id="Default Cursor"/>
             </Property>
             <Property name="focusable" type="boolean" value="false"/>
             <Property name="inheritsPopupMenu" type="boolean" value="false"/>
@@ -163,7 +169,7 @@
             <Property name="toolTipText" type="java.lang.String" value="Number of creatures."/>
             <Property name="verticalAlignment" type="int" value="1"/>
             <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
-              <Color id="Standardcursor"/>
+              <Color id="Default Cursor"/>
             </Property>
             <Property name="focusable" type="boolean" value="false"/>
             <Property name="inheritsPopupMenu" type="boolean" value="false"/>
@@ -181,7 +187,7 @@
             <Property name="toolTipText" type="java.lang.String" value="Number of sorceries."/>
             <Property name="verticalAlignment" type="int" value="1"/>
             <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
-              <Color id="Standardcursor"/>
+              <Color id="Default Cursor"/>
             </Property>
             <Property name="focusable" type="boolean" value="false"/>
             <Property name="inheritsPopupMenu" type="boolean" value="false"/>
@@ -199,7 +205,7 @@
             <Property name="toolTipText" type="java.lang.String" value="Number of instants."/>
             <Property name="verticalAlignment" type="int" value="1"/>
             <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
-              <Color id="Standardcursor"/>
+              <Color id="Default Cursor"/>
             </Property>
             <Property name="focusable" type="boolean" value="false"/>
             <Property name="inheritsPopupMenu" type="boolean" value="false"/>
@@ -217,7 +223,7 @@
             <Property name="toolTipText" type="java.lang.String" value="Number of enchantments."/>
             <Property name="verticalAlignment" type="int" value="1"/>
             <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
-              <Color id="Standardcursor"/>
+              <Color id="Default Cursor"/>
             </Property>
             <Property name="focusable" type="boolean" value="false"/>
             <Property name="inheritsPopupMenu" type="boolean" value="false"/>
@@ -317,6 +323,24 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jToggleCardViewActionPerformed"/>
           </Events>
+        </Component>
+        <Component class="javax.swing.JLabel" name="lblArtifactCount">
+          <Properties>
+            <Property name="horizontalAlignment" type="int" value="2"/>
+            <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
+              <Image iconType="3" name="/buttons/type_artifact.png"/>
+            </Property>
+            <Property name="text" type="java.lang.String" value="999"/>
+            <Property name="toolTipText" type="java.lang.String" value="Number of artifacts"/>
+            <Property name="verticalAlignment" type="int" value="1"/>
+            <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
+              <Color id="Default Cursor"/>
+            </Property>
+            <Property name="focusable" type="boolean" value="false"/>
+            <Property name="inheritsPopupMenu" type="boolean" value="false"/>
+            <Property name="requestFocusEnabled" type="boolean" value="false"/>
+            <Property name="verifyInputWhenFocusTarget" type="boolean" value="false"/>
+          </Properties>
         </Component>
       </SubComponents>
     </Container>

--- a/Mage.Client/src/main/java/mage/client/cards/CardsList.java
+++ b/Mage.Client/src/main/java/mage/client/cards/CardsList.java
@@ -211,7 +211,7 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
             }
         });
 
-        mainModel.setUpdateCountsCallback(new UpdateCountsCallback(lblCount, lblCreatureCount, lblLandCount, lblSorceryCount, lblInstantCount, lblEnchantmentCount));
+        mainModel.setUpdateCountsCallback(new UpdateCountsCallback(lblCount, lblCreatureCount, lblLandCount, lblSorceryCount, lblInstantCount, lblEnchantmentCount, lblArtifactCount));
     }
 
     // if you use the deck ediot to build a free deck, numbers can be set directly in deck and sideboard
@@ -391,6 +391,8 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
         int sorceryCount = 0;
         int instantCount = 0;
         int enchantmentCount = 0;
+        int artifactCount = 0;
+       
         for (CardView card : cards.values()) {
             if (card.getCardTypes().contains(CardType.LAND)) {
                 landCount++;
@@ -407,6 +409,9 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
             if (card.getCardTypes().contains(CardType.ENCHANTMENT)) {
                 enchantmentCount++;
             }
+            if (card.getCardTypes().contains(CardType.ARTIFACT)) {
+                artifactCount++;
+            }
         }
 
         int count = cards != null ? cards.size() : 0;
@@ -416,6 +421,7 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
         this.lblSorceryCount.setText(Integer.toString(sorceryCount));
         this.lblInstantCount.setText(Integer.toString(instantCount));
         this.lblEnchantmentCount.setText(Integer.toString(enchantmentCount));
+        this.lblArtifactCount.setText(Integer.toString(artifactCount));
     }
 
     private MageCard addCard(CardView card, BigCard bigCard, UUID gameId) {
@@ -483,6 +489,7 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
         cbSortBy = new javax.swing.JComboBox();
         jToggleListView = new javax.swing.JToggleButton();
         jToggleCardView = new javax.swing.JToggleButton();
+        lblArtifactCount = new javax.swing.JLabel();
         panelCardArea = new javax.swing.JScrollPane();
         cardArea = new javax.swing.JLayeredPane();
 
@@ -612,6 +619,17 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
             }
         });
 
+        lblArtifactCount.setHorizontalAlignment(javax.swing.SwingConstants.LEFT);
+        lblArtifactCount.setIcon(new javax.swing.ImageIcon(getClass().getResource("/buttons/type_artifact.png"))); // NOI18N
+        lblArtifactCount.setText("999");
+        lblArtifactCount.setToolTipText("Number of artifacts");
+        lblArtifactCount.setVerticalAlignment(javax.swing.SwingConstants.TOP);
+        lblArtifactCount.setCursor(new java.awt.Cursor(java.awt.Cursor.DEFAULT_CURSOR));
+        lblArtifactCount.setFocusable(false);
+        lblArtifactCount.setInheritsPopupMenu(false);
+        lblArtifactCount.setRequestFocusEnabled(false);
+        lblArtifactCount.setVerifyInputWhenFocusTarget(false);
+
         javax.swing.GroupLayout panelControlLayout = new javax.swing.GroupLayout(panelControl);
         panelControl.setLayout(panelControlLayout);
         panelControlLayout.setHorizontalGroup(
@@ -628,7 +646,9 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
                 .addComponent(lblInstantCount)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(lblEnchantmentCount)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGap(4, 4, 4)
+                .addComponent(lblArtifactCount)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(chkPiles)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(cbSortBy, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -636,7 +656,7 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
                 .addComponent(jToggleListView, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jToggleCardView, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(0, 0, Short.MAX_VALUE))
+                .addGap(0, 62, Short.MAX_VALUE))
         );
         panelControlLayout.setVerticalGroup(
             panelControlLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -649,7 +669,8 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
                         .addComponent(lblSorceryCount)
                         .addComponent(lblInstantCount)
                         .addComponent(lblEnchantmentCount)
-                        .addComponent(chkPiles))
+                        .addComponent(chkPiles)
+                        .addComponent(lblArtifactCount))
                     .addComponent(cbSortBy, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jToggleListView, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jToggleCardView, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
@@ -668,7 +689,7 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
             .addGroup(layout.createSequentialGroup()
                 .addGap(1, 1, 1)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(panelControl, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(panelControl, javax.swing.GroupLayout.DEFAULT_SIZE, 703, Short.MAX_VALUE)
                     .addComponent(panelCardArea)))
         );
         layout.setVerticalGroup(
@@ -676,7 +697,7 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
             .addGroup(layout.createSequentialGroup()
                 .addComponent(panelControl, javax.swing.GroupLayout.PREFERRED_SIZE, 25, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addGap(0, 0, 0)
-                .addComponent(panelCardArea, javax.swing.GroupLayout.DEFAULT_SIZE, 330, Short.MAX_VALUE))
+                .addComponent(panelCardArea, javax.swing.GroupLayout.DEFAULT_SIZE, 86, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -715,6 +736,7 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
     private javax.swing.JCheckBox chkPiles;
     private javax.swing.JToggleButton jToggleCardView;
     private javax.swing.JToggleButton jToggleListView;
+    private javax.swing.JLabel lblArtifactCount;
     private javax.swing.JLabel lblCount;
     private javax.swing.JLabel lblCreatureCount;
     private javax.swing.JLabel lblEnchantmentCount;

--- a/Mage.Client/src/main/java/mage/client/deckeditor/table/TableModel.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/table/TableModel.java
@@ -123,6 +123,7 @@ public class TableModel extends AbstractTableModel implements ICardGrid {
         int instantCount = 0;
         int sorceryCount = 0;
         int enchantmentCount = 0;
+        int artifactCount = 0;
         if (!merge) {
             this.clearCards();
             for (CardView card : showCards.values()) {
@@ -148,6 +149,9 @@ public class TableModel extends AbstractTableModel implements ICardGrid {
                     }
                     if (card.getCardTypes().contains(CardType.ENCHANTMENT)) {
                         enchantmentCount++;
+                    }
+                    if (card.getCardTypes().contains(CardType.ARTIFACT)) {
+                        artifactCount++;
                     }
                 }
             }
@@ -199,7 +203,7 @@ public class TableModel extends AbstractTableModel implements ICardGrid {
             }
 
             if (updateCountsCallback != null) {
-                updateCountsCallback.update(cards.size(), creatureCount, landCount, sorceryCount, instantCount, enchantmentCount);
+                updateCountsCallback.update(cards.size(), creatureCount, landCount, sorceryCount, instantCount, enchantmentCount, artifactCount);
             }
         }
 

--- a/Mage.Client/src/main/java/mage/client/deckeditor/table/UpdateCountsCallback.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/table/UpdateCountsCallback.java
@@ -14,22 +14,25 @@ public class UpdateCountsCallback {
     private final javax.swing.JLabel lblSoerceryCount;
     private final javax.swing.JLabel lblInstantCount;
     private final javax.swing.JLabel lblEnchantmentCount;
+    private final javax.swing.JLabel lblArtifactCount;
 
-    public UpdateCountsCallback(JLabel count, JLabel creatures, JLabel lands, JLabel sorceries, JLabel instants, JLabel enchantments) {
+    public UpdateCountsCallback(JLabel count, JLabel creatures, JLabel lands, JLabel sorceries, JLabel instants, JLabel enchantments, JLabel artifacts) {
         this.lblCount = count;
         this.lblCreatureCount = creatures;
         this.lblLandCount = lands;
         this.lblSoerceryCount = sorceries;
         this.lblInstantCount = instants;
         this.lblEnchantmentCount = enchantments;
+        this.lblArtifactCount = artifacts;
     }
 
-    public void update(int count, int creatures, int lands, int sorceries, int instants, int enchantments) {
+    public void update(int count, int creatures, int lands, int sorceries, int instants, int enchantments, int artifacts) {
         this.lblCount.setText(Integer.toString(count));
         this.lblCreatureCount.setText(Integer.toString(creatures));
         this.lblLandCount.setText(Integer.toString(lands));
         this.lblSoerceryCount.setText(Integer.toString(sorceries));
         this.lblInstantCount.setText(Integer.toString(instants));
         this.lblEnchantmentCount.setText(Integer.toString(enchantments));
+        this.lblArtifactCount.setText(Integer.toString(artifacts));
     }
 }

--- a/Mage.Client/src/main/java/mage/client/dialog/CardInfoWindowDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/CardInfoWindowDialog.java
@@ -36,6 +36,9 @@ package mage.client.dialog;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.beans.PropertyVetoException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import javax.swing.ImageIcon;
 import javax.swing.SwingUtilities;
@@ -46,6 +49,8 @@ import mage.client.util.GUISizeHelper;
 import mage.client.util.ImageHelper;
 import mage.client.util.SettingsManager;
 import mage.client.util.gui.GuiDisplayUtil;
+import mage.constants.CardType;
+import mage.view.CardView;
 import mage.view.CardsView;
 import mage.view.ExileView;
 import mage.view.SimpleCardsView;
@@ -158,7 +163,8 @@ public class CardInfoWindowDialog extends MageDialog {
     public void loadCards(CardsView showCards, BigCard bigCard, UUID gameId, boolean revertOrder) {
         cards.loadCards(showCards, bigCard, gameId, revertOrder);
         if (showType.equals(ShowType.GRAVEYARD)) {
-            String titel = name + "'s Graveyard (" + showCards.size() + ")";
+            int qty = qtyCardTypes(showCards);
+            String titel = name + "'s Graveyard (" + showCards.size() + ")  -  " + qty + ((qty == 1) ? " Card Type" : " Card Types");
             setTitle(titel);
             this.setTitelBarToolTip(titel);
         }
@@ -199,6 +205,17 @@ public class CardInfoWindowDialog extends MageDialog {
         });
     }
 
+        private int qtyCardTypes(mage.view.CardsView cardsView){
+        Set<String> cardTypesPresent = new LinkedHashSet<String>() {};
+        for (CardView card : cardsView.values()){
+            List<CardType> cardTypes = card.getCardTypes();
+            for (CardType cardType : cardTypes){
+                cardTypesPresent.add(cardType.toString());
+            }
+        }
+        if (cardTypesPresent.isEmpty()) return 0;
+        else return cardTypesPresent.size();
+    }
     /**
      * This method is called from within the constructor to initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is always

--- a/Mage.Client/src/main/java/mage/client/game/PlayerPanelExt.java
+++ b/Mage.Client/src/main/java/mage/client/game/PlayerPanelExt.java
@@ -42,7 +42,10 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import javax.swing.BorderFactory;
 import javax.swing.GroupLayout;
@@ -69,6 +72,7 @@ import mage.client.util.ImageHelper;
 import mage.client.util.gui.BufferedImageBuilder;
 import mage.client.util.gui.countryBox.CountryUtil;
 import mage.components.ImagePanel;
+import mage.constants.CardType;
 import static mage.constants.Constants.DEFAULT_AVATAR_ID;
 import static mage.constants.Constants.MAX_AVATAR_ID;
 import static mage.constants.Constants.MIN_AVATAR_ID;
@@ -78,6 +82,8 @@ import mage.utils.timer.PriorityTimer;
 import mage.view.ManaPoolView;
 import mage.view.PlayerView;
 import org.mage.card.arcane.ManaSymbols;
+import mage.players.Player;
+import mage.view.CardView;
 
 /**
  * Enhanced player pane.
@@ -215,7 +221,8 @@ public class PlayerPanelExt extends javax.swing.JPanel {
             changedFontGrave = false;
         }
         graveLabel.setText(Integer.toString(graveCards));
-
+        graveLabel.setToolTipText("Card Types: " +  qtyCardTypes(player.getGraveyard()));
+        
         int exileCards = player.getExile().size();
         if (exileCards > 99) {
             if (!changedFontExile) {
@@ -439,7 +446,7 @@ public class PlayerPanelExt extends javax.swing.JPanel {
 
         // Grave count and open graveyard button
         r = new Rectangle(21, 21);
-        graveLabel.setToolTipText("Graveyard");
+        graveLabel.setToolTipText("Card Types: 0");
         Image imageGrave = ImageHelper.getImageFromResources("/info/grave.png");
         BufferedImage resizedGrave = ImageHelper.getResizedImage(BufferedImageBuilder.bufferImage(imageGrave, BufferedImage.TYPE_INT_ARGB), r);
 
@@ -858,6 +865,18 @@ public class PlayerPanelExt extends javax.swing.JPanel {
         return player;
     }
 
+    private int qtyCardTypes(mage.view.CardsView cardsView){
+        Set<String> cardTypesPresent = new LinkedHashSet<String>() {};
+        for (CardView card : cardsView.values()){
+            List<CardType> cardTypes = card.getCardTypes();
+            for (CardType cardType : cardTypes){
+                cardTypesPresent.add(cardType.toString());
+            }
+        }
+        if (cardTypesPresent.isEmpty()) return 0;
+        else return cardTypesPresent.size();
+    }
+    
     private HoverButton avatar;
     private JLabel avatarFlag;
     private JButton btnPlayer;


### PR DESCRIPTION
I've been wondering why artifacts were left off from the cardlists such as in drafts and building. I think that they should be there so I added them in. I can quickly put planeswalkers as well, but didn't yet, they would also require the addition of a new card type icon.

I also saw that MTGO now reports the number of card types in the graveyard (presumably for delirium purposes) and thought that this would be nice to have implemented as well. 