### PR TITLE
Fix for Sanguine Praetor

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SanguinePraetor.java
+++ b/Mage.Sets/src/mage/cards/s/SanguinePraetor.java
@@ -98,7 +98,7 @@ class SanguinePraetorEffect extends OneShotEffect {
             }
         }
 
-        for (Permanent permanent : game.getBattlefield().getAllActivePermanents(new FilterCreaturePermanent(), source.getControllerId(), game)) {
+        for (Permanent permanent : game.getBattlefield().getAllActivePermanents(new FilterCreaturePermanent(), game)) {
             if (permanent.getConvertedManaCost() == cmc) {
                 permanent.destroy(source.getSourceId(), game, false);
             }


### PR DESCRIPTION
Sanguine Praetor’s activated ability is only destroying creatures its
owner controls.  This fix changes it to target all creatures.  If my
interpretation of the card text is incorrect then feel free to close
this pull request.