### PR TITLE
Dominator drone's trigger should be life loss, while was implemented as damage.

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DominatorDrone.java
+++ b/Mage.Sets/src/mage/cards/d/DominatorDrone.java
@@ -34,7 +34,7 @@ import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.condition.common.PermanentsOnTheBattlefieldCondition;
 import mage.abilities.condition.common.PermanentsOnTheBattlefieldCondition.CountType;
 import mage.abilities.decorator.ConditionalTriggeredAbility;
-import mage.abilities.effects.common.DamagePlayersEffect;
+import mage.abilities.effects.common.LoseLifeOpponentsEffect;
 import mage.abilities.keyword.DevoidAbility;
 import mage.abilities.keyword.IngestAbility;
 import mage.cards.CardImpl;
@@ -72,7 +72,7 @@ public class DominatorDrone extends CardImpl {
         this.addAbility(new IngestAbility());
 
         // When Dominator Drone enters the battlefield, if you control another colorless creature, each opponent loses 2 life.
-        TriggeredAbility triggeredAbility = new EntersBattlefieldTriggeredAbility(new DamagePlayersEffect(2, TargetController.OPPONENT));
+        TriggeredAbility triggeredAbility = new EntersBattlefieldTriggeredAbility(new LoseLifeOpponentsEffect(2));
         this.addAbility(new ConditionalTriggeredAbility(
                 triggeredAbility,
                 new PermanentsOnTheBattlefieldCondition(filter, CountType.MORE_THAN, 0),


### PR DESCRIPTION
#2739 