### PR TITLE
Narset

### DIFF
--- a/Mage.Sets/src/mage/cards/i/IntetTheDreamer.java
+++ b/Mage.Sets/src/mage/cards/i/IntetTheDreamer.java
@@ -162,7 +162,7 @@ class IntetTheDreamerCastEffect extends AsThoughEffectImpl {
                                 return controller.chooseUse(outcome, "Play " + card.getIdName() + '?', source, game);
                             }
                         } else {
-                            controller.setCastSourceIdWithAlternateMana(objectId, null, null);
+                            controller.setCastSourceIdWithAlternateMana(objectId, null, card.getSpellAbility().getCosts());
                             return true;
                         }
                     }

--- a/Mage.Sets/src/mage/cards/k/KheruSpellsnatcher.java
+++ b/Mage.Sets/src/mage/cards/k/KheruSpellsnatcher.java
@@ -158,7 +158,7 @@ class KheruSpellsnatcherCastFromExileEffect extends AsThoughEffectImpl {
                 if (card != null) {
                     if (game.getState().getZone(sourceId) == Zone.EXILED) {
                         Player player = game.getPlayer(affectedControllerId);
-                        player.setCastSourceIdWithAlternateMana(sourceId, null, null);
+                        player.setCastSourceIdWithAlternateMana(sourceId, null, card.getSpellAbility().getCosts());
                         return true;
                     } else {
                         this.discard();

--- a/Mage.Sets/src/mage/cards/m/MindsDesire.java
+++ b/Mage.Sets/src/mage/cards/m/MindsDesire.java
@@ -139,7 +139,7 @@ class MindsDesireCastFromExileEffect extends AsThoughEffectImpl {
                 Card card = game.getCard(sourceId);
                 if (card != null && game.getState().getZone(sourceId) == Zone.EXILED) {
                     Player player = game.getPlayer(affectedControllerId);
-                    player.setCastSourceIdWithAlternateMana(sourceId, null, null);
+                    player.setCastSourceIdWithAlternateMana(sourceId, null, card.getSpellAbility().getCosts());
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/s/StolenGoods.java
+++ b/Mage.Sets/src/mage/cards/s/StolenGoods.java
@@ -140,7 +140,7 @@ class StolenGoodsCastFromExileEffect extends AsThoughEffectImpl {
             Card card = game.getCard(sourceId);
             if (card != null && game.getState().getZone(sourceId) == Zone.EXILED) {
                 Player player = game.getPlayer(affectedControllerId);
-                player.setCastSourceIdWithAlternateMana(sourceId, null, null);
+                player.setCastSourceIdWithAlternateMana(sourceId, null, card.getSpellAbility().getCosts());
                 return true;
             }
         }


### PR DESCRIPTION
After fixing the reported bug for Narset not requiring additional costs when casting a spell for free, I looked through other cards that also use player.setCastSourceIdWithAlternateMana. Several cards, Intet the Dreamer, Kheru Spellsnatcher, Mind's Desire and Stolen Goods were also missing the additional casting cost. 

There are still some cards left, but they don't seem to have a direct reference to the cardId, so we have to look into those, those cards are:

Spelljack
Oracles Vault
Sins of the Past