### PR TITLE
Fix set codes of 3 sets

### DIFF
--- a/Mage.Sets/src/mage/sets/CommanderAnthology.java
+++ b/Mage.Sets/src/mage/sets/CommanderAnthology.java
@@ -42,7 +42,7 @@ public class CommanderAnthology extends ExpansionSet {
     }
 
     private CommanderAnthology() {
-        super("Commander Anthology", "CMA2", ExpansionSet.buildDate(2017, 6, 9), SetType.SUPPLEMENTAL);
+        super("Commander Anthology", "CMA", ExpansionSet.buildDate(2017, 6, 9), SetType.SUPPLEMENTAL);
         this.blockName = "Commander Anthology";
         this.hasBasicLands = false;
     }

--- a/Mage.Sets/src/mage/sets/CommandersArsenal.java
+++ b/Mage.Sets/src/mage/sets/CommandersArsenal.java
@@ -45,7 +45,7 @@ public class CommandersArsenal extends ExpansionSet {
     }
 
     private CommandersArsenal() {
-        super("Commander's Arsenal", "CMA", ExpansionSet.buildDate(2012, 11, 2), SetType.SUPPLEMENTAL);
+        super("Commander's Arsenal", "CM1", ExpansionSet.buildDate(2012, 11, 2), SetType.SUPPLEMENTAL);
         this.blockName = "Command Zone";
         cards.add(new SetCardInfo("Chaos Warp", 1, Rarity.SPECIAL, mage.cards.c.ChaosWarp.class));
         cards.add(new SetCardInfo("Command Tower", 2, Rarity.COMMON, mage.cards.c.CommandTower.class));

--- a/Mage.Sets/src/mage/sets/PortalSecondAge.java
+++ b/Mage.Sets/src/mage/sets/PortalSecondAge.java
@@ -51,7 +51,7 @@ public class PortalSecondAge extends ExpansionSet {
     }
 
     private PortalSecondAge() {
-        super("Portal Second Age", "PO2", ExpansionSet.buildDate(1998, 6, 24), SetType.SUPPLEMENTAL);
+        super("Portal Second Age", "P02", ExpansionSet.buildDate(1998, 6, 24), SetType.SUPPLEMENTAL);
         this.blockName = "Beginner";
         this.hasBasicLands = true;
         this.hasBoosters = true;

--- a/Utils/mtg-sets-data.txt
+++ b/Utils/mtg-sets-data.txt
@@ -35,7 +35,7 @@ Champions of Kamigawa|CHK|
 Chronicles|CHR|
 Clash Pack|CLASH|
 Commander Anthology|CMA|
-Commander's Arsenal|CMA|
+Commander's Arsenal|CM1|
 Conspiracy: Take the Crown|CN2|
 Conflux|CON|
 Champs|CP|


### PR DESCRIPTION
* *Commander's Arsenal*: CMA→CM1. This is the set code used on Gatherer, and the only official source for CMA is the Card Set Archive, which conflicts with itself (since it also lists the *Commander Anthology* set code as CMA).
* *Commander Anthology*: CMA2→CMA.
* *Portal Second Age*: PO2→P02. This change was [previously reverted](https://github.com/magefree/mage/pull/1860#issuecomment-233456007) by @fireshoes, citing the Card Set Archive. While it is an official source, the Card Set Archive is known to be inconsistent with other official sources on multiple occasions, and has not been updated even after I have contacted Wizards pointing out the *Theros* inconsistency and missing set codes for e.g. *10th Edition*.