### PR TITLE
Fixed gen-card to work after reorg

### DIFF
--- a/Utils/cardClass.tmpl
+++ b/Utils/cardClass.tmpl
@@ -25,7 +25,7 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.sets.[=$set=];
+package mage.cards.[=$cardNameFirstLetter=];
 
 import java.util.UUID;[=
 if ($power || $power eq 0) {
@@ -33,8 +33,8 @@ if ($power || $power eq 0) {
 }
 =][=$abilitiesImports=]
 import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Rarity;
 
 /**
  *
@@ -42,9 +42,9 @@ import mage.constants.Rarity;
  */
 public class [=$className=] extends CardImpl {
 
-    public [=$className=](UUID ownerId) {
-        super(ownerId, [=$cardNumber=], "[=$name=]", Rarity.[=$rarity=], new CardType[]{[=$type=]}, "[=$manaCost=]");
-        this.expansionSetCode = "[=$expansionSetCode=]";[=$subType=][=$colors=][=
+    public [=$className=](UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{[=$type=]}, "[=$manaCost=]");
+        [=$subType=][=$colors=][=
 if ($power || $power eq 0) {
     $OUT .= "\n        this.power = new MageInt($power);";
     $OUT .= "\n        this.toughness = new MageInt($toughness);";

--- a/Utils/gen-card.pl
+++ b/Utils/gen-card.pl
@@ -12,7 +12,6 @@ my $setsFile = 'mtg-sets-data.txt';
 my $knownSetsFile = 'known-sets.txt';
 my $keywordsFile = 'keywords.txt';
 
-
 my %cards;
 my %sets;
 my %knownSets;
@@ -21,7 +20,7 @@ my %keywords;
 sub toCamelCase {
     my $string = $_[0];
     $string =~ s/\b([\w']+)\b/ucfirst($1)/ge;
-    $string =~ s/[-,\s\']//g;
+    $string =~ s/[-,\s\':]//g;
     $string;
 }
 
@@ -102,154 +101,146 @@ if (!exists $cards{$cardName}) {
 }
 
 # Check if card is already implemented
-foreach my $setName (keys %{$cards{$cardName}}) {
-    if (exists $knownSets{$setName}) {
-        my $fileName = "../Mage.Sets/src/mage/sets/" . $knownSets{$setName} . "/" . toCamelCase($cardName) . ".java";
-        print "gvim $fileName\n";
-        my $fileName2 = $fileName;
-        $fileName2 =~ s/\//\\/img;
-        print "gvim $fileName2\n";
-        if(-e $fileName) {
-            die "$cardName is already implemented (set found in: $setName).\n";
-        }
-    }
+my $fileName = "../Mage.Sets/src/mage/cards/".substr($cardName, 0, 1)."/".toCamelCase($cardName).".java";
+if(-e $fileName) {
+  die "$cardName is already implemented.\n";
 }
-
-# Generate the cards
-my $simpleOnly = $ARGV[1] || 'false';
-my $template = Text::Template->new(TYPE => 'FILE', SOURCE => 'cardClass.tmpl', DELIMITERS => [ '[=', '=]' ]);
-my $templateExtended = Text::Template->new(TYPE => 'FILE', SOURCE => 'cardExtendedClass.tmpl', DELIMITERS => [ '[=', '=]' ]);
+                                                                          
+# Generate lines to corresponding sets
 my %vars;
-
-$vars{'author'} = $author;
-$vars{'name'} = $cardName;
 $vars{'className'} = toCamelCase($cardName);
+$vars{'cardNameFirstLetter'} = lc substr($cardName, 0, 1);
+my @card;
 
-if ($simpleOnly ne 'true') {
-    print "Files generated:\n";
-}
-my $baseRarity = '';
 foreach my $setName (keys %{$cards{$cardName}}) {
-    if (exists $knownSets{$setName}) {
-        my $fileName = "../Mage.Sets/src/mage/sets/" . $knownSets{$setName} . "/" . toCamelCase($cardName) . ".java";
-        print "gvim $fileName\n";
-        my $fileName2 = $fileName;
-        $fileName2 =~ s/\//\\/img;
-        print "gvim $fileName2\n";
-        my $result;
+  my $setFileName = "../Mage.Sets/src/mage/sets/".toCamelCase($setName).".java";
+  @card = @{${cards{$cardName}{$setName}}}; 
+  my $line = "\tcards.add(new SetCardInfo(\"".$card[0]."\", ".$card[2].", Rarity.".$raritiesConversion{$card[3]}.", mage.cards.".$vars{'cardNameFirstLetter'}.".".$vars{'className'}.".class));\n";  
+  
+  @ARGV = ($setFileName);
+  $^I = '.bak';
+  my $last;
+  my $lastName;
+  my $currName;
+  while (<>) {
+    if ($_ !~ m/cards.add/) {      
+      if (defined($last)) {
+        print $last; 
+      }
+      # print card line as last
+      if (defined($currName) && ($cardName cmp $currName) > 0) {
+        print $line;
+        undef $currName;
+      }
+      $last = $_;
+      print $last if eof;   
+      next;
+    }
+    
+    ($lastName) = $last =~ m/"(.*?)"/;
+    ($currName) = $_ =~ m/"(.*?)"/;
+    print $last;
+    $last = $_;
+    # print card line as first
+    if (!defined($lastName) && defined($currName) && ($currName cmp $cardName) > 0) {
+      print $line;
+    }
+    # print card line in the middle
+    if (defined($lastName) && defined($currName) && ($cardName cmp $lastName) > 0 && ($currName cmp $cardName) > 0) {
+      print $line;
+    }
+  }
 
-        $vars{'set'} = $knownSets{$setName};
-        $vars{'expansionSetCode'} = $sets{$setName};
-        $vars{'cardNumber'} = $cards{$cardName}{$setName}[2];
-        $vars{'rarity'} = $raritiesConversion{$cards{$cardName}{$setName}[3]};
+  unlink $setFileName.".bak";
+  print "$setFileName\n";
+}
 
-        if (!$baseRarity) {
-            $baseRarity = $cards{$cardName}{$setName}[3];
+# Generate the the card
+my $result;
+my $template = Text::Template->new(TYPE => 'FILE', SOURCE => 'cardClass.tmpl', DELIMITERS => [ '[=', '=]' ]);
+$vars{'author'} = $author;
+$vars{'manaCost'} = fixCost($card[4]);
+$vars{'power'} = $card[6];
+$vars{'toughness'} = $card[7];
 
-            $vars{'manaCost'} = fixCost($cards{$cardName}{$setName}[4]);
-            $vars{'power'} = $cards{$cardName}{$setName}[6];
-            $vars{'toughness'} = $cards{$cardName}{$setName}[7];
-
-            my @types;
-            $vars{'subType'} = '';
-            my $type = $cards{$cardName}{$setName}[5];
-            while ($type =~ m/([a-zA-Z]+)( )*/g) {
-                if (exists($cardTypes{$1})) {
-                    push(@types, $cardTypes{$1});
-                } else {
-                    if (@types) {
-                        $vars{'subType'} .= "\n        this.subtype.add(\"$1\");";
-                    } else {
-                        $vars{'subType'} .= "\n        this.supertype.add(\"$1\");";
-                    }
-                }
-            }
-            $vars{'type'} = join(', ', @types);
-
-            $vars{'abilitiesImports'} = '';
-            $vars{'abilities'} = '';
-
-            my @abilities = split('\$', $cards{$cardName}{$setName}[8]);
-            foreach my $ability (@abilities) {
-                $ability =~ s/ <i>.+?<\/i>//g;
-
-                my $notKeyWord;
-                foreach my $keyword (keys %keywords) {
-                    if (toCamelCase($ability) =~ m/^$keyword(?=[A-Z{\d]|$)/g) {
-                        $notKeyWord = 'false';
-                        my @ka = split(', ', $ability);
-                        foreach my $kw (@ka) {
-                            my $kwUnchanged = $kw;
-                            foreach my $kk (keys %keywords) {
-                                if (toCamelCase($kw) =~ m/^$kk(?=[A-Z{\d]|$)/g) {
-                                    $kw = $kk;
-                                }
-                            }
-                            if ($keywords{$kw}) {
-                                $vars{'abilities'} .= "\n        // " . ucfirst($kwUnchanged);
-                                if ($keywords{$kw} eq 'instance') {
-                                    $vars{'abilities'} .= "\n        this.addAbility(" . $kw . "Ability.getInstance());";
-                                } elsif ($keywords{$kw} eq 'new') {
-                                    $vars{'abilities'} .= "\n        this.addAbility(new " . $kw . "Ability());";
-                                } elsif ($keywords{$kw} eq 'color') {
-                                    $vars{'abilities'} .= "\n        this.addAbility(new " . $kw . "Ability(this.color));";
-                                } elsif ($keywords{$kw} eq 'number') {
-                                    $ability =~ m/(\b\d+?\b)/g;
-                                    $vars{'abilities'} .= "\n        this.addAbility(new " . $kw . 'Ability(' . $1 . '));';
-                                } elsif ($keywords{$kw} eq 'cost') {
-                                    $ability =~ m/({.*})/g;
-                                    $vars{'abilities'} .= "\n        this.addAbility(new " . $kw . 'Ability(new ManaCostsImpl("' . fixCost($1) . '")));';
-                                    $vars{'abilitiesImports'} .= "\nimport mage.abilities.costs.mana.ManaCostsImpl;";
-                                } elsif ($keywords{$kw} eq 'card, manaString') {
-                                    $ability =~ m/({.*})/g;
-                                    $vars{'abilities'} .= "\n        this.addAbility(new " . $kw . 'Ability(this, "' . fixCost($1) . '"));';
-                                } elsif ($keywords{$kw} eq 'card, cost') {
-                                    $ability =~ m/({.*})/g;
-                                    $vars{'abilities'} .= "\n        this.addAbility(new " . $kw . 'Ability(this, new ManaCostsImpl("' . fixCost($1) . '")));';
-                                    $vars{'abilitiesImports'} .= "\nimport mage.abilities.costs.mana.ManaCostsImpl;";
-                                }
-
-
-                                $vars{'abilitiesImports'} .= "\nimport mage.abilities.keyword." . $kw . "Ability;";
-                            } else {
-                                $vars{'abilities'} .= "\n        // $kwUnchanged";
-                                if ($simpleOnly eq 'true') {
-                                    exit 0;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if (!$notKeyWord) {
-                    $vars{'abilities'} .= "\n        // $ability";
-                    if ($simpleOnly eq 'true') {
-                        exit 0;
-                    }
-                }
-            }
-            if ($vars{'abilities'}) {
-                $vars{'abilities'} = "\n" . $vars{'abilities'};
-            }
-
-            $vars{'baseSet'} = $vars{'set'};
-            $vars{'baseClassName'} = $vars{'className'};
-
-            $result = $template->fill_in(HASH => \%vars);
-        } else {
-            $vars{'rarityExtended'} = '';
-            if ($baseRarity ne $cards{$cardName}{$setName}[3]) {
-                $vars{'rarityExtended'} = "\n        this.rarity = Rarity.$raritiesConversion{$cards{$cardName}{$setName}[3]};";
-            }
-            $result = $templateExtended->fill_in(HASH => \%vars);
-        }
-
-        open CARD, "> $fileName";
-        print CARD $result;
-        close CARD;
-
-        print "$vars{'set'}.$vars{'className'}\n";
+my @types;
+$vars{'subType'} = '';
+my $type = $card[5];
+while ($type =~ m/([a-zA-Z]+)( )*/g) {
+    if (exists($cardTypes{$1})) {
+        push(@types, $cardTypes{$1});
     } else {
-        print "Set not found in known sets: $setName\n";
+        if (@types) {
+            $vars{'subType'} .= "\n        this.subtype.add(\"$1\");";
+        } else {
+            $vars{'subType'} .= "\n        this.supertype.add(\"$1\");";
+        }
     }
 }
+$vars{'type'} = join(', ', @types);
+
+$vars{'abilitiesImports'} = '';
+$vars{'abilities'} = '';
+
+my @abilities = split('\$', $card[8]);
+foreach my $ability (@abilities) {
+    $ability =~ s/ <i>.+?<\/i>//g;
+
+    my $notKeyWord;
+    foreach my $keyword (keys %keywords) {
+        if (toCamelCase($ability) =~ m/^$keyword(?=[A-Z{\d]|$)/g) {
+            $notKeyWord = 'false';
+            my @ka = split(', ', $ability);
+            foreach my $kw (@ka) {
+                my $kwUnchanged = $kw;
+                foreach my $kk (keys %keywords) {
+                    if (toCamelCase($kw) =~ m/^$kk(?=[A-Z{\d]|$)/g) {
+                        $kw = $kk;
+                    }
+                }
+                if ($keywords{$kw}) {
+                    $vars{'abilities'} .= "\n        // " . ucfirst($kwUnchanged);
+                    if ($keywords{$kw} eq 'instance') {
+                        $vars{'abilities'} .= "\n        this.addAbility(" . $kw . "Ability.getInstance());";
+                    } elsif ($keywords{$kw} eq 'new') {
+                        $vars{'abilities'} .= "\n        this.addAbility(new " . $kw . "Ability());";
+                    } elsif ($keywords{$kw} eq 'color') {
+                        $vars{'abilities'} .= "\n        this.addAbility(new " . $kw . "Ability(this.color));";
+                    } elsif ($keywords{$kw} eq 'number') {
+                        $ability =~ m/(\b\d+?\b)/g;
+                        $vars{'abilities'} .= "\n        this.addAbility(new " . $kw . 'Ability(' . $1 . '));';
+                    } elsif ($keywords{$kw} eq 'cost') {
+                        $ability =~ m/({.*})/g;
+                        $vars{'abilities'} .= "\n        this.addAbility(new " . $kw . 'Ability(new ManaCostsImpl("' . fixCost($1) . '")));';
+                        $vars{'abilitiesImports'} .= "\nimport mage.abilities.costs.mana.ManaCostsImpl;";
+                    } elsif ($keywords{$kw} eq 'card, manaString') {
+                        $ability =~ m/({.*})/g;
+                        $vars{'abilities'} .= "\n        this.addAbility(new " . $kw . 'Ability(this, "' . fixCost($1) . '"));';
+                    } elsif ($keywords{$kw} eq 'card, cost') {
+                        $ability =~ m/({.*})/g;
+                        $vars{'abilities'} .= "\n        this.addAbility(new " . $kw . 'Ability(this, new ManaCostsImpl("' . fixCost($1) . '")));';
+                        $vars{'abilitiesImports'} .= "\nimport mage.abilities.costs.mana.ManaCostsImpl;";
+                    }
+                    $vars{'abilitiesImports'} .= "\nimport mage.abilities.keyword." . $kw . "Ability;";
+                } else {
+                    $vars{'abilities'} .= "\n        // $kwUnchanged";
+                }
+            }
+        }
+    }
+
+    if (!$notKeyWord) {
+        $vars{'abilities'} .= "\n        // $ability";
+    }
+}
+if ($vars{'abilities'}) {
+    $vars{'abilities'} = "\n" . $vars{'abilities'};
+}
+
+$result = $template->fill_in(HASH => \%vars);
+
+open CARD, "> $fileName";
+print CARD $result;
+close CARD;
+
+print "$fileName\n";


### PR DESCRIPTION
Script generates card class into name-corresponding package and adds line with card info at alphabetical place into each set the card was printed in.