### PR TITLE
spjspj - Fixes for KormusBell not creating 1/1s from swamps.  Copies …

### DIFF
--- a/Mage.Sets/src/mage/sets/limitedalpha/KormusBell.java
+++ b/Mage.Sets/src/mage/sets/limitedalpha/KormusBell.java
@@ -54,7 +54,7 @@ public class KormusBell extends CardImpl {
 
         // All Swamps are 1/1 black creatures that are still lands.
         ContinuousEffect effect = new BecomesCreatureAllEffect(new KormusBellToken(), "lands", new FilterPermanent("Swamp", "Swamps"), Duration.WhileOnBattlefield);
-        effect.getDependencyTypes().add(DependencyType.BecomeSwamp);
+        effect.setDependedToType(DependencyType.BecomeSwamp);
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, effect));
     }
 

--- a/Mage.Sets/src/mage/sets/planarchaos/UrborgTombOfYawgmoth.java
+++ b/Mage.Sets/src/mage/sets/planarchaos/UrborgTombOfYawgmoth.java
@@ -77,6 +77,7 @@ class AddCardSubtypeAllEffect extends ContinuousEffectImpl {
     public AddCardSubtypeAllEffect() {
         super(Duration.WhileOnBattlefield, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.Benefit);
         staticText = "";
+        addDependencyType(DependencyType.BecomeSwamp);
     }
 
     public AddCardSubtypeAllEffect(final AddCardSubtypeAllEffect effect) {

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
@@ -109,6 +109,7 @@ public abstract class ContinuousEffectImpl extends EffectImpl implements Continu
         this.startingTurn = effect.startingTurn;
         this.startingControllerId = effect.startingControllerId;
         this.dependencyTypes = effect.dependencyTypes;
+        this.dependendToType = effect.dependendToType;
         this.characterDefining = effect.characterDefining;
     }
 


### PR DESCRIPTION
…of ContinuousEffect weren't having dependendToType set (was defaulting to null).  Add addDependencyType to UrborgTombOfYawgmoth and setDependedToType to KormusBell.