### PR TITLE
Recognize double clicks made in rapid succession

### DIFF
--- a/Mage.Client/src/main/java/mage/client/cards/CardArea.java
+++ b/Mage.Client/src/main/java/mage/client/cards/CardArea.java
@@ -236,7 +236,7 @@ public class CardArea extends JPanel implements MouseListener {
     public void mousePressed(MouseEvent e) {
         if (e.getClickCount() >= 1 && !e.isConsumed()) {
             Object obj = e.getSource();
-            if (e.getClickCount() == 2) {
+            if ((e.getClickCount() & 1) == 0 && (e.getClickCount() > 0)) { // double clicks and repeated double clicks
                 e.consume();
                 if (obj instanceof Card) {
                     if (e.isAltDown()) {

--- a/Mage.Client/src/main/java/mage/client/cards/CardGrid.java
+++ b/Mage.Client/src/main/java/mage/client/cards/CardGrid.java
@@ -308,7 +308,7 @@ public class CardGrid extends javax.swing.JLayeredPane implements MouseListener,
     // End of variables declaration//GEN-END:variables
     @Override
     public void mouseClicked(MouseEvent e) {
-        if (e.getClickCount() == 2 && !e.isConsumed()) {
+        if ((e.getClickCount() & 1) == 0 && (e.getClickCount() > 0) && !e.isConsumed()) { // double clicks and repeated double clicks
             e.consume();
             Object obj = e.getSource();
             if (obj instanceof Card) {

--- a/Mage.Client/src/main/java/mage/client/cards/CardsList.java
+++ b/Mage.Client/src/main/java/mage/client/cards/CardsList.java
@@ -200,7 +200,7 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
         mainTable.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
-                if (e.getClickCount() == 2 && !e.isConsumed()) {
+                if ((e.getClickCount() & 1) == 0 && (e.getClickCount() > 0) && !e.isConsumed()) { // double clicks and repeated double clicks
                     e.consume();
                     if (e.isAltDown()) {
                         handleAltDoubleClick();
@@ -755,7 +755,7 @@ public class CardsList extends javax.swing.JPanel implements MouseListener, ICar
     public void mousePressed(MouseEvent e) {
         if (e.getClickCount() >= 1 && !e.isConsumed()) {
             Object obj = e.getSource();
-            if (e.getClickCount() == 2) {
+            if ((e.getClickCount() & 1) == 0 && (e.getClickCount() > 0)) { // double clicks and repeated double clicks
                 e.consume();
                 if (obj instanceof Card) {
                     if (e.isAltDown()) {

--- a/Mage.Client/src/main/java/mage/client/cards/DraftGrid.java
+++ b/Mage.Client/src/main/java/mage/client/cards/DraftGrid.java
@@ -183,7 +183,7 @@ public class DraftGrid extends javax.swing.JPanel implements MouseListener {
 
     @Override
     public void mouseClicked(MouseEvent e) {
-        if (e.getClickCount() == 2) {
+        if ((e.getClickCount() & 1) == 0 && (e.getClickCount() > 0)) { // double clicks and repeated double clicks
             if (e.getButton() == MouseEvent.BUTTON1) {
                 Object obj = e.getSource();
                 if (obj instanceof MageCard) {

--- a/Mage.Client/src/main/java/mage/client/deckeditor/CardSelector.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/CardSelector.java
@@ -157,7 +157,7 @@ public class CardSelector extends javax.swing.JPanel implements ComponentListene
         mainTable.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
-                if (e.getClickCount() == 2 && !e.isConsumed()) {
+                if ((e.getClickCount() & 1) == 0 && (e.getClickCount() > 0) && !e.isConsumed()) { // double clicks and repeated double clicks
                     e.consume();
                     if (e.isAltDown()) {
                         jButtonAddToSideboardActionPerformed(null);


### PR DESCRIPTION
Currently they are not recognized, because getClickCount() will be higher than 2 since Java interprets them as quadruple, sextuple, etc. clicks.

So, instead of checking for getClickCount() == 2, check for getClickCount() being an even number.

This allows to quickly remove or add many cards to a deck.