### PR TITLE
Fixed Sirens Call

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SirensCall.java
+++ b/Mage.Sets/src/mage/cards/s/SirensCall.java
@@ -133,6 +133,11 @@ class SirensCallDestroyEffect extends OneShotEffect {
         Player player = game.getPlayer(game.getActivePlayerId());
         if (player != null) {
             for (Permanent permanent : game.getBattlefield().getAllActivePermanents(player.getId())) {
+                                
+                   // Non Creature Cards are safe.
+                if(!permanent.getCardType().contains(CardType.CREATURE))
+                    continue;  
+                
                 // Walls are safe.
                 if (permanent.getSubtype(game).contains("Wall")) {
                     continue;


### PR DESCRIPTION
Bug description: Sirens call destroys _all_  of the opponent permanents, except for those creatures which attacked in the current round.