### PR TITLE
Fix the combat code to support Slayer's Cleaver

### DIFF
--- a/Mage.Sets/src/mage/sets/eldritchmoon/SlayersCleaver.java
+++ b/Mage.Sets/src/mage/sets/eldritchmoon/SlayersCleaver.java
@@ -56,7 +56,6 @@ public class SlayersCleaver extends CardImpl {
 
         // Equipped creature gets +3/+1 and must be blocked by an Eldrazi if able.
         Ability ability = new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEquippedEffect(3, 1));
-        // TODO: The effect does not work correctly yet, we need to do some chnanges to combat handling to fix this
         ability.addEffect(new SlayersCleaverEffect());
         this.addAbility(ability);
         // Equip {4}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/requirement/BlockRequirementTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/requirement/BlockRequirementTest.java
@@ -231,12 +231,12 @@ public class BlockRequirementTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
         addCard(Zone.BATTLEFIELD, playerA, "Memnite"); // {1} 1/1
         
-        addCard(Zone.BATTLEFIELD, playerB, "Wretched Gryff"); // {7} Flying 3/4 - Eldrazi Hippogriff
-        addCard(Zone.BATTLEFIELD, playerB, "Hill Giant"); // {3}{R} 3/3
+        addCard(Zone.BATTLEFIELD, playerB, "Dimensional Infiltrator"); // 2/1 - Eldrazi
+        addCard(Zone.BATTLEFIELD, playerB, "Llanowar Elves"); // 1/1
         
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Equip", "Memnite"); // pumps to 4/2
-        attack(1, playerA, "Memnite"); // must be blocked by Wretched Gryff
-        block(1, playerB, "Hill Giant", "Memnite"); // should not be allowed as only blocker
+        attack(1, playerA, "Memnite"); // must be blocked by Dimensional Infiltrator
+        block(1, playerB, "Llanowar Elves", "Memnite"); // should not be allowed as only blocker
         
         setStopAt(1, PhaseStep.END_COMBAT);
         execute();
@@ -244,7 +244,7 @@ public class BlockRequirementTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Slayer's Cleaver", 1);
         assertLife(playerB, 20);
         assertGraveyardCount(playerA, "Memnite", 1);
-        assertGraveyardCount(playerB, "Wretched Gryff", 1);
-        assertPermanentCount(playerB, "Hill Giant", 1);
+        assertGraveyardCount(playerB, "Dimensional Infiltrator", 1);
+        assertGraveyardCount(playerB, "Llanowar Elves", 1);
     }
 }


### PR DESCRIPTION
Update the checks for unfulfilled conditions to confirm the blocking
creatures actually are fulfilled.
Update the check for whether a blocker is already being used correctly
to confirm that there isn’t a stricter condition that is unfulfilled.

This change also updates the Slayer’s Cleaver test to make it more
robust.