### PR TITLE
Fixed Historical Type 2 Issues #3417.

### DIFF
--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/HistoricalType2.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/HistoricalType2.java
@@ -51,11 +51,11 @@ public class HistoricalType2 extends Constructed {
         {"TMP", "STH", "EXO", "USG", "ULG", "6ED", "UDS"},
         //  8th Standard: Urza's Saga, Urza's Legacy, 6th, Urza's Destiny,
         //                Mercadian Masques, Nemesis, Prophecy.
-        {"USG", "ULG", "6ED", "UDS", "MMQ", "NMS", "PCY"},
+        {"USG", "ULG", "6ED", "UDS", "MMQ", "NEM", "PCY"},
         //  9th Standard
-        {"6ED", "MMQ", "NMS", "PCY", "INV", "PLS"},
+        {"6ED", "MMQ", "NEM", "PCY", "INV", "PLS"},
         //  10th Standard
-        {"7ED", "MMQ", "NMS", "PCY", "INV", "PLS", "APC"},
+        {"7ED", "MMQ", "NEM", "PCY", "INV", "PLS", "APC"},
         // 11th Standard
         {"7ED", "INV", "APC", "PLS", "ODY", "TOR", "JUD"},
         // 12th Standard

--- a/Mage.Sets/src/mage/sets/ShardsOfAlara.java
+++ b/Mage.Sets/src/mage/sets/ShardsOfAlara.java
@@ -46,7 +46,8 @@ public class ShardsOfAlara extends ExpansionSet {
     }
 
     private ShardsOfAlara() {
-        super("Shards of Alara", "ALA", ExpansionSet.buildDate(2008, 8, 27), SetType.EXPANSION);
+        // release date of Shards of Alara was October 3rd, 2008. Was previously entered as August 27.
+        super("Shards of Alara", "ALA", ExpansionSet.buildDate(2008, 10, 3), SetType.EXPANSION);
         this.blockName = "Shards of Alara";
         this.hasBoosters = true;
         this.numBoosterLands = 1;


### PR DESCRIPTION
Shards of Alara had an incorrect release date.
Nemisis had the wrong set code in the hardcoded standards.