### PR TITLE
Fixed Leeching Sliver bug

### DIFF
--- a/Mage.Sets/src/mage/sets/magic2015/LeechingSliver.java
+++ b/Mage.Sets/src/mage/sets/magic2015/LeechingSliver.java
@@ -61,7 +61,7 @@ public class LeechingSliver extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Whenever a Sliver you control attacks, defending player loses 1 life.
-        this.addAbility(new AttacksAllTriggeredAbility(new LoseLifeDefendingPlayerEffect(1, true), false, filter, SetTargetPointer.PLAYER, false));
+        this.addAbility(new AttacksAllTriggeredAbility(new LoseLifeDefendingPlayerEffect(1, false), false, filter, SetTargetPointer.PLAYER, false));
     }
 
     public LeechingSliver(final LeechingSliver card) {

--- a/Mage/src/main/java/mage/abilities/effects/common/LoseLifeDefendingPlayerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/LoseLifeDefendingPlayerEffect.java
@@ -77,7 +77,7 @@ public class LoseLifeDefendingPlayerEffect extends OneShotEffect {
         if (attackerIsSource) {
             defender = game.getPlayer(game.getCombat().getDefenderId(source.getSourceId()));
         } else {
-            defender = game.getPlayer(game.getCombat().getDefenderId(getTargetPointer().getFirst(game, source)));
+            defender = game.getPlayer(getTargetPointer().getFirst(game, source));
         }
         if (defender != null) {
             defender.loseLife(amount.calculate(game, source, this), game);


### PR DESCRIPTION
Following bugs fixed:
No life loss from a trigger when Leeching Sliver attacks a planeswalker
No life loss from a trigger when Leeching Sliver doesn't attack a player
and another sliver does