### PR TITLE
Fix for stolen exert creatures that should untap during their owner's next untap step.

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/DontUntapInControllersNextUntapStepTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DontUntapInControllersNextUntapStepTargetEffect.java
@@ -120,7 +120,7 @@ public class DontUntapInControllersNextUntapStepTargetEffect extends ContinuousR
                 Permanent permanent = game.getPermanent(targetId);
                 if (permanent != null) {
                     if (game.getActivePlayerId().equals(permanent.getControllerId())
-                            || (game.getActivePlayerId().equals(onlyIfControlledByPlayer))) { // if effect works only for specific player, all permanents have to be set to handled in that players untap step
+                            && ((onlyIfControlledByPlayer == null) || (game.getActivePlayerId().equals(onlyIfControlledByPlayer)))) { // if effect works only for specific player, all permanents have to be set to handled in that players untap step
                         if (!handledTargetsDuringTurn.containsKey(targetId)) {
                             // it's the untep step of the current controller and the effect was not handled for this target yet, so do it now
                             handledTargetsDuringTurn.put(targetId, false);
@@ -145,8 +145,10 @@ public class DontUntapInControllersNextUntapStepTargetEffect extends ContinuousR
                     && getTargetPointer().getTargets(game, source).contains(event.getTargetId())) {
                 Permanent permanent = game.getPermanent(event.getTargetId());
                 if (permanent != null && game.getActivePlayerId().equals(permanent.getControllerId())) {
-                    handledTargetsDuringTurn.put(event.getTargetId(), true);
-                    return true;
+                    if ((onlyIfControlledByPlayer == null) || game.getActivePlayerId().equals(onlyIfControlledByPlayer)) { // If onlyIfControlledByPlayer is set, then don't apply unless we're currently controlled by the specified player.
+                        handledTargetsDuringTurn.put(event.getTargetId(), true);
+                        return true;
+                    }
                 }
             }
         }

--- a/Mage/src/main/java/mage/abilities/keyword/ExertAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ExertAbility.java
@@ -147,7 +147,7 @@ class ExertReplacementEffect extends ReplacementEffectImpl {
                     game.informPlayers(controller.getLogName() + " exerted " + creature.getName());
                 }
                 game.fireEvent(GameEvent.getEvent(GameEvent.EventType.BECOMES_EXERTED, creature.getId(), creature.getId(), creature.getControllerId()));
-                ContinuousEffect effect = new DontUntapInControllersNextUntapStepTargetEffect();
+                ContinuousEffect effect = new DontUntapInControllersNextUntapStepTargetEffect("", creature.getControllerId());
                 effect.setTargetPointer(new FixedTarget(creature, game));
                 game.addEffect(effect, source);
             }


### PR DESCRIPTION
Fixing check for objects that should not untap during a specific player's next untap step ('your next untap step' vs. 'its controllers next untap step' lanugage).

The issue seemed to be that `onlyIfControlledByPlayer` was being set, but it was never really being checked.

I'm not entirely sure if I got all of the "handle" language correct in `DontUntapInControllersNextUntapStepTargetEffect.java`, but I think this should be correct.  If there is a better way to do a null check for an unset UUID, I do apologize for missing it.

Resolves issue #3183 