### PR TITLE
Phyrexian Purge impl and tests

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PhyrexianPurge.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianPurge.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.p;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.costs.common.PayLifeCost;
+import mage.abilities.effects.common.DestroyMultiTargetEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.game.Game;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author escplan9 - Derek Monturo
+ */
+public class PhyrexianPurge extends CardImpl {
+    
+    public int maxTargets = 0;
+
+    public PhyrexianPurge(UUID ownerId, CardSetInfo setInfo) {
+        
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{B}{R}");
+                
+        // Destroy any number of target creatures.
+        // Phyrexian Purge costs 3 life more to cast for each target.
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(0, Integer.MAX_VALUE));
+        this.getSpellAbility().addEffect(new DestroyMultiTargetEffect());
+    }
+    
+    @Override
+    public void adjustCosts(Ability ability, Game game) {
+        int numTargets = ability.getTargets().get(0).getTargets().size();
+        if (numTargets > 0) {
+            ability.getCosts().add(new PayLifeCost(numTargets * 3));
+        }
+    }   
+
+    public PhyrexianPurge(final PhyrexianPurge card) {
+        super(card);
+    }
+
+    @Override
+    public PhyrexianPurge copy() {
+        return new PhyrexianPurge(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/Mirage.java
+++ b/Mage.Sets/src/mage/sets/Mirage.java
@@ -203,6 +203,7 @@ public class Mirage extends ExpansionSet {
         cards.add(new SetCardInfo("Paupers' Cage", 279, Rarity.RARE, mage.cards.p.PaupersCage.class));
         cards.add(new SetCardInfo("Pearl Dragon", 237, Rarity.RARE, mage.cards.p.PearlDragon.class));
         cards.add(new SetCardInfo("Phyrexian Dreadnought", 280, Rarity.RARE, mage.cards.p.PhyrexianDreadnought.class));
+        cards.add(new SetCardInfo("Phyrexian Purge", 333, Rarity.RARE, mage.cards.p.PhyrexianPurge.class));
         cards.add(new SetCardInfo("Phyrexian Tribute", 32, Rarity.RARE, mage.cards.p.PhyrexianTribute.class));
         cards.add(new SetCardInfo("Phyrexian Vault", 281, Rarity.UNCOMMON, mage.cards.p.PhyrexianVault.class));
         cards.add(new SetCardInfo("Plains", 306, Rarity.LAND, mage.cards.basiclands.Plains.class, new CardGraphicInfo(null, true)));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/additional/PhyrexianPurgeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/additional/PhyrexianPurgeTest.java
@@ -1,0 +1,111 @@
+package org.mage.test.cards.cost.additional;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author escplan9 (Derek Monturo - dmontur1 at gmail dot com)
+ */
+public class PhyrexianPurgeTest extends CardTestPlayerBase {
+
+    /*
+     Target two creatures, pay 3 life for each.
+    */
+    @Test
+    public void simpleTest() {
+        
+        String pPurge = "Phyrexian Purge";
+        
+        // Sorcery {2}{B}{R}
+        // Destroy any number of target creatures.
+        // Phyrexian Purge costs 3 life more to cast for each target.
+        addCard(Zone.HAND, playerA, pPurge);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        
+        addCard(Zone.BATTLEFIELD, playerB, "Memnite"); // {0} 1/1 artifact creature
+        addCard(Zone.BATTLEFIELD, playerB, "Hill Giant"); // {3}{R} 3/3
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, pPurge);
+        addTarget(playerA, "Memnite^Hill Giant");
+        
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+        
+        assertGraveyardCount(playerA, pPurge, 1);
+        assertGraveyardCount(playerB, "Memnite", 1);
+        assertGraveyardCount(playerB, "Hill Giant", 1);
+        assertLife(playerA, 14); // lost 6 life (3 * 2 targets)
+    }
+    
+    /*
+     * Target two creatures, one of them bounced before resolution. Still pay 6 life.
+    */
+    @Test
+    public void bouncedCreatureStillPaysFullCost() {
+        
+        String pPurge = "Phyrexian Purge";
+        
+        // Sorcery {2}{B}{R}
+        // Destroy any number of target creatures.
+        // Phyrexian Purge costs 3 life more to cast for each target.
+        addCard(Zone.HAND, playerA, pPurge);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        
+        addCard(Zone.HAND, playerB, "Unsummon"); // {U} instant return target creature back to hand
+        addCard(Zone.BATTLEFIELD, playerB, "Island"); 
+        addCard(Zone.BATTLEFIELD, playerB, "Memnite"); // {0} 1/1 artifact creature
+        addCard(Zone.BATTLEFIELD, playerB, "Hill Giant"); // {3}{R} 3/3
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, pPurge);
+        addTarget(playerA, "Memnite^Hill Giant");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Unsummon", "Hill Giant");
+        
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+        
+        assertGraveyardCount(playerA, pPurge, 1);
+        assertGraveyardCount(playerB, "Unsummon", 1);
+        assertGraveyardCount(playerB, "Memnite", 1);
+        assertHandCount(playerB, "Hill Giant", 1);
+        assertLife(playerA, 14); // lost 6 life (3 * 2 targets)
+    }
+    
+    /*
+     * Target two creatures, spell is countered. Still pays 6 life.
+    */
+    @Test
+    public void counteredSpellStillPaysFullCost() {
+        
+        String pPurge = "Phyrexian Purge";
+        
+        // Sorcery {2}{B}{R}
+        // Destroy any number of target creatures.
+        // Phyrexian Purge costs 3 life more to cast for each target.
+        addCard(Zone.HAND, playerA, pPurge);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        
+        addCard(Zone.HAND, playerB, "Counterspell"); // {U}{U} instant - counter target spell
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2); 
+        addCard(Zone.BATTLEFIELD, playerB, "Memnite"); // {0} 1/1 artifact creature
+        addCard(Zone.BATTLEFIELD, playerB, "Hill Giant"); // {3}{R} 3/3
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, pPurge);
+        addTarget(playerA, "Memnite^Hill Giant");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Counterspell", pPurge);
+        
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+        
+        assertGraveyardCount(playerA, pPurge, 1);
+        assertGraveyardCount(playerB, "Counterspell", 1);
+        assertPermanentCount(playerB, "Memnite", 1);
+        assertPermanentCount(playerB, "Hill Giant", 1);
+        assertLife(playerA, 14); // lost 6 life (3 * 2 targets)
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -1166,12 +1166,12 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Set target permanents
      *
      * @param player
-     * @param target you can add multiple targets by seperating them by the "^"
+     * @param target you can add multiple targets by separating them by the "^"
      * character e.g. "creatureName1^creatureName2" you can qualify the target
      * additional by setcode e.g. "creatureName-M15" you can add [no copy] to
-     * the end of the target name to prohibite targets that are copied you can
+     * the end of the target name to prohibit targets that are copied you can
      * add [only copy] to the end of the target name to allow only targets that
-     * are copies For modal spells use a prefix with the mode number:
+     * are copies. For modal spells use a prefix with the mode number:
      * mode=1Lightning Bolt^mode=2Silvercoat Lion
      */
     public void addTarget(TestPlayer player, String target) {


### PR DESCRIPTION
Not 100% sure if this is done right. In testing I was allowed to select more targets than I could pay in life, and then I immediately lost the game upon doing so. PayLifeCost should already be checking if this is payable or not so not sure if this is fine. Let me know any adjustments that may need to be made.

Card: http://gatherer.wizards.com/Pages/Card/Details.aspx?name=phyrexian+purge