### PR TITLE
Fix problem in Permanent.destroy(), implement Cinder Cloud

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CinderCloud.java
+++ b/Mage.Sets/src/mage/cards/c/CinderCloud.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.c;
+
+import mage.ObjectColor;
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author ciaccona007
+ */
+public class CinderCloud extends CardImpl {
+
+    public CinderCloud(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{R}{R}");
+        
+
+        // Destroy target creature. If a white creature dies this way, Cinder Cloud deals damage to that creature's controller equal to the creature's power.
+        this.getSpellAbility().addEffect(new CinderCloudEffect());
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent());
+    }
+
+    public CinderCloud(final CinderCloud card) {
+        super(card);
+    }
+
+    @Override
+    public CinderCloud copy() {
+        return new CinderCloud(this);
+    }
+}
+
+class CinderCloudEffect extends OneShotEffect {
+
+    public CinderCloudEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "Destroy target creature. If a white creature dies this way, {this} deals damage to that creature's controller equal to the creature's power";
+    }
+
+    public CinderCloudEffect(final CinderCloudEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public CinderCloudEffect copy() {
+        return new CinderCloudEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanent(getTargetPointer().getFirst(game, source));
+        if(permanent != null && permanent.destroy(source.getSourceId(), game, false) && permanent.getColor(game).equals(ObjectColor.WHITE)) {
+            int damage = permanent.getPower().getValue();
+            Player player = game.getPlayer(permanent.getControllerId());
+            if(player != null) {
+                player.damage(damage, source.getSourceId(), game, false, true);
+            }
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/k/KalitasBloodchiefOfGhet.java
+++ b/Mage.Sets/src/mage/cards/k/KalitasBloodchiefOfGhet.java
@@ -27,7 +27,6 @@
  */
 package mage.cards.k;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -45,6 +44,8 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.game.permanent.token.KalitasVampireToken;
 import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
 
 /**
  *

--- a/Mage.Sets/src/mage/sets/Mirage.java
+++ b/Mage.Sets/src/mage/sets/Mirage.java
@@ -88,6 +88,7 @@ public class Mirage extends ExpansionSet {
         cards.add(new SetCardInfo("Chaosphere", 164, Rarity.RARE, mage.cards.c.Chaosphere.class));
         cards.add(new SetCardInfo("Charcoal Diamond", 261, Rarity.UNCOMMON, mage.cards.c.CharcoalDiamond.class));
         cards.add(new SetCardInfo("Choking Sands", 11, Rarity.COMMON, mage.cards.c.ChokingSands.class));
+        cards.add(new SetCardInfo("Cinder Cloud", 165, Rarity.UNCOMMON, mage.cards.c.CinderCloud.class));
         cards.add(new SetCardInfo("Civic Guildmage", 211, Rarity.COMMON, mage.cards.c.CivicGuildmage.class));
         cards.add(new SetCardInfo("Cloak of Invisibility", 58, Rarity.COMMON, mage.cards.c.CloakOfInvisibility.class));
         cards.add(new SetCardInfo("Coral Fighters", 59, Rarity.UNCOMMON, mage.cards.c.CoralFighters.class));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/CinderCloudTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/CinderCloudTest.java
@@ -1,0 +1,68 @@
+package org.mage.test.cards.single;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author ciaccona007
+ */
+public class CinderCloudTest extends CardTestPlayerBase {
+
+    //Destroy target creature. If a white creature dies this way, Cinder Cloud deals damage to that creature's controller equal to the creature's power.
+
+    @Test
+    public void testDamageWhenWhiteCreatureDies() {
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        addCard(Zone.HAND, playerA, "Cinder Cloud");
+
+        addCard(Zone.BATTLEFIELD, playerB, "Savannah Lions"); //Creature - Cat 2/1
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cinder Cloud", "Savannah Lions");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertLife(playerA, 20);
+        assertLife(playerB, 18);
+        assertPermanentCount(playerB, 0);
+    }
+
+    @Test
+    public void testNoDamageWhenWhiteCreatureDoesntDie() {
+
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        addCard(Zone.HAND, playerA, "Cinder Cloud");
+        // When Rest in Peace enters the battlefield, exile all cards from all graveyards.
+        // If a card or token would be put into a graveyard from anywhere, exile it instead.
+        addCard(Zone.BATTLEFIELD, playerA, "Rest in Peace"); //Enchantment
+
+        addCard(Zone.BATTLEFIELD, playerB, "Savannah Lions"); //Creature - Cat 2/1
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cinder Cloud", "Savannah Lions");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+        assertExileCount(playerB, 1);
+        assertPermanentCount(playerB, 0);
+    }
+    @Test
+    public void testNoDamageIfNonwhiteCreature() {
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        addCard(Zone.HAND, playerA, "Cinder Cloud");
+        addCard(Zone.BATTLEFIELD, playerB, "Gray Ogre"); //Creature - Ogre 2/2
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cinder Cloud", "Gray Ogre");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+        assertPermanentCount(playerB, 0);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/KalitasBloodchiefOfGhetTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/KalitasBloodchiefOfGhetTest.java
@@ -20,6 +20,7 @@ public class KalitasBloodchiefOfGhetTest extends CardTestPlayerBase {
         execute();
 
         assertPermanentCount(playerA, 5);
+        assertPermanentCount(playerA, "Vampire", 0);
         assertPermanentCount(playerB, 0);
     }
 }

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -27,7 +27,6 @@
  */
 package mage.game.permanent;
 
-import java.util.*;
 import mage.MageObject;
 import mage.MageObjectReference;
 import mage.ObjectColor;
@@ -55,6 +54,8 @@ import mage.game.stack.StackObject;
 import mage.players.Player;
 import mage.util.GameLog;
 import mage.util.ThreadLocalStringBuilder;
+
+import java.util.*;
 
 /**
  * @author BetaSteward_at_googlemail.com
@@ -953,8 +954,8 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
         }
 
         if (!game.replaceEvent(GameEvent.getEvent(EventType.DESTROY_PERMANENT, objectId, sourceId, controllerId, noRegen ? 1 : 0))) {
-            // this means destroy was successfull, if object movement to graveyard will be replaced (e.g. commander to command zone) does not count for
-            // successfull destroying.
+            // this means destroy was successful, if object movement to graveyard will be replaced (e.g. commander to command zone) does not count for
+            // successful destroying.
             if (moveToZone(Zone.GRAVEYARD, sourceId, game, false)) {
                 if (!game.isSimulation()) {
                     String logName;
@@ -971,8 +972,8 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                     }
                 }
                 game.fireEvent(GameEvent.getEvent(EventType.DESTROYED_PERMANENT, objectId, sourceId, controllerId));
+                return true;
             }
-            return true; //
         }
         return false;
     }


### PR DESCRIPTION
Permanent.destroy() had a return statement in a bad place which caused the problem in Kalitas, Bloodchief of Ghet which is fixed in this commit, allowing implementation of Cinder Cloud as well