### PR TITLE
Fix the Snapcaster Mage X cost tests.

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/FlashbackTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/FlashbackTest.java
@@ -119,7 +119,7 @@ public class FlashbackTest extends CardTestPlayerBase {
         addCard(Zone.GRAVEYARD, playerA, "Blaze", 1);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Snapcaster Mage");
-        setChoice(playerA, "B   laze");
+        setChoice(playerA, "Blaze");
 
         activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Flashback");
         setChoice(playerA, "X=1");

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -328,7 +328,9 @@ public abstract class AbilityImpl implements Ability {
             if (sourceObject != null && !this.getAbilityType().equals(AbilityType.TRIGGERED)) { // triggered abilities check this already in playerImpl.triggerAbility
                 sourceObject.adjustTargets(this, game);
             }
-            if (mode.getTargets().size() > 0 && mode.getTargets().chooseTargets(getEffects().get(0).getOutcome(), this.controllerId, this, noMana, game) == false) {
+            // Flashback abilities haven't made the choices the underlying spell might need for targetting.
+            if (!(this instanceof FlashbackAbility) && mode.getTargets().size() > 0 && mode.getTargets().chooseTargets(
+                    getEffects().get(0).getOutcome(), this.controllerId, this, noMana, game) == false) {
                 if ((variableManaCost != null || announceString != null) && !game.isSimulation()) {
                     game.informPlayer(controller, (sourceObject != null ? sourceObject.getIdName() : "") + ": no valid targets with this value of X");
                 }

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -1284,7 +1284,7 @@ public abstract class GameImpl implements Game, Serializable {
                         state.setPriorityPlayerId(player.getId());
                         while (!player.isPassed() && player.canRespond() && !isPaused() && !gameOver(null)) {
                             if (!resuming) {
-                                // 603.3. Once an ability has triggered, its controller puts it on the stack as an object thats not a card the next time a player would receive priority
+                                // 603.3. Once an ability has triggered, its controller puts it on the stack as an object that's not a card the next time a player would receive priority
                                 checkStateAndTriggered();
                                 applyEffects();
                                 if (state.getStack().isEmpty()) {

--- a/Mage/src/main/java/mage/target/Targets.java
+++ b/Mage/src/main/java/mage/target/Targets.java
@@ -100,7 +100,7 @@ public class Targets extends ArrayList<Target> {
                 if (target.getTargetController() != null) { // some targets can have controller different than ability controller
                     targetController = target.getTargetController();
                 }
-                if (noMana) { // if cast without mana (e.g. by supend you may notr be able to cancel the casting if you are able to cast it
+                if (noMana) { // if cast without mana (e.g. by suspend you may not be able to cancel the casting if you are able to cast it
                     target.setRequired(true);
                 }
                 if (!target.chooseTarget(outcome, targetController, source, game)) {


### PR DESCRIPTION
The flashback ability was attempting to choose targets. That doesn’t
really make sense since the Targets should be chosen by the actual
spell being cast.