### PR TITLE
Fix - enable Siege-Gang Commander to sacrifice Boggart Shenanigans

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SiegeGangCommander.java
+++ b/Mage.Sets/src/mage/cards/s/SiegeGangCommander.java
@@ -41,10 +41,10 @@ import mage.abilities.effects.common.DamageTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.mageobject.SubtypePredicate;
 import mage.game.permanent.token.GoblinToken;
-import mage.target.common.TargetControlledCreaturePermanent;
+import mage.target.common.TargetControlledPermanent;
 import mage.target.common.TargetCreatureOrPlayer;
 
 /**
@@ -53,7 +53,7 @@ import mage.target.common.TargetCreatureOrPlayer;
  */
 public class SiegeGangCommander extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("a Goblin");
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent("a Goblin");
 
     static {
         filter.add(new SubtypePredicate("Goblin"));
@@ -67,7 +67,7 @@ public class SiegeGangCommander extends CardImpl {
         this.toughness = new MageInt(2);
         this.addAbility(new EntersBattlefieldTriggeredAbility(new CreateTokenEffect(new GoblinToken(), 3), false));
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(2), new ManaCostsImpl("{1}{R}"));
-        ability.addCost(new SacrificeTargetCost(new TargetControlledCreaturePermanent(1, 1, filter, false)));
+        ability.addCost(new SacrificeTargetCost(new TargetControlledPermanent(1, 1, filter, false)));
         ability.addTarget(new TargetCreatureOrPlayer());
         this.addAbility(ability);
     }


### PR DESCRIPTION
Fixes a problem similar to #2576. Siege-Gang Commander should be able to sacrifice Boggart Shenanigans because it is a goblin, even though it is not a creature.