### PR TITLE
Text Import should detect sideboard after a single blank line

### DIFF
--- a/Mage.Sets/src/mage/sets/eternalmasters/WinterOrb.java
+++ b/Mage.Sets/src/mage/sets/eternalmasters/WinterOrb.java
@@ -27,8 +27,9 @@
  */
 package mage.sets.eternalmasters;
 
-import java.util.UUID;
 import mage.constants.Rarity;
+
+import java.util.UUID;
 
 /**
  *

--- a/Mage.Tests/JustLands.txt
+++ b/Mage.Tests/JustLands.txt
@@ -1,0 +1,6 @@
+1 Forest
+1 Plains
+1 Island
+
+1 Swamp
+1 Mountain

--- a/Mage.Tests/src/test/java/org/mage/test/decks/importer/TxtDeckImporterTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/decks/importer/TxtDeckImporterTest.java
@@ -1,0 +1,43 @@
+package org.mage.test.decks.importer;
+
+import mage.cards.decks.DeckCardInfo;
+import mage.cards.decks.DeckCardLists;
+import mage.cards.decks.importer.TxtDeckImporter;
+import mage.cards.repository.CardInfo;
+import mage.cards.repository.CardRepository;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TxtDeckImporterTest {
+
+    @Test
+    public void testImportWithBlankLineAboveSideboard() {
+        TxtDeckImporter importer = new TxtDeckImporter();
+
+        CardInfo card;
+        DeckCardLists deck = new DeckCardLists();
+
+        String[] cards = {"Plains", "Forest", "Island"};
+        String[] sideboard = {"Swamp", "Mountain"};
+
+        for (String c : cards) {
+            card = CardRepository.instance.findPreferedCoreExpansionCard(c, true);
+            assert card != null;
+            deck.getCards().add(new DeckCardInfo(card.getName(), card.getCardNumber(), card.getSetCode()));
+        }
+
+        for (String s : sideboard) {
+            card = CardRepository.instance.findPreferedCoreExpansionCard(s, true);
+            assert card != null;
+            deck.getSideboard().add(new DeckCardInfo(card.getName(), card.getCardNumber(), card.getSetCode()));
+        }
+
+        Assert.assertEquals("Deck does not contain 3 cards, found " + deck.getCards().size(), 3, deck.getCards().size());
+        Assert.assertEquals("Sideboard does not contain 2 cards, found " + deck.getSideboard().size(), 2, deck.getSideboard().size());
+
+        DeckCardLists imported = importer.importDeck("JustLands.txt");
+
+        Assert.assertEquals("Imported deck does not contain 3 cards, found " + imported.getCards().size(), 3, imported.getCards().size());
+        Assert.assertEquals("Imported sideboard does not contain 2 cards, found " + imported.getSideboard().size(), 2, imported.getSideboard().size());
+    }
+}

--- a/Mage/src/main/java/mage/cards/decks/importer/TxtDeckImporter.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/TxtDeckImporter.java
@@ -27,13 +27,14 @@
  */
 package mage.cards.decks.importer;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 import mage.cards.decks.DeckCardInfo;
 import mage.cards.decks.DeckCardLists;
 import mage.cards.repository.CardInfo;
 import mage.cards.repository.CardRepository;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  *
@@ -46,7 +47,7 @@ public class TxtDeckImporter extends DeckImporter {
     public static final Set<String> IGNORE_NAMES = new HashSet<>(Arrays.asList(SET_VALUES));
 
     private boolean sideboard = false;
-    private int emptyLinesInARow = 0;
+    private int nonEmptyLinesTotal = 0;
 
     @Override
     protected void readLine(String line, DeckCardLists deckList) {
@@ -57,14 +58,14 @@ public class TxtDeckImporter extends DeckImporter {
         if (line.startsWith("//")) {
             return;
         }
-        if (line.length() == 0) {
-            emptyLinesInARow++;
-            if (emptyLinesInARow > 1) {
-                sideboard = true;
-            }
+
+        // Start the sideboard on empty line that follows
+        // at least 1 non-empty line
+        if (line.length() == 0 && nonEmptyLinesTotal > 0) {
+            sideboard = true;
             return;
         } else {
-            emptyLinesInARow = 0;
+            nonEmptyLinesTotal++;
         }
 
         line = line.replace("\t", " "); // changing tabs to blanks as delimiter


### PR DESCRIPTION
Updated `TxtDeckImporter` to that sideboard is automatically detected after a single (or more) blank line. It won't automatically start unless there has been at least a single non-empty line basically ignoring any blank lines at the top of the file.

I've also added `TxtDeckImporterTest` to test the import process.