### PR TITLE
[TOKEN] Goblin with Haste

### DIFF
--- a/Mage/src/main/java/mage/game/permanent/token/GoblinTokenWithHaste.java
+++ b/Mage/src/main/java/mage/game/permanent/token/GoblinTokenWithHaste.java
@@ -41,5 +41,6 @@ public class GoblinTokenWithHaste extends GoblinToken {
     public GoblinTokenWithHaste() {
         super();
         addAbility(HasteAbility.getInstance());
+        this.description = "1/1 red Goblin creature token with haste";
     }
 }


### PR DESCRIPTION
The 1/1 red goblin with haste token was failing to specify that it was a token with haste is the fallback autotext.