### PR TITLE
Changed Indulgent Aristocrat filter to prevent 'each' appearing twice…

### DIFF
--- a/Mage.Sets/src/mage/sets/shadowsoverinnistrad/IndulgentAristocrat.java
+++ b/Mage.Sets/src/mage/sets/shadowsoverinnistrad/IndulgentAristocrat.java
@@ -51,7 +51,7 @@ import mage.target.common.TargetControlledCreaturePermanent;
  */
 public class IndulgentAristocrat extends CardImpl {
 
-    private static final FilterControlledPermanent filter = new FilterControlledPermanent("each Vampire you control");
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent("Vampire you control");
 
     static {
         filter.add(new SubtypePredicate("Vampire"));


### PR DESCRIPTION
Fixes Issue #2159

Tested in game, removing 'each' from the filter does not affect the functionality of the card but the tooltip now shows the correct wording.