### PR TITLE
Guardian Angel and added Dynamic Value constructor to PreventDamageToTargetEffect

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GuardianAngel.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianAngel.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.g;
+
+import java.util.UUID;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.dynamicvalue.common.ManacostVariableValue;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.PreventDamageToTargetEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.TimingRule;
+import mage.constants.Zone;
+import mage.target.common.TargetCreatureOrPlayer;
+import mage.target.targetpointer.FixedTarget;
+
+/**
+ *
+ * @author MTGfan
+ */
+public class GuardianAngel extends CardImpl {
+
+    public GuardianAngel(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{X}{W}");
+        
+
+        // Prevent the next X damage that would be dealt to target creature or player this turn. Until end of turn, you may pay {1} any time you could cast an instant. If you do, prevent the next 1 damage that would be dealt to that creature or player this turn.
+        ManacostVariableValue manaX = new ManacostVariableValue();
+        Effect effect = new PreventDamageToTargetEffect(Duration.EndOfTurn, false, true, manaX);
+        effect.setText("Prevent the next X damage that would be dealt to target creature or player this turn.");
+        this.getSpellAbility().addEffect(effect);
+        this.getSpellAbility().addTarget(new TargetCreatureOrPlayer());
+        Effect effect2 = new PreventDamageToTargetEffect(Duration.EndOfTurn, 1);
+        effect2.setTargetPointer(new FixedTarget(this.getSpellAbility().getFirstTarget()));
+        effect2.setText(" Until end of turn, you may pay {1} any time you could cast an instant. If you do, prevent the next 1 damage that would be dealt to that creature or player this turn.");
+        SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.ALL, effect2, new GenericManaCost(1));
+        ability.setTiming(TimingRule.INSTANT);
+        this.addAbility(ability);
+    }
+
+    public GuardianAngel(final GuardianAngel card) {
+        super(card);
+    }
+
+    @Override
+    public GuardianAngel copy() {
+        return new GuardianAngel(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
@@ -122,6 +122,7 @@ public class LimitedEditionAlpha extends ExpansionSet {
         cards.add(new SetCardInfo("Gray Ogre", 157, Rarity.COMMON, mage.cards.g.GrayOgre.class));
         cards.add(new SetCardInfo("Green Ward", 204, Rarity.UNCOMMON, mage.cards.g.GreenWard.class));
         cards.add(new SetCardInfo("Grizzly Bears", 108, Rarity.COMMON, mage.cards.g.GrizzlyBears.class));
+        cards.add(new SetCardInfo("Guardian Angel", 205, Rarity.COMMON, mage.cards.g.GuardianAngel.class));
         cards.add(new SetCardInfo("Healing Salve", 206, Rarity.COMMON, mage.cards.h.HealingSalve.class));
         cards.add(new SetCardInfo("Hill Giant", 158, Rarity.COMMON, mage.cards.h.HillGiant.class));
         cards.add(new SetCardInfo("Holy Armor", 207, Rarity.COMMON, mage.cards.h.HolyArmor.class));

--- a/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
@@ -124,6 +124,7 @@ public class LimitedEditionBeta extends ExpansionSet {
         cards.add(new SetCardInfo("Gray Ogre", 158, Rarity.COMMON, mage.cards.g.GrayOgre.class));
         cards.add(new SetCardInfo("Green Ward", 206, Rarity.UNCOMMON, mage.cards.g.GreenWard.class));
         cards.add(new SetCardInfo("Grizzly Bears", 108, Rarity.COMMON, mage.cards.g.GrizzlyBears.class));
+        cards.add(new SetCardInfo("Guardian Angel", 207, Rarity.COMMON, mage.cards.g.GuardianAngel.class));
         cards.add(new SetCardInfo("Healing Salve", 208, Rarity.COMMON, mage.cards.h.HealingSalve.class));
         cards.add(new SetCardInfo("Hill Giant", 159, Rarity.COMMON, mage.cards.h.HillGiant.class));
         cards.add(new SetCardInfo("Holy Armor", 209, Rarity.COMMON, mage.cards.h.HolyArmor.class));

--- a/Mage.Sets/src/mage/sets/RevisedEdition.java
+++ b/Mage.Sets/src/mage/sets/RevisedEdition.java
@@ -133,6 +133,7 @@ public class RevisedEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Gray Ogre", 156, Rarity.COMMON, mage.cards.g.GrayOgre.class));
         cards.add(new SetCardInfo("Green Ward", 204, Rarity.UNCOMMON, mage.cards.g.GreenWard.class));
         cards.add(new SetCardInfo("Grizzly Bears", 108, Rarity.COMMON, mage.cards.g.GrizzlyBears.class));
+        cards.add(new SetCardInfo("Guardian Angel", 205, Rarity.COMMON, mage.cards.g.GuardianAngel.class));
         cards.add(new SetCardInfo("Healing Salve", 206, Rarity.COMMON, mage.cards.h.HealingSalve.class));
         cards.add(new SetCardInfo("Hill Giant", 157, Rarity.COMMON, mage.cards.h.HillGiant.class));
         cards.add(new SetCardInfo("Holy Armor", 207, Rarity.COMMON, mage.cards.h.HolyArmor.class));

--- a/Mage.Sets/src/mage/sets/UnlimitedEdition.java
+++ b/Mage.Sets/src/mage/sets/UnlimitedEdition.java
@@ -124,6 +124,7 @@ public class UnlimitedEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Gray Ogre", 157, Rarity.COMMON, mage.cards.g.GrayOgre.class));
         cards.add(new SetCardInfo("Green Ward", 205, Rarity.UNCOMMON, mage.cards.g.GreenWard.class));
         cards.add(new SetCardInfo("Grizzly Bears", 108, Rarity.COMMON, mage.cards.g.GrizzlyBears.class));
+        cards.add(new SetCardInfo("Guardian Angel", 206, Rarity.COMMON, mage.cards.g.GuardianAngel.class));
         cards.add(new SetCardInfo("Healing Salve", 207, Rarity.COMMON, mage.cards.h.HealingSalve.class));
         cards.add(new SetCardInfo("Hill Giant", 158, Rarity.COMMON, mage.cards.h.HillGiant.class));
         cards.add(new SetCardInfo("Holy Armor", 208, Rarity.COMMON, mage.cards.h.HolyArmor.class));

--- a/Mage/src/main/java/mage/abilities/effects/common/PreventDamageToTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/PreventDamageToTargetEffect.java
@@ -31,6 +31,7 @@ package mage.abilities.effects.common;
 import mage.constants.Duration;
 import mage.abilities.Ability;
 import mage.abilities.Mode;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.PreventionEffectImpl;
 import mage.game.Game;
 import mage.game.events.GameEvent;
@@ -55,6 +56,10 @@ public class PreventDamageToTargetEffect extends PreventionEffectImpl {
     
     public PreventDamageToTargetEffect(Duration duration, int amount, boolean onlyCombat) {
         super(duration, amount, onlyCombat);
+    }
+    
+    public PreventDamageToTargetEffect(Duration duration, boolean onlyCombat, boolean consumable, DynamicValue amountToPreventDynamic) {
+        super(duration, 0, onlyCombat, consumable, amountToPreventDynamic);
     }
     
     public PreventDamageToTargetEffect(final PreventDamageToTargetEffect effect) {


### PR DESCRIPTION
If instead of `effect2.setTargetPointer(new FixedTarget(this.getSpellAbility().getFirstTarget()));` the code is `ability.addTarget(new TargetCreatureOrPlayer());` just before the addability line. The activated ability correctly prevents damage but would ask the player to pick the target which is incorrect as the activated ability is supposed to use the target chosen when the card was cast. Because I can't seem to get netbeans to show me any debug info such as variable values and breakpoints and what not I have no idea what exactly is happening. As far as I can tell by referencing other cards that use the same selected target in more than one ability `effect2.setTargetPointer(new FixedTarget(this.getSpellAbility().getFirstTarget()));` should have the correct value. But since playing out a scenario with the card in a match no damage is being prevented after activating the second part, I don't know if the issue is with this line of code or code in PreventDamageToTargetEffect and related.

Also unless the card has been cast, the second part should not be available as a choice. However if zone is set to graveyard, that excludes the possibility the player returns Guardian Angel to hand and still has the valid option to activate the second part. So I'm not sure what should be done with this dilemma.