### PR TITLE
Fix #4130 Decree of Justice

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DecreeOfJustice.java
+++ b/Mage.Sets/src/mage/cards/d/DecreeOfJustice.java
@@ -34,6 +34,7 @@ import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.costs.mana.ManaCost;
 import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.costs.mana.VariableManaCost;
 import mage.abilities.dynamicvalue.common.ManacostVariableValue;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
@@ -66,6 +67,7 @@ public class DecreeOfJustice extends CardImpl {
         
         // When you cycle Decree of Justice, you may pay {X}. If you do, create X 1/1 white Soldier creature tokens.
         Ability ability = new CycleTriggeredAbility(new DecreeOfJusticeCycleEffect(), true);
+        ability.addCost(new ManaCostsImpl<>("{X}"));
         this.addAbility(ability);
     }
 
@@ -98,14 +100,12 @@ class DecreeOfJusticeCycleEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
-        ManaCosts<ManaCost> cost = new ManaCostsImpl<>("{X}");
         if (player != null) {
-            int costX = player.announceXMana(0, Integer.MAX_VALUE, "Announce the value for {X}", game, source);
-            cost.add(new GenericManaCost(costX));
-            if (cost.pay(source, game, source.getSourceId(), source.getControllerId(), false, null)) {
-                Token token = new SoldierToken();
-                token.putOntoBattlefield(costX, game, source.getSourceId(), source.getControllerId());
-            }
+            Token token = new SoldierToken();
+            int X = new ManacostVariableValue().calculate(game, source, this);
+            token.putOntoBattlefield(X, game, source.getSourceId(), source.getControllerId());
+            return true;
+            
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/d/DecreeOfJustice.java
+++ b/Mage.Sets/src/mage/cards/d/DecreeOfJustice.java
@@ -32,10 +32,7 @@ import mage.abilities.Ability;
 import mage.abilities.common.CycleTriggeredAbility;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.costs.mana.ManaCost;
-import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.costs.mana.VariableManaCost;
 import mage.abilities.dynamicvalue.common.ManacostVariableValue;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
@@ -109,6 +106,6 @@ class DecreeOfJusticeCycleEffect extends OneShotEffect {
                 return true;
             }
         }
-        return false;        
+        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DecreeOfJustice.java
+++ b/Mage.Sets/src/mage/cards/d/DecreeOfJustice.java
@@ -30,6 +30,7 @@ package mage.cards.d;
 import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.CycleTriggeredAbility;
+import mage.abilities.costs.Cost;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.costs.mana.ManaCost;
 import mage.abilities.costs.mana.ManaCosts;
@@ -67,7 +68,6 @@ public class DecreeOfJustice extends CardImpl {
         
         // When you cycle Decree of Justice, you may pay {X}. If you do, create X 1/1 white Soldier creature tokens.
         Ability ability = new CycleTriggeredAbility(new DecreeOfJusticeCycleEffect(), true);
-        ability.addCost(new ManaCostsImpl<>("{X}"));
         this.addAbility(ability);
     }
 
@@ -101,12 +101,14 @@ class DecreeOfJusticeCycleEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            Token token = new SoldierToken();
-            int X = new ManacostVariableValue().calculate(game, source, this);
-            token.putOntoBattlefield(X, game, source.getSourceId(), source.getControllerId());
-            return true;
-            
+            int X = player.announceXMana(0, Integer.MAX_VALUE, "Announce the value for {X}", game, source);
+            Cost cost = new GenericManaCost(X);
+            if(cost.pay(source, game, source.getSourceId(), source.getControllerId(), false)){
+                Token token = new SoldierToken();
+                token.putOntoBattlefield(X, game, source.getSourceId(), source.getControllerId());
+                return true;
+            }
         }
-        return false;
+        return false;        
     }
 }


### PR DESCRIPTION
The original Problem was caused by VariableManaCost behaving strangely(eating all mana in the mana pool) This solution gets the card to behave correctly by never involving that class. 

Originally `ManaCostsImpl<>("{X}")` created a ManaCost container that contained a VariableManaCost, and later a GenericManaCost set to the player's declared X was added to it. When it was time to pay the player was asked for (0<X1<INT_MAX)+X2 mana. X1's value was irrelevant, but any floated mana would go to pay for it even if X2 was unpaid.

I think there might be some change to VariableManaCost that would make a better fix, but I'm not sure what to do about it. 