### PR TITLE
Fix AlternativeCostSourceAbility 

### DIFF
--- a/Mage/src/main/java/mage/abilities/costs/AlternativeCostSourceAbility.java
+++ b/Mage/src/main/java/mage/abilities/costs/AlternativeCostSourceAbility.java
@@ -131,10 +131,10 @@ public class AlternativeCostSourceAbility extends StaticAbility implements Alter
 
     @Override
     public boolean isAvailable(Ability source, Game game) {
-        if (condition != null) {
-            return condition.apply(game, source);
-        }
-        return true;
+        boolean conditionApplies = condition == null || condition.apply(game, source);
+        boolean filterApplies = filter == null || filter.match(game.getCard(source.getSourceId()), game);
+
+        return conditionApplies && filterApplies;
     }
 
     @Override


### PR DESCRIPTION
At the moment it doesn't apply it's filter early enough and so it has strange effects in certain edge cases. Specifically it allows Hypergenesis to be cast with Aluren and Kentaro.

This fixes https://github.com/magefree/mage/issues/2601