### PR TITLE
Fixes Issue #1958: Creatures copying Lost Auramancers fail to trigger…

### DIFF
--- a/Mage.Sets/src/mage/sets/futuresight/LostAuramancers.java
+++ b/Mage.Sets/src/mage/sets/futuresight/LostAuramancers.java
@@ -33,10 +33,12 @@ import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.DiesTriggeredAbility;
 import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.condition.Condition;
 import mage.abilities.condition.InvertCondition;
 import mage.abilities.condition.common.SourceHasCounterCondition;
 import mage.abilities.decorator.ConditionalTriggeredAbility;
 import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.ReturnSourceFromGraveyardToBattlefieldEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.abilities.keyword.VanishingSacrificeAbility;
@@ -44,8 +46,12 @@ import mage.abilities.keyword.VanishingUpkeepAbility;
 import mage.cards.CardImpl;
 import mage.constants.CardType;
 import mage.constants.Rarity;
+import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.filter.common.FilterEnchantmentCard;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
 import mage.target.common.TargetCardInLibrary;
 
 /**
@@ -70,15 +76,10 @@ public class LostAuramancers extends CardImpl {
         this.addAbility(new VanishingSacrificeAbility());
 
         // When Lost Auramancers dies, if it had no time counters on it, you may search your library
-        // for an enchantment card and put it onto the battlefield. If you do, shuffle your library.
-        Effect effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterEnchantmentCard()));
-        ability = new ConditionalTriggeredAbility(
-                new DiesTriggeredAbility(effect),
-                new InvertCondition(new SourceHasCounterCondition(CounterType.TIME)),
-                "When {this} dies, if it had no time counters on it, you may search your library " +
-                "for an enchantment card and put it onto the battlefield. If you do, shuffle your library.");
-        this.addAbility(ability);
+        // for an enchantment card and put it onto the battlefield. If you do, shuffle your library.        
+        this.addAbility(new LostAuramancersAbility());
     }
+
 
     public LostAuramancers(final LostAuramancers card) {
         super(card);
@@ -87,5 +88,41 @@ public class LostAuramancers extends CardImpl {
     @Override
     public LostAuramancers copy() {
         return new LostAuramancers(this);
+    }
+    
+}
+    
+class LostAuramancersAbility extends DiesTriggeredAbility {
+
+    public LostAuramancersAbility() {
+
+        super(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterEnchantmentCard())));
+    }
+    
+    
+
+    public LostAuramancersAbility(final LostAuramancersAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public DiesTriggeredAbility copy() {
+        return new LostAuramancersAbility(this);
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        if (super.checkTrigger(event, game)) {
+            Permanent permanent = (Permanent) game.getLastKnownInformation(event.getTargetId(), Zone.BATTLEFIELD);
+            if (!permanent.getCounters().containsKey(CounterType.TIME) || permanent.getCounters().getCount(CounterType.TIME) == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String getRule() {
+        return "When Lost Auramancers is put into a graveyard from play, if it had no time counters on it, you may search your library for an enchantment card and put it into play. If you do, shuffle your library.";
     }
 }


### PR DESCRIPTION
… its death effect. My solution was to copy the Undying template, but I'm not sure why the original implementation didn't work.