### PR TITLE
Fixing gen-card.pl

### DIFF
--- a/Utils/gen-card.pl
+++ b/Utils/gen-card.pl
@@ -108,7 +108,7 @@ if (!exists $cards{$cardName}) {
 }
 
 # Check if card is already implemented
-my $fileName = "../Mage.Sets/src/mage/cards/".substr($cardName, 0, 1)."/".toCamelCase($cardName).".java";
+my $fileName = "../Mage.Sets/src/mage/cards/".lc(substr($cardName, 0, 1))."/".toCamelCase($cardName).".java";
 if(-e $fileName) {
   die "$cardName is already implemented.\n";
 }


### PR DESCRIPTION
When generating a card, instead of getting Mage.Sets/src/mage/cards/s/SomeCard.java I get Mage.Sets/src/mage/cards/S/SomeCard.java
I fixed it wrapping a folder name with lowercase function.