### PR TITLE
Fix Flagbearer to not require triggered abilities to target a flagbearer

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/ruleModifying/TargetsHaveToTargetPermanentIfAbleEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ruleModifying/TargetsHaveToTargetPermanentIfAbleEffect.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Ability;
+import mage.abilities.ActivatedAbility;
+import mage.abilities.SpellAbility;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.constants.Duration;
 import mage.constants.Outcome;
@@ -24,6 +26,11 @@ import mage.target.Target;
  * 6/8/2016 If a spell or ability’s targets are changed, or if a copy of a spell
  * or ability is put onto the stack and has new targets chosen, it doesn’t have
  * to target a Flagbearer.
+ * 
+ * 3/16/2017 A Flagbearer only requires targeting of itself when choosing targets
+ * as a result of casting a spell or activating an ability.  Notably, triggered
+ * abilities are exempt from this targeting restriction (in addition to the note
+ * about choosing targets for a copy from 6/8/2016).
  *
  * @author LevelX2
  */
@@ -71,6 +78,12 @@ public class TargetsHaveToTargetPermanentIfAbleEffect extends ContinuousRuleModi
                 && controller.hasOpponent(event.getPlayerId(), game)) {
             StackObject stackObject = game.getStack().getStackObject(event.getSourceId());
             if (stackObject.isCopy()) {
+                return false;
+            }
+            Ability stackAbility = stackObject.getStackAbility();
+            // Ensure that this ability is activated or a cast spell, because Flag Bearer effects don't require triggered abilities to choose a Standard Bearer
+            if (!(stackAbility instanceof ActivatedAbility) &&
+                !(stackAbility instanceof SpellAbility)) {
                 return false;
             }
             Ability ability = (Ability) getValue("targetAbility");


### PR DESCRIPTION
Currently, Flagbearers require that they be targeted no matter what sort of spell or ability is targeting.  

However, the Flagbearer is only supposed to enforce its requirement for spells that are cast and abilities that are activated -- choosing targets from triggered abilities is exempt.  For instance, in Eternal Masters, Ghitu Stinger's targeted damage is a triggered ability, and is not required to target a flagbearer.  Same with Shrine of Burning Rage.  Before this fix, both of those cards would be required to target the Flagbearer when it did not necessitate that.

When testing this fix, I noticed some other related issues that I don't believe were introduced with this change.  For one, if I activate an ability (such as Prodigal Sorcerer) and try to target a player with it, the game properly tells me that I must target a flagbearer.  But if I then choose the flagbearer, the damage never gets applied to the flagbearer, nor does it get applied to the original player that was attempted to be targeted.  However, if I rewind the game state and re-do the actions (but this time, only choose the flagbearer so that the popup never shows), then the flagbearer takes damage as expected.

Not sure what's up with the bug, but I don't believe that was anything I caused (but I wanted to make note of it).  