### PR TITLE
fixing tokens exiled at end of combat - not at end step

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GeistOfSaintTraft.java
+++ b/Mage.Sets/src/mage/cards/g/GeistOfSaintTraft.java
@@ -89,7 +89,7 @@ class GeistOfSaintTraftEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         
         if (controller != null && effect.apply(game, source)) {
-            effect.exileTokensCreatedAtNextEndStep(game, source);
+            effect.exileTokensCreatedAtEndOfCombat(game, source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/i/InvocationOfSaintTraft.java
+++ b/Mage.Sets/src/mage/cards/i/InvocationOfSaintTraft.java
@@ -97,7 +97,7 @@ class InvocationOfSaintTraftEffect extends OneShotEffect {
         CreateTokenEffect effect = new CreateTokenEffect(new AngelToken(), 1, true, true);
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && (effect.apply(game, source))) {
-            effect.exileTokensCreatedAtNextEndStep(game, source);
+            effect.exileTokensCreatedAtEndOfCombat(game, source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/k/KariZevSkyshipRaider.java
+++ b/Mage.Sets/src/mage/cards/k/KariZevSkyshipRaider.java
@@ -94,7 +94,7 @@ class KariZevSkyshipRaiderEffect extends OneShotEffect {
         CreateTokenEffect effect = new CreateTokenEffect(new RagavanToken(), 1, true, true);
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && effect.apply(game, source)) {
-            effect.exileTokensCreatedAtNextEndStep(game, source);
+            effect.exileTokensCreatedAtEndOfCombat(game, source);
             return true;
         }
         return false;

--- a/Mage/src/main/java/mage/abilities/effects/common/CreateTokenEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CreateTokenEffect.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
+import mage.abilities.common.delayed.AtTheEndOfCombatDelayedTriggeredAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.OneShotEffect;
@@ -124,6 +125,17 @@ public class CreateTokenEffect extends OneShotEffect {
         }        
     }
 
+    public void exileTokensCreatedAtEndOfCombat(Game game, Ability source) {
+        for (UUID tokenId : this.getLastAddedTokenIds()) {
+            Permanent tokenPermanent = game.getPermanent(tokenId);
+            if (tokenPermanent != null) {
+                ExileTargetEffect exileEffect = new ExileTargetEffect(null, "", Zone.BATTLEFIELD);
+                exileEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
+                game.addDelayedTriggeredAbility(new AtTheEndOfCombatDelayedTriggeredAbility(exileEffect), source);
+            }
+        }        
+    }
+    
     private void setText() {
         StringBuilder sb = new StringBuilder("create ");
         if (amount.toString().equals("1")) {


### PR DESCRIPTION
quick patch of bugs I introduced when I neglected to discern between next end step and end of combat with a few tokens exile. Added a dumb additional method to simplify the fix. Can likely combine both the exileTokens methods into one and then adjusting all calls that use it. For now just fixing the 3 cards affected.