### PR TITLE
Adding way to import deck from clipboard

### DIFF
--- a/Mage.Client/src/main/java/mage/client/deckeditor/DeckEditorPanel.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/DeckEditorPanel.java
@@ -27,28 +27,6 @@
  */
 package mage.client.deckeditor;
 
-import java.awt.Component;
-import java.awt.Cursor;
-import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import javax.swing.JComponent;
-import javax.swing.JFileChooser;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.SwingUtilities;
-import javax.swing.SwingWorker;
-import javax.swing.Timer;
-import javax.swing.filechooser.FileFilter;
 import mage.cards.Card;
 import mage.cards.Sets;
 import mage.cards.decks.Deck;
@@ -62,7 +40,6 @@ import mage.client.cards.ICardGrid;
 import mage.client.constants.Constants.DeckEditorMode;
 import mage.client.deck.generator.DeckGenerator;
 import mage.client.deck.generator.DeckGenerator.DeckGeneratorException;
-
 import mage.client.dialog.AddLandDialog;
 import mage.client.plugins.impl.Plugins;
 import mage.client.util.Event;
@@ -74,6 +51,21 @@ import mage.remote.Session;
 import mage.view.CardView;
 import mage.view.SimpleCardView;
 import org.apache.log4j.Logger;
+
+import javax.swing.*;
+import javax.swing.Timer;
+import javax.swing.filechooser.FileFilter;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
 
 /**
  *
@@ -573,7 +565,27 @@ public class DeckEditorPanel extends javax.swing.JPanel {
         btnImport.addActionListener(new java.awt.event.ActionListener() {
             @Override
             public void actionPerformed(java.awt.event.ActionEvent evt) {
-                btnImportActionPerformed(evt);
+                Object[] options = {"File", "Clipboard"};
+
+                int n = JOptionPane.showOptionDialog(MageFrame.getDesktop(),
+                        "Where would you like to import from?",
+                        "Deck import",
+                        JOptionPane.YES_NO_CANCEL_OPTION,
+                        JOptionPane.QUESTION_MESSAGE,
+                        null,
+                        options,
+                        options[0]
+                );
+
+                logger.info(n);
+
+                switch (n) {
+                    case 0:
+                        btnImportActionPerformed(evt);
+                        break;
+                    case 1:
+                        btnImportFromClipboardActionPerformed(evt);
+                }
             }
         });
 
@@ -688,6 +700,27 @@ public class DeckEditorPanel extends javax.swing.JPanel {
                 layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                 .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addComponent(jSplitPane1, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, 615, Short.MAX_VALUE));
+    }
+
+    /**
+     * @param evt ActionEvent
+     */
+    private void btnImportFromClipboardActionPerformed(ActionEvent evt) {
+        final DeckImportFromClipboardDialog dialog = new DeckImportFromClipboardDialog();
+        dialog.pack();
+        dialog.setVisible(true);
+
+        dialog.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                try {
+                    deck = Deck.load(DeckImporterUtil.importDeck(dialog.getTmpPath()), true, true);
+                    refreshDeck();
+                } catch (GameException e1) {
+                    JOptionPane.showMessageDialog(MageFrame.getDesktop(), e1.getMessage(), "Error loading deck", JOptionPane.ERROR_MESSAGE);
+                }
+            }
+        });
     }
 
     private void btnLoadActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnLoadActionPerformed

--- a/Mage.Client/src/main/java/mage/client/deckeditor/DeckImportFromClipboardDialog.form
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/DeckImportFromClipboardDialog.form
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="mage.client.deckeditor.DeckImportFromClipboardDialog">
+  <grid id="cbd77" binding="contentPane" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="10" left="10" bottom="10" right="10"/>
+    <constraints>
+      <xy x="48" y="54" width="540" height="500"/>
+    </constraints>
+    <properties>
+      <minimumSize width="540" height="450"/>
+    </properties>
+    <border type="none"/>
+    <children>
+      <grid id="94766" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <hspacer id="98af6">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <grid id="9538f" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="true" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="e7465" class="javax.swing.JButton" binding="buttonOK">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Import"/>
+                </properties>
+              </component>
+              <component id="5723f" class="javax.swing.JButton" binding="buttonCancel">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Cancel"/>
+                </properties>
+              </component>
+            </children>
+          </grid>
+        </children>
+      </grid>
+      <grid id="e3588" layout-manager="FormLayout">
+        <rowspec value="center:d:grow"/>
+        <colspec value="fill:d:noGrow"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="f8bac" class="javax.swing.JEditorPane" binding="txtDeckList">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="50"/>
+              </grid>
+              <forms defaultalign-horz="false" defaultalign-vert="false"/>
+            </constraints>
+            <properties>
+              <minimumSize width="250" height="400"/>
+              <preferredSize width="550" height="400"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+    </children>
+  </grid>
+</form>

--- a/Mage.Client/src/main/java/mage/client/deckeditor/DeckImportFromClipboardDialog.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/DeckImportFromClipboardDialog.java
@@ -1,0 +1,72 @@
+package mage.client.deckeditor;
+
+import javax.swing.*;
+import java.awt.event.*;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class DeckImportFromClipboardDialog extends JDialog {
+    private JPanel contentPane;
+    private JButton buttonOK;
+    private JButton buttonCancel;
+    private JEditorPane txtDeckList;
+
+    private String tmpPath;
+
+
+    public DeckImportFromClipboardDialog() {
+        setContentPane(contentPane);
+        setModal(true);
+        getRootPane().setDefaultButton(buttonOK);
+
+        buttonOK.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                onOK();
+            }
+        });
+        buttonCancel.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                onCancel();
+            }
+        });
+
+        setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
+        addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent e) {
+                onCancel();
+            }
+        });
+
+        // Close on "ESC"
+        contentPane.registerKeyboardAction(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                onCancel();
+            }
+        }, KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+    }
+
+    private void onOK() {
+        try {
+            File temp = File.createTempFile("cbimportdeck", ".txt");
+            BufferedWriter bw = new BufferedWriter(new FileWriter(temp));
+            bw.write(txtDeckList.getText());
+            bw.close();
+
+            tmpPath = temp.getPath();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        dispose();
+    }
+
+    private void onCancel() {
+        dispose();
+    }
+
+    public String getTmpPath() {
+        return tmpPath;
+    }
+}


### PR DESCRIPTION
This commit adds support for deck import from the clipboard. I'd like to get review on the process. In order to not add to many buttons on the deck editor panel, I combined file and clipboard import under the same "Import" button.

Clicking "Import" prompts the user for "File" or "Clipboard". Clicking "File" opens the file chooser dialog just like the current import works. Clicking "Clipboard" opens the new clipboard import dialog which consists of a text box and "Import" / "Cancel" buttons.

Behind the scene, when the clipboard import dialog is closed, the content is saved to a temporary .txt file and loaded normally using `TxtDeckImporter`.

I spent some times trying to recreate the Forge import from clipboard which has a split window that verifies cards in real time but I couldn't find a way to efficiently analyse each line in real time and find them using the CardRepository. I definitely want to go back to it and implement this though.

There are some improvements that could be done with the current version. For instance, the content is always passed to `TxtDeckImporter` and so only that format is supported. Ideally all the format supported by the File Chooser import should be supported but since this is based on the file extension it needs a bit of extra work.

I should also mention that the new dialog was created in IntelliJ IDEA. If it causes issues with Netbeans let me know and I'll check if I can rebuild it in Netbeans. The .java file shouldn't change anyways.

 - Alex