### PR TITLE
Fix Gratuitous Violence bug

### DIFF
--- a/Mage.Sets/src/mage/sets/onslaught/GratuitousViolence.java
+++ b/Mage.Sets/src/mage/sets/onslaught/GratuitousViolence.java
@@ -95,7 +95,9 @@ class GratuitousViolenceReplacementEffect extends ReplacementEffectImpl {
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         Permanent permanent = game.getPermanentOrLKIBattlefield(event.getSourceId());
-        return permanent != null && permanent.getControllerId().equals(source.getControllerId());
+        return permanent != null
+                && permanent.getCardType().contains(CardType.CREATURE)
+                && permanent.getControllerId().equals(source.getControllerId());
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/GratuitousViolenceTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/GratuitousViolenceTest.java
@@ -11,7 +11,9 @@ import org.mage.test.serverside.base.CardTestPlayerBase;
  */
 public class GratuitousViolenceTest extends CardTestPlayerBase {
     @Test
-    public void testWorksOnCreatures() {
+    public void testDoublesDamageFromCreatures() {
+        // Enchantment: If a creature you control would deal damage to a creature
+        // or player, it deals double that damage to that creature or player instead.
         addCard(Zone.BATTLEFIELD, playerA, "Gratuitous Violence");
         addCard(Zone.BATTLEFIELD, playerA, "Elvish Visionary"); // 1/1
         
@@ -24,8 +26,10 @@ public class GratuitousViolenceTest extends CardTestPlayerBase {
     
     @Test
     public void testIgnoresNonCreatures() {
-        addCard(Zone.BATTLEFIELD, playerA, "Gratuitous Violence");
+        // Legendary Enchantment - Shrine: At the beginning of your upkeep, Honden of Infinite
+        // Rage deals damage to target creature or player equal to the number of Shrines you control.
         addCard(Zone.BATTLEFIELD, playerA, "Honden of Infinite Rage");
+        addCard(Zone.BATTLEFIELD, playerA, "Gratuitous Violence");
         
         addTarget(playerA, playerB);
         

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/GratuitousViolenceTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/GratuitousViolenceTest.java
@@ -1,0 +1,52 @@
+package org.mage.test.cards.single;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author cg5
+ */
+public class GratuitousViolenceTest extends CardTestPlayerBase {
+    @Test
+    public void testWorksOnCreatures() {
+        addCard(Zone.BATTLEFIELD, playerA, "Gratuitous Violence");
+        addCard(Zone.BATTLEFIELD, playerA, "Elvish Visionary"); // 1/1
+        
+        attack(1, playerA, "Elvish Visionary");
+        
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+        assertLife(playerB, 18);
+    }
+    
+    @Test
+    public void testIgnoresNonCreatures() {
+        addCard(Zone.BATTLEFIELD, playerA, "Gratuitous Violence");
+        addCard(Zone.BATTLEFIELD, playerA, "Honden of Infinite Rage");
+        
+        addTarget(playerA, playerB);
+        
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+        
+        // Honden should deal 1 damage at upkeep (since playerA only
+        // has one Shrine). GV should not double this.
+        assertLife(playerB, 19);
+    }
+    
+    @Test
+    public void testIgnoresInstants() {
+        addCard(Zone.BATTLEFIELD, playerA, "Gratuitous Violence");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.HAND, playerA, "Lightning Bolt");
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
+        
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+        assertLife(playerB, 17);
+    }
+}


### PR DESCRIPTION
GV was doubling damage from all permanent sources - not just creatures.