### PR TITLE
spjspj - Fix for must attack effects not forcing attacks in multiplayer

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -52,6 +52,7 @@ import mage.abilities.costs.mana.ManaCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.costs.mana.PhyrexianManaCost;
 import mage.abilities.effects.RequirementEffect;
+import mage.abilities.effects.common.combat.AttacksIfAbleAllEffect;
 import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.Card;
 import mage.cards.Cards;
@@ -921,7 +922,10 @@ public class HumanPlayer extends PlayerImpl {
         FilterCreatureForCombat filter = filterCreatureForCombat.copy();
         filter.add(new ControllerIdPredicate(attackingPlayerId));
         while (!abort) {
-
+            if (passedAllTurns || passedUntilEndStepBeforeMyTurn
+                    || (!getUserData().getUserSkipPrioritySteps().isStopOnDeclareAttackersDuringSkipAction() && (passedTurn || passedTurnSkipStack || passedUntilEndOfTurn || passedUntilNextMain))) {
+                return;
+            }
             Map<String, Serializable> options = new HashMap<>();
 
             List<UUID> possibleAttackers = new ArrayList<>();
@@ -933,12 +937,6 @@ public class HumanPlayer extends PlayerImpl {
             options.put(Constants.Option.POSSIBLE_ATTACKERS, (Serializable) possibleAttackers);
             if (possibleAttackers.size() > 0) {
                 options.put(Constants.Option.SPECIAL_BUTTON, (Serializable) "All attack");
-                if (getUserData().getUserSkipPrioritySteps().isStopOnDeclareAttackersDuringSkipAction()) {
-                    resetPlayerPassedActions();
-                }
-            } else if (passedAllTurns || passedUntilEndStepBeforeMyTurn
-                    || (!getUserData().getUserSkipPrioritySteps().isStopOnDeclareAttackersDuringSkipAction() && (passedTurn || passedTurnSkipStack || passedUntilEndOfTurn || passedUntilNextMain))) {
-                return;
             }
 
             game.fireSelectEvent(playerId, "Select attackers", options);

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -52,7 +52,6 @@ import mage.abilities.costs.mana.ManaCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.costs.mana.PhyrexianManaCost;
 import mage.abilities.effects.RequirementEffect;
-import mage.abilities.effects.common.combat.AttacksIfAbleAllEffect;
 import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.Card;
 import mage.cards.Cards;

--- a/Mage/src/main/java/mage/game/combat/Combat.java
+++ b/Mage/src/main/java/mage/game/combat/Combat.java
@@ -339,8 +339,17 @@ public class Combat implements Serializable, Copyable<Combat> {
                     // No need to attack a special defender
                     if (defendersForcedToAttack.isEmpty()) {
                         if (defendersForcedToAttack.isEmpty()) {
-                            if (defendersCostlessAttackable.size() == 1) {
-                                player.declareAttacker(creature.getId(), defenders.iterator().next(), game, false);
+                            if (defendersCostlessAttackable.size() >= 1) {
+                                if (defenders.size() == 1) {
+                                    player.declareAttacker(creature.getId(), defenders.iterator().next(), game, false);
+                                } else {
+                                    TargetDefender target = new TargetDefender(defenders, creature.getId());
+                                    target.setRequired(true);
+                                    target.setTargetName("planeswalker or player for " + creature.getLogName() + " to attack");
+                                    if (player.chooseTarget(Outcome.Damage, target, null, game)) {
+                                        player.declareAttacker(creature.getId(), target.getFirstTarget(), game, false);
+                                    }
+                                }
                             }
                         } else {
                             TargetDefender target = new TargetDefender(defendersCostlessAttackable, creature.getId());


### PR DESCRIPTION
Revert to old way in HumanPlayer for skipping attacks, but force players to attack in multiplayer.  Previously, if forced to attack in multiplayer, was only checking if defendersCostlessAttackable.size == 1 (in combat.java) - so in multiplayer would not force player to actually attack.