### PR TITLE
Allow lands with AnyColorManaAbility to be have automatic payments done

### DIFF
--- a/Mage/src/main/java/mage/util/ManaUtil.java
+++ b/Mage/src/main/java/mage/util/ManaUtil.java
@@ -17,6 +17,7 @@ import mage.abilities.mana.BlackManaAbility;
 import mage.abilities.mana.BlueManaAbility;
 import mage.abilities.mana.GreenManaAbility;
 import mage.abilities.mana.ActivatedManaAbilityImpl;
+import mage.abilities.mana.AnyColorManaAbility;
 import mage.abilities.mana.RedManaAbility;
 import mage.abilities.mana.WhiteManaAbility;
 import mage.cards.Card;
@@ -62,7 +63,9 @@ public class ManaUtil {
         for (ActivatedManaAbilityImpl ability : useableAbilities.values()) {
             if (!(ability instanceof BasicManaAbility)) {
                 // return map as-is without any modification
-                return useableAbilities;
+                if (!(ability instanceof AnyColorManaAbility)) {
+                    return useableAbilities;
+                }
             }
         }
 


### PR DESCRIPTION
This makes it easier to tap lands for mana when there is for example Chromatic Lantern out.  If you have a plains + Urborg + Chromatic Lantern out, it will currently always ask via a popup (super slow).  If you need a single Red man and tap the plains, it will still ask via the popup.  But if you need a single White or Black, it will tap and add it automatically now from the basicManaAbility of (t: add {w} or t: add {b}).