### PR TITLE
CardRepository.findCard SQL query optimisation

### DIFF
--- a/Mage/src/main/java/mage/cards/repository/CardRepository.java
+++ b/Mage/src/main/java/mage/cards/repository/CardRepository.java
@@ -37,19 +37,16 @@ import com.j256.ormlite.stmt.Where;
 import com.j256.ormlite.support.ConnectionSource;
 import com.j256.ormlite.support.DatabaseConnection;
 import com.j256.ormlite.table.TableUtils;
-import java.io.File;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.Callable;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SetType;
 import mage.util.RandomUtil;
 import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.concurrent.Callable;
 
 /**
  *
@@ -65,11 +62,9 @@ public enum CardRepository {
     private static final long CARD_DB_VERSION = 48;
     // raise this if new cards were added to the server
     private static final long CARD_CONTENT_VERSION = 65;
-
+    private final TreeSet<String> landTypes = new TreeSet<>();
     private Dao<CardInfo, Object> cardDao;
     private Set<String> classNames;
-
-    private final TreeSet<String> landTypes = new TreeSet();
 
     CardRepository() {
         File file = new File("db");
@@ -315,7 +310,7 @@ public enum CardRepository {
     public CardInfo findCard(String setCode, String cardNumber) {
         try {
             QueryBuilder<CardInfo, Object> queryBuilder = cardDao.queryBuilder();
-            queryBuilder.where().eq("setCode", new SelectArg(setCode)).and().eq("cardNumber", cardNumber).and().eq("nightCard", false);
+            queryBuilder.limit(1L).where().eq("setCode", new SelectArg(setCode)).and().eq("cardNumber", cardNumber).and().eq("nightCard", false);
             List<CardInfo> result = cardDao.query(queryBuilder.prepare());
             if (!result.isEmpty()) {
                 return result.get(0);

--- a/Mage/src/main/java/mage/cards/repository/CardScanner.java
+++ b/Mage/src/main/java/mage/cards/repository/CardScanner.java
@@ -40,8 +40,9 @@ import java.util.List;
  */
 public class CardScanner {
 
-    private static final Logger logger = Logger.getLogger(CardScanner.class);
     public static boolean scanned = false;
+
+    private static final Logger logger = Logger.getLogger(CardScanner.class);
 
     public static void scan() {
         if (scanned) {

--- a/Mage/src/main/java/mage/cards/repository/CardScanner.java
+++ b/Mage/src/main/java/mage/cards/repository/CardScanner.java
@@ -28,11 +28,11 @@
 
 package mage.cards.repository;
 
-import mage.cards.*;
-import org.apache.log4j.Logger;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import mage.cards.*;
+import org.apache.log4j.Logger;
 
 /**
  *
@@ -62,7 +62,7 @@ public class CardScanner {
                 if (CardRepository.instance.findCard(set.getCode(), setInfo.getCardNumber()) == null) {
                     Card card = CardImpl.createCard(setInfo.getCardClass(),
                             new CardSetInfo(setInfo.getName(), set.getCode(), setInfo.getCardNumber(),
-                                    setInfo.getRarity(), setInfo.getGraphicInfo()));
+                                            setInfo.getRarity(), setInfo.getGraphicInfo()));
                     if (card != null) {
                         cardsToAdd.add(new CardInfo(card));
                         if (card instanceof SplitCard) {


### PR DESCRIPTION
There will be always 0 or 1 distinct card. If we don't limit this query it will find a card, and still will go through the whole table, which is unneccesary and have performance impact.
Also changed landTypes declaration from new TreeSet() to  new TreeSet<>() to avoid "unchecked cast" warning in IDE.