### PR TITLE
add TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: required
+dist: trusty
+language: java
+before_install:
+  - echo "MAVEN_OPTS='-Xmx2g'" > ~/.mavenrc

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # XMage — Magic, Another Game Engine
 
-[![Join the chat at https://gitter.im/magefree/mage](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/magefree/mage?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/magefree/mage](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/magefree/mage?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/magefree/mage.svg?branch=master)](https://travis-ci.org/magefree/mage)
 
 XMage allows you to play Magic against one or more online players or computer opponents. It includes full rules enforcement for over **14 000** unique cards (over 27 000 counting all cards from different editions). Starting with *Morningtide*, all regular sets have nearly all the cards implemented ([detailed overview](http://ct-magefree.rhcloud.com/stats)).
 


### PR DESCRIPTION
The old Jenkins server seems to no longer be around, and it'd be great to have CI going again. It's really nice to see whether pull requests compile & pass tests before merging them.

I could merge these changes, but an administrator in the `magefree` organization will need to go to https://travis-ci.org/profile/magefree and enable builds for this repository. (@LevelX2)