### PR TITLE
ChandraTorchOfDefiance should only be able to cast spells with a cast…

### DIFF
--- a/Mage.Sets/src/mage/cards/c/ChandraPyromaster.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraPyromaster.java
@@ -30,6 +30,7 @@ package mage.cards.c;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.LoyaltyAbility;
@@ -62,13 +63,12 @@ import mage.target.TargetPlayer;
 import mage.target.targetpointer.FixedTarget;
 
 /**
- *
  * @author jeffwadsworth
  */
 public class ChandraPyromaster extends CardImpl {
 
     public ChandraPyromaster(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.PLANESWALKER},"{2}{R}{R}");
+        super(ownerId, setInfo, new CardType[]{CardType.PLANESWALKER}, "{2}{R}{R}");
         this.subtype.add("Chandra");
 
         this.addAbility(new PlanswalkerEntersWithLoyalityCountersAbility(4));
@@ -211,9 +211,11 @@ class ChandraPyromasterEffect2 extends OneShotEffect {
             Card card = library.removeFromTop(game);
             if (card != null) {
                 controller.moveCardToExileWithInfo(card, source.getSourceId(), sourceObject.getIdName() + " <this card may be played the turn it was exiled>", source.getSourceId(), game, Zone.LIBRARY, true);
-                ContinuousEffect effect = new ChandraPyromasterCastFromExileEffect();
-                effect.setTargetPointer(new FixedTarget(card.getId()));
-                game.addEffect(effect, source);
+                if (!card.getManaCost().isEmpty()) {
+                    ContinuousEffect effect = new ChandraPyromasterCastFromExileEffect();
+                    effect.setTargetPointer(new FixedTarget(card.getId()));
+                    game.addEffect(effect, source);
+                }
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/c/ChandraTorchOfDefiance.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraTorchOfDefiance.java
@@ -28,6 +28,7 @@
 package mage.cards.c;
 
 import java.util.UUID;
+
 import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
@@ -57,7 +58,6 @@ import mage.target.common.TargetCreatureOrPlayer;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
- *
  * @author fireshoes
  */
 public class ChandraTorchOfDefiance extends CardImpl {
@@ -117,7 +117,7 @@ class ChandraTorchOfDefianceEffect extends OneShotEffect {
         if (controller != null && sourceObject != null && controller.getLibrary().size() > 0) {
             Library library = controller.getLibrary();
             Card card = library.removeFromTop(game);
-            if (card != null) {
+            if (card != null && !card.getManaCost().isEmpty()) {
                 boolean exiledCardWasCast = false;
                 controller.moveCardToExileWithInfo(card, source.getSourceId(), sourceObject.getIdName(), source.getSourceId(), game, Zone.LIBRARY, true);
                 if (controller.chooseUse(Outcome.Benefit, "Cast the card? (You still pay the costs)", source, game) && !card.getCardType().contains(CardType.LAND)) {

--- a/Mage.Sets/src/mage/cards/c/ChandraTorchOfDefiance.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraTorchOfDefiance.java
@@ -117,20 +117,22 @@ class ChandraTorchOfDefianceEffect extends OneShotEffect {
         if (controller != null && sourceObject != null && controller.getLibrary().size() > 0) {
             Library library = controller.getLibrary();
             Card card = library.removeFromTop(game);
-            if (card != null && !card.getManaCost().isEmpty()) {
+            if (card != null) {
                 boolean exiledCardWasCast = false;
                 controller.moveCardToExileWithInfo(card, source.getSourceId(), sourceObject.getIdName(), source.getSourceId(), game, Zone.LIBRARY, true);
-                if (controller.chooseUse(Outcome.Benefit, "Cast the card? (You still pay the costs)", source, game) && !card.getCardType().contains(CardType.LAND)) {
+                if (!card.getManaCost().isEmpty())
+                    if (controller.chooseUse(Outcome.Benefit, "Cast the card? (You still pay the costs)", source, game) && !card.getCardType().contains(CardType.LAND)) {
 //                    LinkedHashMap<UUID, ActivatedAbility> useableAbilities = controller.getUseableActivatedAbilities(card, Zone.EXILED, game);
 //                    for (ActivatedAbility ability : useableAbilities.values()) {
 //
 //                    }
 //                    controller.activateAbility(useableAbilities, game);
-                    exiledCardWasCast = controller.cast(card.getSpellAbility(), game, false);
-                }
+                        exiledCardWasCast = controller.cast(card.getSpellAbility(), game, false);
+                    }
                 if (!exiledCardWasCast) {
                     new DamagePlayersEffect(Outcome.Damage, new StaticValue(2), TargetController.OPPONENT).apply(game, source);
                 }
+
             }
             return true;
         }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ChandraPyromasterTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ChandraPyromasterTest.java
@@ -43,6 +43,29 @@ public class ChandraPyromasterTest extends CardTestPlayerBase {
         assertGraveyardCount(playerB, "Silvercoat Lion", 1);
 
     }
+
+    @Test
+    public void testAbility2AncestralVision() {
+        addCard(Zone.BATTLEFIELD, playerA, "Chandra, Pyromaster");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+
+        skipInitShuffling();
+        addCard(Zone.LIBRARY, playerA, "Ancestral Vision");
+
+        addCard(Zone.BATTLEFIELD, playerB, "Silvercoat Lion", 1);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "+0: Exile the top card of your library. You may play it this turn.");
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+
+        assertPermanentCount(playerA, "Chandra, Pyromaster", 1);
+        assertGraveyardCount(playerA, "Ancestral Vision", 0);
+
+        assertExileCount(playerA, "Ancestral Vision", 1);
+    }
     
     @Test
     public void testAbility2CastCardFromExileWithOverlaod() {

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -863,6 +863,25 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     /**
      * Assert card count in player's graveyard.
      *
+     * @param owner {@link Player} who's graveyard should be counted.
+     * @param cardName Name of the cards that should be counted.
+     * @param count Expected count.
+     */
+    public void assertExileCount(Player owner, String cardName, int count) throws AssertionError {
+        int actualCount = 0;
+        for (ExileZone exile : currentGame.getExile().getExileZones()) {
+            for (Card card : exile.getCards(currentGame)) {
+                if (card.getOwnerId().equals(owner.getId()) && card.getName().equals(cardName)) {
+                    actualCount++;
+                }
+            }
+        }
+        Assert.assertEquals("(Exile " + owner.getName() + ") Card counts are not equal (" + cardName + ')', count, actualCount);
+    }
+
+    /**
+     * Assert card count in player's graveyard.
+     *
      * @param player {@link Player} who's graveyard should be counted.
      * @param cardName Name of the cards that should be counted.
      * @param count Expected count.

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -861,9 +861,9 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     }
 
     /**
-     * Assert card count in player's graveyard.
+     * Assert card count in player's exile.
      *
-     * @param owner {@link Player} who's graveyard should be counted.
+     * @param owner {@link Player} who's exile should be counted.
      * @param cardName Name of the cards that should be counted.
      * @param count Expected count.
      */


### PR DESCRIPTION
ChandraTorchOfDefiance should only be able to cast spells with a casting cost. Cards like Ancestral Visions can not be cast.