### PR TITLE
Implement Council's Dilemma Cards

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CapitalPunishment.java
+++ b/Mage.Sets/src/mage/cards/c/CapitalPunishment.java
@@ -1,0 +1,121 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.c;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.dynamicvalue.common.StaticValue;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.SacrificeOpponentsEffect;
+import mage.abilities.effects.common.discard.DiscardEachPlayerEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.TargetController;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.game.Game;
+import mage.players.Player;
+
+/**
+ *
+ * @author JRHerlehy
+ */
+public class CapitalPunishment extends CardImpl {
+
+    public CapitalPunishment(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{B}{B}");
+        
+
+        // <i>Council's dilemma</i> &mdash; Starting with you, each player votes for death or taxes. Each opponent sacrifices a creature for each death vote and discards a card for each taxes vote.
+        this.getSpellAbility().addEffect(new CapitalPunishmentDilemmaEffect());
+    }
+
+    public CapitalPunishment(final CapitalPunishment card) {
+        super(card);
+    }
+
+    @Override
+    public CapitalPunishment copy() {
+        return new CapitalPunishment(this);
+    }
+}
+
+class CapitalPunishmentDilemmaEffect extends OneShotEffect {
+
+    public CapitalPunishmentDilemmaEffect() {
+        super(Outcome.Detriment);
+        this.staticText = "<i>Council's dilemma</i> — Starting with you, each player votes for death or taxes. Each opponent sacrifices a creature for each death vote and discards a card for each taxes vote";
+    }
+
+    public CapitalPunishmentDilemmaEffect(final CapitalPunishmentDilemmaEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+
+        //If no controller, exit out here and do not vote.
+        if (controller == null) return false;
+
+        int deathCount = 0, taxesCount = 0;
+
+        for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
+            Player player = game.getPlayer(playerId);
+            if (player != null) {
+                if (player.chooseUse(Outcome.Detriment, "Choose death?", source, game)) {
+                    deathCount++;
+                    game.informPlayers(player.getName() + " has voted for death");
+                } else {
+                    taxesCount++;
+                    game.informPlayers(player.getName() + " has voted for taxes");
+                }
+            }
+        }
+
+        if (deathCount > 0) {
+            Effect sacraficeEffect = new SacrificeOpponentsEffect(deathCount, new FilterControlledCreaturePermanent());
+            sacraficeEffect.apply(game, source);
+        }
+
+        if (taxesCount > 0) {
+            Effect discardEffect = new DiscardEachPlayerEffect(new StaticValue(taxesCount), false, TargetController.OPPONENT);
+            discardEffect.apply(game, source);
+        }
+
+        return true;
+    }
+
+    @Override
+    public CapitalPunishmentDilemmaEffect copy() {
+        return new CapitalPunishmentDilemmaEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/e/Expropriate.java
+++ b/Mage.Sets/src/mage/cards/e/Expropriate.java
@@ -28,21 +28,15 @@
 
 package mage.cards.e;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
 import mage.abilities.Ability;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.ExileSpellEffect;
-import mage.abilities.effects.common.continuous.GainControlTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
 import mage.filter.predicate.other.OwnerIdPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -53,8 +47,11 @@ import mage.target.Target;
 import mage.target.TargetPermanent;
 import mage.target.targetpointer.FixedTarget;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 /**
- *
  * @author JRHerlehy
  */
 public class Expropriate extends CardImpl {
@@ -150,6 +147,7 @@ class ExpropriateDilemmaEffect extends OneShotEffect {
                 ContinuousEffect effect = new ExpropriateControlEffect(controller.getId());
                 effect.setTargetPointer(new FixedTarget(permanent.getId()));
                 game.addEffect(effect, source);
+                game.informPlayers(controller.getName() + " gained control of " + permanent.getName() + " owned by " + game.getPlayer(permanent.getOwnerId()).getName());
             }
         } //End moneyCount if statement
 

--- a/Mage.Sets/src/mage/cards/e/Expropriate.java
+++ b/Mage.Sets/src/mage/cards/e/Expropriate.java
@@ -1,0 +1,193 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+
+package mage.cards.e;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.ContinuousEffectImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.ExileSpellEffect;
+import mage.abilities.effects.common.continuous.GainControlTargetEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.other.OwnerIdPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.game.turn.TurnMod;
+import mage.players.Player;
+import mage.players.Players;
+import mage.target.Target;
+import mage.target.TargetPermanent;
+import mage.target.targetpointer.FixedTarget;
+
+/**
+ *
+ * @author JRHerlehy
+ */
+public class Expropriate extends CardImpl {
+
+    public Expropriate(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{7}{U}{U}");
+
+        // <i>Council's dilemma</i> &mdash; Starting with you, each player votes for time or money. For each time vote, take an extra turn after this one. For each money vote, choose a permanent owned by the voter and gain control of it. Exile Expropriate
+        this.getSpellAbility().addEffect(new ExpropriateDilemmaEffect());
+        this.getSpellAbility().addEffect(ExileSpellEffect.getInstance());
+    }
+
+    public Expropriate(final Expropriate card) {
+        super(card);
+    }
+
+    @Override
+    public Expropriate copy() {
+        return new Expropriate(this);
+    }
+}
+
+class ExpropriateDilemmaEffect extends OneShotEffect {
+
+    public ExpropriateDilemmaEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "<i>Council's dilemma</i> — Starting with you, each player votes for time or money. For each time vote, take an extra turn after this one. For each money vote, choose a permanent owned by the voter and gain control of it.";
+    }
+
+    public ExpropriateDilemmaEffect(final ExpropriateDilemmaEffect effect) {
+        super(effect);
+    }
+
+    public ExpropriateDilemmaEffect(Outcome outcome) {
+        super(outcome);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+
+        //If not controller, exit out here and do not vote.
+        if (controller == null) return false;
+
+        int timeCount = 0, moneyCount = 0;
+        Players moneyVoters = new Players();
+
+        for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
+            Player player = game.getPlayer(playerId);
+            if (player != null) {
+                if (player.chooseUse(Outcome.Benefit, "Choose time?", source, game)) {
+                    timeCount++;
+                    game.informPlayers(player.getName() + " has voted for time");
+                } else {
+                    moneyCount++;
+                    moneyVoters.addPlayer(player);
+                    game.informPlayers(player.getName() + " has voted for money");
+                }
+            }
+        }
+
+        if (timeCount > 0) {
+            if (timeCount == 1) {
+                game.informPlayers(controller.getName() + " will take an extra turn");
+            } else {
+                game.informPlayers(controller.getName() + " will take " + timeCount + " extra turns");
+            }
+
+            do {
+                game.getState().getTurnMods().add(new TurnMod(source.getControllerId(), false));
+                timeCount--;
+            } while (timeCount > 0);
+        }
+
+        if (moneyCount > 0) {
+            List<Permanent> chosenCards = new ArrayList<>();
+
+            for (UUID playerId : moneyVoters.keySet()) {
+                FilterPermanent filter = new FilterPermanent("permanent owned by " + game.getPlayer(playerId).getName());
+                filter.add(new OwnerIdPredicate(playerId));
+
+                Target target = new TargetPermanent(filter);
+                target.setNotTarget(true);
+
+                if (controller.choose(Outcome.GainControl, target, source.getSourceId(), game)) {
+                    Permanent targetPermanent = game.getPermanent(target.getFirstTarget());
+
+                    if (targetPermanent != null) chosenCards.add(targetPermanent);
+                }
+            }
+
+            for (Permanent permanent : chosenCards) {
+                ContinuousEffect effect = new ExpropriateControlEffect(controller.getId());
+                effect.setTargetPointer(new FixedTarget(permanent.getId()));
+                game.addEffect(effect, source);
+            }
+        } //End moneyCount if statement
+
+        return true;
+    }
+
+    @Override
+    public ExpropriateDilemmaEffect copy() {
+        return new ExpropriateDilemmaEffect(this);
+    }
+
+}
+
+class ExpropriateControlEffect extends ContinuousEffectImpl {
+
+    private UUID controllerId;
+
+    public ExpropriateControlEffect(UUID controllerId) {
+        super(Duration.EndOfGame, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
+        this.controllerId = controllerId;
+    }
+
+    public ExpropriateControlEffect(final ExpropriateControlEffect effect) {
+        super(effect);
+        this.controllerId = effect.controllerId;
+    }
+
+    @Override
+    public ExpropriateControlEffect copy() {
+        return new ExpropriateControlEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanent(targetPointer.getFirst(game, source));
+        if (permanent != null && controllerId != null) {
+            return permanent.changeControllerId(controllerId, game);
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/l/LieutenantsOfTheGuard.java
+++ b/Mage.Sets/src/mage/cards/l/LieutenantsOfTheGuard.java
@@ -1,0 +1,126 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.l;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.game.permanent.token.SoldierToken;
+import mage.players.Player;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author JRHerlehy
+ */
+public class LieutenantsOfTheGuard extends CardImpl {
+
+    public LieutenantsOfTheGuard(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{W}");
+        
+        this.subtype.add("Human");
+        this.subtype.add("Soldier");
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(2);
+
+        // <i>Council's dilemma</i> &mdash; When Lieutenants of the Guard enters the battlefield, starting with you, each player votes for strength or numbers. Put a +1/+1 counter on Lieutenants of the Guard for each strength vote and put a 1/1 white Soldier creature token onto the battlefield for each numbers vote.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new LieutenantsOfTheGuardDilemmaEffect(), false, "<i>Council's dilemma</i> — "));
+    }
+
+    public LieutenantsOfTheGuard(final LieutenantsOfTheGuard card) {
+        super(card);
+    }
+
+    @Override
+    public LieutenantsOfTheGuard copy() {
+        return new LieutenantsOfTheGuard(this);
+    }
+}
+
+class LieutenantsOfTheGuardDilemmaEffect extends OneShotEffect {
+    public LieutenantsOfTheGuardDilemmaEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "starting with you, each player votes for strength or numbers. Put a +1/+1 counter on {this} for each strength vote and put a 1/1 white Soldier creature token onto the battlefield for each numbers vote.";
+    }
+
+    public LieutenantsOfTheGuardDilemmaEffect(final LieutenantsOfTheGuardDilemmaEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+
+        //If no controller, exit out here and do not vote.
+        if (controller == null) return false;
+
+        int strengthCount = 0, numbersCount = 0;
+
+        for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
+            Player player = game.getPlayer(playerId);
+            if (player != null) {
+                if (player.chooseUse(Outcome.BoostCreature, "Choose strength?", source, game)) {
+                    strengthCount++;
+                    game.informPlayers(player.getName() + " has voted for strength");
+                } else {
+                    numbersCount++;
+                    game.informPlayers(player.getName() + " has voted for numbers");
+                }
+            }
+        }
+
+        Permanent permanent = game.getPermanent(source.getSourceId());
+
+        //If strength received zero votes or the permanent is no longer on the battlefield, do not attempt to put P1P1 counters on it.
+        if (strengthCount > 0 && permanent != null) permanent.addCounters(CounterType.P1P1.createInstance(strengthCount), game);
+
+        //Create the appropriate number of tokens for the controller.
+        if (numbersCount > 0) {
+            Effect tokenEffect = new CreateTokenEffect(new SoldierToken(), numbersCount);
+            tokenEffect.apply(game, source);
+        }
+
+        return true;
+    }
+
+    @Override
+    public LieutenantsOfTheGuardDilemmaEffect copy() {
+        return new LieutenantsOfTheGuardDilemmaEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/m/MessengerJays.java
+++ b/Mage.Sets/src/mage/cards/m/MessengerJays.java
@@ -1,0 +1,128 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.m;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DrawDiscardControllerEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author JRHerlehy
+ */
+public class MessengerJays extends CardImpl {
+
+    public MessengerJays(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{U}");
+        
+        this.subtype.add("Bird");
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(1);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+        // <i>Council's dilemma &mdash; When Messenger Jays enters the battlefield, starting with you, each player votes for feather or quill. Put a +1/+1 counter on Messenger Jays for each feather vote and draw a card for each quill vote. For each card drawn this way, discard a card.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new MessengerJaysDilemmaEffect(), false, "<i>Council's dilemma</i> — "));
+    }
+
+    public MessengerJays(final MessengerJays card) {
+        super(card);
+    }
+
+    @Override
+    public MessengerJays copy() {
+        return new MessengerJays(this);
+    }
+}
+
+class MessengerJaysDilemmaEffect extends OneShotEffect {
+
+    public MessengerJaysDilemmaEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "starting with you, each player votes for feather or quill. Put a +1/+1 counter on {this} for each feather vote and draw a card for each quill vote. For each card drawn this way, discard a card.";
+    }
+
+    public MessengerJaysDilemmaEffect(final MessengerJaysDilemmaEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+
+        //If no controller, exit out here and do not vote.
+        if (controller == null) return false;
+
+        int featherCount = 0, quillCount = 0;
+
+        for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
+            Player player = game.getPlayer(playerId);
+            if (player != null) {
+                if (player.chooseUse(Outcome.BoostCreature, "Choose feather?", source, game)) {
+                    featherCount++;
+                    game.informPlayers(player.getName() + " has voted for feather");
+                } else {
+                    quillCount++;
+                    game.informPlayers(player.getName() + " has voted for quill");
+                }
+            }
+        }
+
+        Permanent permanent = game.getPermanent(source.getSourceId());
+
+        //If feathers received zero votes or the permanent is no longer on the battlefield, do not attempt to put P1P1 counter on it.
+        if (featherCount > 0 && permanent != null) permanent.addCounters(CounterType.P1P1.createInstance(featherCount), game);
+
+        //Only let the controller loot the appropriate amount of cards if it was voted for.
+        if (quillCount > 0) {
+            Effect lootCardsEffect = new DrawDiscardControllerEffect(quillCount, quillCount);
+            lootCardsEffect.apply(game, source);
+        }
+
+        return true;
+    }
+
+    @Override
+    public MessengerJaysDilemmaEffect copy() {
+        return new MessengerJaysDilemmaEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/o/OrchardElemental.java
+++ b/Mage.Sets/src/mage/cards/o/OrchardElemental.java
@@ -1,0 +1,121 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.o;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.GainLifeEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+
+/**
+ *
+ * @author JRHerlehy
+ */
+public class OrchardElemental extends CardImpl {
+
+    public OrchardElemental(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{G}");
+        
+        this.subtype.add("Elemental");
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(2);
+
+        // <i>Council's dilemma</i> &mdash When Orchard Elemental enters the battlefield, starting with you, each player votes for sprout or harvest. Put two +1/+1 counters on Orchard Elemental for each sprout vote. You gain 3 life for each harvest vote.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new OrchardElementalDilemmaEffect(), false, "<i>Council's dilemma</i> — "));
+    }
+
+    public OrchardElemental(final OrchardElemental card) {
+        super(card);
+    }
+
+    @Override
+    public OrchardElemental copy() {
+        return new OrchardElemental(this);
+    }
+}
+
+class OrchardElementalDilemmaEffect extends OneShotEffect {
+
+    public OrchardElementalDilemmaEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "starting with you, each player votes for sprout or harvest. Put two +1/+1 counters on Orchard Elemental for each sprout vote. You gain 3 life for each harvest vote";
+    }
+
+    public OrchardElementalDilemmaEffect(final OrchardElementalDilemmaEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+
+        if (controller == null) return false;
+
+        int sproutCount = 0, harvestCount = 0;
+
+        for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
+            Player player = game.getPlayer(playerId);
+            if (player != null) {
+                if (player.chooseUse(Outcome.BoostCreature, "Choose sprout?", source, game)) {
+                    sproutCount++;
+                    game.informPlayers(player.getName() + " has voted for sprout");
+                } else {
+                    harvestCount++;
+                    game.informPlayers(player.getName() + " has voted for harvest");
+                }
+            }
+        }
+
+        Permanent permanent = game.getPermanent(source.getSourceId());
+
+        if (sproutCount > 0 && permanent != null) permanent.addCounters(CounterType.P1P1.createInstance(sproutCount * 2), game);
+
+        if (harvestCount > 0) {
+            Effect gainLifeEffect = new GainLifeEffect(harvestCount * 3);
+            gainLifeEffect.apply(game, source);
+        }
+
+        return true;
+    }
+
+    @Override
+    public OrchardElementalDilemmaEffect copy() {
+        return new OrchardElementalDilemmaEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SelvalasStampede.java
+++ b/Mage.Sets/src/mage/cards/s/SelvalasStampede.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.s;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.*;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Zone;
+import mage.filter.common.FilterPermanentCard;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.common.TargetCardInHand;
+
+/**
+ *
+ * @author JRHerlehy
+ */
+public class SelvalasStampede extends CardImpl {
+
+    public SelvalasStampede(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{G}{G}");
+        
+
+        // <i>Council's dilemma</i> &mdash Starting with you, each player votes for wild or free. Reveal cards from the top of your library until you reveal a creature card for each wild vote. Put those creature cards onto the battlefield, then shuffle the rest into your library. You may put a permanent card from your hand onto the battlefield for each free vote.
+        this.getSpellAbility().addEffect(new SelvalasStampedeDilemmaEffect());
+    }
+
+    public SelvalasStampede(final SelvalasStampede card) {
+        super(card);
+    }
+
+    @Override
+    public SelvalasStampede copy() {
+        return new SelvalasStampede(this);
+    }
+}
+
+class SelvalasStampedeDilemmaEffect extends OneShotEffect {
+
+    public SelvalasStampedeDilemmaEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "<i>Council's dilemma</i> — Starting with you, each player votes for wild or free. Reveal cards from the top of your library until you reveal a creature card for each wild vote. Put those creature cards onto the battlefield, then shuffle the rest into your library. You may put a permanent card from your hand onto the battlefield for each free vote";
+    }
+
+    public SelvalasStampedeDilemmaEffect(final SelvalasStampedeDilemmaEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+
+        //If no controller, exit here and do not vote.
+        if (controller == null) return false;
+
+        int wildCount = 0, freeCount = 0;
+
+        for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
+            Player player = game.getPlayer(playerId);
+            if (player != null) {
+                if (player.chooseUse(Outcome.Benefit, "Choose wild?", source, game)) {
+                    wildCount++;
+                    game.informPlayers(player.getName() + " has voted for wild");
+                } else {
+                    freeCount++;
+                    game.informPlayers(player.getName() + " has voted for free");
+                }
+            }
+        }
+
+        if (wildCount > 0) {
+            Cards revealedCards = new CardsImpl();
+
+            while (wildCount > 0 && controller.getLibrary().size() > 0) {
+                Card card = controller.getLibrary().removeFromTop(game);
+                if (card.getCardType().contains(CardType.CREATURE)) {
+                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+                    wildCount--;
+                } else {
+                    revealedCards.add(card);
+                }
+            }
+
+            controller.revealCards("Selvala's Stampede", revealedCards, game);
+            controller.moveCards(revealedCards, Zone.LIBRARY, source, game);
+            controller.shuffleLibrary(source, game);
+        }
+
+        if (freeCount > 0) {
+            TargetCardInHand target = new TargetCardInHand(0, freeCount, new FilterPermanentCard("permanent cards"));
+            if (controller.choose(Outcome.PutCardInPlay, target, source.getSourceId(), game)) {
+                controller.moveCards(new CardsImpl(target.getTargets()), Zone.BATTLEFIELD, source, game);
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public SelvalasStampedeDilemmaEffect copy() {
+        return new SelvalasStampedeDilemmaEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/ConspiracyTakeTheCrown.java
+++ b/Mage.Sets/src/mage/sets/ConspiracyTakeTheCrown.java
@@ -74,6 +74,7 @@ public class ConspiracyTakeTheCrown extends ExpansionSet {
         cards.add(new SetCardInfo("Burning Wish", 152, Rarity.RARE, mage.cards.b.BurningWish.class));
         cards.add(new SetCardInfo("Caller of Gales", 103, Rarity.COMMON, mage.cards.c.CallerOfGales.class));
         cards.add(new SetCardInfo("Canal Courier", 28, Rarity.COMMON, mage.cards.c.CanalCourier.class));
+        cards.add(new SetCardInfo("Capital Punishment", 40, Rarity.RARE, mage.cards.c.CapitalPunishment.class));
         cards.add(new SetCardInfo("Carnage Gladiator", 199, Rarity.UNCOMMON, mage.cards.c.CarnageGladiator.class));
         cards.add(new SetCardInfo("Charmbreaker Devils", 153, Rarity.RARE, mage.cards.c.CharmbreakerDevils.class));
         cards.add(new SetCardInfo("Child of Night", 130, Rarity.COMMON, mage.cards.c.ChildOfNight.class));
@@ -155,11 +156,13 @@ public class ConspiracyTakeTheCrown extends ExpansionSet {
         cards.add(new SetCardInfo("Lace with Moonglove", 184, Rarity.COMMON, mage.cards.l.LaceWithMoonglove.class));
         cards.add(new SetCardInfo("Lay of the Land", 185, Rarity.COMMON, mage.cards.l.LayOfTheLand.class));
         cards.add(new SetCardInfo("Leovold, Emissary of Trest", 77, Rarity.MYTHIC, mage.cards.l.LeovoldEmissaryOfTrest.class));
+        cards.add(new SetCardInfo("Lieutenants of the Guard", 16, Rarity.COMMON, mage.cards.l.LieutenantsOfTheGuard.class));
         cards.add(new SetCardInfo("Manaplasm", 186, Rarity.UNCOMMON, mage.cards.m.Manaplasm.class));
         cards.add(new SetCardInfo("Marchesa's Decree", 44, Rarity.UNCOMMON, mage.cards.m.MarchesasDecree.class));
         cards.add(new SetCardInfo("Menagerie Liberator", 67, Rarity.COMMON, mage.cards.m.MenagerieLiberator.class));
         cards.add(new SetCardInfo("Merfolk Looter", 114, Rarity.UNCOMMON, mage.cards.m.MerfolkLooter.class));
         cards.add(new SetCardInfo("Merfolk Skyscout", 115, Rarity.UNCOMMON, mage.cards.m.MerfolkSkyscout.class));
+        cards.add(new SetCardInfo("Messenger Jays", 35, Rarity.COMMON, mage.cards.m.MessengerJays.class));
         cards.add(new SetCardInfo("Mnemonic Wall", 116, Rarity.COMMON, mage.cards.m.MnemonicWall.class));
         cards.add(new SetCardInfo("Murder", 143, Rarity.COMMON, mage.cards.m.Murder.class));
         cards.add(new SetCardInfo("Negate", 117, Rarity.COMMON, mage.cards.n.Negate.class));
@@ -168,6 +171,7 @@ public class ConspiracyTakeTheCrown extends ExpansionSet {
         cards.add(new SetCardInfo("Ogre Sentry", 168, Rarity.COMMON, mage.cards.o.OgreSentry.class));
         cards.add(new SetCardInfo("Omenspeaker", 118, Rarity.COMMON, mage.cards.o.Omenspeaker.class));
         cards.add(new SetCardInfo("Opaline Unicorn", 213, Rarity.COMMON, mage.cards.o.OpalineUnicorn.class));
+        cards.add(new SetCardInfo("Orchard Elemental", 68, Rarity.COMMON, mage.cards.o.OrchardElemental.class));
         cards.add(new SetCardInfo("Overrun", 189, Rarity.UNCOMMON, mage.cards.o.Overrun.class));
         cards.add(new SetCardInfo("Palace Jailer", 18, Rarity.UNCOMMON, mage.cards.p.PalaceJailer.class));
         cards.add(new SetCardInfo("Palace Sentinels", 19, Rarity.COMMON, mage.cards.p.PalaceSentinels.class));
@@ -192,6 +196,7 @@ public class ConspiracyTakeTheCrown extends ExpansionSet {
         cards.add(new SetCardInfo("Runed Servitor", 216, Rarity.UNCOMMON, mage.cards.r.RunedServitor.class));
         cards.add(new SetCardInfo("Sanctum Prelate", 23, Rarity.MYTHIC, mage.cards.s.SanctumPrelate.class));
         cards.add(new SetCardInfo("Sangromancer", 147, Rarity.RARE, mage.cards.s.Sangromancer.class));
+        cards.add(new SetCardInfo("Selvala's Stampede", 71, Rarity.RARE, mage.cards.s.SelvalasStampede.class));
         cards.add(new SetCardInfo("Selvala, Heart of the Wilds", 70, Rarity.MYTHIC, mage.cards.s.SelvalaHeartOfTheWilds.class));
         cards.add(new SetCardInfo("Serum Visions", 120, Rarity.UNCOMMON, mage.cards.s.SerumVisions.class));
         cards.add(new SetCardInfo("Shambling Goblin", 148, Rarity.COMMON, mage.cards.s.ShamblingGoblin.class));

--- a/Mage.Sets/src/mage/sets/ConspiracyTakeTheCrown.java
+++ b/Mage.Sets/src/mage/sets/ConspiracyTakeTheCrown.java
@@ -105,6 +105,7 @@ public class ConspiracyTakeTheCrown extends ExpansionSet {
         cards.add(new SetCardInfo("Evolving Wilds", 218, Rarity.COMMON, mage.cards.e.EvolvingWilds.class));
         cards.add(new SetCardInfo("Exotic Orchard", 219, Rarity.RARE, mage.cards.e.ExoticOrchard.class));
         cards.add(new SetCardInfo("Explosive Vegetation", 180, Rarity.UNCOMMON, mage.cards.e.ExplosiveVegetation.class));
+        cards.add(new SetCardInfo("Expropriate", 30, Rarity.MYTHIC, mage.cards.e.Expropriate.class));
         cards.add(new SetCardInfo("Fade into Antiquity", 181, Rarity.COMMON, mage.cards.f.FadeIntoAntiquity.class));
         cards.add(new SetCardInfo("Faith's Reward", 84, Rarity.RARE, mage.cards.f.FaithsReward.class));
         cards.add(new SetCardInfo("Farbog Boneflinger", 134, Rarity.UNCOMMON, mage.cards.f.FarbogBoneflinger.class));


### PR DESCRIPTION
Implement cards with the Council's Dilemma from Conspriacy: Take the
Crown expansion.

Card - Lieutenants of the Guard, Messenger Jays, Capital Punishment,
Orchard Elemental, and Selvala's Stampede.   Still missing is Expropriate.

Cards have been tested locally with up to three players.