### PR TITLE
Correction to Protean Hydra code

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GaeasLiege.java
+++ b/Mage.Sets/src/mage/cards/g/GaeasLiege.java
@@ -30,10 +30,11 @@ package mage.cards.g;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.AttacksTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.common.AttackingCondition;
 import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.decorator.ConditionalContinuousEffect;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.Effect;
@@ -72,8 +73,11 @@ public class GaeasLiege extends CardImpl {
         this.toughness = new MageInt(0);
 
         // As long as Gaea's Liege isn't attacking, its power and toughness are each equal to the number of Forests you control. As long as Gaea's Liege is attacking, its power and toughness are each equal to the number of Forests defending player controls.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetPowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands), Duration.EndOfGame)));
-        this.addAbility(new AttacksTriggeredAbility(new SetPowerToughnessSourceEffect(new DefendersForestCount(), Duration.EndOfCombat), false));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new ConditionalContinuousEffect(
+                new SetPowerToughnessSourceEffect(new DefendersForestCount(), Duration.EndOfCombat),
+                new SetPowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands), Duration.EndOfGame),
+                AttackingCondition.getInstance(),
+                "As long as {this} isn't attacking, its power and toughness are each equal to the number of Forests you control. As long as {this} is attacking, its power and toughness are each equal to the number of Forests defending player controls.")));
         // {tap}: Target land becomes a Forest until Gaea's Liege leaves the battlefield.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesBasicLandTargetEffect(Duration.WhileOnBattlefield, "Forest"), new TapSourceCost());
         ability.addTarget(new TargetLandPermanent());

--- a/Mage.Sets/src/mage/cards/g/GaeasLiege.java
+++ b/Mage.Sets/src/mage/cards/g/GaeasLiege.java
@@ -1,0 +1,130 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.g;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.AttacksTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.continuous.BecomesBasicLandTargetEffect;
+import mage.abilities.effects.common.continuous.SetPowerToughnessSourceEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Zone;
+import mage.filter.common.FilterControlledPermanent;
+import mage.filter.common.FilterLandPermanent;
+import mage.filter.predicate.mageobject.SubtypePredicate;
+import mage.game.Game;
+import mage.game.combat.CombatGroup;
+import mage.game.permanent.Permanent;
+import mage.target.common.TargetLandPermanent;
+
+/**
+ *
+ * @author anonymous
+ */
+public class GaeasLiege extends CardImpl {
+    
+    final static FilterControlledPermanent filterLands = new FilterControlledPermanent("Forests you control");
+
+    static {
+        filterLands.add(new SubtypePredicate("Forest"));
+    }
+
+    public GaeasLiege(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{G}{G}{G}");
+        
+        this.subtype.add("Avatar");
+        this.power = new MageInt(0);
+        this.toughness = new MageInt(0);
+
+        // As long as Gaea's Liege isn't attacking, its power and toughness are each equal to the number of Forests you control. As long as Gaea's Liege is attacking, its power and toughness are each equal to the number of Forests defending player controls.
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetPowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands), Duration.EndOfGame)));
+        this.addAbility(new AttacksTriggeredAbility(new SetPowerToughnessSourceEffect(new DefendersForestCount(), Duration.EndOfCombat), false));
+        // {tap}: Target land becomes a Forest until Gaea's Liege leaves the battlefield.
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesBasicLandTargetEffect(Duration.WhileOnBattlefield, "Forest"), new TapSourceCost());
+        ability.addTarget(new TargetLandPermanent());
+        this.addAbility(ability);
+    }
+
+    public GaeasLiege(final GaeasLiege card) {
+        super(card);
+    }
+
+    @Override
+    public GaeasLiege copy() {
+        return new GaeasLiege(this);
+    }
+}
+
+class DefendersForestCount implements DynamicValue {
+
+    @Override
+    public int calculate(Game game, Ability sourceAbility, Effect effect) {
+        for (CombatGroup group :game.getCombat().getGroups()) {
+            if (group.getAttackers().contains(sourceAbility.getSourceId())) {
+                UUID defenderId = group.getDefenderId();
+                if (group.isDefenderIsPlaneswalker()) {
+                    Permanent permanent = game.getPermanent(defenderId);
+                    if (permanent != null) {
+                        defenderId = permanent.getControllerId();
+                    }
+                }
+                
+                FilterLandPermanent filter = new FilterLandPermanent("forest");
+                filter.add(new SubtypePredicate("Forest"));
+                return game.getBattlefield().countAll(filter, defenderId, game);
+
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public DynamicValue copy() {
+        return new DefendersForestCount();
+    }
+
+    @Override
+    public String toString() {
+        return "X";
+    }
+
+    @Override
+    public String getMessage() {
+        return "the number of Forests defending player controls";
+    }
+}

--- a/Mage.Sets/src/mage/cards/p/ProteanHydra.java
+++ b/Mage.Sets/src/mage/cards/p/ProteanHydra.java
@@ -34,7 +34,6 @@ import mage.abilities.DelayedTriggeredAbility;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.PreventionEffectData;
 import mage.abilities.effects.PreventionEffectImpl;
 import mage.abilities.effects.common.CreateDelayedTriggeredAbilityEffect;
 import mage.abilities.effects.common.EntersBattlefieldWithXCountersEffect;

--- a/Mage.Sets/src/mage/cards/p/ProteanHydra.java
+++ b/Mage.Sets/src/mage/cards/p/ProteanHydra.java
@@ -106,12 +106,11 @@ public class ProteanHydra extends CardImpl {
 
         @Override
         public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-            PreventionEffectData preventionEffectData = preventDamageAction(event, source, game);
-            if (preventionEffectData.getPreventedDamage() > 0) {
-                Permanent permanent = game.getPermanent(source.getSourceId());
-                if (permanent != null) {
-                    permanent.removeCounters(CounterType.P1P1.createInstance(preventionEffectData.getPreventedDamage()), game);
-                }
+            int damage = event.getAmount();
+            preventDamageAction(event, source, game);
+            Permanent permanent = game.getPermanent(source.getSourceId());
+            if (permanent != null) {
+                permanent.removeCounters(CounterType.P1P1.createInstance(damage), game); //MTG ruling Protean Hydra loses counters even if the damage isn't prevented
             }
             return false;
         }

--- a/Mage.Sets/src/mage/cards/r/RockHydra.java
+++ b/Mage.Sets/src/mage/cards/r/RockHydra.java
@@ -87,7 +87,7 @@ public class RockHydra extends CardImpl {
 
         public RockHydraEffect() {
             super(Duration.WhileOnBattlefield, Integer.MAX_VALUE, false, false);
-            staticText = "For each 1 damage that would be dealt to Rock Hydra, if it has a +1/+1 counter on it, remove a +1/+1 counter from it and prevent that 1 damage.";
+            staticText = "For each 1 damage that would be dealt to {this}, if it has a +1/+1 counter on it, remove a +1/+1 counter from it and prevent that 1 damage.";
         }
 
         public RockHydraEffect(final RockHydraEffect effect) {

--- a/Mage.Sets/src/mage/sets/FourthEdition.java
+++ b/Mage.Sets/src/mage/sets/FourthEdition.java
@@ -170,6 +170,7 @@ public class FourthEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Forest", 177, Rarity.LAND, mage.cards.basiclands.Forest.class, new CardGraphicInfo(null, true)));
         cards.add(new SetCardInfo("Frozen Shade", 22, Rarity.COMMON, mage.cards.f.FrozenShade.class));
         cards.add(new SetCardInfo("Fungusaur", 130, Rarity.RARE, mage.cards.f.Fungusaur.class));
+        cards.add(new SetCardInfo("Gaea's Liege", 131, Rarity.RARE, mage.cards.g.GaeasLiege.class));
         cards.add(new SetCardInfo("Gaseous Form", 74, Rarity.COMMON, mage.cards.g.GaseousForm.class));
         cards.add(new SetCardInfo("Ghost Ship", 75, Rarity.UNCOMMON, mage.cards.g.GhostShip.class));
         cards.add(new SetCardInfo("Giant Growth", 132, Rarity.COMMON, mage.cards.g.GiantGrowth.class));

--- a/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
@@ -107,6 +107,7 @@ public class LimitedEditionAlpha extends ExpansionSet {
         cards.add(new SetCardInfo("Fork", 153, Rarity.RARE, mage.cards.f.Fork.class));
         cards.add(new SetCardInfo("Frozen Shade", 18, Rarity.COMMON, mage.cards.f.FrozenShade.class));
         cards.add(new SetCardInfo("Fungusaur", 104, Rarity.RARE, mage.cards.f.Fungusaur.class));
+        cards.add(new SetCardInfo("Gaea's Liege", 105, Rarity.RARE, mage.cards.g.GaeasLiege.class));
         cards.add(new SetCardInfo("Gauntlet of Might", 244, Rarity.RARE, mage.cards.g.GauntletOfMight.class));
         cards.add(new SetCardInfo("Giant Growth", 106, Rarity.COMMON, mage.cards.g.GiantGrowth.class));
         cards.add(new SetCardInfo("Giant Spider", 107, Rarity.COMMON, mage.cards.g.GiantSpider.class));

--- a/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
@@ -109,6 +109,7 @@ public class LimitedEditionBeta extends ExpansionSet {
         cards.add(new SetCardInfo("Fork", 154, Rarity.RARE, mage.cards.f.Fork.class));
         cards.add(new SetCardInfo("Frozen Shade", 18, Rarity.COMMON, mage.cards.f.FrozenShade.class));
         cards.add(new SetCardInfo("Fungusaur", 104, Rarity.RARE, mage.cards.f.Fungusaur.class));
+        cards.add(new SetCardInfo("Gaea's Liege", 105, Rarity.RARE, mage.cards.g.GaeasLiege.class));
         cards.add(new SetCardInfo("Gauntlet of Might", 246, Rarity.RARE, mage.cards.g.GauntletOfMight.class));
         cards.add(new SetCardInfo("Giant Growth", 106, Rarity.COMMON, mage.cards.g.GiantGrowth.class));
         cards.add(new SetCardInfo("Giant Spider", 107, Rarity.COMMON, mage.cards.g.GiantSpider.class));

--- a/Mage.Sets/src/mage/sets/RevisedEdition.java
+++ b/Mage.Sets/src/mage/sets/RevisedEdition.java
@@ -120,6 +120,7 @@ public class RevisedEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Fork", 152, Rarity.RARE, mage.cards.f.Fork.class));
         cards.add(new SetCardInfo("Frozen Shade", 20, Rarity.COMMON, mage.cards.f.FrozenShade.class));
         cards.add(new SetCardInfo("Fungusaur", 104, Rarity.RARE, mage.cards.f.Fungusaur.class));
+        cards.add(new SetCardInfo("Gaea's Liege", 105, Rarity.RARE, mage.cards.g.GaeasLiege.class));
         cards.add(new SetCardInfo("Giant Growth", 106, Rarity.COMMON, mage.cards.g.GiantGrowth.class));
         cards.add(new SetCardInfo("Giant Spider", 107, Rarity.COMMON, mage.cards.g.GiantSpider.class));
         cards.add(new SetCardInfo("Glasses of Urza", 249, Rarity.UNCOMMON, mage.cards.g.GlassesOfUrza.class));

--- a/Mage.Sets/src/mage/sets/TimeSpiralTimeshifted.java
+++ b/Mage.Sets/src/mage/sets/TimeSpiralTimeshifted.java
@@ -87,6 +87,7 @@ public class TimeSpiralTimeshifted extends ExpansionSet {
         cards.add(new SetCardInfo("Flying Men", 20, Rarity.COMMON, mage.cards.f.FlyingMen.class));
         cards.add(new SetCardInfo("Funeral Charm", 44, Rarity.COMMON, mage.cards.f.FuneralCharm.class));
         cards.add(new SetCardInfo("Gaea's Blessing", 77, Rarity.SPECIAL, mage.cards.g.GaeasBlessing.class));
+        cards.add(new SetCardInfo("Gaea's Liege", 78, Rarity.SPECIAL, mage.cards.g.GaeasLiege.class));
         cards.add(new SetCardInfo("Gemstone Mine", 119, Rarity.RARE, mage.cards.g.GemstoneMine.class));
         cards.add(new SetCardInfo("Ghost Ship", 21, Rarity.SPECIAL, mage.cards.g.GhostShip.class));
         cards.add(new SetCardInfo("Goblin Snowman", 64, Rarity.UNCOMMON, mage.cards.g.GoblinSnowman.class));

--- a/Mage.Sets/src/mage/sets/UnlimitedEdition.java
+++ b/Mage.Sets/src/mage/sets/UnlimitedEdition.java
@@ -109,6 +109,7 @@ public class UnlimitedEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Fork", 153, Rarity.RARE, mage.cards.f.Fork.class));
         cards.add(new SetCardInfo("Frozen Shade", 18, Rarity.COMMON, mage.cards.f.FrozenShade.class));
         cards.add(new SetCardInfo("Fungusaur", 104, Rarity.RARE, mage.cards.f.Fungusaur.class));
+        cards.add(new SetCardInfo("Gaea's Liege", 105, Rarity.RARE, mage.cards.g.GaeasLiege.class));
         cards.add(new SetCardInfo("Gauntlet of Might", 245, Rarity.RARE, mage.cards.g.GauntletOfMight.class));
         cards.add(new SetCardInfo("Giant Growth", 106, Rarity.COMMON, mage.cards.g.GiantGrowth.class));
         cards.add(new SetCardInfo("Giant Spider", 107, Rarity.COMMON, mage.cards.g.GiantSpider.class));

--- a/Mage/src/main/java/mage/abilities/condition/common/AttackingCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/AttackingCondition.java
@@ -1,0 +1,30 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package mage.abilities.condition.common;
+
+import mage.abilities.Ability;
+import mage.abilities.condition.Condition;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+/**
+ *
+ * @author anonymous
+ */
+public class AttackingCondition implements Condition {
+
+    private static final AttachedCondition fInstance = new AttachedCondition();
+
+    public static AttachedCondition getInstance() {
+        return fInstance;
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanent(source.getSourceId());
+        return permanent != null && permanent.isAttacking();
+    }
+}


### PR DESCRIPTION
Fixed removal of the +1/+1 counters regardless of if the damage is prevented per rulings for the card.