### PR TITLE
remove usermap by name, introduced more optionals

### DIFF
--- a/Mage.Server/src/main/java/mage/server/SessionManager.java
+++ b/Mage.Server/src/main/java/mage/server/SessionManager.java
@@ -51,7 +51,11 @@ public enum SessionManager {
 
     public Optional<Session> getSession(@Nonnull String sessionId) {
         Session session = sessions.get(sessionId);
-        if (session != null && session.getUserId() != null && UserManager.instance.getUser(session.getUserId()) == null) {
+        if(session == null){
+            logger.error("Session with sessionId " + sessionId + " is not found");
+            return Optional.empty();
+        }
+        if (session.getUserId() != null && UserManager.instance.getUser(session.getUserId()) == null) {
             logger.error("User for session " + sessionId + " with userId " + session.getUserId() + " is missing. Session removed.");
             // can happen if user from same host signs in multiple time with multiple clients, after he disconnects with one client
             disconnect(sessionId, DisconnectReason.ConnectingOtherInstance);

--- a/Mage.Server/src/main/java/mage/server/UserManager.java
+++ b/Mage.Server/src/main/java/mage/server/UserManager.java
@@ -42,7 +42,7 @@ import java.util.concurrent.*;
  *
  * @author BetaSteward_at_googlemail.com
  */
-public enum  UserManager {
+public enum UserManager {
     instance;
 
     protected final ScheduledExecutorService expireExecutor = Executors.newSingleThreadScheduledExecutor();
@@ -50,7 +50,6 @@ public enum  UserManager {
     private static final Logger LOGGER = Logger.getLogger(UserManager.class);
 
     private final ConcurrentHashMap<UUID, User> users = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, User> usersByName = new ConcurrentHashMap<>();
 
     private static final ExecutorService USER_EXECUTOR = ThreadExecutor.getInstance().getCallExecutor();
 
@@ -58,32 +57,36 @@ public enum  UserManager {
         expireExecutor.scheduleAtFixedRate(this::checkExpired, 60, 60, TimeUnit.SECONDS);
     }
 
-    public User createUser(String userName, String host, AuthorizedUser authorizedUser) {
-        if (getUserByName(userName) != null) {
-            return null; //user already exists
+    public Optional<User> createUser(String userName, String host, AuthorizedUser authorizedUser) {
+        if (getUserByName(userName).isPresent()) {
+            return Optional.empty(); //user already exists
         }
         User user = new User(userName, host, authorizedUser);
         users.put(user.getId(), user);
-        usersByName.put(userName, user);
-        return user;
+        return Optional.of(user);
     }
 
     public Optional<User> getUser(UUID userId) {
-        if (users.get(userId) == null) {
+        if (!users.containsKey(userId)) {
             LOGGER.error(String.format("User with id %s could not be found", userId));
+
             return Optional.empty();
         } else {
             return Optional.of(users.get(userId));
         }
-      /*  if (userId != null) {
-            return users.get(userId);
-        }
-        return null;
-        */
     }
 
-    public User getUserByName(String userName) {
-        return usersByName.get(userName);
+    public Optional<User> getUserByName(String userName) {
+        Optional<User> u = users.values().stream().filter(user -> user.getName().equals(userName))
+                .findFirst();
+        if (u.isPresent()) {
+            return u;
+        } else {
+
+            LOGGER.error("User with name " + userName + " could not be found");
+            return Optional.empty();
+
+        }
     }
 
     public Collection<User> getUsers() {
@@ -103,12 +106,9 @@ public enum  UserManager {
 
     public void disconnect(UUID userId, DisconnectReason reason) {
         if (userId != null) {
-            User user = users.get(userId);
-            if (user != null) {
-                user.setSessionId(""); // Session will be set again with new id if user reconnects
-            }
-            ChatManager.instance.removeUser(userId, reason);
+            getUser(userId).ifPresent(user -> user.setSessionId(""));// Session will be set again with new id if user reconnects
         }
+        ChatManager.instance.removeUser(userId, reason);
     }
 
     public boolean isAdmin(UUID userId) {
@@ -123,25 +123,21 @@ public enum  UserManager {
 
     public void removeUser(final UUID userId, final DisconnectReason reason) {
         if (userId != null) {
-            final User user = users.get(userId);
-            if (user != null) {
-                USER_EXECUTOR.execute(
-                        () -> {
-                            try {
-                                LOGGER.info("USER REMOVE - " + user.getName() + " (" + reason.toString() + ")  userId: " + userId + " [" + user.getGameInfo() + ']');
-                                user.remove(reason);
-                                LOGGER.debug("USER REMOVE END - " + user.getName());
-                            } catch (Exception ex) {
-                                handleException(ex);
-                            } finally {
-                                users.remove(userId);
-                                usersByName.remove(user.getName());
+            getUser(userId).ifPresent(user ->
+                    USER_EXECUTOR.execute(
+                            () -> {
+                                try {
+                                    LOGGER.info("USER REMOVE - " + user.getName() + " (" + reason.toString() + ")  userId: " + userId + " [" + user.getGameInfo() + ']');
+                                    user.remove(reason);
+                                    LOGGER.debug("USER REMOVE END - " + user.getName());
+                                } catch (Exception ex) {
+                                    handleException(ex);
+                                } finally {
+                                    users.remove(userId);
+                                }
                             }
-                        }
-                );
-            } else {
-                LOGGER.warn("Trying to remove userId: " + userId + " - but it does not exist.");
-            }
+                    ));
+
         }
     }
 
@@ -183,9 +179,9 @@ public enum  UserManager {
     }
 
     public String getUserHistory(String userName) {
-        User user = getUserByName(userName);
-        if (user != null) {
-            return "History of user " + userName + " - " + user.getUserData().getHistory();
+        Optional<User> user = getUserByName(userName);
+        if (user.isPresent()) {
+            return "History of user " + userName + " - " + user.get().getUserData().getHistory();
         }
 
         UserStats userStats = UserStatsRepository.instance.getUser(userName);
@@ -199,10 +195,7 @@ public enum  UserManager {
     public void updateUserHistory() {
         USER_EXECUTOR.execute(() -> {
             for (String updatedUser : UserStatsRepository.instance.updateUserStats()) {
-                User user = getUserByName(updatedUser);
-                if (user != null) {
-                    user.resetUserStats();
-                }
+                getUserByName(updatedUser).ifPresent(User::resetUserStats);
             }
         });
     }


### PR DESCRIPTION
I removed the map usersByName from the UserManager. This class had two maps of users, sorted by id, and sorted by name. I think it is sufficient to stick with just one map. 
Next to that, I introduced more optionals where possible. 