### PR TITLE
Nettling Imp, TargetController and ControllerPredicate updated to include active choice

### DIFF
--- a/Mage.Sets/src/mage/cards/n/NettlingImp.java
+++ b/Mage.Sets/src/mage/cards/n/NettlingImp.java
@@ -78,7 +78,7 @@ public class NettlingImp extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {tap}: Choose target non-Wall creature the active player has controlled continuously since the beginning of the turn. That creature attacks this turn if able. If it doesn't, destroy it at the beginning of the next end step. Activate this ability only during an opponent's turn, before attackers are declared.
-        Ability ability = new ConditionalActivatedAbility(Zone.BATTLEFIELD, new AttacksIfAbleTargetEffect(Duration.EndOfTurn), new TapSourceCost(), new NettlingImpTurnCondition(), "{tap}: Choose target non-Wall creature the active player has controlled continuously since the beginning of the turn. That creature attacks this turn if able. If it doesn't, destroy it at the beginning of the next end step. Activate this ability only during an opponent's turn, before attackers are declared.");
+        Ability ability = new ConditionalActivatedAbility(Zone.BATTLEFIELD, new AttacksIfAbleTargetEffect(Duration.EndOfTurn), new TapSourceCost(), new NettlingImpTurnCondition(), "{T}: Choose target non-Wall creature the active player has controlled continuously since the beginning of the turn. That creature attacks this turn if able. If it doesn't, destroy it at the beginning of the next end step. Activate this ability only during an opponent's turn, before attackers are declared.");
         ability.addEffect(new ConditionalOneShotEffect(new DestroyTargetAtBeginningOfNextEndStepEffect(), new InvertCondition(new TargetAttackedThisTurnCondition())));
         ability.addTarget(new TargetCreaturePermanent(filter));
         this.addAbility(ability, new AttackedThisTurnWatcher());
@@ -100,7 +100,7 @@ class NettlingImpTurnCondition implements Condition {
     @Override
     public boolean apply(Game game, Ability source) {
 	Player activePlayer = game.getPlayer(game.getActivePlayerId());
-        return activePlayer != null && game.getPlayer(game.getActivePlayerId()).hasOpponent(source.getControllerId(), game) && game.getPhase().getStep().getType().getIndex() < 5;
+        return activePlayer != null && activePlayer.hasOpponent(source.getControllerId(), game) && game.getPhase().getStep().getType().getIndex() < 5;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/n/NettlingImp.java
+++ b/Mage.Sets/src/mage/cards/n/NettlingImp.java
@@ -50,6 +50,7 @@ import mage.filter.predicate.mageobject.SubtypePredicate;
 import mage.filter.predicate.permanent.ControlledFromStartOfControllerTurnPredicate;
 import mage.filter.predicate.permanent.ControllerPredicate;
 import mage.game.Game;
+import mage.players.Player;
 import mage.target.common.TargetCreaturePermanent;
 import mage.watchers.common.AttackedThisTurnWatcher;
 
@@ -65,6 +66,7 @@ public class NettlingImp extends CardImpl {
         filter.add(Predicates.not(new SubtypePredicate("Wall")));
 	filter.add(new ControlledFromStartOfControllerTurnPredicate());
         filter.add(new ControllerPredicate(TargetController.ACTIVE));
+        filter.setMessage("non-Wall creature the active player has controlled continuously since the beginning of the turn.");
     }
 
 
@@ -76,7 +78,7 @@ public class NettlingImp extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {tap}: Choose target non-Wall creature the active player has controlled continuously since the beginning of the turn. That creature attacks this turn if able. If it doesn't, destroy it at the beginning of the next end step. Activate this ability only during an opponent's turn, before attackers are declared.
-        Ability ability = new ConditionalActivatedAbility(Zone.BATTLEFIELD, new AttacksIfAbleTargetEffect(Duration.EndOfTurn), new TapSourceCost(), new TurnCondition(), "{tap}: Choose target non-Wall creature the active player has controlled continuously since the beginning of the turn. That creature attacks this turn if able. If it doesn't, destroy it at the beginning of the next end step. Activate this ability only during an opponent's turn, before attackers are declared.");
+        Ability ability = new ConditionalActivatedAbility(Zone.BATTLEFIELD, new AttacksIfAbleTargetEffect(Duration.EndOfTurn), new TapSourceCost(), new NettlingImpTurnCondition(), "{tap}: Choose target non-Wall creature the active player has controlled continuously since the beginning of the turn. That creature attacks this turn if able. If it doesn't, destroy it at the beginning of the next end step. Activate this ability only during an opponent's turn, before attackers are declared.");
         ability.addEffect(new ConditionalOneShotEffect(new DestroyTargetAtBeginningOfNextEndStepEffect(), new InvertCondition(new TargetAttackedThisTurnCondition())));
         ability.addTarget(new TargetCreaturePermanent(filter));
         this.addAbility(ability, new AttackedThisTurnWatcher());
@@ -93,12 +95,12 @@ public class NettlingImp extends CardImpl {
     }
 }
 
-class TurnCondition implements Condition {
+class NettlingImpTurnCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-	UUID activePlayerId = game.getActivePlayerId();
-        return activePlayerId != null && game.getPlayer(activePlayerId).hasOpponent(source.getControllerId(), game) && game.getPhase().getStep().getType().getIndex() < 5;
+	Player activePlayer = game.getPlayer(game.getActivePlayerId());
+        return activePlayer != null && game.getPlayer(game.getActivePlayerId()).hasOpponent(source.getControllerId(), game) && game.getPhase().getStep().getType().getIndex() < 5;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/n/NettlingImp.java
+++ b/Mage.Sets/src/mage/cards/n/NettlingImp.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.n;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.condition.Condition;
+import mage.abilities.condition.InvertCondition;
+import mage.abilities.condition.common.TargetAttackedThisTurnCondition;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.decorator.ConditionalActivatedAbility;
+import mage.abilities.decorator.ConditionalOneShotEffect;
+import mage.abilities.effects.common.DestroyTargetAtBeginningOfNextEndStepEffect;
+import mage.abilities.effects.common.combat.AttacksIfAbleTargetEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.TargetController;
+import mage.constants.Zone;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.SubtypePredicate;
+import mage.filter.predicate.permanent.ControlledFromStartOfControllerTurnPredicate;
+import mage.filter.predicate.permanent.ControllerPredicate;
+import mage.game.Game;
+import mage.target.common.TargetCreaturePermanent;
+import mage.watchers.common.AttackedThisTurnWatcher;
+
+/**
+ *
+ * @author MTGfan
+ */
+public class NettlingImp extends CardImpl {
+    
+    final static FilterCreaturePermanent filter = new FilterCreaturePermanent("non-Wall");
+
+    static {
+        filter.add(Predicates.not(new SubtypePredicate("Wall")));
+	filter.add(new ControlledFromStartOfControllerTurnPredicate());
+        filter.add(new ControllerPredicate(TargetController.ACTIVE));
+    }
+
+
+    public NettlingImp(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{B}");
+        
+        this.subtype.add("Imp");
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(1);
+
+        // {tap}: Choose target non-Wall creature the active player has controlled continuously since the beginning of the turn. That creature attacks this turn if able. If it doesn't, destroy it at the beginning of the next end step. Activate this ability only during an opponent's turn, before attackers are declared.
+        Ability ability = new ConditionalActivatedAbility(Zone.BATTLEFIELD, new AttacksIfAbleTargetEffect(Duration.EndOfTurn), new TapSourceCost(), new TurnCondition(), "{tap}: Choose target non-Wall creature the active player has controlled continuously since the beginning of the turn. That creature attacks this turn if able. If it doesn't, destroy it at the beginning of the next end step. Activate this ability only during an opponent's turn, before attackers are declared.");
+        ability.addEffect(new ConditionalOneShotEffect(new DestroyTargetAtBeginningOfNextEndStepEffect(), new InvertCondition(new TargetAttackedThisTurnCondition())));
+        ability.addTarget(new TargetCreaturePermanent(filter));
+        this.addAbility(ability, new AttackedThisTurnWatcher());
+        
+    }
+
+    public NettlingImp(final NettlingImp card) {
+        super(card);
+    }
+
+    @Override
+    public NettlingImp copy() {
+        return new NettlingImp(this);
+    }
+}
+
+class TurnCondition implements Condition {
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+	UUID activePlayerId = game.getActivePlayerId();
+        return activePlayerId != null && game.getPlayer(activePlayerId).hasOpponent(source.getControllerId(), game) && game.getPhase().getStep().getType().getIndex() < 5;
+    }
+
+    @Override
+    public String toString() {
+        return "";
+    }
+}

--- a/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
@@ -183,6 +183,7 @@ public class LimitedEditionAlpha extends ExpansionSet {
         cards.add(new SetCardInfo("Mox Sapphire", 265, Rarity.RARE, mage.cards.m.MoxSapphire.class));
         cards.add(new SetCardInfo("Natural Selection", 121, Rarity.RARE, mage.cards.n.NaturalSelection.class));
         cards.add(new SetCardInfo("Nether Shadow", 25, Rarity.RARE, mage.cards.n.NetherShadow.class));
+        cards.add(new SetCardInfo("Nettling Imp", 26, Rarity.UNCOMMON, mage.cards.n.NettlingImp.class));
         cards.add(new SetCardInfo("Nevinyrral's Disk", 266, Rarity.RARE, mage.cards.n.NevinyrralsDisk.class));
         cards.add(new SetCardInfo("Nightmare", 27, Rarity.RARE, mage.cards.n.Nightmare.class));
         cards.add(new SetCardInfo("Northern Paladin", 213, Rarity.RARE, mage.cards.n.NorthernPaladin.class));

--- a/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
@@ -187,6 +187,7 @@ public class LimitedEditionBeta extends ExpansionSet {
         cards.add(new SetCardInfo("Mox Sapphire", 267, Rarity.RARE, mage.cards.m.MoxSapphire.class));
         cards.add(new SetCardInfo("Natural Selection", 121, Rarity.RARE, mage.cards.n.NaturalSelection.class));
         cards.add(new SetCardInfo("Nether Shadow", 25, Rarity.RARE, mage.cards.n.NetherShadow.class));
+        cards.add(new SetCardInfo("Nettling Imp", 26, Rarity.UNCOMMON, mage.cards.n.NettlingImp.class));
         cards.add(new SetCardInfo("Nevinyrral's Disk", 268, Rarity.RARE, mage.cards.n.NevinyrralsDisk.class));
         cards.add(new SetCardInfo("Nightmare", 27, Rarity.RARE, mage.cards.n.Nightmare.class));
         cards.add(new SetCardInfo("Northern Paladin", 215, Rarity.RARE, mage.cards.n.NorthernPaladin.class));

--- a/Mage.Sets/src/mage/sets/RevisedEdition.java
+++ b/Mage.Sets/src/mage/sets/RevisedEdition.java
@@ -193,6 +193,7 @@ public class RevisedEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Mountain", 291, Rarity.LAND, mage.cards.basiclands.Mountain.class, new CardGraphicInfo(null, true)));
         cards.add(new SetCardInfo("Mountain", 292, Rarity.LAND, mage.cards.basiclands.Mountain.class, new CardGraphicInfo(null, true)));
         cards.add(new SetCardInfo("Nether Shadow", 26, Rarity.RARE, mage.cards.n.NetherShadow.class));
+        cards.add(new SetCardInfo("Nettling Imp", 27, Rarity.UNCOMMON, mage.cards.n.NettlingImp.class));
         cards.add(new SetCardInfo("Nevinyrral's Disk", 267, Rarity.RARE, mage.cards.n.NevinyrralsDisk.class));
         cards.add(new SetCardInfo("Nightmare", 28, Rarity.RARE, mage.cards.n.Nightmare.class));
         cards.add(new SetCardInfo("Northern Paladin", 213, Rarity.RARE, mage.cards.n.NorthernPaladin.class));

--- a/Mage.Sets/src/mage/sets/UnlimitedEdition.java
+++ b/Mage.Sets/src/mage/sets/UnlimitedEdition.java
@@ -187,6 +187,7 @@ public class UnlimitedEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Mox Sapphire", 266, Rarity.RARE, mage.cards.m.MoxSapphire.class));
         cards.add(new SetCardInfo("Natural Selection", 121, Rarity.RARE, mage.cards.n.NaturalSelection.class));
         cards.add(new SetCardInfo("Nether Shadow", 25, Rarity.RARE, mage.cards.n.NetherShadow.class));
+        cards.add(new SetCardInfo("Nettling Imp", 26, Rarity.UNCOMMON, mage.cards.n.NettlingImp.class));
         cards.add(new SetCardInfo("Nevinyrral's Disk", 267, Rarity.RARE, mage.cards.n.NevinyrralsDisk.class));
         cards.add(new SetCardInfo("Nightmare", 27, Rarity.RARE, mage.cards.n.Nightmare.class));
         cards.add(new SetCardInfo("Northern Paladin", 214, Rarity.RARE, mage.cards.n.NorthernPaladin.class));

--- a/Mage/src/main/java/mage/abilities/condition/common/TargetAttackedThisTurnCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/TargetAttackedThisTurnCondition.java
@@ -25,63 +25,24 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.filter.predicate.permanent;
+package mage.abilities.condition.common;
 
-import mage.constants.TargetController;
-import mage.filter.predicate.ObjectPlayer;
-import mage.filter.predicate.ObjectPlayerPredicate;
-import mage.game.Controllable;
+import mage.abilities.Ability;
+import mage.abilities.condition.Condition;
 import mage.game.Game;
-
-import java.util.UUID;
+import mage.game.permanent.Permanent;
+import mage.watchers.common.AttackedThisTurnWatcher;
 
 /**
  *
- * @author North
+ * @author MTGfan
  */
-public class ControllerPredicate implements ObjectPlayerPredicate<ObjectPlayer<Controllable>> {
-
-    private final TargetController controller;
-
-    public ControllerPredicate(TargetController controller) {
-        this.controller = controller;
-    }
+public class TargetAttackedThisTurnCondition implements Condition {
 
     @Override
-    public boolean apply(ObjectPlayer<Controllable> input, Game game) {
-        Controllable object = input.getObject();
-        UUID playerId = input.getPlayerId();
-
-        switch (controller) {
-            case YOU:
-                if (object.getControllerId().equals(playerId)) {
-                    return true;
-                }
-                break;
-            case OPPONENT:
-                if (!object.getControllerId().equals(playerId) &&
-                        game.getPlayer(playerId).hasOpponent(object.getControllerId(), game)) {
-                    return true;
-                }
-                break;
-            case NOT_YOU:
-                if (!object.getControllerId().equals(playerId)) {
-                    return true;
-                }
-                break;
-            case ACTIVE:
-                if (object.getControllerId().equals(game.getActivePlayerId())) {
-                    return true;
-                }
-            case ANY:
-                return true;
-        }
-
-        return false;
-    }
-
-    @Override
-    public String toString() {
-        return "TargetController(" + controller.toString() + ')';
+    public boolean apply(Game game, Ability source) {
+        Permanent creature = game.getPermanentOrLKIBattlefield(source.getTargets().getFirstTarget());
+        AttackedThisTurnWatcher watcher = (AttackedThisTurnWatcher) game.getState().getWatchers().get("AttackedThisTurn");
+        return watcher.getAttackedThisTurnCreatures().contains(creature.getId());
     }
 }

--- a/Mage/src/main/java/mage/constants/TargetController.java
+++ b/Mage/src/main/java/mage/constants/TargetController.java
@@ -6,5 +6,5 @@ package mage.constants;
  */
 public enum TargetController {
 
-    ANY, YOU, NOT_YOU, OPPONENT, OWNER, CONTROLLER_ATTACHED_TO, NEXT
+    ACTIVE, ANY, YOU, NOT_YOU, OPPONENT, OWNER, CONTROLLER_ATTACHED_TO, NEXT
 }

--- a/Mage/src/main/java/mage/filter/predicate/permanent/ControlledFromStartOfControllerTurnPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/ControlledFromStartOfControllerTurnPredicate.java
@@ -27,61 +27,23 @@
  */
 package mage.filter.predicate.permanent;
 
-import mage.constants.TargetController;
-import mage.filter.predicate.ObjectPlayer;
-import mage.filter.predicate.ObjectPlayerPredicate;
-import mage.game.Controllable;
+import mage.filter.predicate.Predicate;
 import mage.game.Game;
-
-import java.util.UUID;
+import mage.game.permanent.Permanent;
 
 /**
  *
- * @author North
+ * @author MTGfan
  */
-public class ControllerPredicate implements ObjectPlayerPredicate<ObjectPlayer<Controllable>> {
-
-    private final TargetController controller;
-
-    public ControllerPredicate(TargetController controller) {
-        this.controller = controller;
-    }
+public class ControlledFromStartOfControllerTurnPredicate implements Predicate<Permanent> {
 
     @Override
-    public boolean apply(ObjectPlayer<Controllable> input, Game game) {
-        Controllable object = input.getObject();
-        UUID playerId = input.getPlayerId();
-
-        switch (controller) {
-            case YOU:
-                if (object.getControllerId().equals(playerId)) {
-                    return true;
-                }
-                break;
-            case OPPONENT:
-                if (!object.getControllerId().equals(playerId) &&
-                        game.getPlayer(playerId).hasOpponent(object.getControllerId(), game)) {
-                    return true;
-                }
-                break;
-            case NOT_YOU:
-                if (!object.getControllerId().equals(playerId)) {
-                    return true;
-                }
-                break;
-            case ACTIVE:
-                if (object.getControllerId().equals(game.getActivePlayerId())) {
-                    return true;
-                }
-            case ANY:
-                return true;
-        }
-
-        return false;
+    public boolean apply(Permanent input, Game game) {
+        return input.wasControlledFromStartOfControllerTurn();
     }
 
     @Override
     public String toString() {
-        return "TargetController(" + controller.toString() + ')';
+        return "has controlled since the beginning of the turn";
     }
 }

--- a/Mage/src/main/java/mage/filter/predicate/permanent/ControllerPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/ControllerPredicate.java
@@ -73,6 +73,7 @@ public class ControllerPredicate implements ObjectPlayerPredicate<ObjectPlayer<C
                 if (object.getControllerId().equals(game.getActivePlayerId())) {
                     return true;
                 }
+                break;
             case ANY:
                 return true;
         }


### PR DESCRIPTION
The only concern I have is with the card text is "the active player". My assumption is that this means that the controller of Nettling Imp can only use the ability against non-wall creatures that the current opponent controlled since the beginning of that opponents turn. If so then I don't have the code right for the active player portion of ControllerPredicate. As it stands currently Nettling Imp is able to target creatures the controller of Nettling Imp controls. And I'm not sure exactly how to change it.

Tested with Demonic Torment, Mons Goblin Raiders and Wall of Fire. Card functions as expected and can't target newly summoned creature or the wall. And when a creature with Demonic Torment on it is selected as the target DT prevents that creature from attacking and Nettling Imp's ability destroys that creature due to it not attacking.