### PR TITLE
Implement Glint-Eye Nephilim

### DIFF
--- a/Mage.Sets/src/mage/sets/guildpact/GlintEyeNephilim.java
+++ b/Mage.Sets/src/mage/sets/guildpact/GlintEyeNephilim.java
@@ -1,0 +1,109 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.sets.guildpact;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.DiscardCardCost;
+import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.BoostSourceEffect;
+import mage.cards.CardImpl;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Rarity;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.players.Player;
+
+/**
+ * @author fenhl
+ */
+public class GlintEyeNephilim extends CardImpl {
+
+    public GlintEyeNephilim(UUID ownerId) {
+        super(ownerId, 115, "Glint-Eye Nephilim", Rarity.RARE, new CardType[]{CardType.CREATURE}, "{U}{B}{R}{G}");
+        this.expansionSetCode = "GPT";
+        this.subtype.add("Nephilim");
+
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(2);
+
+        // Whenever Glint-Eye Nephilim deals combat damage to a player, draw that many cards.
+        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new GlintEyeNephilimEffect(), false, true));
+
+        // {1}, Discard a card: Glint-Eye Nephilim gets +1/+1 until end of turn.
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn), new GenericManaCost(1));
+        ability.addCost(new DiscardCardCost());
+        this.addAbility(ability);
+
+    }
+
+    public GlintEyeNephilim(final GlintEyeNephilim card) {
+        super(card);
+    }
+
+    @Override
+    public GlintEyeNephilim copy() {
+        return new GlintEyeNephilim(this);
+    }
+}
+
+class GlintEyeNephilimEffect extends OneShotEffect {
+
+    public GlintEyeNephilimEffect() {
+        super(Outcome.DrawCard);
+        this.staticText = "draw that many cards";
+    }
+
+    public GlintEyeNephilimEffect(final GlintEyeNephilimEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public GlintEyeNephilimEffect copy() {
+        return new GlintEyeNephilimEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        int amount = (Integer) getValue("damage");
+        if (amount > 0) {
+            Player controller = game.getPlayer(source.getControllerId());
+            if (controller != null) {
+                controller.drawCards(amount, game);
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
[Glint-Eye Nephilim](http://magiccards.info/query?q=%21Glint-Eye+Nephilim), appears in GPT.

This completes the Nephilim cycle. I have copied the combat damage trigger from [Cold-Eyed Selkie](http://magiccards.info/query?q=%21Cold-Eyed+Selkie), except it's not optional here. Should this be moved to common?