### PR TITLE
Refactor/tokens exiled - DO NOT MERGE YET

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AkoumStonewaker.java
+++ b/Mage.Sets/src/mage/cards/a/AkoumStonewaker.java
@@ -31,11 +31,10 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.LandfallAbility;
-import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.DoIfCostPaid;
-import mage.abilities.effects.common.ExileTargetEffect;
 import mage.abilities.keyword.HasteAbility;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
@@ -43,9 +42,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.Token;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -94,16 +91,10 @@ class AkoumStonewakerEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Token token = new AkoumStonewakerElementalToken();
-        if (token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId())) {
-            for (UUID tokenId : token.getLastAddedTokenIds()) {
-                Permanent tokenPermanent = game.getPermanent(tokenId);
-                if (tokenPermanent != null) {
-                    ExileTargetEffect exileEffect = new ExileTargetEffect();
-                    exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                    game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(exileEffect), source);
-                }
-            }
+                
+        CreateTokenEffect effect = new CreateTokenEffect(new AkoumStonewakerElementalToken());
+        if(effect.apply(game, source)) {
+            effect.exileTokensCreatedAtNextEndStep(game, source);            
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/c/ChandraFlamecaller.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraFlamecaller.java
@@ -29,11 +29,9 @@ package mage.cards.c;
 
 import java.util.Set;
 import java.util.UUID;
-import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.LoyaltyAbility;
 import mage.abilities.common.PlanswalkerEntersWithLoyalityCountersAbility;
-import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.PayVariableLoyaltyCost;
 import mage.abilities.dynamicvalue.DynamicValue;
@@ -41,20 +39,15 @@ import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.DamageAllEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
-import mage.abilities.keyword.HasteAbility;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.Zone;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.game.permanent.token.Token;
+import mage.game.permanent.token.ElementalToken;
 import mage.players.Player;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -108,36 +101,13 @@ class ChandraElementalEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            CreateTokenEffect effect = new CreateTokenEffect(new ChandraElementalElementalToken(), 2);
+            CreateTokenEffect effect = new CreateTokenEffect(new ElementalToken("OGW", 1, true), 2);
             effect.apply(game, source);
-            for (UUID tokenId : effect.getLastAddedTokenIds()) {
-                Permanent tokenPermanent = game.getPermanent(tokenId);
-                if (tokenPermanent != null) {
-                    ExileTargetEffect exileEffect = new ExileTargetEffect(null, "", Zone.BATTLEFIELD);
-                    exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                    game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(exileEffect), source);
-                }
-            }
+            effect.exileTokensCreatedAtNextEndStep(game, source);
             return true;
         }
 
         return false;
-    }
-}
-
-class ChandraElementalElementalToken extends Token {
-
-    public ChandraElementalElementalToken() {
-        super("Elemental", "3/1 red Elemental creature tokens with haste");
-        setTokenType(1);
-        setOriginalExpansionSetCode("OGW");
-        cardType.add(CardType.CREATURE);
-        color.setRed(true);
-        subtype.add("Elemental");
-        power = new MageInt(3);
-        toughness = new MageInt(1);
-
-        this.addAbility(HasteAbility.getInstance());
     }
 }
 

--- a/Mage.Sets/src/mage/cards/e/ElementalAppeal.java
+++ b/Mage.Sets/src/mage/cards/e/ElementalAppeal.java
@@ -28,28 +28,24 @@
 package mage.cards.e;
 
 import java.util.UUID;
-
 import mage.MageInt;
-import mage.abilities.keyword.HasteAbility;
-import mage.abilities.keyword.TrampleAbility;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
 import mage.abilities.Ability;
-import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.condition.LockedInCondition;
 import mage.abilities.condition.common.KickedCondition;
 import mage.abilities.decorator.ConditionalContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
+import mage.abilities.keyword.HasteAbility;
 import mage.abilities.keyword.KickerAbility;
+import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.Token;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -100,18 +96,14 @@ class ElementalAppealEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        ElementalToken token = new ElementalToken();
-        token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId());
-
-        for (UUID tokenId : token.getLastAddedTokenIds()) {
-            Permanent tokenPermanent = game.getPermanent(tokenId);
-            if (tokenPermanent != null) {
-                ExileTargetEffect exileEffect = new ExileTargetEffect();
-                exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(exileEffect), source);
-            }
+        
+        CreateTokenEffect effect = new CreateTokenEffect(new ElementalToken());
+        if(effect.apply(game, source))
+        {
+            effect.exileTokensCreatedAtNextEndStep(game, source);            
+            return true;
         }
-        return true;
+        return false;
     }
 
     class ElementalToken extends Token {

--- a/Mage.Sets/src/mage/cards/e/ElementalMastery.java
+++ b/Mage.Sets/src/mage/cards/e/ElementalMastery.java
@@ -32,11 +32,10 @@ import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.AttachEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
 import mage.abilities.keyword.EnchantAbility;
 import mage.abilities.keyword.HasteAbility;
@@ -51,7 +50,6 @@ import mage.game.permanent.Permanent;
 import mage.game.permanent.token.Token;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -73,7 +71,6 @@ public class ElementalMastery extends CardImpl {
         // Enchanted creature has "{tap}: create X 1/1 red Elemental creature tokens with haste, where X is this creature's power. Exile them at the beginning of the next end step."
         Ability ability2 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ElementalMasteryEffect(), new TapSourceCost());
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(ability2, AttachmentType.AURA)));
-
     }
 
     public ElementalMastery(final ElementalMastery card) {
@@ -108,18 +105,11 @@ class ElementalMasteryEffect extends OneShotEffect {
         if (creatureAttached != null) {
             int power = creatureAttached.getPower().getValue();
             if (power > 0) {
-                ElementalToken token = new ElementalToken();
-                token.putOntoBattlefield(power, game, creatureAttached.getId(), creatureAttached.getControllerId());
-                for (UUID tokenId : token.getLastAddedTokenIds()) {
-                    Permanent tokenPermanent = game.getPermanent(tokenId);
-                    if (tokenPermanent != null) {
-                        ExileTargetEffect exileEffect = new ExileTargetEffect();
-                        exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                        game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(exileEffect), source);
-                    }
-                }
+                CreateTokenEffect effect = new CreateTokenEffect(new ElementalToken(), power);
+                effect.apply(game, source);
+                effect.exileTokensCreatedAtNextEndStep(game, source);                
+                return true;
             }
-            return true;
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/f/FeralLightning.java
+++ b/Mage.Sets/src/mage/cards/f/FeralLightning.java
@@ -28,23 +28,16 @@
 package mage.cards.f;
 
 import java.util.UUID;
-import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
-import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.Zone;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.game.permanent.token.Token;
+import mage.game.permanent.token.ElementalToken;
 import mage.players.Player;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -90,33 +83,12 @@ class FeralLightningEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            CreateTokenEffect effect = new CreateTokenEffect(new FeralLightningElementalToken(), 3);
+            CreateTokenEffect effect = new CreateTokenEffect(new ElementalToken("CON", 1, true), 3);
             effect.apply(game, source);
-            for (UUID tokenId : effect.getLastAddedTokenIds()) {
-                Permanent tokenPermanent = game.getPermanent(tokenId);
-                if (tokenPermanent != null) {
-                    ExileTargetEffect exileEffect = new ExileTargetEffect(null, "", Zone.BATTLEFIELD);
-                    exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                    game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(exileEffect), source);
-                }
-            }
+            effect.exileTokensCreatedAtNextEndStep(game, source);
             return true;
         }
 
         return false;
-    }
-}
-
-class FeralLightningElementalToken extends Token {
-
-    public FeralLightningElementalToken() {
-        super("Elemental", "3/1 red Elemental creature tokens with haste");
-        cardType.add(CardType.CREATURE);
-        color.setRed(true);
-        subtype.add("Elemental");
-        power = new MageInt(3);
-        toughness = new MageInt(1);
-
-        this.addAbility(HasteAbility.getInstance());
     }
 }

--- a/Mage.Sets/src/mage/cards/f/FirecatBlitz.java
+++ b/Mage.Sets/src/mage/cards/f/FirecatBlitz.java
@@ -30,14 +30,12 @@ package mage.cards.f;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.costs.common.SacrificeXTargetCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
 import mage.abilities.keyword.FlashbackAbility;
 import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
@@ -45,14 +43,11 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.TimingRule;
-import mage.constants.Zone;
 import mage.filter.common.FilterControlledLandPermanent;
 import mage.filter.predicate.mageobject.SubtypePredicate;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.Token;
 import mage.players.Player;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -116,14 +111,7 @@ class FirecatBlitzEffect extends OneShotEffect {
             }
             CreateTokenEffect effect = new CreateTokenEffect(new ElementalCatToken(), xValue);
             effect.apply(game, source);
-            for (UUID tokenId : effect.getLastAddedTokenIds()) {
-                Permanent tokenPermanent = game.getPermanent(tokenId);
-                if (tokenPermanent != null) {
-                    ExileTargetEffect exileEffect = new ExileTargetEffect(null, "", Zone.BATTLEFIELD);
-                    exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                    game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(exileEffect), source);
-                }
-            }
+            effect.exileTokensCreatedAtNextEndStep(game, source);
             return true;
         }
 

--- a/Mage.Sets/src/mage/cards/g/GeistOfSaintTraft.java
+++ b/Mage.Sets/src/mage/cards/g/GeistOfSaintTraft.java
@@ -31,19 +31,16 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
-import mage.abilities.common.delayed.AtTheEndOfCombatDelayedTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.keyword.HexproofAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.AngelToken;
 import mage.players.Player;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  * @author Loki
@@ -87,18 +84,12 @@ class GeistOfSaintTraftEffect extends OneShotEffect {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        AngelToken token = new AngelToken();
+    public boolean apply(Game game, Ability source) {        
+        CreateTokenEffect effect = new CreateTokenEffect(new AngelToken());        
         Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null && token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId(), true, true)) {
-            for (UUID tokenId : token.getLastAddedTokenIds()) {
-                Permanent tokenPermanent = game.getPermanent(tokenId);
-                if (tokenPermanent != null) {
-                    ExileTargetEffect exileEffect = new ExileTargetEffect();
-                    exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                    game.addDelayedTriggeredAbility(new AtTheEndOfCombatDelayedTriggeredAbility(exileEffect), source);
-                }
-            }
+        
+        if (controller != null && effect.apply(game, source)) {
+            effect.exileTokensCreatedAtNextEndStep(game, source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/g/Giantbaiting.java
+++ b/Mage.Sets/src/mage/cards/g/Giantbaiting.java
@@ -30,9 +30,8 @@ package mage.cards.g;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.keyword.ConspireAbility;
 import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
@@ -40,9 +39,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.Token;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -89,16 +86,10 @@ class GiantbaitingEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Token token = new GiantWarriorToken();
-        if (token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId())) {
-            for (UUID tokenId : token.getLastAddedTokenIds()) {
-                Permanent tokenPermanent = game.getPermanent(tokenId);
-                if (tokenPermanent != null) {
-                    ExileTargetEffect exileEffect = new ExileTargetEffect();
-                    exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                    game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(exileEffect), source);
-                }
-            }
+        CreateTokenEffect effect = new CreateTokenEffect(new GiantWarriorToken());
+        if(effect.apply(game, source))
+        {
+            effect.exileTokensCreatedAtNextEndStep(game, source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/i/InvocationOfSaintTraft.java
+++ b/Mage.Sets/src/mage/cards/i/InvocationOfSaintTraft.java
@@ -31,10 +31,9 @@ import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.common.delayed.AtTheEndOfCombatDelayedTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.AttachEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
 import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
@@ -44,12 +43,10 @@ import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.AngelToken;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -96,18 +93,11 @@ class InvocationOfSaintTraftEffect extends OneShotEffect {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        AngelToken token = new AngelToken();
+    public boolean apply(Game game, Ability source) {        
+        CreateTokenEffect effect = new CreateTokenEffect(new AngelToken());
         Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null && token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId(), true, true)) {
-            for (UUID tokenId : token.getLastAddedTokenIds()) {
-                Permanent tokenPermanent = game.getPermanent(tokenId);
-                if (tokenPermanent != null) {
-                    ExileTargetEffect exileEffect = new ExileTargetEffect();
-                    exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                    game.addDelayedTriggeredAbility(new AtTheEndOfCombatDelayedTriggeredAbility(exileEffect), source);
-                }
-            }
+        if (controller != null && (effect.apply(game, source))) {
+            effect.exileTokensCreatedAtNextEndStep(game, source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/k/KariZevSkyshipRaider.java
+++ b/Mage.Sets/src/mage/cards/k/KariZevSkyshipRaider.java
@@ -31,9 +31,8 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
-import mage.abilities.common.delayed.AtTheEndOfCombatDelayedTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.keyword.FirstStrikeAbility;
 import mage.abilities.keyword.MenaceAbility;
 import mage.cards.CardImpl;
@@ -41,10 +40,8 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.Token;
 import mage.players.Player;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -94,17 +91,10 @@ class KariZevSkyshipRaiderEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        RagavanToken token = new RagavanToken();
+        CreateTokenEffect effect = new CreateTokenEffect(new RagavanToken());
         Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null && token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId(), true, true)) {
-            for (UUID tokenId : token.getLastAddedTokenIds()) {
-                Permanent tokenPermanent = game.getPermanent(tokenId);
-                if (tokenPermanent != null) {
-                    ExileTargetEffect exileEffect = new ExileTargetEffect();
-                    exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                    game.addDelayedTriggeredAbility(new AtTheEndOfCombatDelayedTriggeredAbility(exileEffect), source);
-                }
-            }
+        if (controller != null && effect.apply(game, source)) {
+            effect.exileTokensCreatedAtNextEndStep(game, source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/r/RakdosGuildmage.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosGuildmage.java
@@ -31,11 +31,10 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.costs.common.DiscardCardCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
@@ -45,10 +44,8 @@ import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.Token;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -103,16 +100,10 @@ class RakdosGuildmageEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Token token = new RakdosGuildmageGoblinToken();
-        if (token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId())) {
-            for (UUID tokenId : token.getLastAddedTokenIds()) {
-                Permanent tokenPermanent = game.getPermanent(tokenId);
-                if (tokenPermanent != null) {
-                    ExileTargetEffect exileEffect = new ExileTargetEffect();
-                    exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                    game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(exileEffect), source);
-                }
-            }
+        CreateTokenEffect effect = new CreateTokenEffect(new RakdosGuildmageGoblinToken());
+        if (effect.apply(game, source))
+        {
+            effect.exileTokensCreatedAtNextEndStep(game, source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/StoneIdolTrap.java
+++ b/Mage.Sets/src/mage/cards/s/StoneIdolTrap.java
@@ -32,9 +32,8 @@ import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
@@ -43,14 +42,11 @@ import mage.constants.CardType;
 import mage.constants.CostModificationType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.permanent.AttackingPredicate;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.Token;
-import mage.target.targetpointer.FixedTarget;
 import mage.util.CardUtil;
 
 /**
@@ -137,18 +133,14 @@ class StoneIdolTrapEffect extends OneShotEffect {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        StoneTrapIdolToken token = new StoneTrapIdolToken();
-        token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId());
-        for (UUID tokenId : token.getLastAddedTokenIds()) {
-            Permanent tokenPermanent = game.getPermanent(tokenId);
-            if (tokenPermanent != null) {
-                ExileTargetEffect exileEffect = new ExileTargetEffect();
-                exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(Zone.ALL, exileEffect, TargetController.YOU), source);
-            }
+    public boolean apply(Game game, Ability source) {        
+        CreateTokenEffect effect = new CreateTokenEffect(new StoneTrapIdolToken());
+        if(effect.apply(game, source))
+        {
+            effect.exileTokensCreatedAtNextEndStep(game, source);
+            return true;
         }
-        return true;
+        return false;
     }
 }
 

--- a/Mage.Sets/src/mage/cards/t/Thunderheads.java
+++ b/Mage.Sets/src/mage/cards/t/Thunderheads.java
@@ -30,9 +30,8 @@ package mage.cards.t;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.keyword.DefenderAbility;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.ReplicateAbility;
@@ -41,9 +40,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.Token;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -88,16 +85,9 @@ class ThunderheadsEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Token token = new WeirdToken();
-        if (token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId())) {
-            for (UUID tokenId : token.getLastAddedTokenIds()) {
-                Permanent tokenPermanent = game.getPermanent(tokenId);
-                if (tokenPermanent != null) {
-                    ExileTargetEffect exileEffect = new ExileTargetEffect();
-                    exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                    game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(exileEffect), source);
-                }
-            }
+        CreateTokenEffect effect = new CreateTokenEffect(new WeirdToken());
+        if (effect.apply(game, source)) {
+            effect.exileTokensCreatedAtNextEndStep(game, source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/z/ZektarShrineExpedition.java
+++ b/Mage.Sets/src/mage/cards/z/ZektarShrineExpedition.java
@@ -27,15 +27,15 @@
  */
 package mage.cards.z;
 
+import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.LandfallAbility;
 import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.costs.common.RemoveCountersSourceCost;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.HasteAbility;
 import mage.abilities.keyword.TrampleAbility;
@@ -46,11 +46,7 @@ import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.Token;
-import mage.target.targetpointer.FixedTarget;
-
-import java.util.UUID;
 
 /**
  *
@@ -97,17 +93,14 @@ class ZektarShrineExpeditionEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        ElementalToken token = new ElementalToken();
-        token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId());
-        for (UUID tokenId : token.getLastAddedTokenIds()) {
-            Permanent tokenPermanent = game.getPermanent(tokenId);
-            if (tokenPermanent != null) {
-                ExileTargetEffect exileEffect = new ExileTargetEffect();
-                exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
-                game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(exileEffect), source);
-            }
+        
+        CreateTokenEffect effect = new CreateTokenEffect(new ElementalToken());
+        if(effect.apply(game, source))
+        {
+            effect.exileTokensCreatedAtNextEndStep(game, source);            
+            return true;
         }
-        return true;
+        return false;
     }
 
     static class ElementalToken extends Token {


### PR DESCRIPTION
went through cards database to find cards where tokens were created and exiled at the end step. refactored them to use CreateTokenEffect and then also the method I created there to reduce duplicates. Also refactored some cards to use the general ElementalToken instead of an unnecessary additional implementation.