### PR TITLE
Act of Heroism fixes

### DIFF
--- a/Mage.Sets/src/mage/cards/a/ActOfHeroism.java
+++ b/Mage.Sets/src/mage/cards/a/ActOfHeroism.java
@@ -27,19 +27,17 @@
  */
 package mage.cards.a;
 
-import java.util.UUID;
-import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.UntapTargetEffect;
-import mage.abilities.effects.common.combat.CanBlockAdditionalCreatureEffect;
+import mage.abilities.effects.common.combat.CanBlockAdditionalCreatureTargetEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
-import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.Zone;
 import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -55,12 +53,14 @@ public class ActOfHeroism extends CardImpl {
         effect.setText("Untap target creature");
         this.getSpellAbility().addEffect(effect);
 
-        // It gets +2/+2 and can block an additional creature this turn.
+        // It gets +2/+2 until end of turn
         effect = new BoostTargetEffect(2, 2, Duration.EndOfTurn);
         effect.setText("It gets +2/+2");
         this.getSpellAbility().addEffect(effect);
-        effect = new GainAbilityTargetEffect(new SimpleStaticAbility(Zone.BATTLEFIELD, new CanBlockAdditionalCreatureEffect()), Duration.EndOfTurn);
-        effect.setText("and can block an additional creature this turn");
+
+        // and can block an additional creature this turn
+        effect = new CanBlockAdditionalCreatureTargetEffect();
+        effect.setText("and can block an additional creature this turn.");
         this.getSpellAbility().addEffect(effect);
 
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/a/ActOfHeroism.java
+++ b/Mage.Sets/src/mage/cards/a/ActOfHeroism.java
@@ -48,7 +48,7 @@ import mage.target.common.TargetCreaturePermanent;
 public class ActOfHeroism extends CardImpl {
 
     public ActOfHeroism(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{G}");
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{W}");
 
         // Untap target creature.
         Effect effect = new UntapTargetEffect();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/ActOfHeroismTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/ActOfHeroismTest.java
@@ -10,6 +10,7 @@ import org.mage.test.serverside.base.CardTestPlayerBase;
  */
 public class ActOfHeroismTest extends CardTestPlayerBase {
 
+    // Test that loss of abilities doesn't remove Act of Heroism's "block an additional creature" effect
     @Test
     public void testCanBlockMultiple() {
         // 0/4 Creature - Camel
@@ -36,8 +37,7 @@ public class ActOfHeroismTest extends CardTestPlayerBase {
 
         setStopAt(2, PhaseStep.COMBAT_DAMAGE);
 
+        // Fails if A's creature is unable to block both attackers
         execute();
-
-        assertLife(playerA, 20); // No damage taken
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/ActOfHeroismTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/ActOfHeroismTest.java
@@ -1,0 +1,43 @@
+package org.mage.test.cards.continuous;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author mzulch
+ */
+public class ActOfHeroismTest extends CardTestPlayerBase {
+
+    @Test
+    public void testCanBlockMultiple() {
+        // 0/4 Creature - Camel
+        addCard(Zone.BATTLEFIELD, playerA, "Tasseled Dromedary");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+        addCard(Zone.HAND, playerA, "Act of Heroism");
+
+        addCard(Zone.BATTLEFIELD, playerB, "Unwavering Initiate");
+        addCard(Zone.BATTLEFIELD, playerB, "Sacred Cat");
+        addCard(Zone.BATTLEFIELD, playerB, "Plains", 8);
+        addCard(Zone.HAND, playerB, "Overwhelming Splendor");
+
+        // Untap target creature. It gets +2/+2 until end of turn and can block an additional creature this turn
+        castSpell(2, PhaseStep.UPKEEP, playerA, "Act of Heroism", "Tasseled Dromedary");
+
+        // Creatures enchanted player controls loses all abilities and have base power and toughness 1/1
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Overwhelming Splendor", playerA);
+
+        attack(2, playerB, "Unwavering Initiate");
+        attack(2, playerB, "Sacred Cat");
+
+        block(2, playerA, "Tasseled Dromedary", "Unwavering Initiate");
+        block(2, playerA, "Tasseled Dromedary", "Sacred Cat");
+
+        setStopAt(2, PhaseStep.COMBAT_DAMAGE);
+
+        execute();
+
+        assertLife(playerA, 20); // No damage taken
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/combat/CanBlockAdditionalCreatureTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/combat/CanBlockAdditionalCreatureTargetEffect.java
@@ -1,0 +1,84 @@
+package mage.abilities.effects.common.combat;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.ContinuousEffectImpl;
+import mage.constants.Duration;
+import mage.constants.Layer;
+import mage.constants.Outcome;
+import mage.constants.SubLayer;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.util.CardUtil;
+
+/**
+ * @author mzulch
+ */
+public class CanBlockAdditionalCreatureTargetEffect extends ContinuousEffectImpl {
+
+    protected int amount;
+
+    public CanBlockAdditionalCreatureTargetEffect() {
+        this(Duration.EndOfTurn, 1);
+    }
+
+    public CanBlockAdditionalCreatureTargetEffect(Duration duration, int amount) {
+        super(duration, Outcome.Benefit);
+        this.amount = amount;
+        staticText = setText();
+    }
+
+    public CanBlockAdditionalCreatureTargetEffect(final CanBlockAdditionalCreatureTargetEffect effect) {
+        super(effect);
+        this.amount = effect.amount;
+    }
+
+    @Override
+    public CanBlockAdditionalCreatureTargetEffect copy() {
+        return new CanBlockAdditionalCreatureTargetEffect(this);
+    }
+
+    @Override
+    public boolean apply(Layer layer, SubLayer sublayer, Ability source, Game game) {
+        Permanent target = game.getPermanent(this.getTargetPointer().getFirst(game, source));
+        if (target == null) {
+            return false;
+        }
+
+        // maxBlocks = 0 equals to "can block any number of creatures"
+        if (amount > 0) {
+            target.setMaxBlocks(target.getMaxBlocks() + amount);
+        } else {
+            target.setMaxBlocks(0);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return false;
+    }
+
+    private String setText() {
+        String text = "target can block ";
+        switch (amount) {
+            case 0:
+                text += "any number of creatures";
+                break;
+            default:
+                text += CardUtil.numberToText(amount, "an") + " additional creature" + (amount > 1 ? "s" : "");
+        }
+        if (duration == Duration.EndOfTurn) {
+            text += " this turn";
+        }
+        if (duration == Duration.WhileOnBattlefield) {
+            text += " each combat";
+        }
+        return text;
+    }
+
+    @Override
+    public boolean hasLayer(Layer layer) {
+        return layer == Layer.RulesEffects;
+    }
+}


### PR DESCRIPTION
The changes in this pull request:
- Fix the color of the mana cost
- Fix interaction with cards that cause creatures to lose abilities (as blocking an additional creature is an effect created by Act of Heroism, not an ability granted to the target creature)
- Add automated test case for the above interaction

This is my first attempt at a contribution, so feel free to coach, criticize, etc. as needed. I'm least confident about the `CanBlockAdditionalCreatureTargetEffect` implementation. It's based on the original `CanBlockAdditionalCreatureEffect` (without "Target") but someone more knowledgeable should definitely double check that one.