### PR TITLE
fixed test to deal with infinite loop check

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/WorldgorgerDragonTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/WorldgorgerDragonTest.java
@@ -114,6 +114,13 @@ public class WorldgorgerDragonTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Volcanic Geyser", playerB, 22);
         setChoice(playerA, "X=20");
 
+        // not an infinite loop resulting in a draw
+        for (int i = 0; i < 6; ++i)
+        {
+            setChoice(playerA, "No");
+            setChoice(playerB, "No");
+        }
+
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 


### PR DESCRIPTION
infinite loop check added 5ce813ad875b3d43e4c946c673c5a7b0fe9c61d5 broke the test. now have to explicitly specify if this is infinite loop or not resulting in a draw (i.e. set to No here)