### PR TITLE
Fix ArrayIndexOutOfBoundsException in ButtonColumn.actionPerformed

### DIFF
--- a/Mage.Client/src/main/java/mage/client/util/ButtonColumn.java
+++ b/Mage.Client/src/main/java/mage/client/util/ButtonColumn.java
@@ -111,7 +111,7 @@ public class ButtonColumn extends AbstractCellEditor implements TableCellRendere
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        if (table.getRowCount() > 0 && table.getRowCount() >= table.getEditingRow()) {
+        if (table.getRowCount() > 0 && table.getRowCount() >= table.getEditingRow() && table.getEditingRow() >= 0) {
             int row = table.convertRowIndexToModel(table.getEditingRow());
             fireEditingStopped();
             ActionEvent event = new ActionEvent(table, ActionEvent.ACTION_PERFORMED, "" + row);


### PR DESCRIPTION
This fixes an exception I saw, but I'm not totally sure about what the code is trying to do.

Maybe fireEditingStopped() should still be invoked when table.getEditingRow() < 0, and perhaps also when the other conditions fail.

Also maybe "table.getRowCount() >= table.getEditingRow()" should have a > instead of a >=, but perhaps this check is entirely useless (how could the editing row be greater than the number of rows?).
