### PR TITLE
#2705 if an empty email address is used, display a more specific message

### DIFF
--- a/Mage.Server/src/main/java/mage/server/Session.java
+++ b/Mage.Server/src/main/java/mage/server/Session.java
@@ -172,6 +172,10 @@ public class Session {
     }
 
     static private String validateEmail(String email) {
+
+        if (email == null || email.isEmpty()) {
+            return "Email address cannot be blank";
+        }
         AuthorizedUser authorizedUser = AuthorizedUserRepository.instance.getByEmail(email);
         if (authorizedUser != null) {
             return "Email address '" + email + "' is associated with another user";


### PR DESCRIPTION
Simply checks for an empty email and returns a more specific message if detected. 