### PR TITLE
Added 3 cards, little refactoring (Unattach cost)

### DIFF
--- a/Mage.Sets/src/mage/cards/h/Heartseeker.java
+++ b/Mage.Sets/src/mage/cards/h/Heartseeker.java
@@ -25,51 +25,57 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.cards.b;
+package mage.cards.h;
 
 import java.util.UUID;
+
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.PreventCombatDamageToSourceEffect;
+import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
 import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
 import mage.abilities.keyword.EquipAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AttachmentType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
 import mage.abilities.costs.common.UnattachCost;
+import mage.constants.*;
+import mage.target.common.TargetCreaturePermanent;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.DestroyTargetEffect;
 
 /**
  *
- * @author LevelX2
+ * @author Galatolol
  */
-public class BlindingPowder extends CardImpl {
+public class Heartseeker extends CardImpl {
 
-    public BlindingPowder(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
+    public Heartseeker(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{4}");
+        
         this.subtype.add("Equipment");
 
-        // Equipped creature has "Unattach Blinding Powder: Prevent all combat damage that would be dealt to this creature this turn."
-        Effect effect = new PreventCombatDamageToSourceEffect(Duration.EndOfTurn);
-        effect.setText("Prevent all combat damage that would be dealt to this creature this turn");
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new UnattachCost(this.getName(), this.getId()));
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(ability, AttachmentType.EQUIPMENT, Duration.WhileOnBattlefield)));
-        // Equip {2}
-        this.addAbility(new EquipAbility(Outcome.PreventDamage, new GenericManaCost(2)));
+        // Equipped creature gets +2/+1 and has "{tap}, Unattach Heartseeker: Destroy target creature."
+        Ability ability = new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(2, 1, Duration.WhileOnBattlefield));
+        Ability gainedAbility = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DestroyTargetEffect(), new TapSourceCost());
+        gainedAbility.addCost(new UnattachCost(this.getName(), this.getId()));
+        gainedAbility.addTarget(new TargetCreaturePermanent());
+        Effect effect = new GainAbilityAttachedEffect(gainedAbility, AttachmentType.EQUIPMENT);
+        effect.setText("and has \"{T}, Unattach {this}: Destroy target creature.\"");
+        ability.addEffect(effect);
+        this.addAbility(ability);
+
+        // Equip {5}
+        this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(5)));
     }
 
-    public BlindingPowder(final BlindingPowder card) {
+    public Heartseeker(final Heartseeker card) {
         super(card);
     }
 
     @Override
-    public BlindingPowder copy() {
-        return new BlindingPowder(this);
+    public Heartseeker copy() {
+        return new Heartseeker(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LeoninBola.java
+++ b/Mage.Sets/src/mage/cards/l/LeoninBola.java
@@ -33,8 +33,6 @@ import mage.constants.*;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.costs.Cost;
-import mage.abilities.costs.CostImpl;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.TapTargetEffect;
@@ -42,9 +40,8 @@ import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
 import mage.abilities.keyword.EquipAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
+import mage.abilities.costs.common.UnattachCost;
 
 /**
  *
@@ -58,7 +55,7 @@ public class LeoninBola extends CardImpl {
 
         // Equipped creature has "{tap}, Unattach Leonin Bola: Tap target creature."
         Ability gainAbility = new SimpleActivatedAbility(Zone.BATTLEFIELD, new TapTargetEffect(), new TapSourceCost());
-        gainAbility.addCost(new UnattachCost(this.getId()));
+        gainAbility.addCost(new UnattachCost(this.getName(), this.getId()));
         gainAbility.addTarget(new TargetCreaturePermanent());
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(gainAbility, AttachmentType.EQUIPMENT)));
         
@@ -73,50 +70,5 @@ public class LeoninBola extends CardImpl {
     @Override
     public LeoninBola copy() {
         return new LeoninBola(this);
-    }
-}
-
-class UnattachCost extends CostImpl {
-    
-    private UUID attachmentid;
-
-    public UnattachCost(UUID attachmentid) {
-        this.text = "Unattach Leonin Bola";
-        this.attachmentid = attachmentid;
-    }
-
-    public UnattachCost(UnattachCost cost) {
-        super(cost);
-        this.attachmentid = cost.attachmentid;
-    }
-
-    @Override
-    public boolean pay(Ability ability, Game game, UUID sourceId, UUID controllerId, boolean noMana, Cost costToPay) {
-        Permanent permanent = game.getPermanent(sourceId);
-        if (permanent != null) {
-                Permanent attachment = game.getPermanent(attachmentid);
-                if (attachment != null) {
-                    permanent.removeAttachment(attachmentid, game);
-                    this.paid = true;
-                }
-            }
-        return paid;
-    }
-
-    @Override
-    public boolean canPay(Ability ability, UUID sourceId, UUID controllerId, Game game) {
-        Permanent permanent = game.getPermanent(sourceId);
-        if (permanent != null) {
-                Permanent attachment = game.getPermanent(attachmentid);
-                if (attachment != null && permanent.getAttachments().contains(attachmentid)) {
-                    return true;
-                }
-        }
-        return false;
-    }
-
-    @Override
-    public UnattachCost copy() {
-        return new UnattachCost(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/m/MaggotTherapy.java
+++ b/Mage.Sets/src/mage/cards/m/MaggotTherapy.java
@@ -25,51 +25,51 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.cards.b;
+package mage.cards.m;
 
 import java.util.UUID;
+
 import mage.abilities.Ability;
-import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.PreventCombatDamageToSourceEffect;
-import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
-import mage.abilities.keyword.EquipAbility;
+import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
+import mage.abilities.keyword.EnchantAbility;
+import mage.abilities.keyword.FlashAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AttachmentType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
-import mage.abilities.costs.common.UnattachCost;
+import mage.constants.*;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetCreaturePermanent;
 
 /**
  *
- * @author LevelX2
+ * @author Galatolol
  */
-public class BlindingPowder extends CardImpl {
+public class MaggotTherapy extends CardImpl {
 
-    public BlindingPowder(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
-        this.subtype.add("Equipment");
+    public MaggotTherapy(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{B}");
+        
+        this.subtype.add("Aura");
 
-        // Equipped creature has "Unattach Blinding Powder: Prevent all combat damage that would be dealt to this creature this turn."
-        Effect effect = new PreventCombatDamageToSourceEffect(Duration.EndOfTurn);
-        effect.setText("Prevent all combat damage that would be dealt to this creature this turn");
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new UnattachCost(this.getName(), this.getId()));
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(ability, AttachmentType.EQUIPMENT, Duration.WhileOnBattlefield)));
-        // Equip {2}
-        this.addAbility(new EquipAbility(Outcome.PreventDamage, new GenericManaCost(2)));
+        // Flash
+        this.addAbility(FlashAbility.getInstance());
+        // Enchant creature
+        TargetPermanent auraTarget = new TargetCreaturePermanent();
+        this.getSpellAbility().addTarget(auraTarget);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.UnboostCreature));
+        Ability ability = new EnchantAbility(auraTarget.getTargetName());
+        this.addAbility(ability);
+        // Enchanted creature gets +2/-2.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(2, -2, Duration.WhileOnBattlefield)));
     }
 
-    public BlindingPowder(final BlindingPowder card) {
+    public MaggotTherapy(final MaggotTherapy card) {
         super(card);
     }
 
     @Override
-    public BlindingPowder copy() {
-        return new BlindingPowder(this);
+    public MaggotTherapy copy() {
+        return new MaggotTherapy(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RazorBoomerang.java
+++ b/Mage.Sets/src/mage/cards/r/RazorBoomerang.java
@@ -33,8 +33,6 @@ import mage.constants.*;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.costs.Cost;
-import mage.abilities.costs.CostImpl;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.OneShotEffect;
@@ -46,6 +44,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCreatureOrPlayer;
+import mage.abilities.costs.common.UnattachCost;
 
 /**
  *
@@ -59,7 +58,7 @@ public class RazorBoomerang extends CardImpl {
 
         // Equipped creature has "{tap}, Unattach Razor Boomerang: Razor Boomerang deals 1 damage to target creature or player. Return Razor Boomerang to its owner's hand."
         Ability gainAbility = new SimpleActivatedAbility(Zone.BATTLEFIELD, new RazorBoomerangEffect(this.getId()), new TapSourceCost());
-        gainAbility.addCost(new UnattachCost(this.getId()));
+        gainAbility.addCost(new UnattachCost(this.getName(), this.getId()));
         gainAbility.addTarget(new TargetCreatureOrPlayer());
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(gainAbility, AttachmentType.EQUIPMENT)));
 
@@ -74,51 +73,6 @@ public class RazorBoomerang extends CardImpl {
     @Override
     public RazorBoomerang copy() {
         return new RazorBoomerang(this);
-    }
-}
-
-class UnattachCost extends CostImpl {
-
-    private UUID attachmentid;
-
-    public UnattachCost(UUID attachmentid) {
-        this.text = "Unattach Razor Boomerang";
-        this.attachmentid = attachmentid;
-    }
-
-    public UnattachCost(UnattachCost cost) {
-        super(cost);
-        this.attachmentid = cost.attachmentid;
-    }
-
-    @Override
-    public boolean pay(Ability ability, Game game, UUID sourceId, UUID controllerId, boolean noMana, Cost costToPay) {
-        Permanent permanent = game.getPermanent(sourceId);
-        if (permanent != null) {
-            Permanent attachment = game.getPermanent(attachmentid);
-            if (attachment != null) {
-                permanent.removeAttachment(attachmentid, game);
-                this.paid = true;
-            }
-        }
-        return paid;
-    }
-
-    @Override
-    public boolean canPay(Ability ability, UUID sourceId, UUID controllerId, Game game) {
-        Permanent permanent = game.getPermanent(sourceId);
-        if (permanent != null) {
-            Permanent attachment = game.getPermanent(attachmentid);
-            if (attachment != null && permanent.getAttachments().contains(attachmentid)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public UnattachCost copy() {
-        return new UnattachCost(this);
     }
 }
 

--- a/Mage.Sets/src/mage/cards/s/SoulChanneling.java
+++ b/Mage.Sets/src/mage/cards/s/SoulChanneling.java
@@ -25,51 +25,51 @@
  *  authors and should not be interpreted as representing official policies, either expressed
  *  or implied, of BetaSteward_at_googlemail.com.
  */
-package mage.cards.b;
+package mage.cards.s;
 
 import java.util.UUID;
+
 import mage.abilities.Ability;
-import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.PreventCombatDamageToSourceEffect;
-import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
-import mage.abilities.keyword.EquipAbility;
+import mage.abilities.costs.common.PayLifeCost;
+import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AttachmentType;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.constants.Zone;
-import mage.abilities.costs.common.UnattachCost;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetCreaturePermanent;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.effects.common.RegenerateAttachedEffect;
+import mage.constants.*;
 
 /**
  *
- * @author LevelX2
+ * @author Galatolol
  */
-public class BlindingPowder extends CardImpl {
+public class SoulChanneling extends CardImpl {
 
-    public BlindingPowder(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
-        this.subtype.add("Equipment");
+    public SoulChanneling(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{B}");
+        
+        this.subtype.add("Aura");
 
-        // Equipped creature has "Unattach Blinding Powder: Prevent all combat damage that would be dealt to this creature this turn."
-        Effect effect = new PreventCombatDamageToSourceEffect(Duration.EndOfTurn);
-        effect.setText("Prevent all combat damage that would be dealt to this creature this turn");
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new UnattachCost(this.getName(), this.getId()));
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(ability, AttachmentType.EQUIPMENT, Duration.WhileOnBattlefield)));
-        // Equip {2}
-        this.addAbility(new EquipAbility(Outcome.PreventDamage, new GenericManaCost(2)));
+        // Enchant creature
+        TargetPermanent auraTarget = new TargetCreaturePermanent();
+        this.getSpellAbility().addTarget(auraTarget);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.Regenerate));
+        Ability ability = new EnchantAbility(auraTarget.getTargetName());
+        this.addAbility(ability);
+        // Pay 2 life: Regenerate enchanted creature.
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateAttachedEffect(AttachmentType.AURA), new PayLifeCost(2)));
     }
 
-    public BlindingPowder(final BlindingPowder card) {
+    public SoulChanneling(final SoulChanneling card) {
         super(card);
     }
 
     @Override
-    public BlindingPowder copy() {
-        return new BlindingPowder(this);
+    public SoulChanneling copy() {
+        return new SoulChanneling(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/Sunforger.java
+++ b/Mage.Sets/src/mage/cards/s/Sunforger.java
@@ -32,8 +32,6 @@ import mage.ObjectColor;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.costs.Cost;
-import mage.abilities.costs.CostImpl;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
@@ -53,10 +51,9 @@ import mage.filter.predicate.mageobject.CardTypePredicate;
 import mage.filter.predicate.mageobject.ColorPredicate;
 import mage.filter.predicate.mageobject.ConvertedManaCostPredicate;
 import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
+import mage.abilities.costs.common.UnattachCost;
 
 /**
  *
@@ -73,7 +70,7 @@ public class Sunforger extends CardImpl {
 
         // {R}{W}, Unattach Sunforger: Search your library for a red or white instant card with converted mana cost 4 or less and cast that card without paying its mana cost. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SunforgerEffect(), new ManaCostsImpl("{R}{W}"));
-        ability.addCost(new UnattachSourceCost());
+        ability.addCost(new UnattachCost(this.getName(), this.getId()));
         this.addAbility(ability);
 
         // Equip {3}
@@ -135,43 +132,5 @@ class SunforgerEffect extends OneShotEffect {
             return true;
         }
         return false;
-    }
-}
-
-class UnattachSourceCost extends CostImpl {
-
-    public UnattachSourceCost() {
-        this.text = "Unattach Sunforger";
-    }
-
-    public UnattachSourceCost(UnattachSourceCost cost) {
-        super(cost);
-    }
-
-    @Override
-    public boolean pay(Ability ability, Game game, UUID sourceId, UUID controllerId, boolean noMana, Cost costToPay) {
-        Permanent attachment = game.getPermanent(sourceId);
-        Permanent permanent = game.getPermanent(attachment.getAttachedTo());
-        if (permanent != null) {
-            paid = permanent.removeAttachment(attachment.getId(), game);
-            if (paid) {
-                game.fireEvent(GameEvent.getEvent(GameEvent.EventType.UNATTACHED, sourceId, sourceId, controllerId));
-            }
-        }
-        return paid;
-    }
-
-    @Override
-    public boolean canPay(Ability ability, UUID sourceId, UUID controllerId, Game game) {
-        Permanent attachment = game.getPermanent(sourceId);
-        if (attachment != null) {
-            return attachment.getAttachedTo() != null;
-        }
-        return false;
-    }
-
-    @Override
-    public UnattachSourceCost copy() {
-        return new UnattachSourceCost(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SurestrikeTrident.java
+++ b/Mage.Sets/src/mage/cards/s/SurestrikeTrident.java
@@ -31,8 +31,6 @@ import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.costs.Cost;
-import mage.abilities.costs.CostImpl;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.dynamicvalue.DynamicValue;
@@ -48,9 +46,8 @@ import mage.constants.AttachmentType;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.target.TargetPlayer;
+import mage.abilities.costs.common.UnattachCost;
 
 /**
  *
@@ -69,7 +66,7 @@ public class SurestrikeTrident extends CardImpl {
         effect.setText("This creature deals damage equal to its power to target player");
         Ability gainedAbility = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new TapSourceCost());
         gainedAbility.addTarget(new TargetPlayer());
-        gainedAbility.addCost(new SurestrikeTridentUnattachCost(getName(), getId()));
+        gainedAbility.addCost(new UnattachCost(this.getName(), this.getId()));
         effect = new GainAbilityAttachedEffect(gainedAbility, AttachmentType.EQUIPMENT);
         effect.setText("and \"{T}, Unattach {this}: This creature deals damage equal to its power to target player.\"");
         ability.addEffect(effect);
@@ -87,58 +84,4 @@ public class SurestrikeTrident extends CardImpl {
     public SurestrikeTrident copy() {
         return new SurestrikeTrident(this);
     }
-}
-
-class SurestrikeTridentUnattachCost extends CostImpl {
-
-    protected UUID sourceEquipmentId;
-
-    public SurestrikeTridentUnattachCost(String name, UUID sourceId) {
-        this.text = "Unattach " + name;
-        this.sourceEquipmentId = sourceId;
-    }
-
-    public SurestrikeTridentUnattachCost(final SurestrikeTridentUnattachCost cost) {
-        super(cost);
-        this.sourceEquipmentId = cost.sourceEquipmentId;
-    }
-
-    @Override
-    public boolean pay(Ability ability, Game game, UUID sourceId, UUID controllerId, boolean noMana, Cost costToPay) {
-        Permanent permanent = game.getPermanent(sourceId);
-        if (permanent != null) {
-            for (UUID attachmentId : permanent.getAttachments()) {
-                Permanent attachment = game.getPermanent(attachmentId);
-                if (attachment != null && attachment.getId().equals(sourceEquipmentId)) {
-                    paid = permanent.removeAttachment(attachmentId, game);
-                    if (paid) {
-                        break;
-                    }
-                }
-            }
-
-        }
-        return paid;
-    }
-
-    @Override
-    public boolean canPay(Ability ability, UUID sourceId, UUID controllerId, Game game) {
-        Permanent permanent = game.getPermanent(sourceId);
-        if (permanent != null) {
-            for (UUID attachmentId : permanent.getAttachments()) {
-                Permanent attachment = game.getPermanent(attachmentId);
-                if (attachment != null && attachment.getId().equals(sourceEquipmentId)) {
-                    return true;
-                }
-            }
-
-        }
-        return false;
-    }
-
-    @Override
-    public SurestrikeTridentUnattachCost copy() {
-        return new SurestrikeTridentUnattachCost(this);
-    }
-
 }

--- a/Mage.Sets/src/mage/sets/Darksteel.java
+++ b/Mage.Sets/src/mage/sets/Darksteel.java
@@ -82,6 +82,7 @@ public class Darksteel extends ExpansionSet {
         cards.add(new SetCardInfo("Greater Harvester", 44, Rarity.RARE, mage.cards.g.GreaterHarvester.class));
         cards.add(new SetCardInfo("Grimclaw Bats", 45, Rarity.COMMON, mage.cards.g.GrimclawBats.class));
         cards.add(new SetCardInfo("Hallow", 4, Rarity.COMMON, mage.cards.h.Hallow.class));
+        cards.add(new SetCardInfo("Heartseeker", 124, Rarity.RARE, mage.cards.h.Heartseeker.class));
         cards.add(new SetCardInfo("Hoverguard Observer", 22, Rarity.UNCOMMON, mage.cards.h.HoverguardObserver.class));
         cards.add(new SetCardInfo("Hunger of the Nim", 46, Rarity.COMMON, mage.cards.h.HungerOfTheNim.class));
         cards.add(new SetCardInfo("Inflame", 64, Rarity.COMMON, mage.cards.i.Inflame.class));

--- a/Mage.Sets/src/mage/sets/MercadianMasques.java
+++ b/Mage.Sets/src/mage/sets/MercadianMasques.java
@@ -184,6 +184,7 @@ public class MercadianMasques extends ExpansionSet {
         cards.add(new SetCardInfo("Lumbering Satyr", 257, Rarity.UNCOMMON, mage.cards.l.LumberingSatyr.class));
         cards.add(new SetCardInfo("Lunge", 203, Rarity.COMMON, mage.cards.l.Lunge.class));
         cards.add(new SetCardInfo("Lure", 258, Rarity.UNCOMMON, mage.cards.l.Lure.class));
+        cards.add(new SetCardInfo("Maggot Therapy", 145, Rarity.COMMON, mage.cards.m.MaggotTherapy.class));
         cards.add(new SetCardInfo("Magistrate's Scepter", 304, Rarity.RARE, mage.cards.m.MagistratesScepter.class));
         cards.add(new SetCardInfo("Magistrate's Veto", 204, Rarity.UNCOMMON, mage.cards.m.MagistratesVeto.class));
         cards.add(new SetCardInfo("Mercadian Bazaar", 321, Rarity.UNCOMMON, mage.cards.m.MercadianBazaar.class));
@@ -264,6 +265,7 @@ public class MercadianMasques extends ExpansionSet {
         cards.add(new SetCardInfo("Snuff Out", 162, Rarity.COMMON, mage.cards.s.SnuffOut.class));
         cards.add(new SetCardInfo("Soothing Balm", 48, Rarity.COMMON, mage.cards.s.SoothingBalm.class));
         cards.add(new SetCardInfo("Soothsaying", 104, Rarity.UNCOMMON, mage.cards.s.Soothsaying.class));
+        cards.add(new SetCardInfo("Soul Channeling", 163, Rarity.COMMON, mage.cards.s.SoulChanneling.class));
         cards.add(new SetCardInfo("Specter's Wail", 164, Rarity.COMMON, mage.cards.s.SpectersWail.class));
         cards.add(new SetCardInfo("Spidersilk Armor", 273, Rarity.COMMON, mage.cards.s.SpidersilkArmor.class));
         cards.add(new SetCardInfo("Spontaneous Generation", 274, Rarity.RARE, mage.cards.s.SpontaneousGeneration.class));

--- a/Mage/src/main/java/mage/abilities/costs/common/UnattachCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/UnattachCost.java
@@ -1,0 +1,64 @@
+package mage.abilities.costs.common;
+
+import mage.abilities.Ability;
+import mage.abilities.costs.Cost;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import java.util.UUID;
+import mage.abilities.costs.CostImpl;
+
+/**
+ * @author Galatolol
+ */
+public class UnattachCost extends CostImpl {
+
+    protected UUID sourceEquipmentId;
+
+    public UnattachCost(String name, UUID sourceId) {
+        this.text = "Unattach " + name;
+        this.sourceEquipmentId = sourceId;
+    }
+
+    public UnattachCost(final UnattachCost cost) {
+        super(cost);
+        this.sourceEquipmentId = cost.sourceEquipmentId;
+    }
+
+    @Override
+    public boolean pay(Ability ability, Game game, UUID sourceId, UUID controllerId, boolean noMana, Cost costToPay) {
+        Permanent permanent = game.getPermanent(sourceId);
+        if (permanent != null) {
+            for (UUID attachmentId : permanent.getAttachments()) {
+                Permanent attachment = game.getPermanent(attachmentId);
+                if (attachment != null && attachment.getId().equals(sourceEquipmentId)) {
+                    paid = permanent.removeAttachment(attachmentId, game);
+                    if (paid) {
+                        break;
+                    }
+                }
+            }
+
+        }
+        return paid;
+    }
+
+    @Override
+    public boolean canPay(Ability ability, UUID sourceId, UUID controllerId, Game game) {
+        Permanent permanent = game.getPermanent(sourceId);
+        if (permanent != null) {
+            for (UUID attachmentId : permanent.getAttachments()) {
+                Permanent attachment = game.getPermanent(attachmentId);
+                if (attachment != null && attachment.getId().equals(sourceEquipmentId)) {
+                    return true;
+                }
+            }
+
+        }
+        return false;
+    }
+
+    @Override
+    public UnattachCost copy() {
+        return new UnattachCost(this);
+    }
+}


### PR DESCRIPTION
Added 3 cards:
- Heartseeker
- Maggot Therapy
- Soul Channeling

Several cards had its own unattach cost classes, so I decided to unify it by addidng common `UnattachCost` cost ability.
Modified cards with Unattach cost:

- Blinding Powder
- Leonin Bola
- Razor Boomerang
- Sunforger
- Surestrike Trident