### PR TITLE
Fix bug with Watchers of the Dead that stops game from proceeding (AKH)

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WatchersOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/w/WatchersOfTheDead.java
@@ -34,10 +34,7 @@ import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.ExileSourceCost;
 import mage.abilities.effects.OneShotEffect;
-import mage.cards.Card;
-import mage.cards.CardImpl;
-import mage.cards.CardSetInfo;
-import mage.cards.Cards;
+import mage.cards.*;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
@@ -103,8 +100,9 @@ class WatchersOfTheDeadEffect extends OneShotEffect {
                     TargetCard target = new TargetCardInYourGraveyard(2, 2, new FilterCard());
                     target.setNotTarget(true);
                     Cards cardsInGraveyard = opponent.getGraveyard();
-                    opponent.choose(outcome, cardsInGraveyard, target, game);
-                    if (!cardsInGraveyard.isEmpty()) {
+
+                    if (cardsInGraveyard.size() > 2) {
+                        opponent.choose(outcome, cardsInGraveyard, target, game);
                         for (Card cardInGraveyard : cardsInGraveyard.getCards(game)) {
                             if (!target.getTargets().contains(cardInGraveyard.getId())) {
                                 opponent.moveCardToExileWithInfo(cardInGraveyard, CardUtil.getCardExileZoneId(game, source.getId()),


### PR DESCRIPTION
I was playing around with AKH on the latest version of master and noticed that when you activate Watchers of the Dead's exile ability, and your opponent only has one card in their graveyard, it still forces the player to pick a second card in their graveyard, even though there's no graveyard to pick, so the game can't proceed. Screenshot below:

<img width="1280" alt="screen shot 2017-04-16 at 1 42 06 pm" src="https://cloud.githubusercontent.com/assets/3782005/25073219/c5289198-22af-11e7-9922-dc964e4bea9d.png">

This PR makes it so that we don't present the opponent with a choice if they have 2 or fewer cards in their graveyard, as we can assume that the opponent chooses all cards in the graveyard (since they don't have a choice), and then no cards are exiled. This seemed to be the same kind of approach as done in GiftsUngiven.java, which has a similar card wording. 

Hopefully I have done this correctly! Let me know if any changes are desired.