### PR TITLE
Personal Incarnation

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PersonalIncarnation.java
+++ b/Mage.Sets/src/mage/cards/p/PersonalIncarnation.java
@@ -1,0 +1,135 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.p;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DiesTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.RedirectionEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.players.Player;
+import mage.target.TargetPlayer;
+
+/**
+ *
+ * @author MTGfan
+ */
+public class PersonalIncarnation extends CardImpl {
+
+    public PersonalIncarnation(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{W}{W}{W}");
+        
+        this.subtype.add("Avatar");
+        this.subtype.add("Incarnation");
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // {0}: The next 1 damage that would be dealt to Personal Incarnation this turn is dealt to its owner instead. Only Personal Incarnation's owner may activate this ability.
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new PersonalIncarnationRedirectEffect(Duration.EndOfTurn, 1), new GenericManaCost(0)));
+        // When Personal Incarnation dies, its owner loses half his or her life, rounded up.
+        this.addAbility(new DiesTriggeredAbility(new PersonalIncarnationLoseHalfLifeEffect()));
+    }
+
+    public PersonalIncarnation(final PersonalIncarnation card) {
+        super(card);
+    }
+
+    @Override
+    public PersonalIncarnation copy() {
+        return new PersonalIncarnation(this);
+    }
+}
+
+class PersonalIncarnationRedirectEffect extends RedirectionEffect {
+
+    public PersonalIncarnationRedirectEffect(Duration duration, int amountToRedirect) {
+        super(duration, amountToRedirect, true);
+        staticText = "The next 1 damage that would be dealt to {this} this turn is dealt to its owner instead.";
+    }
+
+    public PersonalIncarnationRedirectEffect(final PersonalIncarnationRedirectEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public PersonalIncarnationRedirectEffect copy() {
+        return new PersonalIncarnationRedirectEffect(this);
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (event.getTargetId().equals(getTargetPointer().getFirst(game, source))) {
+            TargetPlayer target = new TargetPlayer();
+            target.add(game.getOwnerId(source.getSourceId()), game);
+            redirectTarget = target;
+            return true;
+        }
+        return false;
+    }
+}
+
+class PersonalIncarnationLoseHalfLifeEffect extends OneShotEffect {
+
+    public PersonalIncarnationLoseHalfLifeEffect() {
+        super(Outcome.LoseLife);
+        staticText = "its owner lose half his or her life, rounded up";
+    }
+
+    public PersonalIncarnationLoseHalfLifeEffect(final PersonalIncarnationLoseHalfLifeEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public PersonalIncarnationLoseHalfLifeEffect copy() {
+        return new PersonalIncarnationLoseHalfLifeEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(game.getOwnerId(source.getSourceId()));
+        if (player != null) {
+            int amount = (player.getLife() + 1) / 2;
+            if (amount > 0) {
+                player.loseLife(amount, game, false);
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/FifthEdition.java
+++ b/Mage.Sets/src/mage/sets/FifthEdition.java
@@ -297,6 +297,7 @@ public class FifthEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Paralyze", 47, Rarity.COMMON, mage.cards.p.Paralyze.class));
         cards.add(new SetCardInfo("Pearled Unicorn", 326, Rarity.COMMON, mage.cards.p.PearledUnicorn.class));
         cards.add(new SetCardInfo("Pentagram of the Ages", 394, Rarity.RARE, mage.cards.p.PentagramOfTheAges.class));
+        cards.add(new SetCardInfo("Personal Incarnation", 327, Rarity.RARE, mage.cards.p.PersonalIncarnation.class));
         cards.add(new SetCardInfo("Pestilence", 48, Rarity.COMMON, mage.cards.p.Pestilence.class));
         cards.add(new SetCardInfo("Phantasmal Forces", 106, Rarity.UNCOMMON, mage.cards.p.PhantasmalForces.class));
         cards.add(new SetCardInfo("Phantasmal Terrain", 107, Rarity.COMMON, mage.cards.p.PhantasmalTerrain.class));

--- a/Mage.Sets/src/mage/sets/FourthEdition.java
+++ b/Mage.Sets/src/mage/sets/FourthEdition.java
@@ -269,6 +269,7 @@ public class FourthEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Osai Vultures", 288, Rarity.UNCOMMON, mage.cards.o.OsaiVultures.class));
         cards.add(new SetCardInfo("Paralyze", 35, Rarity.COMMON, mage.cards.p.Paralyze.class));
         cards.add(new SetCardInfo("Pearled Unicorn", 289, Rarity.COMMON, mage.cards.p.PearledUnicorn.class));
+        cards.add(new SetCardInfo("Personal Incarnation", 290, Rarity.RARE, mage.cards.p.PersonalIncarnation.class));
         cards.add(new SetCardInfo("Pestilence", 36, Rarity.COMMON, mage.cards.p.Pestilence.class));
         cards.add(new SetCardInfo("Phantasmal Forces", 88, Rarity.UNCOMMON, mage.cards.p.PhantasmalForces.class));
         cards.add(new SetCardInfo("Phantasmal Terrain", 89, Rarity.COMMON, mage.cards.p.PhantasmalTerrain.class));

--- a/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
@@ -189,6 +189,7 @@ public class LimitedEditionAlpha extends ExpansionSet {
         cards.add(new SetCardInfo("Orcish Oriflamme", 167, Rarity.UNCOMMON, mage.cards.o.OrcishOriflamme.class));
         cards.add(new SetCardInfo("Paralyze", 28, Rarity.COMMON, mage.cards.p.Paralyze.class));
         cards.add(new SetCardInfo("Pearled Unicorn", 214, Rarity.COMMON, mage.cards.p.PearledUnicorn.class));
+        cards.add(new SetCardInfo("Personal Incarnation", 215, Rarity.RARE, mage.cards.p.PersonalIncarnation.class));
         cards.add(new SetCardInfo("Pestilence", 29, Rarity.COMMON, mage.cards.p.Pestilence.class));
         cards.add(new SetCardInfo("Phantasmal Forces", 68, Rarity.UNCOMMON, mage.cards.p.PhantasmalForces.class));
         cards.add(new SetCardInfo("Phantasmal Terrain", 69, Rarity.COMMON, mage.cards.p.PhantasmalTerrain.class));

--- a/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
@@ -193,6 +193,7 @@ public class LimitedEditionBeta extends ExpansionSet {
         cards.add(new SetCardInfo("Orcish Oriflamme", 168, Rarity.UNCOMMON, mage.cards.o.OrcishOriflamme.class));
         cards.add(new SetCardInfo("Paralyze", 28, Rarity.COMMON, mage.cards.p.Paralyze.class));
         cards.add(new SetCardInfo("Pearled Unicorn", 216, Rarity.COMMON, mage.cards.p.PearledUnicorn.class));
+        cards.add(new SetCardInfo("Personal Incarnation", 217, Rarity.RARE, mage.cards.p.PersonalIncarnation.class));
         cards.add(new SetCardInfo("Pestilence", 29, Rarity.COMMON, mage.cards.p.Pestilence.class));
         cards.add(new SetCardInfo("Phantasmal Forces", 68, Rarity.UNCOMMON, mage.cards.p.PhantasmalForces.class));
         cards.add(new SetCardInfo("Phantasmal Terrain", 69, Rarity.COMMON, mage.cards.p.PhantasmalTerrain.class));

--- a/Mage.Sets/src/mage/sets/MastersEditionIV.java
+++ b/Mage.Sets/src/mage/sets/MastersEditionIV.java
@@ -197,6 +197,7 @@ public class MastersEditionIV extends ExpansionSet {
         cards.add(new SetCardInfo("Overwhelming Forces", 92, Rarity.RARE, mage.cards.o.OverwhelmingForces.class));
         cards.add(new SetCardInfo("Owl Familiar", 54, Rarity.COMMON, mage.cards.o.OwlFamiliar.class));
         cards.add(new SetCardInfo("Pentagram of the Ages", 220, Rarity.UNCOMMON, mage.cards.p.PentagramOfTheAges.class));
+        cards.add(new SetCardInfo("Personal Incarnation", 22, Rarity.RARE, mage.cards.p.PersonalIncarnation.class));
         cards.add(new SetCardInfo("Phantasmal Forces", 55, Rarity.COMMON, mage.cards.p.PhantasmalForces.class));
         cards.add(new SetCardInfo("Phantasmal Terrain", 56, Rarity.COMMON, mage.cards.p.PhantasmalTerrain.class));
         cards.add(new SetCardInfo("Planar Gate", 221, Rarity.UNCOMMON, mage.cards.p.PlanarGate.class));

--- a/Mage.Sets/src/mage/sets/RevisedEdition.java
+++ b/Mage.Sets/src/mage/sets/RevisedEdition.java
@@ -202,6 +202,7 @@ public class RevisedEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Ornithopter", 270, Rarity.UNCOMMON, mage.cards.o.Ornithopter.class));
         cards.add(new SetCardInfo("Paralyze", 29, Rarity.COMMON, mage.cards.p.Paralyze.class));
         cards.add(new SetCardInfo("Pearled Unicorn", 214, Rarity.COMMON, mage.cards.p.PearledUnicorn.class));
+        cards.add(new SetCardInfo("Personal Incarnation", 215, Rarity.RARE, mage.cards.p.PersonalIncarnation.class));
         cards.add(new SetCardInfo("Pestilence", 30, Rarity.COMMON, mage.cards.p.Pestilence.class));
         cards.add(new SetCardInfo("Phantasmal Forces", 69, Rarity.UNCOMMON, mage.cards.p.PhantasmalForces.class));
         cards.add(new SetCardInfo("Phantasmal Terrain", 70, Rarity.COMMON, mage.cards.p.PhantasmalTerrain.class));

--- a/Mage.Sets/src/mage/sets/UnlimitedEdition.java
+++ b/Mage.Sets/src/mage/sets/UnlimitedEdition.java
@@ -193,6 +193,7 @@ public class UnlimitedEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Orcish Oriflamme", 167, Rarity.UNCOMMON, mage.cards.o.OrcishOriflamme.class));
         cards.add(new SetCardInfo("Paralyze", 28, Rarity.COMMON, mage.cards.p.Paralyze.class));
         cards.add(new SetCardInfo("Pearled Unicorn", 215, Rarity.COMMON, mage.cards.p.PearledUnicorn.class));
+        cards.add(new SetCardInfo("Personal Incarnation", 216, Rarity.RARE, mage.cards.p.PersonalIncarnation.class));
         cards.add(new SetCardInfo("Pestilence", 29, Rarity.COMMON, mage.cards.p.Pestilence.class));
         cards.add(new SetCardInfo("Phantasmal Forces", 68, Rarity.UNCOMMON, mage.cards.p.PhantasmalForces.class));
         cards.add(new SetCardInfo("Phantasmal Terrain", 69, Rarity.COMMON, mage.cards.p.PhantasmalTerrain.class));


### PR DESCRIPTION
I don't have the redirect ability 100% correct. The code I patterned it after expects a target to redirect the damage from. But since this ability is not targeting something but rather redirecting the damage from itself to the owner. I assume we would automatically set itself as the target the damage is being redirected from but I'm not sure how to do that. And I assume the if line needs to be changed to fit.

```
public boolean applies(GameEvent event, Ability source, Game game) {
        if (event.getTargetId().equals(getTargetPointer().getFirst(game, source))) {
            TargetPlayer target = new TargetPlayer();
            target.add(game.getOwnerId(source.getSourceId()), game);
            redirectTarget = target;
            return true;
        }
        return false;
}
```

Also only the owner can activate the redirect ability. I am not sure how to do that. As I assume that means that the owner can activate the ability regardless of if he/she controls it. Also there appears to have been an issue with the line endings in some of the set files. On my end I set the line endings to LF but several of them must have been inadvertently changed to something else in someone elses merge or something. As I confirmed my local files have the LF line endings yet this commit has all the lines changed in some of the files.