### PR TITLE
 spjspj - Add in a new way to allow just the Face Art for cards to be shown

### DIFF
--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderImpl.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderImpl.java
@@ -218,12 +218,14 @@ public class CardPanelRenderImpl extends CardPanel {
         }
     }
 
-
     // Map of generated images
     private final static Map<ImageKey, BufferedImage> IMAGE_CACHE = new MapMaker().softValues().makeMap();
 
     // The art image for the card, loaded in from the disk
     private BufferedImage artImage;
+
+    // The faceart image for the card, loaded in from the disk (based on artid from mtgo)
+    private BufferedImage faceArtImage;
 
     // Factory to generate card appropriate views
     private CardRendererFactory cardRendererFactory = new CardRendererFactory();
@@ -252,6 +254,8 @@ public class CardPanelRenderImpl extends CardPanel {
             // Use the art image and current rendered image from the card
             artImage = impl.artImage;
             cardRenderer.setArtImage(artImage);
+            faceArtImage = impl.faceArtImage;
+            cardRenderer.setFaceArtImage(faceArtImage);
             cardImage = impl.cardImage;
         }
     }
@@ -263,8 +267,8 @@ public class CardPanelRenderImpl extends CardPanel {
             // Try to get card image from cache based on our card characteristics
             ImageKey key
                     = new ImageKey(gameCard, artImage,
-                    getCardWidth(), getCardHeight(),
-                    isChoosable(), isSelected());
+                            getCardWidth(), getCardHeight(),
+                            isChoosable(), isSelected());
             cardImage = IMAGE_CACHE.computeIfAbsent(key, k -> renderCard());
 
             // No cached copy exists? Render one and cache it
@@ -277,7 +281,6 @@ public class CardPanelRenderImpl extends CardPanel {
     /**
      * Create an appropriate card renderer for the
      */
-
     /**
      * Render the card to a new BufferedImage at it's current dimensions
      *
@@ -315,6 +318,7 @@ public class CardPanelRenderImpl extends CardPanel {
         artImage = null;
         cardImage = null;
         cardRenderer.setArtImage(null);
+        cardRenderer.setFaceArtImage(null);
 
         // Stop animation
         tappedAngle = isTapped() ? CardPanel.TAPPED_ANGLE : 0;
@@ -332,19 +336,26 @@ public class CardPanelRenderImpl extends CardPanel {
             Util.threadPool.submit(() -> {
                 try {
                     final BufferedImage srcImage;
+                    final BufferedImage faceArtSrcImage;
                     if (gameCard.isFaceDown()) {
                         // Nothing to do
                         srcImage = null;
+                        faceArtSrcImage = null;
                     } else if (getCardWidth() > THUMBNAIL_SIZE_FULL.width) {
                         srcImage = ImageCache.getImage(gameCard, getCardWidth(), getCardHeight());
+                        faceArtSrcImage = ImageCache.getFaceImage(gameCard, getCardWidth(), getCardHeight());
                     } else {
                         srcImage = ImageCache.getThumbnail(gameCard);
+                        faceArtSrcImage = ImageCache.getFaceImage(gameCard, getCardWidth(), getCardHeight());
                     }
 
                     UI.invokeLater(() -> {
                         if (stamp == updateArtImageStamp) {
                             artImage = srcImage;
                             cardRenderer.setArtImage(srcImage);
+                            faceArtImage = faceArtSrcImage;
+                            cardRenderer.setFaceArtImage(faceArtSrcImage);
+
                             if (srcImage != null) {
                                 // Invalidate and repaint
                                 cardImage = null;
@@ -370,6 +381,7 @@ public class CardPanelRenderImpl extends CardPanel {
         cardImage = null;
         cardRenderer = cardRendererFactory.create(gameCard, isTransformed());
         cardRenderer.setArtImage(artImage);
+        cardRenderer.setFaceArtImage(faceArtImage);
 
         // Repaint
         repaint();

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardRenderer.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardRenderer.java
@@ -66,6 +66,9 @@ public abstract class CardRenderer {
     // The card image
     protected BufferedImage artImage;
 
+    // The face card image
+    protected BufferedImage faceArtImage;
+
     ///////////////////////////////////////////////////////////////////////////
     // Common layout metrics between all cards
     // Polygons for counters
@@ -289,14 +292,48 @@ public abstract class CardRenderer {
         try {
             BufferedImage subImg
                     = artImage.getSubimage(
-                    (int) (artRect.getX() * fullCardImgWidth), (int) (artRect.getY() * fullCardImgHeight),
-                    (int) artWidth, (int) artHeight);
+                            (int) (artRect.getX() * fullCardImgWidth), (int) (artRect.getY() * fullCardImgHeight),
+                            (int) artWidth, (int) artHeight);
             g.drawImage(subImg,
                     x, y,
                     (int) targetWidth, (int) targetHeight,
                     null);
         } catch (RasterFormatException e) {
             // At very small card sizes we may encounter a problem with rounding error making the rect not fit
+        }
+    }
+
+    protected void drawFaceArtIntoRect(Graphics2D g, int x, int y, int w, int h, Rectangle2D artRect, boolean shouldPreserveAspect) {
+        // Perform a process to make sure that the art is scaled uniformly to fill the frame, cutting
+        // off the minimum amount necessary to make it completely fill the frame without "squashing" it.
+        double fullCardImgWidth = faceArtImage.getWidth();
+        double fullCardImgHeight = faceArtImage.getHeight();
+        double artWidth = fullCardImgWidth;
+        double artHeight = fullCardImgHeight;
+        double targetWidth = w;
+        double targetHeight = h;
+        double targetAspect = targetWidth / targetHeight;
+        if (!shouldPreserveAspect) {
+            // No adjustment to art
+        } else if (targetAspect * artHeight < artWidth) {
+            // Trim off some width
+            artWidth = targetAspect * artHeight;
+        } else {
+            // Trim off some height
+            artHeight = artWidth / targetAspect;
+        }
+        try {
+            /*BufferedImage subImg
+                    = faceArtImage.getSubimage(
+                    (int) (artRect.getX() * fullCardImgWidth), (int) (artRect.getY() * fullCardImgHeight),
+                    (int) artWidth, (int) artHeight);*/
+            g.drawImage(faceArtImage,
+                    x, y,
+                    (int) targetWidth, (int) targetHeight,
+                    null);
+        } catch (RasterFormatException e) {
+            // At very small card sizes we may encounter a problem with rounding error making the rect not fit
+            System.out.println(e);
         }
     }
 
@@ -441,5 +478,11 @@ public abstract class CardRenderer {
     // is loaded and ready)
     public void setArtImage(Image image) {
         artImage = CardRendererUtils.toBufferedImage(image);
+    }
+
+    // Set the card art image (CardPanel will give it to us when it
+    // is loaded and ready)
+    public void setFaceArtImage(Image image) {
+        faceArtImage = CardRendererUtils.toBufferedImage(image);
     }
 }

--- a/Mage.Client/src/main/java/org/mage/card/arcane/ModernCardRenderer.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/ModernCardRenderer.java
@@ -279,6 +279,8 @@ public class ModernCardRenderer extends CardRenderer {
             // Just draw a brown rectangle
             drawCardBack(g);
         } else {
+            BufferedImage bufferedImage = new BufferedImage(300, 300, BufferedImage.TYPE_INT_RGB);
+
             // Set texture to paint with
             g.setPaint(getBackgroundPaint(cardView.getColor(), cardView.getCardTypes(), cardView.getSubTypes()));
 
@@ -348,8 +350,15 @@ public class ModernCardRenderer extends CardRenderer {
     @Override
     protected void drawArt(Graphics2D g) {
         if (artImage != null && !cardView.isFaceDown()) {
+
+            boolean useFaceArt = false;
+            if (faceArtImage != null) {
+                useFaceArt = true;
+            }
+
             // Invention rendering, art fills the entire frame
             if (useInventionFrame()) {
+                useFaceArt = false;
                 drawArtIntoRect(g,
                         borderWidth, borderWidth,
                         cardWidth - 2 * borderWidth, cardHeight - 2 * borderWidth,
@@ -360,6 +369,7 @@ public class ModernCardRenderer extends CardRenderer {
             Rectangle2D sourceRect = getArtRect();
 
             if (cardView.getMageObjectType() == MageObjectType.SPELL) {
+                useFaceArt = false;
                 ArtRect rect = cardView.getArtRect();
                 if (rect == ArtRect.SPLIT_FUSED) {
                     // Special handling for fused, draw the art from both halves stacked on top of one and other
@@ -380,10 +390,17 @@ public class ModernCardRenderer extends CardRenderer {
             }
 
             // Normal drawing of art from a source part of the card frame into the rect
-            drawArtIntoRect(g,
-                    totalContentInset + 1, totalContentInset + boxHeight,
-                    contentWidth - 2, typeLineY - totalContentInset - boxHeight,
-                    sourceRect, shouldPreserveAspect);
+            if (useFaceArt) {
+                drawFaceArtIntoRect(g,
+                        totalContentInset + 1, totalContentInset + boxHeight,
+                        contentWidth - 2, typeLineY - totalContentInset - boxHeight,
+                        sourceRect, shouldPreserveAspect);
+            } else {
+                drawArtIntoRect(g,
+                        totalContentInset + 1, totalContentInset + boxHeight,
+                        contentWidth - 2, typeLineY - totalContentInset - boxHeight,
+                        sourceRect, shouldPreserveAspect);
+            }
         }
     }
 
@@ -420,6 +437,7 @@ public class ModernCardRenderer extends CardRenderer {
             g.setPaint(new Color(255, 255, 255, 150));
         } else {
             g.setPaint(textboxPaint);
+
         }
         g.fillRect(
                 totalContentInset + 1, typeLineY,
@@ -475,6 +493,9 @@ public class ModernCardRenderer extends CardRenderer {
 
         // Draw the transform circle
         int nameOffset = drawTransformationCircle(g, borderPaint);
+
+        // Draw the transform circle
+        nameOffset = drawTransformationCircle(g, borderPaint);
 
         // Draw the name line
         drawNameLine(g, cardView.getDisplayName(), manaCostString,

--- a/Mage.Client/src/main/java/org/mage/plugins/card/utils/CardImageUtils.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/utils/CardImageUtils.java
@@ -48,7 +48,7 @@ public final class CardImageUtils {
         log.warn("Token image file not found: " + card.getSet() + " - " + card.getTokenSetCode() + " - " + card.getName());
         return null;
     }
-    
+
     /**
      *
      * @param card
@@ -202,6 +202,14 @@ public final class CardImageUtils {
         }
 
         return imageDir + TFile.separator + imageName;
+    }
+
+    public static String generateFaceImagePath(String cardname, String set) {
+        String useDefault = PreferencesDialog.getCachedValue(PreferencesDialog.KEY_CARD_IMAGES_USE_DEFAULT, "true");
+        String imagesPath = Objects.equals(useDefault, "true") ? Constants.IO.imageBaseDir : PreferencesDialog.getCachedValue(PreferencesDialog.KEY_CARD_IMAGES_PATH, null);
+        String imageDir = imagesPath;
+        String imageName = set + TFile.separator + cardname + ".jpg";
+        return imageDir + TFile.separator + "FACE" + TFile.separator + imageName;
     }
 
     public static String generateTokenDescriptorImagePath(CardDownloadData card) {

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/CanadianHighlander.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/CanadianHighlander.java
@@ -117,9 +117,9 @@ public class CanadianHighlander extends Constructed {
                     || cn.equals("Mana Crypt")
                     || cn.equals("Mystical Tutor")
                     || cn.equals("Strip Mine")
-                    || cn.equals("Summoner’s Pact")
+                    || cn.equals("Summoner's Pact")
                     || cn.equals("Survival of the Fittest")
-                    || cn.equals("Umezawa’s Jitte")) {
+                    || cn.equals("Umezawa's Jitte")) {
                 totalPoints += 2;
                 invalid.put(entry.getKey(), " 2 points " + cn);
             }

--- a/Utils/cut.pl
+++ b/Utils/cut.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 ##
-#   File : get_all.pl
+#   File : cut.pl
 #   Author : spjspj
 ##  
 
@@ -22,6 +22,7 @@ use POSIX qw(strftime);
         print ("   cut.pl full_text.txt keys 0 filegrep\n");
         print ("   cut.pl full_text.txt 0  0 make_code_bat\n");
         print ("   dir /a /b /s *.java | cut.pl stdin 0  0 make_code_bat > bob.bat\n");
+        print ("   dir /a /b /s *.xml | cut.pl stdin 0  0 make_code_bat > bob_xml.bat\n");
         print ("   cut.pl d:\\perl_programs output.*txt  7 age_dir | cut.pl list . 0 grep\n");
         print ("   cut.pl bob.txt 0 0 uniquelines \n");
         print ("   cut.pl file 0 0 strip_http\n");
@@ -331,16 +332,27 @@ use POSIX qw(strftime);
         {
             my $i;
             {
-                my $url = $term;
-                print ("Download :$url:\n");
-                my $content = get $url;
-                print ("Saw " . length ($content) . " bytes!\n");
-                print ("Save in $helper\n");
-                open OUTPUT, "> " . $helper or die "No dice!";
-                binmode (OUTPUT);
-                print OUTPUT $content;
-                close OUTPUT;
-                print $url, " >>> ", $helper, "\n";
+                if (!(-f "$helper"))
+                {
+                    my $url = $term;
+                    print ("Download :$url:\n");
+                    my $content = get $url;
+                    print ("Saw " . length ($content) . " bytes!\n");
+                    print ("Save in $helper\n");
+                    open OUTPUT, "> " . $helper or die "No dice!";
+                    binmode (OUTPUT);
+                    print OUTPUT $content;
+                    close OUTPUT;
+                    print $url, " >>> ", $helper, "\n";
+                }
+                else
+                {
+                    print ("Found $helper existed already..\n");
+                    if (-s "$helper" == 0)
+                    {
+                        `del "$helper"`;
+                    }
+                }
             }
         }
         if ($operation eq "grep")
@@ -898,5 +910,4 @@ use POSIX qw(strftime);
             }
         }
     }
-
 }

--- a/Utils/get_modo_artids.pl
+++ b/Utils/get_modo_artids.pl
@@ -1,0 +1,263 @@
+#!/usr/bin/perl
+##
+#   File : get_modo_artids.pl
+#   Date : 12/Nov/2017
+#   Author : spjspj
+#   Purpose : Get the artid for each face art of each card from modo (mtgo)
+#             this then goes into some form of image such as:
+#             http://mtgoclientdepot.onlinegaming.wizards.com/Graphics/Cards/Pics/161922_typ_reg_sty_050.jpg
+#              "" /00100_typ_reg_sty_001.jpg
+#              "" /01440_typ_reg_sty_010.jpg
+#              "" /102392_typ_reg_sty_010.jpg
+#              "" /400603_typ_reg_sty_050.jpg
+#             This program expects that you've copied the relevant .xml files from an installation of mtgo 
+#             into the current working directory for this perl script:
+#                 For example: CARDNAME_STRING.xml, client_BNG.xml, 
+#             Also, it expects to be running on windows
+##  
+
+use strict;
+use LWP::Simple;
+use POSIX qw(strftime);
+
+
+# From xmage code - fix from MODO to XMAGE type set codes
+my %fix_set_codes;
+$fix_set_codes {"2U"} = "2ED";
+$fix_set_codes {"3E"} = "3ED";
+$fix_set_codes {"4E"} = "4ED";
+$fix_set_codes {"5E"} = "5ED";
+$fix_set_codes {"6E"} = "6ED";
+$fix_set_codes {"7E"} = "7ED";
+$fix_set_codes {"AL"} = "ALL";
+$fix_set_codes {"AP"} = "APC";
+$fix_set_codes {"AN"} = "ARN";
+$fix_set_codes {"AQ"} = "ATQ";
+$fix_set_codes {"CM1"} = "CMA";
+$fix_set_codes {"DD3_DVD"} = "DD3DVD";
+$fix_set_codes {"DD3_EVG"} = "DD3EVG";
+$fix_set_codes {"DD3_GLV"} = "DD3GLV";
+$fix_set_codes {"DD3_JVC"} = "DD3JVC";
+$fix_set_codes {"DK"} = "DRK";
+$fix_set_codes {"EX"} = "EXO";
+$fix_set_codes {"FE"} = "FEM";
+$fix_set_codes {"HM"} = "HML";
+$fix_set_codes {"IA"} = "ICE";
+$fix_set_codes {"IN"} = "INV";
+$fix_set_codes {"1E"} = "LEA";
+$fix_set_codes {"2E"} = "LEB";
+$fix_set_codes {"LE"} = "LEG";
+$fix_set_codes {"MI"} = "MIR";
+$fix_set_codes {"MM"} = "MMQ";
+$fix_set_codes {"MPS_KLD"} = "MPS";
+$fix_set_codes {"NE"} = "NEM";
+$fix_set_codes {"NE"} = "NMS";
+$fix_set_codes {"OD"} = "ODY";
+$fix_set_codes {"PR"} = "PCY";
+$fix_set_codes {"PS"} = "PLS";
+$fix_set_codes {"P2"} = "PO2";
+$fix_set_codes {"PO"} = "POR";
+$fix_set_codes {"PK"} = "PTK";
+$fix_set_codes {"ST"} = "STH";
+$fix_set_codes {"TE"} = "TMP";
+$fix_set_codes {"CG"} = "UDS";
+$fix_set_codes {"UD"} = "UDS";
+$fix_set_codes {"GU"} = "ULG";
+$fix_set_codes {"UZ"} = "USG";
+$fix_set_codes {"VI"} = "VIS";
+$fix_set_codes {"WL"} = "WTH";
+
+# Main
+{
+    my $card = $ARGV [0];
+
+    # Example: <CARDNAME_STRING_ITEM id='ID258_461'>Abandoned Sarcophagus</CARDNAME_STRING_ITEM>
+    my $vals = `find /I "CARDNAME" *CARDNAME*STR*`;
+    my %ids;
+    my %set_names;
+    my $count = 0;
+    while ($vals =~ s/^.*CARDNAME_STRING_ITEM id='(.*?)'>(.*?)<\/CARDNAME_STRING.*\n//im)
+    {
+        $ids {$1} = $2;
+        $count++;
+    }
+    print ("Finished reading $count names\n"); 
+
+
+    #$vals = `find /I "<" *lient*`;
+    $vals = `findstr /I "CARDNAME_STRING DIGITALOBJECT ARTID CLONE" *lient* | find /I /V "_DO.xml"`;
+
+    my $current_artid = "";
+    my $current_clone_id = "";
+    my $current_doc_id = "";
+    my $current_line = "";
+    my $current_name = "";
+    my $current_set = "";
+    my $num_set = 1;
+    my %docid_to_clone;
+
+    while ($vals =~ s/^(.*)\n//im)
+    {
+        my $line = $1;
+        $line =~ m/^client_(.*)?\.xml/;
+        $current_set = $1;
+        
+#<DigitalObject DigitalObjectCatalogID='DOC_26588'> *** IN
+#   <ARTID value='100691'/> *** IN
+#   <ARTIST_NAME_STRING id='ID257_266'/>
+#   <CARDNAME_STRING id='ID258_12464'/> *** IN
+#   <CARDNAME_TOKEN id='ID259_12464'/>
+#   <CARDSETNAME_STRING id='ID516_103'/>
+#   <CARDTEXTURE_NUMBER value='53176'/>
+#   <COLLECTOR_INFO_STRING value='150/180'/>
+#   <COLOR id='ID517_6'/>
+#   <COLOR_IDENTITY id='ID518_4'/>
+#   <CONVERTED_MANA_COST id='ID520_3'/>
+#   <CREATURE_TYPE_STRING0 id='ID777_71'/>
+#   <CREATURE_TYPEID0 id='ID521_12'/>
+#   <FRAMESTYLE value='7'/>
+#   <IS_CREATURE value='1'/>
+#   <MANA_COST_STRING id='ID1811_114'/>
+#   <POWER value='4'/>
+#   <POWERTOUGHNESS_STRING value='4/5'/>
+#   <RARITY_STATUS id='ID1818_3'/>
+#   <REAL_ORACLETEXT_STRING id='ID1819_11686'/>
+#   <SHOULDWORK value='1'/>
+#   <SHROUD value='1'/>
+#   <TOUGHNESS value='5'/>
+#   <WATERMARK value='0'/>
+#</DigitalObject>
+
+        if ($line =~ m/<DigitalObject DigitalObjectCatalogID='([^']+)'/)
+        {
+            $current_line = "$current_set;$1;";
+            $current_doc_id = $1; 
+        }
+        if ($line =~ m/\s*<ARTID value='(\d+)'/)
+        {
+            $current_line .= "artid=$1;";
+        }
+        if ($line =~ m/CARDNAME_STRING id='([^']+)'/)
+        {
+            $current_line = "$ids{$1};$current_line;($1)";
+            $current_name = "$ids{$1}";
+        }
+        if ($line =~ m/CLONE_ID value='([^']+)'/)
+        {
+            my $clone_id = $1;
+            $current_line .= ";Clone=($clone_id)";
+            $current_clone_id = $clone_id;
+        }
+
+        if ($line =~ m/<\/DigitalObject/)
+        {
+            if ($current_name =~ m/.+/ && $current_doc_id =~ m/.+/)
+            {
+                $docid_to_clone {$current_doc_id} = $current_name;
+            }
+                
+            $current_line = "";
+            $current_name = "";
+            $current_clone_id = "";
+            $current_doc_id = "";
+        }
+    }
+   
+    # Run it again..
+    $vals = `findstr /I "CARDNAME_STRING DIGITALOBJECT ARTID CLONE" *lient* | find /I /V "_DO.xml"`;
+
+    $current_set = "";
+    $num_set = 1;
+    $current_artid = "";
+    $current_clone_id = "";
+    $current_doc_id = "";
+    $current_line = "";
+    $current_name = "";
+    my %seen_artids;
+
+    while ($vals =~ s/^(.*)\n//im)
+    {
+        my $line = $1;
+        $line =~ m/^client_(.*)?\.xml/;
+        $current_set = $1;
+        if (defined ($fix_set_codes {$current_set}))
+        {
+            $current_set = $fix_set_codes {$current_set};
+        }
+        
+        if ($line =~ m/<DigitalObject DigitalObjectCatalogID='([^']+)'/)
+        {
+            $current_line = "$current_set;$1;";
+            $current_doc_id = $1; 
+        }
+        if ($line =~ m/\s*<ARTID value='(\d+)'/)
+        {
+            $current_line .= "artid=$1;";
+            $current_artid = $1;
+        }
+        if ($line =~ m/CARDNAME_STRING id='([^']+)'/)
+        {
+            $current_line = "$ids{$1};$current_line;($1)";
+            $current_name = "$ids{$1}";
+        }
+        if ($line =~ m/CLONE_ID value='([^']+)'/)
+        {
+            my $clone_id = $1;
+            $current_line .= ";Clone=($clone_id)";
+            $current_clone_id = $clone_id;
+        }
+
+        if ($line =~ m/<\/DigitalObject/)
+        {
+            if ($docid_to_clone {$current_doc_id} =~ m/.+/) 
+            {
+                $current_name = "$docid_to_clone{$current_doc_id}";
+            }
+            if ($current_name =~ m/.+/ && $current_doc_id =~ m/.+/)
+            {
+                $docid_to_clone {$current_doc_id} = $current_name;
+            }
+            if ($current_name =~ m/^$/)
+            {
+                $current_name = $docid_to_clone {$current_clone_id};
+            }
+                
+            if ($current_name =~ m/..*/ && $current_set =~ m/..*/ && $current_artid =~ m/..*/)
+            {
+                print ("$current_name;$current_set;$current_artid\n");
+                # cut.pl statement..
+                #   echo "1" | cut.pl stdin "http://mtgoclientdepot.onlinegaming.wizards.com/Graphics/Cards/Pics/00010_typ_reg_sty_001.jpg" "ME4\Badlands.jpg" wget_image
+                if (!defined ($seen_artids {$current_artid}))
+                {
+                    $seen_artids {$current_artid} = "$current_set\\$current_name.jpg";
+                    if ($current_artid < 100)
+                    {
+                        print ("  echo \"1\" | cut.pl stdin \"http://mtgoclientdepot.onlinegaming.wizards.com/Graphics/Cards/Pics/000$current_artid" . "_typ_reg_sty_001.jpg\" \"$current_set\\$current_name.jpg\" wget_image\n");
+                    }
+                    elsif ($current_artid < 1000)
+                    {
+                        print ("  echo \"1\" | cut.pl stdin \"http://mtgoclientdepot.onlinegaming.wizards.com/Graphics/Cards/Pics/00$current_artid" . "_typ_reg_sty_001.jpg\" \"$current_set\\$current_name.jpg\" wget_image\n");
+                    }
+                    elsif ($current_artid < 10000)
+                    {
+                        print ("  echo \"1\" | cut.pl stdin \"http://mtgoclientdepot.onlinegaming.wizards.com/Graphics/Cards/Pics/0$current_artid" . "_typ_reg_sty_010.jpg\" \"$current_set\\$current_name.jpg\" wget_image\n");
+                    }
+                    else
+                    {
+                        print ("  echo \"1\" | cut.pl stdin \"http://mtgoclientdepot.onlinegaming.wizards.com/Graphics/Cards/Pics/$current_artid" . "_typ_reg_sty_010.jpg\" \"$current_set\\$current_name.jpg\" wget_image\n");
+                    }
+                }
+                else
+                {
+                    print ("   copy \"$seen_artids{$current_artid}\" \"$current_set\\$current_name.jpg\"\n");
+                }
+            }
+
+            $current_artid = "";
+            $current_clone_id = "";
+            $current_doc_id = "";
+            $current_line = "";
+            $current_name = "";
+        }
+    }
+}

--- a/Utils/modo_artids
+++ b/Utils/modo_artids
@@ -1,0 +1,31904 @@
+Abandon Hope;TMP;3222
+Abandon Reason;EMN;162101
+Abandoned Outpost;ODY;33244
+Abandoned Sarcophagus;HOU;401600
+Abattoir Ghoul;DPA;138222
+Abattoir Ghoul;ISD;138222
+Abbey Gargoyles;5ED;1442
+Abbey Gargoyles;HML;1442
+Abbey Gargoyles;ME2;1442
+Abbey Griffin;ISD;138391
+Abbey Matron;HML;1443
+Abbey Matron;HML;1444
+Abbot of Keral Keep;ORI;160307
+Abbot of Keral Keep;PRM;161278
+Abduction;6ED;2947
+Abduction;WTH;2947
+Aberrant Researcher;SOI;161416
+Abeyance;WTH;2903
+Abhorrent Overlord;PRM;151410
+Abhorrent Overlord;THS;149966
+Abjure;WTH;2830
+Abolish;DDF;22020
+Abolish;PCY;22020
+Abolisher of Bloodlines;EMN;162092
+Abomination of Gudul;KTK;157069
+Abomination;4ED;487
+Abomination;LEG;487
+Aboroth;WTH;2875
+Aboshan, Cephalid Emperor;ODY;33460
+Aboshan's Desire;ODY;33479
+About Face;UL;10342
+Abrade;HOU;401598
+Abrade;PRM;402218
+Abrupt Decay;MM3;145230
+Abrupt Decay;PRM;161284
+Abrupt Decay;RTR;145230
+Absolute Grace;USG;8820
+Absolute Law;USG;8959
+Absolver Thrull;GPT;91778
+Absorb Vis;CON;118709
+Absorb Vis;DDK;118709
+Absorb Vis;MMA;118709
+Absorb;DPA;24041
+Absorb;INV;24041
+Abstruse Interference;OGW;161117
+Abu Ja'far;ARN;303
+Abu Ja'far;CH;303
+Abu Ja'far;PRM;156396
+Abuna Acolyte;SOM;130969
+Abuna's Chant;5DN;77078
+Abundance;10E;8763
+Abundance;USG;8763
+Abundant Growth;AVR;141562
+Abundant Growth;EMA;141562
+Abundant Maw;EMN;162074
+Abyssal Gatekeeper;DDC;2792
+Abyssal Gatekeeper;DPA;2792
+Abyssal Gatekeeper;TD0;2792
+Abyssal Gatekeeper;WTH;2792
+Abyssal Horror;7ED;27524
+Abyssal Horror;USG;8099
+Abyssal Hunter;6ED;1781
+Abyssal Hunter;MIR;1781
+Abyssal Nightstalker;PO2;5441
+Abyssal Nocturnus;GPT;91685
+Abyssal Persecutor;C14;126474
+Abyssal Persecutor;PZ1;126474
+Abyssal Persecutor;WWK;126474
+Abyssal Specter;5ED;2298
+Abyssal Specter;6ED;2298
+Abyssal Specter;7ED;27525
+Abyssal Specter;8ED;27525
+Abyssal Specter;DDC;27525
+Abyssal Specter;DPA;27525
+Abyssal Specter;ICE;1059
+Abyssal Specter;MM3;400711
+Abzan Advantage;FRF;157311
+Abzan Ascendancy;KTK;157074
+Abzan Banner;KTK;156531
+Abzan Battle Priest;KTK;156998
+Abzan Beastmaster;FRF;157280
+Abzan Beastmaster;PRM;160089
+Abzan Charm;KTK;156566
+Abzan Falconer;KTK;156996
+Abzan Guide;KTK;156571
+Abzan Kin-Guard;FRF;157272
+Abzan Runemark;FRF;157226
+Abzan Skycaptain;FRF;157162
+Academy Elite;VMA;153130
+Academy Raider;M14;147433
+Academy Rector;UD;15609
+Academy Researchers;10E;8695
+Academy Researchers;DPA;8695
+Academy Researchers;USG;8695
+Academy Ruins;MMA;97477
+Academy Ruins;TSP;97477
+Academy at Tolaria West;PC1;125868
+Accelerate;TOR;36480
+Accelerated Mutation;SCG;48111
+Acceptable Losses;ODY;33373
+Accomplished Automaton;KLD;162336
+Accorder Paladin;DPA;131613
+Accorder Paladin;MBS;131613
+Accorder's Shield;M14;131085
+Accorder's Shield;SOM;131085
+Accumulated Knowledge;NMS;21211
+Accumulated Knowledge;PRM;153381
+Accumulated Knowledge;PRM;21211
+Accursed Centaur;ONS;43036
+Accursed Horde;HOU;401529
+Accursed Spirit;M14;147434
+Accursed Spirit;M15;147434
+Accursed Witch;SOI;161775
+Acid Rain;LEG;4612
+Acid Rain;ME4;4612
+Acid Web Spider;SOM;131099
+Acid-Spewer Dragon;DTK;159841
+Acidic Dagger;MIR;1782
+Acidic Slime;C13;121561
+Acidic Slime;CMD;121561
+Acidic Slime;DDM;121561
+Acidic Slime;DPA;121561
+Acidic Slime;M10;121561
+Acidic Slime;M11;121561
+Acidic Slime;M12;121561
+Acidic Slime;M13;121561
+Acidic Slime;PRM;143397
+Acidic Sliver;H09;3642
+Acidic Sliver;STH;3642
+Acidic Sliver;TPR;3642
+Acidic Soil;USG;8789
+Acolyte of Xathrid;M10;121644
+Acolyte of the Inferno;ORI;160296
+Acolyte's Reward;BNG;152538
+Acorn Catapult;CMD;137529
+Acorn Harvest;TOR;36510
+Acquire;5DN;77126
+Acridian;USG;8848
+Acrobatic Maneuver;KLD;162190
+Act of Aggression;NPH;134368
+Act of Authority;C13;151743
+Act of Heroism;HOU;401518
+Act of Treason;DPA;121664
+Act of Treason;GTC;146316
+Act of Treason;KTK;156514
+Act of Treason;M10;121664
+Act of Treason;M11;121664
+Act of Treason;M12;121664
+Act of Treason;M14;121664
+Act of Treason;ORI;121664
+Act on Impulse;M15;155289
+Active Volcano;CH;488
+Active Volcano;LEG;488
+Active Volcano;ME3;488
+Ad Nauseam;ALA;88663
+Adamaro, First to Desire;SOK;86066
+Adanto Vanguard;XLN;401429
+Adanto, the First Fort;XLN;402058
+Adaptive Automaton;M12;139245
+Adaptive Snapjaw;GTC;146288
+Adarkar Sentinel;ICE;1060
+Adarkar Sentinel;ME2;1060
+Adarkar Unicorn;ICE;1061
+Adarkar Valkyrie;C14;96932
+Adarkar Valkyrie;CSP;96932
+Adarkar Valkyrie;MMA;96932
+Adarkar Wastes;10E;27526
+Adarkar Wastes;5ED;2299
+Adarkar Wastes;6ED;2299
+Adarkar Wastes;7ED;27526
+Adarkar Wastes;9ED;27526
+Adarkar Wastes;ICE;1062
+Adarkar Windform;CSP;97004
+Adder-Staff Boggart;LRW;106399
+Addle;INV;24625
+Addle;VMA;24625
+Admiral Beckett Brass;XLN;402069
+Admonition Angel;DPA;126520
+Admonition Angel;WWK;126520
+Adorned Pouncer;HOU;401549
+Adorned Pouncer;PRM;401777
+Adorned Pouncer;TOK;401881
+Adriana, Captain of the Guard;PZ2;161542
+Adun Oakenshield;LEG;4613
+Adun Oakenshield;MED;4613
+Advance Scout;TMP;3058
+Advanced Hoverguard;5DN;77092
+Advanced Stitchwing;EMN;162062
+Advent of the Wurm;DGM;146864
+Advent of the Wurm;MM3;146864
+Adventurers' Guildhouse;LEG;489
+Adventuring Gear;ZEN;123577
+Adverse Conditions;BFZ;160644
+Advice from the Fae;SHM;111808
+Advocate of the Beast;M14;147397
+Aegis Angel;M12;131605
+Aegis Angel;M15;131605
+Aegis Angel;ORI;131605
+Aegis Angel;W16;131605
+Aegis Automaton;AER;400369
+Aegis of Honor;ODY;33503
+Aegis of the Gods;JOU;153085
+Aegis of the Meek;ICE;1063
+Aeolipile;FEM;852
+Aeolipile;ME2;852
+Aeon Chronicler;DDM;100704
+Aeon Chronicler;PLC;100704
+Aerathi Berserker;LEG;490
+Aerial Caravan;MMQ;19047
+Aerial Formation;JOU;152840
+Aerial Guide;HOU;402206
+Aerial Maneuver;GTC;146563
+Aerial Modification;AER;400247
+Aerial Predation;RTR;145146
+Aerial Responder;KLD;162472
+Aerial Volley;ORI;160329
+Aerie Bowmasters;DTK;159812
+Aerie Mystics;C13;118654
+Aerie Mystics;CON;118654
+Aerie Ouphes;EVE;113675
+Aerie Worshippers;BNG;152064
+Aeronaut Admiral;AER;400242
+Aeronaut Tinkerer;M15;155365
+Aesthir Glider;ALL;1582
+Aesthir Glider;ALL;1583
+Aesthir Glider;ME4;1582
+Aether Adept;DDM;129110
+Aether Adept;DPA;129110
+Aether Adept;M11;129110
+Aether Adept;M12;129110
+Aether Barrier;NMS;21228
+Aether Burst;ODY;33482
+Aether Charge;ONS;43125
+Aether Chaser;AER;400307
+Aether Figment;DDM;102621
+Aether Figment;DPA;102621
+Aether Figment;ZEN;102621
+Aether Flash;6ED;2941
+Aether Flash;7ED;27527
+Aether Flash;WTH;2941
+Aether Gale;C14;155661
+Aether Herder;AER;400335
+Aether Hub;KLD;162632
+Aether Hub;PRM;401443
+Aether Inspector;AER;400234
+Aether Meltdown;KLD;162247
+Aether Membrane;DDI;100752
+Aether Membrane;PLC;100752
+Aether Mutation;APC;31135
+Aether Mutation;DPA;31135
+Aether Mutation;VMA;31135
+Aether Poisoner;AER;400281
+Aether Rift;INV;24081
+Aether Shockwave;SOK;86079
+Aether Snap;C14;75199
+Aether Snap;DST;75199
+Aether Spellbomb;DDF;50289
+Aether Spellbomb;MMA;50289
+Aether Spellbomb;MRD;50289
+Aether Sting;UD;15592
+Aether Storm;5ED;1445
+Aether Storm;HML;1445
+Aether Storm;ME2;1445
+Aether Storm;PRM;148899
+Aether Swooper;AER;400257
+Aether Theorist;KLD;162474
+Aether Tide;EXO;4640
+Aether Tradewinds;DPA;126522
+Aether Tradewinds;KLD;162258
+Aether Tradewinds;WWK;126522
+Aether Vial;DST;75185
+Aether Vial;MMA;129510
+Aether Vial;MS2;162584
+Aether Vial;TD0;75185
+Aether Vial;V10;129510
+Aether Web;TSP;97304
+Aetherborn Marauder;KLD;162269
+Aetherflame Wall;TSP;97431
+Aetherflux Reservoir;KLD;162337
+Aethergeode Miner;AER;162471
+Aetherize;GTC;146388
+Aetherling;DGM;147730
+Aethermage's Touch;C13;94664
+Aethermage's Touch;DIS;94664
+Aethermage's Touch;MM3;94664
+Aetherplasm;GPT;91751
+Aethersnatch;PZ1;160440
+Aethersnipe;CMD;107622
+Aethersnipe;DD2;107622
+Aethersnipe;LRW;107622
+Aethersnipe;MM2;107622
+Aethersnipe;MMA;107622
+Aethersphere Harvester;AER;400395
+Aetherspouts;M15;155238
+Aethersquall Ancient;KLD;162480
+Aetherstorm Roc;KLD;400229
+Aetherstream Leopard;AER;400336
+Aethertide Whale;AER;400274
+Aethertorch Renegade;KLD;162523
+Aethertow;MM3;111861
+Aethertow;SHM;111861
+Aetherwind Basker;AER;400350
+Aetherworks Marvel;KLD;162326
+Affa Guard Hound;ROE;127477
+Affa Protector;OGW;161097
+Afflict;10E;33412
+Afflict;ODY;33412
+Afflicted Deserter;DKA;139832
+Afiya Grove;MIR;1783
+Afterlife;C14;19259
+Afterlife;CMD;19259
+Afterlife;MIR;1784
+Afterlife;MMQ;19259
+Afterlife;VMA;19259
+Aftershock;TMP;3025
+Aftershock;TPR;3025
+Aftershock;VMA;3025
+Agadeem Occultist;WWK;126469
+Ageless Entity;DDH;75168
+Ageless Entity;DST;75168
+Ageless Sentinels;SCG;48962
+Agent of Erebos;JOU;153038
+Agent of Horizons;THS;150761
+Agent of Masks;GPT;91719
+Agent of Masks;MM3;400714
+Agent of Shauku;PCY;21980
+Agent of Stromgald;ALL;1584
+Agent of Stromgald;ALL;1585
+Agent of the Fates;THS;150810
+Aggravate;AVR;141804
+Aggravated Assault;MS3;401640
+Aggravated Assault;ONS;43143
+Aggression;ICE;1064
+Aggressive Mining;M15;155243
+Aggressive Urge;10E;24190
+Aggressive Urge;INV;24190
+Agility;MIR;1785
+Agonizing Demise;DDH;24034
+Agonizing Demise;INV;24034
+Agonizing Memories;10E;27528
+Agonizing Memories;6ED;2917
+Agonizing Memories;7ED;27528
+Agonizing Memories;WTH;2917
+Agony Warp;ALA;115162
+Agony Warp;MM2;115162
+Agony Warp;MM3;115162
+Agoraphobia;DDM;146566
+Agoraphobia;GTC;146566
+Agrus Kos, Wojek Veteran;RAV;89142
+Agyrem;PC1;125885
+Ahn-Crop Champion;AKH;401347
+Ahn-Crop Crasher;AKH;400821
+Aid from the Cowl;AER;400355
+Aim High;SOI;161342
+Ainok Artillerist;DTK;160079
+Ainok Bond-Kin;KTK;156990
+Ainok Guide;FRF;157211
+Ainok Survivalist;DTK;159708
+Ainok Tracker;KTK;156510
+Ainok Tracker;PRM;159779
+Air Bladder;NMS;21213
+Air Elemental;10E;101044
+Air Elemental;2ED;1
+Air Elemental;3ED;1
+Air Elemental;4ED;1
+Air Elemental;5ED;2300
+Air Elemental;6ED;4693
+Air Elemental;7ED;27529
+Air Elemental;8ED;27529
+Air Elemental;9ED;86909
+Air Elemental;DD2;101044
+Air Elemental;DPA;101044
+Air Elemental;LEA;1
+Air Elemental;LEB;1
+Air Elemental;M10;101044
+Air Elemental;ME4;1
+Air Elemental;PO2;4693
+Air Elemental;W17;101044
+Air Elemental;XLN;402373
+Air Servant;DPA;129155
+Air Servant;M11;129155
+Air Servant;M14;129155
+Air Servant;MM2;129155
+Air Servant;W16;129155
+Airborne Aid;ONS;42990
+Airdrop Aeronauts;AER;400244
+Airdrop Condor;ONS;43122
+Aisling Leprechaun;LEG;491
+Aisling Leprechaun;PRM;491
+Ajani Goldmane;LRW;105545
+Ajani Goldmane;M10;105545
+Ajani Goldmane;M11;105545
+Ajani Goldmane;PRM;131556
+Ajani Steadfast;M15;155204
+Ajani Unyielding;AER;400367
+Ajani Vengeant;ALA;114969
+Ajani Vengeant;DDH;138680
+Ajani Vengeant;PRM;117021
+Ajani, Caller of the Pride;M13;134116
+Ajani, Caller of the Pride;M14;134116
+Ajani, Mentor of Heroes;JOU;152975
+Ajani, Valiant Protector;AER;400411
+Ajani's Aid;AER;400431
+Ajani's Chosen;DPA;147491
+Ajani's Chosen;M14;147491
+Ajani's Comrade;AER;400212
+Ajani's Mantra;DDH;129081
+Ajani's Mantra;DPA;129081
+Ajani's Mantra;M11;129081
+Ajani's Presence;JOU;153053
+Ajani's Pridemate;C13;129151
+Ajani's Pridemate;DDH;129151
+Ajani's Pridemate;DPA;129151
+Ajani's Pridemate;M11;129151
+Ajani's Pridemate;M15;129151
+Ajani's Sunstriker;DPA;143835
+Ajani's Sunstriker;M13;143835
+Akiri, Line-Slinger;PZ2;162377
+Akki Avalanchers;COK;81008
+Akki Blizzard-Herder;BOK;83853
+Akki Coalflinger;COK;82589
+Akki Coalflinger;EVG;82589
+Akki Drillmaster;SOK;86094
+Akki Lavarunner;COK;80907
+Akki Raider;BOK;83923
+Akki Rockspeaker;COK;82600
+Akki Underling;SOK;81050
+Akki Underminer;COK;82598
+Akoum Battlesinger;WWK;126597
+Akoum Boulderfoot;ROE;127313
+Akoum Firebird;BFZ;160872
+Akoum Flameseeker;OGW;161132
+Akoum Hellkite;BFZ;160933
+Akoum Refuge;C13;123670
+Akoum Refuge;CMD;123670
+Akoum Refuge;DDK;123670
+Akoum Refuge;ZEN;123670
+Akoum Stonewaker;BFZ;160675
+Akoum;PC2;140379
+Akrasan Squire;ALA;115042
+Akrasan Squire;DPA;115042
+Akroan Conscriptor;BNG;152075
+Akroan Crusader;THS;150801
+Akroan Hoplite;THS;149099
+Akroan Horse;THS;149215
+Akroan Jailer;ORI;160194
+Akroan Line Breaker;JOU;153033
+Akroan Mastiff;JOU;152808
+Akroan Phalanx;BNG;152536
+Akroan Sergeant;ORI;158740
+Akroan Skyguard;BNG;152013
+Akroma, Angel of Fury;CMD;100698
+Akroma, Angel of Fury;PLC;100698
+Akroma, Angel of Fury;V15;160188
+Akroma, Angel of Wrath;DDC;122099
+Akroma, Angel of Wrath;LGN;45869
+Akroma, Angel of Wrath;TSB;45869
+Akroma, Angel of Wrath;V15;160187
+Akroma's Blessing;ONS;42946
+Akroma's Blessing;VMA;42946
+Akroma's Devoted;LGN;47518
+Akroma's Memorial;FUT;102471
+Akroma's Memorial;M13;102471
+Akroma's Vengeance;CMD;42963
+Akroma's Vengeance;ONS;42963
+Akroma's Vengeance;PC1;42963
+Akroma's Vengeance;V13;148935
+Akron Legionnaire;5ED;492
+Akron Legionnaire;CH;492
+Akron Legionnaire;LEG;492
+Akron Legionnaire;ME3;492
+Aku Djinn;VIS;2131
+Akuta, Born of Ash;SOK;86050
+Al-abara's Carpet;LEG;4614
+Al-abara's Carpet;ME4;4614
+Alabaster Dragon;POR;6724
+Alabaster Dragon;WTH;2897
+Alabaster Kirin;KTK;156992
+Alabaster Leech;INV;25138
+Alabaster Mage;M12;134147
+Alabaster Potion;4ED;493
+Alabaster Potion;5ED;493
+Alabaster Potion;LEG;493
+Alabaster Potion;ME3;493
+Alabaster Wall;MMQ;19093
+Alaborn Cavalier;DDG;4671
+Alaborn Cavalier;PO2;4671
+Alaborn Grenadier;PO2;4587
+Alaborn Musketeer;ME4;4664
+Alaborn Musketeer;PO2;4664
+Alaborn Trooper;ME4;4659
+Alaborn Trooper;PO2;4659
+Alaborn Veteran;PO2;4677
+Alaborn Zealot;PO2;4658
+Aladdin;ARN;304
+Aladdin;CH;304
+Aladdin;ME4;304
+Aladdin's Lamp;3ED;305
+Aladdin's Lamp;4ED;305
+Aladdin's Lamp;ARN;305
+Aladdin's Ring;3ED;306
+Aladdin's Ring;4ED;306
+Aladdin's Ring;5ED;2301
+Aladdin's Ring;6ED;2301
+Aladdin's Ring;7ED;27530
+Aladdin's Ring;8ED;27530
+Aladdin's Ring;9ED;27530
+Aladdin's Ring;ARN;306
+Alarum;MIR;1786
+Albino Troll;DDD;8842
+Albino Troll;PRM;8842
+Albino Troll;USG;8842
+Alchemist's Apprentice;AVR;141576
+Alchemist's Greeting;EMN;161974
+Alchemist's Refuge;AVR;141734
+Alchemist's Vial;ORI;160344
+Alchor's Tomb;LEG;4615
+Alchor's Tomb;ME4;4615
+Aleatory;MIR;1787
+Alert Shu Infantry;PTK;9127
+Alesha, Who Smiles at Death;FRF;157223
+Alesha's Vanguard;FRF;157234
+Alexi, Zephyr Mage;PCY;22117
+Alexi's Cloak;PCY;21955
+Algae Gharial;ALA;115059
+Algae Gharial;MM2;115059
+Alhammarret, High Arbiter;ORI;160222
+Alhammarret, High Arbiter;PRM;160403
+Alhammarret's Archive;ORI;160352
+Ali Baba;4ED;307
+Ali Baba;ARN;307
+Ali from Cairo;ARN;308
+Ali from Cairo;ME4;308
+Aliban's Tower;HML;1446
+Aliban's Tower;HML;1447
+Aligned Hedron Network;BFZ;159977
+Alive;DGM;147717
+All Hallow's Eve;LEG;4616
+All Hallow's Eve;ME3;4616
+All Hallow's Eve;TD0;4616
+All Is Dust;DPA;127411
+All Is Dust;MM2;127411
+All Is Dust;ROE;127411
+All Suns' Dawn;5DN;50263
+All Suns' Dawn;MM2;50263
+Allay;EXO;5438
+Alley Evasion;AER;400237
+Alley Grifters;MMQ;19212
+Alley Strangler;AER;400282
+Alliance of Arms;CMD;137516
+Allied Reinforcements;OGW;161206
+Allied Strategies;DDE;27999
+Allied Strategies;PLS;27999
+Allosaurus Rider;CSP;96893
+Allosaurus Rider;EVG;96893
+Allosaurus Rider;PRM;98040
+Alloy Golem;INV;25139
+Alloy Myr;MM2;134200
+Alloy Myr;NPH;134200
+Alluring Scent;ME4;4787
+Alluring Scent;PO2;4787
+Alluring Scent;POR;6642
+Alluring Siren;M10;121568
+Alluring Siren;M11;121568
+Alluring Siren;M12;121568
+Ally Encampment;BFZ;160826
+Alms Beast;GTC;146524
+Alms of the Vein;SOI;161739
+Alms;WTH;2845
+Alpha Authority;GTC;146331
+Alpha Brawl;DKA;139814
+Alpha Kavu;PLS;28788
+Alpha Myr;DPA;50341
+Alpha Myr;MRD;50341
+Alpha Status;SCG;48097
+Alpha Tyrranax;SOM;130987
+Alpine Grizzly;KTK;156519
+Altac Bloodseeker;M15;155236
+Altar Golem;EVE;113743
+Altar of Bone;ICE;1065
+Altar of Dementia;TMP;3097
+Altar of Shadows;MRD;51057
+Altar of the Brood;KTK;157090
+Altar of the Brood;PRM;159840
+Altar of the Lost;DKA;139882
+Altar's Light;MRD;51068
+Altar's Reap;BFZ;160672
+Altar's Reap;ISD;138258
+Altar's Reap;M14;138258
+Alter Reality;TOR;36427
+Altered Ego;SOI;161430
+Aluren;TMP;3137
+Aluren;TPR;3137
+Always Watching;SOI;161718
+Amass the Components;AVR;141774
+Ambassador Laquatus;10E;104538
+Ambassador Laquatus;TOR;36428
+Ambassador Oak;DPA;109986
+Ambassador Oak;MOR;109986
+Amber Prison;6ED;1788
+Amber Prison;MIR;1788
+Ambition's Cost;8ED;9141
+Ambition's Cost;PRM;162423
+Ambition's Cost;PTK;9141
+Ambitious Aetherborn;KLD;162495
+Ambuscade Shaman;DTK;160031
+Ambuscade;HOU;401541
+Ambush Commander;EVG;111908
+Ambush Commander;SCG;48103
+Ambush Krotiq;FRF;157336
+Ambush Party;5ED;2302
+Ambush Party;HML;1449
+Ambush Party;HML;1450
+Ambush Party;ME2;2302
+Ambush Viper;ISD;138149
+Ambush;HML;1448
+Ammit Eternal;HOU;401802
+Amnesia;DRK;728
+Amnesia;MED;728
+Amoeboid Changeling;H09;105549
+Amoeboid Changeling;LRW;105549
+Amok;STH;3643
+Amphibious Kavu;PLS;24007
+Amphin Cutthroat;M12;134124
+Amphin Pathmage;M15;155396
+Ampryn Tactician;ORI;160203
+Amrou Kithkin;4ED;494
+Amrou Kithkin;LEG;494
+Amrou Kithkin;ME3;494
+Amrou Scout;MMA;97446
+Amrou Scout;TSP;97446
+Amrou Seekers;MMA;97406
+Amrou Seekers;TSP;97406
+Amugaba;ODY;33458
+Amulet of Kroog;4ED;380
+Amulet of Kroog;5ED;380
+Amulet of Kroog;ATQ;380
+Amulet of Kroog;ME4;380
+Amulet of Quoz;ICE;1066
+Amulet of Unmaking;MIR;1789
+Amulet of Vigor;WWK;126515
+An-Havva Constable;5ED;1451
+An-Havva Constable;HML;1451
+An-Havva Inn;HML;1452
+An-Havva Township;HML;1453
+An-Zerrin Ruins;HML;1454
+An-Zerrin Ruins;ME2;1454
+Ana Battlemage;PLC;100734
+Ana Disciple;APC;31109
+Ana Sanctuary;APC;31111
+Anaba Ancestor;HML;1455
+Anaba Ancestor;ME3;1455
+Anaba Bodyguard;10E;100647
+Anaba Bodyguard;6ED;1456
+Anaba Bodyguard;HML;1456
+Anaba Bodyguard;HML;1457
+Anaba Shaman;6ED;1458
+Anaba Shaman;8ED;49668
+Anaba Shaman;9ED;86898
+Anaba Shaman;HML;1458
+Anaba Shaman;HML;1459
+Anaba Spirit Crafter;HML;1460
+Anaba Spirit Crafter;ME3;1460
+Anaconda;7ED;27531
+Anaconda;9ED;6643
+Anaconda;POR;6643
+Anaconda;USG;8687
+Anafenza, Kin-Tree Spirit;DTK;159739
+Anafenza, the Foremost;KTK;156634
+Anarchist;9ED;5660
+Anarchist;EXO;5660
+Anarchist;ODY;33379
+Anarchist;TD0;5660
+Anarchist;TPR;5660
+Anarchy;ICE;1067
+Anarchy;ME2;1067
+Anathemancer;ARB;120958
+Anathemancer;PRM;129536
+Anavolver;APC;31110
+Anax and Cymede;DDL;149213
+Anax and Cymede;THS;149213
+Ancestor's Chosen;10E;40179
+Ancestor's Chosen;JUD;40179
+Ancestor's Prophet;ONS;42951
+Ancestral Knowledge;WTH;2891
+Ancestral Mask;EMA;161566
+Ancestral Mask;MMQ;19220
+Ancestral Memories;6ED;1790
+Ancestral Memories;7ED;27532
+Ancestral Memories;MIR;1790
+Ancestral Memories;POR;6603
+Ancestral Recall;2ED;2
+Ancestral Recall;LEA;2
+Ancestral Recall;LEB;2
+Ancestral Recall;PRM;92305
+Ancestral Recall;VMA;151983
+Ancestral Statue;DTK;160104
+Ancestral Tribute;ODY;28010
+Ancestral Vengeance;FRF;157256
+Ancestral Vision;DD2;97402
+Ancestral Vision;TSP;97402
+Anchor to the Aether;ORI;160224
+Ancient Amphitheater;LRW;109165
+Ancient Brontodon;XLN;402295
+Ancient Carp;DTK;160092
+Ancient Crab;AKH;401289
+Ancient Crab;OGW;160909
+Ancient Craving;DDK;4733
+Ancient Craving;PO2;4733
+Ancient Den;MRD;51006
+Ancient Den;PC1;51006
+Ancient Den;TD2;51006
+Ancient Excavation;PZ2;162448
+Ancient Grudge;ISD;138396
+Ancient Grudge;MM3;138396
+Ancient Grudge;PRM;143394
+Ancient Grudge;TD0;97360
+Ancient Grudge;TSP;97360
+Ancient Hellkite;M11;129075
+Ancient Hellkite;PRM;129297
+Ancient Hydra;NMS;21205
+Ancient Kavu;INV;24170
+Ancient Ooze;SCG;48244
+Ancient Runes;TMP;3267
+Ancient Silverback;7ED;27533
+Ancient Silverback;9ED;27533
+Ancient Silverback;M15;27533
+Ancient Silverback;UD;15715
+Ancient Spider;PLS;27927
+Ancient Spring;INV;25140
+Ancient Stirrings;ROE;127263
+Ancient Tomb;EXP;160959
+Ancient Tomb;TMP;3248
+Ancient Tomb;V12;3248
+Ancient Tomb;VMA;3248
+Ancient Ziggurat;CON;119791
+Ancient Ziggurat;H09;119791
+Ancient Ziggurat;PRM;126728
+Ancient of the Equinox;SOI;161610
+Andradite Leech;INV;25174
+Angel of Condemnation;HOU;401576
+Angel of Deliverance;PRM;161765
+Angel of Deliverance;SOI;161433
+Angel of Despair;CMD;88825
+Angel of Despair;GPT;88825
+Angel of Finality;C13;151772
+Angel of Flight Alabaster;ISD;138322
+Angel of Fury;ME2;4578
+Angel of Fury;PO2;4578
+Angel of Glory's Rise;AVR;141538
+Angel of Invention;KLD;162470
+Angel of Jubilation;AVR;141661
+Angel of Light;ME2;17558
+Angel of Mercy;10E;101029
+Angel of Mercy;8ED;4670
+Angel of Mercy;9ED;4670
+Angel of Mercy;DDC;101029
+Angel of Mercy;DPA;101029
+Angel of Mercy;INV;23999
+Angel of Mercy;PO2;4670
+Angel of Renewal;BFZ;160919
+Angel of Retribution;TOR;36403
+Angel of Salvation;DDF;97286
+Angel of Salvation;FUT;97286
+Angel of Sanctions;AKH;400914
+Angel of Sanctions;TOK;401246
+Angel of Serenity;RTR;145976
+Angel of the Dire Hour;C14;155630
+Angel of the God-Pharaoh;HOU;401520
+Angel;TOK;119801
+Angel;TOK;125094
+Angel;TOK;138497
+Angel;TOK;141792
+Angel;TOK;142219
+Angel;TOK;147258
+Angel;TOK;161198
+Angel;TOK;161724
+Angel;TOK;35346
+Angel;TOK;49013
+Angel's Feather;10E;75223
+Angel's Feather;9ED;75223
+Angel's Feather;DDC;75223
+Angel's Feather;DPA;75223
+Angel's Feather;DST;75223
+Angel's Feather;M10;75223
+Angel's Feather;M11;75223
+Angel's Feather;M12;75223
+Angel's Grace;MMA;97370
+Angel's Grace;TSP;97370
+Angel's Herald;ALA;115168
+Angel's Mercy;AVR;141589
+Angel's Mercy;M10;121628
+Angel's Mercy;M12;121628
+Angel's Mercy;M13;121628
+Angel's Tomb;AVR;141604
+Angel's Tomb;ORI;141604
+Angel's Trumpet;UL;10417
+Angelfire Crusader;APC;31035
+Angelheart Vial;ROE;127262
+Angelic Accord;M14;147399
+Angelic Arbiter;CMD;129070
+Angelic Arbiter;M11;129070
+Angelic Armaments;AVR;141619
+Angelic Benediction;ALA;116999
+Angelic Benediction;DDC;116999
+Angelic Benediction;DPA;116999
+Angelic Benediction;M13;116999
+Angelic Blessing;10E;5653
+Angelic Blessing;9ED;5653
+Angelic Blessing;DPA;5653
+Angelic Blessing;EXO;5653
+Angelic Blessing;PO2;4665
+Angelic Blessing;POR;6725
+Angelic Blessing;TPR;5653
+Angelic Captain;BFZ;160829
+Angelic Chorus;10E;104531
+Angelic Chorus;USG;8656
+Angelic Curator;UL;10403
+Angelic Destiny;DPA;134131
+Angelic Destiny;M12;134131
+Angelic Edict;GTC;146238
+Angelic Favor;NMS;21241
+Angelic Field Marshal;C14;155618
+Angelic Gift;BFZ;161166
+Angelic Overseer;DPA;138124
+Angelic Overseer;ISD;138124
+Angelic Page;7ED;27534
+Angelic Page;8ED;27534
+Angelic Page;DDC;27534
+Angelic Page;USG;8768
+Angelic Protector;DDC;3292
+Angelic Protector;TMP;3292
+Angelic Protector;TPR;3292
+Angelic Purge;SOI;161344
+Angelic Renewal;WTH;2847
+Angelic Shield;DDI;25485
+Angelic Shield;INV;25485
+Angelic Skirmisher;GTC;146574
+Angelic Voices;CH;495
+Angelic Voices;LEG;495
+Angelic Voices;ME4;495
+Angelic Wall;10E;33200
+Angelic Wall;AVR;141845
+Angelic Wall;DPA;33200
+Angelic Wall;M14;141845
+Angelic Wall;ODY;33200
+Angelic Wall;PO2;4663
+Angelsong;ALA;115068
+Angelsong;DDC;115068
+Anger of the Gods;THS;150855
+Anger;CMD;40247
+Anger;DDI;140035
+Anger;JUD;40247
+Anger;PZ1;40247
+Anger;TD0;40247
+Angler Drake;AKH;400755
+Angrath's Marauders;XLN;402128
+Angry Mob;4ED;729
+Angry Mob;5ED;729
+Angry Mob;DRK;729
+Angry Mob;MED;729
+Anguished Unmaking;PRM;161640
+Anguished Unmaking;SOI;161602
+Angus Mackenzie;LEG;4617
+Angus Mackenzie;ME3;4617
+Animal Boneyard;ODY;33266
+Animal Magnetism;ONS;43191
+Animar, Soul of Elements;CMD;137548
+Animar, Soul of Elements;PZ1;137548
+Animate Artifact;2ED;3
+Animate Artifact;3ED;3
+Animate Artifact;4ED;3
+Animate Artifact;LEA;3
+Animate Artifact;LEB;3
+Animate Artifact;ME4;3
+Animate Dead;2ED;4
+Animate Dead;3ED;4
+Animate Dead;4ED;4
+Animate Dead;5ED;4
+Animate Dead;EMA;161028
+Animate Dead;LEA;4
+Animate Dead;LEB;4
+Animate Dead;MED;4
+Animate Dead;PD3;139582
+Animate Dead;TD0;4
+Animate Dead;VMA;139582
+Animate Land;NMS;21154
+Animate Wall;2ED;5
+Animate Wall;3ED;5
+Animate Wall;4ED;5
+Animate Wall;5ED;2303
+Animate Wall;6ED;2303
+Animate Wall;LEA;5
+Animate Wall;LEB;5
+Animate Wall;MED;5
+Animation Module;KLD;162574
+Animist's Awakening;ORI;160313
+Ankh of Mishra;2ED;6
+Ankh of Mishra;3ED;6
+Ankh of Mishra;4ED;6
+Ankh of Mishra;5ED;2304
+Ankh of Mishra;6ED;2304
+Ankh of Mishra;LEA;6
+Ankh of Mishra;LEB;6
+Ankh of Mishra;MED;6
+Ankh of Mishra;VMA;2304
+Ankle Shanker;KTK;157107
+Ankle Shanker;PRM;156597
+Annex;9ED;42994
+Annex;ONS;42994
+Annihilate;C13;24095
+Annihilate;C14;24095
+Annihilate;EMA;24095
+Annihilate;INV;24095
+Annihilating Fire;RTR;145139
+Annul;MRD;50198
+Annul;THS;149049
+Annul;USG;8886
+Anodet Lurker;5DN;75389
+Anoint;TMP;3067
+Anoint;TPR;3067
+Anointed Deacon;XLN;402094
+Anointed Procession;AKH;401261
+Anointer Priest;AKH;400912
+Anointer Priest;TOK;401244
+Anointer of Champions;ORI;160213
+Anowon, the Ruin Sage;DPA;126482
+Anowon, the Ruin Sage;WWK;126482
+Ant Queen;DPA;122179
+Ant Queen;M10;122179
+Ant Queen;MM2;122179
+Ant Queen;PRM;121651
+Antagonism;USG;8750
+Antelope;TOK;43180
+Anthem of Rakdos;DIS;94313
+Anthousa, Setessan Hero;PRM;151408
+Anthousa, Setessan Hero;THS;150830
+Anthroplasm;UL;10399
+Anti-Magic Aura;5ED;2305
+Anti-Magic Aura;LEG;496
+Anticipate;BFZ;161055
+Anticipate;DTK;160155
+Anticipate;PRM;160849
+Antler Skulkin;EVE;113755
+Anurid Barkripper;JUD;40265
+Anurid Brushhopper;JUD;40293
+Anurid Murkdiver;ONS;44474
+Anurid Scavenger;TOR;36515
+Anurid Swarmsnapper;JUD;40281
+Anvil of Bogardan;VIS;2132
+Anvilwrought Raptor;THS;149077
+Anya, Merciless Angel;PZ1;160085
+Apathy;WTH;2835
+Ape;TOK;103852
+Apes of Rath;TMP;3228
+Apex Hawks;WWK;126596
+Aphetto Alchemist;ONS;42993
+Aphetto Dredging;H09;43048
+Aphetto Dredging;ONS;43048
+Aphetto Exterminator;LGN;46554
+Aphetto Grifter;ONS;36419
+Aphetto Runecaster;SCG;48144
+Aphetto Vulture;ONS;43062
+Aphotic Wisps;SHM;111794
+Apocalypse Chime;HML;1461
+Apocalypse Demon;HOU;401803
+Apocalypse Hydra;CON;118755
+Apocalypse Hydra;MM2;118755
+Apocalypse;TMP;3163
+Apostle's Blessing;MM2;134190
+Apostle's Blessing;NPH;134190
+Apothecary Geist;SOI;161763
+Apothecary Initiate;SHM;111524
+Appeal;HOU;401834
+Appetite for Brains;AVR;143365
+Appetite for the Unnatural;KLD;162303
+Apprentice Necromancer;UD;15596
+Apprentice Sorcerer;PO2;4692
+Apprentice Wizard;4ED;730
+Apprentice Wizard;DRK;730
+Apprentice Wizard;MED;730
+Approach of the Second Sun;AKH;401605
+Aquamoeba;TOR;36409
+Aquamoeba;VMA;36409
+Aquamorph Entity;PLC;100777
+Aquastrand Spider;CMD;94530
+Aquastrand Spider;DIS;94530
+Aquastrand Spider;MM2;94530
+Aqueous Form;THS;150772
+Aquitect's Will;LRW;105596
+Aquus Steed;RTR;131637
+Araba Mothrider;DPA;86028
+Araba Mothrider;SOK;86028
+Arachnogenesis;PZ1;160434
+Arachnoid;5DN;50837
+Arachnus Spinner;M12;134139
+Arachnus Spinner;MM3;134139
+Arachnus Web;M12;134160
+Arachnus Web;MM3;134160
+Aradara Express;KLD;162325
+Arashi, the Sky Asunder;SOK;86141
+Arashin Cleric;FRF;157349
+Arashin Foremost;DTK;159810
+Arashin Sovereign;DTK;160068
+Arashin Sovereign;PRM;159715
+Arashin War Beast;FRF;157192
+Arashin War Beast;PRM;159377
+Arbalest Elite;M12;134073
+Arbiter of Knollridge;CMD;105512
+Arbiter of Knollridge;LRW;105512
+Arbiter of the Ideal;BNG;152091
+Arbiter of the Ideal;PRM;152560
+Arbor Colossus;THS;149967
+Arbor Elf;M13;126593
+Arbor Elf;WWK;126593
+Arborback Stomper;KLD;162298
+Arboria;LEG;497
+Arboria;ME3;497
+Arc Blade;FUT;102358
+Arc Lightning;DPA;8761
+Arc Lightning;KTK;156558
+Arc Lightning;PC1;8761
+Arc Lightning;PRM;159862
+Arc Lightning;PRM;8761
+Arc Lightning;USG;8761
+Arc Mage;NMS;21238
+Arc Runner;DPA;129084
+Arc Runner;M11;129084
+Arc Trail;PC2;131020
+Arc Trail;SOM;131020
+Arc-Slogger;MRD;51075
+Arcades Sabboth;CH;498
+Arcades Sabboth;LEG;498
+Arcades Sabboth;ME3;498
+Arcane Adaptation;XLN;402379
+Arcane Denial;ALL;1586
+Arcane Denial;ALL;1587
+Arcane Denial;C13;143387
+Arcane Denial;MED;1586
+Arcane Laboratory;7ED;27536
+Arcane Laboratory;USG;8689
+Arcane Lighthouse;C14;155668
+Arcane Melee;AVR;141779
+Arcane Melee;C13;141779
+Arcane Sanctum;ALA;115159
+Arcane Sanctum;C13;115159
+Arcane Sanctum;MM3;115159
+Arcane Sanctum;PZ1;115159
+Arcane Spyglass;DST;75130
+Arcane Teachings;10E;104548
+Arcane Teachings;JUD;36478
+Arcanis the Omnipotent;10E;43022
+Arcanis the Omnipotent;EMA;43022
+Arcanis the Omnipotent;ONS;43022
+Arcanis the Omnipotent;PRM;156589
+Arcanum Wings;FUT;102459
+Arcbond;FRF;157324
+Arcbound Bruiser;DST;51983
+Arcbound Crusher;DST;52038
+Arcbound Crusher;PC1;52038
+Arcbound Fiend;DST;75211
+Arcbound Hybrid;DST;51974
+Arcbound Lancer;DST;51985
+Arcbound Overseer;DST;51758
+Arcbound Ravager;DST;75213
+Arcbound Ravager;MMA;147517
+Arcbound Ravager;MS2;400923
+Arcbound Reclaimer;DST;52052
+Arcbound Slith;DST;75212
+Arcbound Slith;PC1;75212
+Arcbound Stinger;DST;51992
+Arcbound Stinger;MMA;51992
+Arcbound Wanderer;5DN;77189
+Arcbound Wanderer;MMA;77189
+Arcbound Worker;DDF;75191
+Arcbound Worker;DST;75191
+Arcbound Worker;MMA;75191
+Archaeological Dig;INV;25141
+Archaeomancer;DDM;143838
+Archaeomancer;DPA;143838
+Archaeomancer;M13;143838
+Archaeomancer;M14;143838
+Archangel Avacyn;SOI;161350
+Archangel of Strife;CMD;131682
+Archangel of Strife;DPA;131682
+Archangel of Strife;V15;131682
+Archangel of Thune;M14;147395
+Archangel of Tithes;ORI;158744
+Archangel;6ED;6726
+Archangel;AVR;141745
+Archangel;C13;6726
+Archangel;DPA;141745
+Archangel;PO2;4577
+Archangel;POR;6726
+Archangel;VIS;2133
+Archangel's Light;DKA;139755
+Archdemon of Greed;DKA;140332
+Archdemon of Greed;PRM;138295
+Archdemon of Unx;ALA;114965
+Archdemon of Unx;DPA;114965
+Archers of Qarsi;FRF;157254
+Archers' Parapet;KTK;156517
+Archery Training;UD;15608
+Archetype of Aggression;BNG;152582
+Archetype of Courage;BNG;152535
+Archetype of Endurance;BNG;152595
+Archetype of Finality;BNG;152570
+Archetype of Imagination;BNG;152555
+Archfiend of Depravity;FRF;157331
+Archfiend of Depravity;PRM;158886
+Archfiend of Ifnir;AKH;401364
+Archfiend of Ifnir;PRM;400786
+Architect of the Untamed;KLD;162550
+Architects of Will;ARB;120988
+Archive Trap;DPA;125080
+Archive Trap;ZEN;125080
+Archivist;7ED;27537
+Archivist;8ED;27537
+Archivist;9ED;27537
+Archivist;UL;10413
+Archmage Ascension;ZEN;125088
+Archon of Justice;DPA;113598
+Archon of Justice;EVE;113598
+Archon of Justice;M12;113598
+Archon of Redemption;DPA;126536
+Archon of Redemption;WWK;126536
+Archon of the Triumvirate;PRM;145957
+Archon of the Triumvirate;RTR;145221
+Archweaver;RTR;145913
+Archwing Dragon;AVR;141843
+Arctic Aven;M13;143928
+Arctic Flats;CSP;96894
+Arctic Foxes;ICE;1068
+Arctic Merfolk;PLS;27877
+Arctic Nishoba;CSP;96965
+Arctic Wolves;WTH;2923
+Arcum Dagsson;CSP;97263
+Arcum's Sleigh;ICE;1069
+Arcum's Weathervane;ICE;1070
+Arcum's Whistle;ICE;1071
+Ardent Militia;6ED;2839
+Ardent Militia;7ED;27538
+Ardent Militia;8ED;27538
+Ardent Militia;POR;6727
+Ardent Militia;WTH;2839
+Ardent Plea;ARB;121043
+Ardent Recruit;MBS;133181
+Ardent Recruit;TD2;133181
+Ardent Soldier;INV;24026
+Arena Athlete;THS;149090
+Arena of the Ancients;CH;499
+Arena of the Ancients;LEG;499
+Arena of the Ancients;ME3;499
+Arena;PRM;482
+Arena;TSB;482
+Arenson's Aura;5ED;2306
+Arenson's Aura;ICE;1072
+Aretopolis;PC2;131685
+Argent Mutation;NPH;134263
+Argent Sphinx;MM2;131194
+Argent Sphinx;SOM;131194
+Argent Sphinx;TD2;131194
+Argentum Armor;C14;131408
+Argentum Armor;DPA;131408
+Argentum Armor;SOM;131408
+Argivian Archaeologist;ATQ;381
+Argivian Archaeologist;MED;381
+Argivian Archaeologist;PRM;381
+Argivian Blacksmith;ATQ;382
+Argivian Blacksmith;ME4;382
+Argivian Find;WTH;2956
+Argivian Restoration;DDF;2950
+Argivian Restoration;WTH;2950
+Argothian Elder;USG;8703
+Argothian Enchantress;EMA;7378
+Argothian Enchantress;PRM;7378
+Argothian Enchantress;USG;7378
+Argothian Pixies;ATQ;383
+Argothian Pixies;CH;383
+Argothian Pixies;ME4;383
+Argothian Swine;USG;8721
+Argothian Treefolk;ATQ;384
+Argothian Treefolk;ME4;384
+Argothian Wurm;USG;8105
+Arguel's Blood Fast;XLN;402048
+Arid Mesa;EXP;160785
+Arid Mesa;MM3;123565
+Arid Mesa;ZEN;123565
+Arjun, the Shifting Flame;PZ1;160042
+Ark of Blight;SCG;49009
+Arlinn Kord;SOI;161347
+Arlinn, Embraced by the Moon;SOI;161346
+Arm with Aether;NPH;134197
+Armada Wurm;RTR;145265
+Armadillo Cloak;DDE;127998
+Armadillo Cloak;DPA;127998
+Armadillo Cloak;EMA;127998
+Armadillo Cloak;INV;24001
+Armadillo Cloak;PRM;24001
+Armadillo Cloak;TD0;24001
+Armadillo Cloak;VMA;127998
+Armageddon Clock;3ED;385
+Armageddon Clock;4ED;385
+Armageddon Clock;ATQ;385
+Armageddon Clock;ME4;385
+Armageddon;2ED;7
+Armageddon;3ED;7
+Armageddon;4ED;7
+Armageddon;5ED;7
+Armageddon;6ED;4681
+Armageddon;LEA;7
+Armageddon;LEB;7
+Armageddon;ME4;6728
+Armageddon;MED;7
+Armageddon;MS3;402460
+Armageddon;PO2;4681
+Armageddon;POR;6728
+Armageddon;PRM;6728
+Armageddon;V14;155833
+Armageddon;VMA;6728
+Armament Corps;KTK;157070
+Armament Master;DPA;123694
+Armament Master;ZEN;123694
+Armament of Nyx;JOU;153008
+Armed Response;5DN;77196
+Armed;DGM;146826
+Armillary Sphere;C13;119805
+Armillary Sphere;CMD;119805
+Armillary Sphere;CON;119805
+Armillary Sphere;DDG;119805
+Armillary Sphere;DDI;119805
+Armillary Sphere;PC2;119805
+Armistice;C14;19086
+Armistice;MMQ;19086
+Armor Sliver;H09;3291
+Armor Sliver;TMP;3291
+Armor Sliver;TPR;3291
+Armor Thrull;FEM;853
+Armor Thrull;FEM;854
+Armor Thrull;FEM;855
+Armor Thrull;FEM;856
+Armor Thrull;ME2;856
+Armor of Faith;5ED;1073
+Armor of Faith;ICE;1073
+Armor of Faith;ME2;1073
+Armor of Thorns;MIR;1791
+Armor of Thorns;VMA;1791
+Armorcraft Judge;KLD;162295
+Armored Ascension;DPA;122162
+Armored Ascension;M10;122162
+Armored Ascension;M11;122162
+Armored Ascension;SHM;111614
+Armored Cancrix;M11;129159
+Armored Cancrix;M14;129159
+Armored Galleon;PO2;4694
+Armored Griffin;ME2;4673
+Armored Griffin;PC2;140773
+Armored Griffin;PO2;4673
+Armored Guardian;INV;25143
+Armored Pegasus;6ED;6729
+Armored Pegasus;POR;6729
+Armored Pegasus;TMP;3053
+Armored Pegasus;TPR;3053
+Armored Skaab;ISD;138447
+Armored Transport;GTC;146326
+Armored Warhorse;M12;135281
+Armored Wolf-Rider;DGM;146870
+Armorer Guildmage;MIR;1792
+Armory Automaton;PZ2;162445
+Armory Guard;DDL;145116
+Armory Guard;RTR;145116
+Armory of Iroas;JOU;152821
+Arms Dealer;DPA;143954
+Arms Dealer;M13;143954
+Arms Dealer;MMQ;19217
+Army Ants;VIS;2134
+Army of Allah;ARN;309
+Army of the Damned;C13;138317
+Army of the Damned;ISD;138317
+Arnjlot's Ascent;ICE;1074
+Arrest;DPA;131066
+Arrest;MM2;131066
+Arrest;MMQ;19087
+Arrest;MRD;50327
+Arrest;RTR;145118
+Arrest;SOM;131066
+Arrest;TD2;131066
+Arrogant Bloodlord;DPA;127316
+Arrogant Bloodlord;ROE;127316
+Arrogant Vampire;POR;6563
+Arrogant Wurm;PRM;38116
+Arrogant Wurm;TOR;38116
+Arrogant Wurm;VMA;38116
+Arrow Storm;KTK;157040
+Arrow Volley Trap;ZEN;123746
+Arrows of Justice;GTC;146559
+Arsenal Thresher;ARB;121076
+Arsenal Thresher;PC1;121076
+Artful Dodge;DKA;139876
+Artful Maneuver;DTK;159727
+Artifact Blast;ATQ;386
+Artifact Blast;ME4;386
+Artifact Blast;MED;386
+Artifact Mutation;INV;24135
+Artifact Possession;ATQ;387
+Artifact Ward;ATQ;388
+Artificer's Epiphany;ORI;160227
+Artificer's Hex;M14;147421
+Artificer's Intuition;5DN;77103
+Artificial Evolution;ONS;43021
+Artillerize;NPH;134327
+Artisan of Forms;THS;150825
+Artisan of Kozilek;C14;127257
+Artisan of Kozilek;CMD;127257
+Artisan of Kozilek;DPA;127257
+Artisan of Kozilek;MM2;127257
+Artisan of Kozilek;PRM;136798
+Artisan of Kozilek;ROE;127257
+Artisan's Sorrow;THS;149095
+As Foretold;AKH;400833
+Ascendant Evincar;10E;21168
+Ascendant Evincar;DPA;21168
+Ascendant Evincar;NMS;21168
+Ascendant Evincar;PC1;21168
+Ascended Lawmage;DGM;147746
+Ascending Aven;ONS;42971
+Asceticism;DPA;131191
+Asceticism;SOM;131191
+Ash Barrens;PZ2;162399
+Ash Zealot;RTR;145946
+Asha's Favor;CON;118651
+Ashaya, the Awoken World;TOK;160419
+Ashcloud Phoenix;KTK;157049
+Ashcoat Bear;TSP;97450
+Ashen Firebeast;ODY;33346
+Ashen Ghoul;ICE;1075
+Ashen Ghoul;ME2;1075
+Ashen Monstrosity;BOK;80883
+Ashen Powder;6ED;1793
+Ashen Powder;MIR;1793
+Ashen Rider;THS;150850
+Ashen-Skin Zubera;COK;80672
+Ashenmoor Cohort;SHM;111592
+Ashenmoor Gouger;DPA;111890
+Ashenmoor Gouger;MM2;111890
+Ashenmoor Gouger;SHM;111890
+Ashenmoor Liege;DPA;111625
+Ashenmoor Liege;SHM;111625
+Ashes of the Abhorrent;XLN;402381
+Ashes of the Fallen;SOK;86142
+Ashes to Ashes;4ED;731
+Ashes to Ashes;5ED;2307
+Ashes to Ashes;DRK;731
+Ashes to Ashes;ME3;731
+Ashes to Ashes;TD0;731
+Ashiok, Nightmare Weaver;THS;149146
+Ashiok's Adept;BNG;152569
+Ashling the Pilgrim;LRW;105441
+Ashling, the Extinguisher;EVE;113631
+Ashling's Prerogative;LRW;107638
+Ashmouth Blade;SOI;161353
+Ashmouth Hound;DDK;138365
+Ashmouth Hound;ISD;138365
+Ashnod's Altar;5ED;389
+Ashnod's Altar;6ED;389
+Ashnod's Altar;ATQ;389
+Ashnod's Altar;CH;389
+Ashnod's Altar;EMA;161575
+Ashnod's Altar;ME4;389
+Ashnod's Battle Gear;4ED;390
+Ashnod's Battle Gear;ATQ;390
+Ashnod's Cylix;ALL;1588
+Ashnod's Cylix;ME2;1588
+Ashnod's Transmogrant;5ED;391
+Ashnod's Transmogrant;ATQ;391
+Ashnod's Transmogrant;CH;391
+Ashnod's Transmogrant;MED;391
+Asmira, Holy Avenger;MIR;1794
+Aspect of Gorgon;JOU;153012
+Aspect of Hydra;BNG;149073
+Aspect of Mongoose;TSP;97488
+Aspect of Wolf;2ED;8
+Aspect of Wolf;3ED;8
+Aspect of Wolf;4ED;8
+Aspect of Wolf;5ED;2308
+Aspect of Wolf;LEA;8
+Aspect of Wolf;LEB;8
+Asphodel Wanderer;THS;150793
+Asphyxiate;BNG;152037
+Aspiring Aeronaut;ORI;160246
+Assassin;TOK;145987
+Assassin;TOK;161880
+Assassin's Blade;POR;6564
+Assassin's Strike;RTR;145134
+Assassinate;10E;97461
+Assassinate;DPA;97461
+Assassinate;M10;97461
+Assassinate;M11;97461
+Assassinate;PC2;97461
+Assassinate;TSP;97461
+Assault Formation;DTK;159781
+Assault Griffin;GTC;146304
+Assault Griffin;M11;129194
+Assault Griffin;M12;129194
+Assault Strobe;DPA;130894
+Assault Strobe;SOM;130894
+Assault Suit;C14;155657
+Assault Zeppelid;DIS;94310
+Assault Zeppelid;DPA;94310
+Assault;INV;25580
+Assault;PC1;25580
+Assault;TSB;25580
+Assemble the Legion;GTC;146505
+Assembled Alphas;EMN;162109
+Assembled Alphas;PRM;161982
+Assembly Hall;MMQ;19175
+Assembly-Worker;DDF;97459
+Assembly-Worker;TOK;99734
+Assembly-Worker;TSP;97459
+Assert Authority;MRD;51111
+Astral Arena;PC2;138717
+Astral Cornucopia;BNG;152099
+Astral Slide;ONS;42934
+Astral Slide;PRM;42934
+Astral Slide;VMA;42934
+Astral Steel;SCG;47498
+Astrolabe;ALL;1589
+Astrolabe;ALL;1590
+Astrolabe;ME3;1590
+Asylum Visitor;SOI;161746
+Atalya, Samite Master;INV;25147
+Atarka Beastbreaker;DTK;160091
+Atarka Efreet;DTK;160123
+Atarka Monument;DTK;159743
+Atarka Pummeler;DTK;159803
+Atarka, World Render;FRF;157169
+Atarka's Command;DTK;159776
+Athreos, God of Passage;JOU;152935
+Atog;3ED;392
+Atog;5ED;392
+Atog;ATQ;392
+Atog;ME4;392
+Atog;MRD;50250
+Atogatog;ODY;17683
+Atraxa, Praetors' Voice;PZ2;162392
+Attended Knight;DPA;143836
+Attended Knight;M13;143836
+Attended Knight;MM3;143836
+Attrition;CMD;15639
+Attrition;MS3;401627
+Attrition;UD;15639
+Attune with Aether;KLD;162308
+Attunement;USG;8741
+Atzocan Archer;XLN;402012
+Audacious Infiltrator;AER;400230
+Auger Spree;MM3;145887
+Auger Spree;RTR;145887
+Augmenting Automaton;AER;400373
+Augur il-Vec;FUT;102427
+Augur of Bolas;C13;143862
+Augur of Bolas;M13;143862
+Augur of Bolas;MM3;143862
+Augur of Skulls;FUT;102439
+Augury Adept;C13;111682
+Augury Adept;SHM;111682
+Augury Owl;DDI;129176
+Augury Owl;M11;129176
+Augury Owl;PC2;129176
+Auntie's Hovel;LRW;109168
+Auntie's Snitch;MMA;110012
+Auntie's Snitch;MOR;110012
+Aura Barbs;BOK;83892
+Aura Blast;PLS;27879
+Aura Extraction;ONS;42947
+Aura Finesse;ROE;127375
+Aura Flux;UL;10324
+Aura Fracture;PCY;21957
+Aura Gnarlid;DPA;127292
+Aura Gnarlid;PC2;127292
+Aura Gnarlid;ROE;127292
+Aura Graft;10E;33449
+Aura Graft;ODY;33449
+Aura Mutation;INV;24134
+Aura Shards;CMD;24000
+Aura Shards;INV;24000
+Aura Thief;UD;15687
+Aura of Dominion;COK;82597
+Aura of Silence;10E;2959
+Aura of Silence;PRM;2959
+Aura of Silence;TD0;2959
+Aura of Silence;WTH;2959
+Auramancer;DDL;33527
+Auramancer;DPA;33527
+Auramancer;M12;33527
+Auramancer;M14;33527
+Auramancer;ODY;33527
+Auramancer;ORI;33527
+Auramancer;PC2;33527
+Auramancer;PRM;137395
+Auramancer;TD0;33527
+Auramancer's Guise;PLC;101382
+Auratog;TMP;3183
+Auratog;TSB;3183
+Auratouched Mage;DPA;88941
+Auratouched Mage;PC2;88941
+Auratouched Mage;RAV;88941
+Aurelia, the Warleader;GTC;146447
+Aurelia, the Warleader;V15;146447
+Aurelia's Fury;GTC;147256
+Aurification;ONS;42968
+Auriok Bladewarden;MRD;51074
+Auriok Champion;5DN;77213
+Auriok Edgewright;SOM;131056
+Auriok Glaivemaster;DST;52039
+Auriok Replica;SOM;131089
+Auriok Salvagers;5DN;77159
+Auriok Salvagers;MMA;77159
+Auriok Siege Sled;DST;50827
+Auriok Steelshaper;MRD;50242
+Auriok Sunchaser;SOM;131047
+Auriok Survivors;NPH;134208
+Auriok Transfixer;MRD;50192
+Auriok Windwalker;5DN;77190
+Aurochs Herd;CSP;96996
+Aurochs;5ED;2309
+Aurochs;ICE;1076
+Aurochs;ME2;1076
+Aurora Eidolon;DIS;94655
+Aurora Griffin;PLS;27880
+Aurora of Emrakul;EMN;162146
+Auspicious Ancestor;MIR;1795
+Austere Command;CMD;105569
+Austere Command;LRW;105569
+Austere Command;MS3;401604
+Authority of the Consuls;KLD;162465
+Authority;HOU;401857
+Autochthon Wurm;RAV;89137
+Autumn Willow;HML;1462
+Autumn Willow;MED;1462
+Autumn's Veil;M11;129140
+Autumn's Veil;M12;129140
+Autumnal Gloom;SOI;161653
+Avacyn, Angel of Hope;AVR;141506
+Avacyn, Angel of Hope;PRM;401361
+Avacyn, Angel of Hope;V15;141506
+Avacyn, Guardian Angel;M15;155276
+Avacyn, the Purifier;SOI;161351
+Avacyn's Collar;DKA;139898
+Avacyn's Judgment;SOI;161600
+Avacyn's Pilgrim;ISD;138434
+Avacyn's Pilgrim;MM3;138434
+Avacyn's Pilgrim;PRM;143966
+Avacynian Missionaries;SOI;161414
+Avacynian Priest;ISD;138132
+Avalanche Riders;PRM;9163
+Avalanche Riders;TSB;9163
+Avalanche Riders;UL;9163
+Avalanche Tusker;KTK;157109
+Avalanche Tusker;PRM;156601
+Avalanche;ICE;1077
+Avarax;EMA;44428
+Avarax;ONS;44428
+Avarice Amulet;M15;155373
+Avarice Totem;5DN;77071
+Avaricious Dragon;ORI;160305
+Avatar - Aeon Chronicler;VAN;143411
+Avatar - Ajani Steadfast;VAN;151956
+Avatar - Ajani Unyielding Prestige;VAN;400367
+Avatar - Akroma, Angel of Wrath;VAN;124304
+Avatar - Anowon, the Ruin Sage;VAN;131462
+Avatar - Arcanis, the Omnipotent;VAN;124312
+Avatar - Arcbound Overseer;VAN;126982
+Avatar - Archangel of Thune;VAN;151949
+Avatar - Armament Master;VAN;128955
+Avatar - Ashling the Pilgrim;VAN;124301
+Avatar - Ashling, the Extinguisher;VAN;126967
+Avatar - Aurelia, the Warleader;VAN;148556
+Avatar - Auriok;VAN;137584
+Avatar - Avacyn, Angel of Hope;VAN;146177
+Avatar - Avacyn, the Purifier;VAN;400727
+Avatar - Avatar of Woe;VAN;142300
+Avatar - Axe of the Warmonger;VAN;155454
+Avatar - Balance;VAN;137587
+Avatar - Battle the Horde;VAN;151946
+Avatar - Birds of Paradise (Alt.);VAN;130123
+Avatar - Birds of Paradise;VAN;124311
+Avatar - Black Lotus;VAN;151945
+Avatar - Bloodline Keeper;VAN;142086
+Avatar - Borborygmos;VAN;148558
+Avatar - Bosh, Iron Golem;VAN;125776
+Avatar - Bottle Gnomes;VAN;160943
+Avatar - Bow of the Hunter;VAN;155453
+Avatar - Braids, Conjurer Adept;VAN;125774
+Avatar - Brimaz, King of Oreskos;VAN;151958
+Avatar - Captain Lannery Storm;VAN;405601
+Avatar - Chandra Nalaar of Kaladesh;VAN;400434
+Avatar - Chandra, Fire of Kaladesh;VAN;160946
+Avatar - Chandra, Pyromaster;VAN;151954
+Avatar - Chandra, Torch of Defiance Prestige;VAN;162187
+Avatar - Chronatog;VAN;126975
+Avatar - Cloak of the Philosopher;VAN;155452
+Avatar - Commander Greven il-Vec;VAN;128957
+Avatar - Congress;CC;1000128
+Avatar - Dack Fayden;VAN;151957
+Avatar - Dakkon Blackblade;VAN;124313
+Avatar - Dakra Mystic;VAN;151950
+Avatar - Dark Confidant;VAN;160944
+Avatar - Dauntless Escort;VAN;126317
+Avatar - Diamond Faerie;VAN;125758
+Avatar - Dovin Baan Prestige;VAN;162188
+Avatar - Echo Mage;VAN;133451
+Avatar - Eight-and-a-Half-Tails;VAN;125768
+Avatar - Eladamri, Lord of Leaves;VAN;123173
+Avatar - Elesh Norn, Grand Cenobite;VAN;139686
+Avatar - Elvish Champion;VAN;126964
+Avatar - Emmara Tandris;VAN;151953
+Avatar - Emrakul, the Promised End;VAN;401679
+Avatar - Enigma Sphinx;VAN;126318
+Avatar - Erhnam Djinn (Alt.);VAN;128184
+Avatar - Erhnam Djinn;VAN;124305
+Avatar - Ertai, Wizard Adept;VAN;128958
+Avatar - Etched Oracle;VAN;126965
+Avatar - Face the Hydra;VAN;151940
+Avatar - Fallen Angel;VAN;126971
+Avatar - Figure of Destiny;VAN;125771
+Avatar - Flametongue Kavu;VAN;124310
+Avatar - Frenetic Efreet;VAN;126979
+Avatar - Freyalise, Llanowar's Fury;VAN;159959
+Avatar - Garruk, Apex Predator;VAN;159956
+Avatar - Geth, Lord of the Vault;VAN;136767
+Avatar - Ghave, Guru of Spores;VAN;140394
+Avatar - Gideon Jura on Amonkhet;VAN;403060
+Avatar - Gideon, Ally of Zendikar;VAN;160955
+Avatar - Gishath, Sun's Avatar Treasure;VAN;405600
+Avatar - Glissa, the Traitor;VAN;138065
+Avatar - Goblin Warchief (Alt.);VAN;128187
+Avatar - Goblin Warchief;VAN;124302
+Avatar - Goblin Welder;VAN;133456
+Avatar - Grand Arbiter Augustin IV;VAN;159961
+Avatar - Grimgrin, Corpse-Born;VAN;142087
+Avatar - Grinning Demon (Alt.);VAN;128186
+Avatar - Grinning Demon;VAN;124297
+Avatar - Griselbrand;VAN;146176
+Avatar - Haakon, Stromgald Scourge;VAN;126978
+Avatar - Hapatra, Vizier of Poisons Prestige;VAN;403061
+Avatar - Hazoret the Fervent Prestige;VAN;404367
+Avatar - Heartwood Storyteller;VAN;125779
+Avatar - Hell's Caretaker;VAN;124300
+Avatar - Hermit Druid;VAN;125766
+Avatar - Hero of Oxid Ridge;VAN;138066
+Avatar - Higure, the Still Wind;VAN;124306
+Avatar - Hijinks;CC;1000129
+Avatar - Huatli, Warrior-Poet Prestige;VAN;405598
+Avatar - Hythonia the Cruel;VAN;151951
+Avatar - Ink-Eyes, Servant of Oni;VAN;126972
+Avatar - Isperia, Supreme Judge;VAN;148561
+Avatar - Jace Beleren;VAN;140632
+Avatar - Jace, Ingenious Mind-Mage Prestige;VAN;405597
+Avatar - Jace, Unraveler of Secrets;VAN;400906
+Avatar - Jace, Vryn's Prodigy;VAN;160951
+Avatar - Jace, the Living Guildpact;VAN;151944
+Avatar - Jarad, Lich Lord of the Golgari;VAN;148559
+Avatar - Jaya Ballard;VAN;125773
+Avatar - Jhoira of the Ghitu;VAN;125764
+Avatar - Joraga Warcaller;VAN;131461
+Avatar - Judge's Familiar;VAN;151959
+Avatar - Kaalia of the Vast;VAN;140391
+Avatar - Kari Zev Prestige;VAN;400323
+Avatar - Karn, Silver Golem;VAN;132242
+Avatar - Karona, False God;VAN;125778
+Avatar - Kiora, Master of the Depths;VAN;160950
+Avatar - Knight Exemplar;VAN;133453
+Avatar - Kozilek, the Great Distortion;VAN;160948
+Avatar - Krenko, Mob Boss;VAN;147331
+Avatar - Kresh the Bloodbraided;VAN;122187
+Avatar - Kytheon, Hero of Akros;VAN;160952
+Avatar - Lash of the Tyrant;VAN;155455
+Avatar - Lazav, Dimir Mastermind;VAN;148564
+Avatar - Liliana Vess;VAN;151947
+Avatar - Liliana, Death's Majesty Prestige;VAN;403063
+Avatar - Liliana, Heretical Healer;VAN;160947
+Avatar - Loxodon Hierarch;VAN;124296
+Avatar - Lyzolda, the Blood Witch;VAN;126976
+Avatar - Maelstrom Archangel;VAN;123174
+Avatar - Malfegor;VAN;123175
+Avatar - Maralen of the Mornsong;VAN;126974
+Avatar - Maro;VAN;126970
+Avatar - Master of the Wild Hunt;VAN;126957
+Avatar - Mayael the Anima;VAN;122186
+Avatar - Mirko Vosk, Mind Drinker;VAN;151948
+Avatar - Mirri the Cursed;VAN;125767
+Avatar - Mirror Entity;VAN;125760
+Avatar - Momir Vig, Simic Visionary (Alt.);VAN;136768
+Avatar - Momir Vig, Simic Visionary;VAN;124295
+Avatar - Morinfen;VAN;126981
+Avatar - Moriok;VAN;137586
+Avatar - Morphling;VAN;132241
+Avatar - Murderous Redcap;VAN;124307
+Avatar - Nahiri, the Harbinger;VAN;400905
+Avatar - Nahiri, the Lithomancer;VAN;159960
+Avatar - Narset Transcendant;VAN;159965
+Avatar - Necropotence;VAN;126966
+Avatar - Nekrataal;VAN;126969
+Avatar - Nicol Bolas, God-Pharaoh Prestige;VAN;404370
+Avatar - Nissa, Nature's Artisan Prestige;VAN;162311
+Avatar - Nissa, Vastwood Seer;VAN;160956
+Avatar - Nissa, Worldwaker;VAN;151942
+Avatar - Niv-Mizzet, Dracogenius;VAN;148560
+Avatar - Ob Nixilis, the Fallen;VAN;128956
+Avatar - Obzedat, Ghost Council;VAN;148555
+Avatar - Oketra the True Prestige;VAN;403062
+Avatar - Oni of Wild Places;VAN;125759
+Avatar - Orcish Squatters;VAN;126961
+Avatar - Peacekeeper;VAN;126980
+Avatar - Phage the Untouchable;VAN;125770
+Avatar - Phyrexian Metamorph;VAN;139687
+Avatar - Phyrexian Negator;VAN;139340
+Avatar - Platinum Angel (Alt.);VAN;130122
+Avatar - Platinum Angel;VAN;125761
+Avatar - Platinum Emperion;VAN;136766
+Avatar - Prime Speaker Zegana;VAN;148563
+Avatar - Prodigal Sorcerer (Alt.);VAN;128185
+Avatar - Prodigal Sorcerer;VAN;124309
+Avatar - Prophetic Flamespeaker;VAN;151955
+Avatar - Radiant, Archangel;VAN;133455
+Avatar - Ragavan the Monkey Treasure;VAN;404371
+Avatar - Rakdos, Lord of Riots;VAN;148557
+Avatar - Raksha Golden Cub;VAN;125765
+Avatar - Rathi Dragon;VAN;159966
+Avatar - Ravager of the Fells;VAN;144080
+Avatar - Reaper King;VAN;124308
+Avatar - Riku of Two Reflections;VAN;140395
+Avatar - Rith, the Awakener (Alt.);VAN;130121
+Avatar - Rith, the Awakener;VAN;124303
+Avatar - Rofellos, Llanowar Emissary;VAN;139341
+Avatar - Rootwater Thief;VAN;142301
+Avatar - Royal Assassin (Alt.);VAN;130120
+Avatar - Royal Assassin;VAN;125763
+Avatar - Rumbling Slum;VAN;126973
+Avatar - Rune-Scarred Demon;VAN;140634
+Avatar - Saheeli Rai;VAN;401895
+Avatar - Sakashima the Impostor;VAN;126968
+Avatar - Samut, the Tested Prestige;VAN;404368
+Avatar - Sarkhan Unbroken;VAN;159964
+Avatar - Sarkhan, the Dragonspeaker;VAN;159957
+Avatar - Serra Angel (Alt.);VAN;126773
+Avatar - Serra Angel;VAN;124294
+Avatar - Seshiro the Anointed;VAN;125772
+Avatar - Sisters of Stone Death;VAN;126977
+Avatar - Skinshifter;VAN;140633
+Avatar - Sliver Queen;VAN;125775
+Avatar - Sorin, Grim Nemesis;VAN;400904
+Avatar - Sorin, Solemn Visitor;VAN;159958
+Avatar - Spear of the General;VAN;151237
+Avatar - Squee, Goblin Nabob;VAN;126963
+Avatar - Stalking Tiger;VAN;125762
+Avatar - Stangg;VAN;126960
+Avatar - Steel Overseer;VAN;133454
+Avatar - Stonehewer Giant;VAN;125769
+Avatar - Stuffy Doll;VAN;124299
+Avatar - Talrand, Sky Summoner;VAN;147332
+Avatar - Teysa, Orzhov Scion;VAN;124298
+Avatar - Tezzeret the Schemer Prestige;VAN;162200
+Avatar - Tezzeret, Agent of Bolas;VAN;160945
+Avatar - The Avenger;VAN;151395
+Avatar - The Champion;VAN;151231
+Avatar - The Destined;VAN;151236
+Avatar - The Explorer;VAN;151232
+Avatar - The General;VAN;152546
+Avatar - The Harvester;VAN;151234
+Avatar - The Hour of Devastation;VAN;404372
+Avatar - The Hunter;VAN;151393
+Avatar - The Locust God Prestige;VAN;404369
+Avatar - The Mimeoplasm;VAN;140393
+Avatar - The Philosopher;VAN;151394
+Avatar - The Protector;VAN;151391
+Avatar - The Provider;VAN;152603
+Avatar - The Savant;VAN;152564
+Avatar - The Slayer;VAN;151239
+Avatar - The Tyrant;VAN;152578
+Avatar - The Vanquisher;VAN;151238
+Avatar - The Warmonger;VAN;152592
+Avatar - The Warrior;VAN;151392
+Avatar - Tradewind Rider (Alt.);VAN;130124
+Avatar - Tradewind Rider;VAN;123172
+Avatar - Transcendent Master;VAN;133452
+Avatar - Trostani, Selesnya's Voice;VAN;148562
+Avatar - Two-Headed Giant of Foriys;VAN;125777
+Avatar - Tymaret, the Murder King;VAN;151943
+Avatar - Ugin, the Spirit Dragon;VAN;159963
+Avatar - Vampire Nocturnus;VAN;126958
+Avatar - Viridian Zealot;VAN;126962
+Avatar - Vraska, Relic Seeker Prestige;VAN;405599
+Avatar - Windreader Sphinx;VAN;151941
+Avatar - Withengar Unbound;VAN;144079
+Avatar - Word of Command;VAN;137580
+Avatar - Yasova Dragonclaw;VAN;159962
+Avatar - Zedruu the Greathearted;VAN;140392
+Avatar - Zodiac Dragon;VAN;126959
+Avatar of Discord;DIS;49240
+Avatar of Discord;DPA;49240
+Avatar of Discord;PRM;94306
+Avatar of Fury;CMD;21942
+Avatar of Fury;PCY;21942
+Avatar of Hope;8ED;49664
+Avatar of Hope;PCY;21943
+Avatar of Hope;PRM;21943
+Avatar of Might;10E;21944
+Avatar of Might;PCY;21944
+Avatar of Slaughter;CMD;137544
+Avatar of Slaughter;DPA;137544
+Avatar of Will;PCY;21945
+Avatar of Woe;CMD;21946
+Avatar of Woe;DPA;21946
+Avatar of Woe;MS3;401632
+Avatar of Woe;PCY;21946
+Avatar of Woe;PD3;21946
+Avatar of Woe;PRM;125908
+Avatar of Woe;TD0;21946
+Avatar of Woe;TSB;21946
+Avatar of the Resolute;DTK;160154
+Avatar;TOK;107709
+Aven Archer;ODY;33530
+Aven Augur;FUT;102440
+Aven Battle Priest;ORI;160195
+Aven Brigadier;ONS;42954
+Aven Cloudchaser;10E;33195
+Aven Cloudchaser;8ED;33195
+Aven Cloudchaser;9ED;33195
+Aven Cloudchaser;ODY;33195
+Aven Envoy;LGN;47502
+Aven Farseer;SCG;48146
+Aven Fateshaper;ONS;42995
+Aven Fisher;10E;33471
+Aven Fisher;8ED;33471
+Aven Fisher;9ED;33471
+Aven Fisher;ODY;33471
+Aven Fleetwing;DPA;103539
+Aven Fleetwing;M12;103539
+Aven Flock;8ED;33476
+Aven Flock;9ED;33476
+Aven Flock;ODY;33476
+Aven Fogbringer;JUD;40195
+Aven Initiate;AKH;400836
+Aven Initiate;TOK;401247
+Aven Liberator;SCG;46579
+Aven Mimeomancer;ARB;121017
+Aven Mimeomancer;DPA;121017
+Aven Mindcensor;AKH;400835
+Aven Mindcensor;FUT;42974
+Aven Mindcensor;MS3;401603
+Aven Redeemer;LGN;46572
+Aven Reedstalker;HOU;401783
+Aven Riftwatcher;EMA;100644
+Aven Riftwatcher;PLC;100644
+Aven Shrine;ODY;33502
+Aven Skirmisher;FRF;157188
+Aven Smokeweaver;ODY;33517
+Aven Soulgazer;ONS;42939
+Aven Squire;CON;118763
+Aven Squire;DPA;118763
+Aven Squire;M13;118763
+Aven Sunstriker;DTK;159757
+Aven Surveyor;FRF;157210
+Aven Tactician;DTK;159790
+Aven Trailblazer;CON;118729
+Aven Trooper;TOR;36390
+Aven Warcraft;JUD;40180
+Aven Warhawk;LGN;48213
+Aven Wind Guide;AKH;400919
+Aven Wind Guide;TOK;401251
+Aven Windreader;10E;33491
+Aven Windreader;9ED;33491
+Aven Windreader;ODY;33491
+Aven of Enduring Hope;HOU;401771
+Avenger en-Dal;NMS;21262
+Avenger of Zendikar;C13;126560
+Avenger of Zendikar;PRM;160771
+Avenger of Zendikar;WWK;126560
+Avenging Angel;TMP;3184
+Avenging Angel;TPR;3184
+Avenging Arrow;RTR;145119
+Avenging Druid;EXO;5419
+Avian Changeling;LRW;106367
+Avian Changeling;MMA;106367
+Aviary Mechanic;KLD;162240
+Avid Reclaimer;HOU;401722
+Avizoa;WTH;2890
+Avoid Fate;LEG;500
+Avoid Fate;TSB;500
+Awaken the Ancient;M14;147427
+Awaken the Bear;KTK;157054
+Awaken the Sky Tyrant;PZ1;160435
+Awakener Druid;DPA;121576
+Awakener Druid;M10;121576
+Awakener Druid;M11;121576
+Awakening Zone;CMD;127314
+Awakening Zone;PC2;127314
+Awakening Zone;ROE;127314
+Awakening;STH;3644
+Away;DGM;150996
+Awe Strike;MRD;51048
+Awe for the Guilds;DGM;146842
+Awesome Presence;ALL;1591
+Awesome Presence;ALL;1592
+Awoken Horror;SOI;161411
+Axebane Guardian;RTR;145874
+Axebane Stag;RTR;145875
+Axegrinder Giant;DPA;104080
+Axegrinder Giant;LRW;104080
+Axelrod Gunnarson;CH;501
+Axelrod Gunnarson;LEG;501
+Axelrod Gunnarson;ME3;501
+Axis of Mortality;XLN;402375
+Ayesha Tanaka;CH;502
+Ayesha Tanaka;LEG;502
+Ayli, Eternal Pilgrim;OGW;161257
+Aysen Abbey;HML;1463
+Aysen Bureaucrats;5ED;2310
+Aysen Bureaucrats;HML;1464
+Aysen Bureaucrats;HML;1465
+Aysen Bureaucrats;ME2;1464
+Aysen Crusader;HML;1466
+Aysen Crusader;ME2;1466
+Aysen Highway;HML;1467
+Ayumi, the Last Visitor;SOK;86119
+Azami, Lady of Scrolls;C13;80910
+Azami, Lady of Scrolls;COK;80910
+Azcanta, the Sunken Ruin;XLN;402119
+Azimaet Drake;MIR;1796
+Azor's Elocutors;RTR;145956
+Azorius Aethermage;DIS;94728
+Azorius Arrester;RTR;145109
+Azorius Chancery;C13;94290
+Azorius Chancery;CMD;94290
+Azorius Chancery;DDI;94290
+Azorius Chancery;DIS;94290
+Azorius Chancery;MM2;94290
+Azorius Chancery;TD0;94290
+Azorius Charm;RTR;145187
+Azorius Cluestone;DGM;147766
+Azorius First-Wing;DIS;94304
+Azorius Guildgate;C13;145159
+Azorius Guildgate;DGM;146889
+Azorius Guildgate;MM3;146889
+Azorius Guildgate;RTR;145159
+Azorius Guildmage;CMD;94280
+Azorius Guildmage;DIS;94280
+Azorius Guildmage;PRM;94280
+Azorius Guildmage;TD0;94280
+Azorius Herald;C13;94632
+Azorius Herald;DIS;94632
+Azorius Justiciar;RTR;145893
+Azorius Keyrune;C13;145212
+Azorius Keyrune;RTR;145212
+Azorius Ploy;DIS;94487
+Azorius Signet;DIS;94288
+Azorius Signet;MM3;131715
+Azorius Signet;PRM;131715
+Azorius Signet;TD0;94288
+Azure Drake;5ED;2311
+Azure Drake;9ED;2311
+Azure Drake;CH;503
+Azure Drake;LEG;503
+Azure Drake;M11;2311
+Azure Mage;C14;134150
+Azure Mage;M12;134150
+Azure Mage;MM3;134150
+Azusa, Lost but Seeking;COK;82624
+Azusa, Lost but Seeking;PRM;161281
+Back from the Brink;ISD;139299
+Back to Basics;USG;8872
+Back to Nature;M11;129188
+Back to Nature;M15;129188
+Backdraft;LEG;504
+Backfire;4ED;505
+Backfire;LEG;505
+Backlash;INV;24152
+Backslide;ONS;42982
+Backwoods Survivalists;EMN;162404
+Bad Moon;2ED;9
+Bad Moon;3ED;9
+Bad Moon;4ED;9
+Bad Moon;5ED;2312
+Bad Moon;C14;2312
+Bad Moon;DDD;2312
+Bad Moon;LEA;9
+Bad Moon;LEB;9
+Bad Moon;TSB;9
+Bad River;MIR;1797
+Bad River;VMA;1797
+Badlands;2ED;10
+Badlands;3ED;10
+Badlands;LEA;10
+Badlands;LEB;10
+Badlands;ME2;10
+Badlands;ME4;10
+Badlands;PRM;144158
+Badlands;VMA;144158
+Baki's Curse;HML;1468
+Baku Altar;BOK;83850
+Bala Ged Scorpion;ROE;127439
+Bala Ged Thief;ZEN;125064
+Balance of Power;8ED;6604
+Balance of Power;POR;6604
+Balance of Power;PTK;9002
+Balance;2ED;11
+Balance;3ED;11
+Balance;4ED;11
+Balance;EMA;77104
+Balance;LEA;11
+Balance;LEB;11
+Balance;ME4;11
+Balance;PRM;77104
+Balance;V09;122577
+Balance;VMA;77104
+Balancing Act;ODY;33393
+Balduvian Barbarians;6ED;1078
+Balduvian Barbarians;7ED;27539
+Balduvian Barbarians;8ED;27539
+Balduvian Barbarians;9ED;27539
+Balduvian Barbarians;ICE;1078
+Balduvian Bears;ICE;1079
+Balduvian Conjurer;ICE;1080
+Balduvian Conjurer;ME2;1080
+Balduvian Dead;ALL;1593
+Balduvian Dead;ME2;1593
+Balduvian Fallen;CSP;97008
+Balduvian Frostwaker;CSP;96911
+Balduvian Horde;6ED;1594
+Balduvian Horde;ALL;1594
+Balduvian Horde;MED;1594
+Balduvian Horde;PRM;1594
+Balduvian Hydra;ICE;1081
+Balduvian Hydra;ME2;1081
+Balduvian Rage;CSP;96984
+Balduvian Shaman;ICE;1082
+Balduvian Trading Post;ALL;1595
+Balduvian Trading Post;ME2;1595
+Balduvian War-Makers;ALL;1596
+Balduvian War-Makers;ALL;1597
+Balduvian Warlord;CSP;97026
+Balefire Dragon;ISD;138336
+Balefire Liege;EVE;113650
+Balefire Liege;PC1;113650
+Baleful Ammit;AKH;400770
+Baleful Eidolon;THS;149052
+Baleful Force;C13;151771
+Baleful Force;VMA;151771
+Baleful Stare;7ED;27540
+Baleful Stare;9ED;86947
+Baleful Stare;POR;6605
+Baleful Strix;C13;140355
+Baleful Strix;EMA;140355
+Baleful Strix;PC2;140355
+Baleful Strix;VMA;140355
+Ball Lightning;4ED;732
+Ball Lightning;5ED;732
+Ball Lightning;DPA;122161
+Ball Lightning;DRK;732
+Ball Lightning;M10;122161
+Ball Lightning;MED;732
+Ball Lightning;PD2;122161
+Ball Lightning;PRM;732
+Ballista Charger;KLD;162580
+Ballista Squad;10E;19316
+Ballista Squad;9ED;19316
+Ballista Squad;MMQ;19316
+Balloon Peddler;MMQ;19211
+Ballynock Cohort;EMA;111583
+Ballynock Cohort;SHM;111583
+Ballynock Trapper;EVE;113699
+Ballyrush Banneret;MOR;109917
+Balm of Restoration;FEM;857
+Baloth Cage Trap;MM3;125074
+Baloth Cage Trap;ZEN;125074
+Baloth Null;OGW;161258
+Baloth Pup;OGW;161252
+Baloth Woodcrasher;C13;121574
+Baloth Woodcrasher;CMD;121574
+Baloth Woodcrasher;DPA;121574
+Baloth Woodcrasher;ZEN;121574
+Balshan Beguiler;ODY;33464
+Balshan Collaborator;TOR;36422
+Balshan Griffin;ODY;33197
+Balthor the Defiled;JUD;40235
+Balthor the Stout;TOR;36495
+Balustrade Spy;GTC;146579
+Bamboozle;ODY;33465
+Bandage;10E;3645
+Bandage;STH;3645
+Bandage;TPR;3645
+Bane Alley Blackguard;DGM;146717
+Bane Alley Broker;GTC;146311
+Bane of Bala Ged;BFZ;160612
+Bane of Hanweir;ISD;138449
+Bane of Progress;C13;151769
+Bane of the Living;LGN;46565
+Banefire;CON;118773
+Banefire;DPA;118773
+Banefire;MM2;118773
+Baneful Omen;ROE;127474
+Baneslayer Angel;DPA;87090
+Baneslayer Angel;M10;87090
+Baneslayer Angel;M11;87090
+Baneslayer Angel;V15;87090
+Banewasp Affliction;ALA;114940
+Banewhip Punisher;HOU;401543
+Banisher Priest;M14;148778
+Banisher Priest;PRM;152534
+Banishing Knack;EVE;113709
+Banishing Light;JOU;153060
+Banishing Light;PRM;155873
+Banishing Stroke;AVR;141697
+Banishing Stroke;MM3;141697
+Banishment Decree;MBS;133179
+Banners Raised;AVR;141559
+Banshee of the Dread Choir;PZ1;160432
+Banshee;CH;733
+Banshee;DRK;733
+Banshee;ME3;733
+Banshee's Blade;MRD;50281
+Bant Battlemage;ALA;115154
+Bant Charm;ALA;114912
+Bant Charm;DPA;114912
+Bant Panorama;ALA;114961
+Bant Panorama;C13;114961
+Bant Panorama;TD0;114961
+Bant Sojourners;ARB;121051
+Bant Sureblade;ARB;121062
+Bant;PC1;125894
+Bar the Door;DKA;139894
+Baral, Chief of Compliance;AER;400275
+Baral's Expertise;AER;400278
+Barbarian Bully;JUD;40240
+Barbarian General;PTK;9074
+Barbarian Guides;ICE;1083
+Barbarian Horde;PTK;9073
+Barbarian Lunatic;ODY;33380
+Barbarian Outcast;TOR;36476
+Barbarian Riftcutter;RAV;88961
+Barbarian Ring;ODY;33236
+Barbarian Ring;PD2;33236
+Barbary Apes;LEG;506
+Barbed Battlegear;SOM;131053
+Barbed Field;PCY;21958
+Barbed Foliage;MIR;1798
+Barbed Lightning;DST;75194
+Barbed Sextant;5ED;1084
+Barbed Sextant;ICE;1084
+Barbed Sextant;ME2;1084
+Barbed Shocker;TSP;97364
+Barbed Sliver;H09;3261
+Barbed Sliver;TMP;3261
+Barbed Sliver;TPR;3261
+Barbed Wire;MMQ;19266
+Barbed-Back Wurm;MIR;1799
+Barbtooth Wurm;PO2;4776
+Bargain;PO2;4637
+Bargaining Table;MMQ;19079
+Barishi;WTH;2926
+Barkhide Mauler;ONS;43159
+Barkshell Blessing;SHM;111883
+Barktooth Warbeard;LEG;507
+Barktooth Warbeard;ME3;507
+Barl's Cage;5ED;734
+Barl's Cage;CH;734
+Barl's Cage;DRK;734
+Barl's Cage;ME3;734
+Baron Sengir;HML;1469
+Baron Sengir;MED;1469
+Baron Sengir;PRM;1469
+Barony Vampire;DPA;129093
+Barony Vampire;M11;129093
+Barrage Ogre;SOM;130952
+Barrage Tyrant;BFZ;160874
+Barrage Tyrant;PRM;160677
+Barrage of Boulders;KTK;157038
+Barrage of Expendables;M14;148280
+Barrel Down Sokenzan;SOK;86074
+Barreling Attack;MIR;1800
+Barren Glory;FUT;102454
+Barren Moor;C13;43216
+Barren Moor;C14;43216
+Barren Moor;CMD;43216
+Barren Moor;DDC;43216
+Barren Moor;DDJ;43216
+Barren Moor;ONS;43216
+Barren Moor;TD0;43216
+Barren Moor;VMA;43216
+Barrenton Cragtreads;SHM;111558
+Barrenton Medic;SHM;111519
+Barricade Breaker;AER;400392
+Barrin, Master Wizard;USG;8921
+Barrin's Codex;USG;8702
+Barrin's Spite;INV;25481
+Barrin's Unmaking;INV;24194
+Barrow Ghoul;WTH;2794
+Bartel Runeaxe;LEG;2526
+Bartel Runeaxe;ME3;2526
+Barter in Blood;AVR;141555
+Barter in Blood;DDC;51089
+Barter in Blood;MRD;51089
+Barter in Blood;TD2;51089
+Baru, Fist of Krosa;FUT;102475
+Basal Sliver;TSP;97279
+Basal Thrull;FEM;858
+Basal Thrull;FEM;859
+Basal Thrull;FEM;860
+Basal Thrull;FEM;861
+Basal Thrull;MED;858
+Basalt Gargoyle;TSP;97510
+Basalt Golem;MIR;1801
+Basalt Monolith;2ED;12
+Basalt Monolith;3ED;12
+Basalt Monolith;C13;144160
+Basalt Monolith;LEA;12
+Basalt Monolith;LEB;12
+Basalt Monolith;ME4;12
+Basalt Monolith;PRM;144160
+Basalt Monolith;PZ1;144160
+Basandra, Battle Seraph;CMD;137543
+Basandra, Battle Seraph;VMA;137543
+Bash to Bits;ODY;33358
+Basilica Guards;GTC;146353
+Basilica Screecher;GTC;146420
+Basilisk Collar;DPA;126549
+Basilisk Collar;MM3;126549
+Basilisk Collar;WWK;126549
+Basking Rootwalla;DDD;36509
+Basking Rootwalla;PRM;36509
+Basking Rootwalla;TOR;36509
+Basking Rootwalla;VMA;36509
+Bassara Tower Archer;JOU;152052
+Bastion Enforcer;AER;400232
+Bastion Inventor;AER;400256
+Bastion Mastodon;KLD;162342
+Bastion Protector;PZ1;160035
+Bat;TOK;93487
+Bat;TOK;97539
+Bathe in Dragonfire;FRF;157207
+Bathe in Light;CMD;88900
+Bathe in Light;RAV;88900
+Baton of Courage;5DN;77176
+Baton of Morale;ICE;1085
+Battered Golem;5DN;77237
+Batterhorn;RTR;145866
+Battering Craghorn;ONS;43091
+Battering Krasis;DGM;147708
+Battering Ram;4ED;393
+Battering Ram;5ED;393
+Battering Ram;ATQ;393
+Battering Sliver;PLC;100795
+Battering Wurm;GPT;91789
+Batterskull;NPH;134394
+Batterskull;PRM;152616
+Battery;INV;25581
+Battery;PC1;25581
+Battery;TSB;25581
+Battle Brawler;FRF;157156
+Battle Cry;ICE;1086
+Battle Frenzy;ICE;1087
+Battle Hurda;WWK;126582
+Battle Hymn;AVR;141782
+Battle Mastery;DDL;106381
+Battle Mastery;DTK;160066
+Battle Mastery;LRW;106381
+Battle Mastery;M15;106381
+Battle Rampart;MMQ;19263
+Battle Rampart;ROE;127349
+Battle Screech;JUD;40181
+Battle Screech;VMA;40181
+Battle Sliver;DPA;147381
+Battle Sliver;M14;147381
+Battle Squadron;EMA;19283
+Battle Squadron;MMQ;19283
+Battle Strain;ODY;33356
+Battle at the Bridge;AER;400302
+Battle of Wits;9ED;86911
+Battle of Wits;M13;143933
+Battle of Wits;ODY;33445
+Battle-Mad Ronin;COK;82590
+Battle-Mad Ronin;DPA;82590
+Battle-Rattle Shaman;DPA;127326
+Battle-Rattle Shaman;MM3;127326
+Battle-Rattle Shaman;ROE;127326
+Battlefield Forge;10E;31067
+Battlefield Forge;9ED;31067
+Battlefield Forge;APC;31067
+Battlefield Forge;M15;31067
+Battlefield Forge;ORI;31067
+Battlefield Medic;ONS;42914
+Battlefield Percher;NMS;21183
+Battlefield Scavenger;AKH;401326
+Battlefield Scrounger;JUD;40270
+Battlefield Thaumaturge;JOU;152800
+Battleflight Eagle;M13;143907
+Battlefront Krushok;FRF;157295
+Battlegate Mimic;EVE;113644
+Battlegate Mimic;PC1;113644
+Battlegrace Angel;ALA;115206
+Battlegrace Angel;DPA;115206
+Battlegrace Angel;MM2;115206
+Battleground Geist;ISD;138410
+Battlegrowth;MRD;50291
+Battletide Alchemist;MOR;109608
+Battlewand Oak;LRW;105587
+Battlewise Aven;JUD;40167
+Battlewise Hoplite;THS;150827
+Battlewise Valor;THS;150854
+Batwing Brume;EVE;113733
+Bay Falcon;MIR;1802
+Bayou Dragonfly;TMP;2993
+Bayou;2ED;13
+Bayou;3ED;13
+Bayou;LEA;13
+Bayou;LEB;13
+Bayou;ME3;13
+Bayou;ME4;13
+Bayou;PRM;144161
+Bayou;VMA;144161
+Bazaar Krovod;RTR;145894
+Bazaar Trader;WWK;126487
+Bazaar of Baghdad;ARN;310
+Bazaar of Baghdad;ME3;310
+Bazaar of Baghdad;VMA;158841
+Bazaar of Wonders;MIR;1803
+Beacon Behemoth;CON;118735
+Beacon Hawk;DIS;94697
+Beacon of Creation;5DN;77180
+Beacon of Destiny;LGN;47512
+Beacon of Destruction;10E;77179
+Beacon of Destruction;5DN;77179
+Beacon of Destruction;DPA;77179
+Beacon of Immortality;10E;77091
+Beacon of Immortality;5DN;77091
+Beacon of Immortality;DPA;77091
+Beacon of Tomorrows;5DN;52035
+Beacon of Unrest;10E;77178
+Beacon of Unrest;5DN;77178
+Beacon of Unrest;DPA;77178
+Beacon of Unrest;PC1;77178
+Beacon of Unrest;PRM;162421
+Bear Cub;PO2;4763
+Bear Umbra;ROE;127476
+Bear;TOK;156682
+Bear;TOK;33672
+Bear;TOK;44681
+Bear's Companion;KTK;156528
+Bearer of Overwhelming Truths;SOI;161663
+Bearer of Silence;OGW;161222
+Bearer of the Heavens;JOU;152964
+Bearscape;ODY;33281
+Beast Attack;DDD;33299
+Beast Attack;ODY;33299
+Beast Hunt;DPA;123631
+Beast Hunt;PC1;123631
+Beast Hunt;ZEN;123631
+Beast Walkers;HML;1470
+Beast Within;DDL;150062
+Beast Within;DPA;134335
+Beast Within;NPH;134335
+Beast Within;PC2;134335
+Beast of Burden;7ED;27541
+Beast of Burden;8ED;27541
+Beast of Burden;9ED;27541
+Beast of Burden;PRM;9503
+Beast of Burden;UL;9503
+Beast;TOK;107645
+Beast;TOK;113775
+Beast;TOK;117015
+Beast;TOK;123771
+Beast;TOK;128458
+Beast;TOK;134383
+Beast;TOK;150061
+Beast;TOK;151773
+Beast;TOK;155673
+Beast;TOK;160431
+Beast;TOK;162565
+Beast;TOK;33668
+Beast;TOK;401254
+Beast;TOK;49014
+Beast;TOK;51115
+Beast;TOK;77064
+Beastbreaker of Bala Ged;ROE;127401
+Beastcaller Savant;BFZ;160903
+Beastmaster Ascension;C14;125085
+Beastmaster Ascension;DPA;125085
+Beastmaster Ascension;ZEN;125085
+Beastmaster's Magemark;GPT;91879
+Beasts of Bogardan;CH;508
+Beasts of Bogardan;LEG;508
+Beck;DGM;147695
+Beckon Apparition;EVE;113737
+Beckon Apparition;GTC;146561
+Become Immense;KTK;157061
+Bedlam Reveler;EMN;161990
+Bedlam;7ED;27542
+Bedlam;USG;8915
+Bee Sting;ME4;4782
+Bee Sting;PO2;4782
+Bee Sting;POR;6645
+Beetleback Chief;C14;140344
+Beetleback Chief;EMA;140344
+Beetleback Chief;PC2;140344
+Beetleback Chief;VMA;140344
+Beetleform Mage;DGM;146871
+Befoul;7ED;27543
+Befoul;COK;80579
+Befoul;DPA;80579
+Befoul;USG;8787
+Beguiler of Wills;DKA;138271
+Behemoth Sledge;ARB;120963
+Behemoth Sledge;C13;120963
+Behemoth Sledge;DDH;138681
+Behemoth Sledge;DPA;120963
+Behemoth Sledge;DPA;138681
+Behemoth Sledge;PZ1;120963
+Behemoth's Herald;ALA;115193
+Behind the Scenes;SOI;161715
+Behold the Beyond;SOI;161345
+Belbe's Armor;NMS;21145
+Belbe's Percher;NMS;21146
+Belbe's Portal;NMS;21272
+Belfry Spirit;GPT;91787
+Believe;HOU;401866
+Belligerent Brontodon;XLN;402100
+Belligerent Hatchling;EVE;113698
+Belligerent Sliver;M15;155310
+Belligerent Whiptail;BFZ;160676
+Bellowing Aegisaur;XLN;402081
+Bellowing Fiend;7ED;27544
+Bellowing Fiend;TMP;3117
+Bellowing Saddlebrute;KTK;156551
+Bellowing Tanglewurm;DPA;131086
+Bellowing Tanglewurm;SOM;131086
+Bellows Lizard;ORI;145863
+Bellows Lizard;RTR;145863
+Belltoll Dragon;DTK;159741
+Belltower Sphinx;M12;89022
+Belltower Sphinx;RAV;89022
+Beloved Chaplain;ODY;33533
+Ben-Ben, Akki Hermit;COK;80609
+Benalish Cavalry;TSP;97554
+Benalish Commander;PLC;100687
+Benalish Emissary;INV;25142
+Benalish Heralds;INV;24009
+Benalish Hero;2ED;14
+Benalish Hero;3ED;14
+Benalish Hero;4ED;14
+Benalish Hero;5ED;14
+Benalish Hero;LEA;14
+Benalish Hero;LEB;14
+Benalish Hero;MED;14
+Benalish Infantry;WTH;2837
+Benalish Knight;10E;104570
+Benalish Knight;WTH;2840
+Benalish Lancer;DDG;24025
+Benalish Lancer;INV;24025
+Benalish Missionary;WTH;2841
+Benalish Trapper;INV;24085
+Benalish Trapper;VMA;24085
+Benalish Veteran;M12;134181
+Bend or Break;INV;25496
+Beneath the Sands;HOU;401819
+Benediction of Moons;GPT;91776
+Benefaction of Rhonas;AKH;400828
+Benefactor's Draught;PZ2;162442
+Benevolent Ancestor;RAV;89088
+Benevolent Bodyguard;EMA;36396
+Benevolent Bodyguard;JUD;36396
+Benevolent Bodyguard;TD0;36396
+Benevolent Bodyguard;VMA;36396
+Benevolent Offering;C14;156025
+Benevolent Unicorn;MIR;1804
+Benthic Behemoth;7ED;27545
+Benthic Behemoth;TMP;3167
+Benthic Djinn;MIR;1805
+Benthic Explorers;ALL;1598
+Benthic Explorers;ALL;1599
+Benthic Explorers;ME3;1599
+Benthic Giant;THS;149048
+Benthic Infiltrator;BFZ;160642
+Benthicore;LRW;105455
+Bequeathal;EXO;5595
+Bereavement;7ED;27546
+Bereavement;USG;8760
+Berserk Murlodont;LGN;47506
+Berserk;2ED;15
+Berserk;LEA;15
+Berserk;LEB;15
+Berserk;MED;15
+Berserk;V09;122580
+Berserk;VMA;122580
+Berserkers of Blood Ridge;M10;121659
+Berserkers of Blood Ridge;M11;121659
+Berserkers' Onslaught;DTK;160084
+Beseech the Queen;PC1;111729
+Beseech the Queen;SHM;111729
+Beseech the Queen;V16;111729
+Bestial Fury;ALL;1600
+Bestial Fury;ALL;1601
+Bestial Fury;MED;1600
+Bestial Menace;CMD;126463
+Bestial Menace;DPA;126463
+Bestial Menace;MM2;126463
+Bestial Menace;WWK;126463
+Betrayal of Flesh;MRD;50331
+Betrayal;VIS;2135
+Betrothed of Fire;WTH;2816
+Bewilder;TSP;97525
+Bident of Thassa;PRM;151401
+Bident of Thassa;THS;149970
+Bifurcate;MMQ;19167
+Big Game Hunter;PLC;101529
+Bile Blight;BNG;152576
+Bile Blight;PRM;155872
+Bile Urchin;BOK;83852
+Bind;INV;24147
+Binding Agony;MIR;1806
+Binding Grasp;5ED;2313
+Binding Grasp;ICE;1088
+Binding Grasp;ME2;1088
+Binding Mummy;AKH;401259
+Biomantic Mastery;DIS;94350
+Biomass Mutation;GTC;146478
+Bioplasm;GPT;91684
+Biorhythm;9ED;43195
+Biorhythm;DPA;43195
+Biorhythm;ONS;43195
+Bioshift;GTC;146292
+Biovisionary;GTC;146467
+Birchlore Rangers;ONS;43150
+Bird Maiden;4ED;311
+Bird Maiden;5ED;311
+Bird Maiden;ARN;311
+Bird Maiden;ME4;311
+Bird Soldier;TOK;121079
+Bird;TOK;113770
+Bird;TOK;123774
+Bird;TOK;129180
+Bird;TOK;145983
+Bird;TOK;150893
+Bird;TOK;152106
+Bird;TOK;152548
+Bird;TOK;156685
+Bird;TOK;162426
+Bird;TOK;35349
+Bird;TOK;41294
+Bird;TOK;49264
+Bird;TOK;94342
+Bird;TOK;97254
+Birds of Paradise;10E;88690
+Birds of Paradise;2ED;16
+Birds of Paradise;3ED;16
+Birds of Paradise;4ED;16
+Birds of Paradise;5ED;16
+Birds of Paradise;6ED;16
+Birds of Paradise;7ED;27547
+Birds of Paradise;8ED;27547
+Birds of Paradise;LEA;16
+Birds of Paradise;LEB;16
+Birds of Paradise;M10;88690
+Birds of Paradise;M11;88690
+Birds of Paradise;M12;88690
+Birds of Paradise;PRM;129299
+Birds of Paradise;RAV;88690
+Birthing Hulk;OGW;161082
+Birthing Pod;NPH;134268
+Bishop of Rebirth;PRM;402102
+Bishop of Rebirth;XLN;402433
+Bishop of the Bloodstained;XLN;402288
+Bishop's Soldier;XLN;402277
+Biting Rain;SOI;161687
+Biting Tether;SHM;111520
+Bitter Feud;C14;156029
+Bitter Ordeal;FUT;102455
+Bitter Revelation;KTK;156503
+Bitterblade Warrior;AKH;401334
+Bitterblossom;MM2;109921
+Bitterblossom;MOR;109921
+Bitterblossom;PRM;134050
+Bitterbow Sharpshooters;HOU;401568
+Bitterheart Witch;ISD;139295
+Bituminous Blast;ARB;121045
+Bituminous Blast;DPA;121045
+Bituminous Blast;PC2;121045
+Bituminous Blast;PRM;128447
+Black Carriage;HML;1471
+Black Cat;DKA;138151
+Black Cat;DPA;138151
+Black Cat;M15;138151
+Black Knight;2ED;17
+Black Knight;3ED;17
+Black Knight;4ED;17
+Black Knight;5ED;2314
+Black Knight;LEA;17
+Black Knight;LEB;17
+Black Knight;M10;121622
+Black Knight;M11;121622
+Black Knight;ME4;17
+Black Knight;MED;17
+Black Knight;PRM;17
+Black Lotus;2ED;18
+Black Lotus;LEA;18
+Black Lotus;LEB;18
+Black Lotus;PRM;149230
+Black Lotus;VMA;149230
+Black Mana Battery;4ED;509
+Black Mana Battery;LEG;509
+Black Market;MMQ;19067
+Black Oak of Odunos;BNG;152568
+Black Poplar Shaman;LRW;105370
+Black Scarab;ICE;1089
+Black Sun's Zenith;C14;133229
+Black Sun's Zenith;MBS;133229
+Black Sun's Zenith;PRM;134058
+Black Sun's Zenith;TD2;133229
+Black Vise;2ED;19
+Black Vise;3ED;19
+Black Vise;4ED;19
+Black Vise;LEA;19
+Black Vise;LEB;19
+Black Vise;ME3;19
+Black Vise;MS2;400924
+Black Vise;V10;129512
+Black Ward;2ED;20
+Black Ward;3ED;20
+Black Ward;4ED;20
+Black Ward;LEA;20
+Black Ward;LEB;20
+Blackcleave Cliffs;SOM;131102
+Blackcleave Goblin;SOM;130946
+Blackmail;9ED;43043
+Blackmail;ONS;43043
+Blade Sliver;LGN;46538
+Blade Splicer;MM3;134407
+Blade Splicer;NPH;134407
+Blade of Selves;PZ1;138749
+Blade of the Bloodchief;DPA;123740
+Blade of the Bloodchief;ZEN;123740
+Blade of the Sixth Pride;DPA;102408
+Blade of the Sixth Pride;FUT;102408
+Blade-Tribe Berserkers;SOM;130911
+Bladed Bracers;AVR;141510
+Bladed Pinions;SOM;131027
+Bladed Sentinel;MBS;131033
+Blademane Baku;BOK;83896
+Blades of Velis Vel;LRW;105394
+Blades of Velis Vel;MM2;105394
+Bladetusk Boar;DPA;123592
+Bladetusk Boar;JOU;152831
+Bladetusk Boar;M13;123592
+Bladetusk Boar;ZEN;123592
+Bladewing the Risen;CMD;48101
+Bladewing the Risen;DRB;48101
+Bladewing the Risen;SCG;48101
+Bladewing's Thrall;SCG;49006
+Blanchwood Armor;10E;8835
+Blanchwood Armor;7ED;27548
+Blanchwood Armor;8ED;27548
+Blanchwood Armor;9ED;27548
+Blanchwood Armor;DPA;8835
+Blanchwood Armor;USG;8835
+Blanchwood Treefolk;USG;8658
+Blanket of Night;VIS;2136
+Blasphemous Act;C14;138216
+Blasphemous Act;ISD;138216
+Blast of Genius;DGM;147744
+Blasted Landscape;USG;8670
+Blaster Mage;MMQ;20045
+Blastfire Bolt;M15;156679
+Blasting Station;5DN;77143
+Blasting Station;PRM;155896
+Blastoderm;DDD;125854
+Blastoderm;NMS;21246
+Blastoderm;PRM;21246
+Blastoderm;VMA;125854
+Blatant Thievery;ONS;43002
+Blaze Commando;DGM;147743
+Blaze of Glory;2ED;21
+Blaze of Glory;LEA;21
+Blaze of Glory;LEB;21
+Blaze of Glory;ME4;21
+Blaze;10E;27549
+Blaze;6ED;6683
+Blaze;7ED;27549
+Blaze;8ED;27549
+Blaze;9ED;27549
+Blaze;DPA;27549
+Blaze;PC1;27549
+Blaze;PO2;4753
+Blaze;POR;6683
+Blaze;PTK;8995
+Blazethorn Scarecrow;SHM;111705
+Blazing Archon;PD3;91372
+Blazing Archon;RAV;91372
+Blazing Blade Askari;TSP;97284
+Blazing Effigy;LEG;510
+Blazing Hellhound;ORI;160335
+Blazing Salvo;DDK;33368
+Blazing Salvo;ODY;33368
+Blazing Shoal;BOK;83859
+Blazing Specter;DDH;24055
+Blazing Specter;DPA;24055
+Blazing Specter;INV;24055
+Blazing Specter;VMA;24055
+Blazing Torch;ISD;138181
+Blazing Torch;ZEN;123708
+Blazing Volley;AKH;401324
+Bleak Coven Vampires;SOM;131065
+Blessed Alliance;EMN;161916
+Blessed Breath;COK;82592
+Blessed Orator;9ED;33534
+Blessed Orator;ODY;33534
+Blessed Reincarnation;DTK;159806
+Blessed Reversal;7ED;27550
+Blessed Reversal;8ED;27550
+Blessed Reversal;POR;6730
+Blessed Reversal;UL;10412
+Blessed Spirits;ORI;160196
+Blessed Wind;PCY;21963
+Blessed Wine;5ED;1090
+Blessed Wine;ICE;1090
+Blessing of Leeches;BOK;83849
+Blessing of the Nephilim;DIS;94378
+Blessing;2ED;22
+Blessing;3ED;22
+Blessing;4ED;22
+Blessing;LEA;22
+Blessing;LEB;22
+Blessing;M14;144170
+Blessings of Nature;AVR;141585
+Blight Herder;BFZ;160616
+Blight Herder;PRM;160842
+Blight Keeper;XLN;402290
+Blight Mamba;SOM;130908
+Blight Sickle;SHM;111515
+Blight;4ED;511
+Blight;5ED;2315
+Blight;6ED;2315
+Blight;LEG;511
+Blight;MED;511
+Blightcaster;M14;147489
+Blightcaster;ORI;147489
+Blighted Agent;NPH;134232
+Blighted Bat;AKH;400771
+Blighted Cataract;BFZ;160765
+Blighted Fen;BFZ;160732
+Blighted Fen;PRM;161656
+Blighted Gorge;BFZ;160734
+Blighted Shaman;6ED;1807
+Blighted Shaman;MIR;1807
+Blighted Steppe;BFZ;160735
+Blighted Woodland;BFZ;160767
+Blightning;ALA;115010
+Blightning;DDK;147654
+Blightning;DPA;115010
+Blightning;PRM;120091
+Blightsoil Druid;EMA;109936
+Blightsoil Druid;MOR;109936
+Blightspeaker;MMA;100754
+Blightspeaker;PLC;100754
+Blightsteel Colossus;MBS;133258
+Blightwidow;MBS;133201
+Blind Creeper;5DN;51014
+Blind Fury;MIR;1808
+Blind Hunter;GPT;91837
+Blind Obedience;GTC;146583
+Blind Phantasm;DPA;102338
+Blind Phantasm;FUT;102338
+Blind Seer;INV;24016
+Blind Zealot;NPH;134261
+Blind with Anger;COK;80850
+Blind-Spot Giant;LRW;107640
+Blind-Spot Giant;MMA;107640
+Blinding Angel;8ED;21225
+Blinding Angel;9ED;21225
+Blinding Angel;NMS;21225
+Blinding Beam;DDF;50238
+Blinding Beam;MMA;50238
+Blinding Beam;MRD;50238
+Blinding Drone;OGW;161140
+Blinding Flare;JOU;153045
+Blinding Fog;XLN;402305
+Blinding Light;INV;24071
+Blinding Light;MIR;1809
+Blinding Light;POR;6731
+Blinding Mage;M10;121614
+Blinding Mage;M11;121614
+Blinding Powder;BOK;83976
+Blinding Souleater;MM2;134384
+Blinding Souleater;NPH;134384
+Blinding Spray;KTK;157015
+Blinking Spirit;5ED;2316
+Blinking Spirit;9ED;2316
+Blinking Spirit;ICE;1091
+Blinkmoth Infusion;5DN;77187
+Blinkmoth Nexus;DST;75137
+Blinkmoth Nexus;MM2;148257
+Blinkmoth Nexus;MMA;148257
+Blinkmoth Nexus;TD2;75137
+Blinkmoth Urn;MRD;50226
+Blinkmoth Well;MRD;51098
+Blister Beetle;ALA;114997
+Blister Beetle;DPA;114997
+Blistercoil Weird;RTR;145151
+Blistergrub;SOM;131001
+Blistering Barrier;MIR;1810
+Blistering Dieflyn;SHM;111552
+Blistering Firecat;ONS;43129
+Blisterpod;BFZ;160697
+Blisterstick Shaman;DPA;133180
+Blisterstick Shaman;MBS;133180
+Blitz Hellion;ARB;120953
+Blizzard Elemental;UD;15613
+Blizzard Specter;CSP;96887
+Blizzard;ICE;1092
+Bloated Toad;UL;10362
+Blockade Runner;MMQ;19028
+Blockbuster;RAV;88966
+Blood Artist;AVR;141719
+Blood Artist;DPA;141719
+Blood Artist;EMA;141719
+Blood Bairn;M14;148274
+Blood Baron of Vizkopa;DGM;146779
+Blood Celebrant;LGN;47491
+Blood Clock;SOK;86132
+Blood Crypt;DIS;94305
+Blood Crypt;EXP;160788
+Blood Crypt;RTR;145239
+Blood Cultist;ALA;115133
+Blood Cultist;DPA;115133
+Blood Feud;DKA;139766
+Blood Frenzy;TMP;3027
+Blood Funnel;RAV;89143
+Blood Host;M15;155325
+Blood Hound;MMQ;19310
+Blood Knight;PLC;101374
+Blood Knight;PRM;101374
+Blood Lust;4ED;512
+Blood Lust;5ED;512
+Blood Lust;LEG;512
+Blood Lust;ME3;512
+Blood Mist;EMN;162097
+Blood Moon;8ED;49248
+Blood Moon;9ED;49248
+Blood Moon;CH;735
+Blood Moon;DRK;735
+Blood Moon;MM3;49248
+Blood Moon;MMA;49248
+Blood Moon;MS3;401637
+Blood Oath;MMQ;19227
+Blood Ogre;DDL;134130
+Blood Ogre;M12;134130
+Blood Ogre;MM2;134130
+Blood Pet;6ED;2968
+Blood Pet;7ED;27551
+Blood Pet;TMP;2968
+Blood Reckoning;M13;143944
+Blood Rites;C13;151978
+Blood Rites;COK;80717
+Blood Scrivener;DGM;146860
+Blood Seeker;DPA;123730
+Blood Seeker;M12;123730
+Blood Seeker;ZEN;123730
+Blood Speaker;COK;81052
+Blood Tithe;DPA;129141
+Blood Tithe;M11;129141
+Blood Tribute;ZEN;123543
+Blood Tyrant;CON;118725
+Blood Vassal;USG;8889
+Blood of the Martyr;CH;737
+Blood of the Martyr;DRK;737
+Blood-Chin Fanatic;DTK;159726
+Blood-Chin Rager;DTK;160127
+Blood-Cursed Knight;ORI;160333
+Blood-Toll Harpy;THS;149053
+Blood;DGM;151018
+Bloodbond March;RAV;89041
+Bloodbond Vampire;BFZ;160655
+Bloodbraid Elf;ARB;121042
+Bloodbraid Elf;EMA;161314
+Bloodbraid Elf;PC2;128452
+Bloodbraid Elf;PRM;128452
+Bloodbriar;EMN;162126
+Bloodchief Ascension;DPA;125087
+Bloodchief Ascension;ZEN;125087
+Bloodcrazed Goblin;M11;129098
+Bloodcrazed Hoplite;JOU;152861
+Bloodcrazed Neonate;ISD;139444
+Bloodcrazed Neonate;PRM;138127
+Bloodcrazed Paladin;XLN;402042
+Bloodcurdler;ODY;33477
+Bloodcurdling Scream;PO2;4727
+Bloodfell Caves;EMA;157283
+Bloodfell Caves;FRF;157283
+Bloodfell Caves;KTK;157095
+Bloodfire Colossus;10E;31040
+Bloodfire Colossus;9ED;31040
+Bloodfire Colossus;APC;31040
+Bloodfire Colossus;DDI;31040
+Bloodfire Colossus;DPA;31040
+Bloodfire Dwarf;APC;31038
+Bloodfire Enforcers;FRF;157327
+Bloodfire Expert;KTK;156507
+Bloodfire Infusion;APC;31033
+Bloodfire Kavu;APC;31039
+Bloodfire Kavu;DDI;31039
+Bloodfire Mentor;KTK;157035
+Bloodflow Connoisseur;AVR;141736
+Bloodflow Connoisseur;DPA;141736
+Bloodfray Giant;RTR;145907
+Bloodghast;DPA;123734
+Bloodghast;ZEN;123734
+Bloodgift Demon;C14;139296
+Bloodgift Demon;DPA;139296
+Bloodgift Demon;ISD;139296
+Bloodhall Ooze;CON;118658
+Bloodhall Priest;EMN;162142
+Bloodhill Bastion;PC2;138726
+Bloodhunter Bat;DPA;143844
+Bloodhunter Bat;M13;143844
+Bloodhunter Bat;W17;143844
+Bloodhusk Ritualist;WWK;126566
+Bloodied Ghost;EVE;113620
+Bloodletter Quill;RAV;88874
+Bloodline Keeper;ISD;138260
+Bloodline Shaman;ONS;43181
+Bloodlord of Vaasgoth;M12;137397
+Bloodlord of Vaasgoth;PRM;134175
+Bloodlust Inciter;AKH;401320
+Bloodmad Vampire;SOI;161689
+Bloodmark Mentor;DDG;111593
+Bloodmark Mentor;DPA;111593
+Bloodmark Mentor;SHM;111593
+Bloodpyre Elemental;ALA;115149
+Bloodpyre Elemental;DPA;115149
+Bloodrage Brawler;AKH;400754
+Bloodrage Vampire;DDK;134092
+Bloodrage Vampire;DPA;134092
+Bloodrage Vampire;M12;134092
+Bloodrite Invoker;DPA;127337
+Bloodrite Invoker;ROE;127337
+Bloodrock Cyclops;10E;104542
+Bloodrock Cyclops;WTH;2813
+Bloodscale Prowler;GPT;91663
+Bloodscent;MRD;51091
+Bloodshed Fever;SHM;111886
+Bloodshot Cyclops;7ED;27552
+Bloodshot Cyclops;8ED;27552
+Bloodshot Cyclops;UD;15655
+Bloodshot Trainee;FUT;102412
+Bloodshot Trainee;MM2;130935
+Bloodshot Trainee;SOM;130935
+Bloodsoaked Champion;KTK;156590
+Bloodspore Thrinax;PZ1;160446
+Bloodstained Mire;EXP;160778
+Bloodstained Mire;KTK;156609
+Bloodstained Mire;ONS;43221
+Bloodstained Mire;PRM;43221
+Bloodstoke Howler;LGN;46576
+Bloodstone Cameo;INV;25144
+Bloodthirsty Ogre;COK;80924
+Bloodthorn Taunter;ALA;114944
+Bloodthrone Vampire;M11;127479
+Bloodthrone Vampire;M13;127479
+Bloodthrone Vampire;MM2;127479
+Bloodthrone Vampire;ROE;127479
+Bloodwater Entity;HOU;401526
+Bloom Tender;EVE;113763
+Blooming Marsh;KLD;162361
+Blossom Dryad;XLN;402010
+Blossoming Defense;KLD;162556
+Blossoming Sands;EMA;157285
+Blossoming Sands;FRF;157285
+Blossoming Sands;KTK;157097
+Blossoming Wreath;WTH;2809
+Blowfly Infestation;SHM;111516
+Bludgeon Brawl;NPH;134306
+Blue Elemental Blast;2ED;23
+Blue Elemental Blast;3ED;23
+Blue Elemental Blast;4ED;23
+Blue Elemental Blast;LEA;23
+Blue Elemental Blast;LEB;23
+Blue Elemental Blast;ME4;23
+Blue Elemental Blast;PRM;144171
+Blue Elemental Blast;PRM;23
+Blue Mana Battery;4ED;513
+Blue Mana Battery;LEG;513
+Blue Scarab;ICE;1093
+Blue Sun's Zenith;C13;133252
+Blue Sun's Zenith;MBS;133252
+Blue Ward;2ED;24
+Blue Ward;3ED;24
+Blue Ward;4ED;24
+Blue Ward;LEA;24
+Blue Ward;LEB;24
+Blunt the Assault;SOM;131016
+Blur Sliver;DPA;147376
+Blur Sliver;M14;147376
+Blur of Blades;HOU;401808
+Blurred Mongoose;INV;25469
+Blustersquall;RTR;145169
+Boa Constrictor;MMQ;19036
+Boar Umbra;DPA;127315
+Boar Umbra;PC2;127315
+Boar Umbra;ROE;127315
+Boar;TOK;143413
+Boar;TOK;150894
+Boartusk Liege;SHM;111694
+Body Double;DDM;153258
+Body Double;DPA;100737
+Body Double;PLC;100737
+Body Snatcher;UD;15638
+Body of Jukai;BOK;83932
+Bog Down;PLS;27882
+Bog Elemental;PCY;21964
+Bog Glider;PCY;21965
+Bog Gnarr;APC;31084
+Bog Hoodlums;LRW;106374
+Bog Imp;4ED;738
+Bog Imp;5ED;738
+Bog Imp;6ED;6565
+Bog Imp;7ED;27553
+Bog Imp;8ED;27553
+Bog Imp;9ED;27553
+Bog Imp;DRK;738
+Bog Imp;POR;6565
+Bog Initiate;INV;23971
+Bog Raiders;M11;8678
+Bog Raiders;POR;6566
+Bog Raiders;USG;8678
+Bog Rats;5ED;739
+Bog Rats;6ED;739
+Bog Rats;CH;739
+Bog Rats;DRK;739
+Bog Serpent;PLC;100665
+Bog Smugglers;MMQ;19223
+Bog Tatters;ZEN;123547
+Bog Witch;MMQ;19101
+Bog Wraith;10E;106215
+Bog Wraith;2ED;25
+Bog Wraith;3ED;25
+Bog Wraith;4ED;25
+Bog Wraith;5ED;25
+Bog Wraith;6ED;25
+Bog Wraith;7ED;27554
+Bog Wraith;8ED;27554
+Bog Wraith;9ED;6567
+Bog Wraith;LEA;25
+Bog Wraith;LEB;25
+Bog Wraith;M10;106215
+Bog Wraith;POR;6567
+Bog Wreckage;ODY;33242
+Bog-Strider Ash;LRW;109115
+Bogardan Firefiend;10E;2817
+Bogardan Firefiend;PC1;2817
+Bogardan Firefiend;WTH;2817
+Bogardan Hellkite;C14;97381
+Bogardan Hellkite;DDG;134057
+Bogardan Hellkite;DRB;97381
+Bogardan Hellkite;M10;97381
+Bogardan Hellkite;TSP;97381
+Bogardan Lancer;FUT;102349
+Bogardan Phoenix;VIS;2137
+Bogardan Rager;DDG;97319
+Bogardan Rager;PC1;97319
+Bogardan Rager;TSP;97319
+Bogbrew Witch;M14;147481
+Boggart Arsonists;SHM;111845
+Boggart Birth Rite;LRW;105601
+Boggart Brute;ORI;159400
+Boggart Forager;LRW;106408
+Boggart Harbinger;LRW;105359
+Boggart Loggers;LRW;105465
+Boggart Mob;LRW;105543
+Boggart Ram-Gang;PD2;111767
+Boggart Ram-Gang;PRM;113117
+Boggart Ram-Gang;SHM;111767
+Boggart Shenanigans;EVG;105310
+Boggart Shenanigans;LRW;105310
+Boggart Sprite-Chaser;LRW;107628
+Boil;6ED;3268
+Boil;7ED;27555
+Boil;8ED;3268
+Boil;MS3;401636
+Boil;TMP;3268
+Boiling Blood;WTH;2822
+Boiling Earth;BFZ;160690
+Boiling Seas;9ED;6685
+Boiling Seas;POR;6685
+Bojuka Bog;C13;123559
+Bojuka Bog;C14;123559
+Bojuka Bog;CMD;123559
+Bojuka Bog;PZ1;123559
+Bojuka Bog;WWK;123559
+Bojuka Brigand;WWK;126519
+Bola Warrior;NMS;21258
+Bold Defense;DPA;123620
+Bold Defense;ZEN;123620
+Bold Impaler;EMN;161977
+Boldwyr Heavyweights;MOR;105541
+Boldwyr Intimidator;FUT;102406
+Boldwyr Intimidator;MOR;109979
+Bolt of Keranos;BNG;152047
+Boltwing Marauder;DTK;160054
+Boltwing Marauder;PRM;159723
+Bomat Bazaar Barge;KLD;162573
+Bomat Courier;KLD;162599
+Bomb Squad;ODY;33344
+Bomber Corps;GTC;146278
+Bond Beetle;DPA;143855
+Bond Beetle;M13;143855
+Bond of Agony;DIS;94377
+Bonded Construct;ORI;160343
+Bonded Fetch;FUT;102443
+Bonded Horncrest;XLN;401435
+Bonds of Faith;DDL;138176
+Bonds of Faith;ISD;138176
+Bonds of Mortality;OGW;161078
+Bonds of Quicksilver;SOM;130982
+Bone Dancer;WTH;2865
+Bone Flute;DRK;740
+Bone Flute;ME3;740
+Bone Harvest;MIR;1811
+Bone Mask;MIR;1812
+Bone Picker;AKH;400853
+Bone Saw;CON;119803
+Bone Saw;DPA;119803
+Bone Saw;OGW;161145
+Bone Shaman;ICE;1094
+Bone Shredder;DDE;10400
+Bone Shredder;UL;10400
+Bone Splinters;ALA;117003
+Bone Splinters;AVR;141528
+Bone Splinters;BFZ;160911
+Bone Splinters;MM2;117003
+Bone Splinters;MM3;117003
+Bone to Ash;DKA;139881
+Bone to Ash;ORI;139881
+Bonebreaker Giant;M12;137398
+Bonehoard;C14;133214
+Bonehoard;MBS;133214
+Boneknitter;ONS;43051
+Bonescythe Sliver;DPA;147375
+Bonescythe Sliver;M14;147375
+Boneshard Slasher;TOR;36453
+Bonesplitter Sliver;TSP;97340
+Bonesplitter;MMA;50268
+Bonesplitter;MRD;50268
+Bonesplitter;PRM;50268
+Bonesplitter;TD0;50268
+Bonesplitter;TD2;50268
+Bonethorn Valesk;SCG;48145
+Boneyard Parley;XLN;402036
+Boneyard Wurm;DDJ;139462
+Boneyard Wurm;ISD;139462
+Boneyard Wurm;PRM;138116
+Bonfire of the Damned;AVR;141789
+Bonfire of the Damned;MM3;141789
+Bontu the Glorified;AKH;400810
+Bontu the Glorified;MS3;401369
+Bontu's Last Reckoning;HOU;401804
+Bontu's Monument;AKH;400839
+Booby Trap;9ED;3104
+Booby Trap;TMP;3104
+Book Burning;JUD;40246
+Book of Rass;CH;741
+Book of Rass;DRK;741
+Book of Rass;ME4;741
+Boom;PLC;100782
+Boomerang;10E;86899
+Boomerang;5ED;2317
+Boomerang;6ED;1813
+Boomerang;7ED;27556
+Boomerang;8ED;2317
+Boomerang;9ED;86899
+Boomerang;CH;514
+Boomerang;DPA;86899
+Boomerang;LEG;514
+Boomerang;ME3;514
+Boomerang;MIR;1813
+Boomerang;PRM;27556
+Boompile;PZ2;162397
+Boon Reflection;SHM;111654
+Boon Satyr;THS;138748
+Boon of Emrakul;EMN;162083
+Boon of Erebos;THS;150856
+Boonweaver Giant;M15;155209
+Borborygmos Enraged;GTC;146499
+Borborygmos;GPT;91839
+Border Guard;POR;6732
+Border Patrol;JUD;40163
+Borderland Behemoth;DPA;109993
+Borderland Behemoth;MOR;109993
+Borderland Marauder;EMA;138756
+Borderland Marauder;M15;138756
+Borderland Marauder;W16;138756
+Borderland Minotaur;THS;149186
+Borderland Ranger;AVR;141509
+Borderland Ranger;DPA;122141
+Borderland Ranger;M10;122141
+Borderland Ranger;TD0;122141
+Boreal Centaur;CSP;96936
+Boreal Druid;CSP;96929
+Boreal Griffin;CSP;96980
+Boreal Shelf;CSP;96925
+Boris Devilboon;LEG;4619
+Boris Devilboon;ME3;4619
+Boros Battleshaper;DGM;146868
+Boros Charm;C13;145919
+Boros Charm;GTC;145919
+Boros Cluestone;DGM;147750
+Boros Elite;GTC;146263
+Boros Fury-Shield;RAV;89047
+Boros Garrison;C13;88851
+Boros Garrison;CMD;88851
+Boros Garrison;MM2;88851
+Boros Garrison;PC1;88851
+Boros Garrison;RAV;88851
+Boros Guildgate;C13;145157
+Boros Guildgate;DDL;145157
+Boros Guildgate;DGM;146888
+Boros Guildgate;GTC;145157
+Boros Guildgate;MM3;146888
+Boros Guildmage;CMD;88908
+Boros Guildmage;PC1;88908
+Boros Guildmage;RAV;88908
+Boros Keyrune;GTC;145929
+Boros Mastiff;DGM;146849
+Boros Reckoner;GTC;147250
+Boros Reckoner;MM3;147250
+Boros Recruit;RAV;89033
+Boros Signet;CMD;89181
+Boros Signet;MM3;131714
+Boros Signet;PC1;89181
+Boros Signet;PRM;131714
+Boros Signet;RAV;89181
+Boros Swiftblade;MM2;88614
+Boros Swiftblade;PC1;88614
+Boros Swiftblade;RAV;88614
+Borrowed Grace;EMN;161919
+Borrowed Hostility;EMN;162107
+Borrowed Malevolence;EMN;161957
+Borrowing 100,000 Arrows;C13;9033
+Borrowing 100,000 Arrows;ME3;9033
+Borrowing 100,000 Arrows;PTK;9033
+Borrowing the East Wind;PTK;9094
+Boseiju, Who Shelters All;COK;80769
+Boseiju, Who Shelters All;V12;80769
+Bosh, Iron Golem;C14;49680
+Bosh, Iron Golem;MRD;49680
+Bosh, Iron Golem;PC1;49680
+Bosium Strip;WTH;2855
+Bosk Banneret;MOR;109904
+Botanical Sanctum;KLD;162363
+Bottle Gnomes;10E;50215
+Bottle Gnomes;9ED;50215
+Bottle Gnomes;C14;50215
+Bottle Gnomes;DD2;50215
+Bottle Gnomes;DPA;50215
+Bottle Gnomes;MRD;50215
+Bottle Gnomes;PRM;3204
+Bottle Gnomes;TMP;3204
+Bottle Gnomes;TPR;3204
+Bottle of Suleiman;3ED;312
+Bottle of Suleiman;4ED;312
+Bottle of Suleiman;5ED;2318
+Bottle of Suleiman;6ED;2318
+Bottle of Suleiman;ARN;312
+Bottle of Suleiman;ME4;312
+Bottled Cloister;RAV;89059
+Bottomless Pit;STH;3647
+Bottomless Vault;5ED;2319
+Bottomless Vault;FEM;862
+Boulder Salvo;OGW;161133
+Boulderfall;THS;150847
+Bouncing Beebles;UL;10385
+Bound by Moonsilver;SOI;161463
+Bound in Silence;FUT;102379
+Bound in Silence;MMA;102379
+Bound;DIS;94438
+Bounding Krasis;ORI;160339
+Boundless Realms;DPA;143884
+Boundless Realms;M13;143884
+Bounteous Kirin;SOK;86111
+Bountiful Harvest;DPA;121580
+Bountiful Harvest;M10;121580
+Bountiful Harvest;M12;121580
+Bountiful Harvest;M13;121580
+Bounty Hunter;TMP;3116
+Bounty of the Hunt;ALL;1602
+Bounty of the Hunt;ME2;1602
+Bounty of the Luxa;AKH;400805
+Bow of Nylea;THS;149973
+Bower Passage;AVR;142209
+Brace for Impact;DIS;94592
+Brackwater Elemental;CON;118721
+Brackwater Elemental;DDH;118721
+Brago, King Eternal;EMA;153167
+Brago, King Eternal;VMA;153167
+Braid of Fire;CSP;97262
+Braids, Cabal Minion;EMA;33395
+Braids, Cabal Minion;ODY;33395
+Braids, Conjurer Adept;PLC;100733
+Braidwood Cup;UD;15772
+Braidwood Sextant;UD;15679
+Brain Freeze;SCG;49012
+Brain Freeze;VMA;49012
+Brain Gorgers;PLC;100720
+Brain Maggot;JOU;153098
+Brain Maggot;PRM;157100
+Brain Pry;DIS;94408
+Brain Weevil;DDJ;138392
+Brain Weevil;ISD;138392
+Brain in a Jar;SOI;161357
+Brainbite;ARB;120995
+Braingeyser;2ED;26
+Braingeyser;3ED;26
+Braingeyser;LEA;26
+Braingeyser;LEB;26
+Braingeyser;ME4;26
+Braingeyser;PRM;26
+Brainspoil;RAV;89103
+Brainstorm;5ED;1095
+Brainstorm;CMD;19043
+Brainstorm;DDJ;145061
+Brainstorm;EMA;145061
+Brainstorm;ICE;1095
+Brainstorm;ME2;1095
+Brainstorm;MMQ;19043
+Brainstorm;PRM;19043
+Brainstorm;PZ1;19043
+Brainstorm;VMA;145062
+Brainwash;4ED;742
+Brainwash;5ED;2320
+Brainwash;DRK;742
+Bramble Creeper;M10;121582
+Bramble Elemental;DPA;88953
+Bramble Elemental;PC2;88953
+Bramble Elemental;RAV;88953
+Bramblecrush;DPA;138284
+Bramblecrush;ISD;138284
+Bramblecrush;M14;138284
+Bramblesnap;ROE;127283
+Brambleweft Behemoth;HOU;401723
+Bramblewood Paragon;DPA;109612
+Bramblewood Paragon;MOR;109612
+Bramblewood Paragon;PRM;109612
+Branching Bolt;ALA;117008
+Branching Bolt;PC1;117008
+Branchsnap Lorian;LGN;46530
+Brand of Ill Omen;ICE;1096
+Brand;USG;8749
+Branded Brawlers;PCY;22044
+Branded Howler;SOI;161490
+Brass Gnat;TSP;97503
+Brass Herald;8ED;31041
+Brass Herald;APC;31041
+Brass Man;3ED;313
+Brass Man;4ED;313
+Brass Man;ARN;313
+Brass Man;ME4;313
+Brass Secretary;UD;15674
+Brass Squire;MBS;133187
+Brass-Talon Chimera;VIS;2138
+Brassclaw Orcs;5ED;863
+Brassclaw Orcs;FEM;863
+Brassclaw Orcs;FEM;864
+Brassclaw Orcs;FEM;866
+Brassclaw Orcs;FEM;983
+Brassclaw Orcs;ME2;863
+Bravado;USG;8930
+Brave the Elements;C14;123638
+Brave the Elements;DPA;123638
+Brave the Elements;M14;123638
+Brave the Elements;PRM;131561
+Brave the Elements;ZEN;123638
+Brave the Sands;KTK;156525
+Brawl;MMQ;19014
+Brawler's Plate;M15;155374
+Brawler's Plate;ORI;155374
+Brawn;CMD;40277
+Brawn;EMA;40277
+Brawn;JUD;40277
+Brawn;PZ1;40277
+Brawn;TD0;40277
+Brazen Buccaneers;XLN;402237
+Brazen Scourge;KLD;162192
+Brazen Wolves;EMN;161980
+Breach;USG;8912
+Breaching Hippocamp;THS;150768
+Breaching Leviathan;C14;155660
+Break Asunder;SCG;49003
+Break Open;ONS;43103
+Break Through the Line;FRF;157342
+Break of Day;DKA;139859
+Breaker of Armies;BFZ;160610
+Breaking Point;DDK;40262
+Breaking Point;DPA;40262
+Breaking Point;JUD;40262
+Breaking Wave;INV;24177
+Breaking;DGM;147697
+Breaking;PRM;148809
+Breakneck Rider;SOI;161358
+Breakthrough;TOR;36424
+Breath of Darigaaz;CMD;24157
+Breath of Darigaaz;DDG;24157
+Breath of Darigaaz;INV;24157
+Breath of Dreams;ICE;1097
+Breath of Fury;RAV;88911
+Breath of Life;7ED;27789
+Breath of Life;PO2;4666
+Breath of Life;POR;6733
+Breath of Life;VMA;27789
+Breath of Malfegor;ARB;120950
+Breathstealer;MIR;1814
+Breathstealer's Crypt;VIS;2139
+Bred for the Hunt;DGM;147726
+Breeding Pit;5ED;2321
+Breeding Pit;DDC;2321
+Breeding Pit;FEM;867
+Breeding Pit;MED;867
+Breeding Pool;DIS;94291
+Breeding Pool;EXP;160795
+Breeding Pool;GTC;145240
+Breezekeeper;VIS;2140
+Breya, Etherium Shaper;PZ2;162626
+Briar Patch;MMQ;19123
+Briar Shield;WTH;2811
+Briarberry Cohort;SHM;111615
+Briarbridge Patrol;SOI;161637
+Briarhorn;DDH;105607
+Briarhorn;LRW;105607
+Briarhorn;PC1;105607
+Briarknit Kami;SOK;86055
+Briarpack Alpha;DKA;139821
+Briarpack Alpha;DPA;139821
+Briarpack Alpha;M14;139821
+Briber's Purse;KTK;156582
+Briber's Purse;PRM;159780
+Bribery;8ED;19256
+Bribery;MMQ;19256
+Bribery;PRM;147352
+Bridge from Below;FUT;43073
+Bridge from Below;MMA;147519
+Bright Reprisal;XLN;402269
+Brightflame;RAV;89109
+Brighthearth Banneret;MOR;109923
+Brightstone Ritual;ONS;43109
+Brigid, Hero of Kinsbaile;LRW;105578
+Brilliant Halo;USG;8748
+Brilliant Halo;VMA;8748
+Brilliant Plan;C13;9031
+Brilliant Plan;ME3;9031
+Brilliant Plan;PTK;9031
+Brilliant Spectrum;BFZ;161154
+Brilliant Ultimatum;ALA;115170
+Brimaz, King of Oreskos;BNG;152100
+Brimstone Dragon;ME2;4584
+Brimstone Dragon;PO2;4584
+Brimstone Mage;ROE;127267
+Brimstone Volley;ISD;138363
+Brindle Boar;DPA;129128
+Brindle Boar;M11;129128
+Brindle Boar;M12;129128
+Brindle Boar;M14;129128
+Brindle Shoat;PC2;140340
+Brindle Shoat;VMA;140340
+Brine Elemental;C14;99359
+Brine Elemental;DD2;99359
+Brine Elemental;TSP;99359
+Brine Hag;LEG;515
+Brine Seer;UD;15615
+Brine Shaman;ICE;1098
+Brine Shaman;ME2;1098
+Bring Low;KTK;156515
+Bring to Light;BFZ;160828
+Bringer of the Black Dawn;5DN;77203
+Bringer of the Blue Dawn;5DN;77202
+Bringer of the Green Dawn;5DN;77200
+Bringer of the Red Dawn;5DN;77201
+Bringer of the White Dawn;5DN;77204
+Brink of Disaster;M12;126534
+Brink of Disaster;WWK;126534
+Brink of Madness;UL;13550
+Brion Stoutarm;CMD;105533
+Brion Stoutarm;DPA;105533
+Brion Stoutarm;LRW;105533
+Brion Stoutarm;PRM;105533
+Brisela, Voice of Nightmares;EMN;161922
+Bristling Hydra;KLD;162552
+Brittle Effigy;M11;129094
+Broken Ambitions;LRW;106396
+Broken Concentration;SOI;161464
+Broken Dam;PTK;9187
+Broken Fall;TMP;3006
+Broken Visage;5ED;2322
+Broken Visage;HML;1472
+Broken Visage;ME2;1472
+Brontotherium;LGN;47529
+Bronze Bombshell;DIS;94396
+Bronze Horse;CH;516
+Bronze Horse;LEG;516
+Bronze Horse;ME4;516
+Bronze Sable;M15;149076
+Bronze Sable;THS;149076
+Bronze Tablet;4ED;394
+Bronze Tablet;ATQ;394
+Bronzebeak Moa;DGM;146832
+Bronzebeak Moa;MM3;146832
+Brood Birthing;ROE;127397
+Brood Butcher;BFZ;160838
+Brood Keeper;M15;155244
+Brood Monitor;BFZ;160695
+Brood Sliver;H09;46536
+Brood Sliver;LGN;46536
+Brood of Cockroaches;VIS;2141
+Broodbirth Viper;PZ1;160076
+Broodhatch Nantuko;ONS;43171
+Broodhunter Wurm;BFZ;160709
+Brooding Saurian;C13;97025
+Brooding Saurian;CSP;97025
+Broodmate Dragon;ALA;116186
+Broodmate Dragon;DPA;116186
+Broodmate Dragon;MM3;116186
+Broodmate Dragon;PRM;116186
+Broodstar;MRD;51023
+Broodstar;PC1;51023
+Broodwarden;ROE;127398
+Brothers Yamazaki;COK;80921
+Brothers Yamazaki;COK;82432
+Brothers of Fire;4ED;1040
+Brothers of Fire;5ED;743
+Brothers of Fire;DRK;743
+Brothers of Fire;MED;743
+Browbeat;DDK;147656
+Browbeat;JUD;40250
+Browbeat;PC1;40250
+Browbeat;PD2;40250
+Browbeat;PRM;122192
+Browbeat;TSB;40250
+Brown Ouphe;ICE;1099
+Brown Ouphe;MRD;51000
+Browse;6ED;1603
+Browse;ALL;1603
+Browse;ME2;1603
+Bruna, Light of Alabaster;AVR;141748
+Bruna, the Fading Light;EMN;161923
+Bruse Tarl, Boorish Herder;PZ2;162378
+Brush with Death;STH;3648
+Brushland;10E;27557
+Brushland;5ED;2323
+Brushland;6ED;2323
+Brushland;7ED;27557
+Brushland;9ED;27557
+Brushland;ICE;1100
+Brushstrider;RTR;138758
+Brushwagg;MIR;1815
+Brutal Deceiver;COK;80791
+Brutal Expulsion;BFZ;160831
+Brutal Hordechief;FRF;157203
+Brutal Nightstalker;PO2;4720
+Brutal Suppression;PCY;22048
+Brutalizer Exarch;NPH;134260
+Brutalizer Exarch;PC2;134260
+Brute Force;DPA;100681
+Brute Force;MM2;100681
+Brute Force;MMA;100681
+Brute Force;PLC;100681
+Brute Strength;AKH;400877
+Brute Strength;OGW;161238
+Bubble Matrix;WTH;2859
+Bubbling Beebles;UD;15705
+Bubbling Cauldron;M14;147488
+Bubbling Muck;UD;15770
+Budoka Gardener;COK;80900
+Budoka Pupil;BOK;83897
+Budoka Pupil;PRM;83897
+Builder's Bane;MIR;1816
+Builder's Blessing;AVR;141535
+Built to Last;KLD;162242
+Built to Smash;KLD;162280
+Bull Aurochs;CSP;96888
+Bull Cerodon;ALA;115032
+Bull Cerodon;DPA;115032
+Bull Cerodon;PC1;115032
+Bull Elephant;VIS;2142
+Bull Hippo;7ED;27558
+Bull Hippo;POR;6646
+Bull Hippo;USG;8641
+Bull Rush;WWK;126490
+Bullwhip;STH;3649
+Bulwark;USG;8898
+Bump in the Night;DDK;138215
+Bump in the Night;ISD;138215
+Buoyancy;MMQ;19182
+Burden of Greed;DST;51890
+Burden of Guilt;DKA;139908
+Burgeoning;PRM;161897
+Burgeoning;STH;3650
+Buried Alive;CMD;33409
+Buried Alive;ODY;33409
+Buried Alive;PD3;33409
+Buried Alive;TD0;2919
+Buried Alive;WTH;2919
+Buried Ruin;C14;134172
+Buried Ruin;M12;134172
+Burn Away;KTK;156559
+Burn Trail;SHM;111849
+Burn at the Stake;AVR;141800
+Burn from Within;SOI;161672
+Burn the Impure;MBS;133159
+Burn;DGM;150997
+Burning Anger;M15;155346
+Burning Cloak;POR;6686
+Burning Earth;M14;149823
+Burning Fields;PTK;9126
+Burning Inquiry;M10;121675
+Burning Oil;DKA;139862
+Burning Palm Efreet;MIR;1817
+Burning Sands;ODY;33376
+Burning Shield Askari;MIR;1818
+Burning Sun's Avatar;PRM;402302
+Burning Sun's Avatar;XLN;402436
+Burning Vengeance;EMA;138433
+Burning Vengeance;ISD;138433
+Burning Wish;JUD;40259
+Burning Wish;PRM;120087
+Burning Wish;VMA;40259
+Burning of Xinye;ME3;9125
+Burning of Xinye;PTK;9125
+Burning of Xinye;V14;9125
+Burning of Xinye;VMA;9125
+Burning-Eye Zubera;SOK;80550
+Burning-Fist Minotaur;HOU;401809
+Burning-Tree Bloodscale;GPT;91725
+Burning-Tree Emissary;GTC;146259
+Burning-Tree Emissary;MM3;146259
+Burning-Tree Shaman;GPT;91815
+Burnished Hart;C14;149100
+Burnished Hart;THS;149100
+Burnout;ALL;1604
+Burnout;ME2;1604
+Burnt Offering;ICE;1101
+Burr Grafter;COK;81030
+Burrenton Bombardier;DDF;109932
+Burrenton Bombardier;MOR;109932
+Burrenton Forge-Tender;LRW;105319
+Burrenton Shield-Bearers;MOR;109929
+Burrowing;2ED;27
+Burrowing;3ED;27
+Burrowing;4ED;27
+Burrowing;6ED;27
+Burrowing;LEA;27
+Burrowing;LEB;27
+Burst Lightning;DPA;123560
+Burst Lightning;MM2;123560
+Burst Lightning;PRM;129538
+Burst Lightning;ZEN;123560
+Burst of Energy;UL;14065
+Burst of Speed;M10;122157
+Burst of Strength;GTC;146275
+Bushi Tenderfoot;COK;80881
+Bust;PLC;104384
+Butcher Ghoul;AVR;141795
+Butcher Ghoul;DPA;141795
+Butcher Orgg;ONS;43130
+Butcher of Malakir;C14;126546
+Butcher of Malakir;CMD;126546
+Butcher of Malakir;DDK;126546
+Butcher of Malakir;DPA;126546
+Butcher of Malakir;WWK;126546
+Butcher of the Horde;KTK;156596
+Butcher's Cleaver;ISD;138115
+Butcher's Glee;DTK;159752
+Butterfly;TOK;143400
+Butterfly;TOK;751
+By Force;AKH;400842
+Bygone Bishop;SOI;161680
+Byway Courier;SOI;161756
+Cabal Archon;ONS;43057
+Cabal Coffers;PC1;36531
+Cabal Coffers;PRM;36531
+Cabal Coffers;TOR;36531
+Cabal Conditioning;SCG;48127
+Cabal Executioner;ONS;43053
+Cabal Inquisitor;ODY;33417
+Cabal Interrogator;SCG;48246
+Cabal Patriarch;ODY;33406
+Cabal Pit;ODY;33237
+Cabal Ritual;TOR;36450
+Cabal Ritual;V16;162185
+Cabal Ritual;VMA;36450
+Cabal Shrine;ODY;33390
+Cabal Slaver;ONS;43032
+Cabal Surgeon;TOR;36437
+Cabal Therapy;EMA;139581
+Cabal Therapy;JUD;40233
+Cabal Therapy;PD3;139581
+Cabal Therapy;PRM;40233
+Cabal Torturer;TOR;36440
+Cabal Trainee;JUD;40225
+Cache Raiders;DDI;113670
+Cache Raiders;EVE;113670
+Cached Defenses;FRF;157315
+Cackling Counterpart;C14;138451
+Cackling Counterpart;ISD;138451
+Cackling Counterpart;MM3;138451
+Cackling Fiend;USG;8697
+Cackling Flames;DIS;94332
+Cackling Imp;5DN;77228
+Cackling Imp;DDC;77228
+Cackling Witch;MMQ;19042
+Cadaver Imp;PC2;127320
+Cadaver Imp;ROE;127320
+Cadaverous Bloom;MIR;1819
+Cadaverous Knight;MIR;1820
+Cadaverous Knight;PC1;1820
+Cage of Hands;COK;82585
+Cage of Hands;PC2;82585
+Caged Sun;C14;134201
+Caged Sun;NPH;134201
+Cagemail;JUD;40171
+Cairn Wanderer;LRW;105495
+Calciderm;EMA;100675
+Calciderm;PLC;100675
+Calciderm;PRM;101550
+Calciform Pools;TSP;97329
+Calcite Snapper;WWK;126462
+Calculated Dismissal;ORI;160226
+Caldera Hellion;ALA;115118
+Caldera Kavu;PLS;27885
+Caldera Lake;TMP;3147
+Caldera Lake;TPR;3147
+Caldera Lake;VMA;3147
+Call for Blood;BOK;83934
+Call for Unity;AER;400249
+Call of the Conclave;MM3;145917
+Call of the Conclave;PRM;149241
+Call of the Conclave;RTR;145917
+Call of the Full Moon;ORI;160287
+Call of the Herd;MM3;33317
+Call of the Herd;ODY;33317
+Call of the Herd;PRM;107710
+Call of the Herd;TSB;33317
+Call of the Nightwing;GTC;147243
+Call of the Wild;6ED;2873
+Call of the Wild;8ED;49679
+Call of the Wild;WTH;2873
+Call the Bloodline;PRM;162509
+Call the Bloodline;SOI;161671
+Call the Gatewatch;OGW;159984
+Call the Scions;BFZ;160696
+Call the Skybreaker;CMD;113728
+Call the Skybreaker;EMA;113728
+Call the Skybreaker;EVE;113728
+Call to Arms;ICE;1102
+Call to Arms;ME3;1102
+Call to Glory;COK;80838
+Call to Glory;DPA;80838
+Call to Heel;ALA;115106
+Call to Heel;DDJ;115106
+Call to Mind;C14;129174
+Call to Mind;M11;129174
+Call to Serve;AVR;141626
+Call to the Feast;XLN;402861
+Call to the Grave;M12;137609
+Call to the Grave;SCG;48134
+Call to the Kindred;DKA;139863
+Call to the Netherworld;TSP;97296
+Call;DGM;151028
+Caller of Gales;ZEN;123624
+Caller of the Claw;DPA;47477
+Caller of the Claw;LGN;47477
+Caller of the Hunt;MMQ;19022
+Caller of the Pack;PZ1;160083
+Callous Deceiver;COK;80861
+Callous Giant;INV;24168
+Callous Oppressor;ONS;43016
+Callow Jushi;BOK;83879
+Calming Licid;STH;3651
+Calming Verse;PCY;21967
+Caltrops;7ED;27559
+Caltrops;UD;15680
+Camarid;TOK;98955
+Camel;ARN;314
+Camouflage;2ED;28
+Camouflage;LEA;28
+Camouflage;LEB;28
+Campaign of Vengeance;EMN;162013
+Cancel;10E;97414
+Cancel;AKH;400767
+Cancel;ALA;116179
+Cancel;DPA;116179
+Cancel;DPA;97414
+Cancel;KTK;156494
+Cancel;M10;116179
+Cancel;M11;116179
+Cancel;M12;116179
+Cancel;M14;116179
+Cancel;M15;116179
+Cancel;PC2;116179
+Cancel;PRM;125916
+Cancel;RTR;145222
+Cancel;TSP;97414
+Cancel;XLN;402045
+Cancel;ZEN;123652
+Candelabra of Tawnos;ATQ;395
+Candelabra of Tawnos;ME4;395
+Candelabra of Tawnos;PRM;400643
+Candles of Leng;TSP;97418
+Candles' Glow;COK;82629
+Canker Abomination;EVE;113648
+Cankerous Thirst;EVE;113723
+Cannibalize;STH;3652
+Cannibalize;TPR;3652
+Canopy Claws;JUD;40273
+Canopy Cover;DPA;125537
+Canopy Cover;WWK;125537
+Canopy Crawler;LGN;47534
+Canopy Dragon;MIR;1821
+Canopy Gorger;OGW;161124
+Canopy Spider;10E;2995
+Canopy Spider;7ED;27560
+Canopy Spider;8ED;2995
+Canopy Spider;TMP;2995
+Canopy Spider;TPR;2995
+Canopy Surge;INV;24021
+Canopy Vista;BFZ;160890
+Canopy Vista;EXP;161286
+Cantivore;ODY;33505
+Canyon Drake;TMP;3152
+Canyon Lurkers;KTK;156509
+Canyon Minotaur;CON;118765
+Canyon Minotaur;DPA;118765
+Canyon Minotaur;M10;118765
+Canyon Minotaur;M11;118765
+Canyon Minotaur;M13;118765
+Canyon Minotaur;M14;118765
+Canyon Slough;AKH;400882
+Canyon Wildcat;8ED;3016
+Canyon Wildcat;DDH;3016
+Canyon Wildcat;TMP;3016
+Canyon Wildcat;TPR;3016
+Cao Cao, Lord of Wei;PTK;8998
+Cao Cao, Lord of Wei;V11;8998
+Cao Ren, Wei Commander;PTK;9145
+Capashen Knight;M14;148299
+Capashen Knight;UD;15602
+Capashen Standard;UD;15716
+Capashen Templar;UD;15694
+Capashen Unicorn;INV;24131
+Capricious Efreet;C13;121581
+Capricious Efreet;DPA;121581
+Capricious Efreet;M10;121581
+Capricious Sorcerer;POR;6606
+Capsize;MS3;401617
+Capsize;PRM;3047
+Capsize;TD0;3047
+Capsize;TMP;3047
+Capsize;TPR;3047
+Captain Lannery Storm;XLN;402039
+Captain Sisay;INV;25145
+Captain Sisay;V11;25145
+Captain of the Mists;AVR;141810
+Captain of the Watch;DPA;121658
+Captain of the Watch;M10;121658
+Captain of the Watch;M13;121658
+Captain's Call;DPA;143837
+Captain's Call;M13;143837
+Captain's Claws;OGW;161261
+Captain's Maneuver;APC;31116
+Captain's Maneuver;PC1;31116
+Captivating Crew;XLN;402368
+Captivating Glance;LRW;106412
+Captivating Vampire;DPA;131382
+Captivating Vampire;M11;131382
+Captive Flame;DDG;86181
+Captive Flame;SOK;86181
+Capture of Jingzhou;ME3;9055
+Capture of Jingzhou;PRM;9055
+Capture of Jingzhou;PTK;9055
+Captured Sunlight;ARB;121049
+Captured by the Consulate;KLD;162245
+Carapace Forger;SOM;131048
+Carapace;5ED;1473
+Carapace;HML;1473
+Carapace;HML;1474
+Carapace;ME2;1473
+Caravan Escort;DDG;127351
+Caravan Escort;ROE;127351
+Caravan Hurda;ZEN;123627
+Caravan Vigil;ISD;138379
+Carbonize;EMA;161560
+Carbonize;SCG;49007
+Careful Consideration;MMA;97339
+Careful Consideration;TSP;97339
+Careful Study;ODY;33489
+Caregiver;RAV;88635
+Caress of Phyrexia;NPH;134312
+Caribou Range;5ED;2325
+Caribou Range;ICE;1103
+Caribou Range;ME2;1103
+Caribou;TOK;121557
+Carnage Altar;C13;123748
+Carnage Altar;ZEN;123748
+Carnage Gladiator;DGM;147745
+Carnage Gladiator;MM3;147745
+Carnage Tyrant;XLN;401444
+Carnage Wurm;M12;134126
+Carnassid;STH;3751
+Carnassid;TPR;3751
+Carnifex Demon;SOM;131028
+Carnival Hellsteed;PRM;145966
+Carnival Hellsteed;RTR;145227
+Carnival of Souls;UD;15724
+Carnivore;TOK;122195
+Carnivore;TOK;161561
+Carnivorous Moss-Beast;M15;155894
+Carnivorous Plant;4ED;744
+Carnivorous Plant;DRK;744
+Carnivorous Plant;MED;744
+Carnophage;EXO;5637
+Carnophage;PRM;5637
+Carnophage;TPR;5637
+Carnophage;VMA;5637
+Carom;DIS;94381
+Carpet of Flowers;USG;8771
+Carrier Pigeons;ALL;1605
+Carrier Pigeons;ALL;1606
+Carrier Thrall;BFZ;160824
+Carrion Ants;4ED;517
+Carrion Ants;5ED;2326
+Carrion Ants;LEG;517
+Carrion Ants;ME3;517
+Carrion Beetles;USG;8903
+Carrion Call;SOM;130963
+Carrion Crow;M15;155358
+Carrion Feeder;DDE;48104
+Carrion Feeder;EMA;48104
+Carrion Feeder;PRM;48104
+Carrion Feeder;SCG;48104
+Carrion Feeder;TD0;48104
+Carrion Howler;RAV;89015
+Carrion Rats;TOR;36473
+Carrion Screecher;HOU;401503
+Carrion Thrash;ALA;115115
+Carrion Wall;8ED;21267
+Carrion Wall;NMS;21267
+Carrion Wurm;TOR;36457
+Carrion;MIR;1822
+Carrionette;TMP;3126
+Carry Away;DST;75188
+Cartel Aristocrat;GTC;146287
+Cartographer;EXO;5601
+Cartographer;ODY;33319
+Cartouche of Ambition;AKH;400867
+Cartouche of Knowledge;AKH;400776
+Cartouche of Solidarity;AKH;400855
+Cartouche of Strength;AKH;400858
+Cartouche of Zeal;AKH;400826
+Carven Caryatid;DPA;89089
+Carven Caryatid;RAV;89089
+Cascade Bluffs;EVE;113680
+Cascade Bluffs;EXP;161024
+Cascading Cataracts;AKH;400772
+Cast Out;AKH;402169
+Cast Through Time;ROE;101051
+Cast into Darkness;JOU;152804
+Castaway's Despair;XLN;402343
+Castigate;GPT;91829
+Castigate;PRM;91829
+Casting of Bones;ALL;1607
+Casting of Bones;ALL;1608
+Castle Raptors;TSP;97442
+Castle Sengir;HML;1475
+Castle;2ED;29
+Castle;3ED;29
+Castle;4ED;29
+Castle;5ED;2327
+Castle;6ED;29
+Castle;7ED;27561
+Castle;LEA;29
+Castle;LEB;29
+Cat Burglar;EXO;5596
+Cat Soldier;TOK;152105
+Cat Warrior;TOK;100724
+Cat Warriors;5ED;518
+Cat Warriors;6ED;518
+Cat Warriors;CH;518
+Cat Warriors;LEG;518
+Cat;TOK;122142
+Cat;TOK;132321
+Cat;TOK;143919
+Cat;TOK;2111
+Cat;TOK;35345
+Cat;TOK;401243
+Cataclysm;EXO;4638
+Cataclysm;TPR;4638
+Cataclysm;V14;155835
+Cataclysmic Gearhulk;KLD;162469
+Cataclysmic Gearhulk;MS2;400613
+Catacomb Dragon;MIR;1823
+Catacomb Sifter;BFZ;160716
+Catacomb Slug;ORI;145860
+Catacomb Slug;RTR;145860
+Catalog;8ED;8668
+Catalog;SOI;161366
+Catalog;USG;8668
+Catalyst Stone;ODY;33245
+Catapult Master;DDF;42956
+Catapult Master;ONS;42956
+Catapult Squad;ONS;42941
+Catastrophe;USG;8870
+Catch;DGM;146824
+Cateran Brute;MMQ;19012
+Cateran Enforcer;MMQ;19225
+Cateran Kidnappers;MMQ;19035
+Cateran Overlord;MMQ;19690
+Cateran Persuader;MMQ;19029
+Cateran Slaver;MMQ;19031
+Cateran Summons;MMQ;19235
+Caterwauling Boggart;LRW;105385
+Cathar's Companion;SOI;161748
+Cathar's Shield;EMN;162144
+Cathars' Crusade;AVR;141822
+Cathars' Crusade;C14;141822
+Cathartic Adept;ALA;115217
+Cathartic Reunion;KLD;162281
+Cathedral Membrane;NPH;134285
+Cathedral Sanctifier;AVR;141677
+Cathedral Sanctifier;DPA;141677
+Cathedral of Serra;LEG;519
+Cathedral of War;DPA;138677
+Cathedral of War;M13;138677
+Cathedral of War;PRM;143993
+Cathodion;C14;156394
+Cathodion;MM2;156394
+Cathodion;MRD;51062
+Cathodion;USG;8775
+Caught in the Brights;AER;400236
+Cauldron Dance;INV;24112
+Cauldron Dance;TD0;24112
+Cauldron Haze;EVE;113609
+Cauldron of Souls;SHM;111723
+Caustic Caterpillar;ORI;160315
+Caustic Crawler;WWK;123597
+Caustic Hound;MBS;133176
+Caustic Rain;GPT;93483
+Caustic Tar;M15;155892
+Caustic Tar;ODY;33268
+Caustic Wasps;MMQ;19000
+Cautery Sliver;PLC;100774
+Cavalry Master;TSP;99367
+Cavalry Pegasus;DDL;150759
+Cavalry Pegasus;THS;150759
+Cave People;4ED;1042
+Cave People;5ED;2328
+Cave People;DRK;746
+Cave Sense;MMQ;18983
+Cave Tiger;USG;8790
+Cave-In;MMQ;19284
+Cavern Crawler;MMQ;19289
+Cavern Harpy;PLS;27886
+Cavern Lampad;THS;149181
+Cavern Thoctar;ALA;115065
+Cavern of Souls;AVR;141838
+Cavern of Souls;MM3;400108
+Caverns of Despair;LEG;4620
+Caves of Koilos;10E;31044
+Caves of Koilos;9ED;31044
+Caves of Koilos;APC;31044
+Caves of Koilos;M15;31044
+Caves of Koilos;ORI;31044
+Cease-Fire;ODY;33539
+Ceaseless Searblades;LRW;105380
+Celestial Ancient;DIS;94386
+Celestial Ancient;DPA;94386
+Celestial Ancient;PC2;94386
+Celestial Archon;PRM;151411
+Celestial Archon;THS;149204
+Celestial Colonnade;PRM;126733
+Celestial Colonnade;WWK;126518
+Celestial Convergence;PCY;22008
+Celestial Crusader;C14;99546
+Celestial Crusader;DDF;99546
+Celestial Crusader;TSP;99546
+Celestial Dawn;6ED;1824
+Celestial Dawn;MIR;1824
+Celestial Dawn;TSB;1824
+Celestial Flare;M14;147383
+Celestial Flare;ORI;147383
+Celestial Force;CMD;137523
+Celestial Force;DPA;137523
+Celestial Gatekeeper;LGN;47479
+Celestial Kirin;SOK;86124
+Celestial Mantle;DPA;125097
+Celestial Mantle;ZEN;125097
+Celestial Prism;2ED;30
+Celestial Prism;3ED;30
+Celestial Prism;4ED;30
+Celestial Prism;LEA;30
+Celestial Prism;LEB;30
+Celestial Purge;CON;118751
+Celestial Purge;M10;118751
+Celestial Purge;M11;118751
+Celestial Purge;M12;118751
+Celestial Purge;MM2;118751
+Celestial Purge;PRM;128448
+Celestial Sword;ICE;1104
+Celestial Sword;ME4;1104
+Celestine Reef;PRM;125901
+Cellar Door;ISD;138138
+Cemetery Gate;HML;1476
+Cemetery Gate;HML;1477
+Cemetery Puca;SHM;111878
+Cemetery Reaper;M10;120968
+Cemetery Reaper;M12;120968
+Cemetery Recruitment;EMN;161961
+Cenn's Enlistment;EVE;113691
+Cenn's Enlistment;MMA;113691
+Cenn's Heir;LRW;105602
+Cenn's Tactician;MOR;109964
+Cenn's Tactician;PRM;110131
+Censor;AKH;400875
+Centaur Archer;ICE;1105
+Centaur Archer;MED;1105
+Centaur Battlemaster;THS;150800
+Centaur Chieftain;EMA;36514
+Centaur Chieftain;TOR;36514
+Centaur Courser;DPA;121563
+Centaur Courser;M10;121563
+Centaur Courser;M13;121563
+Centaur Courser;M15;121563
+Centaur Garden;ODY;33235
+Centaur Glade;ONS;43198
+Centaur Healer;MM3;145147
+Centaur Healer;RTR;145147
+Centaur Omenreader;FUT;102411
+Centaur Rootcaster;JUD;40272
+Centaur Safeguard;RAV;88644
+Centaur Veteran;TOR;36508
+Centaur Vinecrasher;PZ1;131686
+Centaur;TOK;145990
+Centaur;TOK;152110
+Centaur;TOK;44677
+Centaur;TOK;89183
+Centaur's Herald;RTR;145872
+Center Soul;DTK;160149
+Cephalid Aristocrat;TOR;36408
+Cephalid Broker;DPA;33475
+Cephalid Broker;ODY;33475
+Cephalid Coliseum;ODY;33238
+Cephalid Coliseum;V12;143995
+Cephalid Constable;10E;40307
+Cephalid Constable;JUD;40307
+Cephalid Illusionist;TOR;36412
+Cephalid Inkshrouder;JUD;40207
+Cephalid Looter;ODY;33498
+Cephalid Pathmage;LGN;46523
+Cephalid Retainer;ODY;33474
+Cephalid Sage;EMA;36421
+Cephalid Sage;TOR;36421
+Cephalid Scout;ODY;33497
+Cephalid Shrine;ODY;33665
+Cephalid Snitch;TOR;36420
+Cephalid Vandal;TOR;36494
+Cerebral Eruption;DPA;131182
+Cerebral Eruption;SOM;131182
+Cerebral Vortex;GPT;91734
+Ceremonial Guard;MMQ;19001
+Ceremonious Rejection;KLD;162262
+Cerodon Yearling;ARB;121013
+Cerodon Yearling;PC1;121013
+Certain Death;EMN;161953
+Certain Death;W17;161953
+Cerulean Sphinx;RAV;89136
+Cerulean Wisps;SHM;111844
+Cerulean Wyvern;MIR;1825
+Cessation;UL;10420
+Ceta Disciple;APC;31092
+Ceta Sanctuary;APC;31094
+Cetavolver;APC;31093
+Chain Lightning;EMA;131550
+Chain Lightning;LEG;520
+Chain Lightning;ME3;520
+Chain Lightning;MS3;401638
+Chain Lightning;PD2;131550
+Chain Lightning;TD0;520
+Chain Lightning;VMA;131550
+Chain Reaction;CMD;126517
+Chain Reaction;DPA;126517
+Chain Reaction;WWK;126517
+Chain Stasis;HML;1478
+Chain of Acid;ONS;43186
+Chain of Plasma;ONS;43126
+Chain of Silence;ONS;42948
+Chain of Smog;ONS;43068
+Chain of Vapor;ONS;43008
+Chain of Vapor;PRM;162418
+Chainbreaker;SHM;111687
+Chained Throatseeker;NPH;134323
+Chained to the Rocks;THS;149105
+Chainer, Dementia Master;TOR;36465
+Chainer's Edict;PRM;36458
+Chainer's Edict;TOR;36458
+Chainer's Edict;V13;149952
+Chainer's Edict;VMA;149952
+Chainflinger;ODY;33272
+Chains of Mephistopheles;LEG;4621
+Chains of Mephistopheles;MED;4621
+Chains of Mephistopheles;PRM;402820
+Chalice of Death;DKA;139725
+Chalice of Life;DKA;139728
+Chalice of the Void;MMA;50996
+Chalice of the Void;MRD;50996
+Chalice of the Void;MS2;400926
+Chamber of Manipulation;ODY;33446
+Chambered Nautilus;MMQ;19168
+Chameleon Blur;TSP;97546
+Chameleon Colossus;DPA;110014
+Chameleon Colossus;MOR;110014
+Chameleon Colossus;V13;110014
+Chameleon Spirit;MMQ;19311
+Champion Lancer;ME4;17564
+Champion of Arashin;DTK;159838
+Champion of Lambholt;AVR;142217
+Champion of Rhonas;AKH;400797
+Champion of Stray Souls;BNG;152579
+Champion of Wits;HOU;401790
+Champion of Wits;TOK;401840
+Champion of the Parish;DPA;139897
+Champion of the Parish;ISD;139897
+Champion's Drake;ROE;127265
+Champion's Helm;CMD;137530
+Champion's Helm;MS2;400608
+Champion's Victory;PTK;9061
+Chance Encounter;ODY;33333
+Chance;HOU;401865
+Chancellor of the Annex;NPH;134329
+Chancellor of the Dross;NPH;134281
+Chancellor of the Forge;DPA;134282
+Chancellor of the Forge;NPH;134282
+Chancellor of the Spires;DPA;134215
+Chancellor of the Spires;NPH;134215
+Chancellor of the Tangle;NPH;134313
+Chandler;HML;1479
+Chandra Ablaze;ZEN;123772
+Chandra Nalaar;DD2;118215
+Chandra Nalaar;LRW;105500
+Chandra Nalaar;M10;105500
+Chandra Nalaar;M11;105500
+Chandra, Fire of Kaladesh;ORI;160281
+Chandra, Flamecaller;OGW;161096
+Chandra, Pyrogenius;KLD;162291
+Chandra, Pyromaster;M14;147373
+Chandra, Pyromaster;M15;147373
+Chandra, Pyromaster;PRM;401718
+Chandra, Roaring Flame;ORI;160282
+Chandra, Torch of Defiance;KLD;162187
+Chandra, the Firebrand;M12;134100
+Chandra, the Firebrand;M13;134100
+Chandra's Defeat;HOU;401596
+Chandra's Fury;DPA;143854
+Chandra's Fury;M13;143854
+Chandra's Fury;ORI;143854
+Chandra's Ignition;ORI;160278
+Chandra's Outrage;DPA;129156
+Chandra's Outrage;M11;129156
+Chandra's Outrage;M12;129156
+Chandra's Outrage;M14;129156
+Chandra's Outrage;MM3;129156
+Chandra's Phoenix;DPA;134170
+Chandra's Phoenix;M12;134170
+Chandra's Phoenix;M14;134170
+Chandra's Phoenix;PRM;137399
+Chandra's Pyrohelix;KLD;162286
+Chandra's Revolution;AER;400311
+Chandra's Spitfire;DPA;129115
+Chandra's Spitfire;M11;129115
+Change of Heart;STH;3655
+Changeling Berserker;LRW;106358
+Changeling Hero;LRW;105327
+Changeling Sentinel;MOR;109892
+Changeling Titan;LRW;107624
+Channel Harm;FRF;157288
+Channel the Suns;5DN;77212
+Channel;2ED;31
+Channel;3ED;31
+Channel;4ED;31
+Channel;LEA;31
+Channel;LEB;31
+Channel;ME4;31
+Channel;V09;122578
+Channel;VMA;122578
+Channeler Initiate;AKH;400799
+Chant of Vitu-Ghazi;RAV;88946
+Chant of the Skifsang;DKA;139865
+Chaos Charm;MIR;1826
+Chaos Harlequin;ALL;1609
+Chaos Imps;RTR;145947
+Chaos Lord;ICE;1106
+Chaos Maw;HOU;401813
+Chaos Moon;ICE;1107
+Chaos Orb;2ED;32
+Chaos Orb;LEA;32
+Chaos Orb;LEB;32
+Chaos Warp;C14;137533
+Chaos Warp;CMD;137533
+Chaos Warp;DPA;137533
+Chaos Warp;PZ1;137533
+Chaos Warp;VMA;137533
+Chaos;APC;31045
+Chaos;PC1;31045
+Chaoslace;2ED;33
+Chaoslace;3ED;33
+Chaoslace;4ED;33
+Chaoslace;LEA;33
+Chaoslace;LEB;33
+Chaosphere;MIR;1827
+Chaotic Aether;PC2;138705
+Chaotic Backlash;EVE;113765
+Chaotic Goo;TMP;3154
+Chaotic Strike;INV;23998
+Chapel Geist;ISD;138324
+Chaplain's Blessing;SOI;161703
+Char-Rumbler;FUT;102391
+Char;DPA;113854
+Char;PRM;113854
+Char;RAV;88932
+Char;V13;88932
+Charcoal Diamond;6ED;1828
+Charcoal Diamond;7ED;27562
+Charcoal Diamond;C14;156377
+Charcoal Diamond;MIR;1828
+Charge Across the Araba;SOK;86065
+Charging Badger;BNG;152049
+Charging Bandits;POR;6568
+Charging Cinderhorn;PZ2;162374
+Charging Griffin;M14;147372
+Charging Griffin;ORI;147372
+Charging Monstrosaur;XLN;402080
+Charging Paladin;DDC;4642
+Charging Paladin;EXO;4642
+Charging Paladin;POR;6734
+Charging Paladin;TPR;4642
+Charging Rhino;M15;3232
+Charging Rhino;POR;6647
+Charging Rhino;TMP;3232
+Charging Slateback;ONS;43090
+Charging Troll;DDE;24155
+Charging Troll;INV;24155
+Chariot of Victory;JOU;152812
+Chariot of the Sun;MIR;1829
+Charisma;MMQ;19473
+Charm Peddler;MMQ;19162
+Charmbreaker Devils;C13;138300
+Charmbreaker Devils;DPA;138300
+Charmbreaker Devils;ISD;138300
+Charmed Griffin;MMQ;19150
+Charmed Pendant;ODY;33246
+Charnelhoard Wurm;C13;118696
+Charnelhoard Wurm;CON;118696
+Chart a Course;XLN;402230
+Chartooth Cougar;CMD;47499
+Chartooth Cougar;DD2;47499
+Chartooth Cougar;DDI;143393
+Chartooth Cougar;SCG;47499
+Chartooth Cougar;TD0;47499
+Chartooth Cougar;VMA;143393
+Chasm Drake;M12;134128
+Chasm Guide;BFZ;160681
+Chasm Skulker;M15;155320
+Chastise;8ED;41059
+Chastise;9ED;41059
+Chastise;DPA;41059
+Chastise;JUD;41059
+Chatter of the Squirrel;ODY;33318
+Chemister's Trick;RTR;145152
+Chief Engineer;M15;155329
+Chief Engineer;PRM;155859
+Chief of the Edge;KTK;156574
+Chief of the Foundry;KLD;160347
+Chief of the Foundry;ORI;160347
+Chief of the Scale;KTK;156573
+Chieftain en-Dal;NMS;21192
+Child of Alara;CON;118738
+Child of Alara;V14;118738
+Child of Gaea;USG;8843
+Child of Night;DDK;98590
+Child of Night;DPA;98590
+Child of Night;M10;98590
+Child of Night;M11;98590
+Child of Night;M12;98590
+Child of Night;M14;98590
+Child of Night;M15;98590
+Child of Thorns;BOK;83868
+Childhood Horror;ODY;33419
+Children of Korlis;TSP;97378
+Chill Haunting;SCG;48986
+Chill of Foreboding;DKA;139738
+Chill to the Bone;CSP;96926
+Chill;6ED;3287
+Chill;PRM;3287
+Chill;TMP;3287
+Chilling Apparition;PCY;22482
+Chilling Grasp;EMN;161931
+Chilling Shade;CSP;96994
+Chime of Night;UD;15699
+Chimeric Coils;5DN;75207
+Chimeric Egg;DST;75202
+Chimeric Idol;PCY;21941
+Chimeric Idol;VMA;21941
+Chimeric Mass;MM2;131109
+Chimeric Mass;SOM;131109
+Chimeric Sphere;WTH;2909
+Chimeric Staff;10E;7380
+Chimeric Staff;USG;7380
+Chimney Imp;MRD;50201
+Chisei, Heart of Oceans;BOK;83832
+Chitinous Cloak;OGW;161262
+Chittering Host;EMN;161958
+Chittering Rats;DPA;148336
+Chittering Rats;DST;51973
+Chittering Rats;PRM;148336
+Chlorophant;ODY;33287
+Cho-Arrim Alchemist;MMQ;19074
+Cho-Arrim Bruiser;MMQ;19213
+Cho-Arrim Legate;MMQ;19239
+Cho-Manno, Revolutionary;10E;104553
+Cho-Manno, Revolutionary;DPA;104553
+Cho-Manno, Revolutionary;MMQ;19466
+Cho-Manno's Blessing;MMQ;19163
+Choice of Damnations;SOK;86175
+Choke;8ED;3243
+Choke;MS3;401641
+Choke;TMP;3243
+Choked Estuary;SOI;161435
+Choking Fumes;MBS;133194
+Choking Restraints;EMN;161914
+Choking Sands;MIR;1830
+Choking Sands;VMA;1830
+Choking Tethers;ONS;43004
+Choking Tethers;VMA;43004
+Choking Vines;WTH;2924
+Chord of Calling;M15;155888
+Chord of Calling;RAV;89105
+Chorus of Might;RTR;145879
+Chorus of Woe;PO2;4718
+Chorus of the Conclave;CMD;88804
+Chorus of the Conclave;RAV;88804
+Chorus of the Tides;BNG;152550
+Chosen by Heliod;THS;149177
+Chosen of Markov;DKA;139745
+Chromanticore;BNG;152613
+Chromatic Armor;ICE;1108
+Chromatic Lantern;MS2;162586
+Chromatic Lantern;RTR;145972
+Chromatic Sphere;INV;25158
+Chromatic Sphere;MRD;50299
+Chromatic Star;10E;97517
+Chromatic Star;TSP;97517
+Chrome Mox;EMA;161576
+Chrome Mox;MRD;50269
+Chrome Mox;MS2;162587
+Chrome Mox;PRM;120081
+Chrome Steed;SOM;131135
+Chromescale Drake;DST;52027
+Chromeshell Crab;CMD;46574
+Chromeshell Crab;LGN;46574
+Chromium;CH;521
+Chromium;LEG;521
+Chromium;ME3;521
+Chronatog Totem;TSP;97265
+Chronatog;VIS;2143
+Chronic Flooding;RTR;145854
+Chronicler of Heroes;THS;150829
+Chronomantic Escape;FUT;102362
+Chronomaton;DDM;143983
+Chronomaton;M13;143983
+Chronosavant;TSP;97369
+Chronostutter;M15;155227
+Chronozoa;PLC;100652
+Chub Toad;5ED;1109
+Chub Toad;ICE;1109
+Chub Toad;MED;1109
+Churning Eddy;TOR;36430
+Cinder Barrens;AKH;161108
+Cinder Barrens;HOU;401736
+Cinder Barrens;OGW;161108
+Cinder Cloud;MIR;1831
+Cinder Crawler;EXO;5662
+Cinder Elemental;GTC;146357
+Cinder Elemental;MMQ;19272
+Cinder Elemental;PC1;19272
+Cinder Giant;WTH;2934
+Cinder Glade;BFZ;160902
+Cinder Glade;EXP;161288
+Cinder Hellion;OGW;161068
+Cinder Marsh;TMP;3251
+Cinder Marsh;TPR;3251
+Cinder Pyromancer;DPA;113610
+Cinder Pyromancer;EVE;113610
+Cinder Pyromancer;PD2;113610
+Cinder Seer;UD;15645
+Cinder Shade;INV;24024
+Cinder Storm;ME3;17573
+Cinder Wall;8ED;49244
+Cinder Wall;DDG;49244
+Cinder Wall;DPA;49244
+Cinder Wall;WTH;2819
+Cinderbones;SHM;111587
+Cinderhaze Wretch;SHM;111518
+Circle of Affliction;PLC;100791
+Circle of Despair;MIR;1832
+Circle of Elders;DTK;160161
+Circle of Flame;M12;134154
+Circle of Flame;M15;134154
+Circle of Flame;PRM;137400
+Circle of Protection: Artifacts;4ED;396
+Circle of Protection: Artifacts;5DN;77209
+Circle of Protection: Artifacts;5ED;396
+Circle of Protection: Artifacts;ATQ;396
+Circle of Protection: Black;2ED;296
+Circle of Protection: Black;3ED;296
+Circle of Protection: Black;4ED;296
+Circle of Protection: Black;5ED;2329
+Circle of Protection: Black;6ED;2329
+Circle of Protection: Black;7ED;27563
+Circle of Protection: Black;8ED;27563
+Circle of Protection: Black;9ED;86944
+Circle of Protection: Black;ICE;1110
+Circle of Protection: Black;LEB;296
+Circle of Protection: Black;TMP;3063
+Circle of Protection: Blue;2ED;34
+Circle of Protection: Blue;3ED;34
+Circle of Protection: Blue;4ED;34
+Circle of Protection: Blue;5ED;2330
+Circle of Protection: Blue;6ED;2330
+Circle of Protection: Blue;7ED;27564
+Circle of Protection: Blue;8ED;27564
+Circle of Protection: Blue;ICE;1111
+Circle of Protection: Blue;LEA;34
+Circle of Protection: Blue;LEB;34
+Circle of Protection: Blue;TMP;3062
+Circle of Protection: Green;2ED;35
+Circle of Protection: Green;3ED;35
+Circle of Protection: Green;4ED;35
+Circle of Protection: Green;5ED;2331
+Circle of Protection: Green;6ED;2331
+Circle of Protection: Green;7ED;27565
+Circle of Protection: Green;8ED;27565
+Circle of Protection: Green;ICE;1112
+Circle of Protection: Green;LEA;35
+Circle of Protection: Green;LEB;35
+Circle of Protection: Green;TMP;3065
+Circle of Protection: Red;2ED;36
+Circle of Protection: Red;3ED;36
+Circle of Protection: Red;4ED;36
+Circle of Protection: Red;5ED;2332
+Circle of Protection: Red;6ED;2332
+Circle of Protection: Red;7ED;27566
+Circle of Protection: Red;8ED;27566
+Circle of Protection: Red;9ED;86914
+Circle of Protection: Red;ICE;1113
+Circle of Protection: Red;LEA;36
+Circle of Protection: Red;LEB;36
+Circle of Protection: Red;PRM;36
+Circle of Protection: Red;TMP;3064
+Circle of Protection: Shadow;TMP;3066
+Circle of Protection: White;2ED;37
+Circle of Protection: White;3ED;37
+Circle of Protection: White;4ED;37
+Circle of Protection: White;5ED;2333
+Circle of Protection: White;6ED;2333
+Circle of Protection: White;7ED;27567
+Circle of Protection: White;8ED;27567
+Circle of Protection: White;ICE;1114
+Circle of Protection: White;LEA;37
+Circle of Protection: White;LEB;37
+Circle of Protection: White;TMP;3061
+Circle of Solace;ONS;42967
+Circling Vultures;WTH;2918
+Circu, Dimir Lobotomist;RAV;88732
+Circular Logic;PRM;36727
+Circular Logic;TOR;36727
+Circular Logic;VMA;36727
+Citadel Castellan;ORI;160341
+Citadel Siege;FRF;157224
+Citadel of Pain;PCY;22055
+Citanul Centaurs;USG;8807
+Citanul Druid;ATQ;397
+Citanul Druid;ME4;397
+Citanul Flute;10E;104564
+Citanul Flute;USG;8667
+Citanul Hierophants;USG;8723
+Citanul Woodreaders;MMA;100661
+Citanul Woodreaders;PLC;100661
+Citizen;TOK;98950
+City in a Bottle;ARN;315
+City in a Bottle;VMA;158842
+City of Brass;5ED;2334
+City of Brass;6ED;2334
+City of Brass;7ED;27568
+City of Brass;8ED;27568
+City of Brass;ARN;316
+City of Brass;CH;316
+City of Brass;ME4;316
+City of Brass;MMA;147646
+City of Brass;PRM;316
+City of Shadows;DRK;747
+City of Shadows;ME3;747
+City of Solitude;VIS;2144
+City of Traitors;EXO;5652
+City of Traitors;TPR;5652
+Civic Guildmage;MIR;1833
+Civic Saber;RTR;145208
+Civic Wayfinder;10E;88610
+Civic Wayfinder;DPA;88610
+Civic Wayfinder;EMA;88610
+Civic Wayfinder;RAV;88610
+Civic Wayfinder;TD0;88610
+Civilized Scholar;ISD;138170
+Claim of Erebos;BNG;152035
+Claim;HOU;401533
+Clairvoyance;ICE;1115
+Clan Defiance;GTC;146498
+Clarion Ultimatum;ALA;115169
+Clash of Realities;BOK;83875
+Clash of Wills;ORI;160231
+Clash of Wills;PRM;161275
+Claustrophobia;DDM;138397
+Claustrophobia;DPA;138397
+Claustrophobia;ISD;138397
+Claustrophobia;M14;138397
+Claustrophobia;ORI;138397
+Claws of Gix;TSB;8774
+Claws of Gix;USG;8774
+Claws of Valakut;DDG;126547
+Claws of Valakut;DPA;126547
+Claws of Valakut;WWK;126547
+Claws of Wirewood;SCG;48112
+Claws of Wirewood;VMA;48112
+Clay Statue;4ED;398
+Clay Statue;5ED;2335
+Clay Statue;ATQ;398
+Clay Statue;ME4;398
+Cleanfall;COK;82633
+Cleanse;LEG;4622
+Cleanse;ME3;4622
+Cleansing Beam;CMD;88596
+Cleansing Beam;RAV;88596
+Cleansing Meditation;TOR;36399
+Cleansing;DRK;748
+Clear Shot;EMN;162003
+Clear a Path;DGM;146716
+Clear a Path;M15;146716
+Clear the Land;MMQ;19312
+Clear;USG;8871
+Clearwater Goblet;5DN;77112
+Cleaver Riot;M13;143958
+Clergy en-Vec;TMP;3056
+Clergy of the Holy Nimbus;LEG;522
+Cleric of the Forward Order;ORI;160214
+Cleric;TOK;146584
+Cleric;TOK;150899
+Clever Impersonator;KTK;157020
+Clickslither;DPA;46568
+Clickslither;EVG;46568
+Clickslither;LGN;46568
+Clickslither;VMA;46568
+Cliff Threader;DPA;123715
+Cliff Threader;ZEN;123715
+Cliffhaven Vampire;OGW;161017
+Cliffrunner Behemoth;CON;118659
+Cliffside Lookout;BFZ;160900
+Cliffside Market;PC1;125872
+Clifftop Retreat;ISD;138421
+Clinging Anemones;GTC;146479
+Clinging Darkness;RAV;88784
+Clinging Mists;DKA;139880
+Clip Wings;SOI;161683
+Cloak and Dagger;MOR;109913
+Cloak of Confusion;5ED;1116
+Cloak of Confusion;ICE;1116
+Cloak of Confusion;ME2;1116
+Cloak of Feathers;POR;6607
+Cloak of Invisibility;MIR;1834
+Cloak of Mists;USG;8801
+Cloaked Siren;JOU;152911
+Clock of Omens;5DN;77142
+Clock of Omens;M13;143985
+Clockspinning;TSP;97333
+Clockwork Avian;4ED;399
+Clockwork Avian;ATQ;399
+Clockwork Avian;ME4;399
+Clockwork Beast;2ED;38
+Clockwork Beast;3ED;38
+Clockwork Beast;4ED;38
+Clockwork Beast;5ED;38
+Clockwork Beast;LEA;38
+Clockwork Beast;LEB;38
+Clockwork Beast;MED;38
+Clockwork Beetle;MRD;50292
+Clockwork Condor;DDF;50257
+Clockwork Condor;MRD;50257
+Clockwork Dragon;MRD;51032
+Clockwork Gnomes;HML;1480
+Clockwork Gnomes;ME4;1480
+Clockwork Hydra;DDF;97419
+Clockwork Hydra;TSP;97419
+Clockwork Steed;5ED;2336
+Clockwork Steed;HML;1481
+Clockwork Steed;ME2;2336
+Clockwork Swarm;HML;1482
+Clockwork Swarm;ME4;1482
+Clockwork Vorrac;MRD;50256
+Cloistered Youth;ISD;138173
+Clone Legion;DTK;159706
+Clone Shell;SOM;131091
+Clone;10E;86939
+Clone;2ED;39
+Clone;3ED;39
+Clone;9ED;86939
+Clone;DDI;86939
+Clone;DPA;86939
+Clone;LEA;39
+Clone;LEB;39
+Clone;M10;86939
+Clone;M11;86939
+Clone;M13;86939
+Clone;M14;86939
+Clone;ONS;43011
+Close Quarters;MMQ;19265
+Clot Sliver;H09;2974
+Clot Sliver;TMP;2974
+Clot Sliver;TPR;2974
+Cloud Cover;PLS;27887
+Cloud Crusader;M11;129191
+Cloud Djinn;VMA;2948
+Cloud Djinn;WTH;2948
+Cloud Dragon;ME4;6608
+Cloud Dragon;POR;6608
+Cloud Elemental;10E;104536
+Cloud Elemental;DPA;104536
+Cloud Elemental;M11;104536
+Cloud Elemental;MM2;104536
+Cloud Elemental;VIS;2145
+Cloud Key;FUT;102476
+Cloud Manta;BFZ;160643
+Cloud Pirates;POR;6609
+Cloud Spirit;ME4;6610
+Cloud Spirit;POR;6610
+Cloud Spirit;STH;3656
+Cloud Sprite;10E;19325
+Cloud Sprite;DPA;19325
+Cloud Sprite;MMQ;19325
+Cloud Sprite;TOK;19325
+Cloud of Faeries;UL;10341
+Cloud of Faeries;VMA;10341
+Cloudblazer;KLD;162560
+Cloudchaser Eagle;7ED;27569
+Cloudchaser Eagle;TMP;3052
+Cloudchaser Kestrel;TSP;97404
+Cloudcrest Lake;COK;81001
+Cloudcrown Oak;DPA;105404
+Cloudcrown Oak;LRW;105404
+Cloudfin Raptor;GTC;146256
+Cloudform;FRF;157167
+Cloudgoat Ranger;LRW;105427
+Cloudgoat Ranger;MMA;105427
+Cloudheath Drake;ALA;115013
+Cloudhoof Kirin;SOK;87223
+Cloudpost;MRD;51107
+Cloudpost;PRM;128453
+Cloudreach Cavalry;LGN;47532
+Cloudseeder;FUT;102367
+Cloudshift;AVR;141551
+Cloudskate;NMS;21187
+Cloudstone Curio;MS2;162588
+Cloudstone Curio;RAV;89130
+Cloudthresher;LRW;106413
+Clout of the Dominus;EVE;113658
+Cloven Casting;ARB;121077
+Clue;TOK;161608
+Clue;TOK;161804
+Clue;TOK;161805
+Clue;TOK;161808
+Clue;TOK;161847
+Clue;TOK;161848
+Clutch of Currents;BFZ;160645
+Clutch of Undeath;SCG;48967
+Clutch of the Undercity;RAV;89078
+Coal Golem;DRK;749
+Coal Golem;ME3;749
+Coal Stoker;DDK;97445
+Coal Stoker;TSP;97445
+Coalhauler Swine;RAV;88938
+Coalition Flag;APC;31147
+Coalition Honor Guard;APC;31049
+Coalition Honor Guard;EMA;31049
+Coalition Relic;DDE;31034
+Coalition Relic;FUT;31034
+Coalition Victory;INV;25802
+Coalition Victory;TSB;25802
+Coast Watcher;SCG;49008
+Coastal Discovery;BFZ;160646
+Coastal Drake;APC;31096
+Coastal Hornclaw;8ED;21984
+Coastal Hornclaw;PCY;21984
+Coastal Piracy;8ED;19318
+Coastal Piracy;MMQ;19318
+Coastal Tower;8ED;25470
+Coastal Tower;INV;25470
+Coastal Tower;TD0;25470
+Coastal Tower;TD2;25470
+Coastal Wizard;PO2;4701
+Coastline Chimera;THS;150795
+Coat of Arms;10E;5670
+Coat of Arms;7ED;27570
+Coat of Arms;8ED;5670
+Coat of Arms;9ED;5670
+Coat of Arms;DPA;5670
+Coat of Arms;EXO;5670
+Coat of Arms;H09;5670
+Coat of Arms;M10;5670
+Coat of Arms;TPR;5670
+Coat with Venom;DTK;160037
+Coax from the Blind Eternities;EMN;161943
+Cobalt Golem;MRD;50275
+Cobblebrute;ORI;145865
+Cobblebrute;RTR;145865
+Cobbled Wings;ISD;138153
+Cobbled Wings;XLN;402292
+Cobra Trap;CMD;125077
+Cobra Trap;ZEN;125077
+Cockatrice;2ED;40
+Cockatrice;3ED;40
+Cockatrice;4ED;40
+Cockatrice;5ED;40
+Cockatrice;LEA;40
+Cockatrice;LEB;40
+Cockatrice;TSB;40
+Cocoon;CH;523
+Cocoon;LEG;523
+Codex Shredder;RTR;145210
+Coerced Confession;GTC;146291
+Coercion;6ED;2146
+Coercion;8ED;2146
+Coercion;9ED;2146
+Coercion;PO2;4724
+Coercion;PTK;9043
+Coercion;TMP;2980
+Coercion;TPR;2980
+Coercion;VIS;2146
+Coercive Portal;VMA;153126
+Coffin Puppets;PCY;22128
+Coffin Purge;ODY;33425
+Coffin Queen;TMP;3115
+Coffin Queen;TPR;3115
+Cognivore;ODY;33456
+Cogwork Assembler;AER;400390
+Cogworker's Puzzleknot;KLD;162330
+Coiled Tinviper;TMP;2961
+Coiled Tinviper;TPR;2961
+Coiling Oracle;DIS;94309
+Coiling Oracle;DPA;94309
+Coiling Oracle;MM3;94309
+Coiling Oracle;PRM;94309
+Coiling Oracle;TD0;94309
+Coiling Woodworm;NMS;21227
+Coils of the Medusa;WTH;2800
+Cold Snap;ICE;1117
+Cold Storage;TMP;3102
+Cold-Eyed Selkie;EVE;113692
+Cold-Eyed Selkie;MMA;113692
+Coldsteel Heart;CSP;96859
+Colfenor's Plans;LRW;107631
+Colfenor's Urn;LRW;105527
+Collapsing Borders;INV;25226
+Collateral Damage;FRF;157185
+Collected Company;DTK;160102
+Collective Blessing;RTR;145980
+Collective Brutality;EMN;161948
+Collective Defiance;EMN;162110
+Collective Effort;EMN;161920
+Collective Restraint;INV;25219
+Collective Unconscious;8ED;19113
+Collective Unconscious;C14;19113
+Collective Unconscious;MMQ;19113
+Collective Voyage;CMD;137560
+Colos Yearling;UD;15642
+Colossal Dreadmaw;XLN;402333
+Colossal Heroics;JOU;153046
+Colossal Might;ARB;121001
+Colossal Might;CMD;121001
+Colossal Might;DPA;121001
+Colossal Whale;M14;147477
+Colossal Whale;PRM;149173
+Colossapede;AKH;400881
+Colossodon Yearling;DTK;160027
+Colossus of Akros;THS;149217
+Colossus of Sardia;10E;104568
+Colossus of Sardia;4ED;400
+Colossus of Sardia;5ED;2337
+Colossus of Sardia;ATQ;400
+Colossus of Sardia;ME4;400
+Coma Veil;ALA;115097
+Combat Celebrant;AKH;401330
+Combat Medic;FEM;868
+Combat Medic;FEM;869
+Combat Medic;FEM;870
+Combat Medic;FEM;871
+Combat Medic;ME2;868
+Combust;M11;129101
+Combust;M12;129101
+Combust;MM2;129101
+Combustible Gearhulk;KLD;162533
+Combustible Gearhulk;MS2;400609
+Comet Storm;CMD;126584
+Comet Storm;MM2;126584
+Comet Storm;PRM;126734
+Comet Storm;WWK;126584
+Comeuppance;C14;155624
+Command Beacon;PZ1;160428
+Command Tower;C13;137553
+Command Tower;CMD;137553
+Command Tower;PRM;147071
+Command Tower;PZ1;147071
+Command of Unsummoning;POR;6611
+Commandeer;CSP;96979
+Commander Eesha;JUD;40191
+Commander Greven il-Vec;TMP;3121
+Commander Greven il-Vec;TPR;3121
+Commander's Authority;AVR;142203
+Commander's Sphere;C14;155632
+Commando Raid;ONS;43104
+Commencement of Festivities;KLD;162540
+Commit;AKH;401298
+Common Bond;RTR;145881
+Common Cause;MMQ;19165
+Commune with Dinosaurs;XLN;402313
+Commune with Lava;DTK;160157
+Commune with Nature;10E;104546
+Commune with Nature;COK;80823
+Commune with Nature;MM2;104546
+Commune with the Gods;EMA;150863
+Commune with the Gods;THS;150863
+Companion of the Trials;AKH;401055
+Comparative Analysis;OGW;161047
+Compelling Argument;AKH;401292
+Compelling Deterrence;SOI;161623
+Complete Disregard;BFZ;160835
+Complex Automaton;NMS;21223
+Complicate;ONS;43009
+Comply;AKH;401050
+Composite Golem;10E;77205
+Composite Golem;5DN;77205
+Compost;7ED;27572
+Compost;UD;15714
+Compulsion;TOR;36434
+Compulsive Research;C14;88979
+Compulsive Research;DPA;88979
+Compulsive Research;MM3;400102
+Compulsive Research;PZ1;88979
+Compulsive Research;RAV;88979
+Compulsive Research;TD0;88979
+Compulsory Rest;AKH;400775
+Concealed Courtyard;KLD;162366
+Concentrate;8ED;33447
+Concentrate;C14;131706
+Concentrate;DPA;131706
+Concentrate;ODY;33447
+Concentrate;PC2;131706
+Concerted Effort;RAV;89150
+Conch Horn;FEM;872
+Conclave Equenaut;DDF;88905
+Conclave Equenaut;RAV;88905
+Conclave Naturalists;ORI;160308
+Conclave Naturalists;PRM;160413
+Conclave Phalanx;DDF;89051
+Conclave Phalanx;MM2;89051
+Conclave Phalanx;RAV;89051
+Conclave's Blessing;RAV;88958
+Concordant Crossroads;CH;524
+Concordant Crossroads;LEG;524
+Concordant Crossroads;ME3;524
+Concordant Crossroads;TD0;524
+Concordia Pegasus;RTR;145111
+Concussive Bolt;MBS;133145
+Condemn;10E;94551
+Condemn;C14;94551
+Condemn;DDL;94551
+Condemn;DIS;94551
+Condemn;DPA;94551
+Condemn;M11;94551
+Condemn;PRM;100408
+Condemn;TD0;94551
+Condemn;TD2;94551
+Condescend;5DN;77173
+Condescend;DD2;77173
+Conduit of Emrakul;EMN;162098
+Conduit of Ruin;BFZ;160813
+Conduit of Storms;EMN;162104
+Cone of Flame;10E;104549
+Cone of Flame;DD2;104549
+Cone of Flame;DDG;104549
+Cone of Flame;DPA;104549
+Cone of Flame;M15;104549
+Cone of Flame;PC1;104549
+Cone of Flame;W16;104549
+Cone of Flame;WTH;2939
+Confessor;ODY;33201
+Confirm Suspicions;SOI;161749
+Confiscate;7ED;27573
+Confiscate;8ED;8867
+Confiscate;9ED;8867
+Confiscate;TD0;8867
+Confiscate;USG;8867
+Confiscation Coup;KLD;162250
+Conflagrate;TSP;100436
+Conflux;CON;118695
+Conflux;V16;118695
+Confound;PLS;29794
+Confront the Unknown;SOI;161643
+Confusion in the Ranks;MRD;51131
+Congregate;CMD;8960
+Congregate;DPA;8960
+Congregate;M14;8960
+Congregate;M15;8960
+Congregate;PC1;8960
+Congregate;USG;8960
+Congregation at Dawn;RAV;88983
+Conifer Strider;DTK;159689
+Conjured Currency;RTR;145217
+Conjurer's Ban;GPT;91804
+Conjurer's Bauble;5DN;77099
+Conjurer's Closet;AVR;141575
+Conjurer's Closet;C13;141575
+Conquer;5ED;2338
+Conquer;6ED;1118
+Conquer;ICE;1118
+Conquer;ME2;1118
+Conquering Manticore;DDL;127285
+Conquering Manticore;DPA;127285
+Conquering Manticore;ROE;127285
+Conqueror's Foothold;XLN;402276
+Conqueror's Galleon;XLN;402275
+Conqueror's Pledge;DPA;123781
+Conqueror's Pledge;ZEN;123781
+Consecrate Land;2ED;41
+Consecrate Land;LEA;41
+Consecrate Land;LEB;41
+Consecrate Land;TSB;41
+Consecrated Sphinx;MBS;133231
+Consecrated Sphinx;MS3;401608
+Consecrated by Blood;ORI;160268
+Conservator;2ED;42
+Conservator;3ED;42
+Conservator;4ED;42
+Conservator;LEA;42
+Conservator;LEB;42
+Consign to Dream;SHM;111577
+Consign to Dust;JOU;153102
+Consign;HOU;401532
+Conspiracy;MMQ;19064
+Conspiracy;TSB;19064
+Constant Mists;STH;3657
+Constant Mists;TD0;3657
+Constricting Sliver;M15;155350
+Constricting Tendrils;CON;118727
+Construct;TOK;126586
+Construct;TOK;161901
+Construct;TOK;162567
+Construct;TOK;162568
+Consul's Lieutenant;ORI;160215
+Consul's Shieldguard;KLD;162459
+Consulate Crackdown;AER;400252
+Consulate Dreadnought;AER;400393
+Consulate Skygate;KLD;162578
+Consulate Surveillance;KLD;162198
+Consulate Turret;AER;400398
+Consult the Necrosages;RAV;88913
+Consume Spirit;10E;50202
+Consume Spirit;9ED;50202
+Consume Spirit;DDC;50202
+Consume Spirit;DPA;50202
+Consume Spirit;M10;122140
+Consume Spirit;M12;122140
+Consume Spirit;MRD;50202
+Consume Spirit;PC1;122140
+Consume Strength;APC;31101
+Consume Strength;DDM;31101
+Consume Strength;DPA;31101
+Consume the Meek;PRM;160773
+Consume the Meek;ROE;127290
+Consuming Aberration;GTC;146585
+Consuming Aberration;PRM;147343
+Consuming Bonfire;LRW;105448
+Consuming Ferocity;MIR;1835
+Consuming Fervor;AKH;400825
+Consuming Sinkhole;OGW;161237
+Consuming Vapors;ROE;127498
+Consuming Vortex;COK;82619
+Consumptive Goo;SCG;49000
+Contagion Clasp;DDF;130964
+Contagion Clasp;PRM;139456
+Contagion Clasp;SOM;130964
+Contagion Clasp;TD2;130964
+Contagion Engine;SOM;131140
+Contagion;ALL;1610
+Contagion;MED;1610
+Contagion;PRM;158839
+Contagious Nim;SOM;130907
+Containment Membrane;OGW;161164
+Containment Priest;C14;156011
+Containment Priest;MS3;401635
+Containment Priest;PZ1;156011
+Contaminated Bond;10E;51130
+Contaminated Bond;9ED;51130
+Contaminated Bond;MRD;51130
+Contaminated Ground;GTC;146508
+Contaminated Ground;ROE;127381
+Contamination;USG;8690
+Contemplation;STH;3659
+Contempt;STH;3660
+Contested Cliffs;C13;43227
+Contested Cliffs;ONS;43227
+Contested War Zone;MBS;133163
+Contingency Plan;EMN;161930
+Contraband Kingpin;KLD;162316
+Contract Killing;XLN;402125
+Contract from Below;2ED;43
+Contract from Below;3ED;43
+Contract from Below;LEA;43
+Contract from Below;LEB;43
+Contradict;DTK;160056
+Control Magic;2ED;44
+Control Magic;3ED;44
+Control Magic;4ED;44
+Control Magic;C13;143935
+Control Magic;DDM;143935
+Control Magic;EMA;161067
+Control Magic;LEA;44
+Control Magic;LEB;44
+Control Magic;ME4;44
+Control Magic;PRM;143935
+Control Magic;VMA;143935
+Control of the Court;PTK;9053
+Controlled Instincts;CON;118749
+Controvert;CSP;97260
+Conundrum Sphinx;CMD;129077
+Conundrum Sphinx;M11;129077
+Convalescence;EXO;5591
+Convalescent Care;ONS;42962
+Conversion Chamber;NPH;134362
+Conversion;2ED;45
+Conversion;3ED;45
+Conversion;4ED;45
+Conversion;LEA;45
+Conversion;LEB;45
+Conversion;ME4;45
+Convicted Killer;SOI;161491
+Conviction;AER;400238
+Conviction;STH;3661
+Conviction;TPR;3661
+Convincing Mirage;M10;121592
+Convolute;EMN;161927
+Convolute;RAV;89039
+Convulsing Licid;STH;3663
+Cooperate;HOU;401863
+Cooperation;ICE;1119
+Coordinated Assault;THS;149199
+Coordinated Barrage;MOR;110002
+Copper Carapace;MBS;133191
+Copper Carapace;MM2;133191
+Copper Gnomes;USG;8799
+Copper Myr;MRD;50859
+Copper Myr;PC1;50859
+Copper Myr;SOM;130875
+Copper Tablet;2ED;46
+Copper Tablet;LEA;46
+Copper Tablet;LEB;46
+Copper Tablet;MED;46
+Copper-Leaf Angel;PCY;22050
+Copperhoof Vorrac;MRD;50305
+Copperhorn Scout;SOM;130942
+Copperline Gorge;SOM;131107
+Copy Artifact;2ED;47
+Copy Artifact;3ED;47
+Copy Artifact;LEA;47
+Copy Artifact;LEB;47
+Copy Artifact;ME4;47
+Copy Artifact;PRM;402822
+Copy Enchantment;RAV;88779
+Copy Enchantment;TD0;88779
+Coral Atoll;C14;2147
+Coral Atoll;VIS;2147
+Coral Barrier;M15;155214
+Coral Eel;8ED;6612
+Coral Eel;9ED;6612
+Coral Eel;POR;6612
+Coral Fighters;DDI;1836
+Coral Fighters;MIR;1836
+Coral Helm;4ED;401
+Coral Helm;5ED;2339
+Coral Helm;ATQ;401
+Coral Helm;ME4;401
+Coral Merfolk;7ED;27574
+Coral Merfolk;M10;122166
+Coral Merfolk;M12;122166
+Coral Merfolk;M14;122166
+Coral Merfolk;USG;8846
+Coral Merfolk;W17;122166
+Coral Net;TOR;36414
+Coral Reef;HML;1483
+Coral Trickster;TSP;97374
+Coralhelm Commander;ROE;127406
+Coralhelm Guide;BFZ;160934
+Core Prowler;MBS;133203
+Coretapper;DST;75195
+Cornered Market;MMQ;19010
+Corpse Augur;PZ1;131676
+Corpse Blockade;GTC;146295
+Corpse Churn;OGW;161035
+Corpse Connoisseur;ALA;115229
+Corpse Connoisseur;DDK;115229
+Corpse Connoisseur;MM3;115229
+Corpse Cur;SOM;130962
+Corpse Dance;TMP;3127
+Corpse Dance;TPR;3127
+Corpse Harvester;LGN;46921
+Corpse Harvester;PC1;46921
+Corpse Hauler;M14;147401
+Corpse Lunge;ISD;138442
+Corpse Traders;AVR;141516
+Corpse Traders;DDM;141516
+Corpsehatch;ROE;127392
+Corpsejack Menace;PRM;145970
+Corpsejack Menace;RTR;145229
+Corpseweft;DTK;160139
+Corpulent Corpse;TSP;97325
+Corrosion;VIS;2148
+Corrosive Gale;NPH;134367
+Corrosive Mentor;SHM;111578
+Corrupt Court Official;PTK;9054
+Corrupt Eunuchs;ME3;9051
+Corrupt Eunuchs;PTK;9051
+Corrupt Official;MMQ;19472
+Corrupt;7ED;27575
+Corrupt;DDC;111602
+Corrupt;DDD;111602
+Corrupt;DPA;111602
+Corrupt;M11;111602
+Corrupt;M14;111602
+Corrupt;PRM;113864
+Corrupt;SHM;111602
+Corrupt;USG;8725
+Corrupted Conscience;MBS;133217
+Corrupted Crossroads;OGW;161266
+Corrupted Grafstone;SOI;161392
+Corrupted Harvester;SOM;130983
+Corrupted Resolve;NPH;134419
+Corrupted Roots;CON;118750
+Corrupted Zendikon;WWK;126491
+Corrupting Licid;STH;3662
+Cosi's Ravager;DDI;126603
+Cosi's Ravager;WWK;126603
+Cosi's Trickster;ZEN;123649
+Cosmic Horror;4ED;525
+Cosmic Horror;LEG;525
+Cosmic Horror;ME3;525
+Cosmic Larva;5DN;75386
+Costly Plunder;XLN;402278
+Council of Advisors;PTK;9109
+Council of the Absolute;DGM;147700
+Council's Judgment;VMA;153125
+Counsel of the Soratami;10E;82206
+Counsel of the Soratami;9ED;82206
+Counsel of the Soratami;COK;82206
+Counterbalance;CSP;96895
+Counterbalance;MS3;401375
+Counterbore;DPA;111763
+Counterbore;SHM;111763
+Counterflux;RTR;145225
+Counterintelligence;PTK;9049
+Counterlash;DKA;139866
+Countermand;JOU;153054
+Counterspell;2ED;48
+Counterspell;3ED;48
+Counterspell;4ED;48
+Counterspell;5ED;2340
+Counterspell;6ED;2340
+Counterspell;7ED;27576
+Counterspell;DD2;118220
+Counterspell;DPA;118220
+Counterspell;EMA;161306
+Counterspell;ICE;1120
+Counterspell;LEA;48
+Counterspell;LEB;48
+Counterspell;ME2;1120
+Counterspell;ME4;48
+Counterspell;MMQ;19100
+Counterspell;MS3;401618
+Counterspell;PRM;22851
+Counterspell;PRM;48
+Counterspell;TMP;3042
+Counterspell;TPR;3042
+Counterspell;VMA;118220
+Countersquall;CON;118780
+Countersquall;DDH;138682
+Countersquall;DPA;118780
+Countervailing Winds;HOU;401498
+Countless Gears Renegade;AER;400231
+Countryside Crusher;MMA;148264
+Countryside Crusher;MOR;109981
+Courageous Outrider;EMN;162048
+Courier Griffin;BFZ;160619
+Courier Hawk;RAV;88903
+Courier's Capsule;ALA;114926
+Courser of Kruphix;BNG;152598
+Courser of Kruphix;PRM;159373
+Coursers' Accord;RTR;145880
+Court Archers;ALA;115039
+Court Archers;DPA;115039
+Court Homunculus;CON;118740
+Court Homunculus;MM2;118740
+Court Homunculus;MMA;118740
+Court Hussar;CMD;94339
+Court Hussar;DIS;94339
+Court Hussar;TD0;94339
+Court Street Denizen;GTC;146338
+Courtly Provocateur;M13;143929
+Covenant of Blood;M15;155366
+Covenant of Minds;ALA;98615
+Cover of Darkness;ONS;43086
+Cover of Winter;CSP;96876
+Covert Operative;LGN;46524
+Covetous Dragon;UD;15701
+Cowardice;8ED;19075
+Cowardice;9ED;87021
+Cowardice;MMQ;19075
+Cowed by Wisdom;SOK;86042
+Cower in Fear;M13;143943
+Cower in Fear;MM3;143943
+Cowl Prowler;KLD;162302
+Crab Umbra;ROE;127309
+Crabapple Cohort;SHM;111601
+Crack the Earth;BOK;83925
+Crackdown Construct;AER;400402
+Crackdown;MMQ;19117
+Crackleburr;EVE;113740
+Crackling Club;TOR;36483
+Crackling Doom;KTK;157077
+Crackling Perimeter;GTC;146580
+Crackling Triton;THS;150821
+Cradle Guard;USG;8955
+Cradle of Vitality;ALA;114920
+Cradle of Vitality;C13;114920
+Cradle of the Accursed;AKH;401356
+Cradle to Grave;PLC;100648
+Crafty Pathmage;10E;43003
+Crafty Pathmage;9ED;43003
+Crafty Pathmage;ONS;43003
+Crag Puca;EVE;113719
+Crag Saurian;MMQ;19315
+Cragganwick Cremator;SHM;111893
+Cranial Archive;KTK;157089
+Cranial Extraction;COK;82623
+Cranial Plating;5DN;77166
+Cranial Plating;MM2;77166
+Cranial Plating;PC1;77166
+Crash Landing;GPT;93728
+Crash Through;HOU;401807
+Crash of Rhinos;MIR;1837
+Crash the Ramparts;XLN;402068
+Crash;MMQ;19026
+Crashing Boars;EXO;5635
+Crashing Boars;TPR;5635
+Crashing Centaur;ODY;33301
+Crater Elemental;DTK;159870
+Crater Hellion;C13;8640
+Crater Hellion;DDL;8640
+Crater Hellion;EMA;8640
+Crater Hellion;USG;8640
+Crater Hellion;VMA;8640
+Crater's Claws;KTK;157048
+Craterhoof Behemoth;AVR;141572
+Craterhoof Behemoth;MM3;141572
+Craterize;M13;143952
+Craven Giant;POR;6687
+Craven Giant;STH;3664
+Craven Giant;TPR;3664
+Craven Knight;POR;6569
+Craw Giant;5ED;2341
+Craw Giant;CH;526
+Craw Giant;LEG;526
+Craw Giant;TSB;526
+Craw Wurm;10E;86904
+Craw Wurm;2ED;49
+Craw Wurm;3ED;49
+Craw Wurm;4ED;49
+Craw Wurm;5ED;49
+Craw Wurm;8ED;49263
+Craw Wurm;9ED;86904
+Craw Wurm;DPA;86904
+Craw Wurm;LEA;49
+Craw Wurm;LEB;49
+Craw Wurm;M10;86904
+Crawling Filth;BOK;83818
+Crawling Sensation;SOI;161652
+Crawlspace;C13;151969
+Crawlspace;UL;13557
+Crazed Armodon;TMP;3131
+Crazed Firecat;TOR;36489
+Crazed Goblin;DST;51142
+Crazed Skirge;USG;7203
+Creakwood Ghoul;EVE;104521
+Creakwood Liege;DPA;113627
+Creakwood Liege;EVE;113627
+Creakwood Liege;MM2;113627
+Cream of the Crop;MOR;110217
+Creature Bond;2ED;50
+Creature Bond;3ED;50
+Creature Bond;4ED;50
+Creature Bond;LEA;50
+Creature Bond;LEB;50
+Credit Voucher;MMQ;18988
+Creeperhulk;C14;155634
+Creeping Corrosion;MBS;133205
+Creeping Dread;SOI;161390
+Creeping Mold;10E;27577
+Creeping Mold;6ED;2149
+Creeping Mold;7ED;27577
+Creeping Mold;8ED;27577
+Creeping Mold;9ED;86913
+Creeping Mold;KLD;162309
+Creeping Mold;MRD;51122
+Creeping Mold;PRM;2149
+Creeping Mold;VIS;2149
+Creeping Renaissance;ISD;138454
+Creeping Tar Pit;WWK;126527
+Creepy Doll;ISD;138131
+Cremate;GPT;91762
+Cremate;INV;24054
+Cremate;RTR;145131
+Crenellated Wall;MMQ;19276
+Crescendo of War;CMD;137521
+Crescendo of War;VMA;137521
+Crested Craghorn;LGN;46586
+Crested Sunmare;HOU;401780
+Crevasse;LEG;527
+Crib Swap;LRW;105628
+Crime;DIS;94358
+Crimson Acolyte;INV;24192
+Crimson Hellkite;6ED;1838
+Crimson Hellkite;7ED;27578
+Crimson Hellkite;MIR;1838
+Crimson Kobolds;LEG;528
+Crimson Kobolds;ME3;528
+Crimson Mage;DPA;134068
+Crimson Mage;M12;134068
+Crimson Manticore;4ED;529
+Crimson Manticore;5ED;2342
+Crimson Manticore;LEG;529
+Crimson Manticore;ME3;529
+Crimson Muckwader;M13;143953
+Crimson Roc;MIR;1839
+Crimson Wisps;SHM;111623
+Crippling Blight;DPA;143846
+Crippling Blight;M13;143846
+Crippling Blight;M15;143846
+Crippling Chill;AVR;141587
+Crippling Chill;DPA;141587
+Crippling Chill;KTK;157009
+Crippling Chill;MM3;141587
+Crippling Fatigue;TOR;36452
+Crocanura;GTC;146329
+Crocodile of the Crossing;AKH;400823
+Cromat;APC;31149
+Crook of Condemnation;HOU;401849
+Crookclaw Elder;LGN;47475
+Crookclaw Transmuter;TSP;97276
+Crooked Scales;MMQ;19091
+Crookshank Kobolds;LEG;530
+Crookshank Kobolds;MED;530
+Crop Rotation;PRM;162422
+Crop Rotation;UL;10351
+Crop Sigil;EMN;162134
+Crosis, the Purger;INV;25186
+Crosis, the Purger;PD3;140051
+Crosis's Attendant;INV;25189
+Crosis's Catacombs;PLS;27892
+Crosis's Charm;C13;138750
+Crosis's Charm;PLS;27893
+Crossbow Ambush;STH;3665
+Crossbow Infantry;7ED;27579
+Crossbow Infantry;8ED;27579
+Crossbow Infantry;9ED;27579
+Crossbow Infantry;MMQ;20035
+Crossroads Consecrator;EMN;162115
+Crosstown Courier;DDM;145121
+Crosstown Courier;RTR;145121
+Crossway Vampire;ISD;138340
+Crosswinds;USG;8720
+Crovax the Cursed;STH;3640
+Crovax the Cursed;TPR;3640
+Crovax the Cursed;VMA;3640
+Crovax, Ascendant Hero;PLC;100716
+Crow of Dark Tidings;SOI;161461
+Crowd Favorites;ONS;42959
+Crowd of Cinders;DPA;111620
+Crowd of Cinders;SHM;111620
+Crowd's Favor;M15;155386
+Crown of Ascension;ONS;42986
+Crown of Awe;ONS;42926
+Crown of Convergence;RAV;88852
+Crown of Doom;C14;156014
+Crown of Empires;M12;134169
+Crown of Flames;INV;24031
+Crown of Flames;TMP;3021
+Crown of Fury;ONS;43108
+Crown of Suspicion;ONS;43041
+Crown of Vigor;ONS;43163
+Crown of the Ages;5ED;2343
+Crown of the Ages;ICE;1121
+Crowned Ceratok;DDL;146359
+Crowned Ceratok;GTC;146359
+Crucible of Fire;ALA;116192
+Crucible of Fire;DPA;116192
+Crucible of Fire;M15;116192
+Crucible of Worlds;10E;77145
+Crucible of Worlds;5DN;77145
+Crucible of Worlds;MS2;400605
+Crucible of Worlds;PRM;77145
+Crucible of the Spirit Dragon;FRF;157183
+Crude Rampart;ONS;42931
+Cruel Bargain;POR;6570
+Cruel Bargain;VMA;6570
+Cruel Deceiver;COK;80822
+Cruel Edict;10E;86957
+Cruel Edict;9ED;86957
+Cruel Edict;DDC;86957
+Cruel Edict;PO2;4715
+Cruel Edict;PRM;101026
+Cruel Fate;POR;6613
+Cruel Feeding;JOU;153019
+Cruel Finality;AER;400287
+Cruel Reality;AKH;401319
+Cruel Revival;DPA;43046
+Cruel Revival;ONS;43046
+Cruel Revival;ORI;160251
+Cruel Revival;PC1;43046
+Cruel Sadist;M15;155291
+Cruel Tutor;POR;6571
+Cruel Ultimatum;ALA;115122
+Cruel Ultimatum;C13;148713
+Cruel Ultimatum;DDH;115122
+Cruel Ultimatum;MM3;148713
+Cruel Ultimatum;V13;148713
+Crumble to Dust;BFZ;160925
+Crumble;3ED;402
+Crumble;4ED;402
+Crumble;5ED;402
+Crumble;ATQ;402
+Crumble;ME4;402
+Crumbling Ashes;EVE;113750
+Crumbling Colossus;M12;134089
+Crumbling Necropolis;ALA;115145
+Crumbling Necropolis;C13;115145
+Crumbling Necropolis;DDH;115145
+Crumbling Necropolis;MM3;115145
+Crumbling Necropolis;PZ1;115145
+Crumbling Sanctuary;MMQ;19098
+Crumbling Vestige;OGW;161063
+Crumbling Vestige;PRM;162153
+Crusade;2ED;51
+Crusade;3ED;51
+Crusade;4ED;51
+Crusade;5ED;2344
+Crusade;6ED;2344
+Crusade;DDF;131782
+Crusade;LEA;51
+Crusade;LEB;51
+Crusade;MED;51
+Crusade;PRM;51
+Crusader of Odric;DPA;143860
+Crusader of Odric;M13;143860
+Crusading Knight;INV;24032
+Crush Underfoot;LRW;105632
+Crush Underfoot;MMA;105632
+Crush of Tentacles;OGW;161219
+Crush of Wurms;JUD;40291
+Crush;MBS;133192
+Crusher Zendikon;WWK;126468
+Crushing Canopy;XLN;402051
+Crushing Pain;COK;80721
+Crushing Vines;DKA;139902
+Crux of Fate;FRF;157220
+Cry of Contrition;GPT;91786
+Cryoclasm;10E;96905
+Cryoclasm;CSP;96905
+Cryoclasm;DPA;96905
+Crypsis;BNG;152551
+Crypt Angel;INV;24094
+Crypt Champion;DIS;94405
+Crypt Cobra;MIR;1840
+Crypt Creeper;AVR;141648
+Crypt Creeper;ODY;33434
+Crypt Ghast;C14;146459
+Crypt Ghast;GTC;146459
+Crypt Incursion;DGM;147704
+Crypt Rats;7ED;27581
+Crypt Rats;VIS;2150
+Crypt Ripper;ZEN;123574
+Crypt Sliver;LGN;46543
+Crypt of Agadeem;C14;123673
+Crypt of Agadeem;ZEN;123673
+Crypt of the Eternals;HOU;401574
+Cryptborn Horror;PRM;145965
+Cryptborn Horror;RTR;145964
+Cryptbreaker;EMN;162078
+Cryptic Annelid;DDI;102337
+Cryptic Annelid;FUT;102337
+Cryptic Command;LRW;105571
+Cryptic Command;MM2;105571
+Cryptic Command;MMA;105571
+Cryptic Command;MS3;401612
+Cryptic Command;PRM;117978
+Cryptic Cruiser;BFZ;160637
+Cryptic Gateway;ONS;43208
+Cryptic Serpent;AKH;401264
+Cryptolith Fragment;EMN;162145
+Cryptolith Rite;SOI;161364
+Cryptoplasm;MBS;133211
+Cryptwailing;GPT;91703
+Crystal Ball;M11;129138
+Crystal Chimes;USG;8752
+Crystal Golem;MIR;1841
+Crystal Quarry;ODY;33229
+Crystal Rod;2ED;52
+Crystal Rod;3ED;52
+Crystal Rod;4ED;52
+Crystal Rod;5ED;2345
+Crystal Rod;6ED;2345
+Crystal Rod;7ED;27582
+Crystal Rod;8ED;2345
+Crystal Rod;LEA;52
+Crystal Rod;LEB;52
+Crystal Seer;GPT;88721
+Crystal Shard;MRD;51002
+Crystal Spray;INV;25146
+Crystal Vein;6ED;1842
+Crystal Vein;C14;1842
+Crystal Vein;MIR;1842
+Crystal Vein;PD3;1842
+Crystalline Crawler;PZ2;162428
+Crystalline Nautilus;JOU;152847
+Crystalline Sliver;H09;3668
+Crystalline Sliver;PRM;3668
+Crystalline Sliver;STH;3668
+Crystalline Sliver;TPR;3668
+Crystallization;ARB;121000
+Cudgel Troll;DPA;121570
+Cudgel Troll;M10;121570
+Cudgel Troll;M11;121570
+Cudgel Troll;M12;121570
+Culling Dais;MM2;130898
+Culling Dais;SOM;130898
+Culling Drone;BFZ;160665
+Culling Mark;BNG;152056
+Culling Scales;MRD;51043
+Culling Sun;GPT;91825
+Culling the Weak;EXO;5669
+Cult of the Waxing Moon;SOI;161372
+Cultbrand Cinder;SHM;111596
+Cultist's Staff;EMN;162018
+Cultivate;C13;129089
+Cultivate;CMD;129089
+Cultivate;DPA;129089
+Cultivate;M11;129089
+Cultivate;PC2;129089
+Cultivate;PRM;136801
+Cultivate;PZ1;129089
+Cultivator Drone;OGW;160702
+Cultivator of Blades;KLD;162554
+Cultivator of Blades;PRM;162544
+Cultivator's Caravan;KLD;162569
+Cultural Exchange;ODY;33452
+Cumber Stone;CON;118732
+Cunning Advisor;PTK;9022
+Cunning Bandit;BOK;83971
+Cunning Breezedancer;DTK;160043
+Cunning Giant;PO2;4756
+Cunning Lethemancer;ALA;115387
+Cunning Lethemancer;DPA;115387
+Cunning Sparkmage;WWK;126501
+Cunning Strike;FRF;157229
+Cunning Survivor;HOU;401493
+Cunning Wish;JUD;40219
+Cunning Wish;PRM;100414
+Cunning;EXO;5649
+Cuombajj Witches;ARN;317
+Cuombajj Witches;CH;317
+Cuombajj Witches;MED;317
+Cuombajj Witches;PRM;402823
+Curator of Mysteries;AKH;400879
+Curfew;USG;8747
+Curio Vendor;KLD;162485
+Curiosity;8ED;49233
+Curiosity;DPA;138331
+Curiosity;EXO;5605
+Curiosity;ISD;138331
+Curiosity;TPR;5605
+Curious Homunculus;EMN;162071
+Curse Artifact;DRK;750
+Curse of Bloodletting;DKA;138281
+Curse of Chains;SHM;111631
+Curse of Chaos;C13;151751
+Curse of Death's Hold;ISD;138267
+Curse of Echoes;DKA;139877
+Curse of Exhaustion;DKA;139727
+Curse of Inertia;C13;151753
+Curse of Marit Lage;ICE;1122
+Curse of Misfortunes;DKA;139909
+Curse of Oblivion;ISD;138409
+Curse of Predation;C13;151761
+Curse of Shallow Graves;C13;151765
+Curse of Stalked Prey;ISD;138257
+Curse of Thirst;DKA;140324
+Curse of Thirst;PRM;138097
+Curse of Vengeance;PZ2;162444
+Curse of Wizardry;PRM;128450
+Curse of Wizardry;ROE;127271
+Curse of the Bloody Tome;ISD;138328
+Curse of the Bloody Tome;PRM;139441
+Curse of the Cabal;TSP;97386
+Curse of the Forsaken;C13;151760
+Curse of the Nightly Hunt;ISD;138251
+Curse of the Pierced Heart;ISD;98654
+Curse of the Swine;THS;149208
+Cursebreak;AVR;141665
+Cursecatcher;SHM;111874
+Cursed Flesh;EXO;5642
+Cursed Flesh;INV;24150
+Cursed Flesh;TPR;5642
+Cursed Land;2ED;53
+Cursed Land;3ED;53
+Cursed Land;4ED;53
+Cursed Land;5ED;53
+Cursed Land;LEA;53
+Cursed Land;LEB;53
+Cursed Minotaur;AKH;401303
+Cursed Monstrosity;ODY;33399
+Cursed Rack;4ED;403
+Cursed Rack;ATQ;403
+Cursed Rack;MED;403
+Cursed Ronin;COK;80742
+Cursed Scroll;TMP;3096
+Cursed Scroll;TPR;3096
+Cursed Scroll;VMA;3096
+Cursed Totem;6ED;1843
+Cursed Totem;MIR;1843
+Curtain of Light;SOK;86137
+Custodi Lich;PZ2;143498
+Custodi Soulbinders;PZ2;153173
+Custodian of the Trove;DTK;160048
+Custody Battle;ONS;43124
+Customs Depot;MMQ;19072
+Cut the Earthly Bond;SOK;86161
+Cut the Tethers;COK;81115
+Cut;AKH;401277
+Cutthroat Maneuver;THS;149089
+Cutthroat il-Dal;FUT;102354
+Cycle of Life;MIR;1844
+Cyclical Evolution;FUT;102353
+Cyclone Sire;OGW;161220
+Cyclone;ARN;318
+Cyclone;CH;318
+Cyclone;ME4;318
+Cyclonic Rift;C14;145940
+Cyclonic Rift;MM3;145940
+Cyclonic Rift;RTR;145940
+Cyclopean Giant;TSP;97458
+Cyclopean Mummy;4ED;1043
+Cyclopean Mummy;LEG;531
+Cyclopean Mummy;ME4;531
+Cyclopean Snare;RAV;89076
+Cyclopean Tomb;2ED;54
+Cyclopean Tomb;LEA;54
+Cyclopean Tomb;LEB;54
+Cyclopean Tomb;ME4;54
+Cyclops Gladiator;M11;129160
+Cyclops Tyrant;M14;145467
+Cyclops of Eternal Fury;JOU;131659
+Cyclops of One-Eyed Pass;BNG;152581
+Cylian Elf;ALA;115163
+Cylian Sunsinger;CON;118724
+Cystbearer;SOM;131010
+Cytoplast Manipulator;DIS;96177
+Cytoplast Root-Kin;DIS;94383
+Cytoplast Root-Kin;MM2;94383
+Cytoshape;DIS;94414
+Cytospawn Shambler;DIS;94563
+D'Avenant Archer;5ED;532
+D'Avenant Archer;6ED;532
+D'Avenant Archer;CH;532
+D'Avenant Archer;LEG;532
+D'Avenant Archer;ME3;532
+D'Avenant Healer;TSP;97409
+Dack Fayden;EMA;138761
+Dack Fayden;PZ1;138761
+Dack Fayden;VMA;138761
+Dack's Duplicate;VMA;153163
+Dagger of the Worthy;HOU;401855
+Daggerback Basilisk;ROE;127428
+Daggerclaw Imp;DDC;91774
+Daggerclaw Imp;DPA;91774
+Daggerclaw Imp;GPT;91774
+Daggerclaw Imp;MM2;91774
+Daggerdrome Imp;RTR;145128
+Daghatar the Adamant;FRF;157144
+Daily Regimen;DDL;109956
+Daily Regimen;MOR;109956
+Dakkon Blackblade;CH;533
+Dakkon Blackblade;LEG;533
+Dakkon Blackblade;MED;533
+Dakmor Bat;PO2;4709
+Dakmor Lancer;7ED;27583
+Dakmor Plague;ME4;4725
+Dakmor Plague;PO2;4725
+Dakmor Salvage;DDJ;102457
+Dakmor Salvage;FUT;102457
+Dakmor Salvage;MMA;102457
+Dakmor Scorpion;PO2;4708
+Dakmor Sorceress;PO2;4730
+Dakra Mystic;JOU;152933
+Damia, Sage of Stone;CMD;137539
+Damnable Pact;DTK;160018
+Damnation;MM3;100693
+Damnation;MS3;401629
+Damnation;PLC;100693
+Damnation;PRM;100693
+Damnation;PRM;107706
+Dampen Thought;COK;82625
+Dampen Thought;MMA;82625
+Dampening Pulse;BFZ;161080
+Damping Engine;UL;13552
+Damping Field;ATQ;404
+Damping Matrix;MM3;51037
+Damping Matrix;MRD;51037
+Dance of Many;5ED;751
+Dance of Many;CH;751
+Dance of Many;DRK;751
+Dance of Many;ME3;751
+Dance of Shadows;COK;80980
+Dance of the Dead;ICE;1123
+Dance of the Dead;ME2;1123
+Dance of the Skywise;DTK;160147
+Dance with Devils;SOI;161738
+Dancing Scimitar;3ED;319
+Dancing Scimitar;4ED;319
+Dancing Scimitar;5ED;319
+Dancing Scimitar;6ED;319
+Dancing Scimitar;9ED;86725
+Dancing Scimitar;ARN;319
+Dandân;5ED;320
+Dandân;ARN;320
+Dandân;CH;320
+Dandân;TSB;320
+Dangerous Wager;AVR;141742
+Dangerous;DGM;150999
+Daraja Griffin;6ED;2151
+Daraja Griffin;VIS;2151
+Darba;PCY;21968
+Daredevil Dragster;AER;400403
+Daretti, Ingenious Iconoclast;PZ2;161900
+Daretti, Scrap Savant;C14;155598
+Daretti, Scrap Savant;PZ1;155598
+Darien, King of Kjeldor;CSP;97019
+Darigaaz, the Igniter;DDE;24788
+Darigaaz, the Igniter;INV;24788
+Darigaaz's Attendant;INV;25193
+Darigaaz's Caldera;PLS;27895
+Darigaaz's Caldera;TD0;27895
+Darigaaz's Charm;DDE;27896
+Darigaaz's Charm;PLS;27896
+Daring Apprentice;6ED;1845
+Daring Apprentice;7ED;27584
+Daring Apprentice;8ED;27584
+Daring Apprentice;9ED;27584
+Daring Apprentice;MIR;1845
+Daring Demolition;AER;400289
+Daring Leap;PLS;27987
+Daring Saboteur;XLN;402281
+Daring Skyjek;GTC;146322
+Daring Sleuth;SOI;161665
+Daring Thief;JOU;153069
+Dark Banishing;7ED;27585
+Dark Banishing;8ED;1846
+Dark Banishing;9ED;1846
+Dark Banishing;DDC;1846
+Dark Banishing;ICE;1124
+Dark Banishing;ME2;1124
+Dark Banishing;MIR;1846
+Dark Banishing;TMP;2985
+Dark Banishing;TPR;2985
+Dark Betrayal;THS;150887
+Dark Confidant;MM2;147074
+Dark Confidant;MMA;147074
+Dark Confidant;RAV;88747
+Dark Dabbling;ORI;160276
+Dark Deal;FRF;157266
+Dark Depths;CSP;96891
+Dark Depths;V16;96891
+Dark Favor;M12;134165
+Dark Favor;M13;134165
+Dark Favor;M14;134165
+Dark Hatchling;CMD;8826
+Dark Hatchling;PC2;140772
+Dark Hatchling;USG;8826
+Dark Hatchling;VMA;140772
+Dark Heart of the Wood;DPA;89058
+Dark Heart of the Wood;DRK;752
+Dark Heart of the Wood;RAV;89058
+Dark Impostor;AVR;141694
+Dark Intimations;AER;400368
+Dark Maze;5ED;2346
+Dark Maze;HML;1484
+Dark Maze;HML;1485
+Dark Nourishment;XLN;402085
+Dark Offering;PO2;4723
+Dark Petition;ORI;160267
+Dark Privilege;VIS;2152
+Dark Prophecy;M14;147426
+Dark Revenant;RTR;145172
+Dark Ritual;2ED;55
+Dark Ritual;3ED;55
+Dark Ritual;4ED;55
+Dark Ritual;5ED;2347
+Dark Ritual;DDC;2347
+Dark Ritual;DDE;8738
+Dark Ritual;ICE;1125
+Dark Ritual;LEA;55
+Dark Ritual;LEB;55
+Dark Ritual;ME4;55
+Dark Ritual;MIR;1847
+Dark Ritual;MMQ;19115
+Dark Ritual;MS3;401623
+Dark Ritual;PC1;2347
+Dark Ritual;PRM;120089
+Dark Ritual;TMP;2983
+Dark Ritual;TPR;2983
+Dark Ritual;USG;8738
+Dark Ritual;V13;2347
+Dark Ritual;VMA;2347
+Dark Salvation;EMN;161963
+Dark Sphere;DRK;753
+Dark Supplicant;LGN;47470
+Dark Suspicions;PLS;27902
+Dark Temper;CON;118666
+Dark Triumph;NMS;21157
+Dark Tutelage;M11;129074
+Dark Withering;TSP;97518
+Darkblast;RAV;88907
+Darkest Hour;7ED;27586
+Darkest Hour;USG;8777
+Darkheart Sliver;PLC;100769
+Darkling Stalker;TMP;2970
+Darklit Gargoyle;CON;118733
+Darklit Gargoyle;DPA;118733
+Darkness;LEG;534
+Darkness;TSB;534
+Darkpact;2ED;56
+Darkpact;3ED;56
+Darkpact;LEA;56
+Darkpact;LEB;56
+Darkslick Drake;SOM;130928
+Darkslick Shores;SOM;131101
+Darksteel Axe;DPA;131073
+Darksteel Axe;MM2;131073
+Darksteel Axe;SOM;131073
+Darksteel Brute;DST;51896
+Darksteel Citadel;C14;75157
+Darksteel Citadel;DDF;75157
+Darksteel Citadel;DST;75157
+Darksteel Citadel;M15;75157
+Darksteel Citadel;MM2;75157
+Darksteel Colossus;DPA;51759
+Darksteel Colossus;DST;51759
+Darksteel Colossus;M10;51759
+Darksteel Forge;DST;75183
+Darksteel Forge;M14;75183
+Darksteel Forge;PC1;75183
+Darksteel Gargoyle;DST;51994
+Darksteel Gargoyle;TD2;51994
+Darksteel Garrison;FUT;36532
+Darksteel Ingot;C13;52025
+Darksteel Ingot;CMD;52025
+Darksteel Ingot;DST;52025
+Darksteel Ingot;M14;52025
+Darksteel Ingot;PRM;52025
+Darksteel Juggernaut;SOM;131070
+Darksteel Mutation;C13;151744
+Darksteel Myr;SOM;131061
+Darksteel Pendant;DST;75138
+Darksteel Plate;DPA;133140
+Darksteel Plate;MBS;133140
+Darksteel Reactor;DST;75152
+Darksteel Relic;NPH;134316
+Darksteel Relic;PRM;134316
+Darksteel Sentinel;SOM;131035
+Darksteel Sentinel;TD2;131035
+Darkthicket Wolf;ISD;138427
+Darkwatch Elves;UL;14824
+Darkwater Catacombs;ODY;33233
+Darkwater Egg;ODY;33259
+Darting Merfolk;MMQ;19320
+Daru Cavalier;ONS;44549
+Daru Encampment;DDF;43233
+Daru Encampment;ONS;43233
+Daru Healer;ONS;42932
+Daru Lancer;ONS;42911
+Daru Mender;LGN;46547
+Daru Sanctifier;LGN;46596
+Daru Spiritualist;SCG;48984
+Daru Stinger;LGN;47480
+Daru Warchief;SCG;48131
+Dash Hopes;PLC;97434
+Daughter of Autumn;HML;1486
+Daunting Defender;ONS;42920
+Dauntless Aven;HOU;401502
+Dauntless Cathar;SOI;161376
+Dauntless Dourbark;LRW;105584
+Dauntless Dourbark;PRM;105584
+Dauntless Escort;ARB;121022
+Dauntless Escort;DPA;121022
+Dauntless Onslaught;THS;149083
+Dauntless River Marshal;M15;155231
+Dauthi Cutthroat;EXO;5665
+Dauthi Embrace;TMP;3219
+Dauthi Ghoul;TMP;3210
+Dauthi Horror;TMP;2966
+Dauthi Horror;TPR;2966
+Dauthi Jackal;EXO;5432
+Dauthi Jackal;TPR;5432
+Dauthi Marauder;TMP;2965
+Dauthi Marauder;TPR;2965
+Dauthi Mercenary;TMP;3212
+Dauthi Mercenary;VMA;3212
+Dauthi Mindripper;TMP;3211
+Dauthi Slayer;PRM;2967
+Dauthi Slayer;TMP;2967
+Dauthi Slayer;TPR;2967
+Dauthi Slayer;TSB;2967
+Dauthi Trapper;STH;3669
+Dauthi Warlord;EXO;5651
+Dauthi Warlord;TPR;5651
+Dawn Charm;PLC;100732
+Dawn Elemental;DPA;48139
+Dawn Elemental;SCG;48139
+Dawn Gryff;EMN;161913
+Dawn of the Dead;TOR;33398
+Dawn to Dusk;BNG;152018
+Dawn;AKH;401039
+Dawn's Reflection;5DN;77172
+Dawnbreak Reclaimer;PZ1;147393
+Dawnbringer Charioteers;JOU;153037
+Dawnbringer Charioteers;PRM;155427
+Dawnfeather Eagle;AER;400235
+Dawnfluke;LRW;106355
+Dawnglare Invoker;ROE;127352
+Dawnglow Infusion;SHM;111858
+Dawning Purist;ONS;42912
+Dawnray Archer;ALA;115125
+Dawnstrider;MMQ;19243
+Dawnstrike Paladin;DDL;138798
+Dawnstrike Paladin;DPA;138798
+Dawnstrike Paladin;M14;138798
+Dawntreader Elk;DKA;139740
+Daxos of Meletis;THS;150826
+Daxos the Returned;PZ1;160021
+Daxos's Torment;PZ1;160427
+Day of Destiny;BOK;83889
+Day of Judgment;DPA;123645
+Day of Judgment;M11;123645
+Day of Judgment;M12;123645
+Day of Judgment;PRM;125915
+Day of Judgment;PRM;133700
+Day of Judgment;ZEN;123645
+Day of the Dragons;SCG;48124
+Day;APC;31055
+Day's Undoing;ORI;160244
+Daybreak Coronet;DPA;102400
+Daybreak Coronet;FUT;102400
+Daybreak Coronet;MM2;160143
+Daybreak Ranger;ISD;138200
+Daze;DD2;21283
+Daze;EMA;161307
+Daze;MS3;401374
+Daze;NMS;21283
+Dazzling Beauty;MIR;1848
+Dazzling Ramparts;KTK;156542
+Dazzling Reflection;OGW;161200
+Dead Drop;KTK;156554
+Dead Reckoning;DPA;126562
+Dead Reckoning;WWK;126562
+Dead Reveler;RTR;145857
+Dead Ringers;APC;27951
+Dead Weight;ISD;138139
+Dead Weight;SOI;138139
+Dead-Iron Sledge;MRD;51064
+Dead;PLC;100789
+Deadapult;PLS;27920
+Deadbridge Chant;DGM;146827
+Deadbridge Goliath;PRM;145951
+Deadbridge Goliath;RTR;145950
+Deadbridge Shaman;EMA;131600
+Deadbridge Shaman;ORI;131600
+Deadeye Harpooner;AER;400241
+Deadeye Navigator;AVR;141567
+Deadeye Navigator;MM3;141567
+Deadeye Plunderers;XLN;402255
+Deadeye Quartermaster;XLN;401431
+Deadeye Tormentor;XLN;402849
+Deadeye Tracker;XLN;402105
+Deadfall;LEG;535
+Deadlock Trap;KLD;162322
+Deadly Allure;DKA;139847
+Deadly Grub;PLC;100649
+Deadly Insect;ALL;1611
+Deadly Insect;ALL;1612
+Deadly Insect;MMQ;19097
+Deadly Recluse;CMD;121590
+Deadly Recluse;DDL;121590
+Deadly Recluse;M10;121590
+Deadly Recluse;M13;121590
+Deadly Recluse;M14;121590
+Deadly Tempest;PZ1;160100
+Deadly Wanderings;DTK;160105
+Deadshot Minotaur;ARB;120961
+Deadshot;TMP;3164
+Deadshot;TPR;3164
+Deadwood Treefolk;C13;100645
+Deadwood Treefolk;CMD;100645
+Deadwood Treefolk;PLC;100645
+Dearly Departed;ISD;138212
+Death Baron;ALA;117201
+Death Baron;PC1;117201
+Death Bomb;PLS;27960
+Death Charmer;PCY;21991
+Death Cloud;DST;52055
+Death Cloud;MMA;52055
+Death Cultist;ROE;125538
+Death Denied;MM2;148260
+Death Denied;MMA;148260
+Death Denied;SOK;86145
+Death Frenzy;KTK;156577
+Death Grasp;APC;31104
+Death Grasp;C13;145073
+Death Grasp;DDK;145073
+Death Grasp;VMA;145073
+Death Match;ONS;43083
+Death Mutation;APC;31134
+Death Mutation;CMD;31134
+Death Mutation;DPA;31134
+Death Pit Offering;8ED;21278
+Death Pit Offering;NMS;21278
+Death Pits of Rath;8ED;3122
+Death Pits of Rath;9ED;75128
+Death Pits of Rath;TMP;3122
+Death Pits of Rath;TPR;3122
+Death Pulse;ONS;43069
+Death Rattle;FUT;102449
+Death Rattle;MMA;102449
+Death Spark;ALL;1613
+Death Spark;ME2;1613
+Death Speakers;5ED;2348
+Death Speakers;HML;1487
+Death Speakers;MED;1487
+Death Stroke;STH;3671
+Death Stroke;TPR;3671
+Death Ward;2ED;57
+Death Ward;3ED;57
+Death Ward;4ED;57
+Death Ward;5ED;57
+Death Ward;ICE;1126
+Death Ward;LEA;57
+Death Ward;LEB;57
+Death Ward;MED;57
+Death Watch;VIS;2153
+Death Wind;AVR;141747
+Death Wind;DTK;159707
+Death Wish;JUD;40237
+Death by Dragons;CMD;137525
+Death of a Thousand Stings;SOK;86075
+Death or Glory;INV;24035
+Death-Hood Cobra;DDM;134404
+Death-Hood Cobra;MM3;134404
+Death-Hood Cobra;NPH;134404
+Death-Mask Duplicant;DST;75160
+Death;APC;31056
+Death;DDJ;146773
+Death;PRM;31056
+Death's Approach;GTC;146289
+Death's Caress;DKA;139890
+Death's Duet;EXO;5609
+Death's Duet;TPR;5609
+Death's Presence;RTR;145952
+Death's Shadow;MM3;126484
+Death's Shadow;WWK;126484
+Death's-Head Buzzard;SCG;49005
+Death's-Head Buzzard;VMA;49005
+Deathbellow Raider;THS;149060
+Deathbringer Liege;DPA;113656
+Deathbringer Liege;EVE;113656
+Deathbringer Regent;DTK;159869
+Deathbringer Regent;PRM;160117
+Deathbringer Thoctar;ARB;121028
+Deathbringer Thoctar;C13;121028
+Deathbringer Thoctar;DPA;121028
+Deathcap Cultivator;SOI;161441
+Deathcoil Wurm;ME4;4786
+Deathcoil Wurm;PO2;4786
+Deathcult Rogue;GTC;146258
+Deathcurse Ogre;COK;81116
+Deathforge Shaman;WWK;126576
+Deathgaze Cockatrice;M14;147493
+Deathgazer;8ED;19104
+Deathgazer;9ED;19104
+Deathgazer;MMQ;19104
+Deathgorge Scavenger;XLN;402366
+Deathgreeter;ALA;115119
+Deathgreeter;DDD;115119
+Deathgreeter;DPA;115119
+Deathgrip;2ED;58
+Deathgrip;3ED;58
+Deathgrip;4ED;58
+Deathgrip;5ED;58
+Deathgrip;LEA;58
+Deathgrip;LEB;58
+Deathgrip;ME4;58
+Deathknell Kami;SOK;86019
+Deathlace;2ED;59
+Deathlace;3ED;59
+Deathlace;4ED;59
+Deathlace;LEA;59
+Deathlace;LEB;59
+Deathless Ancient;XLN;401433
+Deathless Angel;PRM;127395
+Deathless Angel;ROE;127395
+Deathless Behemoth;BFZ;160814
+Deathmark Prelate;LGN;46527
+Deathmark;10E;96855
+Deathmark;CSP;96855
+Deathmark;DPA;96855
+Deathmark;M10;122155
+Deathmark;M11;122155
+Deathmark;M12;122155
+Deathmark;MM2;122155
+Deathmask Nezumi;SOK;86129
+Deathmist Raptor;DTK;160607
+Deathpact Angel;GTC;146462
+Deathreap Ritual;VMA;153171
+Deathrender;LRW;105476
+Deathrite Shaman;EMA;145968
+Deathrite Shaman;RTR;145968
+Deathspore Thallid;TSP;97491
+Debilitating Injury;KTK;156502
+Debilitating Injury;PRM;159692
+Debt of Loyalty;WTH;2898
+Debt to the Deathless;DGM;147722
+Debtor's Pulpit;GTC;145236
+Debtors' Knell;DPA;91803
+Debtors' Knell;GPT;91803
+Decaying Soil;ODY;33394
+Deceiver Exarch;C13;134218
+Deceiver Exarch;NPH;134218
+Deceiver Exarch;PZ1;134218
+Deceiver of Form;OGW;161192
+Deception;PTK;9050
+Decimate;ODY;33262
+Decimate;PRM;153361
+Decimator Beetle;AKH;401348
+Decimator Web;MBS;133225
+Decimator of the Provinces;EMN;162130
+Decision Paralysis;AKH;400808
+Declaration in Stone;SOI;161412
+Declaration of Naught;MOR;110008
+Decoction Module;KLD;162564
+Decommission;AER;400239
+Decompose;DDK;33411
+Decompose;ODY;33411
+Decomposition;MIR;1849
+Deconstruct;MRD;51110
+Decorated Griffin;THS;150762
+Decree of Annihilation;SCG;48969
+Decree of Annihilation;V14;48969
+Decree of Justice;C14;48973
+Decree of Justice;PRM;101027
+Decree of Justice;PRM;159704
+Decree of Justice;SCG;48973
+Decree of Justice;TD0;48973
+Decree of Justice;VMA;48973
+Decree of Pain;C13;147111
+Decree of Pain;PRM;147111
+Decree of Pain;PZ1;147111
+Decree of Pain;SCG;48953
+Decree of Savagery;SCG;48990
+Decree of Silence;SCG;48994
+Dedicated Martyr;ODY;33531
+Deem Worthy;AKH;400759
+Deep Analysis;C13;36418
+Deep Analysis;DDH;138683
+Deep Analysis;EMA;138683
+Deep Analysis;PRM;36418
+Deep Analysis;PZ1;36418
+Deep Analysis;TOR;36418
+Deep Analysis;VMA;36418
+Deep Reconnaissance;ODY;33205
+Deep Spawn;FEM;873
+Deep Spawn;ME2;873
+Deep Water;DRK;754
+Deep Wood;PO2;4780
+Deep Wood;POR;6648
+Deep-Sea Kraken;C14;97403
+Deep-Sea Kraken;TSP;97403
+Deep-Sea Serpent;POR;6614
+Deep-Sea Terror;ORI;160239
+Deep-Slumber Titan;SHM;111725
+Deepcavern Imp;FUT;102441
+Deepcavern Imp;MMA;102441
+Deepchannel Mentor;SHM;111547
+Deepfathom Skulker;OGW;161216
+Deepfathom Skulker;PRM;161131
+Deepfire Elemental;C13;97027
+Deepfire Elemental;CSP;97027
+Deepglow Skate;PZ2;162440
+Deeproot Champion;XLN;402060
+Deeproot Warrior;XLN;402101
+Deeproot Waters;XLN;402324
+Deeptread Merrow;LRW;105594
+Deepwater Hypnotist;BNG;152549
+Deepwood Drummer;MMQ;19090
+Deepwood Elder;MMQ;19471
+Deepwood Ghoul;8ED;19232
+Deepwood Ghoul;MMQ;19232
+Deepwood Legate;MMQ;19294
+Deepwood Tantiv;MMQ;19020
+Deepwood Wolverine;MMQ;19149
+Defang;AVR;141632
+Defeat;DTK;159764
+Defend the Hearth;THS;150789
+Defender en-Vec;NMS;21151
+Defender of Chaos;UL;10348
+Defender of Law;UL;10345
+Defender of the Order;LGN;47504
+Defense Grid;8ED;14066
+Defense Grid;9ED;14066
+Defense Grid;MS2;400927
+Defense Grid;UL;14066
+Defense of the Heart;UL;10367
+Defensive Formation;USG;8911
+Defensive Maneuvers;ONS;42936
+Defensive Stance;NPH;134249
+Defiant Bloodlord;BFZ;160853
+Defiant Bloodlord;PRM;160669
+Defiant Elf;LGN;47482
+Defiant Falcon;NMS;21219
+Defiant Greatmaw;AKH;402001
+Defiant Khenra;HOU;401506
+Defiant Ogre;FRF;157213
+Defiant Salvager;AER;400283
+Defiant Stand;POR;6735
+Defiant Strike;KTK;156481
+Defiant Vanguard;NMS;21214
+Defiant Vanguard;TSB;21214
+Defiler of Souls;ARB;121070
+Defiler of Souls;DPA;121070
+Defiling Tears;INV;25228
+Deflecting Palm;KTK;157088
+Deflection;5ED;1127
+Deflection;6ED;1127
+Deflection;7ED;27587
+Deflection;8ED;49266
+Deflection;ICE;1127
+Deft Dismissal;AER;400246
+Deft Duelist;ALA;115152
+Deft Duelist;DPA;115152
+Deftblade Elite;LGN;47528
+Deftblade Elite;VMA;47528
+Defy Death;AVR;141522
+Defy Gravity;JUD;40201
+Dega Disciple;APC;31058
+Dega Sanctuary;APC;31060
+Degavolver;APC;31059
+Deglamer;MOR;105554
+Dehydration;10E;49234
+Dehydration;8ED;49234
+Dehydration;9ED;49234
+Dehydration;MMQ;19170
+Deicide;JOU;152941
+Deity of Scars;EVE;113703
+Delay;FUT;97366
+Delaying Shield;ODY;33509
+Delif's Cone;FEM;874
+Delif's Cube;FEM;875
+Delirium Skeins;DIS;94495
+Delirium Skeins;MM3;94495
+Delirium;MIR;1850
+Deliver;INV;25576
+Delraich;MMQ;19156
+Deluge;10E;33468
+Deluge;DPA;33468
+Deluge;ODY;33468
+Delusions of Mediocrity;7ED;27588
+Delusions of Mediocrity;UL;10381
+Delver of Secrets;ISD;138242
+Demand;DIS;100950
+Dematerialize;ODY;33492
+Dementia Bat;NPH;134423
+Dementia Sliver;TSP;97331
+Demigod of Revenge;DPA;111769
+Demigod of Revenge;MMA;111769
+Demigod of Revenge;PRM;112143
+Demigod of Revenge;SHM;111769
+Demolish;10E;33696
+Demolish;8ED;33696
+Demolish;9ED;33696
+Demolish;AVR;141605
+Demolish;KLD;162457
+Demolish;M11;123684
+Demolish;M14;123684
+Demolish;ODY;33696
+Demolish;ORI;123684
+Demolish;THS;150857
+Demolish;XLN;402316
+Demolish;ZEN;123684
+Demolition Stomper;KLD;162324
+Demon of Dark Schemes;KLD;162265
+Demon of Death's Gate;M11;129162
+Demon of Wailing Agonies;C14;155609
+Demon-Possessed Witch;SOI;161377
+Demon;TOK;138478
+Demon;TOK;153352
+Demon;TOK;51114
+Demon's Grasp;BFZ;160658
+Demon's Herald;ALA;115177
+Demon's Horn;10E;75220
+Demon's Horn;9ED;75220
+Demon's Horn;DDC;75220
+Demon's Horn;DPA;75220
+Demon's Horn;DST;75220
+Demon's Horn;M10;75220
+Demon's Horn;M11;75220
+Demon's Horn;M12;75220
+Demon's Jester;DDC;94652
+Demon's Jester;DIS;94652
+Demonfire;DD2;94326
+Demonfire;DIS;94326
+Demonic Appetite;ROE;125539
+Demonic Attorney;2ED;60
+Demonic Attorney;3ED;60
+Demonic Attorney;LEA;60
+Demonic Attorney;LEB;60
+Demonic Collusion;TSP;97500
+Demonic Consultation;ICE;1128
+Demonic Consultation;ME2;1128
+Demonic Dread;ARB;121047
+Demonic Hordes;2ED;61
+Demonic Hordes;3ED;61
+Demonic Hordes;LEA;61
+Demonic Hordes;LEB;61
+Demonic Hordes;ME4;61
+Demonic Pact;ORI;160249
+Demonic Rising;AVR;141840
+Demonic Taskmaster;AVR;141786
+Demonic Torment;LEG;536
+Demonic Torment;ME3;536
+Demonic Tutor;2ED;62
+Demonic Tutor;3ED;62
+Demonic Tutor;DDC;122095
+Demonic Tutor;LEA;62
+Demonic Tutor;LEB;62
+Demonic Tutor;ME4;62
+Demonic Tutor;PRM;107689
+Demonic Tutor;VMA;122095
+Demonlord of Ashmouth;AVR;141707
+Demonmail Hauberk;ISD;138290
+Demonspine Whip;ARB;121004
+Demoralize;ODY;33378
+Demystify;10E;42928
+Demystify;8ED;42928
+Demystify;9ED;42928
+Demystify;M12;127483
+Demystify;ONS;42928
+Demystify;ROE;127483
+Demystify;XLN;402323
+Den Protector;DTK;159794
+Denizen of the Deep;10E;104199
+Denizen of the Deep;DPA;104199
+Denizen of the Deep;PO2;4703
+Dense Canopy;SOK;86186
+Dense Foliage;6ED;2874
+Dense Foliage;WTH;2874
+Deny Existence;SOI;161380
+Deny Reality;ARB;121039
+Deny Reality;PC2;121039
+Denying Wind;PCY;21956
+Depala, Pilot Exemplar;KLD;162557
+Deploy the Gatewatch;EMN;162049
+Deploy to the Front;C14;156034
+Deprive;DPA;127324
+Deprive;ROE;127324
+Depths of Desire;XLN;402372
+Deputy of Acquittals;DGM;147772
+Deputy of Acquittals;MM3;147772
+Deranged Assistant;ISD;138156
+Deranged Hermit;PRM;9161
+Deranged Hermit;UL;9161
+Deranged Hermit;VMA;9161
+Deranged Outcast;DKA;139806
+Deranged Whelp;EMN;161968
+Derelor;5ED;876
+Derelor;6ED;876
+Derelor;FEM;876
+Derelor;MED;876
+Derevi, Empyrial Tactician;C13;151730
+Dermoplasm;LGN;47497
+Descend upon the Sinful;SOI;161667
+Descendant of Kiyomaro;SOK;87224
+Descendant of Masumaro;SOK;86040
+Descendant of Soramaro;SOK;86128
+Descendants' Path;AVR;141830
+Descent into Madness;AVR;138676
+Descent of the Dragons;DTK;160160
+Desecrated Earth;ZEN;123621
+Desecration Demon;MM3;145943
+Desecration Demon;RTR;145943
+Desecration Elemental;5DN;77115
+Desecration Elemental;TD2;77115
+Desecration Plague;JOU;152881
+Desecrator Hag;CMD;113739
+Desecrator Hag;EVE;113739
+Desert Cerodon;AKH;400870
+Desert Drake;POR;6688
+Desert Nomads;ARN;322
+Desert Sandstorm;PTK;9172
+Desert Twister;3ED;323
+Desert Twister;4ED;323
+Desert Twister;5ED;323
+Desert Twister;ARN;323
+Desert Twister;C14;156392
+Desert Twister;ME3;323
+Desert Twister;MMQ;19201
+Desert Twister;VMA;156392
+Desert of the Fervent;HOU;401578
+Desert of the Glorified;HOU;401577
+Desert of the Indomitable;HOU;401570
+Desert of the Mindful;HOU;401579
+Desert of the True;HOU;401569
+Desert;ARN;321
+Desert;PRM;33232
+Desert;TSB;321
+Desert;V12;33232
+Desert's Hold;HOU;401775
+Deserted Temple;ODY;33226
+Deserter;TOK;121558
+Deserter's Quarters;JOU;152806
+Desertion;6ED;2154
+Desertion;PRM;2154
+Desertion;PZ1;2154
+Desertion;VIS;2154
+Desiccated Naga;AKH;401058
+Desolate Lighthouse;AVR;138666
+Desolation Angel;APC;31061
+Desolation Angel;MS3;401621
+Desolation Giant;APC;31062
+Desolation Giant;TSB;31062
+Desolation Twin;BFZ;160935
+Desolation;VIS;2155
+Despair;HOU;401864
+Desperate Castaways;XLN;402367
+Desperate Charge;ME3;9089
+Desperate Charge;PTK;9089
+Desperate Gambit;WTH;2940
+Desperate Ravings;EMA;138414
+Desperate Ravings;ISD;138414
+Desperate Research;INV;24033
+Desperate Ritual;COK;82621
+Desperate Ritual;MMA;82621
+Desperate Sentry;EMN;162606
+Desperate Stand;JOU;152908
+Despise;KTK;156552
+Despise;NPH;134382
+Despise;PRM;140382
+Despoil;PCY;22063
+Despoiler of Souls;ORI;160260
+Despondency;USG;8630
+Despotic Scepter;ICE;1129
+Despotic Scepter;ME2;1129
+Destined;AKH;400802
+Destroy the Evidence;RTR;145905
+Destructive Flow;PLS;27973
+Destructive Force;M11;129135
+Destructive Revelry;DDL;150066
+Destructive Revelry;THS;150066
+Destructive Tampering;AER;400313
+Destructive Urge;USG;8877
+Destructor Dragon;FRF;157277
+Detainment Spell;TSP;97480
+Detention Sphere;RTR;145188
+Determined;DIS;100953
+Detonate;4ED;405
+Detonate;5ED;405
+Detonate;ATQ;405
+Detonate;ME4;405
+Detonate;MRD;50340
+Detritivore;PLC;102116
+Deus of Calamity;DDL;111663
+Deus of Calamity;SHM;111663
+Devastate;PCY;22074
+Devastating Dreams;TOR;36503
+Devastating Summons;ROE;127429
+Devastation Tide;AVR;141817
+Devastation;ME4;6689
+Devastation;POR;6689
+Development;DIS;100954
+Deviant Glee;RTR;145132
+Devil;TOK;161713
+Devil's Play;DDK;139445
+Devil's Play;ISD;139445
+Devil's Play;PRM;138503
+Devils' Playground;SOI;161379
+Devilthorn Fox;SOI;161410
+Devoted Caretaker;ODY;33192
+Devoted Crop-Mate;AKH;401285
+Devoted Druid;SHM;111521
+Devoted Hero;POR;6736
+Devoted Retainer;COK;80678
+Devoted Retainer;DPA;80678
+Devotee of Strength;HOU;401524
+Devour Flesh;GTC;146540
+Devour in Flames;OGW;161059
+Devour in Shadow;5DN;77117
+Devouring Deep;LEG;537
+Devouring Greed;COK;81037
+Devouring Greed;MM2;81037
+Devouring Light;M15;155889
+Devouring Light;RAV;89081
+Devouring Rage;COK;80806
+Devouring Strossus;INV;24062
+Devouring Swarm;M12;136807
+Devout Chaplain;AVR;141819
+Devout Harpist;UL;10368
+Devout Invocation;M14;147408
+Devout Lightcaster;ZEN;123710
+Devout Witness;MMQ;19133
+Devout Witness;VMA;19133
+Dewdrop Spy;MOR;109951
+Dhund Operative;KLD;162266
+Diabolic Edict;DPA;143940
+Diabolic Edict;MS3;402210
+Diabolic Edict;PRM;143940
+Diabolic Edict;PRM;2982
+Diabolic Edict;TMP;2982
+Diabolic Edict;TPR;2982
+Diabolic Intent;MS3;401624
+Diabolic Intent;PLS;27894
+Diabolic Machine;4ED;755
+Diabolic Machine;5ED;2349
+Diabolic Machine;DRK;755
+Diabolic Machine;ME4;755
+Diabolic Revelation;M13;143877
+Diabolic Servitude;PD3;8735
+Diabolic Servitude;TD2;8735
+Diabolic Servitude;USG;8735
+Diabolic Tutor;10E;101052
+Diabolic Tutor;8ED;28004
+Diabolic Tutor;9ED;28004
+Diabolic Tutor;CMD;101052
+Diabolic Tutor;KLD;162510
+Diabolic Tutor;M10;101052
+Diabolic Tutor;M11;101052
+Diabolic Tutor;M12;101052
+Diabolic Tutor;M14;101052
+Diabolic Tutor;ODY;28004
+Diabolic Vision;ICE;1130
+Diabolic Vision;ME2;1130
+Diamond Faerie;CSP;96874
+Diamond Kaleidoscope;VIS;2156
+Diamond Valley;ARN;324
+Diamond Valley;MED;324
+Diaochan, Artful Beauty;PRM;9076
+Diaochan, Artful Beauty;PTK;9076
+Diaochan, Artful Beauty;PZ1;9076
+Dichotomancy;PLC;100706
+Dictate of Erebos;JOU;153087
+Dictate of Heliod;JOU;153079
+Dictate of Karametra;JOU;153086
+Dictate of Kruphix;JOU;152947
+Dictate of Kruphix;PRM;155424
+Dictate of the Twin Gods;JOU;153084
+Dictate of the Twin Gods;PRM;155428
+Didgeridoo;HML;1488
+Didgeridoo;ME3;1488
+Die Young;KLD;162267
+Diffusion Sliver;M15;147384
+Dig Through Time;KTK;157019
+Diligent Farmhand;ODY;33329
+Diluvian Primordial;GTC;147245
+Dimensional Breach;SCG;48155
+Dimensional Infiltrator;OGW;161211
+Diminish;M11;129177
+Diminishing Returns;6ED;1614
+Diminishing Returns;ALL;1614
+Diminishing Returns;EMA;161547
+Diminishing Returns;MED;1614
+Dimir Aqueduct;CMD;88919
+Dimir Aqueduct;MM2;88919
+Dimir Aqueduct;PC2;88919
+Dimir Aqueduct;RAV;88919
+Dimir Charm;GTC;145921
+Dimir Charm;PRM;149964
+Dimir Cluestone;DGM;147761
+Dimir Cutpurse;DDH;88896
+Dimir Cutpurse;RAV;88896
+Dimir Doppelganger;RAV;88807
+Dimir Guildgate;C13;145160
+Dimir Guildgate;DGM;146887
+Dimir Guildgate;GTC;145160
+Dimir Guildgate;MM3;146887
+Dimir Guildmage;DPA;88978
+Dimir Guildmage;MM2;88978
+Dimir Guildmage;PRM;88978
+Dimir Guildmage;RAV;88978
+Dimir House Guard;RAV;88916
+Dimir Infiltrator;PC2;88975
+Dimir Infiltrator;RAV;88975
+Dimir Keyrune;GTC;145931
+Dimir Machinations;RAV;88970
+Dimir Signet;CMD;89179
+Dimir Signet;MM3;145427
+Dimir Signet;PRM;145427
+Dimir Signet;RAV;89179
+Din of the Fireherd;DPA;111642
+Din of the Fireherd;SHM;111642
+Dingus Egg;2ED;63
+Dingus Egg;3ED;63
+Dingus Egg;4ED;63
+Dingus Egg;5ED;2350
+Dingus Egg;6ED;2350
+Dingus Egg;7ED;27590
+Dingus Egg;8ED;2350
+Dingus Egg;LEA;63
+Dingus Egg;LEB;63
+Dingus Staff;WTH;2911
+Dinosaur Stampede;XLN;402311
+Dinosaur;TOK;402425
+Dinrova Horror;GTC;146368
+Dinrova Horror;MM3;146368
+Diplomacy of the Wastes;FRF;157340
+Diplomatic Escort;MMQ;19124
+Diplomatic Immunity;MMQ;19203
+Dire Fleet Captain;XLN;402859
+Dire Fleet Hoarder;XLN;402308
+Dire Fleet Interloper;XLN;402056
+Dire Fleet Ravager;XLN;402245
+Dire Undercurrents;SHM;111754
+Dire Wolves;ICE;1131
+Diregraf Captain;DKA;139820
+Diregraf Colossus;SOI;161495
+Diregraf Escort;AVR;141678
+Diregraf Ghoul;DPA;138240
+Diregraf Ghoul;ISD;138240
+Diregraf Ghoul;PRM;139461
+Dirge of Dread;C13;43042
+Dirge of Dread;ONS;43042
+Dirgur Nemesis;DTK;159845
+Dirtcowl Wurm;PRM;3136
+Dirtcowl Wurm;TMP;3136
+Dirtwater Wraith;MIR;1851
+Dirty Wererat;ODY;33443
+Dirty;DGM;151040
+Disallow;AER;400279
+Disappear;UD;15617
+Disappearing Act;KLD;162251
+Disarm;MRD;50244
+Disaster Radius;CMD;127362
+Disaster Radius;DPA;127362
+Disaster Radius;ROE;127362
+Disciple of Bolas;C14;143874
+Disciple of Bolas;M13;143874
+Disciple of Deceit;JOU;152914
+Disciple of Grace;ONS;42916
+Disciple of Grace;USG;8878
+Disciple of Griselbrand;C13;138441
+Disciple of Griselbrand;ISD;138441
+Disciple of Kangee;PLS;27931
+Disciple of Law;USG;8950
+Disciple of Malice;ONS;43035
+Disciple of Phenax;THS;150780
+Disciple of Tevesh Szat;CSP;96958
+Disciple of the Old Ways;GTC;146241
+Disciple of the Ring;ORI;160241
+Disciple of the Vault;MRD;51121
+Discombobulate;10E;43006
+Discombobulate;ONS;43006
+Discordant Dirge;USG;8684
+Discordant Spirit;MIR;1852
+Disdainful Stroke;KTK;156491
+Disdainful Stroke;PRM;159836
+Disease Carriers;UD;15628
+Diseased Vermin;ALL;1615
+Disembowel;RAV;2655
+Disempower;MIR;1853
+Disenchant;2ED;64
+Disenchant;3ED;64
+Disenchant;4ED;64
+Disenchant;5ED;1132
+Disenchant;6ED;1132
+Disenchant;7ED;27591
+Disenchant;ICE;1132
+Disenchant;LEA;64
+Disenchant;LEB;64
+Disenchant;ME2;1132
+Disenchant;ME3;64
+Disenchant;MIR;1854
+Disenchant;MMQ;19248
+Disenchant;PRM;101025
+Disenchant;PRM;21312
+Disenchant;TMP;3060
+Disenchant;TPR;3060
+Disenchant;TSB;64
+Disenchant;USG;8751
+Disentomb;DPA;121633
+Disentomb;M10;121633
+Disentomb;M11;121633
+Disentomb;M12;121633
+Disentomb;M13;121633
+Disfigure;DPA;123586
+Disfigure;ZEN;123586
+Disharmony;LEG;4623
+Disharmony;ME3;4623
+Disintegrate;2ED;65
+Disintegrate;3ED;65
+Disintegrate;4ED;65
+Disintegrate;5ED;65
+Disintegrate;DPA;145066
+Disintegrate;LEA;65
+Disintegrate;LEB;65
+Disintegrate;PRM;145066
+Disintegrate;TSB;65
+Dismal Backwater;EMA;157264
+Dismal Backwater;FRF;157264
+Dismal Backwater;KTK;157094
+Dismal Failure;PLC;100819
+Dismantle;DST;75149
+Dismantling Blow;INV;24039
+Dismantling Blow;TD0;24039
+Dismember;MM2;134374
+Dismember;NPH;134374
+Dismember;PRM;143390
+Dismiss into Dream;M14;147455
+Dismiss;C13;3284
+Dismiss;C14;3284
+Dismiss;PRM;3284
+Dismiss;TMP;3284
+Dismiss;TPR;3284
+Disorder;7ED;27592
+Disorder;USG;8831
+Disorient;DPA;121598
+Disorient;M10;121598
+Disowned Ancestor;KTK;157021
+Dispatch;MM2;134320
+Dispatch;NPH;134320
+Dispatch;TD2;134320
+Dispel;BFZ;160650
+Dispel;DPA;126467
+Dispel;RTR;145853
+Dispel;WWK;126467
+Dispeller's Capsule;ALA;114951
+Dispeller's Capsule;DPA;114951
+Dispeller's Capsule;MMA;114951
+Dispense Justice;DPA;131072
+Dispense Justice;SOM;131072
+Dispersal Shield;SCG;48149
+Dispersal Technician;AER;400259
+Disperse;DPA;131132
+Disperse;M14;109942
+Disperse;MOR;109942
+Disperse;ORI;155868
+Disperse;SOM;131132
+Disperse;W16;155868
+Dispersing Orb;ONS;43020
+Displace;EMN;162055
+Displacement Wave;ORI;131630
+Display of Dominance;DTK;160029
+Disposal Mummy;HOU;401770
+Dispossess;AKH;401672
+Disrupt;INV;24040
+Disrupt;WTH;2836
+Disrupting Scepter;2ED;66
+Disrupting Scepter;3ED;66
+Disrupting Scepter;4ED;66
+Disrupting Scepter;5ED;2351
+Disrupting Scepter;6ED;2351
+Disrupting Scepter;7ED;27593
+Disrupting Scepter;8ED;2351
+Disrupting Scepter;9ED;2351
+Disrupting Scepter;LEA;66
+Disrupting Scepter;LEB;66
+Disrupting Shoal;BOK;83844
+Disruption Aura;5DN;78808
+Disruptive Pitmage;ONS;42972
+Disruptive Student;USG;8628
+Dissension in the Ranks;SOI;161657
+Dissenter's Deliverance;AKH;401338
+Dissipate;DDJ;138426
+Dissipate;ISD;138426
+Dissipate;M15;138426
+Dissipate;MIR;1855
+Dissipate;PRM;1855
+Dissipation Field;SOM;130980
+Dissolve;PRM;155430
+Dissolve;THS;149196
+Distant Melody;H09;109997
+Distant Melody;MOR;109997
+Distant Memories;MBS;133154
+Distemper of the Blood;EMN;161969
+Distended Mindbender;EMN;162089
+Distorting Lens;8ED;18998
+Distorting Lens;MMQ;18998
+Distorting Wake;C14;25499
+Distorting Wake;INV;25499
+Distortion Strike;ROE;127453
+Distress;10E;81015
+Distress;COK;81015
+Distress;M12;137401
+Disturbed Burial;TMP;2979
+Disturbing Plot;SHM;111850
+Dive Bomber;ONS;42979
+Dive Down;XLN;402031
+Divebomber Griffin;RAV;90344
+Divergent Growth;SCG;48987
+Diversionary Tactics;APC;31063
+Divert;MS3;401620
+Divert;ODY;33448
+Divination;BNG;152027
+Divination;DKA;139884
+Divination;DPA;121599
+Divination;M10;121599
+Divination;M12;121599
+Divination;M13;121599
+Divination;M14;121599
+Divination;M15;121599
+Divine Congregation;TSP;100065
+Divine Deflection;AVR;141617
+Divine Favor;DPA;134125
+Divine Favor;M12;134125
+Divine Favor;M13;134125
+Divine Favor;M14;134125
+Divine Favor;M15;134125
+Divine Intervention;LEG;4624
+Divine Intervention;ME3;4624
+Divine Light;APC;31064
+Divine Offering;5ED;538
+Divine Offering;CH;538
+Divine Offering;LEG;538
+Divine Offering;MBS;133149
+Divine Offering;ME4;538
+Divine Offering;MIR;1856
+Divine Presence;INV;24626
+Divine Reckoning;ISD;138452
+Divine Retribution;MIR;1857
+Divine Sacrament;ODY;33508
+Divine Transformation;4ED;539
+Divine Transformation;5ED;539
+Divine Transformation;6ED;539
+Divine Transformation;DPA;147121
+Divine Transformation;LEG;539
+Divine Transformation;MED;539
+Divine Verdict;DPA;103536
+Divine Verdict;M10;103536
+Divine Verdict;M13;103536
+Divine Verdict;M15;103536
+Divine Verdict;ORI;103536
+Divine Verdict;THS;149044
+Divine Verdict;W17;103536
+Diviner Spirit;C13;151732
+Diviner's Wand;MOR;110027
+Diving Griffin;8ED;22049
+Diving Griffin;PCY;22049
+Divining Witch;NMS;21212
+Divinity of Pride;C13;113606
+Divinity of Pride;DPA;113606
+Divinity of Pride;EVE;113606
+Divinity of Pride;MMA;113606
+Dizzy Spell;RAV;88915
+Dizzying Gaze;EXO;5422
+Djeru, With Eyes Open;HOU;401601
+Djeru's Renunciation;HOU;401772
+Djeru's Resolve;AKH;401281
+Djinn Illuminatus;DDJ;91807
+Djinn Illuminatus;GPT;91807
+Djinn Illuminatus;PRM;93490
+Djinn Monk;TOK;160097
+Djinn of Infinite Deceits;C13;151716
+Djinn of Wishes;DPA;121616
+Djinn of Wishes;M10;121616
+Djinn of Wishes;M12;121616
+Djinn of the Lamp;POR;6616
+Djinn;TOK;137167
+Do or Die;INV;24042
+Docent of Perfection;EMN;161942
+Dodecapod;APC;32554
+Dodecapod;TSB;32554
+Dogged Hunter;ODY;33193
+Dogpile;RAV;89140
+Dolmen Gate;LRW;105524
+Domesticated Hydra;PZ2;162181
+Domestication;M14;127376
+Domestication;ROE;127376
+Dominaria's Judgment;PLS;27955
+Dominate;NMS;21217
+Dominating Licid;EXO;3673
+Dominator Drone;BFZ;160664
+Domineer;MRD;51079
+Domineering Will;C14;156019
+Dominus of Fealty;CMD;113640
+Dominus of Fealty;DPA;113640
+Dominus of Fealty;EVE;113640
+Domri Rade;GTC;146548
+Domri Rade;MM3;146548
+Donate;UD;15627
+Dong Zhou, the Tyrant;ME3;9142
+Dong Zhou, the Tyrant;PTK;9142
+Doom Blade;CMD;121618
+Doom Blade;DPA;121618
+Doom Blade;M10;121618
+Doom Blade;M11;121618
+Doom Blade;M12;121618
+Doom Blade;M14;121618
+Doom Blade;PRM;131560
+Doom Blade;PRM;162424
+Doom Cannon;ONS;43212
+Doomed Dissenter;AKH;400748
+Doomed Necromancer;10E;104537
+Doomed Necromancer;ONS;44667
+Doomed Traveler;DDK;138419
+Doomed Traveler;DPA;138419
+Doomed Traveler;ISD;138419
+Doomfall;HOU;401854
+Doomgape;DDJ;113599
+Doomgape;EVE;113599
+Doomsday Specter;PLS;27904
+Doomsday;6ED;2866
+Doomsday;MS3;401622
+Doomsday;PRM;162511
+Doomsday;WTH;2866
+Doomwake Giant;JOU;153097
+Doomwake Giant;PRM;155422
+Door of Destinies;M14;110121
+Door of Destinies;MOR;110121
+Door of Destinies;PRM;105626
+Door to Nothingness;5DN;80182
+Door to Nothingness;M13;138801
+Door to Nothingness;PC1;80182
+Doorkeeper;RTR;145846
+Doran, the Siege Tower;LRW;106421
+Doran, the Siege Tower;PRM;106421
+Doran, the Siege Tower;PRM;402439
+Doran, the Siege Tower;V11;106421
+Dormant Gomazoa;ROE;127365
+Dormant Sliver;PLC;100778
+Dormant Volcano;C14;2157
+Dormant Volcano;VIS;2157
+Dosan the Falling Leaf;COK;80936
+Dosan's Oldest Chant;SOK;86140
+Double Cleave;DPA;113666
+Double Cleave;EVE;113666
+Double Cleave;PC1;113666
+Double Negative;ARB;120962
+Doubling Chant;M12;134104
+Doubling Cube;10E;77146
+Doubling Cube;5DN;77146
+Doubling Season;MMA;134053
+Doubling Season;RAV;89157
+Doubtless One;ONS;42935
+Douse in Gloom;FRF;157341
+Douse in Gloom;GPT;91831
+Douse;USG;8810
+Dovescape;DIS;94488
+Dovin Baan;KLD;162188
+Down;DGM;146811
+Downdraft;WTH;2928
+Downhill Charge;DDI;21171
+Downhill Charge;NMS;21171
+Downpour;M13;143841
+Downsize;RTR;145123
+Dowsing Dagger;XLN;402052
+Dowsing Shaman;PC2;90343
+Dowsing Shaman;RAV;90343
+Draco;DRB;27997
+Draco;PLS;27997
+Draconian Cylix;FEM;877
+Draconic Roar;DTK;159765
+Dracoplasm;TMP;3198
+Dracoplasm;TPR;3198
+Drafna's Restoration;ATQ;406
+Drag Down;CON;118687
+Drag Down;MMA;118687
+Drag Under;EMN;161926
+Drag Under;W17;161926
+Dragon Appeasement;ARB;121023
+Dragon Arch;APC;31065
+Dragon Bell Monk;FRF;157237
+Dragon Blood;DDL;50303
+Dragon Blood;MRD;50303
+Dragon Blood;USG;8885
+Dragon Breath;SCG;48954
+Dragon Broodmother;ARB;121072
+Dragon Broodmother;PRM;121326
+Dragon Egg;EMA;147403
+Dragon Egg;M14;147403
+Dragon Engine;3ED;407
+Dragon Engine;4ED;407
+Dragon Engine;5ED;407
+Dragon Engine;6ED;407
+Dragon Engine;ATQ;407
+Dragon Engine;ME4;407
+Dragon Engine;MED;407
+Dragon Fangs;SCG;49001
+Dragon Fodder;ALA;115021
+Dragon Fodder;DDG;115021
+Dragon Fodder;DPA;115021
+Dragon Fodder;DTK;159828
+Dragon Fodder;MM3;115021
+Dragon Fodder;ORI;115021
+Dragon Fodder;PRM;160136
+Dragon Grip;KTK;157044
+Dragon Hatchling;DPA;143848
+Dragon Hatchling;M13;143848
+Dragon Hatchling;M14;143848
+Dragon Hunter;DTK;159744
+Dragon Mage;SCG;48115
+Dragon Mantle;THS;149187
+Dragon Mask;6ED;2158
+Dragon Mask;VIS;2158
+Dragon Roost;10E;104550
+Dragon Roost;DPA;104550
+Dragon Roost;ONS;43136
+Dragon Scales;SCG;48971
+Dragon Shadow;SCG;48974
+Dragon Spirit;TOK;82655
+Dragon Tempest;DTK;160014
+Dragon Throne of Tarkir;KTK;157091
+Dragon Throne of Tarkir;PRM;157112
+Dragon Tyrant;SCG;48132
+Dragon Whelp;2ED;67
+Dragon Whelp;3ED;67
+Dragon Whelp;4ED;67
+Dragon Whelp;CMD;115926
+Dragon Whelp;DDG;115926
+Dragon Whelp;DRB;115926
+Dragon Whelp;LEA;67
+Dragon Whelp;LEB;67
+Dragon Whelp;M10;115926
+Dragon Whelp;TSB;67
+Dragon Whisperer;DTK;159826
+Dragon Wings;SCG;48993
+Dragon-Scarred Bear;DTK;160095
+Dragon-Style Twins;KTK;157046
+Dragon;TOK;104572
+Dragon;TOK;117012
+Dragon;TOK;121080
+Dragon;TOK;126511
+Dragon;TOK;145989
+Dragon;TOK;148785
+Dragon;TOK;160044
+Dragon;TOK;44676
+Dragon's Claw;10E;75221
+Dragon's Claw;9ED;75221
+Dragon's Claw;DDG;75221
+Dragon's Claw;DPA;75221
+Dragon's Claw;DST;75221
+Dragon's Claw;M10;75221
+Dragon's Claw;M11;75221
+Dragon's Claw;M12;75221
+Dragon's Eye Savants;KTK;157011
+Dragon's Eye Sentry;DTK;160119
+Dragon's Herald;ALA;115174
+Dragonlair Spider;PC2;140361
+Dragonlair Spider;PZ1;140361
+Dragonloft Idol;DTK;159801
+Dragonlord Atarka;DTK;159737
+Dragonlord Dromoka;DTK;159747
+Dragonlord Kolaghan;DTK;159830
+Dragonlord Ojutai;DTK;159783
+Dragonlord Silumgar;DTK;159712
+Dragonlord's Prerogative;DTK;160162
+Dragonlord's Servant;DTK;159693
+Dragonlord's Servant;PRM;160036
+Dragonmaster Outcast;BFZ;126481
+Dragonmaster Outcast;DPA;126481
+Dragonmaster Outcast;WWK;126481
+Dragonrage;FRF;157160
+Dragonscale Boon;KTK;157052
+Dragonscale Boon;PRM;159874
+Dragonscale General;FRF;157291
+Dragonscale General;PRM;158884
+Dragonshift;DGM;147721
+Dragonskull Summit;M10;121671
+Dragonskull Summit;M11;121671
+Dragonskull Summit;M12;121671
+Dragonskull Summit;M13;121671
+Dragonskull Summit;XLN;404081
+Dragonsoul Knight;CON;118784
+Dragonsoul Knight;MM2;118784
+Dragonspeaker Shaman;DDG;48999
+Dragonspeaker Shaman;DPA;48999
+Dragonspeaker Shaman;SCG;48999
+Dragonstalker;SCG;48098
+Dragonstorm;DRB;48992
+Dragonstorm;MMA;48992
+Dragonstorm;SCG;48992
+Dragonstorm;TSB;48992
+Drain Life;2ED;68
+Drain Life;3ED;68
+Drain Life;4ED;68
+Drain Life;5ED;2352
+Drain Life;LEA;68
+Drain Life;LEB;68
+Drain Life;MIR;1858
+Drain Life;PRM;68
+Drain Power;2ED;69
+Drain Power;3ED;69
+Drain Power;4ED;69
+Drain Power;5ED;2353
+Drain Power;LEA;69
+Drain Power;LEB;69
+Drain Power;ME4;69
+Drain the Well;EVE;113612
+Draining Whelk;DPA;97388
+Draining Whelk;TSP;97388
+Drainpipe Vermin;RTR;145126
+Drake Familiar;RAV;88949
+Drake Hatchling;MMQ;19308
+Drake Haven;AKH;400801
+Drake Umbra;DPA;127399
+Drake Umbra;ROE;127399
+Drake-Skull Cameo;INV;25167
+Drake;TOK;143889
+Drake;TOK;400960
+Drake;TOK;94685
+Drakestown Forgotten;VMA;153154
+Drakewing Krasis;GTC;146301
+Dralnu, Lich Lord;TSP;97428
+Dralnu's Crusade;PLS;27966
+Dralnu's Pet;PLS;27905
+Dramatic Entrance;SHM;111789
+Dramatic Rescue;RTR;145884
+Dramatic Reversal;KLD;162488
+Drana, Kalastria Bloodchief;C14;127370
+Drana, Kalastria Bloodchief;DPA;127370
+Drana, Kalastria Bloodchief;ROE;127370
+Drana, Liberator of Malakir;BFZ;160673
+Drana's Chosen;OGW;161227
+Drana's Emissary;BFZ;160723
+Drastic Revelation;ARB;118728
+Dread Cacodemon;CMD;121067
+Dread Charge;POR;6572
+Dread Defiler;OGW;161224
+Dread Defiler;PRM;161137
+Dread Drone;MM2;127339
+Dread Drone;ROE;127339
+Dread Reaper;ME4;6573
+Dread Reaper;POR;6573
+Dread Return;C14;97474
+Dread Return;PD3;97474
+Dread Return;PRM;161781
+Dread Return;TD0;97474
+Dread Return;TSP;97474
+Dread Slag;DIS;94391
+Dread Slaver;AVR;141552
+Dread Specter;MIR;1859
+Dread Statuary;DDM;126755
+Dread Statuary;WWK;126755
+Dread Summons;PZ1;160444
+Dread Wanderer;AKH;401265
+Dread Warlock;DPA;121641
+Dread Warlock;M10;121641
+Dread Wight;ICE;1133
+Dread Wight;ME4;1133
+Dread of Night;6ED;3224
+Dread of Night;TMP;3224
+Dread;DPA;109030
+Dread;LRW;109030
+Dreadbore;RTR;145202
+Dreadbringer Lampads;JOU;152864
+Dreadship Reef;CMD;97291
+Dreadship Reef;PZ1;97291
+Dreadship Reef;TSP;97291
+Dreadwaters;AVR;141553
+Dreadwaters;ORI;141553
+Dreadwing;CON;118661
+Dream Cache;6ED;1860
+Dream Cache;MIR;1860
+Dream Cache;TMP;3040
+Dream Chisel;ONS;43211
+Dream Coat;LEG;540
+Dream Fighter;MIR;1861
+Dream Fracture;DPA;113664
+Dream Fracture;EVE;113664
+Dream Halls;STH;3639
+Dream Halls;TPR;3639
+Dream Leash;RAV;88986
+Dream Pillager;PZ1;160046
+Dream Prowler;9ED;86922
+Dream Prowler;STH;3674
+Dream Prowler;TPR;3674
+Dream Salvage;SHM;111885
+Dream Stalker;DDM;97306
+Dream Stalker;TSP;97306
+Dream Thief;EVE;113716
+Dream Thrush;INV;25475
+Dream Tides;VIS;2159
+Dream Twist;EMA;138435
+Dream Twist;ISD;138435
+Dream's Grip;MRD;51058
+Dreamborn Muse;10E;47520
+Dreamborn Muse;CMD;47520
+Dreamborn Muse;DPA;47520
+Dreamborn Muse;LGN;47520
+Dreamcaller Siren;XLN;402271
+Dreamcatcher;SOK;86015
+Dreampod Druid;PC2;140377
+Dreampod Druid;VMA;140377
+Dreams of the Dead;ICE;1134
+Dreams of the Dead;ME2;1134
+Dreamscape Artist;PLC;101533
+Dreamspoiler Witches;LRW;106377
+Dreamspoiler Witches;MMA;106377
+Dreamstealer;HOU;401586
+Dreamstealer;TOK;401880
+Dreamstone Hedron;C14;127310
+Dreamstone Hedron;CMD;127310
+Dreamstone Hedron;ROE;127310
+Dreamwinder;ODY;33496
+Dredge;INV;24070
+Dreg Mangler;DDJ;145204
+Dreg Mangler;RTR;145204
+Dreg Reaver;ALA;114966
+Dregs of Sorrow;7ED;27594
+Dregs of Sorrow;C14;3125
+Dregs of Sorrow;TMP;3125
+Dregscape Zombie;ALA;114955
+Dregscape Zombie;MM3;114955
+Dregscape Zombie;PC1;114955
+Drekavac;DIS;94730
+Drelnoch;CSP;96910
+Drift of Phantasms;RAV;88982
+Drift of the Dead;ICE;1135
+Drift of the Dead;ME2;1135
+Drifter il-Dal;TSP;97327
+Drifting Djinn;USG;8680
+Drifting Meadow;C13;148948
+Drifting Meadow;C14;148948
+Drifting Meadow;USG;8715
+Drifting Shade;M12;134079
+Drill-Skimmer;DST;50816
+Drinker of Sorrow;LGN;47510
+Dripping Dead;LGN;46590
+Dripping-Tongue Zubera;COK;82637
+Driven;HOU;401534
+Driver of the Dead;AVR;141508
+Drogskol Captain;DKA;139777
+Drogskol Cavalry;PRM;161660
+Drogskol Cavalry;SOI;161537
+Drogskol Reaver;DKA;139896
+Drogskol Shieldmate;EMN;162041
+Dromad Purebred;RAV;88901
+Dromar, the Banisher;INV;25163
+Dromar's Attendant;INV;25164
+Dromar's Cavern;PLS;27906
+Dromar's Charm;C13;148951
+Dromar's Charm;PLS;27907
+Dromoka Captain;DTK;160087
+Dromoka Dunecaster;DTK;160128
+Dromoka Monument;DTK;159768
+Dromoka Warrior;DTK;159856
+Dromoka, the Eternal;FRF;157145
+Dromoka, the Eternal;PRM;160421
+Dromoka's Command;DTK;159865
+Dromoka's Gift;DTK;159755
+Dromosaur;USG;8671
+Dronepack Kindred;EMN;161973
+Droning Bureaucrats;GPT;91756
+Drooling Groodion;DDM;88977
+Drooling Groodion;DPA;88977
+Drooling Groodion;MM2;88977
+Drooling Groodion;RAV;88977
+Drooling Groodion;TD2;88977
+Drooling Ogre;DST;52043
+Drop of Honey;ARN;325
+Drop of Honey;ME4;325
+Dross Crocodile;10E;104562
+Dross Crocodile;5DN;77169
+Dross Golem;DST;75171
+Dross Harvester;MRD;51011
+Dross Hopper;SOM;130943
+Dross Prowler;MRD;51078
+Dross Ripper;MBS;133207
+Dross Scorpion;MRD;51022
+Drought;ICE;1136
+Drove of Elves;C14;111820
+Drove of Elves;DPA;111820
+Drove of Elves;SHM;111820
+Drover of the Mighty;XLN;402107
+Drown in Filth;DGM;147769
+Drown in Sorrow;BNG;152069
+Drowned Catacomb;M10;121655
+Drowned Catacomb;M11;121655
+Drowned Catacomb;M12;121655
+Drowned Catacomb;M13;121655
+Drowned Catacomb;XLN;402110
+Drowned Rusalka;GPT;91877
+Drowned;DRK;756
+Drowned;ME4;756
+Drowner Initiate;SHM;111563
+Drowner of Hope;BFZ;160860
+Drowner of Hope;PRM;160639
+Drowner of Secrets;LRW;106386
+Drownyard Behemoth;EMN;161928
+Drownyard Explorers;SOI;161645
+Drownyard Temple;SOI;161849
+Drudge Beetle;RTR;145141
+Drudge Reavers;TSP;97302
+Drudge Skeletons;10E;27595
+Drudge Skeletons;2ED;70
+Drudge Skeletons;3ED;70
+Drudge Skeletons;4ED;70
+Drudge Skeletons;5ED;2354
+Drudge Skeletons;6ED;2354
+Drudge Skeletons;7ED;27595
+Drudge Skeletons;8ED;27595
+Drudge Skeletons;9ED;27595
+Drudge Skeletons;DDD;122151
+Drudge Skeletons;DPA;27595
+Drudge Skeletons;LEA;70
+Drudge Skeletons;LEB;70
+Drudge Skeletons;M10;122151
+Drudge Spell;HML;1489
+Druid Lyrist;ODY;33324
+Druid of the Anima;ALA;115003
+Druid of the Cowl;AER;400332
+Druid's Call;ODY;33286
+Druid's Deliverance;MM3;145878
+Druid's Deliverance;RTR;145878
+Druid's Familiar;AVR;141633
+Druidic Satchel;C13;134081
+Druidic Satchel;M12;134081
+Druids' Repository;AVR;141676
+Drumhunter;ALA;115384
+Drumhunter;C13;115384
+Drunau Corpse Trawler;SOI;161706
+Dry Spell;6ED;1490
+Dry Spell;HML;1490
+Dry Spell;HML;1491
+Dry Spell;ME2;1490
+Dry Spell;POR;6574
+Dryad Arbor;FUT;102485
+Dryad Arbor;V12;143415
+Dryad Militant;PRM;145180
+Dryad Militant;PRM;145916
+Dryad Militant;RTR;145180
+Dryad Sophisticate;GPT;91675
+Dryad's Caress;RAV;90342
+Dryad's Favor;M11;129161
+Dual Casting;AVR;141679
+Dual Nature;PCY;23828
+Dual Shot;SOI;161711
+Dual Shot;XLN;402007
+Dualcaster Mage;C14;152943
+Dualcaster Mage;EMA;152943
+Dualcaster Mage;PRM;152943
+Dubious Challenge;KLD;162555
+Duct Crawler;10E;3675
+Duct Crawler;STH;3675
+Due Respect;NPH;134416
+Dueling Grounds;INV;25666
+Duelist's Heritage;PZ2;162447
+Duergar Assailant;EVE;113211
+Duergar Cave-Guard;EVE;112141
+Duergar Hedge-Mage;CMD;113768
+Duergar Hedge-Mage;EVE;113768
+Duergar Hedge-Mage;PC1;113768
+Duergar Hedge-Mage;PRM;113862
+Duergar Mine-Captain;EVE;113622
+Dukhara Peafowl;KLD;162344
+Dukhara Scavenger;KLD;162274
+Dulcet Sirens;C14;156426
+Dune Beetle;AKH;400751
+Dune Diviner;HOU;401565
+Dune-Brood Nephilim;GPT;91861
+Duneblast;KTK;157075
+Dunerider Outlaw;PLC;100805
+Dunes of the Dead;HOU;401853
+Dungeon Geists;C13;139801
+Dungeon Geists;DKA;139801
+Dungeon Shade;STH;3676
+Dungeon Shade;TPR;3676
+Dungrove Elder;DPA;134123
+Dungrove Elder;M12;134123
+Dungrove Elder;PRM;137412
+Duplicant;EMA;147110
+Duplicant;MRD;51127
+Duplicant;MS2;400928
+Duplicant;PRM;147110
+Duplicant;PZ1;147110
+Duplicant;TD2;51127
+Duplicity;TMP;3173
+Durable Handicraft;KLD;162541
+Duress;7ED;27589
+Duress;DDC;122154
+Duress;DTK;159709
+Duress;EMA;122154
+Duress;M10;122154
+Duress;M11;122154
+Duress;M13;122154
+Duress;M14;122154
+Duress;PD3;122154
+Duress;PRM;8887
+Duress;USG;8887
+Duress;XLN;402004
+Durkwood Baloth;MMA;97287
+Durkwood Baloth;TSP;97287
+Durkwood Boars;4ED;541
+Durkwood Boars;5ED;541
+Durkwood Boars;LEG;541
+Durkwood Tracker;TSP;97519
+Dusk Feaster;EMN;161949
+Dusk Imp;10E;104520
+Dusk Imp;8ED;33435
+Dusk Imp;DDC;104520
+Dusk Imp;DPA;104520
+Dusk Imp;ODY;33435
+Dusk Legion Dreadnought;XLN;402229
+Dusk Urchins;SHM;111599
+Dusk;AKH;401983
+Duskborne Skymarcher;XLN;402317
+Duskdale Wurm;DPA;113643
+Duskdale Wurm;EVE;113643
+Duskdale Wurm;M11;113643
+Duskdale Wurm;M13;113643
+Duskhunter Bat;DDK;134144
+Duskhunter Bat;DPA;134144
+Duskhunter Bat;M12;134144
+Duskhunter Bat;MM2;134144
+Duskmantle Guildmage;GTC;145189
+Duskmantle Prowler;DPA;143865
+Duskmantle Prowler;M13;143865
+Duskmantle Seer;GTC;146476
+Duskmantle, House of Shadow;RAV;88720
+Duskrider Falcon;WTH;2838
+Duskrider Peregrine;TSP;97311
+Duskwalker;INV;24088
+Duskwatch Recruiter;SOI;161733
+Duskworker;MRD;50228
+Dust Bowl;EXP;160960
+Dust Bowl;MMQ;19287
+Dust Corona;PLC;102167
+Dust Elemental;PLC;97390
+Dust Stalker;BFZ;160854
+Dust of Moments;FUT;102495
+Dust to Dust;5ED;2355
+Dust to Dust;DRK;757
+Dust to Dust;ME4;757
+Dust to Dust;MED;757
+Dust;HOU;401862
+Dutiful Attendant;DTK;159868
+Dutiful Return;BFZ;160915
+Dutiful Return;KTK;157026
+Dutiful Servants;HOU;401542
+Dutiful Thrull;GTC;146246
+Duty-Bound Dead;DPA;143842
+Duty-Bound Dead;M13;143842
+Dwarven Armorer;FEM;878
+Dwarven Armory;ICE;1137
+Dwarven Berserker;WTH;2818
+Dwarven Blastminer;ONS;43112
+Dwarven Bloodboiler;JUD;40255
+Dwarven Catapult;5ED;879
+Dwarven Catapult;FEM;879
+Dwarven Catapult;MED;879
+Dwarven Demolition Team;2ED;71
+Dwarven Demolition Team;8ED;49245
+Dwarven Demolition Team;LEA;71
+Dwarven Demolition Team;LEB;71
+Dwarven Driller;JUD;40248
+Dwarven Grunt;ODY;33386
+Dwarven Hold;5ED;2356
+Dwarven Hold;FEM;880
+Dwarven Landslide;APC;31099
+Dwarven Lieutenant;FEM;881
+Dwarven Miner;MIR;1862
+Dwarven Nomad;MIR;1863
+Dwarven Patrol;APC;31133
+Dwarven Pony;HML;1492
+Dwarven Recruiter;ODY;33364
+Dwarven Ruins;5ED;2357
+Dwarven Ruins;6ED;2357
+Dwarven Ruins;FEM;882
+Dwarven Ruins;ME2;882
+Dwarven Scorcher;JUD;40242
+Dwarven Sea Clan;HML;1493
+Dwarven Shrine;ODY;33334
+Dwarven Soldier;5ED;883
+Dwarven Soldier;FEM;883
+Dwarven Soldier;FEM;884
+Dwarven Soldier;FEM;885
+Dwarven Soldier;MED;884
+Dwarven Song;LEG;542
+Dwarven Strike Force;ODY;33336
+Dwarven Thaumaturgist;WTH;2888
+Dwarven Trader;HML;1494
+Dwarven Trader;HML;1495
+Dwarven Vigilantes;VIS;2160
+Dwarven Warriors;2ED;72
+Dwarven Warriors;3ED;72
+Dwarven Warriors;4ED;72
+Dwarven Warriors;5ED;72
+Dwarven Warriors;LEA;72
+Dwarven Warriors;LEB;72
+Dwarven Weaponsmith;3ED;408
+Dwarven Weaponsmith;ATQ;408
+Dwell on the Past;TOR;36519
+Dwynen, Gilt-Leaf Daen;ORI;159398
+Dwynen, Gilt-Leaf Daen;PRM;160415
+Dwynen's Elite;ORI;160323
+Dying Wail;UD;15635
+Dying Wish;GTC;146543
+Dynacharge;MM3;145137
+Dynacharge;RTR;145137
+Dynavolt Tower;KLD;162597
+Dystopia;ALL;1616
+Dystopia;ME2;1616
+Déjà Vu;PO2;4687
+Déjà Vu;POR;6615
+Eager Cadet;7ED;27854
+Eager Cadet;8ED;27854
+Eager Cadet;9ED;17561
+Eager Construct;KLD;162334
+Eagle of the Watch;JOU;152837
+Eagle of the Watch;ORI;152837
+Early Frost;5DN;77218
+Early Harvest;6ED;1864
+Early Harvest;7ED;27596
+Early Harvest;9ED;27596
+Early Harvest;MIR;1864
+Earnest Fellowship;ODY;33507
+Earsplitting Rats;JUD;36442
+Earth Elemental;10E;104525
+Earth Elemental;2ED;73
+Earth Elemental;3ED;73
+Earth Elemental;4ED;73
+Earth Elemental;DPA;104525
+Earth Elemental;LEA;73
+Earth Elemental;LEB;73
+Earth Rift;ODY;33332
+Earth Servant;DDI;129080
+Earth Servant;DPA;129080
+Earth Servant;M11;129080
+Earth Surge;GPT;91848
+Earth;AKH;401053
+Earthbind;2ED;74
+Earthbind;3ED;74
+Earthbind;LEA;74
+Earthbind;LEB;74
+Earthblighter;LGN;47474
+Earthbrawn;MOR;109609
+Earthcraft;TMP;3138
+Earthen Arms;BFZ;160873
+Earthen Goo;CSP;96990
+Earthlink;ICE;1138
+Earthlink;ME2;1138
+Earthlore;ICE;1139
+Earthquake;2ED;75
+Earthquake;3ED;75
+Earthquake;4ED;75
+Earthquake;5ED;2358
+Earthquake;6ED;2358
+Earthquake;7ED;27597
+Earthquake;CMD;6690
+Earthquake;DPA;27597
+Earthquake;LEA;75
+Earthquake;LEB;75
+Earthquake;M10;6690
+Earthquake;PO2;4759
+Earthquake;POR;6690
+Earthshaker Khenra;HOU;401812
+Earthshaker Khenra;TOK;401841
+Earthshaker;COK;81100
+Earwig Squad;MMA;109998
+Earwig Squad;MOR;109998
+Earwig Squad;PRM;109998
+Eastern Paladin;7ED;27629
+Eastern Paladin;8ED;8682
+Eastern Paladin;USG;8682
+Eaten by Spiders;AVR;141773
+Eater of Days;DST;75175
+Eater of Hope;BNG;152093
+Eater of Hope;PRM;152575
+Eater of the Dead;DRK;758
+Eater of the Dead;MED;758
+Ebon Dragon;DRB;6575
+Ebon Dragon;ME4;6575
+Ebon Dragon;POR;6575
+Ebon Drake;5DN;50836
+Ebon Praetor;FEM;886
+Ebon Praetor;ME2;886
+Ebon Stronghold;5ED;2359
+Ebon Stronghold;6ED;2359
+Ebon Stronghold;FEM;887
+Ebon Stronghold;ME2;887
+Ebon Stronghold;PD3;2359
+Ebonblade Reaper;ONS;43071
+Ebony Charm;MIR;1865
+Ebony Horse;3ED;326
+Ebony Horse;4ED;326
+Ebony Horse;ARN;326
+Ebony Horse;ME4;326
+Ebony Owl Netsuke;SOK;86173
+Ebony Rhino;HML;1496
+Ebony Rhino;ME4;1496
+Ebony Treefolk;APC;31159
+Echo Chamber;TMP;3094
+Echo Circlet;SOM;131081
+Echo Mage;C13;127448
+Echo Mage;ROE;127448
+Echo Tracer;LGN;46553
+Echoes of the Kin Tree;DTK;160016
+Echoing Calm;DST;51898
+Echoing Courage;DST;51901
+Echoing Courage;MMA;51901
+Echoing Decay;DST;51902
+Echoing Ruin;DST;51899
+Echoing Truth;DDF;51900
+Echoing Truth;DST;51900
+Echoing Truth;MMA;51900
+Eddytrail Hawk;KLD;162458
+Edge of Autumn;DDG;102334
+Edge of Autumn;FUT;102334
+Edge of Autumn;TD0;102334
+Edge of Malacol;PC2;138718
+Edge of the Divinity;EVE;113641
+Edgewalker;SCG;48952
+Edifice of Authority;AKH;400829
+Edric, Spymaster of Trest;CMD;137526
+Edric, Spymaster of Trest;DPA;137526
+Edric, Spymaster of Trest;PZ1;137526
+Edric, Spymaster of Trest;VMA;137526
+Eel Umbra;DPA;127304
+Eel Umbra;ROE;127304
+Eerie Interlude;SOI;161722
+Eerie Procession;COK;82612
+Efficient Construction;AER;400270
+Efreet Weaponmaster;KTK;157067
+Ego Erasure;LRW;105452
+Eidolon of Blossoms;JOU;152980
+Eidolon of Blossoms;PRM;155420
+Eidolon of Countless Battles;BNG;152088
+Eidolon of Rhetoric;JOU;153071
+Eidolon of the Great Revel;JOU;153080
+Eiganjo Castle;COK;81091
+Eiganjo Free-Riders;SOK;86090
+Eight-and-a-Half-Tails;COK;80583
+Eight-and-a-Half-Tails;EMA;80583
+Eightfold Maze;ME3;9016
+Eightfold Maze;PTK;9016
+Ekundu Cyclops;MIR;1866
+Ekundu Griffin;6ED;1867
+Ekundu Griffin;MIR;1867
+El-Hajjâj;3ED;327
+El-Hajjâj;4ED;327
+El-Hajjâj;ARN;327
+Elaborate Firecannon;XLN;402857
+Eladamri, Lord of Leaves;TMP;3133
+Eladamri's Call;PLS;27908
+Eladamri's Vineyard;TMP;3130
+Eland Umbra;ROE;127438
+Elbrus, the Binding Blade;DKA;139770
+Elder Cathar;DPA;138221
+Elder Cathar;ISD;138221
+Elder Deep-Fiend;EMN;162051
+Elder Druid;5ED;1140
+Elder Druid;6ED;1140
+Elder Druid;7ED;27599
+Elder Druid;ICE;1140
+Elder Land Wurm;4ED;543
+Elder Land Wurm;LEG;543
+Elder Land Wurm;MED;543
+Elder Mastery;CON;118747
+Elder Mastery;DDH;118747
+Elder Pine of Jukai;SOK;86076
+Elder Spawn;LEG;4625
+Elder of Laurels;ISD;138502
+Elderscale Wurm;DPA;143888
+Elderscale Wurm;M13;143888
+Elderwood Scion;PC2;140360
+Eldrazi Aggressor;OGW;161127
+Eldrazi Conscription;DPA;127303
+Eldrazi Conscription;ROE;127303
+Eldrazi Devastator;BFZ;161126
+Eldrazi Displacer;OGW;161196
+Eldrazi Horror;TOK;162027
+Eldrazi Mimic;OGW;161116
+Eldrazi Monument;ZEN;123741
+Eldrazi Obligator;OGW;161233
+Eldrazi Scion;TOK;160844
+Eldrazi Scion;TOK;160897
+Eldrazi Scion;TOK;160929
+Eldrazi Scion;TOK;161190
+Eldrazi Scion;TOK;161191
+Eldrazi Scion;TOK;161193
+Eldrazi Skyspawner;BFZ;160636
+Eldrazi Spawn;TOK;127496
+Eldrazi Spawn;TOK;127508
+Eldrazi Spawn;TOK;127514
+Eldrazi Temple;MM2;127482
+Eldrazi Temple;ROE;127482
+Eldrazi;TOK;143409
+Eldrazi;TOK;160882
+Eldritch Evolution;EMN;162132
+Electric Eel;DRK;759
+Electrickery;RTR;145138
+Electrify;AKH;400841
+Electrolyze;CMD;91656
+Electrolyze;DPA;91656
+Electrolyze;GPT;91656
+Electrolyze;MM2;91656
+Electrolyze;MMA;91656
+Electrolyze;PRM;91656
+Electrolyze;PZ1;91656
+Electropotence;DPA;123709
+Electropotence;ZEN;123709
+Electrostatic Bolt;MRD;50208
+Electrostatic Pummeler;KLD;162628
+Electryte;USG;8654
+Elegant Edgecrafters;KLD;162549
+Elemental Appeal;ZEN;123725
+Elemental Augury;ICE;1141
+Elemental Augury;ME2;1141
+Elemental Bond;ORI;159703
+Elemental Cat;TOK;40824
+Elemental Mastery;SHM;111632
+Elemental Resonance;DIS;94434
+Elemental Shaman;TOK;107650
+Elemental Uprising;OGW;161109
+Elemental;TOK;107639
+Elemental;TOK;107649
+Elemental;TOK;111892
+Elemental;TOK;112139
+Elemental;TOK;113771
+Elemental;TOK;119797
+Elemental;TOK;125095
+Elemental;TOK;127512
+Elemental;TOK;145996
+Elemental;TOK;148783
+Elemental;TOK;148784
+Elemental;TOK;148786
+Elemental;TOK;150892
+Elemental;TOK;151774
+Elemental;TOK;152109
+Elemental;TOK;156421
+Elemental;TOK;160418
+Elemental;TOK;160861
+Elemental;TOK;161060
+Elemental;TOK;161242
+Elemental;TOK;161253
+Elemental;TOK;44678
+Elemental;TOK;51117
+Elemental;TOK;77062
+Elemental;TOK;77063
+Elemental;TOK;82651
+Elemental;TOK;87231
+Elemental;TOK;94298
+Elephant Ambush;ODY;34362
+Elephant Grass;VIS;2161
+Elephant Graveyard;ARN;328
+Elephant Graveyard;ME4;328
+Elephant Guide;DDD;40284
+Elephant Guide;DPA;131668
+Elephant Guide;EMA;131668
+Elephant Guide;JUD;40284
+Elephant Guide;VMA;131668
+Elephant Resurgence;PCY;21194
+Elephant;TOK;100407
+Elephant;TOK;126530
+Elephant;TOK;143401
+Elephant;TOK;33667
+Elephant;TOK;37222
+Elesh Norn, Grand Cenobite;MM2;134207
+Elesh Norn, Grand Cenobite;NPH;134207
+Elesh Norn, Grand Cenobite;PRM;134207
+Elf Druid;TOK;156423
+Elf Replica;MRD;50236
+Elf Warrior;TOK;107641
+Elf Warrior;TOK;111896
+Elf Warrior;TOK;111902
+Elf;TOK;95878
+Elfhame Palace;8ED;49262
+Elfhame Palace;DDE;25584
+Elfhame Palace;INV;25584
+Elfhame Palace;TD0;25584
+Elfhame Sanctuary;INV;24169
+Elgaud Inquisitor;DKA;139780
+Elgaud Inquisitor;DPA;139780
+Elgaud Shieldmate;AVR;141513
+Eliminate the Competition;KLD;162497
+Elite Arcanist;M14;147480
+Elite Archers;7ED;27600
+Elite Archers;8ED;8916
+Elite Archers;USG;8916
+Elite Cat Warrior;ME4;6649
+Elite Cat Warrior;POR;6649
+Elite Inquisitor;ISD;138491
+Elite Inquisitor;PRM;139460
+Elite Javelineer;8ED;3055
+Elite Javelineer;TMP;3055
+Elite Scaleguard;FRF;157289
+Elite Skirmisher;BNG;152530
+Elite Vanguard;DDF;103534
+Elite Vanguard;DPA;103534
+Elite Vanguard;EMA;103534
+Elite Vanguard;M10;103534
+Elite Vanguard;M11;103534
+Elite Vanguard;M12;103534
+Elixir of Immortality;DDF;129148
+Elixir of Immortality;DPA;129148
+Elixir of Immortality;M11;129148
+Elixir of Immortality;M12;129148
+Elixir of Immortality;M13;129148
+Elixir of Immortality;M14;129148
+Elixir of Vitality;MIR;1868
+Elkin Bottle;5ED;1142
+Elkin Bottle;ICE;1142
+Elkin Bottle;ME2;1142
+Elkin Lair;VIS;2162
+Eloren Wilds;PC1;125903
+Elsewhere Flask;SHM;102388
+Elspeth Tirel;SOM;131131
+Elspeth, Knight-Errant;ALA;114973
+Elspeth, Knight-Errant;DDF;130867
+Elspeth, Knight-Errant;MMA;114973
+Elspeth, Sun's Champion;PRM;159751
+Elspeth, Sun's Champion;THS;149143
+Elusive Krasis;GTC;146422
+Elusive Spellfist;DTK;159850
+Elusive Tormentor;PRM;161755
+Elusive Tormentor;SOI;162024
+Elven Cache;6ED;6651
+Elven Cache;POR;6651
+Elven Cache;TD0;2163
+Elven Cache;VIS;2163
+Elven Fortress;FEM;888
+Elven Fortress;FEM;889
+Elven Fortress;FEM;890
+Elven Fortress;FEM;891
+Elven Lyre;FEM;892
+Elven Lyre;ME2;892
+Elven Palisade;EXO;5655
+Elven Riders;10E;43183
+Elven Riders;4ED;544
+Elven Riders;5ED;2360
+Elven Riders;6ED;2360
+Elven Riders;DPA;43183
+Elven Riders;LEG;544
+Elven Riders;ONS;43183
+Elven Rite;STH;3678
+Elven Rite;TPR;3678
+Elven Warhounds;TMP;3134
+Elves of Deep Shadow;DDJ;88793
+Elves of Deep Shadow;DRK;760
+Elves of Deep Shadow;ME3;760
+Elves of Deep Shadow;PRM;760
+Elves of Deep Shadow;RAV;88793
+Elvish Aberration;CMD;48110
+Elvish Aberration;PRM;48110
+Elvish Aberration;SCG;48110
+Elvish Aberration;VMA;48110
+Elvish Archdruid;C14;121692
+Elvish Archdruid;M10;121692
+Elvish Archdruid;M11;121692
+Elvish Archdruid;M12;121692
+Elvish Archdruid;M13;121692
+Elvish Archers;2ED;76
+Elvish Archers;3ED;76
+Elvish Archers;4ED;76
+Elvish Archers;5ED;76
+Elvish Archers;6ED;76
+Elvish Archers;7ED;27601
+Elvish Archers;LEA;76
+Elvish Archers;LEB;76
+Elvish Bard;9ED;86895
+Elvish Bard;ALL;1617
+Elvish Berserker;10E;6102
+Elvish Berserker;9ED;6102
+Elvish Berserker;EXO;6102
+Elvish Branchbender;DPA;106409
+Elvish Branchbender;LRW;106409
+Elvish Champion;10E;25888
+Elvish Champion;7ED;27602
+Elvish Champion;8ED;49096
+Elvish Champion;9ED;25888
+Elvish Champion;DPA;25888
+Elvish Champion;INV;25888
+Elvish Champion;PRM;110212
+Elvish Eulogist;DPA;105564
+Elvish Eulogist;EVG;105564
+Elvish Eulogist;LRW;105564
+Elvish Farmer;FEM;893
+Elvish Farmer;ME2;893
+Elvish Fury;TMP;3005
+Elvish Fury;TPR;3005
+Elvish Guidance;ONS;43164
+Elvish Handservant;LRW;106419
+Elvish Harbinger;EVG;105398
+Elvish Harbinger;LRW;105398
+Elvish Healer;ICE;1143
+Elvish Herder;USG;8739
+Elvish Hexhunter;SHM;111537
+Elvish Hunter;FEM;894
+Elvish Hunter;FEM;895
+Elvish Hunter;FEM;896
+Elvish Hunter;ME2;896
+Elvish Lookout;UD;15775
+Elvish Lyrist;7ED;27603
+Elvish Lyrist;8ED;27603
+Elvish Lyrist;DPA;8767
+Elvish Lyrist;PRM;8767
+Elvish Lyrist;USG;8767
+Elvish Mystic;C14;147464
+Elvish Mystic;M14;147464
+Elvish Mystic;M15;147464
+Elvish Mystic;PRM;152593
+Elvish Pathcutter;ONS;44668
+Elvish Pioneer;8ED;49677
+Elvish Pioneer;ONS;43151
+Elvish Pioneer;PRM;156883
+Elvish Piper;10E;86736
+Elvish Piper;7ED;27604
+Elvish Piper;8ED;27604
+Elvish Piper;9ED;86736
+Elvish Piper;DPA;86736
+Elvish Piper;M10;86736
+Elvish Piper;UD;15673
+Elvish Promenade;DPA;105438
+Elvish Promenade;EVG;105438
+Elvish Promenade;LRW;105438
+Elvish Ranger;ALL;1618
+Elvish Ranger;ALL;1619
+Elvish Ranger;ME2;1618
+Elvish Ranger;POR;6652
+Elvish Scout;FEM;897
+Elvish Scout;FEM;898
+Elvish Scout;FEM;899
+Elvish Scrapper;8ED;43153
+Elvish Scrapper;ONS;43153
+Elvish Skysweeper;C13;88918
+Elvish Skysweeper;C14;88918
+Elvish Skysweeper;DPA;88918
+Elvish Skysweeper;RAV;88918
+Elvish Soultiller;LGN;47472
+Elvish Spirit Guide;ALL;1620
+Elvish Spirit Guide;ME2;1620
+Elvish Spirit Guide;PRM;402824
+Elvish Vanguard;DPA;148335
+Elvish Vanguard;EMA;148335
+Elvish Vanguard;ONS;43205
+Elvish Visionary;ALA;115155
+Elvish Visionary;C14;115155
+Elvish Visionary;DPA;115155
+Elvish Visionary;M10;115155
+Elvish Visionary;M13;115155
+Elvish Visionary;ORI;115155
+Elvish Visionary;PRM;128451
+Elvish Visionary;TD0;115155
+Elvish Warrior;9ED;44730
+Elvish Warrior;DPA;109988
+Elvish Warrior;EVG;44730
+Elvish Warrior;MOR;109988
+Elvish Warrior;ONS;44730
+Emancipation Angel;AVR;141525
+Embalmed Brawler;LGN;47486
+Embalmer's Tools;AKH;400798
+Embargo;MMQ;18985
+Ember Beast;GTC;146285
+Ember Beast;ODY;33361
+Ember Gale;SHM;111877
+Ember Hauler;DPA;129173
+Ember Hauler;M11;129173
+Ember Shot;DPA;36485
+Ember Shot;JUD;36485
+Ember Swallower;PRM;151412
+Ember Swallower;THS;150760
+Ember Weaver;CON;118761
+Ember-Eye Wolf;SOI;161440
+Ember-Fist Zubera;COK;82635
+Emberhorn Minotaur;AKH;401322
+Embermage Goblin;ONS;43093
+Embermaw Hellion;ORI;157372
+Embersmith;SOM;130922
+Emberstrike Duo;SHM;111750
+Emberwilde Augur;EVG;102429
+Emberwilde Augur;FUT;102429
+Emberwilde Caliph;MIR;1869
+Emberwilde Djinn;MIR;1870
+Emblazoned Golem;APC;31046
+Emblem of the Warmind;FUT;102502
+Embodiment of Fury;OGW;161039
+Embodiment of Insight;OGW;161093
+Embodiment of Spring;KTK;156484
+Embolden;ODY;33660
+Embraal Bruiser;KLD;162514
+Embraal Gear-Smasher;AER;400318
+Emerald Charm;VIS;2164
+Emerald Dragonfly;CH;545
+Emerald Dragonfly;LEG;545
+Emerald Medallion;C14;144005
+Emerald Medallion;DPA;144005
+Emerald Medallion;TMP;3111
+Emerald Oryx;M10;43180
+Emerge Unscathed;ROE;127443
+Emergent Growth;XLN;402089
+Emeria Angel;DPA;123678
+Emeria Angel;PRM;125914
+Emeria Angel;ZEN;123678
+Emeria Shepherd;BFZ;160886
+Emeria, the Sky Ruin;C14;123690
+Emeria, the Sky Ruin;ZEN;123690
+Emissary of Despair;DST;50834
+Emissary of Hope;DST;52034
+Emissary of Sunrise;XLN;402240
+Emissary of the Sleepless;SOI;161776
+Emmara Tandris;DGM;146796
+Emmessi Tome;EMA;162026
+Emmessi Tome;TMP;3101
+Emmessi Tome;TPR;3101
+Emperor Crocodile;8ED;15704
+Emperor Crocodile;9ED;15704
+Emperor Crocodile;EMA;15704
+Emperor Crocodile;UD;15704
+Emperor's Vanguard;XLN;402232
+Empress Galina;INV;25664
+Empty City Ruse;PTK;8994
+Empty the Catacombs;RAV;89056
+Empty the Pits;KTK;157034
+Empty the Warrens;MMA;148258
+Empty the Warrens;TSP;97358
+Empty-Shrine Kannushi;BOK;83887
+Empyreal Voyager;KLD;162559
+Empyrial Archangel;ALA;115137
+Empyrial Armor;DPA;2848
+Empyrial Armor;PRM;2848
+Empyrial Armor;TD0;2848
+Empyrial Armor;VMA;2848
+Empyrial Armor;WTH;2848
+Empyrial Plate;MRD;51123
+Emrakul, the Aeons Torn;MM2;127274
+Emrakul, the Aeons Torn;PRM;128455
+Emrakul, the Aeons Torn;PRM;400724
+Emrakul, the Aeons Torn;ROE;127274
+Emrakul, the Promised End;EMN;161905
+Emrakul's Evangel;EMN;162403
+Emrakul's Hatcher;ROE;127298
+Emrakul's Influence;EMN;162005
+Enatu Golem;ROE;127393
+Encampment Keeper;XLN;402336
+Encase in Ice;DTK;159720
+Enchanted Being;LEG;546
+Enchanted Evening;SHM;111709
+Enchantment Alteration;CH;547
+Enchantment Alteration;LEG;547
+Enchantment Alteration;USG;8632
+Enchantress's Presence;ONS;43190
+Encircling Fissure;BFZ;160847
+Enclave Cryptologist;ROE;127414
+Enclave Elite;WWK;126498
+Encroach;UD;15632
+Encroaching Wastes;M14;147473
+Encroaching Wastes;PRM;155429
+Encrust;M13;143924
+Encrust;M15;143924
+End Hostilities;KTK;156588
+Endangered Armodon;STH;3679
+Endangered Armodon;TPR;3679
+Endbringer;OGW;161087
+Endbringer;PRM;161269
+Endbringer's Revel;PCY;21972
+Endemic Plague;ONS;43084
+Endless Cockroaches;C13;6576
+Endless Cockroaches;POR;6576
+Endless Horizons;EVE;113744
+Endless Obedience;M15;155381
+Endless One;BFZ;160931
+Endless Ranks of the Dead;DPA;138369
+Endless Ranks of the Dead;ISD;138369
+Endless Sands;HOU;401566
+Endless Scream;TMP;2984
+Endless Swarm;SOK;86151
+Endless Whispers;5DN;77085
+Endless Wurm;USG;8706
+Endoskeleton;USG;8927
+Endrek Sahr, Master Breeder;C13;97416
+Endrek Sahr, Master Breeder;MM2;97416
+Endrek Sahr, Master Breeder;TSP;97416
+Ends;DIS;100949
+Endure;EVE;113710
+Enduring Ideal;SOK;86154
+Enduring Renewal;ICE;1144
+Enduring Renewal;TSB;1144
+Enduring Scalelord;DTK;160108
+Enduring Victory;DTK;159844
+Enemy of the Guildpact;DIS;94410
+Energizer;TMP;3090
+Energy Arc;ALL;1621
+Energy Arc;MED;1621
+Energy Bolt;MIR;1871
+Energy Chamber;5DN;77077
+Energy Chamber;DDF;77077
+Energy Field;USG;8805
+Energy Flux;3ED;409
+Energy Flux;4ED;409
+Energy Flux;5ED;409
+Energy Flux;ATQ;409
+Energy Flux;ME4;409
+Energy Flux;MMQ;19322
+Energy Storm;ICE;1145
+Energy Storm;ME2;1145
+Energy Tap;4ED;548
+Energy Tap;LEG;548
+Energy Vortex;MIR;1872
+Enervate;5ED;1146
+Enervate;ICE;1146
+Enervate;ME2;1146
+Enfeeblement;6ED;1873
+Enfeeblement;9ED;1873
+Enfeeblement;MIR;1873
+Enfeeblement;TMP;2978
+Engineered Explosives;5DN;77090
+Engineered Explosives;MMA;148256
+Engineered Explosives;MS2;400929
+Engineered Might;KLD;162319
+Engineered Plague;7ED;27605
+Engineered Plague;PRM;10540
+Engineered Plague;UL;10540
+Engulf the Shore;SOI;161717
+Engulfing Flames;ODY;33366
+Engulfing Slagwurm;DPA;131189
+Engulfing Slagwurm;SOM;131189
+Enhanced Awareness;FRF;157309
+Enigma Drake;AKH;401271
+Enigma Eidolon;DIS;94656
+Enigma Sphinx;ARB;121009
+Enigma Sphinx;PC2;121009
+Enlarge;DPA;147453
+Enlarge;M14;147453
+Enlightened Ascetic;ORI;160217
+Enlightened Maniac;EMN;162631
+Enlightened Tutor;6ED;1874
+Enlightened Tutor;EMA;161303
+Enlightened Tutor;MIR;1874
+Enlightened Tutor;PRM;1874
+Enlightened Tutor;TD0;1874
+Enlisted Wurm;ARB;121040
+Enlisted Wurm;PC2;121040
+Enlistment Officer;APC;31113
+Enormous Baloth;10E;46595
+Enormous Baloth;8ED;46595
+Enormous Baloth;9ED;46595
+Enormous Baloth;LGN;46595
+Enormous Baloth;M10;46595
+Enrage;8ED;48156
+Enrage;9ED;48156
+Enrage;DPA;48156
+Enrage;SCG;48156
+Enraged Giant;AER;400309
+Enraging Licid;TMP;3262
+Enshrined Memories;BOK;80785
+Enshrouding Mist;ORI;160193
+Enslave;DDD;100689
+Enslave;NPH;134399
+Enslave;PLC;100689
+Enslaved Dwarf;TOR;36475
+Enslaved Horror;MMQ;19229
+Enslaved Scout;ALL;1622
+Enslaved Scout;ALL;1623
+Ensnare;NMS;21288
+Ensnaring Bridge;7ED;27606
+Ensnaring Bridge;8ED;27606
+Ensnaring Bridge;MS2;400930
+Ensnaring Bridge;STH;3658
+Ensoul Artifact;M15;155296
+Ensouled Scimitar;5DN;77134
+Entangler;PCY;22043
+Entangling Trap;LRW;105311
+Entangling Vines;M10;121573
+Enter the Infinite;GTC;146483
+Entering;DGM;151019
+Entering;PRM;151010
+Enthralling Victor;ORI;160285
+Entomb;EMA;161054
+Entomb;MS3;401631
+Entomb;ODY;35351
+Entomb;PD3;35351
+Entomb;PRM;35351
+Entomber Exarch;MM3;134284
+Entomber Exarch;NPH;134284
+Entrails Feaster;ONS;43081
+Entrancing Melody;XLN;402055
+Entrapment Maneuver;PZ2;162367
+Entreat the Angels;AVR;138510
+Entreat the Angels;MM3;138510
+Entreat the Angels;V15;138510
+Entropic Eidolon;DIS;94657
+Entropic Specter;EXO;5633
+Envelop;JUD;40203
+Eon Hub;5DN;77155
+Ephara, God of the Polis;BNG;131624
+Ephara's Enlightenment;BNG;152605
+Ephara's Radiance;BNG;152532
+Ephara's Warden;THS;150883
+Ephemeral Shields;M15;155228
+Ephemeron;EXO;4591
+Ephemeron;TPR;4591
+Ephemeron;VMA;4591
+Epic Confrontation;DTK;159782
+Epic Experiment;RTR;145981
+Epic Proportions;DPA;108067
+Epic Proportions;LRW;108067
+Epic Struggle;JUD;33277
+Epic Struggle;PRM;148338
+Epicenter;ODY;33337
+Epiphany Storm;BNG;152043
+Epiphany at the Drownyard;SOI;161596
+Epitaph Golem;SOI;161481
+Epochrasite;C14;102466
+Epochrasite;FUT;102466
+Epochrasite;MMA;102466
+Equal Treatment;TOR;36405
+Equestrian Skill;SOI;161735
+Equilibrium;7ED;27607
+Equilibrium;EXO;5593
+Equinox;LEG;549
+Equipoise;VIS;2165
+Era of Innovation;KLD;161817
+Eradicate;BOK;83903
+Eradicate;UD;15637
+Erase;KTK;156479
+Erase;M13;143910
+Erase;UL;10396
+Erayo, Soratami Ascendant;SOK;86155
+Erdwal Illuminator;SOI;161723
+Erdwal Ripper;DKA;139807
+Erebos, God of the Dead;THS;149145
+Erebos's Emissary;THS;150788
+Erebos's Titan;ORI;159679
+Erg Raiders;3ED;480
+Erg Raiders;4ED;329
+Erg Raiders;5ED;2361
+Erg Raiders;ARN;329
+Erg Raiders;MED;329
+Erhnam Djinn;ARN;330
+Erhnam Djinn;CH;330
+Erhnam Djinn;JUD;40286
+Erhnam Djinn;VMA;40286
+Erithizon;MMQ;19077
+Eron the Relentless;HML;1497
+Eron the Relentless;TSB;1497
+Erosion;4ED;761
+Erosion;DRK;761
+Errand of Duty;ALL;1624
+Errand of Duty;ALL;1625
+Errand of Duty;ME2;1624
+Errant Doomsayers;TSP;97464
+Errant Ephemeron;DD2;97324
+Errant Ephemeron;DDM;97324
+Errant Ephemeron;MMA;97324
+Errant Ephemeron;TSP;97324
+Errant Minion;ICE;1147
+Errantry;5ED;2362
+Errantry;ICE;1148
+Errantry;ME2;2362
+Erratic Explosion;ONS;43101
+Erratic Explosion;PC2;43101
+Erratic Mutation;MMA;100748
+Erratic Mutation;PLC;100748
+Erratic Portal;DPA;143988
+Erratic Portal;EXO;5631
+Erratic Portal;PRM;143988
+Erratic Portal;TPR;5631
+Error;DIS;100952
+Ersatz Gnomes;MIR;1875
+Ertai, Wizard Adept;EXO;3680
+Ertai, the Corrupted;PLS;27910
+Ertai's Familiar;WTH;2889
+Ertai's Meddling;TMP;3177
+Ertai's Trickery;PLS;27911
+Erupting Dreadwolf;EMN;161972
+Escape Artist;ODY;33494
+Escape Routes;PLS;27912
+Escaped Null;DPA;127451
+Escaped Null;ROE;127451
+Escaped Shapeshifter;TMP;3168
+Esper Battlemage;ALA;114982
+Esper Charm;ALA;114910
+Esper Cormorants;CON;118756
+Esper Panorama;ALA;116197
+Esper Panorama;C13;116197
+Esper Sojourners;ARB;121054
+Esper Stormblade;ARB;121055
+Esperzoa;CON;114960
+Esperzoa;DDF;114960
+Esperzoa;MMA;114960
+Essence Backlash;RTR;145885
+Essence Bottle;TMP;3206
+Essence Depleter;OGW;161225
+Essence Drain;10E;101058
+Essence Drain;DPA;101058
+Essence Drain;DST;52053
+Essence Drain;M13;101058
+Essence Extraction;KLD;162279
+Essence Extraction;PRM;162501
+Essence Feed;ROE;127436
+Essence Filter;ICE;1149
+Essence Filter;ME2;1149
+Essence Flare;ICE;1150
+Essence Flare;ME2;1150
+Essence Flux;SOI;161355
+Essence Fracture;ONS;42981
+Essence Harvest;AVR;141794
+Essence Leak;INV;24184
+Essence Scatter;AKH;401263
+Essence Scatter;M10;103538
+Essence Scatter;M13;103538
+Essence Scatter;M14;103538
+Essence Sliver;LGN;46540
+Essence Sliver;TSB;46540
+Essence Vortex;ICE;1151
+Essence Warden;C14;100695
+Essence Warden;DDH;100695
+Essence Warden;DPA;100695
+Essence Warden;PLC;100695
+Essence of the Wild;ISD;139308
+Etched Champion;DPA;131208
+Etched Champion;MM2;159682
+Etched Champion;SOM;131208
+Etched Monstrosity;MM2;134258
+Etched Monstrosity;NPH;134258
+Etched Oracle;5DN;77191
+Etched Oracle;MM2;77191
+Etched Oracle;MMA;77191
+Etched Oracle;PC1;77191
+Eternal Dominion;SOK;86157
+Eternal Dragon;C13;100411
+Eternal Dragon;PRM;100411
+Eternal Dragon;SCG;48147
+Eternal Dragon;VMA;100411
+Eternal Flame;DRK;762
+Eternal Scourge;EMN;161904
+Eternal Thirst;M15;155362
+Eternal Warrior;4ED;550
+Eternal Warrior;5ED;550
+Eternal Warrior;LEG;550
+Eternal Witness;5DN;77182
+Eternal Witness;CMD;77182
+Eternal Witness;DDJ;77182
+Eternal Witness;DPA;77182
+Eternal Witness;MMA;77182
+Eternal Witness;PRM;110127
+Eternal Witness;PZ1;77182
+Eternal Witness;TD0;77182
+Eternal of Harsh Truths;HOU;401511
+Eternity Snare;BNG;152558
+Eternity Snare;TSP;97278
+Eternity Vessel;ZEN;123654
+Ether Well;MIR;1876
+Ethercaste Knight;ARB;120960
+Ethercaste Knight;MM2;120960
+Ethereal Ambush;FRF;157247
+Ethereal Armor;RTR;145844
+Ethereal Champion;6ED;1877
+Ethereal Champion;MIR;1877
+Ethereal Guidance;SOI;161668
+Ethereal Haze;COK;82645
+Ethereal Usher;RAV;89064
+Ethereal Whiskergill;LRW;105351
+Etherium Abomination;ARB;98608
+Etherium Astrolabe;ALA;115166
+Etherium Cell;TOK;400726
+Etherium Sculptor;ALA;115165
+Etherium Sculptor;DPA;115165
+Etherium Sculptor;MMA;115165
+Etherium-Horn Sorcerer;PC2;140343
+Ethersworn Adjudicator;CON;118676
+Ethersworn Canonist;ALA;115019
+Ethersworn Canonist;MMA;115019
+Ethersworn Canonist;TD0;115019
+Ethersworn Shieldmage;ARB;120979
+Etherwrought Page;ARB;120999
+Eunuchs' Intrigues;PTK;9052
+Eureka;LEG;4626
+Eureka;MED;4626
+Eureka;PRM;149237
+Eureka;VMA;149237
+Evacuation;10E;104524
+Evacuation;7ED;27608
+Evacuation;8ED;3681
+Evacuation;9ED;3681
+Evacuation;DPA;104524
+Evacuation;STH;3681
+Evanescent Intellect;BNG;152023
+Evangel of Heliod;THS;149192
+Evangelize;TSP;97371
+Evaporate;HML;1498
+Evasive Action;APC;27890
+Evasive Action;DDE;27890
+Even the Odds;FUT;102482
+Ever After;SOI;161731
+Everbark Shaman;MOR;109978
+Everflame Eidolon;BNG;152073
+Everflowing Chalice;C14;126542
+Everflowing Chalice;DDF;126542
+Everflowing Chalice;MM2;126542
+Everflowing Chalice;PRM;134047
+Everflowing Chalice;WWK;126542
+Everglades;C14;2166
+Everglades;VIS;2166
+Everglove Courier;ONS;43188
+Everlasting Torment;SHM;111580
+Evermind;SOK;86048
+Evernight Shade;AVR;141666
+Evernight Shade;C14;141666
+Evershrike;EVE;113747
+Evil Eye of Orms-by-Gore;5ED;2363
+Evil Eye of Orms-by-Gore;6ED;2363
+Evil Eye of Orms-by-Gore;LEG;551
+Evil Eye of Orms-by-Gore;TSB;551
+Evil Eye of Urborg;TSP;97264
+Evil Presence;2ED;77
+Evil Presence;3ED;77
+Evil Presence;4ED;77
+Evil Presence;5ED;2364
+Evil Presence;LEA;77
+Evil Presence;LEB;77
+Evil Presence;ME3;77
+Evil Presence;NPH;134321
+Evil Twin;ISD;138315
+Evil Twin;MM3;138315
+Evincar's Justice;CMD;2981
+Evincar's Justice;TMP;2981
+Evincar's Justice;TPR;2981
+Eviscerator;UL;10407
+Evolution Charm;PLC;100723
+Evolution Vat;DIS;94296
+Evolutionary Escalation;PZ2;162446
+Evolutionary Leap;ORI;156397
+Evolving Wilds;AKH;401355
+Evolving Wilds;BFZ;160738
+Evolving Wilds;C13;127296
+Evolving Wilds;C14;127296
+Evolving Wilds;CMD;127296
+Evolving Wilds;DDH;127296
+Evolving Wilds;DDK;127296
+Evolving Wilds;DKA;139837
+Evolving Wilds;DPA;127296
+Evolving Wilds;DTK;159750
+Evolving Wilds;M13;127296
+Evolving Wilds;M15;127296
+Evolving Wilds;MM2;127296
+Evolving Wilds;ORI;127296
+Evolving Wilds;PRM;145891
+Evolving Wilds;PRM;160022
+Evolving Wilds;ROE;127296
+Exalted Angel;ONS;9081
+Exalted Angel;PRM;92881
+Exalted Angel;V15;160775
+Exalted Dragon;EXO;4589
+Exalted Dragon;TPR;4589
+Exava, Rakdos Blood Witch;DGM;146739
+Excavation;PCY;21990
+Excavator;TMP;3208
+Excise;PCY;22096
+Exclude;C14;156388
+Exclude;INV;24073
+Exclude;PRM;156388
+Exclusion Ritual;NPH;134217
+Excommunicate;ALA;117023
+Excommunicate;DPA;117023
+Excommunicate;M10;117023
+Excommunicate;M11;117023
+Excoriate;BNG;152019
+Excruciator;RAV;88890
+Execute;8ED;33413
+Execute;9ED;33413
+Execute;ODY;33413
+Executioner's Capsule;ALA;114999
+Executioner's Capsule;DPA;114999
+Executioner's Capsule;MMA;114999
+Executioner's Hood;DKA;139768
+Executioner's Swing;GTC;146412
+Exemplar of Strength;AKH;401978
+Exert Influence;BFZ;160852
+Exhaustion;9ED;8836
+Exhaustion;PO2;4705
+Exhaustion;POR;6617
+Exhaustion;PTK;9100
+Exhaustion;USG;8836
+Exhume;PD3;8677
+Exhume;TD2;8677
+Exhume;USG;8677
+Exhumer Thrull;GPT;91835
+Exile into Darkness;SOK;86096
+Exile;6ED;1626
+Exile;ALL;1626
+Exile;MED;1626
+Exile;VMA;145060
+Exiled Boggart;LRW;107625
+Exiled Doomsayer;SCG;48099
+Exorcist;DRK;763
+Exorcist;ME3;763
+Exoskeletal Armor;JUD;40283
+Exotic Curse;DDE;25222
+Exotic Curse;INV;25222
+Exotic Disease;PLS;27938
+Exotic Orchard;CON;119806
+Exotic Orchard;PC2;119806
+Expedite;OGW;161240
+Expedition Envoy;BFZ;160823
+Expedition Map;MM2;126609
+Expedition Map;ZEN;126609
+Expedition Raptor;OGW;161045
+Expendable Troops;UL;10346
+Experiment Kraj;DIS;94450
+Experiment One;GTC;146274
+Experiment One;PRM;149963
+Experimental Aviator;KLD;162484
+Exploding Borders;CON;119808
+Exploration;PRM;153365
+Exploration;USG;8897
+Explore;DPA;126486
+Explore;MM3;126486
+Explore;PRM;159695
+Explore;WWK;126486
+Explorer's Scope;ZEN;123675
+Explosive Apparatus;SOI;161395
+Explosive Growth;INV;24052
+Explosive Impact;RTR;145871
+Explosive Revelation;ROE;127293
+Explosive Vegetation;CMD;43176
+Explosive Vegetation;DPA;43176
+Explosive Vegetation;DTK;160168
+Explosive Vegetation;ONS;43176
+Explosive Vegetation;PC1;43176
+Explosive Vegetation;TD0;43176
+Expose Evil;SOI;161614
+Expunge;USG;8824
+Expunge;VMA;8824
+Exquisite Archangel;AER;400254
+Exquisite Blood;AVR;141675
+Exquisite Firecraft;ORI;160293
+Exquisite Firecraft;PRM;161279
+Exsanguinate;DPA;131125
+Exsanguinate;SOM;131125
+Extinction;TMP;3123
+Extinguish All Hope;JOU;152816
+Extinguish;PO2;4691
+Extinguish;PTK;9066
+Extirpate;MMA;100792
+Extirpate;PLC;100792
+Extortion;MMQ;19292
+Extra Arms;SCG;48960
+Extract from Darkness;EMA;153170
+Extract;ODY;33473
+Extractor Demon;CMD;119794
+Extractor Demon;CON;119794
+Extractor Demon;MM3;119794
+Extraplanar Lens;MRD;51128
+Extraplanar Lens;MS2;400931
+Extravagant Spirit;MMQ;19011
+Extricator of Flesh;EMN;162031
+Extricator of Sin;EMN;162046
+Extruder;UD;15682
+Exuberant Firestoker;ALA;115102
+Exultant Cultist;EMN;161939
+Eye Gouge;BNG;152033
+Eye Spy;PO2;4695
+Eye for an Eye;3ED;331
+Eye for an Eye;4ED;331
+Eye for an Eye;5ED;331
+Eye for an Eye;ARN;331
+Eye for an Eye;ME4;331
+Eye of Doom;C13;151741
+Eye of Nowhere;COK;81041
+Eye of Ramos;MMQ;19160
+Eye of Singularity;VIS;2167
+Eye of Ugin;EXP;160958
+Eye of Ugin;MM2;126465
+Eye of Ugin;WWK;126465
+Eye of Yawgmoth;NMS;21195
+Eye of the Storm;RAV;90340
+Eyeblight Assassin;ORI;160265
+Eyeblight Massacre;ORI;159711
+Eyeblight's Ending;DPA;105365
+Eyeblight's Ending;EMA;105365
+Eyeblight's Ending;LRW;105365
+Eyeless Watcher;BFZ;160699
+Eyes in the Skies;MM3;145112
+Eyes in the Skies;RTR;145112
+Eyes of the Watcher;5DN;77230
+Eyes of the Wisent;DPA;105662
+Eyes of the Wisent;LRW;105662
+Ezuri, Claw of Progress;PZ1;160045
+Ezuri, Renegade Leader;C14;130934
+Ezuri, Renegade Leader;DPA;130934
+Ezuri, Renegade Leader;SOM;130934
+Ezuri's Archers;DPA;130883
+Ezuri's Archers;SOM;130883
+Ezuri's Brigade;SOM;131144
+Ezuri's Predation;PZ1;160426
+Fa'adiyah Seer;PLC;100682
+Fable of Wolf and Owl;EVE;113655
+Fabled Hero;THS;150758
+Fabricate;M10;122139
+Fabricate;MRD;51077
+Fabricate;PC1;51077
+Fabrication Module;KLD;162571
+Face of Fear;ODY;33416
+Faceless Butcher;PD3;36443
+Faceless Butcher;TOR;36443
+Faceless Butcher;TSB;36443
+Faceless Devourer;TSP;97350
+Faces of the Past;SCG;48988
+Facevaulter;LRW;105603
+Facevaulter;MMA;105603
+Fact or Fiction;CMD;118219
+Fact or Fiction;DD2;118219
+Fact or Fiction;EMA;24097
+Fact or Fiction;INV;24097
+Fact or Fiction;PRM;24097
+Fact or Fiction;PZ1;118219
+Fact or Fiction;TD0;24097
+Fact or Fiction;V13;24097
+Fact or Fiction;VMA;118219
+Fade Away;EXO;6097
+Fade from Memory;ONS;43060
+Fade into Antiquity;THS;150770
+Faerie Artisans;PZ2;162434
+Faerie Conclave;10E;104517
+Faerie Conclave;C13;104517
+Faerie Conclave;PRM;104517
+Faerie Conclave;UL;13566
+Faerie Harbinger;LRW;105347
+Faerie Impostor;RTR;145897
+Faerie Invaders;M13;143921
+Faerie Macabre;DDD;111761
+Faerie Macabre;MMA;111761
+Faerie Macabre;SHM;111761
+Faerie Mechanist;CON;118741
+Faerie Mechanist;DDF;118741
+Faerie Mechanist;MM2;118741
+Faerie Mechanist;MMA;118741
+Faerie Miscreant;ORI;160223
+Faerie Noble;HML;1499
+Faerie Noble;ME3;1499
+Faerie Rogue;TOK;110120
+Faerie Rogue;TOK;112136
+Faerie Rogue;TOK;160164
+Faerie Squadron;INV;23972
+Faerie Swarm;SHM;111846
+Faerie Tauntings;LRW;105445
+Faerie Trickery;LRW;105354
+Faerie;TOK;89188
+Failed Inspection;KLD;162261
+Failure;AKH;401987
+Fairgrounds Trumpeter;KLD;162548
+Fairgrounds Warden;KLD;162241
+Faith Healer;USG;8746
+Faith Unbroken;EMN;161907
+Faith of the Devoted;AKH;401315
+Faith's Fetters;DDC;122097
+Faith's Fetters;EMA;88633
+Faith's Fetters;RAV;88633
+Faith's Fetters;TD0;88633
+Faith's Reward;M13;143915
+Faith's Shield;DKA;139853
+Faithbearer Paladin;EMN;162045
+Faithful Squire;BOK;83830
+Faithless Looting;C14;139787
+Faithless Looting;DDK;139787
+Faithless Looting;DKA;139787
+Faithless Looting;EMA;139787
+Faithless Looting;PZ1;139787
+Falkenrath Aristocrat;DKA;139883
+Falkenrath Aristocrat;MM3;139883
+Falkenrath Exterminator;AVR;141831
+Falkenrath Gorger;SOI;161356
+Falkenrath Marauders;ISD;138496
+Falkenrath Noble;ISD;138243
+Falkenrath Noble;MM3;138243
+Falkenrath Reaver;EMN;161985
+Falkenrath Reaver;W17;161985
+Falkenrath Torturer;DKA;139854
+Fall of the Gavel;RTR;145190
+Fall of the Hammer;BNG;152048
+Fall of the Titans;OGW;161120
+Fall;DDH;100946
+Fall;DIS;100946
+Fallen Angel;5ED;552
+Fallen Angel;6ED;552
+Fallen Angel;7ED;27609
+Fallen Angel;8ED;50349
+Fallen Angel;CH;552
+Fallen Angel;CMD;50349
+Fallen Angel;DDC;50349
+Fallen Angel;LEG;552
+Fallen Askari;VIS;2168
+Fallen Askari;VMA;2168
+Fallen Cleric;ONS;43030
+Fallen Ferromancer;NPH;134350
+Fallen Ideal;TSP;97451
+Falling Star;LEG;4627
+Falling Timber;PLS;28009
+Fallow Earth;6ED;1878
+Fallow Earth;MIR;1878
+Fallow Wurm;WTH;2808
+Fallowsage;LRW;105443
+False Cure;ONS;43085
+False Dawn;APC;31070
+False Defeat;ME3;9024
+False Defeat;PTK;9024
+False Demise;ALL;1627
+False Demise;ALL;1628
+False Demise;MMQ;19199
+False Memories;TOR;36431
+False Mourning;PTK;9137
+False Orders;2ED;78
+False Orders;LEA;78
+False Orders;LEB;78
+False Peace;POR;6737
+False Prophet;CMD;15697
+False Prophet;PRM;153382
+False Prophet;PRM;15697
+False Prophet;UD;15697
+False Summoning;ME4;4690
+False Summoning;PO2;4690
+Falter;USG;8856
+Falter;VMA;8856
+Fame;HOU;401860
+Familiar Ground;6ED;2929
+Familiar Ground;7ED;27610
+Familiar Ground;WTH;2929
+Familiar's Ruse;LRW;107634
+Familiar's Ruse;MM3;107634
+Famine;C13;152009
+Famine;ME3;9103
+Famine;PTK;9103
+Famine;VMA;152009
+Famished Ghoul;ODY;33415
+Fan Bearer;AKH;400800
+Fanatic of Mogis;THS;150778
+Fanatic of Xenagos;BNG;152608
+Fanatic of Xenagos;PRM;157104
+Fanatical Devotion;NMS;21208
+Fanatical Fever;ICE;1152
+Fang Skulkin;EVE;113758
+Fangren Firstborn;DPA;51931
+Fangren Firstborn;DST;51931
+Fangren Hunter;MRD;50253
+Fangren Marauder;MBS;133127
+Fangren Pathcutter;5DN;77102
+Fanning the Flames;STH;3682
+Fanning the Flames;TPR;3682
+Far Wanderings;TOR;36512
+Far;DGM;147694
+Farbog Boneflinger;DKA;139834
+Farbog Explorer;AVR;141652
+Farbog Revenant;SOI;161760
+Farhaven Elf;C13;111740
+Farhaven Elf;C14;111740
+Farhaven Elf;DPA;111740
+Farhaven Elf;SHM;111740
+Farm;HOU;401835
+Farmstead;2ED;79
+Farmstead;3ED;79
+Farmstead;LEA;79
+Farmstead;LEB;79
+Farrel's Mantle;FEM;900
+Farrel's Mantle;ME2;900
+Farrel's Zealot;FEM;901
+Farrel's Zealot;FEM;902
+Farrel's Zealot;FEM;903
+Farrel's Zealot;ME2;902
+Farrelite Priest;FEM;904
+Farseek;M13;88959
+Farseek;PRM;147349
+Farseek;RAV;88959
+Farsight Mask;MRD;51019
+Farsight Mask;PC2;51019
+Fascination;FRF;157260
+Fastbond;2ED;80
+Fastbond;3ED;80
+Fastbond;LEA;80
+Fastbond;LEB;80
+Fastbond;ME4;80
+Fastbond;VMA;158911
+Fasting;DRK;764
+Fatal Attraction;FUT;102419
+Fatal Blow;6ED;2795
+Fatal Blow;WTH;2795
+Fatal Frenzy;PLC;100757
+Fatal Fumes;DGM;146718
+Fatal Lore;ALL;1629
+Fatal Mutation;SCG;48966
+Fatal Push;AER;400294
+Fatal Push;PRM;401799
+Fate Foretold;THS;150845
+Fate Forgotten;DTK;159777
+Fate Transfer;SHM;111684
+Fate Unraveler;BNG;152574
+Fated Conflagration;BNG;152591
+Fated Conflagration;PRM;152590
+Fated Infatuation;BNG;152563
+Fated Intervention;BNG;152601
+Fated Intervention;PRM;138763
+Fated Retribution;BNG;152545
+Fated Return;BNG;152577
+Fateful Showdown;KLD;162535
+Fatespinner;MRD;50194
+Fatestitcher;ALA;98607
+Fathom Feeder;BFZ;160889
+Fathom Fleet Captain;XLN;402371
+Fathom Fleet Cutthroat;XLN;402059
+Fathom Fleet Firebrand;XLN;402047
+Fathom Mage;GTC;146475
+Fathom Mage;PRM;147346
+Fathom Seer;C14;97535
+Fathom Seer;DD2;97535
+Fathom Seer;TSP;97535
+Fathom Trawl;LRW;106410
+Fatigue;UD;15719
+Fault Line;DPA;8791
+Fault Line;USG;8791
+Fault Riders;PCY;21975
+Faultgrinder;CMD;106372
+Faultgrinder;LRW;106372
+Fauna Shaman;DPA;129146
+Fauna Shaman;M11;129146
+Favor of the Mighty;LRW;105659
+Favor of the Overbeing;EVE;113626
+Favor of the Woods;DKA;139844
+Favorable Destiny;MIR;1879
+Favorable Winds;AVR;141672
+Favorable Winds;DPA;141672
+Favorable Winds;XLN;402239
+Favored Hoplite;THS;149108
+Fear;10E;27611
+Fear;2ED;81
+Fear;3ED;81
+Fear;4ED;81
+Fear;5ED;2365
+Fear;6ED;2365
+Fear;7ED;27611
+Fear;8ED;27611
+Fear;9ED;27611
+Fear;ICE;1153
+Fear;LEA;81
+Fear;LEB;81
+Fearsome Awakening;FRF;157333
+Fearsome Temper;BNG;152044
+Feast of Blood;DPA;123563
+Feast of Blood;ZEN;123563
+Feast of Dreams;JOU;153031
+Feast of Flesh;CSP;96873
+Feast of Worms;COK;80807
+Feast of the Unicorn;6ED;1501
+Feast of the Unicorn;HML;1500
+Feast of the Unicorn;HML;1501
+Feast on the Fallen;M15;155197
+Feast or Famine;ALL;1630
+Feast or Famine;ALL;1631
+Feast or Famine;DDJ;143389
+Feast or Famine;MED;1630
+Feat of Resistance;KTK;156993
+Fecundity;8ED;8765
+Fecundity;C13;8765
+Fecundity;USG;8765
+Feebleness;TSP;97314
+Feed the Clan;KTK;157056
+Feed the Pack;DKA;139893
+Feed;AKH;401043
+Feedback Bolt;5DN;77074
+Feedback;2ED;82
+Feedback;3ED;82
+Feedback;4ED;82
+Feedback;5ED;82
+Feedback;LEA;82
+Feedback;LEB;82
+Feeding Frenzy;ONS;43054
+Feeding Grounds;PC1;125861
+Feeling of Dread;ISD;138415
+Feint;LEG;553
+Feldon of the Third Path;C14;155575
+Feldon of the Third Path;PRM;155575
+Feldon's Cane;5ED;410
+Feldon's Cane;ATQ;410
+Feldon's Cane;CH;410
+Feldon's Cane;TSB;410
+Felhide Brawler;BNG;152028
+Felhide Minotaur;THS;149182
+Felhide Petrifier;JOU;152905
+Felhide Spiritbinder;BNG;152095
+Felidar Cub;BFZ;160859
+Felidar Guardian;AER;400243
+Felidar Sovereign;BFZ;123640
+Felidar Sovereign;DPA;123640
+Felidar Sovereign;ZEN;123640
+Felidar Umbra;PC2;140371
+Fell Flagship;XLN;402301
+Fell Shepherd;C13;151731
+Fell the Mighty;C14;156024
+Fellwar Stone;4ED;765
+Fellwar Stone;5ED;765
+Fellwar Stone;9ED;86937
+Fellwar Stone;CMD;86937
+Fellwar Stone;DRK;765
+Fellwar Stone;ME3;765
+Femeref Archers;10E;104559
+Femeref Archers;6ED;1880
+Femeref Archers;7ED;27612
+Femeref Archers;MIR;1880
+Femeref Enchantress;DPA;2169
+Femeref Enchantress;VIS;2169
+Femeref Healer;MIR;1881
+Femeref Knight;MIR;1882
+Femeref Scouts;MIR;1883
+Fen Hauler;AER;400285
+Fen Stalker;PCY;21976
+Fencer Clique;MOR;110218
+Fencer's Magemark;GPT;91871
+Fencing Ace;DDL;145167
+Fencing Ace;RTR;145167
+Fend Off;UD;15695
+Fendeep Summoner;MOR;109914
+Feral Animist;DGM;147742
+Feral Animist;GPT;91770
+Feral Contest;WWK;126595
+Feral Deceiver;COK;82586
+Feral Hydra;ALA;115048
+Feral Incarnation;M15;155191
+Feral Instinct;VIS;2170
+Feral Invocation;THS;150774
+Feral Krushok;FRF;157258
+Feral Lightning;SOK;86121
+Feral Prowler;HOU;401564
+Feral Ridgewolf;ISD;138102
+Feral Shadow;6ED;1884
+Feral Shadow;MIR;1884
+Feral Shadow;POR;6577
+Feral Thallid;FEM;905
+Feral Thallid;ME2;905
+Feral Throwback;LGN;46525
+Feral Throwback;PRM;46525
+Ferocious Charge;5DN;77181
+Ferocity;MMQ;19290
+Feroz's Ban;5ED;1502
+Feroz's Ban;7ED;27613
+Feroz's Ban;HML;1502
+Ferropede;5DN;75388
+Ferrovore;SOM;130953
+Fertile Ground;8ED;8778
+Fertile Ground;DDE;25150
+Fertile Ground;INV;25150
+Fertile Ground;LRW;105414
+Fertile Ground;PC1;105414
+Fertile Ground;TD0;8778
+Fertile Ground;USG;8778
+Fertile Imagination;DIS;94675
+Fertile Thicket;BFZ;160766
+Fertilid;CMD;109971
+Fertilid;MOR;109971
+Fertilid;PC1;109971
+Fervent Cathar;AVR;141627
+Fervent Cathar;EMA;141627
+Fervent Charge;APC;31122
+Fervent Denial;ODY;33457
+Fervent Paincaster;HOU;401550
+Fervor;6ED;2885
+Fervor;7ED;27614
+Fervor;DPA;27614
+Fervor;M13;27614
+Fervor;WTH;2885
+Festercreep;MOR;109975
+Festergloom;M15;155354
+Festerhide Boar;DDM;138361
+Festerhide Boar;ISD;138361
+Festering Evil;WTH;2921
+Festering Goblin;10E;43038
+Festering Goblin;9ED;43038
+Festering Goblin;DPA;43038
+Festering Goblin;MMA;43038
+Festering Goblin;ONS;43038
+Festering Goblin;PC1;43038
+Festering Goblin;TOK;43038
+Festering March;FUT;102333
+Festering Mummy;AKH;401301
+Festering Newt;M14;147483
+Festering Wound;UD;15636
+Festival of Trokin;PO2;4669
+Festival of the Guildpact;RAV;88836
+Festival;DRK;766
+Fetid Heath;EVE;113689
+Fetid Heath;EXP;161025
+Fetid Horror;MIR;1885
+Fetid Imp;ORI;160255
+Fetid Pools;AKH;400785
+Fettergeist;AVR;141625
+Feudkiller's Verdict;MMA;109922
+Feudkiller's Verdict;MOR;109922
+Fever Charm;ONS;43107
+Fevered Convulsions;TMP;3128
+Fevered Strength;ALL;1632
+Fevered Strength;ALL;1633
+Fevered Strength;ME3;1632
+Fevered Visions;SOI;161349
+Fibrous Entangler;EMN;161996
+Fickle Efreet;PCY;21977
+Fiddlehead Kami;SOK;86056
+Field Creeper;EMN;162017
+Field Marshal;10E;97001
+Field Marshal;CSP;97001
+Field Surgeon;UD;15599
+Field of Dreams;LEG;4628
+Field of Reality;COK;80569
+Field of Ruin;XLN;402358
+Field of Souls;DDK;3191
+Field of Souls;EMA;3191
+Field of Souls;TMP;3191
+Field of Souls;TPR;3191
+Fieldmist Borderpost;ARB;121031
+Fields of Summer;PC1;125892
+Fiend Binder;EMN;161910
+Fiend Hunter;C13;138187
+Fiend Hunter;DDK;138187
+Fiend Hunter;DPA;138187
+Fiend Hunter;ISD;138187
+Fiend of the Shadows;DKA;139873
+Fiendslayer Paladin;M14;147487
+Fierce Empath;CMD;48965
+Fierce Empath;SCG;48965
+Fierce Invocation;FRF;157251
+Fierce Invocation;PRM;159378
+Fiery Bombardment;EVE;113711
+Fiery Cannonade;XLN;402307
+Fiery Conclusion;ORI;88640
+Fiery Conclusion;PC2;88640
+Fiery Conclusion;RAV;88640
+Fiery Confluence;PZ1;160159
+Fiery Fall;CON;118711
+Fiery Fall;DDG;118711
+Fiery Fall;MM2;118711
+Fiery Fall;MMA;118711
+Fiery Fall;PC2;118711
+Fiery Gambit;MRD;51047
+Fiery Hellhound;DDI;121662
+Fiery Hellhound;DPA;121662
+Fiery Hellhound;M10;121662
+Fiery Hellhound;M11;121662
+Fiery Hellhound;M12;121662
+Fiery Hellhound;ORI;121662
+Fiery Impulse;ORI;160289
+Fiery Justice;C13;145444
+Fiery Justice;ICE;1154
+Fiery Justice;MM3;145444
+Fiery Justice;TSB;1154
+Fiery Mantle;USG;8718
+Fiery Temper;PRM;101170
+Fiery Temper;PRM;162530
+Fiery Temper;SOI;161442
+Fiery Temper;TOR;36481
+Fiery Temper;TSB;36481
+Fight or Flight;INV;24053
+Fight to the Death;ARB;120972
+Fight;AKH;401049
+Fighting Chance;EXO;3718
+Fighting Drake;7ED;27615
+Fighting Drake;8ED;27615
+Fighting Drake;TMP;3278
+Fighting Drake;TPR;3278
+Figure of Destiny;DDL;113752
+Figure of Destiny;EVE;113752
+Figure of Destiny;MMA;113752
+Figure of Destiny;PD2;113752
+Figure of Destiny;PRM;113752
+Filigree Angel;ARB;121052
+Filigree Angel;C13;121052
+Filigree Crawler;AER;400375
+Filigree Familiar;KLD;162329
+Filigree Fracture;CON;118697
+Filigree Sages;ALA;114992
+Fill with Fright;5DN;77075
+Filth;JUD;40229
+Filthy Cur;ODY;33441
+Final Fortune;6ED;1886
+Final Fortune;7ED;27616
+Final Fortune;MIR;1886
+Final Iteration;EMN;161941
+Final Judgment;BOK;80778
+Final Punishment;9ED;48963
+Final Punishment;SCG;48963
+Final Revels;DPA;106411
+Final Revels;LRW;106411
+Final Reward;AKH;400857
+Final Strike;POR;6578
+Final-Sting Faerie;MOR;109920
+Finest Hour;ARB;121018
+Finish;AKH;401044
+Fire Ambush;ME3;9091
+Fire Ambush;PTK;9091
+Fire Ants;USG;8737
+Fire Bowman;PTK;9117
+Fire Covenant;ICE;1155
+Fire Covenant;MED;1155
+Fire Diamond;6ED;1887
+Fire Diamond;7ED;27617
+Fire Diamond;C14;156379
+Fire Diamond;MIR;1887
+Fire Dragon;ME2;6691
+Fire Dragon;POR;6691
+Fire Drake;5ED;768
+Fire Drake;CH;768
+Fire Drake;DRK;768
+Fire Drake;ME3;768
+Fire Elemental;2ED;83
+Fire Elemental;3ED;83
+Fire Elemental;4ED;83
+Fire Elemental;6ED;83
+Fire Elemental;7ED;27618
+Fire Elemental;DPA;27618
+Fire Elemental;LEA;83
+Fire Elemental;LEB;83
+Fire Elemental;M13;131704
+Fire Imp;ME4;6692
+Fire Imp;POR;6692
+Fire Juggler;MOR;109897
+Fire Servant;DPA;129085
+Fire Servant;M11;129085
+Fire Servant;PD2;129085
+Fire Shrine Keeper;XLN;402231
+Fire Snake;POR;6693
+Fire Sprites;LEG;554
+Fire Sprites;ME3;554
+Fire Tempest;ME4;6694
+Fire Tempest;POR;6694
+Fire Whip;TSB;2820
+Fire Whip;WTH;2820
+Fire and Brimstone;DRK;767
+Fire at Will;EVE;113636
+Fire-Belly Changeling;DDG;105548
+Fire-Belly Changeling;LRW;105548
+Fire-Field Ogre;ALA;98577
+Fire-Field Ogre;DDH;98577
+Fire-Lit Thicket;EXP;161057
+Fire-Lit Thicket;PRM;152619
+Fire-Lit Thicket;SHM;111655
+Fire;APC;31073
+Fire;CMD;31073
+Fire;DDJ;145069
+Fire;PRM;31073
+Fireball;2ED;84
+Fireball;3ED;84
+Fireball;4ED;84
+Fireball;5ED;84
+Fireball;C13;52012
+Fireball;DD2;52012
+Fireball;DST;52012
+Fireball;LEA;84
+Fireball;LEB;84
+Fireball;M10;52012
+Fireball;M11;52012
+Fireball;M12;52012
+Fireball;ME4;84
+Fireball;PD2;52012
+Fireball;PRM;22849
+Fireball;PRM;81005
+Fireblast;DD2;2171
+Fireblast;DPA;143949
+Fireblast;PD2;2171
+Fireblast;PRM;143949
+Fireblast;PRM;2171
+Fireblast;TD0;2171
+Fireblast;VIS;2171
+Fireblast;VMA;143949
+Firebolt;DD2;33370
+Firebolt;EMA;161562
+Firebolt;ODY;33370
+Firebolt;PRM;33370
+Firebrand Archer;HOU;401554
+Firebrand Ranger;INV;25175
+Firebreathing;10E;101053
+Firebreathing;2ED;85
+Firebreathing;3ED;85
+Firebreathing;4ED;85
+Firebreathing;5ED;85
+Firebreathing;6ED;1888
+Firebreathing;9ED;1888
+Firebreathing;LEA;85
+Firebreathing;LEB;85
+Firebreathing;M10;101053
+Firebreathing;M12;101053
+Firebreathing;MIR;1888
+Firecannon Blast;XLN;402251
+Firecat Blitz;JUD;40252
+Firedrinker Satyr;THS;150880
+Firefiend Elemental;ORI;160300
+Firefist Striker;GTC;146378
+Firefly;TMP;3255
+Fireforger's Puzzleknot;KLD;162328
+Firefright Mage;PLC;101379
+Firehoof Cavalry;KTK;156475
+Firemane Angel;DDH;89115
+Firemane Angel;RAV;89115
+Firemane Avenger;GTC;146404
+Firemane Avenger;PRM;147340
+Firemantle Mage;BFZ;160680
+Firemaw Kavu;TSP;97392
+Firemind's Foresight;RTR;145963
+Fires of Undeath;DKA;139868
+Fires of Yavimaya;C13;150064
+Fires of Yavimaya;DDL;150064
+Fires of Yavimaya;INV;25202
+Fires of Yavimaya;PC1;25202
+Fires of Yavimaya;PC2;25202
+Fires of Yavimaya;TD0;25202
+Fires of Yavimaya;VMA;150064
+Firescreamer;INV;24096
+Fireshrieker;M14;50301
+Fireshrieker;MRD;50301
+Fireslinger;DD2;3017
+Fireslinger;PRM;3017
+Fireslinger;TMP;3017
+Firespout;CMD;111756
+Firespout;PZ1;111756
+Firespout;SHM;111756
+Firespout;V14;155834
+Firestorm Hellkite;VIS;2172
+Firestorm Phoenix;LEG;4629
+Firestorm Phoenix;ME3;4629
+Firestorm;WTH;2887
+Firewake Sliver;TSP;97354
+Firewild Borderpost;ARB;121061
+Firewing Phoenix;DPA;143878
+Firewing Phoenix;M13;143878
+First Response;M15;155402
+First Volley;BOK;83864
+Fish;TOK;156417
+Fishliver Oil;9ED;86934
+Fishliver Oil;ARN;332
+Fishliver Oil;CH;332
+Fissure Vent;C13;127455
+Fissure Vent;ROE;127455
+Fissure;4ED;769
+Fissure;DRK;769
+Fissure;MED;769
+Fist of Suns;5DN;77081
+Fistful of Force;LRW;105620
+Fists of Ironwood;CMD;88679
+Fists of Ironwood;DPA;88679
+Fists of Ironwood;MM3;88679
+Fists of Ironwood;RAV;88679
+Fists of the Anvil;10E;50304
+Fists of the Anvil;MRD;50304
+Fists of the Demigod;SHM;111864
+Fit of Rage;6ED;2821
+Fit of Rage;WTH;2821
+Five-Alarm Fire;GTC;146485
+Flagstones of Trokair;TD0;97484
+Flagstones of Trokair;TSP;97484
+Flailing Drake;TMP;3233
+Flailing Manticore;MMQ;19246
+Flailing Ogre;MMQ;19136
+Flailing Soldier;MMQ;19218
+Flame Burst;ODY;33493
+Flame Elemental;MIR;1889
+Flame Fusillade;RAV;88860
+Flame Jab;EMA;113679
+Flame Jab;EVE;113679
+Flame Javelin;DD2;111605
+Flame Javelin;DDK;111605
+Flame Javelin;PRM;117979
+Flame Javelin;SHM;111605
+Flame Jet;UD;15647
+Flame Lash;KLD;162517
+Flame Rift;NMS;21275
+Flame Slash;DDK;127404
+Flame Slash;DPA;127404
+Flame Slash;ROE;127404
+Flame Spirit;5ED;1156
+Flame Spirit;6ED;1156
+Flame Spirit;ICE;1156
+Flame Spirit;ME2;1156
+Flame Wave;9ED;3684
+Flame Wave;DPA;3684
+Flame Wave;STH;3684
+Flame Wave;TPR;3684
+Flame-Kin War Scout;DIS;94406
+Flame-Kin Zealot;EMA;88634
+Flame-Kin Zealot;RAV;88634
+Flame-Wreathed Phoenix;BNG;152101
+Flameblade Adept;AKH;400811
+Flameblade Angel;PRM;161538
+Flameblade Angel;SOI;161681
+Flameblast Dragon;ALA;115242
+Flameblast Dragon;DPA;115242
+Flameblast Dragon;M12;115242
+Flameborn Hellion;DPA;131054
+Flameborn Hellion;SOM;131054
+Flameborn Viron;NPH;134425
+Flamebreak;DPA;52054
+Flamebreak;DST;52054
+Flamecast Wheel;THS;150874
+Flamecore Elemental;TSP;97308
+Flameheart Werewolf;SOI;161622
+Flamekin Bladewhirl;LRW;106424
+Flamekin Brawler;DD2;105376
+Flamekin Brawler;DPA;105376
+Flamekin Brawler;LRW;105376
+Flamekin Harbinger;LRW;105378
+Flamekin Harbinger;PC1;105378
+Flamekin Spitfire;DPA;105477
+Flamekin Spitfire;LRW;105477
+Flamekin Village;C14;104081
+Flamerush Rider;FRF;157329
+Flamerush Rider;PRM;158887
+Flames of the Blood Hand;BOK;83939
+Flames of the Blood Hand;DPA;83939
+Flames of the Blood Hand;PD2;83939
+Flames of the Blood Hand;TD0;83939
+Flames of the Firebrand;DPA;143869
+Flames of the Firebrand;M13;143869
+Flames of the Firebrand;M14;143869
+Flameshadow Conjuring;ORI;160292
+Flameshot;PCY;21971
+Flamespeaker Adept;THS;150836
+Flamespeaker's Will;JOU;153076
+Flamestick Courier;ONS;43128
+Flametongue Kavu;C14;131688
+Flametongue Kavu;CMD;131688
+Flametongue Kavu;DD2;27991
+Flametongue Kavu;DPA;131688
+Flametongue Kavu;PC1;27991
+Flametongue Kavu;PLS;27991
+Flametongue Kavu;PRM;27991
+Flametongue Kavu;PZ1;131688
+Flametongue Kavu;TD0;27991
+Flametongue Kavu;VMA;131688
+Flamewake Phoenix;FRF;157325
+Flamewave Invoker;10E;46587
+Flamewave Invoker;DD2;46587
+Flamewave Invoker;DPA;46587
+Flamewave Invoker;EVG;46587
+Flamewave Invoker;LGN;46587
+Flaming Gambit;TOR;36492
+Flaming Sword;MMQ;19096
+Flanking Troops;PTK;9025
+Flare;5ED;2366
+Flare;ICE;1157
+Flare;MIR;1890
+Flaring Flame-Kin;DIS;94719
+Flaring Pain;JUD;40243
+Flash Conscription;RAV;88942
+Flash Counter;8ED;49232
+Flash Counter;LEG;555
+Flash Flood;CH;556
+Flash Flood;LEG;556
+Flash Flood;ME3;556
+Flash Foliage;DIS;94338
+Flash of Defiance;TOR;36484
+Flash of Insight;JUD;40211
+Flash;6ED;1891
+Flash;MIR;1891
+Flashfires;2ED;86
+Flashfires;3ED;86
+Flashfires;4ED;86
+Flashfires;5ED;86
+Flashfires;6ED;6695
+Flashfires;8ED;6695
+Flashfires;9ED;6695
+Flashfires;LEA;86
+Flashfires;LEB;86
+Flashfires;POR;6695
+Flashfreeze;10E;96954
+Flashfreeze;CSP;96954
+Flashfreeze;DPA;96954
+Flashfreeze;M10;96954
+Flashfreeze;M11;96954
+Flashfreeze;M12;96954
+Flashfreeze;MM2;96954
+Flatten;DTK;159848
+Flay;PCY;22031
+Flayed Nim;MRD;50247
+Flayer Drone;OGW;161147
+Flayer Husk;MBS;133256
+Flayer Husk;MM2;133256
+Flayer Husk;PC2;133256
+Flayer of the Hatebound;DKA;139889
+Flaying Tendrils;OGW;161230
+Flaying Tendrils;PRM;162088
+Fledgling Djinn;VMA;2791
+Fledgling Djinn;WTH;2791
+Fledgling Dragon;JUD;40256
+Fledgling Griffin;DPA;126580
+Fledgling Griffin;WWK;126580
+Fledgling Imp;ODY;33433
+Fledgling Mawcor;DD2;99480
+Fledgling Mawcor;TSP;99480
+Fledgling Osprey;UD;15612
+Fleecemane Lion;THS;149110
+Fleet Swallower;XLN;402289
+Fleet-Footed Monk;POR;6738
+Fleetfeather Cockatrice;JOU;153065
+Fleetfeather Sandals;THS;149079
+Fleetfoot Panther;DDH;27914
+Fleetfoot Panther;PLS;27914
+Fleeting Aven;ONS;42998
+Fleeting Distraction;AVR;141703
+Fleeting Distraction;DPA;127481
+Fleeting Distraction;ROE;127481
+Fleeting Image;7ED;27619
+Fleeting Image;8ED;27619
+Fleeting Image;9ED;27619
+Fleeting Image;UL;10355
+Fleeting Memories;SOI;161613
+Fleetwheel Cruiser;KLD;162596
+Flensermite;MBS;133199
+Flesh Allergy;SOM;131060
+Flesh Carver;C14;156036
+Flesh Reaver;USG;8104
+Flesh to Dust;M15;156673
+Flesh to Dust;ORI;156673
+Flesh-Eater Imp;MBS;133148
+Flesh-Eater Imp;TD2;133148
+Flesh;DGM;146825
+Fleshbag Marauder;ALA;115239
+Fleshbag Marauder;CMD;115239
+Fleshbag Marauder;DDD;115239
+Fleshbag Marauder;DPA;115239
+Fleshbag Marauder;ORI;143391
+Fleshformer;CON;118717
+Fleshgrafter;5DN;51177
+Fleshmad Steed;THS;149180
+Fleshpulper Giant;M14;147430
+Fleshwrither;FUT;81026
+Flicker;UD;15603
+Flickerform;C13;88627
+Flickerform;RAV;88627
+Flickering Spirit;TSP;97301
+Flickering Ward;TMP;3303
+Flickerwisp;C13;113615
+Flickerwisp;C14;113615
+Flickerwisp;DPA;113615
+Flickerwisp;EVE;113615
+Flickerwisp;MM3;113615
+Flickerwisp;MMA;113615
+Flickerwisp;TD0;113615
+Flight Spellbomb;SOM;131123
+Flight of Fancy;RAV;88684
+Flight;2ED;87
+Flight;3ED;87
+Flight;4ED;87
+Flight;5ED;2367
+Flight;6ED;2367
+Flight;7ED;27620
+Flight;8ED;49230
+Flight;9ED;49230
+Flight;LEA;87
+Flight;LEB;87
+Flight;M12;137403
+Fling;AKH;401323
+Fling;DKA;139906
+Fling;M11;3685
+Fling;M12;3685
+Fling;PC2;3685
+Fling;PRM;3685
+Fling;PRM;37201
+Fling;STH;3685
+Flint Golem;NMS;21178
+Flinthoof Boar;EMA;143972
+Flinthoof Boar;M13;143972
+Flitterstep Eidolon;BNG;152063
+Floating Shield;TOR;36393
+Floating-Dream Zubera;COK;82634
+Flood Plain;DDI;1892
+Flood Plain;MIR;1892
+Flood Plain;VMA;1892
+Flood;4ED;770
+Flood;5ED;770
+Flood;DRK;770
+Floodbringer;BOK;83947
+Floodchaser;MOR;109952
+Flooded Grove;EVE;113700
+Flooded Grove;EXP;161148
+Flooded Shoreline;VIS;2173
+Flooded Strand;EXP;160777
+Flooded Strand;KTK;156607
+Flooded Strand;ONS;43219
+Flooded Strand;PRM;43219
+Flooded Woodlands;ICE;1158
+Floodgate;MIR;1893
+Floodtide Serpent;BNG;152022
+Floodwater Dam;ALL;1634
+Floodwater Dam;ME4;1634
+Floodwaters;AKH;401294
+Floral Spuzzem;LEG;557
+Flourishing Defenses;SHM;111875
+Flow of Ideas;DPA;111852
+Flow of Ideas;RAV;91401
+Flow of Ideas;SHM;111852
+Flow of Maggots;ICE;1159
+Flowering Field;PCY;22059
+Flowering Lumberknot;AVR;141749
+Flowstone Armor;NMS;21242
+Flowstone Blade;STH;3686
+Flowstone Blade;TPR;3686
+Flowstone Channeler;TSP;97272
+Flowstone Charger;APC;31074
+Flowstone Crusher;9ED;21274
+Flowstone Crusher;NMS;21274
+Flowstone Embrace;FUT;102442
+Flowstone Flood;EXO;6101
+Flowstone Giant;TMP;3009
+Flowstone Hellion;STH;3687
+Flowstone Hellion;VMA;3687
+Flowstone Mauler;STH;3688
+Flowstone Mauler;TPR;3688
+Flowstone Overseer;DPA;21215
+Flowstone Overseer;NMS;21215
+Flowstone Salamander;TMP;3260
+Flowstone Sculpture;TMP;3091
+Flowstone Sculpture;VMA;3091
+Flowstone Shambler;9ED;3690
+Flowstone Shambler;STH;3690
+Flowstone Slide;10E;21201
+Flowstone Slide;9ED;21201
+Flowstone Slide;NMS;21201
+Flowstone Strike;NMS;21249
+Flowstone Surge;NMS;21218
+Flowstone Thopter;NMS;21250
+Flowstone Wall;NMS;21229
+Flowstone Wyvern;TMP;3155
+Flowstone Wyvern;TPR;3155
+Fluctuator;USG;8803
+Flurry of Horns;JOU;152822
+Flurry of Wings;ARB;120994
+Flusterstorm;CMD;137522
+Flusterstorm;PZ1;137522
+Flusterstorm;VMA;137522
+Flux;POR;6618
+Flux;WTH;2832
+Fluxcharger;DGM;146697
+Flying Carpet;3ED;333
+Flying Carpet;4ED;333
+Flying Carpet;5ED;333
+Flying Carpet;6ED;333
+Flying Carpet;7ED;27621
+Flying Carpet;8ED;49670
+Flying Carpet;ARN;333
+Flying Carpet;ME4;333
+Flying Crane Technique;KTK;157080
+Flying Men;ARN;334
+Flying Men;TSB;334
+Fodder Cannon;8ED;49257
+Fodder Cannon;UD;15678
+Fodder Launch;LRW;107629
+Foe-Razer Regent;DTK;159749
+Foe-Razer Regent;PRM;160096
+Fog Bank;C13;143926
+Fog Bank;C14;143926
+Fog Bank;CMD;8795
+Fog Bank;DPA;143926
+Fog Bank;M13;143926
+Fog Bank;USG;8795
+Fog Elemental;10E;2825
+Fog Elemental;6ED;2825
+Fog Elemental;WTH;2825
+Fog Patch;NMS;21216
+Fog of Gnats;UL;10384
+Fog;2ED;88
+Fog;3ED;88
+Fog;4ED;88
+Fog;5ED;2368
+Fog;6ED;1894
+Fog;7ED;27622
+Fog;DPA;137404
+Fog;EMA;137404
+Fog;LEA;88
+Fog;LEB;88
+Fog;M10;2368
+Fog;M11;2368
+Fog;M12;137404
+Fog;M13;137404
+Fog;M14;137404
+Fog;ME4;88
+Fog;MIR;1894
+Fogwalker;EMN;162053
+Foil;DDF;22130
+Foil;PCY;22130
+Fold into Aether;5DN;77185
+Folk Medicine;JUD;40276
+Folk of An-Havva;HML;1503
+Folk of An-Havva;HML;1504
+Folk of the Pines;ICE;1160
+Folk of the Pines;ME2;1160
+Followed Footsteps;DPA;88697
+Followed Footsteps;RAV;88697
+Fomori Nomad;FUT;102342
+Font of Fertility;JOU;152892
+Font of Fertility;PRM;158169
+Font of Fortunes;JOU;152826
+Font of Ire;JOU;152860
+Font of Mythos;CON;119800
+Font of Mythos;DPA;119800
+Font of Return;JOU;152868
+Font of Vigor;JOU;152827
+Food Chain;MMQ;19174
+Fool's Demise;C14;99553
+Fool's Demise;DPA;99553
+Fool's Demise;TSP;99553
+Fool's Tome;TMP;3092
+Foot Soldiers;9ED;6739
+Foot Soldiers;POR;6739
+Footbottom Feast;CMD;105358
+Footbottom Feast;LRW;105358
+Foothill Guide;ONS;42909
+Footsteps of the Goryo;SOK;86097
+Foratog;8ED;1895
+Foratog;MIR;1895
+Forbid;EXO;3691
+Forbid;MS3;401614
+Forbid;PRM;3691
+Forbid;TPR;3691
+Forbidden Alchemy;ISD;138246
+Forbidden Alchemy;MM3;138246
+Forbidden Alchemy;PRM;143923
+Forbidden Crypt;6ED;1896
+Forbidden Crypt;MIR;1896
+Forbidden Lore;ICE;1161
+Forbidden Lore;ME2;1161
+Forbidden Orchard;COK;81138
+Forbidden Orchard;EXP;160965
+Forbidden Orchard;PRM;143414
+Forbidden Orchard;V12;143414
+Forbidden Ritual;VIS;2174
+Forbidding Watchtower;10E;104514
+Forbidding Watchtower;TD2;104514
+Forbidding Watchtower;UL;13568
+Force Away;KTK;156490
+Force Bubble;SCG;48151
+Force Spike;5ED;2370
+Force Spike;7ED;27623
+Force Spike;DDJ;27623
+Force Spike;LEG;558
+Force Spike;ME3;558
+Force Spike;PRM;558
+Force Void;ICE;1162
+Force of Nature;2ED;89
+Force of Nature;3ED;89
+Force of Nature;4ED;89
+Force of Nature;5ED;2369
+Force of Nature;9ED;86941
+Force of Nature;LEA;89
+Force of Nature;LEB;89
+Force of Nature;ME4;89
+Force of Nature;PRM;86941
+Force of Savagery;FUT;102425
+Force of Will;ALL;1635
+Force of Will;EMA;161142
+Force of Will;MED;1635
+Force of Will;MS3;401373
+Force of Will;PRM;131631
+Force of Will;VMA;131631
+Forced Adaptation;GTC;146544
+Forced Fruition;LRW;106406
+Forced March;MMQ;19468
+Forced Retreat;ME3;9065
+Forced Retreat;PTK;9065
+Forced Worship;NPH;134375
+Forcefield;2ED;90
+Forcefield;LEA;90
+Forcefield;LEB;90
+Forcefield;MED;90
+Forcemage Advocate;JUD;40279
+Foreboding Ruins;SOI;161594
+Forerunner of Slaughter;BFZ;160722
+Foresee;FUT;102404
+Foresee;M11;102404
+Foreshadow;VIS;2175
+Foresight;ALL;1636
+Foresight;ALL;1637
+Forest Bear;PTK;9063
+Forest;10E;25153
+Forest;10E;80954
+Forest;10E;89160
+Forest;10E;8946
+Forest;2ED;297
+Forest;2ED;91
+Forest;2ED;92
+Forest;3ED;297
+Forest;3ED;91
+Forest;3ED;92
+Forest;4ED;297
+Forest;4ED;91
+Forest;4ED;92
+Forest;5ED;2371
+Forest;5ED;2372
+Forest;5ED;2373
+Forest;5ED;2374
+Forest;6ED;4801
+Forest;6ED;4802
+Forest;6ED;6768
+Forest;6ED;6770
+Forest;7ED;27624
+Forest;7ED;27625
+Forest;7ED;27626
+Forest;7ED;27627
+Forest;8ED;25153
+Forest;8ED;43251
+Forest;8ED;6769
+Forest;8ED;6771
+Forest;9ED;25153
+Forest;9ED;43251
+Forest;9ED;6769
+Forest;9ED;6771
+Forest;AKH;400900
+Forest;AKH;400901
+Forest;AKH;400902
+Forest;AKH;402702
+Forest;ALA;115015
+Forest;ALA;115016
+Forest;ALA;115017
+Forest;ALA;115018
+Forest;AVR;141760
+Forest;AVR;141766
+Forest;AVR;141767
+Forest;BFZ;123765
+Forest;BFZ;160739
+Forest;BFZ;160740
+Forest;BFZ;160741
+Forest;BFZ;160742
+Forest;C01;17597
+Forest;C13;105646
+Forest;C13;138473
+Forest;C13;141760
+Forest;C13;141766
+Forest;C14;96761
+Forest;C14;97530
+Forest;C14;97555
+Forest;C14;97559
+Forest;CMD;105646
+Forest;CMD;115016
+Forest;CMD;121707
+Forest;CMD;89161
+Forest;COK;80948
+Forest;COK;80954
+Forest;COK;80964
+Forest;COK;80965
+Forest;DDD;121707
+Forest;DDD;121708
+Forest;DDD;25501
+Forest;DDD;27625
+Forest;DDE;25153
+Forest;DDE;25154
+Forest;DDG;115018
+Forest;DDG;21589
+Forest;DDG;21591
+Forest;DDG;33208
+Forest;DDH;115016
+Forest;DDH;115017
+Forest;DDJ;89160
+Forest;DDJ;89161
+Forest;DDJ;89162
+Forest;DDJ;89169
+Forest;DDL;111840
+Forest;DDL;137568
+Forest;DDL;138785
+Forest;DDL;27627
+Forest;DDM;145258
+Forest;DDM;145259
+Forest;DDM;145260
+Forest;DDM;145261
+Forest;DDM;89169
+Forest;DPA;25153
+Forest;DPA;80954
+Forest;DPA;89160
+Forest;DPA;8946
+Forest;DTK;159700
+Forest;DTK;159710
+Forest;DTK;159819
+Forest;EVG;105646
+Forest;EVG;25501
+Forest;EVG;6768
+Forest;EVG;6769
+Forest;FK;6769
+Forest;FRF;158898
+Forest;FRF;158899
+Forest;H09;3084
+Forest;HOU;401927
+Forest;HOU;402761
+Forest;HOU;402766
+Forest;ICE;1163
+Forest;ICE;1164
+Forest;ICE;1165
+Forest;INV;25153
+Forest;INV;25154
+Forest;INV;25488
+Forest;INV;25501
+Forest;ISD;138471
+Forest;ISD;138472
+Forest;ISD;138473
+Forest;KLD;162191
+Forest;KLD;162350
+Forest;KLD;162351
+Forest;KTK;156628
+Forest;KTK;156629
+Forest;KTK;156630
+Forest;KTK;156631
+Forest;LEA;91
+Forest;LEA;92
+Forest;LEB;297
+Forest;LEB;91
+Forest;LEB;92
+Forest;LRW;105640
+Forest;LRW;105641
+Forest;LRW;105646
+Forest;LRW;105653
+Forest;M10;121707
+Forest;M10;121708
+Forest;M10;25501
+Forest;M10;6769
+Forest;M11;106210
+Forest;M11;121707
+Forest;M11;121708
+Forest;M11;27625
+Forest;M12;121708
+Forest;M12;137567
+Forest;M12;137568
+Forest;M12;25501
+Forest;M13;121707
+Forest;M13;121708
+Forest;M13;131692
+Forest;M13;137567
+Forest;M14;121707
+Forest;M14;131619
+Forest;M14;137567
+Forest;M14;138785
+Forest;M15;121707
+Forest;M15;131692
+Forest;M15;138785
+Forest;M15;153333
+Forest;MBS;133206
+Forest;MBS;133242
+Forest;ME3;9019
+Forest;ME3;9020
+Forest;ME3;9021
+Forest;MED;297
+Forest;MED;91
+Forest;MED;92
+Forest;MIR;1897
+Forest;MIR;1898
+Forest;MIR;1899
+Forest;MIR;1900
+Forest;MMQ;18994
+Forest;MMQ;18995
+Forest;MMQ;19107
+Forest;MMQ;19271
+Forest;MRD;50322
+Forest;MRD;50323
+Forest;MRD;50324
+Forest;MRD;50325
+Forest;NPH;134363
+Forest;NPH;134373
+Forest;ODY;33204
+Forest;ODY;33206
+Forest;ODY;33208
+Forest;ODY;33315
+Forest;ONS;43249
+Forest;ONS;43250
+Forest;ONS;43251
+Forest;ONS;43252
+Forest;ORI;123752
+Forest;ORI;123765
+Forest;ORI;159391
+Forest;ORI;159392
+Forest;PC1;111840
+Forest;PC1;25501
+Forest;PC1;27626
+Forest;PC1;50322
+Forest;PC1;96761
+Forest;PC2;115015
+Forest;PC2;123752
+Forest;PC2;123761
+Forest;PC2;123765
+Forest;PC2;25153
+Forest;PC2;97530
+Forest;PO2;4801
+Forest;PO2;4802
+Forest;PO2;6150
+Forest;POR;6768
+Forest;POR;6769
+Forest;POR;6770
+Forest;POR;6771
+Forest;PRM;116169
+Forest;PRM;125121
+Forest;PRM;132686
+Forest;PRM;156667
+Forest;PRM;160801
+Forest;PRM;17597
+Forest;PRM;21433
+Forest;PRM;21438
+Forest;PRM;21589
+Forest;PRM;21591
+Forest;PRM;49944
+Forest;PRM;75381
+Forest;PRM;83872
+Forest;PRM;8511
+Forest;PRM;8524
+Forest;PRM;90388
+Forest;PRM;9511
+Forest;PRM;97548
+Forest;PTK;9019
+Forest;PTK;9020
+Forest;PTK;9021
+Forest;RAV;89160
+Forest;RAV;89161
+Forest;RAV;89162
+Forest;RAV;89169
+Forest;ROE;127489
+Forest;ROE;127495
+Forest;ROE;127497
+Forest;ROE;127511
+Forest;RTR;145258
+Forest;RTR;145259
+Forest;RTR;145260
+Forest;RTR;145261
+Forest;RTR;89169
+Forest;SHM;111812
+Forest;SHM;111819
+Forest;SHM;111839
+Forest;SHM;111840
+Forest;SOI;161502
+Forest;SOI;161503
+Forest;SOI;161504
+Forest;SOM;131157
+Forest;SOM;131162
+Forest;SOM;131165
+Forest;SOM;131172
+Forest;TD0;9019
+Forest;TD0;9020
+Forest;TD0;9021
+Forest;TD2;131162
+Forest;TD2;133242
+Forest;TD2;134373
+Forest;THS;149138
+Forest;THS;149139
+Forest;THS;149141
+Forest;THS;149980
+Forest;TMP;3074
+Forest;TMP;3079
+Forest;TMP;3084
+Forest;TMP;3089
+Forest;TPR;3074
+Forest;TPR;3079
+Forest;TPR;3084
+Forest;TPR;3089
+Forest;TSP;96761
+Forest;TSP;97530
+Forest;TSP;97555
+Forest;TSP;97559
+Forest;USG;8943
+Forest;USG;8944
+Forest;USG;8945
+Forest;USG;8946
+Forest;XLN;401909
+Forest;XLN;401910
+Forest;XLN;401911
+Forest;XLN;402024
+Forest;ZEN;123752
+Forest;ZEN;123761
+Forest;ZEN;123765
+Forest;ZEN;123768
+Forethought Amulet;LEG;4630
+Forfend;MOR;110221
+Forge Armor;MRD;51148
+Forge Devil;DKA;139716
+Forge Devil;M15;139716
+Forgeborn Oreads;JOU;152985
+Forgestoker Dragon;BNG;152096
+Forgestoker Dragon;PRM;152588
+Forget;5ED;1505
+Forget;6ED;1505
+Forget;HML;1505
+Forgotten Ancient;PC1;48792
+Forgotten Ancient;SCG;48792
+Forgotten Cave;C13;43230
+Forgotten Cave;C14;156384
+Forgotten Cave;CMD;43230
+Forgotten Cave;DDJ;43230
+Forgotten Cave;EVG;43230
+Forgotten Cave;ONS;43230
+Forgotten Cave;TD0;43230
+Forgotten Cave;VMA;156384
+Forgotten Creation;SOI;161745
+Forgotten Harvest;PCY;21979
+Forgotten Lore;ICE;1166
+Forgotten Lore;ME2;1166
+Foriysian Brigade;WTH;2954
+Foriysian Interceptor;TSP;97271
+Foriysian Totem;TSP;97321
+Fork in the Road;SOI;161714
+Fork;2ED;93
+Fork;3ED;93
+Fork;LEA;93
+Fork;LEB;93
+Fork;ME4;93
+Fork;PRM;93
+Forked Bolt;ROE;127317
+Forked Lightning;ME3;6696
+Forked Lightning;POR;6696
+Forked Lightning;PRM;6696
+Forked-Branch Garami;BOK;83845
+Forlorn Pseudamma;BNG;152067
+Form of the Dragon;9ED;48114
+Form of the Dragon;DRB;115925
+Form of the Dragon;SCG;48114
+Formation;ICE;1167
+Formless Nurturing;FRF;157193
+Formless Nurturing;PRM;159380
+Forsake the Worldly;AKH;400860
+Forsaken City;PLS;27915
+Forsaken Drifters;BNG;152031
+Forsaken Sanctuary;AKH;161341
+Forsaken Sanctuary;SOI;161341
+Forsaken Wastes;MIR;1901
+Fortified Area;4ED;559
+Fortified Area;LEG;559
+Fortified Rampart;BFZ;160908
+Fortified Village;SOI;161393
+Fortify;M14;97483
+Fortify;MM2;97483
+Fortify;TSP;97483
+Fortitude;USG;8649
+Fortress Crab;ISD;138368
+Fortress Cyclops;GTC;146429
+Fortuitous Find;KLD;162504
+Fortune Thief;TSP;99552
+Fortune's Favor;EMN;162057
+Fortune's Favor;PRM;400717
+Fossil Find;SHM;100696
+Foster;C13;19033
+Foster;MMQ;19033
+Foul Emissary;EMN;162124
+Foul Familiar;ICE;1168
+Foul Familiar;ME2;1168
+Foul Imp;7ED;27628
+Foul Imp;9ED;27628
+Foul Imp;DDC;27628
+Foul Imp;DPA;27628
+Foul Imp;STH;3692
+Foul Orchard;AKH;400734
+Foul Orchard;SOI;161394
+Foul Presence;APC;31168
+Foul Renewal;DTK;159725
+Foul Spirit;ME4;4722
+Foul Spirit;PO2;4722
+Foul-Tongue Invocation;DTK;159691
+Foul-Tongue Shriek;DTK;160062
+Foundry Assembler;AER;400379
+Foundry Champion;GTC;146577
+Foundry Champion;PRM;147341
+Foundry Hornet;AER;400291
+Foundry Inspector;KLD;400635
+Foundry Screecher;KLD;162275
+Foundry Street Denizen;GTC;146260
+Foundry Street Denizen;M15;146260
+Foundry of the Consuls;ORI;160365
+Fountain Watch;MMQ;19187
+Fountain of Cho;MMQ;19131
+Fountain of Youth;10E;102962
+Fountain of Youth;5ED;771
+Fountain of Youth;6ED;771
+Fountain of Youth;CH;771
+Fountain of Youth;DPA;102962
+Fountain of Youth;DRK;771
+Fourth Bridge Prowler;AER;400280
+Foxfire Oak;SHM;111557
+Foxfire;5ED;1169
+Foxfire;ICE;1169
+Fractured Loyalty;MRD;50838
+Fractured Powerstone;PC2;140350
+Fracturing Gust;SHM;111657
+Fracturing Gust;V14;111657
+Fragmentize;KLD;162243
+Frankenstein's Monster;DRK;772
+Frantic Purification;TOR;36392
+Frantic Salvage;MBS;133178
+Frantic Search;UL;10386
+Frantic Search;VMA;10386
+Fraying Sanity;HOU;401791
+Frazzle;GPT;91717
+Freed from the Real;SOK;86144
+Freejam Regent;AER;400327
+Freewind Equenaut;DDL;96015
+Freewind Equenaut;DIS;96015
+Freewind Falcon;VIS;2176
+Frenetic Efreet;MIR;1902
+Frenetic Ogre;ODY;33365
+Frenetic Raptor;LGN;46537
+Frenetic Sliver;PLC;100768
+Frenzied Fugue;PZ2;162372
+Frenzied Goblin;M15;88936
+Frenzied Goblin;PRM;156560
+Frenzied Goblin;RAV;88936
+Frenzied Raptor;XLN;402088
+Frenzied Tilling;GTC;146300
+Frenzied Tilling;INV;24051
+Frenzy Sliver;FUT;102357
+Frenzy Sliver;H09;102357
+Fresh Meat;C14;134302
+Fresh Meat;NPH;134302
+Fresh Volunteers;MMQ;19179
+Fretwork Colony;KLD;162506
+Freyalise Supplicant;ICE;1170
+Freyalise, Llanowar's Fury;C14;156033
+Freyalise, Llanowar's Fury;PZ1;156033
+Freyalise's Charm;ICE;1171
+Freyalise's Radiance;CSP;97028
+Freyalise's Winds;ICE;1172
+Freyalise's Winds;ME3;1172
+Friendly Fire;FRF;157293
+Frightcrawler;ODY;33439
+Frightful Delusion;ISD;138108
+Frightshroud Courier;ONS;43070
+Frilled Oculus;GTC;146264
+Frilled Sandwalla;HOU;401560
+Frog Lizard;TOK;147260
+Frog Tongue;TMP;2999
+Frogmite;DDF;51145
+Frogmite;MM2;51145
+Frogmite;MMA;51145
+Frogmite;MRD;51145
+Frogtosser Banneret;MOR;109912
+From Beyond;BFZ;160725
+From Under the Floorboards;SOI;161609
+From the Ashes;C13;151747
+Frontier Bivouac;KTK;156587
+Frontier Guide;DPA;101060
+Frontier Guide;ZEN;101060
+Frontier Mastodon;FRF;157255
+Frontier Siege;FRF;157201
+Frontline Devastator;HOU;401509
+Frontline Medic;GTC;146442
+Frontline Rebel;AER;400305
+Frontline Sage;CON;118764
+Frontline Strategist;SCG;48102
+Frost Breath;DPA;134161
+Frost Breath;M12;134161
+Frost Breath;M14;134161
+Frost Giant;LEG;4631
+Frost Giant;ME3;4631
+Frost Lynx;M15;155293
+Frost Marsh;CSP;96948
+Frost Ogre;BOK;83920
+Frost Raptor;CSP;96868
+Frost Titan;C14;129092
+Frost Titan;M11;129092
+Frost Titan;M12;129092
+Frost Walker;FRF;157176
+Frost Walker;PRM;160075
+Frostburn Weird;RTR;145191
+Frostling;BOK;83937
+Frostweb Spider;CSP;96933
+Frostwielder;COK;80575
+Frostwind Invoker;ROE;127291
+Frozen Aether;PLC;100684
+Frozen Shade;2ED;94
+Frozen Shade;3ED;94
+Frozen Shade;4ED;94
+Frozen Shade;5ED;2375
+Frozen Shade;LEA;94
+Frozen Shade;LEB;94
+Frozen Solid;CSP;96964
+Frozen Solid;SCG;48117
+Fruit of the First Tree;FRF;157307
+Fruition;POR;6653
+Fuel for the Cause;MBS;133130
+Fugitive Druid;TMP;3132
+Fugitive Wizard;10E;101046
+Fugitive Wizard;8ED;46559
+Fugitive Wizard;9ED;46559
+Fugitive Wizard;LGN;46559
+Fugitive Wizard;M15;101046
+Fugue;7ED;27598
+Fugue;EXO;3693
+Fugue;TPR;3693
+Fulgent Distraction;SOM;132374
+Full Moon's Rise;ISD;138422
+Fulminator Mage;MM2;111545
+Fulminator Mage;SHM;111545
+Fumarole;ICE;1173
+Fumarole;ME2;1173
+Fume Spitter;DPA;131615
+Fume Spitter;SOM;131615
+Fume Spitter;TD2;131615
+Fumigate;KLD;162246
+Fumiko the Lowblood;BOK;81575
+Funeral Charm;TSB;2177
+Funeral Charm;VIS;2177
+Funeral March;5ED;2376
+Funeral March;HML;1506
+Funeral March;ME2;2376
+Funeral Pyre;JUD;40173
+Fungal Behemoth;PLC;100728
+Fungal Bloom;FEM;906
+Fungal Bloom;ME2;906
+Fungal Reaches;CMD;97281
+Fungal Reaches;PZ1;97281
+Fungal Reaches;TSP;97281
+Fungal Shambler;APC;31153
+Fungal Shambler;PRM;31153
+Fungal Sprouting;M13;143975
+Fungus Elemental;WTH;2872
+Fungus Sliver;H09;97508
+Fungus Sliver;TSP;97508
+Fungusaur;2ED;95
+Fungusaur;3ED;95
+Fungusaur;4ED;95
+Fungusaur;5ED;2377
+Fungusaur;8ED;49253
+Fungusaur;LEA;95
+Fungusaur;LEB;95
+Furious Assault;MMQ;19273
+Furious Reprisal;KLD;162531
+Furious Resistance;GTC;146277
+Furnace Brood;EXO;5594
+Furnace Brood;TPR;5594
+Furnace Celebration;C13;130971
+Furnace Celebration;SOM;130971
+Furnace Dragon;DST;51754
+Furnace Layer;PC2;138724
+Furnace Scamp;NPH;134241
+Furnace Spirit;STH;3694
+Furnace Whelp;10E;77223
+Furnace Whelp;5DN;77223
+Furnace Whelp;CMD;77223
+Furnace Whelp;DD2;77223
+Furnace Whelp;DPA;77223
+Furnace Whelp;M13;77223
+Furnace Whelp;M15;77223
+Furnace of Rath;10E;3161
+Furnace of Rath;8ED;3161
+Furnace of Rath;9ED;3161
+Furnace of Rath;DPA;3161
+Furnace of Rath;PC1;3161
+Furnace of Rath;TMP;3161
+Furor of the Bitten;ISD;138370
+Furtive Homunculus;SOI;161662
+Fury Charm;MMA;100719
+Fury Charm;PLC;100719
+Fury Sliver;H09;97352
+Fury Sliver;TSP;97352
+Fury of the Horde;CSP;96917
+Furyblade Vampire;EMN;162103
+Furyborn Hellkite;DPA;134084
+Furyborn Hellkite;M12;134084
+Furystoke Giant;SHM;111887
+Fusion Elemental;CON;118699
+Fusion Elemental;PC2;118699
+Future Sight;DDM;143936
+Future Sight;EMA;143936
+Future Sight;ONS;43024
+Future Sight;PRM;143936
+Future Sight;VMA;143936
+Fylamarid;TMP;3275
+Fylgja;ICE;1174
+Fyndhorn Bow;ICE;1175
+Fyndhorn Brownie;6ED;1176
+Fyndhorn Brownie;ICE;1176
+Fyndhorn Druid;ALL;1638
+Fyndhorn Druid;ALL;1639
+Fyndhorn Elder;5ED;2378
+Fyndhorn Elder;6ED;2378
+Fyndhorn Elder;7ED;30843
+Fyndhorn Elder;8ED;2378
+Fyndhorn Elder;ICE;1177
+Fyndhorn Elves;ICE;1178
+Fyndhorn Elves;MED;1178
+Fyndhorn Elves;PRM;144453
+Fyndhorn Elves;V13;144453
+Fyndhorn Elves;VMA;144453
+Fyndhorn Pollen;ICE;1179
+Fyndhorn Pollen;ME2;1179
+Gabriel Angelfire;CH;560
+Gabriel Angelfire;LEG;560
+Gabriel Angelfire;ME3;560
+Gaddock Teeg;LRW;105511
+Gaddock Teeg;PRM;401367
+Gaea's Anthem;MM3;100678
+Gaea's Anthem;PLC;100678
+Gaea's Avenger;ATQ;411
+Gaea's Avenger;ME4;411
+Gaea's Balance;APC;31118
+Gaea's Blessing;EMA;2930
+Gaea's Blessing;PRM;2930
+Gaea's Blessing;TSB;2930
+Gaea's Blessing;WTH;2930
+Gaea's Bounty;USG;8880
+Gaea's Cradle;PRM;160452
+Gaea's Cradle;PRM;8662
+Gaea's Cradle;USG;8662
+Gaea's Embrace;USG;8839
+Gaea's Embrace;VMA;8839
+Gaea's Herald;10E;104581
+Gaea's Herald;8ED;27917
+Gaea's Herald;DPA;104581
+Gaea's Herald;PLS;27917
+Gaea's Liege;2ED;96
+Gaea's Liege;3ED;96
+Gaea's Liege;4ED;96
+Gaea's Liege;LEA;96
+Gaea's Liege;LEB;96
+Gaea's Liege;TSB;96
+Gaea's Might;PLS;27884
+Gaea's Revenge;DPA;129122
+Gaea's Revenge;M11;129122
+Gaea's Revenge;ORI;129122
+Gaea's Skyfolk;APC;31068
+Gaea's Touch;DRK;773
+Gaea's Touch;ME3;773
+Gahiji, Honored One;C13;151748
+Gainsay;PLS;27918
+Gainsay;THS;150882
+Gale Force;COK;81130
+Galepowder Mage;DDI;105429
+Galepowder Mage;LRW;105429
+Galerider Sliver;M14;147369
+Galestrike;AKH;400814
+Galina's Knight;INV;24086
+Gallantry;ODY;36337
+Gallantry;TMP;3299
+Gallantry;TPR;3299
+Gallowbraid;WTH;2862
+Gallows Warden;ISD;138360
+Gallows at Willow Hill;AVR;139831
+Galvanic Alchemist;AVR;141751
+Galvanic Arc;RAV;88957
+Galvanic Blast;SOM;131049
+Galvanic Bombardment;EMN;161987
+Galvanic Juggernaut;ISD;138335
+Galvanic Key;MRD;51071
+Galvanoth;DDJ;133223
+Galvanoth;MBS;133223
+Gamble;EMA;161850
+Gamble;USG;8762
+Gamble;VMA;8762
+Game Preserve;MMQ;19216
+Game Trail;SOI;161420
+Game of Chaos;5ED;2379
+Game of Chaos;ICE;1180
+Game-Trail Changeling;MOR;109893
+Gamekeeper;UD;15667
+Gang of Devils;AVR;141708
+Gang of Devils;DDK;141708
+Gang of Elk;7ED;27631
+Gang of Elk;UL;10364
+Gangrenous Goliath;ONS;43075
+Gangrenous Zombies;ICE;1181
+Gangrenous Zombies;ME2;1181
+Gargantuan Gorilla;ALL;1640
+Gargantuan Gorilla;MED;1640
+Gargoyle Castle;C14;122169
+Gargoyle Castle;M10;122169
+Gargoyle Sentinel;M11;129079
+Gargoyle Sentinel;M15;129079
+Gargoyle;TOK;122174
+Garruk Relentless;ISD;138475
+Garruk Wildspeaker;CMD;105523
+Garruk Wildspeaker;DDD;125535
+Garruk Wildspeaker;LRW;105523
+Garruk Wildspeaker;M10;105523
+Garruk Wildspeaker;M11;105523
+Garruk Wildspeaker;PRM;120599
+Garruk, Apex Predator;M15;155261
+Garruk, Caller of Beasts;M14;147378
+Garruk, Primal Hunter;M12;134083
+Garruk, Primal Hunter;M13;134083
+Garruk, the Veil-Cursed;ISD;138476
+Garruk's Companion;DPA;129114
+Garruk's Companion;M11;129114
+Garruk's Companion;M12;129114
+Garruk's Horde;DPA;137407
+Garruk's Horde;M12;137407
+Garruk's Horde;M14;137407
+Garruk's Horde;PRM;134072
+Garruk's Horde;W17;137407
+Garruk's Packleader;DPA;129147
+Garruk's Packleader;M11;129147
+Garruk's Packleader;M13;129147
+Garruk's Packleader;M15;129147
+Garrulous Sycophant;PZ2;162169
+Garza Zol, Plague Queen;CSP;96862
+Garza's Assassin;CSP;97021
+Gaseous Form;4ED;1049
+Gaseous Form;5ED;2380
+Gaseous Form;6ED;3038
+Gaseous Form;EMA;3038
+Gaseous Form;LEG;561
+Gaseous Form;TMP;3038
+Gaseous Form;TPR;3038
+Gate Hound;RAV;88971
+Gate Smasher;DTK;160148
+Gate to Phyrexia;ATQ;412
+Gate to Phyrexia;ME4;412
+Gate to the Aether;MRD;51035
+Gate to the Afterlife;AKH;401353
+Gatecreeper Vine;DDM;145142
+Gatecreeper Vine;RTR;145142
+Gatekeeper of Malakir;DDK;123628
+Gatekeeper of Malakir;DPA;123628
+Gatekeeper of Malakir;PRM;131559
+Gatekeeper of Malakir;ZEN;123628
+Gateway Shade;GTC;146558
+Gathan Raiders;FUT;100699
+Gather Courage;M15;88930
+Gather Courage;RAV;88930
+Gather Specimens;ALA;115074
+Gather the Pack;ORI;159863
+Gather the Townsfolk;DKA;140325
+Gather the Townsfolk;DPA;140325
+Gather the Townsfolk;PRM;139843
+Gatherer of Graces;GPT;91704
+Gatstaf Arsonists;SOI;161348
+Gatstaf Howler;ISD;138289
+Gatstaf Ravagers;SOI;161477
+Gatstaf Shepherd;ISD;138296
+Gauntlet of Might;2ED;97
+Gauntlet of Might;LEA;97
+Gauntlet of Might;LEB;97
+Gauntlet of Might;ME4;97
+Gauntlet of Might;PRM;402825
+Gauntlet of Power;MS2;400607
+Gauntlet of Power;TSP;98953
+Gauntlets of Chaos;5ED;2381
+Gauntlets of Chaos;CH;562
+Gauntlets of Chaos;LEG;562
+Gauntlets of Chaos;ME3;562
+Gavony Ironwright;DKA;139842
+Gavony Township;ISD;138357
+Gavony Unhallowed;EMN;161956
+Gavony;PC2;138729
+Gaze of Adamaro;SOK;87225
+Gaze of Granite;DGM;146744
+Gaze of Justice;TSP;97292
+Gaze of Pain;ICE;1182
+Gaze of the Gorgon;RAV;88879
+Gearseeker Serpent;KLD;162475
+Gearshift Ace;KLD;162232
+Geier Reach Bandit;SOI;161425
+Geier Reach Sanitarium;EMN;162020
+Geist Snatch;AVR;141566
+Geist Trappers;AVR;141569
+Geist of Saint Traft;ISD;139449
+Geist of Saint Traft;PRM;152612
+Geist of Saint Traft;PRM;161782
+Geist of the Archives;EMN;162063
+Geist of the Lonely Vigil;EMN;162037
+Geist of the Moors;M15;155278
+Geist-Fueled Scarecrow;EMN;162019
+Geist-Honored Monk;C14;138347
+Geist-Honored Monk;DPA;138347
+Geist-Honored Monk;ISD;138347
+Geistblast;SOI;161654
+Geistcatcher's Rig;ISD;138380
+Geistflame;DDK;138511
+Geistflame;ISD;138511
+Gelatinous Genesis;ROE;127311
+Gelectrode;DDJ;91718
+Gelectrode;DPA;91718
+Gelectrode;GPT;91718
+Gelid Shackles;CSP;96949
+Gem of Becoming;M13;143870
+Gemhide Sliver;H09;97543
+Gemhide Sliver;TSP;97543
+Gemini Engine;DST;75176
+Gempalm Avenger;LGN;47487
+Gempalm Incinerator;DPA;47466
+Gempalm Incinerator;EVG;47466
+Gempalm Incinerator;LGN;47466
+Gempalm Polluter;LGN;47465
+Gempalm Sorcerer;LGN;47464
+Gempalm Strider;DPA;47467
+Gempalm Strider;EVG;47467
+Gempalm Strider;LGN;47467
+Gemstone Array;5DN;77095
+Gemstone Caverns;TSP;97564
+Gemstone Mine;PRM;2932
+Gemstone Mine;TSB;2932
+Gemstone Mine;WTH;2932
+General Jarkeld;ICE;1183
+General Tazri;OGW;161151
+General's Kabuto;COK;81577
+General's Regalia;MMQ;19195
+Generator Servant;M15;155389
+Genesis Chamber;DST;75173
+Genesis Hydra;M15;155275
+Genesis Hydra;PRM;155275
+Genesis Wave;SOM;131042
+Genesis;JUD;40288
+Genesis;TD0;40288
+Genesis;VMA;40288
+Genju of the Cedars;BOK;83851
+Genju of the Cedars;DDD;83851
+Genju of the Falls;BOK;83916
+Genju of the Fens;BOK;83821
+Genju of the Fens;DDD;83821
+Genju of the Fields;BOK;83826
+Genju of the Realm;BOK;83967
+Genju of the Spires;BOK;80794
+Genju of the Spires;PRM;80794
+Geosurge;NPH;134266
+Geothermal Crevice;INV;25657
+Geralf's Masterpiece;SOI;161730
+Geralf's Messenger;DKA;139750
+Geralf's Mindcrusher;DKA;139875
+Germ;TOK;133123
+Gerrard Capashen;APC;31075
+Gerrard Capashen;DDE;31075
+Gerrard's Battle Cry;TMP;3190
+Gerrard's Battle Cry;TPR;3190
+Gerrard's Battle Cry;VMA;3190
+Gerrard's Command;DDE;27889
+Gerrard's Command;PLS;27889
+Gerrard's Irregulars;MMQ;19304
+Gerrard's Verdict;APC;31072
+Gerrard's Verdict;PRM;31072
+Gerrard's Wisdom;7ED;27632
+Gerrard's Wisdom;WTH;2955
+Geth, Lord of the Vault;SOM;131185
+Geth's Grimoire;DST;75216
+Geth's Verdict;NPH;134226
+Geyser Glider;DDI;125083
+Geyser Glider;ZEN;125083
+Geyserfield Stalker;BFZ;160662
+Ghalma's Warden;SOM;130897
+Ghastlord of Fugue;SHM;111745
+Ghastly Conscription;FRF;157175
+Ghastly Demise;ODY;33430
+Ghastly Discovery;SHM;111843
+Ghastly Haunting;DKA;139734
+Ghastly Remains;LGN;47476
+Ghave, Guru of Spores;CMD;137547
+Ghave, Guru of Spores;PZ1;137547
+Ghazbán Ogre;5ED;2382
+Ghazbán Ogre;ARN;335
+Ghazbán Ogre;CH;335
+Ghazbán Ogre;MED;335
+Ghirapur Aether Grid;ORI;160290
+Ghirapur Gearcrafter;ORI;160306
+Ghirapur Guide;KLD;162314
+Ghirapur Orrery;KLD;162566
+Ghirapur Osprey;AER;400233
+Ghitu Encampment;10E;104519
+Ghitu Encampment;PD2;104519
+Ghitu Encampment;UL;10371
+Ghitu Fire-Eater;7ED;27633
+Ghitu Fire-Eater;UL;10344
+Ghitu Fire;INV;25221
+Ghitu Firebreathing;TSP;97267
+Ghitu Slinger;EMA;161310
+Ghitu Slinger;UL;10343
+Ghitu War Cry;UL;13559
+Ghor-Clan Bloodscale;GPT;91661
+Ghor-Clan Rampager;GTC;146411
+Ghor-Clan Rampager;MM3;146411
+Ghor-Clan Rampager;PRM;151398
+Ghor-Clan Savage;DDL;91676
+Ghor-Clan Savage;GPT;91676
+Ghost Council of Orzhova;GPT;91735
+Ghost Council of Orzhova;MM2;91735
+Ghost Hounds;HML;1507
+Ghost Quarter;C14;138125
+Ghost Quarter;DIS;94560
+Ghost Quarter;ISD;138125
+Ghost Quarter;TD0;94560
+Ghost Ship;4ED;1050
+Ghost Ship;DRK;774
+Ghost Ship;TSB;774
+Ghost Tactician;PLC;100796
+Ghost Town;TMP;3246
+Ghost Warden;10E;91728
+Ghost Warden;GPT;91728
+Ghost-Lit Nourisher;SOK;86035
+Ghost-Lit Raider;PRM;86148
+Ghost-Lit Raider;SOK;86148
+Ghost-Lit Redeemer;SOK;86038
+Ghost-Lit Stalker;DDD;86098
+Ghost-Lit Stalker;SOK;86098
+Ghost-Lit Warder;SOK;86017
+Ghostblade Eidolon;BNG;152060
+Ghostfire Blade;KTK;156605
+Ghostfire Blade;PRM;159778
+Ghostfire;DDG;102450
+Ghostfire;FUT;102450
+Ghostflame Sliver;TSP;97349
+Ghostform;AVR;141548
+Ghosthelm Courier;ONS;44729
+Ghostly Changeling;LRW;105363
+Ghostly Changeling;MM2;105363
+Ghostly Flame;ICE;1184
+Ghostly Flicker;AVR;141645
+Ghostly Flicker;MM3;141645
+Ghostly Possession;ISD;138117
+Ghostly Prison;CMD;102613
+Ghostly Prison;COK;80776
+Ghostly Prison;PC2;102613
+Ghostly Prison;PRM;102613
+Ghostly Prison;PZ1;102613
+Ghostly Prison;TD0;80776
+Ghostly Sentinel;BFZ;160618
+Ghostly Touch;AVR;142205
+Ghostly Visit;ME3;9042
+Ghostly Visit;PTK;9042
+Ghostly Wings;SOI;161655
+Ghostly Wings;TOR;36416
+Ghosts of the Damned;LEG;563
+Ghosts of the Damned;ME3;563
+Ghosts of the Innocent;RAV;89083
+Ghostway;GPT;91669
+Ghoul's Feast;DDJ;19233
+Ghoul's Feast;MMQ;19233
+Ghoulcaller Gisa;C14;155587
+Ghoulcaller's Accomplice;SOI;161397
+Ghoulcaller's Bell;ISD;138417
+Ghoulcaller's Chant;ISD;138101
+Ghoulflesh;AVR;141515
+Ghoulraiser;ISD;138100
+Ghoulsteed;SOI;161642
+Ghoultree;DKA;139819
+Giant Adephage;GTC;147255
+Giant Albatross;HML;1508
+Giant Albatross;HML;1509
+Giant Ambush Beetle;ARB;120989
+Giant Badger;8ED;49252
+Giant Badger;PRM;483
+Giant Caterpillar;MMQ;19278
+Giant Caterpillar;VIS;2178
+Giant Cockroach;7ED;27634
+Giant Cockroach;8ED;10378
+Giant Cockroach;9ED;10378
+Giant Cockroach;UL;10378
+Giant Crab;TMP;3036
+Giant Dustwasp;MMA;100663
+Giant Dustwasp;PLC;100663
+Giant Growth;10E;101059
+Giant Growth;2ED;98
+Giant Growth;3ED;98
+Giant Growth;4ED;98
+Giant Growth;5ED;2383
+Giant Growth;6ED;2383
+Giant Growth;7ED;27635
+Giant Growth;8ED;2383
+Giant Growth;9ED;86908
+Giant Growth;DDD;101059
+Giant Growth;DPA;101059
+Giant Growth;EVG;101059
+Giant Growth;ICE;1185
+Giant Growth;LEA;98
+Giant Growth;LEB;98
+Giant Growth;M10;101059
+Giant Growth;M11;101059
+Giant Growth;M14;101059
+Giant Growth;ME2;1185
+Giant Growth;ME3;2383
+Giant Growth;ME4;98
+Giant Growth;PRM;27635
+Giant Growth;PRM;90393
+Giant Growth;PRM;98
+Giant Growth;RTR;145263
+Giant Harbinger;LRW;105388
+Giant Mantis;BFZ;160705
+Giant Mantis;MIR;1903
+Giant Mantis;VMA;1903
+Giant Octopus;7ED;31243
+Giant Octopus;8ED;31243
+Giant Octopus;9ED;31243
+Giant Octopus;DPA;31243
+Giant Octopus;POR;6619
+Giant Oyster;HML;1510
+Giant Oyster;TSB;1510
+Giant Scorpion;DPA;122164
+Giant Scorpion;M13;122164
+Giant Scorpion;ZEN;122164
+Giant Shark;DRK;775
+Giant Slug;CH;564
+Giant Slug;LEG;564
+Giant Solifuge;EMA;161313
+Giant Solifuge;GPT;91858
+Giant Spectacle;KLD;162522
+Giant Spider;10E;6654
+Giant Spider;2ED;99
+Giant Spider;3ED;99
+Giant Spider;4ED;99
+Giant Spider;5ED;2384
+Giant Spider;6ED;6654
+Giant Spider;7ED;27636
+Giant Spider;8ED;6654
+Giant Spider;9ED;6654
+Giant Spider;AKH;400758
+Giant Spider;DPA;6654
+Giant Spider;LEA;99
+Giant Spider;LEB;99
+Giant Spider;M10;6654
+Giant Spider;M11;6654
+Giant Spider;M12;6654
+Giant Spider;M14;6654
+Giant Spider;POR;6654
+Giant Strength;4ED;565
+Giant Strength;5ED;2385
+Giant Strength;6ED;2385
+Giant Strength;LEG;565
+Giant Strength;TMP;3022
+Giant Strength;VMA;3022
+Giant Tortoise;4ED;336
+Giant Tortoise;ARN;336
+Giant Tortoise;EMA;161548
+Giant Tortoise;ME4;336
+Giant Tortoise;MED;336
+Giant Trap Door Spider;ICE;1186
+Giant Trap Door Spider;ME2;1186
+Giant Turtle;LEG;566
+Giant Warrior;TOK;110025
+Giant Warrior;TOK;112138
+Giant Warrior;TOK;148270
+Giant Warthog;JUD;40269
+Giant;TOK;102401
+Giant's Ire;LRW;105391
+Giantbaiting;MM3;111853
+Giantbaiting;SHM;111853
+Gibbering Descent;FUT;102414
+Gibbering Fiend;SOI;161707
+Gibbering Hyenas;MIR;1904
+Gibbering Kami;COK;82603
+Gideon Jura;M12;127248
+Gideon Jura;PRM;401716
+Gideon Jura;ROE;127248
+Gideon of the Trials;AKH;400873
+Gideon, Ally of Zendikar;BFZ;160622
+Gideon, Battle-Forged;ORI;160216
+Gideon, Champion of Justice;GTC;146562
+Gideon, Martial Paragon;AKH;400731
+Gideon's Avenger;DPA;134137
+Gideon's Avenger;M12;134137
+Gideon's Defeat;HOU;401593
+Gideon's Intervention;AKH;400874
+Gideon's Lawkeeper;DPA;137408
+Gideon's Lawkeeper;M12;137408
+Gideon's Lawkeeper;MM3;137408
+Gideon's Phalanx;ORI;160212
+Gideon's Reproach;BFZ;160623
+Gideon's Resolve;AKH;401056
+Gift of Estates;9ED;86948
+Gift of Estates;C14;86948
+Gift of Estates;POR;6740
+Gift of Granite;DPA;102489
+Gift of Granite;FUT;102489
+Gift of Immortality;THS;149206
+Gift of Orzhova;GTC;146302
+Gift of Orzhova;MM3;146302
+Gift of Paradise;AKH;400831
+Gift of Strength;HOU;401563
+Gift of Tusks;OGW;161217
+Gift of the Deity;EVE;113639
+Gift of the Gargantuan;ALA;115092
+Gift of the Woods;ALL;1641
+Gift of the Woods;ALL;1642
+Gifted Aetherborn;AER;400290
+Gifts Ungiven;COK;80976
+Gifts Ungiven;MM3;80976
+Gifts Ungiven;MMA;80976
+Gifts Ungiven;TD0;80976
+Gifts Ungiven;V09;80976
+Gigadrowse;GPT;91691
+Gigantiform;DPA;123782
+Gigantiform;ZEN;123782
+Gigantomancer;ROE;127457
+Gigantoplasm;PZ1;160437
+Gigapede;ONS;43174
+Gigapede;VMA;43174
+Gild;BNG;152070
+Gilded Cerodon;HOU;401806
+Gilded Drake;USG;8716
+Gilded Light;SCG;48130
+Gilded Light;VMA;48130
+Gilded Lotus;M13;51061
+Gilded Lotus;MRD;51061
+Gilded Lotus;V13;148828
+Gilded Sentinel;XLN;402298
+Gilder Bairn;EVE;113651
+Gilt-Leaf Ambush;LRW;104088
+Gilt-Leaf Archdruid;MOR;110016
+Gilt-Leaf Palace;LRW;109166
+Gilt-Leaf Seer;LRW;106366
+Gilt-Leaf Winnower;ORI;160273
+Giltspire Avenger;CON;118787
+Giltspire Avenger;DPA;118787
+Gisa and Geralf;EMN;162012
+Gisa's Bidding;SOI;161754
+Gisela, Blade of Goldnight;AVR;141579
+Gisela, the Broken Blade;EMN;161924
+Gishath, Sun's Avatar;XLN;402095
+Gitaxian Probe;NPH;134395
+Gitaxian Probe;PRM;145847
+Give No Ground;EMN;162040
+Give;DGM;147713
+Glacial Chasm;ICE;1187
+Glacial Chasm;ME2;1187
+Glacial Chasm;V12;143996
+Glacial Crasher;M15;155333
+Glacial Crevasses;ICE;1188
+Glacial Crevasses;ME2;1188
+Glacial Fortress;M10;121634
+Glacial Fortress;M11;121634
+Glacial Fortress;M12;121634
+Glacial Fortress;M13;121634
+Glacial Fortress;XLN;404077
+Glacial Plating;CSP;96947
+Glacial Ray;COK;82614
+Glacial Ray;MMA;82614
+Glacial Ray;PRM;82614
+Glacial Stalker;KTK;156489
+Glacial Wall;5ED;2386
+Glacial Wall;6ED;1189
+Glacial Wall;7ED;27637
+Glacial Wall;EMA;161549
+Glacial Wall;ICE;1189
+Glaciers;ICE;1190
+Glade Gnarr;APC;31066
+Glade Watcher;DTK;160175
+Gladecover Scout;DPA;134074
+Gladecover Scout;M12;134074
+Gladecover Scout;M14;134074
+Gladehart Cavalry;OGW;161251
+Gladehart Cavalry;PRM;161092
+Glamer Spinners;SHM;111576
+Glamerdye;EVE;113685
+Glare of Heresy;THS;150872
+Glare of Subdual;EMA;89068
+Glare of Subdual;RAV;89068
+Glarecaster;ONS;42913
+Glarewielder;LRW;106388
+Glaring Aegis;DTK;160146
+Glaring Spotlight;GTC;146520
+Glass Asp;TSP;97424
+Glass Golem;RAV;88711
+Glassblower's Puzzleknot;KLD;162331
+Glassdust Hulk;ARB;120978
+Glassdust Hulk;MM2;120978
+Glasses of Urza;2ED;100
+Glasses of Urza;3ED;100
+Glasses of Urza;4ED;100
+Glasses of Urza;5ED;100
+Glasses of Urza;6ED;100
+Glasses of Urza;LEA;100
+Glasses of Urza;LEB;100
+Glasses of Urza;ME4;100
+Glaze Fiend;ALA;98588
+Glaze Fiend;DPA;98588
+Gleam of Authority;DTK;160135
+Gleam of Battle;DGM;146845
+Gleam of Resistance;CON;118706
+Gleam of Resistance;DPA;118706
+Gleam of Resistance;MMA;118706
+Gleancrawler;DDJ;88876
+Gleancrawler;DPA;88700
+Gleancrawler;PRM;88876
+Gleancrawler;RAV;88700
+Gleeful Sabotage;SHM;111842
+Gleemox;PRM;110226
+Glen Elendra Archmage;EVE;113746
+Glen Elendra Archmage;MMA;113746
+Glen Elendra Liege;PC2;111649
+Glen Elendra Liege;SHM;111649
+Glen Elendra Pranksters;LRW;104078
+Glen Elendra;PC2;131674
+Gliding Licid;STH;3696
+Glimmer of Genius;KLD;162491
+Glimmerdust Nap;LRW;105355
+Glimmering Angel;INV;24060
+Glimmerpoint Stag;EMA;130869
+Glimmerpoint Stag;SOM;130869
+Glimmerpoint Stag;TD2;130869
+Glimmerpost;SOM;131082
+Glimmervoid Basin;PC1;125863
+Glimmervoid;MMA;50294
+Glimmervoid;MRD;50294
+Glimpse of Nature;COK;80723
+Glimpse the Future;M14;123695
+Glimpse the Sun God;BNG;152540
+Glimpse the Unthinkable;RAV;88623
+Glint Hawk Idol;MM2;130870
+Glint Hawk Idol;SOM;130870
+Glint Hawk;SOM;131029
+Glint-Eye Nephilim;GPT;91864
+Glint-Nest Crane;KLD;162494
+Glint-Sleeve Artisan;KLD;162233
+Glint-Sleeve Siphoner;AER;400298
+Glint;DTK;160041
+Glintwing Invoker;LGN;47490
+Glissa Sunseeker;MRD;49643
+Glissa, the Traitor;MBS;134059
+Glissa, the Traitor;PRM;133239
+Glissa, the Traitor;V16;134059
+Glissa's Courier;MBS;133171
+Glissa's Scorn;NPH;134189
+Glistener Elf;NPH;134391
+Glistener Elf;PRM;140383
+Glistening Oil;NPH;134202
+Glitterfang;SOK;87564
+Glittering Lion;PCY;21959
+Glittering Lynx;PCY;21960
+Glittering Wish;FUT;102477
+Global Ruin;INV;24127
+Gloom Surgeon;AVR;141706
+Gloom;2ED;101
+Gloom;3ED;101
+Gloom;4ED;101
+Gloom;5ED;2387
+Gloom;LEA;101
+Gloom;LEB;101
+Gloom;ME4;101
+Gloomdrifter;TOR;36454
+Gloomhunter;DPA;127277
+Gloomhunter;ROE;127277
+Gloomlance;SHM;111868
+Gloomwidow;AVR;142208
+Gloomwidow;DPA;142208
+Gloomwidow;SHM;111666
+Gloomwidow;SOI;142208
+Gloomwidow's Feast;SHM;111796
+Glorifier of Dusk;XLN;402037
+Glorious Anthem;10E;8941
+Glorious Anthem;7ED;27580
+Glorious Anthem;8ED;8941
+Glorious Anthem;9ED;8941
+Glorious Anthem;DPA;8941
+Glorious Anthem;PRM;110213
+Glorious Anthem;USG;8941
+Glorious Charge;M10;122149
+Glorious Charge;M13;122149
+Glorious End;AKH;401331
+Glory Seeker;8ED;42915
+Glory Seeker;9ED;42915
+Glory Seeker;DDF;127422
+Glory Seeker;DPA;127422
+Glory Seeker;ONS;42915
+Glory Seeker;ROE;127422
+Glory Seeker;W17;127422
+Glory of Warfare;ARB;120996
+Glory of Warfare;DPA;120996
+Glory of Warfare;PC1;120996
+Glory-Bound Initiate;AKH;400792
+Glory;JUD;40186
+Glory;PRM;40186
+Glorybringer;AKH;400840
+Glorybringer;PRM;401365
+Gloryscale Viashino;ARB;121078
+Glowering Rogon;LGN;47485
+Glowing Anemone;MMQ;19293
+Glowrider;LGN;47469
+Gluttonous Cyclops;JOU;152852
+Gluttonous Slime;CON;118708
+Gluttonous Slime;PC2;118708
+Gluttonous Zombie;8ED;44666
+Gluttonous Zombie;9ED;44666
+Gluttonous Zombie;ONS;44666
+Glyph Keeper;AKH;400916
+Glyph Keeper;TOK;401249
+Glyph of Delusion;LEG;567
+Glyph of Destruction;LEG;568
+Glyph of Doom;LEG;569
+Glyph of Life;LEG;570
+Glyph of Reincarnation;LEG;571
+Gnarled Effigy;SHM;111603
+Gnarled Mass;BOK;83941
+Gnarled Scarhide;JOU;153059
+Gnarlid Pack;MM2;126594
+Gnarlid Pack;WWK;126594
+Gnarlroot Trapper;ORI;160250
+Gnarlwood Dryad;EMN;162007
+Gnat Alley Creeper;DIS;94581
+Gnat Miser;SOK;86169
+Gnathosaur;MBS;133152
+Gnaw to the Bone;ISD;138504
+Gnawing Zombie;M14;147490
+Gnawing Zombie;MM3;147490
+Gnome;TOK;132692
+Go for the Throat;DPA;133186
+Go for the Throat;MBS;133186
+Go for the Throat;PRM;139457
+Goat;TOK;113776
+Goat;TOK;143917
+Goatnapper;LRW;105605
+Gobbling Ooze;RTR;145912
+Gobhobbler Rats;DIS;94597
+Goblin Archaeologist;DST;52005
+Goblin Arsonist;DDK;127413
+Goblin Arsonist;DPA;127413
+Goblin Arsonist;M12;127413
+Goblin Arsonist;M13;127413
+Goblin Arsonist;ROE;127413
+Goblin Artillery;DPA;121672
+Goblin Artillery;M10;121672
+Goblin Artisans;ATQ;413
+Goblin Artisans;CH;413
+Goblin Assassin;LGN;47517
+Goblin Assault;ALA;115023
+Goblin Assault;MM3;115023
+Goblin Balloon Brigade;2ED;102
+Goblin Balloon Brigade;3ED;102
+Goblin Balloon Brigade;4ED;102
+Goblin Balloon Brigade;9ED;86949
+Goblin Balloon Brigade;DPA;86949
+Goblin Balloon Brigade;LEA;102
+Goblin Balloon Brigade;LEB;102
+Goblin Balloon Brigade;M11;86949
+Goblin Bangchuckers;M12;134187
+Goblin Battle Jester;M13;143950
+Goblin Berserker;UD;15712
+Goblin Bomb;WTH;2882
+Goblin Bombardment;C13;3265
+Goblin Bombardment;PRM;156561
+Goblin Bombardment;PRM;3265
+Goblin Bombardment;TMP;3265
+Goblin Bombardment;TPR;3265
+Goblin Boom Keg;FRF;159399
+Goblin Brawler;5DN;77160
+Goblin Brigand;9ED;48106
+Goblin Brigand;SCG;48106
+Goblin Bully;ME4;6697
+Goblin Bully;POR;6697
+Goblin Burrows;EVG;43248
+Goblin Burrows;ONS;43248
+Goblin Bushwhacker;DPA;123548
+Goblin Bushwhacker;ZEN;123548
+Goblin Cadets;CMD;8928
+Goblin Cadets;USG;8928
+Goblin Cannon;5DN;77080
+Goblin Cavaliers;ME4;4740
+Goblin Cavaliers;PO2;4740
+Goblin Caves;DRK;776
+Goblin Caves;ME4;776
+Goblin Charbelcher;EMA;161578
+Goblin Charbelcher;MRD;51139
+Goblin Chariot;7ED;27638
+Goblin Chariot;8ED;27638
+Goblin Chariot;9ED;27638
+Goblin Chieftain;DPA;121632
+Goblin Chieftain;M10;121632
+Goblin Chieftain;M11;121632
+Goblin Chieftain;M12;121632
+Goblin Chirurgeon;FEM;907
+Goblin Chirurgeon;FEM;908
+Goblin Chirurgeon;FEM;909
+Goblin Chirurgeon;MED;907
+Goblin Clearcutter;LGN;48210
+Goblin Cohort;BOK;83856
+Goblin Cohort;EVG;83856
+Goblin Commando;VMA;17571
+Goblin Dark-Dwellers;OGW;161234
+Goblin Dark-Dwellers;PRM;161276
+Goblin Deathraiders;ALA;115044
+Goblin Deathraiders;DPA;115044
+Goblin Digging Team;5ED;2388
+Goblin Digging Team;6ED;2388
+Goblin Digging Team;7ED;27639
+Goblin Digging Team;CH;777
+Goblin Digging Team;DRK;777
+Goblin Diplomats;M14;147419
+Goblin Diplomats;PRM;149172
+Goblin Dirigible;MRD;50280
+Goblin Dynamo;DPA;46567
+Goblin Dynamo;LGN;46567
+Goblin Electromancer;DDJ;145150
+Goblin Electromancer;MM3;145150
+Goblin Electromancer;RTR;145150
+Goblin Elite Infantry;10E;1905
+Goblin Elite Infantry;6ED;1905
+Goblin Elite Infantry;7ED;27640
+Goblin Elite Infantry;MIR;1905
+Goblin Festival;UD;15702
+Goblin Fire Fiend;DPA;88954
+Goblin Fire Fiend;RAV;88954
+Goblin Firebug;LGN;46591
+Goblin Fireslinger;DPA;135412
+Goblin Fireslinger;M12;135412
+Goblin Fireslinger;MM2;135412
+Goblin Firestarter;ME4;4751
+Goblin Firestarter;PO2;4751
+Goblin Flectomancer;GPT;91821
+Goblin Flotilla;FEM;910
+Goblin Freerunner;OGW;161241
+Goblin Furrier;CSP;96921
+Goblin Game;PLS;27922
+Goblin Gardener;7ED;27641
+Goblin Gardener;UD;15643
+Goblin Gaveleer;SOM;130970
+Goblin General;ME4;4583
+Goblin General;PO2;4583
+Goblin General;VMA;4583
+Goblin Glider;7ED;27642
+Goblin Glider;8ED;27642
+Goblin Glider;PO2;4737
+Goblin Glory Chaser;ORI;160302
+Goblin Goon;DPA;46600
+Goblin Goon;LGN;46600
+Goblin Goon;VMA;46600
+Goblin Grappler;LGN;47525
+Goblin Grenade;DPA;137409
+Goblin Grenade;FEM;911
+Goblin Grenade;FEM;912
+Goblin Grenade;FEM;913
+Goblin Grenade;M12;137409
+Goblin Grenade;MED;913
+Goblin Grenadiers;WTH;2937
+Goblin Guide;DPA;123540
+Goblin Guide;MM3;400106
+Goblin Guide;PRM;140038
+Goblin Guide;TD0;123540
+Goblin Guide;ZEN;123540
+Goblin Heelcutter;FRF;157239
+Goblin Hero;5ED;2389
+Goblin Hero;6ED;2389
+Goblin Hero;DRK;778
+Goblin Kaboomist;M15;155221
+Goblin King;10E;27643
+Goblin King;2ED;103
+Goblin King;3ED;103
+Goblin King;4ED;103
+Goblin King;5ED;2390
+Goblin King;6ED;2390
+Goblin King;7ED;27643
+Goblin King;8ED;27643
+Goblin King;9ED;27643
+Goblin King;DPA;27643
+Goblin King;LEA;103
+Goblin King;LEB;103
+Goblin Kites;FEM;914
+Goblin Lackey;USG;8931
+Goblin Lackey;V09;122582
+Goblin Lackey;VMA;122582
+Goblin Legionnaire;APC;31081
+Goblin Legionnaire;PRM;31081
+Goblin Lookout;LGN;46558
+Goblin Lore;10E;4755
+Goblin Lore;PO2;4755
+Goblin Lyre;ICE;1191
+Goblin Machinist;ONS;43119
+Goblin Marshal;UD;15654
+Goblin Masons;UD;15648
+Goblin Matron;7ED;27644
+Goblin Matron;EVG;4749
+Goblin Matron;PO2;4749
+Goblin Matron;USG;8707
+Goblin Matron;VMA;27644
+Goblin Medics;UL;10383
+Goblin Mountaineer;9ED;86900
+Goblin Mountaineer;ALA;115022
+Goblin Mountaineer;DPA;115022
+Goblin Mountaineer;PO2;4738
+Goblin Mutant;ICE;1192
+Goblin Mutant;MED;1192
+Goblin Offensive;DPA;8686
+Goblin Offensive;PC1;8686
+Goblin Offensive;USG;8686
+Goblin Outlander;CON;118772
+Goblin Outlander;DPA;118772
+Goblin Patrol;USG;8913
+Goblin Patrol;VMA;8913
+Goblin Piker;10E;4588
+Goblin Piker;9ED;4588
+Goblin Piker;DPA;4588
+Goblin Piker;M10;4588
+Goblin Piker;M11;4588
+Goblin Piker;M12;4588
+Goblin Piker;PO2;4588
+Goblin Piledriver;DPA;43140
+Goblin Piledriver;ONS;43140
+Goblin Piledriver;ORI;43140
+Goblin Piledriver;PRM;107687
+Goblin Piledriver;VMA;107687
+Goblin Psychopath;SCG;47494
+Goblin Pyromancer;ONS;43133
+Goblin Rabblemaster;M15;155201
+Goblin Rabblemaster;PRM;155863
+Goblin Raider;7ED;27645
+Goblin Raider;8ED;8914
+Goblin Raider;9ED;8914
+Goblin Raider;PO2;4736
+Goblin Raider;USG;8914
+Goblin Rally;RTR;145908
+Goblin Razerunners;CON;118700
+Goblin Recruiter;6ED;2179
+Goblin Recruiter;VIS;2179
+Goblin Replica;MRD;50233
+Goblin Rimerunner;CSP;96955
+Goblin Ringleader;APC;31080
+Goblin Ringleader;DPA;143955
+Goblin Ringleader;EVG;31080
+Goblin Ringleader;PRM;31080
+Goblin Ringleader;VMA;143955
+Goblin Rock Sled;4ED;779
+Goblin Rock Sled;DRK;779
+Goblin Rogue;TOK;107648
+Goblin Rogue;TOK;148269
+Goblin Roughrider;DPA;126598
+Goblin Roughrider;M15;126598
+Goblin Roughrider;WWK;126598
+Goblin Ruinblaster;ZEN;123599
+Goblin Sappers;ICE;1193
+Goblin Scout;TOK;6170
+Goblin Scouts;MIR;1906
+Goblin Settler;VMA;17572
+Goblin Sharpshooter;C13;151431
+Goblin Sharpshooter;ONS;43123
+Goblin Sharpshooter;PZ1;151431
+Goblin Shortcutter;M14;123611
+Goblin Shortcutter;ZEN;123611
+Goblin Shrine;CH;780
+Goblin Shrine;DRK;780
+Goblin Shrine;ME4;780
+Goblin Ski Patrol;ICE;1194
+Goblin Ski Patrol;ME2;1194
+Goblin Sky Raider;10E;43096
+Goblin Sky Raider;9ED;43096
+Goblin Sky Raider;DPA;43096
+Goblin Sky Raider;ONS;43096
+Goblin Skycutter;TSP;98954
+Goblin Sledder;EVG;43097
+Goblin Sledder;ONS;43097
+Goblin Snowman;ICE;1195
+Goblin Snowman;TSB;1195
+Goblin Soldier;TOK;113772
+Goblin Soldier;TOK;161572
+Goblin Soldier;TOK;35342
+Goblin Soothsayer;MIR;1907
+Goblin Spelunkers;7ED;27646
+Goblin Spelunkers;RAV;88775
+Goblin Spelunkers;USG;8700
+Goblin Spy;INV;25660
+Goblin Spymaster;PZ2;162429
+Goblin Striker;MRD;50334
+Goblin Swine-Rider;VIS;2180
+Goblin Taskmaster;ONS;43089
+Goblin Test Pilot;DGM;146852
+Goblin Tinkerer;MIR;1908
+Goblin Trenches;APC;31036
+Goblin Trenches;EMA;161573
+Goblin Trenches;VMA;31036
+Goblin Tunneler;M11;127259
+Goblin Tunneler;M12;127259
+Goblin Tunneler;ROE;127259
+Goblin Turncoat;LGN;47495
+Goblin Vandal;PRM;43095
+Goblin Vandal;WTH;2814
+Goblin War Buggy;USG;8704
+Goblin War Cry;PO2;4582
+Goblin War Drums;5ED;915
+Goblin War Drums;7ED;27647
+Goblin War Drums;FEM;915
+Goblin War Drums;FEM;916
+Goblin War Drums;FEM;917
+Goblin War Drums;FEM;918
+Goblin War Paint;BFZ;160693
+Goblin War Paint;DPA;123630
+Goblin War Paint;M12;123630
+Goblin War Paint;MM2;123630
+Goblin War Paint;ZEN;123630
+Goblin War Strike;PO2;4747
+Goblin War Strike;SCG;48968
+Goblin War Wagon;MRD;50230
+Goblin Warchief;DPA;48122
+Goblin Warchief;EVG;48122
+Goblin Warchief;PRM;161041
+Goblin Warchief;PRM;48122
+Goblin Warchief;SCG;48122
+Goblin Warchief;VMA;48122
+Goblin Wardriver;DPA;133170
+Goblin Wardriver;MBS;133170
+Goblin Warrens;5ED;919
+Goblin Warrens;6ED;919
+Goblin Warrens;FEM;919
+Goblin Warrens;ME4;919
+Goblin Warrior;TOK;111546
+Goblin Welder;C14;10358
+Goblin Welder;UL;10358
+Goblin Wizard;DRK;781
+Goblin Wizard;MED;781
+Goblin;TOK;104574
+Goblin;TOK;117016
+Goblin;TOK;125148
+Goblin;TOK;131404
+Goblin;TOK;136857
+Goblin;TOK;143965
+Goblin;TOK;145988
+Goblin;TOK;156689
+Goblin;TOK;160150
+Goblin;TOK;162425
+Goblin;TOK;47536
+Goblin;TOK;89184
+Goblin;TOK;98946
+Goblins of the Flarg;CH;782
+Goblins of the Flarg;DRK;782
+Goblins of the Flarg;MED;782
+Goblinslide;KTK;157045
+God-Favored General;BNG;152059
+God-Pharaoh's Faithful;HOU;401515
+God-Pharaoh's Gift;HOU;401580
+Godhead of Awe;DPA;111570
+Godhead of Awe;SHM;111570
+Godhunter Octopus;JOU;152824
+Godless Shrine;EXP;160791
+Godless Shrine;GPT;91761
+Godless Shrine;GTC;145162
+Godo, Bandit Warlord;COK;80863
+Godo's Irregulars;SOK;81570
+Gods Willing;THS;150790
+Gods' Eye, Gate to the Reikai;BOK;83968
+Godsend;JOU;152978
+Godsire;ALA;115138
+Godsire;DPA;115138
+Godtoucher;ALA;114945
+Godtracker of Jund;ARB;121038
+Goham Djinn;INV;24072
+Gold Myr;MRD;50860
+Gold Myr;PC1;50860
+Gold Myr;SOM;130974
+Gold Myr;TD2;130974
+Gold-Forged Sentinel;JOU;152818
+Gold-Forged Sentinel;ORI;152818
+Gold;TOK;152617
+Golden Bear;PO2;4585
+Golden Hind;JOU;152882
+Golden Urn;DPA;131156
+Golden Urn;SOM;131156
+Golden Wish;JUD;40193
+Goldenglow Moth;DPA;111904
+Goldenglow Moth;M11;111904
+Goldenglow Moth;SHM;111904
+Goldenhide Ox;JOU;153052
+Goldmeadow Dodger;LRW;105456
+Goldmeadow Harrier;DDF;103471
+Goldmeadow Harrier;LRW;103471
+Goldmeadow Harrier;TOK;103471
+Goldmeadow Lookout;FUT;102368
+Goldmeadow Stalwart;LRW;105598
+Goldmeadow;PC1;126702
+Goldnight Castigator;SOI;161661
+Goldnight Commander;AVR;141574
+Goldnight Commander;DPA;141574
+Goldnight Redeemer;AVR;141543
+Golem Artisan;SOM;131030
+Golem Foundry;SOM;130951
+Golem-Skin Gauntlets;MRD;50237
+Golem;TOK;131553
+Golem;TOK;133267
+Golem;TOK;134385
+Golem;TOK;150896
+Golem's Heart;DPA;131007
+Golem's Heart;PRM;132558
+Golem's Heart;SOM;131007
+Golgari Brownscale;RAV;89009
+Golgari Charm;RTR;145207
+Golgari Cluestone;DGM;147760
+Golgari Decoy;RTR;145178
+Golgari Germination;DDJ;89110
+Golgari Germination;DPA;89110
+Golgari Germination;MM3;400713
+Golgari Germination;RAV;89110
+Golgari Grave-Troll;DDJ;89001
+Golgari Grave-Troll;RAV;89001
+Golgari Grave-Troll;TD0;89001
+Golgari Guildgate;C13;145165
+Golgari Guildgate;DDM;145165
+Golgari Guildgate;DGM;146880
+Golgari Guildgate;MM3;146880
+Golgari Guildgate;RTR;145165
+Golgari Guildmage;C13;88798
+Golgari Guildmage;CMD;88798
+Golgari Guildmage;RAV;88798
+Golgari Keyrune;RTR;145215
+Golgari Longlegs;RTR;145889
+Golgari Rot Farm;C13;88929
+Golgari Rot Farm;CMD;88929
+Golgari Rot Farm;DDJ;88929
+Golgari Rot Farm;MM2;88929
+Golgari Rot Farm;RAV;88929
+Golgari Rot Farm;TD0;88929
+Golgari Rotwurm;DDJ;89079
+Golgari Rotwurm;MM3;89079
+Golgari Rotwurm;RAV;89079
+Golgari Signet;CMD;89180
+Golgari Signet;DDJ;131723
+Golgari Signet;MM3;131723
+Golgari Signet;PRM;131723
+Golgari Signet;RAV;89180
+Golgari Signet;TD0;89180
+Golgari Thug;DDJ;145064
+Golgari Thug;RAV;89035
+Golgari Thug;TD0;89035
+Golgothian Sylex;ATQ;414
+Goliath Beetle;UD;15663
+Goliath Sphinx;DPA;126544
+Goliath Sphinx;WWK;126544
+Goliath Spider;RAV;89000
+Gomazoa;CMD;125096
+Gomazoa;ZEN;125096
+Gone Missing;SOI;161764
+Gone;PLC;104385
+Gonti, Lord of Luxury;KLD;162512
+Gonti's Aether Heart;AER;400409
+Gonti's Machinations;AER;400295
+Gore Swine;FRF;157275
+Gore Vassal;MBS;133185
+Gore-House Chainwalker;RTR;145864
+Gorehorn Minotaurs;DDL;127464
+Gorehorn Minotaurs;M12;127464
+Gorehorn Minotaurs;MM2;127464
+Goretusk Firebeast;JUD;40241
+Gorger Wurm;ARB;120971
+Gorger Wurm;DPA;120971
+Gorgon Flail;M10;121712
+Gorgon Recluse;TSP;97544
+Gorgon's Head;BNG;149102
+Gorilla Berserkers;ALL;1643
+Gorilla Berserkers;ALL;1644
+Gorilla Chieftain;6ED;1645
+Gorilla Chieftain;7ED;27648
+Gorilla Chieftain;ALL;1645
+Gorilla Chieftain;ALL;1646
+Gorilla Pack;ICE;1196
+Gorilla Shaman;ALL;1647
+Gorilla Shaman;ALL;1648
+Gorilla Shaman;ME2;1648
+Gorilla Shaman;PRM;400622
+Gorilla Titan;ODY;33293
+Gorilla War Cry;ALL;1649
+Gorilla War Cry;ALL;1650
+Gorilla War Cry;ME4;1649
+Gorilla Warrior;POR;6655
+Gorilla Warrior;USG;8948
+Goring Ceratops;XLN;402091
+Goryo's Vengeance;BOK;83873
+Gossamer Chains;VIS;2181
+Gossamer Phantasm;DPA;100657
+Gossamer Phantasm;PLC;100657
+Gosta Dirk;LEG;4632
+Govern the Guildless;DIS;94459
+Grab the Reins;MRD;50279
+Graceblade Artisan;DTK;160059
+Graceful Adept;COK;80559
+Graceful Antelope;ODY;33512
+Graceful Cat;AKH;401054
+Graceful Reprieve;MM3;110000
+Graceful Reprieve;MOR;110000
+Graf Harvest;EMN;161947
+Graf Mole;SOI;161679
+Graf Rats;EMN;161960
+Grafdigger's Cage;DKA;141828
+Grafdigger's Cage;MM3;141828
+Grafted Exoskeleton;SOM;131084
+Grafted Exoskeleton;TD2;131084
+Grafted Skullcap;7ED;27649
+Grafted Skullcap;USG;8698
+Grafted Wargear;5DN;77120
+Grand Abolisher;C14;134095
+Grand Abolisher;M12;134095
+Grand Arbiter Augustin IV;DIS;94398
+Grand Arbiter Augustin IV;DPA;94398
+Grand Arbiter Augustin IV;MMA;94398
+Grand Architect;SOM;131044
+Grand Architect;TD2;131044
+Grand Coliseum;ONS;43232
+Grand Coliseum;VMA;43232
+Grand Melee;ONS;33352
+Grand Ossuary;PC2;138738
+Grandmother Sengir;HML;1511
+Grandmother Sengir;ME2;1511
+Granger Guildmage;MIR;1909
+Granite Gargoyle;2ED;104
+Granite Gargoyle;3ED;104
+Granite Gargoyle;LEA;104
+Granite Gargoyle;LEB;104
+Granite Gargoyle;MED;104
+Granite Grip;7ED;27650
+Granite Grip;UL;10387
+Granite Shard;MRD;51003
+Granitic Titan;HOU;401512
+Granulate;5DN;51975
+Grapeshot Catapult;4ED;415
+Grapeshot Catapult;5ED;415
+Grapeshot Catapult;7ED;27651
+Grapeshot Catapult;ATQ;415
+Grapeshot Catapult;ME4;415
+Grapeshot;MMA;148259
+Grapeshot;TSP;97509
+Grapple with the Past;EMN;161993
+Grappler Spider;WWK;126485
+Grappling Hook;ZEN;123724
+Grasp of Darkness;OGW;161141
+Grasp of Darkness;SOM;130890
+Grasp of Fate;PZ1;160445
+Grasp of Phantoms;ISD;138430
+Grasp of Phantoms;MM3;138430
+Grasp of the Hieromancer;ORI;160206
+Grasping Current;XLN;402341
+Grasping Dunes;AKH;400784
+Grassland Crusader;ONS;42919
+Grasslands;DDG;1910
+Grasslands;MIR;1910
+Grasslands;VMA;1910
+Gratuitous Violence;ONS;43145
+Grave Betrayal;RTR;145945
+Grave Birthing;BFZ;160895
+Grave Bramble;ISD;138314
+Grave Consequences;JUD;40231
+Grave Defiler;APC;31155
+Grave Exchange;AVR;142199
+Grave Pact;10E;86738
+Grave Pact;8ED;49242
+Grave Pact;9ED;86738
+Grave Pact;CMD;86738
+Grave Pact;DPA;86738
+Grave Pact;PC1;86738
+Grave Pact;STH;3670
+Grave Peril;FUT;102347
+Grave Robbers;DRK;783
+Grave Scrabbler;FUT;102426
+Grave Servitude;MIR;1911
+Grave Sifter;C14;155639
+Grave Strength;FRF;157328
+Grave Titan;C14;129102
+Grave Titan;DPA;129102
+Grave Titan;M11;129102
+Grave Titan;M12;129102
+Grave Titan;PRM;139232
+Grave Upheaval;PZ2;162433
+Grave-Shell Scarab;RAV;89075
+Gravebane Zombie;6ED;1912
+Gravebane Zombie;MIR;1912
+Gravebind;ICE;1197
+Gravebind;ME4;1197
+Graveblade Marauder;ORI;160270
+Graveborn Muse;10E;47521
+Graveborn Muse;LGN;47521
+Graveborn;TOK;97957
+Gravecrawler;DKA;139723
+Gravecrawler;DPA;139723
+Gravecrawler;PRM;140331
+Gravedigger;10E;2972
+Gravedigger;6ED;2972
+Gravedigger;7ED;27652
+Gravedigger;8ED;2972
+Gravedigger;9ED;2972
+Gravedigger;AKH;400807
+Gravedigger;CMD;2972
+Gravedigger;DPA;2972
+Gravedigger;EMA;2972
+Gravedigger;M10;2972
+Gravedigger;M11;2972
+Gravedigger;M12;2972
+Gravedigger;M15;2972
+Gravedigger;ODY;33436
+Gravedigger;PC1;2972
+Gravedigger;POR;6579
+Gravedigger;TMP;2972
+Gravedigger;TPR;2972
+Gravegouger;TOR;36456
+Gravel Slinger;ONS;42910
+Gravelgill Axeshark;SHM;111528
+Gravelgill Duo;SHM;111751
+Graven Abomination;HOU;401847
+Graven Cairns;EXP;161115
+Graven Cairns;FUT;102390
+Graven Cairns;SHM;111660
+Graven Dominator;GPT;91838
+Gravepurge;DKA;138120
+Gravepurge;DTK;159800
+Graverobber Spider;BNG;152078
+Gravespawn Sovereign;ONS;43076
+Gravestorm;ODY;33405
+Gravetiller Wurm;DKA;139830
+Graveyard Shovel;ISD;138182
+Gravitational Shift;ROE;127279
+Gravity Negator;OGW;161110
+Gravity Sphere;LEG;4633
+Gravity Well;ROE;127423
+Graxiplon;ONS;42980
+Gray Merchant of Asphodel;C14;150846
+Gray Merchant of Asphodel;THS;150846
+Gray Ogre;2ED;105
+Gray Ogre;3ED;105
+Gray Ogre;4ED;105
+Gray Ogre;LEA;105
+Gray Ogre;LEB;105
+Graypelt Hunter;WWK;126592
+Graypelt Refuge;DDH;123664
+Graypelt Refuge;PC2;123664
+Graypelt Refuge;ZEN;123664
+Grayscaled Gharial;RAV;88904
+Grazing Gladehart;C13;123656
+Grazing Gladehart;DDH;123656
+Grazing Gladehart;DPA;123656
+Grazing Gladehart;ZEN;123656
+Grazing Kelpie;EVE;113676
+Grazing Whiptail;XLN;402250
+Great Defender;LEG;572
+Great Furnace;C14;51009
+Great Furnace;MRD;51009
+Great Furnace;PC1;51009
+Great Hart;BNG;152015
+Great Oak Guardian;PZ1;137402
+Great Sable Stag;DPA;122172
+Great Sable Stag;M10;122172
+Great Teacher's Decree;DTK;159724
+Great Wall;LEG;573
+Great Whale;USG;8719
+Great-Horn Krushok;FRF;157299
+Greatbow Doyen;MOR;110005
+Greater Auramancy;SHM;111691
+Greater Basilisk;M11;129106
+Greater Basilisk;M12;129106
+Greater Forgeling;RAV;88924
+Greater Gargadon;MMA;97385
+Greater Gargadon;TSP;97385
+Greater Good;9ED;86903
+Greater Good;DPA;86903
+Greater Good;PRM;153384
+Greater Good;USG;8938
+Greater Harvester;DST;52050
+Greater Mossdog;DDJ;88889
+Greater Mossdog;MMA;88889
+Greater Mossdog;RAV;88889
+Greater Realm of Preservation;5ED;2391
+Greater Realm of Preservation;LEG;574
+Greater Realm of Preservation;MED;574
+Greater Sandwurm;AKH;400878
+Greater Stone Spirit;CSP;96944
+Greater Stone Spirit;DDI;96944
+Greater Werewolf;5ED;1512
+Greater Werewolf;HML;1512
+Greatsword;M12;134168
+Greed;4ED;2517
+Greed;6ED;2517
+Greed;7ED;27653
+Greed;C13;151967
+Greed;LEG;2517
+Greel, Mind Raker;PCY;21947
+Greel's Caress;PCY;22054
+Green Mana Battery;4ED;575
+Green Mana Battery;LEG;575
+Green Scarab;ICE;1198
+Green Sun's Zenith;EMA;133255
+Green Sun's Zenith;MBS;133255
+Green Sun's Zenith;V13;133255
+Green Ward;2ED;106
+Green Ward;3ED;106
+Green Ward;4ED;106
+Green Ward;LEA;106
+Green Ward;LEB;106
+Greenbelt Rampager;AER;400352
+Greener Pastures;USG;8784
+Greenhilt Trainee;NPH;134402
+Greenseeker;TSP;97295
+Greenside Watcher;GTC;146565
+Greenwarden of Murasa;BFZ;160870
+Greenweaver Druid;ZEN;123626
+Greenwheel Liberator;AER;400351
+Gremlin Infestation;AER;400322
+Gremlin Mine;NPH;134317
+Gremlin;TOK;400429
+Grenzo, Dungeon Warden;VMA;153180
+Grenzo, Havoc Raiser;PZ2;161891
+Grid Monitor;MRD;50297
+Gridlock;GTC;146375
+Grief Tyrant;SHM;111611
+Griffin Canyon;VIS;2182
+Griffin Dreamfinder;BNG;152016
+Griffin Guide;DDG;97375
+Griffin Guide;DDH;97375
+Griffin Guide;DDL;150063
+Griffin Guide;DPA;97375
+Griffin Guide;TSP;97375
+Griffin Protector;M13;143906
+Griffin Rider;M12;134159
+Griffin Sentinel;M10;121597
+Griffin Sentinel;M12;121597
+Griffin Sentinel;M14;121597
+Griffin;TOK;150069
+Griffin;TOK;98951
+Grifter's Blade;RAV;88639
+Grim Affliction;MM2;134237
+Grim Affliction;NPH;134237
+Grim Backwoods;C13;140334
+Grim Backwoods;DKA;140334
+Grim Captain's Call;XLN;402335
+Grim Contest;FRF;157345
+Grim Discovery;ZEN;123587
+Grim Feast;MIR;1913
+Grim Flayer;EMN;162607
+Grim Flowering;C14;139878
+Grim Flowering;DDJ;139878
+Grim Flowering;DKA;139878
+Grim Guardian;JOU;152853
+Grim Haruspex;KTK;157031
+Grim Haruspex;PRM;159860
+Grim Harvest;CSP;97253
+Grim Harvest;TD0;97253
+Grim Lavamancer;DPA;92880
+Grim Lavamancer;M12;92880
+Grim Lavamancer;PD2;92880
+Grim Lavamancer;PRM;92880
+Grim Lavamancer;TOR;37296
+Grim Monolith;PRM;400641
+Grim Monolith;UL;10353
+Grim Poppet;SHM;111646
+Grim Reminder;MRD;51120
+Grim Return;DPA;147416
+Grim Return;M14;147416
+Grim Roustabout;RTR;145127
+Grim Strider;AKH;401312
+Grim Tutor;ME3;17569
+Grimclaw Bats;DST;75162
+Grimgrin, Corpse-Born;ISD;138501
+Grimoire Thief;MOR;109960
+Grimoire of the Dead;ISD;138352
+Grind;HOU;401838
+Grindclock;DPA;130901
+Grindclock;M15;130901
+Grindclock;SOM;130901
+Grinding Station;5DN;77174
+Grindstone;MS2;400932
+Grindstone;PRM;143992
+Grindstone;TMP;3100
+Grindstone;TPR;3100
+Grinning Demon;ONS;43072
+Grinning Ignus;FUT;102447
+Grinning Ignus;MMA;102447
+Grinning Totem;6ED;1914
+Grinning Totem;MIR;1914
+Grinning Totem;TSB;1914
+Grip of Amnesia;JUD;40204
+Grip of Chaos;SCG;48116
+Grip of Desolation;BFZ;160657
+Grip of Phyresis;PZ2;162371
+Grip of the Roil;OGW;161033
+Griptide;DDM;139744
+Griptide;DKA;139744
+Griptide;THS;151413
+Griselbrand;AVR;141739
+Griselbrand;DPA;141739
+Griselbrand;MM3;141739
+Griselbrand;PRM;159367
+Grisly Anglerfish;EMN;162064
+Grisly Salvage;PRM;151397
+Grisly Salvage;RTR;145156
+Grisly Spectacle;DDM;146425
+Grisly Spectacle;GTC;146425
+Grisly Spectacle;MM3;146425
+Grisly Survivor;HOU;401504
+Grisly Transformation;BNG;152034
+Gristle Grinner;CSP;96869
+Gristleback;GPT;91660
+Grixis Battlemage;ALA;114978
+Grixis Battlemage;DPA;114978
+Grixis Charm;ALA;114911
+Grixis Charm;C13;114911
+Grixis Charm;DDH;114911
+Grixis Grimblade;ARB;121063
+Grixis Illusionist;CON;118678
+Grixis Panorama;ALA;116199
+Grixis Panorama;C13;116199
+Grixis Slavedriver;CON;118660
+Grixis Slavedriver;MM3;118660
+Grixis Sojourners;ARB;121059
+Grixis;PC1;125866
+Grizzled Angler;EMN;162065
+Grizzled Leotau;ARB;121071
+Grizzled Outcasts;ISD;138202
+Grizzled Wolverine;ICE;1199
+Grizzly Bears;10E;27654
+Grizzly Bears;2ED;107
+Grizzly Bears;3ED;107
+Grizzly Bears;4ED;107
+Grizzly Bears;5ED;2392
+Grizzly Bears;6ED;2392
+Grizzly Bears;7ED;27654
+Grizzly Bears;8ED;27654
+Grizzly Bears;9ED;27654
+Grizzly Bears;DPA;27654
+Grizzly Bears;LEA;107
+Grizzly Bears;LEB;107
+Grizzly Bears;POR;6656
+Grizzly Fate;JUD;40282
+Grizzly Fate;VMA;40282
+Groffskithur;MRD;51093
+Grollub;EXO;5619
+Grotag Siege-Runner;ROE;127305
+Grotag Thrasher;WWK;126495
+Grotesque Hybrid;TOR;36455
+Grotesque Mutation;SOI;162155
+Ground Assault;GTC;146307
+Ground Assault;MM3;146307
+Ground Rift;TSP;97322
+Ground Seal;M13;143978
+Ground Seal;ODY;33282
+Groundbreaker;PLC;103678
+Groundbreaker;PRM;103678
+Grounded;AVR;141554
+Groundling Pouncer;EVE;113668
+Groundshaker Sliver;DPA;147468
+Groundshaker Sliver;M14;147468
+Groundskeeper;9ED;19245
+Groundskeeper;MMQ;19245
+Groundskeeper;SOI;161659
+Groundswell;WWK;126475
+Grove Rumbler;BFZ;160724
+Grove of the Burnwillows;FUT;102394
+Grove of the Burnwillows;V12;143997
+Grove of the Dreampods;PC2;138728
+Grove of the Guardian;PRM;145974
+Grove of the Guardian;RTR;145975
+Grovetender Druids;BFZ;160865
+Growing Ranks;RTR;145954
+Growing Rites of Itlimoc;XLN;402073
+Growth Spasm;ROE;127328
+Grozoth;RAV;88792
+Gruesome Deformity;ISD;138487
+Gruesome Discovery;DKA;139879
+Gruesome Encore;MBS;133240
+Gruesome Slaughter;BFZ;160617
+Gruul Charm;GTC;145925
+Gruul Cluestone;DGM;147765
+Gruul Guildgate;C13;145163
+Gruul Guildgate;DGM;146875
+Gruul Guildgate;GTC;145163
+Gruul Guildgate;MM3;146875
+Gruul Guildmage;GPT;91664
+Gruul Guildmage;PRM;91664
+Gruul Keyrune;GTC;145933
+Gruul Nodorog;GPT;91873
+Gruul Ragebeast;GTC;147251
+Gruul Scrapper;GPT;91714
+Gruul Signet;CMD;91686
+Gruul Signet;GPT;91686
+Gruul Signet;MM3;138782
+Gruul Signet;PRM;138782
+Gruul Signet;TD0;91686
+Gruul Turf;CMD;91833
+Gruul Turf;GPT;91833
+Gruul Turf;MM2;91833
+Gruul Turf;PC1;91833
+Gruul Turf;PC2;91833
+Gruul Turf;TD0;91833
+Gruul War Chant;DGM;146835
+Gruul War Chant;MM3;146835
+Gruul War Plow;GPT;91868
+Gryff Vanguard;AVR;141527
+Gryff's Boon;SOI;161636
+Guan Yu, Sainted Warrior;ME3;8993
+Guan Yu, Sainted Warrior;PTK;8993
+Guan Yu's 1,000-Li March;ME3;9048
+Guan Yu's 1,000-Li March;PTK;9048
+Guard Dogs;PLS;27923
+Guard Duty;DPA;127270
+Guard Duty;ROE;127270
+Guard Gomazoa;C13;127377
+Guard Gomazoa;CMD;127377
+Guard Gomazoa;PC2;127377
+Guard Gomazoa;ROE;127377
+Guardian Angel;2ED;108
+Guardian Angel;3ED;108
+Guardian Angel;LEA;108
+Guardian Angel;LEB;108
+Guardian Automaton;ORI;160357
+Guardian Beast;ARN;337
+Guardian Beast;ME4;337
+Guardian Idol;5DN;77148
+Guardian Lions;M13;143909
+Guardian Seraph;DPA;121653
+Guardian Seraph;M10;121653
+Guardian Shield-Bearer;DTK;159789
+Guardian Zendikon;WWK;126552
+Guardian of Cloverdell;LRW;105428
+Guardian of Pilgrims;EMN;161917
+Guardian of Solitude;COK;80614
+Guardian of Tazeem;BFZ;160846
+Guardian of Vitu-Ghazi;RAV;89071
+Guardian of the Ages;M14;147458
+Guardian of the Gateless;GTC;146394
+Guardian of the Great Conduit;KLD;162547
+Guardian of the Guildpact;DIS;94638
+Guardian's Magemark;GPT;91878
+Guardians of Akrasa;ALA;115136
+Guardians of Akrasa;DPA;115136
+Guardians of Akrasa;M13;115136
+Guardians of Meletis;ORI;150864
+Guardians of Meletis;THS;150864
+Guardians' Pledge;DPA;135409
+Guardians' Pledge;M12;135409
+Gudul Lurker;DTK;159717
+Guerrilla Tactics;10E;104526
+Guerrilla Tactics;8ED;49247
+Guerrilla Tactics;9ED;49247
+Guerrilla Tactics;ALL;1651
+Guerrilla Tactics;ALL;1652
+Guided Passage;APC;31132
+Guided Strike;JUD;40172
+Guided Strike;WTH;2844
+Guiding Spirit;VIS;2183
+Guild Feud;RTR;145948
+Guildscorn Ward;GTC;146346
+Guile;DD2;109116
+Guile;LRW;109116
+Guile;MM2;109116
+Guiltfeeder;JUD;36466
+Guilty Conscience;SCG;48995
+Guise of Fire;AVR;141547
+Gulf Squid;PCY;22051
+Guma;USG;8648
+Gurmag Angler;FRF;157236
+Gurmag Drowner;DTK;159753
+Gurmag Swiftwing;KTK;156550
+Gurzigost;TOR;24148
+Gush;DD2;19305
+Gush;MMQ;19305
+Gush;PRM;162486
+Gush;VMA;19305
+Gust Walker;AKH;400851
+Gust-Skimmer;DPA;133157
+Gust-Skimmer;MBS;133157
+Gust-Skimmer;MM2;133157
+Gustcloak Cavalier;TSP;97312
+Gustcloak Harrier;ONS;42918
+Gustcloak Harrier;VMA;42918
+Gustcloak Runner;ONS;42917
+Gustcloak Savior;ONS;42953
+Gustcloak Sentinel;DDL;42937
+Gustcloak Sentinel;ONS;42937
+Gustcloak Skirmisher;ONS;44731
+Gustha's Scepter;ALL;1653
+Gustha's Scepter;ME2;1653
+Gustrider Exuberant;ALA;114930
+Gut Shot;MM2;134366
+Gut Shot;NPH;134366
+Gutless Ghoul;CSP;97255
+Gutter Grime;ISD;138384
+Gutter Skulk;GTC;146236
+Guttersnipe;C13;145175
+Guttersnipe;RTR;145175
+Guttural Response;SHM;111884
+Gutwrencher Oni;COK;81579
+Guul Draz Assassin;PRM;128456
+Guul Draz Assassin;ROE;126557
+Guul Draz Overseer;BFZ;160887
+Guul Draz Specter;DPA;123625
+Guul Draz Specter;ZEN;123625
+Guul Draz Vampire;DPA;123537
+Guul Draz Vampire;ZEN;123537
+Gwafa Hazid, Profiteer;CON;118776
+Gwendlyn Di Corci;LEG;2518
+Gwendlyn Di Corci;ME3;2518
+Gwyllion Hedge-Mage;CMD;113769
+Gwyllion Hedge-Mage;EVE;113769
+Gyre Sage;GTC;138780
+Haakon, Stromgald Scourge;CSP;97015
+Haazda Exonerator;DIS;94525
+Haazda Shield Mate;DIS;94327
+Haazda Snare Squad;DGM;146792
+Hada Freeblade;PRM;126588
+Hada Freeblade;WWK;126588
+Hada Spy Patrol;C13;127430
+Hada Spy Patrol;ROE;127430
+Hag Hedge-Mage;EVE;113749
+Hagra Crocodile;ZEN;123544
+Hagra Diabolist;ZEN;125066
+Hagra Sharpshooter;BFZ;160850
+Hail Storm;ALL;1654
+Hail Storm;TSB;1654
+Hail of Arrows;10E;86045
+Hail of Arrows;SOK;86045
+Hair-Strung Koto;COK;81105
+Hakim, Loreweaver;MIR;1915
+Halam Djinn;INV;24128
+Halberdier;ODY;33383
+Halcyon Glaze;RAV;88742
+Halfdane;LEG;2519
+Halfdane;ME3;2519
+Halimar Depths;DDM;123661
+Halimar Depths;WWK;123661
+Halimar Excavator;WWK;126502
+Halimar Tidecaller;BFZ;161015
+Halimar Wavewatch;ROE;127441
+Hall of Gemstone;MIR;1916
+Hall of Triumph;JOU;152799
+Hall of Triumph;PRM;156606
+Hall of the Bandit Lord;COK;80849
+Hallow;DPA;51762
+Hallow;DST;51762
+Hallowed Burial;EVE;113724
+Hallowed Fountain;DIS;94274
+Hallowed Fountain;EXP;160786
+Hallowed Fountain;RTR;145235
+Hallowed Ground;ICE;1200
+Hallowed Ground;MED;1200
+Hallowed Healer;ODY;33194
+Hallowed Moonlight;ORI;160208
+Hallowed Spiritkeeper;C14;156425
+Halls of Mist;ICE;1201
+Halo Hunter;DPA;123643
+Halo Hunter;ZEN;123643
+Halt Order;SOM;130893
+Hamlet Captain;EMN;138381
+Hamlet Captain;ISD;138381
+Hamletback Goliath;DPA;105658
+Hamletback Goliath;LRW;105658
+Hamletback Goliath;M13;105658
+Hammer Mage;MMQ;19119
+Hammer of Bogardan;6ED;1917
+Hammer of Bogardan;8ED;1917
+Hammer of Bogardan;MIR;1917
+Hammer of Bogardan;PD2;1917
+Hammer of Bogardan;PRM;1917
+Hammer of Purphoros;THS;149972
+Hammer of Ruin;WWK;126512
+Hammerfist Giant;RAV;88708
+Hammerhand;M15;155326
+Hammerhead Shark;STH;3697
+Hammerhead Shark;TPR;3697
+Hammerheim Deadeye;MMA;100813
+Hammerheim Deadeye;PLC;100813
+Hammerheim;LEG;576
+Hammerheim;ME3;576
+Hana Kami;COK;80705
+Hana Kami;MMA;80705
+Hanabi Blast;COK;80789
+Hand of Cruelty;SOK;86033
+Hand of Death;PO2;4717
+Hand of Death;POR;6580
+Hand of Emrakul;ROE;127387
+Hand of Honor;SOK;86059
+Hand of Justice;FEM;920
+Hand of Justice;MED;920
+Hand of Justice;PRM;920
+Hand of Silumgar;DTK;159872
+Hand of the Praetors;SOM;131195
+Hand to Hand;TMP;3159
+Hands of Binding;GTC;146363
+Hangarback Walker;MS2;162595
+Hangarback Walker;ORI;160353
+Hankyu;COK;80694
+Hanna, Ship's Navigator;DPA;143982
+Hanna, Ship's Navigator;INV;25472
+Hanna, Ship's Navigator;PRM;143982
+Hanna's Custody;TMP;3188
+Hanweir Battlements;EMN;161992
+Hanweir Garrison;EMN;161988
+Hanweir Lancer;AVR;141618
+Hanweir Lancer;MM3;141618
+Hanweir Militia Captain;SOI;161428
+Hanweir Watchkeep;ISD;138445
+Hanweir, the Writhing Township;EMN;161989
+Hapatra, Vizier of Poisons;AKH;401255
+Hapatra's Mark;AKH;401342
+Hapless Researcher;JUD;40198
+Harabaz Druid;WWK;126466
+Harbinger of Night;MIR;1918
+Harbinger of Spring;BOK;83917
+Harbinger of the Hunt;DTK;160121
+Harbinger of the Hunt;PRM;159859
+Harbinger of the Tides;ORI;160237
+Harbor Bandit;M13;143942
+Harbor Guardian;MIR;1919
+Harbor Serpent;M11;129069
+Harbor Serpent;M12;129069
+Harbor Serpent;M13;129069
+Hardened Berserker;DTK;160058
+Hardened Scales;KTK;157064
+Harm's Way;DDG;101030
+Harm's Way;M10;101030
+Harmattan Efreet;6ED;1920
+Harmattan Efreet;MIR;1920
+Harmless Assault;DPA;127450
+Harmless Assault;ROE;127450
+Harmless Offering;EMN;162100
+Harmonic Convergence;UL;10326
+Harmonic Sliver;TSP;97343
+Harmonize;C13;125852
+Harmonize;CMD;125852
+Harmonize;DDD;125852
+Harmonize;EMA;125852
+Harmonize;EVG;100676
+Harmonize;MM3;100676
+Harmonize;PLC;100676
+Harmonize;PRM;110129
+Harmonize;PZ1;125852
+Harmonize;TD0;100676
+Harmony of Nature;PO2;4781
+Harness by Force;JOU;153030
+Harness the Storm;SOI;161473
+Harnessed Lightning;KLD;162534
+Harpoon Sniper;LRW;105329
+Harpy;TOK;150889
+Harrier Griffin;GPT;91670
+Harrier Naga;HOU;401561
+Harrow;C14;24064
+Harrow;DDE;24064
+Harrow;DPA;123598
+Harrow;INV;24064
+Harrow;PRM;129539
+Harrow;TMP;3239
+Harrow;TPR;3239
+Harrow;ZEN;123598
+Harrowing Journey;DKA;138467
+Harrowing Journey;DPA;138467
+Harsh Deceiver;COK;80773
+Harsh Judgment;INV;25667
+Harsh Justice;ME4;6741
+Harsh Justice;POR;6741
+Harsh Mentor;AKH;401674
+Harsh Mercy;ONS;42966
+Harsh Scrutiny;KLD;162278
+Harsh Sustenance;FRF;157154
+Haru-Onna;SOK;86032
+Harvest Gwyllion;EVE;98592
+Harvest Hand;SOI;161448
+Harvest Mage;NMS;21207
+Harvest Pyre;ISD;138098
+Harvest Season;AKH;401343
+Harvest Wurm;WTH;2807
+Harvester Druid;JUD;40264
+Harvester Troll;OGW;161032
+Harvester of Souls;AVR;141540
+Harvestguard Alseids;JOU;152875
+Hashep Oasis;HOU;401825
+Hasran Ogress;ARN;338
+Hasran Ogress;CH;338
+Hasran Ogress;ME4;338
+Hatchet Bully;EVE;113210
+Hatching Plans;GPT;91700
+Hate Weaver;10E;25156
+Hate Weaver;INV;25156
+Hateflayer;EVE;113662
+Hatred;EXO;5659
+Haunted Angel;APC;31082
+Haunted Cadaver;ONS;43050
+Haunted Cloak;SOI;161773
+Haunted Crossroads;MMQ;19032
+Haunted Dead;EMN;161951
+Haunted Fengraf;C14;139782
+Haunted Fengraf;DKA;139782
+Haunted Guardian;AVR;142211
+Haunted Plate Mail;M14;147474
+Haunted Plate Mail;M15;147474
+Haunter of Nightveil;DGM;147740
+Haunting Apparition;MIR;1921
+Haunting Echoes;M10;122152
+Haunting Echoes;M11;122152
+Haunting Echoes;ODY;33444
+Haunting Hymn;TSP;99368
+Haunting Misery;WTH;2797
+Haunting Wind;ATQ;416
+Haven of the Spirit Dragon;DTK;159699
+Havengul Lich;DKA;139888
+Havengul Runebinder;DKA;139802
+Havengul Skaab;AVR;141639
+Havengul Vampire;AVR;141693
+Havenwood Battleground;5ED;2393
+Havenwood Battleground;6ED;2393
+Havenwood Battleground;C14;2393
+Havenwood Battleground;FEM;921
+Havenwood Battleground;ME2;921
+Havenwood Wurm;TSP;97288
+Havoc Demon;EMA;148782
+Havoc Demon;LGN;47496
+Havoc Festival;RTR;145967
+Havoc Sower;OGW;161150
+Havoc;TMP;3270
+Hawkeater Moth;USG;8785
+Hazardous Conditions;KLD;162318
+Hazduhr the Abbot;HML;1513
+Haze Frog;ROE;127357
+Haze of Pollen;AKH;401336
+Haze of Rage;FUT;97298
+Hazerider Drake;MIR;1922
+Hazezon Tamar;LEG;2520
+Hazezon Tamar;ME3;2520
+Hazezon Tamar;PRM;2520
+Hazoret the Fervent;AKH;400834
+Hazoret the Fervent;MS3;401371
+Hazoret's Favor;AKH;400866
+Hazoret's Monument;AKH;400750
+Hazoret's Undying Fury;HOU;401591
+Hazy Homunculus;PCY;21981
+He Who Hungers;COK;82601
+Head Games;10E;43077
+Head Games;ONS;43077
+Headhunter;ONS;43045
+Headless Horseman;LEG;577
+Headless Horseman;PRM;577
+Headless Skaab;DKA;139773
+Headlong Rush;USG;8854
+Headstone;HML;1514
+Headstrong Brute;XLN;402066
+Headwater Sentries;XLN;402249
+Heal the Scars;LRW;105402
+Heal;5ED;1202
+Heal;ICE;1202
+Heal;ME3;1202
+Healer of the Pride;DPA;143913
+Healer of the Pride;M13;143913
+Healer's Headdress;5DN;77164
+Healing Hands;ORI;160205
+Healing Leaves;PLC;100680
+Healing Salve;2ED;109
+Healing Salve;3ED;109
+Healing Salve;4ED;109
+Healing Salve;5ED;2394
+Healing Salve;6ED;109
+Healing Salve;7ED;27655
+Healing Salve;8ED;27655
+Healing Salve;DDC;27655
+Healing Salve;LEA;109
+Healing Salve;LEB;109
+Healing Salve;ME4;109
+Healing Salve;MIR;1923
+Healing Salve;USG;8783
+Heap Doll;SHM;111797
+Heart Sliver;H09;3013
+Heart Sliver;TMP;3013
+Heart Warden;UD;15660
+Heart Wolf;HML;1515
+Heart of Bogardan;WTH;2886
+Heart of Kiran;AER;400408
+Heart of Light;10E;81095
+Heart of Light;BOK;81095
+Heart of Ramos;MMQ;19161
+Heart of Yavimaya;ALL;1655
+Heart of Yavimaya;ME2;1655
+Heart-Piercer Bow;KTK;156581
+Heart-Piercer Manticore;AKH;400917
+Heart-Piercer Manticore;TOK;401250
+Heartbeat of Spring;COK;80691
+Hearth Charm;VIS;2184
+Hearth Kami;COK;81139
+Hearthcage Giant;LRW;105451
+Hearthfire Hobgoblin;EVE;113712
+Hearthfire Hobgoblin;MM2;113712
+Hearthfire Hobgoblin;PC1;113712
+Heartlash Cinder;EVE;113594
+Heartless Hidetsugu;BOK;83909
+Heartless Pillage;XLN;402124
+Heartless Summoning;ISD;138440
+Heartmender;SHM;111755
+Heartseeker;DST;50267
+Heartstabber Mosquito;DPA;123704
+Heartstabber Mosquito;ZEN;123704
+Heartstone;H09;3698
+Heartstone;STH;3698
+Heartwood Dryad;TMP;2998
+Heartwood Dryad;TPR;2998
+Heartwood Giant;TMP;3135
+Heartwood Giant;TPR;3135
+Heartwood Shard;MRD;51005
+Heartwood Storyteller;FUT;102431
+Heartwood Treefolk;TMP;3227
+Heat Ray;DPA;127405
+Heat Ray;M15;127405
+Heat Ray;ROE;127405
+Heat Ray;USG;8900
+Heat Shimmer;DPA;105382
+Heat Shimmer;LRW;105382
+Heat Stroke;WTH;2884
+Heat Wave;VIS;2185
+Heat of Battle;STH;3699
+Heaven;AKH;401351
+Heaven's Gate;LEG;578
+Heavy Arbalest;SOM;131088
+Heavy Ballista;6ED;2842
+Heavy Ballista;7ED;27656
+Heavy Ballista;WTH;2842
+Heavy Fog;ME3;9107
+Heavy Fog;PTK;9107
+Heavy Infantry;ORI;160191
+Heavy Mattock;DKA;139774
+Hecatomb;5ED;2395
+Hecatomb;6ED;2395
+Hecatomb;ICE;1203
+Hecatomb;MED;1203
+Heckling Fiends;DKA;139861
+Hedge Troll;PLC;100685
+Hedge Troll;PRM;100685
+Hedonist's Trove;DTK;159831
+Hedron Alignment;OGW;161212
+Hedron Archive;BFZ;160730
+Hedron Blade;BFZ;160727
+Hedron Crab;DPA;123591
+Hedron Crab;ZEN;123591
+Hedron Crawler;OGW;161264
+Hedron Fields of Agadeem;PC2;131634
+Hedron Matrix;ROE;127335
+Hedron Rover;WWK;126505
+Hedron Scrabbler;ZEN;123737
+Hedron-Field Purists;ROE;127253
+Heed the Mists;BOK;83964
+Heedless One;DPA;43173
+Heedless One;EVG;43173
+Heedless One;ONS;43173
+Heidar, Rimewind Master;CSP;96883
+Heightened Awareness;PCY;21982
+Heir of Falkenrath;SOI;161456
+Heir of the Wilds;KTK;156562
+Heir of the Wilds;PRM;157102
+Heir to the Night;SOI;161370
+Heirs of Stromkirk;AVR;141741
+Hekma Sentinels;AKH;400876
+Heliod, God of the Sun;THS;149142
+Heliod's Emissary;THS;150794
+Heliod's Pilgrim;M15;155368
+Helionaut;APC;31085
+Heliophial;5DN;77111
+Helium Squirter;DIS;94590
+Helium Squirter;MM2;94590
+Helix Pinnacle;EVE;113605
+Hell Swarm;LEG;579
+Hell-Bent Raider;TOR;36499
+Hell's Caretaker;9ED;86953
+Hell's Caretaker;CH;580
+Hell's Caretaker;LEG;580
+Hell's Thunder;ALA;115234
+Hellcarver Demon;ROE;127318
+Helldozer;PC1;89031
+Helldozer;RAV;89031
+Hellfire Mongrel;DDH;123720
+Hellfire Mongrel;ZEN;123720
+Hellfire;LEG;2521
+Hellfire;ME3;2521
+Hellhole Flailer;RTR;145199
+Hellhole Rats;DIS;94303
+Hellhole Rats;DPA;94303
+Hellion Crucible;M13;143994
+Hellion Eruption;PC2;127478
+Hellion Eruption;ROE;127478
+Hellion;TOK;128390
+Hellkite Charger;DPA;123637
+Hellkite Charger;MM2;123637
+Hellkite Charger;ZEN;123637
+Hellkite Hatchling;CON;119799
+Hellkite Hatchling;DPA;119799
+Hellkite Hatchling;PC2;119799
+Hellkite Igniter;MBS;133222
+Hellkite Overlord;ALA;115109
+Hellkite Overlord;DPA;115109
+Hellkite Overlord;DRB;115109
+Hellkite Tyrant;GTC;147254
+Hellraiser Goblin;GTC;146382
+Hellrider;DDK;139730
+Hellrider;DKA;139730
+Hellrider;MM3;139730
+Hellspark Elemental;CON;118669
+Hellspark Elemental;DDK;118669
+Hellspark Elemental;PD2;118669
+Hellspark Elemental;PRM;120095
+Hellspark Elemental;TD0;118669
+Helm of Awakening;VIS;2186
+Helm of Chatzuk;2ED;110
+Helm of Chatzuk;3ED;110
+Helm of Chatzuk;4ED;110
+Helm of Chatzuk;5ED;110
+Helm of Chatzuk;LEA;110
+Helm of Chatzuk;LEB;110
+Helm of Kaldra;5DN;75675
+Helm of Kaldra;PRM;50339
+Helm of Obedience;ALL;1656
+Helm of Obedience;ME2;1656
+Helm of Obedience;PRM;402818
+Helm of Possession;TMP;3105
+Helm of the Ghastlord;SHM;111880
+Helm of the Gods;ORI;160346
+Helvault;DKA;139836
+Helvault;V16;139836
+Hematite Golem;MRD;50277
+Hematite Talisman;ICE;1204
+Henchfiend of Ukor;FUT;102417
+Henge Guardian;DDG;19059
+Henge Guardian;MMQ;19059
+Henge of Ramos;MMQ;19015
+Herald of Anafenza;KTK;157001
+Herald of Anguish;AER;400304
+Herald of Dromoka;DTK;159866
+Herald of Kozilek;BFZ;160718
+Herald of Leshrac;CSP;96986
+Herald of Secret Streams;XLN;402247
+Herald of Serra;USG;7381
+Herald of Torment;BNG;152571
+Herald of War;AVR;141702
+Herald of the Fair;KLD;162230
+Herald of the Host;PZ1;160423
+Herald of the Pantheon;ORI;160311
+Herbal Poultice;LRW;105486
+Herd Gnarr;DPA;97501
+Herd Gnarr;TSP;97501
+Herdchaser Dragon;DTK;159853
+Heretic's Punishment;ISD;139304
+Heritage Druid;EMA;109903
+Heritage Druid;MOR;109903
+Hermetic Study;USG;8908
+Hermit Druid;PRM;3700
+Hermit Druid;STH;3700
+Hermit Druid;TPR;3700
+Hermit Druid;VMA;3700
+Hermit of the Natterknolls;SOI;161734
+Hero of Bladehold;DPA;133232
+Hero of Bladehold;MBS;133232
+Hero of Bladehold;PRM;135407
+Hero of Goma Fada;BFZ;160866
+Hero of Goma Fada;PRM;160631
+Hero of Iroas;BNG;152087
+Hero of Leina Tower;BNG;152097
+Hero of Oxid Ridge;DPA;133204
+Hero of Oxid Ridge;MBS;133204
+Hero's Blade;FRF;157241
+Hero's Demise;BOK;83869
+Hero's Downfall;PRM;159370
+Hero's Downfall;THS;150865
+Hero's Resolve;6ED;3069
+Hero's Resolve;TMP;3069
+Heroes Remembered;PLC;97290
+Heroes' Bane;JOU;153017
+Heroes' Bane;PRM;155425
+Heroes' Podium;BNG;152615
+Heroes' Reunion;DDG;24138
+Heroes' Reunion;DPA;24138
+Heroes' Reunion;INV;24138
+Heroes' Reunion;RTR;145920
+Heroic Defiance;PLS;27967
+Heroic Intervention;AER;400353
+Heroism;FEM;922
+Heron's Grace Champion;EMN;162141
+Heron's Grace Champion;PRM;162139
+Hesitation;STH;3701
+Hewed Stone Retainers;FRF;157301
+Hewed Stone Retainers;PRM;159379
+Hex Parasite;NPH;134229
+Hex;CMD;89100
+Hex;RAV;89100
+Hexplate Golem;MBS;133193
+Hibernation Sliver;H09;3702
+Hibernation Sliver;STH;3702
+Hibernation Sliver;TPR;3702
+Hibernation;7ED;27657
+Hibernation;8ED;27657
+Hibernation;USG;8792
+Hibernation's End;CSP;96875
+Hickory Woodlot;MMQ;19178
+Hidden Ancients;USG;8645
+Hidden Dragonslayer;DTK;159718
+Hidden Gibbons;UL;10361
+Hidden Guerrillas;USG;8823
+Hidden Herbalists;AER;400333
+Hidden Herd;USG;8874
+Hidden Horror;10E;4728
+Hidden Horror;6ED;2915
+Hidden Horror;DPA;4728
+Hidden Horror;PD3;4728
+Hidden Horror;PO2;4728
+Hidden Horror;WTH;2915
+Hidden Path;DRK;784
+Hidden Predators;USG;8802
+Hidden Retreat;STH;3703
+Hidden Spider;USG;8652
+Hidden Stag;USG;8665
+Hidden Stockpile;AER;400361
+Hidden Strings;DGM;146752
+Hide;DIS;94385
+Hideous End;DDD;123602
+Hideous End;DDE;123602
+Hideous End;DPA;123602
+Hideous End;PC1;123602
+Hideous End;ZEN;123602
+Hideous Laughter;COK;81090
+Hideous Visage;M12;134174
+Hidetsugu's Second Rite;SOK;86188
+Hieroglyphic Illumination;AKH;400868
+Hierophant's Chalice;XLN;402014
+High Ground;10E;5626
+High Ground;EXO;5626
+High Market;MMQ;19040
+High Market;V12;19040
+High Priest of Penance;GTC;146470
+High Seas;MMQ;19221
+High Sentinels of Arashin;KTK;157003
+High Tide;FEM;923
+High Tide;FEM;924
+High Tide;FEM;925
+High Tide;MED;923
+High Tide;VMA;155832
+Highborn Ghoul;DKA;139736
+Highland Berserker;ZEN;123610
+Highland Game;KTK;156518
+Highland Giant;POR;6698
+Highland Lake;AKH;161343
+Highland Lake;SOI;161343
+Highland Weald;CSP;96995
+Highspire Artisan;KLD;162189
+Highspire Infusion;AER;400339
+Highspire Mantis;KTK;157072
+Hightide Hermit;KLD;162248
+Highway Robber;10E;19300
+Highway Robber;9ED;19300
+Highway Robber;DDM;19300
+Highway Robber;MMQ;19300
+Higure, the Still Wind;BOK;83863
+Higure, the Still Wind;PC2;83863
+Hijack;KLD;162284
+Hijack;XLN;402049
+Hikari, Twilight Guardian;COK;80582
+Hikari, Twilight Guardian;MM2;80582
+Hill Giant;10E;102615
+Hill Giant;2ED;111
+Hill Giant;3ED;111
+Hill Giant;4ED;111
+Hill Giant;5ED;2396
+Hill Giant;7ED;27834
+Hill Giant;8ED;27834
+Hill Giant;9ED;27834
+Hill Giant;DPA;102615
+Hill Giant;LEA;111
+Hill Giant;LEB;111
+Hill Giant;POR;6699
+Hillcomber Giant;LRW;106379
+Hillcomber Giant;MMA;106379
+Hinder;COK;80666
+Hinder;PRM;90395
+Hinder;TD0;80666
+Hindering Light;ALA;115258
+Hindering Touch;SCG;48980
+Hindervines;GTC;146391
+Hint of Insanity;ODY;33664
+Hinterland Drake;AER;400255
+Hinterland Harbor;ISD;138429
+Hinterland Hermit;DKA;139796
+Hinterland Logger;SOI;161483
+Hinterland Scourge;DKA;139794
+Hipparion;5ED;2397
+Hipparion;ICE;1205
+Hippo;TOK;35347
+Hippo;TOK;400962
+Hired Giant;MMQ;19288
+Hired Muscle;BOK;83874
+Hired Torturer;DGM;146715
+Hisoka, Minamo Sensei;COK;80698
+Hisoka's Defiance;COK;80677
+Hisoka's Guard;COK;81073
+Hissing Iguanar;ALA;114983
+Hissing Iguanar;DPA;114983
+Hissing Iguanar;PC2;114983
+Hissing Iguanar;TD0;114983
+Hissing Miasma;GPT;91749
+Hissing Quagmire;OGW;160759
+Hit;DIS;94452
+Hitchclaw Recluse;ORI;160316
+Hive Mind;M10;121630
+Hive Stirrings;DPA;147406
+Hive Stirrings;M14;147406
+Hive Stirrings;PRM;149170
+Hivestone;TSP;100416
+Hivis of the Scale;MIR;1924
+Hixus, Prison Warden;ORI;159397
+Hixus, Prison Warden;PRM;160399
+Hoar Shade;ICE;1206
+Hoard-Smelter Dragon;C14;131183
+Hoard-Smelter Dragon;DPA;131183
+Hoard-Smelter Dragon;SOM;131183
+Hoarder's Greed;LRW;106400
+Hoarding Dragon;M11;129166
+Hoarding Dragon;M15;129166
+Hobble;PLS;27924
+Hobgoblin Dragoon;EVE;113616
+Hokori, Dust Drinker;BOK;83955
+Hold at Bay;BNG;152531
+Hold the Gates;GTC;146432
+Hold the Line;COK;80686
+Holdout Settlement;OGW;161604
+Holistic Wisdom;ODY;33295
+Hollow Dogs;7ED;27658
+Hollow Dogs;9ED;8817
+Hollow Dogs;USG;8817
+Hollow One;HOU;401848
+Hollow Specter;LGN;46522
+Hollow Trees;5ED;2398
+Hollow Trees;FEM;926
+Hollow Warrior;PCY;21983
+Hollowborn Barghest;DPA;111636
+Hollowborn Barghest;SHM;111636
+Hollowhenge Beast;DKA;139903
+Hollowhenge Scavenger;ISD;138253
+Hollowhenge Spirit;DKA;138184
+Hollowsage;SHM;111832
+Holy Armor;2ED;112
+Holy Armor;3ED;112
+Holy Armor;4ED;112
+Holy Armor;LEA;112
+Holy Armor;LEB;112
+Holy Day;10E;102620
+Holy Day;8ED;49226
+Holy Day;9ED;49226
+Holy Day;DPA;102620
+Holy Day;INV;24067
+Holy Day;LEG;582
+Holy Justiciar;AVR;141570
+Holy Light;DRK;786
+Holy Light;MED;786
+Holy Mantle;GTC;146344
+Holy Strength;10E;104527
+Holy Strength;2ED;113
+Holy Strength;3ED;113
+Holy Strength;4ED;113
+Holy Strength;5ED;113
+Holy Strength;7ED;29896
+Holy Strength;8ED;29896
+Holy Strength;9ED;29896
+Holy Strength;DPA;104527
+Holy Strength;LEA;113
+Holy Strength;LEB;113
+Holy Strength;M10;104527
+Holy Strength;M11;104527
+Homarid Shaman;FEM;931
+Homarid Spawning Bed;FEM;932
+Homarid Spawning Bed;MED;932
+Homarid Warrior;5ED;2399
+Homarid Warrior;FEM;933
+Homarid Warrior;FEM;934
+Homarid Warrior;FEM;935
+Homarid;FEM;927
+Homarid;FEM;928
+Homarid;FEM;929
+Homarid;FEM;930
+Homeward Path;C13;137531
+Homeward Path;CMD;137531
+Homeward Path;PZ1;137531
+Homicidal Brute;ISD;138163
+Homicidal Seclusion;AVR;141584
+Homing Lightning;GTC;146380
+Homing Sliver;FUT;102350
+Homing Sliver;H09;102350
+Homunculus;TOK;117014
+Homunculus;TOK;138479
+Homura, Human Ascendant;SOK;86135
+Honden of Cleansing Fire;COK;81045
+Honden of Cleansing Fire;EMA;81045
+Honden of Infinite Rage;COK;80996
+Honden of Infinite Rage;EMA;80996
+Honden of Life's Web;COK;81066
+Honden of Life's Web;EMA;81066
+Honden of Night's Reach;COK;80984
+Honden of Night's Reach;EMA;80984
+Honden of Seeing Winds;COK;81062
+Honden of Seeing Winds;EMA;81062
+Honed Khopesh;AKH;401352
+Honor Guard;10E;101031
+Honor Guard;7ED;27660
+Honor Guard;8ED;27660
+Honor Guard;9ED;27660
+Honor Guard;STH;3704
+Honor of the Pure;DPA;102628
+Honor of the Pure;M10;102628
+Honor of the Pure;M11;102628
+Honor of the Pure;M12;102628
+Honor of the Pure;PRM;125679
+Honor the Fallen;MMQ;19206
+Honor-Worn Shaku;COK;80841
+Honor's Reward;FRF;157244
+Honorable Passage;TSB;2187
+Honorable Passage;VIS;2187
+Honorable Scout;PLS;27875
+Honored Crop-Captain;AKH;401272
+Honored Hierarch;ORI;160310
+Honored Hierarch;PRM;160414
+Honored Hydra;AKH;400768
+Honored Hydra;TOK;400958
+Hooded Assassin;FRF;157206
+Hooded Brawler;AKH;400753
+Hooded Horror;C13;151762
+Hooded Hydra;KTK;157066
+Hooded Kavu;INV;24069
+Hoodwink;MMQ;19277
+Hoodwink;PRM;148602
+Hoof Skulkin;EVE;113756
+Hoofprints of the Stag;LRW;105664
+Hooting Mandrills;KTK;156521
+Hope Against Hope;SOI;161354
+Hope Charm;VIS;2188
+Hope Tender;HOU;401587
+Hope and Glory;UL;10377
+Hope of Ghirapur;AER;400399
+Hopeful Eidolon;THS;149040
+Hopping Automaton;USG;8809
+Horde Ambusher;KTK;157041
+Horde of Boggarts;SHM;111728
+Horde of Notions;LRW;105534
+Horde of Notions;MM2;105534
+Hordeling Outburst;KTK;157042
+Hordeling Outburst;PRM;159829
+Horizon Boughs;PRM;125886
+Horizon Canopy;EXP;160963
+Horizon Canopy;FUT;102389
+Horizon Chimera;THS;149202
+Horizon Drake;WWK;126558
+Horizon Scholar;THS;149084
+Horizon Seed;COK;81112
+Horizon Spellbomb;SOM;131119
+Horn of Deafening;CH;583
+Horn of Deafening;LEG;583
+Horn of Deafening;ME4;583
+Horn of Greed;STH;3706
+Horn of Plenty;MMQ;19041
+Horn of Ramos;MMQ;19158
+Horncaller's Chant;RTR;145876
+Horned Cheetah;INV;24061
+Horned Helm;5DN;77168
+Horned Kavu;PLS;27925
+Horned Sliver;TMP;3229
+Horned Sliver;TPR;3229
+Horned Troll;8ED;49250
+Horned Troll;MMQ;19137
+Horned Turtle;6ED;3032
+Horned Turtle;7ED;27661
+Horned Turtle;8ED;3032
+Horned Turtle;9ED;3032
+Horned Turtle;M10;3032
+Horned Turtle;POR;6620
+Horned Turtle;TMP;3032
+Horned Turtle;TPR;3032
+Hornet Cannon;DDE;3707
+Hornet Cannon;STH;3707
+Hornet Cobra;LEG;584
+Hornet Harasser;LRW;105597
+Hornet Nest;M15;155377
+Hornet Queen;CMD;137557
+Hornet Queen;M15;137557
+Hornet Sting;M11;129139
+Hornet;TOK;125147
+Horobi, Death's Wail;COK;80912
+Horobi's Whisper;BOK;83921
+Horobi's Whisper;MMA;83921
+Horrible Hordes;MIR;1925
+Horribly Awry;BFZ;160652
+Horrifying Revelation;MBS;133119
+Horror of Horrors;9ED;86930
+Horror of Horrors;LEG;585
+Horror of the Broken Lands;AKH;400761
+Horror of the Dim;GTC;146324
+Horror;TOK;133266
+Horror;TOK;147263
+Horror;TOK;156420
+Horror;TOK;89189
+Horse;TOK;402205
+Horseshoe Crab;10E;8857
+Horseshoe Crab;USG;8857
+Hostage Taker;XLN;401445
+Hostile Desert;HOU;401852
+Hostile Realm;MOR;109902
+Hostility;DD2;105489
+Hostility;DPA;105489
+Hostility;LRW;105489
+Hot Soup;M15;155248
+Hot Springs;ICE;1207
+Hotheaded Giant;EVE;113674
+Hound of Griselbrand;AVR;141687
+Hound of the Farbogs;SOI;161408
+Hound;TOK;122196
+Hour of Devastation;HOU;401585
+Hour of Eternity;HOU;401582
+Hour of Glory;HOU;401583
+Hour of Need;JOU;152955
+Hour of Promise;HOU;401581
+Hour of Reckoning;CMD;89026
+Hour of Reckoning;RAV;89026
+Hour of Revelation;HOU;401584
+Hover Barrier;RTR;145898
+Hoverguard Observer;DST;52040
+Hoverguard Sweepers;5DN;77125
+Hoverguard Sweepers;C14;77125
+Hovermyr;NPH;134341
+Howl from Beyond;2ED;114
+Howl from Beyond;3ED;114
+Howl from Beyond;4ED;114
+Howl from Beyond;5ED;2400
+Howl from Beyond;6ED;2400
+Howl from Beyond;7ED;27662
+Howl from Beyond;ICE;1208
+Howl from Beyond;LEA;114
+Howl from Beyond;LEB;114
+Howl from Beyond;ME4;114
+Howl of the Horde;KTK;157047
+Howl of the Night Pack;DPA;111785
+Howl of the Night Pack;M10;111785
+Howl of the Night Pack;M14;111785
+Howl of the Night Pack;SHM;111785
+Howlgeist;AVR;141646
+Howling Banshee;DDD;121627
+Howling Banshee;M10;121627
+Howling Banshee;M11;121627
+Howling Chorus;EMN;161995
+Howling Fury;POR;6582
+Howling Gale;ODY;33327
+Howling Mine;10E;102959
+Howling Mine;2ED;115
+Howling Mine;3ED;115
+Howling Mine;4ED;115
+Howling Mine;5ED;115
+Howling Mine;6ED;115
+Howling Mine;7ED;27663
+Howling Mine;8ED;27663
+Howling Mine;9ED;27663
+Howling Mine;CMD;102959
+Howling Mine;DPA;102959
+Howling Mine;LEA;115
+Howling Mine;LEB;115
+Howling Mine;M10;102959
+Howling Wolf;MMQ;19138
+Howlpack Alpha;ISD;139446
+Howlpack Alpha;PRM;138206
+Howlpack Resurgence;SOI;161677
+Howlpack Wolf;SOI;161409
+Howlpack of Estwald;ISD;138220
+Howltooth Hollow;LRW;105423
+Hua Tuo, Honored Physician;C13;9001
+Hua Tuo, Honored Physician;ME3;9001
+Hua Tuo, Honored Physician;PTK;9001
+Huang Zhong, Shu General;PTK;9058
+Huatli, Dinosaur Knight;XLN;402030
+Huatli, Warrior Poet;XLN;402038
+Huatli's Snubhorn;XLN;402345
+Huatli's Spurring;XLN;402346
+Hubris;JOU;152843
+Hulking Cyclops;6ED;6700
+Hulking Cyclops;8ED;6700
+Hulking Cyclops;POR;6700
+Hulking Cyclops;VIS;2189
+Hulking Devil;SOI;161709
+Hulking Goblin;POR;6701
+Hulking Goblin;VMA;6701
+Hulking Ogre;UD;15771
+Hull Breach;C13;27926
+Hull Breach;CMD;27926
+Hull Breach;PC1;27926
+Hull Breach;PLS;27926
+Hull Breach;PZ1;27926
+Hum of the Radix;MRD;51051
+Human Cleric;TOK;161691
+Human Frailty;AVR;143366
+Human Soldier;TOK;162025
+Human Wizard;TOK;162054
+Human;TOK;139867
+Human;TOK;141826
+Human;TOK;141852
+Human;TOK;162102
+Humble Budoka;COK;80897
+Humble Defector;FRF;157200
+Humble the Brute;SOI;161468
+Humble;EMA;161546
+Humble;USG;8838
+Humbler of Mortals;JOU;153072
+Humility;TMP;3192
+Humility;TPR;3192
+Hunding Gjornersen;LEG;586
+Hunding Gjornersen;ME3;586
+Hundred-Handed One;THS;149205
+Hundred-Talon Kami;COK;81031
+Hundred-Talon Strike;BOK;83915
+Hundroog;LGN;46563
+Hunger of the Howlpack;DKA;139753
+Hunger of the Nim;DPA;51954
+Hunger of the Nim;DST;51954
+Hungering Yeti;FRF;157158
+Hungry Flames;AER;400320
+Hungry Mist;5ED;1516
+Hungry Mist;HML;1516
+Hungry Mist;HML;1517
+Hungry Mist;MED;1517
+Hungry Spriggan;DPA;111786
+Hungry Spriggan;MM3;111786
+Hungry Spriggan;SHM;111786
+Hunt Down;LRW;105639
+Hunt the Hunter;THS;150870
+Hunt the Weak;DPA;147413
+Hunt the Weak;FRF;157227
+Hunt the Weak;KLD;162310
+Hunt the Weak;M14;147413
+Hunt the Weak;M15;147413
+Hunted Dragon;RAV;89127
+Hunted Ghoul;AVR;141602
+Hunted Horror;RAV;89046
+Hunted Lammasu;RAV;89092
+Hunted Phantasm;RAV;88600
+Hunted Troll;C13;89120
+Hunted Troll;RAV;89120
+Hunted Wumpus;10E;49678
+Hunted Wumpus;8ED;49678
+Hunted Wumpus;9ED;49678
+Hunted Wumpus;DPA;49678
+Hunted Wumpus;MMQ;19262
+Hunter Sliver;LGN;46597
+Hunter of Eyeblights;LRW;105473
+Hunter's Ambush;M15;155343
+Hunter's Insight;M12;134163
+Hunter's Prowess;BNG;152602
+Hunters' Feast;DPA;129126
+Hunters' Feast;M11;129126
+Hunting Cheetah;ME3;9118
+Hunting Cheetah;PTK;9118
+Hunting Drake;PLS;25196
+Hunting Grounds;JUD;40295
+Hunting Kavu;INV;24076
+Hunting Moa;TSB;16336
+Hunting Moa;UD;16336
+Hunting Pack;CMD;48983
+Hunting Pack;SCG;48983
+Hunting Triad;C14;109976
+Hunting Triad;MOR;109976
+Hunting Wilds;PLC;100707
+Huntmaster of the Fells;DKA;139910
+Hurkyl's Recall;10E;104567
+Hurkyl's Recall;3ED;417
+Hurkyl's Recall;4ED;417
+Hurkyl's Recall;5ED;417
+Hurkyl's Recall;ATQ;417
+Hurkyl's Recall;MM2;104567
+Hurloon Minotaur;2ED;116
+Hurloon Minotaur;3ED;116
+Hurloon Minotaur;4ED;116
+Hurloon Minotaur;5ED;116
+Hurloon Minotaur;LEA;116
+Hurloon Minotaur;LEB;116
+Hurloon Minotaur;ME3;116
+Hurloon Shaman;WTH;2815
+Hurly-Burly;LRW;105629
+Hurr Jackal;4ED;339
+Hurr Jackal;ARN;339
+Hurricane;10E;29796
+Hurricane;2ED;117
+Hurricane;3ED;117
+Hurricane;4ED;117
+Hurricane;5ED;2401
+Hurricane;6ED;6657
+Hurricane;7ED;29796
+Hurricane;DPA;29796
+Hurricane;ICE;1209
+Hurricane;LEA;117
+Hurricane;LEB;117
+Hurricane;PO2;4788
+Hurricane;POR;6657
+Hush;USG;8769
+Hushwing Gryff;M15;155294
+Hussar Patrol;RTR;145883
+Hyalopterous Lemure;ICE;1210
+Hyalopterous Lemure;MED;1210
+Hydra Broodmaster;JOU;153026
+Hydra Broodmaster;PRM;158171
+Hydra Omnivore;CMD;139244
+Hydra;TOK;155467
+Hydroblast;5ED;1211
+Hydroblast;EMA;161550
+Hydroblast;ICE;1211
+Hydroblast;MED;1211
+Hydroform;GTC;146502
+Hydrolash;ORI;160247
+Hydromorph Guardian;TOR;36410
+Hydromorph Gull;TOR;36423
+Hydrosurge;DPA;143839
+Hydrosurge;M13;143839
+Hydrosurge;M15;143839
+Hyena Pack;AKH;400880
+Hyena Umbra;DPA;127467
+Hyena Umbra;PC2;127467
+Hyena Umbra;ROE;127467
+Hymn of Rebirth;ICE;1212
+Hymn of Rebirth;MED;1212
+Hymn to Tourach;EMA;144454
+Hymn to Tourach;FEM;936
+Hymn to Tourach;FEM;937
+Hymn to Tourach;FEM;938
+Hymn to Tourach;FEM;939
+Hymn to Tourach;MED;938
+Hymn to Tourach;PRM;144454
+Hymn to Tourach;V13;144454
+Hymn to Tourach;VMA;144454
+Hypergenesis;TSP;97421
+Hyperion Blacksmith;LEG;587
+Hypersonic Dragon;PRM;145962
+Hypersonic Dragon;RTR;145224
+Hypervolt Grasp;GPT;91667
+Hypnotic Cloud;DDM;24107
+Hypnotic Cloud;INV;24107
+Hypnotic Siren;JOU;153040
+Hypnotic Specter;10E;86931
+Hypnotic Specter;2ED;118
+Hypnotic Specter;3ED;118
+Hypnotic Specter;4ED;118
+Hypnotic Specter;9ED;86931
+Hypnotic Specter;DPA;86931
+Hypnotic Specter;LEA;118
+Hypnotic Specter;LEB;118
+Hypnotic Specter;M10;86931
+Hypnotic Specter;PRM;118
+Hypnox;TOR;36467
+Hypochondria;TOR;33538
+Hysterical Blindness;ISD;138372
+Hystrodon;ONS;43131
+Hythonia the Cruel;THS;150796
+Ib Halfheart, Goblin Tactician;EVG;97455
+Ib Halfheart, Goblin Tactician;TSP;97455
+Icatian Crier;TSP;97318
+Icatian Infantry;FEM;940
+Icatian Infantry;FEM;941
+Icatian Infantry;FEM;942
+Icatian Infantry;FEM;943
+Icatian Javelineers;FEM;944
+Icatian Javelineers;FEM;945
+Icatian Javelineers;FEM;946
+Icatian Javelineers;ME2;945
+Icatian Javelineers;PRM;101171
+Icatian Javelineers;TSB;946
+Icatian Lieutenant;FEM;947
+Icatian Lieutenant;MED;947
+Icatian Moneychanger;FEM;948
+Icatian Moneychanger;FEM;949
+Icatian Moneychanger;FEM;950
+Icatian Phalanx;5ED;951
+Icatian Phalanx;FEM;951
+Icatian Phalanx;ME2;951
+Icatian Priest;10E;101042
+Icatian Priest;DDC;101042
+Icatian Priest;FEM;952
+Icatian Scout;5ED;955
+Icatian Scout;FEM;953
+Icatian Scout;FEM;954
+Icatian Scout;FEM;955
+Icatian Scout;FEM;956
+Icatian Scout;ME2;953
+Icatian Skirmishers;FEM;957
+Icatian Store;5ED;2402
+Icatian Store;FEM;958
+Icatian Town;5ED;959
+Icatian Town;6ED;959
+Icatian Town;FEM;959
+Icatian Town;MED;959
+Ice Cage;M10;121586
+Ice Cage;M11;121586
+Ice Cage;M12;121586
+Ice Cauldron;ICE;1213
+Ice Cauldron;ME4;1213
+Ice Cave;APC;31088
+Ice Floe;5ED;2403
+Ice Floe;ICE;1214
+Ice Floe;ME2;1214
+Ice Over;AER;400261
+Ice Storm;2ED;119
+Ice Storm;LEA;119
+Ice Storm;LEB;119
+Ice Storm;MED;119
+Ice;APC;31087
+Ice;CMD;31087
+Ice;DDJ;146771
+Ice;PRM;31087
+Iceberg;ICE;1215
+Iceberg;ME2;1215
+Icefall Regent;DTK;159792
+Icefall;CSP;96879
+Icefeather Aven;KTK;156578
+Icequake;ICE;1216
+Icequake;ME2;1216
+Ichneumon Druid;LEG;588
+Ichor Explosion;NPH;134315
+Ichor Rats;SOM;130916
+Ichor Slick;DDD;102410
+Ichor Slick;FUT;102410
+Ichor Wellspring;C14;133131
+Ichor Wellspring;MBS;133131
+Ichorclaw Myr;SOM;130936
+Ichorid;EMA;37366
+Ichorid;TOR;37366
+Ichorid;VMA;37366
+Icy Blast;KTK;157018
+Icy Manipulator;10E;86933
+Icy Manipulator;2ED;120
+Icy Manipulator;9ED;86933
+Icy Manipulator;DDH;86933
+Icy Manipulator;DPA;86933
+Icy Manipulator;ICE;1217
+Icy Manipulator;LEA;120
+Icy Manipulator;LEB;120
+Icy Manipulator;ME4;120
+Icy Manipulator;MRD;51038
+Icy Manipulator;PRM;120
+Icy Prison;ICE;1218
+Icy Prison;ME2;1218
+Ideas Unbound;SOK;86164
+Identity Crisis;ARB;115142
+Identity Thief;EMN;162068
+Identity Thief;PRM;162073
+Idle Thoughts;EVE;113735
+Idyllic Tutor;MOR;109974
+Ifh-Bíff Efreet;ARN;340
+Ifh-Bíff Efreet;MED;340
+Ifh-Bíff Efreet;PRM;340
+Ifnir Deadlands;HOU;401801
+Igneous Golem;MIR;1926
+Igneous Pouncer;ARB;120976
+Igneous Pouncer;DDH;120976
+Igneous Pouncer;DPA;120976
+Ignite Disorder;CON;118752
+Ignite Disorder;M10;118752
+Ignite Memories;TSP;97362
+Ignoble Soldier;MMQ;18981
+Ignorant Bliss;DIS;94753
+Ihsan's Shade;HML;1518
+Ihsan's Shade;ME2;1518
+Iizuka the Ruthless;SOK;86112
+Ikiral Outrider;ROE;127461
+Ikra Shidiqi, the Usurper;PZ2;162386
+Ill-Gotten Gains;USG;8910
+Ill-Tempered Cyclops;THS;149185
+Illicit Auction;6ED;1927
+Illicit Auction;MIR;1927
+Illness in the Ranks;GTC;147337
+Illuminate;APC;31050
+Illuminated Folio;SHM;111613
+Illuminated Wings;UD;15718
+Illumination;MIR;1928
+Illusion;APC;31089
+Illusion;TOK;123778
+Illusion;TOK;148268
+Illusion;TOK;402423
+Illusion;TOK;82656
+Illusionary Armor;DPA;147450
+Illusionary Armor;M14;147450
+Illusionary Forces;ICE;1219
+Illusionary Forces;MED;1219
+Illusionary Mask;2ED;121
+Illusionary Mask;LEA;121
+Illusionary Mask;LEB;121
+Illusionary Mask;ME3;121
+Illusionary Mask;TD0;121
+Illusionary Presence;ICE;1220
+Illusionary Servant;DPA;103537
+Illusionary Servant;M10;103537
+Illusionary Terrain;ICE;1221
+Illusionary Wall;ICE;1222
+Illusionary Wall;MED;1222
+Illusionist's Bracers;GTC;147252
+Illusionist's Gambit;C13;151723
+Illusionist's Stratagem;AER;400271
+Illusions of Grandeur;ICE;1223
+Illusions of Grandeur;MED;1223
+Illusory Ambusher;PZ1;160030
+Illusory Angel;M15;140342
+Illusory Angel;PC2;140342
+Illusory Demon;ARB;120987
+Illusory Gains;DTK;160125
+Illusory Wrappings;AKH;401293
+Imagecrafter;ONS;42970
+Imaginary Pet;9ED;86956
+Imaginary Pet;USG;8781
+Imaginary Threats;HOU;401786
+Imi Statue;COK;80587
+Immaculate Magistrate;C14;107623
+Immaculate Magistrate;DPA;107623
+Immaculate Magistrate;LRW;107623
+Immersturm;PC1;125879
+Immerwolf;DKA;139857
+Imminent Doom;HOU;401815
+Immobilizer Eldrazi;OGW;161058
+Immobilizing Ink;ODY;33466
+Immolating Glare;OGW;161195
+Immolating Glare;PRM;161271
+Immolating Souleater;NPH;134397
+Immolation;4ED;589
+Immolation;LEG;589
+Immolation;ME3;589
+Immortal Coil;ALA;115156
+Immortal Servitude;GTC;146468
+Imp's Mischief;PLC;100700
+Impact Resonance;C14;156015
+Impact Tremors;DTK;160057
+Impaler Shrike;NPH;134250
+Impatience;7ED;27666
+Impatience;UD;15657
+Impeccable Timing;AKH;401282
+Impeccable Timing;KLD;162462
+Impelled Giant;EVE;113652
+Impending Disaster;UL;9506
+Imperial Aerosaur;XLN;402084
+Imperial Edict;PTK;9005
+Imperial Hellkite;LGN;47514
+Imperial Lancer;XLN;402263
+Imperial Mask;FUT;38149
+Imperial Recruiter;ME2;9184
+Imperial Recruiter;PTK;9184
+Imperial Seal;ME2;9146
+Imperial Seal;PTK;9146
+Imperiosaur;FUT;102399
+Imperiosaur;MMA;102399
+Imperious Perfect;C14;105444
+Imperious Perfect;DPA;105444
+Imperious Perfect;EMA;105444
+Imperious Perfect;EVG;105444
+Imperious Perfect;LRW;105444
+Imperious Perfect;PRM;105444
+Impetuous Devils;EMN;162112
+Impetuous Sunchaser;BNG;152040
+Implement of Combustion;AER;400387
+Implement of Examination;AER;400385
+Implement of Ferocity;AER;400388
+Implement of Improvement;AER;400384
+Implement of Malice;AER;400386
+Implements of Sacrifice;FEM;960
+Implode;PLS;27928
+Imposing Sovereign;M14;149822
+Imposing Visage;5ED;2404
+Imposing Visage;ICE;1224
+Imprison;LEG;2522
+Imprisoned in the Moon;EMN;161932
+Impromptu Raid;SHM;111637
+Improvised Armor;ONS;42945
+Imps' Taunt;TMP;3220
+Impulse;PRM;2190
+Impulse;V13;148714
+Impulse;VIS;2190
+Impulsive Maneuvers;ODY;33359
+In Garruk's Wake;M15;155382
+In Garruk's Wake;PRM;155861
+In Oketra's Name;AKH;401283
+In the Eye of Chaos;LEG;2523
+In the Eye of Chaos;ME4;2523
+In the Web of War;BOK;83823
+Inaction Injunction;RTR;145124
+Iname as One;SOK;86110
+Iname, Death Aspect;COK;80933
+Iname, Life Aspect;COK;80914
+Incandescent Soulstoke;LRW;105478
+Incandescent Soulstoke;MM2;105478
+Incendiary Command;C13;105579
+Incendiary Command;LRW;105579
+Incendiary Flow;EMN;161981
+Incendiary Flow;PRM;400719
+Incendiary Sabotage;KLD;162526
+Incendiary;UD;15653
+Incinerate;10E;102955
+Incinerate;5ED;2405
+Incinerate;DD2;118218
+Incinerate;DPA;102955
+Incinerate;ICE;1225
+Incinerate;M12;102955
+Incinerate;ME2;1225
+Incinerate;MIR;1929
+Incinerate;PRM;107707
+Incite Hysteria;RAV;88981
+Incite Rebellion;C14;155570
+Incite War;MRD;51054
+Incite;M11;129134
+Incited Rabble;SOI;161387
+Incorrigible Youths;PRM;161719
+Incorrigible Youths;SOI;161391
+Increasing Ambition;DKA;139869
+Increasing Confusion;DKA;139892
+Increasing Devotion;DKA;139905
+Increasing Savagery;DKA;139870
+Increasing Vengeance;DKA;139818
+Incremental Blight;DPA;111699
+Incremental Blight;PC1;111699
+Incremental Blight;SHM;111699
+Incremental Growth;DPA;107654
+Incremental Growth;KTK;157062
+Incremental Growth;LRW;107654
+Incremental Growth;MMA;107654
+Incremental Growth;W16;107654
+Incubator Drone;BFZ;160848
+Incurable Ogre;ALA;115045
+Incursion Specialist;GTC;146361
+Indebted Samurai;BOK;83828
+Indebted Samurai;DPA;83828
+Indentured Djinn;MMQ;19177
+Indentured Oaf;RAV;88887
+Independent Troops;PTK;9072
+Indestructibility;DPA;121638
+Indestructibility;M10;121638
+Indestructibility;M14;121638
+Indestructible Aura;CH;590
+Indestructible Aura;LEG;590
+Index;8ED;31102
+Index;9ED;31102
+Index;APC;31102
+Index;M13;31102
+Indigo Faerie;EVE;113672
+Indomitable Ancients;MOR;109977
+Indomitable Archangel;MM2;131136
+Indomitable Archangel;SOM;131136
+Indomitable Creativity;AER;400330
+Indomitable Will;COK;80714
+Indrik Stomphowler;DDD;94442
+Indrik Stomphowler;DIS;94442
+Indrik Stomphowler;DPA;94442
+Indrik Umbra;PC2;140359
+Induce Despair;ROE;127325
+Induce Paranoia;RAV;88787
+Indulgent Aristocrat;SOI;161488
+Indulgent Tormentor;M15;155300
+Indulgent Tormentor;PRM;155858
+Inertia Bubble;MRD;51129
+Inescapable Brute;SHM;111604
+Inexorable Blob;SOI;161631
+Inexorable Tide;MM2;130968
+Inexorable Tide;SOM;130968
+Infantry Veteran;6ED;2191
+Infantry Veteran;9ED;2191
+Infantry Veteran;DDF;2191
+Infantry Veteran;M11;2191
+Infantry Veteran;VIS;2191
+Infected Vermin;ODY;33421
+Infectious Bloodlust;ORI;160301
+Infectious Curse;SOI;161741
+Infectious Horror;CON;118656
+Infectious Host;RAV;88955
+Infectious Rage;JUD;40251
+Infernal Caretaker;LGN;47508
+Infernal Contract;6ED;1930
+Infernal Contract;7ED;27667
+Infernal Contract;MIR;1930
+Infernal Darkness;ICE;1226
+Infernal Darkness;ME2;1226
+Infernal Denizen;ICE;1227
+Infernal Genesis;PCY;22045
+Infernal Harvest;VIS;2192
+Infernal Kirin;SOK;87218
+Infernal Medusa;LEG;591
+Infernal Offering;C14;155667
+Infernal Plunge;ISD;138398
+Infernal Scarring;ORI;160256
+Infernal Tribute;WTH;2869
+Infernal Tutor;DIS;94379
+Inferno Elemental;DPA;121670
+Inferno Elemental;M10;121670
+Inferno Fist;M15;155392
+Inferno Jet;HOU;401811
+Inferno Titan;C13;129131
+Inferno Titan;DPA;129131
+Inferno Titan;M11;129131
+Inferno Titan;M12;129131
+Inferno Titan;PRM;139233
+Inferno Trap;ZEN;123744
+Inferno;4ED;787
+Inferno;5ED;2406
+Inferno;6ED;2406
+Inferno;7ED;27668
+Inferno;8ED;27668
+Inferno;DRK;787
+Inferno;PRM;148281
+Infest;ALA;114998
+Infest;C13;114998
+Infest;DPA;114998
+Infest;ONS;43064
+Infest;PRM;126731
+Infested Roothold;DST;75190
+Infiltrate;NMS;21177
+Infiltration Lens;DPA;131011
+Infiltration Lens;SOM;131011
+Infiltrator il-Kor;FUT;102416
+Infiltrator's Magemark;DPA;91874
+Infiltrator's Magemark;GPT;91874
+Infinite Authority;LEG;2524
+Infinite Hourglass;5ED;2407
+Infinite Hourglass;ICE;1228
+Infinite Obliteration;ORI;160275
+Infinite Reflection;AVR;141797
+Infinite Reflection;C14;141797
+Inflame;DST;75184
+Inflame;PCY;21989
+Information Dealer;ONS;42975
+Infuse with the Elements;BFZ;160893
+Infuse;ICE;1229
+Infuse;ME3;1229
+Infused Arrows;5DN;77151
+Ingenious Skaab;EMN;162061
+Ingenious Thief;POR;6621
+Ingot Chewer;C14;106415
+Ingot Chewer;DD2;106415
+Ingot Chewer;LRW;106415
+Inheritance;ALL;1657
+Inheritance;ME2;1657
+Initiate of Blood;COK;80901
+Initiate's Companion;AKH;401332
+Initiates of the Ebon Hand;5ED;961
+Initiates of the Ebon Hand;FEM;961
+Initiates of the Ebon Hand;FEM;962
+Initiates of the Ebon Hand;FEM;963
+Injury;AKH;401042
+Ink Dissolver;MOR;109946
+Ink-Eyes, Servant of Oni;BOK;83940
+Ink-Eyes, Servant of Oni;PC2;83940
+Ink-Eyes, Servant of Oni;PRM;86890
+Ink-Eyes, Servant of Oni;V13;83940
+Ink-Treader Nephilim;GPT;91862
+Inkfathom Divers;LRW;105339
+Inkfathom Infiltrator;SHM;111764
+Inkfathom Witch;PC2;111821
+Inkfathom Witch;SHM;111821
+Inkmoth Nexus;MBS;133126
+Inkmoth Nexus;PRM;400723
+Inkwell Leviathan;CON;118655
+Inkwell Leviathan;DPA;118655
+Inkwell Leviathan;EMA;118655
+Inkwell Leviathan;PD3;118655
+Inner Calm, Outer Strength;SOK;86027
+Inner Fire;SOK;86133
+Inner Sanctum;WTH;2904
+Inner Struggle;SOI;161692
+Inner-Chamber Guard;SOK;86018
+Inner-Flame Acolyte;DD2;105553
+Inner-Flame Acolyte;LRW;105553
+Inner-Flame Igniter;LRW;105377
+Inner-Flame Igniter;MM2;105377
+Innocence Kami;COK;80820
+Innocent Blood;DPA;33426
+Innocent Blood;EMA;33426
+Innocent Blood;ODY;33426
+Innocent Blood;PC1;33426
+Innocent Blood;TD2;33426
+Inquisition of Kozilek;MM3;161165
+Inquisition of Kozilek;ROE;127256
+Inquisition;DRK;788
+Inquisitor Exarch;NPH;134319
+Inquisitor's Flail;ISD;138213
+Inquisitor's Ox;SOI;161401
+Inquisitor's Snare;SHM;111876
+Insatiable Gorgers;EMN;162099
+Insatiable Harpy;THS;149087
+Insatiable Souleater;NPH;134405
+Insect;TOK;101527
+Insect;TOK;122183
+Insect;TOK;131403
+Insect;TOK;140631
+Insect;TOK;143399
+Insect;TOK;161611
+Insect;TOK;401252
+Insect;TOK;401795
+Insect;TOK;44680
+Insect;TOK;51147
+Insect;TOK;684
+Insectile Aberration;ISD;138245
+Inside Out;EVE;113706
+Insidious Bookworms;ALL;1658
+Insidious Bookworms;ALL;1659
+Insidious Dreams;TOR;36470
+Insidious Mist;PRM;161700
+Insidious Mist;SOI;162023
+Insidious Will;KLD;162260
+Insight;6ED;3286
+Insight;TMP;3286
+Insist;TOR;36524
+Insolence;PLS;27929
+Insolent Neonate;SOI;161736
+Inspiration;6ED;2193
+Inspiration;7ED;30845
+Inspiration;8ED;30845
+Inspiration;RTR;145125
+Inspiration;VIS;2193
+Inspiration;W17;145125
+Inspired Charge;BFZ;160633
+Inspired Charge;KLD;162467
+Inspired Charge;M11;129157
+Inspired Charge;M15;129157
+Inspired Sprite;MOR;107684
+Inspiring Call;DTK;159735
+Inspiring Captain;SOI;161454
+Inspiring Cleric;XLN;401928
+Inspiring Roar;AER;400211
+Inspiring Statuary;AER;400405
+Inspiring Vantage;KLD;162364
+Inspirit;9ED;86950
+Inspirit;ONS;42961
+Instigator Gang;ISD;138274
+Instigator;MMQ;19069
+Instill Energy;2ED;122
+Instill Energy;3ED;122
+Instill Energy;4ED;122
+Instill Energy;5ED;2408
+Instill Energy;LEA;122
+Instill Energy;LEB;122
+Instill Energy;ME4;122
+Instill Furor;RAV;89038
+Instill Infection;MM2;130965
+Instill Infection;SOM;130965
+Insubordination;MMQ;19110
+Insult;AKH;401984
+Insurrection;CMD;43137
+Insurrection;DPA;43137
+Insurrection;ONS;43137
+Insurrection;PC1;43137
+Intangible Virtue;DPA;138439
+Intangible Virtue;EMA;138439
+Intangible Virtue;ISD;138439
+Intangible Virtue;MM3;138439
+Intellectual Offering;C14;156018
+Interdict;TMP;3279
+Interplanar Tunnel;PC2;138735
+Interpret the Signs;JOU;152959
+Intervene;UL;10375
+Intervention Pact;FUT;102409
+Intet, the Dreamer;CMD;100730
+Intet, the Dreamer;PLC;100730
+Intimidation Bolt;ARB;120974
+Intimidation;MMQ;19207
+Intimidator Initiate;SHM;111572
+Into Thin Air;5DN;77094
+Into the Core;MBS;133175
+Into the Fray;SOK;83977
+Into the Maw of Hell;ISD;138109
+Into the North;CSP;96935
+Into the Roil;C14;123585
+Into the Roil;DDM;123585
+Into the Roil;DPA;123585
+Into the Roil;ZEN;123585
+Into the Void;AVR;141844
+Into the Void;M15;141844
+Into the Void;ORI;141844
+Into the Wilds;M14;147424
+Intrepid Hero;7ED;27670
+Intrepid Hero;8ED;49666
+Intrepid Hero;DPA;49666
+Intrepid Hero;M13;49666
+Intrepid Hero;USG;8894
+Intrepid Provisioner;SOI;161626
+Intruder Alarm;8ED;49667
+Intruder Alarm;STH;3708
+Intuition;PRM;3175
+Intuition;TMP;3175
+Intuition;TPR;3175
+Inundate;EVE;113595
+Invader Parasite;NPH;134406
+Invasion Plans;STH;3709
+Invasive Species;M15;155337
+Invasive Surgery;SOI;161427
+Inventor's Apprentice;KLD;162536
+Inventor's Goggles;KLD;162572
+Inventors' Fair;KLD;162365
+Invert the Skies;EVE;113623
+Inverter of Truth;OGW;161104
+Invigorate;CMD;19085
+Invigorate;DDD;19085
+Invigorate;EMA;161567
+Invigorate;MMQ;19085
+Invigorate;PZ1;19085
+Invigorated Rampage;AER;400319
+Invigorating Boon;ONS;43185
+Invigorating Falls;TOR;36517
+Invincible Hymn;ALA;115095
+Inviolability;MMQ;19050
+Invisibility;2ED;123
+Invisibility;8ED;49231
+Invisibility;LEA;123
+Invisibility;LEB;123
+Invisibility;M15;49231
+Invisible Stalker;DPA;138111
+Invisible Stalker;ISD;138111
+Invocation of Saint Traft;SOI;161628
+Invoke Prejudice;LEG;2525
+Invoke the Firemind;DDJ;88648
+Invoke the Firemind;DPA;88648
+Invoke the Firemind;GPT;88648
+Invulnerability;TMP;3298
+Ion Storm;5DN;77197
+Iona, Shield of Emeria;MM2;123685
+Iona, Shield of Emeria;V15;160448
+Iona, Shield of Emeria;ZEN;123685
+Iona's Blessing;OGW;161201
+Iona's Judgment;WWK;126578
+Ior Ruin Expedition;ZEN;123635
+Ipnu Rivulet;HOU;401789
+Ire Shaman;DTK;159814
+Ire of Kaminari;BOK;83929
+Iridescent Angel;ODY;33265
+Iridescent Angel;V15;160449
+Iridescent Drake;UD;15625
+Irini Sengir;HML;1519
+Iroas, God of Victory;JOU;152833
+Iroas's Champion;ORI;160337
+Iron Lance;MMQ;19080
+Iron League Steed;KLD;162570
+Iron Maiden;UL;13563
+Iron Myr;MRD;50863
+Iron Myr;PC1;50863
+Iron Myr;SOM;130913
+Iron Star;2ED;124
+Iron Star;3ED;124
+Iron Star;4ED;124
+Iron Star;5ED;2409
+Iron Star;6ED;2409
+Iron Star;7ED;27671
+Iron Star;8ED;2409
+Iron Star;LEA;124
+Iron Star;LEB;124
+Iron Tusk Elephant;MIR;1931
+Iron Will;UL;13565
+Iron-Barb Hellion;5DN;77073
+Iron-Heart Chimera;VIS;2194
+Ironclad Revolutionary;AER;400299
+Ironclad Slayer;EMN;162035
+Ironclaw Buzzardiers;TSP;97475
+Ironclaw Curse;5ED;1520
+Ironclaw Curse;HML;1520
+Ironclaw Orcs;2ED;125
+Ironclaw Orcs;4ED;125
+Ironclaw Orcs;5ED;125
+Ironclaw Orcs;LEA;125
+Ironclaw Orcs;LEB;125
+Ironclaw Orcs;ME2;125
+Ironfang;ISD;138193
+Ironfist Crusher;ONS;42933
+Ironhoof Ox;ME4;4777
+Ironhoof Ox;PO2;4777
+Ironroot Treefolk;2ED;126
+Ironroot Treefolk;3ED;126
+Ironroot Treefolk;4ED;126
+Ironroot Treefolk;5ED;2410
+Ironroot Treefolk;LEA;126
+Ironroot Treefolk;LEB;126
+Ironshell Beetle;JUD;40271
+Irontread Crusher;AER;400380
+Ironwright's Cleansing;EMN;162036
+Irradiate;MRD;51081
+Irresistible Prey;ROE;127269
+Irrigated Farmland;AKH;400791
+Irrigation Ditch;INV;25160
+Isamaru, Hound of Konda;COK;81103
+Isao, Enlightened Bushi;BOK;80736
+Ishai, Ojutai Dragonspeaker;PZ2;162379
+Ishi-Ishi, Akki Crackshot;BOK;83946
+Ishkanah, Grafwidow;EMN;162008
+Island Fish Jasconius;3ED;341
+Island Fish Jasconius;4ED;341
+Island Fish Jasconius;ARN;341
+Island Sanctuary;2ED;129
+Island Sanctuary;3ED;129
+Island Sanctuary;4ED;129
+Island Sanctuary;5ED;129
+Island Sanctuary;LEA;129
+Island Sanctuary;LEB;129
+Island Sanctuary;ME4;129
+Island of Wak-Wak;ARN;342
+Island of Wak-Wak;MED;342
+Island;10E;25162
+Island;10E;80957
+Island;10E;8754
+Island;10E;89166
+Island;2ED;127
+Island;2ED;128
+Island;2ED;298
+Island;3ED;127
+Island;3ED;128
+Island;3ED;298
+Island;4ED;127
+Island;4ED;128
+Island;4ED;298
+Island;5ED;2411
+Island;5ED;2412
+Island;5ED;2413
+Island;5ED;2414
+Island;6ED;1933
+Island;6ED;2413
+Island;6ED;4792
+Island;6ED;6776
+Island;7ED;27672
+Island;7ED;27673
+Island;7ED;27674
+Island;7ED;27675
+Island;8ED;19006
+Island;8ED;25161
+Island;8ED;25162
+Island;8ED;27674
+Island;9ED;19006
+Island;9ED;25161
+Island;9ED;25162
+Island;9ED;27674
+Island;AKH;400888
+Island;AKH;400889
+Island;AKH;400890
+Island;AKH;402700
+Island;ALA;115051
+Island;ALA;115052
+Island;ALA;115053
+Island;ALA;115054
+Island;AVR;141756
+Island;AVR;141764
+Island;AVR;141770
+Island;BFZ;123757
+Island;BFZ;160743
+Island;BFZ;160744
+Island;BFZ;160745
+Island;BFZ;160746
+Island;C01;17598
+Island;C13;115051
+Island;C13;137569
+Island;C13;138793
+Island;C13;141764
+Island;C14;96762
+Island;C14;97529
+Island;C14;97550
+Island;C14;97565
+Island;CMD;104082
+Island;CMD;25162
+Island;CMD;27674
+Island;CMD;89176
+Island;COK;80947
+Island;COK;80955
+Island;COK;80957
+Island;COK;80960
+Island;DD2;19006
+Island;DD2;27674
+Island;DD2;8754
+Island;DD2;89170
+Island;DDE;25489
+Island;DDF;115052
+Island;DDF;115054
+Island;DDF;50311
+Island;DDF;50313
+Island;DDH;115053
+Island;DDI;131170
+Island;DDI;50311
+Island;DDI;50312
+Island;DDJ;89163
+Island;DDJ;89166
+Island;DDJ;89170
+Island;DDJ;89176
+Island;DDM;145246
+Island;DDM;145247
+Island;DDM;145248
+Island;DDM;145249
+Island;DDM;89176
+Island;DPA;25162
+Island;DPA;80957
+Island;DPA;8754
+Island;DPA;89166
+Island;DTK;159769
+Island;DTK;159786
+Island;DTK;159791
+Island;FK;19006
+Island;FRF;158892
+Island;FRF;158893
+Island;H09;3081
+Island;HOU;401921
+Island;HOU;402759
+Island;HOU;402764
+Island;ICE;1230
+Island;ICE;1231
+Island;ICE;1232
+Island;INV;25161
+Island;INV;25162
+Island;INV;25489
+Island;INV;25656
+Island;ISD;138460
+Island;ISD;138461
+Island;ISD;138462
+Island;KLD;162193
+Island;KLD;162352
+Island;KLD;162353
+Island;KTK;156616
+Island;KTK;156617
+Island;KTK;156618
+Island;KTK;156619
+Island;LEA;127
+Island;LEA;128
+Island;LEB;127
+Island;LEB;128
+Island;LEB;298
+Island;LRW;104082
+Island;LRW;105645
+Island;LRW;105649
+Island;LRW;105652
+Island;M10;121687
+Island;M10;121700
+Island;M10;19006
+Island;M10;25162
+Island;M11;106211
+Island;M11;121687
+Island;M11;121700
+Island;M11;6779
+Island;M12;115051
+Island;M12;121687
+Island;M12;137569
+Island;M12;137570
+Island;M13;121687
+Island;M13;137569
+Island;M13;137570
+Island;M13;138793
+Island;M14;137569
+Island;M14;138766
+Island;M14;138769
+Island;M14;138793
+Island;M15;137569
+Island;M15;137570
+Island;M15;138766
+Island;M15;153335
+Island;MBS;133244
+Island;MBS;133248
+Island;ME3;9037
+Island;ME3;9038
+Island;ME3;9039
+Island;MED;127
+Island;MED;128
+Island;MED;298
+Island;MIR;1932
+Island;MIR;1933
+Island;MIR;1934
+Island;MIR;1935
+Island;MMQ;19006
+Island;MMQ;19007
+Island;MMQ;19268
+Island;MMQ;19281
+Island;MRD;50311
+Island;MRD;50312
+Island;MRD;50313
+Island;MRD;50345
+Island;NPH;134337
+Island;NPH;134348
+Island;ODY;33218
+Island;ODY;33219
+Island;ODY;33220
+Island;ODY;33221
+Island;ONS;43237
+Island;ONS;43238
+Island;ONS;43239
+Island;ONS;43240
+Island;ORI;138712
+Island;ORI;145247
+Island;ORI;160367
+Island;ORI;89176
+Island;PC1;50311
+Island;PC1;50312
+Island;PC1;50313
+Island;PC1;50345
+Island;PC2;25162
+Island;PC2;80947
+Island;PC2;80955
+Island;PC2;80957
+Island;PC2;80960
+Island;PO2;4792
+Island;PO2;4793
+Island;PO2;4794
+Island;POR;6776
+Island;POR;6777
+Island;POR;6778
+Island;POR;6779
+Island;PRM;116170
+Island;PRM;125122
+Island;PRM;132687
+Island;PRM;156670
+Island;PRM;160798
+Island;PRM;17598
+Island;PRM;21430
+Island;PRM;21435
+Island;PRM;21440
+Island;PRM;21441
+Island;PRM;49942
+Island;PRM;75382
+Island;PRM;8512
+Island;PRM;8520
+Island;PRM;8523
+Island;PRM;85582
+Island;PRM;90386
+Island;PRM;97560
+Island;PTK;9037
+Island;PTK;9038
+Island;PTK;9039
+Island;RAV;89163
+Island;RAV;89166
+Island;RAV;89170
+Island;RAV;89176
+Island;ROE;127494
+Island;ROE;127501
+Island;ROE;127506
+Island;ROE;127507
+Island;RTR;145246
+Island;RTR;145247
+Island;RTR;145248
+Island;RTR;145249
+Island;RTR;89176
+Island;SHM;111816
+Island;SHM;111817
+Island;SHM;111825
+Island;SHM;111835
+Island;SOI;161505
+Island;SOI;161506
+Island;SOI;161507
+Island;SOM;131158
+Island;SOM;131164
+Island;SOM;131170
+Island;SOM;131174
+Island;TD0;9037
+Island;TD0;9038
+Island;TD0;9039
+Island;TD2;131164
+Island;TD2;131170
+Island;TD2;50313
+Island;THS;149126
+Island;THS;149127
+Island;THS;149976
+Island;THS;149977
+Island;TMP;3071
+Island;TMP;3076
+Island;TMP;3081
+Island;TMP;3086
+Island;TPR;3071
+Island;TPR;3076
+Island;TPR;3081
+Island;TPR;3086
+Island;TSP;96762
+Island;TSP;97529
+Island;TSP;97550
+Island;TSP;97565
+Island;USG;8754
+Island;USG;8755
+Island;USG;8756
+Island;USG;8757
+Island;XLN;401900
+Island;XLN;401901
+Island;XLN;401902
+Island;XLN;402021
+Island;ZEN;123754
+Island;ZEN;123756
+Island;ZEN;123757
+Island;ZEN;123767
+Isle of Vesuva;PC1;125891
+Isleback Spawn;DPA;111664
+Isleback Spawn;SHM;111664
+Isochron Scepter;DDJ;9402
+Isochron Scepter;EMA;131078
+Isochron Scepter;MRD;9402
+Isochron Scepter;PRM;101063
+Isochron Scepter;V10;131078
+Isolated Chapel;ISD;138420
+Isolation Cell;NPH;134308
+Isolation Zone;OGW;161122
+Isperia the Inscrutable;DIS;94507
+Isperia, Supreme Judge;RTR;145266
+Isperia's Skywatch;RTR;145852
+It That Betrays;DPA;127456
+It That Betrays;ROE;127456
+It That Rides as One;EMN;161911
+It of the Horrid Swarm;EMN;162117
+Ith, High Arcanist;TSP;97448
+Itlimoc, Cradle of the Sun;XLN;402098
+Ivory Charm;MIR;1936
+Ivory Crane Netsuke;SOK;86171
+Ivory Cup;2ED;130
+Ivory Cup;3ED;130
+Ivory Cup;4ED;130
+Ivory Cup;5ED;2415
+Ivory Cup;6ED;2415
+Ivory Cup;7ED;27676
+Ivory Cup;8ED;2415
+Ivory Cup;LEA;130
+Ivory Cup;LEB;130
+Ivory Gargoyle;ALL;1660
+Ivory Gargoyle;ME2;1660
+Ivory Giant;MMA;148261
+Ivory Giant;TSP;97359
+Ivory Guardians;5ED;2416
+Ivory Guardians;CH;592
+Ivory Guardians;LEG;592
+Ivory Guardians;ME3;592
+Ivory Mask;8ED;18996
+Ivory Mask;9ED;18996
+Ivory Mask;MMQ;18996
+Ivory Tower;3ED;418
+Ivory Tower;4ED;418
+Ivory Tower;ATQ;418
+Ivory Tower;MED;418
+Ivory Tower;V10;129515
+Ivory Tower;VMA;129515
+Ivorytusk Fortress;KTK;157106
+Ivorytusk Fortress;PRM;156595
+Ivy Dancer;RAV;88906
+Ivy Elemental;ODY;33308
+Ivy Elemental;PC1;33308
+Ivy Lane Denizen;GTC;146284
+Ivy Seer;UD;15664
+Iwamori of the Open Fist;BOK;83884
+Ixalan's Binding;XLN;402864
+Ixalli's Diviner;XLN;402268
+Ixalli's Keeper;XLN;401943
+Ixidor, Reality Sculptor;ONS;41924
+Ixidor's Will;ONS;42987
+Ixidron;C14;99652
+Ixidron;TSP;99652
+Izzet Boilerworks;C13;91830
+Izzet Boilerworks;CMD;91830
+Izzet Boilerworks;DDJ;91830
+Izzet Boilerworks;GPT;91830
+Izzet Boilerworks;MM2;91830
+Izzet Charm;DDJ;145196
+Izzet Charm;MM3;149242
+Izzet Charm;PRM;149242
+Izzet Charm;RTR;145196
+Izzet Chronarch;CMD;91812
+Izzet Chronarch;DDJ;143981
+Izzet Chronarch;DPA;143981
+Izzet Chronarch;GPT;91812
+Izzet Cluestone;DGM;147748
+Izzet Guildgate;C13;146228
+Izzet Guildgate;DGM;146885
+Izzet Guildgate;MM3;146885
+Izzet Guildgate;RTR;146228
+Izzet Guildmage;DDJ;91791
+Izzet Guildmage;GPT;91791
+Izzet Keyrune;RTR;145213
+Izzet Signet;CMD;91694
+Izzet Signet;DDJ;131623
+Izzet Signet;GPT;91694
+Izzet Signet;MM3;131623
+Izzet Signet;PRM;131623
+Izzet Staticaster;RTR;145193
+Izzet Steam Maze;PC1;125860
+Jabari's Banner;WTH;2912
+Jabari's Influence;MIR;1937
+Jace Beleren;DD2;118216
+Jace Beleren;LRW;105537
+Jace Beleren;M10;105537
+Jace Beleren;M11;105537
+Jace Beleren;PRM;120564
+Jace, Architect of Thought;DDM;153184
+Jace, Architect of Thought;RTR;145262
+Jace, Cunning Castaway;XLN;402034
+Jace, Ingenious Mind-Mage;XLN;402029
+Jace, Memory Adept;M12;134145
+Jace, Memory Adept;M13;134145
+Jace, Memory Adept;M14;134145
+Jace, Telepath Unbound;ORI;160221
+Jace, Unraveler of Secrets;SOI;161418
+Jace, Vryn's Prodigy;ORI;160220
+Jace, the Living Guildpact;M15;155270
+Jace, the Mind Sculptor;EMA;126493
+Jace, the Mind Sculptor;V13;126493
+Jace, the Mind Sculptor;VMA;126493
+Jace, the Mind Sculptor;WWK;126493
+Jace's Archivist;C13;134185
+Jace's Archivist;M12;134185
+Jace's Defeat;HOU;401594
+Jace's Erasure;DPA;125788
+Jace's Erasure;M11;125788
+Jace's Erasure;M12;125788
+Jace's Ingenuity;DDM;129105
+Jace's Ingenuity;DPA;129105
+Jace's Ingenuity;M11;129105
+Jace's Ingenuity;M15;129105
+Jace's Ingenuity;PRM;136802
+Jace's Mindseeker;DDM;147476
+Jace's Mindseeker;DPA;147476
+Jace's Mindseeker;M14;147476
+Jace's Phantasm;DDM;143861
+Jace's Phantasm;DPA;143861
+Jace's Phantasm;M13;143861
+Jace's Sanctum;ORI;160243
+Jace's Scrutiny;SOI;161460
+Jace's Sentinel;XLN;402342
+Jackal Familiar;M10;121661
+Jackal Pup;PD2;131547
+Jackal Pup;PRM;3258
+Jackal Pup;TMP;3258
+Jackalope Herd;EXO;5634
+Jacques le Vert;LEG;4618
+Jacques le Vert;MED;4618
+Jaddi Lifestrider;ROE;127282
+Jaddi Offshoot;BFZ;160712
+Jade Guardian;XLN;402274
+Jade Idol;COK;82647
+Jade Leech;INV;25473
+Jade Mage;C13;134157
+Jade Mage;DDH;134157
+Jade Mage;DPA;134157
+Jade Mage;M12;134157
+Jade Monolith;2ED;131
+Jade Monolith;3ED;131
+Jade Monolith;4ED;131
+Jade Monolith;5ED;2417
+Jade Monolith;6ED;2417
+Jade Monolith;LEA;131
+Jade Monolith;LEB;131
+Jade Monolith;ME4;131
+Jade Statue;2ED;132
+Jade Statue;9ED;86929
+Jade Statue;LEA;132
+Jade Statue;LEB;132
+Jaded Response;APC;31091
+Jagged Lightning;DPA;8861
+Jagged Lightning;PO2;4754
+Jagged Lightning;USG;8861
+Jagged Poppet;DIS;94289
+Jagged-Scar Archers;DPA;105475
+Jagged-Scar Archers;LRW;105475
+Jagwasp Swarm;WWK;126470
+Jalira, Master Polymorphist;M15;155282
+Jalum Tome;5ED;419
+Jalum Tome;6ED;419
+Jalum Tome;7ED;27679
+Jalum Tome;ATQ;419
+Jalum Tome;C14;27679
+Jalum Tome;CH;419
+Jamuraan Lion;VIS;2195
+Jandor's Ring;3ED;343
+Jandor's Ring;ARN;343
+Jandor's Saddlebags;3ED;344
+Jandor's Saddlebags;4ED;344
+Jandor's Saddlebags;5ED;2418
+Jandor's Saddlebags;7ED;27678
+Jandor's Saddlebags;ARN;344
+Jangling Automaton;WTH;2787
+Janjeet Sentry;KLD;162255
+Jar of Eyeballs;C13;139757
+Jar of Eyeballs;DKA;139757
+Jarad, Golgari Lich Lord;DDJ;145074
+Jarad, Golgari Lich Lord;RTR;145982
+Jarad's Orders;RTR;145971
+Jareth, Leonine Titan;EMA;42958
+Jareth, Leonine Titan;ONS;42958
+Jareth, Leonine Titan;VMA;42958
+Jasmine Boreal;LEG;593
+Jasmine Boreal;TSB;593
+Jasmine Seer;UD;15601
+Jawbone Skulkin;EVE;113757
+Jaws of Stone;DDG;111628
+Jaws of Stone;DDI;111628
+Jaws of Stone;SHM;111628
+Jaya Ballard, Task Mage;PD2;97361
+Jaya Ballard, Task Mage;PRM;97361
+Jaya Ballard, Task Mage;TSP;97361
+Jayemdae Tome;10E;27677
+Jayemdae Tome;2ED;133
+Jayemdae Tome;3ED;133
+Jayemdae Tome;4ED;133
+Jayemdae Tome;5ED;133
+Jayemdae Tome;6ED;133
+Jayemdae Tome;7ED;27677
+Jayemdae Tome;8ED;27677
+Jayemdae Tome;DPA;27677
+Jayemdae Tome;LEA;133
+Jayemdae Tome;LEB;133
+Jayemdae Tome;M13;27677
+Jayemdae Tome;ORI;27677
+Jazal Goldmane;C14;155601
+Jedit Ojanen of Efrava;PLC;100736
+Jedit Ojanen;LEG;594
+Jedit Ojanen;ME3;594
+Jedit's Dragoons;DDI;97437
+Jedit's Dragoons;TSP;97437
+Jeering Instigator;KTK;156591
+Jeering Instigator;PRM;159756
+Jelenn Sphinx;DGM;146844
+Jeleva, Nephalia's Scourge;C13;151710
+Jenara, Asura of War;ARB;121014
+Jenara, Asura of War;V15;121014
+Jerrard of the Closed Fist;LEG;595
+Jerrard of the Closed Fist;ME3;595
+Jeska, Warrior Adept;JUD;40258
+Jeskai Ascendancy;KTK;157079
+Jeskai Banner;KTK;156533
+Jeskai Barricade;FRF;157151
+Jeskai Charm;KTK;156568
+Jeskai Elder;KTK;156544
+Jeskai Infiltrator;FRF;157195
+Jeskai Infiltrator;PRM;159385
+Jeskai Runemark;FRF;157221
+Jeskai Sage;FRF;157178
+Jeskai Student;KTK;156476
+Jeskai Windscout;KTK;156487
+Jester's Cap;5ED;1233
+Jester's Cap;9ED;86955
+Jester's Cap;ICE;1233
+Jester's Cap;V10;86955
+Jester's Mask;ICE;1234
+Jester's Mask;ME2;1234
+Jester's Scepter;CSP;97029
+Jet Medallion;C14;144003
+Jet Medallion;DPA;144003
+Jet Medallion;TMP;3109
+Jetting Glasskite;BOK;83973
+Jetting Glasskite;EMA;83973
+Jeweled Amulet;ICE;1235
+Jeweled Amulet;ME2;1235
+Jeweled Bird;ARN;345
+Jeweled Bird;CH;345
+Jeweled Spirit;PCY;22052
+Jeweled Torque;MMQ;19326
+Jhessian Balmgiver;CON;118667
+Jhessian Infiltrator;ALA;115205
+Jhessian Lookout;ALA;115214
+Jhessian Thief;ORI;160236
+Jhessian Zombies;ARB;98618
+Jhessian Zombies;DDH;98618
+Jhoira of the Ghitu;FUT;102483
+Jhoira of the Ghitu;MMA;102483
+Jhoira's Timebug;TSP;97506
+Jhoira's Toolbox;UL;10388
+Jhovall Queen;MMQ;19782
+Jhovall Rider;MMQ;19081
+Jihad;ARN;346
+Jilt;APC;31095
+Jin-Gitaxias, Core Augur;NPH;134204
+Jinx;HML;1521
+Jinxed Choker;MRD;51042
+Jinxed Idol;M11;129171
+Jinxed Idol;TMP;3093
+Jinxed Idol;TPR;3093
+Jinxed Ring;STH;3711
+Jiwari, the Earth Aflame;SOK;86025
+Jodah's Avenger;PLC;100751
+Johan;CH;596
+Johan;LEG;596
+Johtull Wurm;5ED;2419
+Johtull Wurm;ICE;1236
+Johtull Wurm;ME2;1236
+Join the Ranks;WWK;126480
+Joiner Adept;10E;104545
+Joiner Adept;5DN;77198
+Joint Assault;AVR;141594
+Jokulhaups;5ED;2420
+Jokulhaups;6ED;2420
+Jokulhaups;ICE;1237
+Jokulhaups;MED;1237
+Jokulmorder;CSP;96934
+Jolrael, Empress of Beasts;PCY;21987
+Jolrael, Empress of Beasts;TSB;21987
+Jolrael's Centaur;MIR;1938
+Jolrael's Favor;PCY;21988
+Jolt;MIR;1939
+Jolting Merfolk;NMS;21180
+Jor Kadeen, the Prevailer;NPH;134339
+Joraga Auxiliary;OGW;161159
+Joraga Bard;ZEN;123731
+Joraga Invocation;ORI;160321
+Joraga Treespeaker;ROE;127280
+Joraga Warcaller;C14;126735
+Joraga Warcaller;DPA;126735
+Joraga Warcaller;PRM;126577
+Joraga Warcaller;WWK;126735
+Jori En, Ruin Diver;OGW;161146
+Jori En, Ruin Diver;PRM;161283
+Jorubai Murk Lurker;M15;155312
+Jotun Grunt;CMD;97038
+Jotun Grunt;CSP;97038
+Jotun Grunt;TD0;97038
+Jotun Owl Keeper;CSP;96972
+Journey of Discovery;MRD;51126
+Journey to Nowhere;CMD;123549
+Journey to Nowhere;DDF;123549
+Journey to Nowhere;DPA;123549
+Journey to Nowhere;ZEN;123549
+Journeyer's Kite;COK;81119
+Journeyer's Kite;DDI;81119
+Joven;HML;1522
+Joven's Ferrets;HML;1523
+Joven's Ferrets;ME2;1523
+Joven's Tools;5ED;2421
+Joven's Tools;HML;1524
+Jovial Evil;LEG;2527
+Joyous Respite;COK;80934
+Judge Unworthy;FUT;97332
+Judge of Currents;LRW;105600
+Judge's Familiar;PRM;149243
+Judge's Familiar;RTR;145184
+Jugan, the Rising Star;COK;80557
+Jugan, the Rising Star;MMA;80557
+Juggernaut;10E;50815
+Juggernaut;2ED;134
+Juggernaut;3ED;134
+Juggernaut;DDF;129164
+Juggernaut;DST;50815
+Juggernaut;EMA;155891
+Juggernaut;LEA;134
+Juggernaut;LEB;134
+Juggernaut;M11;129164
+Juggernaut;M15;155891
+Juggernaut;ME4;134
+Juggernaut;PRM;134
+Juju Bubble;VIS;2196
+Jukai Messenger;COK;82644
+Jump;2ED;135
+Jump;3ED;135
+Jump;4ED;135
+Jump;LEA;135
+Jump;LEB;135
+Jump;M10;122165
+Jund Battlemage;ALA;115103
+Jund Charm;ALA;114908
+Jund Charm;C13;114908
+Jund Charm;DPA;114908
+Jund Hackblade;ARB;121060
+Jund Panorama;ALA;116191
+Jund Panorama;C13;116191
+Jund Panorama;TD0;116191
+Jund Sojourners;ARB;121053
+Jund;PC2;131607
+Jungle Barrier;APC;31163
+Jungle Barrier;TD0;31163
+Jungle Basin;C14;2197
+Jungle Basin;VIS;2197
+Jungle Delver;XLN;403131
+Jungle Hollow;EMA;157269
+Jungle Hollow;FRF;157269
+Jungle Hollow;KTK;156537
+Jungle Lion;ME3;6658
+Jungle Lion;POR;6658
+Jungle Lion;TD0;6658
+Jungle Patrol;MIR;1940
+Jungle Shrine;ALA;115111
+Jungle Shrine;C13;115111
+Jungle Shrine;DDH;115111
+Jungle Shrine;MM3;115111
+Jungle Shrine;PZ1;115111
+Jungle Troll;MIR;1941
+Jungle Weaver;ALA;115192
+Jungle Wurm;MIR;1942
+Jungle Wurm;VMA;1942
+Juniper Order Advocate;ALL;1661
+Juniper Order Advocate;ME2;1661
+Juniper Order Druid;ICE;1238
+Juniper Order Ranger;CSP;96908
+Juniper Order Ranger;DDG;96908
+Juniper Order Ranger;DPA;96908
+Junk Diver;C14;15683
+Junk Diver;UD;15683
+Junk Golem;ODY;33247
+Junktroller;RAV;89018
+Junkyo Bell;COK;82622
+Juntu Stakes;INV;25185
+Junún Efreet;4ED;347
+Junún Efreet;ARN;347
+Junún Efreet;ME4;347
+Jushi Apprentice;COK;80899
+Just Fate;ME4;4680
+Just Fate;PO2;4680
+Just the Wind;SOI;161419
+Justice;5ED;1239
+Justice;ICE;1239
+Juvenile Gloomwidow;SHM;111772
+Juxtapose;5ED;597
+Juxtapose;6ED;597
+Juxtapose;CH;597
+Juxtapose;LEG;597
+Juxtapose;MED;597
+Juzám Djinn;ARN;348
+Juzám Djinn;MED;348
+Jwar Isle Avenger;OGW;161129
+Jwar Isle Refuge;C13;123529
+Jwar Isle Refuge;CMD;123529
+Jwar Isle Refuge;PC2;123529
+Jwar Isle Refuge;ZEN;123529
+Jwari Scuttler;ROE;127287
+Jwari Shapeshifter;WWK;126523
+Kaalia of the Vast;CMD;137537
+Kaalia of the Vast;PZ1;137537
+Kabira Crossroads;DDF;126610
+Kabira Crossroads;ZEN;126610
+Kabira Evangel;ZEN;123590
+Kabira Vindicator;DDG;127260
+Kabira Vindicator;ROE;127260
+Kaboom!;ONS;43139
+Kabuto Moth;COK;80991
+Kaervek the Merciless;DPA;97423
+Kaervek the Merciless;TSP;97423
+Kaervek's Hex;MIR;1943
+Kaervek's Purge;MIR;1944
+Kaervek's Spite;VIS;2198
+Kaervek's Torch;MIR;1945
+Kaervek's Torch;VMA;1945
+Kagemaro, First to Suffer;SOK;86020
+Kagemaro's Clutch;SOK;86108
+Kaho, Minamo Historian;SOK;86030
+Kaijin of the Vanishing Touch;BOK;83908
+Kalastria Healer;BFZ;160663
+Kalastria Highborn;PRM;124406
+Kalastria Highborn;WWK;124406
+Kalastria Nightwatch;BFZ;160656
+Kaldra;TOK;51119
+Kaleidostone;CON;118644
+Kalemne, Disciple of Iroas;PZ1;160133
+Kalemne's Captain;PZ1;160439
+Kalitas, Bloodchief of Ghet;ZEN;123632
+Kalitas, Traitor of Ghet;OGW;161135
+Kalonian Behemoth;DPA;121694
+Kalonian Behemoth;M10;121694
+Kalonian Hydra;M14;147365
+Kalonian Tusker;DPA;147389
+Kalonian Tusker;M14;147389
+Kalonian Twingrove;M15;155347
+Kamahl, Fist of Krosa;ONS;43194
+Kamahl, Pit Fighter;10E;104513
+Kamahl, Pit Fighter;DDL;104513
+Kamahl, Pit Fighter;DPA;104513
+Kamahl, Pit Fighter;ODY;33348
+Kamahl, Pit Fighter;PRM;104513
+Kamahl's Desire;ODY;33367
+Kamahl's Sledge;TOR;36482
+Kamahl's Summons;ONS;43200
+Kambal, Consul of Allocation;KLD;162561
+Kami of Ancient Law;COK;80617
+Kami of Ancient Law;MM2;80617
+Kami of Ancient Law;TD0;80617
+Kami of Empty Graves;SOK;86143
+Kami of False Hope;BOK;83833
+Kami of Fire's Roar;COK;80566
+Kami of Lunacy;COK;80593
+Kami of Old Stone;9ED;81122
+Kami of Old Stone;COK;81122
+Kami of Tattered Shoji;BOK;83867
+Kami of Twisted Reflection;COK;80693
+Kami of the Crescent Moon;SOK;86116
+Kami of the Honored Dead;BOK;81069
+Kami of the Hunt;COK;80704
+Kami of the Painted Road;COK;80866
+Kami of the Palace Fields;COK;80627
+Kami of the Tended Garden;SOK;86084
+Kami of the Waning Moon;COK;80919
+Kangee, Aerie Keeper;INV;24012
+Kapsho Kitefins;M15;155245
+Karador, Ghost Chieftain;CMD;137534
+Karador, Ghost Chieftain;PRM;137534
+Karakas;EMA;143408
+Karakas;LEG;598
+Karakas;ME3;598
+Karakas;PRM;143408
+Karakas;TD0;598
+Karametra, God of Harvests;BNG;152104
+Karametra's Acolyte;PRM;151405
+Karametra's Acolyte;THS;149092
+Karametra's Favor;BNG;152058
+Kargan Dragonlord;ROE;127295
+Kari Zev, Skyship Raider;AER;400323
+Kari Zev's Expertise;AER;400740
+Karlov of the Ghost Council;PZ1;160443
+Karma;2ED;136
+Karma;3ED;136
+Karma;4ED;136
+Karma;5ED;2422
+Karma;8ED;2422
+Karma;LEA;136
+Karma;LEB;136
+Karmic Guide;C13;140381
+Karmic Guide;EMA;140381
+Karmic Guide;UL;10379
+Karmic Guide;VMA;140381
+Karmic Justice;ODY;33526
+Karn Liberated;MM2;134205
+Karn Liberated;NPH;134205
+Karn, Silver Golem;PRM;7382
+Karn, Silver Golem;USG;7382
+Karn, Silver Golem;V10;7382
+Karn, Silver Golem;VMA;7382
+Karn's Touch;MMQ;19231
+Karona, False God;SCG;48137
+Karona's Zealot;SCG;48951
+Karoo Meerkat;MIR;1946
+Karoo;C14;2199
+Karoo;VIS;2199
+Karplusan Forest;10E;86951
+Karplusan Forest;5ED;2423
+Karplusan Forest;6ED;2423
+Karplusan Forest;7ED;27680
+Karplusan Forest;9ED;86951
+Karplusan Forest;ICE;1240
+Karplusan Giant;ICE;1241
+Karplusan Giant;ME2;1241
+Karplusan Minotaur;CSP;97033
+Karplusan Strider;10E;96950
+Karplusan Strider;CSP;96950
+Karplusan Strider;DPA;96950
+Karplusan Strider;MM2;96950
+Karplusan Wolverine;CSP;96915
+Karplusan Yeti;9ED;86894
+Karplusan Yeti;ICE;1242
+Karrthus, Tyrant of Jund;ARB;121005
+Karrthus, Tyrant of Jund;DPA;121005
+Karstoderm;DST;51887
+Kaseto, Orochi Archmage;PZ1;160115
+Kashi-Tribe Elite;SOK;86070
+Kashi-Tribe Reaver;COK;82205
+Kashi-Tribe Warriors;COK;80612
+Kasimir the Lone Wolf;LEG;599
+Katabatic Winds;VIS;2200
+Kataki, War's Wage;MMA;86945
+Kataki, War's Wage;SOK;86945
+Kathari Bomber;ARB;120992
+Kathari Bomber;MM3;120992
+Kathari Remnant;ARB;121046
+Kathari Remnant;PC2;121046
+Kathari Screecher;ALA;114956
+Kavu Aggressor;INV;24030
+Kavu Chameleon;INV;24037
+Kavu Climber;10E;24065
+Kavu Climber;9ED;24065
+Kavu Climber;INV;24065
+Kavu Glider;APC;31123
+Kavu Howler;APC;31098
+Kavu Lair;INV;24038
+Kavu Mauler;APC;31097
+Kavu Monarch;INV;25168
+Kavu Predator;DDL;97504
+Kavu Predator;PLC;97504
+Kavu Primarch;FUT;102433
+Kavu Primarch;MM2;102433
+Kavu Recluse;PLS;24139
+Kavu Runner;INV;24047
+Kavu Scout;INV;24185
+Kavu Titan;INV;25803
+Kavu;TOK;35344
+Kaya, Ghost Assassin;PZ2;161811
+Kaysa;ALL;1662
+Kaysa;ME2;1662
+Kazandu Blademaster;ZEN;123533
+Kazandu Refuge;C13;123667
+Kazandu Refuge;CMD;123667
+Kazandu Refuge;DDH;123667
+Kazandu Refuge;DDL;123667
+Kazandu Refuge;PC2;123667
+Kazandu Refuge;ZEN;123667
+Kazandu Tuskcaller;C13;127383
+Kazandu Tuskcaller;ROE;127383
+Kazuul Warlord;ZEN;123733
+Kazuul, Tyrant of the Cliffs;WWK;126529
+Kazuul's Toll Collector;OGW;161098
+Kederekt Creeper;ALA;115237
+Kederekt Leviathan;ALA;114989
+Kederekt Parasite;CON;119793
+Keen Sense;PLC;100705
+Keen-Eyed Archers;POR;6742
+Keeneye Aven;LGN;46529
+Keeneye Aven;VMA;46529
+Keening Apparition;RTR;145110
+Keening Banshee;DDD;88624
+Keening Banshee;RAV;88624
+Keening Stone;ROE;127266
+Keep Watch;JUD;40200
+Keep Watch;PC1;40200
+Keeper of Keys;PZ2;162163
+Keeper of Kookus;VIS;2201
+Keeper of Progenitus;ALA;115091
+Keeper of Tresserhorn;ALL;1663
+Keeper of the Beasts;EXO;5625
+Keeper of the Dead;EXO;5657
+Keeper of the Flame;EXO;5435
+Keeper of the Lens;DTK;159728
+Keeper of the Light;EXO;5639
+Keeper of the Mind;EXO;4590
+Keeper of the Nine Gales;LGN;47515
+Keepers of the Faith;CH;600
+Keepers of the Faith;LEG;600
+Keepsake Gorgon;THS;149197
+Kefnet the Mindful;AKH;400819
+Kefnet the Mindful;MS3;401372
+Kefnet's Last Word;HOU;401792
+Kefnet's Monument;AKH;400790
+Kei Takahashi;CH;601
+Kei Takahashi;LEG;601
+Kei Takahashi;ME3;601
+Keiga, the Tide Star;COK;80758
+Keiga, the Tide Star;MMA;80758
+Keldon Arsonist;PCY;22132
+Keldon Battlewagon;PCY;21961
+Keldon Berserker;PCY;22058
+Keldon Champion;EMA;15651
+Keldon Champion;PC1;15651
+Keldon Champion;PD2;15651
+Keldon Champion;UD;15651
+Keldon Firebombers;PCY;21978
+Keldon Halberdier;TSP;97313
+Keldon Mantle;PLS;27934
+Keldon Marauders;EMA;100767
+Keldon Marauders;PD2;100767
+Keldon Marauders;PLC;100767
+Keldon Marauders;TD0;100767
+Keldon Megaliths;DD2;102452
+Keldon Megaliths;FUT;102452
+Keldon Necropolis;INV;25480
+Keldon Necropolis;VMA;25480
+Keldon Twilight;PLS;27935
+Keldon Vandals;TD0;15641
+Keldon Vandals;UD;15641
+Keldon Warlord;2ED;137
+Keldon Warlord;3ED;137
+Keldon Warlord;4ED;137
+Keldon Warlord;5ED;137
+Keldon Warlord;LEA;137
+Keldon Warlord;LEB;137
+Keldon Warlord;MED;137
+Kelinore Bat;M10;121619
+Kelp;TOK;121554
+Kelsinko Ranger;ICE;1243
+Kemba, Kha Regent;C14;131200
+Kemba, Kha Regent;SOM;131200
+Kemba's Legion;MBS;133226
+Kemba's Skyguard;DDF;130880
+Kemba's Skyguard;DPA;130880
+Kemba's Skyguard;SOM;130880
+Kemuri-Onna;SOK;86131
+Kentaro, the Smiling Cat;BOK;80592
+Keranos, God of Storms;JOU;152932
+Kessig Cagebreakers;ISD;139301
+Kessig Dire Swine;SOI;161421
+Kessig Forgemaster;SOI;161676
+Kessig Malcontents;AVR;141655
+Kessig Prowler;EMN;162123
+Kessig Recluse;DKA;139748
+Kessig Wolf Run;ISD;138366
+Kessig Wolf Run;V13;138366
+Kessig Wolf;ISD;138110
+Kessig;PC2;138725
+Key to the City;KLD;162582
+Keymaster Rogue;GTC;146303
+Kezzerdrix;TMP;3114
+Kezzerdrix;TPR;3114
+Kezzerdrix;VMA;3114
+Khabál Ghoul;ARN;349
+Khabál Ghoul;MED;349
+Khabál Ghoul;PRM;349
+Khalni Garden;C13;123552
+Khalni Garden;PC2;123552
+Khalni Garden;PZ1;123552
+Khalni Garden;WWK;123552
+Khalni Gem;ZEN;125092
+Khalni Heart Expedition;DPA;123647
+Khalni Heart Expedition;ZEN;123647
+Khalni Hydra;DPA;127347
+Khalni Hydra;ROE;127347
+Kharasha Foothills;PC2;138722
+Khenra Charioteer;AKH;401346
+Khenra Eternal;HOU;401508
+Khenra Scrapper;HOU;401552
+Kher Keep;C13;97430
+Kher Keep;TSP;97430
+Kheru Bloodsucker;KTK;157027
+Kheru Dreadmaw;KTK;156499
+Kheru Lich Lord;KTK;157083
+Kheru Spellsnatcher;KTK;156632
+Kiki-Jiki, Mirror Breaker;COK;80600
+Kiki-Jiki, Mirror Breaker;MM2;137596
+Kiki-Jiki, Mirror Breaker;MMA;137596
+Kiki-Jiki, Mirror Breaker;V11;137596
+Kiku, Night's Flower;COK;80915
+Kiku's Shadow;SOK;86051
+Kill Shot;KTK;156480
+Kill Switch;NMS;21260
+Kill-Suit Cultist;DIS;94550
+Killer Bees;4ED;602
+Killer Bees;5ED;602
+Killer Bees;LEG;602
+Killer Bees;ME3;602
+Killer Instinct;GPT;91817
+Killer Whale;EXO;5618
+Killer Whale;TPR;5618
+Killer Whale;VMA;5618
+Killing Glare;GTC;146587
+Killing Wave;AVR;141721
+Killing Wave;PRM;142214
+Kiln Fiend;DDJ;127418
+Kiln Fiend;DPA;127418
+Kiln Fiend;ROE;127418
+Kiln Walker;NPH;134270
+Kilnmouth Dragon;DDG;46564
+Kilnmouth Dragon;LGN;46564
+Kilnspire District;PC2;131669
+Kin-Tree Invocation;KTK;157071
+Kin-Tree Warden;KTK;156516
+Kindercatch;ISD;138278
+Kindle the Carnage;DIS;94505
+Kindle;TMP;3020
+Kindle;TPR;3020
+Kindle;VMA;3020
+Kindled Fury;DTK;160039
+Kindled Fury;HOU;401571
+Kindled Fury;M10;102618
+Kindled Fury;M13;102618
+Kindled Fury;MOR;109905
+Kindly Stranger;SOI;161422
+King Cheetah;9ED;2202
+King Cheetah;VIS;2202
+King Crab;UL;10365
+King Macar, the Gold-Cursed;JOU;152942
+King Suleiman;ARN;350
+King's Assassin;POR;6583
+Kingfisher;UD;15614
+Kingpin's Pet;GTC;146551
+Kinjalli's Caller;XLN;402033
+Kinjalli's Sunwing;XLN;402287
+Kinsbaile Balloonist;LRW;105325
+Kinsbaile Borderguard;MOR;109980
+Kinsbaile Cavalier;DDG;110011
+Kinsbaile Cavalier;MOR;110011
+Kinsbaile Skirmisher;LRW;107647
+Kinsbaile Skirmisher;M15;107647
+Kinscaer Harpoonist;SHM;111818
+Kiora, Master of the Depths;BFZ;160719
+Kiora, the Crashing Wave;BNG;137433
+Kiora, the Crashing Wave;PRM;159787
+Kiora's Dismissal;JOU;153057
+Kiora's Follower;BNG;152084
+Kiora's Follower;PRM;152610
+Kira, Great Glass-Spinner;BOK;83861
+Kira, Great Glass-Spinner;MMA;83861
+Kird Ape;3ED;351
+Kird Ape;9ED;86928
+Kird Ape;ARN;351
+Kird Ape;DDH;86928
+Kird Ape;EMA;86928
+Kird Ape;PRM;351
+Kird Ape;V09;86928
+Kird Chieftain;M15;155205
+Kiri-Onna;SOK;86130
+Kirtar's Desire;ODY;33536
+Kirtar's Wrath;C13;33504
+Kirtar's Wrath;ODY;33504
+Kismet;4ED;603
+Kismet;5ED;603
+Kismet;6ED;603
+Kismet;LEG;603
+Kismet;ME4;603
+Kiss of Death;PO2;4726
+Kiss of the Amesha;ALA;115050
+Kiss of the Amesha;DPA;115050
+Kitchen Finks;MMA;111543
+Kitchen Finks;PRM;120085
+Kitchen Finks;SHM;111543
+Kite Shield;M12;137411
+Kitesail Apprentice;DPA;126601
+Kitesail Apprentice;WWK;126601
+Kitesail Freebooter;XLN;402374
+Kitesail Scout;BFZ;160624
+Kitesail;DPA;126591
+Kitesail;M13;126591
+Kitesail;MM2;126591
+Kitesail;WWK;126591
+Kithkin Armor;WTH;2846
+Kithkin Daggerdare;LRW;105410
+Kithkin Greatheart;LRW;107626
+Kithkin Greatheart;MMA;107626
+Kithkin Harbinger;LRW;105322
+Kithkin Healer;LRW;106393
+Kithkin Mourncaller;LRW;105409
+Kithkin Rabble;SHM;111855
+Kithkin Shielddare;SHM;111836
+Kithkin Soldier;TOK;105610
+Kithkin Soldier;TOK;111894
+Kithkin Spellduster;EVE;113659
+Kithkin Zealot;EVE;113707
+Kithkin Zephyrnaut;MOR;109959
+Kitsune Blademaster;COK;80653
+Kitsune Blademaster;DPA;80653
+Kitsune Bonesetter;SOK;86024
+Kitsune Dawnblade;SOK;86114
+Kitsune Diviner;COK;80655
+Kitsune Healer;COK;80675
+Kitsune Loreweaver;SOK;86082
+Kitsune Mystic;COK;80908
+Kitsune Palliator;BOK;80549
+Kitsune Riftwalker;COK;80831
+Kiyomaro, First to Stand;PRM;87230
+Kiyomaro, First to Stand;SOK;86029
+Kjeldoran Dead;5ED;1244
+Kjeldoran Dead;6ED;1244
+Kjeldoran Dead;ICE;1244
+Kjeldoran Dead;ME2;1244
+Kjeldoran Elite Guard;ICE;1245
+Kjeldoran Elite Guard;ME2;1245
+Kjeldoran Escort;ALL;1664
+Kjeldoran Escort;ALL;1665
+Kjeldoran Frostbeast;ICE;1246
+Kjeldoran Frostbeast;ME3;1246
+Kjeldoran Gargoyle;CSP;96943
+Kjeldoran Guard;ICE;1247
+Kjeldoran Home Guard;ALL;1666
+Kjeldoran Home Guard;ME2;1666
+Kjeldoran Javelineer;CSP;96971
+Kjeldoran Knight;ICE;1248
+Kjeldoran Outpost;ALL;1667
+Kjeldoran Outpost;ME2;1667
+Kjeldoran Outpost;PRM;144451
+Kjeldoran Outpost;PRM;1667
+Kjeldoran Outpost;VMA;144451
+Kjeldoran Outrider;CSP;96924
+Kjeldoran Phalanx;ICE;1249
+Kjeldoran Pride;ALL;1668
+Kjeldoran Pride;ALL;1669
+Kjeldoran Royal Guard;10E;27682
+Kjeldoran Royal Guard;5ED;1250
+Kjeldoran Royal Guard;6ED;1250
+Kjeldoran Royal Guard;7ED;27682
+Kjeldoran Royal Guard;ICE;1250
+Kjeldoran Skycaptain;5ED;1251
+Kjeldoran Skycaptain;ICE;1251
+Kjeldoran Skycaptain;ME2;1251
+Kjeldoran Skyknight;ICE;1252
+Kjeldoran War Cry;CSP;96884
+Kjeldoran Warrior;ICE;1253
+Knacksaw Clique;SHM;111612
+Knight Ally;TOK;160808
+Knight Errant;7ED;27873
+Knight Errant;POR;6743
+Knight Exemplar;DDG;129082
+Knight Exemplar;M11;129082
+Knight Watch;GTC;146334
+Knight of Cliffhaven;DDG;127445
+Knight of Cliffhaven;ROE;127445
+Knight of Dawn;TMP;3293
+Knight of Dusk;10E;104528
+Knight of Dusk;TMP;3214
+Knight of Glory;DPA;143859
+Knight of Glory;M13;143859
+Knight of Infamy;DPA;143864
+Knight of Infamy;M13;143864
+Knight of Meadowgrain;DDG;105468
+Knight of Meadowgrain;DPA;105468
+Knight of Meadowgrain;LRW;105468
+Knight of New Alara;ARB;121066
+Knight of New Alara;PRM;121327
+Knight of Obligation;GTC;146362
+Knight of Stromgald;5ED;1254
+Knight of Stromgald;ICE;1254
+Knight of Stromgald;ME2;1254
+Knight of Sursi;FUT;102418
+Knight of Valor;VIS;2204
+Knight of the Holy Nimbus;TSP;97531
+Knight of the Mists;VIS;2203
+Knight of the Pilgrim's Road;ORI;160219
+Knight of the Reliquary;CON;119798
+Knight of the Reliquary;DDG;134056
+Knight of the Reliquary;MMA;119798
+Knight of the Skyward Eye;ALA;115100
+Knight of the Skyward Eye;DPA;115100
+Knight of the White Orchid;ALA;116188
+Knight of the White Orchid;DDG;116188
+Knight of the White Orchid;ORI;116188
+Knight-Captain of Eos;ALA;116187
+Knight;TOK;100662
+Knight;TOK;121556
+Knight;TOK;132691
+Knight;TOK;145985
+Knight;TOK;89186
+Knighthood;7ED;27683
+Knighthood;UL;10416
+Knightly Valor;ORI;145843
+Knightly Valor;RTR;145843
+Knights of Thorn;DRK;789
+Knights of Thorn;MED;789
+Knollspine Dragon;SHM;111677
+Knollspine Invocation;SHM;111773
+Knotvine Mystic;CON;118723
+Knotvine Paladin;ARB;121029
+Knotvine Paladin;DDG;121029
+Knotvine Paladin;DPA;121029
+Knowledge Exploitation;MOR;109927
+Knowledge Pool;MBS;133209
+Knowledge Vault;LEG;2528
+Knowledge Vault;ME3;2528
+Knowledge and Power;JOU;142206
+Knucklebone Witch;LRW;105638
+Kobold Drill Sergeant;LEG;604
+Kobold Drill Sergeant;ME3;604
+Kobold Overlord;LEG;2529
+Kobold Overlord;ME3;2529
+Kobold Taskmaster;LEG;605
+Kobold Taskmaster;ME3;605
+Kobold Taskmaster;TSB;605
+Kobolds of Kher Keep;LEG;606
+Kobolds of Kher Keep;ME3;606
+Kobolds of Kher Keep;TOK;98949
+Kodama of the Center Tree;BOK;83842
+Kodama of the North Tree;COK;80552
+Kodama of the South Tree;COK;46526
+Kodama's Might;COK;82649
+Kodama's Reach;CMD;80586
+Kodama's Reach;COK;80586
+Kodama's Reach;MMA;80586
+Kodama's Reach;TD0;80586
+Kokusho, the Evening Star;COK;80681
+Kokusho, the Evening Star;DRB;80681
+Kokusho, the Evening Star;MMA;80681
+Kolaghan Aspirant;DTK;159849
+Kolaghan Forerunners;DTK;160019
+Kolaghan Monument;DTK;159714
+Kolaghan Skirmisher;DTK;159846
+Kolaghan Stormsinger;DTK;159740
+Kolaghan, the Storm's Fury;FRF;157164
+Kolaghan's Command;DTK;159802
+Konda, Lord of Eiganjo;COK;80875
+Konda's Banner;COK;82599
+Konda's Hatamoto;COK;80798
+Kongming, \"Sleeping Dragon\";C13;9092
+Kongming, \"Sleeping Dragon\";ME3;9092
+Kongming, \"Sleeping Dragon\";PRM;9092
+Kongming, \"Sleeping Dragon\";PTK;9092
+Kongming, \"Sleeping Dragon\";VMA;9092
+Kongming's Contraptions;PTK;9028
+Kookus;VIS;2205
+Kopala, Warden of Waves;XLN;402334
+Kor Aeronaut;DDF;123551
+Kor Aeronaut;ZEN;123551
+Kor Ally;TOK;160832
+Kor Bladewhirl;BFZ;160625
+Kor Cartographer;DDI;123541
+Kor Cartographer;DPA;123541
+Kor Cartographer;ZEN;123541
+Kor Castigator;BFZ;160899
+Kor Chant;EXO;5628
+Kor Chant;TPR;5628
+Kor Dirge;PLC;101390
+Kor Duelist;DPA;123554
+Kor Duelist;MM2;123554
+Kor Duelist;PRM;125911
+Kor Duelist;ZEN;123554
+Kor Entanglers;BFZ;160926
+Kor Firewalker;PRM;126736
+Kor Firewalker;TD0;126599
+Kor Firewalker;WWK;126599
+Kor Haven;EXP;160966
+Kor Haven;NMS;21259
+Kor Hookmaster;DDF;123575
+Kor Hookmaster;DPA;123575
+Kor Hookmaster;EMA;123575
+Kor Hookmaster;MM3;123575
+Kor Hookmaster;ZEN;123575
+Kor Line-Slinger;ROE;127346
+Kor Outfitter;DPA;123669
+Kor Outfitter;ZEN;123669
+Kor Sanctifiers;C14;123719
+Kor Sanctifiers;DPA;123719
+Kor Sanctifiers;PC1;123719
+Kor Sanctifiers;ZEN;123719
+Kor Scythemaster;OGW;161157
+Kor Sky Climber;OGW;161204
+Kor Skyfisher;DDF;123583
+Kor Skyfisher;DPA;123583
+Kor Skyfisher;MM3;123583
+Kor Skyfisher;PRM;123583
+Kor Skyfisher;ZEN;123583
+Kor Soldier;TOK;123780
+Kor Spiritdancer;DPA;127341
+Kor Spiritdancer;PC2;127341
+Kor Spiritdancer;ROE;127341
+Korlash, Heir to Blackblade;FUT;102496
+Korlash, Heir to Blackblade;PRM;103476
+Kormus Bell;2ED;138
+Kormus Bell;3ED;138
+Kormus Bell;4ED;138
+Kormus Bell;LEA;138
+Kormus Bell;LEB;138
+Kormus Bell;ME4;138
+Korozda Gorgon;DGM;147738
+Korozda Guildmage;DDJ;145203
+Korozda Guildmage;RTR;145203
+Korozda Monitor;RTR;145144
+Koskun Falls;HML;1525
+Koskun Keep;HML;1526
+Koth of the Hammer;DDI;140036
+Koth of the Hammer;SOM;131128
+Koth's Courier;DPA;133155
+Koth's Courier;MBS;133155
+Kothophed, Soul Hoarder;ORI;159680
+Kothophed, Soul Hoarder;PRM;160406
+Kozilek, Butcher of Truth;DPA;127396
+Kozilek, Butcher of Truth;MM2;127396
+Kozilek, Butcher of Truth;ROE;127396
+Kozilek, the Great Distortion;OGW;161061
+Kozilek, the Great Distortion;PRM;161043
+Kozilek's Channeler;BFZ;160609
+Kozilek's Pathfinder;OGW;161062
+Kozilek's Predator;MM2;127475
+Kozilek's Predator;ROE;127475
+Kozilek's Return;OGW;161071
+Kozilek's Sentinel;BFZ;160678
+Kozilek's Shrieker;OGW;161114
+Kozilek's Translator;OGW;161223
+Kragma Butcher;BNG;152041
+Kragma Warcaller;THS;149097
+Kraken Hatchling;DPA;123566
+Kraken Hatchling;M13;123566
+Kraken Hatchling;MM3;123566
+Kraken Hatchling;ZEN;123566
+Kraken of the Straits;BNG;152556
+Kraken;TOK;152565
+Kraken's Eye;10E;75197
+Kraken's Eye;9ED;75197
+Kraken's Eye;DPA;75197
+Kraken's Eye;DST;75197
+Kraken's Eye;M10;75197
+Kraken's Eye;M11;75197
+Kraken's Eye;M12;75197
+Krakilin;TMP;3234
+Krakilin;TPR;3234
+Krallenhorde Howler;SOI;161732
+Krallenhorde Killer;DKA;139811
+Krallenhorde Wantons;ISD;138201
+Kranioceros;CON;118681
+Krark-Clan Engineers;5DN;77113
+Krark-Clan Grunt;MRD;50205
+Krark-Clan Ironworks;5DN;77186
+Krark-Clan Ogre;5DN;77129
+Krark-Clan Shaman;MRD;50207
+Krark-Clan Stoker;DST;51888
+Krark's Thumb;MRD;51100
+Krasis Incubation;DGM;146691
+Kraul Warrior;DGM;146727
+Kraum, Ludevic's Opus;PZ2;162381
+Krenko, Mob Boss;DPA;143879
+Krenko, Mob Boss;M13;143879
+Krenko's Command;DPA;143849
+Krenko's Command;M13;143849
+Krenko's Enforcer;M15;155338
+Kresh the Bloodbraided;ALA;114985
+Kresh the Bloodbraided;V11;137602
+Kris Mage;MMQ;19319
+Krond the Dawn-Clad;PC2;140373
+Krosa;PC1;125895
+Krosan Archer;ODY;33322
+Krosan Avenger;ODY;33516
+Krosan Beast;ODY;33285
+Krosan Cloudscraper;LGN;48075
+Krosan Cloudscraper;TSB;48075
+Krosan Colossus;ONS;43193
+Krosan Constrictor;TOR;36507
+Krosan Drover;SCG;48141
+Krosan Grip;C13;99540
+Krosan Grip;MMA;99540
+Krosan Grip;PRM;129535
+Krosan Grip;PZ1;99540
+Krosan Grip;TSP;99540
+Krosan Groundshaker;ONS;43177
+Krosan Reclamation;JUD;40285
+Krosan Restorer;TOR;36513
+Krosan Tusker;C13;44543
+Krosan Tusker;CMD;44543
+Krosan Tusker;DDD;44543
+Krosan Tusker;DDL;44543
+Krosan Tusker;ONS;44543
+Krosan Tusker;PRM;44543
+Krosan Tusker;TD0;44543
+Krosan Tusker;VMA;44543
+Krosan Verge;JUD;40299
+Krosan Verge;PC2;40299
+Krosan Verge;PZ1;40299
+Krosan Vorine;LGN;47530
+Krosan Vorine;VMA;47530
+Krosan Warchief;C13;48108
+Krosan Warchief;PRM;48108
+Krosan Warchief;SCG;48108
+Krosan Wayfarer;JUD;40263
+Krovikan Elementalist;ICE;1255
+Krovikan Fetish;5ED;1256
+Krovikan Fetish;ICE;1256
+Krovikan Fetish;ME2;1256
+Krovikan Horror;ALL;1670
+Krovikan Horror;ME2;1670
+Krovikan Mist;CSP;98041
+Krovikan Mist;DDM;98041
+Krovikan Mist;DPA;98041
+Krovikan Plague;ALL;1671
+Krovikan Rot;CSP;97020
+Krovikan Scoundrel;CSP;96962
+Krovikan Sorcerer;5ED;1257
+Krovikan Sorcerer;ICE;1257
+Krovikan Sorcerer;ME2;1257
+Krovikan Sorcerer;VMA;140095
+Krovikan Vampire;ICE;1258
+Krovikan Vampire;ME2;1258
+Krovikan Whispers;CSP;97012
+Kruin Outlaw;ISD;138297
+Kruin Striker;AVR;141638
+Krumar Bond-Kin;KTK;156498
+Kruphix, God of Horizons;JOU;138781
+Kruphix's Insight;JOU;152997
+Kry Shield;LEG;607
+Kudzu;2ED;139
+Kudzu;3ED;139
+Kudzu;LEA;139
+Kudzu;LEB;139
+Kudzu;ME4;139
+Kujar Seedsculptor;KLD;162299
+Kukemssa Pirates;MIR;1947
+Kukemssa Serpent;MIR;1948
+Kuldotha Flamefiend;MBS;133195
+Kuldotha Forgemaster;SOM;131207
+Kuldotha Forgemaster;TD2;131207
+Kuldotha Phoenix;SOM;130956
+Kuldotha Rebirth;SOM;130933
+Kuldotha Ringleader;MBS;133174
+Kulrath Knight;SHM;111689
+Kumano, Master Yamabushi;COK;80917
+Kumano's Blessing;BOK;83910
+Kumano's Pupils;COK;80745
+Kumena's Speaker;XLN;402862
+Kuon, Ogre Ascendant;SOK;86153
+Kurgadon;SCG;48153
+Kurkesh, Onakke Ancient;M15;155355
+Kuro, Pitlord;COK;80918
+Kuro, Pitlord;DDC;80918
+Kuro's Taken;SOK;86034
+Kusari-Gama;COK;80747
+Kydele, Chosen of Kruphix;PZ2;162382
+Kynaios and Tiro of Meletis;PZ2;162608
+Kyoki, Sanity's Eclipse;BOK;83904
+Kyren Archive;MMQ;19247
+Kyren Glider;MMQ;19002
+Kyren Legate;MMQ;19056
+Kyren Negotiations;MMQ;19129
+Kyren Sniper;MMQ;19030
+Kyren Toy;MMQ;19275
+Kyscu Drake;VIS;2206
+Kytheon, Hero of Akros;ORI;160218
+Kytheon's Irregulars;ORI;160768
+Kytheon's Tactics;ORI;160211
+Lab Rats;STH;3712
+Lab Rats;TPR;3712
+Laboratory Brute;EMN;162066
+Laboratory Maniac;ISD;138348
+Labyrinth Champion;THS;149081
+Labyrinth Guardian;AKH;400915
+Labyrinth Guardian;TOK;401248
+Labyrinth Minotaur;5ED;1528
+Labyrinth Minotaur;HML;1527
+Labyrinth Minotaur;HML;1528
+Labyrinth Minotaur;ME3;1528
+Laccolith Grunt;NMS;21265
+Laccolith Rig;NMS;21210
+Laccolith Titan;NMS;21269
+Laccolith Warrior;NMS;21427
+Laccolith Whelp;NMS;21197
+Lace with Moonglove;LRW;105624
+Lady Caleria;LEG;2530
+Lady Caleria;ME3;2530
+Lady Evangela;LEG;2531
+Lady Evangela;ME3;2531
+Lady Orca;LEG;608
+Lady Orca;ME3;608
+Lady Sun;PTK;9075
+Lady Zhurong, Warrior Queen;PTK;9077
+Lagac Lizard;ROE;127447
+Lagonna-Band Elder;THS;150817
+Lagonna-Band Trailblazer;JOU;152836
+Lair Delve;AVR;141787
+Lair of the Ashen Idol;PC2;131694
+Lairwatch Giant;LRW;105631
+Lake of the Dead;ALL;1672
+Lake of the Dead;MED;1672
+Lake of the Dead;PRM;144452
+Lake of the Dead;PRM;1672
+Lake of the Dead;VMA;144452
+Lambholt Butcher;SOI;161698
+Lambholt Elder;DKA;139741
+Lambholt Pacifist;SOI;161620
+Lammastide Weave;LRW;105326
+Lamplighter of Selhoff;SOI;161405
+Lance;2ED;140
+Lance;3ED;140
+Lance;LEA;140
+Lance;LEB;140
+Lancers en-Kor;STH;3713
+Land Cap;ICE;1259
+Land Equilibrium;LEG;2532
+Land Equilibrium;ME3;2532
+Land Grant;MMQ;18987
+Land Leeches;4ED;790
+Land Leeches;DRK;790
+Land Mine;TOK;155674
+Land Tax;4ED;609
+Land Tax;LEG;609
+Land Tax;ME3;609
+Land Tax;PRM;128446
+Land's Edge;CH;610
+Land's Edge;LEG;610
+Landbind Ritual;DPA;123651
+Landbind Ritual;ZEN;123651
+Landslide;UD;15595
+Languish;ORI;160407
+Languish;PRM;160407
+Lantern Kami;COK;82596
+Lantern Scout;BFZ;160815
+Lantern Spirit;ISD;138425
+Lantern of Insight;5DN;77232
+Lantern-Lit Graveyard;COK;80966
+Lapis Lazuli Talisman;ICE;1260
+Lapse of Certainty;CON;118674
+Laquatus's Champion;PRM;36464
+Laquatus's Champion;TOR;36464
+Laquatus's Champion;VMA;36464
+Laquatus's Creativity;ODY;33469
+Laquatus's Disdain;JUD;36425
+Larceny;8ED;19055
+Larceny;MMQ;19055
+Larger Than Life;KLD;162306
+Lash Out;CMD;106401
+Lash Out;LRW;106401
+Lash of the Whip;THS;149056
+Lashknife Barrier;PLS;27986
+Lashknife;NMS;21221
+Lashweed Lurker;EMN;162136
+Lashwrithe;C14;134214
+Lashwrithe;NPH;134214
+Last Breath;MMQ;19046
+Last Breath;SHM;111690
+Last Breath;THS;149178
+Last Caress;APC;31100
+Last Chance;ME4;6702
+Last Chance;POR;6702
+Last Gasp;DPA;89097
+Last Gasp;RAV;89097
+Last Kiss;DDM;127343
+Last Kiss;DPA;127343
+Last Kiss;ROE;127343
+Last Laugh;TOR;36728
+Last Rites;ODY;33431
+Last Rites;PD3;33431
+Last Stand;APC;31048
+Last Stand;PC2;31048
+Last Thoughts;GTC;146516
+Last Word;DST;75210
+Last-Ditch Effort;UL;13555
+Lat-Nam's Legacy;ALL;1673
+Lat-Nam's Legacy;ALL;1674
+Lat-Nam's Legacy;ME2;1674
+Latch Seeker;AVR;141550
+Latch Seeker;PRM;142204
+Latchkey Faerie;MMA;109616
+Latchkey Faerie;MOR;109616
+Lathnu Hellion;KLD;162294
+Lathnu Sailback;AER;400306
+Latulla, Keldon Overseer;PCY;21948
+Latulla's Orders;PCY;21985
+Launch Party;RTR;145133
+Launch the Fleet;JOU;153056
+Launch;USG;8812
+Lava Axe;10E;10394
+Lava Axe;7ED;27684
+Lava Axe;8ED;10394
+Lava Axe;9ED;10394
+Lava Axe;DPA;10394
+Lava Axe;M10;10394
+Lava Axe;M11;10394
+Lava Axe;M12;10394
+Lava Axe;M14;10394
+Lava Axe;M15;10394
+Lava Axe;PO2;4744
+Lava Axe;POR;6703
+Lava Axe;PRM;27684
+Lava Axe;UL;10394
+Lava Blister;ODY;33362
+Lava Burst;ICE;1261
+Lava Burst;ME2;1261
+Lava Dart;JUD;40245
+Lava Flow;ME4;6704
+Lava Flow;POR;6704
+Lava Hounds;8ED;2936
+Lava Hounds;WTH;2936
+Lava Runner;MMQ;19105
+Lava Spike;COK;80970
+Lava Spike;MMA;80970
+Lava Spike;TD0;80970
+Lava Storm;WTH;2824
+Lava Tubes;ICE;1262
+Lava Zombie;PLS;27937
+Lavaball Trap;ZEN;125072
+Lavaborn Muse;10E;47522
+Lavaborn Muse;DDK;47522
+Lavaborn Muse;DPA;47522
+Lavaborn Muse;LGN;47522
+Lavaclaw Reaches;WWK;126532
+Lavacore Elemental;PLC;100651
+Lavafume Invoker;DPA;127391
+Lavafume Invoker;ROE;127391
+Lavalanche;ARB;121020
+Lavamancer's Skill;ONS;43102
+Lavastep Raider;BFZ;160682
+Lavinia of the Tenth;DGM;146857
+Lawbringer;NMS;21191
+Lawless Broker;KLD;162263
+Lay Bare the Heart;AKH;401310
+Lay Bare;ROE;127286
+Lay Claim;AKH;401297
+Lay Waste;ONS;43098
+Lay Waste;USG;8830
+Lay of the Land;APC;31037
+Lay of the Land;M14;148277
+Lazav, Dimir Mastermind;GTC;146501
+Lead Astray;JUD;40174
+Lead Golem;6ED;1949
+Lead Golem;MIR;1949
+Lead by Example;OGW;161153
+Lead the Stampede;DDH;133133
+Lead the Stampede;DPA;133133
+Lead the Stampede;MBS;133133
+Lead-Belly Chimera;VIS;2207
+Lead;AKH;401046
+Leaden Fists;FUT;102336
+Leaden Myr;MRD;50862
+Leaden Myr;PC1;50862
+Leaden Myr;SOM;130923
+Leaf Arrow;ROE;127491
+Leaf Dancer;ODY;33320
+Leaf Gilder;LRW;105400
+Leaf Gilder;ORI;105400
+Leaf-Crowned Elder;MOR;109611
+Leafcrown Dryad;THS;149189
+Leafdrake Roost;C13;94612
+Leafdrake Roost;DIS;94612
+Leap of Faith;AVR;141568
+Leap of Flame;GPT;91870
+Leap;STH;3714
+Leaping Lizard;HML;1529
+Leaping Lizard;ME2;1529
+Leaping Master;KTK;156506
+Learn from the Past;DTK;160069
+Leashling;RAV;89049
+Leatherback Baloth;DPA;126464
+Leatherback Baloth;PRM;126737
+Leatherback Baloth;WWK;126464
+Leave No Trace;RAV;90403
+Leave in the Dust;AER;400264
+Leave;HOU;401535
+Leech Bonder;SHM;111681
+Leeches;HML;1530
+Leeches;ME4;1530
+Leeching Bite;NPH;134289
+Leeching Licid;TMP;3217
+Leeching Sliver;M15;155192
+Leechridden Swamp;PC1;111571
+Leechridden Swamp;SHM;111571
+Leering Emblem;EVE;113741
+Leering Gargoyle;MIR;1950
+Leery Fogbeast;ONS;43162
+Legacy Weapon;10E;106437
+Legacy Weapon;APC;31152
+Legacy's Allure;TMP;3281
+Legacy's Allure;TPR;3281
+Legerdemain;TMP;3283
+Legerdemain;TPR;3283
+Legion Conquistador;XLN;402296
+Legion Loyalist;GTC;146493
+Legion's Initiative;DGM;146872
+Legion's Judgment;XLN;402079
+Legion's Landing;XLN;402053
+Legions of Lim-Dûl;ICE;1263
+Lens of Clarity;KTK;156530
+Leonin Abunas;MRD;50260
+Leonin Arbiter;SOM;131722
+Leonin Armorguard;ARB;121015
+Leonin Armorguard;DPA;121015
+Leonin Battlemage;DST;75156
+Leonin Bladetrap;C13;51067
+Leonin Bladetrap;MRD;51067
+Leonin Bola;DST;75165
+Leonin Den-Guard;MRD;50190
+Leonin Elder;MRD;50240
+Leonin Iconoclast;JOU;153003
+Leonin Relic-Warder;MBS;133260
+Leonin Scimitar;10E;50222
+Leonin Scimitar;DPA;50222
+Leonin Scimitar;MRD;50222
+Leonin Shikari;DST;52037
+Leonin Skyhunter;9ED;50191
+Leonin Skyhunter;DDG;50191
+Leonin Skyhunter;MBS;133158
+Leonin Skyhunter;MRD;50191
+Leonin Snarecaster;THS;150812
+Leonin Squire;5DN;77076
+Leonin Sun Standard;MRD;51136
+Leovold, Emissary of Trest;PZ2;161545
+Leshrac's Rite;5ED;2424
+Leshrac's Rite;6ED;2424
+Leshrac's Rite;7ED;27685
+Leshrac's Rite;ICE;1264
+Leshrac's Sigil;ICE;1265
+Lesser Gargadon;8ED;21952
+Lesser Gargadon;PCY;21952
+Lesser Werewolf;LEG;611
+Lesser Werewolf;ME3;611
+Lethal Sting;HOU;401531
+Lethal Vapors;SCG;48245
+Lethargy Trap;ZEN;123569
+Lethe Lake;PC1;125900
+Leveler;MRD;50264
+Leviathan;4ED;1052
+Leviathan;5ED;791
+Leviathan;DRK;791
+Leviathan;TSB;791
+Levitation;7ED;27686
+Levitation;9ED;10376
+Levitation;DPA;101047
+Levitation;M10;101047
+Levitation;M12;101047
+Levitation;UL;10376
+Ley Druid;2ED;141
+Ley Druid;3ED;141
+Ley Druid;4ED;141
+Ley Druid;5ED;141
+Ley Druid;9ED;86907
+Ley Druid;LEA;141
+Ley Druid;LEB;141
+Ley Line;MMQ;19208
+Leyline Phantom;DDM;146262
+Leyline Phantom;GTC;146262
+Leyline of Anticipation;M11;129099
+Leyline of Lifeforce;GPT;91885
+Leyline of Lightning;GPT;91872
+Leyline of Punishment;M11;129108
+Leyline of Sanctity;M11;129086
+Leyline of Sanctity;MM2;129086
+Leyline of Singularity;GPT;91887
+Leyline of Vitality;M11;129120
+Leyline of the Meek;GPT;91889
+Leyline of the Void;GPT;91876
+Leyline of the Void;M11;129103
+Lhurgoyf;5ED;1266
+Lhurgoyf;8ED;49665
+Lhurgoyf;CMD;49665
+Lhurgoyf;ICE;1266
+Liability;MMQ;19191
+Liar's Pendulum;MRD;51041
+Liberate;INV;24124
+Liberated Dwarf;JUD;40238
+Liberating Combustion;KLD;162519
+Library of Alexandria;ARN;352
+Library of Alexandria;ME4;352
+Library of Alexandria;PRM;149234
+Library of Alexandria;VMA;149234
+Library of Congress;CC;1
+Library of Lat-Nam;6ED;1675
+Library of Lat-Nam;ALL;1675
+Library of Leng;2ED;142
+Library of Leng;3ED;142
+Library of Leng;4ED;142
+Library of Leng;5ED;142
+Library of Leng;LEA;142
+Library of Leng;LEB;142
+Library of Leng;ME4;142
+Lich Lord of Unx;ARB;121499
+Lich;2ED;143
+Lich;LEA;143
+Lich;LEB;143
+Lich;ME4;143
+Lich's Mirror;ALA;98626
+Lich's Tomb;DST;77055
+Lichenthrope;VIS;2208
+Liege of the Axe;LGN;46532
+Liege of the Hollows;WTH;2871
+Liege of the Pit;TSP;99549
+Liege of the Tangle;SOM;130900
+Lieutenant Kirtar;ODY;33518
+Life Burst;ODY;33511
+Life Chisel;LEG;612
+Life Chisel;ME3;612
+Life Goes On;HOU;401820
+Life Matrix;LEG;2533
+Life and Limb;PLC;100810
+Life from the Loam;DDJ;89042
+Life from the Loam;MMA;89042
+Life from the Loam;RAV;89042
+Life from the Loam;TD0;89042
+Life;APC;31103
+Life;DDJ;138778
+Life;PRM;31103
+Life's Finale;NPH;134216
+Life's Legacy;M15;155225
+Lifebane Zombie;M14;147428
+Lifeblood Hydra;C14;155664
+Lifeblood;LEG;2534
+Lifecraft Awakening;AER;400348
+Lifecraft Cavalry;AER;400334
+Lifecrafter's Bestiary;AER;400400
+Lifecrafter's Gift;AER;400346
+Lifeforce;2ED;144
+Lifeforce;3ED;144
+Lifeforce;4ED;144
+Lifeforce;5ED;2425
+Lifeforce;LEA;144
+Lifeforce;LEB;144
+Lifeforce;ME4;144
+Lifegift;BOK;80590
+Lifelace;2ED;145
+Lifelace;3ED;145
+Lifelace;4ED;145
+Lifelace;LEA;145
+Lifelace;LEB;145
+Lifeline;USG;9036
+Lifelink;DPA;122146
+Lifelink;M10;122146
+Lifelink;M12;122146
+Lifesmith;SOM;131050
+Lifespark Spellbomb;MRD;50287
+Lifespinner;BOK;83950
+Lifespring Druid;BFZ;160707
+Lifetap;2ED;146
+Lifetap;3ED;146
+Lifetap;4ED;146
+Lifetap;5ED;2426
+Lifetap;LEA;146
+Lifetap;LEB;146
+Lifted by Clouds;COK;80599
+Light from Within;EVE;113632
+Light of Day;6ED;3304
+Light of Day;TMP;3304
+Light of Sanction;RAV;88993
+Lightbringer;NMS;21240
+Lightform;FRF;157346
+Lighthouse Chronologist;ROE;127368
+Lightkeeper of Emeria;CMD;126550
+Lightkeeper of Emeria;WWK;126550
+Lightmine Field;ROE;127281
+Lightning Angel;APC;31105
+Lightning Angel;TSB;31105
+Lightning Angel;V15;31105
+Lightning Axe;SOI;161424
+Lightning Axe;TSP;97435
+Lightning Berserker;DTK;159736
+Lightning Blast;6ED;3023
+Lightning Blast;7ED;27687
+Lightning Blast;8ED;3023
+Lightning Blast;TMP;3023
+Lightning Blast;TPR;3023
+Lightning Blow;ICE;1267
+Lightning Blow;ME3;1267
+Lightning Bolt;2ED;147
+Lightning Bolt;3ED;147
+Lightning Bolt;4ED;147
+Lightning Bolt;DPA;121669
+Lightning Bolt;LEA;147
+Lightning Bolt;LEB;147
+Lightning Bolt;M10;121669
+Lightning Bolt;M11;121669
+Lightning Bolt;MED;147
+Lightning Bolt;MM2;121669
+Lightning Bolt;PD2;121669
+Lightning Bolt;PRM;125917
+Lightning Bolt;PRM;147
+Lightning Bolt;TD0;121669
+Lightning Bolt;TD0;147
+Lightning Cloud;VIS;2209
+Lightning Coils;MRD;51016
+Lightning Crafter;MOR;109966
+Lightning Dart;INV;24142
+Lightning Diadem;JOU;152998
+Lightning Dragon;PRM;7383
+Lightning Dragon;USG;7383
+Lightning Dragon;VMA;7383
+Lightning Elemental;10E;27688
+Lightning Elemental;7ED;27688
+Lightning Elemental;8ED;27688
+Lightning Elemental;9ED;27688
+Lightning Elemental;DPA;27688
+Lightning Elemental;M10;27688
+Lightning Elemental;M12;27688
+Lightning Elemental;TMP;3011
+Lightning Greaves;CMD;50217
+Lightning Greaves;DDE;50217
+Lightning Greaves;DPA;122190
+Lightning Greaves;MRD;50217
+Lightning Greaves;MS2;162589
+Lightning Greaves;PRM;122190
+Lightning Greaves;PZ1;50217
+Lightning Greaves;TD0;50217
+Lightning Helix;DDH;138684
+Lightning Helix;DPA;138684
+Lightning Helix;DPA;88898
+Lightning Helix;MMA;138684
+Lightning Helix;PC1;88898
+Lightning Helix;PRM;90392
+Lightning Helix;RAV;88898
+Lightning Hounds;MMQ;19255
+Lightning Hounds;PRM;19255
+Lightning Javelin;ORI;160295
+Lightning Mauler;AVR;141799
+Lightning Prowess;AVR;141631
+Lightning Rager;TOK;160051
+Lightning Reaver;ARB;121024
+Lightning Reflexes;MIR;1951
+Lightning Rift;ONS;43113
+Lightning Rift;PRM;43113
+Lightning Rift;VMA;43113
+Lightning Runner;AER;400329
+Lightning Serpent;CSP;96956
+Lightning Serpent;DPA;96956
+Lightning Shrieker;FRF;157252
+Lightning Storm;CSP;97014
+Lightning Strike;M15;150851
+Lightning Strike;THS;150851
+Lightning Strike;XLN;402008
+Lightning Surge;JUD;40261
+Lightning Talons;ALA;115227
+Lightning Talons;M14;148273
+Lightning Volley;BNG;152586
+Lightning-Rig Crew;XLN;402855
+Lightwalker;DTK;160026
+Lightwielder Paladin;M10;122173
+Lignify;DDD;105460
+Lignify;LRW;105460
+Liliana Vess;DDD;125536
+Liliana Vess;LRW;105529
+Liliana Vess;M10;105529
+Liliana Vess;M11;105529
+Liliana Vess;M15;105529
+Liliana of the Dark Realms;M13;134120
+Liliana of the Dark Realms;M14;134120
+Liliana of the Veil;ISD;138393
+Liliana of the Veil;MM3;138393
+Liliana of the Veil;PRM;138393
+Liliana, Death Wielder;AKH;400732
+Liliana, Death's Majesty;AKH;400809
+Liliana, Defiant Necromancer;ORI;160253
+Liliana, Heretical Healer;ORI;160252
+Liliana, the Last Hope;EMN;161952
+Liliana's Caress;DPA;129124
+Liliana's Caress;M11;129124
+Liliana's Defeat;HOU;401595
+Liliana's Elite;EMN;161950
+Liliana's Indignation;SOI;161757
+Liliana's Influence;AKH;401059
+Liliana's Mastery;AKH;400794
+Liliana's Reaver;C14;148900
+Liliana's Reaver;DPA;148900
+Liliana's Reaver;M14;148900
+Liliana's Shade;DPA;143845
+Liliana's Shade;M13;143845
+Liliana's Specter;DPA;129091
+Liliana's Specter;M11;129091
+Liliana's Specter;PC2;129091
+Liliana's Specter;PRM;129301
+Lilting Refrain;USG;8663
+Lim-Dûl the Necromancer;TSP;97413
+Lim-Dûl's Cohort;ICE;1268
+Lim-Dûl's Cohort;ME4;1268
+Lim-Dûl's Hex;ICE;1269
+Lim-Dûl's High Guard;ALL;1676
+Lim-Dûl's High Guard;ALL;1677
+Lim-Dûl's High Guard;ME2;1676
+Lim-Dûl's Paladin;ALL;1678
+Lim-Dûl's Vault;ALL;1679
+Lim-Dûl's Vault;C13;145070
+Lim-Dûl's Vault;MED;1679
+Limestone Golem;ODY;33254
+Limited Resources;EXO;5610
+Limits of Solidarity;AKH;400865
+Lin Sivvi, Defiant Hero;NMS;21255
+Linessa, Zephyr Mage;FUT;102487
+Lingering Death;SCG;48150
+Lingering Mirage;USG;8932
+Lingering Souls;DDK;143914
+Lingering Souls;DKA;139852
+Lingering Souls;MM3;143914
+Lingering Souls;PRM;143914
+Lingering Tormentor;EVE;98647
+Linvala, Keeper of Silence;MM3;127412
+Linvala, Keeper of Silence;ROE;127412
+Linvala, the Preserver;OGW;161197
+Lion's Eye Diamond;MIR;1952
+Lion's Eye Diamond;PRM;156360
+Lion's Eye Diamond;VMA;156360
+Lionheart Maverick;DDG;91668
+Lionheart Maverick;GPT;91668
+Liquid Fire;ODY;33351
+Liquify;TOR;36417
+Liquimetal Coating;C14;131146
+Liquimetal Coating;SOM;131146
+Lithatog;ODY;33260
+Lithomancer's Focus;BFZ;160627
+Lithophage;DDI;19228
+Lithophage;MMQ;19228
+Liturgy of Blood;M14;148777
+Liu Bei, Lord of Shu;ME3;9179
+Liu Bei, Lord of Shu;PTK;9179
+Live Fast;KLD;162270
+Livewire Lash;SOM;131129
+Living Airship;APC;31106
+Living Armor;CH;792
+Living Armor;DRK;792
+Living Artifact;2ED;148
+Living Artifact;3ED;148
+Living Artifact;4ED;148
+Living Artifact;5ED;148
+Living Artifact;LEA;148
+Living Artifact;LEB;148
+Living Death;CMD;3124
+Living Death;DDE;3124
+Living Death;PRM;3124
+Living Death;TMP;3124
+Living Death;TPR;3124
+Living Death;V14;153383
+Living Death;VMA;153383
+Living Destiny;DPA;127300
+Living Destiny;ROE;127300
+Living End;TSP;97412
+Living Hive;MRD;51028
+Living Hive;PC1;51028
+Living Inferno;DPA;91701
+Living Inferno;GPT;91701
+Living Lands;2ED;149
+Living Lands;3ED;149
+Living Lands;4ED;149
+Living Lands;5ED;2427
+Living Lands;6ED;2427
+Living Lands;LEA;149
+Living Lands;LEB;149
+Living Lands;ME4;149
+Living Lore;DTK;159815
+Living Plane;LEG;2535
+Living Plane;ME3;2535
+Living Terrain;8ED;21992
+Living Terrain;PCY;21992
+Living Totem;M15;156427
+Living Tsunami;ZEN;123668
+Living Wall;2ED;150
+Living Wall;3ED;150
+Living Wall;LEA;150
+Living Wall;LEB;150
+Living Wall;ME4;150
+Living Wish;JUD;40289
+Living Wish;PRM;107685
+Livonya Silone;LEG;2536
+Livonya Silone;ME3;2536
+Lizard Warrior;POR;6705
+Lizard;TOK;121081
+Lizard;TOK;161890
+Llanowar Augur;FUT;102428
+Llanowar Behemoth;8ED;2870
+Llanowar Behemoth;9ED;86912
+Llanowar Behemoth;WTH;2870
+Llanowar Cavalry;INV;24140
+Llanowar Dead;APC;31069
+Llanowar Druid;WTH;2802
+Llanowar Elite;INV;24078
+Llanowar Elves;10E;86938
+Llanowar Elves;2ED;151
+Llanowar Elves;3ED;151
+Llanowar Elves;4ED;151
+Llanowar Elves;5ED;151
+Llanowar Elves;6ED;151
+Llanowar Elves;7ED;27689
+Llanowar Elves;9ED;86938
+Llanowar Elves;C14;86938
+Llanowar Elves;EMA;86938
+Llanowar Elves;EVG;86938
+Llanowar Elves;LEA;151
+Llanowar Elves;LEB;151
+Llanowar Elves;M10;86938
+Llanowar Elves;M11;86938
+Llanowar Elves;M12;86938
+Llanowar Elves;PRM;151
+Llanowar Elves;TOK;86938
+Llanowar Empath;FUT;102340
+Llanowar Empath;ORI;102340
+Llanowar Knight;INV;24046
+Llanowar Mentor;FUT;102352
+Llanowar Reborn;C13;102446
+Llanowar Reborn;DDL;102446
+Llanowar Reborn;FUT;102446
+Llanowar Sentinel;10E;104523
+Llanowar Sentinel;WTH;2806
+Llanowar Vanguard;INV;24045
+Llanowar Wastes;10E;31107
+Llanowar Wastes;9ED;31107
+Llanowar Wastes;APC;31107
+Llanowar Wastes;M15;31107
+Llanowar Wastes;ORI;31107
+Llanowar;PC1;125902
+Llawan, Cephalid Empress;TOR;28020
+Loafing Giant;INV;24057
+Loam Dryad;SOI;161384
+Loam Dweller;BOK;83857
+Loam Larva;OGW;161254
+Loam Lion;DDH;126526
+Loam Lion;WWK;126526
+Loamdragger Giant;SHM;111559
+Loaming Shaman;DIS;94623
+Loathsome Catoblepas;THS;149054
+Lobber Crew;RTR;145906
+Lobotomy;INV;24080
+Lobotomy;PRM;3306
+Lobotomy;TMP;3306
+Loch Korrigan;SHM;111685
+Locket of Yesterdays;TSP;97408
+Lockjaw Snapper;SHM;111811
+Locust Miser;SOK;86095
+Locust Swarm;MIR;1953
+Lodestone Bauble;ALL;1680
+Lodestone Bauble;ME2;1680
+Lodestone Golem;MM2;126556
+Lodestone Golem;WWK;126556
+Lodestone Myr;MM2;50232
+Lodestone Myr;MRD;50232
+Lodestone Myr;PC1;50232
+Logic Knot;FUT;102343
+Logic Knot;MMA;102343
+Lone Missionary;DPA;127255
+Lone Missionary;MM3;127255
+Lone Missionary;ROE;127255
+Lone Revenant;AVR;141803
+Lone Rider;EMN;161915
+Lone Wolf of the Natterknolls;SOI;161625
+Lone Wolf;7ED;27690
+Lone Wolf;8ED;10360
+Lone Wolf;PO2;4764
+Lone Wolf;PTK;9135
+Lone Wolf;UL;10360
+Lonely Sandbar;C13;43215
+Lonely Sandbar;C14;43215
+Lonely Sandbar;CMD;43215
+Lonely Sandbar;DDJ;43215
+Lonely Sandbar;ONS;43215
+Lonely Sandbar;VMA;43215
+Long Road Home;EMN;162032
+Long-Finned Skywhale;KLD;162481
+Long-Forgotten Gohei;COK;82648
+Long-Forgotten Gohei;MM2;82648
+Long-Term Plans;SCG;48126
+Longbow Archer;6ED;2210
+Longbow Archer;7ED;27691
+Longbow Archer;PRM;2210
+Longbow Archer;VIS;2210
+Longhorn Firebeast;TOR;36479
+Longshot Squad;KTK;157051
+Longtusk Cub;KLD;162297
+Lookout's Dispersal;XLN;402362
+Looming Altisaur;XLN;402315
+Looming Hoverguard;MRD;50290
+Looming Shade;10E;27692
+Looming Shade;7ED;27692
+Looming Shade;8ED;27692
+Looming Shade;9ED;27692
+Looming Shade;M10;27692
+Looming Shade;USG;8722
+Looming Spires;BFZ;160737
+Looter il-Kor;TD0;97541
+Looter il-Kor;TSP;97541
+Lord Magnus;LEG;613
+Lord of Atlantis;2ED;152
+Lord of Atlantis;3ED;152
+Lord of Atlantis;4ED;152
+Lord of Atlantis;5ED;152
+Lord of Atlantis;6ED;152
+Lord of Atlantis;7ED;27693
+Lord of Atlantis;LEA;152
+Lord of Atlantis;LEB;152
+Lord of Atlantis;PRM;152
+Lord of Atlantis;TSB;152
+Lord of Extinction;ARB;120952
+Lord of Extinction;DPA;120952
+Lord of Extinction;MS3;401642
+Lord of Lineage;ISD;138266
+Lord of Shatterskull Pass;PRM;128454
+Lord of Shatterskull Pass;ROE;127449
+Lord of Tresserhorn;ALL;1681
+Lord of Tresserhorn;MED;1681
+Lord of the Accursed;AKH;400793
+Lord of the Pit;10E;102952
+Lord of the Pit;2ED;153
+Lord of the Pit;3ED;153
+Lord of the Pit;4ED;153
+Lord of the Pit;5ED;153
+Lord of the Pit;DDC;122096
+Lord of the Pit;DPA;122096
+Lord of the Pit;LEA;153
+Lord of the Pit;LEB;153
+Lord of the Undead;10E;28021
+Lord of the Undead;8ED;28021
+Lord of the Undead;9ED;28021
+Lord of the Undead;PLS;28021
+Lord of the Unreal;DPA;134140
+Lord of the Unreal;M12;134140
+Lord of the Void;DPA;147253
+Lord of the Void;GTC;147253
+Lore Broker;RAV;88931
+Lorescale Coatl;ARB;121003
+Lorescale Coatl;MM2;121003
+Loreseeker's Stone;C14;138675
+Lorthos, the Tidemaker;C14;123706
+Lorthos, the Tidemaker;DPA;123706
+Lorthos, the Tidemaker;ZEN;123706
+Lose Calm;DTK;160017
+Lose Hope;5DN;77116
+Loss;DGM;151022
+Lost Auramancers;FUT;102339
+Lost Hours;FUT;102378
+Lost Legacy;KLD;162515
+Lost Leonin;NPH;134304
+Lost Order of Jarkeld;ICE;1270
+Lost Order of Jarkeld;ME2;1270
+Lost Soul;4ED;614
+Lost Soul;5ED;614
+Lost Soul;6ED;614
+Lost Soul;LEG;614
+Lost Vale;XLN;402075
+Lost in Thought;JUD;36451
+Lost in a Labyrinth;THS;149051
+Lost in the Mist;ISD;138423
+Lost in the Woods;DKA;121585
+Lotleth Troll;RTR;145969
+Lotus Bloom;MMA;97449
+Lotus Bloom;PRM;99481
+Lotus Bloom;TSP;97449
+Lotus Blossom;USG;8743
+Lotus Cobra;PRM;143398
+Lotus Cobra;ZEN;123641
+Lotus Guardian;INV;25537
+Lotus Path Djinn;FRF;157253
+Lotus Petal;MS2;400615
+Lotus Petal;TMP;2964
+Lotus Petal;TPR;2964
+Lotus Petal;V09;2964
+Lotus Vale;WTH;2880
+Lotus-Eye Mystics;FRF;157276
+Lovisa Coldeyes;CSP;96854
+Lowland Basilisk;STH;3715
+Lowland Basilisk;TPR;3715
+Lowland Giant;TMP;3008
+Lowland Giant;TPR;3008
+Lowland Oaf;DPA;143948
+Lowland Oaf;LRW;105506
+Lowland Oaf;PRM;143948
+Lowland Tracker;LGN;47527
+Loxodon Anchorite;5DN;77088
+Loxodon Convert;NPH;134274
+Loxodon Gatekeeper;RAV;88665
+Loxodon Hierarch;DDH;89024
+Loxodon Hierarch;DPA;89024
+Loxodon Hierarch;RAV;89024
+Loxodon Mender;MRD;50239
+Loxodon Mystic;10E;104529
+Loxodon Mystic;DST;75139
+Loxodon Partisan;MBS;133150
+Loxodon Peacekeeper;MRD;51060
+Loxodon Punisher;MRD;50249
+Loxodon Smiter;RTR;145220
+Loxodon Stalwart;5DN;77214
+Loxodon Warhammer;10E;51133
+Loxodon Warhammer;9ED;51133
+Loxodon Warhammer;C14;51133
+Loxodon Warhammer;DDG;135660
+Loxodon Warhammer;DPA;51133
+Loxodon Warhammer;MRD;51133
+Loxodon Warhammer;PC1;51133
+Loxodon Wayfarer;SOM;131045
+Loyal Cathar;DKA;139763
+Loyal Gyrfalcon;EVE;113608
+Loyal Pegasus;BNG;152012
+Loyal Retainers;ME3;9128
+Loyal Retainers;MS3;401376
+Loyal Retainers;PRM;9128
+Loyal Retainers;PTK;9128
+Loyal Retainers;PZ1;9128
+Loyal Sentry;10E;100738
+Loyal Sentry;DDF;100738
+Loyal Sentry;DPA;100738
+Lu Bu, Master-at-Arms;ME3;8999
+Lu Bu, Master-at-Arms;PRM;8999
+Lu Bu, Master-at-Arms;PTK;8999
+Lu Meng, Wu General;ME3;9095
+Lu Meng, Wu General;PTK;9095
+Lu Su, Wu Advisor;PTK;9015
+Lu Xun, Scholar General;C13;9010
+Lu Xun, Scholar General;ME3;9010
+Lu Xun, Scholar General;PTK;9010
+Lucent Liminid;FUT;102415
+Ludevic, Necro-Alchemist;PZ2;162383
+Ludevic's Abomination;ISD;138157
+Ludevic's Abomination;PRM;139442
+Ludevic's Test Subject;ISD;138160
+Ludevic's Test Subject;PRM;139443
+Lull;USG;8740
+Lullmage Mentor;ZEN;123682
+Lumbering Falls;BFZ;160760
+Lumbering Satyr;MMQ;19236
+Lumberknot;ISD;138325
+Lumberknot;PC2;138325
+Lumengrid Augur;MRD;50295
+Lumengrid Drake;SOM;130917
+Lumengrid Gargoyle;MBS;133228
+Lumengrid Gargoyle;TD2;133228
+Lumengrid Sentinel;MRD;50246
+Lumengrid Warden;10E;87020
+Lumengrid Warden;9ED;87020
+Lumengrid Warden;MRD;50271
+Luminarch Ascension;DPA;125084
+Luminarch Ascension;ZEN;125084
+Luminate Primordial;GTC;147244
+Luminesce;10E;96889
+Luminesce;CSP;96889
+Luminesce;DPA;96889
+Luminescent Rain;MOR;110001
+Luminous Angel;DDC;122100
+Luminous Angel;MRD;50259
+Luminous Guardian;ODY;33500
+Luminous Wake;ROE;127345
+Lumithread Field;FUT;102356
+Lunar Avenger;5DN;77194
+Lunar Force;EMN;161934
+Lunar Mystic;AVR;141814
+Lunarch Inquisitors;SOI;161458
+Lunarch Mantle;EMN;162030
+Lunge;MMQ;19084
+Lunk Errant;MOR;109910
+Lupine Prototype;EMN;162150
+Lurching Rotbeast;HOU;401507
+Lure of Prey;MIR;1954
+Lure;10E;81038
+Lure;2ED;154
+Lure;3ED;154
+Lure;4ED;154
+Lure;5ED;154
+Lure;6ED;154
+Lure;7ED;27694
+Lure;8ED;19052
+Lure;COK;81038
+Lure;DPA;81038
+Lure;ICE;1271
+Lure;LEA;154
+Lure;LEB;154
+Lure;M12;81038
+Lure;MMQ;19052
+Lurebound Scarecrow;SHM;111799
+Lurker;DRK;793
+Lurking Arynx;DTK;160082
+Lurking Chupacabra;XLN;402320
+Lurking Crocodile;M12;134119
+Lurking Evil;USG;8797
+Lurking Evil;VMA;8797
+Lurking Informant;RAV;88794
+Lurking Jackals;UD;15725
+Lurking Nightstalker;PO2;4712
+Lurking Predators;DPA;121688
+Lurking Predators;M10;121688
+Lurking Skirge;UL;9508
+Lush Growth;ALA;115223
+Lust for War;ROE;127323
+Lux Cannon;SOM;131126
+Luxa River Shrine;AKH;400822
+Lyev Decree;DGM;145185
+Lyev Skyknight;RTR;145186
+Lymph Sliver;FUT;102351
+Lynx;PO2;4761
+Lys Alana Bowmaster;MOR;110018
+Lys Alana Huntmaster;C14;105324
+Lys Alana Huntmaster;DPA;105324
+Lys Alana Huntmaster;EMA;105324
+Lys Alana Huntmaster;EVG;105324
+Lys Alana Huntmaster;LRW;105324
+Lys Alana Scarblade;DPA;105615
+Lys Alana Scarblade;EMA;105615
+Lys Alana Scarblade;LRW;105615
+Lyzolda, the Blood Witch;DIS;94428
+Lyzolda, the Blood Witch;DPA;94428
+Ma Chao, Western Warrior;PTK;9138
+Maalfeld Twins;AVR;141557
+Macabre Waltz;DIS;94319
+Macabre Waltz;ORI;94319
+Macabre Waltz;SOI;161648
+Macetail Hystrodon;LGN;46569
+Machinate;DST;52048
+Mad Auntie;LRW;104079
+Mad Auntie;MMA;104079
+Mad Auntie;PRM;104079
+Mad Dog;ODY;33381
+Mad Prophet;AVR;141651
+Mad Prophet;DDK;141651
+Mad Prophet;SOI;161726
+Madblind Mountain;SHM;111538
+Madcap Experiment;KLD;162516
+Madcap Skills;GTC;146320
+Madcap Skills;MM3;146320
+Maddening Imp;TMP;3119
+Maddening Wind;ICE;1272
+Madrush Cyclops;ARB;121030
+Madrush Cyclops;DPA;121030
+Maelstrom Archangel;CON;118767
+Maelstrom Djinn;FUT;102484
+Maelstrom Nexus;ARB;120959
+Maelstrom Pulse;ARB;121021
+Maelstrom Pulse;DPA;121021
+Maelstrom Pulse;MMA;131555
+Maelstrom Pulse;MS3;401644
+Maelstrom Pulse;PRM;131555
+Maelstrom Wanderer;EMA;161852
+Maelstrom Wanderer;PC2;140353
+Maelstrom Wanderer;PZ1;140353
+Maga, Traitor to Mortals;SOK;81571
+Mage Slayer;ARB;120973
+Mage Slayer;PC1;120973
+Mage il-Vec;EXO;5630
+Mage il-Vec;TPR;5630
+Mage-Ring Bully;ORI;160277
+Mage-Ring Network;ORI;160364
+Mage-Ring Responder;ORI;160349
+Mage's Guile;ONS;42989
+Magebane Armor;M10;121709
+Magefire Wings;ARB;120985
+Mages' Contest;INV;24077
+Mageta the Lion;PCY;21949
+Mageta's Boon;PCY;22116
+Magewright's Stone;DIS;94731
+Maggot Carrier;8ED;27939
+Maggot Carrier;PLS;27939
+Maggot Therapy;MMQ;19063
+Magical Hack;2ED;155
+Magical Hack;3ED;155
+Magical Hack;4ED;155
+Magical Hack;5ED;155
+Magical Hack;LEA;155
+Magical Hack;LEB;155
+Magister Sphinx;CON;118720
+Magister Sphinx;DPA;118720
+Magister of Worth;PRM;156598
+Magister of Worth;VMA;153144
+Magistrate's Scepter;MMQ;19251
+Magistrate's Veto;MMQ;19261
+Magma Burst;PLS;27984
+Magma Giant;5DN;77131
+Magma Giant;PO2;4757
+Magma Jet;5DN;77163
+Magma Jet;DD2;77163
+Magma Jet;DDL;77163
+Magma Jet;MM3;149091
+Magma Jet;PRM;120083
+Magma Jet;TD0;77163
+Magma Jet;THS;149091
+Magma Mine;VIS;2211
+Magma Phoenix;DPA;121697
+Magma Phoenix;M10;121697
+Magma Phoenix;M11;121697
+Magma Rift;DPA;123593
+Magma Rift;ZEN;123593
+Magma Sliver;LGN;46546
+Magma Spray;AKH;401267
+Magma Spray;ALA;115179
+Magma Spray;DDJ;115179
+Magma Spray;JOU;152859
+Magma Spray;PRM;155874
+Magma Vein;ODY;33340
+Magmaquake;C14;143962
+Magmaquake;M13;143962
+Magmaquake;PRM;143961
+Magmaroth;HOU;401810
+Magmasaur;TMP;3157
+Magmasaur;TPR;3157
+Magmatic Chasm;DTK;160172
+Magmatic Chasm;SOI;161634
+Magmatic Core;CSP;96899
+Magmatic Force;CMD;137518
+Magmatic Insight;ORI;160291
+Magmaw;ROE;127275
+Magnetic Flux;DST;51895
+Magnetic Mine;MBS;133134
+Magnetic Mountain;3ED;353
+Magnetic Mountain;4ED;353
+Magnetic Mountain;ARN;353
+Magnetic Theft;5DN;77130
+Magnetic Web;TMP;3103
+Magnify;UD;15708
+Magnifying Glass;SOI;161633
+Magnigoth Treefolk;PLS;27940
+Magnivore;9ED;33342
+Magnivore;ODY;33342
+Magosi, the Waterveil;ZEN;123688
+Magus of the Abyss;FUT;102445
+Magus of the Arena;C13;101536
+Magus of the Arena;PLC;101536
+Magus of the Bazaar;PLC;101392
+Magus of the Candelabra;TSP;99539
+Magus of the Coffers;C14;100755
+Magus of the Coffers;PLC;100755
+Magus of the Disk;TSP;99554
+Magus of the Future;FUT;102456
+Magus of the Jar;TSP;99551
+Magus of the Library;PLC;101531
+Magus of the Mirror;TSP;99543
+Magus of the Moat;FUT;102469
+Magus of the Moon;FUT;102473
+Magus of the Scroll;TSP;99544
+Magus of the Tabernacle;PLC;101378
+Magus of the Unseen;5ED;1273
+Magus of the Unseen;ICE;1273
+Magus of the Unseen;ME2;1273
+Magus of the Vineyard;CMD;102479
+Magus of the Vineyard;FUT;102479
+Magus of the Wheel;PZ1;160424
+Magus of the Will;PZ2;162436
+Mahamoti Djinn;10E;86730
+Mahamoti Djinn;2ED;156
+Mahamoti Djinn;3ED;156
+Mahamoti Djinn;4ED;156
+Mahamoti Djinn;7ED;27695
+Mahamoti Djinn;8ED;27695
+Mahamoti Djinn;9ED;86730
+Mahamoti Djinn;DPA;86730
+Mahamoti Djinn;LEA;156
+Mahamoti Djinn;LEB;156
+Mahamoti Djinn;M15;86730
+Mahamoti Djinn;ME4;156
+Mahamoti Djinn;ORI;86730
+Majestic Myriarch;HOU;401831
+Major Teroh;TOR;36401
+Make Mischief;EMN;161970
+Make Obsolete;KLD;162277
+Make a Stand;OGW;161207
+Make a Wish;ISD;138211
+Makeshift Mannequin;LRW;105433
+Makeshift Mauler;ISD;138226
+Makeshift Munitions;XLN;402106
+Makindi Aeronaut;OGW;161089
+Makindi Griffin;DPA;127319
+Makindi Griffin;ROE;127319
+Makindi Patrol;BFZ;160628
+Makindi Shieldmate;ZEN;123783
+Makindi Sliderunner;BFZ;160851
+Malach of the Dawn;PLC;100715
+Malachite Golem;MRD;50278
+Malachite Talisman;ICE;1274
+Malakir Bloodwitch;DPA;123677
+Malakir Bloodwitch;ZEN;123677
+Malakir Cullblade;ORI;159401
+Malakir Familiar;BFZ;160807
+Malakir Soothsayer;OGW;161232
+Malevolent Awakening;ODY;33418
+Malevolent Whispers;SOI;161378
+Malfegor;CMD;118777
+Malfegor;CON;118777
+Malfegor;DPA;118777
+Malfegor;PRM;119807
+Malfunction;KLD;162253
+Malice;DDH;25533
+Malice;INV;25533
+Malicious Advice;PLS;27897
+Malicious Affliction;C14;156030
+Malicious Affliction;EMA;156030
+Malicious Intent;AVR;142200
+Malignant Growth;MIR;1955
+Malignus;AVR;141607
+Mammoth Harness;HML;1531
+Mammoth Umbra;DPA;127338
+Mammoth Umbra;PC2;127338
+Mammoth Umbra;ROE;127338
+Man-o'-War;DD2;2212
+Man-o'-War;EMA;2212
+Man-o'-War;POR;6622
+Man-o'-War;PRM;2212
+Man-o'-War;TD0;2212
+Man-o'-War;VIS;2212
+Man-o'-War;VMA;2212
+Mana Bloom;RTR;145953
+Mana Breach;7ED;27696
+Mana Breach;EXO;4641
+Mana Cache;NMS;21256
+Mana Chains;WTH;2834
+Mana Clash;4ED;794
+Mana Clash;5ED;794
+Mana Clash;7ED;27697
+Mana Clash;8ED;49249
+Mana Clash;9ED;49249
+Mana Clash;DRK;794
+Mana Confluence;EXP;160964
+Mana Confluence;JOU;152950
+Mana Crypt;EMA;134052
+Mana Crypt;ME2;484
+Mana Crypt;MS2;400600
+Mana Crypt;PRM;134052
+Mana Crypt;PRM;484
+Mana Crypt;VMA;134052
+Mana Cylix;CON;119802
+Mana Cylix;PLS;27981
+Mana Drain;LEG;615
+Mana Drain;ME3;615
+Mana Drain;PRM;149231
+Mana Drain;VMA;149231
+Mana Echoes;ONS;43144
+Mana Flare;2ED;157
+Mana Flare;3ED;157
+Mana Flare;4ED;157
+Mana Flare;5ED;157
+Mana Flare;LEA;157
+Mana Flare;LEB;157
+Mana Flare;MED;157
+Mana Flare;PRM;145067
+Mana Geyser;5DN;75153
+Mana Leak;8ED;3716
+Mana Leak;9ED;3716
+Mana Leak;DPA;129076
+Mana Leak;M11;129076
+Mana Leak;M12;129076
+Mana Leak;MM2;129076
+Mana Leak;PRM;79857
+Mana Leak;STH;3716
+Mana Leak;TPR;3716
+Mana Leech;USG;8827
+Mana Matrix;LEG;2537
+Mana Matrix;ME4;2537
+Mana Maze;INV;24083
+Mana Prism;6ED;1956
+Mana Prism;MIR;1956
+Mana Prism;VMA;1956
+Mana Reflection;SHM;111653
+Mana Seism;COK;81019
+Mana Severance;TMP;3176
+Mana Short;2ED;158
+Mana Short;3ED;158
+Mana Short;4ED;158
+Mana Short;6ED;158
+Mana Short;7ED;27698
+Mana Short;LEA;158
+Mana Short;LEB;158
+Mana Skimmer;TSP;97275
+Mana Tithe;PLC;102608
+Mana Tithe;PRM;110130
+Mana Vapors;PCY;21993
+Mana Vault;2ED;159
+Mana Vault;3ED;159
+Mana Vault;4ED;159
+Mana Vault;5ED;159
+Mana Vault;LEA;159
+Mana Vault;LEB;159
+Mana Vault;ME4;159
+Mana Vault;MS2;400618
+Mana Vault;PRM;149235
+Mana Vault;VMA;149235
+Mana Vortex;DRK;795
+Mana Vortex;ME3;795
+Mana Web;WTH;2858
+Mana-Charged Dragon;CMD;137532
+Manabarbs;10E;104539
+Manabarbs;2ED;160
+Manabarbs;3ED;160
+Manabarbs;4ED;160
+Manabarbs;5ED;2428
+Manabarbs;6ED;160
+Manabarbs;LEA;160
+Manabarbs;LEB;160
+Manabarbs;M10;104539
+Manabarbs;M12;104539
+Manabond;EXO;5423
+Manabond;TPR;5423
+Manacles of Decay;APC;31136
+Manaforce Mace;CON;115175
+Manaforge Cinder;SHM;111822
+Managorger Hydra;ORI;160331
+Manakin;TMP;2960
+Manalith;HOU;401573
+Manalith;M12;134109
+Manamorphose;MMA;148263
+Manamorphose;SHM;111765
+Manaplasm;ALA;115071
+Manaplasm;DPA;115071
+Manaweft Sliver;M14;147371
+Mangara of Corondor;TD0;97433
+Mangara of Corondor;TSP;97433
+Mangara's Blessing;MIR;1957
+Mangara's Equity;MIR;1958
+Mangara's Tome;MIR;1959
+Manglehorn;AKH;400861
+Maniacal Rage;CON;118742
+Maniacal Rage;EXO;5663
+Maniacal Rage;INV;24008
+Maniacal Rage;TPR;5663
+Manic Scribe;SOI;161444
+Manic Vandal;DPA;129172
+Manic Vandal;M11;129172
+Manic Vandal;M12;129172
+Manifest;TOK;158967
+Manipulate Fate;INV;24058
+Mannichi, the Fevered Dream;BOK;83880
+Manor Gargoyle;ISD;138273
+Manor Skeleton;ISD;139306
+Manriki-Gusari;SOK;86052
+Manta Ray;WTH;2829
+Manta Riders;TMP;3037
+Manticore Eternal;HOU;401500
+Manticore of the Gauntlet;AKH;400757
+Mantis Engine;10E;15676
+Mantis Engine;UD;15676
+Mantis Rider;KTK;157078
+Mantle of Leadership;PLC;100672
+Mantle of Webs;ORI;160326
+Map the Wastes;FRF;157166
+Maralen of the Mornsong;MOR;109899
+Marang River Prowler;FRF;157150
+Marang River Skeleton;DTK;159833
+Marath, Will of the Wild;C13;151754
+Marauding Boneslasher;HOU;401499
+Marauding Knight;INV;24084
+Marauding Looter;XLN;402252
+Marauding Maulhorn;M14;147423
+Maraxus of Keld;WTH;2881
+Marble Chalice;ALA;115182
+Marble Diamond;6ED;1960
+Marble Diamond;7ED;27699
+Marble Diamond;C14;156364
+Marble Diamond;DDC;27699
+Marble Diamond;MIR;1960
+Marble Priest;LEG;616
+Marble Titan;9ED;3185
+Marble Titan;TMP;3185
+March from the Tomb;BFZ;160927
+March of Souls;PLS;27936
+March of the Drowned;XLN;402273
+March of the Machines;10E;51029
+March of the Machines;MRD;51029
+March of the Returned;THS;150791
+Marchesa, the Black Rose;PZ1;153147
+Marchesa, the Black Rose;VMA;153147
+Marchesa's Decree;PZ2;161876
+Mardu Ascendancy;KTK;157076
+Mardu Banner;KTK;156532
+Mardu Blazebringer;KTK;157043
+Mardu Charm;KTK;156567
+Mardu Hateblade;KTK;156472
+Mardu Heart-Piercer;KTK;156557
+Mardu Hordechief;KTK;156473
+Mardu Roughrider;KTK;156526
+Mardu Runemark;FRF;157205
+Mardu Scout;FRF;157242
+Mardu Shadowspear;FRF;157238
+Mardu Shadowspear;PRM;158974
+Mardu Skullhunter;KTK;156495
+Mardu Strike Leader;FRF;157344
+Mardu Warshrieker;KTK;156508
+Mardu Woe-Reaper;FRF;157298
+Marhault Elsdragon;CH;617
+Marhault Elsdragon;LEG;617
+Marhault Elsdragon;ME3;617
+Marionette Master;KLD;162502
+Marisi's Twinclaws;ARB;120982
+Marisi's Twinclaws;DDH;120982
+Marisi's Twinclaws;PRM;121329
+Marit Lage;TOK;97958
+Maritime Guard;M11;129129
+Maritime Guard;ORI;129129
+Marjhan;HML;1532
+Marjhan;ME2;1532
+Mark for Death;GTC;146448
+Mark of Asylum;CON;117020
+Mark of Asylum;DPA;117020
+Mark of Eviction;RAV;88868
+Mark of Fury;UD;15649
+Mark of Mutiny;M13;123650
+Mark of Mutiny;PC2;123650
+Mark of Mutiny;ZEN;123650
+Mark of Sakiko;BOK;83854
+Mark of the Oni;BOK;83814
+Mark of the Vampire;DDK;143941
+Mark of the Vampire;M13;143941
+Mark of the Vampire;M14;143941
+Mark of the Vampire;XLN;402369
+Marked by Honor;M15;155280
+Marked by Honor;W16;155280
+Marker Beetles;UD;15662
+Market Festival;JOU;152872
+Market;HOU;401858
+Markov Blademaster;DKA;139799
+Markov Crusader;EMN;162077
+Markov Dreadknight;PRM;161540
+Markov Dreadknight;SOI;161684
+Markov Patrician;ISD;138244
+Markov Warlord;DKA;139850
+Markov's Servant;DKA;139761
+Maro;6ED;1961
+Maro;7ED;27700
+Maro;8ED;1961
+Maro;9ED;1961
+Maro;MIR;1961
+Marrow Bats;AVR;141704
+Marrow Bats;C13;141704
+Marrow Chomper;ARB;121036
+Marrow Shards;NPH;134364
+Marrow-Gnawer;COK;80560
+Marsh Boa;PCY;21997
+Marsh Casualties;DDM;123555
+Marsh Casualties;DPA;123555
+Marsh Casualties;ZEN;123555
+Marsh Crocodile;PLS;27941
+Marsh Flats;EXP;160782
+Marsh Flats;MM3;123707
+Marsh Flats;ZEN;123707
+Marsh Flitter;LRW;105462
+Marsh Flitter;MMA;105462
+Marsh Gas;4ED;796
+Marsh Gas;DRK;796
+Marsh Goblins;DRK;797
+Marsh Hulk;DTK;159785
+Marsh Lurker;TMP;2973
+Marsh Threader;DPA;126508
+Marsh Threader;WWK;126508
+Marsh Viper;4ED;798
+Marsh Viper;5ED;798
+Marsh Viper;DRK;798
+Marshal's Anthem;C14;126585
+Marshal's Anthem;WWK;126585
+Marshaling Cry;FUT;102413
+Marshaling the Troops;PTK;9108
+Marshdrinker Giant;EVE;113596
+Marshmist Titan;BNG;152032
+Martial Coup;C14;118685
+Martial Coup;CON;118685
+Martial Coup;DPA;118685
+Martial Coup;V14;118685
+Martial Glory;GTC;146546
+Martial Law;RTR;145938
+Martyr of Ashes;CSP;96906
+Martyr of Bones;CSP;96867
+Martyr of Frost;CSP;96900
+Martyr of Frost;DD2;96900
+Martyr of Sands;CSP;96999
+Martyr of Spores;CSP;96881
+Martyr's Bond;CMD;137540
+Martyr's Cause;UL;10380
+Martyr's Cry;DRK;799
+Martyr's Cry;ME4;799
+Martyrdom;ALL;1682
+Martyrdom;ALL;1683
+Martyred Rusalka;GPT;91886
+Martyrs of Korlis;ATQ;420
+Martyrs of Korlis;ME4;420
+Martyrs' Tomb;APC;31083
+Masako the Humorless;COK;80898
+Mask of Avacyn;ISD;138167
+Mask of Intolerance;APC;31112
+Mask of Law and Grace;UD;15604
+Mask of Memory;C14;50307
+Mask of Memory;MRD;50307
+Mask of Memory;PC1;50307
+Mask of Riddles;ARB;120981
+Mask of the Mimic;STH;3717
+Masked Admirers;C14;105471
+Masked Admirers;LRW;105471
+Masked Admirers;MMA;105471
+Masked Gorgon;JUD;40234
+Mass Appeal;AVR;141640
+Mass Calcify;DPA;111621
+Mass Calcify;M15;111621
+Mass Calcify;SHM;111621
+Mass Hysteria;MRD;50300
+Mass Mutiny;C13;140378
+Mass Mutiny;PC2;140378
+Mass Polymorph;DPA;129072
+Mass Polymorph;M11;129072
+Mass of Ghouls;10E;102346
+Mass of Ghouls;FUT;102346
+Massacre Wurm;DPA;131726
+Massacre Wurm;MBS;131726
+Massacre;NMS;21277
+Massacre;TD0;21277
+Massive Raid;GTC;146310
+Master Apothecary;ODY;33514
+Master Biomancer;GTC;147257
+Master Decoy;8ED;49225
+Master Decoy;9ED;49225
+Master Decoy;DPA;49225
+Master Decoy;TMP;3059
+Master Decoy;TPR;3059
+Master Healer;7ED;27701
+Master Healer;8ED;27701
+Master Healer;9ED;15710
+Master Healer;UD;15710
+Master Splicer;MM3;134401
+Master Splicer;NPH;134401
+Master Thief;M12;134183
+Master Transmuter;CON;118692
+Master Trinketeer;KLD;162464
+Master Warcraft;CMD;88599
+Master Warcraft;RAV;88599
+Master of Arms;WTH;2957
+Master of Cruelties;DGM;146772
+Master of Diversion;M14;147382
+Master of Etherium;ALA;115147
+Master of Etherium;DDF;115147
+Master of Etherium;DPA;115147
+Master of Etherium;PC1;115147
+Master of Pearls;KTK;157002
+Master of Predicaments;M15;155318
+Master of Waves;THS;150840
+Master of the Feast;JOU;153043
+Master of the Hunt;LEG;2538
+Master of the Pearl Trident;M13;143932
+Master of the Veil;LGN;47468
+Master of the Wild Hunt;DPA;121652
+Master of the Wild Hunt;M10;121652
+Master the Way;KTK;156576
+Master's Call;MBS;133250
+Master's Call;PRM;134064
+Masterwork of Ingenuity;C14;156027
+Mastery of the Unseen;FRF;159389
+Mastery of the Unseen;PRM;157174
+Masticore;UD;15594
+Masticore;V10;129509
+Masticore;VMA;129509
+Masumaro, First to Live;SOK;86064
+Matca Rioters;CON;118691
+Matca Rioters;MM2;118691
+Matopi Golem;VIS;2213
+Matsu-Tribe Birdstalker;SOK;86016
+Matsu-Tribe Decoy;COK;81565
+Matsu-Tribe Sniper;BOK;83935
+Matter Reshaper;OGW;161189
+Maul Splicer;NPH;134379
+Maul Splicer;PRM;136794
+Maulfist Doorbuster;KLD;162288
+Maulfist Revolutionary;AER;400359
+Maulfist Squad;KLD;162271
+Mausoleum Guard;DDK;138411
+Mausoleum Guard;DPA;138411
+Mausoleum Guard;ISD;138411
+Mausoleum Turnkey;RAV;88844
+Mausoleum Wanderer;EMN;161945
+Maverick Thopterist;AER;400362
+Mavren Fein, Dusk Apostle;XLN;402074
+Maw of Kozilek;OGW;161051
+Maw of the Mire;ISD;138494
+Maw of the Obzedat;DGM;147741
+Mawcor;7ED;27702
+Mawcor;TMP;3178
+Mawcor;TPR;3178
+Mayael the Anima;ALA;115110
+Mayael the Anima;C13;115110
+Mayael's Aria;ARB;121027
+Mayor of Avabruck;ISD;139447
+Mayor of Avabruck;PRM;138209
+Maze Abomination;DGM;147782
+Maze Behemoth;DGM;147783
+Maze Glider;DGM;147785
+Maze Rusher;DGM;147781
+Maze Sentinel;DGM;147780
+Maze of Ith;DRK;800
+Maze of Ith;EMA;143998
+Maze of Ith;ME4;800
+Maze of Ith;PRM;120090
+Maze of Ith;V12;143998
+Maze of Shadows;TMP;3247
+Maze of Shadows;TPR;3247
+Maze's End;DGM;147861
+Maze's End;PRM;146790
+Mazirek, Kraul Death Priest;PZ1;160510
+Meadowboon;MMA;110222
+Meadowboon;MOR;110222
+Meandering River;AKH;161130
+Meandering River;OGW;161130
+Meandering Towershell;KTK;157063
+Measure of Wickedness;SOK;86189
+Mechanized Production;AER;162227
+Meddle;MIR;1962
+Meddle;ONS;43007
+Meddling Mage;ARB;120964
+Meddling Mage;PLS;27942
+Meddling Mage;PRM;92879
+Medicine Bag;EXO;5599
+Medicine Runner;SHM;111544
+Meditate;TMP;3172
+Meditate;TPR;3172
+Meditation Puzzle;M15;155206
+Medomai the Ageless;THS;150853
+Meekstone;2ED;161
+Meekstone;3ED;161
+Meekstone;4ED;161
+Meekstone;5ED;161
+Meekstone;6ED;161
+Meekstone;7ED;27703
+Meekstone;LEA;161
+Meekstone;LEB;161
+Meekstone;MS2;400933
+Megantic Sliver;DPA;147431
+Megantic Sliver;M14;147431
+Megantic Sliver;PRM;149171
+Megatherium;MMQ;17227
+Megatog;MRD;51026
+Meglonoth;CON;118718
+Megrim;10E;86915
+Megrim;7ED;27704
+Megrim;8ED;27704
+Megrim;9ED;86915
+Megrim;DPA;86915
+Megrim;M10;86915
+Megrim;STH;3719
+Meishin, the Mind Cage;SOK;87229
+Melancholy;PLC;101373
+Melee;ICE;1276
+Melek, Izzet Paragon;DGM;146777
+Melek, Izzet Paragon;PRM;148808
+Melesse Spirit;MIR;1963
+Meletis Astronomer;BNG;152553
+Meletis Charlatan;THS;150805
+Melira, Sylvok Outcast;NPH;134193
+Melira's Keepers;MBS;133183
+Meloku the Clouded Mirror;COK;80746
+Meloku the Clouded Mirror;MMA;80746
+Melt Terrain;SOM;130891
+Meltdown;USG;8758
+Melting;ICE;1277
+Memnarch;DST;51760
+Memnarch;V16;51760
+Memnite;PRM;132559
+Memnite;SOM;130879
+Memnite;TD2;130879
+Memoricide;PRM;131733
+Memoricide;SOM;131212
+Memory Crystal;EXO;5648
+Memory Erosion;ALA;115141
+Memory Erosion;CMD;115141
+Memory Erosion;DPA;115141
+Memory Jar;UL;13549
+Memory Jar;V10;13549
+Memory Jar;VMA;13549
+Memory Lapse;5ED;1533
+Memory Lapse;6ED;1533
+Memory Lapse;7ED;27705
+Memory Lapse;DDM;1964
+Memory Lapse;EMA;161551
+Memory Lapse;HML;1533
+Memory Lapse;HML;1534
+Memory Lapse;MIR;1964
+Memory Lapse;PRM;1533
+Memory Plunder;SHM;111648
+Memory Sluice;SHM;111870
+Memory;AKH;401040
+Memory's Journey;ISD;139309
+Menacing Ogre;ONS;36729
+Menacing Ogre;PC1;36729
+Mending Hands;9ED;83898
+Mending Hands;BOK;83898
+Mending Touch;DGM;146730
+Meng Huo, Barbarian King;ME3;9047
+Meng Huo, Barbarian King;PTK;9047
+Meng Huo's Horde;ME3;9148
+Meng Huo's Horde;PTK;9148
+Mental Agony;AVR;141511
+Mental Discipline;UD;15621
+Mental Misstep;NPH;134358
+Mental Note;JUD;40202
+Mental Vapors;GTC;146531
+Mentor of the Meek;C14;138444
+Mentor of the Meek;DPA;138444
+Mentor of the Meek;ISD;138444
+Mephidross Vampire;5DN;50833
+Mephitic Ooze;DST;75170
+Mer-Ek Nightblade;KTK;157029
+Mercadia's Downfall;MMQ;19296
+Mercadian Atlas;MMQ;19088
+Mercadian Bazaar;MMQ;19209
+Mercadian Lift;MMQ;19258
+Mercenaries;ICE;1278
+Mercenary Informer;PCY;21994
+Mercenary Knight;POR;6584
+Merchant Scroll;8ED;49238
+Merchant Scroll;HML;1535
+Merchant Ship;ARN;354
+Merchant of Secrets;8ED;47513
+Merchant of Secrets;DPA;47513
+Merchant of Secrets;LGN;47513
+Merchant's Dockhand;AER;400389
+Merciless Eternal;HOU;401501
+Merciless Eviction;GTC;146455
+Merciless Executioner;FRF;157246
+Merciless Javelineer;AKH;401345
+Merciless Predator;ISD;138198
+Merciless Resolve;SOI;161678
+Mercurial Chemister;RTR;145961
+Mercurial Geists;EMN;162137
+Mercurial Kite;SCG;46570
+Mercurial Pretender;M15;155349
+Mercurial Pretender;PRM;155860
+Mercy Killing;SHM;111882
+Meren of Clan Nel Toth;PZ1;160049
+Merfolk Assassin;DRK;801
+Merfolk Assassin;TSB;801
+Merfolk Branchwalker;XLN;402259
+Merfolk Looter;10E;27706
+Merfolk Looter;7ED;27706
+Merfolk Looter;DPA;122145
+Merfolk Looter;EMA;122145
+Merfolk Looter;EXO;5641
+Merfolk Looter;M10;122145
+Merfolk Looter;M12;122145
+Merfolk Looter;TD0;5641
+Merfolk Looter;TPR;5641
+Merfolk Mesmerist;M12;134086
+Merfolk Observer;ROE;127458
+Merfolk Raiders;MIR;1965
+Merfolk Seastalkers;ZEN;123659
+Merfolk Seer;MIR;1966
+Merfolk Skyscout;ROE;127312
+Merfolk Sovereign;M10;121667
+Merfolk Sovereign;M11;121667
+Merfolk Spy;M11;129100
+Merfolk Spy;M14;129100
+Merfolk Thaumaturgist;PLC;100762
+Merfolk Traders;WTH;2828
+Merfolk Wayfinder;DDM;123535
+Merfolk Wayfinder;ZEN;123535
+Merfolk Wizard;TOK;107635
+Merfolk of the Depths;GTC;146402
+Merfolk of the Pearl Trident;2ED;162
+Merfolk of the Pearl Trident;3ED;162
+Merfolk of the Pearl Trident;4ED;162
+Merfolk of the Pearl Trident;5ED;2429
+Merfolk of the Pearl Trident;6ED;6623
+Merfolk of the Pearl Trident;7ED;27707
+Merfolk of the Pearl Trident;LEA;162
+Merfolk of the Pearl Trident;LEB;162
+Merfolk of the Pearl Trident;M13;27707
+Merfolk of the Pearl Trident;POR;6623
+Merfolk;TOK;125081
+Merfolk;TOK;402422
+Merieke Ri Berit;ICE;1279
+Merieke Ri Berit;TSB;1279
+Merrow Bonegnawer;EVE;113642
+Merrow Commerce;LRW;105426
+Merrow Grimeblotter;SHM;111530
+Merrow Harbinger;LRW;105340
+Merrow Levitator;EVE;113614
+Merrow Reejerey;LRW;105459
+Merrow Reejerey;PRM;120084
+Merrow Wavebreakers;SHM;111758
+Merrow Witsniper;MOR;109934
+Merseine;FEM;964
+Merseine;FEM;965
+Merseine;FEM;966
+Merseine;FEM;967
+Mesa Enchantress;DPA;100780
+Mesa Enchantress;EMA;100780
+Mesa Enchantress;M10;100780
+Mesa Enchantress;M12;100780
+Mesa Enchantress;PLC;100780
+Mesa Falcon;5ED;1537
+Mesa Falcon;6ED;1537
+Mesa Falcon;HML;1536
+Mesa Falcon;HML;1537
+Mesa Pegasus;2ED;163
+Mesa Pegasus;3ED;163
+Mesa Pegasus;4ED;163
+Mesa Pegasus;5ED;163
+Mesa Pegasus;LEA;163
+Mesa Pegasus;LEB;163
+Mesa Pegasus;MED;163
+Mesmeric Fiend;DDK;36438
+Mesmeric Fiend;TOR;36438
+Mesmeric Fiend;VMA;36438
+Mesmeric Orb;MRD;50231
+Mesmeric Sliver;FUT;102491
+Mesmeric Trance;ICE;1280
+Mesmeric Trance;ME2;1280
+Messenger Drake;M14;147451
+Messenger Falcons;ARB;121068
+Messenger's Speed;THS;149188
+Metal Fatigue;DST;51903
+Metallic Mastery;MBS;133196
+Metallic Mimic;AER;162594
+Metallic Rebuke;AER;400263
+Metallic Sliver;H09;2963
+Metallic Sliver;TMP;2963
+Metallic Sliver;TOK;2963
+Metallic Sliver;TPR;2963
+Metallurgeon;ALA;115146
+Metallurgic Summonings;KLD;162490
+Metalspinner's Puzzleknot;KLD;162327
+Metalwork Colossus;KLD;162338
+Metalworker;PRM;149239
+Metalworker;UD;15675
+Metamorphic Wurm;ODY;33302
+Metamorphose;SCG;48136
+Metamorphosis;ARN;355
+Metamorphosis;CH;355
+Metathran Aerostat;INV;25137
+Metathran Elite;UD;15620
+Metathran Soldier;UD;15717
+Metathran Transport;INV;25619
+Metathran Zombie;INV;24090
+Meteor Blast;PZ1;160067
+Meteor Crater;PLS;27945
+Meteor Shower;ICE;1281
+Meteor Shower;ME2;1281
+Meteor Storm;DPA;24108
+Meteor Storm;INV;24108
+Meteorite;M15;155390
+Meteorite;ORI;155390
+Metrognome;USG;8800
+Metropolis Sprite;GTC;146538
+Miasmic Mummy;AKH;401302
+Michiko Konda, Truth Seeker;SOK;83972
+Midnight Banshee;MM2;111697
+Midnight Banshee;SHM;111697
+Midnight Charm;PLC;100718
+Midnight Covenant;COK;80684
+Midnight Duelist;AVR;141539
+Midnight Entourage;AER;400301
+Midnight Guard;DKA;139895
+Midnight Guard;DPA;139895
+Midnight Guard;M15;139895
+Midnight Haunting;C14;138174
+Midnight Haunting;DPA;138174
+Midnight Haunting;ISD;138174
+Midnight Oil;KLD;162505
+Midnight Recovery;GTC;146503
+Midnight Ritual;10E;19065
+Midnight Ritual;MMQ;19065
+Midnight Scavengers;EMN;161959
+Midsummer Revel;USG;8729
+Midvast Protector;AVR;141846
+Might Beyond Reason;SOI;161386
+Might Makes Right;M15;155285
+Might Sliver;H09;97382
+Might Sliver;TSP;97382
+Might Weaver;10E;25206
+Might Weaver;INV;25206
+Might of Alara;CON;118650
+Might of Oaks;10E;102958
+Might of Oaks;7ED;27708
+Might of Oaks;8ED;27708
+Might of Oaks;9ED;27708
+Might of Oaks;M10;102958
+Might of Oaks;UL;10397
+Might of Old Krosa;MM3;400208
+Might of Old Krosa;TSP;97365
+Might of the Masses;DPA;127344
+Might of the Masses;ORI;127344
+Might of the Masses;ROE;127344
+Might of the Nephilim;DIS;94389
+Mightstone;ATQ;421
+Mightstone;ME4;421
+Mighty Emergence;ALA;116184
+Mighty Leap;AKH;400843
+Mighty Leap;DDF;129186
+Mighty Leap;DDG;129186
+Mighty Leap;DPA;129186
+Mighty Leap;M11;129186
+Mighty Leap;M12;129186
+Mighty Leap;MM2;129186
+Mighty Leap;OGW;161065
+Mighty Leap;ORI;129186
+Migratory Route;PZ2;162435
+Mijae Djinn;3ED;356
+Mijae Djinn;ARN;356
+Mijae Djinn;ME4;356
+Mikaeus, the Lunarch;ISD;138498
+Mikaeus, the Lunarch;V11;138498
+Mikaeus, the Unhallowed;DKA;139804
+Mikokoro, Center of the Sea;SOK;86093
+Militant Inquisitor;SOI;161641
+Militant Monk;TOR;36389
+Military Intelligence;M15;155404
+Militia's Pride;LRW;105515
+Millennial Gargoyle;GTC;146271
+Millikin;EMA;33252
+Millikin;ODY;33252
+Millstone;10E;27709
+Millstone;3ED;422
+Millstone;4ED;422
+Millstone;5ED;422
+Millstone;6ED;422
+Millstone;7ED;27709
+Millstone;8ED;27709
+Millstone;9ED;27709
+Millstone;ATQ;422
+Millstone;M14;148278
+Mimeofacture;GPT;91850
+Mimic Vat;SOM;131043
+Miming Slime;GTC;146339
+Mina and Denn, Wildborn;OGW;161091
+Minamo Scrollkeeper;SOK;86166
+Minamo Sightbender;BOK;83926
+Minamo Sightbender;DDI;83926
+Minamo, School at Water's Edge;COK;81065
+Minamo;PC1;125873
+Minamo's Meddling;BOK;83966
+Mind Bend;10E;1967
+Mind Bend;8ED;49237
+Mind Bend;9ED;49237
+Mind Bend;MIR;1967
+Mind Bomb;4ED;802
+Mind Bomb;5ED;802
+Mind Bomb;DRK;802
+Mind Burst;ODY;33428
+Mind Control;DPA;129175
+Mind Control;M10;121615
+Mind Control;M11;129175
+Mind Control;M12;129175
+Mind Control;PRM;89028
+Mind Extraction;APC;31090
+Mind Funeral;ARB;120990
+Mind Funeral;MMA;120990
+Mind Games;STH;3720
+Mind Grind;GTC;146374
+Mind Harness;MIR;1968
+Mind Knives;POR;6585
+Mind Maggots;EXO;5632
+Mind Over Matter;EXO;5612
+Mind Peel;STH;3721
+Mind Raker;BFZ;160817
+Mind Ravel;5ED;1282
+Mind Ravel;ICE;1282
+Mind Rot;10E;6586
+Mind Rot;7ED;27710
+Mind Rot;8ED;6586
+Mind Rot;9ED;6586
+Mind Rot;DPA;6586
+Mind Rot;DTK;160072
+Mind Rot;KLD;162276
+Mind Rot;M10;6586
+Mind Rot;M11;6586
+Mind Rot;M12;6586
+Mind Rot;M13;6586
+Mind Rot;M14;6586
+Mind Rot;M15;6586
+Mind Rot;ORI;6586
+Mind Rot;PO2;4716
+Mind Rot;POR;6586
+Mind Rot;RTR;145861
+Mind Rot;W16;6586
+Mind Sculpt;DPA;143840
+Mind Sculpt;M13;143840
+Mind Sculpt;M15;143840
+Mind Shatter;DPA;110216
+Mind Shatter;M10;110216
+Mind Shatter;MM3;110216
+Mind Shatter;MOR;110216
+Mind Slash;8ED;21158
+Mind Slash;NMS;21158
+Mind Sludge;8ED;36460
+Mind Sludge;TOR;36460
+Mind Sludge;ZEN;123745
+Mind Spring;DPA;109919
+Mind Spring;M10;109919
+Mind Spring;MOR;109919
+Mind Stone;10E;2788
+Mind Stone;C14;2788
+Mind Stone;DD2;2788
+Mind Stone;PRM;105312
+Mind Stone;WTH;2788
+Mind Swords;NMS;21182
+Mind Twist;2ED;164
+Mind Twist;3ED;164
+Mind Twist;4ED;164
+Mind Twist;LEA;164
+Mind Twist;LEB;164
+Mind Twist;ME3;164
+Mind Twist;MS3;401630
+Mind Twist;PRM;145065
+Mind Unbound;M12;137396
+Mind Warp;5ED;1283
+Mind Warp;6ED;1283
+Mind Warp;ICE;1283
+Mind Warp;PRM;1283
+Mind Whip;ICE;1284
+Mind;AKH;401048
+Mind's Desire;PRM;107686
+Mind's Desire;SCG;48991
+Mind's Desire;V16;162184
+Mind's Desire;VMA;107686
+Mind's Dilation;EMN;161933
+Mind's Eye;MRD;51099
+Mind's Eye;MS2;162249
+Mind's Eye;PRM;147073
+Mind's Eye;PZ1;147073
+Mindbender Spores;MIR;1969
+Mindblaze;COK;80729
+Mindbreak Trap;ZEN;125075
+Mindclaw Shaman;M13;143868
+Mindcrank;NPH;134417
+Mindculling;NPH;134331
+Mindeye Drake;GTC;146370
+Mindlash Sliver;TSP;97496
+Mindleech Mass;RAV;89095
+Mindless Automaton;EMA;3705
+Mindless Automaton;EXO;3705
+Mindless Automaton;TPR;3705
+Mindless Automaton;TSB;3705
+Mindless Null;DPA;123600
+Mindless Null;ZEN;123600
+Mindlock Orb;ALA;115198
+Mindmelter;OGW;161072
+Mindmoil;DPA;89023
+Mindmoil;RAV;89023
+Mindreaver;BNG;152090
+Minds Aglow;CMD;129238
+Mindscour Dragon;FRF;157182
+Mindshrieker;ISD;138311
+Mindslaver;MRD;50266
+Mindslaver;SOM;131083
+Mindslicer;9ED;33400
+Mindslicer;ODY;33400
+Mindsparker;M14;147411
+Mindstab Thrull;5ED;970
+Mindstab Thrull;FEM;968
+Mindstab Thrull;FEM;969
+Mindstab Thrull;FEM;970
+Mindstab Thrull;MED;970
+Mindstab;TSP;97315
+Mindstatic;DGM;147768
+Mindstorm Crown;MRD;51033
+Mindswipe;KTK;156575
+Mindwarper;STH;3722
+Mindwhip Sliver;TMP;3216
+Mindwrack Demon;PRM;161780
+Mindwrack Demon;SOI;161429
+Mindwrack Liege;DPA;113629
+Mindwrack Liege;EVE;113629
+Mine Bearer;PCY;21995
+Mine Excavation;SHM;111867
+Mine Layer;ODY;33347
+Miner's Bane;M15;155391
+Minion Reflector;ALA;114924
+Minion of Leshrac;ICE;1285
+Minion of Leshrac;ME2;1285
+Minion of Tevesh Szat;ICE;1286
+Minion of Tevesh Szat;ME4;1286
+Minion of the Wastes;TMP;3118
+Minion;TOK;128000
+Minion;TOK;143392
+Minions' Murmurs;FUT;102370
+Minister of Impediments;DIS;94286
+Minister of Inquiries;KLD;162477
+Minister of Pain;DTK;160118
+Minor Demon;TOK;126955
+Minotaur Abomination;M14;147443
+Minotaur Aggressor;RTR;145176
+Minotaur Explorer;ODY;33385
+Minotaur Illusionist;APC;31115
+Minotaur Skullcleaver;THS;149061
+Minotaur Sureshot;AKH;400787
+Minotaur Tactician;APC;31114
+Minotaur Warrior;POR;6706
+Minotaur;TOK;155465
+Miracle Worker;DRK;803
+Miraculous Recovery;DDL;150013
+Miraculous Recovery;VIS;2214
+Mirage Mirror;HOU;401850
+Mirari;C13;33249
+Mirari;ODY;33249
+Mirari;TSB;33249
+Mirari;V10;33249
+Mirari's Wake;JUD;40294
+Mirari's Wake;PRM;107711
+Mirari's Wake;PZ1;107711
+Mirari's Wake;TD0;40294
+Mire Blight;ZEN;123680
+Mire Boa;PLC;100692
+Mire Kavu;PLS;27878
+Mire Shade;MIR;1970
+Mire's Malice;BFZ;160666
+Mire's Toll;DPA;126506
+Mire's Toll;WWK;126506
+Miren, the Moaning Well;SOK;86179
+Miren, the Moaning Well;TD0;86179
+Mirko Vosk, Mind Drinker;DGM;146780
+Mirozel;EXO;3723
+Mirran Crusader;MBS;133189
+Mirran Crusader;MM2;133189
+Mirran Crusader;PRM;134060
+Mirran Mettle;MBS;133200
+Mirran Spy;MBS;133167
+Mirri the Cursed;DPA;100686
+Mirri the Cursed;PLC;100686
+Mirri, Cat Warrior;10E;5421
+Mirri, Cat Warrior;DPA;5421
+Mirri, Cat Warrior;EXO;5421
+Mirri, Cat Warrior;TPR;5421
+Mirri's Guile;TMP;3142
+Mirrodin's Core;DST;75136
+Mirror Entity;C13;105570
+Mirror Entity;LRW;105570
+Mirror Entity;MM2;105570
+Mirror Gallery;BOK;83906
+Mirror Golem;MRD;51063
+Mirror Match;PZ1;160131
+Mirror Mockery;DTK;160137
+Mirror Sheen;EVE;113660
+Mirror Strike;PCY;21996
+Mirror Universe;LEG;2539
+Mirror Universe;MED;2539
+Mirror Wall;JUD;40199
+Mirror of Fate;M10;122176
+Mirror-Mad Phantasm;ISD;138291
+Mirror-Sigil Sergeant;CON;118657
+Mirrored Depths;PRM;125877
+Mirrorpool;OGW;161052
+Mirrorweave;SHM;111770
+Mirrorwing Dragon;EMN;161991
+Mirrorwood Treefolk;PLS;27946
+Mirrorworks;DPA;133235
+Mirrorworks;MBS;133235
+Miscalculation;UL;10382
+Mischief and Mayhem;BNG;152597
+Mischievous Poltergeist;6ED;2922
+Mischievous Poltergeist;WTH;2922
+Mischievous Quanar;SCG;48972
+Misdirection;MMQ;19214
+Misdirection;PRM;153364
+Misers' Cage;MIR;1971
+Misery Charm;ONS;43047
+Misfortune;ALL;1684
+Misfortune's Gain;ME3;9027
+Misfortune's Gain;PTK;9027
+Misguided Rage;SCG;48957
+Mishra, Artificer Prodigy;TSP;97426
+Mishra's Bauble;CSP;97261
+Mishra's Factory;4ED;423
+Mishra's Factory;ATQ;423
+Mishra's Factory;ATQ;424
+Mishra's Factory;ATQ;425
+Mishra's Factory;ATQ;426
+Mishra's Factory;DDF;131568
+Mishra's Factory;EMA;131568
+Mishra's Factory;MED;423
+Mishra's Factory;PRM;423
+Mishra's Factory;PRM;426
+Mishra's Factory;TD0;131568
+Mishra's Groundbreaker;ALL;1685
+Mishra's Groundbreaker;ME2;1685
+Mishra's Helix;USG;8669
+Mishra's War Machine;3ED;427
+Mishra's War Machine;4ED;427
+Mishra's War Machine;ATQ;427
+Mishra's Workshop;ATQ;428
+Mishra's Workshop;ME4;428
+Mishra's Workshop;PRM;149236
+Mishra's Workshop;VMA;149236
+Misinformation;ALL;1686
+Misinformation;ME2;1686
+Misshapen Fiend;MMQ;19249
+Misstep;MMQ;19299
+Mist Dragon;MIR;1972
+Mist Intruder;BFZ;160881
+Mist Leopard;M10;122142
+Mist Raven;AVR;141801
+Mist Raven;MM3;141801
+Mist of Stagnation;JUD;40222
+Mistbind Clique;LRW;105575
+Mistblade Shinobi;BOK;83824
+Mistblade Shinobi;PC2;83824
+Mistcutter Hydra;THS;149212
+Mistfire Adept;FRF;157189
+Mistfire Weaver;KTK;156545
+Mistfolk;ICE;1287
+Mistform Dreamer;ONS;42999
+Mistform Mask;ONS;42983
+Mistform Mutant;ONS;43000
+Mistform Seaswift;LGN;46573
+Mistform Shrieker;ONS;42991
+Mistform Skyreaver;ONS;43015
+Mistform Sliver;LGN;46544
+Mistform Stalker;ONS;42978
+Mistform Ultimus;LGN;47533
+Mistform Ultimus;TSB;47533
+Mistform Wakecaster;LGN;46561
+Mistform Wall;ONS;42977
+Mistform Warchief;SCG;49002
+Misthollow Griffin;AVR;141836
+Misthoof Kirin;DTK;160156
+Mistmeadow Skulk;FUT;102385
+Mistmeadow Skulk;SHM;102385
+Mistmeadow Witch;C13;111823
+Mistmeadow Witch;DDI;111823
+Mistmeadow Witch;MM3;111823
+Mistmeadow Witch;SHM;111823
+Mistmeadow Witch;TD0;111823
+Mistmoon Griffin;VMA;2952
+Mistmoon Griffin;WTH;2952
+Mistral Charger;DIS;94334
+Mistral Charger;EMA;94334
+Mistveil Plains;SHM;111568
+Mistvein Borderpost;ARB;120949
+Misty Rainforest;EXP;160780
+Misty Rainforest;MM3;123689
+Misty Rainforest;ZEN;123689
+Mitotic Manipulation;MBS;133238
+Mitotic Slime;DPA;129121
+Mitotic Slime;M11;129121
+Mitotic Slime;PC2;129121
+Mitotic Slime;PRM;129300
+Mitotic Slime;TD2;129121
+Mizzium Meddler;ORI;160240
+Mizzium Meddler;PRM;160770
+Mizzium Mortars;MM3;145218
+Mizzium Mortars;RTR;145218
+Mizzium Skin;RTR;145122
+Mizzium Transreliquat;GPT;91866
+Mizzix of the Izmagnus;PZ1;160023
+Mizzix's Mastery;PZ1;160436
+Mnemonic Nexus;RAV;89004
+Mnemonic Sliver;TMP;3273
+Mnemonic Sliver;TPR;3273
+Mnemonic Wall;C13;127302
+Mnemonic Wall;DPA;127302
+Mnemonic Wall;ROE;127302
+Mnemonic Wall;THS;150849
+Moan of the Unhallowed;DPA;138286
+Moan of the Unhallowed;ISD;138286
+Moaning Spirit;PO2;4710
+Moaning Wall;HOU;401798
+Moat;LEG;2540
+Moat;MED;2540
+Moat;PRM;149238
+Mob Justice;STH;3635
+Mob Mentality;VIS;2215
+Mob Rule;FRF;159995
+Mobile Fort;USG;8923
+Mobile Garrison;AER;400381
+Mobilization;10E;42944
+Mobilization;C14;42944
+Mobilization;ONS;42944
+Mobilize;POR;6659
+Mockery of Nature;EMN;161994
+Mogg Alarm;NMS;21198
+Mogg Assassin;EXO;5666
+Mogg Bombers;STH;3633
+Mogg Cannon;TMP;3205
+Mogg Conscripts;TMP;3007
+Mogg Conscripts;TPR;3007
+Mogg Fanatic;10E;3015
+Mogg Fanatic;EMA;3015
+Mogg Fanatic;EVG;3015
+Mogg Fanatic;PD2;3015
+Mogg Fanatic;PRM;105313
+Mogg Fanatic;PRM;3015
+Mogg Fanatic;TMP;3015
+Mogg Fanatic;TPR;3015
+Mogg Flunkies;M13;3634
+Mogg Flunkies;MM3;3634
+Mogg Flunkies;PD2;3634
+Mogg Flunkies;STH;3634
+Mogg Flunkies;TPR;3634
+Mogg Hollows;TMP;3252
+Mogg Hollows;TPR;3252
+Mogg Infestation;STH;3641
+Mogg Infestation;TPR;3641
+Mogg Jailer;PLS;27947
+Mogg Maniac;STH;3654
+Mogg Maniac;TPR;3654
+Mogg Raider;TMP;3014
+Mogg Salvage;NMS;21244
+Mogg Sentry;8ED;49673
+Mogg Sentry;9ED;49673
+Mogg Sentry;PLS;27948
+Mogg Squad;TMP;3254
+Mogg Toady;NMS;21251
+Mogg War Marshal;EMA;161563
+Mogg War Marshal;EVG;97487
+Mogg War Marshal;MMA;97487
+Mogg War Marshal;TSP;97487
+Moggcatcher;NMS;21279
+Mogis, God of Slaughter;BNG;152102
+Mogis's Marauder;THS;150784
+Mogis's Warhound;JOU;152815
+Mold Adder;M10;121577
+Mold Demon;LEG;2541
+Mold Shambler;C13;123623
+Mold Shambler;DDM;123623
+Mold Shambler;ZEN;123623
+Molder Beast;SOM;131104
+Molder Slug;MRD;51050
+Molder;TSP;97457
+Moldervine Cloak;MMA;89050
+Moldervine Cloak;RAV;89050
+Moldgraf Monstrosity;ISD;139300
+Moldgraf Scavenger;SOI;161500
+Mole Worms;5ED;2430
+Mole Worms;ICE;1288
+Molimo, Maro-Sorcerer;10E;24079
+Molimo, Maro-Sorcerer;DPA;24079
+Molimo, Maro-Sorcerer;INV;24079
+Molten Birth;M14;147420
+Molten Disaster;C13;102474
+Molten Disaster;FUT;102474
+Molten Disaster;MMA;102474
+Molten Firebird;PLC;101528
+Molten Frame;CON;118759
+Molten Hydra;UL;10402
+Molten Influence;ODY;33339
+Molten Nursery;BFZ;160918
+Molten Primordial;GTC;147248
+Molten Psyche;SOM;131152
+Molten Rain;MM3;400712
+Molten Rain;MRD;50210
+Molten Ravager;DPA;123619
+Molten Ravager;ZEN;123619
+Molten Sentry;RAV;89121
+Molten Slagheap;C13;97307
+Molten Slagheap;CMD;97307
+Molten Slagheap;PZ1;97307
+Molten Slagheap;TSP;97307
+Molten Vortex;ORI;160303
+Molten-Tail Masticore;SOM;131198
+Moltensteel Dragon;NPH;134390
+Molting Harpy;MMQ;19152
+Molting Skin;SOK;86139
+Molting Snakeskin;KTK;156501
+Moment of Heroism;DDL;138252
+Moment of Heroism;DPA;138252
+Moment of Heroism;ISD;138252
+Moment of Silence;MMQ;19200
+Moment's Peace;ODY;33510
+Moment's Peace;TD0;33510
+Momentary Blink;MM3;161779
+Momentary Blink;PRM;161779
+Momentary Blink;TD0;97357
+Momentary Blink;TSP;97357
+Momentous Fall;DPA;127306
+Momentous Fall;ROE;127306
+Momentum;UD;15669
+Momir Vig, Simic Visionary;DIS;94562
+Momir Vig, Simic Visionary;V16;162186
+Monastery Flock;KTK;157005
+Monastery Loremaster;DTK;159827
+Monastery Mentor;FRF;157198
+Monastery Siege;FRF;157217
+Monastery Swiftspear;KTK;156555
+Mondronen Shaman;DKA;140330
+Mondronen Shaman;PRM;139812
+Mongrel Pack;TMP;3143
+Monk Idealist;EMA;8643
+Monk Idealist;USG;8643
+Monk Realist;CMD;8644
+Monk Realist;USG;8644
+Monk;TOK;158965
+Monkey Cage;MMQ;19039
+Monkey;TOK;143402
+Monomania;DPA;137413
+Monomania;M12;137413
+Mons's Goblin Raiders;2ED;165
+Mons's Goblin Raiders;3ED;165
+Mons's Goblin Raiders;4ED;165
+Mons's Goblin Raiders;5ED;2431
+Mons's Goblin Raiders;LEA;165
+Mons's Goblin Raiders;LEB;165
+Monsoon;ICE;1289
+Monstrify;EVE;113686
+Monstrous Carabid;ARB;121041
+Monstrous Growth;7ED;31241
+Monstrous Growth;8ED;31241
+Monstrous Growth;PO2;4770
+Monstrous Growth;POR;6660
+Monstrous Hound;EXO;5667
+Monstrous Hound;PRM;5667
+Monstrous Onslaught;AER;400347
+Moon Heron;ISD;138165
+Moon Sprite;POR;6662
+Moonbow Illusionist;SOK;86072
+Moonglove Changeling;MOR;109891
+Moonglove Extract;DDF;105417
+Moonglove Extract;EVG;105417
+Moonglove Extract;LRW;105417
+Moonglove Winnower;DPA;105396
+Moonglove Winnower;LRW;105396
+Moonhold;EVE;113730
+Moonlace;TSP;97472
+Moonlight Bargain;RAV;89129
+Moonlight Geist;AVR;141839
+Moonlight Hunt;SOI;161497
+Moonlit Strider;BOK;83817
+Moonlit Strider;MM2;83817
+Moonlit Wake;MMQ;19470
+Moonmist;ISD;138237
+Moonring Island;SHM;111533
+Moonring Mirror;COK;80722
+Moonrise Intruder;SOI;161417
+Moonscarred Werewolf;DKA;139816
+Moonsilver Spear;AVR;142218
+Moonsilver Spear;C14;142218
+Moonsilver Spear;PRM;141610
+Moonveil Dragon;DKA;139803
+Moonwing Moth;SOK;86127
+Moor Fiend;ICE;1290
+Moorish Cavalry;ARN;357
+Moorish Cavalry;TSB;357
+Moorland Drifter;SOI;161617
+Moorland Haunt;ISD;138355
+Moorland Inquisitor;AVR;141752
+Morale;4ED;804
+Morale;DRK;804
+Morality Shift;JUD;40236
+Moratorium Stone;GPT;91802
+Morbid Bloom;ARB;120998
+Morbid Curiosity;KLD;162268
+Morbid Hunger;ODY;33427
+Morbid Plunder;MBS;133262
+Morbid Plunder;TD2;133262
+Mordant Dragon;DDG;126535
+Mordant Dragon;WWK;126535
+Morgue Burst;DGM;147712
+Morgue Theft;ODY;33424
+Morgue Thrull;STH;3725
+Morgue Toad;DDH;28158
+Morgue Toad;PLS;28158
+Morinfen;WTH;2863
+Moriok Reaver;SOM;130949
+Moriok Replica;SOM;131077
+Moriok Rigger;5DN;77127
+Moriok Scavenger;MRD;50193
+Morkrut Banshee;C14;138339
+Morkrut Banshee;ISD;138339
+Morkrut Necropod;SOI;161434
+Morningtide;TOR;36404
+Moroii;DDH;88649
+Moroii;DPA;88649
+Moroii;MM3;88649
+Moroii;RAV;88649
+Morph;TOK;157352
+Morphic Tide;PC2;138709
+Morphling;PRM;8849
+Morphling;USG;8849
+Morphling;VMA;8849
+Morsel Theft;MOR;109967
+Morselhoarder;SHM;98604
+Mortal Combat;10E;33389
+Mortal Combat;TOR;33389
+Mortal Obstinacy;JOU;152832
+Mortal Wound;VIS;2216
+Mortal's Ardor;BNG;152017
+Mortal's Resolve;BNG;152057
+Mortarpod;MBS;133121
+Mortarpod;MM2;133121
+Mortarpod;TD2;133121
+Mortician Beetle;DPA;128392
+Mortician Beetle;MM3;128392
+Mortician Beetle;ROE;128392
+Mortify;CMD;91757
+Mortify;DDK;147653
+Mortify;GPT;91757
+Mortify;PRM;100409
+Mortipede;RAV;88944
+Mortiphobia;TOR;36518
+Mortis Dogs;NPH;103544
+Mortivore;10E;33403
+Mortivore;9ED;33403
+Mortivore;CMD;33403
+Mortivore;DPA;33403
+Mortivore;ODY;33403
+Mortuary Mire;BFZ;160731
+Mortuary;STH;3726
+Mortus Strider;GTC;146424
+Mosquito Guard;DDF;109911
+Mosquito Guard;MOR;109911
+Moss Diamond;6ED;1973
+Moss Diamond;7ED;27712
+Moss Diamond;C14;156372
+Moss Diamond;MIR;1973
+Moss Kami;COK;80825
+Moss Monster;8ED;49251
+Moss Monster;LEG;618
+Mossbridge Troll;SHM;111606
+Mossdog;NMS;21185
+Mossfire Egg;ODY;33257
+Mossfire Valley;ODY;33231
+Mosstodon;ALA;115020
+Mosswort Bridge;C13;105425
+Mosswort Bridge;LRW;105425
+Mothdust Changeling;MMA;109894
+Mothdust Changeling;MOR;109894
+Mother of Runes;CMD;10354
+Mother of Runes;EMA;159775
+Mother of Runes;PRM;10354
+Mother of Runes;PRM;159775
+Mother of Runes;UL;10354
+Mothrider Samurai;COK;80639
+Mothrider Samurai;DPA;80639
+Mount Keralia;PC2;138710
+Mountain Bandit;PTK;9011
+Mountain Goat;5ED;1294
+Mountain Goat;6ED;1294
+Mountain Goat;ICE;1294
+Mountain Goat;POR;6707
+Mountain Stronghold;LEG;619
+Mountain Titan;ICE;1295
+Mountain Valley;MIR;1978
+Mountain Valley;VMA;1978
+Mountain Yeti;CH;620
+Mountain Yeti;LEG;620
+Mountain Yeti;MED;620
+Mountain;10E;25502
+Mountain;10E;80963
+Mountain;10E;8637
+Mountain;10E;89159
+Mountain;2ED;166
+Mountain;2ED;167
+Mountain;2ED;299
+Mountain;3ED;166
+Mountain;3ED;167
+Mountain;3ED;299
+Mountain;4ED;166
+Mountain;4ED;167
+Mountain;4ED;299
+Mountain;5ED;2432
+Mountain;5ED;2433
+Mountain;5ED;2434
+Mountain;5ED;2435
+Mountain;6ED;1975
+Mountain;6ED;1977
+Mountain;6ED;2434
+Mountain;6ED;6774
+Mountain;7ED;27713
+Mountain;7ED;27714
+Mountain;7ED;27715
+Mountain;7ED;27716
+Mountain;8ED;19716
+Mountain;8ED;1976
+Mountain;8ED;1977
+Mountain;8ED;2433
+Mountain;9ED;19716
+Mountain;9ED;1976
+Mountain;9ED;1977
+Mountain;9ED;2433
+Mountain;AKH;400896
+Mountain;AKH;400897
+Mountain;AKH;400898
+Mountain;AKH;402701
+Mountain;ALA;115080
+Mountain;ALA;115081
+Mountain;ALA;115082
+Mountain;ALA;115083
+Mountain;ARN;166
+Mountain;AVR;141753
+Mountain;AVR;141761
+Mountain;AVR;141763
+Mountain;BFZ;123764
+Mountain;BFZ;160747
+Mountain;BFZ;160748
+Mountain;BFZ;160749
+Mountain;BFZ;160750
+Mountain;C01;17596
+Mountain;C13;137571
+Mountain;C13;138790
+Mountain;C13;147504
+Mountain;C13;96760
+Mountain;C14;121704
+Mountain;C14;137571
+Mountain;C14;138790
+Mountain;C14;147504
+Mountain;CMD;105648
+Mountain;CMD;121704
+Mountain;CMD;80956
+Mountain;CMD;8637
+Mountain;COK;80950
+Mountain;COK;80956
+Mountain;COK;80961
+Mountain;COK;80963
+Mountain;DD2;27715
+Mountain;DD2;50318
+Mountain;DD2;89167
+Mountain;DD2;97547
+Mountain;DDE;25503
+Mountain;DDG;115080
+Mountain;DDG;115081
+Mountain;DDG;25169
+Mountain;DDG;25502
+Mountain;DDH;115082
+Mountain;DDH;115083
+Mountain;DDI;131160
+Mountain;DDI;131167
+Mountain;DDI;50318
+Mountain;DDI;50320
+Mountain;DDJ;89159
+Mountain;DDJ;89165
+Mountain;DDJ;89167
+Mountain;DDJ;89172
+Mountain;DDK;141753
+Mountain;DDK;141761
+Mountain;DDK;141763
+Mountain;DDL;111838
+Mountain;DDL;121704
+Mountain;DDL;137571
+Mountain;DDL;138790
+Mountain;DDL;141761
+Mountain;DDL;147504
+Mountain;DDL;27716
+Mountain;DDL;97561
+Mountain;DPA;25502
+Mountain;DPA;80963
+Mountain;DPA;8637
+Mountain;DPA;89159
+Mountain;DTK;159766
+Mountain;DTK;159767
+Mountain;DTK;159816
+Mountain;EVG;25170
+Mountain;EVG;27715
+Mountain;EVG;43246
+Mountain;EVG;43247
+Mountain;FK;2433
+Mountain;FRF;158896
+Mountain;FRF;158897
+Mountain;H09;3078
+Mountain;HOU;401925
+Mountain;HOU;402760
+Mountain;HOU;402765
+Mountain;ICE;1291
+Mountain;ICE;1292
+Mountain;ICE;1293
+Mountain;INV;25169
+Mountain;INV;25170
+Mountain;INV;25502
+Mountain;INV;25503
+Mountain;ISD;138468
+Mountain;ISD;138470
+Mountain;ISD;138776
+Mountain;KLD;162194
+Mountain;KLD;162354
+Mountain;KLD;162355
+Mountain;KTK;156624
+Mountain;KTK;156625
+Mountain;KTK;156626
+Mountain;KTK;156627
+Mountain;LEA;166
+Mountain;LEA;167
+Mountain;LEB;166
+Mountain;LEB;167
+Mountain;LEB;299
+Mountain;LRW;104086
+Mountain;LRW;105647
+Mountain;LRW;105648
+Mountain;LRW;105651
+Mountain;M10;121703
+Mountain;M10;121704
+Mountain;M10;27715
+Mountain;M10;43246
+Mountain;M11;106212
+Mountain;M11;121703
+Mountain;M11;121704
+Mountain;M11;19716
+Mountain;M12;121704
+Mountain;M12;137571
+Mountain;M12;137572
+Mountain;M12;43246
+Mountain;M13;121703
+Mountain;M13;121704
+Mountain;M13;137571
+Mountain;M13;137572
+Mountain;M14;121704
+Mountain;M14;137571
+Mountain;M14;138790
+Mountain;M14;147504
+Mountain;M15;121703
+Mountain;M15;121704
+Mountain;M15;137571
+Mountain;M15;153334
+Mountain;MBS;133218
+Mountain;MBS;133233
+Mountain;ME3;9150
+Mountain;ME3;9151
+Mountain;ME3;9152
+Mountain;MED;166
+Mountain;MED;167
+Mountain;MED;299
+Mountain;MIR;1974
+Mountain;MIR;1975
+Mountain;MIR;1976
+Mountain;MIR;1977
+Mountain;MMQ;19008
+Mountain;MMQ;19148
+Mountain;MMQ;19270
+Mountain;MMQ;19716
+Mountain;MRD;50318
+Mountain;MRD;50319
+Mountain;MRD;50320
+Mountain;MRD;50321
+Mountain;NPH;134338
+Mountain;NPH;134356
+Mountain;ODY;33209
+Mountain;ODY;33210
+Mountain;ODY;33212
+Mountain;ODY;33213
+Mountain;ONS;43217
+Mountain;ONS;43245
+Mountain;ONS;43246
+Mountain;ONS;43247
+Mountain;ORI;160360
+Mountain;ORI;160361
+Mountain;ORI;160362
+Mountain;ORI;160368
+Mountain;PC1;111830
+Mountain;PC1;111838
+Mountain;PC1;115080
+Mountain;PC1;115081
+Mountain;PC1;121703
+Mountain;PC1;50318
+Mountain;PC1;89159
+Mountain;PC1;89172
+Mountain;PC1;96760
+Mountain;PC2;115080
+Mountain;PC2;123764
+Mountain;PC2;8637
+Mountain;PC2;97561
+Mountain;PD2;115080
+Mountain;PD2;115081
+Mountain;PD2;50321
+Mountain;PD2;89172
+Mountain;PO2;4798
+Mountain;PO2;4799
+Mountain;PO2;4800
+Mountain;POR;6772
+Mountain;POR;6773
+Mountain;POR;6774
+Mountain;POR;6775
+Mountain;PRM;116171
+Mountain;PRM;125123
+Mountain;PRM;132688
+Mountain;PRM;156668
+Mountain;PRM;160800
+Mountain;PRM;17596
+Mountain;PRM;21432
+Mountain;PRM;21437
+Mountain;PRM;21443
+Mountain;PRM;21444
+Mountain;PRM;49943
+Mountain;PRM;75383
+Mountain;PRM;83831
+Mountain;PRM;8513
+Mountain;PRM;8514
+Mountain;PRM;8515
+Mountain;PRM;90387
+Mountain;PRM;97553
+Mountain;PTK;9150
+Mountain;PTK;9151
+Mountain;PTK;9152
+Mountain;RAV;89159
+Mountain;RAV;89165
+Mountain;RAV;89167
+Mountain;RAV;89172
+Mountain;ROE;127485
+Mountain;ROE;127488
+Mountain;ROE;127499
+Mountain;ROE;127509
+Mountain;RTR;145254
+Mountain;RTR;145255
+Mountain;RTR;145256
+Mountain;RTR;145257
+Mountain;RTR;89172
+Mountain;SHM;111824
+Mountain;SHM;111827
+Mountain;SHM;111830
+Mountain;SHM;111838
+Mountain;SOI;161508
+Mountain;SOI;161509
+Mountain;SOI;161510
+Mountain;SOM;131159
+Mountain;SOM;131160
+Mountain;SOM;131167
+Mountain;SOM;131173
+Mountain;TD0;121703
+Mountain;TD0;121704
+Mountain;TD0;19716
+Mountain;TD0;27715
+Mountain;TD0;9150
+Mountain;TD0;9151
+Mountain;TD0;9152
+Mountain;THS;149134
+Mountain;THS;149135
+Mountain;THS;149136
+Mountain;THS;149137
+Mountain;TMP;3073
+Mountain;TMP;3078
+Mountain;TMP;3083
+Mountain;TMP;3088
+Mountain;TPR;3073
+Mountain;TPR;3078
+Mountain;TPR;3083
+Mountain;TPR;3088
+Mountain;TSP;96760
+Mountain;TSP;97542
+Mountain;TSP;97547
+Mountain;TSP;97561
+Mountain;USG;8636
+Mountain;USG;8637
+Mountain;USG;8638
+Mountain;USG;8639
+Mountain;XLN;401906
+Mountain;XLN;401907
+Mountain;XLN;401908
+Mountain;XLN;402023
+Mountain;ZEN;123758
+Mountain;ZEN;123762
+Mountain;ZEN;123764
+Mountain;ZEN;123766
+Mounted Archers;TMP;3054
+Mounted Archers;TPR;3054
+Mourner's Shield;MRD;51174
+Mournful Zombie;APC;31177
+Mourning Thrull;GPT;91737
+Mourning;INV;24093
+Mournwhelk;LRW;106354
+Mournwillow;EMN;162138
+Mouth of Ronom;CSP;96970
+Mouth;AKH;401985
+Mox Diamond;STH;3727
+Mox Diamond;TPR;3727
+Mox Diamond;V10;129511
+Mox Emerald;2ED;168
+Mox Emerald;LEA;168
+Mox Emerald;LEB;168
+Mox Emerald;PRM;125855
+Mox Emerald;VMA;125855
+Mox Jet;2ED;169
+Mox Jet;LEA;169
+Mox Jet;LEB;169
+Mox Jet;PRM;104615
+Mox Jet;VMA;104615
+Mox Opal;MM2;131046
+Mox Opal;MS2;162590
+Mox Opal;SOM;131046
+Mox Pearl;2ED;170
+Mox Pearl;LEA;170
+Mox Pearl;LEB;170
+Mox Pearl;PRM;100811
+Mox Pearl;VMA;100811
+Mox Ruby;2ED;171
+Mox Ruby;LEA;171
+Mox Ruby;LEB;171
+Mox Ruby;PRM;80770
+Mox Ruby;VMA;80770
+Mox Sapphire;2ED;172
+Mox Sapphire;LEA;172
+Mox Sapphire;LEB;172
+Mox Sapphire;PRM;131709
+Mox Sapphire;VMA;131709
+Mtenda Griffin;MIR;1979
+Mtenda Herder;MIR;1980
+Mtenda Lion;MIR;1981
+Muck Drubb;PLC;100714
+Muck Rats;PO2;4707
+Muck Rats;POR;6587
+Mudbrawler Cohort;SHM;111624
+Mudbrawler Raiders;SHM;111555
+Mudbutton Clanger;MOR;109963
+Mudbutton Torchrunner;DDG;105488
+Mudbutton Torchrunner;DPA;105488
+Mudbutton Torchrunner;EVG;105488
+Mudbutton Torchrunner;LRW;105488
+Mudbutton Torchrunner;MM3;105488
+Mudbutton Torchrunner;PC2;105488
+Muddle the Mixture;RAV;88996
+Mudhole;ODY;33353
+Mudslide;ICE;1296
+Mudslide;ME2;1296
+Mugging;GTC;146252
+Mul Daya Channelers;ROE;127452
+Mulch;ISD;138401
+Mulch;STH;3728
+Mulch;TPR;3728
+Mulldrifter;C14;105350
+Mulldrifter;CMD;105350
+Mulldrifter;DD2;105350
+Mulldrifter;LRW;105350
+Mulldrifter;MM2;105350
+Mulldrifter;MMA;105350
+Mulldrifter;PRM;122188
+Mulldrifter;TD0;105350
+Multani, Maro-Sorcerer;DPA;9505
+Multani, Maro-Sorcerer;UL;9505
+Multani's Acolyte;UL;10339
+Multani's Decree;UD;15666
+Multani's Harmony;PLS;27975
+Multani's Presence;UL;10357
+Multiform Wonder;KLD;162347
+Mummy Paramount;HOU;401767
+Munda, Ambush Leader;BFZ;160809
+Munda's Vanguard;OGW;161205
+Munda's Vanguard;PRM;161073
+Mundungu;VIS;2217
+Mungha Wurm;PCY;22804
+Muraganda Petroglyphs;FUT;102395
+Murasa Pyromancer;ZEN;123789
+Murasa Ranger;BFZ;160703
+Murasa;PC1;125869
+Murder Investigation;GTC;146532
+Murder Investigation;ORI;146532
+Murder of Crows;DPA;138318
+Murder of Crows;ISD;138318
+Murder;DPA;143847
+Murder;EMN;162091
+Murder;M13;143847
+Murderer's Axe;SOI;161699
+Murderous Betrayal;8ED;21161
+Murderous Betrayal;NMS;21161
+Murderous Compulsion;SOI;161674
+Murderous Cut;KTK;156553
+Murderous Redcap;MMA;111746
+Murderous Redcap;PRM;122189
+Murderous Redcap;SHM;111746
+Murderous Spoils;DST;51886
+Murk Dwellers;4ED;805
+Murk Dwellers;5ED;805
+Murk Dwellers;DRK;805
+Murk Strider;BFZ;160812
+Murkfiend Liege;C13;113715
+Murkfiend Liege;EVE;113715
+Murmuring Bosk;MOR;110023
+Murmuring Bosk;V12;110023
+Murmuring Phantasm;DGM;146737
+Murmurs from Beyond;CMD;86138
+Murmurs from Beyond;SOK;86138
+Muscle Burst;ODY;33314
+Muscle Sliver;H09;2990
+Muscle Sliver;PRM;2990
+Muscle Sliver;TMP;2990
+Muscle Sliver;TPR;2990
+Muse Vessel;DIS;94608
+Musician;ICE;1297
+Musician;ME2;1297
+Mutagenic Growth;MM2;134409
+Mutagenic Growth;NPH;134409
+Mutant's Prey;DGM;147770
+Mutavault;M14;109941
+Mutavault;MOR;109941
+Mutavault;PRM;109941
+Mutilate;C14;143946
+Mutilate;DDD;125853
+Mutilate;DPA;143946
+Mutilate;M13;143946
+Mutilate;TOR;36731
+Mutual Epiphany;PC2;138713
+Muzzio, Visionary Architect;VMA;153177
+Muzzle;MMQ;19025
+Mwonvuli Acid-Moss;TSP;97514
+Mwonvuli Beast Tracker;M13;143973
+Mwonvuli Beast Tracker;PRM;143974
+Mwonvuli Ooze;WTH;2876
+Mycoid Shepherd;ARB;120965
+Mycoid Shepherd;PRM;125906
+Mycologist;PLC;100717
+Mycoloth;ALA;117004
+Mycoloth;PC2;117004
+Mycosynth Fiend;NPH;134257
+Mycosynth Golem;5DN;77147
+Mycosynth Lattice;DST;75205
+Mycosynth Wellspring;C14;134292
+Mycosynth Wellspring;NPH;134292
+Myojin of Cleansing Fire;COK;80894
+Myojin of Infinite Rage;COK;80939
+Myojin of Life's Web;COK;80929
+Myojin of Night's Reach;COK;80998
+Myojin of Seeing Winds;COK;80889
+Myr Adapter;MRD;50213
+Myr Battlesphere;C13;131110
+Myr Battlesphere;C14;131110
+Myr Battlesphere;SOM;131110
+Myr Enforcer;MM2;51176
+Myr Enforcer;MMA;51176
+Myr Enforcer;MRD;50224
+Myr Enforcer;PC1;50224
+Myr Enforcer;PRM;51176
+Myr Galvanizer;SOM;132184
+Myr Incubator;MRD;51044
+Myr Landshaper;DST;50235
+Myr Matrix;DST;52026
+Myr Mindservant;MRD;51101
+Myr Moonvessel;DST;51993
+Myr Propagator;SOM;131178
+Myr Prototype;MRD;50347
+Myr Quadropod;5DN;77105
+Myr Reservoir;SOM;131223
+Myr Retriever;C14;50258
+Myr Retriever;MMA;50258
+Myr Retriever;MRD;50258
+Myr Retriever;TD2;50258
+Myr Servitor;5DN;77106
+Myr Sire;C14;133128
+Myr Sire;MBS;133128
+Myr Sire;TD2;133128
+Myr Superion;NPH;134194
+Myr Superion;PRM;136790
+Myr Turbine;MBS;133146
+Myr Welder;MBS;133234
+Myr;TOK;131405
+Myr;TOK;134378
+Myr;TOK;51116
+Myriad Landscape;C14;156020
+Myrsmith;MM2;131108
+Myrsmith;SOM;131108
+Mysteries of the Deep;WWK;126565
+Mystic Barrier;C13;151717
+Mystic Compass;6ED;1687
+Mystic Compass;ALL;1687
+Mystic Confluence;PZ1;160020
+Mystic Crusader;ODY;33529
+Mystic Decree;HML;1538
+Mystic Decree;ME4;1538
+Mystic Denial;PO2;4699
+Mystic Denial;POR;6624
+Mystic Denial;PTK;9007
+Mystic Enforcer;ODY;33261
+Mystic Enforcer;TSB;33261
+Mystic Familiar;TOR;36373
+Mystic Gate;EXP;161048
+Mystic Gate;SHM;111650
+Mystic Genesis;GTC;146430
+Mystic Genesis;MM3;146430
+Mystic Meditation;DTK;159805
+Mystic Melting;CSP;96877
+Mystic Might;ICE;1298
+Mystic Monastery;KTK;156584
+Mystic Penitent;ODY;33188
+Mystic Remora;ICE;1299
+Mystic Remora;MED;1299
+Mystic Restraints;COK;81074
+Mystic Retrieval;DKA;139835
+Mystic Snake;APC;31117
+Mystic Snake;MM2;31117
+Mystic Snake;TSB;31117
+Mystic Speculation;FUT;102345
+Mystic Veil;VIS;2218
+Mystic Visionary;ODY;33202
+Mystic Zealot;ODY;33189
+Mystic Zealot;VMA;33189
+Mystic of the Hidden Way;KTK;156488
+Mystic of the Hidden Way;PRM;159773
+Mystical Teachings;MM3;97389
+Mystical Teachings;TSP;97389
+Mystical Tutor;6ED;1982
+Mystical Tutor;EMA;161304
+Mystical Tutor;MIR;1982
+Mystical Tutor;V09;1982
+Mystifying Maze;M11;129073
+Myth Realized;DTK;160024
+Mythic Proportions;DPA;43197
+Mythic Proportions;ONS;43197
+Márton Stromgald;ICE;1275
+Márton Stromgald;MED;1275
+Naar Isle;PC1;125865
+Nacatl Hunt-Pride;CON;119789
+Nacatl Hunt-Pride;DDH;119789
+Nacatl Outlander;CON;118770
+Nacatl Savage;CON;118745
+Nacatl War-Pride;FUT;102392
+Nacre Talisman;ICE;1300
+Nafs Asp;4ED;358
+Nafs Asp;ARN;358
+Naga Oracle;AKH;400818
+Naga Vitalist;AKH;401269
+Nagao, Bound by Honor;COK;80767
+Nagao, Bound by Honor;DPA;80767
+Nagging Thoughts;SOI;161452
+Nahiri, the Harbinger;SOI;161437
+Nahiri, the Lithomancer;C14;156010
+Nahiri, the Lithomancer;PZ1;156010
+Nahiri's Machinations;SOI;161704
+Nahiri's Wrath;EMN;161983
+Nakaya Shade;PCY;22002
+Naked Singularity;ICE;1301
+Naked Singularity;ME4;1301
+Nalathni Dragon;PRM;481
+Nameless Inversion;LRW;105635
+Nameless Inversion;MM2;105635
+Nameless Inversion;PRM;120092
+Nameless One;ONS;42996
+Nameless Race;DRK;806
+Nantuko Blightcutter;TOR;36521
+Nantuko Calmer;TOR;36506
+Nantuko Cultivator;TOR;36526
+Nantuko Disciple;8ED;33307
+Nantuko Disciple;ODY;33307
+Nantuko Elder;ODY;33309
+Nantuko Husk;10E;43037
+Nantuko Husk;9ED;43037
+Nantuko Husk;CMD;43037
+Nantuko Husk;ONS;43037
+Nantuko Husk;ORI;43037
+Nantuko Mentor;ODY;33292
+Nantuko Monastery;JUD;40298
+Nantuko Shade;C14;36461
+Nantuko Shade;DPA;36461
+Nantuko Shade;M11;36461
+Nantuko Shade;TOR;36461
+Nantuko Shaman;MMA;97353
+Nantuko Shaman;TSP;97353
+Nantuko Shrine;ODY;33278
+Nantuko Tracer;JUD;40268
+Nantuko Vigilante;LGN;46577
+Narcissism;TOR;36462
+Narcolepsy;DPA;127371
+Narcolepsy;MM2;127371
+Narcolepsy;ROE;127371
+Narcomoeba;FUT;102463
+Narcomoeba;MMA;102463
+Narnam Cobra;KLD;162575
+Narnam Renegade;AER;400341
+Narrow Escape;DDE;123595
+Narrow Escape;ZEN;123595
+Narset Transcendent;DTK;159799
+Narset, Enlightened Master;KTK;156636
+Narstad Scrapper;AVR;142202
+Narwhal;HML;1539
+Narwhal;ME2;1539
+Nath of the Gilt-Leaf;DPA;105618
+Nath of the Gilt-Leaf;LRW;105618
+Nath's Buffoon;LRW;105362
+Nath's Elite;LRW;106397
+Natural Affinity;8ED;19297
+Natural Affinity;9ED;19297
+Natural Affinity;MMQ;19297
+Natural Balance;MIR;1983
+Natural Connection;BFZ;160706
+Natural Emergence;PLS;27903
+Natural End;AVR;141621
+Natural Obsolescence;AER;400338
+Natural Order;DPA;2219
+Natural Order;EMA;2219
+Natural Order;POR;6663
+Natural Order;PRM;2219
+Natural Order;VIS;2219
+Natural Selection;2ED;173
+Natural Selection;LEA;173
+Natural Selection;LEB;173
+Natural Spring;10E;4773
+Natural Spring;9ED;6664
+Natural Spring;DPA;4773
+Natural Spring;PO2;4773
+Natural Spring;POR;6664
+Natural Spring;TMP;3003
+Natural State;OGW;161249
+Naturalize;10E;49669
+Naturalize;8ED;49669
+Naturalize;9ED;86917
+Naturalize;ALA;114994
+Naturalize;DPA;49669
+Naturalize;DTK;159759
+Naturalize;GTC;146536
+Naturalize;ISD;138404
+Naturalize;KTK;157053
+Naturalize;M10;49669
+Naturalize;M11;49669
+Naturalize;M12;49669
+Naturalize;M13;138404
+Naturalize;M14;49669
+Naturalize;M15;49669
+Naturalize;ONS;43166
+Naturalize;ROE;127264
+Nature's Blessing;ALL;1688
+Nature's Blessing;ME2;1688
+Nature's Chosen;ALL;1689
+Nature's Claim;EMA;153370
+Nature's Claim;WWK;126551
+Nature's Cloak;POR;6665
+Nature's Kiss;WTH;2931
+Nature's Lore;5ED;2436
+Nature's Lore;DDD;6666
+Nature's Lore;DPA;6666
+Nature's Lore;ICE;1302
+Nature's Lore;MED;1302
+Nature's Lore;PO2;4772
+Nature's Lore;POR;6666
+Nature's Lore;VMA;6666
+Nature's Panoply;JOU;153062
+Nature's Resurgence;6ED;2877
+Nature's Resurgence;7ED;27718
+Nature's Resurgence;WTH;2877
+Nature's Revolt;7ED;27719
+Nature's Revolt;TMP;3139
+Nature's Ruin;POR;6588
+Nature's Ruin;VMA;6588
+Nature's Spiral;DPA;121584
+Nature's Spiral;M10;121584
+Nature's Spiral;M11;121584
+Nature's Way;KLD;162307
+Nature's Will;COK;81044
+Nature's Wrath;ALL;1690
+Nature's Wrath;ME2;1690
+Nausea;7ED;27720
+Nausea;8ED;27720
+Nausea;EMA;161556
+Nausea;EXO;5606
+Nav Squad Commandos;GTC;146349
+Navigator's Ruin;XLN;402044
+Naya Battlemage;ALA;115027
+Naya Charm;ALA;114909
+Naya Charm;C13;114909
+Naya Charm;DDH;114909
+Naya Hushblade;ARB;121056
+Naya Panorama;ALA;116189
+Naya Panorama;C13;116189
+Naya Sojourners;ARB;121057
+Naya Sojourners;PRM;121330
+Naya Soulbeast;C13;151712
+Naya;PC1;125898
+Near-Death Experience;ROE;127284
+Near-Death Experience;V16;127284
+Nearheath Chaplain;SOI;161404
+Nearheath Pilgrim;AVR;141673
+Nearheath Stalker;DKA;140327
+Nearheath Stalker;PRM;139838
+Nebelgast Herald;EMN;161935
+Nebuchadnezzar;CH;621
+Nebuchadnezzar;LEG;621
+Nebuchadnezzar;ME3;621
+Neck Breaker;SOI;161439
+Neck Snap;LRW;105453
+Necra Disciple;APC;19183
+Necra Sanctuary;APC;31171
+Necratog;WTH;2914
+Necravolver;APC;31170
+Necrite;5ED;972
+Necrite;FEM;971
+Necrite;FEM;972
+Necrite;FEM;973
+Necrite;ME2;972
+Necrobite;AVR;141727
+Necrobite;BNG;152036
+Necrobite;M15;141727
+Necrogen Censer;SOM;130929
+Necrogen Mists;MRD;50333
+Necrogen Scudder;M15;130989
+Necrogen Scudder;SOM;130989
+Necrogen Spellbomb;MRD;50234
+Necrogenesis;ALA;115084
+Necrogenesis;CMD;115084
+Necrogenesis;MM2;115084
+Necrologia;7ED;27721
+Necrologia;EXO;5587
+Necrologia;TPR;5587
+Necromancer's Assistant;M15;155364
+Necromancer's Covenant;ARB;121035
+Necromancer's Magemark;GPT;91875
+Necromancer's Stockpile;M15;155304
+Necromancy;VIS;2220
+Necromantic Selection;C14;155608
+Necromantic Summons;ORI;160272
+Necromantic Thirst;RAV;88973
+Necromaster Dragon;DTK;160114
+Necromaster Dragon;PRM;159731
+Necropede;SOM;130871
+Necroplasm;RAV;90339
+Necropolis Fiend;KTK;157032
+Necropolis Fiend;PRM;159368
+Necropolis Regent;DPA;145977
+Necropolis Regent;RTR;145977
+Necropolis;DRK;807
+Necropotence;5ED;1303
+Necropotence;EMA;122583
+Necropotence;ICE;1303
+Necropotence;ME2;1303
+Necropotence;V09;122583
+Necropotence;VMA;122583
+Necropouncer;NPH;134219
+Necrosavant;6ED;2221
+Necrosavant;VIS;2221
+Necroskitter;EVE;113653
+Necroskitter;MM2;113653
+Necroskitter;TD2;113653
+Necrotic Ooze;SOM;131041
+Necrotic Plague;M11;129168
+Necrotic Sliver;H09;97470
+Necrotic Sliver;PLC;97470
+Nectar Faerie;LRW;105367
+Need for Speed;ODY;33528
+Needle Drop;LRW;106394
+Needle Specter;EVE;113694
+Needle Spires;OGW;160762
+Needle Storm;9ED;3241
+Needle Storm;POR;6667
+Needle Storm;TMP;3241
+Needle Storm;TPR;3241
+Needlebite Trap;ZEN;125073
+Needlebug;MRD;51102
+Needlepeak Spider;PLC;100656
+Needleshot Gourna;LGN;47462
+Nef-Crop Entangler;AKH;400788
+Nefarious Lich;ODY;33397
+Nefarox, Overlord of Grixis;DPA;143876
+Nefarox, Overlord of Grixis;M13;143876
+Nefashu;PC1;48105
+Nefashu;SCG;48105
+Negate;AER;400262
+Negate;DPA;109907
+Negate;DTK;159716
+Negate;M10;109907
+Negate;M11;109907
+Negate;M12;109907
+Negate;M13;109907
+Negate;M14;109907
+Negate;M15;109907
+Negate;MOR;109907
+Negate;OGW;161218
+Negate;ORI;109907
+Negate;PRM;124485
+Neglected Heirloom;SOI;161402
+Neheb, the Eternal;HOU;401816
+Neheb, the Worthy;AKH;401256
+Neko-Te;BOK;83913
+Nekrataal;10E;102954
+Nekrataal;8ED;2222
+Nekrataal;9ED;2222
+Nekrataal;C14;102954
+Nekrataal;DDM;102954
+Nekrataal;DPA;102954
+Nekrataal;EMA;102954
+Nekrataal;VIS;2222
+Nekusar, the Mindrazer;C13;151770
+Nekusar, the Mindrazer;PRM;151770
+Nema Siltlurker;ROE;127394
+Nemata, Grove Guardian;DPA;27952
+Nemata, Grove Guardian;PLS;27952
+Nemesis Mask;DST;75178
+Nemesis Trap;CMD;126478
+Nemesis Trap;WWK;126478
+Nemesis of Mortals;THS;150797
+Nemesis of Reason;ARB;121050
+Nephalia Academy;EMN;162152
+Nephalia Drownyard;ISD;138349
+Nephalia Moondrakes;PRM;161541
+Nephalia Moondrakes;SOI;161761
+Nephalia Seakite;DKA;139797
+Nephalia Seakite;M14;139797
+Nephalia Smuggler;AVR;141700
+Nephalia;PC2;138730
+Nessian Asp;THS;149190
+Nessian Courser;FUT;102462
+Nessian Courser;THS;149961
+Nessian Demolok;BNG;152080
+Nessian Game Warden;JOU;153022
+Nessian Wilds Ravager;BNG;148528
+Nessian Wilds Ravager;PRM;152600
+Nest Invader;MM2;127252
+Nest Invader;PC2;127252
+Nest Invader;PZ1;127252
+Nest Invader;ROE;127252
+Nest Robber;XLN;402850
+Nest of Scarabs;AKH;401316
+Nested Ghoul;DPA;133198
+Nested Ghoul;MBS;133198
+Nesting Wurm;NMS;21257
+Netcaster Spider;M15;156680
+Netcaster Spider;OGW;161111
+Nether Horror;M11;129087
+Nether Shadow;2ED;174
+Nether Shadow;3ED;174
+Nether Shadow;4ED;174
+Nether Shadow;5ED;2437
+Nether Shadow;LEA;174
+Nether Shadow;LEB;174
+Nether Shadow;MED;174
+Nether Spirit;MMQ;19234
+Nether Traitor;TSP;97490
+Nether Void;LEG;2542
+Nether Void;ME3;2542
+Nether Void;PRM;149232
+Netherborn Phalanx;RAV;89013
+Netter en-Dal;NMS;21222
+Nettle Drone;BFZ;160907
+Nettle Sentinel;EVE;113617
+Nettle Swine;AVR;141523
+Nettletooth Djinn;MIR;1984
+Nettlevine Blight;LRW;105665
+Nettling Curse;DIS;94439
+Nettling Imp;2ED;175
+Nettling Imp;3ED;175
+Nettling Imp;LEA;175
+Nettling Imp;LEB;175
+Neurok Commando;MBS;131679
+Neurok Familiar;MRD;50243
+Neurok Hoversail;MRD;50227
+Neurok Invisimancer;DDI;130892
+Neurok Invisimancer;SOM;130892
+Neurok Prodigy;DST;51969
+Neurok Replica;SOM;131079
+Neurok Spy;MRD;50197
+Neurok Stealthsuit;5DN;77165
+Neurok Stealthsuit;TD2;77165
+Neurok Transmuter;DST;52051
+Neutralizing Blast;FRF;159676
+Never;AKH;400782
+Neverending Torment;SOK;86150
+Nevermaker;MOR;109972
+Nevermore;ISD;138248
+Nevinyrral's Disk;2ED;176
+Nevinyrral's Disk;3ED;176
+Nevinyrral's Disk;4ED;176
+Nevinyrral's Disk;5ED;176
+Nevinyrral's Disk;C13;129513
+Nevinyrral's Disk;C14;129513
+Nevinyrral's Disk;EMA;129513
+Nevinyrral's Disk;LEA;176
+Nevinyrral's Disk;LEB;176
+Nevinyrral's Disk;MED;176
+Nevinyrral's Disk;V10;129513
+Nevinyrral's Disk;VMA;129513
+New Benalia;C13;102359
+New Benalia;DDI;102359
+New Benalia;DDL;102359
+New Benalia;FUT;102359
+New Frontiers;DPA;33276
+New Frontiers;ODY;33276
+New Horizons;XLN;402011
+New Perspectives;AKH;401299
+New Prahv Guildmage;RTR;146094
+Nezumi Bone-Reader;COK;81572
+Nezumi Cutthroat;COK;80715
+Nezumi Graverobber;CMD;80891
+Nezumi Graverobber;COK;80891
+Nezumi Graverobber;TD0;80891
+Nezumi Ronin;COK;82595
+Nezumi Shadow-Watcher;BOK;83870
+Nezumi Shortfang;COK;80892
+Niall Silvain;DRK;808
+Niblis of Dusk;SOI;161772
+Niblis of Frost;EMN;162058
+Niblis of Frost;PRM;161936
+Niblis of the Breath;DKA;139726
+Niblis of the Mist;DKA;139784
+Niblis of the Urn;DKA;139771
+Nicol Bolas, God-Pharaoh;HOU;401538
+Nicol Bolas, Planeswalker;CON;118790
+Nicol Bolas, Planeswalker;DDH;138685
+Nicol Bolas, Planeswalker;M13;118790
+Nicol Bolas, Planeswalker;PRM;401719
+Nicol Bolas, the Deceiver;HOU;401676
+Nicol Bolas;CH;622
+Nicol Bolas;DPA;115929
+Nicol Bolas;DRB;115929
+Nicol Bolas;LEG;622
+Nicol Bolas;ME3;622
+Nicol Bolas;TSB;622
+Night Dealings;COK;81568
+Night Market Aeronaut;AER;400284
+Night Market Guard;AER;400372
+Night Market Lookout;KLD;162508
+Night Revelers;ISD;138249
+Night Soil;C13;143396
+Night Soil;FEM;974
+Night Soil;FEM;975
+Night Soil;FEM;976
+Night Soil;ME2;974
+Night Terrors;ISD;138489
+Night Terrors;MM3;138489
+Night of Souls' Betrayal;COK;80944
+Night;APC;31119
+Night's Whisper;5DN;77162
+Night's Whisper;DDM;153259
+Night's Whisper;EMA;153259
+Nightbird's Clutches;ISD;138134
+Nightcreep;DIS;94476
+Nightfall Predator;ISD;138197
+Nightfire Giant;M15;155308
+Nightguard Patrol;DPA;88964
+Nightguard Patrol;RAV;88964
+Nighthaze;DPA;127299
+Nighthaze;ROE;127299
+Nighthowler;PRM;151407
+Nighthowler;THS;150837
+Nightmare Incursion;DPA;113736
+Nightmare Incursion;EVE;113736
+Nightmare Lash;MRD;51507
+Nightmare Void;DDJ;89006
+Nightmare Void;RAV;89006
+Nightmare;10E;27722
+Nightmare;2ED;177
+Nightmare;3ED;177
+Nightmare;4ED;177
+Nightmare;5ED;177
+Nightmare;6ED;177
+Nightmare;7ED;27722
+Nightmare;8ED;27722
+Nightmare;9ED;27722
+Nightmare;DPA;27722
+Nightmare;LEA;177
+Nightmare;LEB;177
+Nightmare;M10;27722
+Nightmare;M14;148276
+Nightmare;M15;148276
+Nightmare;ORI;148276
+Nightmare;W16;148276
+Nightmare;W17;148276
+Nightmarish End;JOU;153024
+Nightscape Apprentice;INV;25171
+Nightscape Battlemage;PLS;28013
+Nightscape Familiar;C13;27953
+Nightscape Familiar;DDH;27953
+Nightscape Familiar;PLS;27953
+Nightscape Familiar;VMA;27953
+Nightscape Master;INV;25172
+Nightshade Assassin;TSP;97398
+Nightshade Peddler;AVR;141590
+Nightshade Schemers;MOR;109987
+Nightshade Seer;UD;15631
+Nightshade Stinger;LRW;105372
+Nightsky Mimic;EVE;113621
+Nightsnare;ORI;160269
+Nightsoil Kami;SOK;86185
+Nightstalker Engine;PO2;4731
+Nightveil Specter;GTC;146456
+Nightveil Specter;PRM;147342
+Nightwind Glider;MMQ;19094
+Nightwing Shade;DPA;129167
+Nightwing Shade;M11;129167
+Nightwing Shade;M14;129167
+Nihil Spellbomb;C13;131117
+Nihil Spellbomb;SOM;131117
+Nihilistic Glee;DIS;94572
+Nihilith;FUT;102494
+Nikko-Onna;SOK;86125
+Nim Abomination;DST;50830
+Nim Deathmantle;SOM;131098
+Nim Devourer;MRD;51013
+Nim Grotesque;5DN;77221
+Nim Lasher;MRD;50902
+Nim Replica;MRD;50229
+Nim Shambler;MRD;51053
+Nim Shrieker;MRD;51080
+Nimana Sell-Sword;ZEN;125065
+Nimble Innovator;KLD;162257
+Nimble Mongoose;EMA;161044
+Nimble Mongoose;ODY;33326
+Nimble Obstructionist;HOU;401793
+Nimble-Blade Khenra;AKH;400783
+Nimbus Maze;FUT;102451
+Nimbus Naiad;THS;149047
+Nimbus Swimmer;GTC;146426
+Nimbus Wings;DPA;123589
+Nimbus Wings;ZEN;123589
+Nimbus of the Isles;M15;155344
+Nin, the Pain Artist;CMD;137536
+Nine-Ringed Bo;COK;80656
+Ninja of the Deep Hours;BOK;83919
+Ninja of the Deep Hours;PC2;83919
+Ninth Bridge Patrol;KLD;162231
+Nip Gwyllion;EVE;113604
+Nirkana Assassin;BFZ;161020
+Nirkana Cutthroat;ROE;127433
+Nirkana Revenant;ROE;127288
+Nissa Revane;ZEN;118791
+Nissa, Genesis Mage;HOU;401677
+Nissa, Nature's Artisan;KLD;162311
+Nissa, Sage Animist;ORI;160309
+Nissa, Steward of Elements;AKH;400789
+Nissa, Vastwood Seer;ORI;160314
+Nissa, Vital Force;KLD;162195
+Nissa, Voice of Zendikar;OGW;161076
+Nissa, Voice of Zendikar;PRM;162402
+Nissa, Worldwaker;M15;155269
+Nissa, Worldwaker;PRM;401717
+Nissa's Chosen;DPA;123629
+Nissa's Chosen;PRM;125913
+Nissa's Chosen;ZEN;123629
+Nissa's Defeat;HOU;401597
+Nissa's Encouragement;HOU;401721
+Nissa's Expedition;M15;155290
+Nissa's Judgment;OGW;161247
+Nissa's Pilgrimage;ORI;160325
+Nissa's Pilgrimage;PRM;161282
+Nissa's Renewal;BFZ;160713
+Nissa's Revelation;ORI;159687
+Niv-Mizzet, Dracogenius;MM3;145268
+Niv-Mizzet, Dracogenius;RTR;145268
+Niv-Mizzet, the Firemind;DDJ;145072
+Niv-Mizzet, the Firemind;DPA;91777
+Niv-Mizzet, the Firemind;DRB;91777
+Niv-Mizzet, the Firemind;GPT;91777
+Niv-Mizzet, the Firemind;MM2;91777
+Niv-Mizzet, the Firemind;PRM;91777
+Niveous Wisps;SHM;111854
+Nivix Barrier;ORI;160228
+Nivix Cyclops;DGM;146879
+Nivix Guildmage;C13;146221
+Nivix Guildmage;RTR;146221
+Nivix, Aerie of the Firemind;DDJ;91763
+Nivix, Aerie of the Firemind;GPT;91763
+Nivmagus Elemental;RTR;145960
+Nix;FUT;104382
+No Mercy;DPA;10408
+No Mercy;MS3;401628
+No Mercy;UL;10408
+No Quarter;TMP;3158
+No Rest for the Wicked;10E;8685
+No Rest for the Wicked;USG;8685
+No-Dachi;COK;80821
+No-Dachi;DPA;80821
+Nobilis of War;DDL;113704
+Nobilis of War;EVE;113704
+Nobilis of War;MM2;113704
+Noble Benefactor;WTH;2944
+Noble Elephant;MIR;1985
+Noble Hierarch;CON;118694
+Noble Hierarch;MM2;118694
+Noble Hierarch;PRM;118694
+Noble Panther;INV;24015
+Noble Purpose;8ED;19302
+Noble Purpose;MMQ;19302
+Noble Quarry;BNG;152077
+Noble Stand;NMS;21170
+Noble Steeds;ALL;1691
+Noble Steeds;ALL;1692
+Noble Templar;SCG;48152
+Noble Templar;TD0;48152
+Noble Templar;VMA;48152
+Noble Vestige;ZEN;123545
+Nocturnal Raid;7ED;27723
+Nocturnal Raid;MIR;1986
+Noetic Scales;USG;8876
+Noggin Whack;MOR;109957
+Noggle Bandit;EVE;113720
+Noggle Bridgebreaker;EVE;113761
+Noggle Hedge-Mage;EVE;113766
+Noggle Ransacker;EVE;113647
+Noggle Ransacker;PC2;113647
+Nomad Decoy;ODY;33532
+Nomad Mythmaker;10E;104551
+Nomad Mythmaker;DPA;104551
+Nomad Mythmaker;JUD;40189
+Nomad Outpost;KTK;156586
+Nomad Stadium;ODY;33239
+Nomadic Elf;DDE;25476
+Nomadic Elf;INV;25476
+Nomads en-Kor;STH;3811
+Nomads en-Kor;TPR;3811
+Nomads' Assembly;C14;127465
+Nomads' Assembly;ROE;127465
+Noose Constrictor;EMN;162135
+Noose Constrictor;PRM;400721
+Noosegraf Mob;EMN;162079
+Noosegraf Mob;PRM;161966
+Norin the Wary;TSP;97407
+Norn's Annex;NPH;134389
+Norn's Dominion;PC2;138727
+Norritt;ICE;1304
+North Star;LEG;2543
+Northern Paladin;2ED;178
+Northern Paladin;3ED;178
+Northern Paladin;4ED;178
+Northern Paladin;7ED;27724
+Northern Paladin;LEA;178
+Northern Paladin;LEB;178
+Norwood Archers;PO2;4767
+Norwood Priestess;PO2;4783
+Norwood Priestess;VMA;4783
+Norwood Ranger;8ED;4785
+Norwood Ranger;9ED;4785
+Norwood Ranger;DPA;4785
+Norwood Ranger;PO2;4785
+Norwood Riders;PO2;4765
+Norwood Warrior;PO2;4769
+Nostalgic Dreams;TOR;36525
+Nostalgic Dreams;VMA;36525
+Nosy Goblin;ONS;44664
+Not Forgotten;SOI;161399
+Not of This World;ROE;127469
+Notion Thief;DGM;146854
+Notorious Assassin;MMQ;19139
+Notorious Throng;MOR;109909
+Nourish;DST;51942
+Nourishing Shoal;BOK;83835
+Nova Chaser;LRW;105381
+Nova Cleric;ONS;42940
+Nova Pentacle;LEG;623
+Nova Pentacle;ME3;623
+Novablast Wurm;DPA;126473
+Novablast Wurm;WWK;126473
+Novijen Sages;DIS;94294
+Novijen Sages;MM2;94294
+Novijen, Heart of Progress;DIS;94302
+Noxious Dragon;FRF;157281
+Noxious Field;PCY;21998
+Noxious Gearhulk;KLD;162513
+Noxious Gearhulk;MS2;400602
+Noxious Ghoul;LGN;47493
+Noxious Ghoul;PC1;47493
+Noxious Hatchling;EVE;113690
+Noxious Revival;NPH;134359
+Noxious Toad;POR;6589
+Noxious Vapors;PLS;28002
+Noyan Dar, Roil Shaper;BFZ;160924
+Nucklavee;CMD;113669
+Nucklavee;EVE;113669
+Nuisance Engine;MRD;51144
+Nuisance Engine;PC1;51144
+Null Brooch;EXO;3710
+Null Caller;OGW;161155
+Null Chamber;MIR;1987
+Null Champion;ROE;127403
+Null Profusion;PLC;100761
+Null Rod;VMA;2856
+Null Rod;WTH;2856
+Nullify;BNG;152026
+Nullmage Advocate;JUD;40266
+Nullmage Advocate;PC2;40266
+Nullmage Shepherd;RAV;88861
+Nullstone Gargoyle;RAV;88716
+Nulltread Gargantuan;ARB;120980
+Numai Outcast;COK;80720
+Numbing Dose;NPH;134293
+Numot, the Devastator;CMD;100727
+Numot, the Devastator;PLC;100727
+Nurturer Initiate;SHM;111579
+Nurturing Licid;TMP;3235
+Nut Collector;ODY;33306
+Nykthos, Shrine to Nyx;THS;149121
+Nylea, God of the Hunt;THS;149148
+Nylea's Disciple;THS;149070
+Nylea's Emissary;THS;150809
+Nylea's Presence;THS;149074
+Nyx Infusion;JOU;152862
+Nyx Weaver;JOU;152896
+Nyx-Fleece Ram;JOU;152886
+Nyxathid;CON;118789
+Nyxborn Eidolon;BNG;152029
+Nyxborn Rollicker;BNG;153376
+Nyxborn Shieldmate;BNG;152011
+Nyxborn Triton;BNG;152020
+Nyxborn Wolf;BNG;152053
+O-Naginata;SOK;86049
+Oak Street Innkeeper;RTR;145911
+Oaken Brawler;LRW;106395
+Oakenform;DPA;121588
+Oakenform;M10;121588
+Oakenform;W16;121588
+Oakenform;W17;121588
+Oakgnarl Warrior;DPA;105406
+Oakgnarl Warrior;LRW;105406
+Oakheart Dryads;JOU;153004
+Oashra Cultivator;AKH;401977
+Oasis Ritualist;HOU;401817
+Oasis;4ED;359
+Oasis;ARN;359
+Oasis;ME4;359
+Oath of Ajani;AER;400366
+Oath of Chandra;OGW;161019
+Oath of Druids;EXO;5420
+Oath of Druids;PRM;5420
+Oath of Druids;TPR;5420
+Oath of Druids;VMA;5420
+Oath of Ghouls;EXO;5658
+Oath of Gideon;OGW;161016
+Oath of Jace;OGW;161128
+Oath of Lieges;EXO;5654
+Oath of Liliana;EMN;161967
+Oath of Lim-Dûl;ICE;1305
+Oath of Mages;EXO;5613
+Oath of Nissa;OGW;161118
+Oath of Scholars;EXO;5647
+Oath of the Ancient Wood;M14;149968
+Oathkeeper, Takeno's Daisho;COK;80702
+Oathkeeper, Takeno's Daisho;DPA;80702
+Oathsworn Giant;RAV;89053
+Ob Nixilis Reignited;BFZ;160668
+Ob Nixilis Reignited;PRM;162401
+Ob Nixilis of the Black Oath;C14;156038
+Ob Nixilis of the Black Oath;PZ1;156038
+Ob Nixilis, Unshackled;M15;155260
+Ob Nixilis, the Fallen;DPA;123723
+Ob Nixilis, the Fallen;ZEN;123723
+Obelisk Spider;HOU;401530
+Obelisk of Alara;CON;118743
+Obelisk of Alara;PRM;120600
+Obelisk of Bant;ALA;115135
+Obelisk of Esper;ALA;115004
+Obelisk of Esper;C13;115004
+Obelisk of Grixis;ALA;114991
+Obelisk of Grixis;C13;114991
+Obelisk of Grixis;DDH;114991
+Obelisk of Jund;ALA;114996
+Obelisk of Jund;C13;114996
+Obelisk of Naya;ALA;115112
+Obelisk of Undoing;5ED;429
+Obelisk of Undoing;ATQ;429
+Obelisk of Undoing;CH;429
+Obelisk of Undoing;ME4;429
+Obelisk of Urd;M15;155341
+Oblation;C14;42964
+Oblation;CMD;42964
+Oblation;ONS;42964
+Obliterate;8ED;24029
+Obliterate;INV;24029
+Obliterate;V16;24029
+Oblivion Crown;FUT;102434
+Oblivion Ring;ALA;115005
+Oblivion Ring;CMD;115005
+Oblivion Ring;DDG;122194
+Oblivion Ring;DDI;115005
+Oblivion Ring;DPA;115005
+Oblivion Ring;LRW;105336
+Oblivion Ring;M12;115005
+Oblivion Ring;M13;115005
+Oblivion Ring;MM2;115005
+Oblivion Ring;PC1;115005
+Oblivion Ring;PRM;122194
+Oblivion Ring;TD0;105336
+Oblivion Ring;TD0;115005
+Oblivion Sower;BFZ;160615
+Oblivion Sower;PRM;160769
+Oblivion Stone;CMD;51055
+Oblivion Stone;MRD;51055
+Oblivion Stone;MS2;400934
+Oblivion Strike;OGW;161040
+Oblivion;HOU;401859
+Oboro Breezecaller;SOK;86159
+Oboro Envoy;SOK;86081
+Oboro, Palace in the Clouds;SOK;86077
+Obscuring Aether;DTK;160080
+Observant Alseid;THS;149175
+Obsessive Search;TOR;36415
+Obsessive Search;VMA;36415
+Obsessive Skinner;SOI;161445
+Obsianus Golem;2ED;179
+Obsianus Golem;3ED;179
+Obsianus Golem;4ED;179
+Obsianus Golem;6ED;179
+Obsianus Golem;LEA;179
+Obsianus Golem;LEB;179
+Obsianus Golem;ME4;179
+Obsidian Acolyte;INV;24099
+Obsidian Battle-Axe;DPA;110028
+Obsidian Battle-Axe;MOR;110028
+Obsidian Fireheart;DPA;123702
+Obsidian Fireheart;ZEN;123702
+Obsidian Giant;PO2;4752
+Obstinate Baloth;M11;129158
+Obstinate Familiar;ODY;33343
+Obzedat, Ghost Council;GTC;146474
+Obzedat, Ghost Council;MM3;146474
+Obzedat's Aid;DGM;146745
+Octopus;TOK;160811
+Ocular Halo;DIS;94397
+Ocular Halo;DPA;94397
+Oculus;MBS;133210
+Odds;DIS;94504
+Odious Trow;EVE;113603
+Odric, Lunarch Marshal;SOI;161447
+Odric, Master Tactician;DPA;143872
+Odric, Master Tactician;M13;143872
+Odunos River Trawler;BNG;152066
+Odylic Wraith;WTH;2920
+Off Balance;NMS;21230
+Offalsnout;MOR;109908
+Offering to Asha;ARB;121032
+Ogre Arsonist;PO2;4748
+Ogre Battledriver;M14;101055
+Ogre Berserker;PO2;4739
+Ogre Enforcer;VIS;2223
+Ogre Gatecrasher;DIS;94454
+Ogre Geargrabber;SOM;131210
+Ogre Jailbreaker;MM3;145858
+Ogre Jailbreaker;RTR;145858
+Ogre Leadfoot;MRD;50206
+Ogre Marauder;BOK;83922
+Ogre Menial;NPH;134421
+Ogre Recluse;BOK;83871
+Ogre Resister;MBS;133182
+Ogre Savant;DDH;91846
+Ogre Savant;DDJ;91846
+Ogre Savant;GPT;91846
+Ogre Sentry;ROE;127364
+Ogre Shaman;EXO;5424
+Ogre Shaman;TPR;5424
+Ogre Slumlord;GTC;146542
+Ogre Taskmaster;7ED;30846
+Ogre Taskmaster;8ED;19219
+Ogre Taskmaster;9ED;19219
+Ogre Taskmaster;ME4;4750
+Ogre Taskmaster;MMQ;19219
+Ogre Taskmaster;PO2;4741
+Ogre Warrior;PO2;4750
+Ogre;TOK;126472
+Ogre's Cleaver;DPA;127322
+Ogre's Cleaver;ROE;127322
+Ohran Viper;CSP;97002
+Ohran Viper;DDM;97002
+Ohran Yeti;CSP;96880
+Ojutai Exemplars;DTK;159818
+Ojutai Interceptor;DTK;159760
+Ojutai Monument;DTK;159713
+Ojutai, Soul of Winter;FRF;157168
+Ojutai's Breath;DTK;159851
+Ojutai's Command;DTK;160111
+Ojutai's Command;PRM;159867
+Ojutai's Summons;DTK;159854
+Oketra the True;AKH;400762
+Oketra the True;MS3;401368
+Oketra's Attendant;AKH;400845
+Oketra's Attendant;TOK;400955
+Oketra's Avenger;HOU;401769
+Oketra's Last Mercy;HOU;401779
+Oketra's Monument;AKH;400764
+Okiba-Gang Shinobi;BOK;83911
+Okiba-Gang Shinobi;PC2;83911
+Okina Nightwatch;PRM;86071
+Okina Nightwatch;SOK;86071
+Okina, Temple to the Grandfathers;COK;82617
+Okk;7ED;27725
+Okk;8ED;27725
+Okk;USG;8860
+Old Ghastbark;SHM;111564
+Old Man of the Sea;ARN;360
+Old Man of the Sea;ME3;360
+Old Man of the Sea;PRM;144459
+Old-Growth Dryads;XLN;402363
+Olivia Voldaren;ISD;138499
+Olivia Voldaren;MM3;138499
+Olivia, Mobilized for War;SOI;161449
+Olivia's Bloodsworn;SOI;161752
+Olivia's Dragoon;EMN;162094
+Oloro, Ageless Ascetic;C13;152795
+Oloro, Ageless Ascetic;PRM;152795
+Omega Myr;MRD;50336
+Omen Machine;NPH;134381
+Omen of Fire;ALL;1693
+Omen;POR;6625
+Omenspeaker;THS;149046
+Ominous Sphinx;HOU;401517
+Omnath, Locus of Mana;V11;123701
+Omnath, Locus of Mana;WWK;123701
+Omnath, Locus of Rage;BFZ;161173
+Omnibian;DIS;88724
+Omniscience;M13;118212
+Omniscience;MS3;401611
+Onakke Catacomb;PC2;131670
+Ondu Champion;BFZ;160684
+Ondu Cleric;ZEN;123556
+Ondu Giant;DPA;127431
+Ondu Giant;PC2;127431
+Ondu Giant;ROE;127431
+Ondu Greathorn;BFZ;160629
+Ondu Rising;BFZ;160891
+Ondu War Cleric;OGW;161034
+One Dozen Eyes;C13;51069
+One Dozen Eyes;MRD;51069
+One Dozen Eyes;TD2;51069
+One Thousand Lashes;GTC;146249
+One With the Wind;XLN;402234
+One of the Pack;SOI;161453
+One with Nature;SCG;48955
+One with Nothing;SOK;86187
+One-Eyed Scarecrow;ISD;139425
+Ongoing Investigation;SOI;161766
+Oni Possession;COK;80645
+Oni Possession;DDC;80645
+Oni of Wild Places;CMD;86026
+Oni of Wild Places;SOK;86026
+Onslaught;EXO;6100
+Onulet;3ED;430
+Onulet;4ED;430
+Onulet;ATQ;430
+Onulet;ME4;430
+Onulet;MED;430
+Onward;AKH;401350
+Onyx Goblet;ALA;114952
+Onyx Goblet;DPA;114952
+Onyx Mage;DPA;134069
+Onyx Mage;M12;134069
+Onyx Talisman;ICE;1306
+Oona, Queen of the Fae;MMA;111722
+Oona, Queen of the Fae;SHM;111722
+Oona, Queen of the Fae;V11;111722
+Oona's Blackguard;MOR;109991
+Oona's Blackguard;PRM;105666
+Oona's Gatewarden;SHM;111542
+Oona's Grace;EMA;113695
+Oona's Grace;EVE;113695
+Oona's Prowler;LRW;107632
+Ooze Flux;GTC;146435
+Ooze Garden;ALA;114990
+Ooze;TOK;117017
+Ooze;TOK;128391
+Ooze;TOK;129187
+Ooze;TOK;129190
+Ooze;TOK;138481
+Ooze;TOK;145992
+Ooze;TOK;161669
+Opal Acrolith;USG;8103
+Opal Archangel;USG;8840
+Opal Avenger;UL;10335
+Opal Caryatid;USG;8666
+Opal Champion;UL;10336
+Opal Gargoyle;USG;8940
+Opal Guardian;TSP;97493
+Opal Lake Gatekeepers;DGM;147786
+Opal Palace;C13;151725
+Opal Titan;USG;8100
+Opal-Eye, Konda's Yojimbo;BOK;83960
+Opalescence;UD;15610
+Opaline Bracers;5DN;77098
+Opaline Sliver;TSP;97347
+Opaline Unicorn;THS;149075
+Open Fire;HOU;401495
+Open into Wonder;AKH;400766
+Open the Armory;SOI;161459
+Open the Vaults;M10;122175
+Ophidian Eye;DPA;97280
+Ophidian Eye;TSP;97280
+Ophidian;DD2;2826
+Ophidian;PRM;2826
+Ophidian;VMA;2826
+Ophidian;WTH;2826
+Ophiomancer;C13;151718
+Opportunist;TMP;3257
+Opportunity;7ED;27726
+Opportunity;C13;148279
+Opportunity;DPA;148279
+Opportunity;M14;148279
+Opportunity;MM3;148279
+Opportunity;UL;9509
+Opposition;7ED;27727
+Opposition;MS3;401610
+Opposition;UD;15624
+Oppression;7ED;27728
+Oppression;USG;8936
+Oppressive Rays;JOU;153081
+Oppressive Rays;M15;153081
+Oppressive Will;SOK;87227
+Opt;INV;25477
+Opt;XLN;402057
+Opulent Palace;KTK;156585
+Oracle en-Vec;TMP;3181
+Oracle of Bones;BNG;152587
+Oracle of Dust;BFZ;160640
+Oracle of Mul Daya;DPA;123639
+Oracle of Mul Daya;ZEN;123639
+Oracle of Nectars;SHM;111905
+Oracle's Attendants;8ED;21193
+Oracle's Attendants;9ED;21193
+Oracle's Attendants;NMS;21193
+Oracle's Insight;BNG;152557
+Oracle's Vault;AKH;400824
+Oracle's Vault;PRM;401448
+Oran-Rief Hydra;BFZ;160896
+Oran-Rief Hydra;PRM;160704
+Oran-Rief Invoker;BFZ;160700
+Oran-Rief Recluse;DDM;102627
+Oran-Rief Recluse;DPA;102627
+Oran-Rief Recluse;ZEN;102627
+Oran-Rief Survivalist;ZEN;123580
+Oran-Rief, the Vastwood;C14;123692
+Oran-Rief, the Vastwood;ZEN;123692
+Orator of Ojutai;DTK;160099
+Orator of Ojutai;PRM;160396
+Oraxid;NMS;21199
+Orb of Dreams;BOK;83928
+Orbs of Warding;ORI;160354
+Orbweaver Kumo;COK;80932
+Orc General;DRK;809
+Orc General;ME2;809
+Orc Sureshot;FRF;157319
+Orchard Spirit;ISD;138389
+Orchard Spirit;ORI;138389
+Orchard Warden;MOR;109985
+Orcish Artillery;10E;86924
+Orcish Artillery;2ED;180
+Orcish Artillery;3ED;180
+Orcish Artillery;4ED;180
+Orcish Artillery;5ED;2438
+Orcish Artillery;6ED;2438
+Orcish Artillery;7ED;27729
+Orcish Artillery;8ED;2438
+Orcish Artillery;9ED;86924
+Orcish Artillery;LEA;180
+Orcish Artillery;LEB;180
+Orcish Bloodpainter;CSP;96968
+Orcish Cannonade;TSP;97447
+Orcish Cannoneers;ICE;1307
+Orcish Cannoneers;ME2;1307
+Orcish Captain;5ED;2439
+Orcish Captain;FEM;977
+Orcish Captain;ME2;977
+Orcish Conscripts;5ED;1308
+Orcish Conscripts;ICE;1308
+Orcish Conscripts;ME2;1308
+Orcish Farmer;5ED;1309
+Orcish Farmer;ICE;1309
+Orcish Farmer;ME2;1309
+Orcish Healer;ICE;1310
+Orcish Librarian;ICE;1311
+Orcish Librarian;TSB;1311
+Orcish Lumberjack;DDL;144456
+Orcish Lumberjack;ICE;1312
+Orcish Lumberjack;ME2;1312
+Orcish Lumberjack;PRM;144456
+Orcish Lumberjack;VMA;144456
+Orcish Mechanics;ATQ;431
+Orcish Mechanics;ME4;431
+Orcish Mechanics;MED;431
+Orcish Mine;HML;1540
+Orcish Oriflamme;2ED;181
+Orcish Oriflamme;3ED;181
+Orcish Oriflamme;4ED;181
+Orcish Oriflamme;5ED;181
+Orcish Oriflamme;6ED;181
+Orcish Oriflamme;7ED;27730
+Orcish Oriflamme;EMA;27730
+Orcish Oriflamme;LEA;181
+Orcish Oriflamme;LEB;181
+Orcish Settlers;WTH;2935
+Orcish Spy;8ED;49672
+Orcish Spy;FEM;978
+Orcish Spy;FEM;979
+Orcish Spy;FEM;980
+Orcish Squatters;5ED;1313
+Orcish Squatters;ICE;1313
+Orcish Squatters;ME2;1313
+Orcish Veteran;FEM;865
+Orcish Veteran;FEM;981
+Orcish Veteran;FEM;982
+Orcish Veteran;FEM;984
+Orcish Veteran;ME2;865
+Ordeal of Erebos;THS;149088
+Ordeal of Heliod;THS;149082
+Ordeal of Nylea;THS;149093
+Ordeal of Purphoros;DDL;149200
+Ordeal of Purphoros;THS;149200
+Ordeal of Thassa;THS;149086
+Order of Leitbur;FEM;985
+Order of Leitbur;FEM;986
+Order of Leitbur;FEM;987
+Order of Leitbur;MED;987
+Order of Succession;C13;151749
+Order of Whiteclay;SHM;111600
+Order of Yawgmoth;DDE;8708
+Order of Yawgmoth;USG;8708
+Order of the Ebon Hand;FEM;988
+Order of the Ebon Hand;FEM;989
+Order of the Ebon Hand;FEM;990
+Order of the Ebon Hand;MED;990
+Order of the Golden Cricket;MOR;110019
+Order of the Sacred Bell;9ED;82593
+Order of the Sacred Bell;COK;82593
+Order of the Sacred Torch;5ED;1314
+Order of the Sacred Torch;6ED;1314
+Order of the Sacred Torch;ICE;1314
+Order of the Sacred Torch;ME2;1314
+Order of the Stars;GPT;91764
+Order of the White Shield;5ED;1315
+Order of the White Shield;ICE;1315
+Order of the White Shield;ME2;1315
+Order;APC;31120
+Order;PC1;31120
+Ordered Migration;INV;24006
+Ordruun Commando;RAV;88892
+Ordruun Veteran;GTC;146385
+Ore Gorger;COK;82606
+Oreskos Explorer;PZ1;160132
+Oreskos Sun Guide;BNG;152014
+Oreskos Swiftclaw;JOU;153083
+Oreskos Swiftclaw;M15;153083
+Organ Grinder;TOR;36441
+Orgg;5ED;991
+Orgg;FEM;991
+Orgg;TSB;991
+Origin Spellbomb;SOM;131127
+Orim, Samite Healer;TMP;3194
+Orim, Samite Healer;TPR;3194
+Orim's Chant;PLS;27954
+Orim's Chant;PRM;107688
+Orim's Cure;MMQ;19135
+Orim's Prayer;TMP;3301
+Orim's Thunder;APC;31121
+Orim's Thunder;CMD;31121
+Orim's Thunder;PC1;31121
+Orim's Touch;INV;24130
+Oriss, Samite Guardian;FUT;102497
+Ormendahl, Profane Prince;SOI;161450
+Ornamental Courage;KLD;162539
+Ornate Kanzashi;BOK;83886
+Ornery Kudu;AKH;401335
+Ornitharch;BNG;152537
+Ornithopter;10E;50214
+Ornithopter;3ED;432
+Ornithopter;4ED;432
+Ornithopter;5ED;432
+Ornithopter;6ED;432
+Ornithopter;9ED;50214
+Ornithopter;AER;400396
+Ornithopter;ATQ;432
+Ornithopter;DPA;50214
+Ornithopter;M10;122159
+Ornithopter;M11;122159
+Ornithopter;M15;122159
+Ornithopter;MRD;50214
+Ornithopter;MS2;400935
+Orochi Colony;PC2;131616
+Orochi Eggwatcher;COK;80928
+Orochi Hatchery;COK;82610
+Orochi Leafcaller;COK;80819
+Orochi Ranger;COK;80728
+Orochi Sustainer;COK;80808
+Oros, the Avenger;CMD;100722
+Oros, the Avenger;PLC;100722
+Oros, the Avenger;PRM;101822
+Orzhov Advokist;PZ2;400428
+Orzhov Basilica;C13;91698
+Orzhov Basilica;CMD;91698
+Orzhov Basilica;GPT;91698
+Orzhov Basilica;MM2;91698
+Orzhov Charm;GTC;145922
+Orzhov Cluestone;DGM;147758
+Orzhov Euthanist;GPT;91720
+Orzhov Guildgate;C13;146330
+Orzhov Guildgate;DGM;146883
+Orzhov Guildgate;GTC;146330
+Orzhov Guildgate;MM3;146883
+Orzhov Guildmage;CMD;91748
+Orzhov Guildmage;GPT;91748
+Orzhov Keyrune;GTC;145932
+Orzhov Pontiff;GPT;91671
+Orzhov Signet;CMD;91697
+Orzhov Signet;GPT;91697
+Orzhov Signet;MM3;138757
+Orzhov Signet;PRM;138757
+Orzhova, the Church of Deals;GPT;91816
+Orzhova;PC2;138703
+Osai Vultures;4ED;624
+Osai Vultures;LEG;624
+Osai Vultures;ME4;624
+Ostiary Thrull;GPT;91799
+Ostracize;7ED;27571
+Ostracize;UL;10352
+Otaria;PC1;125890
+Otarian Juggernaut;ODY;33251
+Otepec Huntmaster;XLN;402319
+Otherworld Atlas;AVR;141597
+Otherworldly Journey;COK;80562
+Otherworldly Journey;DDC;80562
+Otherworldly Journey;MM2;80562
+Otherworldly Journey;MMA;80562
+Otherworldly Outburst;EMN;162106
+Oubliette;ARN;361
+Oubliette;MED;361
+Ouphe Vandals;5DN;77108
+Oust;ROE;127425
+Outbreak;PCY;22115
+Outland Boar;AER;400343
+Outland Colossus;ORI;157363
+Outmaneuver;USG;8862
+Outnumber;BFZ;160691
+Outpost Siege;FRF;157214
+Outrage Shaman;EVE;113693
+Outrider en-Kor;TSP;97526
+Outrider of Jhess;ALA;115036
+Outwit;AVR;141595
+Ovalchase Daredevil;KLD;162507
+Ovalchase Dragster;KLD;162340
+Overabundance;INV;25151
+Overbeing of Myth;EVE;113638
+Overbeing of Myth;PRM;113777
+Overblaze;BOK;80650
+Overburden;PCY;22064
+Overcome;HOU;401824
+Overeager Apprentice;DDC;33437
+Overeager Apprentice;ODY;33437
+Overflowing Insight;XLN;402310
+Overgrown Battlement;ROE;127382
+Overgrown Estate;APC;31054
+Overgrown Tomb;EXP;160793
+Overgrown Tomb;RAV;90399
+Overgrown Tomb;RTR;145241
+Overgrowth;10E;104569
+Overgrowth;9ED;86959
+Overgrowth;STH;3732
+Overlaid Terrain;NMS;21196
+Overload;INV;25478
+Overmaster;TOR;36502
+Override;MRD;50196
+Overrule;DDI;94314
+Overrule;DIS;94314
+Overrun;10E;33280
+Overrun;C14;33280
+Overrun;DDD;33280
+Overrun;DPA;33280
+Overrun;M10;33280
+Overrun;M12;33280
+Overrun;ODY;33280
+Overrun;PC2;33280
+Overrun;TMP;3242
+Overrun;TPR;3242
+Overseer of the Damned;C14;155625
+Oversold Cemetery;ONS;43087
+Oversoul of Dusk;SHM;111644
+Overtaker;MMQ;19021
+Overtaker;PRM;19021
+Overwhelm;M15;89085
+Overwhelm;MM2;89085
+Overwhelm;RAV;89085
+Overwhelming Denial;OGW;161208
+Overwhelming Forces;ME4;9090
+Overwhelming Forces;PTK;9090
+Overwhelming Instinct;ONS;43206
+Overwhelming Intellect;DDJ;86102
+Overwhelming Intellect;SOK;86102
+Overwhelming Intellect;TD0;86102
+Overwhelming Splendor;HOU;401781
+Overwhelming Stampede;C14;129095
+Overwhelming Stampede;M11;129095
+Overwhelming Stampede;MM2;129095
+Ovinize;PLC;100779
+Ovinomancer;TSB;2224
+Ovinomancer;VIS;2224
+Oviya Pashiri, Sage Lifecrafter;KLD;162553
+Owl Familiar;ME4;6626
+Owl Familiar;POR;6626
+Owl Familiar;VMA;6626
+Oxidda Daredevil;SOM;130927
+Oxidda Golem;DD2;75174
+Oxidda Golem;DST;75174
+Oxidda Scrapmelter;DPA;130945
+Oxidda Scrapmelter;SOM;130945
+Oxidize;DST;51907
+Oxidize;PRM;81084
+Oyobi, Who Split the Heavens;BOK;83816
+Pacification Array;AER;400397
+Pacifism;10E;1988
+Pacifism;6ED;1988
+Pacifism;7ED;27731
+Pacifism;8ED;1988
+Pacifism;9ED;1988
+Pacifism;DDC;42923
+Pacifism;DPA;1988
+Pacifism;DTK;160109
+Pacifism;EMA;1988
+Pacifism;M10;1988
+Pacifism;M11;1988
+Pacifism;M12;1988
+Pacifism;M13;1988
+Pacifism;M14;1988
+Pacifism;MIR;1988
+Pacifism;ONS;42923
+Pacifism;TMP;3068
+Pacifism;TPR;3068
+Pacifism;USG;8744
+Pack Guardian;SOI;161396
+Pack Hunt;NMS;21286
+Pack Rat;RTR;145942
+Pack's Disdain;MOR;110006
+Pact of Negation;FUT;102420
+Pact of Negation;MMA;102420
+Pact of Negation;MS3;401619
+Pact of the Titan;FUT;104612
+Padeem, Consul of Innovation;KLD;162492
+Pain Kami;COK;80937
+Pain Magnification;DIS;94308
+Pain Magnification;DPA;94308
+Pain Seer;BNG;152573
+Pain Seer;PRM;152572
+Pain;DDH;25578
+Pain;INV;25578
+Pain's Reward;SOK;80782
+Painbringer;ODY;33420
+Painful Lesson;AKH;401314
+Painful Memories;6ED;1989
+Painful Memories;MIR;1989
+Painful Quandary;SOM;131133
+Painful Truths;BFZ;160810
+Painsmith;SOM;130926
+Painted Bluffs;AKH;400780
+Painter's Servant;MS2;400634
+Painter's Servant;SHM;111607
+Painwracker Oni;COK;82607
+Palace Familiar;DTK;160138
+Palace Guard;M10;121617
+Palace Guard;M11;121617
+Palace Jailer;PZ2;162158
+Palace Sentinels;PZ2;143491
+Palace Siege;FRF;157216
+Paladin en-Vec;10E;104547
+Paladin en-Vec;9ED;86893
+Paladin en-Vec;DPA;104547
+Paladin en-Vec;EXO;3733
+Paladin en-Vec;TPR;3733
+Paladin of Prahv;DDG;94493
+Paladin of Prahv;DIS;94493
+Paladin of the Bloodstained;XLN;401428
+Pale Bears;ICE;1316
+Pale Moon;NMS;21276
+Pale Recluse;ARB;114913
+Pale Recluse;DPA;114913
+Pale Rider of Trostad;SOI;161759
+Pale Wayfarer;SHM;111753
+Paleoloth;CON;119809
+Palinchron;UL;9159
+Palinchron;VMA;9159
+Palisade Giant;RTR;145937
+Palladia-Mors;CH;625
+Palladia-Mors;LEG;625
+Palladia-Mors;ME3;625
+Palladium Myr;C14;131139
+Palladium Myr;SOM;131139
+Palliation Accord;DIS;94321
+Pallid Mycoderm;MMA;100756
+Pallid Mycoderm;PLC;100756
+Pallimud;TMP;3150
+Panacea;MMQ;19106
+Pandemonium;EXO;6098
+Pandemonium;TPR;6098
+Pandemonium;TSB;6098
+Pang Tong, \"Young Phoenix\";PTK;9149
+Panglacial Wurm;CSP;97000
+Pangosaur;MMQ;19285
+Panharmonicon;KLD;162335
+Panic Attack;8ED;22000
+Panic Attack;9ED;22000
+Panic Attack;M10;122158
+Panic Attack;PCY;22000
+Panic Spellbomb;C14;131124
+Panic Spellbomb;SOM;131124
+Panic;5ED;2440
+Panic;ICE;1317
+Panic;ME2;1317
+Panoptic Mirror;DST;52024
+Panopticon;PC1;125859
+Panther Warriors;6ED;6668
+Panther Warriors;POR;6668
+Panther Warriors;VIS;2225
+Paperfin Rascal;LRW;106368
+Paradigm Shift;WTH;2893
+Paradise Mantle;5DN;77206
+Paradise Mantle;MMA;77206
+Paradise Plume;TSP;97562
+Paradox Engine;AER;400407
+Paradox Engine;MS2;400920
+Paradox Haze;TSP;97351
+Paradoxical Outcome;KLD;162483
+Paragon of Eternal Wilds;M15;155375
+Paragon of Fierce Defiance;M15;155208
+Paragon of Gathering Mists;M15;155263
+Paragon of New Dawns;M15;155219
+Paragon of Open Graves;M15;155271
+Paragon of the Amesha;CON;118716
+Parallax Dementia;NMS;21245
+Parallax Inhibitor;NMS;21150
+Parallax Nexus;NMS;21149
+Parallax Tide;NMS;21190
+Parallax Wave;NMS;21148
+Parallax Wave;VMA;21148
+Parallectric Feedback;GPT;91827
+Parallel Evolution;TOR;26163
+Parallel Lives;DPA;139298
+Parallel Lives;ISD;139298
+Parallel Thoughts;SCG;48125
+Paralyze;2ED;182
+Paralyze;3ED;182
+Paralyze;4ED;182
+Paralyze;5ED;2441
+Paralyze;LEA;182
+Paralyze;LEB;182
+Paralyze;MED;182
+Paralyze;VMA;2441
+Paralyzing Grasp;RTR;145855
+Paralyzing Grasp;ZEN;125076
+Paranoid Delusions;GTC;146552
+Paranoid Parish-Blade;SOI;161423
+Parapet Watchers;SHM;111720
+Parapet;VIS;2226
+Paraselene;ISD;139305
+Parasitic Bond;USG;8796
+Parasitic Implant;NPH;134191
+Parasitic Strix;CON;118673
+Parch;UL;10401
+Pardic Arsonist;TOR;36488
+Pardic Collaborator;TOR;36490
+Pardic Dragon;MMA;97337
+Pardic Dragon;TSP;97337
+Pardic Firecat;ODY;33387
+Pardic Lancer;TOR;36477
+Pardic Miner;ODY;33349
+Pardic Swordsmith;ODY;33384
+Pariah;10E;9397
+Pariah;7ED;27732
+Pariah;DPA;9397
+Pariah;USG;9397
+Pariah's Shield;RAV;88719
+Paroxysm;EXO;5614
+Part Water;LEG;626
+Part the Veil;COK;82628
+Part the Waterveil;BFZ;160916
+Parting Thoughts;PZ2;155871
+Past in Flames;ISD;138453
+Past in Flames;MM3;400107
+Patagia Golem;6ED;1990
+Patagia Golem;7ED;27733
+Patagia Golem;8ED;27733
+Patagia Golem;MIR;1990
+Patagia Viper;DIS;94604
+Patchwork Gnomes;ODY;33253
+Patchwork Gnomes;TMP;3202
+Patchwork Gnomes;TPR;3202
+Path of Anger's Flame;SOK;86062
+Path of Bravery;M14;147370
+Path of Peace;PO2;4667
+Path of Peace;POR;6744
+Path of Peace;USG;8808
+Path to Exile;CMD;118686
+Path to Exile;CON;118686
+Path to Exile;DDI;140032
+Path to Exile;DPA;118686
+Path to Exile;MM3;118686
+Path to Exile;MMA;118686
+Path to Exile;PRM;120096
+Path to Exile;PRM;160397
+Pathbreaker Ibex;PZ1;160442
+Pathbreaker Wurm;AVR;141647
+Pathmaker Initiate;AKH;400804
+Pathrazer of Ulamog;DPA;127380
+Pathrazer of Ulamog;PRM;128449
+Pathrazer of Ulamog;ROE;127380
+Pathway Arrows;BFZ;160827
+Patriarch's Bidding;ONS;43080
+Patriarch's Desire;ODY;33423
+Patrician's Scorn;FUT;102500
+Patrol Hound;ODY;33196
+Patrol Signaler;EVE;113717
+Patron Wizard;ODY;33462
+Patron of the Akki;BOK;83837
+Patron of the Kitsune;BOK;83936
+Patron of the Moon;BOK;83969
+Patron of the Nezumi;BOK;83954
+Patron of the Nezumi;CMD;83954
+Patron of the Orochi;BOK;83900
+Patron of the Valiant;ORI;160197
+Patron of the Wild;LGN;46551
+Pattern of Rebirth;UD;15668
+Paupers' Cage;MIR;1991
+Pavel Maliki;LEG;627
+Pavel Maliki;ME3;627
+Pawn of Ulamog;ROE;127415
+Pay No Heed;DDL;36395
+Pay No Heed;M14;36395
+Pay No Heed;TOR;36395
+Peace Strider;DPA;133169
+Peace Strider;MBS;133169
+Peace Strider;PRM;133169
+Peace Talks;VIS;2227
+Peace and Quiet;UL;10369
+Peace of Mind;9ED;5429
+Peace of Mind;EMN;162047
+Peace of Mind;EXO;5429
+Peacekeeper;WTH;2902
+Peacewalker Colossus;AER;400404
+Peach Garden Oath;8ED;9130
+Peach Garden Oath;ME3;9130
+Peach Garden Oath;PTK;9130
+Peak Eruption;THS;150877
+Pearl Dragon;6ED;1992
+Pearl Dragon;MIR;1992
+Pearl Lake Ancient;KTK;158889
+Pearl Medallion;C14;144001
+Pearl Medallion;DPA;144001
+Pearl Medallion;TMP;3107
+Pearl Shard;MRD;51001
+Pearled Unicorn;2ED;183
+Pearled Unicorn;3ED;183
+Pearled Unicorn;4ED;183
+Pearled Unicorn;5ED;2442
+Pearled Unicorn;LEA;183
+Pearled Unicorn;LEB;183
+Pearlspear Courier;ONS;42950
+Peat Bog;MMQ;19172
+Pedantic Learning;ODY;33450
+Peek;10E;33488
+Peek;ODY;33488
+Peel from Reality;AVR;141682
+Peel from Reality;M15;141682
+Peel from Reality;RAV;88940
+Peema Aether-Seer;AER;400342
+Peema Outrider;KLD;162300
+Peer Pressure;ONS;43017
+Peer Through Depths;COK;82602
+Peer Through Depths;MMA;82602
+Pegasus Charger;9ED;8811
+Pegasus Charger;USG;8811
+Pegasus Refuge;TMP;3187
+Pegasus Stampede;EXO;4592
+Pegasus Stampede;TPR;4592
+Pegasus;TOK;100820
+Pegasus;TOK;128459
+Pegasus;TOK;93486
+Pelakka Wurm;DPA;127389
+Pelakka Wurm;MM2;127389
+Pelakka Wurm;ROE;127389
+Pemmin's Aura;SCG;48119
+Penance;EXO;5433
+Pendelhaven Elder;TSP;97400
+Pendelhaven;LEG;628
+Pendelhaven;PRM;110123
+Pendelhaven;PRM;402440
+Pendelhaven;TSB;628
+Pendrell Drake;USG;8816
+Pendrell Flux;USG;8869
+Pendrell Mists;WTH;2895
+Pendulum of Patterns;AER;400426
+Pennon Blade;DPA;127330
+Pennon Blade;ROE;127330
+Pensive Minotaur;JOU;152851
+Pentad Prism;5DN;77193
+Pentad Prism;PC1;77193
+Pentagram of the Ages;5ED;1318
+Pentagram of the Ages;6ED;1318
+Pentagram of the Ages;ICE;1318
+Pentagram of the Ages;ME4;1318
+Pentarch Paladin;TSP;97380
+Pentarch Ward;TSP;97309
+Pentavite;TOK;51118
+Pentavus;C14;51031
+Pentavus;DDF;51031
+Pentavus;M12;51031
+Pentavus;MRD;51031
+Pentavus;PC1;51031
+Penumbra Bobcat;APC;31051
+Penumbra Bobcat;TD0;31051
+Penumbra Kavu;APC;31052
+Penumbra Spider;CMD;97523
+Penumbra Spider;MM3;97523
+Penumbra Spider;MMA;97523
+Penumbra Spider;PC2;97523
+Penumbra Spider;TSP;97523
+Penumbra Wurm;APC;31053
+Penumbra Wurm;DPA;143976
+Penumbra Wurm;VMA;143976
+People of the Woods;DRK;810
+Peppersmoke;LRW;105374
+Peppersmoke;MMA;105374
+Peregrination;BNG;152596
+Peregrine Drake;EMA;161552
+Peregrine Drake;PC2;8712
+Peregrine Drake;USG;8712
+Peregrine Griffin;M12;137414
+Peregrine Mask;RAV;89131
+Perfected Form;SOI;161415
+Perilous Forays;RAV;88731
+Perilous Myr;SOM;130873
+Perilous Predicament;AER;400296
+Perilous Research;CMD;96974
+Perilous Research;CSP;96974
+Perilous Research;MMA;134096
+Perilous Shadow;RTR;145859
+Perilous Vault;M15;155887
+Perilous Voyage;XLN;404049
+Perimeter Captain;WWK;126561
+Perish the Thought;ROE;127419
+Perish;6ED;3226
+Perish;TMP;3226
+Permafrost Trap;WWK;126471
+Permeating Mass;EMN;162114
+Pernicious Deed;APC;31124
+Pernicious Deed;DPA;31124
+Pernicious Deed;PRM;92882
+Perpetual Timepiece;KLD;162601
+Perplex;RAV;88914
+Perplexing Chimera;BNG;152559
+Persecute;7ED;27734
+Persecute;8ED;8631
+Persecute;9ED;8631
+Persecute;USG;8631
+Persistent Nightmare;SOI;161365
+Personal Incarnation;2ED;184
+Personal Incarnation;3ED;184
+Personal Incarnation;4ED;184
+Personal Incarnation;5ED;2443
+Personal Incarnation;LEA;184
+Personal Incarnation;LEB;184
+Personal Incarnation;ME4;184
+Personal Sanctuary;M12;134134
+Personal Tutor;ME2;6627
+Personal Tutor;POR;6627
+Persuasion;10E;101045
+Persuasion;DPA;101045
+Persuasion;ODY;33663
+Pest;TOK;51511
+Pestermite;LRW;105348
+Pestermite;MMA;105348
+Pestilence Demon;C14;127258
+Pestilence Demon;DPA;127258
+Pestilence Demon;ROE;127258
+Pestilence Rats;ICE;1319
+Pestilence;2ED;185
+Pestilence;3ED;185
+Pestilence;4ED;185
+Pestilence;5ED;2444
+Pestilence;6ED;2444
+Pestilence;LEA;185
+Pestilence;LEB;185
+Pestilence;USG;8934
+Pestilent Kathari;CON;118710
+Pestilent Souleater;NPH;134424
+Petalmane Baku;BOK;83865
+Petals of Insight;COK;82203
+Petals of Insight;MMA;82203
+Petra Sphinx;CH;629
+Petra Sphinx;LEG;629
+Petra Sphinx;MED;629
+Petradon;TOR;36497
+Petrahydrox;DPA;91724
+Petrahydrox;GPT;91724
+Petravark;TOR;36498
+Petrified Field;ODY;33227
+Petrified Plating;FUT;102438
+Petrified Wood-Kin;GPT;91680
+Pewter Golem;MRD;50276
+Phage the Untouchable;10E;45870
+Phage the Untouchable;LGN;45870
+Phalanx Formation;JOU;152939
+Phalanx Leader;PRM;151404
+Phalanx Leader;THS;149191
+Phantasmagorian;PLC;100746
+Phantasmal Abomination;ROE;127459
+Phantasmal Bear;DDM;134142
+Phantasmal Bear;DPA;134142
+Phantasmal Bear;M12;134142
+Phantasmal Dragon;DDM;134067
+Phantasmal Dragon;DPA;134067
+Phantasmal Dragon;M12;134067
+Phantasmal Fiend;ALL;1694
+Phantasmal Fiend;ALL;1695
+Phantasmal Fiend;ME2;1694
+Phantasmal Forces;2ED;186
+Phantasmal Forces;3ED;186
+Phantasmal Forces;4ED;186
+Phantasmal Forces;5ED;186
+Phantasmal Forces;LEA;186
+Phantasmal Forces;LEB;186
+Phantasmal Forces;ME4;186
+Phantasmal Image;DPA;134082
+Phantasmal Image;M12;134082
+Phantasmal Image;MM3;134082
+Phantasmal Mount;ICE;1320
+Phantasmal Mount;ME2;1320
+Phantasmal Sphere;ALL;1696
+Phantasmal Terrain;2ED;187
+Phantasmal Terrain;3ED;187
+Phantasmal Terrain;4ED;187
+Phantasmal Terrain;5ED;2445
+Phantasmal Terrain;6ED;2445
+Phantasmal Terrain;INV;25668
+Phantasmal Terrain;LEA;187
+Phantasmal Terrain;LEB;187
+Phantasmal Terrain;ME4;187
+Phantatog;ODY;33275
+Phantom Beast;DPA;129107
+Phantom Beast;M11;129107
+Phantom Centaur;JUD;40278
+Phantom Centaur;TD0;40278
+Phantom Flock;JUD;40178
+Phantom General;DDK;145168
+Phantom General;RTR;145168
+Phantom Monster;2ED;188
+Phantom Monster;3ED;188
+Phantom Monster;4ED;188
+Phantom Monster;5ED;2446
+Phantom Monster;EMA;161553
+Phantom Monster;LEA;188
+Phantom Monster;LEB;188
+Phantom Monster;MED;188
+Phantom Nantuko;C13;40290
+Phantom Nantuko;JUD;40290
+Phantom Nishoba;JUD;40296
+Phantom Nomad;JUD;40164
+Phantom Nomad;VMA;40164
+Phantom Tiger;JUD;40267
+Phantom Warrior;10E;27735
+Phantom Warrior;6ED;2945
+Phantom Warrior;7ED;27735
+Phantom Warrior;8ED;27735
+Phantom Warrior;9ED;27735
+Phantom Warrior;DPA;27735
+Phantom Warrior;M10;27735
+Phantom Warrior;M14;27735
+Phantom Warrior;POR;6628
+Phantom Warrior;WTH;2945
+Phantom Whelp;ODY;33478
+Phantom Wings;BOK;83882
+Phantom Wings;WTH;2831
+Phantom Wurm;TSP;97497
+Pharagax Giant;BNG;152042
+Pharika, God of Affliction;JOU;152946
+Pharika's Chosen;JOU;152857
+Pharika's Cure;THS;149184
+Pharika's Disciple;ORI;160328
+Pharika's Mender;THS;150839
+Phelddagrif;ALL;1697
+Phelddagrif;MED;1697
+Phenax, God of Deception;BNG;148946
+Pheres-Band Centaurs;THS;150841
+Pheres-Band Raiders;BNG;152081
+Pheres-Band Thunderhoof;JOU;152876
+Pheres-Band Tromper;BNG;152054
+Pheres-Band Warchief;JOU;153005
+Phobian Phantasm;CSP;96882
+Phosphorescent Feast;EVE;113624
+Phosphorescent Feast;FUT;102348
+Phthisis;C13;97363
+Phthisis;MMA;97363
+Phthisis;TSP;97363
+Phylactery Lich;M11;129123
+Phylactery Lich;M13;129123
+Phyresis;MBS;133184
+Phyrexia's Core;C14;134276
+Phyrexia's Core;NPH;134276
+Phyrexian Altar;INV;24172
+Phyrexian Altar;TD2;24172
+Phyrexian Arena;8ED;49243
+Phyrexian Arena;9ED;49243
+Phyrexian Arena;APC;31173
+Phyrexian Arena;DDE;31173
+Phyrexian Arena;PC1;49243
+Phyrexian Arena;TD0;31173
+Phyrexian Battleflies;DDE;24102
+Phyrexian Battleflies;INV;24102
+Phyrexian Bloodstock;PLS;27958
+Phyrexian Boon;ALL;1698
+Phyrexian Boon;ALL;1699
+Phyrexian Boon;MED;1699
+Phyrexian Broodlings;DDE;10333
+Phyrexian Broodlings;UL;10333
+Phyrexian Colossus;7ED;27736
+Phyrexian Colossus;8ED;27736
+Phyrexian Colossus;DDE;7379
+Phyrexian Colossus;USG;7379
+Phyrexian Crusader;MBS;133120
+Phyrexian Debaser;DDE;10409
+Phyrexian Debaser;UL;10409
+Phyrexian Defiler;DDE;10317
+Phyrexian Defiler;UL;10317
+Phyrexian Defiler;VMA;10317
+Phyrexian Delver;C13;151434
+Phyrexian Delver;INV;24103
+Phyrexian Denouncer;DDE;10393
+Phyrexian Denouncer;UL;10393
+Phyrexian Devourer;ALL;1700
+Phyrexian Devourer;ME2;1700
+Phyrexian Digester;MBS;133136
+Phyrexian Dreadnought;MIR;1993
+Phyrexian Dreadnought;PRM;1993
+Phyrexian Driver;NMS;21202
+Phyrexian Etchings;CSP;96857
+Phyrexian Furnace;WTH;2910
+Phyrexian Gargantua;9ED;31174
+Phyrexian Gargantua;APC;31174
+Phyrexian Gargantua;C13;148942
+Phyrexian Gargantua;C14;148942
+Phyrexian Gargantua;DDE;31174
+Phyrexian Gargantua;EMA;148942
+Phyrexian Ghoul;DDE;8935
+Phyrexian Ghoul;PC1;8935
+Phyrexian Ghoul;TD2;8935
+Phyrexian Ghoul;USG;8935
+Phyrexian Gremlins;ATQ;433
+Phyrexian Grimoire;TMP;3095
+Phyrexian Hulk;7ED;27737
+Phyrexian Hulk;8ED;3203
+Phyrexian Hulk;9ED;3203
+Phyrexian Hulk;DDE;3203
+Phyrexian Hulk;M13;134228
+Phyrexian Hulk;NPH;134228
+Phyrexian Hulk;TMP;3203
+Phyrexian Hulk;TPR;3203
+Phyrexian Hydra;MBS;131700
+Phyrexian Infiltrator;INV;25655
+Phyrexian Ingester;C14;134233
+Phyrexian Ingester;EMA;134233
+Phyrexian Ingester;NPH;134233
+Phyrexian Ironfoot;CSP;96896
+Phyrexian Juggernaut;MBS;133212
+Phyrexian Juggernaut;TD2;133212
+Phyrexian Lens;INV;25176
+Phyrexian Marauder;VIS;2228
+Phyrexian Metamorph;NPH;134225
+Phyrexian Metamorph;PRM;136792
+Phyrexian Monitor;UD;15722
+Phyrexian Negator;DDE;127999
+Phyrexian Negator;PRM;15590
+Phyrexian Negator;UD;15590
+Phyrexian Obliterator;NPH;134235
+Phyrexian Plaguelord;8ED;9160
+Phyrexian Plaguelord;DDE;9160
+Phyrexian Plaguelord;TD2;9160
+Phyrexian Plaguelord;UL;9160
+Phyrexian Portal;ALL;1701
+Phyrexian Portal;ME2;1701
+Phyrexian Processor;DDE;127996
+Phyrexian Processor;USG;8902
+Phyrexian Processor;V16;127996
+Phyrexian Prowler;NMS;21428
+Phyrexian Purge;MIR;1994
+Phyrexian Rager;10E;31175
+Phyrexian Rager;APC;31175
+Phyrexian Rager;DDD;31175
+Phyrexian Rager;EMA;133190
+Phyrexian Rager;MBS;133190
+Phyrexian Reaper;INV;24193
+Phyrexian Rebirth;MBS;133220
+Phyrexian Reclamation;C13;13553
+Phyrexian Reclamation;UL;13553
+Phyrexian Revoker;M15;133249
+Phyrexian Revoker;MBS;133249
+Phyrexian Scuta;PLS;27959
+Phyrexian Slayer;INV;24105
+Phyrexian Snowcrusher;CSP;96878
+Phyrexian Soulgorger;CSP;96863
+Phyrexian Splicer;TMP;3209
+Phyrexian Swarmlord;NPH;134332
+Phyrexian Totem;DDE;97293
+Phyrexian Totem;TSP;97293
+Phyrexian Tower;USG;8709
+Phyrexian Tribute;MIR;1995
+Phyrexian Tyranny;PLS;27957
+Phyrexian Unlife;NPH;134309
+Phyrexian Vatmother;MBS;131017
+Phyrexian Vault;10E;1996
+Phyrexian Vault;6ED;1996
+Phyrexian Vault;DDE;1996
+Phyrexian Vault;MIR;1996
+Phyrexian Walker;VIS;2229
+Phyrexian War Beast;ALL;1702
+Phyrexian War Beast;ALL;1703
+Phyrexian War Beast;MED;1702
+Phytoburst;DGM;146703
+Phytohydra;RAV;89010
+Phytotitan;M15;155194
+Phytotitan;PRM;155862
+Pia Nalaar;KLD;162292
+Pia and Kiran Nalaar;ORI;160279
+Pia and Kiran Nalaar;PRM;160410
+Pia's Revolution;AER;400326
+Pianna, Nomad Captain;ODY;33513
+Pianna, Nomad Captain;VMA;33513
+Pick the Brain;SOI;161777
+Pieces of the Puzzle;SOI;161367
+Pierce Strider;MBS;131661
+Pierce Strider;PRM;131661
+Piety Charm;ONS;42927
+Piety;4ED;362
+Piety;ARN;362
+Pikemen;4ED;811
+Pikemen;5ED;2447
+Pikemen;DRK;811
+Pilfered Plans;DGM;146874
+Pilfered Plans;MM3;146874
+Pilgrim of Justice;ODY;33191
+Pilgrim of Virtue;ODY;33190
+Pilgrim of the Fires;FRF;157184
+Pilgrim's Eye;BFZ;160728
+Pilgrim's Eye;C13;126600
+Pilgrim's Eye;C14;126600
+Pilgrim's Eye;DDI;126600
+Pilgrim's Eye;DPA;126600
+Pilgrim's Eye;EMA;126600
+Pilgrim's Eye;WWK;126600
+Pili-Pala;SHM;111671
+Pillage;6ED;1704
+Pillage;7ED;27738
+Pillage;ALL;1704
+Pillage;ME2;1704
+Pillage;PD2;27738
+Pillage;PRM;1704
+Pillaging Horde;POR;6708
+Pillaging Horde;VMA;6708
+Pillar Tombs of Aku;VIS;2230
+Pillar of Flame;AVR;141558
+Pillar of Flame;DPA;141558
+Pillar of Flame;PRM;145868
+Pillar of Light;M15;156672
+Pillar of Origins;XLN;402382
+Pillar of War;BNG;152085
+Pillar of the Paruns;DIS;94352
+Pillarfield Ox;M13;123674
+Pillarfield Ox;M14;123674
+Pillarfield Ox;ZEN;123674
+Pillory of the Sleepless;GPT;91709
+Pillory of the Sleepless;MM2;160081
+Pin to the Earth;JOU;153070
+Pincer Spider;INV;24027
+Pincher Beetles;10E;2991
+Pincher Beetles;TMP;2991
+Pincher;TOK;80438
+Pine Barrens;TMP;3145
+Pine Barrens;TPR;3145
+Pine Barrens;VMA;3145
+Pine Walker;KTK;157059
+Pinecrest Ridge;COK;81018
+Pinion Feast;DTK;159825
+Pinnacle of Rage;BNG;152076
+Pinpoint Avalanche;ONS;43105
+Pious Evangel;SOI;161487
+Pious Interdiction;XLN;402300
+Pious Kitsune;COK;82204
+Pious Warrior;MMQ;19180
+Piper's Melody;ODY;33297
+Piracy Charm;PLC;100729
+Piracy;PO2;4706
+Piranha Marsh;ZEN;123530
+Pirate Ship;2ED;189
+Pirate Ship;3ED;189
+Pirate Ship;4ED;189
+Pirate Ship;5ED;189
+Pirate Ship;LEA;189
+Pirate Ship;LEB;189
+Pirate Ship;TSB;189
+Pirate;TOK;402424
+Pirate's Cutlass;XLN;402843
+Pirate's Prize;XLN;402054
+Piston Sledge;MBS;133135
+Pistus Strike;MBS;133137
+Pit Fight;GTC;147692
+Pit Imp;TMP;2975
+Pit Keeper;MM3;97473
+Pit Keeper;TSP;97473
+Pit Raptor;PCY;22162
+Pit Scorpion;4ED;630
+Pit Scorpion;5ED;2448
+Pit Scorpion;LEG;630
+Pit Spawn;EXO;3667
+Pit Trap;7ED;27739
+Pit Trap;ICE;1321
+Pit Trap;USG;8896
+Pitchburn Devils;ISD;138218
+Pitchburn Devils;M14;138218
+Pitchstone Wall;TOR;38135
+Pitfall Trap;MM3;123738
+Pitfall Trap;ZEN;123738
+Pith Driller;NPH;134371
+Pithing Needle;10E;86078
+Pithing Needle;M10;86078
+Pithing Needle;MS2;400921
+Pithing Needle;RTR;145231
+Pithing Needle;SOK;86078
+Pitiless Horde;DTK;159771
+Pitiless Vizier;AKH;401304
+Pixie Queen;LEG;2544
+Plagiarize;10E;86946
+Plagiarize;9ED;86946
+Plagiarize;TOR;36435
+Plague Beetle;10E;10359
+Plague Beetle;7ED;27740
+Plague Beetle;8ED;27740
+Plague Beetle;9ED;10359
+Plague Beetle;DPA;10359
+Plague Beetle;UL;10359
+Plague Belcher;AKH;401266
+Plague Boiler;C13;88588
+Plague Boiler;RAV;88588
+Plague Dogs;UD;15634
+Plague Fiend;PCY;22003
+Plague Myr;MBS;133172
+Plague Myr;PRM;134062
+Plague Myr;TD2;133172
+Plague Rats;2ED;190
+Plague Rats;3ED;190
+Plague Rats;4ED;190
+Plague Rats;5ED;190
+Plague Rats;LEA;190
+Plague Rats;LEB;190
+Plague Sliver;TSP;99366
+Plague Spitter;INV;25662
+Plague Spores;INV;24106
+Plague Stinger;PRM;132557
+Plague Stinger;SOM;131057
+Plague Wind;10E;22004
+Plague Wind;8ED;22004
+Plague Wind;9ED;22004
+Plague Wind;DPA;22004
+Plague Wind;PCY;22004
+Plague Witch;EMA;21176
+Plague Witch;NMS;21176
+Plague of Vermin;SHM;111897
+Plaguebearer;EXO;3734
+Plagued Rusalka;DDJ;91881
+Plagued Rusalka;GPT;91881
+Plagued Rusalka;MM2;91881
+Plaguemaw Beast;MBS;133142
+Plaguemaw Beast;TD2;133142
+Plains;10E;25178
+Plains;10E;80949
+Plains;10E;8661
+Plains;10E;89178
+Plains;2ED;191
+Plains;2ED;192
+Plains;2ED;300
+Plains;3ED;191
+Plains;3ED;192
+Plains;3ED;300
+Plains;4ED;191
+Plains;4ED;192
+Plains;4ED;300
+Plains;5ED;2449
+Plains;5ED;2450
+Plains;5ED;2451
+Plains;5ED;2452
+Plains;6ED;1997
+Plains;6ED;1998
+Plains;6ED;4789
+Plains;6ED;6783
+Plains;7ED;27741
+Plains;7ED;27742
+Plains;7ED;27743
+Plains;7ED;27744
+Plains;8ED;25178
+Plains;8ED;27744
+Plains;8ED;43234
+Plains;8ED;4791
+Plains;9ED;25178
+Plains;9ED;27744
+Plains;9ED;43234
+Plains;9ED;4791
+Plains;AKH;400884
+Plains;AKH;400885
+Plains;AKH;400886
+Plains;AKH;402699
+Plains;ALA;115087
+Plains;ALA;115088
+Plains;ALA;115089
+Plains;ALA;115090
+Plains;AVR;141765
+Plains;AVR;141768
+Plains;AVR;141769
+Plains;BFZ;123755
+Plains;BFZ;160751
+Plains;BFZ;160752
+Plains;BFZ;160753
+Plains;BFZ;160754
+Plains;C01;17595
+Plains;C13;106213
+Plains;C13;115089
+Plains;C13;138765
+Plains;C13;141765
+Plains;C14;123755
+Plains;C14;123760
+Plains;C14;123763
+Plains;C14;123770
+Plains;CMD;115088
+Plains;CMD;123763
+Plains;CMD;25178
+Plains;CMD;43234
+Plains;COK;80946
+Plains;COK;80949
+Plains;COK;80958
+Plains;COK;80962
+Plains;DDC;8659
+Plains;DDC;8660
+Plains;DDC;8661
+Plains;DDC;9035
+Plains;DDE;25492
+Plains;DDF;115088
+Plains;DDF;115089
+Plains;DDF;50309
+Plains;DDF;50310
+Plains;DDG;115088
+Plains;DDG;115089
+Plains;DDG;19005
+Plains;DDG;25493
+Plains;DDH;115087
+Plains;DDI;131171
+Plains;DDI;50310
+Plains;DDI;50346
+Plains;DDK;138455
+Plains;DDK;138456
+Plains;DDK;138458
+Plains;DDL;115089
+Plains;DDL;121682
+Plains;DDL;141768
+Plains;DDL;33222
+Plains;DPA;25178
+Plains;DPA;80949
+Plains;DPA;8661
+Plains;DPA;89178
+Plains;DTK;159694
+Plains;DTK;159732
+Plains;DTK;159808
+Plains;FK;4791
+Plains;FRF;158890
+Plains;FRF;158891
+Plains;H09;3070
+Plains;HOU;401919
+Plains;HOU;402758
+Plains;HOU;402763
+Plains;ICE;1322
+Plains;ICE;1323
+Plains;ICE;1324
+Plains;INV;25178
+Plains;INV;25179
+Plains;INV;25492
+Plains;INV;25493
+Plains;ISD;138455
+Plains;ISD;138456
+Plains;ISD;138458
+Plains;KLD;162196
+Plains;KLD;162356
+Plains;KLD;162357
+Plains;KTK;156612
+Plains;KTK;156613
+Plains;KTK;156614
+Plains;KTK;156615
+Plains;LEA;191
+Plains;LEA;192
+Plains;LEB;191
+Plains;LEB;192
+Plains;LEB;300
+Plains;LRW;104087
+Plains;LRW;105642
+Plains;LRW;105643
+Plains;LRW;105644
+Plains;M10;121682
+Plains;M10;121696
+Plains;M10;33222
+Plains;M10;33224
+Plains;M11;106213
+Plains;M11;121682
+Plains;M11;121696
+Plains;M11;25492
+Plains;M12;137573
+Plains;M12;137574
+Plains;M12;25492
+Plains;M12;27743
+Plains;M13;121682
+Plains;M13;131643
+Plains;M13;137573
+Plains;M13;138668
+Plains;M14;121682
+Plains;M14;138668
+Plains;M14;138765
+Plains;M14;145503
+Plains;M15;137574
+Plains;M15;138668
+Plains;M15;138765
+Plains;M15;153336
+Plains;MBS;133227
+Plains;MBS;133245
+Plains;ME3;9121
+Plains;ME3;9122
+Plains;ME3;9123
+Plains;MED;191
+Plains;MED;192
+Plains;MED;300
+Plains;MIR;1997
+Plains;MIR;1998
+Plains;MIR;1999
+Plains;MIR;2000
+Plains;MMQ;19005
+Plains;MMQ;19018
+Plains;MMQ;19147
+Plains;MMQ;19267
+Plains;MRD;50308
+Plains;MRD;50309
+Plains;MRD;50310
+Plains;MRD;50346
+Plains;NPH;134342
+Plains;NPH;134355
+Plains;ODY;33222
+Plains;ODY;33223
+Plains;ODY;33224
+Plains;ODY;33225
+Plains;ONS;43223
+Plains;ONS;43234
+Plains;ONS;43235
+Plains;ONS;43236
+Plains;ORI;115088
+Plains;ORI;115089
+Plains;ORI;149122
+Plains;ORI;149974
+Plains;PC1;111815
+Plains;PC1;111829
+Plains;PC1;50310
+Plains;PC1;89171
+Plains;PC1;89178
+Plains;PC2;123755
+Plains;PC2;123760
+Plains;PC2;123763
+Plains;PC2;123770
+Plains;PC2;25178
+Plains;PO2;4789
+Plains;PO2;4790
+Plains;PO2;4791
+Plains;POR;6780
+Plains;POR;6781
+Plains;POR;6782
+Plains;POR;6783
+Plains;PRM;116172
+Plains;PRM;125124
+Plains;PRM;132689
+Plains;PRM;148810
+Plains;PRM;156669
+Plains;PRM;160797
+Plains;PRM;17595
+Plains;PRM;21429
+Plains;PRM;21434
+Plains;PRM;21439
+Plains;PRM;21590
+Plains;PRM;49940
+Plains;PRM;75384
+Plains;PRM;8504
+Plains;PRM;8505
+Plains;PRM;85583
+Plains;PRM;90384
+Plains;PRM;9175
+Plains;PRM;97558
+Plains;PTK;9121
+Plains;PTK;9122
+Plains;PTK;9123
+Plains;RAV;89168
+Plains;RAV;89171
+Plains;RAV;89175
+Plains;RAV;89178
+Plains;ROE;127487
+Plains;ROE;127490
+Plains;ROE;127493
+Plains;ROE;127500
+Plains;RTR;145242
+Plains;RTR;145243
+Plains;RTR;145244
+Plains;RTR;145245
+Plains;RTR;89178
+Plains;SHM;111815
+Plains;SHM;111829
+Plains;SHM;111833
+Plains;SHM;111834
+Plains;SOI;161511
+Plains;SOI;161512
+Plains;SOI;161513
+Plains;SOM;131163
+Plains;SOM;131169
+Plains;SOM;131171
+Plains;SOM;131175
+Plains;TD0;121682
+Plains;TD0;121696
+Plains;TD0;25492
+Plains;TD0;33224
+Plains;TD0;9121
+Plains;TD0;9122
+Plains;TD0;9123
+Plains;TD2;131169
+Plains;TD2;50310
+Plains;TD2;50346
+Plains;THS;149122
+Plains;THS;149125
+Plains;THS;149974
+Plains;THS;149975
+Plains;TMP;3070
+Plains;TMP;3075
+Plains;TMP;3080
+Plains;TMP;3085
+Plains;TPR;3070
+Plains;TPR;3075
+Plains;TPR;3080
+Plains;TPR;3085
+Plains;TSP;96763
+Plains;TSP;97556
+Plains;TSP;97557
+Plains;TSP;97563
+Plains;USG;8659
+Plains;USG;8660
+Plains;USG;8661
+Plains;USG;9035
+Plains;XLN;401897
+Plains;XLN;401898
+Plains;XLN;401899
+Plains;XLN;402020
+Plains;ZEN;123755
+Plains;ZEN;123760
+Plains;ZEN;123763
+Plains;ZEN;123770
+Planar Birth;USG;8864
+Planar Bridge;AER;400410
+Planar Bridge;MS2;400925
+Planar Chaos;JUD;40253
+Planar Cleansing;DPA;121714
+Planar Cleansing;M10;121714
+Planar Cleansing;M13;121714
+Planar Cleansing;M14;121714
+Planar Collapse;UL;10421
+Planar Despair;APC;31125
+Planar Die;C02;1000157
+Planar Gate;LEG;2545
+Planar Gate;ME4;2545
+Planar Guide;LGN;47501
+Planar Outburst;BFZ;160635
+Planar Overlay;PLS;27921
+Planar Portal;8ED;25180
+Planar Portal;INV;25180
+Planar Void;USG;8759
+Planeswalker's Favor;PLS;27964
+Planeswalker's Fury;PLS;27961
+Planeswalker's Mirth;PLS;27962
+Planeswalker's Mischief;PLS;27963
+Planeswalker's Scorn;PLS;27965
+Planewide Disaster;PC2;138731
+Plant Elemental;POR;6669
+Plant;TOK;126539
+Plant;TOK;160868
+Plant;TOK;402427
+Plasm Capture;DGM;146877
+Plasma Elemental;5DN;77210
+Plateau;2ED;16812
+Plateau;3ED;193
+Plateau;LEA;16812
+Plateau;LEB;16812
+Plateau;ME3;193
+Plateau;ME4;193
+Plateau;PRM;144346
+Plateau;VMA;144346
+Plated Crusher;BFZ;160830
+Plated Geopede;DDI;140034
+Plated Geopede;ZEN;123534
+Plated Pegasus;TSP;97373
+Plated Rootwalla;EXO;3735
+Plated Seastrider;SOM;130874
+Plated Slagwurm;DDD;50270
+Plated Slagwurm;MRD;50270
+Plated Sliver;LGN;46539
+Plated Spider;UD;15726
+Plated Wurm;PO2;4766
+Platinum Angel;10E;49681
+Platinum Angel;DPA;49681
+Platinum Angel;M10;49681
+Platinum Angel;M11;49681
+Platinum Angel;MRD;49681
+Platinum Angel;MS2;400922
+Platinum Angel;TD2;49681
+Platinum Angel;V15;49681
+Platinum Emperion;SOM;131201
+Plaxcaster Frogling;DIS;94307
+Plaxcaster Frogling;MM2;94307
+Plaxmanta;DIS;94359
+Plea for Guidance;BNG;152544
+Plea for Power;VMA;153169
+Pledge of Loyalty;INV;24110
+Plover Knights;DDG;105320
+Plover Knights;LRW;105320
+Plow Through Reito;SOK;87221
+Plow Under;8ED;49254
+Plow Under;UD;15593
+Plumes of Peace;DIS;94444
+Plumeveil;CMD;111776
+Plumeveil;MMA;111776
+Plumeveil;SHM;111776
+Plummet;BFZ;160834
+Plummet;DPA;129149
+Plummet;M11;129149
+Plummet;M12;129149
+Plummet;M13;129149
+Plummet;M14;129149
+Plummet;M15;129149
+Plummet;MM2;129149
+Plummet;ORI;129149
+Plunder;TSP;97328
+Plunge into Darkness;5DN;52015
+Poison Arrow;PTK;9147
+Poison the Well;SHM;111693
+Poisonbelly Ogre;GPT;91869
+Polar Kraken;ICE;1325
+Polar Kraken;MED;1325
+Polis Crusher;THS;150786
+Political Trickery;MIR;2001
+Pollen Lullaby;CMD;106369
+Pollen Lullaby;LRW;106369
+Pollen Remedy;PLS;27891
+Pollenbright Wings;DPA;89052
+Pollenbright Wings;PC2;89052
+Pollenbright Wings;RAV;89052
+Polluted Bonds;SHM;111661
+Polluted Dead;AVR;141821
+Polluted Delta;EXP;160796
+Polluted Delta;KTK;156608
+Polluted Delta;ONS;43220
+Polluted Delta;PRM;43220
+Polluted Mire;C14;8692
+Polluted Mire;DDD;8692
+Polluted Mire;PD3;8692
+Polluted Mire;USG;8692
+Polukranos, World Eater;DDL;150065
+Polukranos, World Eater;THS;151414
+Polymorph;6ED;2002
+Polymorph;9ED;2002
+Polymorph;DPA;2002
+Polymorph;M10;2002
+Polymorph;MIR;2002
+Polymorphist's Jest;M15;155222
+Polymorphous Rush;JOU;153047
+Ponder;LRW;105422
+Ponder;M10;122143
+Ponder;M12;122143
+Ponder;PRM;113861
+Pongify;C14;100818
+Pongify;PLC;100818
+Pontiff of Blight;C14;146865
+Pontiff of Blight;DGM;146865
+Ponyback Brigade;KTK;156572
+Pooling Venom;FUT;100655
+Pools of Becoming;PC1;125875
+Porcelain Legionnaire;NPH;134295
+Pore Over the Pages;SOI;161619
+Porphyry Nodes;PLC;100744
+Port Inspector;MMQ;19082
+Port Town;SOI;161438
+Portcullis;STH;3736
+Portent of Betrayal;THS;150787
+Portent;5ED;1326
+Portent;ICE;1326
+Portent;ME2;1326
+Possessed Aven;TOR;36429
+Possessed Barbarian;TOR;36496
+Possessed Centaur;TOR;36522
+Possessed Nomad;TOR;36402
+Possessed Portal;5DN;77082
+Possessed Skaab;ORI;160340
+Possibility Storm;DGM;146882
+Postmortem Lunge;NPH;134393
+Poultice Sliver;PLC;100771
+Pounce;XLN;402291
+Pouncing Cheetah;AKH;400816
+Pouncing Jaguar;PRM;8642
+Pouncing Jaguar;USG;8642
+Pouncing Kavu;INV;24115
+Pouncing Wurm;PLC;100666
+Powder Keg;PRM;15685
+Powder Keg;UD;15685
+Power Armor;DDE;25230
+Power Armor;INV;25230
+Power Artifact;ATQ;434
+Power Artifact;ME4;434
+Power Conduit;MRD;51105
+Power Leak;2ED;194
+Power Leak;3ED;194
+Power Leak;4ED;194
+Power Leak;LEA;194
+Power Leak;LEB;194
+Power Matrix;MMQ;19238
+Power Sink;2ED;195
+Power Sink;3ED;195
+Power Sink;4ED;195
+Power Sink;5ED;195
+Power Sink;6ED;1327
+Power Sink;ICE;1327
+Power Sink;LEA;195
+Power Sink;LEB;195
+Power Sink;MIR;2003
+Power Sink;TMP;3041
+Power Sink;USG;8873
+Power Sink;VMA;8873
+Power Surge;2ED;196
+Power Surge;3ED;196
+Power Surge;4ED;196
+Power Surge;LEA;196
+Power Surge;LEB;196
+Power Taint;USG;8893
+Power of Fire;SHM;111733
+Powerleech;ATQ;435
+Powerstone Minefield;APC;31127
+Pox;5ED;2453
+Pox;ICE;1328
+Pox;MED;1328
+Pradesh Gypsies;4ED;631
+Pradesh Gypsies;5ED;631
+Pradesh Gypsies;6ED;631
+Pradesh Gypsies;LEG;631
+Praetor's Counsel;C14;133208
+Praetor's Counsel;MBS;133208
+Praetor's Grasp;NPH;134301
+Prahv, Spires of Order;DIS;94320
+Prahv;PC2;138736
+Prairie Stream;BFZ;160857
+Prairie Stream;EXP;161290
+Prakhata Club Security;KLD;162273
+Prakhata Pillar-Bug;KLD;162341
+Preacher;DRK;813
+Preacher;MED;813
+Preacher;PRM;813
+Precinct Captain;RTR;145936
+Precise Strike;AER;400312
+Precognition;TMP;3171
+Precursor Golem;MM2;131023
+Precursor Golem;SOM;131023
+Predator Dragon;ALA;115046
+Predator Dragon;DPA;115046
+Predator Ooze;DKA;139901
+Predator, Flagship;C14;21271
+Predator, Flagship;NMS;21271
+Predator, Flagship;VMA;21271
+Predator's Gambit;AVR;141802
+Predator's Rapport;GTC;146541
+Predator's Strike;MRD;50335
+Predatory Advantage;ARB;121012
+Predatory Focus;GPT;91758
+Predatory Hunger;EXO;5661
+Predatory Nightstalker;PO2;4719
+Predatory Nightstalker;VMA;4719
+Predatory Rampage;DPA;143883
+Predatory Rampage;M13;143883
+Predatory Sliver;DPA;149953
+Predatory Sliver;M14;149953
+Predatory Urge;PC2;123525
+Predatory Urge;ZEN;123525
+Predict;ODY;33470
+Preeminent Captain;M15;109607
+Preeminent Captain;MOR;109607
+Preemptive Strike;PTK;9030
+Preferred Selection;MIR;2004
+Premature Burial;TSP;97310
+Preordain;DDI;140033
+Preordain;M11;129109
+Prepare;AKH;401275
+Prescient Chimera;THS;149179
+Presence of Gond;C13;111879
+Presence of Gond;SHM;111879
+Presence of the Master;LEG;632
+Presence of the Master;USG;8674
+Presence of the Wise;SOK;86083
+Press for Answers;SOI;161649
+Press into Service;OGW;161168
+Press the Advantage;DTK;160061
+Pressure Point;FRF;157248
+Pressure Point;KLD;162468
+Pretender's Claim;MMQ;19467
+Prey Upon;AER;400337
+Prey Upon;DDL;138133
+Prey Upon;DPA;138133
+Prey Upon;EMN;162001
+Prey Upon;ISD;138133
+Prey Upon;M13;138133
+Prey's Vengeance;ROE;127354
+Preyseizer Dragon;PC2;140349
+Price of Glory;ODY;28782
+Price of Knowledge;C13;151764
+Price of Progress;EMA;161851
+Price of Progress;EXO;5590
+Price of Progress;PD2;5590
+Price of Progress;TD0;5590
+Prickleboar;ORI;160280
+Prickly Boggart;MOR;109939
+Pride Guardian;M12;137410
+Pride Sovereign;HOU;401826
+Pride of Lions;7ED;27745
+Pride of Lions;DDH;17578
+Pride of the Clouds;DIS;94300
+Priest of Gix;DDE;8699
+Priest of Gix;USG;8699
+Priest of Iroas;THS;149058
+Priest of Titania;C14;8770
+Priest of Titania;PRM;8770
+Priest of Titania;USG;8770
+Priest of Urabrask;NPH;134290
+Priest of Urabrask;PRM;136791
+Priest of Yawgmoth;ATQ;436
+Priest of the Blood Rite;ORI;160257
+Priest of the Wakening Sun;XLN;402120
+Priests of Norn;MBS;133197
+Primal Amulet;XLN;402279
+Primal Bellow;DPA;123749
+Primal Bellow;ZEN;123749
+Primal Beyond;MOR;110020
+Primal Boost;ONS;43187
+Primal Clay;3ED;437
+Primal Clay;4ED;437
+Primal Clay;5ED;2454
+Primal Clay;6ED;2454
+Primal Clay;ATQ;437
+Primal Clay;M13;143984
+Primal Clay;ME4;437
+Primal Cocoon;M11;129088
+Primal Command;LRW;105574
+Primal Command;MM3;105574
+Primal Command;PRM;160772
+Primal Druid;EMN;161998
+Primal Forcemage;TSP;97372
+Primal Frenzy;ODY;33467
+Primal Growth;PLS;27971
+Primal Huntbeast;DPA;143857
+Primal Huntbeast;M13;143857
+Primal Order;5ED;2455
+Primal Order;HML;1541
+Primal Order;MED;1541
+Primal Plasma;DDI;97379
+Primal Plasma;PC2;97379
+Primal Plasma;PLC;97379
+Primal Rage;10E;3683
+Primal Rage;STH;3683
+Primal Surge;AVR;141699
+Primal Surge;DPA;141699
+Primal Vigor;C13;151763
+Primal Visitation;GTC;146549
+Primal Wellspring;XLN;402306
+Primal Whisperer;LGN;46566
+Primalcrux;DPA;113678
+Primalcrux;EVE;113678
+Prime Speaker Zegana;GTC;146471
+Primeval Bounty;DPA;147446
+Primeval Bounty;M14;147446
+Primeval Force;8ED;6670
+Primeval Force;POR;6670
+Primeval Light;DPA;93484
+Primeval Light;GPT;93484
+Primeval Protector;PZ2;162430
+Primeval Shambler;8ED;19060
+Primeval Shambler;MMQ;19060
+Primeval Titan;DPA;129116
+Primeval Titan;M11;129116
+Primeval Titan;M12;129116
+Primeval Titan;MM2;129116
+Primitive Etchings;SCG;48996
+Primitive Justice;ALL;1705
+Primitive Justice;ME4;1705
+Primoc Escapee;LGN;47481
+Primordial Hydra;DPA;134113
+Primordial Hydra;M12;134113
+Primordial Hydra;M13;134113
+Primordial Ooze;5ED;2456
+Primordial Ooze;CH;633
+Primordial Ooze;LEG;633
+Primordial Sage;C14;89124
+Primordial Sage;DPA;89124
+Primordial Sage;RAV;89124
+Prince of Thralls;ALA;115139
+Princess Lucrezia;LEG;634
+Princess Lucrezia;ME3;634
+Prism Array;BFZ;160879
+Prism Ring;ORI;160350
+Prism;TOK;2156
+Prismatic Boon;MIR;2005
+Prismatic Circle;MIR;2006
+Prismatic Geoscope;PZ2;162398
+Prismatic Lace;MIR;2007
+Prismatic Lens;EMA;97507
+Prismatic Lens;TSP;97507
+Prismatic Omen;SHM;111716
+Prismatic Strands;JUD;40169
+Prismatic Ward;5ED;2457
+Prismatic Ward;ICE;1329
+Prismwake Merrow;SHM;111802
+Prison Barricade;INV;25182
+Prison Term;CMD;111598
+Prison Term;PC1;111598
+Prison Term;SHM;111598
+Prison Term;TD0;111598
+Pristine Angel;DST;75182
+Pristine Skywise;DTK;160074
+Pristine Skywise;PRM;159807
+Pristine Talisman;C13;134413
+Pristine Talisman;C14;134413
+Pristine Talisman;NPH;134413
+Pristine Talisman;PRM;134413
+Private Research;UD;15623
+Privileged Position;RAV;88712
+Prized Amalgam;SOI;161646
+Prized Elephant;M13;143912
+Prized Unicorn;M10;121572
+Prized Unicorn;M11;121572
+Prized Unicorn;ORI;121572
+Prizefighter Construct;AER;400378
+Probe;INV;24109
+Processor Assault;BFZ;161083
+Proclamation of Rebirth;DIS;94409
+Prodigal Pyromancer;10E;100670
+Prodigal Pyromancer;DPA;100670
+Prodigal Pyromancer;M10;100670
+Prodigal Pyromancer;M11;100670
+Prodigal Pyromancer;PLC;100670
+Prodigal Sorcerer;2ED;197
+Prodigal Sorcerer;3ED;197
+Prodigal Sorcerer;4ED;197
+Prodigal Sorcerer;5ED;197
+Prodigal Sorcerer;6ED;197
+Prodigal Sorcerer;7ED;27746
+Prodigal Sorcerer;EMA;161305
+Prodigal Sorcerer;LEA;197
+Prodigal Sorcerer;LEB;197
+Prodigal Sorcerer;ME4;197
+Prodigal Sorcerer;PRM;197
+Prodigal Sorcerer;TSB;197
+Profane Command;C14;105567
+Profane Command;DDH;105567
+Profane Command;LRW;105567
+Profane Command;MM2;105567
+Profane Command;PC1;105567
+Profane Memento;M15;155258
+Profane Prayers;ONS;43049
+Profaner of the Dead;DTK;160073
+Profit;DGM;147719
+Profound Journey;DTK;159788
+Progenitor Mimic;DGM;146665
+Progenitus;CON;118704
+Progenitus;MMA;118704
+Progenitus;V11;137605
+Prognostic Sphinx;PRM;158164
+Prognostic Sphinx;THS;149207
+Prohibit;DDM;24003
+Prohibit;INV;24003
+Promise of Bunrei;SOK;86122
+Promise of Power;C14;50283
+Promise of Power;DDC;50283
+Promise of Power;MRD;50283
+Promised Kannushi;SOK;86022
+Propaganda;C13;151990
+Propaganda;CMD;3285
+Propaganda;PZ1;3285
+Propaganda;TMP;3285
+Propeller Pioneer;KLD;162234
+Proper Burial;DIS;94524
+Prophecy;HML;1542
+Prophet of Distortion;OGW;161042
+Prophet of Kruphix;PRM;158165
+Prophet of Kruphix;THS;150885
+Prophetic Bolt;APC;31142
+Prophetic Bolt;CMD;31142
+Prophetic Bolt;DDJ;143407
+Prophetic Bolt;DPA;31142
+Prophetic Bolt;VMA;143407
+Prophetic Flamespeaker;JOU;155880
+Prophetic Prism;CMD;127468
+Prophetic Prism;GTC;146269
+Prophetic Prism;KLD;162346
+Prophetic Prism;ROE;127468
+Prophetic Ravings;EMN;162108
+Prosperity;6ED;2231
+Prosperity;C13;143927
+Prosperity;DPA;2231
+Prosperity;POR;6629
+Prosperity;VIS;2231
+Prosperous Pirates;XLN;401430
+Prossh, Skyraider of Kher;C13;151739
+Protean Hulk;DIS;94651
+Protean Hulk;TD2;94651
+Protean Hydra;M10;122168
+Protean Hydra;M11;122168
+Protect;DGM;147693
+Protection of the Hekma;AKH;400760
+Protective Bubble;LRW;105447
+Protective Sphere;INV;25471
+Protector of the Crown;PZ2;161865
+Proteus Machine;SCG;48163
+Proteus Staff;MRD;51137
+Protomatter Powder;ALA;114953
+Prototype Portal;SOM;131068
+Proven Combatant;HOU;401546
+Proven Combatant;TOK;401882
+Providence;EMN;162033
+Provoke;STH;3737
+Provoke;TPR;3737
+Provoke;VMA;3737
+Prowess of the Fair;LRW;111065
+Prowler's Helm;THS;149104
+Prowling Nightstalker;ME4;4580
+Prowling Nightstalker;PO2;4580
+Prowling Pangolin;EMA;161557
+Prowling Pangolin;ONS;43063
+Prowling Serpopard;AKH;400918
+Prying Blade;XLN;402015
+Prying Questions;EMN;161964
+Psionic Blast;2ED;198
+Psionic Blast;LEA;198
+Psionic Blast;LEB;198
+Psionic Blast;PRM;101023
+Psionic Blast;TSB;198
+Psionic Entity;4ED;635
+Psionic Entity;LEG;635
+Psionic Gift;ODY;33486
+Psionic Sliver;TSP;97432
+Psychatog;ODY;33274
+Psychatog;PRM;33274
+Psychatog;VMA;158840
+Psychic Allergy;DRK;814
+Psychic Barrier;NPH;134277
+Psychic Battle;INV;25184
+Psychic Drain;RAV;89155
+Psychic Intrusion;THS;150802
+Psychic Membrane;MRD;50296
+Psychic Miasma;SOM;131022
+Psychic Overload;DST;75390
+Psychic Possession;DIS;94328
+Psychic Puppetry;COK;82611
+Psychic Purge;LEG;636
+Psychic Purge;MED;636
+Psychic Rebuttal;ORI;160225
+Psychic Spear;BOK;83905
+Psychic Spiral;RTR;145901
+Psychic Strike;GTC;146279
+Psychic Surgery;NPH;134203
+Psychic Theft;PCY;22005
+Psychic Trance;ONS;43012
+Psychic Transfer;6ED;2008
+Psychic Transfer;MIR;2008
+Psychic Venom;2ED;199
+Psychic Venom;3ED;199
+Psychic Venom;4ED;199
+Psychic Venom;5ED;199
+Psychic Venom;6ED;199
+Psychic Venom;LEA;199
+Psychic Venom;LEB;199
+Psychic Venom;MED;199
+Psychic Vortex;WTH;2892
+Psychogenic Probe;MRD;51027
+Psychosis Crawler;DPA;133219
+Psychosis Crawler;MBS;133219
+Psychotic Episode;TSP;99653
+Psychotic Fury;DIS;94407
+Psychotic Haze;TOR;36445
+Psychotrope Thallid;PLC;100809
+Pterodon Knight;XLN;402339
+Pteron Ghost;DST;50328
+Public Execution;DPA;143867
+Public Execution;M13;143867
+Puca's Mischief;DPA;111556
+Puca's Mischief;SHM;111556
+Puffer Extract;MMQ;19143
+Pull Under;COK;80925
+Pull from Eternity;TSP;97274
+Pull from Tomorrow;AKH;400854
+Pull from the Deep;JOU;152897
+Pulling Teeth;MOR;109928
+Pulmonic Sliver;TSP;97438
+Pulsating Illusion;ODY;32758
+Pulse Tracker;DDM;126567
+Pulse Tracker;DPA;126567
+Pulse Tracker;WWK;126567
+Pulse of Llanowar;INV;24111
+Pulse of Murasa;OGW;160820
+Pulse of the Dross;DST;75144
+Pulse of the Fields;DST;75145
+Pulse of the Forge;DST;75135
+Pulse of the Grid;DST;75159
+Pulse of the Tangle;DST;75143
+Pulsemage Advocate;JUD;40192
+Pulverize;MMQ;19076
+Puncture Blast;EVE;113649
+Puncture Bolt;SHM;111629
+Puncturing Blow;HOU;402538
+Puncturing Light;ROE;127355
+Puncturing Light;SOI;161651
+Punish Ignorance;ALA;115231
+Punish the Enemy;DGM;146663
+Punishing Fire;CMD;103540
+Punishing Fire;DDG;135663
+Punishing Fire;DPA;103540
+Punishing Fire;PZ1;103540
+Punishing Fire;ZEN;103540
+Punishment;DIS;100955
+Puppet Conjurer;ALA;115075
+Puppet Master;CH;637
+Puppet Master;LEG;637
+Puppet Strings;DDE;3207
+Puppet Strings;TMP;3207
+Puppet's Verdict;MMQ;19013
+Puppeteer Clique;MM2;111658
+Puppeteer Clique;SHM;111658
+Puppeteer;10E;101048
+Puppeteer;8ED;33484
+Puppeteer;9ED;33484
+Puppeteer;ODY;33484
+Pure Intentions;SOK;86160
+Pure Reflection;INV;24188
+Pure;DIS;94587
+Purelace;2ED;200
+Purelace;3ED;200
+Purelace;4ED;200
+Purelace;LEA;200
+Purelace;LEB;200
+Puresight Merrow;SHM;111856
+Puresteel Paladin;DPA;134336
+Puresteel Paladin;NPH;134336
+Purgatory;MIR;2009
+Purge the Profane;GTC;146410
+Purge;DST;75134
+Purge;TD2;75134
+Purging Scythe;USG;8953
+Purify the Grave;ISD;138254
+Purify;7ED;27748
+Purify;UL;10323
+Purity;DPA;105530
+Purity;LRW;105530
+Purphoros, God of the Forge;THS;149147
+Purphoros's Emissary;THS;150804
+Purraj of Urborg;MIR;2010
+Pursue Glory;AKH;401325
+Pursuit of Flight;RTR;145869
+Pursuit of Knowledge;STH;3738
+Pus Kami;BOK;81658
+Put Away;DPA;111889
+Put Away;SHM;111889
+Putrefaction;MMQ;19051
+Putrefax;SOM;131037
+Putrefy;DDJ;145071
+Putrefy;DGM;146850
+Putrefy;MM3;146850
+Putrefy;PRM;90390
+Putrefy;RAV;88912
+Putrefy;TD0;88912
+Putrefy;TD2;88912
+Putrid Cyclops;FUT;102341
+Putrid Imp;PD3;36436
+Putrid Imp;TOR;36436
+Putrid Imp;VMA;36436
+Putrid Leech;ARB;120997
+Putrid Leech;DDJ;120997
+Putrid Leech;DDM;153260
+Putrid Raptor;SCG;48157
+Putrid Warrior;APC;31178
+Pygmy Allosaurus;ICE;1330
+Pygmy Hippo;VIS;2232
+Pygmy Kavu;PLS;28008
+Pygmy Pyrosaur;7ED;27749
+Pygmy Pyrosaur;DDI;27749
+Pygmy Pyrosaur;UL;13554
+Pygmy Razorback;PCY;22006
+Pygmy Troll;EXO;5640
+Pyknite;ICE;1331
+Pyramid of the Pantheon;AKH;401354
+Pyramids;ARN;363
+Pyre Charger;DD2;111777
+Pyre Charger;DPA;111777
+Pyre Charger;SHM;111777
+Pyre Hound;SOI;161682
+Pyre Zombie;INV;25227
+Pyreheart Wolf;DKA;139808
+Pyretic Ritual;M11;129153
+Pyrewild Shaman;DGM;146782
+Pyrewild Shaman;MM3;146782
+Pyric Salamander;MIR;2011
+Pyrite Spellbomb;MMA;50288
+Pyrite Spellbomb;MRD;50288
+Pyroblast;5ED;1332
+Pyroblast;EMA;161564
+Pyroblast;ICE;1332
+Pyroblast;MED;1332
+Pyroblast;TD0;1332
+Pyroclasm;10E;49671
+Pyroclasm;7ED;27750
+Pyroclasm;8ED;49671
+Pyroclasm;9ED;49671
+Pyroclasm;DDK;49671
+Pyroclasm;DDL;49671
+Pyroclasm;DPA;49671
+Pyroclasm;ICE;1333
+Pyroclasm;M10;49671
+Pyroclasm;M11;49671
+Pyroclasm;MM3;49671
+Pyroclasm;POR;6709
+Pyroclasm;PRM;90391
+Pyroclast Consul;MOR;109613
+Pyroconvergence;RTR;145909
+Pyrohemia;CMD;101524
+Pyrohemia;PLC;101524
+Pyrokinesis;ALL;1706
+Pyrokinesis;DDL;144457
+Pyrokinesis;EMA;144457
+Pyrokinesis;ME2;1706
+Pyrokinesis;PRM;144457
+Pyromancer Ascension;MM3;125086
+Pyromancer Ascension;ZEN;125086
+Pyromancer's Assault;OGW;161239
+Pyromancer's Gauntlet;M14;147484
+Pyromancer's Goggles;ORI;160359
+Pyromancer's Swath;FUT;102503
+Pyromancer's Swath;MMA;102503
+Pyromancy;UL;10374
+Pyromania;TOR;36491
+Pyromatics;DDJ;91672
+Pyromatics;GPT;91672
+Pyrostatic Pillar;SCG;48138
+Pyrostatic Pillar;TD0;48138
+Pyrotechnics;4ED;638
+Pyrotechnics;5ED;638
+Pyrotechnics;6ED;638
+Pyrotechnics;7ED;27535
+Pyrotechnics;8ED;27535
+Pyrotechnics;FRF;157228
+Pyrotechnics;LEG;638
+Pyrotechnics;PC1;27535
+Pyrrhic Revival;EVE;113726
+Python;6ED;2233
+Python;POR;6590
+Python;VIS;2233
+Pyxis of Pandemonium;THS;150764
+Qal Sisma Behemoth;DTK;159748
+Qarsi Deceiver;DTK;159719
+Qarsi High Priest;FRF;157204
+Qarsi Sadist;DTK;160163
+Qasali Ambusher;ALA;114979
+Qasali Pridemage;ARB;120969
+Qasali Pridemage;DDH;120969
+Qasali Pridemage;DPA;120969
+Qasali Pridemage;PRM;129537
+Quag Sickness;DPA;129117
+Quag Sickness;M11;129117
+Quag Sickness;M14;129117
+Quag Vampires;DPA;126538
+Quag Vampires;WWK;126538
+Quagmire Druid;APC;31128
+Quagmire Druid;C13;151992
+Quagmire Lamprey;MMQ;18999
+Quagmire;LEG;639
+Quagnoth;FUT;100691
+Quarantine Field;BFZ;160816
+Quarry Beetle;HOU;401821
+Quarry Colossus;JOU;152996
+Quarry Hauler;AKH;401333
+Quarum Trench Gnomes;LEG;640
+Quash;BOK;83883
+Quash;UD;15622
+Queen Marchesa;PZ2;161539
+Queen's Agent;XLN;402314
+Queen's Bay Soldier;XLN;402064
+Queen's Commission;XLN;402043
+Quenchable Fire;CON;118698
+Quest for Ancient Secrets;ZEN;123790
+Quest for Pure Flame;DPA;125069
+Quest for Pure Flame;ZEN;125069
+Quest for Renewal;WWK;126497
+Quest for Ula's Temple;WWK;126568
+Quest for the Gemblades;ZEN;123777
+Quest for the Goblin Lord;WWK;126531
+Quest for the Gravelord;DPA;123604
+Quest for the Gravelord;ZEN;123604
+Quest for the Holy Relic;ZEN;125068
+Quest for the Nihil Stone;WWK;126553
+Questing Phelddagrif;PLS;28787
+Questing Phelddagrif;PRM;28787
+Questing Phelddagrif;TD0;28787
+Quick Sliver;H09;46542
+Quick Sliver;LGN;46542
+Quickchange;RAV;88968
+Quicken;GPT;91653
+Quicken;M14;91653
+Quickening Licid;TMP;3295
+Quickling;M15;155336
+Quicksand;10E;2234
+Quicksand;9ED;2234
+Quicksand;VIS;2234
+Quicksand;WWK;126510
+Quicksilver Amulet;M12;137415
+Quicksilver Amulet;UL;13556
+Quicksilver Behemoth;DST;52023
+Quicksilver Dagger;APC;31129
+Quicksilver Dagger;DDJ;31129
+Quicksilver Dagger;DPA;31129
+Quicksilver Dragon;DD2;43014
+Quicksilver Dragon;ONS;43014
+Quicksilver Elemental;MRD;51024
+Quicksilver Fountain;MRD;51140
+Quicksilver Gargantuan;SOM;131039
+Quicksilver Geyser;DPA;133151
+Quicksilver Geyser;MBS;133151
+Quicksilver Sea;PC2;131707
+Quicksilver Wall;PCY;22007
+Quicksmith Genius;KLD;162290
+Quicksmith Rebel;AER;400324
+Quicksmith Rebel;PRM;400720
+Quicksmith Spy;AER;400273
+Quiet Contemplation;KTK;156546
+Quiet Disrepair;FUT;102432
+Quiet Disrepair;PC2;102432
+Quiet Purity;COK;80595
+Quiet Speculation;EMA;36413
+Quiet Speculation;JUD;36413
+Quietus Spike;ALA;98612
+Quietus Spike;PC2;98612
+Quill-Slinger Boggart;LRW;105383
+Quilled Slagwurm;MBS;133144
+Quilled Sliver;TSP;97387
+Quilled Wolf;SOI;161455
+Quillmane Baku;BOK;83962
+Quillspike;EVE;113654
+Quirion Druid;VIS;2235
+Quirion Dryad;10E;104543
+Quirion Dryad;M13;104543
+Quirion Dryad;PLS;27969
+Quirion Elves;DDE;24113
+Quirion Elves;INV;24113
+Quirion Elves;MIR;2012
+Quirion Explorer;PLS;27968
+Quirion Ranger;PRM;148325
+Quirion Ranger;PRM;2236
+Quirion Ranger;VIS;2236
+Quirion Sentinel;INV;25889
+Quirion Trailblazer;INV;24114
+Qumulox;5DN;51010
+Qumulox;DDF;51010
+Qumulox;MM2;51010
+Qumulox;PC1;51010
+Rabble-Rouser;GPT;91810
+Rabid Bite;SOI;161451
+Rabid Bite;W17;161451
+Rabid Bloodsucker;ORI;160264
+Rabid Elephant;ODY;33303
+Rabid Rats;STH;3739
+Rabid Wolverines;EXO;5418
+Rabid Wombat;5ED;641
+Rabid Wombat;CH;641
+Rabid Wombat;LEG;641
+Rabid Wombat;MED;641
+Racecourse Fury;RTR;145867
+Rack and Ruin;UL;13551
+Rackling;NMS;21179
+Radha, Heir to Keld;PLC;100814
+Radiant Essence;MIR;2013
+Radiant Flames;BFZ;160930
+Radiant Flames;PRM;160912
+Radiant Fountain;M15;155387
+Radiant Kavu;PLS;27970
+Radiant Purge;DTK;160053
+Radiant, Archangel;UL;14055
+Radiant, Archangel;VMA;14055
+Radiant's Dragoons;UL;10411
+Radiant's Judgment;UL;10404
+Radiant's Judgment;VMA;10404
+Radiate;TOR;36501
+Radjan Spirit;4ED;642
+Radjan Spirit;5ED;642
+Radjan Spirit;6ED;642
+Radjan Spirit;LEG;642
+Radjan Spirit;ME4;642
+Rafiq of the Many;ALA;115029
+Rafiq of the Many;V11;137599
+Rag Dealer;COK;81576
+Rag Man;4ED;816
+Rag Man;5ED;816
+Rag Man;6ED;816
+Rag Man;7ED;27751
+Rag Man;DRK;816
+Ragamuffyn;DIS;94625
+Ragavan;TOK;401438
+Rage Extractor;NPH;134234
+Rage Forger;MOR;109994
+Rage Nimbus;ROE;127276
+Rage Reflection;DPA;111639
+Rage Reflection;SHM;111639
+Rage Thrower;ISD;138229
+Rage Weaver;10E;25483
+Rage Weaver;INV;25483
+Rage of Purphoros;THS;149065
+Rageblood Shaman;THS;149210
+Rageform;FRF;157191
+Ragemonger;BNG;152607
+Ragged Veins;COK;82608
+Raging Bull;LEG;643
+Raging Cougar;POR;6710
+Raging Goblin;10E;4735
+Raging Goblin;6ED;4735
+Raging Goblin;7ED;27752
+Raging Goblin;8ED;4735
+Raging Goblin;9ED;4735
+Raging Goblin;DPA;4735
+Raging Goblin;EVG;4735
+Raging Goblin;EXO;5425
+Raging Goblin;M10;4735
+Raging Goblin;PO2;4735
+Raging Goblin;POR;6711
+Raging Gorilla;VIS;2237
+Raging Kavu;INV;24166
+Raging Kavu;PRM;24166
+Raging Minotaur;ME3;6713
+Raging Minotaur;POR;6713
+Raging Poltergeist;AVR;141728
+Raging Ravine;WWK;126537
+Raging River;2ED;201
+Raging River;LEA;201
+Raging River;LEB;201
+Raging Spirit;MIR;2014
+Raging Swordtooth;XLN;402013
+Ragnar;LEG;644
+Ragnar;ME3;644
+Rags;AKH;401276
+Raid Bombardment;ROE;127359
+Raiders' Spoils;KTK;157030
+Raiders' Wake;XLN;402266
+Raiding Nightstalker;PO2;4581
+Raiding Party;FEM;992
+Rain of Blades;8ED;48129
+Rain of Blades;M13;48129
+Rain of Blades;SCG;48129
+Rain of Daggers;ME4;4734
+Rain of Daggers;PO2;4734
+Rain of Embers;DPA;88933
+Rain of Embers;RAV;88933
+Rain of Filth;USG;8693
+Rain of Gore;DIS;94423
+Rain of Rust;5DN;77170
+Rain of Salt;POR;6714
+Rain of Salt;USG;8863
+Rain of Tears;10E;6591
+Rain of Tears;MMQ;19017
+Rain of Tears;POR;6591
+Rain of Tears;TMP;3223
+Rain of Thorns;AVR;141710
+Rain of Thorns;C13;141710
+Rainbow Crow;INV;24116
+Rainbow Efreet;VIS;2238
+Rainbow Vale;FEM;993
+Rainbow Vale;MED;993
+Raise Dead;2ED;202
+Raise Dead;3ED;202
+Raise Dead;4ED;202
+Raise Dead;5ED;2458
+Raise Dead;6ED;6592
+Raise Dead;7ED;27753
+Raise Dead;8ED;27753
+Raise Dead;9ED;27753
+Raise Dead;DPA;27753
+Raise Dead;LEA;202
+Raise Dead;LEB;202
+Raise Dead;PO2;4714
+Raise Dead;POR;6592
+Raise Dead;W17;27753
+Raise the Alarm;DDF;50285
+Raise the Alarm;DPA;50285
+Raise the Alarm;EMA;155870
+Raise the Alarm;M15;155870
+Raise the Alarm;MM2;155870
+Raise the Alarm;MRD;50285
+Raised by Wolves;BNG;152079
+Raka Disciple;APC;31076
+Raka Sanctuary;APC;31078
+Rakalite;ATQ;438
+Rakalite;CH;438
+Rakalite;ME4;438
+Rakavolver;APC;31077
+Rakdos Augermage;DIS;94598
+Rakdos Cackler;PRM;149965
+Rakdos Cackler;RTR;145197
+Rakdos Carnarium;C13;94285
+Rakdos Carnarium;CMD;94285
+Rakdos Carnarium;DDK;94285
+Rakdos Carnarium;DIS;94285
+Rakdos Carnarium;MM2;94285
+Rakdos Carnarium;TD0;94285
+Rakdos Charm;RTR;145200
+Rakdos Cluestone;DGM;147753
+Rakdos Drake;DGM;146855
+Rakdos Guildgate;C13;145164
+Rakdos Guildgate;DGM;146884
+Rakdos Guildgate;MM3;146884
+Rakdos Guildgate;RTR;145164
+Rakdos Guildmage;DIS;94311
+Rakdos Guildmage;PRM;94311
+Rakdos Ickspitter;DIS;94277
+Rakdos Keyrune;RTR;145214
+Rakdos Pit Dragon;DD2;94660
+Rakdos Pit Dragon;DIS;94660
+Rakdos Ragemutt;RTR;145924
+Rakdos Ringleader;RTR;145226
+Rakdos Riteknife;DIS;94322
+Rakdos Shred-Freak;RTR;145153
+Rakdos Signet;CMD;94301
+Rakdos Signet;DIS;94301
+Rakdos Signet;MM3;131651
+Rakdos Signet;PRM;131651
+Rakdos Signet;TD0;94301
+Rakdos the Defiler;DIS;94497
+Rakdos the Defiler;DPA;94497
+Rakdos, Lord of Riots;RTR;145269
+Rakdos's Return;RTR;145270
+Rakeclaw Gargantuan;ALA;115185
+Rakeclaw Gargantuan;C13;115185
+Raking Canopy;SHM;111851
+Rakish Heir;ISD;138376
+Rakka Mar;CON;118775
+Raksha Golden Cub;5DN;77216
+Rakshasa Deathdealer;KTK;157087
+Rakshasa Gravecaller;DTK;159796
+Rakshasa Vizier;KTK;157110
+Rakshasa Vizier;PRM;156602
+Rakshasa's Disdain;FRF;157153
+Rakshasa's Secret;KTK;157024
+Ral Zarek;DGM;137434
+Rally the Ancestors;FRF;157332
+Rally the Forces;DPA;133156
+Rally the Forces;MBS;133156
+Rally the Horde;SOK;86101
+Rally the Peasants;EMA;138416
+Rally the Peasants;ISD;138416
+Rally the Righteous;RAV;88687
+Rally the Troops;PO2;4674
+Rally the Troops;PTK;9018
+Rally;ICE;1334
+Rallying Roar;XLN;402228
+Ramirez DePietro;LEG;645
+Ramirez DePietro;ME3;645
+Ramosian Captain;MMQ;19317
+Ramosian Commander;MMQ;19132
+Ramosian Lieutenant;MMQ;19230
+Ramosian Rally;MMQ;19193
+Ramosian Revivalist;FUT;102467
+Ramosian Sergeant;MMQ;19134
+Ramosian Sky Marshal;MMQ;19023
+Rampaging Baloths;C13;123726
+Rampaging Baloths;C14;123726
+Rampaging Baloths;DPA;123726
+Rampaging Baloths;PRM;125091
+Rampaging Baloths;ZEN;123726
+Rampaging Ferocidon;XLN;402123
+Rampaging Hippo;HOU;401818
+Rampaging Werewolf;ISD;138199
+Rampant Elephant;INV;24171
+Rampant Growth;10E;101061
+Rampant Growth;6ED;3000
+Rampant Growth;7ED;29795
+Rampant Growth;8ED;3000
+Rampant Growth;9ED;3000
+Rampant Growth;DPA;101061
+Rampant Growth;M10;101061
+Rampant Growth;M12;101061
+Rampant Growth;MIR;2015
+Rampant Growth;MM2;101061
+Rampant Growth;PC1;101061
+Rampant Growth;PRM;120093
+Rampant Growth;TD0;3000
+Rampant Growth;TMP;3000
+Rampant Growth;TPR;3000
+Rampart Crawler;MMQ;20059
+Ramroller;ORI;160358
+Ramses Overdark;LEG;2546
+Ramses Overdark;ME3;2546
+Ramunap Excavator;HOU;401827
+Ramunap Excavator;PRM;401828
+Ramunap Hydra;HOU;401830
+Ramunap Ruins;HOU;401559
+Rancid Earth;TOR;33374
+Rancid Rats;SOI;161489
+Rancor;DDD;10418
+Rancor;DPA;10418
+Rancor;EMA;10418
+Rancor;M13;10418
+Rancor;PC2;10418
+Rancor;PRM;10418
+Rancor;PZ1;10418
+Rancor;UL;10418
+Ranger en-Vec;TMP;3309
+Ranger of Eos;ALA;114946
+Ranger of Eos;MM3;400105
+Ranger's Guile;ISD;139303
+Ranger's Guile;M14;139303
+Ranger's Guile;M15;139303
+Ranger's Path;M13;143971
+Ranging Raptors;XLN;402270
+Rank and File;UL;13547
+Ransack;STH;3740
+Rapacious One;CMD;127466
+Rapacious One;ROE;127466
+Rapid Decay;UD;15633
+Rapid Fire;LEG;646
+Rapid Hybridization;GTC;146515
+Rappelling Scouts;MMQ;18986
+Raptor Companion;XLN;402299
+Raptor Hatchling;XLN;402114
+Rashida Scalebane;MIR;2016
+Rashka the Slayer;HML;1543
+Rashmi, Eternities Crafter;KLD;162321
+Rasputin Dreamweaver;LEG;647
+Rasputin Dreamweaver;ME3;647
+Rat;TOK;112144
+Rat;TOK;125145
+Rat;TOK;147259
+Rat;TOK;82652
+Ratcatcher;DIS;94346
+Ratchet Bomb;M14;131012
+Ratchet Bomb;PRM;149174
+Ratchet Bomb;SOM;131012
+Rath's Edge;NMS;21264
+Rathi Assassin;NMS;21224
+Rathi Assassin;PRM;21224
+Rathi Dragon;9ED;3156
+Rathi Dragon;TMP;3156
+Rathi Dragon;TPR;3156
+Rathi Fiend;NMS;21270
+Rathi Intimidator;NMS;21248
+Rathi Trapper;MMA;101377
+Rathi Trapper;PLC;101377
+Rats of Rath;TMP;2969
+Rats of Rath;TPR;2969
+Rats' Feast;JUD;40227
+Rattleblaze Scarecrow;SHM;111704
+Rattlechains;SOI;161363
+Rattleclaw Mystic;KTK;156592
+Rattleclaw Mystic;PRM;157103
+Ravaged Highlands;ODY;33241
+Ravager of the Fells;DKA;139856
+Ravages of War;ME2;9119
+Ravages of War;PRM;9119
+Ravages of War;PTK;9119
+Ravaging Blaze;ORI;160299
+Ravaging Horde;PTK;9132
+Ravaging Riftwurm;FUT;102381
+Raven Familiar;C13;148529
+Raven Familiar;TD0;10337
+Raven Familiar;UL;10337
+Raven Guild Initiate;SCG;48143
+Raven Guild Master;SCG;48120
+Raven's Crime;EVE;113702
+Raven's Crime;MMA;113702
+Raven's Run Dragoon;SHM;111581
+Raven's Run;PC1;125871
+Ravenous Baboons;EXO;3741
+Ravenous Baloth;C13;100412
+Ravenous Baloth;DDD;43184
+Ravenous Baloth;ONS;43184
+Ravenous Baloth;PRM;100412
+Ravenous Bloodseeker;PRM;161845
+Ravenous Bloodseeker;SOI;161685
+Ravenous Daggertooth;XLN;401940
+Ravenous Demon;DKA;140385
+Ravenous Demon;PRM;138298
+Ravenous Intruder;AER;400316
+Ravenous Leucrocota;JOU;153090
+Ravenous Rats;10E;15630
+Ravenous Rats;8ED;24028
+Ravenous Rats;9ED;15630
+Ravenous Rats;DDD;15630
+Ravenous Rats;DDJ;15630
+Ravenous Rats;DPA;15630
+Ravenous Rats;INV;24028
+Ravenous Rats;M13;15630
+Ravenous Rats;PO2;4713
+Ravenous Rats;UD;15630
+Ravenous Skirge;USG;8909
+Ravenous Trap;ZEN;125079
+Ravenous Vampire;MIR;2017
+Raving Dead;C14;146379
+Raving Oni-Slave;SOK;86162
+Ravos, Soultender;PZ2;162384
+Ray of Command;5ED;1335
+Ray of Command;CMD;2018
+Ray of Command;DDM;2018
+Ray of Command;ICE;1335
+Ray of Command;ME2;1335
+Ray of Command;MIR;2018
+Ray of Dissolution;THS;149043
+Ray of Distortion;ODY;33662
+Ray of Erasure;ICE;1336
+Ray of Revelation;DKA;139781
+Ray of Revelation;JUD;40170
+Rayne, Academy Chancellor;UD;15626
+Razaketh, the Foulblooded;HOU;159998
+Razaketh's Rite;HOU;401599
+Raze;USG;8858
+Razia, Boros Archangel;PC1;89102
+Razia, Boros Archangel;RAV;89102
+Razia's Purification;RAV;88943
+Razing Snidd;PLS;27974
+Razor Barrier;DDF;50273
+Razor Barrier;MRD;50273
+Razor Boomerang;WWK;126504
+Razor Golem;DST;75166
+Razor Hippogriff;C13;130955
+Razor Hippogriff;SOM;130955
+Razor Pendulum;MIR;2019
+Razor Swine;NPH;134283
+Razorclaw Bear;PO2;4586
+Razorfield Rhino;DPA;131064
+Razorfield Rhino;MBS;131064
+Razorfield Thresher;DPA;131116
+Razorfield Thresher;SOM;131116
+Razorfin Abolisher;EVE;113687
+Razorfin Hunter;APC;31079
+Razorfin Hunter;DPA;143406
+Razorfin Hunter;PRM;143406
+Razorfoot Griffin;7ED;27754
+Razorfoot Griffin;8ED;24118
+Razorfoot Griffin;INV;24118
+Razorfoot Griffin;M10;24118
+Razorfoot Griffin;M15;24118
+Razorgrass Screen;5DN;77199
+Razorjaw Oni;CMD;87219
+Razorjaw Oni;SOK;87219
+Razormane Masticore;10E;77096
+Razormane Masticore;5DN;77096
+Razormane Masticore;DDF;77096
+Razormane Masticore;DPA;77096
+Razortip Whip;GTC;146250
+Razortooth Rats;6ED;2793
+Razortooth Rats;7ED;27755
+Razortooth Rats;9ED;27755
+Razortooth Rats;WTH;2793
+Razorverge Thicket;SOM;131106
+Reach Through Mists;COK;81133
+Reach Through Mists;MMA;81133
+Reach of Branches;MMA;148266
+Reach of Branches;MOR;110026
+Reach of Shadows;FRF;157152
+Read the Bones;C14;149055
+Read the Bones;ORI;149055
+Read the Bones;THS;149055
+Read the Runes;ONS;43023
+Ready;DGM;146822
+Reality Acid;PLC;100764
+Reality Anchor;TMP;3004
+Reality Anchor;TPR;3004
+Reality Hemorrhage;OGW;161038
+Reality Ripple;MIR;2020
+Reality Shaping;PC2;138704
+Reality Shift;FRF;157146
+Reality Shift;PRM;159386
+Reality Smasher;OGW;161036
+Reality Spasm;ROE;127407
+Reality Strobe;FUT;102344
+Reality Twist;ICE;1337
+Reality;APC;31130
+Realm Razer;ALA;115002
+Realm Seekers;VMA;153165
+Realms Uncharted;ROE;127379
+Realmwright;GTC;146482
+Reanimate;DPA;3221
+Reanimate;PD3;3221
+Reanimate;PRM;3221
+Reanimate;TMP;3221
+Reanimate;TPR;3221
+Reanimate;VMA;3221
+Reap Intellect;DGM;146669
+Reap What Is Sown;BNG;152609
+Reap and Sow;DST;51891
+Reap the Seagraf;DKA;139772
+Reap;TMP;3236
+Reaper King;SHM;111899
+Reaper from the Abyss;C14;138332
+Reaper from the Abyss;ISD;138332
+Reaper of Flight Moonsilver;SOI;161670
+Reaper of Sheoldred;NPH;134224
+Reaper of the Wilds;DDM;150815
+Reaper of the Wilds;PRM;159374
+Reaper of the Wilds;THS;150815
+Reaping the Graves;SCG;48981
+Reaping the Graves;TD0;48981
+Reaping the Rewards;EXO;5608
+Reason;HOU;401536
+Reassembling Skeleton;DDJ;129152
+Reassembling Skeleton;DDK;129152
+Reassembling Skeleton;DPA;129152
+Reassembling Skeleton;M11;129152
+Reassembling Skeleton;M12;129152
+Reassembling Skeleton;MM2;129152
+Reave Soul;ORI;160262
+Reaver Drone;OGW;161221
+Rebel Informer;PCY;22010
+Rebellion of the Flamekin;LRW;107642
+Rebirth;4ED;648
+Rebirth;LEG;648
+Reborn Hero;TOR;36398
+Reborn Hope;ARB;115188
+Rebound;STH;3743
+Rebuff the Wicked;PLC;100660
+Rebuild;UL;13569
+Rebuke;ISD;138507
+Rebuking Ceremony;DST;75208
+Recall;5ED;2459
+Recall;6ED;649
+Recall;CH;649
+Recall;LEG;649
+Recall;ME3;649
+Recantation;USG;8883
+Reciprocate;COK;80652
+Reciprocate;DDG;80652
+Reciprocate;PRM;83841
+Reckless Abandon;UD;15650
+Reckless Assault;INV;24101
+Reckless Brute;M13;143851
+Reckless Bushwhacker;OGW;161021
+Reckless Charge;EMA;33371
+Reckless Charge;ODY;33371
+Reckless Charge;PC1;33371
+Reckless Charge;VMA;33371
+Reckless Cohort;BFZ;160683
+Reckless Embermage;6ED;2021
+Reckless Embermage;7ED;27756
+Reckless Embermage;MIR;2021
+Reckless Fireweaver;KLD;162287
+Reckless Imp;DTK;159702
+Reckless Ogre;EXO;6099
+Reckless One;DPA;43115
+Reckless One;EVG;43115
+Reckless One;ONS;43115
+Reckless Racer;AER;400317
+Reckless Reveler;BNG;152580
+Reckless Scholar;SOI;161647
+Reckless Scholar;ZEN;123616
+Reckless Spite;C13;152006
+Reckless Spite;INV;24120
+Reckless Spite;TMP;3225
+Reckless Waif;ISD;138195
+Reckless Wurm;PLC;100804
+Reckless Wurm;PRM;101551
+Reclaim;7ED;27757
+Reclaim;9ED;5615
+Reclaim;EXO;5615
+Reclaim;M12;5615
+Reclaim;ORI;5615
+Reclaiming Vines;BFZ;160698
+Reclamation Sage;C14;155303
+Reclamation Sage;M15;155303
+Reclamation Sage;PRM;155865
+Reclamation;ICE;1338
+Reclusive Artificer;ORI;160334
+Reclusive Wight;USG;8726
+Recoil;DDH;24119
+Recoil;INV;24119
+Recollect;10E;89007
+Recollect;PRM;101024
+Recollect;RAV;89007
+Recollect;TD0;89007
+Reconnaissance;EXO;5604
+Reconstruction;3ED;439
+Reconstruction;ATQ;439
+Reconstruction;ME4;439
+Recoup;DDK;33335
+Recoup;ODY;33335
+Recover;10E;24175
+Recover;INV;24175
+Recover;MM3;400710
+Recross the Paths;MOR;109962
+Recruiter of the Guard;PZ2;161867
+Recumbent Bliss;DDH;113682
+Recumbent Bliss;DPA;113682
+Recumbent Bliss;EVE;113682
+Recuperate;SCG;49011
+Recurring Insight;DPA;127434
+Recurring Insight;ROE;127434
+Recurring Nightmare;EXO;5600
+Recurring Nightmare;TPR;5600
+Recurring Nightmare;VMA;5600
+Recycle;TMP;3140
+Recycle;TPR;3140
+Red Cliffs Armada;ME2;9079
+Red Cliffs Armada;PTK;9079
+Red Elemental Blast;2ED;203
+Red Elemental Blast;3ED;203
+Red Elemental Blast;4ED;203
+Red Elemental Blast;LEA;203
+Red Elemental Blast;LEB;203
+Red Elemental Blast;ME4;203
+Red Elemental Blast;PRM;144356
+Red Mana Battery;4ED;650
+Red Mana Battery;LEG;650
+Red Scarab;ICE;1339
+Red Sun's Zenith;DPA;133254
+Red Sun's Zenith;MBS;133254
+Red Ward;2ED;204
+Red Ward;3ED;204
+Red Ward;4ED;204
+Red Ward;LEA;204
+Red Ward;LEB;204
+Redeem the Lost;MOR;109687
+Redeem;8ED;8629
+Redeem;USG;8629
+Redirect;M11;129178
+Redirect;M12;129178
+Redirect;M13;129178
+Reduce in Stature;DTK;160186
+Reduce to Ashes;SOI;161360
+Reduce to Dreams;BOK;83838
+Reduce;AKH;401349
+Redwood Treefolk;6ED;6671
+Redwood Treefolk;7ED;27758
+Redwood Treefolk;POR;6671
+Redwood Treefolk;WTH;2804
+Reef Pirates;5ED;1545
+Reef Pirates;HML;1544
+Reef Pirates;HML;1545
+Reef Shaman;APC;31131
+Reef Worm;C14;155656
+Reflect Damage;MIR;2022
+Reflecting Mirror;DRK;817
+Reflecting Pool;PRM;160764
+Reflecting Pool;SHM;111732
+Reflecting Pool;TMP;3149
+Reflection;TOK;122197
+Reflection;TOK;35348
+Reflector Mage;OGW;161259
+Reflex Sliver;PLC;100773
+Reflexes;7ED;27759
+Reflexes;8ED;8949
+Reflexes;9ED;27759
+Reflexes;USG;8949
+Refocus;FRF;157303
+Reforge the Soul;AVR;142216
+Refraction Trap;WWK;126590
+Refresh;ODY;33279
+Refreshing Rain;NMS;21164
+Refurbish;KLD;162237
+Refuse;HOU;401839
+Regal Caracal;AKH;400871
+Regal Force;DPA;113600
+Regal Force;EMA;113600
+Regal Force;EVE;113600
+Regal Unicorn;6ED;6745
+Regal Unicorn;POR;6745
+Regathan Firecat;DPA;147425
+Regathan Firecat;M14;147425
+Regenerate;M10;122163
+Regeneration;10E;104530
+Regeneration;2ED;205
+Regeneration;3ED;205
+Regeneration;4ED;205
+Regeneration;5ED;205
+Regeneration;6ED;205
+Regeneration;7ED;27760
+Regeneration;8ED;27760
+Regeneration;9ED;27760
+Regeneration;ICE;1340
+Regeneration;LEA;205
+Regeneration;LEB;205
+Regeneration;MIR;2023
+Regisaur Alpha;XLN;402376
+Regress;MRD;50272
+Regress;ROE;127378
+Regrowth;2ED;206
+Regrowth;3ED;206
+Regrowth;DDL;144359
+Regrowth;LEA;206
+Regrowth;LEB;206
+Regrowth;ME4;206
+Regrowth;PRM;144359
+Regrowth;PRM;206
+Regrowth;VMA;144359
+Reign of Chaos;MIR;2024
+Reign of Terror;MIR;2025
+Reign of the Pit;VMA;153145
+Reincarnation;C13;151435
+Reincarnation;LEG;651
+Reincarnation;ME3;651
+Reinforced Bulwark;ROE;127408
+Reinforcements;ALL;1707
+Reinforcements;ALL;1708
+Reinforcements;ME2;1708
+Reins of Power;CMD;3744
+Reins of Power;PRM;162420
+Reins of Power;STH;3744
+Reins of the Vinesteed;MOR;109918
+Reiterate;TSP;99938
+Reito Lantern;COK;82620
+Reiver Demon;CMD;49682
+Reiver Demon;DDC;49682
+Reiver Demon;DPA;49682
+Reiver Demon;MRD;49682
+Rejuvenate;USG;8881
+Rejuvenation Chamber;NMS;21252
+Reki, the History of Kamigawa;SOK;86109
+Rekindled Flame;EVE;113754
+Reknit;SHM;111803
+Relearn;6ED;2946
+Relearn;WTH;2946
+Release the Ants;MOR;109916
+Release the Gremlins;AER;400325
+Release;DGM;151017
+Relentless Assault;10E;27761
+Relentless Assault;6ED;2239
+Relentless Assault;7ED;27761
+Relentless Assault;8ED;27761
+Relentless Assault;9ED;27761
+Relentless Assault;DPA;27761
+Relentless Assault;PC1;27761
+Relentless Assault;PO2;4758
+Relentless Assault;PTK;9139
+Relentless Assault;VIS;2239
+Relentless Dead;SOI;161486
+Relentless Hunter;OGW;161031
+Relentless Rats;10E;77220
+Relentless Rats;5DN;77220
+Relentless Rats;M10;77220
+Relentless Rats;M11;77220
+Relentless Skaabs;DKA;139858
+Relic Bane;MRD;51066
+Relic Barrier;5DN;77072
+Relic Barrier;LEG;652
+Relic Bind;4ED;653
+Relic Bind;LEG;653
+Relic Crush;CMD;123571
+Relic Crush;ZEN;123571
+Relic Putrescence;SOM;131113
+Relic Seeker;ORI;160509
+Relic Seeker;PRM;157359
+Relic Ward;VIS;2240
+Relic of Progenitus;ALA;114947
+Relic of Progenitus;EMA;114947
+Relic of Progenitus;MMA;114947
+Relic of Progenitus;PC1;114947
+Relic of Progenitus;TD0;114947
+Relief Captain;OGW;161070
+Reliquary Monk;UD;15600
+Reliquary Tower;C14;119804
+Reliquary Tower;CON;119804
+Reliquary Tower;M13;119804
+Reliquary Tower;PRM;147351
+Remand;DDM;153257
+Remand;DPA;88909
+Remand;MM2;153257
+Remand;PRM;110126
+Remand;RAV;88909
+Remedy;6ED;2241
+Remedy;VIS;2241
+Remember the Fallen;NPH;134325
+Remembrance;USG;8814
+Reminisce;10E;86940
+Reminisce;9ED;86940
+Reminisce;DDJ;86940
+Reminisce;ONS;42992
+Remorseless Punishment;OGW;161134
+Remote Farm;MMQ;18990
+Remote Isle;C14;8673
+Remote Isle;USG;8673
+Remove Enchantments;LEG;654
+Remove Soul;10E;27762
+Remove Soul;5ED;2460
+Remove Soul;6ED;2460
+Remove Soul;7ED;27762
+Remove Soul;8ED;27762
+Remove Soul;9ED;27762
+Remove Soul;CH;655
+Remove Soul;DPA;27762
+Remove Soul;LEG;655
+Remove Soul;ME3;655
+Remove Soul;PRM;120094
+Remove;PO2;4698
+Rend Flesh;COK;80739
+Rend Spirit;COK;80581
+Rendclaw Trow;EVE;113764
+Render Silent;DGM;145856
+Render Silent;PRM;148807
+Rending Vines;SOK;86067
+Rending Volley;DTK;160064
+Renegade Demon;AVR;141505
+Renegade Demon;DPA;141505
+Renegade Doppelganger;ROE;127363
+Renegade Firebrand;KLD;162518
+Renegade Freighter;KLD;162197
+Renegade Krasis;DGM;146831
+Renegade Map;AER;400382
+Renegade Rallier;AER;400360
+Renegade Rallier;PRM;401837
+Renegade Tactics;KLD;162532
+Renegade Troops;PTK;9131
+Renegade Warlord;TMP;3259
+Renegade Warlord;TPR;3259
+Renegade Wheelsmith;AER;400364
+Renegade's Getaway;AER;400286
+Renewal;HML;1546
+Renewed Faith;AKH;401670
+Renewed Faith;ONS;42929
+Renewed Faith;VMA;42929
+Renewing Dawn;POR;6746
+Renewing Touch;PO2;4778
+Renounce the Guilds;DGM;146840
+Renounce;MMQ;19034
+Renowned Weaponsmith;FRF;157186
+Renowned Weaver;JOU;152887
+Reparations;MIR;2026
+Repay in Kind;DPA;127410
+Repay in Kind;ROE;127410
+Repeal;GPT;91654
+Repeal;MM2;156485
+Repeal;PRM;156485
+Repeating Barrage;XLN;402380
+Repel Intruders;SHM;111872
+Repel the Abominable;EMN;162034
+Repel the Darkness;ROE;127432
+Repel;ODY;33481
+Repel;VMA;33481
+Repentance;TMP;3300
+Repentance;TPR;3300
+Repentant Blacksmith;5ED;364
+Repentant Blacksmith;ARN;364
+Repentant Blacksmith;CH;364
+Repentant Vampire;ODY;36336
+Repercussion;UD;15656
+Replenish;UD;15611
+Repopulate;UL;10363
+Reprisal;6ED;1709
+Reprisal;7ED;27763
+Reprisal;ALL;1709
+Reprisal;ALL;1710
+Reprisal;DDG;27763
+Reprisal;JOU;153078
+Reprisal;ME2;1709
+Reprocess;7ED;27764
+Reprocess;TD2;8924
+Reprocess;USG;8924
+Repulse;CMD;24122
+Repulse;DD2;24122
+Repulse;DPA;24122
+Repulse;INV;24122
+Requiem Angel;C14;140323
+Requiem Angel;DKA;140323
+Requiem Angel;DPA;140323
+Reroute;RAV;89128
+Rescind;USG;8865
+Rescind;VMA;8865
+Rescue from the Underworld;THS;149209
+Rescue;UD;15618
+Research Assistant;M15;155403
+Research the Deep;MOR;109915
+Research;DIS;94440
+Reservoir Walker;AER;400377
+Reset;LEG;656
+Reset;ME3;656
+Reshape;DST;75186
+Resilient Khenra;HOU;401829
+Resilient Khenra;TOK;401842
+Resilient Wanderer;ODY;33525
+Resistance Fighter;6ED;2242
+Resistance Fighter;VIS;2242
+Resize;CSP;96959
+Resolute Archangel;M15;155348
+Resolute Archangel;PRM;155857
+Resolute Blademaster;BFZ;160715
+Resolute Survivors;HOU;401527
+Resounding Roar;ALA;114976
+Resounding Scream;ALA;115225
+Resounding Silence;ALA;115058
+Resounding Thunder;ALA;115098
+Resounding Thunder;TD0;115098
+Resounding Wave;ALA;115132
+Resourceful Return;AER;400297
+Respite;TMP;3002
+Resplendent Mentor;SHM;111525
+Rest for the Weary;WWK;126548
+Rest in Peace;RTR;145216
+Restless Apparition;EVE;113722
+Restless Apparition;MM2;113722
+Restless Bones;GPT;91682
+Restless Dead;MIR;2027
+Restless Dreams;TOR;36448
+Restock;INV;24153
+Restock;M15;24153
+Restoration Angel;AVR;141641
+Restoration Angel;MM3;141641
+Restoration Angel;PRM;142213
+Restoration Gearsmith;KLD;162315
+Restoration Specialist;AER;400240
+Restore Balance;TSP;97411
+Restore the Peace;DGM;147716
+Restore;C13;151745
+Restrain;INV;24196
+Resupply;DTK;159821
+Resurrection;2ED;207
+Resurrection;3ED;207
+Resurrection;LEA;207
+Resurrection;LEB;207
+Resurrection;PRM;110124
+Resurrection;TD0;207
+Resurrection;TSB;207
+Resuscitate;EXO;5440
+Retaliate;5DN;77118
+Retaliation;USG;8813
+Retaliator Griffin;ARB;120947
+Retaliator Griffin;PRM;120947
+Retether;DPA;101391
+Retether;PLC;101391
+Rethink;PCY;22011
+Retraced Image;TOR;36432
+Retract;DST;75189
+Retraction Helix;BNG;152024
+Retreat to Coralhelm;BFZ;160923
+Retreat to Emeria;BFZ;160822
+Retreat to Hagra;BFZ;160892
+Retreat to Kazandu;BFZ;160904
+Retreat to Valakut;BFZ;160877
+Retribution of the Ancients;KTK;157033
+Retribution of the Meek;VIS;2243
+Retribution;HML;1547
+Retribution;ME2;1547
+Retromancer;USG;8879
+Return of the Nightstalkers;PO2;4732
+Return to Battle;PTK;9068
+Return to Dust;C14;97345
+Return to Dust;CMD;97345
+Return to Dust;TSP;97345
+Return to the Earth;FRF;157161
+Return to the Ranks;M15;155277
+Return;AKH;401041
+Returned Centaur;ORI;150767
+Returned Centaur;THS;150767
+Returned Phalanx;THS;150766
+Returned Reveler;JOU;152925
+Revealing Wind;DTK;160078
+Reveillark;MMA;109926
+Reveillark;MOR;109926
+Reveille Squad;PCY;22012
+Reveka, Wizard Savant;HML;1548
+Reveka, Wizard Savant;ME3;1548
+Revel in Riches;XLN;402241
+Revel of the Fallen God;JOU;152986
+Revelation;CH;657
+Revelation;LEG;657
+Revelsong Horn;SHM;111618
+Revenant Patriarch;DDK;91797
+Revenant Patriarch;GPT;91797
+Revenant;7ED;27765
+Revenant;ORI;3745
+Revenant;PRM;3745
+Revenant;STH;3745
+Revenant;TPR;3745
+Revenge of the Hunted;AVR;141809
+Reverberate;DPA;129127
+Reverberate;M11;129127
+Reverberate;M12;129127
+Reverberate;M13;129127
+Reverberate;PD2;129127
+Reverberation;LEG;2547
+Revered Dead;PLC;100658
+Revered Elder;MMQ;19103
+Revered Unicorn;WTH;2951
+Reverence;SOK;86120
+Reverent Hunter;THS;150844
+Reverent Mantra;MMQ;19116
+Reverent Silence;NMS;21165
+Reversal of Fortune;5DN;77211
+Reverse Damage;2ED;208
+Reverse Damage;3ED;208
+Reverse Damage;4ED;208
+Reverse Damage;5ED;2461
+Reverse Damage;6ED;2461
+Reverse Damage;7ED;27766
+Reverse Damage;9ED;2461
+Reverse Damage;LEA;208
+Reverse Damage;LEB;208
+Reverse Engineer;AER;400272
+Reverse Engineer;PRM;401788
+Reverse Polarity;3ED;440
+Reverse Polarity;ATQ;440
+Reverse the Sands;COK;81011
+Revive the Fallen;MOR;109954
+Revive;8ED;19314
+Revive;M13;19314
+Revive;MM3;19314
+Revive;MMQ;19314
+Reviving Dose;10E;24066
+Reviving Dose;INV;24066
+Reviving Melody;JOU;153049
+Reviving Vapors;INV;25157
+Reviving Vapors;VMA;25157
+Revoke Existence;BNG;152061
+Revoke Existence;DDI;130896
+Revoke Existence;DPA;130896
+Revoke Existence;SOM;130896
+Revoke Privileges;KLD;162238
+Revolutionary Rebuff;KLD;162630
+Reward the Faithful;SCG;48148
+Rewards of Diversity;INV;24068
+Reweave;COK;81578
+Rewind;8ED;8852
+Rewind;9ED;8852
+Rewind;M13;8852
+Rewind;MM3;8852
+Rewind;PRM;8852
+Rewind;USG;8852
+Reya Dawnbringer;10E;104512
+Reya Dawnbringer;DDC;104512
+Reya Dawnbringer;DPA;104512
+Reya Dawnbringer;INV;24017
+Reya Dawnbringer;PRM;104512
+Reya Dawnbringer;PZ1;24017
+Reyhan, Last of the Abzan;PZ2;162385
+Rhet-Crop Spearmaster;AKH;400850
+Rhino;TOK;121571
+Rhino;TOK;145993
+Rhonas the Indomitable;AKH;400756
+Rhonas the Indomitable;MS3;401370
+Rhonas's Last Stand;HOU;401602
+Rhonas's Monument;AKH;400752
+Rhonas's Stalwart;HOU;401553
+Rhox Bodyguard;CON;118758
+Rhox Brute;ARB;121074
+Rhox Charger;ALA;115038
+Rhox Charger;DPA;115038
+Rhox Faithmender;DPA;143871
+Rhox Faithmender;M13;143871
+Rhox Maulers;ORI;160319
+Rhox Meditant;CON;118662
+Rhox Pikemaster;M10;121642
+Rhox War Monk;ALA;115055
+Rhox War Monk;MM3;115055
+Rhox War Monk;PRM;136800
+Rhox;10E;23748
+Rhox;8ED;21468
+Rhox;NMS;21468
+Rhox;PRM;23748
+Rhys the Exiled;DPA;109614
+Rhys the Exiled;MOR;109614
+Rhys the Redeemed;SHM;111675
+Rhystic Cave;PCY;21953
+Rhystic Circle;PCY;22013
+Rhystic Deluge;PCY;22014
+Rhystic Lightning;PCY;22015
+Rhystic Scrying;PCY;22131
+Rhystic Shield;PCY;22042
+Rhystic Study;PCY;22016
+Rhystic Study;PRM;22016
+Rhystic Study;PZ1;22016
+Rhystic Study;TD0;22016
+Rhystic Syphon;PCY;22017
+Rhystic Tutor;PCY;22018
+Rib Cage Spider;PCY;21962
+Ribbon Snake;PCY;22019
+Ribbons of Night;RAV;88651
+Ribbons of the Reikai;BOK;83894
+Ribbons;AKH;401052
+Riches;AKH;401051
+Ricochet Trap;WWK;126494
+Riddle of Lightning;FUT;102360
+Riddle of Lightning;JOU;152956
+Riddleform;HOU;401785
+Riddlekeeper;CMD;137556
+Riddlesmith;SOM;130984
+Ride Down;EMN;162140
+Ride Down;KTK;157073
+Riders of Gavony;AVR;141560
+Ridge Rannet;ALA;115189
+Ridged Kusite;PLC;101376
+Ridgeline Rager;8ED;22009
+Ridgeline Rager;PCY;22009
+Ridgescale Tusker;AER;400345
+Ridgetop Raptor;LGN;46531
+Riding Red Hare;PTK;9178
+Riding the Dilu Horse;ME3;9060
+Riding the Dilu Horse;PTK;9060
+Rift Bolt;MMA;131557
+Rift Bolt;PRM;131557
+Rift Bolt;TD0;97326
+Rift Bolt;TSP;97326
+Rift Elemental;FUT;102393
+Rift Elemental;MMA;102393
+Riftmarked Knight;PLC;100802
+Riftstone Portal;JUD;40297
+Riftsweeper;FUT;102387
+Riftsweeper;MMA;102387
+Riftwing Cloudskate;DD2;97348
+Riftwing Cloudskate;DDM;97348
+Riftwing Cloudskate;MMA;97348
+Riftwing Cloudskate;TSP;97348
+Rigging Runner;XLN;401434
+Righteous Aura;MMQ;19210
+Righteous Aura;VIS;2244
+Righteous Authority;RTR;145959
+Righteous Avengers;LEG;658
+Righteous Avengers;MED;658
+Righteous Blow;AVR;141725
+Righteous Cause;CMD;42925
+Righteous Cause;DDC;42925
+Righteous Cause;ONS;42925
+Righteous Charge;GTC;146461
+Righteous Charge;ME4;4668
+Righteous Charge;PO2;4668
+Righteous Confluence;PZ1;160169
+Righteous Fury;ME2;4679
+Righteous Fury;PO2;4679
+Righteous Indignation;MMQ;19176
+Righteous War;VIS;2245
+Righteousness;10E;104552
+Righteousness;2ED;209
+Righteousness;3ED;209
+Righteousness;4ED;209
+Righteousness;5ED;2462
+Righteousness;9ED;2462
+Righteousness;DDL;104552
+Righteousness;LEA;209
+Righteousness;LEB;209
+Righteousness;M10;104552
+Riku of Two Reflections;CMD;137535
+Riku of Two Reflections;PRM;137535
+Rile;XLN;402077
+Rime Dryad;ICE;1341
+Rime Transfusion;CSP;96993
+Rimebound Dead;CSP;96872
+Rimefeather Owl;CSP;96930
+Rimehorn Aurochs;CSP;96946
+Rimescale Dragon;CSP;96920
+Rimewind Cryomancer;CSP;96951
+Rimewind Taskmage;CSP;96975
+Ring of Evos Isle;DPA;138671
+Ring of Evos Isle;M13;138671
+Ring of Gix;UL;9504
+Ring of Gix;VMA;9504
+Ring of Immortals;LEG;2548
+Ring of Kalonia;DPA;138674
+Ring of Kalonia;M13;138674
+Ring of Ma'rûf;ARN;365
+Ring of Ma'rûf;MED;365
+Ring of Renewal;FEM;994
+Ring of Renewal;ME4;994
+Ring of Three Wishes;M14;147462
+Ring of Thune;DPA;138670
+Ring of Thune;M13;138670
+Ring of Valkas;DPA;138673
+Ring of Valkas;M13;138673
+Ring of Xathrid;DPA;138672
+Ring of Xathrid;M13;138672
+Rings of Brighthearth;LRW;105532
+Rings of Brighthearth;MS2;400604
+Ringskipper;LRW;106356
+Ringwarden Owl;ORI;157356
+Riot Control;DGM;147784
+Riot Devils;ISD;138152
+Riot Gear;GTC;146237
+Riot Piker;DGM;146714
+Riot Ringleader;AVR;141532
+Riot Spikes;DIS;94279
+Rip-Clan Crasher;ALA;115386
+Rip-Clan Crasher;DPA;115386
+Riparian Tiger;KLD;162543
+Ripjaw Raptor;XLN;402115
+Ripscale Predator;GTC;146534
+Riptide Biologist;ONS;42973
+Riptide Chimera;JOU;152819
+Riptide Chronologist;ONS;43005
+Riptide Crab;INV;24074
+Riptide Director;LGN;46534
+Riptide Entrancer;ONS;19128
+Riptide Laboratory;ONS;43229
+Riptide Mangler;LGN;46599
+Riptide Pilferer;PLC;100668
+Riptide Replicator;ONS;43213
+Riptide Shapeshifter;ONS;43001
+Riptide Survivor;C14;48118
+Riptide Survivor;SCG;48118
+Riptide;DRK;818
+Rise from the Grave;CMD;121611
+Rise from the Grave;DDD;121611
+Rise from the Grave;DPA;121611
+Rise from the Grave;EMN;161965
+Rise from the Grave;M10;121611
+Rise from the Grave;M11;121611
+Rise from the Grave;M13;121611
+Rise from the Grave;PRM;89104
+Rise from the Tides;PRM;162487
+Rise from the Tides;SOI;161382
+Rise of Eagles;JOU;153091
+Rise of the Dark Realms;M14;147441
+Rise of the Hobgoblins;EVE;113625
+Rise to the Challenge;BNG;152046
+Rise;DDH;94483
+Rise;DIS;94483
+Risen Executioner;DTK;160189
+Risen Sanctuary;RTR;145918
+Rishadan Airship;MMQ;19303
+Rishadan Brigand;MMQ;19127
+Rishadan Cutpurse;MMQ;19189
+Rishadan Footpad;MMQ;19254
+Rishadan Pawnshop;MMQ;19019
+Rishadan Port;MMQ;19153
+Rishadan Port;PRM;159376
+Rishkar, Peema Renegade;AER;400349
+Rishkar's Expertise;AER;400354
+Rising Miasma;BFZ;160667
+Rising Waters;NMS;21204
+Risky Move;ONS;43134
+Rite of Consumption;SHM;111891
+Rite of Flame;CSP;96953
+Rite of Passage;5DN;77157
+Rite of Replication;C14;123785
+Rite of Replication;DPA;123785
+Rite of Replication;ZEN;123785
+Rite of Ruin;AVR;141667
+Rite of Undoing;FRF;157218
+Rite of the Raging Storm;PZ1;160106
+Rite of the Serpent;KTK;156504
+Rites of Flourishing;DPA;102405
+Rites of Flourishing;FUT;102405
+Rites of Flourishing;M12;102405
+Rites of Initiation;ODY;33372
+Rites of Initiation;VMA;33372
+Rites of Reaping;RTR;145928
+Rites of Refusal;ODY;33485
+Rites of Spring;ODY;33313
+Rith, the Awakener;DDE;25500
+Rith, the Awakener;DRB;115928
+Rith, the Awakener;INV;25500
+Rith's Attendant;INV;25487
+Rith's Charm;DDE;27976
+Rith's Charm;PLS;27976
+Rith's Grove;PLS;27977
+Ritual of Rejuvenation;XLN;402112
+Ritual of Restoration;DST;52036
+Ritual of Steel;MIR;2028
+Ritual of Subdual;ICE;1342
+Ritual of Subdual;ME2;1342
+Ritual of the Machine;ALL;1711
+Ritual of the Machine;ME2;1711
+Ritual of the Returned;JOU;152863
+Rivalry;UL;10391
+Rivals' Duel;MOR;110214
+Rivals' Duel;PC2;110214
+Riven Turnbull;LEG;659
+Riven Turnbull;ME3;659
+River Bear;9ED;4775
+River Bear;PO2;4775
+River Boa;6ED;2246
+River Boa;DDM;125067
+River Boa;PRM;2246
+River Boa;VIS;2246
+River Boa;ZEN;125067
+River Delta;ICE;1343
+River Heralds' Boon;XLN;402865
+River Hoopoe;HOU;401557
+River Kaijin;COK;80867
+River Kelpie;SHM;111635
+River Merfolk;FEM;995
+River Merfolk;MED;995
+River Serpent;AKH;401291
+River Sneak;XLN;402452
+River of Tears;FUT;102363
+River's Grasp;SHM;111866
+River's Rebuke;XLN;402117
+Riverfall Mimic;EVE;113611
+Riverwheel Aerialists;KTK;157013
+Rix Maadi Guildmage;RTR;145198
+Rix Maadi, Dungeon Palace;DIS;94275
+Roar of Challenge;KTK;157060
+Roar of Jukai;BOK;83943
+Roar of Reclamation;5DN;77124
+Roar of the Crowd;MOR;110004
+Roar of the Kha;MRD;50282
+Roar of the Wurm;EMA;33298
+Roar of the Wurm;ODY;33298
+Roar of the Wurm;PRM;33298
+Roar of the Wurm;VMA;33298
+Roaring Primadox;DPA;141635
+Roaring Primadox;M13;141635
+Roaring Primadox;M15;141635
+Roaring Slagwurm;DST;75161
+Roast;DTK;160107
+Roast;PRM;160818
+Robber Fly;MMQ;19166
+Robe of Mirrors;10E;104557
+Robe of Mirrors;EXO;5629
+Roc Egg;M11;129142
+Roc Egg;M12;129142
+Roc Hatchling;WTH;2933
+Roc of Kher Ridges;2ED;210
+Roc of Kher Ridges;3ED;210
+Roc of Kher Ridges;LEA;210
+Roc of Kher Ridges;LEB;210
+Roc of Kher Ridges;ME4;210
+Rock Badger;10E;19307
+Rock Badger;MMQ;19307
+Rock Basilisk;MIR;2029
+Rock Hydra;2ED;211
+Rock Hydra;3ED;211
+Rock Hydra;LEA;211
+Rock Hydra;LEB;211
+Rock Hydra;ME4;211
+Rock Jockey;SCG;48096
+Rock Slide;VIS;2247
+Rockcaster Platoon;ALA;115085
+Rocket Launcher;3ED;441
+Rocket Launcher;ATQ;441
+Rockshard Elemental;LGN;46535
+Rockslide Ambush;ME4;9143
+Rockslide Ambush;PTK;9143
+Rockslide Elemental;ALA;114948
+Rockslide Elemental;DPA;114948
+Rockslide Elemental;PC1;114948
+Rocky Tar Pit;MIR;2030
+Rocky Tar Pit;VMA;2030
+Rod of Ruin;10E;103543
+Rod of Ruin;2ED;212
+Rod of Ruin;3ED;212
+Rod of Ruin;4ED;212
+Rod of Ruin;5ED;212
+Rod of Ruin;6ED;212
+Rod of Ruin;7ED;27767
+Rod of Ruin;8ED;49256
+Rod of Ruin;9ED;86920
+Rod of Ruin;LEA;212
+Rod of Ruin;LEB;212
+Rod of Ruin;M10;103543
+Rod of Ruin;M14;103543
+Rofellos, Llanowar Emissary;UD;15671
+Rofellos, Llanowar Emissary;VMA;15671
+Rofellos's Gift;UD;15713
+Rogue Elephant;WTH;2801
+Rogue Kavu;9ED;23997
+Rogue Kavu;INV;23997
+Rogue Refiner;AER;400365
+Rogue Skycaptain;ALL;1712
+Rogue Skycaptain;ME2;1712
+Rogue's Gloves;M15;155363
+Rogue's Passage;DDM;145935
+Rogue's Passage;ORI;145935
+Rogue's Passage;RTR;145935
+Rohgahh of Kher Keep;LEG;2549
+Rohgahh of Kher Keep;ME3;2549
+Roil Elemental;DPA;123636
+Roil Elemental;ZEN;123636
+Roil Spout;BFZ;160720
+Roil's Retribution;BFZ;160621
+Roiling Horror;PLC;100697
+Roiling Terrain;WWK;126543
+Roiling Waters;OGW;161213
+Roilmage's Trick;BFZ;160651
+Rollick of Abandon;JOU;153100
+Rolling Earthquake;ME3;9124
+Rolling Earthquake;PTK;9124
+Rolling Earthquake;V14;9124
+Rolling Spoil;RAV;89065
+Rolling Stones;7ED;27768
+Rolling Stones;8ED;27768
+Rolling Stones;STH;3746
+Rolling Temblor;ISD;139297
+Rolling Thunder;BFZ;160932
+Rolling Thunder;PC1;3024
+Rolling Thunder;TMP;3024
+Rolling Thunder;TPR;3024
+Ronin Cavekeeper;SOK;80565
+Ronin Cliffrider;BOK;80637
+Ronin Houndmaster;COK;80762
+Ronin Warclub;BOK;80744
+Ronin Warclub;DPA;80744
+Ronom Hulk;CSP;96912
+Ronom Serpent;CSP;97006
+Ronom Unicorn;CSP;96973
+Roofstalker Wight;RAV;88934
+Rooftop Storm;ISD;138287
+Roon of the Hidden Realm;C13;151767
+Root Cage;PCY;23829
+Root Elemental;SCG;48142
+Root Greevil;PLS;9428
+Root Maze;10E;3141
+Root Maze;TMP;3141
+Root Out;SOI;161846
+Root Sliver;LGN;47535
+Root Spider;HML;1549
+Root-Kin Ally;MM2;89067
+Root-Kin Ally;RAV;89067
+Rootborn Defenses;MM3;145120
+Rootborn Defenses;RTR;145120
+Rootbound Crag;H09;121648
+Rootbound Crag;M10;121648
+Rootbound Crag;M11;121648
+Rootbound Crag;M12;121648
+Rootbound Crag;M13;121648
+Rootbound Crag;XLN;402087
+Rootbreaker Wurm;9ED;2987
+Rootbreaker Wurm;TD0;2987
+Rootbreaker Wurm;TMP;2987
+Rootbreaker Wurm;TPR;2987
+Rootgrapple;LRW;105411
+Rooting Kavu;INV;26560
+Rootrunner;COK;80797
+Roots of Life;MIR;2031
+Roots;EMA;161568
+Roots;HML;1550
+Roots;MED;1550
+Rootwalla;10E;2992
+Rootwalla;9ED;2992
+Rootwalla;M14;2992
+Rootwalla;TMP;2992
+Rootwalla;TPR;2992
+Rootwalla;W17;2992
+Rootwater Alligator;EXO;5617
+Rootwater Commando;10E;21273
+Rootwater Commando;NMS;21273
+Rootwater Depths;TMP;3250
+Rootwater Depths;TPR;3250
+Rootwater Diver;TMP;3272
+Rootwater Hunter;TMP;3031
+Rootwater Hunter;TPR;3031
+Rootwater Matriarch;10E;104565
+Rootwater Matriarch;TMP;3169
+Rootwater Mystic;EXO;5645
+Rootwater Shaman;TMP;3166
+Rootwater Thief;NMS;21261
+Rorix Bladewing;DPA;43132
+Rorix Bladewing;EMA;161311
+Rorix Bladewing;ONS;43132
+Rorix Bladewing;PC1;43132
+Rorix Bladewing;VMA;43132
+Rosheen Meanderer;SHM;111903
+Rot Farm Skeleton;DGM;146838
+Rot Shambler;BFZ;160910
+Rot Wolf;MBS;133162
+Rot Wolf;TD2;133162
+Rotcrown Ghoul;AVR;141603
+Roterothopter;HML;1551
+Roterothopter;ME2;1551
+Rotfeaster Maggot;M15;155399
+Rotlung Reanimator;ONS;43074
+Rotted Hulk;JOU;152869
+Rotted Hystrix;NPH;134403
+Rottenheart Ghoul;SOI;161708
+Rotting Fensnake;ISD;138400
+Rotting Giant;ODY;33422
+Rotting Legion;M11;129136
+Rotting Mastodon;KTK;157022
+Rotting Rats;CON;118652
+Rotting Rats;PC1;118652
+Rough;C13;102115
+Rough;PLC;102115
+Roughshod Mentor;DPA;111541
+Roughshod Mentor;SHM;111541
+Rouse the Mob;JOU;152825
+Rouse;MMQ;19054
+Rout;INV;24121
+Rout;PRM;153368
+Rowan Treefolk;POR;6672
+Rowdy Crew;XLN;402326
+Rowen;6ED;2248
+Rowen;7ED;27769
+Rowen;VIS;2248
+Royal Assassin;10E;48786
+Royal Assassin;2ED;213
+Royal Assassin;3ED;213
+Royal Assassin;4ED;213
+Royal Assassin;8ED;48786
+Royal Assassin;9ED;48786
+Royal Assassin;DPA;48786
+Royal Assassin;LEA;213
+Royal Assassin;LEB;213
+Royal Assassin;M10;48786
+Royal Assassin;M11;48786
+Royal Assassin;M12;48786
+Royal Assassin;PRM;80837
+Royal Decree;ALL;1713
+Royal Decree;ME2;1713
+Royal Herbalist;ALL;1714
+Royal Herbalist;ALL;1715
+Royal Trooper;ME2;17562
+Rubble;AKH;401045
+Rubbleback Rhino;RTR;145145
+Rubblebelt Maaka;DGM;146754
+Rubblebelt Maaka;MM3;146754
+Rubblebelt Raiders;GTC;138802
+Rubblehulk;GTC;147345
+Rubblehulk;PRM;146490
+Rubinia Soulsinger;C13;151437
+Rubinia Soulsinger;CH;660
+Rubinia Soulsinger;LEG;660
+Rubinia Soulsinger;ME3;660
+Rubinia Soulsinger;TD0;660
+Ruby Leech;INV;25201
+Ruby Medallion;C14;144004
+Ruby Medallion;DPA;144004
+Ruby Medallion;DPA;3110
+Ruby Medallion;TMP;3110
+Rude Awakening;5DN;77227
+Rude Awakening;DDD;77227
+Rude Awakening;MMA;77227
+Rugged Highlands;EMA;157270
+Rugged Highlands;FRF;157270
+Rugged Highlands;KTK;157096
+Rugged Prairie;EVE;113681
+Rugged Prairie;EXP;161056
+Ruham Djinn;INV;24100
+Ruhan of the Fomori;CMD;137538
+Ruin Ghost;WWK;126589
+Ruin Processor;BFZ;160611
+Ruin Raider;XLN;402256
+Ruin Rat;HOU;401567
+Ruin in Their Wake;OGW;161245
+Ruination Guide;BFZ;160885
+Ruination Wurm;GTC;146415
+Ruination;CMD;3747
+Ruination;STH;3747
+Ruinous Gremlin;KLD;162537
+Ruinous Minotaur;ZEN;123658
+Ruinous Path;BFZ;160674
+Ruinous Path;PRM;160875
+Ruins of Oran-Rief;OGW;161265
+Ruins of Trokair;5ED;2463
+Ruins of Trokair;6ED;2463
+Ruins of Trokair;FEM;996
+Ruins of Trokair;ME2;996
+Rukh Egg;8ED;48785
+Rukh Egg;9ED;48785
+Rukh Egg;ARN;366
+Rukh Egg;PRM;48785
+Rukh;TOK;49264
+Rule of Law;10E;51049
+Rule of Law;MRD;51049
+Rumbling Aftershocks;WWK;126514
+Rumbling Baloth;M14;147465
+Rumbling Crescendo;USG;8891
+Rumbling Slum;GPT;91809
+Rumbling Slum;PC1;91809
+Rummaging Goblin;DPA;143850
+Rummaging Goblin;M13;143850
+Rummaging Goblin;M15;143850
+Rummaging Goblin;XLN;402264
+Rummaging Wizard;ONS;42997
+Run Aground;XLN;402283
+Run Wild;ONS;43172
+Run;DIS;91884
+Runaway Carriage;SOI;161658
+Rune Snag;CSP;96983
+Rune of Protection: Artifacts;USG;8736
+Rune of Protection: Black;USG;8730
+Rune of Protection: Blue;USG;8731
+Rune of Protection: Green;USG;8732
+Rune of Protection: Lands;USG;8655
+Rune of Protection: Red;USG;8733
+Rune of Protection: White;USG;8734
+Rune-Cervin Rider;SHM;111561
+Rune-Scarred Demon;DPA;134094
+Rune-Scarred Demon;M12;134094
+Rune-Tail, Kitsune Ascendant;SOK;86156
+Runeboggle;GPT;91743
+Runechanter's Pike;ISD;138443
+Runeclaw Bear;DPA;121566
+Runeclaw Bear;M10;121566
+Runeclaw Bear;M11;121566
+Runeclaw Bear;M12;121566
+Runeclaw Bear;M15;121566
+Runed Arch;ICE;1344
+Runed Halo;SHM;111790
+Runed Servitor;DDF;127440
+Runed Servitor;MM2;127440
+Runed Servitor;ORI;127440
+Runed Servitor;ROE;127440
+Runed Stalactite;LRW;105418
+Runed Stalactite;MMA;105418
+Runeflare Trap;ZEN;125078
+Runehorn Hellkite;PZ2;162373
+Runes of the Deus;SHM;111865
+Runesword;CH;819
+Runesword;DRK;819
+Runewing;RTR;145850
+Runic Repetition;ISD;138292
+Runner's Bane;DGM;146740
+Rupture Spire;C13;118648
+Rupture Spire;CMD;118648
+Rupture Spire;CON;118648
+Rupture Spire;DDH;118648
+Rupture Spire;H09;118648
+Rupture Spire;PC2;118648
+Rupture Spire;TD0;118648
+Rupture;NMS;21287
+Rupture;PRM;143956
+Ruric Thar, the Unbowed;DGM;146706
+Rush of Adrenaline;SOI;161694
+Rush of Battle;KTK;156994
+Rush of Blood;AVR;141723
+Rush of Ice;BFZ;160836
+Rush of Knowledge;C14;48135
+Rush of Knowledge;SCG;48135
+Rush of Vitality;KLD;162496
+Rushing River;PLS;27979
+Rushing-Tide Zubera;SOK;80670
+Rushwood Dryad;10E;19155
+Rushwood Dryad;8ED;19155
+Rushwood Dryad;MMQ;19155
+Rushwood Elemental;MMQ;19145
+Rushwood Grove;MMQ;19154
+Rushwood Herbalist;MMQ;19204
+Rushwood Legate;MMQ;18984
+Russet Wolves;DKA;139764
+Rust Elemental;MRD;51059
+Rust Scarab;GTC;146345
+Rust Tick;SOM;131095
+Rust;LEG;661
+Rusted Relic;MM2;130876
+Rusted Relic;SOM;130876
+Rusted Sentinel;M12;136805
+Rusted Slasher;MBS;133138
+Rustic Clachan;DDF;110017
+Rustic Clachan;MOR;110017
+Rusting Golem;NMS;21147
+Rustmouth Ogre;MRD;51018
+Rustrazor Butcher;SHM;111695
+Rustspore Ram;MRD;51020
+Ruthless Cullblade;DPA;126524
+Ruthless Cullblade;WWK;126524
+Ruthless Deathfang;DTK;160141
+Ruthless Disposal;EMN;161955
+Ruthless Instincts;FRF;157305
+Ruthless Invasion;NPH;134347
+Ruthless Knave;XLN;402303
+Ruthless Ripper;KTK;156549
+Ruthless Ripper;PRM;159738
+Ruthless Sniper;AKH;401311
+Rysorian Badger;HML;1552
+Ryusei, the Falling Star;COK;81108
+Ryusei, the Falling Star;DPA;81108
+Ryusei, the Falling Star;MMA;81108
+Ryusei, the Falling Star;PRM;81128
+Saber Ants;MMQ;19274
+Saberclaw Golem;SOM;131153
+Sabertooth Alley Cat;RAV;88927
+Sabertooth Cobra;MIR;2032
+Sabertooth Nishoba;INV;25232
+Sabertooth Outrider;DTK;159852
+Sabertooth Wyvern;EXO;5611
+Sabertooth Wyvern;TPR;5611
+Sabretooth Tiger;5ED;1345
+Sabretooth Tiger;6ED;1345
+Sabretooth Tiger;7ED;27770
+Sabretooth Tiger;8ED;27770
+Sabretooth Tiger;ICE;1345
+Sacellum Archers;CON;118701
+Sacellum Godspeaker;ALA;114950
+Sachi, Daughter of Seshiro;COK;82618
+Sacred Armory;M15;138745
+Sacred Boon;5ED;1346
+Sacred Boon;ICE;1346
+Sacred Boon;ME2;1346
+Sacred Cat;AKH;400817
+Sacred Cat;TOK;400952
+Sacred Excavation;AKH;401296
+Sacred Foundry;EXP;160794
+Sacred Foundry;GTC;146521
+Sacred Foundry;RAV;90398
+Sacred Ground;7ED;27771
+Sacred Ground;8ED;27771
+Sacred Ground;9ED;27771
+Sacred Ground;STH;3748
+Sacred Guide;TMP;3182
+Sacred Knight;POR;6747
+Sacred Mesa;C14;156393
+Sacred Mesa;MIR;2033
+Sacred Mesa;TSB;2033
+Sacred Nectar;7ED;31242
+Sacred Nectar;8ED;6748
+Sacred Nectar;9ED;6748
+Sacred Nectar;POR;6748
+Sacred Prey;MMQ;19122
+Sacred Rites;ODY;33199
+Sacred Wolf;DPA;129113
+Sacred Wolf;M11;129113
+Sacred Wolf;M12;129113
+Sacrifice;2ED;214
+Sacrifice;3ED;214
+Sacrifice;LEA;214
+Sacrifice;LEB;214
+Saddleback Lagac;OGW;161112
+Sadistic Augermage;DDM;89152
+Sadistic Augermage;RAV;89152
+Sadistic Glee;TMP;2976
+Sadistic Hypnotist;DDJ;33442
+Sadistic Hypnotist;ODY;33442
+Sadistic Sacrament;ZEN;123787
+Safe Haven;CH;820
+Safe Haven;DRK;820
+Safe Haven;TSB;820
+Safe Passage;DDI;121601
+Safe Passage;DPA;121601
+Safe Passage;M10;121601
+Safe Passage;M11;121601
+Safe Passage;M13;121601
+Safeguard;TMP;3189
+Safehold Duo;SHM;111760
+Safehold Elite;SHM;111630
+Safehold Sentry;SHM;111676
+Safewright Quest;SHM;111582
+Saffi Eriksdotter;TSP;97427
+Sage Aven;9ED;42921
+Sage Aven;ONS;42921
+Sage Owl;10E;27772
+Sage Owl;6ED;2827
+Sage Owl;7ED;27772
+Sage Owl;8ED;27772
+Sage Owl;M10;122147
+Sage Owl;WTH;2827
+Sage of Ancient Lore;SOI;161747
+Sage of Epityr;TSP;97537
+Sage of Fables;MOR;109961
+Sage of Hours;JOU;153039
+Sage of Lat-Nam;8ED;49236
+Sage of Lat-Nam;ATQ;442
+Sage of Shaila's Claim;KLD;162305
+Sage of the Inward Eye;KTK;156599
+Sage of the Inward Eye;PRM;157108
+Sage-Eye Avengers;FRF;157347
+Sage-Eye Avengers;PRM;158885
+Sage-Eye Harrier;KTK;156477
+Sage's Dousing;MOR;109983
+Sage's Knowledge;PTK;9067
+Sage's Reverie;FRF;157257
+Sage's Row Denizen;GTC;146273
+Sages of the Anima;ARB;121011
+Sagu Archer;KTK;156520
+Sagu Mauler;KTK;156604
+Saheeli Rai;KLD;162201
+Saheeli's Artistry;KLD;162252
+Saheeli's Artistry;PRM;162476
+Sai of the Shinobi;PC2;140366
+Sailmonger;MMQ;19689
+Sailor of Means;XLN;401934
+Sakashima the Impostor;SOK;86106
+Sakashima's Student;PC2;140358
+Sakiko, Mother of Summer;BOK;83901
+Sakura-Tribe Elder;C13;80718
+Sakura-Tribe Elder;CMD;80718
+Sakura-Tribe Elder;COK;80718
+Sakura-Tribe Elder;PRM;122193
+Sakura-Tribe Elder;PRM;80718
+Sakura-Tribe Elder;PZ1;80718
+Sakura-Tribe Elder;TD0;80718
+Sakura-Tribe Scout;SOK;86080
+Sakura-Tribe Springcaller;BOK;83829
+Salivating Gremlins;KLD;162282
+Salt Flats;TMP;3144
+Salt Flats;TPR;3144
+Salt Flats;VMA;3144
+Salt Marsh;8ED;25585
+Salt Marsh;INV;25585
+Salt Road Ambushers;DTK;160088
+Salt Road Patrol;KTK;156991
+Salt Road Quartermasters;DTK;159721
+Saltblast;DDF;100701
+Saltblast;PLC;100701
+Saltcrusted Steppe;C13;97299
+Saltcrusted Steppe;PZ1;97299
+Saltcrusted Steppe;TSP;97299
+Saltfield Recluse;MMA;97320
+Saltfield Recluse;PLC;97320
+Saltskitter;FUT;102371
+Salvage Drone;BFZ;160638
+Salvage Scout;SOM;131019
+Salvage Scuttler;AER;400268
+Salvage Slasher;CON;118693
+Salvage Titan;ALA;115001
+Salvage;PO2;4771
+Salvaging Station;5DN;77144
+Samite Alchemist;HML;1553
+Samite Alchemist;HML;1554
+Samite Archer;INV;24129
+Samite Blessing;STH;3749
+Samite Censer-Bearer;FUT;102374
+Samite Elder;PLS;27950
+Samite Healer;10E;27773
+Samite Healer;2ED;215
+Samite Healer;3ED;215
+Samite Healer;4ED;215
+Samite Healer;5ED;215
+Samite Healer;6ED;215
+Samite Healer;7ED;27773
+Samite Healer;8ED;27773
+Samite Healer;9ED;27773
+Samite Healer;LEA;215
+Samite Healer;LEB;215
+Samite Ministration;INV;24133
+Samite Pilgrim;PLS;27980
+Samite Sanctuary;PCY;22021
+Samurai Enforcers;COK;81569
+Samurai of the Pale Curtain;COK;81574
+Samut, Voice of Dissent;AKH;400779
+Samut, the Tested;HOU;401544
+Sanctified Charge;M15;155394
+Sanctifier of Souls;EMN;162039
+Sanctifier of Souls;PRM;161918
+Sanctimony;7ED;27774
+Sanctimony;8ED;27774
+Sanctimony;UD;15709
+Sanctuary Cat;DKA;139899
+Sanctum Custodian;USG;8837
+Sanctum Gargoyle;ALA;115014
+Sanctum Gargoyle;DPA;115014
+Sanctum Gargoyle;MMA;115014
+Sanctum Guardian;9ED;8101
+Sanctum Guardian;USG;8101
+Sanctum Plowbeast;ARB;114916
+Sanctum Prelate;PZ2;161903
+Sanctum Seeker;XLN;402260
+Sanctum of Serra;PC1;125874
+Sanctum of Ugin;BFZ;160855
+Sand Golem;MIR;2034
+Sand Silos;5ED;2464
+Sand Silos;FEM;997
+Sand Squid;MMQ;19301
+Sand Strangler;HOU;401516
+Sand Warrior;TOK;101549
+Sand Warrior;TOK;126956
+Sand;TOK;93488
+Sandals of Abdallah;ARN;367
+Sandbar Crocodile;MIR;2035
+Sandbar Merfolk;USG;8847
+Sandbar Serpent;USG;8844
+Sandblast;FRF;157240
+Sandblast;HOU;401496
+Sandcrafter Mage;DTK;159804
+Sands of Delirium;DPA;143885
+Sands of Delirium;M13;143885
+Sands of Time;VIS;2249
+Sandskin;ONS;42922
+Sandsower;MMA;90345
+Sandsower;RAV;90345
+Sandsteppe Citadel;KTK;156583
+Sandsteppe Citadel;PRM;160422
+Sandsteppe Mastodon;FRF;157147
+Sandsteppe Mastodon;PRM;158976
+Sandsteppe Outcast;FRF;157225
+Sandsteppe Scavenger;DTK;159798
+Sandstone Bridge;BFZ;160736
+Sandstone Deadfall;ODY;33250
+Sandstone Needle;MMQ;19244
+Sandstone Oracle;PZ1;160101
+Sandstone Warrior;9ED;86943
+Sandstone Warrior;TMP;3012
+Sandstone Warrior;TPR;3012
+Sandstorm Charger;DTK;159847
+Sandstorm Eidolon;DIS;94653
+Sandstorm;4ED;368
+Sandstorm;ARN;368
+Sandstorm;ME4;368
+Sandstorm;MIR;2036
+Sandwurm Convergence;AKH;400832
+Sangrite Backlash;ARB;120967
+Sangrite Surge;ALA;115096
+Sangrite Surge;DPA;115096
+Sangromancer;DPA;133230
+Sangromancer;MBS;133230
+Sangrophage;TSP;97489
+Sanguimancy;BNG;152071
+Sanguinary Mage;SOI;161475
+Sanguine Bond;C13;122148
+Sanguine Bond;DPA;122148
+Sanguine Bond;M10;122148
+Sanguine Bond;M14;122148
+Sanguine Guard;DDE;8939
+Sanguine Guard;USG;8939
+Sanguine Praetor;GPT;91800
+Sanguine Sacrament;XLN;402337
+Sanitarium Skeleton;SOI;161743
+Sanity Gnawers;ARB;94276
+Sanity Grinding;EVE;113714
+Sapling of Colfenor;EVE;113742
+Sapphire Charm;MIR;2037
+Sapphire Drake;GTC;146372
+Sapphire Leech;INV;25474
+Sapphire Medallion;C14;144002
+Sapphire Medallion;DPA;144002
+Sapphire Medallion;TMP;3108
+Saprazzan Bailiff;MMQ;19264
+Saprazzan Breaker;MMQ;19291
+Saprazzan Cove;MMQ;19126
+Saprazzan Heir;MMQ;19205
+Saprazzan Legate;MMQ;19114
+Saprazzan Outrigger;MMQ;19027
+Saprazzan Raider;MMQ;19181
+Saprazzan Skerry;MMQ;19197
+Saproling Burst;NMS;21189
+Saproling Burst;VMA;21189
+Saproling Cluster;NMS;21186
+Saproling Infestation;INV;25192
+Saproling Symbiosis;INV;25599
+Saproling;TOK;117010
+Saproling;TOK;143980
+Saproling;TOK;145030
+Saproling;TOK;145995
+Saproling;TOK;35350
+Saproling;TOK;87023
+Saproling;TOK;89185
+Saproling;TOK;98947
+Sapseep Forest;DDH;111585
+Sapseep Forest;SHM;111585
+Sarcatog;ODY;33273
+Sarcomancy;TMP;3120
+Sarcomancy;TPR;3120
+Sarcomancy;VMA;3120
+Sarcomite Myr;FUT;103470
+Sarcomite Myr;PC1;103470
+Sarkhan Unbroken;DTK;159871
+Sarkhan Vol;ALA;115056
+Sarkhan Vol;MMA;115056
+Sarkhan the Mad;ROE;123775
+Sarkhan, the Dragonspeaker;KTK;156633
+Sarkhan's Rage;DTK;160065
+Sarkhan's Triumph;DTK;160012
+Sarpadian Empires, Vol. VII;TSP;97463
+Saruli Gatekeepers;DGM;147779
+Sasaya, Orochi Ascendant;SOK;86152
+Saskia the Unyielding;PZ2;162394
+Satyr Firedancer;BNG;152094
+Satyr Grovedancer;JOU;152874
+Satyr Hedonist;DDL;149068
+Satyr Hedonist;THS;149068
+Satyr Hoplite;JOU;152817
+Satyr Nyx-Smith;BNG;152072
+Satyr Piper;THS;150771
+Satyr Rambler;THS;149067
+Satyr Wayfinder;BNG;152050
+Satyr Wayfinder;M15;152050
+Satyr;TOK;152171
+Savaen Elves;DRK;821
+Savage Alliance;EMN;162111
+Savage Beating;DST;51892
+Savage Conception;EVE;113684
+Savage Firecat;ODY;33345
+Savage Gorilla;APC;31141
+Savage Hunger;ALA;115025
+Savage Knuckleblade;KTK;156600
+Savage Lands;ALA;114986
+Savage Lands;C13;114986
+Savage Lands;MM3;114986
+Savage Lands;PRM;139455
+Savage Lands;PZ1;114986
+Savage Lands;TD0;114986
+Savage Offensive;INV;24092
+Savage Punch;KTK;156524
+Savage Silhouette;ZEN;123646
+Savage Stomp;XLN;402046
+Savage Summoning;M14;147457
+Savage Surge;RTR;145915
+Savage Surge;THS;150866
+Savage Thallid;TSP;97269
+Savage Twister;C13;131614
+Savage Twister;CMD;2038
+Savage Twister;GPT;91826
+Savage Twister;MIR;2038
+Savage Twister;MM2;131614
+Savage Twister;PC1;2038
+Savage Ventmaw;DTK;160586
+Savageborn Hydra;DGM;146741
+Savannah Lions;2ED;217
+Savannah Lions;3ED;217
+Savannah Lions;4ED;217
+Savannah Lions;8ED;49228
+Savannah Lions;9ED;49228
+Savannah Lions;LEA;217
+Savannah Lions;LEB;217
+Savannah Lions;ME4;217
+Savannah;2ED;216
+Savannah;3ED;216
+Savannah;LEA;216
+Savannah;LEB;216
+Savannah;ME2;216
+Savannah;ME4;216
+Savannah;PRM;144369
+Savannah;VMA;144369
+Saving Grace;HOU;401521
+Saving Grasp;DKA;139785
+Savor the Moment;SHM;111895
+Savra, Queen of the Golgari;RAV;89154
+Sawback Manticore;MIR;2039
+Sawtooth Loon;DDI;28003
+Sawtooth Loon;PLS;28003
+Sawtooth Ogre;WTH;2938
+Sawtooth Thresher;5DN;77150
+Scab-Clan Berserker;ORI;160284
+Scab-Clan Charger;GTC;146248
+Scab-Clan Giant;DGM;146724
+Scab-Clan Mauler;GPT;91731
+Scabland;TMP;3148
+Scabland;TPR;3148
+Scabland;VMA;3148
+Scald;USG;8868
+Scalding Devil;AVR;141529
+Scalding Salamander;EXO;5436
+Scalding Tarn;EXP;160783
+Scalding Tarn;MM3;123672
+Scalding Tarn;ZEN;123672
+Scalding Tongs;TMP;3113
+Scaldkin;KTK;157006
+Scale Blessing;DTK;160013
+Scale of Chiss-Goria;MRD;51072
+Scalebane's Elite;VIS;2250
+Scaled Behemoth;AKH;401341
+Scaled Hulk;BOK;82594
+Scaled Wurm;5ED;1347
+Scaled Wurm;6ED;1347
+Scaled Wurm;9ED;86923
+Scaled Wurm;ICE;1347
+Scaleguard Sentinels;DTK;159795
+Scaleguard Sentinels;PRM;160034
+Scalpelexis;10E;40217
+Scalpelexis;DPA;40217
+Scalpelexis;JUD;40217
+Scandalmonger;MMQ;19102
+Scapegoat;STH;3672
+Scapeshift;MOR;107636
+Scar;SHM;111586
+Scarab Feast;AKH;401306
+Scarab of the Unseen;ALL;1716
+Scarblade Elite;MOR;110010
+Scare Tactics;EXO;5592
+Scarecrone;EVE;113748
+Scarecrow;DRK;822
+Scarecrow;ME4;822
+Scarland Thrinax;C13;118748
+Scarland Thrinax;CON;118748
+Scarland Thrinax;DPA;118748
+Scarred Puma;INV;25173
+Scarred Vinebreeder;LRW;105436
+Scars of the Veteran;ALL;1717
+Scars of the Veteran;ME2;1717
+Scarscale Ritual;SHM;111798
+Scarwood Bandits;DRK;823
+Scarwood Bandits;ME4;823
+Scarwood Goblins;DRK;824
+Scarwood Hag;DRK;825
+Scarwood Treefolk;TSP;97377
+Scathe Zombies;10E;28074
+Scathe Zombies;2ED;218
+Scathe Zombies;3ED;218
+Scathe Zombies;4ED;218
+Scathe Zombies;5ED;2465
+Scathe Zombies;6ED;218
+Scathe Zombies;7ED;28074
+Scathe Zombies;8ED;28074
+Scathe Zombies;9ED;28074
+Scathe Zombies;LEA;218
+Scathe Zombies;LEB;218
+Scatter Arc;GTC;145192
+Scatter the Seeds;MM2;88921
+Scatter the Seeds;RAV;88921
+Scatter to the Winds;BFZ;160858
+Scattered Groves;AKH;400883
+Scattering Stroke;CMD;105431
+Scattering Stroke;LRW;105431
+Scattershot Archer;CON;118778
+Scattershot;SCG;48977
+Scavenged Weaponry;INV;24149
+Scavenger Drake;ALA;115060
+Scavenger Drake;DPA;115060
+Scavenger Drake;MM2;115060
+Scavenger Folk;5ED;2466
+Scavenger Folk;7ED;27844
+Scavenger Folk;CH;826
+Scavenger Folk;DRK;826
+Scavenger Folk;ME4;826
+Scavenger Grounds;HOU;401851
+Scavenging Ghoul;2ED;219
+Scavenging Ghoul;3ED;219
+Scavenging Ghoul;4ED;219
+Scavenging Ghoul;LEA;219
+Scavenging Ghoul;LEB;219
+Scavenging Ghoul;ME4;219
+Scavenging Ooze;CMD;137527
+Scavenging Ooze;M14;137527
+Scavenging Ooze;MM3;137527
+Scavenging Ooze;PRM;148781
+Scavenging Scarab;DST;51756
+Scent of Brine;UD;15692
+Scent of Cinder;PRM;18825
+Scent of Cinder;UD;15690
+Scent of Ivy;UD;15693
+Scent of Jasmine;UD;15689
+Scent of Nightshade;UD;15691
+Scepter of Dominance;CON;118668
+Scepter of Empires;M12;134122
+Scepter of Fugue;CON;118705
+Scepter of Insight;CON;118760
+Schismotivate;DPA;91814
+Schismotivate;GPT;91814
+Scholar of Athreos;THS;150769
+School of Piranha;EXO;5416
+School of the Unseen;ALL;1718
+Scion Summoner;OGW;161255
+Scion of Darkness;LGN;47463
+Scion of Glaciers;KTK;157012
+Scion of Oona;LRW;105487
+Scion of Oona;MMA;105487
+Scion of Ugin;DTK;160120
+Scion of Vitu-Ghazi;DGM;146821
+Scion of the Ur-Dragon;TSP;97492
+Scion of the Wild;10E;90377
+Scion of the Wild;DPA;90377
+Scion of the Wild;MM2;90377
+Scion of the Wild;RAV;90377
+Scorch the Fields;DKA;139864
+Scorched Earth;TMP;3162
+Scorched Ruins;WTH;2879
+Scorched Rusalka;DDK;91888
+Scorched Rusalka;GPT;91888
+Scorched Rusalka;MM3;91888
+Scorching Lava;INV;24156
+Scorching Missile;ODY;33355
+Scorching Spear;POR;6715
+Scorching Winds;POR;6716
+Scorchwalker;GTC;146305
+Scoria Cat;PCY;22133
+Scoria Elemental;SOM;131147
+Scoria Wurm;10E;8727
+Scoria Wurm;USG;8727
+Scorned Villager;DKA;139851
+Scornful Aether-Lich;CON;118781
+Scornful Egotist;SCG;48161
+Scour from Existence;BFZ;160608
+Scour the Laboratory;EMN;161937
+Scour;BOK;83949
+Scour;UD;15607
+Scoured Barrens;EMA;157268
+Scoured Barrens;FRF;157268
+Scoured Barrens;KTK;156536
+Scourge Devil;ALA;114963
+Scourge Devil;DDK;114963
+Scourge Devil;MM3;114963
+Scourge Servant;MBS;133141
+Scourge Wolf;SOI;161501
+Scourge of Fleets;JOU;153082
+Scourge of Fleets;PRM;155423
+Scourge of Geier Reach;ISD;138268
+Scourge of Kher Ridges;FUT;48212
+Scourge of Nel Toth;PZ1;160429
+Scourge of Numai;BOK;83878
+Scourge of Skola Vale;BNG;152599
+Scourge of Valkas;M14;147388
+Scourge of the Nobilis;EVE;113646
+Scourge of the Throne;VMA;153146
+Scourgemark;THS;149183
+Scourglass;ALA;114970
+Scouring Sands;BNG;152045
+Scout the Borders;KTK;157055
+Scout's Warning;FUT;102361
+Scouting Trek;INV;25658
+Scrabbling Claws;MRD;51134
+Scragnoth;PRM;3230
+Scragnoth;TMP;3230
+Scragnoth;TSB;3230
+Scrambleverse;M12;134171
+Scrap Mastery;C14;155620
+Scrap Trawler;AER;400401
+Scrap Trawler;PRM;400722
+Scrap;USG;8753
+Scrapbasket;SHM;111700
+Scrapdiver Serpent;SOM;132375
+Scrapheap Scrounger;KLD;162629
+Scrapheap;UL;14052
+Scrapper Champion;AER;400315
+Scrapskin Drake;AVR;141580
+Scrapskin Drake;ORI;141580
+Scrapyard Mongrel;M15;155317
+Scrapyard Salvo;NPH;134280
+Screaming Fury;5DN;77153
+Screaming Seahawk;ONS;43116
+Screamreach Brawler;DTK;160112
+Screams from Within;DST;51025
+Screams of the Damned;ODY;33410
+Screeching Bat;ISD;138172
+Screeching Buzzard;ONS;43039
+Screeching Drake;ME2;4684
+Screeching Drake;PO2;4684
+Screeching Griffin;RAV;88897
+Screeching Harpy;TMP;3218
+Screeching Harpy;TPR;3218
+Screeching Silcaw;SOM;131094
+Screeching Skaab;DKA;139778
+Screeching Skaab;EMA;139778
+Screeching Skaab;ORI;139778
+Screeching Sliver;TSP;97566
+Scrib Nibblers;WWK;126573
+Scribe of the Mindful;AKH;400869
+Scrivener;EXO;5603
+Scrivener;ODY;33495
+Scrivener;TPR;5603
+Scrivener;VMA;33495
+Scroll Rack;MS2;162591
+Scroll Rack;PRM;3098
+Scroll Rack;PZ1;3098
+Scroll Rack;TMP;3098
+Scroll Thief;DDI;129096
+Scroll Thief;M11;129096
+Scroll Thief;M13;129096
+Scroll Thief;M14;129096
+Scroll of Avacyn;AVR;141649
+Scroll of Griselbrand;AVR;141718
+Scroll of Origins;SOK;86182
+Scroll of the Masters;FRF;157335
+Scrounge;DST;75180
+Scrounged Scythe;SOI;161462
+Scrounger of Souls;HOU;401797
+Scrounging Bandar;AER;400331
+Scrubland;2ED;220
+Scrubland;3ED;220
+Scrubland;LEA;220
+Scrubland;LEB;220
+Scrubland;ME3;220
+Scrubland;ME4;220
+Scrubland;PRM;144373
+Scrubland;VMA;144373
+Scryb Ranger;TSP;97545
+Scryb Sprites;2ED;221
+Scryb Sprites;3ED;221
+Scryb Sprites;4ED;221
+Scryb Sprites;5ED;221
+Scryb Sprites;LEA;221
+Scryb Sprites;LEB;221
+Scryb Sprites;ME3;221
+Scryb Sprites;MED;221
+Scryb Sprites;PRM;145068
+Scrying Glass;UD;15688
+Scrying Sheets;CSP;96940
+Sculpting Steel;10E;51034
+Sculpting Steel;MRD;51034
+Sculpting Steel;MS2;400611
+Scute Mob;DPA;123606
+Scute Mob;MM2;123606
+Scute Mob;ZEN;123606
+Scuttlemutt;SHM;111595
+Scuttling Death;COK;80847
+Scuttling Death;MM2;80847
+Scuttling Doom Engine;M15;155328
+Scuzzback Marauders;SHM;111809
+Scuzzback Scrapper;SHM;111588
+Scythe Leopard;BFZ;160711
+Scythe Leopard;PRM;160867
+Scythe Specter;CMD;137546
+Scythe Tiger;ZEN;123570
+Scythe of the Wretched;MRD;51106
+Scytheclaw;PZ1;160438
+Sea Drake;ME2;4696
+Sea Drake;PO2;4696
+Sea Drake;VMA;4696
+Sea Eagle;8ED;17560
+Sea Gate Loremaster;ZEN;123784
+Sea Gate Oracle;C14;127435
+Sea Gate Oracle;DDM;127435
+Sea Gate Oracle;MM3;127435
+Sea Gate Oracle;ROE;127435
+Sea Gate Wreckage;OGW;161267
+Sea God's Revenge;THS;150860
+Sea Kings' Blessing;LEG;662
+Sea Monster;10E;104532
+Sea Monster;6ED;3035
+Sea Monster;7ED;27776
+Sea Monster;8ED;3035
+Sea Monster;9ED;3035
+Sea Monster;TMP;3035
+Sea Monster;TPR;3035
+Sea Scryer;MIR;2040
+Sea Serpent;2ED;222
+Sea Serpent;3ED;222
+Sea Serpent;4ED;222
+Sea Serpent;5ED;2467
+Sea Serpent;LEA;222
+Sea Serpent;LEB;222
+Sea Serpent;ME4;222
+Sea Snidd;PLS;27944
+Sea Spirit;5ED;2468
+Sea Spirit;ICE;1348
+Sea Spirit;ME2;1348
+Sea Sprite;5ED;2469
+Sea Sprite;HML;1555
+Sea Sprite;MED;1555
+Sea Troll;HML;1556
+Sea of Sand;PC1;125905
+Sea's Claim;9ED;86935
+Sea's Claim;ONS;42984
+Seachrome Coast;SOM;131100
+Seacoast Drake;M14;147475
+Seafarer's Quay;LEG;663
+Seafloor Debris;ODY;33243
+Seagraf Skaab;SOI;161383
+Seahunter;NMS;21220
+Seal of Cleansing;EMA;161123
+Seal of Cleansing;NMS;21232
+Seal of Cleansing;PRM;21232
+Seal of Cleansing;TD0;21232
+Seal of Cleansing;VMA;21232
+Seal of Doom;DIS;94589
+Seal of Doom;MM3;94589
+Seal of Doom;NMS;21234
+Seal of Fire;DD2;118217
+Seal of Fire;DIS;94586
+Seal of Fire;NMS;21235
+Seal of Primordium;MM3;101385
+Seal of Primordium;PLC;101385
+Seal of Removal;NMS;21233
+Seal of Strength;EMA;161312
+Seal of Strength;NMS;21236
+Seal of the Guildpact;PZ1;160425
+Sealed Fate;MIR;2041
+Sealock Monster;THS;151428
+Search Warrant;RTR;145149
+Search for Azcanta;XLN;402111
+Search for Survivors;PCY;22022
+Search for Tomorrow;MMA;97285
+Search for Tomorrow;PC1;97285
+Search for Tomorrow;TSP;97285
+Search the City;RTR;145941
+Searchlight Geist;AVR;141565
+Searing Blaze;DDI;126476
+Searing Blaze;DPA;126476
+Searing Blaze;PRM;134054
+Searing Blaze;WWK;126476
+Searing Blood;BNG;152585
+Searing Flesh;ONS;43114
+Searing Light;OGW;161027
+Searing Meditation;DDH;89158
+Searing Meditation;RAV;89158
+Searing Rays;INV;25181
+Searing Spear Askari;MIR;2042
+Searing Spear;DPA;143853
+Searing Spear;M13;143853
+Searing Spear;PRM;147348
+Searing Touch;TMP;3264
+Searing Touch;TPR;3264
+Searing Wind;8ED;22056
+Searing Wind;PCY;22056
+Seascape Aerialist;ZEN;123786
+Seashell Cameo;INV;25194
+Seaside Citadel;ALA;115030
+Seaside Citadel;C13;115030
+Seaside Citadel;MM3;115030
+Seaside Citadel;PZ1;115030
+Seaside Citadel;TD0;115030
+Seaside Haven;ONS;43228
+Seasinger;5ED;2470
+Seasinger;FEM;998
+Seasinger;MED;998
+Season of the Witch;DRK;827
+Seasoned Marshal;7ED;27777
+Seasoned Marshal;8ED;8951
+Seasoned Marshal;9ED;8951
+Seasoned Marshal;DDF;8951
+Seasoned Marshal;DPA;8951
+Seasoned Marshal;POR;6749
+Seasoned Marshal;USG;8951
+Seasoned Tactician;ALL;1719
+Seasons Past;SOI;161400
+Seat of the Synod;DDF;51007
+Seat of the Synod;MRD;51007
+Seat of the Synod;PC1;51007
+Seat of the Synod;TD2;51007
+Secluded Glen;LRW;109169
+Secluded Steppe;C13;43214
+Secluded Steppe;C14;43214
+Secluded Steppe;CMD;43214
+Secluded Steppe;DDC;43214
+Secluded Steppe;ONS;43214
+Secluded Steppe;VMA;43214
+Second Chance;UL;10410
+Second Guess;AVR;141608
+Second Harvest;SOI;161627
+Second Sight;DST;51893
+Second Sunrise;MRD;51503
+Second Thoughts;EMA;33537
+Second Thoughts;ODY;33537
+Second Wind;FUT;102478
+Secret Plans;KTK;156579
+Secret Salvage;AER;400288
+Secretkeeper;SOK;87222
+Secrets of the Dead;DKA;138323
+Secure the Wastes;DTK;159745
+Security Blockade;RTR;145892
+Security Detail;MMQ;19173
+Sedge Scorpion;THS;149066
+Sedge Sliver;TSP;97540
+Sedge Troll;2ED;223
+Sedge Troll;3ED;223
+Sedge Troll;LEA;223
+Sedge Troll;LEB;223
+Sedge Troll;ME4;223
+Sedge Troll;PRM;223
+Sedraxis Alchemist;CON;118739
+Sedraxis Specter;ALA;114957
+Sedraxis Specter;MM3;114957
+Sedris, the Traitor King;ALA;115216
+See Beyond;PC2;127361
+See Beyond;ROE;127361
+See the Unwritten;KTK;157065
+Seed Guardian;OGW;161256
+Seed Spark;RAV;89025
+Seed the Land;SOK;86057
+Seedborn Muse;10E;47483
+Seedborn Muse;9ED;47483
+Seedborn Muse;LGN;47483
+Seedcradle Witch;SHM;111814
+Seedguide Ash;LRW;106405
+Seedling Charm;MIR;2043
+Seeds of Innocence;MIR;2044
+Seeds of Strength;RAV;89116
+Seedtime;JUD;40292
+Seek the Horizon;KTK;156564
+Seek the Horizon;RTR;145179
+Seek the Horizon;SOK;86031
+Seek the Wilds;BFZ;160856
+Seek;DIS;100951
+Seeker of Insight;AKH;401262
+Seeker of Skybreak;7ED;27778
+Seeker of Skybreak;TMP;2988
+Seeker of the Way;KTK;156995
+Seeker of the Way;PRM;160395
+Seeker;4ED;664
+Seeker;LEG;664
+Seekers' Squire;XLN;402003
+Seer of the Last Tomorrow;HOU;401782
+Seer's Lantern;OGW;161106
+Seer's Sundial;C13;126569
+Seer's Sundial;C14;126569
+Seer's Sundial;DPA;126569
+Seer's Sundial;WWK;126569
+Seer's Vision;INV;25498
+Seething Anger;STH;3752
+Seething Anger;TPR;3752
+Seething Pathblazer;MOR;109992
+Seething Song;9ED;50864
+Seething Song;DDG;135662
+Seething Song;MRD;50864
+Segmented Krotiq;DTK;159839
+Segmented Wurm;TMP;3308
+Segovian Leviathan;4ED;665
+Segovian Leviathan;5ED;665
+Segovian Leviathan;6ED;665
+Segovian Leviathan;LEG;665
+Seht's Tiger;FUT;19108
+Seismic Assault;10E;27779
+Seismic Assault;7ED;27779
+Seismic Assault;8ED;27779
+Seismic Assault;DPA;27779
+Seismic Assault;EXO;5668
+Seismic Elemental;ORI;160298
+Seismic Mage;MMQ;19295
+Seismic Rupture;DTK;159742
+Seismic Shudder;ZEN;123588
+Seismic Spike;RAV;88789
+Seismic Stomp;EMA;147432
+Seismic Stomp;M14;147432
+Seismic Strike;DDG;121674
+Seismic Strike;DDI;121674
+Seismic Strike;M10;121674
+Seismic Strike;M15;121674
+Seizan, Perverter of Truth;COK;82604
+Seize the Day;ODY;33354
+Seize the Initiative;DPA;130924
+Seize the Initiative;SOM;130924
+Seize the Soul;GPT;91715
+Seizures;ICE;1349
+Sejiri Merfolk;WWK;126533
+Sejiri Refuge;C13;123660
+Sejiri Refuge;DDI;123660
+Sejiri Refuge;ZEN;123660
+Sejiri Steppe;DDG;123657
+Sejiri Steppe;WWK;123657
+Sek'Kuar, Deathkeeper;C13;151432
+Sek'Kuar, Deathkeeper;CSP;96997
+Sekki, Seasons' Guide;SOK;86103
+Select for Inspection;KLD;162482
+Selective Memory;WWK;126496
+Selenia, Dark Angel;TMP;3195
+Selenia, Dark Angel;TPR;3195
+Selesnya Charm;C13;145183
+Selesnya Charm;RTR;145183
+Selesnya Cluestone;DGM;147763
+Selesnya Evangel;CMD;88926
+Selesnya Evangel;DPA;88926
+Selesnya Evangel;RAV;88926
+Selesnya Guildgate;C13;145158
+Selesnya Guildgate;DGM;146878
+Selesnya Guildgate;MM3;146878
+Selesnya Guildgate;RTR;145158
+Selesnya Guildmage;C13;88976
+Selesnya Guildmage;CMD;88976
+Selesnya Guildmage;DPA;88976
+Selesnya Guildmage;MM2;88976
+Selesnya Guildmage;RAV;88976
+Selesnya Keyrune;RTR;145211
+Selesnya Loft Gardens;PC2;131612
+Selesnya Sagittars;RAV;88833
+Selesnya Sanctuary;C13;88952
+Selesnya Sanctuary;CMD;88952
+Selesnya Sanctuary;DDG;88952
+Selesnya Sanctuary;MM2;88952
+Selesnya Sanctuary;PC2;88952
+Selesnya Sanctuary;RAV;88952
+Selesnya Sanctuary;TD0;88952
+Selesnya Sentry;RTR;145115
+Selesnya Signet;C13;145428
+Selesnya Signet;CMD;89182
+Selesnya Signet;MM3;145428
+Selesnya Signet;PRM;145428
+Selesnya Signet;RAV;89182
+Selesnya Signet;TD0;89182
+Self-Assembler;KLD;162576
+Self-Inflicted Wound;DTK;160166
+Selfless Cathar;DPA;138177
+Selfless Cathar;ISD;138177
+Selfless Cathar;M15;138177
+Selfless Exorcist;JUD;40190
+Selfless Spirit;EMN;161925
+Selfless Squire;PZ2;162368
+Selhoff Occultist;ISD;138364
+Selkie Hedge-Mage;EVE;113767
+Selkie Hedge-Mage;PRM;113863
+Sell-Sword Brute;RAV;88899
+Seller of Songbirds;RTR;145113
+Selvala, Explorer Returned;VMA;153181
+Selvala, Heart of the Wilds;PZ2;161898
+Semblance Anvil;SOM;131063
+Sen Triplets;ARB;121016
+Send to Sleep;ORI;160232
+Sengir Autocrat;5ED;1557
+Sengir Autocrat;6ED;1557
+Sengir Autocrat;EMA;161558
+Sengir Autocrat;HML;1557
+Sengir Autocrat;TSB;1557
+Sengir Bats;HML;1558
+Sengir Bats;HML;1559
+Sengir Nosferatu;TSP;97466
+Sengir Vampire;10E;36474
+Sengir Vampire;2ED;224
+Sengir Vampire;3ED;224
+Sengir Vampire;4ED;224
+Sengir Vampire;9ED;36474
+Sengir Vampire;DDK;36474
+Sengir Vampire;DPA;36474
+Sengir Vampire;LEA;224
+Sengir Vampire;LEB;224
+Sengir Vampire;M12;36474
+Sengir Vampire;M14;36474
+Sengir Vampire;M15;36474
+Sengir Vampire;ME4;224
+Sengir Vampire;ORI;36474
+Sengir Vampire;TOR;36474
+Sengir Vampire;W16;36474
+Sengir Vampire;W17;36474
+Sensation Gorger;MOR;109898
+Sensei Golden-Tail;COK;80896
+Sensei's Divining Top;COK;80649
+Sensei's Divining Top;EMA;120082
+Sensei's Divining Top;V09;80649
+Senseless Rage;SOI;161769
+Sensor Splicer;MM3;134377
+Sensor Splicer;NPH;134377
+Sensory Deprivation;ISD;138189
+Sensory Deprivation;M14;138189
+Sentinel Sliver;M14;147472
+Sentinel Spider;DPA;143858
+Sentinel Spider;EMA;143858
+Sentinel Spider;M13;143858
+Sentinel Totem;XLN;402129
+Sentinel of the Eternal Watch;ORI;160192
+Sentinel;CH;666
+Sentinel;LEG;666
+Sentinels of Glen Elendra;LRW;105346
+Sentry Oak;LRW;106378
+Sentry of the Underworld;THS;149098
+Separatist Voidmage;ORI;160242
+Septic Rats;MBS;133139
+Sepulchral Primordial;GTC;147247
+Sequestered Stash;KLD;162349
+Seraph Sanctuary;AVR;141716
+Seraph of Dawn;AVR;141623
+Seraph of Dawn;DPA;141623
+Seraph of the Masses;M15;155314
+Seraph of the Suns;AKH;401286
+Seraph of the Sword;M14;147492
+Seraph;5ED;2471
+Seraph;ICE;1350
+Seraph;MED;1350
+Serendib Djinn;ARN;369
+Serendib Djinn;ME4;369
+Serendib Efreet;3ED;340
+Serendib Efreet;ARN;370
+Serendib Efreet;EMA;122581
+Serendib Efreet;MED;370
+Serendib Efreet;PRM;370
+Serendib Efreet;V09;122581
+Serendib Efreet;VMA;122581
+Serendib Sorcerer;PLC;100703
+Serene Heart;MIR;2045
+Serene Master;C13;151755
+Serene Offering;TMP;3302
+Serene Remembrance;GTC;146582
+Serene Steward;BFZ;160876
+Serene Sunset;JUD;36511
+Serenity;6ED;2900
+Serenity;WTH;2900
+Serf;TOK;100405
+Serf;TOK;161559
+Serpent Assassin;POR;6593
+Serpent Generator;5ED;667
+Serpent Generator;CH;667
+Serpent Generator;LEG;667
+Serpent Generator;MED;667
+Serpent Skin;COK;80809
+Serpent Warrior;7ED;27780
+Serpent Warrior;8ED;3753
+Serpent Warrior;9ED;3753
+Serpent Warrior;POR;6594
+Serpent Warrior;STH;3753
+Serpent Warrior;TPR;3753
+Serpent of the Endless Sea;M10;121596
+Serpent's Gift;M13;143970
+Serpentine Basilisk;ONS;43170
+Serpentine Kavu;INV;24159
+Serpentine Spike;BFZ;160845
+Serra Advocate;7ED;27781
+Serra Advocate;DDC;27781
+Serra Advocate;UD;15597
+Serra Angel;10E;86905
+Serra Angel;2ED;225
+Serra Angel;3ED;225
+Serra Angel;4ED;225
+Serra Angel;7ED;28102
+Serra Angel;8ED;28102
+Serra Angel;9ED;86905
+Serra Angel;CMD;86905
+Serra Angel;DDC;86905
+Serra Angel;DPA;86905
+Serra Angel;EMA;86905
+Serra Angel;LEA;225
+Serra Angel;LEB;225
+Serra Angel;M10;86905
+Serra Angel;M11;86905
+Serra Angel;M12;86905
+Serra Angel;M13;86905
+Serra Angel;M14;86905
+Serra Angel;M15;86905
+Serra Angel;ME4;225
+Serra Angel;ORI;86905
+Serra Angel;PRM;225
+Serra Angel;V15;22850
+Serra Angel;W16;86905
+Serra Angel;W17;86905
+Serra Ascendant;DPA;129083
+Serra Ascendant;M11;129083
+Serra Avatar;C13;8853
+Serra Avatar;C14;8853
+Serra Avatar;M13;8853
+Serra Avatar;PRM;8853
+Serra Avatar;USG;8853
+Serra Avenger;M13;97410
+Serra Avenger;PRM;97410
+Serra Avenger;TD0;97410
+Serra Avenger;TSP;97410
+Serra Aviary;HML;1560
+Serra Aviary;ME4;1560
+Serra Bestiary;5ED;2472
+Serra Bestiary;HML;1561
+Serra Bestiary;ME4;2472
+Serra Inquisitors;HML;1562
+Serra Paladin;5ED;2473
+Serra Paladin;HML;1563
+Serra Sphinx;PLC;100760
+Serra Zealot;USG;8701
+Serra's Blessing;6ED;2958
+Serra's Blessing;9ED;2958
+Serra's Blessing;WTH;2958
+Serra's Boon;DDC;100817
+Serra's Boon;DPA;100817
+Serra's Boon;PLC;100817
+Serra's Embrace;10E;101032
+Serra's Embrace;7ED;27783
+Serra's Embrace;DDC;101032
+Serra's Embrace;DPA;101032
+Serra's Embrace;USG;8834
+Serra's Hymn;USG;8764
+Serra's Liturgy;USG;8850
+Serra's Sanctum;USG;8675
+Serrated Arrows;DDD;113860
+Serrated Arrows;DPA;113860
+Serrated Arrows;HML;1564
+Serrated Arrows;PRM;113860
+Serrated Arrows;TSB;1564
+Serrated Biskelion;DDF;2906
+Serrated Biskelion;WTH;2906
+Serum Powder;DST;75192
+Serum Raker;MBS;133168
+Serum Tank;MRD;51021
+Serum Tank;PC1;51021
+Serum Visions;5DN;80183
+Serum Visions;MM3;400104
+Serum Visions;PRM;160402
+Serum Visions;PRM;80183
+Servant of Nefarox;DPA;143843
+Servant of Nefarox;M13;143843
+Servant of Tymaret;BNG;152030
+Servant of Volrath;TMP;2971
+Servant of the Conduit;KLD;162301
+Servant of the Scale;DTK;159758
+Serve;DGM;151027
+Servo Exhibition;KLD;162473
+Servo Exhibition;PRM;401440
+Servo Schematic;AER;400370
+Servo;TOK;162199
+Servo;TOK;162417
+Servo;TOK;162577
+Seshiro the Anointed;COK;80591
+Set Adrift;KTK;156547
+Setessan Battle Priest;THS;149041
+Setessan Griffin;THS;149042
+Setessan Oathsworn;BNG;154933
+Setessan Starbreaker;BNG;152594
+Setessan Tactics;JOU;152973
+Seton, Krosan Protector;ODY;33288
+Seton's Desire;ODY;33311
+Seton's Scout;TOR;36505
+Settle the Wreckage;XLN;402243
+Sever Soul;8ED;49239
+Sever Soul;DPA;49239
+Sever Soul;MMQ;19062
+Sever the Bloodline;ISD;138450
+Sever the Bloodline;MM3;138450
+Severed Legion;10E;43067
+Severed Legion;8ED;43067
+Severed Legion;DPA;43067
+Severed Legion;ONS;43067
+Sewer Nemesis;CMD;98658
+Sewer Nemesis;DPA;98658
+Sewer Rats;MIR;2046
+Sewer Shambler;RTR;145129
+Sewerdreg;RAV;89036
+Sewers of Estark;PRM;485
+Sewn-Eye Drake;ARB;98653
+Shackles;EXO;5602
+Shackles;INV;24141
+Shackles;TPR;5602
+Shade of Trokair;PLC;100787
+Shade's Breath;ONS;43056
+Shade's Form;TOR;36447
+Shadow Alley Denizen;DDM;146351
+Shadow Alley Denizen;GTC;146351
+Shadow Glider;BFZ;160620
+Shadow Guildmage;MIR;2047
+Shadow Guildmage;TSB;2047
+Shadow Lance;GPT;91769
+Shadow Rider;WTH;2790
+Shadow Rift;TMP;3045
+Shadow Rift;TPR;3045
+Shadow Slice;GTC;146512
+Shadow Sliver;TSP;97282
+Shadow of Doubt;RAV;90341
+Shadow of the Grave;AKH;401317
+Shadowbane;MIR;2048
+Shadowblood Egg;ODY;33256
+Shadowblood Ridge;ODY;33360
+Shadowborn Apostle;M14;147435
+Shadowborn Demon;M14;147418
+Shadowcloak Vampire;M15;155357
+Shadowed Caravel;XLN;402325
+Shadowfeed;ALA;117007
+Shadowmage Infiltrator;DPA;34432
+Shadowmage Infiltrator;MM2;145443
+Shadowmage Infiltrator;ODY;34432
+Shadowmage Infiltrator;PRM;145443
+Shadowmage Infiltrator;TSB;34432
+Shadows of the Past;ORI;160266
+Shadowstorm Vizier;AKH;401344
+Shadowstorm;TMP;3263
+Shadowstorm;TPR;3263
+Shah of Naar Isle;FUT;102461
+Shahrazad;ARN;371
+Shaleskin Bruiser;ONS;43121
+Shaleskin Plower;LGN;47503
+Shallow Grave;MIR;2049
+Shaman en-Kor;STH;3754
+Shaman en-Kor;TPR;3754
+Shaman of Forgotten Ways;DTK;160134
+Shaman of Spring;M15;146453
+Shaman of the Great Hunt;FRF;157304
+Shaman of the Pack;EMA;160332
+Shaman of the Pack;ORI;160332
+Shaman's Trance;JUD;40260
+Shamanic Revelation;FRF;157199
+Shamanic Revelation;PRM;158975
+Shamble Back;SOI;161606
+Shambleshark;GTC;146314
+Shambling Attendants;KTK;156500
+Shambling Ghoul;ORI;160263
+Shambling Goblin;DTK;159754
+Shambling Remains;CON;118762
+Shambling Remains;DDK;118762
+Shambling Shell;DDJ;89062
+Shambling Shell;RAV;89062
+Shambling Shell;TD0;89062
+Shambling Strider;ICE;1351
+Shambling Strider;MED;1351
+Shambling Swarm;TOR;33459
+Shambling Vent;BFZ;160761
+Shanodin Dryads;2ED;226
+Shanodin Dryads;3ED;226
+Shanodin Dryads;4ED;226
+Shanodin Dryads;5ED;2474
+Shanodin Dryads;6ED;2474
+Shanodin Dryads;7ED;30844
+Shanodin Dryads;LEA;226
+Shanodin Dryads;LEB;226
+Shape Anew;DPA;130921
+Shape Anew;SOM;130921
+Shape Stealer;SOK;86191
+Shape of the Wiitigo;CSP;97036
+Shape the Sands;DTK;160173
+Shaper Apprentice;XLN;402103
+Shaper Guildmage;MIR;2050
+Shaper Parasite;C14;100683
+Shaper Parasite;PLC;100683
+Shapers of Nature;XLN;402331
+Shapers' Sanctuary;XLN;402309
+Shapesharer;LRW;105521
+Shapeshifter;4ED;443
+Shapeshifter;5ED;2475
+Shapeshifter;ATQ;443
+Shapeshifter;ME4;443
+Shapeshifter;TOK;107646
+Shapeshifter's Marrow;FUT;102501
+Shard Convergence;CON;118675
+Shard Phoenix;9ED;3689
+Shard Phoenix;PRM;94060
+Shard Phoenix;STH;3689
+Shard Phoenix;TPR;3689
+Shard Volley;MOR;109955
+Shard of Broken Glass;SOI;161359
+Sharding Sphinx;ALA;114988
+Sharding Sphinx;C13;114988
+Sharding Sphinx;DPA;114988
+Shardless Agent;EMA;118645
+Shardless Agent;PC2;118645
+Shardless Agent;PRM;118645
+Shardless Agent;PZ1;118645
+Shared Animosity;MOR;110223
+Shared Discovery;ROE;127444
+Shared Fate;MRD;51652
+Shared Trauma;CMD;137524
+Shared Triumph;ONS;42965
+Sharpened Pitchfork;ISD;138148
+Sharuum the Hegemon;ALA;115158
+Sharuum the Hegemon;C13;115158
+Sharuum the Hegemon;V11;137594
+Shatter;2ED;227
+Shatter;3ED;227
+Shatter;4ED;227
+Shatter;5ED;2476
+Shatter;6ED;3026
+Shatter;7ED;27785
+Shatter;8ED;3026
+Shatter;9ED;3026
+Shatter;DPA;50209
+Shatter;ICE;1352
+Shatter;KTK;156513
+Shatter;LEA;227
+Shatter;LEB;227
+Shatter;M10;50209
+Shatter;MRD;50209
+Shatter;SOM;130905
+Shatter;TMP;3026
+Shatter;TPR;3026
+Shattered Angel;CMD;134398
+Shattered Angel;NPH;134398
+Shattered Crypt;WTH;2799
+Shattered Dreams;5DN;77128
+Shattered Perception;DKA;139813
+Shattergang Brothers;C13;151759
+Shattering Blow;GTC;146395
+Shattering Pulse;EXO;3755
+Shattering Spree;GPT;91843
+Shatterskull Giant;DPA;123728
+Shatterskull Giant;ZEN;123728
+Shatterskull Recruit;BFZ;160687
+Shatterstorm;10E;104541
+Shatterstorm;3ED;444
+Shatterstorm;5ED;2477
+Shatterstorm;6ED;2477
+Shatterstorm;ATQ;444
+Shatterstorm;MS3;401634
+Shauku, Endbringer;MIR;2051
+Shauku's Minion;MIR;2052
+Shed Weakness;AKH;400763
+Sheep;TOK;100406
+Sheep;TOK;6171
+Sheer Drop;BFZ;160630
+Shefet Dunes;HOU;401776
+Shefet Monitor;AKH;400830
+Shelkin Brownie;LEG;668
+Shell Skulkin;EVE;113759
+Shell of the Last Kappa;COK;80755
+Shelldock Isle;LRW;106418
+Shelter;EMA;33542
+Shelter;ODY;33542
+Shelter;VMA;33542
+Sheltered Aerie;DTK;159820
+Sheltered Thicket;AKH;400827
+Sheltered Valley;ALL;1720
+Sheltering Ancient;CSP;97032
+Sheltering Light;XLN;403065
+Sheltering Prayers;PCY;21973
+Sheltering Word;AVR;141549
+Sheoldred, Whispering One;NPH;134231
+Sheoldred, Whispering One;PRM;136795
+Shepherd of Rot;ONS;43034
+Shepherd of Rot;PC1;43034
+Shepherd of the Lost;DPA;123742
+Shepherd of the Lost;PRM;123742
+Shepherd of the Lost;ZEN;123742
+Shield Bearer;5ED;1353
+Shield Bearer;ICE;1353
+Shield Bearer;ME2;1353
+Shield Dancer;PCY;22023
+Shield Mate;EXO;5428
+Shield Sphere;ALL;1721
+Shield Sphere;MED;1721
+Shield Wall;5ED;2478
+Shield Wall;7ED;27786
+Shield Wall;CH;669
+Shield Wall;LEG;669
+Shield of Duty and Reason;APC;31137
+Shield of Kaldra;DST;75676
+Shield of Kaldra;PRM;50329
+Shield of the Ages;ICE;1354
+Shield of the Ages;MED;1354
+Shield of the Avatar;M15;156062
+Shield of the Oversoul;SHM;111873
+Shield of the Righteous;ARB;121048
+Shielded Aether Thief;AER;400265
+Shielded Passage;GTC;146417
+Shielded by Faith;PZ1;160015
+Shieldhide Dragon;DTK;159696
+Shielding Plax;DIS;94287
+Shieldmage Advocate;JUD;40161
+Shieldmage Elder;ONS;42943
+Shieldmate's Blessing;ZEN;123572
+Shields of Velis Vel;LRW;105333
+Shifting Borders;SOK;86069
+Shifting Loyalties;FRF;157263
+Shifting Sky;8ED;27901
+Shifting Sky;PLS;27901
+Shifting Sliver;LGN;46556
+Shifting Wall;STH;3756
+Shifty Doppelganger;ODY;33455
+Shimatsu the Bloodcloaked;COK;80597
+Shimian Night Stalker;CH;670
+Shimian Night Stalker;LEG;670
+Shimian Specter;FUT;102335
+Shimian Specter;M13;102335
+Shimmer Myr;MBS;133216
+Shimmer;MIR;2053
+Shimmering Barrier;USG;8657
+Shimmering Efreet;VIS;2251
+Shimmering Glasskite;BOK;83974
+Shimmering Grotto;ISD;138438
+Shimmering Grotto;LRW;105562
+Shimmering Grotto;M14;138438
+Shimmering Grotto;MM3;138438
+Shimmering Grotto;PC2;138438
+Shimmering Mirage;APC;31139
+Shimmering Wings;10E;24143
+Shimmering Wings;INV;24143
+Shimmering Wings;TMP;3039
+Shimmerscale Drake;AKH;401290
+Shinen of Fear's Chill;SOK;86183
+Shinen of Flight's Wings;SOK;86039
+Shinen of Fury's Fire;SOK;86147
+Shinen of Life's Roar;SOK;86021
+Shinen of Stars' Light;SOK;86085
+Shinewend;MOR;109938
+Shining Aerosaur;XLN;402109
+Shining Shoal;BOK;83891
+Shinka Gatekeeper;BOK;83834
+Shinka, the Bloodsoaked Keep;COK;81007
+Shipbreaker Kraken;PRM;150814
+Shipbreaker Kraken;THS;151409
+Shipwreck Looter;XLN;402127
+Shipwreck Moray;AER;400258
+Shipwreck Singer;THS;149096
+Shirei, Shizo's Caretaker;BOK;80888
+Shisato, Whispering Hunter;COK;80911
+Shiv;PC1;125881
+Shiv's Embrace;DDG;129169
+Shiv's Embrace;M11;129169
+Shiv's Embrace;M14;129169
+Shiv's Embrace;USG;8714
+Shivan Dragon;10E;28101
+Shivan Dragon;2ED;228
+Shivan Dragon;3ED;228
+Shivan Dragon;4ED;228
+Shivan Dragon;5ED;228
+Shivan Dragon;7ED;28101
+Shivan Dragon;8ED;28101
+Shivan Dragon;9ED;28101
+Shivan Dragon;DPA;28101
+Shivan Dragon;DRB;117202
+Shivan Dragon;LEA;228
+Shivan Dragon;LEB;228
+Shivan Dragon;M10;28101
+Shivan Dragon;M14;28101
+Shivan Dragon;M15;28101
+Shivan Dragon;ME4;228
+Shivan Dragon;ORI;28101
+Shivan Dragon;PRM;28101
+Shivan Dragon;PRM;401446
+Shivan Dragon;W16;28101
+Shivan Dragon;W17;28101
+Shivan Emissary;INV;25211
+Shivan Gorge;USG;8806
+Shivan Gorge;V12;143999
+Shivan Harvest;INV;25495
+Shivan Hellkite;10E;25804
+Shivan Hellkite;DDG;25804
+Shivan Hellkite;DPA;25804
+Shivan Hellkite;USG;8711
+Shivan Meteor;PLC;97452
+Shivan Oasis;8ED;25155
+Shivan Oasis;DDE;25155
+Shivan Oasis;INV;25155
+Shivan Oasis;PC1;25155
+Shivan Phoenix;UL;9507
+Shivan Raptor;USG;8710
+Shivan Reef;10E;31140
+Shivan Reef;9ED;31140
+Shivan Reef;APC;31140
+Shivan Reef;M15;31140
+Shivan Reef;ORI;31140
+Shivan Sand-Mage;FUT;103997
+Shivan Wumpus;PLC;100702
+Shivan Wurm;PLS;28007
+Shivan Wurm;VMA;28007
+Shivan Zombie;INV;24005
+Shizo, Death's Storehouse;COK;81072
+Shizuko, Caller of Autumn;BOK;83858
+Shoal Serpent;ZEN;123550
+Shock Troops;8ED;19184
+Shock Troops;MMQ;19184
+Shock;10E;101056
+Shock;6ED;3677
+Shock;7ED;27788
+Shock;8ED;3677
+Shock;9ED;3677
+Shock;AER;401425
+Shock;DPA;101056
+Shock;M12;101056
+Shock;M14;101056
+Shock;ONS;44728
+Shock;PRM;3677
+Shock;STH;3677
+Shocker;TMP;3151
+Shockmaw Dragon;FRF;157338
+Shore Keeper;XLN;402280
+Shore Snapper;ALA;117006
+Shorecrasher Elemental;DTK;160033
+Shorecrasher Mimic;EVE;113635
+Shoreline Raider;INV;24010
+Shoreline Ranger;EMA;48978
+Shoreline Ranger;SCG;48978
+Shoreline Ranger;TD0;48978
+Shoreline Salvager;WWK;126528
+Shoulder to Shoulder;OGW;161203
+Shoving Match;MMQ;20316
+Show and Tell;PRM;148805
+Show and Tell;USG;8798
+Show of Valor;M13;143911
+Show of Valor;M14;143911
+Shower of Coals;ODY;33357
+Shower of Sparks;DDL;8822
+Shower of Sparks;USG;8822
+Showstopper;DGM;146839
+Shrapnel Blast;M15;113858
+Shrapnel Blast;MMA;113858
+Shrapnel Blast;MRD;50251
+Shrapnel Blast;PRM;113858
+Shred Memory;RAV;88951
+Shredding Winds;THS;150842
+Shreds of Sanity;EMN;161975
+Shrewd Hatchling;DDJ;113701
+Shrewd Hatchling;EVE;113701
+Shrewd Hatchling;MM2;113701
+Shrewd Negotiation;KLD;162256
+Shriek Raptor;NPH;134256
+Shriek of Dread;PLS;27900
+Shriekgeist;DKA;139739
+Shriekhorn;MBS;133173
+Shrieking Affliction;RTR;145904
+Shrieking Drake;VIS;2252
+Shrieking Grotesque;GPT;91779
+Shrieking Mogg;NMS;21206
+Shriekmaw;C14;106371
+Shriekmaw;CMD;106371
+Shriekmaw;DDH;106371
+Shriekmaw;LRW;106371
+Shriekmaw;PRM;106371
+Shriekmaw;TD0;106371
+Shrike Harpy;BNG;152068
+Shrill Howler;EMN;161999
+Shrine of Boundless Growth;NPH;134244
+Shrine of Burning Rage;NPH;134279
+Shrine of Burning Rage;PRM;136804
+Shrine of Limitless Power;NPH;134242
+Shrine of Loyal Legions;NPH;134198
+Shrine of Piercing Vision;NPH;134195
+Shrine of the Forsaken Gods;BFZ;161029
+Shrink;5ED;1565
+Shrink;HML;1565
+Shrink;HML;1566
+Shrink;ME2;1566
+Shrivel;M14;127333
+Shrivel;MM2;127333
+Shrivel;ROE;127333
+Shriveling Rot;DST;75387
+Shrouded Lore;PLC;100659
+Shrouded Serpent;PCY;22024
+Shu Cavalry;ME3;9156
+Shu Cavalry;PTK;9156
+Shu Defender;PTK;9101
+Shu Elite Companions;ME3;9041
+Shu Elite Companions;PTK;9041
+Shu Elite Infantry;PTK;9032
+Shu Farmer;PTK;9155
+Shu Foot Soldiers;PTK;9165
+Shu General;ME3;9157
+Shu General;PTK;9157
+Shu Grain Caravan;PTK;9026
+Shu Soldier-Farmers;ME3;9158
+Shu Soldier-Farmers;PTK;9158
+Shu Yun, the Silent Tempest;FRF;157157
+Shuko;BOK;83848
+Shunt;10E;52049
+Shunt;DST;52049
+Shuriken;BOK;83895
+Shyft;ICE;1355
+Shyft;ME2;1355
+Sibilant Spirit;5ED;1356
+Sibilant Spirit;6ED;1356
+Sibilant Spirit;ICE;1356
+Sibilant Spirit;ME2;1356
+Sibsig Host;FRF;157190
+Sibsig Icebreakers;DTK;159797
+Sibsig Muckdraggers;FRF;157351
+Sick and Tired;UL;13567
+Sicken;USG;8776
+Sickening Dreams;PD3;36459
+Sickening Dreams;TOR;36459
+Sickening Shoal;BOK;83843
+Sickle Ripper;MM2;111792
+Sickle Ripper;SHM;111792
+Sickleslicer;MM2;134212
+Sickleslicer;NPH;134212
+Sidar Jabari;MIR;2054
+Sidar Jabari;VMA;2054
+Sidar Kondo of Jamuraa;PZ2;162387
+Sideswipe;COK;82643
+Sidewinder Naga;HOU;401519
+Sidewinder Sliver;TSP;97532
+Sidisi, Brood Tyrant;KTK;156638
+Sidisi, Undead Vizier;DTK;159774
+Sidisi's Faithful;DTK;160093
+Sidisi's Pet;KTK;156497
+Siege Behemoth;C14;155659
+Siege Dragon;M15;155353
+Siege Dragon;PRM;155864
+Siege Mastodon;DPA;123434
+Siege Mastodon;M10;123434
+Siege Mastodon;M11;123434
+Siege Mastodon;M12;123434
+Siege Mastodon;M14;123434
+Siege Modification;AER;400321
+Siege Rhino;KTK;156594
+Siege Rhino;PRM;160420
+Siege Wurm;M15;88922
+Siege Wurm;RAV;88922
+Siege of Towers;GPT;91844
+Siege-Gang Commander;10E;48956
+Siege-Gang Commander;DPA;48956
+Siege-Gang Commander;EMA;111907
+Siege-Gang Commander;EVG;111907
+Siege-Gang Commander;M10;48956
+Siege-Gang Commander;SCG;48956
+Siegecraft;KTK;156483
+Sift Through Sands;COK;80690
+Sift;10E;86926
+Sift;9ED;86926
+Sift;STH;3757
+Sift;TPR;3757
+Sifter Wurm;HOU;401823
+Sifter of Skulls;OGW;161229
+Sigarda, Heron's Grace;SOI;161466
+Sigarda, Host of Herons;AVR;141578
+Sigarda's Aid;EMN;162029
+Sigardian Priest;EMN;162038
+Sight Beyond Sight;DTK;160110
+Sight of the Scalelords;DTK;160038
+Sighted-Caste Sorcerer;ALA;115184
+Sightless Brawler;JOU;152834
+Sightless Ghoul;DKA;139839
+Sigil Blessing;ALA;115257
+Sigil Blessing;DDG;115257
+Sigil Blessing;DPA;115257
+Sigil Blessing;MM2;115257
+Sigil Captain;ARB;120970
+Sigil Captain;CMD;120970
+Sigil Tracer;MOR;109610
+Sigil of Distinction;ALA;114977
+Sigil of Distinction;DPA;114977
+Sigil of Sleep;DDI;15773
+Sigil of Sleep;UD;15773
+Sigil of Valor;ORI;160351
+Sigil of the Empty Throne;CON;118726
+Sigil of the Empty Throne;DPA;118726
+Sigil of the Empty Throne;ORI;118726
+Sigil of the Empty Throne;PC2;118726
+Sigil of the Nayan Gods;ARB;121002
+Sigil of the New Dawn;ONS;42955
+Sigiled Behemoth;ARB;120948
+Sigiled Paladin;ALA;115037
+Sigiled Skink;JOU;153094
+Sigiled Starfish;JOU;153101
+Sigiled Starfish;ORI;153101
+Sign in Blood;C14;121620
+Sign in Blood;CMD;121620
+Sign in Blood;DDD;121620
+Sign in Blood;DPA;121620
+Sign in Blood;M10;121620
+Sign in Blood;M11;121620
+Sign in Blood;M13;121620
+Sign in Blood;M15;121620
+Sign in Blood;MM2;121620
+Sign in Blood;PRM;125918
+Signal Pest;DPA;135408
+Signal Pest;MBS;135408
+Signal Pest;PRM;135674
+Signal the Clans;GTC;146469
+Silas Renn, Seeker Adept;PZ2;162388
+Silburlind Snapper;SOI;161494
+Silence the Believers;JOU;153092
+Silence;M10;121665
+Silence;M11;121665
+Silence;M14;121665
+Silence;TD0;121665
+Silent Arbiter;5DN;77229
+Silent Arbiter;DPA;77229
+Silent Arbiter;TD2;77229
+Silent Artisan;THS;150773
+Silent Assassin;MMQ;19240
+Silent Attendant;USG;8766
+Silent Departure;EMA;138113
+Silent Departure;ISD;138113
+Silent Observer;SOI;161771
+Silent Sentinel;BNG;152089
+Silent Sentinel;PRM;152543
+Silent Skimmer;BFZ;160921
+Silent Specter;ONS;43079
+Silent Specter;PRM;43079
+Silent-Blade Oni;PC2;140362
+Silent-Chant Zubera;COK;82636
+Silhana Ledgewalker;DPA;91652
+Silhana Ledgewalker;GPT;91652
+Silhana Ledgewalker;PC2;91652
+Silhana Starfletcher;GPT;91690
+Silhouette;LEG;671
+Silk Net;UL;10331
+Silkbind Faerie;SHM;111573
+Silkenfist Fighter;NMS;21156
+Silkenfist Order;NMS;21173
+Silklash Spider;9ED;43204
+Silklash Spider;C13;43204
+Silklash Spider;C14;43204
+Silklash Spider;DPA;43204
+Silklash Spider;M13;43204
+Silklash Spider;ONS;43204
+Silkweaver Elite;AER;400344
+Silkwing Scout;DIS;94384
+Silkwrap;DTK;160167
+Silkwrap;PRM;161273
+Silt Crawler;PCY;22025
+Silumgar Assassin;DTK;159730
+Silumgar Butcher;DTK;160153
+Silumgar Monument;DTK;159722
+Silumgar Sorcerer;DTK;159690
+Silumgar Spell-Eater;DTK;160129
+Silumgar, the Drifting Death;FRF;157159
+Silumgar's Command;DTK;159835
+Silumgar's Scorn;DTK;159770
+Silver Drake;PLS;27985
+Silver Erne;ICE;1357
+Silver Knight;DDG;135661
+Silver Knight;PRM;48140
+Silver Knight;SCG;48140
+Silver Myr;DDF;50861
+Silver Myr;MRD;50861
+Silver Myr;PC1;50861
+Silver Myr;SOM;130972
+Silver Myr;TD2;130972
+Silver Seraph;JUD;40187
+Silver Wyvern;STH;3637
+Silver Wyvern;TPR;3637
+Silver-Inlaid Dagger;ISD;138210
+Silverback Ape;8ED;17575
+Silverblade Paladin;AVR;142212
+Silverblade Paladin;C14;142212
+Silverblade Paladin;PRM;141696
+Silverchase Fox;ISD;138383
+Silverclaw Griffin;DKA;139911
+Silvercoat Lion;DPA;102612
+Silvercoat Lion;M10;102612
+Silvercoat Lion;M11;102612
+Silvercoat Lion;M13;102612
+Silverfur Partisan;SOI;161498
+Silvergill Adept;LRW;104085
+Silvergill Douser;LRW;108561
+Silverglade Elemental;MMQ;19058
+Silverglade Elemental;PC1;19058
+Silverglade Pathfinder;MMQ;19279
+Silverpelt Werewolf;DKA;139737
+Silverskin Armor;MBS;133132
+Silverstorm Samurai;BOK;83902
+Silverstrike;SOI;161644
+Silvos, Rogue Elemental;EMA;43207
+Silvos, Rogue Elemental;ONS;43207
+Silvos, Rogue Elemental;VMA;43207
+Sima Yi, Wei Field Marshal;PTK;9093
+Simian Brawler;CSP;96919
+Simian Grunts;UL;10415
+Simian Grunts;VMA;10415
+Simian Spirit Guide;PLC;100747
+Simic Basilisk;DIS;94415
+Simic Charm;GTC;145927
+Simic Cluestone;DGM;147757
+Simic Fluxmage;GTC;145206
+Simic Growth Chamber;CMD;94292
+Simic Growth Chamber;DIS;94292
+Simic Growth Chamber;MM2;94292
+Simic Growth Chamber;TD0;94292
+Simic Guildgate;C13;145166
+Simic Guildgate;DGM;146886
+Simic Guildgate;GTC;145166
+Simic Guildgate;MM3;146886
+Simic Guildmage;DIS;94281
+Simic Initiate;DIS;94500
+Simic Initiate;MM2;94500
+Simic Keyrune;GTC;145934
+Simic Manipulator;GTC;146578
+Simic Ragworm;DIS;94620
+Simic Signet;C13;131705
+Simic Signet;CMD;94282
+Simic Signet;DIS;94282
+Simic Signet;MM3;131705
+Simic Signet;PRM;131705
+Simic Signet;TD0;94282
+Simic Sky Swallower;CMD;94676
+Simic Sky Swallower;DIS;94676
+Simic Sky Swallower;DPA;94676
+Simic Sky Swallower;MM3;94676
+Simoon;INV;24137
+Simoon;VIS;2253
+Simple;DIS;100948
+Simplify;ODY;33312
+Simulacrum;2ED;229
+Simulacrum;3ED;229
+Simulacrum;4ED;229
+Simulacrum;LEA;229
+Simulacrum;LEB;229
+Sin Collector;DGM;146834
+Sin Collector;MM3;146834
+Sin Collector;PRM;151399
+Sin Prodder;SOI;161431
+Sindbad;4ED;372
+Sindbad;ARN;372
+Sindbad;TSB;372
+Sinew Sliver;PLC;100763
+Singe-Mind Ogre;ARB;114915
+Singe-Mind Ogre;DPA;114915
+Singe;PLS;27883
+Singing Bell Strike;KTK;156492
+Singing Tree;ARN;373
+Singing Tree;MED;373
+Sinister Concoction;SOI;161740
+Sinister Possession;DGM;147701
+Sinister Strength;PLS;27898
+Sink into Takenuma;SOK;86136
+Sinkhole;2ED;230
+Sinkhole;EMA;161308
+Sinkhole;LEA;230
+Sinkhole;LEB;230
+Sinkhole;ME4;230
+Sinkhole;PRM;126730
+Sinking Feeling;SHM;111871
+Sins of the Past;RAV;90401
+Sinstriker's Will;GPT;91716
+Sinuous Predator;EMN;162118
+Sinuous Striker;HOU;401547
+Sinuous Striker;TOK;401878
+Sip of Hemlock;THS;150822
+Sir Shandlar of Eberyn;LEG;672
+Sir Shandlar of Eberyn;ME3;672
+Sire of Insanity;DGM;146866
+Sire of Stagnation;BFZ;160917
+Sire of the Storm;COK;80902
+Siren Lookout;XLN;402365
+Siren Song Lyre;BNG;152086
+Siren Stormtamer;XLN;402050
+Siren of the Fanged Coast;BNG;152554
+Siren of the Silent Song;BNG;152606
+Siren's Call;2ED;231
+Siren's Call;3ED;231
+Siren's Call;4ED;231
+Siren's Call;LEA;231
+Siren's Call;LEB;231
+Siren's Ruse;XLN;402236
+Sirocco;MIR;2055
+Sisay's Ingenuity;PLS;27982
+Sisay's Ring;7ED;27790
+Sisay's Ring;VIS;2254
+Sisters of Stone Death;RAV;88733
+Sisters of the Flame;4ED;828
+Sisters of the Flame;DRK;828
+Sivitri Scarzam;CH;673
+Sivitri Scarzam;LEG;673
+Sivitri Scarzam;ME3;673
+Sivvi's Ruse;NMS;21280
+Sivvi's Valor;NMS;21231
+Sixth Sense;AKH;400796
+Sizzle;8ED;49676
+Sizzle;DPA;49676
+Sizzle;MMQ;19260
+Skaab Goliath;ISD;138224
+Skaab Goliath;ORI;138224
+Skaab Ruinator;ISD;138341
+Skarrg Goliath;GTC;146547
+Skarrg Goliath;PRM;147339
+Skarrg Guildmage;GTC;145201
+Skarrg, the Rage Pits;DDL;91795
+Skarrg, the Rage Pits;GPT;91795
+Skarrg, the Rage Pits;PC2;91795
+Skarrgan Firebird;DDL;91782
+Skarrgan Firebird;DPA;91782
+Skarrgan Firebird;GPT;91782
+Skarrgan Firebird;MM2;91782
+Skarrgan Pit-Skulk;GPT;91766
+Skarrgan Skybreaker;DDL;91832
+Skarrgan Skybreaker;GPT;91832
+Skeletal Changeling;LRW;106363
+Skeletal Crocodile;POR;6595
+Skeletal Grimace;ISD;138135
+Skeletal Kathari;ALA;115007
+Skeletal Scrying;C14;33391
+Skeletal Scrying;ODY;33391
+Skeletal Snake;POR;6596
+Skeletal Vampire;DDD;91726
+Skeletal Vampire;DPA;91726
+Skeletal Vampire;GPT;91726
+Skeletal Vampire;MMA;91726
+Skeletal Wurm;ROE;127250
+Skeleton Key;SOI;161467
+Skeleton Scavengers;STH;3760
+Skeleton Shard;MRD;51141
+Skeleton Shard;PC1;51141
+Skeleton Ship;ICE;1358
+Skeleton Ship;ME2;1358
+Skeleton;TOK;117018
+Skeletonize;ALA;115116
+Skeletonize;DPA;115116
+Skill Borrower;ALA;117009
+Skillful Lunge;DKA;139912
+Skin Invasion;SOI;161361
+Skin Shedder;SOI;161403
+Skinbrand Goblin;GTC;146299
+Skinrender;SOM;131732
+Skinshifter;M12;134103
+Skinthinner;LGN;46549
+Skinwing;MBS;133257
+Skirge Familiar;USG;8907
+Skirge Familiar;VMA;8907
+Skirk Alarmist;LGN;47500
+Skirk Commando;ONS;43092
+Skirk Drill Sergeant;EVG;47537
+Skirk Drill Sergeant;LGN;47537
+Skirk Drill Sergeant;VMA;47537
+Skirk Fire Marshal;EVG;43141
+Skirk Fire Marshal;ONS;43141
+Skirk Marauder;LGN;46550
+Skirk Marauder;PRM;46550
+Skirk Outrider;LGN;47471
+Skirk Prospector;DDG;43118
+Skirk Prospector;EVG;43118
+Skirk Prospector;ONS;43118
+Skirk Prospector;VMA;43118
+Skirk Ridge Exhumer;FUT;102369
+Skirk Shaman;EVG;102237
+Skirk Shaman;PLC;102237
+Skirk Volcanist;SCG;48950
+Skirsdag Cultist;DDK;138146
+Skirsdag Cultist;DPA;138146
+Skirsdag Cultist;ISD;138146
+Skirsdag Cultist;MM3;138146
+Skirsdag Flayer;DKA;139824
+Skirsdag High Priest;C14;138353
+Skirsdag High Priest;ISD;138353
+Skirsdag Supplicant;EMN;162080
+Skithiryx, the Blight Dragon;SOM;131137
+Skitter of Lizards;WWK;126559
+Skittering Heartstopper;XLN;402002
+Skittering Horror;UD;15707
+Skittering Invasion;ROE;127385
+Skittering Monstrosity;TSP;97505
+Skittering Skirge;PRM;8901
+Skittering Skirge;USG;8901
+Skitterskin;BFZ;160898
+Skittish Kavu;INV;24158
+Skittish Valesk;ONS;43111
+Skizzik Surger;FUT;102480
+Skizzik;DPA;24197
+Skizzik;INV;24197
+Skred;CSP;97259
+Skulduggery;XLN;402267
+Skulking Fugitive;MMQ;19073
+Skulking Ghost;EMA;2056
+Skulking Ghost;MIR;2056
+Skulking Knight;TSP;97522
+Skull Catapult;5ED;2479
+Skull Catapult;6ED;2479
+Skull Catapult;ICE;1359
+Skull Catapult;ME2;1359
+Skull Collector;SOK;86172
+Skull Fracture;ODY;33407
+Skull Rend;RTR;145154
+Skull of Orm;8ED;49260
+Skull of Orm;DRK;829
+Skull of Ramos;MMQ;19159
+Skullbriar, the Walking Grave;CMD;137541
+Skullcage;5DN;77231
+Skullclamp;C14;156385
+Skullclamp;CMD;75187
+Skullclamp;DST;75187
+Skullclamp;TD0;75187
+Skullclamp;V09;75187
+Skullclamp;VMA;156385
+Skullcrack;GTC;146586
+Skullmane Baku;BOK;83912
+Skullmead Cauldron;DIS;94395
+Skullmulcher;ALA;115220
+Skullscorch;TOR;36500
+Skullsnatcher;BOK;83975
+Skullsnatcher;PC2;83975
+Skulltap;SCG;48964
+Skullwinder;PZ1;160090
+Sky Diamond;6ED;2057
+Sky Diamond;7ED;27791
+Sky Diamond;C14;156376
+Sky Diamond;MIR;2057
+Sky Hussar;DIS;94312
+Sky Ruin Drake;DPA;123716
+Sky Ruin Drake;ZEN;123716
+Sky Scourer;OGW;161226
+Sky Skiff;KLD;162602
+Sky Spirit;DDI;3305
+Sky Spirit;TMP;3305
+Sky Swallower;GPT;91662
+Sky Terror;XLN;402860
+Sky Weaver;10E;25217
+Sky Weaver;INV;25217
+Sky-Eel School;SOM;130889
+Skybind;JOU;153066
+Skyblade of the Legion;XLN;402360
+Skyblinder Staff;GTC;146557
+Skybreen;PC1;125896
+Skyclaw Thrash;ARB;120975
+Skycloud Egg;ODY;33255
+Skycloud Expanse;ODY;33234
+Skyfire Kirin;SOK;86168
+Skygames;GTC;146352
+Skyhunter Cub;MRD;50344
+Skyhunter Patrol;10E;50326
+Skyhunter Patrol;DDG;50326
+Skyhunter Patrol;MRD;50326
+Skyhunter Prowler;10E;77087
+Skyhunter Prowler;5DN;77087
+Skyhunter Prowler;9ED;77087
+Skyhunter Skirmisher;10E;77171
+Skyhunter Skirmisher;5DN;77171
+Skyhunter Skirmisher;C14;77171
+Skyhunter Skirmisher;DPA;77171
+Skyhunter Skirmisher;MM2;77171
+Skyknight Legionnaire;GTC;146298
+Skyknight Legionnaire;MM3;89016
+Skyknight Legionnaire;PRM;89016
+Skyknight Legionnaire;RAV;89016
+Skylasher;DGM;146830
+Skyline Cascade;BFZ;160733
+Skyline Despot;PZ2;161888
+Skyline Predator;RTR;145900
+Skymarch Bloodletter;XLN;402078
+Skymark Roc;RTR;145955
+Skyraker Giant;ORI;160283
+Skyreach Manta;5DN;77175
+Skyreach Manta;MM2;77175
+Skyreach Manta;MMA;77175
+Skyreaping;BNG;152082
+Skyrider Elf;BFZ;160841
+Skyrider Trainee;GPT;91665
+Skyscribing;C13;152003
+Skyscribing;CMD;94508
+Skyscribing;DIS;94508
+Skyshaper;EXO;3761
+Skyshaper;TPR;3761
+Skyship Plunderer;AER;400266
+Skyship Stalker;KLD;162293
+Skyship Stalker;PRM;162528
+Skyship Weatherlight;PLS;28019
+Skyship Weatherlight;PRM;24146
+Skyshooter;ODY;33310
+Skyshroud Archer;STH;3762
+Skyshroud Behemoth;NMS;21247
+Skyshroud Blessing;PLS;27916
+Skyshroud Claim;DPA;21175
+Skyshroud Claim;NMS;21175
+Skyshroud Condor;TMP;3271
+Skyshroud Cutter;NMS;21268
+Skyshroud Elf;TMP;2994
+Skyshroud Elf;TPR;2994
+Skyshroud Elite;EXO;3763
+Skyshroud Falcon;7ED;27792
+Skyshroud Falcon;STH;3758
+Skyshroud Forest;TMP;3146
+Skyshroud Forest;TPR;3146
+Skyshroud Forest;VMA;3146
+Skyshroud Poacher;NMS;21263
+Skyshroud Ranger;10E;104558
+Skyshroud Ranger;TMP;2989
+Skyshroud Ridgeback;NMS;21188
+Skyshroud Sentinel;NMS;21155
+Skyshroud Troll;TMP;2986
+Skyshroud Troll;TPR;2986
+Skyshroud Troopers;STH;3764
+Skyshroud Vampire;TMP;3213
+Skyshroud Vampire;TPR;3213
+Skyshroud War Beast;EXO;3765
+Skysnare Spider;ORI;160320
+Skysovereign, Consul Flagship;KLD;162332
+Skyspear Cavalry;JOU;153058
+Skyswirl Harrier;KLD;162236
+Skyward Eye Prophets;C13;115033
+Skyward Eye Prophets;CON;115033
+Skyward Eye Prophets;DPA;115033
+Skywatcher Adept;ROE;127369
+Skywhaler's Shot;KLD;162244
+Skywinder Drake;DPA;137394
+Skywinder Drake;M12;137394
+Skywing Aven;TOR;36411
+Skywing Aven;VMA;36411
+Skywise Teachings;DTK;159855
+Slab Hammer;BFZ;160936
+Slag Fiend;NPH;134272
+Slagstorm;MBS;133224
+Slagwurm Armor;MRD;50220
+Slagwurm Armor;TD2;50220
+Slash Panther;NPH;134357
+Slash of Talons;XLN;402086
+Slashing Tiger;ME3;9133
+Slashing Tiger;PTK;9133
+Slate Street Ruffian;DDM;146416
+Slate Street Ruffian;GTC;146416
+Slate of Ancestry;9ED;43209
+Slate of Ancestry;EVG;43209
+Slate of Ancestry;ONS;43209
+Slaughter Cry;M12;123578
+Slaughter Cry;ZEN;123578
+Slaughter Drone;OGW;161026
+Slaughter Games;RTR;145228
+Slaughter Pact;FUT;102422
+Slaughter Pact;MMA;102422
+Slaughter Pact;MS3;401626
+Slaughter;EXO;5638
+Slaughterhorn;GTC;146526
+Slaughterhorn;MM3;146526
+Slaughterhouse Bouncer;DIS;94337
+Slave of Bolas;ARB;121328
+Slave of Bolas;DDH;121328
+Slave of Bolas;PRM;121058
+Slavering Nulls;DDH;126525
+Slavering Nulls;DPA;126525
+Slavering Nulls;WWK;126525
+Slay;8ED;27899
+Slay;9ED;27899
+Slay;DDE;27899
+Slay;PLS;27899
+Slayer of the Wicked;ISD;138123
+Slayer's Cleaver;EMN;162147
+Slayer's Plate;SOI;161618
+Slayers' Stronghold;AVR;141711
+Sleek Schooner;XLN;402108
+Sleep Paralysis;SOI;161469
+Sleep Paralysis;W17;161469
+Sleep;DPA;121609
+Sleep;M10;121609
+Sleep;M11;121609
+Sleep;M13;121609
+Sleeper Agent;10E;8745
+Sleeper Agent;USG;8745
+Sleeper's Guile;UL;10334
+Sleeper's Robe;INV;24104
+Sleeping Potion;PLS;27988
+Sleight of Hand;7ED;27793
+Sleight of Hand;9ED;86910
+Sleight of Hand;DPA;86910
+Sleight of Hand;ME4;4636
+Sleight of Hand;PO2;4636
+Sleight of Mind;2ED;232
+Sleight of Mind;3ED;232
+Sleight of Mind;4ED;232
+Sleight of Mind;5ED;232
+Sleight of Mind;ICE;1360
+Sleight of Mind;LEA;232
+Sleight of Mind;LEB;232
+Slice and Dice;C13;43135
+Slice and Dice;ONS;43135
+Slice and Dice;PRM;43135
+Slice in Twain;C13;131052
+Slice in Twain;SOM;131052
+Slice in Twain;XLN;402848
+Slime Molding;MM3;145914
+Slime Molding;RTR;145914
+Slimy Kavu;INV;24022
+Slingbow Trap;WWK;126602
+Slingshot Goblin;PLS;27989
+Slinking Giant;SHM;111784
+Slinking Serpent;INV;24179
+Slinking Skirge;UD;15706
+Slip Through Space;OGW;161215
+Slippery Bogle;EVE;113607
+Slippery Karst;C13;8691
+Slippery Karst;C14;8691
+Slippery Karst;DDD;8691
+Slippery Karst;USG;8691
+Slipstream Eel;CMD;42976
+Slipstream Eel;ONS;42976
+Slipstream Serpent;TSP;97468
+Sliptide Serpent;NMS;21159
+Slith Ascendant;DPA;51496
+Slith Ascendant;MRD;51496
+Slith Bloodletter;MRD;51498
+Slith Firewalker;DD2;51499
+Slith Firewalker;MRD;51499
+Slith Firewalker;PRM;51499
+Slith Predator;MRD;51500
+Slith Strider;DDI;51497
+Slith Strider;MRD;51497
+Slither Blade;AKH;401288
+Slitherhead;RTR;145926
+Slithering Shade;DIS;94755
+Slithermuse;MOR;110220
+Slithery Stalker;TOR;36439
+Sliver Construct;DPA;147452
+Sliver Construct;M14;147452
+Sliver Hive;M15;155315
+Sliver Hivelord;M15;156147
+Sliver Legion;FUT;102468
+Sliver Overlord;H09;48154
+Sliver Overlord;SCG;48154
+Sliver Queen;PRM;3767
+Sliver Queen;STH;3767
+Sliver Queen;TPR;3767
+Sliver;TOK;125143
+Sliver;TOK;149244
+Sliver;TOK;46598
+Sliversmith;FUT;102376
+Slobad, Goblin Tinkerer;DST;75214
+Slow Motion;UL;15769
+Sludge Crawler;BFZ;160928
+Sludge Strider;CON;118744
+Sludge Strider;PC1;118744
+Sluggishness;UL;10414
+Sluiceway Scorpion;RTR;145888
+Slum Reaper;RTR;145903
+Slumbering Dragon;M13;143960
+Slumbering Tora;BOK;83942
+Sly Requisitioner;AER;400293
+Smallpox;M12;137608
+Smallpox;TSP;97420
+Smash to Smithereens;MM2;111841
+Smash to Smithereens;ORI;111841
+Smash to Smithereens;PRM;161280
+Smash to Smithereens;SHM;111841
+Smash;10E;88661
+Smash;APC;31042
+Smash;RAV;88661
+Smelt-Ward Gatekeepers;DGM;147778
+Smelt;DPA;143852
+Smelt;M13;143852
+Smelt;M14;143852
+Smite the Monstrous;BFZ;160937
+Smite the Monstrous;DDL;138130
+Smite the Monstrous;ISD;138130
+Smite the Monstrous;KTK;156482
+Smite the Monstrous;PRM;159746
+Smite;GTC;146281
+Smite;ROE;127372
+Smite;STH;3768
+Smite;TPR;3768
+Smog Elemental;GTC;146360
+Smogsteed Rider;GPT;43010
+Smoke Teller;KTK;157050
+Smoke;2ED;233
+Smoke;3ED;233
+Smoke;4ED;233
+Smoke;5ED;2480
+Smoke;LEA;233
+Smoke;LEB;233
+Smoke;ME4;233
+Smokebraider;LRW;105379
+Smokebraider;MM2;105379
+Smokebraider;PC1;105379
+Smokespew Invoker;LGN;47484
+Smokestack;USG;8794
+Smokestack;V14;155836
+Smokestack;VMA;155836
+Smolder Initiate;SHM;111667
+Smoldering Butcher;EVE;113718
+Smoldering Crater;C13;8926
+Smoldering Crater;C14;8926
+Smoldering Crater;USG;8926
+Smoldering Efreet;FRF;157317
+Smoldering Marsh;BFZ;160905
+Smoldering Marsh;EXP;161289
+Smoldering Spires;WWK;123526
+Smoldering Tar;INV;25479
+Smoldering Werewolf;EMN;161971
+Smother;ONS;43059
+Smother;PRM;43059
+Smother;WWK;126581
+Smothering Abomination;BFZ;160914
+Smuggler's Copter;KLD;162333
+Snag;PCY;21974
+Snake Basket;6ED;2255
+Snake Basket;VIS;2255
+Snake Cult Initiation;FUT;102424
+Snake Pit;MMQ;19037
+Snake Umbra;DPA;127366
+Snake Umbra;PC2;127366
+Snake Umbra;ROE;127366
+Snake of the Golden Grove;BNG;152055
+Snake;TOK;125082
+Snake;TOK;143404
+Snake;TOK;152107
+Snake;TOK;155469
+Snake;TOK;156684
+Snake;TOK;401253
+Snake;TOK;401833
+Snake;TOK;6693
+Snake;TOK;82653
+Snake;TOK;94393
+Snakeform;EVE;113729
+Snap;PRM;148324
+Snap;UL;10389
+Snapback;TSP;97316
+Snapcaster Mage;ISD;138304
+Snapcaster Mage;MM3;400209
+Snapcaster Mage;PRM;161940
+Snapping Creeper;DPA;126488
+Snapping Creeper;WWK;126488
+Snapping Drake;10E;88974
+Snapping Drake;DPA;88974
+Snapping Drake;M10;102614
+Snapping Drake;POR;6630
+Snapping Drake;RAV;88974
+Snapping Gnarlid;BFZ;160774
+Snapping Sailback;XLN;402040
+Snapping Thragg;ONS;43110
+Snapsail Glider;DPA;131069
+Snapsail Glider;SOM;131069
+Snare Thopter;KLD;162600
+Snare the Skies;AVR;141784
+Snarling Undorak;ONS;43149
+Sneak Attack;EMA;143395
+Sneak Attack;USG;8929
+Sneaky Homunculus;8ED;21203
+Sneaky Homunculus;NMS;21203
+Snorting Gahr;MMQ;19111
+Snow Devil;ICE;1361
+Snow Fortress;ICE;1362
+Snow Fortress;ME2;1362
+Snow Hound;ICE;1363
+Snow-Covered Forest;CSP;96928
+Snow-Covered Forest;ICE;1364
+Snow-Covered Forest;ME2;1364
+Snow-Covered Island;CSP;96866
+Snow-Covered Island;ICE;1365
+Snow-Covered Island;ME2;1365
+Snow-Covered Mountain;CSP;96969
+Snow-Covered Mountain;ICE;1366
+Snow-Covered Mountain;ME2;1366
+Snow-Covered Plains;CSP;97003
+Snow-Covered Plains;ICE;1367
+Snow-Covered Plains;ME2;1367
+Snow-Covered Swamp;CSP;96992
+Snow-Covered Swamp;ICE;1368
+Snow-Covered Swamp;ME2;1368
+Snowblind;ICE;1369
+Snowfall;ICE;1370
+Snowhorn Rider;KTK;157068
+Snuff Out;DDD;127185
+Snuff Out;MMQ;19222
+Soar;MIR;2058
+Soaring Hope;LRW;105421
+Soaring Seacliff;DDI;123553
+Soaring Seacliff;ZEN;123553
+Soilshaper;COK;81063
+Sokenzan Bruiser;COK;25166
+Sokenzan Renegade;SOK;86043
+Sokenzan Spellblade;SOK;87220
+Sokenzan;PC1;125870
+Sol Grail;ALL;1722
+Sol Grail;ME3;1722
+Sol Ring;2ED;234
+Sol Ring;3ED;234
+Sol Ring;C13;129514
+Sol Ring;C14;129514
+Sol Ring;CMD;129514
+Sol Ring;LEA;234
+Sol Ring;LEB;234
+Sol Ring;ME4;234
+Sol Ring;MS2;162592
+Sol Ring;PRM;234
+Sol Ring;PZ1;129514
+Sol Ring;V10;129514
+Sol Ring;VMA;129514
+Sol'kanar the Swamp King;CH;674
+Sol'kanar the Swamp King;LEG;674
+Sol'kanar the Swamp King;TSB;674
+Solar Blast;ONS;43127
+Solar Blast;VMA;43127
+Solar Tide;MRD;51076
+Solarion;5DN;77183
+Soldevi Adnate;ALL;1723
+Soldevi Adnate;ALL;1724
+Soldevi Digger;ALL;1725
+Soldevi Digger;ME2;1725
+Soldevi Excavations;ALL;1726
+Soldevi Excavations;ME2;1726
+Soldevi Golem;ICE;1371
+Soldevi Golem;ME4;1371
+Soldevi Heretic;ALL;1727
+Soldevi Heretic;ALL;1728
+Soldevi Machinist;ICE;1372
+Soldevi Machinist;ME4;1372
+Soldevi Sage;6ED;1729
+Soldevi Sage;ALL;1729
+Soldevi Sage;ALL;1730
+Soldevi Sentry;ALL;1731
+Soldevi Sentry;ALL;1732
+Soldevi Simulacrum;ICE;1373
+Soldevi Simulacrum;ME2;1373
+Soldevi Steam Beast;ALL;1733
+Soldevi Steam Beast;ALL;1734
+Soldier Ally;TOK;126540
+Soldier Replica;MRD;50219
+Soldier of Fortune;ALL;1735
+Soldier of the Pantheon;THS;150875
+Soldier;TOK;101380
+Soldier;TOK;104575
+Soldier;TOK;114967
+Soldier;TOK;131406
+Soldier;TOK;143918
+Soldier;TOK;145986
+Soldier;TOK;147262
+Soldier;TOK;149982
+Soldier;TOK;150888
+Soldier;TOK;150895
+Soldier;TOK;152123
+Soldier;TOK;400715
+Soldier;TOK;44682
+Soldier;TOK;51112
+Soldier;TOK;97959
+Solemn Offering;DPA;122138
+Solemn Offering;M10;122138
+Solemn Offering;M11;122138
+Solemn Offering;M14;122138
+Solemn Offering;M15;122138
+Solemn Recruit;AER;401031
+Solemn Simulacrum;C14;137417
+Solemn Simulacrum;CMD;51124
+Solemn Simulacrum;M12;137417
+Solemn Simulacrum;MRD;51124
+Solemn Simulacrum;MS2;400610
+Solemnity;HOU;401778
+Solfatara;VIS;2256
+Solidarity of Heroes;JOU;153088
+Solidarity;8ED;15696
+Solidarity;UD;15696
+Solitary Camel;HOU;401768
+Solitary Confinement;JUD;40194
+Solitary Hunter;SOI;161470
+Soliton;SOM;131014
+Soltari Champion;STH;3769
+Soltari Champion;TPR;3769
+Soltari Crusader;TMP;3288
+Soltari Emissary;TMP;3180
+Soltari Emissary;VMA;3180
+Soltari Foot Soldier;TMP;3049
+Soltari Guerrillas;TMP;3199
+Soltari Guerrillas;TPR;3199
+Soltari Lancer;TMP;3051
+Soltari Lancer;TPR;3051
+Soltari Monk;TMP;3289
+Soltari Monk;TPR;3289
+Soltari Priest;PRM;101021
+Soltari Priest;TMP;3290
+Soltari Priest;TPR;3290
+Soltari Priest;TSB;3290
+Soltari Trooper;TMP;3050
+Soltari Trooper;TPR;3050
+Soltari Trooper;VMA;3050
+Soltari Visionary;EXO;5430
+Somber Hoverguard;MM2;50195
+Somber Hoverguard;MRD;50195
+Somberwald Alpha;ORI;160322
+Somberwald Dryad;DKA;139775
+Somberwald Sage;AVR;141808
+Somberwald Spider;ISD;138402
+Somberwald Stag;EMN;162004
+Somberwald Vigilante;AVR;141573
+Somberwald Vigilante;DDL;141573
+Somnomancer;SHM;111678
+Somnophore;USG;8102
+Song of Blood;VIS;2257
+Song of Serenity;EXO;5597
+Song of the Dryads;C14;155642
+Songs of the Damned;ICE;1374
+Songs of the Damned;ME2;1374
+Songstitcher;USG;8664
+Sonic Burst;EXO;5426
+Sonic Seizure;TOR;36730
+Soot Imp;DDC;113762
+Soot Imp;DPA;113762
+Soot Imp;EVE;113762
+Sootfeather Flock;LGN;46575
+Soothing Balm;MMQ;19071
+Soothsaying;MMQ;19198
+Sootstoke Kindler;DPA;111780
+Sootstoke Kindler;SHM;111780
+Sootwalkers;SHM;111529
+Sophic Centaur;PLC;100753
+Soramaro, First to Dream;SOK;86058
+Soratami Cloud Chariot;SOK;86060
+Soratami Cloudskater;COK;82588
+Soratami Mindsweeper;BOK;83812
+Soratami Mirror-Guard;COK;81125
+Soratami Mirror-Mage;COK;82630
+Soratami Rainshaper;COK;82631
+Soratami Savant;COK;82632
+Soratami Seer;COK;80588
+Soraya the Falconer;HML;1567
+Sorcerer's Strongbox;M11;129154
+Sorceress Queen;3ED;374
+Sorceress Queen;4ED;374
+Sorceress Queen;5ED;374
+Sorceress Queen;ARN;374
+Sorcerous Sight;POR;6631
+Sorcerous Spyglass;XLN;402863
+Sorin Markov;M12;123773
+Sorin Markov;ZEN;123773
+Sorin, Grim Nemesis;SOI;161471
+Sorin, Lord of Innistrad;DDK;147652
+Sorin, Lord of Innistrad;DKA;138808
+Sorin, Solemn Visitor;KTK;156639
+Sorin's Thirst;DDK;137418
+Sorin's Thirst;M12;137418
+Sorin's Vengeance;M12;137419
+Sorrow's Path;DRK;830
+Sorrow's Path;ME3;830
+Sorrow's Path;PRM;830
+Sosuke, Son of Seshiro;COK;80942
+Sosuke's Summons;BOK;83827
+Soul Barrier;5ED;1375
+Soul Barrier;ICE;1375
+Soul Bleed;DPA;121631
+Soul Bleed;M10;121631
+Soul Burn;ICE;1376
+Soul Burn;INV;24044
+Soul Channeling;MMQ;19057
+Soul Charmer;PCY;22027
+Soul Collector;PRM;48128
+Soul Collector;SCG;48128
+Soul Collector;TSB;48128
+Soul Conduit;NPH;134387
+Soul Echo;MIR;2059
+Soul Exchange;FEM;999
+Soul Exchange;ME2;999
+Soul Feast;10E;27795
+Soul Feast;7ED;27795
+Soul Feast;8ED;27795
+Soul Feast;9ED;27795
+Soul Feast;UD;15698
+Soul Foundry;MRD;51036
+Soul Kiss;ICE;1377
+Soul Kiss;ME2;1377
+Soul Link;APC;31057
+Soul Manipulation;ARB;121033
+Soul Manipulation;C13;121033
+Soul Manipulation;MM3;121033
+Soul Net;2ED;235
+Soul Net;3ED;235
+Soul Net;4ED;235
+Soul Net;5ED;2481
+Soul Net;6ED;2481
+Soul Net;7ED;27796
+Soul Net;LEA;235
+Soul Net;LEB;235
+Soul Nova;MRD;50284
+Soul Parry;SOM;131142
+Soul Ransom;GTC;146588
+Soul Ransom;MM3;146588
+Soul Reap;EVE;113637
+Soul Rend;MIR;2060
+Soul Scourge;TOR;36444
+Soul Sculptor;USG;8676
+Soul Seizer;DKA;139721
+Soul Separator;EMN;162148
+Soul Shepherd;WTH;2843
+Soul Shred;ME4;6597
+Soul Shred;POR;6597
+Soul Snare;CMD;101057
+Soul Snuffers;EVE;113597
+Soul Snuffers;TD2;113597
+Soul Spike;CSP;96901
+Soul Stair Expedition;ZEN;123567
+Soul Strings;PCY;22026
+Soul Summons;FRF;157172
+Soul Summons;PRM;159382
+Soul Swallower;PRM;161544
+Soul Swallower;SOI;161632
+Soul Tithe;RTR;145895
+Soul Warden;10E;5621
+Soul Warden;9ED;5621
+Soul Warden;DPA;5621
+Soul Warden;EXO;5621
+Soul Warden;M10;5621
+Soul Warden;MM3;5621
+Soul Warden;PC1;5621
+Soul of Innistrad;M15;156154
+Soul of Magma;COK;80844
+Soul of New Phyrexia;M15;155247
+Soul of Ravnica;M15;155684
+Soul of Shandalar;M15;155305
+Soul of Theros;M15;155685
+Soul of Theros;PRM;155246
+Soul of Zendikar;M15;155686
+Soul of the Harvest;AVR;141720
+Soul of the Harvest;C14;141720
+Soul of the Harvest;W16;141720
+Soul-Scar Mage;AKH;401268
+Soul's Attendant;ROE;127308
+Soul's Fire;ALA;115031
+Soul's Fire;DPA;115031
+Soul's Grace;ALA;114936
+Soul's Majesty;CON;118768
+Soul's Might;ALA;114933
+Soulblade Djinn;ORI;160230
+Soulblast;10E;104540
+Soulblast;COK;82615
+Soulbound Guardians;ROE;127386
+Soulbright Flamekin;DD2;105546
+Soulbright Flamekin;LRW;105546
+Soulbright Flamekin;MM2;105546
+Soulcage Fiend;AVR;141691
+Soulcage Fiend;DPA;141691
+Soulcatcher;EMA;153357
+Soulcatcher;ODY;33661
+Soulcatchers' Aerie;JUD;40183
+Souldrinker;DDC;3215
+Souldrinker;TMP;3215
+Soulfire Grand Master;FRF;157330
+Soulflayer;FRF;157202
+Soulgorger Orgg;JUD;40249
+Soulless One;ONS;43055
+Soulless One;PC1;43055
+Soulless Revival;COK;80577
+Soulmender;M14;147385
+Soulmender;M15;147385
+Soulquake;ARB;120954
+Soulquake;DPA;120954
+Souls of the Faultless;GPT;91841
+Soulscour;DST;51894
+Soulshriek;MIR;2061
+Soulstinger;AKH;401305
+Soulsurge Elemental;ROE;127360
+Soulsworn Jury;DIS;94499
+Soulsworn Spirit;RTR;145899
+Soultether Golem;FUT;102365
+Sound the Call;CSP;96892
+Southern Elephant;ME4;9087
+Southern Elephant;PTK;9087
+Southern Paladin;7ED;27797
+Southern Paladin;WTH;2901
+Sovereigns of Lost Alara;ARB;121010
+Sovereigns of Lost Alara;DPA;121010
+Sower of Temptation;DPA;108901
+Sower of Temptation;LRW;108901
+Sowing Salt;BOK;83938
+Sowing Salt;UD;15658
+Spare from Evil;ISD;138320
+Spark Elemental;10E;77224
+Spark Elemental;5DN;77224
+Spark Elemental;DPA;77224
+Spark Elemental;PD2;77224
+Spark Elemental;TOK;77224
+Spark Jolt;THS;150848
+Spark Mage;ODY;33363
+Spark Spray;SCG;43106
+Spark Spray;VMA;43106
+Spark Trooper;GTC;146450
+Spark of Creativity;KLD;162289
+Sparkcaster;PLS;27990
+Sparkmage Apprentice;DPA;122156
+Sparkmage Apprentice;M10;122156
+Sparkmage Apprentice;RAV;88956
+Sparkmage's Gambit;OGW;161103
+Sparksmith;ONS;43094
+Sparksmith;PRM;43094
+Sparkspitter;FUT;102382
+Sparring Collar;5DN;77167
+Sparring Golem;INV;25197
+Sparring Mummy;AKH;401278
+Spatial Binding;MIR;2062
+Spatial Contortion;OGW;161187
+Spatial Contortion;PRM;162028
+Spatial Merging;PC2;138732
+Spawn of Rix Maadi;RTR;145886
+Spawn of Thraxes;JOU;153063
+Spawn of Thraxes;PRM;155421
+Spawn;TOK;77066
+Spawnbinder Mage;OGW;161199
+Spawnbroker;RAV;88735
+Spawning Bed;BFZ;160922
+Spawning Breath;ROE;127261
+Spawning Grounds;C13;151724
+Spawning Pit;DST;75133
+Spawning Pit;TD2;75133
+Spawning Pool;10E;104518
+Spawning Pool;UL;10330
+Spawnsire of Ulamog;ROE;127334
+Spawnwrithe;CMD;111848
+Spawnwrithe;DDM;111848
+Spawnwrithe;SHM;111848
+Spear of Heliod;THS;149969
+Spearbreaker Behemoth;ALA;115123
+Spearpoint Oread;THS;149062
+Species Gorger;DGM;147747
+Specter's Shroud;DST;75201
+Specter's Wail;MMQ;19095
+Spectra Ward;M15;155202
+Spectral Bears;HML;1568
+Spectral Bears;MED;1568
+Spectral Cloak;LEG;2550
+Spectral Flight;ISD;138337
+Spectral Force;TSP;97499
+Spectral Gateguards;AVR;141583
+Spectral Guardian;MIR;2063
+Spectral Lynx;APC;31144
+Spectral Prison;AVR;141512
+Spectral Procession;C14;111726
+Spectral Procession;DDK;147657
+Spectral Procession;MM2;147657
+Spectral Procession;SHM;111726
+Spectral Reserves;EMN;161906
+Spectral Rider;DPA;138126
+Spectral Rider;ISD;138126
+Spectral Searchlight;RAV;89044
+Spectral Shepherd;SOI;161465
+Spectral Shield;ICE;1378
+Spectral Shield;ME3;1378
+Spectral Shift;5DN;77219
+Spectral Sliver;H09;46583
+Spectral Sliver;LGN;46583
+Speedway Fanatic;KLD;162525
+Spell Blast;2ED;236
+Spell Blast;3ED;236
+Spell Blast;4ED;236
+Spell Blast;5ED;2482
+Spell Blast;6ED;2482
+Spell Blast;LEA;236
+Spell Blast;LEB;236
+Spell Blast;M14;148272
+Spell Blast;TMP;3043
+Spell Blast;TPR;3043
+Spell Burst;TSP;97344
+Spell Contortion;WWK;126516
+Spell Crumple;CMD;137554
+Spell Pierce;MM3;123582
+Spell Pierce;MS3;401613
+Spell Pierce;XLN;402096
+Spell Pierce;ZEN;123582
+Spell Queller;EMN;162143
+Spell Rupture;GTC;146286
+Spell Shrivel;BFZ;160726
+Spell Snare;DIS;94354
+Spell Snare;MMA;94354
+Spell Snip;ALA;115094
+Spell Swindle;XLN;402364
+Spell Syphon;SHM;111787
+Spellbane Centaur;ODY;33283
+Spellbinder;DST;75209
+Spellbook;10E;27798
+Spellbook;7ED;27798
+Spellbook;8ED;27798
+Spellbook;9ED;27798
+Spellbook;EXO;4643
+Spellbook;M10;27798
+Spellbound Dragon;ARB;121019
+Spellbound Dragon;DPA;121019
+Spellbreaker Behemoth;ARB;120966
+Spellbreaker Behemoth;C13;120966
+Spellgorger Barbarian;JUD;40239
+Spellheart Chimera;THS;150862
+Spelljack;JUD;40221
+Spellshift;PLC;100708
+Spellshock;EXO;5620
+Spellshock;TPR;5620
+Spellskite;MM2;134254
+Spellskite;NPH;134254
+Spellskite;PRM;400645
+Spellstutter Sprite;LRW;105349
+Spellstutter Sprite;MMA;105349
+Spellstutter Sprite;PRM;134048
+Spelltithe Enforcer;GPT;91692
+Spelltwine;DDM;143934
+Spelltwine;M13;143934
+Spellweaver Eternal;HOU;401510
+Spellweaver Helix;MRD;51046
+Spellweaver Volute;FUT;102444
+Spellwild Ouphe;FUT;102403
+Sphere of Duty;ODY;33519
+Sphere of Grace;ODY;33521
+Sphere of Law;ODY;33520
+Sphere of Purity;MRD;50999
+Sphere of Reason;ODY;33522
+Sphere of Resistance;EXO;5623
+Sphere of Resistance;MS2;400936
+Sphere of Resistance;VMA;5623
+Sphere of Safety;RTR;145896
+Sphere of Truth;ODY;33523
+Sphere of the Suns;MBS;133164
+Sphere of the Suns;MM2;133164
+Sphinx Ambassador;M10;121677
+Sphinx Sovereign;ALA;115140
+Sphinx Summoner;CON;119792
+Sphinx of Jwar Isle;C14;123634
+Sphinx of Jwar Isle;DPA;123634
+Sphinx of Jwar Isle;ZEN;123634
+Sphinx of Lost Truths;DPA;123642
+Sphinx of Lost Truths;ZEN;123642
+Sphinx of Magosi;C14;127454
+Sphinx of Magosi;DPA;127454
+Sphinx of Magosi;ROE;127454
+Sphinx of Magosi;W16;127454
+Sphinx of Magosi;W17;127454
+Sphinx of Uthuun;C14;134080
+Sphinx of Uthuun;DDI;134080
+Sphinx of Uthuun;M12;134080
+Sphinx of Uthuun;M13;134080
+Sphinx of the Chimes;RTR;145939
+Sphinx of the Final Word;OGW;161778
+Sphinx of the Steel Wind;ARB;121065
+Sphinx of the Steel Wind;C13;121065
+Sphinx of the Steel Wind;EMA;121065
+Sphinx of the Steel Wind;PD3;121065
+Sphinx-Bone Wand;DDJ;127373
+Sphinx-Bone Wand;DPA;127373
+Sphinx-Bone Wand;ROE;127373
+Sphinx;TOK;155463
+Sphinx's Disciple;BNG;152021
+Sphinx's Herald;ALA;115176
+Sphinx's Revelation;MM3;145267
+Sphinx's Revelation;RTR;145267
+Sphinx's Tutelage;ORI;160234
+Spider Climb;VIS;2258
+Spider Spawning;ISD;138203
+Spider Umbra;ROE;127427
+Spider;TOK;112142
+Spider;TOK;138483
+Spider;TOK;155466
+Spider;TOK;162125
+Spider;TOK;99735
+Spidersilk Armor;DDG;19130
+Spidersilk Armor;MMQ;19130
+Spidersilk Net;DTK;159763
+Spidersilk Net;ZEN;123576
+Spiderwig Boggart;LRW;107627
+Spidery Grasp;AKH;401337
+Spidery Grasp;ISD;138448
+Spike Breeder;STH;3771
+Spike Breeder;TPR;3771
+Spike Cannibal;EXO;5437
+Spike Colony;STH;3772
+Spike Colony;TPR;3772
+Spike Drone;TMP;2997
+Spike Feeder;CMD;3773
+Spike Feeder;PRM;3773
+Spike Feeder;STH;3773
+Spike Feeder;TPR;3773
+Spike Feeder;TSB;3773
+Spike Hatcher;EXO;6269
+Spike Hatcher;TPR;6269
+Spike Jester;DGM;146890
+Spike Jester;MM3;146890
+Spike Rogue;EXO;5427
+Spike Soldier;STH;3775
+Spike Tiller;TSP;97338
+Spike Weaver;EXO;5616
+Spike Worker;STH;3776
+Spike-Tailed Ceratops;XLN;402097
+Spike;TOK;125146
+Spiked Baloth;M13;143969
+Spikeshot Elder;DPA;131105
+Spikeshot Elder;MM2;131105
+Spikeshot Elder;SOM;131105
+Spikeshot Goblin;MRD;50248
+Spiketail Drake;PCY;21970
+Spiketail Drakeling;TSP;97536
+Spiketail Hatchling;10E;22076
+Spiketail Hatchling;8ED;22076
+Spiketail Hatchling;PCY;22076
+Spin Engine;MBS;133236
+Spin into Myth;FUT;102384
+Spinal Embrace;C13;26248
+Spinal Embrace;INV;26248
+Spinal Graft;TMP;2977
+Spinal Graft;TPR;2977
+Spinal Graft;VMA;2977
+Spinal Parasite;5DN;77233
+Spinal Villain;LEG;2551
+Spinal Villain;MED;2551
+Spincrusher;DST;50817
+Spindrift Drake;STH;3777
+Spine of Ish Sah;C13;133243
+Spine of Ish Sah;C14;133243
+Spine of Ish Sah;MBS;133243
+Spinebiter;NPH;134360
+Spined Basher;ONS;43029
+Spined Fluke;USG;8825
+Spined Sliver;H09;3724
+Spined Sliver;STH;3724
+Spined Sliver;TPR;3724
+Spined Sliver;TSB;3724
+Spined Thopter;NPH;134252
+Spined Wurm;10E;27799
+Spined Wurm;7ED;27799
+Spined Wurm;8ED;3779
+Spined Wurm;9ED;27799
+Spined Wurm;DPA;27799
+Spined Wurm;M11;27799
+Spined Wurm;POR;6673
+Spined Wurm;STH;3779
+Spined Wurm;TPR;3779
+Spineless Thug;10E;21284
+Spineless Thug;7ED;27800
+Spineless Thug;8ED;21284
+Spineless Thug;9ED;21284
+Spineless Thug;NMS;21284
+Spinerock Knoll;LRW;105424
+Spinneret Sliver;TSP;97396
+Spinning Darkness;WTH;2796
+Spiny Starfish;ALL;1736
+Spiny Starfish;ME3;1736
+Spiraling Duelist;MBS;133259
+Spiraling Embers;SOK;86105
+Spire Barrage;DDI;123617
+Spire Barrage;DPA;123617
+Spire Barrage;ZEN;123617
+Spire Golem;DD2;75169
+Spire Golem;DST;75169
+Spire Monitor;MM3;134392
+Spire Monitor;NPH;134392
+Spire Owl;USG;8728
+Spire Patrol;AER;400356
+Spire Serpent;MBS;133188
+Spire Serpent;TD2;133188
+Spire Tracer;DPA;146336
+Spire Tracer;GTC;146336
+Spire of Industry;AER;400406
+Spirebluff Canal;KLD;162362
+Spires of Orazca;XLN;402330
+Spireside Infiltrator;KLD;162520
+Spirespine;JOU;152889
+Spirit Away;AVR;141531
+Spirit Bonds;M15;155218
+Spirit Cairn;JUD;40182
+Spirit Cairn;VMA;40182
+Spirit Flare;TOR;36394
+Spirit Link;10E;86739
+Spirit Link;4ED;675
+Spirit Link;5ED;675
+Spirit Link;6ED;675
+Spirit Link;7ED;27801
+Spirit Link;8ED;49227
+Spirit Link;9ED;86739
+Spirit Link;LEG;675
+Spirit Loop;TSP;97335
+Spirit Mantle;DPA;134105
+Spirit Mantle;M12;134105
+Spirit Mantle;PC2;134105
+Spirit Mantle;PZ1;134105
+Spirit Mirror;TMP;3186
+Spirit Mirror;TPR;3186
+Spirit Mirror;VMA;3186
+Spirit Shackle;4ED;676
+Spirit Shackle;LEG;676
+Spirit Shackle;ME3;676
+Spirit Shield;FEM;1000
+Spirit Warrior;TOK;156688
+Spirit Weaver;10E;24132
+Spirit Weaver;INV;24132
+Spirit en-Dal;FUT;102436
+Spirit en-Kor;STH;3770
+Spirit en-Kor;TPR;3770
+Spirit of Resistance;INV;24151
+Spirit of the Hearth;DPA;113645
+Spirit of the Hearth;EVE;113645
+Spirit of the Hunt;EMN;162009
+Spirit of the Labyrinth;BNG;152541
+Spirit of the Night;MIR;2064
+Spirit;TOK;112140
+Spirit;TOK;113773
+Spirit;TOK;121555
+Spirit;TOK;138437
+Spirit;TOK;141806
+Spirit;TOK;141825
+Spirit;TOK;143416
+Spirit;TOK;147261
+Spirit;TOK;153351
+Spirit;TOK;155675
+Spirit;TOK;158496
+Spirit;TOK;158964
+Spirit;TOK;160152
+Spirit;TOK;161712
+Spirit;TOK;33671
+Spirit;TOK;37223
+Spirit;TOK;51113
+Spirit;TOK;82654
+Spirit;TOK;83847
+Spirit;TOK;89187
+Spiritmonger;APC;31145
+Spiritmonger;DPA;101028
+Spiritmonger;PRM;101028
+Spiritmonger;VMA;101028
+Spiritual Asylum;NMS;21184
+Spiritual Focus;MMQ;19112
+Spiritual Guardian;POR;6750
+Spiritual Sanctuary;LEG;2552
+Spiritual Visit;SOK;86089
+Spiritualize;ODY;33524
+Spite of Mogis;JOU;152988
+Spite;DDH;25577
+Spite;INV;25577
+Spitebellows;C13;105493
+Spitebellows;C14;105493
+Spitebellows;CMD;105493
+Spitebellows;MM2;105493
+Spitebellows;MOR;105493
+Spiteflame Witch;DPA;111565
+Spiteflame Witch;SHM;111565
+Spiteful Blow;JOU;152856
+Spiteful Bully;NMS;21200
+Spiteful Motives;SOI;161673
+Spiteful Returned;BNG;152567
+Spiteful Shadows;DKA;139825
+Spiteful Visions;C13;111633
+Spiteful Visions;SHM;111633
+Spitemare;DDH;113751
+Spitemare;EVE;113751
+Spitfire Bastion;XLN;402445
+Spitfire Handler;ONS;43120
+Spitting Drake;6ED;2259
+Spitting Drake;VIS;2259
+Spitting Earth;10E;27802
+Spitting Earth;6ED;2065
+Spitting Earth;7ED;27802
+Spitting Earth;DDG;27802
+Spitting Earth;DPA;27802
+Spitting Earth;EVG;27802
+Spitting Earth;MIR;2065
+Spitting Earth;PO2;4742
+Spitting Earth;POR;6717
+Spitting Gourna;ONS;43148
+Spitting Hydra;STH;3780
+Spitting Hydra;TPR;3780
+Spitting Image;EVE;113705
+Spitting Sliver;PLC;100775
+Spitting Slug;DRK;831
+Spitting Slug;TSB;831
+Spitting Spider;8ED;22028
+Spitting Spider;PCY;22028
+Splatter Thug;RTR;145136
+Splendid Agony;AKH;401307
+Splendid Reclamation;EMN;162121
+Splinter Twin;MM2;127289
+Splinter Twin;ROE;127289
+Splinter;BOK;83933
+Splinter;UD;15652
+Splinterfright;ISD;138294
+Splintering Wind;ALL;1737
+Split-Tail Miko;BOK;83881
+Splitting Headache;SHM;111669
+Splitting Slime;PZ2;162177
+Spoils of Blood;C14;155648
+Spoils of Evil;ICE;1379
+Spoils of Victory;C13;9102
+Spoils of Victory;ME3;9102
+Spoils of Victory;PTK;9102
+Spoils of War;ICE;1380
+Spoils of the Vault;MRD;50262
+Spontaneous Artist;KLD;162283
+Spontaneous Combustion;TMP;3307
+Spontaneous Generation;MMQ;19237
+Spontaneous Mutation;EMN;161938
+Spore Burst;CON;118779
+Spore Cloud;FEM;1001
+Spore Cloud;FEM;1002
+Spore Cloud;FEM;1003
+Spore Cloud;ME2;1001
+Spore Flower;FEM;1004
+Spore Flower;ME2;1004
+Spore Frog;DPA;22071
+Spore Frog;PCY;22071
+Sporeback Troll;DIS;96853
+Sporecap Spider;ROE;127336
+Sporemound;DPA;147469
+Sporemound;M14;147469
+Sporesower Thallid;MMA;97394
+Sporesower Thallid;TSP;97394
+Sporogenesis;USG;8906
+Sporoloth Ancient;FUT;102372
+Sporoloth Ancient;MMA;102372
+Spotted Griffin;ME4;6751
+Spotted Griffin;POR;6751
+Spread the Sickness;DPA;133253
+Spread the Sickness;MBS;133253
+Spread the Sickness;MM2;133253
+Spread the Sickness;TD2;133253
+Spreading Algae;8ED;8696
+Spreading Algae;USG;8696
+Spreading Flames;EMN;161986
+Spreading Plague;INV;24162
+Spreading Rot;XLN;402304
+Spreading Seas;ZEN;123683
+Spring Cleaning;LRW;107621
+Spring of Eternal Peace;PTK;9085
+Spring;AKH;401274
+Springing Tiger;ODY;33328
+Springjack Knight;LRW;107683
+Springjack Pasture;C13;113745
+Springjack Pasture;EVE;113745
+Springjack Shepherd;EVE;113663
+Springleaf Drum;BNG;152614
+Springleaf Drum;LRW;105419
+Springsage Ritual;EMN;162116
+Sprinting Warbrute;DTK;160116
+Sprite Noble;EMA;97469
+Sprite Noble;TSP;97469
+Sprout Swarm;FUT;102448
+Sprout;DPA;97552
+Sprout;TSP;97552
+Sprouting Phytohydra;DIS;94692
+Sprouting Thrinax;ALA;114974
+Sprouting Thrinax;C13;114974
+Sprouting Thrinax;DPA;114974
+Sprouting Thrinax;MM3;114974
+Sprouting Thrinax;PRM;117982
+Sprouting Vines;C13;48982
+Sprouting Vines;SCG;48982
+Spur Grappler;PCY;22029
+Spurnmage Advocate;CMD;40176
+Spurnmage Advocate;JUD;40176
+Spurred Wolverine;ONS;43099
+Spy Network;ONS;44665
+Squadron Hawk;DPA;136799
+Squadron Hawk;EMA;136799
+Squadron Hawk;M11;129185
+Squadron Hawk;PRM;136799
+Squall Drifter;CSP;97009
+Squall Line;TSP;97341
+Squall;7ED;27665
+Squall;ME4;17577
+Squall;MMQ;19171
+Squallmonger;CMD;19142
+Squallmonger;MMQ;19142
+Squandered Resources;VIS;2260
+Squeaking Pie Grubfellows;MOR;109958
+Squeaking Pie Sneak;LRW;105466
+Squealing Devil;DIS;94375
+Squee, Goblin Nabob;10E;104516
+Squee, Goblin Nabob;DPA;104516
+Squee, Goblin Nabob;MMA;104516
+Squee, Goblin Nabob;MMQ;19194
+Squee's Embrace;APC;31146
+Squee's Revenge;APC;31108
+Squee's Toy;TMP;2962
+Squeeze;MMQ;19048
+Squelch;COK;82627
+Squelching Leeches;JOU;152974
+Squelching Leeches;PRM;155426
+Squid;TOK;155671
+Squire;DRK;832
+Squire;TSB;832
+Squirming Mass;UD;15629
+Squirrel Mob;ODY;33294
+Squirrel Nest;ODY;33270
+Squirrel Wrangler;PCY;22030
+Squirrel;TOK;143403
+Squirrel;TOK;153355
+Squirrel;TOK;33666
+Sram, Senior Edificer;AER;400248
+Sram's Expertise;AER;400253
+Stab Wound;DDM;145174
+Stab Wound;M15;145174
+Stab Wound;RTR;145174
+Stabbing Pain;DPA;129137
+Stabbing Pain;M11;129137
+Stabilizer;SCG;48160
+Staff of Domination;5DN;77100
+Staff of Domination;MS2;400937
+Staff of Nin;M13;143990
+Staff of Nin;PRM;143991
+Staff of Zegon;ATQ;445
+Staff of Zegon;ME4;445
+Staff of the Ages;ICE;1381
+Staff of the Death Magus;DPA;147391
+Staff of the Death Magus;M14;147391
+Staff of the Death Magus;M15;147391
+Staff of the Flame Magus;DPA;147392
+Staff of the Flame Magus;M14;147392
+Staff of the Flame Magus;M15;147392
+Staff of the Mind Magus;DPA;147377
+Staff of the Mind Magus;M14;147377
+Staff of the Mind Magus;M15;147377
+Staff of the Sun Magus;DPA;147396
+Staff of the Sun Magus;M14;147396
+Staff of the Sun Magus;M15;147396
+Staff of the Wild Magus;DPA;147390
+Staff of the Wild Magus;M14;147390
+Staff of the Wild Magus;M15;147390
+Stag Beetle;ONS;43196
+Staggershock;PRM;127358
+Staggershock;ROE;127358
+Stain the Mind;M15;155327
+Stairs to Infinity;PRM;138714
+Stalker Hag;EVE;113732
+Stalking Assassin;INV;25538
+Stalking Bloodsucker;DPA;33401
+Stalking Bloodsucker;ODY;33401
+Stalking Drone;OGW;161086
+Stalking Stones;DDF;50337
+Stalking Stones;MRD;50337
+Stalking Stones;TMP;3245
+Stalking Stones;TPR;3245
+Stalking Tiger;10E;2066
+Stalking Tiger;6ED;2066
+Stalking Tiger;MIR;2066
+Stalking Tiger;POR;6674
+Stalking Tiger;PTK;9006
+Stalking Tiger;W17;2066
+Stalking Vampire;ISD;138175
+Stalking Vengeance;C13;94373
+Stalking Vengeance;DIS;94373
+Stalking Yeti;CSP;97016
+Stallion of Ashmouth;SOI;161728
+Stalwart Aven;ORI;160200
+Stalwart Shield-Bearers;ROE;127327
+Stamina;MMQ;19215
+Stampede Driver;NMS;21162
+Stampede;5ED;1382
+Stampede;ICE;1382
+Stampede;ME2;1382
+Stampeding Elk Herd;DTK;159837
+Stampeding Rhino;M10;121571
+Stampeding Rhino;M12;121571
+Stampeding Rhino;W17;121571
+Stampeding Serow;SOK;86100
+Stampeding Wildebeests;10E;2261
+Stampeding Wildebeests;DDD;2261
+Stampeding Wildebeests;VIS;2261
+Stand Firm;5DN;77089
+Stand Firm;DDL;77089
+Stand Together;DST;52046
+Stand or Fall;INV;25663
+Stand;INV;25575
+Standard Bearer;APC;31047
+Standardize;ONS;43025
+Standing Stones;DRK;833
+Standing Troops;6ED;5415
+Standing Troops;7ED;27804
+Standing Troops;8ED;5415
+Standing Troops;EXO;5415
+Standing Troops;TPR;5415
+Standing Troops;W17;155890
+Standstill;ODY;33451
+Stangg Twin;TOK;126953
+Stangg;CH;677
+Stangg;LEG;677
+Stangg;ME3;677
+Star Compass;8ED;27992
+Star Compass;PLS;27992
+Star of Extinction;XLN;402866
+Starfall;JOU;153067
+Starfield of Nyx;ORI;160210
+Starfish;TOK;126954
+Starke of Rath;TMP;3153
+Starke of Rath;TPR;3153
+Starlight Invoker;10E;47488
+Starlight Invoker;LGN;47488
+Starlight;7ED;27805
+Starlight;POR;6752
+Starlit Angel;POR;6753
+Starlit Sanctum;ONS;43225
+Starstorm;C13;151436
+Starstorm;C14;151436
+Starstorm;ONS;43142
+Starstorm;VMA;151436
+Start Your Engines;KLD;162527
+Start;AKH;401986
+Startled Awake;SOI;161484
+Starved Rusalka;GPT;91882
+Stasis Cell;RAV;88985
+Stasis Cocoon;5DN;77177
+Stasis Snare;BFZ;160634
+Stasis Snare;PRM;160884
+Stasis;2ED;237
+Stasis;3ED;237
+Stasis;4ED;237
+Stasis;5ED;237
+Stasis;LEA;237
+Stasis;LEB;237
+Stasis;ME4;237
+Stasis;PRM;402821
+Statecraft;MMQ;19224
+Static Orb;7ED;27806
+Static Orb;MS2;400606
+Static Orb;TMP;3099
+Statute of Denial;M15;155213
+Staunch Defenders;6ED;3294
+Staunch Defenders;7ED;27807
+Staunch Defenders;8ED;27807
+Staunch Defenders;PRM;3294
+Staunch Defenders;TMP;3294
+Staunch Defenders;TPR;3294
+Staunch-Hearted Warrior;THS;150807
+Stave Off;M12;134167
+Steadfast Armasaur;XLN;402121
+Steadfast Cathar;EMN;161908
+Steadfast Guard;10E;104554
+Steadfast Guard;MMQ;19253
+Steadfast Sentinel;HOU;401548
+Steadfast Sentinel;TOK;401877
+Steadfastness;POR;6754
+Steady Progress;MM2;130967
+Steady Progress;SOM;130967
+Steal Artifact;2ED;238
+Steal Artifact;3ED;238
+Steal Artifact;4ED;238
+Steal Artifact;5ED;2483
+Steal Artifact;7ED;27808
+Steal Artifact;8ED;27808
+Steal Artifact;LEA;238
+Steal Artifact;LEB;238
+Steal Enchantment;TMP;3280
+Steal Strength;PCY;22159
+Stealer of Secrets;DDM;145848
+Stealer of Secrets;PRM;145848
+Stealer of Secrets;RTR;145848
+Stealer of Secrets;W17;145848
+Steam Augury;THS;150867
+Steam Blast;USG;8859
+Steam Catapult;ME4;4678
+Steam Catapult;PO2;4678
+Steam Frigate;PO2;4579
+Steam Spitter;CSP;96976
+Steam Vents;EXP;160792
+Steam Vents;GPT;91750
+Steam Vents;RTR;146211
+Steam Vines;ODY;33267
+Steamclaw;ODY;33248
+Steamcore Weird;DDH;91811
+Steamcore Weird;DDJ;91811
+Steamcore Weird;DPA;91811
+Steamcore Weird;GPT;91811
+Steamflogger Boss;FUT;102472
+Steel Golem;10E;2905
+Steel Golem;WTH;2905
+Steel Hellkite;C14;131026
+Steel Hellkite;PRM;131730
+Steel Hellkite;SOM;131026
+Steel Leaf Paladin;PLS;27993
+Steel Overseer;DDF;129125
+Steel Overseer;DPA;129125
+Steel Overseer;M11;129125
+Steel Overseer;MS2;162593
+Steel Sabotage;MBS;133122
+Steel Wall;DDF;51094
+Steel Wall;MRD;51094
+Steel Wall;TD2;51094
+Steel of the Godhead;DDI;113116
+Steel of the Godhead;SHM;113116
+Steelclad Serpent;ALA;51012
+Steelform Sliver;DPA;147367
+Steelform Sliver;M14;147367
+Steeling Stance;DIS;94318
+Steelshaper Apprentice;DST;75200
+Steelshaper's Gift;5DN;77123
+Steelshaper's Gift;TD2;77123
+Steely Resolve;ONS;43203
+Steeple Roc;DGM;146751
+Stench of Decay;ALL;1738
+Stench of Decay;ALL;1739
+Stench of Evil;ICE;1383
+Stenchskipper;MOR;109995
+Stensia Banquet;EMN;162096
+Stensia Bloodhall;ISD;138358
+Stensia Innkeeper;EMN;162105
+Stensia Masquerade;SOI;161638
+Stensia;PC2;138739
+Steppe Glider;OGW;161143
+Steppe Lynx;DPA;123546
+Steppe Lynx;ZEN;123546
+Sterling Grove;INV;25148
+Sterling Grove;PRM;153380
+Sterling Grove;TD0;25148
+Stern Constable;SOI;161476
+Stern Judge;TOR;29410
+Stern Marshal;POR;6755
+Stern Mentor;AVR;141614
+Stern Proctor;USG;8742
+Steward of Solidarity;HOU;401773
+Steward of Valeron;ALA;115383
+Steward of Valeron;DDG;115383
+Stifle;MS3;401609
+Stifle;PRM;120086
+Stifle;SCG;48997
+Stigma Lasher;EVE;113667
+Still Life;ODY;33300
+Stillmoon Cavalier;EVE;113665
+Stingerfling Spider;DDJ;134071
+Stingerfling Spider;DPA;134071
+Stingerfling Spider;M12;134071
+Stinging Barrier;MMQ;19196
+Stinging Licid;TMP;3277
+Stinging Shot;AKH;400777
+Stingmoggie;MOR;109935
+Stingscourger;EMA;101534
+Stingscourger;MMA;101534
+Stingscourger;PLC;101534
+Stinkdrinker Bandit;MOR;109969
+Stinkdrinker Daredevil;LRW;105636
+Stinkdrinker Daredevil;MMA;105636
+Stinkweed Imp;DDC;122098
+Stinkweed Imp;DDJ;122098
+Stinkweed Imp;MMA;122098
+Stinkweed Imp;RAV;88972
+Stinkweed Imp;TD0;88972
+Stir the Grave;BOK;83951
+Stir the Pride;DST;51904
+Stir the Pride;MMA;51904
+Stir the Sands;AKH;401313
+Stirring Wildwood;WWK;126541
+Stitch Together;CMD;40232
+Stitch Together;JUD;40232
+Stitch in Time;GPT;91755
+Stitched Drake;ISD;138154
+Stitched Mangler;SOI;161705
+Stitcher Geralf;C14;155591
+Stitcher's Apprentice;ISD;138141
+Stitcher's Graft;EMN;162149
+Stitchwing Skaab;SOI;161630
+Stoic Angel;ALA;115207
+Stoic Angel;MM3;115207
+Stoic Builder;SOI;161721
+Stoic Champion;LGN;47478
+Stoic Champion;VMA;47478
+Stoic Ephemera;DIS;94582
+Stoic Rebuttal;DPA;131141
+Stoic Rebuttal;MM2;131141
+Stoic Rebuttal;SOM;131141
+Stoic Rebuttal;TD2;131141
+Stoke the Flames;M15;155239
+Stoke the Flames;PRM;157101
+Stolen Goods;AVR;141815
+Stolen Grain;ME3;9170
+Stolen Grain;PTK;9170
+Stolen Identity;GTC;146480
+Stomp and Howl;DIS;94561
+Stomper Cub;DPA;127356
+Stomper Cub;ROE;127356
+Stomping Ground;EXP;160789
+Stomping Ground;GPT;91723
+Stomping Ground;GTC;146510
+Stomping Slabs;MOR;110215
+Stone Calendar;DRK;834
+Stone Calendar;MED;834
+Stone Catapult;PTK;9017
+Stone Giant;2ED;239
+Stone Giant;3ED;239
+Stone Giant;4ED;239
+Stone Giant;5ED;2484
+Stone Giant;DDI;122263
+Stone Giant;LEA;239
+Stone Giant;LEB;239
+Stone Giant;M10;122263
+Stone Giant;MED;239
+Stone Golem;DPA;129143
+Stone Golem;M11;129143
+Stone Haven Medic;BFZ;160626
+Stone Haven Outfitter;OGW;161037
+Stone Haven Outfitter;PRM;161272
+Stone Idol Trap;WWK;126555
+Stone Kavu;PLS;27994
+Stone Quarry;AKH;400733
+Stone Quarry;KLD;162604
+Stone Quarry;SOI;161472
+Stone Quarry;XLN;402347
+Stone Rain;2ED;240
+Stone Rain;3ED;240
+Stone Rain;4ED;240
+Stone Rain;5ED;2485
+Stone Rain;6ED;6718
+Stone Rain;7ED;27809
+Stone Rain;8ED;6718
+Stone Rain;9ED;6718
+Stone Rain;COK;81109
+Stone Rain;ICE;1384
+Stone Rain;LEA;240
+Stone Rain;LEB;240
+Stone Rain;MIR;2067
+Stone Rain;MMQ;19286
+Stone Rain;PO2;4743
+Stone Rain;POR;6718
+Stone Rain;PRM;240
+Stone Rain;PTK;9182
+Stone Rain;TMP;3018
+Stone Spirit;5ED;2486
+Stone Spirit;ICE;1385
+Stone Spirit;ME2;2486
+Stone-Seeder Hierophant;RAV;89082
+Stone-Throwing Devils;ARN;375
+Stone-Tongue Basilisk;ODY;33290
+Stone-Tongue Basilisk;PRM;33290
+Stonebrow, Krosan Hero;DPA;97538
+Stonebrow, Krosan Hero;TSP;97538
+Stonecloaker;C13;100712
+Stonecloaker;PLC;100712
+Stonecloaker;TD0;100712
+Stonefare Crocodile;DDM;145873
+Stonefare Crocodile;RTR;145873
+Stoneforge Acolyte;OGW;161014
+Stoneforge Masterwork;OGW;161260
+Stoneforge Mystic;DPA;126571
+Stoneforge Mystic;PRM;161274
+Stoneforge Mystic;TD0;126571
+Stoneforge Mystic;WWK;126571
+Stoneforged Blade;TOK;156424
+Stonefury;BFZ;160692
+Stonehands;ICE;1386
+Stonehands;ME2;1386
+Stonehewer Giant;MMA;109618
+Stonehewer Giant;MOR;109618
+Stonehoof Chieftain;PZ2;162376
+Stonehorn Chanter;M14;147400
+Stonehorn Dignitary;M12;134108
+Stoneshaker Shaman;RAV;89146
+Stoneshock Giant;THS;150799
+Stonewing Antagonizer;SOI;161768
+Stonewise Fortifier;JOU;152814
+Stonewood Invocation;TSP;97516
+Stonewood Invoker;EVG;46533
+Stonewood Invoker;LGN;46533
+Stonework Puma;ZEN;123676
+Stonewright;AVR;141520
+Stony Silence;ISD;138509
+Stony Silence;MM3;400103
+Stonybrook Angler;LRW;105328
+Stonybrook Banneret;MOR;109924
+Stonybrook Schoolmaster;MOR;110007
+Storage Matrix;9ED;16334
+Storage Matrix;UD;16334
+Storm Cauldron;6ED;1740
+Storm Cauldron;7ED;27810
+Storm Cauldron;ALL;1740
+Storm Crow;6ED;6632
+Storm Crow;7ED;27811
+Storm Crow;8ED;27811
+Storm Crow;9ED;27811
+Storm Crow;ALL;1741
+Storm Crow;ALL;1742
+Storm Crow;DPA;27811
+Storm Crow;POR;6632
+Storm Elemental;ALL;1743
+Storm Elemental;ME2;1743
+Storm Entity;FUT;102407
+Storm Entity;PRM;102407
+Storm Fleet Aerialist;XLN;402253
+Storm Fleet Arsonist;XLN;402329
+Storm Fleet Pyromancer;XLN;402126
+Storm Fleet Spy;XLN;402332
+Storm Front;TMP;3238
+Storm Herd;CMD;91793
+Storm Herd;GPT;91793
+Storm Sculptor;XLN;401931
+Storm Seeker;CH;678
+Storm Seeker;LEG;678
+Storm Seeker;MED;678
+Storm Shaman;7ED;27812
+Storm Shaman;ALL;1744
+Storm Shaman;ALL;1745
+Storm Spirit;ICE;1387
+Storm Spirit;ME2;1387
+Storm World;LEG;2553
+Storm World;ME3;2553
+Stormbind;ICE;1388
+Stormbind;TSB;1388
+Stormblood Berserker;M12;134156
+Stormblood Berserker;MM2;134156
+Stormbound Geist;DKA;139817
+Stormbreath Dragon;THS;150820
+Stormcaller of Keranos;BNG;152074
+Stormcaller's Boon;ARB;120955
+Stormchaser Chimera;JOU;155457
+Stormchaser Mage;OGW;161161
+Stormcloud Djinn;DPA;97520
+Stormcloud Djinn;TSP;97520
+Stormcrag Elemental;DTK;159858
+Stormfront Pegasus;DPA;121624
+Stormfront Pegasus;M10;121624
+Stormfront Pegasus;M11;121624
+Stormfront Pegasus;M12;121624
+Stormfront Pegasus;W17;121624
+Stormfront Riders;DDF;100688
+Stormfront Riders;PLC;100688
+Stormrider Rig;DTK;159824
+Stormrider Spirit;SOI;161369
+Stormscale Anarch;DIS;94372
+Stormscape Apprentice;INV;25229
+Stormscape Battlemage;C13;27943
+Stormscape Battlemage;PLS;27943
+Stormscape Familiar;PLS;27995
+Stormscape Familiar;TSB;27995
+Stormscape Master;INV;25199
+Stormsurge Kraken;C14;155650
+Stormtide Leviathan;M11;129118
+Stormtide Leviathan;M13;129118
+Stormtide Leviathan;M15;129118
+Stormwatch Eagle;PCY;22126
+Stormwing Dragon;DTK;159809
+Story Circle;10E;102965
+Story Circle;8ED;49675
+Story Circle;9ED;49675
+Story Circle;MMQ;19313
+Strafe;PLS;27996
+Strands of Night;6ED;2916
+Strands of Night;7ED;27813
+Strands of Night;WTH;2916
+Strands of Undeath;RAV;88782
+Strandwalker;MBS;133177
+Strange Augmentation;EMN;162081
+Strange Inversion;COK;82650
+Stranglehold;CMD;137528
+Strangleroot Geist;DKA;131646
+Strangleroot Geist;PRM;140326
+Strangling Soot;DDK;97346
+Strangling Soot;TSP;97346
+Strata Scythe;C14;131036
+Strata Scythe;SOM;131036
+Stratadon;PLS;27998
+Strategic Planning;C13;9080
+Strategic Planning;HOU;401592
+Strategic Planning;ME3;9080
+Strategic Planning;PTK;9080
+Stratozeppelid;GPT;91754
+Stratus Dancer;DTK;159861
+Stratus Walk;BNG;152025
+Stratus Walk;ORI;152025
+Straw Golem;WTH;2907
+Straw Soldiers;PTK;9116
+Stream Hopper;EVE;113628
+Stream of Consciousness;BOK;83813
+Stream of Life;2ED;241
+Stream of Life;3ED;241
+Stream of Life;4ED;241
+Stream of Life;5ED;2487
+Stream of Life;6ED;2487
+Stream of Life;7ED;27814
+Stream of Life;8ED;27814
+Stream of Life;9ED;27814
+Stream of Life;DPA;27814
+Stream of Life;LEA;241
+Stream of Life;LEB;241
+Stream of Unconsciousness;MOR;109940
+Streambed Aquitects;LRW;105344
+Street Savvy;DIS;94436
+Street Spasm;C13;145910
+Street Spasm;DDJ;145910
+Street Spasm;RTR;145910
+Street Sweeper;RTR;145930
+Street Wraith;FUT;102493
+Street Wraith;MMA;102493
+Streetbreaker Wurm;GPT;91857
+Strength from the Fallen;JOU;153050
+Strength in Numbers;MM3;97481
+Strength in Numbers;TSP;97481
+Strength of Arms;SOI;161758
+Strength of Cedars;COK;80796
+Strength of Isolation;TOR;36400
+Strength of Lunacy;TOR;36463
+Strength of Night;APC;31071
+Strength of Unity;INV;25224
+Strength of the Tajuru;WWK;126545
+Strider Harness;DPA;131021
+Strider Harness;OGW;161263
+Strider Harness;SOM;131021
+Striking Sliver;DPA;147445
+Striking Sliver;M14;147445
+Strionic Resonator;M14;147449
+Strip Bare;SHM;111900
+Strip Mine;4ED;447
+Strip Mine;ATQ;446
+Strip Mine;ATQ;447
+Strip Mine;ATQ;448
+Strip Mine;ATQ;449
+Strip Mine;EXP;160962
+Strip Mine;ME4;447
+Strip Mine;V09;122579
+Strip Mine;VMA;122579
+Striped Bears;WTH;2805
+Striped Riverwinder;HOU;401492
+Stroke of Genius;C14;8688
+Stroke of Genius;PRM;8688
+Stroke of Genius;USG;8688
+Stroke of Genius;VMA;8688
+Stromgald Cabal;5ED;1389
+Stromgald Cabal;6ED;1389
+Stromgald Cabal;ICE;1389
+Stromgald Cabal;ME2;1389
+Stromgald Crusader;CSP;96989
+Stromgald Spy;ALL;1746
+Stromkirk Captain;DKA;139833
+Stromkirk Condemned;EMN;161962
+Stromkirk Mentor;SOI;161629
+Stromkirk Noble;ISD;138343
+Stromkirk Occultist;EMN;161984
+Stromkirk Patrol;ISD;138247
+Strongarm Monk;DTK;160124
+Strongarm Tactics;ONS;43082
+Strongarm Thug;MMQ;19118
+Stronghold Assassin;7ED;27815
+Stronghold Assassin;C13;3781
+Stronghold Assassin;STH;3781
+Stronghold Assassin;TPR;3781
+Stronghold Biologist;NMS;21237
+Stronghold Discipline;10E;104560
+Stronghold Discipline;NMS;21169
+Stronghold Furnace;PC1;125858
+Stronghold Gambit;NMS;21172
+Stronghold Machinist;NMS;21239
+Stronghold Overseer;TSP;97494
+Stronghold Rats;FUT;102460
+Stronghold Taskmaster;STH;3783
+Stronghold Zeppelin;NMS;21266
+Structural Collapse;GTC;146280
+Structural Distortion;SOI;161695
+Struggle for Sanity;COK;81054
+Struggle;HOU;401836
+Stubborn Denial;KTK;157014
+Student of Elements;COK;80904
+Student of Ojutai;DTK;159705
+Student of Warfare;ROE;127374
+Stuffy Doll;M13;143986
+Stuffy Doll;TSP;97476
+Stun Sniper;ARB;120983
+Stun Sniper;DDL;120983
+Stun;10E;3019
+Stun;INV;24176
+Stun;TMP;3019
+Stun;TPR;3019
+Stunt Double;PZ2;162166
+Stunted Growth;ICE;1390
+Stunted Growth;ME2;1390
+Stunted Growth;PRM;144458
+Stupefying Touch;EMA;161554
+Stupefying Touch;TOR;36433
+Stupor;6ED;2068
+Stupor;MIR;2068
+Stupor;PRM;2068
+Stupor;TSB;2068
+Sturdy Hatchling;EVE;113697
+Sturmgeist;DPA;138492
+Sturmgeist;ISD;138492
+Stymied Hopes;THS;150843
+Su-Chi;ATQ;450
+Su-Chi;MED;450
+Su-Chi;VMA;158912
+Subdue;LEG;679
+Subjugator Angel;EMN;161909
+Sublime Archangel;DPA;143886
+Sublime Archangel;M13;143886
+Submerge;NMS;21174
+Submerged Boneyard;AER;400213
+Submerged Boneyard;AKH;400213
+Submerged Boneyard;OGW;161095
+Subterranean Hangar;MMQ;19024
+Subterranean Scout;ORI;160288
+Subterranean Shambler;TSP;97441
+Subterranean Spirit;MIR;2069
+Subterranean Tremors;PZ2;143520
+Subtle Strike;KLD;162264
+Subversion;UL;10329
+Succumb to Temptation;EMN;162082
+Sudden Death;TSP;97479
+Sudden Demise;C13;151720
+Sudden Disappearance;DKA;139900
+Sudden Impact;10E;104533
+Sudden Impact;7ED;27816
+Sudden Impact;8ED;27816
+Sudden Impact;9ED;86954
+Sudden Impact;PD2;104533
+Sudden Impact;TMP;3266
+Sudden Reclamation;FRF;157326
+Sudden Shock;MMA;97454
+Sudden Shock;PRM;97454
+Sudden Shock;TSP;97454
+Sudden Spoiling;C13;97415
+Sudden Spoiling;C14;97415
+Sudden Spoiling;TSP;97415
+Sudden Storm;BNG;152552
+Sudden Strength;JUD;40275
+Sudden Strength;VMA;40275
+Suffer the Past;ROE;127388
+Suffering;DDH;25579
+Suffering;INV;25579
+Suffocating Blast;APC;31143
+Suffocation;ALL;1747
+Suicidal Charge;CON;118736
+Sulam Djinn;INV;24048
+Suleiman's Legacy;VIS;2262
+Sulfur Elemental;PLC;102610
+Sulfur Falls;ISD;138428
+Sulfur Vent;INV;25198
+Sulfuric Vapors;USG;8888
+Sulfuric Vortex;DDK;49010
+Sulfuric Vortex;EMA;49010
+Sulfuric Vortex;SCG;49010
+Sulfuric Vortex;VMA;49010
+Sulfurous Blast;CMD;97336
+Sulfurous Blast;DPA;97336
+Sulfurous Blast;TSP;97336
+Sulfurous Springs;10E;27817
+Sulfurous Springs;5ED;2488
+Sulfurous Springs;6ED;2488
+Sulfurous Springs;7ED;27817
+Sulfurous Springs;9ED;27817
+Sulfurous Springs;ICE;1391
+Sultai Ascendancy;KTK;157084
+Sultai Ascendancy;PRM;153200
+Sultai Banner;KTK;156535
+Sultai Charm;KTK;156570
+Sultai Charm;PRM;157105
+Sultai Emissary;FRF;157187
+Sultai Emissary;PRM;159383
+Sultai Flayer;KTK;157058
+Sultai Runemark;FRF;157222
+Sultai Scavenger;KTK;157023
+Sultai Skullkeeper;FRF;157343
+Sultai Soothsayer;KTK;156529
+Summary Dismissal;EMN;162050
+Summer Bloom;6ED;6675
+Summer Bloom;9ED;2263
+Summer Bloom;POR;6675
+Summer Bloom;VIS;2263
+Summit Apes;WWK;126509
+Summit Prowler;DTK;160508
+Summit Prowler;KTK;157036
+Summon the School;LRW;108877
+Summoner's Bane;DDM;123703
+Summoner's Bane;DPA;123703
+Summoner's Bane;ZEN;123703
+Summoner's Egg;5DN;77141
+Summoner's Pact;FUT;102423
+Summoner's Pact;MMA;102423
+Summoning Station;5DN;77192
+Summoning Trap;MM3;125071
+Summoning Trap;ZEN;125071
+Sun Ce, Young Conquerer;ME3;9046
+Sun Ce, Young Conquerer;PTK;9046
+Sun Clasp;VIS;2264
+Sun Droplet;C13;51103
+Sun Droplet;MRD;51103
+Sun Quan, Lord of Wu;ME3;8996
+Sun Quan, Lord of Wu;PTK;8996
+Sun Quan, Lord of Wu;V11;8996
+Sun Titan;C14;129119
+Sun Titan;DDL;150014
+Sun Titan;DPA;129119
+Sun Titan;M11;129119
+Sun Titan;M12;129119
+Sun Titan;PRM;129298
+Sun-Blessed Mount;XLN;402344
+Sun-Crowned Hunters;XLN;402238
+Sun's Bounty;CSP;97013
+Sunastian Falconer;LEG;680
+Sunastian Falconer;ME3;680
+Sunbeam Spellbomb;MRD;50302
+Sunbird's Invocation;XLN;402272
+Sunblade Elf;M15;155272
+Sunblast Angel;C14;131220
+Sunblast Angel;DDI;131220
+Sunblast Angel;SOM;131220
+Sunbond;BNG;152539
+Sunbringer's Touch;DTK;160028
+Suncrusher;5DN;77079
+Sunder from Within;SOK;86180
+Sunder;MS3;401616
+Sunder;USG;8925
+Sundering Growth;MM3;145882
+Sundering Growth;RTR;145882
+Sundering Titan;DST;50828
+Sundering Titan;MS2;400938
+Sundering Titan;V10;50828
+Sundering Vitae;MM2;88917
+Sundering Vitae;RAV;88917
+Sundial of the Infinite;M12;134182
+Sunfire Balm;ONS;42949
+Sunflare Shaman;MOR;110003
+Sunforger;MM2;88638
+Sunforger;RAV;88638
+Sunglasses of Urza;2ED;242
+Sunglasses of Urza;3ED;242
+Sunglasses of Urza;4ED;242
+Sunglasses of Urza;LEA;242
+Sunglasses of Urza;LEB;242
+Sungrace Pegasus;M15;155379
+Sungrass Egg;ODY;33258
+Sungrass Prairie;ODY;33230
+Sunhome Enforcer;RAV;89111
+Sunhome Guildmage;GTC;145182
+Sunhome Guildmage;MM3;145182
+Sunhome, Fortress of the Legion;PC1;89107
+Sunhome, Fortress of the Legion;RAV;89107
+Sunken City;4ED;835
+Sunken City;DRK;835
+Sunken City;MED;835
+Sunken Field;PCY;22032
+Sunken Hollow;BFZ;160883
+Sunken Hollow;EXP;161287
+Sunken Hope;10E;104522
+Sunken Hope;PC2;104522
+Sunken Hope;PLS;28000
+Sunken Ruins;EXP;161099
+Sunken Ruins;SHM;111641
+Sunlance;DDF;100674
+Sunlance;MM2;100674
+Sunlance;PLC;100674
+Sunpetal Grove;M10;121679
+Sunpetal Grove;M11;121679
+Sunpetal Grove;M12;121679
+Sunpetal Grove;M13;121679
+Sunpetal Grove;XLN;404082
+Sunrise Seeker;XLN;401942
+Sunrise Sovereign;LRW;105430
+Sunscape Apprentice;INV;25200
+Sunscape Battlemage;DDE;27881
+Sunscape Battlemage;PLS;27881
+Sunscape Familiar;PLS;28001
+Sunscape Master;INV;25191
+Sunscorch Regent;DTK;159873
+Sunscorch Regent;PRM;160122
+Sunscorched Desert;AKH;400856
+Sunscour;CSP;96987
+Sunscourge Champion;HOU;401545
+Sunscourge Champion;TOK;401879
+Sunseed Nurturer;ALA;115153
+Sunset Pyramid;HOU;401539
+Sunspear Shikari;DPA;131067
+Sunspear Shikari;MM2;131067
+Sunspear Shikari;SOM;131067
+Sunspire Gatekeepers;DGM;131653
+Sunspire Griffin;RTR;145114
+Sunspring Expedition;DPA;123558
+Sunspring Expedition;ZEN;123558
+Sunstone;ICE;1392
+Sunstrike Legionnaire;LGN;46594
+Suntail Hawk;10E;103535
+Suntail Hawk;8ED;40160
+Suntail Hawk;9ED;40160
+Suntail Hawk;DPA;103535
+Suntail Hawk;JUD;40160
+Suntail Hawk;M14;103535
+Suntouched Myr;5DN;77132
+Suntouched Myr;PC1;77132
+Sunweb;6ED;2070
+Sunweb;7ED;27818
+Sunweb;8ED;27818
+Sunweb;MIR;2070
+Superior Numbers;MIR;2071
+Supernatural Stamina;AKH;401308
+Supplant Form;FRF;157350
+Supplant Form;PRM;159003
+Supply Caravan;AKH;401280
+Supply-Line Cranes;JOU;152807
+Supply;DIS;94522
+Suppress;APC;31156
+Suppression Bonds;ORI;160202
+Suppression Field;RAV;88637
+Supreme Exemplar;MOR;109896
+Supreme Inquisitor;ONS;43026
+Supreme Verdict;PRM;145958
+Supreme Verdict;RTR;145223
+Supreme Will;HOU;401537
+Suq'Ata Assassin;VIS;2265
+Suq'Ata Firewalker;MIR;2072
+Suq'Ata Lancer;TSB;2266
+Suq'Ata Lancer;VIS;2266
+Sure Strike;BFZ;160837
+Sure Strike;XLN;402093
+Surestrike Trident;DST;75172
+Surge Node;NPH;134188
+Surge of Righteousness;DTK;160171
+Surge of Strength;ALL;1748
+Surge of Thoughtweft;LRW;106353
+Surge of Zeal;RAV;88945
+Surgespanner;LRW;105577
+Surgical Extraction;MM2;136797
+Surgical Extraction;NPH;136797
+Surgical Extraction;PRM;134380
+Surging Aether;CSP;97022
+Surging Dementia;CSP;90378
+Surging Flame;CSP;97005
+Surging Flame;PRM;97005
+Surging Might;CSP;96941
+Surging Sentinels;CSP;97257
+Surprise Deployment;PLS;27972
+Surrak Dragonclaw;KTK;156637
+Surrak, the Hunt Caller;DTK;159843
+Surrakar Banisher;WWK;126489
+Surrakar Marauder;ZEN;123609
+Surrakar Spellblade;DPA;127480
+Surrakar Spellblade;MM2;127480
+Surrakar Spellblade;ROE;127480
+Surreal Memoir;ROE;127329
+Surveilling Sprite;DDH;88894
+Surveilling Sprite;DPA;88894
+Surveilling Sprite;RAV;88894
+Survey the Wreckage;RTR;145140
+Surveyor's Scope;C13;151715
+Survival Cache;C13;127332
+Survival Cache;ROE;127332
+Survival of the Fittest;EXO;5664
+Survival of the Fittest;PRM;120088
+Survival of the Fittest;TPR;5664
+Survival of the Fittest;VMA;120088
+Survive the Night;SOI;161624
+Survive;HOU;401861
+Survivor of the Unseen;CSP;96960
+Survivor;TOK;112034
+Survivors' Encampment;HOU;401562
+Suspension Field;KTK;156543
+Suspension Field;PRM;159834
+Sustainer of the Realm;7ED;27819
+Sustainer of the Realm;DDC;27819
+Sustainer of the Realm;UL;10406
+Sustaining Spirit;ALL;1749
+Sustaining Spirit;ME2;1749
+Sustenance;MMQ;19323
+Suture Priest;NPH;134243
+Suture Priest;PRM;134243
+Suture Spirit;EVE;113671
+Sutured Ghoul;JUD;36468
+Sutured Ghoul;M12;36468
+Svogthos, the Restless Tomb;CMD;89113
+Svogthos, the Restless Tomb;DDJ;89113
+Svogthos, the Restless Tomb;RAV;89113
+Svyelunite Priest;FEM;1005
+Svyelunite Temple;5ED;2489
+Svyelunite Temple;6ED;2489
+Svyelunite Temple;FEM;1006
+Svyelunite Temple;ME2;1006
+Swallowing Plague;COK;80975
+Swamp Mosquito;ALL;1750
+Swamp Mosquito;ALL;1751
+Swamp Mosquito;TSB;1751
+Swamp;10E;25491
+Swamp;10E;80953
+Swamp;10E;8633
+Swamp;10E;89177
+Swamp;2ED;243
+Swamp;2ED;244
+Swamp;2ED;301
+Swamp;3ED;243
+Swamp;3ED;244
+Swamp;3ED;301
+Swamp;4ED;243
+Swamp;4ED;244
+Swamp;4ED;301
+Swamp;5ED;2490
+Swamp;5ED;2491
+Swamp;5ED;2492
+Swamp;5ED;2493
+Swamp;6ED;1393
+Swamp;6ED;301
+Swamp;6ED;6764
+Swamp;6ED;6765
+Swamp;7ED;27820
+Swamp;7ED;27821
+Swamp;7ED;27822
+Swamp;7ED;27823
+Swamp;8ED;2074
+Swamp;8ED;27822
+Swamp;8ED;43243
+Swamp;8ED;8633
+Swamp;9ED;2074
+Swamp;9ED;27822
+Swamp;9ED;43243
+Swamp;9ED;8633
+Swamp;AKH;400892
+Swamp;AKH;400893
+Swamp;AKH;400894
+Swamp;AKH;402703
+Swamp;ALA;115126
+Swamp;ALA;115127
+Swamp;ALA;115128
+Swamp;ALA;115129
+Swamp;AVR;141758
+Swamp;AVR;141762
+Swamp;AVR;141772
+Swamp;BFZ;123769
+Swamp;BFZ;160755
+Swamp;BFZ;160756
+Swamp;BFZ;160757
+Swamp;BFZ;160758
+Swamp;C01;17599
+Swamp;C13;131610
+Swamp;C13;131687
+Swamp;C13;137575
+Swamp;C13;138795
+Swamp;C14;123751
+Swamp;C14;123753
+Swamp;C14;123759
+Swamp;C14;123769
+Swamp;CMD;121681
+Swamp;CMD;123769
+Swamp;CMD;43243
+Swamp;CMD;89177
+Swamp;COK;80951
+Swamp;COK;80952
+Swamp;COK;80953
+Swamp;COK;80959
+Swamp;DDC;115126
+Swamp;DDC;115127
+Swamp;DDC;97549
+Swamp;DDC;97551
+Swamp;DDD;89164
+Swamp;DDD;89173
+Swamp;DDD;89174
+Swamp;DDD;89177
+Swamp;DDE;25035
+Swamp;DDE;25036
+Swamp;DDE;25490
+Swamp;DDE;25491
+Swamp;DDH;115126
+Swamp;DDH;115127
+Swamp;DDJ;89164
+Swamp;DDJ;89173
+Swamp;DDJ;89174
+Swamp;DDJ;89177
+Swamp;DDK;138464
+Swamp;DDK;138465
+Swamp;DDK;138466
+Swamp;DDK;141758
+Swamp;DDK;141762
+Swamp;DDK;141772
+Swamp;DDM;145250
+Swamp;DDM;145251
+Swamp;DDM;145252
+Swamp;DDM;145253
+Swamp;DDM;89177
+Swamp;DPA;25491
+Swamp;DPA;80953
+Swamp;DPA;8633
+Swamp;DPA;89177
+Swamp;DTK;159729
+Swamp;DTK;159761
+Swamp;DTK;159811
+Swamp;FK;2074
+Swamp;FRF;158894
+Swamp;FRF;158895
+Swamp;H09;3077
+Swamp;HOU;401923
+Swamp;HOU;402762
+Swamp;HOU;402767
+Swamp;ICE;1393
+Swamp;ICE;1394
+Swamp;ICE;1395
+Swamp;INV;25035
+Swamp;INV;25036
+Swamp;INV;25490
+Swamp;INV;25491
+Swamp;ISD;138464
+Swamp;ISD;138465
+Swamp;ISD;138466
+Swamp;KLD;162358
+Swamp;KLD;162359
+Swamp;KLD;162360
+Swamp;KTK;156620
+Swamp;KTK;156621
+Swamp;KTK;156622
+Swamp;KTK;156623
+Swamp;LEA;243
+Swamp;LEA;244
+Swamp;LEB;243
+Swamp;LEB;244
+Swamp;LEB;301
+Swamp;LRW;105650
+Swamp;LRW;105654
+Swamp;LRW;105655
+Swamp;LRW;105656
+Swamp;M10;121681
+Swamp;M10;121691
+Swamp;M10;33214
+Swamp;M10;43243
+Swamp;M11;106214
+Swamp;M11;121681
+Swamp;M11;121691
+Swamp;M11;27822
+Swamp;M12;111828
+Swamp;M12;137575
+Swamp;M12;137576
+Swamp;M12;33214
+Swamp;M13;131610
+Swamp;M13;137575
+Swamp;M13;137576
+Swamp;M13;138669
+Swamp;M14;131687
+Swamp;M14;137575
+Swamp;M14;137576
+Swamp;M14;138795
+Swamp;M15;137575
+Swamp;M15;137576
+Swamp;M15;138795
+Swamp;M15;153337
+Swamp;MBS;133246
+Swamp;MBS;133247
+Swamp;ME3;9104
+Swamp;ME3;9105
+Swamp;ME3;9106
+Swamp;MED;243
+Swamp;MED;244
+Swamp;MED;301
+Swamp;MIR;2073
+Swamp;MIR;2074
+Swamp;MIR;2075
+Swamp;MIR;2076
+Swamp;MMQ;18991
+Swamp;MMQ;18992
+Swamp;MMQ;19068
+Swamp;MMQ;19269
+Swamp;MRD;50314
+Swamp;MRD;50315
+Swamp;MRD;50316
+Swamp;MRD;50317
+Swamp;NPH;134343
+Swamp;NPH;134345
+Swamp;ODY;33214
+Swamp;ODY;33215
+Swamp;ODY;33216
+Swamp;ODY;33217
+Swamp;ONS;43241
+Swamp;ONS;43242
+Swamp;ONS;43243
+Swamp;ONS;43244
+Swamp;ORI;138465
+Swamp;ORI;138466
+Swamp;ORI;27822
+Swamp;ORI;43243
+Swamp;PC1;115126
+Swamp;PC1;115127
+Swamp;PC1;50316
+Swamp;PC1;96764
+Swamp;PC1;97549
+Swamp;PC2;80951
+Swamp;PC2;80952
+Swamp;PC2;80953
+Swamp;PC2;80959
+Swamp;PC2;8633
+Swamp;PD3;115129
+Swamp;PD3;138465
+Swamp;PD3;138466
+Swamp;PD3;33214
+Swamp;PO2;4795
+Swamp;PO2;4796
+Swamp;PO2;4797
+Swamp;POR;6764
+Swamp;POR;6765
+Swamp;POR;6766
+Swamp;POR;6767
+Swamp;PRM;116173
+Swamp;PRM;125125
+Swamp;PRM;132690
+Swamp;PRM;156671
+Swamp;PRM;160799
+Swamp;PRM;17599
+Swamp;PRM;21431
+Swamp;PRM;21436
+Swamp;PRM;21442
+Swamp;PRM;21592
+Swamp;PRM;49941
+Swamp;PRM;75385
+Swamp;PRM;83914
+Swamp;PRM;8507
+Swamp;PRM;90385
+Swamp;PRM;9174
+Swamp;PRM;9388
+Swamp;PRM;97528
+Swamp;PTK;9104
+Swamp;PTK;9105
+Swamp;PTK;9106
+Swamp;RAV;89164
+Swamp;RAV;89173
+Swamp;RAV;89174
+Swamp;RAV;89177
+Swamp;ROE;127502
+Swamp;ROE;127503
+Swamp;ROE;127504
+Swamp;ROE;127510
+Swamp;RTR;145250
+Swamp;RTR;145251
+Swamp;RTR;145252
+Swamp;RTR;145253
+Swamp;RTR;89177
+Swamp;SHM;111813
+Swamp;SHM;111828
+Swamp;SHM;111831
+Swamp;SHM;111837
+Swamp;SOI;161514
+Swamp;SOI;161515
+Swamp;SOI;161516
+Swamp;SOM;131161
+Swamp;SOM;131166
+Swamp;SOM;131168
+Swamp;SOM;131176
+Swamp;TD0;9104
+Swamp;TD0;9105
+Swamp;TD0;9106
+Swamp;TD2;133246
+Swamp;TD2;133247
+Swamp;TD2;134343
+Swamp;THS;149130
+Swamp;THS;149133
+Swamp;THS;149978
+Swamp;THS;149979
+Swamp;TMP;3072
+Swamp;TMP;3077
+Swamp;TMP;3082
+Swamp;TMP;3087
+Swamp;TPR;3072
+Swamp;TPR;3077
+Swamp;TPR;3082
+Swamp;TPR;3087
+Swamp;TSP;96764
+Swamp;TSP;97527
+Swamp;TSP;97549
+Swamp;TSP;97551
+Swamp;USG;8627
+Swamp;USG;8633
+Swamp;USG;8634
+Swamp;USG;8635
+Swamp;XLN;401903
+Swamp;XLN;401904
+Swamp;XLN;401905
+Swamp;XLN;402022
+Swamp;ZEN;123751
+Swamp;ZEN;123753
+Swamp;ZEN;123759
+Swamp;ZEN;123769
+Swan Song;THS;150763
+Swans of Bryn Argoll;MM2;111656
+Swans of Bryn Argoll;SHM;111656
+Swarm Intelligence;HOU;401794
+Swarm Surge;BFZ;160833
+Swarm of Bloodflies;KTK;157028
+Swarm of Rats;8ED;4711
+Swarm of Rats;9ED;4711
+Swarm of Rats;PO2;4711
+Swarmborn Giant;JOU;152893
+Swarmyard;TSP;97456
+Swashbuckling;XLN;402340
+Swat;ONS;43040
+Swat;UL;10332
+Sway of Illusion;INV;24161
+Sway of the Stars;BOK;83820
+Sweatworks Brawler;AER;400308
+Sweep Away;OGW;160648
+Swell of Courage;DDF;109944
+Swell of Courage;DPA;109944
+Swell of Courage;MOR;109944
+Swell of Growth;BFZ;160701
+Swelter;JUD;40254
+Sweltering Suns;AKH;400747
+Swerve;ALA;115073
+Swift Justice;RTR;145117
+Swift Kick;KTK;157039
+Swift Maneuver;CSP;96991
+Swift Reckoning;ORI;160209
+Swift Silence;DIS;94357
+Swift Spinner;EMN;162002
+Swift Warkite;DTK;160142
+Swiftfoot Boots;C13;134146
+Swiftfoot Boots;C14;134146
+Swiftfoot Boots;DPA;134146
+Swiftfoot Boots;M12;134146
+Swiftfoot Boots;PZ1;134146
+Swiftwater Cliffs;EMA;157271
+Swiftwater Cliffs;FRF;157271
+Swiftwater Cliffs;KTK;156539
+Swirl the Mists;COK;80903
+Swirling Sandstorm;JUD;40244
+Swirling Spriggan;EVE;113708
+Switcheroo;M13;143930
+Swooping Talon;LGN;46581
+Sword Dancer;8ED;22033
+Sword Dancer;PCY;22033
+Sword of Body and Mind;DPA;131093
+Sword of Body and Mind;MS2;400939
+Sword of Body and Mind;SOM;131093
+Sword of Body and Mind;V10;131093
+Sword of Feast and Famine;MBS;133237
+Sword of Feast and Famine;MS2;400612
+Sword of Feast and Famine;PRM;133237
+Sword of Feast and Famine;PRM;161285
+Sword of Fire and Ice;DST;75179
+Sword of Fire and Ice;MMA;147076
+Sword of Fire and Ice;MS2;400601
+Sword of Fire and Ice;PRM;75179
+Sword of Kaldra;MRD;51605
+Sword of Kaldra;PRM;50330
+Sword of Light and Shadow;DST;75181
+Sword of Light and Shadow;MMA;147077
+Sword of Light and Shadow;MS2;400614
+Sword of Vengeance;C14;129133
+Sword of Vengeance;DPA;129133
+Sword of Vengeance;M11;129133
+Sword of War and Peace;DPA;134220
+Sword of War and Peace;MS2;400940
+Sword of War and Peace;NPH;134220
+Sword of the Ages;LEG;2554
+Sword of the Ages;ME3;2554
+Sword of the Animist;ORI;160356
+Sword of the Chosen;STH;3810
+Sword of the Meek;FUT;102366
+Sword of the Paruns;C13;91865
+Sword of the Paruns;GPT;91865
+Sword-Point Diplomacy;XLN;402378
+Swords to Plowshares;2ED;245
+Swords to Plowshares;3ED;245
+Swords to Plowshares;4ED;245
+Swords to Plowshares;DDF;131542
+Swords to Plowshares;DPA;131542
+Swords to Plowshares;EMA;131542
+Swords to Plowshares;ICE;1396
+Swords to Plowshares;LEA;245
+Swords to Plowshares;LEB;245
+Swords to Plowshares;ME2;1396
+Swords to Plowshares;ME4;245
+Swords to Plowshares;PRM;245
+Swords to Plowshares;TD0;131542
+Swords to Plowshares;TD0;1396
+Swords to Plowshares;V13;131542
+Swords to Plowshares;VMA;131542
+Swordwise Centaur;BNG;152051
+Sworn Defender;ALL;1752
+Sydri, Galvanic Genius;C13;151757
+Sygg, River Cutthroat;SHM;111668
+Sygg, River Guide;LRW;105496
+Sylvan Advocate;OGW;161248
+Sylvan Basilisk;10E;101062
+Sylvan Basilisk;PO2;4804
+Sylvan Bounty;CON;118713
+Sylvan Bounty;DDH;118713
+Sylvan Bounty;MM2;118713
+Sylvan Bounty;MMA;118713
+Sylvan Caryatid;PRM;151406
+Sylvan Caryatid;THS;149109
+Sylvan Echoes;LRW;107644
+Sylvan Hierophant;WTH;2927
+Sylvan Library;4ED;681
+Sylvan Library;5ED;681
+Sylvan Library;EMA;144455
+Sylvan Library;LEG;681
+Sylvan Library;MED;681
+Sylvan Library;PRM;144455
+Sylvan Library;PRM;681
+Sylvan Library;PZ1;144455
+Sylvan Library;VMA;144455
+Sylvan Messenger;APC;31150
+Sylvan Messenger;DPA;148334
+Sylvan Messenger;EVG;31150
+Sylvan Messenger;ORI;148334
+Sylvan Might;EMA;33296
+Sylvan Might;ODY;33296
+Sylvan Offering;C14;155645
+Sylvan Paradise;LEG;682
+Sylvan Primordial;GTC;147249
+Sylvan Ranger;C14;102617
+Sylvan Ranger;DDH;102617
+Sylvan Ranger;DPA;102617
+Sylvan Ranger;M11;102617
+Sylvan Ranger;MM3;102617
+Sylvan Ranger;PRM;27630
+Sylvan Reclamation;PZ2;162439
+Sylvan Safekeeper;C14;156389
+Sylvan Safekeeper;JUD;36520
+Sylvan Scrying;10E;51132
+Sylvan Scrying;BFZ;160714
+Sylvan Scrying;MRD;51132
+Sylvan Scrying;PRM;161767
+Sylvan Tutor;ME4;6676
+Sylvan Tutor;POR;6676
+Sylvan Yeti;PO2;4784
+Sylvok Explorer;5DN;77140
+Sylvok Lifestaff;SOM;131032
+Sylvok Replica;SOM;131090
+Symbiosis;USG;8818
+Symbiotic Beast;ONS;43178
+Symbiotic Deployment;APC;31148
+Symbiotic Elf;ONS;43157
+Symbiotic Elf;TD2;43157
+Symbiotic Wurm;CMD;43189
+Symbiotic Wurm;ONS;43189
+Symbiotic Wurm;VMA;43189
+Symbol of Unsummoning;ME4;6633
+Symbol of Unsummoning;POR;6633
+Synapse Sliver;LGN;46541
+Synchronized Strike;AKH;400837
+Synchronous Sliver;PLC;100721
+Syncopate;ODY;33483
+Syncopate;RTR;145170
+Syndic of Tithes;GTC;146523
+Syndicate Enforcer;GTC;146247
+Syndicate Trafficker;KLD;162499
+Synod Artificer;DST;52041
+Synod Centurion;5DN;77234
+Synod Centurion;DDF;77234
+Synod Sanctum;MRD;50265
+Synthetic Destiny;PZ1;160433
+Syphon Flesh;CMD;129237
+Syphon Flesh;DPA;129237
+Syphon Life;EVE;98635
+Syphon Life;MMA;98635
+Syphon Mind;C14;43031
+Syphon Mind;CMD;43031
+Syphon Mind;DPA;43031
+Syphon Mind;ONS;43031
+Syphon Mind;PC1;43031
+Syphon Sliver;M14;147374
+Syphon Soul;6ED;683
+Syphon Soul;LEG;683
+Syphon Soul;ONS;43044
+Syphon Soul;PC1;43044
+Szadek, Lord of Secrets;CMD;89133
+Szadek, Lord of Secrets;RAV;89133
+Séance;DKA;139800
+Séance;MM3;139800
+Tablet of Epityr;ATQ;451
+Tablet of Epityr;ME4;451
+Tablet of the Guilds;RTR;145209
+Tah-Crop Elite;AKH;401279
+Tah-Crop Skirmisher;AKH;400813
+Tah-Crop Skirmisher;TOK;400956
+Tahngarth, Talruum Hero;PLS;28005
+Tahngarth's Glare;APC;31151
+Tahngarth's Rage;TMP;3269
+Taiga;2ED;246
+Taiga;3ED;246
+Taiga;LEA;246
+Taiga;LEB;246
+Taiga;ME2;246
+Taiga;ME4;246
+Taiga;PRM;144400
+Taiga;VMA;144400
+Taigam's Scheming;KTK;157008
+Taigam's Strike;DTK;159864
+Tail Slash;DTK;160070
+Tainted Aether;7ED;27824
+Tainted Aether;USG;8651
+Tainted Field;DDK;36527
+Tainted Field;TOR;36527
+Tainted Isle;PC2;36528
+Tainted Isle;TOR;36528
+Tainted Pact;ODY;33396
+Tainted Peak;TOR;36529
+Tainted Remedy;ORI;160258
+Tainted Sigil;ARB;121025
+Tainted Specter;MIR;2077
+Tainted Strike;SOM;131087
+Tainted Well;INV;25152
+Tainted Wood;DDM;36530
+Tainted Wood;TD2;36530
+Tainted Wood;TOR;36530
+Taj-Nar Swordsmith;MM2;51104
+Taj-Nar Swordsmith;MRD;51104
+Tajic, Blade of the Legion;DGM;146699
+Tajuru Archer;ZEN;123607
+Tajuru Beastmaster;BFZ;160694
+Tajuru Pathwarden;OGW;161077
+Tajuru Preserver;ROE;127273
+Tajuru Stalwart;BFZ;160901
+Tajuru Warcaller;BFZ;160708
+Take Down;KLD;162296
+Take Inventory;EMN;162067
+Take Possession;FUT;102488
+Take Possession;MMA;102488
+Take Up Arms;KTK;157000
+Take into Custody;AER;400260
+Take;DGM;151014
+Takeno, Samurai General;COK;81087
+Takeno, Samurai General;DPA;81087
+Takeno's Cavalry;BOK;83924
+Takenuma Bleeder;BOK;83930
+Takenuma;PC2;140380
+Takklemaggot;CH;684
+Takklemaggot;LEG;684
+Takklemaggot;ME3;684
+Talara's Bane;EVE;113633
+Talara's Battalion;DPA;113725
+Talara's Battalion;EVE;113725
+Talas Air Ship;PO2;4576
+Talas Explorer;PO2;4683
+Talas Merchant;PO2;4685
+Talas Researcher;ME4;4634
+Talas Researcher;PO2;4634
+Talas Scout;PO2;4682
+Talas Warrior;PO2;4702
+Talent of the Telepath;ORI;160229
+Talisman of Dominance;MRD;50186
+Talisman of Impulse;MRD;50188
+Talisman of Indulgence;MRD;50187
+Talisman of Progress;MRD;50185
+Talisman of Progress;TD2;50185
+Talisman of Unity;MRD;50189
+Tallowisp;BOK;83846
+Talon Gates;PC2;138716
+Talon Sliver;TMP;3057
+Talon Trooper;ARB;120957
+Talon Trooper;DPA;120957
+Talon Trooper;MM3;120957
+Talon of Pain;DST;75163
+Talonrend;EVE;108902
+Talons of Falkenrath;DKA;139891
+Talrand, Sky Summoner;M13;143873
+Talrand's Invocation;DPA;143863
+Talrand's Invocation;M13;143863
+Talruum Champion;VIS;2267
+Talruum Minotaur;6ED;2078
+Talruum Minotaur;MIR;2078
+Talruum Piper;VIS;2268
+Talus Paladin;WWK;126564
+Tamanoa;CSP;96998
+Tamiyo, Field Researcher;EMN;162011
+Tamiyo, the Moon Sage;AVR;141615
+Tamiyo's Journal;SOI;161595
+Tana, the Bloodsower;PZ2;162389
+Tandem Lookout;AVR;141743
+Tandem Lookout;MM3;141743
+Tandem Tactics;BFZ;160906
+Tangle Angler;SOM;131015
+Tangle Asp;5DN;77114
+Tangle Golem;DST;75177
+Tangle Hulk;MBS;133215
+Tangle Kelp;DRK;836
+Tangle Mantis;MBS;131625
+Tangle Spider;10E;52002
+Tangle Spider;DST;52002
+Tangle Wire;NMS;21181
+Tangle Wire;V13;148934
+Tangle;INV;24125
+Tangle;VMA;24125
+Tanglebloom;9ED;51095
+Tanglebloom;MRD;51095
+Tangleclaw Werewolf;EMN;161997
+Tangleroot;MRD;51135
+Tanglesap;ZEN;123698
+Tanglewalker;DST;50832
+Taniwha;MIR;2079
+Taoist Hermit;PTK;9084
+Taoist Mystic;PTK;9097
+Tapestry of the Ages;DTK;159734
+Tar Fiend;ALA;115134
+Tar Pit Warrior;VIS;2269
+Tar Pitcher;EVG;105384
+Tar Pitcher;LRW;105384
+Tar Pitcher;MMA;105384
+Tar Snare;OGW;161144
+Tarfire;EVG;105390
+Tarfire;LRW;105390
+Tariel, Reckoner of Souls;CMD;137550
+Tariel, Reckoner of Souls;V15;137550
+Tariff;6ED;2899
+Tariff;WTH;2899
+Tarmogoyf;FUT;102465
+Tarmogoyf;MM2;147075
+Tarmogoyf;MM3;147075
+Tarmogoyf;MMA;147075
+Tarnished Citadel;ODY;33228
+Tarox Bladewing;FUT;100793
+Tarpan;5ED;1397
+Tarpan;ICE;1397
+Tasigur, the Golden Fang;FRF;157155
+Tasigur's Cruelty;FRF;157181
+Task Force;MMQ;19257
+Task Mage Assembly;PCY;22034
+Tasseled Dromedary;KLD;162235
+Taste for Mayhem;DIS;91794
+Taste of Blood;M12;136316
+Taste of Paradise;ALL;1753
+Taste of Paradise;ALL;1754
+Tatsumasa, the Dragon's Fang;COK;80761
+Tattered Drake;RAV;88920
+Tattered Haunter;EMN;162059
+Tattered Mummy;AKH;401057
+Tatterkite;SHM;111575
+Tattermunge Duo;SHM;111735
+Tattermunge Maniac;SHM;111673
+Tattermunge Witch;MM3;111826
+Tattermunge Witch;SHM;111826
+Tattoo Ward;ODY;33540
+Taunt;POR;6634
+Taunting Challenge;PTK;9096
+Taunting Elf;DPA;43155
+Taunting Elf;ONS;43155
+Taunting Elf;UD;15661
+Taurean Mauler;MOR;110015
+Taurean Mauler;PC1;110015
+Tavern Swindler;DDM;145902
+Tavern Swindler;RTR;145902
+Tawnos's Coffin;ATQ;452
+Tawnos's Coffin;MED;452
+Tawnos's Coffin;PRM;452
+Tawnos's Wand;4ED;453
+Tawnos's Wand;ATQ;453
+Tawnos's Wand;ME4;453
+Tawnos's Weaponry;4ED;454
+Tawnos's Weaponry;5ED;2494
+Tawnos's Weaponry;ATQ;454
+Tawnos's Weaponry;ME4;454
+Tazeem;PRM;125864
+Tear;DGM;151020
+Teardrop Kami;BOK;83866
+Tears of Rage;DST;51755
+Tears of Valakut;OGW;161235
+Tectonic Break;MMQ;19120
+Tectonic Edge;C14;126492
+Tectonic Edge;EXP;160961
+Tectonic Edge;PRM;140384
+Tectonic Edge;WWK;126492
+Tectonic Fiend;TSP;86892
+Tectonic Instability;INV;24050
+Tectonic Rift;M12;136315
+Teeka's Dragon;MIR;2080
+Teetering Peaks;PD2;123557
+Teetering Peaks;PRM;137578
+Teetering Peaks;ZEN;123557
+Teferi, Mage of Zhalfir;TSP;97007
+Teferi, Mage of Zhalfir;V11;137597
+Teferi, Temporal Archmage;C14;156037
+Teferi, Temporal Archmage;PZ1;156037
+Teferi's Care;INV;24164
+Teferi's Curse;MIR;2081
+Teferi's Drake;MIR;2082
+Teferi's Honor Guard;VIS;2270
+Teferi's Imp;MIR;2083
+Teferi's Isle;MIR;2084
+Teferi's Moat;INV;23973
+Teferi's Moat;TSB;23973
+Teferi's Puzzle Box;6ED;2271
+Teferi's Puzzle Box;7ED;27826
+Teferi's Puzzle Box;8ED;27826
+Teferi's Puzzle Box;9ED;27826
+Teferi's Puzzle Box;VIS;2271
+Teferi's Realm;VIS;2272
+Teferi's Response;INV;24165
+Teferi's Veil;WTH;2949
+Tek;INV;25203
+Tel-Jilad Archers;MRD;50212
+Tel-Jilad Chosen;MRD;50211
+Tel-Jilad Defiance;SOM;130981
+Tel-Jilad Exile;MRD;51125
+Tel-Jilad Fallen;SOM;131013
+Tel-Jilad Justice;5DN;77109
+Tel-Jilad Lifebreather;5DN;77225
+Tel-Jilad Outrider;DST;51905
+Tel-Jilad Stylus;MRD;51039
+Tel-Jilad Wolf;DST;51906
+Telekinesis;LEG;2555
+Telekinesis;MED;2555
+Telekinetic Bonds;JUD;40305
+Telekinetic Sliver;TSP;97401
+Telemin Performance;CON;119796
+Telemin Performance;DPA;119796
+Telepathic Spies;7ED;27827
+Telepathic Spies;UD;15616
+Telepathy;10E;8952
+Telepathy;7ED;27828
+Telepathy;8ED;8952
+Telepathy;9ED;8952
+Telepathy;M10;8952
+Telepathy;USG;8952
+Teleport;CH;685
+Teleport;LEG;685
+Teleportal;MM3;145195
+Teleportal;RTR;145195
+Telethopter;TMP;3200
+Telethopter;TPR;3200
+Telim'Tor;MIR;2085
+Telim'Tor's Darts;MIR;2086
+Telim'Tor's Edict;MIR;2087
+Teller of Tales;COK;80620
+Telling Time;10E;89029
+Telling Time;MM2;89029
+Telling Time;RAV;89029
+Tember City;PRM;125867
+Temmet, Vizier of Naktamun;AKH;400820
+Temmet, Vizier of Naktamun;TOK;400959
+Temper;STH;3785
+Tempered Steel;PRM;131734
+Tempered Steel;SOM;130976
+Tempest Caller;XLN;402322
+Tempest Drake;VIS;2273
+Tempest Efreet;4ED;686
+Tempest Efreet;LEG;686
+Tempest Owl;ZEN;123613
+Tempest of Light;10E;50241
+Tempest of Light;9ED;50241
+Tempest of Light;M10;50241
+Tempest of Light;MRD;50241
+Temple Acolyte;DDF;4661
+Temple Acolyte;ME4;4661
+Temple Acolyte;PO2;4661
+Temple Bell;C13;129145
+Temple Bell;M11;129145
+Temple Elder;PO2;4672
+Temple Garden;EXP;160790
+Temple Garden;RAV;90400
+Temple Garden;RTR;145233
+Temple of Abandon;THS;149114
+Temple of Aclazotz;XLN;402113
+Temple of Deceit;THS;149112
+Temple of Enlightenment;BNG;149111
+Temple of Epiphany;JOU;149117
+Temple of Malady;JOU;149118
+Temple of Malice;BNG;149113
+Temple of Mystery;PRM;158166
+Temple of Mystery;THS;149120
+Temple of Plenty;BNG;149115
+Temple of Silence;THS;149116
+Temple of Triumph;THS;149119
+Temple of the False God;C13;48970
+Temple of the False God;C14;48970
+Temple of the False God;CMD;48970
+Temple of the False God;PRM;159823
+Temple of the False God;PZ1;48970
+Temple of the False God;SCG;48970
+Temporal Adept;7ED;27829
+Temporal Adept;8ED;27829
+Temporal Adept;9ED;86925
+Temporal Adept;UD;15711
+Temporal Aperture;USG;8918
+Temporal Cascade;MRD;51109
+Temporal Distortion;INV;24018
+Temporal Eddy;TSP;97513
+Temporal Extortion;PLC;100801
+Temporal Fissure;SCG;48976
+Temporal Fissure;VMA;158834
+Temporal Isolation;TSP;97273
+Temporal Manipulation;ME2;4704
+Temporal Manipulation;PO2;4704
+Temporal Manipulation;PRM;159366
+Temporal Mastery;AVR;141674
+Temporal Mastery;MM3;141674
+Temporal Spring;APC;31164
+Temporal Spring;TD0;31164
+Temporal Trespass;FRF;157334
+Temporary Insanity;DDG;36487
+Temporary Insanity;TOR;36487
+Temporary Truce;POR;6756
+Tempt with Discovery;C13;151756
+Tempt with Glory;C13;151750
+Tempt with Immortality;C13;151721
+Tempt with Reflections;C13;151709
+Tempt with Vengeance;C13;151738
+Tempting Licid;STH;3786
+Tempting Wurm;ONS;43192
+Temur Ascendancy;KTK;157081
+Temur Banner;KTK;156534
+Temur Battle Rage;FRF;157267
+Temur Charger;KTK;156563
+Temur Charm;KTK;156569
+Temur Runemark;FRF;157212
+Temur Sabertooth;FRF;157339
+Temur War Shaman;FRF;158968
+Temur War Shaman;PRM;158888
+Tenacious Dead;M14;147402
+Tenacious Hunter;HOU;401822
+Tenacity;SOI;161664
+Tendo Ice Bridge;BOK;83877
+Tendrils of Agony;PRM;110128
+Tendrils of Agony;SCG;48979
+Tendrils of Agony;VMA;110128
+Tendrils of Corruption;C14;101040
+Tendrils of Corruption;DDD;101040
+Tendrils of Corruption;DDE;101040
+Tendrils of Corruption;DPA;101040
+Tendrils of Corruption;M10;101040
+Tendrils of Corruption;TSP;97266
+Tendrils of Despair;WTH;2798
+Teneb, the Harvester;CMD;100731
+Teneb, the Harvester;PLC;100731
+Tenement Crasher;RTR;138789
+Tenza, Godo's Maul;COK;81117
+Tephraderm;DPA;21243
+Tephraderm;ONS;21243
+Terashi's Cry;COK;82626
+Terashi's Grasp;BOK;83918
+Terashi's Grasp;MM2;83918
+Terashi's Grasp;MMA;83918
+Terashi's Verdict;BOK;83876
+Terastodon;C14;126513
+Terastodon;DPA;126513
+Terastodon;PD3;126513
+Terastodon;WWK;126513
+Teremko Griffin;MIR;2088
+Terminal Moraine;PLS;27949
+Terminate;ARB;115230
+Terminate;CMD;115230
+Terminate;DDK;115230
+Terminate;DPA;28015
+Terminate;MM3;400210
+Terminate;PLS;28015
+Terminate;PRM;124484
+Terminate;PRM;28015
+Terminate;TD0;28015
+Terminus;AVR;139860
+Terminus;MM3;139860
+Terminus;V14;139860
+Teroh's Faithful;TOR;36391
+Teroh's Faithful;VMA;36391
+Teroh's Vanguard;TOR;36397
+Terra Eternal;WWK;126554
+Terra Ravager;C13;151766
+Terra Stomper;DPA;123648
+Terra Stomper;M15;123648
+Terra Stomper;ORI;123648
+Terra Stomper;PRM;123648
+Terra Stomper;ZEN;123648
+Terraformer;RAV;88895
+Terrain Elemental;KLD;162546
+Terrain Generator;DD2;21253
+Terrain Generator;NMS;21253
+Terramorphic Expanse;10E;97502
+Terramorphic Expanse;C13;97502
+Terramorphic Expanse;C14;97502
+Terramorphic Expanse;CMD;97502
+Terramorphic Expanse;DDE;97502
+Terramorphic Expanse;DDH;97502
+Terramorphic Expanse;DPA;97502
+Terramorphic Expanse;H09;97502
+Terramorphic Expanse;M10;97502
+Terramorphic Expanse;M11;97502
+Terramorphic Expanse;MMA;97502
+Terramorphic Expanse;PC1;97502
+Terramorphic Expanse;PC2;97502
+Terramorphic Expanse;TD0;97502
+Terramorphic Expanse;TD2;97502
+Terramorphic Expanse;TSP;97502
+Terrarion;EMN;162151
+Terrarion;RAV;88647
+Terravore;ODY;33291
+Terrifying Presence;AVR;141611
+Terrifying Presence;DDL;141611
+Territorial Baloth;BFZ;160710
+Territorial Baloth;DPA;123532
+Territorial Baloth;ZEN;123532
+Territorial Dispute;MMQ;19226
+Territorial Gorger;KLD;162285
+Territorial Hammerskull;XLN;402246
+Territorial Roc;DTK;159842
+Terror of Kruin Pass;ISD;138280
+Terror of the Fairgrounds;KLD;162538
+Terror;10E;104561
+Terror;2ED;247
+Terror;3ED;247
+Terror;4ED;247
+Terror;5ED;247
+Terror;6ED;247
+Terror;DPA;104561
+Terror;LEA;247
+Terror;LEB;247
+Terror;ME4;247
+Terror;MRD;50338
+Terror;PRM;247
+Terror;PRM;80780
+Terror;TD0;247
+Terrus Wurm;RTR;145130
+Test of Endurance;JUD;40306
+Test of Faith;DDG;51889
+Test of Faith;DST;51889
+Test of Faith;MMA;51889
+Test of Faith;TD2;51889
+Testament of Faith;ODY;33535
+Tethered Griffin;UD;15700
+Tethered Skirge;UL;10392
+Tethmos High Priest;JOU;152873
+Tetravite;TOK;137166
+Tetravus;4ED;455
+Tetravus;ATQ;455
+Tetravus;ME4;455
+Tetsuo Umezawa;LEG;2556
+Tetsuo Umezawa;ME3;2556
+Teysa, Envoy of Ghosts;DGM;146774
+Teysa, Orzhov Scion;GPT;92020
+Tezzeret the Schemer;AER;162200
+Tezzeret the Seeker;ALA;115006
+Tezzeret the Seeker;DDF;130868
+Tezzeret the Seeker;MM2;115006
+Tezzeret, Agent of Bolas;MBS;131654
+Tezzeret, Master of Metal;AER;400412
+Tezzeret's Ambition;KLD;162493
+Tezzeret's Betrayal;AER;400432
+Tezzeret's Gambit;MM2;134352
+Tezzeret's Gambit;NPH;134352
+Tezzeret's Simulacrum;AER;400427
+Tezzeret's Touch;AER;400357
+Thada Adel, Acquisitor;WWK;126570
+Thalakos Deceiver;STH;3787
+Thalakos Dreamsower;TMP;3274
+Thalakos Drifters;EXO;4639
+Thalakos Drifters;TPR;4639
+Thalakos Drifters;VMA;4639
+Thalakos Lowlands;TMP;3249
+Thalakos Lowlands;TPR;3249
+Thalakos Mistfolk;TMP;3029
+Thalakos Scout;EXO;6103
+Thalakos Scout;TPR;6103
+Thalakos Seer;TMP;3030
+Thalakos Seer;TPR;3030
+Thalakos Sentry;TMP;3028
+Thalia, Guardian of Thraben;DKA;140321
+Thalia, Guardian of Thraben;PRM;152542
+Thalia, Heretic Cathar;EMN;162042
+Thalia, Heretic Cathar;PRM;161921
+Thalia's Lancers;EMN;162043
+Thalia's Lieutenant;SOI;161362
+Thallid Devourer;FEM;1011
+Thallid Devourer;ME2;1011
+Thallid Germinator;MMA;138794
+Thallid Germinator;TSP;97465
+Thallid Shell-Dweller;MMA;51017
+Thallid Shell-Dweller;TSP;51017
+Thallid;FEM;1007
+Thallid;FEM;1008
+Thallid;FEM;1009
+Thallid;FEM;1010
+Thallid;ME2;1009
+Thallid;MMA;148248
+Thallid;TSB;1010
+Thassa, God of the Sea;THS;149144
+Thassa's Bounty;THS;150859
+Thassa's Devourer;JOU;153096
+Thassa's Emissary;THS;150776
+Thassa's Ire;JOU;153035
+Thassa's Rebuff;BNG;152065
+That Which Was Taken;BOK;83952
+Thatcher Revolt;AVR;141504
+Thaumatic Compass;XLN;402261
+Thaumatog;ODY;33271
+Thawing Glaciers;ALL;1755
+Thawing Glaciers;MED;1755
+Thawing Glaciers;PRM;126729
+Thawing Glaciers;VMA;126729
+The Abyss;LEG;2557
+The Abyss;ME3;2557
+The Abyss;PRM;149233
+The Aether Flues;PC1;125893
+The Brute;4ED;687
+The Brute;5ED;2324
+The Brute;LEG;687
+The Chain Veil;M15;156039
+The Dark Barony;PC1;125878
+The Eon Fog;PC1;125887
+The Fallen;CH;837
+The Fallen;DRK;837
+The Fallen;MED;837
+The Fourth Sphere;PC1;125897
+The Gitrog Monster;SOI;161478
+The Great Aurora;ORI;160317
+The Great Forest;PC1;125883
+The Hippodrome;PC1;125862
+The Hive;10E;104566
+The Hive;2ED;248
+The Hive;3ED;248
+The Hive;4ED;248
+The Hive;5ED;248
+The Hive;6ED;248
+The Hive;LEA;248
+The Hive;LEB;248
+The Lady of the Mountain;LEG;688
+The Lady of the Mountain;ME3;688
+The Locust God;HOU;401590
+The Locust God;MS3;401846
+The Maelstrom;PC1;125857
+The Mimeoplasm;CMD;137517
+The Mimeoplasm;PZ1;137517
+The Rack;3ED;456
+The Rack;4ED;456
+The Rack;ATQ;456
+The Rack;DPA;122102
+The Rack;PRM;122102
+The Rack;TSB;456
+The Scarab God;HOU;401588
+The Scarab God;MS3;401844
+The Scorpion God;HOU;401589
+The Scorpion God;MS3;401845
+The Tabernacle at Pendrell Vale;LEG;2558
+The Tabernacle at Pendrell Vale;ME3;2558
+The Tabernacle at Pendrell Vale;PRM;156399
+The Unspeakable;COK;80906
+The Wretched;5ED;689
+The Wretched;CH;689
+The Wretched;LEG;689
+The Wretched;ME3;689
+The Zephyr Maze;PC2;138719
+Theft of Dreams;EXO;3809
+Theft of Dreams;ME4;6635
+Theft of Dreams;PO2;4700
+Theft of Dreams;POR;6635
+Thelon of Havenwood;TSP;97486
+Thelon's Chant;FEM;1012
+Thelon's Curse;FEM;1013
+Thelonite Druid;FEM;1014
+Thelonite Druid;ME2;1014
+Thelonite Hermit;TSP;99541
+Thelonite Monk;FEM;1015
+Thermal Blast;ODY;33377
+Thermal Flux;CSP;97258
+Thermal Glider;MMQ;19324
+Thermal Navigator;5DN;51175
+Thermo-Alchemist;EMN;161976
+Thermokarst;ICE;1398
+Thermokarst;ME2;1398
+Thermopod;CSP;96909
+Thespian's Stage;GTC;146511
+Thick-Skinned Goblin;TSP;97342
+Thicket Basilisk;2ED;249
+Thicket Basilisk;3ED;249
+Thicket Basilisk;4ED;249
+Thicket Basilisk;5ED;249
+Thicket Basilisk;6ED;249
+Thicket Basilisk;LEA;249
+Thicket Basilisk;LEB;249
+Thicket Basilisk;MED;249
+Thicket Elemental;INV;25482
+Thief of Blood;PZ1;160140
+Thief of Hope;COK;80845
+Thief of Hope;MM2;80845
+Thieves' Auction;8ED;19202
+Thieves' Auction;MMQ;19202
+Thieves' Fortune;MOR;109949
+Thieving Magpie;10E;15619
+Thieving Magpie;7ED;27830
+Thieving Magpie;8ED;27830
+Thieving Magpie;9ED;15619
+Thieving Magpie;DPA;15619
+Thieving Magpie;UD;15619
+Thieving Sprite;LRW;105368
+Thieving Sprite;MMA;105368
+Thing from the Deep;ME4;6636
+Thing from the Deep;POR;6636
+Thing in the Ice;SOI;161407
+Think Tank;ODY;33463
+Think Twice;ISD;138327
+Think Twice;TSP;97294
+Thirst for Knowledge;DDF;131781
+Thirst for Knowledge;MMA;131781
+Thirst for Knowledge;MRD;50199
+Thirst for Knowledge;PC1;50199
+Thirst for Knowledge;PRM;113859
+Thirst for Knowledge;TD2;50199
+Thirst;MIR;2089
+Thirsting Axe;EMN;162016
+Thistledown Duo;SHM;111748
+Thistledown Liege;SHM;111683
+Thopter Arrest;AER;400245
+Thopter Assembly;MBS;133213
+Thopter Assembly;PRM;134061
+Thopter Engineer;ORI;160294
+Thopter Foundry;ARB;121037
+Thopter Foundry;C13;121037
+Thopter Spy Network;ORI;160233
+Thopter Squadron;EXO;5622
+Thopter Squadron;TPR;5622
+Thopter Squadron;VMA;5622
+Thopter;TOK;117013
+Thopter;TOK;128457
+Thopter;TOK;133265
+Thopter;TOK;160392
+Thopter;TOK;160394
+Thopter;TOK;162579
+Thorn Elemental;7ED;27831
+Thorn Elemental;8ED;15672
+Thorn Elemental;UD;15672
+Thorn Thallid;FEM;1016
+Thorn Thallid;FEM;1017
+Thorn Thallid;FEM;1018
+Thorn Thallid;FEM;1019
+Thorn Thallid;MED;1019
+Thorn of Amethyst;LRW;105491
+Thorn of the Black Rose;PZ2;161879
+Thorn-Thrash Viashino;ALA;115117
+Thorn-Thrash Viashino;PC2;115117
+Thornbite Staff;MOR;109968
+Thornbow Archer;ORI;160254
+Thorncaster Sliver;DPA;147410
+Thorncaster Sliver;M14;147410
+Thorned Moloch;HOU;401505
+Thornhide Wolves;SOI;161479
+Thornling;CON;118734
+Thornscape Apprentice;DDE;25207
+Thornscape Apprentice;INV;25207
+Thornscape Battlemage;DDE;27909
+Thornscape Battlemage;MM3;27909
+Thornscape Battlemage;PLS;27909
+Thornscape Battlemage;TSB;27909
+Thornscape Familiar;PLS;28006
+Thornscape Master;INV;25205
+Thorntooth Witch;LRW;105609
+Thornwatch Scarecrow;SHM;111707
+Thornweald Archer;C14;102398
+Thornweald Archer;DPA;102398
+Thornweald Archer;EMA;102398
+Thornweald Archer;FUT;102398
+Thornwind Faeries;C13;10366
+Thornwind Faeries;UL;10366
+Thornwood Falls;EMA;157278
+Thornwood Falls;FRF;157278
+Thornwood Falls;KTK;156538
+Those Who Serve;AKH;400848
+Thought Courier;5DN;77217
+Thought Courier;9ED;77217
+Thought Devourer;ODY;33461
+Thought Dissector;DST;75204
+Thought Eater;ODY;33472
+Thought Gorger;ROE;127409
+Thought Harvester;OGW;161139
+Thought Hemorrhage;ARB;121008
+Thought Lash;ALL;1756
+Thought Lash;ME2;1756
+Thought Nibbler;ODY;33499
+Thought Prison;MRD;51097
+Thought Reflection;SHM;111640
+Thought Scour;DDM;139874
+Thought Scour;DKA;139874
+Thought Scour;DPA;139874
+Thought Vessel;PZ1;138814
+Thought-Knot Seer;OGW;161188
+Thoughtbind;COK;80540
+Thoughtbind;DPA;80540
+Thoughtbound Primoc;ONS;9399
+Thoughtcast;DDF;50245
+Thoughtcast;MM2;50245
+Thoughtcast;MRD;50245
+Thoughtcutter Agent;ALA;115199
+Thoughtflare;RTR;145923
+Thoughtlace;2ED;250
+Thoughtlace;3ED;250
+Thoughtlace;4ED;250
+Thoughtlace;LEA;250
+Thoughtlace;LEB;250
+Thoughtleech;7ED;27832
+Thoughtleech;ICE;1399
+Thoughtpicker Witch;RAV;88603
+Thoughtrender Lamia;JOU;153095
+Thoughts of Ruin;SOK;86091
+Thoughtseize;LRW;105369
+Thoughtseize;MS3;401625
+Thoughtseize;THS;149107
+Thoughtweft Gambit;SHM;111608
+Thoughtweft Trio;LRW;105544
+Thousand Winds;KTK;157017
+Thousand-Year Elixir;C13;105416
+Thousand-Year Elixir;LRW;105416
+Thousand-legged Kami;COK;80676
+Thraben Doomsayer;DKA;139849
+Thraben Foulbloods;EMN;162076
+Thraben Gargoyle;SOI;161729
+Thraben Heretic;DKA;139760
+Thraben Inspector;SOI;161696
+Thraben Militia;ISD;138166
+Thraben Purebloods;ISD;138326
+Thraben Sentry;ISD;138190
+Thraben Standard Bearer;EMN;162044
+Thraben Valiant;AVR;139885
+Thraben Valiant;DDL;139885
+Thraben Valiant;DPA;139885
+Thragtusk;DPA;143882
+Thragtusk;M13;143882
+Thragtusk;MM3;143882
+Thran Dynamo;C14;15677
+Thran Dynamo;PZ1;15677
+Thran Dynamo;UD;15677
+Thran Dynamo;V13;15677
+Thran Forge;WTH;2913
+Thran Foundry;UD;15721
+Thran Golem;9ED;15681
+Thran Golem;M12;15681
+Thran Golem;PC2;15681
+Thran Golem;PRM;145075
+Thran Golem;UD;15681
+Thran Lens;UL;13570
+Thran Quarry;PRM;8919
+Thran Quarry;USG;8919
+Thran Tome;WTH;2857
+Thran Turbine;USG;8899
+Thran War Machine;UL;14825
+Thran Weaponry;UL;10419
+Thrash of Raptors;XLN;402118
+Thrashing Mossdog;DGM;146736
+Thrashing Mudspawn;ONS;43052
+Thrashing Wumpus;MMQ;19188
+Thrasios, Triton Hero;PZ2;162380
+Thraximundar;ARB;121007
+Thraximundar;C13;121007
+Threads of Disloyalty;BOK;83959
+Threads of Disloyalty;MS3;401615
+Threaten;10E;86726
+Threaten;9ED;86726
+Threaten;DPA;86726
+Threaten;ONS;44542
+Three Dreams;DPA;88854
+Three Dreams;PC2;88854
+Three Dreams;RAV;88854
+Three Tragedies;BOK;83840
+Three Visits;ME3;9098
+Three Visits;PTK;9098
+Three Wishes;VIS;2274
+Thresher Beast;PCY;22035
+Thresher Lizard;AKH;401321
+Thrill of the Hunt;TSP;97334
+Thrill-Kill Assassin;RTR;145171
+Thriss, Nantuko Primus;JUD;40287
+Thrive;DIS;94455
+Thrive;MM2;94455
+Thrive;PCY;22057
+Thriving Grubs;KLD;162521
+Thriving Ibex;KLD;162463
+Thriving Rats;KLD;162498
+Thriving Rhino;KLD;162304
+Thriving Turtle;KLD;162479
+Throat Slitter;BOK;83836
+Throat Slitter;PC2;83836
+Thromok the Insatiable;PC2;140354
+Throne Warden;PZ2;162157
+Throne of Bone;2ED;251
+Throne of Bone;3ED;251
+Throne of Bone;4ED;251
+Throne of Bone;5ED;2495
+Throne of Bone;6ED;2495
+Throne of Bone;7ED;27833
+Throne of Bone;8ED;2495
+Throne of Bone;LEA;251
+Throne of Bone;LEB;251
+Throne of Empires;M12;134132
+Throne of Geth;SOM;130994
+Throne of the God-Pharaoh;AKH;400765
+Throne of the High City;PZ2;161902
+Throttle;KTK;157025
+Throttle;SOI;161621
+Through the Breach;COK;82616
+Through the Breach;MS3;401639
+Throwing Knife;ORI;138768
+Thrull Champion;FEM;1020
+Thrull Champion;MED;1020
+Thrull Parasite;GTC;146282
+Thrull Retainer;5ED;1021
+Thrull Retainer;FEM;1021
+Thrull Retainer;MED;1021
+Thrull Surgeon;10E;5624
+Thrull Surgeon;EXO;5624
+Thrull Surgeon;TPR;5624
+Thrull Wizard;FEM;1022
+Thrull;TOK;122101
+Thrull;TOK;98952
+Thrumming Stone;CSP;97256
+Thrummingbird;MM2;130959
+Thrummingbird;SOM;130959
+Thrun, the Last Troll;DPA;133221
+Thrun, the Last Troll;MBS;133221
+Thumbscrews;TMP;3112
+Thunder Brute;BNG;152583
+Thunder Dragon;DDG;115930
+Thunder Dragon;DPA;115930
+Thunder Dragon;DRB;115930
+Thunder Dragon;ME4;17574
+Thunder Spirit;LEG;2559
+Thunder Spirit;MED;2559
+Thunder Spirit;PRM;2559
+Thunder Strike;DPA;129068
+Thunder Strike;M11;129068
+Thunder Strike;M14;129068
+Thunder Totem;TSP;97330
+Thunder Wall;ICE;1400
+Thunder Wall;ME2;1400
+Thunder of Hooves;ONS;43117
+Thunder-Thrash Elder;ALA;117285
+Thunder-Thrash Elder;DPA;117285
+Thunder-Thrash Elder;PC2;117285
+Thunderblade Charge;FUT;102380
+Thunderblust;EVE;113734
+Thunderblust;MM2;113734
+Thunderbolt;AVR;141546
+Thunderbolt;PD2;2823
+Thunderbolt;WTH;2823
+Thunderbreak Regent;DTK;160086
+Thunderbreak Regent;PRM;160103
+Thunderclap Wyvern;EMA;160338
+Thunderclap Wyvern;ORI;160338
+Thunderclap;MMQ;19306
+Thundercloud Elemental;SCG;48961
+Thundercloud Shaman;LRW;105484
+Thundercloud Shaman;MMA;105484
+Thunderfoot Baloth;C14;155626
+Thunderheads;DDJ;91771
+Thunderheads;GPT;91771
+Thundering Giant;10E;8957
+Thundering Giant;M15;8957
+Thundering Giant;MMA;8957
+Thundering Giant;USG;8957
+Thundering Giant;W17;8957
+Thundering Spineback;XLN;401436
+Thundering Tanadon;NPH;134324
+Thundering Wurm;POR;6677
+Thundermare;9ED;2883
+Thundermare;DPA;2883
+Thundermare;POR;6719
+Thundermare;WTH;2883
+Thundermaw Hellkite;M13;131725
+Thunderous Might;BNG;152584
+Thunderous Wrath;AVR;141530
+Thunderous Wrath;MM3;141530
+Thunderscape Apprentice;INV;25208
+Thunderscape Battlemage;DDE;27933
+Thunderscape Battlemage;PLS;27933
+Thunderscape Familiar;PLS;25223
+Thunderscape Master;INV;25209
+Thundersong Trumpeter;MM3;88886
+Thundersong Trumpeter;RAV;88886
+Thunderstaff;C13;138777
+Thunderstaff;DST;9403
+Thunderstaff;TD2;9403
+Thwart;MMQ;19192
+Tibalt, the Fiend-Blooded;AVR;141829
+Tibalt, the Fiend-Blooded;DDK;147655
+Tibor and Lumia;GPT;91818
+Ticking Gnomes;EMA;161579
+Ticking Gnomes;UL;10542
+Tidal Bore;MMQ;19089
+Tidal Control;ALL;1757
+Tidal Courier;APC;31154
+Tidal Flats;FEM;1023
+Tidal Flats;FEM;1024
+Tidal Flats;FEM;1025
+Tidal Force;C13;131695
+Tidal Influence;FEM;1026
+Tidal Kraken;8ED;19190
+Tidal Kraken;9ED;19190
+Tidal Kraken;DPA;19190
+Tidal Kraken;MMQ;19190
+Tidal Surge;6ED;3788
+Tidal Surge;PO2;4635
+Tidal Surge;POR;6637
+Tidal Surge;STH;3788
+Tidal Visionary;INV;24167
+Tidal Warrior;STH;3789
+Tidal Wave;EMA;2090
+Tidal Wave;MIR;2090
+Tide Drifter;BFZ;160653
+Tide of War;COK;80887
+Tidebinder Mage;M14;147460
+Tideforce Elemental;WWK;102622
+Tidehollow Sculler;ALA;115107
+Tidehollow Sculler;MMA;115107
+Tidehollow Sculler;PRM;126727
+Tidehollow Strix;ALA;115078
+Tidehollow Strix;C13;115078
+Tidehollow Strix;DPA;115078
+Tideshaper Mystic;LRW;105604
+Tidespout Tyrant;DIS;94470
+Tidewalker;PLC;101383
+Tidewater Minion;RAV;88997
+Tidings;10E;17565
+Tidings;9ED;17565
+Tidings;DPA;17565
+Tidings;PRM;107708
+Tidy Conclusion;KLD;162272
+Tiger Claws;MMQ;19250
+Tigereye Cameo;INV;25195
+Tightening Coils;BFZ;160840
+Tilling Treefolk;EVE;113618
+Tilonalli's Knight;XLN;402122
+Tilonalli's Skinshifter;XLN;402009
+Timber Gorge;AKH;161158
+Timber Gorge;OGW;161158
+Timber Protector;LRW;105450
+Timber Shredder;SOI;161480
+Timber Wolves;2ED;252
+Timber Wolves;3ED;252
+Timber Wolves;4ED;252
+Timber Wolves;LEA;252
+Timber Wolves;LEB;252
+Timberland Guide;AVR;141593
+Timberland Ruins;ODY;33240
+Timberline Ridge;ICE;1401
+Timbermare;PLC;100749
+Timbermaw Larva;DPA;123608
+Timbermaw Larva;ZEN;123608
+Timberpack Wolf;M13;143968
+Timberpack Wolf;ORI;143968
+Timberwatch Elf;C14;48217
+Timberwatch Elf;DPA;48217
+Timberwatch Elf;EMA;161569
+Timberwatch Elf;EVG;48217
+Timberwatch Elf;LGN;48217
+Time Bomb;5ED;2496
+Time Bomb;ICE;1402
+Time Bomb;ME2;1402
+Time Distortion;PC2;138740
+Time Ebb;9ED;3046
+Time Ebb;DPA;6638
+Time Ebb;M14;6638
+Time Ebb;PO2;6132
+Time Ebb;POR;6638
+Time Ebb;TMP;3046
+Time Ebb;TPR;3046
+Time Elemental;4ED;690
+Time Elemental;5ED;690
+Time Elemental;LEG;690
+Time Elemental;MED;690
+Time Reversal;DPA;129112
+Time Reversal;M11;129112
+Time Reversal;M12;129112
+Time Sieve;ARB;121073
+Time Spiral;PRM;400639
+Time Spiral;USG;8922
+Time Stop;10E;80855
+Time Stop;COK;80855
+Time Stretch;10E;104580
+Time Stretch;ODY;33454
+Time Vault;2ED;253
+Time Vault;LEA;253
+Time Vault;LEB;253
+Time Vault;ME4;253
+Time Vault;VMA;144407
+Time Walk;2ED;254
+Time Walk;LEA;254
+Time Walk;LEB;254
+Time Walk;PRM;138773
+Time Walk;VMA;138773
+Time Warp;DPA;122160
+Time Warp;M10;122160
+Time Warp;PRM;3174
+Time Warp;TMP;3174
+Time Warp;TPR;3174
+Time and Tide;VIS;2275
+Time of Heroes;ROE;127272
+Time of Need;COK;80940
+Time to Feed;THS;150816
+Time to Reflect;AKH;401287
+Timebender;PLC;100679
+Timecrafting;PLC;100815
+Timely Hordemate;KTK;156997
+Timely Reinforcements;M12;134070
+Timesifter;MRD;51108
+Timetwister;2ED;255
+Timetwister;LEA;255
+Timetwister;LEB;255
+Timetwister;PRM;145063
+Timetwister;VMA;145063
+Timid Drake;MMQ;19009
+Timid Drake;WTH;2942
+Timmerian Fiends;HML;1569
+Tin Street Hooligan;GPT;91785
+Tin Street Market;GTC;146576
+Tin-Wing Chimera;VIS;2276
+Tinder Farm;INV;25210
+Tinder Wall;ICE;1403
+Tinder Wall;ME2;1403
+Tinder Wall;PRM;158837
+Tine Shrike;MBS;133147
+Tinker;DPA;122584
+Tinker;UL;10390
+Tinker;V09;122584
+Tireless Missionaries;M11;129104
+Tireless Missionaries;M15;129104
+Tireless Tracker;SOI;161744
+Tireless Tribe;ODY;33369
+Tishana, Voice of Thunder;XLN;402032
+Tishana's Wayfinder;XLN;402312
+Titan Forge;MBS;133125
+Titan of Eternal Fire;THS;149211
+Titan's Presence;BFZ;161125
+Titan's Revenge;MOR;109900
+Titan's Strength;ORI;151551
+Titan's Strength;THS;151551
+Titania, Protector of Argoth;C14;155603
+Titania, Protector of Argoth;PZ1;155603
+Titania's Boon;USG;8832
+Titania's Chosen;C14;8958
+Titania's Chosen;DPA;8958
+Titania's Chosen;USG;8958
+Titania's Song;3ED;457
+Titania's Song;4ED;457
+Titania's Song;5ED;2497
+Titania's Song;ATQ;457
+Titania's Song;ME4;457
+Titanic Bulvox;SCG;48162
+Titanic Growth;M12;135280
+Titanic Growth;M13;135280
+Titanic Growth;M15;135280
+Titanic Growth;ORI;135280
+Titanic Ultimatum;ALA;114958
+Titanic Ultimatum;DDH;114958
+Titanic Ultimatum;DPA;114958
+Titanium Golem;MRD;50274
+Tithe Drinker;DGM;147771
+Tithe;VIS;2277
+Tivadar of Thorn;TSP;97485
+Tivadar's Crusade;DRK;838
+Tivadar's Crusade;MED;838
+To Arms!;GPT;88726
+To the Slaughter;SOI;161742
+Tobias Andrion;CH;691
+Tobias Andrion;LEG;691
+Tobias Andrion;ME3;691
+Tocatli Honor Guard;XLN;402377
+Toil to Renown;SHM;111901
+Toil;DGM;147720
+Toils of Night and Day;BOK;83839
+Token Creature;TOK;125144
+Tolaria West;FUT;102453
+Tolaria West;V16;102453
+Tolaria;LEG;692
+Tolarian Academy;USG;8694
+Tolarian Academy;VMA;8694
+Tolarian Drake;WTH;2833
+Tolarian Emissary;INV;24002
+Tolarian Entrancer;WTH;2894
+Tolarian Sentinel;TSP;97323
+Tolarian Serpent;WTH;2896
+Tolarian Winds;7ED;27836
+Tolarian Winds;USG;8890
+Tolsimir Wolfblood;DPA;89151
+Tolsimir Wolfblood;RAV;89151
+Tomb Hex;WWK;126477
+Tomb of Urami;SOK;86104
+Tomb of the Spirit Dragon;KTK;155849
+Tombfire;ODY;33414
+Tombspawn;TOK;95881
+Tombstalker;FUT;97270
+Tombstalker;MMA;97270
+Tombstone Stairwell;MIR;2091
+Tome Scour;DPA;102623
+Tome Scour;M10;102623
+Tome Scour;M11;102623
+Tome Scour;M14;102623
+Tomorrow, Azami's Familiar;BOK;83862
+Tonic Peddler;MMQ;19252
+Toolcraft Exemplar;KLD;162466
+Tooth Collector;SOI;161446
+Tooth and Claw;C13;3160
+Tooth and Claw;EMA;161565
+Tooth and Claw;TMP;3160
+Tooth and Nail;MMA;145437
+Tooth and Nail;MRD;50342
+Tooth of Chiss-Goria;MRD;51073
+Tooth of Ramos;MMQ;19157
+Topan Ascetic;ALA;115067
+Topan Freeblade;ORI;160198
+Topple;NMS;21160
+Topplegeist;SOI;161443
+Tor Giant;ICE;1404
+Tor Wauki;CH;693
+Tor Wauki;LEG;693
+Tor Wauki;ME3;693
+Torch Drake;GPT;91828
+Torch Fiend;DKA;139758
+Torch Fiend;DPA;139758
+Torch Fiend;M13;139758
+Torch Fiend;M15;139758
+Torch Gauntlet;KLD;162583
+Torch Slinger;DPA;123601
+Torch Slinger;ZEN;123601
+Torch Song;USG;8650
+Torchling;DDI;100797
+Torchling;PLC;100797
+Torii Watchward;SOK;86149
+Torment of Hailfire;HOU;401514
+Torment of Scarabs;HOU;401800
+Torment of Venom;HOU;401497
+Torment;STH;3790
+Tormented Angel;UD;15774
+Tormented Hero;PRM;155431
+Tormented Hero;THS;150886
+Tormented Pariah;ISD;138208
+Tormented Soul;DPA;134091
+Tormented Soul;M12;134091
+Tormented Soul;M13;134091
+Tormented Soul;PC2;134091
+Tormented Soul;PRM;137420
+Tormented Thoughts;JOU;152867
+Tormented Thoughts;ORI;152867
+Tormenting Voice;AKH;400864
+Tormenting Voice;DTK;159701
+Tormenting Voice;KTK;156512
+Tormenting Voice;SOI;161482
+Tormentor Exarch;NPH;134328
+Tormentor's Trident;AVR;141534
+Tormod's Crypt;C14;110125
+Tormod's Crypt;CH;839
+Tormod's Crypt;DRK;839
+Tormod's Crypt;M13;110125
+Tormod's Crypt;M15;110125
+Tormod's Crypt;PRM;110125
+Tormod's Crypt;TSB;839
+Tornado Elemental;5DN;77156
+Tornado Elemental;C14;156387
+Tornado Elemental;PC1;77156
+Tornado;ALL;1758
+Tornado;MED;1758
+Torpid Moloch;RAV;89045
+Torpor Dust;SHM;111589
+Torpor Orb;NPH;134408
+Torrent Elemental;FRF;157337
+Torrent of Fire;SCG;48107
+Torrent of Lava;MIR;2092
+Torrent of Souls;DDK;98657
+Torrent of Souls;EMA;98657
+Torrent of Souls;MM3;98657
+Torrent of Souls;SHM;98657
+Torrent of Stone;BOK;83822
+Torrent of Stone;MMA;83822
+Torrential Gearhulk;KLD;162489
+Torrential Gearhulk;MS2;400619
+Torsten Von Ursus;LEG;694
+Torsten Von Ursus;ME3;694
+Tortoise Formation;ALA;116198
+Torture Chamber;TMP;3106
+Torture;5ED;1570
+Torture;HML;1570
+Torture;HML;1571
+Torture;SHM;111597
+Tortured Existence;STH;3729
+Toshiro Umezawa;BOK;83855
+Total War;ICE;1405
+Totally Lost;GTC;146423
+Totem Speaker;LGN;47524
+Totem-Guide Hartebeest;DPA;127460
+Totem-Guide Hartebeest;ORI;127460
+Totem-Guide Hartebeest;ROE;127460
+Touch of Brilliance;PO2;4686
+Touch of Brilliance;POR;6639
+Touch of Darkness;LEG;695
+Touch of Death;5ED;1406
+Touch of Death;ICE;1406
+Touch of Invisibility;ODY;33480
+Touch of Moonglove;ORI;160261
+Touch of Vitae;ICE;1407
+Touch of the Eternal;M13;143916
+Touch of the Void;BFZ;160689
+Touchstone;WTH;2908
+Tourach's Chant;FEM;1027
+Tourach's Gate;FEM;1028
+Tovolar's Magehunter;DKA;140329
+Tovolar's Magehunter;PRM;139810
+Tower Above;SHM;111727
+Tower Defense;GTC;146350
+Tower Drake;INV;24117
+Tower Drake;RTR;145849
+Tower Gargoyle;ALA;114937
+Tower Gargoyle;C13;114937
+Tower Gargoyle;MM3;114937
+Tower Geist;DKA;139822
+Tower Geist;ORI;139822
+Tower of Calamities;SOM;131034
+Tower of Champions;MRD;51056
+Tower of Coireall;DRK;840
+Tower of Eons;MRD;51040
+Tower of Fortunes;C13;50997
+Tower of Fortunes;MRD;50997
+Tower of Murmurs;MRD;51096
+Tower of the Magistrate;MMQ;19109
+Towering Baloth;ONS;43169
+Towering Indrik;RTR;145143
+Towering Thunderfist;GTC;146332
+Town Gossipmonger;SOI;161368
+Town Sentry;PO2;4660
+Toxic Deluge;C13;151737
+Toxic Deluge;EMA;151737
+Toxic Deluge;PZ1;151737
+Toxic Iguanar;CON;118646
+Toxic Nim;NPH;134420
+Toxic Stench;JUD;40228
+Toxin Sliver;LGN;46545
+Toymaker;MMQ;19092
+Trace of Abundance;ARB;120951
+Tracker;DRK;841
+Tracker;ME3;841
+Tracker's Instincts;DKA;139789
+Trade Caravan;HML;1572
+Trade Caravan;HML;1573
+Trade Routes;8ED;19185
+Trade Routes;9ED;19185
+Trade Routes;MMQ;19185
+Trade Secrets;CMD;43019
+Trade Secrets;ONS;43019
+Tradewind Rider;PRM;3179
+Tradewind Rider;TMP;3179
+Tradewind Rider;TPR;3179
+Tradewind Rider;VMA;3179
+Trading Post;C14;143987
+Trading Post;M13;143987
+Trading Post;M14;143987
+Tragic Arrogance;ORI;160201
+Tragic Lesson;HOU;401784
+Tragic Poet;UL;10372
+Tragic Slip;C14;139735
+Tragic Slip;DDM;139735
+Tragic Slip;DKA;139735
+Tragic Slip;EMA;139735
+Tragic Slip;PZ1;139735
+Trail of Evidence;SOI;161725
+Trail of Mystery;KTK;156593
+Trail of the Mage-Rings;PC2;131656
+Trailblazer;ICE;1408
+Trailblazer's Boots;ZEN;123687
+Train of Thought;DDJ;91733
+Train of Thought;GPT;91733
+Trained Armodon;6ED;2996
+Trained Armodon;7ED;27837
+Trained Armodon;8ED;2996
+Trained Armodon;9ED;2996
+Trained Armodon;DPA;2996
+Trained Armodon;TMP;2996
+Trained Armodon;TPR;2996
+Trained Caracal;RTR;145108
+Trained Cheetah;PTK;9120
+Trained Condor;M14;147379
+Trained Jackal;PTK;9136
+Trained Orgg;7ED;27838
+Trained Pronghorn;JUD;40165
+Training Drone;MBS;133153
+Training Grounds;ROE;127301
+Trait Doctoring;DGM;146789
+Traitor's Clutch;TSP;97305
+Traitor's Roar;SHM;111857
+Traitorous Blood;ISD;138373
+Traitorous Instinct;MM3;127462
+Traitorous Instinct;ROE;127462
+Traitorous Instinct;RTR;145870
+Tranquil Cove;EMA;157282
+Tranquil Cove;FRF;157282
+Tranquil Cove;KTK;157093
+Tranquil Domain;MIR;2093
+Tranquil Expanse;AER;400214
+Tranquil Expanse;AKH;400214
+Tranquil Expanse;OGW;161160
+Tranquil Garden;COK;81082
+Tranquil Grove;6ED;2812
+Tranquil Grove;WTH;2812
+Tranquil Path;APC;31043
+Tranquil Thicket;C13;43218
+Tranquil Thicket;C14;43218
+Tranquil Thicket;CMD;43218
+Tranquil Thicket;DDJ;43218
+Tranquil Thicket;EVG;43218
+Tranquil Thicket;ONS;43218
+Tranquil Thicket;TD0;43218
+Tranquil Thicket;VMA;43218
+Tranquility;2ED;256
+Tranquility;3ED;256
+Tranquility;4ED;256
+Tranquility;5ED;256
+Tranquility;6ED;256
+Tranquility;7ED;27839
+Tranquility;INV;24049
+Tranquility;LEA;256
+Tranquility;LEB;256
+Tranquility;MMQ;19146
+Tranquility;TMP;3001
+Tranquility;TPR;3001
+Transcendence;TOR;36407
+Transcendent Master;ROE;127421
+Transgress the Mind;BFZ;160661
+Transguild Courier;DIS;94427
+Transguild Promenade;C13;145890
+Transguild Promenade;RTR;145890
+Transluminant;DPA;88935
+Transluminant;RAV;88935
+Transmogrifying Licid;EXO;5643
+Transmutation;CH;696
+Transmutation;LEG;696
+Transmute Artifact;ATQ;458
+Transmute Artifact;ME4;458
+Transmute Artifact;PRM;402819
+Trap Digger;SCG;48959
+Trap Essence;KTK;157082
+Trap Runner;MMQ;20032
+Trapfinder's Trick;ZEN;123717
+Trapjaw Kelpie;EVE;113661
+Trapmaker's Snare;ZEN;123727
+Traproot Kami;BOK;83899
+Trash for Treasure;MRD;51088
+Traumatic Visions;CON;118107
+Traumatic Visions;MMA;118107
+Traumatize;10E;33487
+Traumatize;9ED;33487
+Traumatize;DPA;33487
+Traumatize;M10;33487
+Traumatize;M11;33487
+Traumatize;M14;33487
+Traumatize;ODY;33487
+Travel Preparations;ISD;138105
+Traveler's Amulet;HOU;401575
+Traveler's Amulet;ISD;138412
+Traveler's Amulet;THS;149078
+Traveler's Cloak;INV;25212
+Traveling Philosopher;THS;149106
+Traveling Plague;ODY;33388
+Traverse the Ulvenwald;SOI;161751
+Treacherous Link;UL;10347
+Treacherous Pit-Dweller;AVR;141793
+Treacherous Terrain;PZ2;162431
+Treacherous Urge;PLC;101386
+Treacherous Vampire;JUD;40230
+Treacherous Werewolf;JUD;40226
+Treachery;UD;16368
+Tread Upon;DTK;160077
+Treasure Cove;XLN;402116
+Treasure Cruise;KTK;157010
+Treasure Hunt;DPA;126503
+Treasure Hunt;PRM;134055
+Treasure Hunt;WWK;126503
+Treasure Hunter;10E;5431
+Treasure Hunter;EXO;5431
+Treasure Keeper;AER;400391
+Treasure Mage;MBS;133143
+Treasure Mage;PRM;134063
+Treasure Map;XLN;402071
+Treasure Trove;7ED;27840
+Treasure Trove;8ED;27840
+Treasure Trove;9ED;27840
+Treasure Trove;EXO;5646
+Treasure;TOK;402025
+Treasure;TOK;402026
+Treasure;TOK;402027
+Treasure;TOK;402028
+Treasured Find;DDM;145205
+Treasured Find;RTR;145205
+Treasury Thrull;GTC;146550
+Treasury Thrull;PRM;147344
+Tree Monkey;9ED;86958
+Tree Monkey;PO2;4768
+Tree of Perdition;EMN;162090
+Tree of Redemption;ISD;138505
+Tree of Tales;MRD;51146
+Tree of Tales;PC1;51146
+Treefolk Harbinger;LRW;105407
+Treefolk Healer;INV;24011
+Treefolk Mystic;UL;10349
+Treefolk Seedlings;7ED;27841
+Treefolk Seedlings;USG;8804
+Treefolk Shaman;TOK;110122
+Treefolk Shaman;TOK;148271
+Treefolk Warrior;TOK;155672
+Treefolk;TOK;156422
+Treespring Lorian;ONS;43147
+Treetop Bracers;10E;21167
+Treetop Bracers;9ED;21167
+Treetop Bracers;NMS;21167
+Treetop Defense;POR;6678
+Treetop Rangers;USG;8788
+Treetop Scout;SCG;46560
+Treetop Sentinel;ODY;32816
+Treetop Village;10E;104515
+Treetop Village;DDD;104515
+Treetop Village;DDG;104515
+Treetop Village;PRM;10328
+Treetop Village;UL;10328
+Tremble;ODY;33338
+Tremor;6ED;5671
+Tremor;7ED;27842
+Tremor;8ED;5671
+Tremor;MMQ;18982
+Tremor;PO2;5671
+Tremor;VIS;2278
+Trench Gorger;CMD;137519
+Trench Wurm;INV;25177
+Trenching Steed;PCY;22036
+Trepanation Blade;ISD;138164
+Trespasser il-Vec;TSP;97300
+Trespasser's Curse;AKH;401309
+Trespassing Souleater;NPH;134412
+Tresserhorn Sinks;CSP;96861
+Tresserhorn Skyknight;CSP;96931
+Trestle Troll;RTR;145155
+Treva, the Renewer;DDE;25590
+Treva, the Renewer;INV;25590
+Treva, the Renewer;PRM;120080
+Treva's Attendant;INV;25204
+Treva's Charm;DDE;28011
+Treva's Charm;PLS;28011
+Treva's Ruins;PLS;28012
+Treva's Ruins;TD0;28012
+Triad of Fates;THS;150813
+Trial of Ambition;AKH;400863
+Trial of Knowledge;AKH;400803
+Trial of Solidarity;AKH;400806
+Trial of Strength;AKH;400847
+Trial of Zeal;AKH;401328
+Trial;DIS;94333
+Triangle of War;VIS;2279
+Triangle of War;VMA;2279
+Triassic Egg;CH;697
+Triassic Egg;LEG;697
+Triassic Egg;ME4;697
+Tribal Flames;DDE;24198
+Tribal Flames;INV;24198
+Tribal Flames;MM2;148265
+Tribal Flames;MMA;148265
+Tribal Flames;TSB;24198
+Tribal Forcemage;LGN;47489
+Tribal Golem;ONS;43210
+Tribal Unity;ONS;43182
+Tribal Unity;PC1;43182
+Tribute to Hunger;ISD;138262
+Tribute to the Wild;CMD;137551
+Tribute to the Wild;VMA;137551
+Trickbind;TSP;97368
+Trickery Charm;ONS;42988
+Tricks of the Trade;M13;143925
+Tricks of the Trade;W17;143925
+Trickster Mage;NMS;21226
+Triclopean Sight;DPA;107630
+Triclopean Sight;LRW;107630
+Trigon of Corruption;SOM;131000
+Trigon of Infestation;SOM;130932
+Trigon of Mending;SOM;131150
+Trigon of Rage;SOM;130977
+Trigon of Thought;SOM;131009
+Trinisphere;DST;75150
+Trinisphere;MS2;400941
+Trinisphere;V09;75150
+Trinket Mage;5DN;77101
+Trinket Mage;DDF;77101
+Trinket Mage;SOM;131080
+Trinket Mage;TD2;131080
+Trip Noose;DDF;111688
+Trip Noose;SHM;111688
+Trip Wire;ME3;9062
+Trip Wire;PTK;9062
+Triplicate Spirits;M15;155309
+Triskaidekaphobia;SOI;161485
+Triskelavite;TOK;98948
+Triskelavus;CMD;97462
+Triskelavus;TSP;97462
+Triskelion;4ED;459
+Triskelion;ATQ;459
+Triskelion;DDF;51030
+Triskelion;DPA;51030
+Triskelion;M11;51030
+Triskelion;MRD;51030
+Triton Cavalry;JOU;152928
+Triton Fortune Hunter;THS;149194
+Triton Shorestalker;JOU;152810
+Triton Shorethief;THS;149045
+Triton Tactics;THS;149195
+Triumph of Cruelty;AVR;141834
+Triumph of Cruelty;DPA;141834
+Triumph of Ferocity;AVR;142210
+Triumph of Ferocity;PRM;155980
+Triumph of the Hordes;NPH;137164
+Triumph of the Hordes;TD2;137164
+Trokin High Guard;PO2;4575
+Troll Ascetic;10E;51143
+Troll Ascetic;CMD;51143
+Troll Ascetic;DDL;51143
+Troll Ascetic;DPA;51143
+Troll Ascetic;MRD;51143
+Troll-Horn Cameo;INV;25218
+Trollhide;M12;134118
+Trollhide;M14;134118
+Trolls of Tel-Jilad;MRD;50254
+Tromokratis;BNG;152092
+Tromokratis;PRM;152561
+Tromp the Domains;MMA;97478
+Tromp the Domains;TSP;97478
+Trophy Hunter;DPA;89148
+Trophy Hunter;RAV;89148
+Trophy Mage;AER;400267
+Trophy Mage;PRM;401975
+Tropical Island;2ED;257
+Tropical Island;3ED;257
+Tropical Island;LEA;257
+Tropical Island;LEB;257
+Tropical Island;ME3;257
+Tropical Island;ME4;257
+Tropical Island;PRM;144411
+Tropical Island;VMA;144411
+Tropical Storm;MIR;2094
+Trostani, Selesnya's Voice;RTR;145264
+Trostani's Judgment;RTR;145845
+Trostani's Summoner;DGM;146666
+Trostani's Summoner;PRM;148804
+Trouble;DGM;151005
+Troubled Healer;PCY;21969
+Troublesome Spirit;PCY;22053
+Trove of Temptation;XLN;402359
+Truce;5ED;2498
+Truce;HML;1574
+True Believer;10E;42960
+True Believer;ONS;42960
+True Conviction;C14;131058
+True Conviction;SOM;131058
+True-Faith Censer;SOI;161457
+True-Name Nemesis;C13;151726
+True-Name Nemesis;PZ1;151726
+Truefire Paladin;DDL;146581
+Truefire Paladin;GTC;146581
+Trueheart Duelist;AKH;400913
+Trueheart Duelist;PRM;401360
+Trueheart Duelist;TOK;401245
+Trueheart Twins;AKH;401327
+Truga Jungle;PC2;138737
+Trumpet Blast;KTK;157037
+Trumpet Blast;M10;15646
+Trumpet Blast;M13;15646
+Trumpet Blast;UD;15646
+Trumpeting Armodon;TMP;3231
+Trusted Advisor;SOK;86176
+Trusted Forcemage;AVR;141609
+Trusty Companion;KLD;162461
+Trusty Machete;DPA;123739
+Trusty Machete;ZEN;123739
+Truth or Tale;TSP;97533
+Trygon Predator;DIS;94315
+Trygon Predator;EMA;148267
+Trygon Predator;MMA;148267
+Tsabo Tavoc;INV;25801
+Tsabo's Assassin;INV;24173
+Tsabo's Decree;INV;25659
+Tsabo's Web;INV;25484
+Tsunami;2ED;258
+Tsunami;3ED;258
+Tsunami;4ED;258
+Tsunami;5ED;258
+Tsunami;LEA;258
+Tsunami;LEB;258
+Tsunami;ME4;258
+Tukatongue Thallid;CON;118766
+Tukatongue Thallid;DPA;118766
+Tukatongue Thallid;MM2;118766
+Tukatongue Thallid;PC2;118766
+Tuknir Deathlock;LEG;2560
+Tuknir Deathlock;ME3;2560
+Tuktuk Grunts;ZEN;123686
+Tuktuk Scrapper;WWK;126574
+Tuktuk the Explorer;C14;127437
+Tuktuk the Explorer;ROE;127437
+Tuktuk the Returned;TOK;128389
+Tumble Magnet;MM2;131122
+Tumble Magnet;SOM;131122
+Tumble;C13;104386
+Tumble;PLC;104386
+Tundra Kavu;APC;31157
+Tundra Wolves;10E;49224
+Tundra Wolves;4ED;698
+Tundra Wolves;5ED;698
+Tundra Wolves;6ED;698
+Tundra Wolves;8ED;49224
+Tundra Wolves;DPA;49224
+Tundra Wolves;LEG;698
+Tundra;2ED;259
+Tundra;3ED;259
+Tundra;LEA;259
+Tundra;LEB;259
+Tundra;ME2;259
+Tundra;ME4;259
+Tundra;PRM;144413
+Tundra;VMA;144413
+Tunnel Ignus;SOM;131031
+Tunnel Vision;RAV;89063
+Tunnel;2ED;260
+Tunnel;3ED;260
+Tunnel;4ED;260
+Tunnel;LEA;260
+Tunnel;LEB;260
+Tunneler Wurm;JUD;40280
+Tunneling Geopede;BFZ;160688
+Turbulent Dreams;TOR;36426
+Turf Wound;INV;24145
+Turn Against;BFZ;160839
+Turn Aside;EMN;162069
+Turn Aside;SOM;130948
+Turn the Tables;DPA;52042
+Turn the Tables;DST;52042
+Turn the Tide;DPA;133202
+Turn the Tide;MBS;133202
+Turn the Tide;TD2;133202
+Turn to Dust;MRD;51090
+Turn to Frog;C14;115108
+Turn to Frog;M12;115108
+Turn to Frog;M15;115108
+Turn to Frog;ORI;115108
+Turn to Mist;SHM;111863
+Turn to Slag;M13;131112
+Turn to Slag;SOM;131112
+Turn;DGM;147718
+Turnabout;USG;8780
+Turnabout;VMA;151976
+Turntimber Basilisk;ZEN;123581
+Turntimber Grove;ZEN;123531
+Turntimber Ranger;ZEN;123528
+Turri Island;PC1;125880
+Turtleshell Changeling;LRW;106361
+Tusked Colossodon;KTK;156522
+Tuskguard Captain;KTK;157057
+Twiddle;2ED;261
+Twiddle;4ED;261
+Twiddle;5ED;261
+Twiddle;7ED;27843
+Twiddle;8ED;49229
+Twiddle;LEA;261
+Twiddle;LEB;261
+Twigwalker;ODY;33305
+Twilight Drover;DDK;90397
+Twilight Drover;RAV;90397
+Twilight Mire;EVE;113673
+Twilight Mire;EXP;161149
+Twilight Mire;PRM;152618
+Twilight Shepherd;C14;111721
+Twilight Shepherd;DDC;111721
+Twilight Shepherd;SHM;111721
+Twilight's Call;DDJ;24174
+Twilight's Call;INV;24174
+Twin Bolt;DTK;160071
+Twin;TOK;77067
+Twinblade Slasher;EVE;113683
+Twincast;10E;86113
+Twincast;M10;86113
+Twincast;SOK;86113
+Twinflame;JOU;153077
+Twinning Glass;LRW;105623
+Twins of Maurer Estate;SOI;161650
+Twinstrike;DIS;94317
+Twist Allegiance;BOK;83815
+Twisted Abomination;DDD;48133
+Twisted Abomination;EMA;48133
+Twisted Abomination;PD3;48133
+Twisted Abomination;SCG;48133
+Twisted Abomination;TD0;48133
+Twisted Abomination;TSB;48133
+Twisted Experiment;UD;15723
+Twisted Image;SOM;131051
+Twisted Justice;RAV;89093
+Twitch;10E;3044
+Twitch;TMP;3044
+Twitch;TPR;3044
+Twitch;WWK;126460
+Two-Headed Cerberus;THS;149063
+Two-Headed Dragon;8ED;19321
+Two-Headed Dragon;DRB;51606
+Two-Headed Dragon;MMQ;19321
+Two-Headed Dragon;PRM;19321
+Two-Headed Giant of Foriys;2ED;262
+Two-Headed Giant of Foriys;LEA;262
+Two-Headed Giant of Foriys;LEB;262
+Two-Headed Giant of Foriys;ME4;262
+Two-Headed Giant of Foriys;PRM;262
+Two-Headed Sliver;TSP;97303
+Tymaret, the Murder King;THS;150823
+Tymna the Weaver;PZ2;162390
+Typhoid Rats;DPA;139426
+Typhoid Rats;FRF;157321
+Typhoid Rats;ISD;139426
+Typhoid Rats;M15;139426
+Typhoon;LEG;2561
+Tyrannize;SHM;111662
+Tyrant of Discord;AVR;141818
+Tyrant of Valakut;OGW;161236
+Tyrant of Valakut;PRM;161049
+Tyrant's Choice;VMA;153153
+Tyrant's Familiar;C14;155606
+Tyrant's Machine;M15;155370
+Tyrranax;5DN;77110
+Uba Mask;COK;80735
+Ubul Sar Gatekeepers;DGM;147777
+Ugin, the Spirit Dragon;FRF;157170
+Ugin, the Spirit Dragon;PRM;159388
+Ugin's Construct;FRF;157320
+Ugin's Construct;PRM;159387
+Ugin's Insight;BFZ;160654
+Ugin's Nexus;KTK;157092
+Uktabi Drake;PLC;101525
+Uktabi Efreet;WTH;2803
+Uktabi Faerie;MIR;2095
+Uktabi Orangutan;6ED;2280
+Uktabi Orangutan;PRM;2280
+Uktabi Orangutan;VIS;2280
+Uktabi Wildcats;6ED;2096
+Uktabi Wildcats;7ED;27845
+Uktabi Wildcats;MIR;2096
+Ukud Cobra;DTK;160098
+Ulamog, the Ceaseless Hunger;BFZ;160614
+Ulamog, the Infinite Gyre;DPA;127417
+Ulamog, the Infinite Gyre;MM2;127417
+Ulamog, the Infinite Gyre;ROE;127417
+Ulamog, the Infinite Gyre;V11;127417
+Ulamog's Crusher;DPA;127416
+Ulamog's Crusher;MM2;127416
+Ulamog's Crusher;ROE;127416
+Ulamog's Despoiler;BFZ;160613
+Ulamog's Nullifier;BFZ;160871
+Ulamog's Reclaimer;BFZ;160913
+Ulasht, the Hate Seed;GPT;91822
+Ulcerate;M15;155210
+Ulrich of the Krallenhorde;EMN;162014
+Ulrich, Uncontested Alpha;EMN;162015
+Ulrich's Kindred;SOI;161750
+Ultimate Price;DTK;160170
+Ultimate Price;PRM;160863
+Ultimate Price;RTR;145862
+Ulvenwald Abomination;EMN;162131
+Ulvenwald Bear;DKA;139765
+Ulvenwald Captive;EMN;162133
+Ulvenwald Hydra;SOI;161398
+Ulvenwald Mysteries;SOI;161710
+Ulvenwald Mystics;ISD;138191
+Ulvenwald Observer;EMN;162127
+Ulvenwald Observer;PRM;162006
+Ulvenwald Primordials;ISD;138194
+Ulvenwald Tracker;AVR;141695
+Ulvenwald Tracker;DPA;141695
+Ulvenwald Tracker;MM3;141695
+Umara Entangler;OGW;161113
+Umara Raptor;ZEN;123603
+Umbilicus;USG;8855
+Umbra Mystic;ROE;127251
+Umbra Stalker;EVE;113727
+Umbral Mantle;SHM;111757
+Umezawa's Jitte;BOK;80766
+Umezawa's Jitte;PRM;125909
+Umezawa's Jitte;TD0;80766
+Umezawa's Jitte;V16;80766
+Unbender Tine;ARB;88990
+Unblinking Bleb;FUT;102383
+Unbreathing Horde;ISD;138346
+Unbridled Growth;AER;400340
+Unburden;AKH;400749
+Unburden;SCG;48100
+Unburial Rites;ISD;138277
+Unburial Rites;MM3;138277
+Uncage the Menagerie;HOU;401832
+Uncaged Fury;SOI;161616
+Uncanny Speed;AVR;141642
+Unchecked Growth;BOK;83970
+Unclaimed Territory;XLN;402017
+Uncle Istvan;4ED;842
+Uncle Istvan;DRK;842
+Uncle Istvan;TSB;842
+Uncontrollable Anger;10E;107655
+Uncontrollable Anger;COK;80596
+Uncontrolled Infestation;SCG;48998
+Unconventional Tactics;HOU;401774
+Uncovered Clues;DGM;147776
+Undead Alchemist;ISD;138446
+Undead Executioner;AVR;141712
+Undead Gladiator;ONS;43078
+Undead Leotau;ALA;115233
+Undead Minotaur;M14;147412
+Undead Servant;ORI;160271
+Undead Slayer;M10;121646
+Undead Warchief;PC1;48121
+Undead Warchief;SCG;48121
+Undead Warchief;TSB;48121
+Undercity Informer;GTC;146376
+Undercity Plague;GTC;147246
+Undercity Reaches;PC1;125904
+Undercity Shade;RAV;88992
+Undercity Troll;ORI;160327
+Underground River;10E;27846
+Underground River;5ED;2499
+Underground River;6ED;2499
+Underground River;7ED;27846
+Underground River;9ED;27846
+Underground River;ICE;1409
+Underground Sea;2ED;263
+Underground Sea;3ED;263
+Underground Sea;LEA;263
+Underground Sea;LEB;263
+Underground Sea;ME2;263
+Underground Sea;ME4;263
+Underground Sea;PRM;144417
+Underground Sea;VMA;144417
+Undergrowth Champion;BFZ;160888
+Undergrowth Scavenger;M15;156851
+Undergrowth;ALL;1759
+Undergrowth;ALL;1760
+Underhanded Designs;KLD;162500
+Undermine;DDH;25213
+Undermine;DPA;25213
+Undermine;INV;25213
+Undertaker;MMQ;20093
+Undertaker;TSB;20093
+Undertow;LEG;699
+Underworld Cerberus;THS;149216
+Underworld Coinsmith;JOU;152937
+Underworld Connections;DDM;145944
+Underworld Connections;RTR;145944
+Underworld Dreams;10E;49241
+Underworld Dreams;8ED;49241
+Underworld Dreams;9ED;49241
+Underworld Dreams;DPA;49241
+Underworld Dreams;LEG;700
+Underworld Dreams;M10;49241
+Underworld Dreams;PRM;700
+Undiscovered Paradise;PRM;400637
+Undiscovered Paradise;VIS;2281
+Undo;PO2;4697
+Undo;VIS;2282
+Undying Beast;POR;6598
+Undying Evil;DKA;139871
+Undying Flames;SOK;86158
+Undying Rage;DDL;96923
+Undying Rage;EMA;96923
+Undying Rage;TSP;96923
+Unearth;UL;10370
+Unearthly Blizzard;COK;80635
+Unerring Sling;MIR;2097
+Unesh, Criosphinx Sovereign;HOU;401540
+Unexpected Results;GTC;146392
+Unexpectedly Absent;C13;151713
+Unexpectedly Absent;EMA;151713
+Unflinching Courage;DGM;147739
+Unflinching Courage;MM3;147739
+Unforge;DST;75218
+Unfriendly Fire;XLN;402370
+Unfulfilled Desires;MIR;2098
+Unhallowed Cathar;DKA;139767
+Unhallowed Pact;AVR;141519
+Unhinge;TOR;36471
+Unholy Citadel;LEG;701
+Unholy Fiend;ISD;138178
+Unholy Grotto;ONS;43226
+Unholy Hunger;ORI;160248
+Unholy Strength;10E;104535
+Unholy Strength;2ED;264
+Unholy Strength;3ED;264
+Unholy Strength;4ED;264
+Unholy Strength;5ED;2500
+Unholy Strength;7ED;27847
+Unholy Strength;8ED;49267
+Unholy Strength;9ED;49267
+Unholy Strength;DDC;104535
+Unholy Strength;DPA;104535
+Unholy Strength;LEA;264
+Unholy Strength;LEB;264
+Unholy Strength;M10;104535
+Unholy Strength;M11;104535
+Unified Front;BFZ;160920
+Unified Strike;ONS;42938
+Unified Will;ROE;127278
+Unifying Theory;ODY;33453
+Unimpeded Trespasser;SOI;161496
+Uninvited Geist;SOI;161381
+Unity of Purpose;OGW;161812
+Universal Solvent;AER;400383
+Unknown Shores;OGW;161079
+Unknown Shores;THS;149962
+Unknown Shores;XLN;402016
+Unlicensed Disintegration;KLD;162558
+Unlicensed Disintegration;PRM;401442
+Unlikely Alliance;ALL;1761
+Unliving Psychopath;DIS;94510
+Unmake the Graves;M15;155212
+Unmake;DDK;113613
+Unmake;DPA;113613
+Unmake;EVE;113613
+Unmake;PRM;117980
+Unmask;MMQ;19242
+Unmask;V16;19242
+Unnatural Aggression;BFZ;161050
+Unnatural Endurance;OGW;161228
+Unnatural Hunger;MMQ;19186
+Unnatural Predation;MBS;133166
+Unnatural Selection;APC;31126
+Unnatural Speed;COK;80851
+Unnerve;CMD;8828
+Unnerve;USG;8828
+Unnerving Assault;EVE;113738
+Unquenchable Thirst;HOU;401523
+Unquestioned Authority;JUD;40184
+Unravel the Aether;BNG;152083
+Unraveling Mummy;HOU;401525
+Unruly Mob;DPA;138137
+Unruly Mob;ISD;138137
+Unruly Mob;SOI;138137
+Unscythe, Killer of Kings;ARB;121075
+Unseen Walker;6ED;2099
+Unseen Walker;MIR;2099
+Unspeakable Symbol;SCG;48989
+Unstable Footing;ZEN;123714
+Unstable Frontier;CON;118649
+Unstable Hulk;LGN;47516
+Unstable Mutation;3ED;376
+Unstable Mutation;4ED;376
+Unstable Mutation;5ED;2501
+Unstable Mutation;ARN;376
+Unstable Mutation;TSB;376
+Unstable Obelisk;C14;155593
+Unstable Shapeshifter;TMP;3165
+Unstoppable Ash;MOR;109973
+Unsubstantiate;EMN;161944
+Unsubstantiate;PRM;162052
+Unsummon;10E;27848
+Unsummon;2ED;265
+Unsummon;3ED;265
+Unsummon;4ED;265
+Unsummon;5ED;265
+Unsummon;6ED;265
+Unsummon;7ED;27848
+Unsummon;8ED;27848
+Unsummon;CON;118680
+Unsummon;DPA;27848
+Unsummon;HOU;401494
+Unsummon;LEA;265
+Unsummon;LEB;265
+Unsummon;M10;118680
+Unsummon;M11;118680
+Unsummon;M12;118680
+Unsummon;M13;118680
+Untaidake, the Cloud Keeper;COK;81104
+Untamed Hunger;OGW;161231
+Untamed Hunger;W17;161231
+Untamed Might;SOM;130909
+Untamed Wilds;4ED;702
+Untamed Wilds;5ED;702
+Untamed Wilds;6ED;702
+Untamed Wilds;7ED;27862
+Untamed Wilds;LEG;702
+Untamed Wilds;PO2;4779
+Untamed Wilds;POR;7013
+Untethered Express;AER;400394
+Unwavering Initiate;AKH;400815
+Unwavering Initiate;TOK;400954
+Unwilling Recruit;EVE;113713
+Unwinding Clock;NPH;134326
+Unworthy Dead;USG;8681
+Unyaro Bee Sting;MIR;2100
+Unyaro Bees;TSP;97439
+Unyaro Griffin;6ED;2101
+Unyaro Griffin;MIR;2101
+Unyielding Krumar;KTK;156496
+Updraft Elemental;DTK;159857
+Updraft;5ED;2502
+Updraft;ICE;1410
+Upheaval;ODY;33429
+Upheaval;V14;33429
+Upheaval;VMA;33429
+Uphill Battle;MMQ;19298
+Uproot;BOK;83907
+Upwelling;10E;104544
+Upwelling;SCG;48958
+Ur-Drago;LEG;2562
+Ur-Golem's Eye;9ED;52045
+Ur-Golem's Eye;C14;52045
+Ur-Golem's Eye;DST;52045
+Urabrask the Hidden;NPH;134227
+Urami;TOK;87233
+Urban Burgeoning;RTR;145877
+Urban Evolution;GTC;146265
+Urban Evolution;MM3;146265
+Urbis Protector;GTC;146337
+Urbis Protector;MM3;400730
+Urborg Drake;INV;25665
+Urborg Elf;APC;31158
+Urborg Emissary;INV;25149
+Urborg Justice;WTH;2868
+Urborg Mindsucker;VIS;2283
+Urborg Panther;MIR;2102
+Urborg Phantom;INV;24091
+Urborg Shambler;INV;24180
+Urborg Skeleton;INV;24019
+Urborg Stalker;WTH;2864
+Urborg Syphon-Mage;DDD;97283
+Urborg Syphon-Mage;TSP;97283
+Urborg Uprising;APC;31160
+Urborg Uprising;EMA;31160
+Urborg Uprising;VMA;31160
+Urborg Volcano;8ED;25214
+Urborg Volcano;INV;25214
+Urborg, Tomb of Yawgmoth;M15;101389
+Urborg, Tomb of Yawgmoth;PLC;101389
+Urborg, Tomb of Yawgmoth;V12;101389
+Urborg;LEG;703
+Urborg;ME3;703
+Urge to Feed;DDK;126499
+Urge to Feed;DPA;126499
+Urge to Feed;WWK;126499
+Urgent Exorcism;ISD;138263
+Uril, the Miststalker;ARB;121069
+Ursapine;RAV;89020
+Ursine Fylgja;CSP;96886
+Urza's Armor;8ED;8845
+Urza's Armor;USG;8845
+Urza's Avenger;4ED;460
+Urza's Avenger;5ED;460
+Urza's Avenger;ATQ;460
+Urza's Bauble;5ED;1411
+Urza's Bauble;ICE;1411
+Urza's Bauble;MED;1411
+Urza's Blueprints;UL;13564
+Urza's Chalice;ATQ;461
+Urza's Chalice;ME4;461
+Urza's Chalice;MED;461
+Urza's Engine;ALL;1762
+Urza's Factory;C13;97467
+Urza's Factory;PRM;97467
+Urza's Factory;TSP;97467
+Urza's Filter;INV;25165
+Urza's Guilt;PLS;27983
+Urza's Incubator;UD;16333
+Urza's Mine;5ED;462
+Urza's Mine;8ED;49255
+Urza's Mine;9ED;86936
+Urza's Mine;ATQ;462
+Urza's Mine;ATQ;463
+Urza's Mine;ATQ;464
+Urza's Mine;ATQ;465
+Urza's Mine;CH;462
+Urza's Mine;CH;463
+Urza's Mine;CH;464
+Urza's Mine;CH;465
+Urza's Mine;ME4;462
+Urza's Mine;ME4;463
+Urza's Mine;ME4;464
+Urza's Mine;ME4;465
+Urza's Miter;ATQ;466
+Urza's Miter;ME4;466
+Urza's Power Plant;5ED;468
+Urza's Power Plant;8ED;49259
+Urza's Power Plant;9ED;49259
+Urza's Power Plant;ATQ;467
+Urza's Power Plant;ATQ;468
+Urza's Power Plant;ATQ;469
+Urza's Power Plant;ATQ;470
+Urza's Power Plant;CH;467
+Urza's Power Plant;CH;468
+Urza's Power Plant;CH;469
+Urza's Power Plant;CH;470
+Urza's Power Plant;ME4;467
+Urza's Power Plant;ME4;468
+Urza's Power Plant;ME4;469
+Urza's Power Plant;ME4;470
+Urza's Rage;DDE;127994
+Urza's Rage;INV;24023
+Urza's Tower;5ED;471
+Urza's Tower;8ED;49258
+Urza's Tower;9ED;49258
+Urza's Tower;ATQ;471
+Urza's Tower;ATQ;472
+Urza's Tower;ATQ;473
+Urza's Tower;ATQ;474
+Urza's Tower;CH;471
+Urza's Tower;CH;472
+Urza's Tower;CH;473
+Urza's Tower;CH;474
+Urza's Tower;ME4;471
+Urza's Tower;ME4;472
+Urza's Tower;ME4;473
+Urza's Tower;ME4;474
+Uthden Troll;2ED;266
+Uthden Troll;3ED;266
+Uthden Troll;4ED;266
+Uthden Troll;LEA;266
+Uthden Troll;LEB;266
+Uthden Troll;TSB;266
+Utopia Mycon;FUT;102396
+Utopia Sprawl;DIS;94624
+Utopia Tree;9ED;25654
+Utopia Tree;INV;25654
+Utopia Vow;PLC;101388
+Utter End;KTK;156603
+Utter End;PRM;157111
+Utvara Hellkite;RTR;145978
+Utvara Scalper;DIS;94349
+Uyo, Silent Prophet;C13;80913
+Uyo, Silent Prophet;COK;80913
+Vacuumelt;DDJ;91678
+Vacuumelt;GPT;91678
+Vaevictis Asmadi;CH;704
+Vaevictis Asmadi;LEG;704
+Vaevictis Asmadi;ME3;704
+Vagrant Plowbeasts;CON;118679
+Valakut Fireboar;ROE;102625
+Valakut Invoker;BFZ;160825
+Valakut Predator;BFZ;160686
+Valakut, the Molten Pinnacle;PRM;125910
+Valakut, the Molten Pinnacle;ZEN;123679
+Valeron Outlander;CON;118774
+Valeron Wardens;ORI;160312
+Valiant Guard;CON;118757
+Valiant Guard;DPA;118757
+Valley Dasher;KTK;156505
+Valley Rannet;ARB;114914
+Valley Rannet;C13;114914
+Valley Rannet;CMD;114914
+Valley Rannet;DDL;114914
+Valley Rannet;DPA;114914
+Valleymaker;SHM;111888
+Valor Made Real;DIS;94491
+Valor in Akros;ORI;160207
+Valor;JUD;40175
+Valor;TSB;40175
+Valorous Charge;POR;6757
+Valorous Stance;FRF;157323
+Valorous Stance;PRM;160398
+Vampire Aristocrat;DPA;121635
+Vampire Aristocrat;M10;121635
+Vampire Aristocrat;MM3;121635
+Vampire Bats;10E;102961
+Vampire Bats;4ED;705
+Vampire Bats;5ED;705
+Vampire Bats;DDD;102961
+Vampire Bats;LEG;705
+Vampire Cutthroat;EMN;162093
+Vampire Envoy;OGW;161084
+Vampire Hexmage;C14;123736
+Vampire Hexmage;ZEN;123736
+Vampire Hounds;EXO;5650
+Vampire Hounds;TPR;5650
+Vampire Interloper;ISD;138241
+Vampire Knight;TOK;161727
+Vampire Lacerator;DDK;123729
+Vampire Lacerator;DPA;123729
+Vampire Lacerator;MM2;123729
+Vampire Lacerator;ZEN;123729
+Vampire Nighthawk;C13;123633
+Vampire Nighthawk;CMD;123633
+Vampire Nighthawk;DDK;123633
+Vampire Nighthawk;DPA;123633
+Vampire Nighthawk;M13;123633
+Vampire Nighthawk;MM3;123633
+Vampire Nighthawk;PRM;125912
+Vampire Nighthawk;ZEN;123633
+Vampire Noble;SOI;161493
+Vampire Nocturnus;DPA;122180
+Vampire Nocturnus;M10;122180
+Vampire Nocturnus;M13;122180
+Vampire Nocturnus;PRM;121684
+Vampire Outcasts;DDK;134093
+Vampire Outcasts;DPA;134093
+Vampire Outcasts;M12;134093
+Vampire Outcasts;MM2;134093
+Vampire Warlord;M14;147415
+Vampire;TOK;123779
+Vampire;TOK;139448
+Vampire;TOK;140322
+Vampire;TOK;156687
+Vampire;TOK;402421
+Vampire's Bite;DDK;123584
+Vampire's Bite;DPA;123584
+Vampire's Bite;ZEN;123584
+Vampire's Zeal;XLN;402248
+Vampiric Dragon;DPA;33263
+Vampiric Dragon;ODY;33263
+Vampiric Dragon;TD0;33263
+Vampiric Embrace;USG;8653
+Vampiric Feast;POR;6599
+Vampiric Fury;ISD;138508
+Vampiric Link;PLC;100677
+Vampiric Rites;BFZ;160869
+Vampiric Sliver;TSP;97524
+Vampiric Spirit;8ED;4729
+Vampiric Spirit;PO2;4729
+Vampiric Touch;POR;6600
+Vampiric Tutor;6ED;2284
+Vampiric Tutor;EMA;161309
+Vampiric Tutor;PRM;2284
+Vampiric Tutor;VIS;2284
+Vampiric Tutor;VMA;2284
+Vampirism;VIS;2285
+Vance's Blasting Cannons;XLN;402447
+Vandalblast;RTR;145177
+Vandalize;DTK;159698
+Vanguard of Brimaz;BNG;152533
+Vanguard's Shield;AVR;141738
+Vanish into Memory;CSP;91402
+Vanish into Memory;DDI;91402
+Vanish into Memory;MM3;91402
+Vanishing;VIS;2286
+Vanishment;AVR;141671
+Vanquish the Foul;THS;149193
+Vanquish the Weak;XLN;402005
+Vanquish;5DN;51506
+Vanquisher's Banner;XLN;402286
+Vapor Snag;DDH;134278
+Vapor Snag;MM2;134278
+Vapor Snag;NPH;134278
+Vapor Snare;WWK;126587
+Vaporkin;THS;150838
+Vaporous Djinn;MIR;2103
+Varchild's Crusader;ALL;1763
+Varchild's Crusader;ALL;1764
+Varchild's Crusader;ME2;1763
+Varchild's War-Riders;ALL;1765
+Varchild's War-Riders;MED;1765
+Varolz, the Scar-Striped;DGM;146795
+Vassal Soul;RTR;145148
+Vassal's Duty;COK;81085
+Vastwood Animist;WWK;126500
+Vastwood Gorger;M12;123605
+Vastwood Gorger;M13;123605
+Vastwood Gorger;ORI;123605
+Vastwood Gorger;ZEN;123605
+Vastwood Hydra;DPA;147398
+Vastwood Hydra;M14;147398
+Vastwood Zendikon;WWK;126507
+Vault Skirge;NPH;134246
+Vault Skirge;PRM;136789
+Vault Skyward;SOM;130939
+Vault of Whispers;MRD;51008
+Vault of Whispers;PC1;51008
+Vault of the Archangel;DKA;140333
+Vaultbreaker;FRF;157194
+Vebulid;USG;8905
+Vec Townships;TMP;3253
+Vec Townships;TPR;3253
+Vectis Agents;CON;118754
+Vectis Dominator;ARB;120986
+Vectis Silencers;ALA;115204
+Vector Asp;SOM;130877
+Vedalken Aethermage;FUT;102373
+Vedalken Anatomist;MBS;133261
+Vedalken Archmage;MRD;50261
+Vedalken Blademaster;KLD;162254
+Vedalken Certarch;SOM;131055
+Vedalken Certarch;TD2;131055
+Vedalken Dismisser;DPA;88888
+Vedalken Dismisser;MMA;88888
+Vedalken Dismisser;RAV;88888
+Vedalken Engineer;DST;52033
+Vedalken Engineer;PC1;52033
+Vedalken Entrancer;DPA;88686
+Vedalken Entrancer;M13;88686
+Vedalken Entrancer;RAV;88686
+Vedalken Ghoul;ARB;121034
+Vedalken Heretic;ARB;121026
+Vedalken Infuser;MBS;131708
+Vedalken Mastermind;10E;77119
+Vedalken Mastermind;5DN;77119
+Vedalken Orrery;5DN;77086
+Vedalken Outlander;CON;118771
+Vedalken Plotter;CMD;91747
+Vedalken Plotter;GPT;91747
+Vedalken Shackles;5DN;77083
+Vedalken Shackles;MMA;145438
+Vedalken Shackles;MS2;400942
+Veil of Birds;USG;8782
+Veil of Secrecy;BOK;83888
+Veilborn Ghoul;DPA;143866
+Veilborn Ghoul;M13;143866
+Veiled Apparition;USG;8875
+Veiled Crocodile;USG;8841
+Veiled Sentry;USG;8724
+Veiled Serpent;USG;8717
+Veiling Oddity;PLC;100794
+Veilstone Amulet;FUT;102470
+Vein Drinker;ALA;115069
+Vein Drinker;DPA;115069
+Veinfire Borderpost;ARB;121064
+Vela the Night-Clad;PC2;140364
+Vela the Night-Clad;PZ1;140364
+Veldrane of Sengir;HML;1575
+Veldt;ICE;1412
+Velis Vel;PC1;125876
+Venarian Glimmer;PLC;97405
+Venarian Gold;LEG;706
+Vendetta;DPA;127424
+Vendetta;MMQ;19083
+Vendetta;ROE;127424
+Vendilion Clique;MM2;159681
+Vendilion Clique;MMA;105490
+Vendilion Clique;MOR;105490
+Vendilion Clique;PRM;134051
+Venerable Kumo;COK;80564
+Venerable Lammasu;KTK;156999
+Venerable Monk;10E;6758
+Venerable Monk;6ED;6758
+Venerable Monk;7ED;27850
+Venerable Monk;8ED;6758
+Venerable Monk;9ED;6758
+Venerable Monk;DDC;6758
+Venerable Monk;DPA;6758
+Venerable Monk;POR;6758
+Venerable Monk;STH;3791
+Venerated Teacher;ROE;127268
+Vengeance;7ED;27794
+Vengeance;8ED;27794
+Vengeance;9ED;27794
+Vengeance;PO2;4676
+Vengeance;POR;6759
+Vengeance;PTK;9129
+Vengeful Archon;M11;129192
+Vengeful Dead;SCG;48158
+Vengeful Dreams;TOR;36406
+Vengeful Firebrand;DPA;104084
+Vengeful Firebrand;MOR;104084
+Vengeful Pharaoh;M12;134112
+Vengeful Rebel;AER;400292
+Vengeful Rebirth;ARB;115104
+Vengeful Rebirth;CMD;115104
+Vengeful Rebirth;MM2;115104
+Vengeful Vampire;DKA;139848
+Vengeful Vampire;DPA;139848
+Vengevine;DPA;127350
+Vengevine;PRM;149981
+Vengevine;ROE;127350
+Venom Sliver;M15;155240
+Venom;4ED;843
+Venom;5ED;843
+Venom;DRK;843
+Venomous Breath;ICE;1413
+Venomous Breath;MMQ;19049
+Venomous Dragonfly;MMQ;18759
+Venomous Fangs;USG;8892
+Venomous Vines;JUD;40274
+Venomspout Brackus;ONS;43168
+Venser, Shaper Savant;FUT;102324
+Venser, Shaper Savant;MM3;148715
+Venser, Shaper Savant;V13;148715
+Venser, the Sojourner;DDI;140037
+Venser, the Sojourner;SOM;131130
+Venser's Diffusion;FUT;102486
+Venser's Journal;DPA;131188
+Venser's Journal;SOM;131188
+Venser's Sliver;TSP;99358
+Vent Sentinel;ROE;127294
+Ventifact Bottle;MIR;2104
+Verdant Automaton;AER;400376
+Verdant Catacombs;EXP;160784
+Verdant Catacombs;MM3;123743
+Verdant Catacombs;ZEN;123743
+Verdant Confluence;PZ1;160430
+Verdant Crescendo;KLD;162545
+Verdant Eidolon;DIS;94654
+Verdant Embrace;TSP;97367
+Verdant Field;PCY;22129
+Verdant Force;10E;3129
+Verdant Force;9ED;3129
+Verdant Force;DPA;3129
+Verdant Force;PC1;3129
+Verdant Force;PD3;3129
+Verdant Force;TMP;3129
+Verdant Force;TPR;3129
+Verdant Haven;GTC;146272
+Verdant Haven;M14;146272
+Verdant Haven;M15;146272
+Verdant Rebirth;XLN;402328
+Verdant Succession;ODY;33284
+Verdant Sun's Avatar;XLN;403130
+Verdant Touch;STH;3792
+Verdant Touch;TPR;3792
+Verdeloth the Ancient;DPA;24082
+Verdeloth the Ancient;INV;24082
+Verdeloth the Ancient;MMA;24082
+Verdeloth the Ancient;TSB;24082
+Verdigris;TMP;3237
+Verdigris;TPR;3237
+Verduran Emissary;DDE;25589
+Verduran Emissary;INV;25589
+Verduran Enchantress;2ED;267
+Verduran Enchantress;3ED;267
+Verduran Enchantress;4ED;267
+Verduran Enchantress;5ED;267
+Verduran Enchantress;6ED;267
+Verduran Enchantress;7ED;27851
+Verduran Enchantress;8ED;27851
+Verduran Enchantress;9ED;27851
+Verduran Enchantress;LEA;267
+Verduran Enchantress;LEB;267
+Verdurous Gearhulk;KLD;162551
+Verdurous Gearhulk;MS2;400603
+Vermiculos;MRD;51045
+Vernal Bloom;7ED;27852
+Vernal Bloom;8ED;8713
+Vernal Bloom;USG;8713
+Vernal Equinox;MMQ;19121
+Vertigo Spawn;GPT;91687
+Vertigo;6ED;1414
+Vertigo;ICE;1414
+Vesper Ghoul;DIS;94535
+Vessel of Endless Rest;AVR;141690
+Vessel of Ephemera;SOI;161762
+Vessel of Malignity;SOI;161720
+Vessel of Nascency;SOI;161690
+Vessel of Paramnesia;SOI;161702
+Vessel of Volatility;SOI;161693
+Vestige of Emrakul;BFZ;160679
+Vesuva;TSP;97429
+Vesuva;V12;97429
+Vesuvan Doppelganger;2ED;268
+Vesuvan Doppelganger;3ED;268
+Vesuvan Doppelganger;LEA;268
+Vesuvan Doppelganger;LEB;268
+Vesuvan Doppelganger;MED;268
+Vesuvan Shapeshifter;TSP;100945
+Veteran Armorer;MMA;148262
+Veteran Armorer;RAV;88939
+Veteran Armorsmith;DPA;121589
+Veteran Armorsmith;M10;121589
+Veteran Bodyguard;2ED;269
+Veteran Bodyguard;3ED;269
+Veteran Bodyguard;LEA;269
+Veteran Bodyguard;LEB;269
+Veteran Bodyguard;ME4;269
+Veteran Brawlers;PCY;22047
+Veteran Cathar;SOI;161615
+Veteran Cavalier;9ED;17559
+Veteran Explorer;CMD;2925
+Veteran Explorer;WTH;2925
+Veteran Motorist;KLD;162562
+Veteran Swordsmith;DPA;121613
+Veteran Swordsmith;M10;121613
+Veteran Warleader;BFZ;160717
+Veteran of the Depths;LRW;105432
+Veteran's Armaments;MOR;109990
+Veteran's Reflexes;DPA;126575
+Veteran's Reflexes;WWK;126575
+Veteran's Sidearm;ORI;160355
+Veteran's Voice;ALL;1766
+Veteran's Voice;ALL;1767
+Vex;DST;52044
+Vexing Arcanix;8ED;49261
+Vexing Arcanix;ICE;1415
+Vexing Beetle;LGN;46593
+Vexing Devil;AVR;142215
+Vexing Devil;DPA;142215
+Vexing Scuttler;EMN;162070
+Vexing Shusher;PRM;105357
+Vexing Shusher;SHM;105357
+Vexing Sphinx;CSP;97034
+Vhati il-Dal;TMP;3196
+Vhati il-Dal;TPR;3196
+Vhati il-Dal;TSB;3196
+Vial Smasher the Fierce;PZ2;162391
+Vial of Dragonfire;DTK;159772
+Vial of Poison;M14;147496
+Viashino Bey;UL;14054
+Viashino Bladescout;TSP;97395
+Viashino Cutthroat;UL;10338
+Viashino Fangtail;RAV;88963
+Viashino Firstblade;DGM;146867
+Viashino Grappler;INV;24163
+Viashino Heretic;UL;13558
+Viashino Outrider;USG;8672
+Viashino Racketeer;RTR;145135
+Viashino Runner;10E;8947
+Viashino Runner;USG;8947
+Viashino Sandscout;10E;10356
+Viashino Sandscout;UL;10356
+Viashino Sandstalker;8ED;2287
+Viashino Sandstalker;9ED;2287
+Viashino Sandstalker;VIS;2287
+Viashino Sandswimmer;USG;8933
+Viashino Shanktail;GTC;146397
+Viashino Skeleton;ALA;115131
+Viashino Slasher;RAV;88629
+Viashino Slaughtermaster;CON;118689
+Viashino Slaughtermaster;MM2;118689
+Viashino Spearhunter;M10;121660
+Viashino Warrior;6ED;2105
+Viashino Warrior;MIR;2105
+Viashino Weaponsmith;USG;8851
+Viashivan Dragon;VIS;2288
+Vibrating Sphere;ICE;1416
+Vibrating Sphere;ME4;1416
+Vicious Betrayal;5DN;77222
+Vicious Conquistador;XLN;402063
+Vicious Hunger;8ED;21209
+Vicious Hunger;DDD;21209
+Vicious Hunger;DPA;21209
+Vicious Hunger;NMS;21209
+Vicious Kavu;INV;24036
+Vicious Shadows;ALA;115101
+Vicious Shadows;DPA;115101
+Victim of Night;ISD;138103
+Victimize;C14;8815
+Victimize;EMA;153362
+Victimize;USG;8815
+Victorious Destruction;NPH;134353
+Victory;AKH;401047
+Victory's Herald;MBS;131681
+Victory's Herald;W17;131681
+Victual Sliver;H09;3731
+Victual Sliver;STH;3731
+Victual Sliver;TPR;3731
+View from Above;CON;118753
+Vigean Graftmage;DIS;94390
+Vigean Graftmage;MM2;94390
+Vigean Hydropon;DIS;94365
+Vigean Intuition;DIS;94323
+Vigil for the Lost;SOM;131018
+Vigilance;COK;80657
+Vigilant Drake;7ED;27853
+Vigilant Drake;UL;10405
+Vigilant Martyr;MIR;2106
+Vigilant Sentry;JUD;40162
+Vigilante Justice;AVR;141577
+Vigor Mortis;DDJ;89027
+Vigor Mortis;RAV;89027
+Vigor;DPA;105540
+Vigor;LRW;105540
+Vigorous Charge;INV;24126
+Vildin-Pack Alpha;SOI;161426
+Vildin-Pack Outcast;EMN;161978
+Vile Aggregate;BFZ;160685
+Vile Consumption;INV;24154
+Vile Deacon;LGN;47531
+Vile Manifestation;HOU;401522
+Vile Rebirth;M13;143939
+Vile Rebirth;M14;143939
+Vile Redeemer;OGW;161243
+Vile Requiem;C13;8679
+Vile Requiem;USG;8679
+Village Bell-Ringer;ISD;138230
+Village Cannibals;ISD;139427
+Village Elder;MIR;2107
+Village Ironsmith;ISD;138196
+Village Messenger;SOI;161492
+Village Survivors;DKA;139845
+Villagers of Estwald;ISD;138225
+Villainous Ogre;COK;82642
+Villainous Wealth;KTK;157085
+Vindicate;APC;31086
+Vindicate;DPA;100413
+Vindicate;EMA;148806
+Vindicate;MS3;401643
+Vindicate;PRM;100413
+Vindictive Mob;RAV;89043
+Vine Dryad;MMQ;19151
+Vine Kami;COK;80613
+Vine Snare;ORI;160318
+Vine Trellis;8ED;19045
+Vine Trellis;DDD;19045
+Vine Trellis;MMQ;19045
+Vinelasher Kudzu;DDM;88589
+Vinelasher Kudzu;RAV;88589
+Vines of Vastwood;MM2;123562
+Vines of Vastwood;ZEN;123562
+Vines of the Recluse;OGW;161250
+Vineshaper Mystic;XLN;402361
+Vineweft;M15;156674
+Vintara Elephant;PCY;21986
+Vintara Snapper;PCY;22061
+Violent Eruption;TOR;36493
+Violent Impact;AKH;400774
+Violent Outburst;ARB;121044
+Violent Ultimatum;ALA;115164
+Violent Ultimatum;DPA;115164
+Violet Pall;MOR;110219
+Viper's Kiss;THS;149057
+Viral Drake;NPH;134386
+Viridescent Wisps;SHM;111869
+Viridian Acolyte;DST;51761
+Viridian Betrayers;NPH;134238
+Viridian Claw;MBS;131684
+Viridian Claw;TD2;131684
+Viridian Corrupter;MBS;133160
+Viridian Corrupter;TD2;133160
+Viridian Emissary;DPA;133124
+Viridian Emissary;MBS;133124
+Viridian Emissary;PC2;133124
+Viridian Emissary;TD2;133124
+Viridian Harvest;NPH;134236
+Viridian Joiner;MRD;50252
+Viridian Longbow;MRD;50216
+Viridian Lorebearers;5DN;77107
+Viridian Revel;SOM;130940
+Viridian Scout;5DN;77226
+Viridian Shaman;10E;50255
+Viridian Shaman;9ED;50255
+Viridian Shaman;DPA;50255
+Viridian Shaman;MRD;50255
+Viridian Zealot;DST;51997
+Virtue's Ruin;POR;6601
+Virtue's Ruin;V14;6601
+Virtuous Charge;PTK;9099
+Virulent Plague;DTK;159817
+Virulent Sliver;FUT;102402
+Virulent Sliver;H09;102402
+Virulent Swipe;ROE;127471
+Virulent Wound;MBS;133165
+Visage of Bolas;HOU;401724
+Visara the Dreadful;EMA;43323
+Visara the Dreadful;ONS;43323
+Visara the Dreadful;V11;137607
+Visara the Dreadful;VMA;43323
+Viscera Dragger;ALA;115171
+Viscera Seer;C13;129165
+Viscera Seer;M11;129165
+Viscera Seer;PZ1;129165
+Viscerid Armor;ALL;1768
+Viscerid Armor;ALL;1769
+Viscerid Armor;ME2;1769
+Viscerid Deepwalker;TSP;97443
+Viscerid Drone;ALL;1770
+Viscerid Drone;ME2;1770
+Viscid Lemures;TSP;97399
+Viseling;C13;21282
+Viseling;NMS;21282
+Vish Kal, Blood Arbiter;CMD;137542
+Vision Charm;VIS;2289
+Vision Skeins;C13;94461
+Vision Skeins;CMD;94461
+Vision Skeins;DIS;94461
+Visionary Augmenter;KLD;162239
+Visions of Beyond;DPA;134129
+Visions of Beyond;M12;134129
+Visions of Brutality;OGW;161022
+Visions;4ED;707
+Visions;LEG;707
+Vital Splicer;MM3;134418
+Vital Splicer;NPH;134418
+Vital Surge;BOK;83931
+Vitality Charm;ONS;43165
+Vitalize;6ED;2810
+Vitalize;WTH;2810
+Vitalizing Cascade;MIR;2108
+Vitalizing Wind;PCY;22060
+Vitaspore Thallid;PLC;100806
+Vithian Renegades;ARB;120956
+Vithian Stinger;ALA;115011
+Vithian Stinger;DDK;115011
+Vithian Stinger;MM3;115011
+Vitu-Ghazi Guildmage;RTR;145181
+Vitu-Ghazi, the City-Tree;C13;89134
+Vitu-Ghazi, the City-Tree;DDH;89134
+Vitu-Ghazi, the City-Tree;PC2;89134
+Vitu-Ghazi, the City-Tree;RAV;89134
+Vivid Crag;C13;105591
+Vivid Crag;CMD;105591
+Vivid Crag;LRW;105591
+Vivid Crag;MMA;105591
+Vivid Creek;C13;105590
+Vivid Creek;CMD;105590
+Vivid Creek;H09;105590
+Vivid Creek;LRW;105590
+Vivid Creek;MMA;105590
+Vivid Creek;PC2;105590
+Vivid Grove;C13;105588
+Vivid Grove;CMD;105588
+Vivid Grove;H09;105588
+Vivid Grove;LRW;105588
+Vivid Grove;MMA;105588
+Vivid Marsh;C13;105589
+Vivid Marsh;CMD;105589
+Vivid Marsh;LRW;105589
+Vivid Marsh;MMA;105589
+Vivid Meadow;CMD;105592
+Vivid Meadow;LRW;105592
+Vivid Meadow;MMA;105592
+Vivify;ODY;33304
+Vivisection;MBS;133129
+Vizier of Deferment;AKH;400846
+Vizier of Many Faces;AKH;400812
+Vizier of Many Faces;TOK;400957
+Vizier of Remedies;AKH;401284
+Vizier of Tumbling Sands;AKH;400862
+Vizier of the Anointed;HOU;401556
+Vizier of the Menagerie;AKH;400872
+Vizier of the True;HOU;401551
+Vizkopa Confessor;GTC;146406
+Vizkopa Guildmage;C13;145194
+Vizkopa Guildmage;GTC;145194
+Vizzerdrix;7ED;31220
+Vizzerdrix;8ED;31220
+Vizzerdrix;9ED;31220
+Vodalian Hypnotist;INV;24181
+Vodalian Illusionist;WTH;2943
+Vodalian Knights;FEM;1029
+Vodalian Knights;MED;1029
+Vodalian Mage;FEM;1030
+Vodalian Mage;FEM;1031
+Vodalian Mage;FEM;1032
+Vodalian Merchant;INV;25661
+Vodalian Mystic;APC;31162
+Vodalian Serpent;INV;24186
+Vodalian Soldiers;5ED;1033
+Vodalian Soldiers;6ED;1033
+Vodalian Soldiers;FEM;1033
+Vodalian Soldiers;FEM;1034
+Vodalian Soldiers;FEM;1035
+Vodalian Soldiers;FEM;1036
+Vodalian War Machine;FEM;1037
+Vodalian Zombie;INV;24087
+Voice of All;10E;27956
+Voice of All;CMD;27956
+Voice of All;DPA;27956
+Voice of All;PLS;27956
+Voice of Duty;UD;15589
+Voice of Grace;USG;8819
+Voice of Law;USG;8956
+Voice of Reason;UD;15605
+Voice of Resurgence;DGM;146828
+Voice of Resurgence;MM3;146828
+Voice of Truth;NMS;21254
+Voice of the Provinces;AVR;141714
+Voice of the Provinces;DPA;141714
+Voice of the Woods;DPA;43201
+Voice of the Woods;EVG;43201
+Voice of the Woods;ONS;43201
+Voiceless Spirit;ISD;138482
+Voices from the Void;CON;115130
+Void Attendant;BFZ;160721
+Void Grafter;OGW;161046
+Void Maw;CSP;96865
+Void Shatter;OGW;161210
+Void Snare;M15;155196
+Void Squall;DTK;160113
+Void Stalker;M13;143931
+Void Winnower;BFZ;160864
+Void;EMA;161574
+Void;INV;25215
+Void;TSB;25215
+Voidmage Apprentice;DD2;46555
+Voidmage Apprentice;LGN;46555
+Voidmage Husher;TSP;97397
+Voidmage Prodigy;ONS;43018
+Voidmage Prodigy;PRM;50475
+Voidmage Prodigy;TSB;50475
+Voidslime;DIS;94299
+Voidslime;PRM;94299
+Voidstone Gargoyle;PLC;100765
+Voidwalk;GTC;146529
+Voidwielder;RTR;145851
+Voja;TOK;88654
+Volatile Rig;RTR;145973
+Volcanic Awakening;TSP;96942
+Volcanic Dragon;6ED;2109
+Volcanic Dragon;DPA;137512
+Volcanic Dragon;M12;137512
+Volcanic Dragon;MIR;2109
+Volcanic Dragon;POR;6720
+Volcanic Eruption;2ED;270
+Volcanic Eruption;3ED;270
+Volcanic Eruption;4ED;270
+Volcanic Eruption;LEA;270
+Volcanic Eruption;LEB;270
+Volcanic Fallout;CON;119790
+Volcanic Fallout;PRM;126732
+Volcanic Geyser;6ED;2110
+Volcanic Geyser;DPA;143959
+Volcanic Geyser;M13;143959
+Volcanic Geyser;M14;143959
+Volcanic Geyser;MIR;2110
+Volcanic Geyser;PRM;2110
+Volcanic Hammer;7ED;31244
+Volcanic Hammer;8ED;31244
+Volcanic Hammer;9ED;31244
+Volcanic Hammer;DPA;31244
+Volcanic Hammer;PO2;4746
+Volcanic Hammer;POR;6721
+Volcanic Hammer;PRM;6721
+Volcanic Island;2ED;302
+Volcanic Island;3ED;302
+Volcanic Island;LEB;302
+Volcanic Island;ME3;302
+Volcanic Island;ME4;302
+Volcanic Island;PRM;144425
+Volcanic Island;VMA;144425
+Volcanic Offering;C14;156026
+Volcanic Rambler;ORI;160304
+Volcanic Rush;DTK;160050
+Volcanic Spray;ODY;33375
+Volcanic Strength;DPA;129170
+Volcanic Strength;M11;129170
+Volcanic Strength;M13;129170
+Volcanic Submersion;ALA;114993
+Volcanic Upheaval;BFZ;160843
+Volcanic Vision;DTK;160145
+Volcanic Wind;MMQ;19125
+Volcano Hellion;PLC;100784
+Volcano Imp;PLS;27913
+Voldaren Duelist;SOI;161639
+Voldaren Pariah;EMN;162095
+Volition Reins;SOM;131062
+Volley of Boulders;DDI;33341
+Volley of Boulders;ODY;33341
+Volrath the Fallen;NMS;21281
+Volrath's Curse;TMP;3048
+Volrath's Curse;TPR;3048
+Volrath's Dungeon;EXO;5607
+Volrath's Gardens;STH;3793
+Volrath's Laboratory;STH;3794
+Volrath's Laboratory;TOK;125144
+Volrath's Laboratory;TPR;3794
+Volrath's Shapeshifter;STH;3795
+Volrath's Shapeshifter;VMA;3795
+Volrath's Stronghold;STH;3796
+Volrath's Stronghold;TPR;3796
+Volt Charge;DDL;134230
+Volt Charge;NPH;134230
+Voltaic Brawler;KLD;162317
+Voltaic Construct;DST;51757
+Voltaic Key;DDE;127997
+Voltaic Key;M11;127997
+Voltaic Key;USG;8772
+Volunteer Militia;PO2;4657
+Volunteer Militia;PTK;4657
+Volunteer Reserves;WTH;2953
+Vona, Butcher of Magan;XLN;402067
+Voodoo Doll;CH;708
+Voodoo Doll;LEG;708
+Voodoo Doll;ME3;708
+Voracious Cobra;INV;25159
+Voracious Dragon;CON;118782
+Voracious Dragon;DDG;118782
+Voracious Dragon;DPA;118782
+Voracious Hatchling;EVE;113688
+Voracious Null;BFZ;160659
+Voracious Reader;EMN;162072
+Voracious Wurm;M14;147467
+Vorapede;DKA;139886
+Vorel of the Hull Clade;DGM;146787
+Vorinclex, Voice of Hunger;NPH;134264
+Vorosh, the Hunter;CMD;100726
+Vorosh, the Hunter;PLC;100726
+Vorrac Battlehorns;MRD;51004
+Vorstclaw;AVR;142207
+Vortex Elemental;BNG;152062
+Votary of the Conclave;RAV;88937
+Vow of Duty;CMD;137549
+Vow of Duty;PZ1;137549
+Vow of Flight;CMD;137558
+Vow of Flight;PZ1;137558
+Vow of Lightning;CMD;137552
+Vow of Lightning;PZ1;137552
+Vow of Malice;CMD;137559
+Vow of Malice;PZ1;137559
+Vow of Wildness;CMD;137555
+Vow of Wildness;PZ1;137555
+Voyage's End;THS;149050
+Voyager Drake;WWK;126461
+Voyager Staff;RAV;89032
+Voyaging Satyr;THS;149059
+Vraska the Unseen;DDM;153185
+Vraska the Unseen;RTR;145271
+Vraska, Relic Seeker;XLN;402082
+Vraska's Contempt;XLN;402035
+Vryn Wingmare;ORI;160204
+Vug Lizard;USG;8779
+Vulpine Goliath;THS;149071
+Vulshok Battlegear;DDI;51052
+Vulshok Battlegear;MRD;51052
+Vulshok Battlemaster;MRD;50293
+Vulshok Berserker;DDI;50184
+Vulshok Berserker;DPA;50184
+Vulshok Berserker;M11;50184
+Vulshok Berserker;MRD;50184
+Vulshok Gauntlets;MRD;50306
+Vulshok Heartstoker;DPA;130954
+Vulshok Heartstoker;SOM;130954
+Vulshok Morningstar;9ED;52047
+Vulshok Morningstar;DDI;52047
+Vulshok Morningstar;DST;52047
+Vulshok Refugee;NPH;134291
+Vulshok Replica;SOM;131074
+Vulshok Sorcerer;5DN;77161
+Vulshok Sorcerer;DDI;77161
+Vulshok Sorcerer;PD2;77161
+Vulshok War Boar;DST;50835
+Vulturous Aven;DTK;160126
+Vulturous Zombie;CMD;89123
+Vulturous Zombie;DPA;89123
+Vulturous Zombie;RAV;89123
+Wail of the Nim;MRD;50286
+Wailing Ghoul;EMN;161954
+Waiting in the Weeds;6ED;2111
+Waiting in the Weeds;MIR;2111
+Wake Thrasher;EVE;113731
+Wake of Destruction;UD;16367
+Wake of Vultures;EMA;2290
+Wake of Vultures;VIS;2290
+Wake the Dead;C14;156032
+Wake the Reflections;DGM;146823
+Wake the Reflections;MM3;146823
+Wakedancer;DKA;139872
+Wakedancer;EMA;139872
+Wakening Sun's Avatar;XLN;402233
+Waker of the Wilds;XLN;401437
+Wakestone Gargoyle;DIS;94698
+Waking Nightmare;COK;80916
+Waking Nightmare;MM2;80916
+Walk the Aeons;TSP;97376
+Walk the Plank;PRM;402435
+Walk the Plank;XLN;402092
+Walker of Secret Ways;BOK;83819
+Walker of Secret Ways;PC2;83819
+Walker of the Grove;C13;109615
+Walker of the Grove;MMA;109615
+Walker of the Grove;MOR;109615
+Walker of the Wastes;OGW;161194
+Walking Archive;DIS;94295
+Walking Atlas;WWK;126479
+Walking Ballista;AER;162323
+Walking Corpse;DPA;138432
+Walking Corpse;ISD;138432
+Walking Corpse;M13;138432
+Walking Corpse;M15;138432
+Walking Corpse;W16;138432
+Walking Dead;LEG;709
+Walking Desecration;ONS;43033
+Walking Dream;STH;3797
+Walking Sponge;UL;10398
+Walking Wall;ICE;1417
+Walking Wall;MED;1417
+Wall of Air;10E;27855
+Wall of Air;2ED;271
+Wall of Air;3ED;271
+Wall of Air;4ED;271
+Wall of Air;5ED;2503
+Wall of Air;6ED;271
+Wall of Air;7ED;27855
+Wall of Air;8ED;27855
+Wall of Air;DPA;27855
+Wall of Air;LEA;271
+Wall of Air;LEB;271
+Wall of Blood;MRD;50298
+Wall of Blossoms;PC2;3798
+Wall of Blossoms;PRM;3798
+Wall of Blossoms;PZ1;3798
+Wall of Blossoms;STH;3798
+Wall of Blossoms;TPR;3798
+Wall of Blossoms;V13;3798
+Wall of Bone;2ED;272
+Wall of Bone;3ED;272
+Wall of Bone;4ED;272
+Wall of Bone;5ED;272
+Wall of Bone;7ED;27856
+Wall of Bone;DDD;122153
+Wall of Bone;LEA;272
+Wall of Bone;LEB;272
+Wall of Bone;M10;122153
+Wall of Brambles;2ED;273
+Wall of Brambles;3ED;273
+Wall of Brambles;4ED;273
+Wall of Brambles;5ED;2504
+Wall of Brambles;LEA;273
+Wall of Brambles;LEB;273
+Wall of Caltrops;LEG;710
+Wall of Corpses;MIR;2112
+Wall of Deceit;DD2;46601
+Wall of Deceit;LGN;46601
+Wall of Denial;ARB;120991
+Wall of Denial;CMD;120991
+Wall of Denial;DDI;120991
+Wall of Denial;MM3;120991
+Wall of Diffusion;TMP;3010
+Wall of Diffusion;TPR;3010
+Wall of Diffusion;VMA;3010
+Wall of Distortion;MMQ;19282
+Wall of Dust;4ED;711
+Wall of Dust;LEG;711
+Wall of Earth;LEG;712
+Wall of Essence;M15;3800
+Wall of Essence;STH;3800
+Wall of Essence;TPR;3800
+Wall of Faith;M10;121606
+Wall of Fire;10E;104571
+Wall of Fire;2ED;274
+Wall of Fire;3ED;274
+Wall of Fire;4ED;274
+Wall of Fire;5ED;2505
+Wall of Fire;6ED;274
+Wall of Fire;7ED;27857
+Wall of Fire;DPA;104571
+Wall of Fire;LEA;274
+Wall of Fire;LEB;274
+Wall of Fire;M10;104571
+Wall of Fire;M13;104571
+Wall of Fire;M15;104571
+Wall of Forgotten Pharaohs;HOU;401572
+Wall of Frost;M10;121591
+Wall of Frost;M11;121591
+Wall of Frost;M14;121591
+Wall of Frost;M15;121591
+Wall of Frost;MM3;121591
+Wall of Frost;PC2;121591
+Wall of Glare;UD;15598
+Wall of Granite;POR;6722
+Wall of Heat;CH;713
+Wall of Heat;LEG;713
+Wall of Hope;LGN;46592
+Wall of Ice;2ED;275
+Wall of Ice;3ED;275
+Wall of Ice;4ED;275
+Wall of Ice;LEA;275
+Wall of Ice;LEB;275
+Wall of Junk;USG;8866
+Wall of Kelp;HML;1576
+Wall of Kelp;ME2;1576
+Wall of Lava;ICE;1418
+Wall of Light;LEG;714
+Wall of Light;ME3;714
+Wall of Limbs;M15;155340
+Wall of Mulch;M15;43154
+Wall of Mulch;ONS;43154
+Wall of Nets;EXO;5434
+Wall of Omens;CMD;127342
+Wall of Omens;DDK;127342
+Wall of Omens;EMA;127342
+Wall of Omens;PRM;134049
+Wall of Omens;PZ1;127342
+Wall of Omens;ROE;127342
+Wall of Opposition;CH;715
+Wall of Opposition;LEG;715
+Wall of Pine Needles;ICE;1419
+Wall of Putrid Flesh;LEG;716
+Wall of Razors;STH;3801
+Wall of Resistance;MIR;2113
+Wall of Resurgence;OGW;161202
+Wall of Reverence;C13;119810
+Wall of Reverence;CON;119810
+Wall of Reverence;DPA;119810
+Wall of Roots;MIR;2114
+Wall of Roots;PRM;113855
+Wall of Roots;TSB;2114
+Wall of Shadows;CH;717
+Wall of Shadows;LEG;717
+Wall of Shards;CSP;96961
+Wall of Shields;ICE;1420
+Wall of Souls;STH;3802
+Wall of Souls;TPR;3802
+Wall of Spears;4ED;475
+Wall of Spears;5ED;2506
+Wall of Spears;7ED;27858
+Wall of Spears;8ED;27858
+Wall of Spears;ATQ;475
+Wall of Spears;DPA;27858
+Wall of Stone;2ED;276
+Wall of Stone;3ED;276
+Wall of Stone;4ED;276
+Wall of Stone;5ED;2507
+Wall of Stone;8ED;49246
+Wall of Stone;LEA;276
+Wall of Stone;LEB;276
+Wall of Swords;10E;104555
+Wall of Swords;2ED;277
+Wall of Swords;3ED;277
+Wall of Swords;4ED;277
+Wall of Swords;5ED;2508
+Wall of Swords;6ED;2508
+Wall of Swords;7ED;27859
+Wall of Swords;8ED;27859
+Wall of Swords;DPA;104555
+Wall of Swords;LEA;277
+Wall of Swords;LEB;277
+Wall of Swords;M14;104555
+Wall of Swords;POR;6760
+Wall of Tanglecord;SOM;130988
+Wall of Tears;STH;3803
+Wall of Tombstones;LEG;718
+Wall of Torches;M12;134117
+Wall of Vapor;CH;719
+Wall of Vapor;LEG;719
+Wall of Vines;DPA;129078
+Wall of Vines;M11;129078
+Wall of Vipers;PCY;22158
+Wall of Water;2ED;278
+Wall of Water;3ED;278
+Wall of Water;4ED;278
+Wall of Water;LEA;278
+Wall of Water;LEB;278
+Wall of Wonder;7ED;27860
+Wall of Wonder;CH;720
+Wall of Wonder;LEG;720
+Wall of Wood;10E;104534
+Wall of Wood;2ED;279
+Wall of Wood;3ED;279
+Wall of Wood;4ED;279
+Wall of Wood;DPA;104534
+Wall of Wood;LEA;279
+Wall of Wood;LEB;279
+Wall;TOK;161555
+Wall;TOK;2090
+Wall;TOK;49246
+Wallop;INV;24182
+Wand of Denial;6ED;2291
+Wand of Denial;VIS;2291
+Wand of Ith;DRK;844
+Wand of the Elements;DPA;75203
+Wand of the Elements;DST;75203
+Wander in Death;AKH;400844
+Wanderbrine Rootcutters;SHM;111566
+Wanderer's Twig;DPA;105420
+Wanderer's Twig;LRW;105420
+Wanderguard Sentry;9ED;50332
+Wanderguard Sentry;MRD;50332
+Wandering Champion;FRF;157149
+Wandering Eye;NMS;21285
+Wandering Fumarole;OGW;160763
+Wandering Goblins;CON;118730
+Wandering Graybeard;MOR;109931
+Wandering Mage;ALL;1771
+Wandering Mage;ME3;1771
+Wandering Ones;COK;80834
+Wandering Stream;INV;25588
+Wandering Tombshell;DTK;160055
+Wandering Wolf;AVR;141596
+Wanderlust;2ED;280
+Wanderlust;3ED;280
+Wanderlust;4ED;280
+Wanderlust;5ED;2509
+Wanderlust;LEA;280
+Wanderlust;LEB;280
+Wanderlust;MED;280
+Wanderwine Hub;LRW;109167
+Wanderwine Prophets;LRW;105501
+Wane;INV;25583
+Waning Wurm;PLC;100646
+Wanted Scoundrels;XLN;402321
+War Barge;DRK;845
+War Barge;TSB;845
+War Behemoth;KTK;156478
+War Cadence;C13;19164
+War Cadence;MMQ;19164
+War Chariot;ICE;1421
+War Dance;USG;8829
+War Elemental;MRD;50998
+War Elephant;ARN;377
+War Elephant;CH;377
+War Falcon;M13;143903
+War Flare;FRF;157287
+War Horn;ORI;160342
+War Mammoth;2ED;281
+War Mammoth;3ED;281
+War Mammoth;4ED;281
+War Mammoth;5ED;281
+War Mammoth;LEA;281
+War Mammoth;LEB;281
+War Mammoth;ME4;281
+War Oracle;ORI;160199
+War Priest of Thune;EMA;129182
+War Priest of Thune;M11;129182
+War Priest of Thune;M13;129182
+War Report;NPH;134370
+War Tax;MMQ;19469
+War-Name Aspirant;KTK;156556
+War-Spike Changeling;MMA;109890
+War-Spike Changeling;MOR;109890
+War-Torch Goblin;RAV;88960
+War-Wing Siren;JOU;152841
+War's Toll;DIS;89156
+Warbreak Trumpeter;LGN;47526
+Warbringer;DTK;160063
+Warchanter of Mogis;BNG;152566
+Warchief Giant;PZ1;160151
+Warclamp Mastiff;M13;143904
+Ward Sliver;LGN;46588
+Ward of Bones;EVE;36472
+Ward of Lights;MIR;2115
+Ward of Piety;BOK;81573
+Warden of Evos Isle;EMA;147454
+Warden of Evos Isle;M14;147454
+Warden of Geometries;OGW;161605
+Warden of the Beyond;M15;155388
+Warden of the Eye;KTK;156527
+Warden of the First Tree;FRF;157215
+Warden of the Wall;DKA;139798
+Wardscale Dragon;FRF;157148
+Warfire Javelineer;AKH;400859
+Wargate;ARB;121006
+Warleader's Helix;DGM;147698
+Warleader's Helix;PRM;152611
+Warlord's Axe;M11;129144
+Warmind Infantry;GTC;146254
+Warmonger Hellkite;C14;143963
+Warmonger;MMQ;19141
+Warmonger;PRM;19141
+Warmonger's Chariot;ROE;127420
+Warmth;6ED;3296
+Warmth;TMP;3296
+Warning;ICE;1422
+Warning;ME2;1422
+Warp Artifact;2ED;282
+Warp Artifact;3ED;282
+Warp Artifact;4ED;282
+Warp Artifact;5ED;282
+Warp Artifact;LEA;282
+Warp Artifact;LEB;282
+Warp Artifact;ME4;282
+Warp World;10E;89125
+Warp World;M10;89125
+Warp World;RAV;89125
+Warpath Ghoul;DPA;101036
+Warpath Ghoul;M10;101036
+Warpath Ghoul;M12;101036
+Warpath;MMQ;20315
+Warped Devotion;8ED;49269
+Warped Devotion;PLS;28017
+Warped Landscape;SOI;161436
+Warped Physique;DGM;146658
+Warped Researcher;LGN;46582
+Warping Wail;OGW;161543
+Warping Wurm;MIR;2116
+Warren Instigator;DPA;123705
+Warren Instigator;ZEN;123705
+Warren Pilferers;LRW;106375
+Warren Pilferers;MMA;106375
+Warren Weirding;MMA;109945
+Warren Weirding;MOR;109945
+Warren-Scourge Elf;LRW;105366
+Warrior Angel;STH;3804
+Warrior en-Kor;STH;3805
+Warrior en-Kor;TPR;3805
+Warrior;TOK;156686
+Warrior;TOK;158501
+Warrior;TOK;158966
+Warrior;TOK;160094
+Warrior;TOK;400953
+Warrior;TOK;87232
+Warrior's Charge;POR;6761
+Warrior's Honor;10E;2292
+Warrior's Honor;6ED;2292
+Warrior's Honor;9ED;2292
+Warrior's Honor;VIS;2292
+Warrior's Oath;PTK;9180
+Warrior's Stand;PO2;4675
+Warrior's Stand;PTK;9004
+Warriors' Lesson;THS;149094
+Warstorm Surge;C13;136808
+Warstorm Surge;M12;136808
+Warstorm Surge;PC2;136808
+Warthog;6ED;2293
+Warthog;VIS;2293
+Wash Out;C13;151974
+Wash Out;INV;24183
+Wasp Lancer;SHM;111801
+Wasp of the Bitter End;HOU;401725
+Wasp;TOK;104576
+Waste Away;TOR;36446
+Waste Not;M15;155195
+Wasteland Scorpion;AKH;400852
+Wasteland Strangler;BFZ;160660
+Wasteland Viper;GTC;146445
+Wasteland;EMA;161844
+Wasteland;EXP;160967
+Wasteland;PRM;155679
+Wasteland;PRM;44391
+Wasteland;TMP;3244
+Wasteland;TPR;3244
+Wastes;OGW;161064
+Wastes;OGW;161268
+Watchdog;TMP;3201
+Watcher Sliver;TSP;99364
+Watcher in the Web;SOI;161701
+Watcher of the Roost;KTK;156541
+Watcher of the Roost;PRM;159762
+Watchers of the Dead;AKH;400838
+Watchful Automaton;AER;400374
+Watchful Naga;AKH;401339
+Watchwing Scarecrow;SHM;111703
+Watchwolf;PRM;122191
+Watchwolf;RAV;88948
+Water Elemental;2ED;283
+Water Elemental;3ED;283
+Water Elemental;4ED;283
+Water Elemental;LEA;283
+Water Elemental;LEB;283
+Water Elemental;ME4;283
+Water Servant;M11;129097
+Water Servant;M14;129097
+Water Servant;MM2;129097
+Water Wurm;DRK;846
+Watercourser;M13;143920
+Watercourser;ORI;143920
+Waterfront Bouncer;MMQ;19053
+Waterfront Bouncer;VMA;19053
+Waterspout Djinn;DD2;2294
+Waterspout Djinn;VIS;2294
+Waterspout Elemental;PLS;28018
+Waterspout Weavers;MOR;109925
+Watertrap Weaver;XLN;402070
+Waterveil Cavern;COK;81077
+Waterwhirl;KTK;156548
+Watery Grave;EXP;160787
+Watery Grave;GTC;145234
+Watery Grave;RAV;90396
+Wave Elemental;MIR;2117
+Wave of Indifference;ONS;43100
+Wave of Reckoning;MMQ;19309
+Wave of Reckoning;PRM;162419
+Wave of Terror;WTH;2867
+Wave of Vitriol;C14;155622
+Wave-Wing Elemental;BFZ;160647
+Wavecrash Triton;THS;150803
+Waves of Aggression;EVE;113753
+Waveskimmer Aven;ALA;115035
+Waveskimmer Aven;DPA;115035
+Wax;INV;25582
+Waxing Moon;EMN;162113
+Waxmane Baku;BOK;83890
+Waxmane Baku;MM2;83890
+Way of the Thief;GTC;146240
+Wayfarer's Bauble;5DN;77133
+Wayfarer's Bauble;C13;77133
+Wayfarer's Bauble;C14;77133
+Wayfarer's Bauble;DDI;77133
+Wayfarer's Bauble;MM2;77133
+Wayfaring Giant;INV;25225
+Wayfaring Temple;MM3;145219
+Wayfaring Temple;RTR;145219
+Waylay;USG;8917
+Wayward Angel;ODY;33515
+Wayward Disciple;SOI;161413
+Wayward Giant;KLD;162524
+Wayward Servant;AKH;401270
+Wayward Soul;EXO;3806
+Wayward Soul;TPR;3806
+Weakness;2ED;284
+Weakness;3ED;284
+Weakness;4ED;284
+Weakness;5ED;2510
+Weakness;LEA;284
+Weakness;LEB;284
+Weakness;M10;2510
+Weakness;ME4;284
+Weakstone;ATQ;476
+Weakstone;ME4;476
+Weapon Surge;DGM;146721
+Weaponcraft Enthusiast;KLD;162503
+Weapons Trainer;OGW;161138
+Wear Away;COK;80567
+Wear;DGM;147696
+Weathered Bodyguards;TSP;99548
+Weathered Wayfarer;9ED;42957
+Weathered Wayfarer;ONS;42957
+Weathered Wayfarer;TD0;42957
+Weatherseed Elf;UL;15311
+Weatherseed Faeries;UL;15310
+Weatherseed Totem;TSP;97289
+Weatherseed Treefolk;UL;9162
+Weave Fate;KTK;156493
+Weave Fate;ORI;156493
+Weaver of Currents;AKH;401273
+Weaver of Lies;LGN;46557
+Weaver of Lightning;EMN;161979
+Web of Inertia;JUD;40210
+Web;2ED;285
+Web;3ED;285
+Web;4ED;285
+Web;9ED;86942
+Web;LEA;285
+Web;LEB;285
+Wee Dragonauts;DDJ;91730
+Wee Dragonauts;DPA;91730
+Wee Dragonauts;EMA;91730
+Wee Dragonauts;GPT;91730
+Wee Dragonauts;PRM;91730
+Weed Strangle;LRW;106398
+Weed-Pruner Poplar;MOR;109948
+Wei Ambush Force;PTK;9040
+Wei Assassins;PTK;9169
+Wei Elite Companions;ME3;9045
+Wei Elite Companions;PTK;9045
+Wei Infantry;ME3;9167
+Wei Infantry;PTK;9167
+Wei Night Raiders;ME3;9083
+Wei Night Raiders;PTK;9083
+Wei Scout;PTK;9185
+Wei Strike Force;ME3;9088
+Wei Strike Force;PTK;9088
+Weight of Conscience;MOR;109947
+Weight of Spires;DIS;94606
+Weight of the Underworld;BNG;152038
+Weight of the Underworld;ORI;152038
+Weird Harvest;9ED;43199
+Weird Harvest;ONS;43199
+Weird;TOK;93485
+Weirded Vampire;EMN;161946
+Weirding Shaman;MOR;109989
+Weirding Wood;SOI;161612
+Welcome to the Fold;SOI;161753
+Welder Automaton;AER;400371
+Weldfast Engineer;AER;400358
+Weldfast Monitor;KLD;162343
+Weldfast Wingsmith;KLD;162478
+Welding Jar;MRD;51065
+Welding Sparks;KLD;162529
+Welkin Guide;ALA;116183
+Welkin Guide;EMA;116183
+Welkin Hawk;EXO;5627
+Welkin Tern;M13;123696
+Welkin Tern;M15;123696
+Welkin Tern;ZEN;123696
+Well of Discovery;PCY;22037
+Well of Ideas;C14;155653
+Well of Knowledge;WTH;2860
+Well of Life;PCY;22038
+Well of Lost Dreams;C13;75193
+Well of Lost Dreams;DPA;75193
+Well of Lost Dreams;DST;75193
+Well-Laid Plans;INV;25216
+Well;DGM;151004
+Wellgabber Apothecary;LRW;105323
+Wellspring;MIR;2118
+Wellwisher;C14;156386
+Wellwisher;DPA;43152
+Wellwisher;EVG;43152
+Wellwisher;ONS;43152
+Werebear;EMA;161570
+Werebear;ODY;33323
+Werebear;TD0;33323
+Werewolf Ransacker;DKA;139855
+Werewolf of Ancient Hunger;SOI;161697
+Western Paladin;7ED;27861
+Western Paladin;8ED;8683
+Western Paladin;USG;8683
+Westvale Abbey;SOI;161373
+Westvale Cult Leader;SOI;161371
+Wetland Sambar;KTK;156486
+Whale;TOK;156418
+Whalebone Glider;ICE;1423
+Wharf Infiltrator;EMN;162056
+Wheel and Deal;DPA;143937
+Wheel and Deal;ONS;43027
+Wheel and Deal;PRM;143937
+Wheel of Fate;TSP;97417
+Wheel of Fortune;2ED;286
+Wheel of Fortune;3ED;286
+Wheel of Fortune;DPA;97383
+Wheel of Fortune;LEA;286
+Wheel of Fortune;LEB;286
+Wheel of Fortune;ME4;286
+Wheel of Fortune;PRM;97383
+Wheel of Fortune;VMA;97383
+Wheel of Sun and Moon;SHM;111647
+Wheel of Torture;UL;10543
+Whelming Wave;BNG;152562
+Where Ancients Tread;ALA;115148
+Where Ancients Tread;C13;115148
+Whetstone;USG;8882
+Whetwheel;FUT;102464
+Whim of Volrath;TMP;3170
+Whims of the Fates;BNG;152589
+Whimwader;SHM;111536
+Whip Sergeant;9ED;22046
+Whip Sergeant;PCY;22046
+Whip Silk;INV;24187
+Whip Vine;ALL;1772
+Whip Vine;ALL;1773
+Whip of Erebos;PRM;159371
+Whip of Erebos;THS;149971
+Whip-Spine Drake;FUT;102355
+Whipcorder;ONS;42930
+Whipcorder;PRM;42930
+Whipflare;C14;134196
+Whipflare;NPH;134196
+Whipgrass Entangler;LGN;47523
+Whipkeeper;ODY;33350
+Whiplash Trap;PC1;125070
+Whiplash Trap;ZEN;125070
+Whippoorwill;DRK;847
+Whipstitched Zombie;PCY;21940
+Whiptail Moloch;DIS;94278
+Whiptail Wurm;ME4;6679
+Whiptail Wurm;POR;6679
+Whiptongue Frog;EXO;5644
+Whir of Invention;AER;400277
+Whirler Rogue;ORI;160245
+Whirler Virtuoso;KLD;162320
+Whirlermaker;KLD;162581
+Whirling Catapult;ALL;1774
+Whirling Catapult;ME2;1774
+Whirling Dervish;4ED;721
+Whirling Dervish;5ED;721
+Whirling Dervish;LEG;721
+Whirling Dervish;PRM;101022
+Whirling Dervish;TSB;721
+Whirlpool Drake;APC;31165
+Whirlpool Rider;APC;31167
+Whirlpool Warrior;APC;31166
+Whirlpool Warrior;PC2;31166
+Whirlpool Whelm;CMD;106383
+Whirlpool Whelm;LRW;106383
+Whirlwind Adept;KTK;157007
+Whirlwind;C14;8884
+Whirlwind;USG;8884
+Whisk Away;FRF;157245
+Whisperer of the Wilds;FRF;157179
+Whispering Madness;GTC;146573
+Whispering Shade;ODY;33438
+Whispering Specter;NPH;134297
+Whispers of Emrakul;EMN;162075
+Whispers of the Muse;TMP;3282
+Whispers of the Muse;TPR;3282
+Whispers of the Muse;TSB;3282
+Whispersilk Cloak;10E;50223
+Whispersilk Cloak;DDE;121663
+Whispersilk Cloak;DPA;121663
+Whispersilk Cloak;DST;50223
+Whispersilk Cloak;M10;121663
+Whispersilk Cloak;M11;121663
+Whispersilk Cloak;PC2;121663
+Whisperwood Elemental;FRF;157314
+White Knight;2ED;287
+White Knight;3ED;287
+White Knight;4ED;287
+White Knight;5ED;287
+White Knight;DDG;121715
+White Knight;LEA;287
+White Knight;LEB;287
+White Knight;LGN;46578
+White Knight;M10;121715
+White Knight;M11;121715
+White Knight;ME4;287
+White Knight;PRM;287
+White Mana Battery;4ED;722
+White Mana Battery;LEG;722
+White Scarab;ICE;1424
+White Shield Crusader;CSP;96952
+White Sun's Zenith;C14;133251
+White Sun's Zenith;DPA;133251
+White Sun's Zenith;MBS;133251
+White Sun's Zenith;TD2;133251
+White Ward;2ED;288
+White Ward;3ED;288
+White Ward;4ED;288
+White Ward;LEA;288
+White Ward;LEB;288
+Whitemane Lion;C14;100713
+Whitemane Lion;DDI;100713
+Whitemane Lion;EMA;100713
+Whitemane Lion;PLC;100713
+Whiteout;ICE;1425
+Whiteout;ME2;1425
+Whitesun's Passage;SOM;131024
+Whitewater Naiads;JOU;153075
+Wicked Akuba;COK;80738
+Wicked Pact;ME4;6602
+Wicked Pact;POR;6602
+Wicked Reward;VIS;2295
+Wicker Warcrawler;SHM;111810
+Wicker Witch;SOI;161474
+Wickerbough Elder;EVE;113619
+Wickerbough Elder;TD0;113619
+Widespread Panic;C13;151768
+Wielding the Green Dragon;PTK;9000
+Wight of Precinct Six;C13;146441
+Wight of Precinct Six;DDM;146441
+Wight of Precinct Six;GTC;146441
+Wiitigo;ICE;1426
+Wiitigo;ME2;1426
+Wild Aesthir;ALL;1775
+Wild Aesthir;ALL;1776
+Wild Aesthir;ME4;1775
+Wild Beastmaster;RTR;145949
+Wild Cantor;GPT;91760
+Wild Celebrants;THS;150835
+Wild Colos;UD;15644
+Wild Defiance;AVR;141823
+Wild Dogs;USG;8833
+Wild Elephant;MIR;2119
+Wild Evocation;M11;123721
+Wild Griffin;10E;104359
+Wild Griffin;M11;104359
+Wild Griffin;ME4;4662
+Wild Griffin;PO2;4662
+Wild Growth;2ED;289
+Wild Growth;3ED;289
+Wild Growth;4ED;289
+Wild Growth;5ED;2511
+Wild Growth;6ED;2511
+Wild Growth;7ED;27849
+Wild Growth;ICE;1427
+Wild Growth;LEA;289
+Wild Growth;LEB;289
+Wild Guess;M13;143951
+Wild Guess;M14;143951
+Wild Hunger;DKA;139783
+Wild Instincts;ORI;159697
+Wild Jhovall;MMQ;19003
+Wild Leotau;CON;118702
+Wild Mammoth;NMS;21153
+Wild Might;PCY;22039
+Wild Mongrel;DDD;33325
+Wild Mongrel;ODY;33325
+Wild Mongrel;PRM;33325
+Wild Mongrel;TD0;33325
+Wild Mongrel;VMA;33325
+Wild Nacatl;ALA;115062
+Wild Nacatl;DDH;115062
+Wild Nacatl;PRM;131558
+Wild Ox;ME4;4774
+Wild Ox;PO2;4774
+Wild Pair;DPA;143977
+Wild Pair;H09;97393
+Wild Pair;PLC;97393
+Wild Pair;PRM;143977
+Wild Research;APC;24020
+Wild Ricochet;C13;107643
+Wild Ricochet;CMD;107643
+Wild Ricochet;LRW;107643
+Wild Ricochet;M14;107643
+Wild Slash;FRF;157318
+Wild Swing;DPA;111847
+Wild Swing;SHM;111847
+Wild Wanderer;KLD;162542
+Wild Wurm;TMP;3256
+Wild-Field Scarecrow;SOI;161389
+Wildblood Pack;ISD;138299
+Wildcall;FRF;157196
+Wildcall;PRM;159381
+Wilderness Elemental;CSP;96927
+Wilderness Hypnotist;EVE;113696
+Wildest Dreams;KLD;162312
+Wildfield Borderpost;ARB;120984
+Wildfire Cerberus;JOU;152915
+Wildfire Emissary;EMA;2120
+Wildfire Emissary;MIR;2120
+Wildfire Emissary;TSB;2120
+Wildfire Eternal;HOU;401528
+Wildfire Eternal;PRM;401814
+Wildfire;7ED;27863
+Wildfire;9ED;8786
+Wildfire;MM2;4760
+Wildfire;PO2;4760
+Wildfire;USG;8786
+Wildgrowth Walker;XLN;402338
+Wildheart Invoker;DPA;127249
+Wildheart Invoker;ROE;127249
+Wildsize;EVG;91867
+Wildsize;GPT;91867
+Wildslayer Elves;SHM;111517
+Wildwood Geist;AVR;141744
+Wildwood Rebirth;GTC;146537
+Will of the Naga;FRF;157262
+Will-Forged Golem;M15;155281
+Will-o'-the-Wisp;2ED;290
+Will-o'-the-Wisp;3ED;290
+Will-o'-the-Wisp;4ED;290
+Will-o'-the-Wisp;9ED;86732
+Will-o'-the-Wisp;LEA;290
+Will-o'-the-Wisp;LEB;290
+Willbender;C14;46548
+Willbender;DD2;46548
+Willbender;LGN;46548
+Willbender;PRM;46548
+Willbender;TD0;46548
+Willbender;TSB;46548
+Willbreaker;ORI;155351
+Willing;DGM;151037
+Willow Dryad;POR;6680
+Willow Faerie;HML;1577
+Willow Faerie;HML;1578
+Willow Priestess;HML;1579
+Willow Priestess;ME3;1579
+Willow Satyr;LEG;2563
+Willow Satyr;ME3;2563
+Wilt-Leaf Cavaliers;DDG;111759
+Wilt-Leaf Cavaliers;PRM;113118
+Wilt-Leaf Cavaliers;SHM;111759
+Wilt-Leaf Liege;DPA;111702
+Wilt-Leaf Liege;MM2;111702
+Wilt-Leaf Liege;SHM;111702
+Wily Bandar;KLD;162313
+Wily Goblin;XLN;402318
+Wind Dancer;7ED;27864
+Wind Dancer;TMP;3276
+Wind Dancer;TPR;3276
+Wind Drake;6ED;6640
+Wind Drake;7ED;27865
+Wind Drake;8ED;27865
+Wind Drake;9ED;27865
+Wind Drake;DGM;147775
+Wind Drake;DPA;122178
+Wind Drake;KLD;162259
+Wind Drake;M10;122178
+Wind Drake;M13;122178
+Wind Drake;POR;6640
+Wind Drake;TMP;3034
+Wind Drake;TPR;3034
+Wind Sail;PO2;4688
+Wind Shear;VIS;2296
+Wind Spirit;5ED;1428
+Wind Spirit;6ED;1428
+Wind Spirit;ICE;1428
+Wind Spirit;ME2;1428
+Wind Strider;XLN;402285
+Wind Zendikon;WWK;126563
+Wind-Kin Raiders;AER;400269
+Wind-Scarred Crag;EMA;157274
+Wind-Scarred Crag;FRF;157274
+Wind-Scarred Crag;KTK;156540
+Windborn Muse;10E;47519
+Windborn Muse;CMD;47519
+Windborn Muse;LGN;47519
+Windborne Charge;DPA;123693
+Windborne Charge;ZEN;123693
+Windbrisk Heights;LRW;106352
+Windbrisk Heights;V12;106352
+Windbrisk Raptor;SHM;111634
+Windfall;CMD;8937
+Windfall;PRM;162609
+Windfall;USG;8937
+Winding Canyons;WTH;2878
+Winding Constrictor;AER;400363
+Winding Wurm;USG;8705
+Windreader Sphinx;M14;147366
+Windreaper Falcon;MIR;2121
+Windreaver;DDI;94297
+Windreaver;DIS;94297
+Windriddle Palaces;PC2;138706
+Windrider Eel;ZEN;123539
+Windrider Patrol;BFZ;160641
+Winds of Change;4ED;723
+Winds of Change;5ED;2512
+Winds of Change;LEG;723
+Winds of Change;MED;723
+Winds of Change;POR;6723
+Winds of Qal Sisma;FRF;157250
+Winds of Rath;DDL;3193
+Winds of Rath;DPA;3193
+Winds of Rath;TMP;3193
+Winds of Rath;TPR;3193
+Winds of Rath;VMA;3193
+Winds of Rebuke;AKH;400773
+Windscouter;PCY;22040
+Windseeker Centaur;PRM;486
+Windstorm;DDD;121711
+Windstorm;KTK;156565
+Windstorm;M10;121711
+Windstorm;M14;121711
+Windswept Heath;EXP;160781
+Windswept Heath;KTK;156611
+Windswept Heath;ONS;43224
+Windswept Heath;PRM;43224
+Windwright Mage;ALA;115385
+Wine of Blood and Iron;SOK;86041
+Wing Puncture;SOM;130887
+Wing Shards;C14;48975
+Wing Shards;PRM;48975
+Wing Shards;SCG;48975
+Wing Snare;7ED;27866
+Wing Snare;8ED;27866
+Wing Snare;UL;10541
+Wing Snare;W17;27866
+Wing Splicer;MM3;134376
+Wing Splicer;NPH;134376
+Wing Storm;PCY;23194
+Wingbeat Warrior;LGN;46552
+Wingcrafter;AVR;141524
+Wingcrafter;MM3;141524
+Winged Coatl;ARB;120993
+Winged Coatl;C13;120993
+Winged Shepherd;AKH;400769
+Winged Sliver;H09;3033
+Winged Sliver;TMP;3033
+Winged Sliver;TPR;3033
+Wingmate Roc;KTK;157004
+Wingrattle Scarecrow;SHM;111706
+Wings of Aesthir;ICE;1429
+Wings of Aesthir;ME2;1429
+Wings of Hope;INV;24014
+Wings of Velis Vel;LRW;105440
+Wings of Velis Vel;MM2;105440
+Wingsteed Rider;THS;149176
+Winnow;INV;24189
+Winnower Patrol;MOR;109930
+Winter Blast;4ED;724
+Winter Blast;5ED;724
+Winter Blast;LEG;724
+Winter Blast;MED;724
+Winter Orb;2ED;291
+Winter Orb;3ED;291
+Winter Orb;4ED;291
+Winter Orb;5ED;291
+Winter Orb;EMA;145076
+Winter Orb;LEA;291
+Winter Orb;LEB;291
+Winter Orb;MED;291
+Winter Orb;PRM;145076
+Winter Sky;HML;1580
+Winter's Chill;ICE;1430
+Winter's Grasp;POR;6681
+Winter's Grasp;TMP;3240
+Winter's Night;ALL;1777
+Winter's Night;ME2;1777
+Winterflame;KTK;157086
+Wintermoon Mesa;PCY;22041
+Wipe Away;TSP;97534
+Wipe Clean;SCG;49004
+Wirecat;USG;8920
+Wirefly Hive;DST;75196
+Wirefly;TOK;77065
+Wirewood Channeler;LGN;46528
+Wirewood Elf;ONS;43156
+Wirewood Guardian;SCG;48109
+Wirewood Guardian;TD0;48109
+Wirewood Herald;EVG;43179
+Wirewood Herald;ONS;43179
+Wirewood Hivemaster;LGN;46562
+Wirewood Lodge;EVG;43231
+Wirewood Lodge;ONS;43231
+Wirewood Pride;ONS;43160
+Wirewood Savage;DDD;43175
+Wirewood Savage;ONS;43175
+Wirewood Symbiote;EMA;161571
+Wirewood Symbiote;EVG;48985
+Wirewood Symbiote;SCG;48985
+Wishmonger;MMQ;19140
+Wispmare;LRW;106382
+Wispweaver Angel;KLD;162460
+Wistful Selkie;EVE;113634
+Wistful Thinking;PLC;100725
+Wit's End;DIS;94617
+Wit's End;M13;131620
+Witch Engine;USG;8942
+Witch Hunt;C13;151729
+Witch Hunter;CH;848
+Witch Hunter;DRK;848
+Witch Hunter;TSB;848
+Witch-Maw Nephilim;GPT;91860
+Witch's Familiar;M15;155223
+Witch's Mist;FUT;102437
+Witchbane Orb;ISD;138356
+Witches' Eye;THS;150861
+Witchstalker;M14;147440
+Withdraw;PCY;22062
+Withengar Unbound;DKA;139769
+Withered Wretch;LGN;46585
+Withered Wretch;PC1;46585
+Withered Wretch;PRM;46585
+Withered Wretch;TSB;46585
+Withering Boon;MIR;2122
+Withering Gaze;9ED;86916
+Withering Gaze;POR;6641
+Withering Hex;ONS;43058
+Withering Wisps;ICE;1431
+Withering Wisps;ME2;1431
+Witherscale Wurm;SHM;111724
+Without Weakness;HOU;401513
+Withstand Death;SOM;131075
+Withstand;GPT;91813
+Witness of the Ages;KTK;156580
+Witness the End;OGW;161162
+Wizard Mentor;USG;8821
+Wizard Replica;MRD;50225
+Wizard Replica;PC1;50225
+Wizards' School;HML;1581
+Wizened Cenn;LRW;105469
+Wizened Snitches;RAV;89012
+Woebearer;MRD;51149
+Woebringer Demon;RAV;89090
+Woeleecher;SHM;111778
+Wojek Apothecary;RAV;89034
+Wojek Embermage;RAV;88987
+Wojek Halberdiers;GTC;146312
+Wojek Siren;RAV;88591
+Wolf Pack;ME2;9134
+Wolf Pack;PTK;9134
+Wolf of Devil's Breach;SOI;161686
+Wolf-Skull Shaman;MOR;109943
+Wolf;TOK;107651
+Wolf;TOK;112137
+Wolf;TOK;123776
+Wolf;TOK;131407
+Wolf;TOK;138484
+Wolf;TOK;139307
+Wolf;TOK;152604
+Wolf;TOK;162154
+Wolf;TOK;97960
+Wolfbitten Captive;DKA;139809
+Wolfbriar Elemental;C14;126583
+Wolfbriar Elemental;DPA;126583
+Wolfbriar Elemental;MM2;126583
+Wolfbriar Elemental;WWK;126583
+Wolfcaller's Howl;C14;155636
+Wolfhunter's Quiver;DKA;139795
+Wolfir Avenger;AVR;141643
+Wolfir Silverheart;AVR;141698
+Wolfkin Bond;EMN;162122
+Wolverine Pack;5ED;2513
+Wolverine Pack;LEG;725
+Wonder;C13;40206
+Wonder;CMD;40206
+Wonder;EMA;40206
+Wonder;JUD;40206
+Wonder;PRM;40206
+Wonder;PZ1;40206
+Wood Elemental;LEG;2564
+Wood Elemental;ME4;2564
+Wood Elves;7ED;27867
+Wood Elves;8ED;27867
+Wood Elves;9ED;27867
+Wood Elves;C14;27867
+Wood Elves;DPA;27867
+Wood Elves;EVG;27867
+Wood Elves;EXO;5439
+Wood Elves;POR;6682
+Wood Elves;PRM;162449
+Wood Elves;PRM;5439
+Wood Elves;TD0;5439
+Wood Sage;TMP;3197
+Wood Sage;TPR;3197
+Wood;TOK;279
+Woodborn Behemoth;M14;147470
+Woodcloaker;SCG;48123
+Woodcutter's Grit;EMN;162128
+Wooded Bastion;EXP;161094
+Wooded Bastion;SHM;111651
+Wooded Foothills;EXP;160779
+Wooded Foothills;KTK;156610
+Wooded Foothills;ONS;43222
+Wooded Foothills;PRM;43222
+Wooden Sphere;2ED;292
+Wooden Sphere;3ED;292
+Wooden Sphere;4ED;292
+Wooden Sphere;5ED;2514
+Wooden Sphere;6ED;2514
+Wooden Sphere;7ED;27868
+Wooden Sphere;8ED;2514
+Wooden Sphere;LEA;292
+Wooden Sphere;LEB;292
+Wooden Stake;ISD;138250
+Woodfall Primus;MMA;111714
+Woodfall Primus;SHM;111714
+Woodland Bellower;ORI;160330
+Woodland Cemetery;ISD;138424
+Woodland Changeling;LRW;106370
+Woodland Druid;ODY;33330
+Woodland Guidance;LRW;107637
+Woodland Patrol;EMN;162000
+Woodland Sleuth;ISD;138155
+Woodland Stream;AKH;162605
+Woodland Stream;HOU;401727
+Woodland Stream;KLD;162605
+Woodland Stream;SOI;161499
+Woodland Stream;XLN;402348
+Woodland Wanderer;BFZ;160880
+Woodlot Crawler;DGM;147773
+Woodlurker Mimic;EVE;113760
+Woodripper;NMS;21166
+Woodweaver's Puzzleknot;KLD;162339
+Woodwraith Corrupter;RAV;88856
+Woodwraith Strangler;RAV;88734
+Woolly Loxodon;KTK;156523
+Woolly Mammoths;ICE;1432
+Woolly Mammoths;ME2;1432
+Woolly Razorback;CSP;96966
+Woolly Spider;ICE;1433
+Woolly Spider;ME2;1433
+Woolly Thoctar;ALA;117002
+Woolly Thoctar;DDH;117002
+Woolly Thoctar;DPA;117002
+Woolly Thoctar;MM3;117002
+Woolly Thoctar;PRM;117981
+Word of Binding;4ED;849
+Word of Binding;DRK;849
+Word of Blasting;5ED;1434
+Word of Blasting;ICE;1434
+Word of Blasting;MMQ;19169
+Word of Command;2ED;293
+Word of Command;LEA;293
+Word of Command;LEB;293
+Word of Command;ME4;293
+Word of Seizing;C14;97498
+Word of Seizing;TSP;97498
+Word of Undoing;ICE;1435
+Word of Undoing;MED;1435
+Words of War;ONS;43146
+Words of Waste;ONS;43088
+Words of Wilding;ONS;43202
+Words of Wind;ONS;43028
+Words of Wisdom;ODY;33490
+Words of Worship;ONS;42969
+Workhorse;EXO;5598
+Workshop Assistant;KLD;162627
+World Breaker;OGW;161246
+World Queller;ZEN;123712
+World at War;ROE;127297
+Worldfire;M13;143887
+Worldgorger Dragon;EMA;40257
+Worldgorger Dragon;JUD;40257
+Worldgorger Dragon;VMA;40257
+Worldheart Phoenix;CON;115211
+Worldheart Phoenix;MM2;115211
+Worldly Counsel;CON;118647
+Worldly Counsel;INV;25486
+Worldly Tutor;6ED;2123
+Worldly Tutor;MIR;2123
+Worldpurge;SHM;111554
+Worldslayer;M12;51502
+Worldslayer;MRD;51502
+Worldspine Wurm;RTR;145979
+Worm Harvest;EVE;113630
+Worm Harvest;MMA;113630
+Worm;TOK;113774
+Wormfang Behemoth;JUD;40215
+Wormfang Crab;JUD;40208
+Wormfang Drake;JUD;40197
+Wormfang Manta;JUD;40214
+Wormfang Newt;JUD;40196
+Wormfang Turtle;JUD;40209
+Worms of the Earth;DRK;850
+Wormwood Dryad;TSP;97440
+Wormwood Treefolk;DRK;851
+Wormwood Treefolk;ME3;851
+Worn Powerstone;C14;8773
+Worn Powerstone;DDE;8773
+Worn Powerstone;EMA;8773
+Worn Powerstone;PZ1;8773
+Worn Powerstone;USG;8773
+Worry Beads;MMQ;19241
+Worship;7ED;27869
+Worship;8ED;8954
+Worship;9ED;8954
+Worship;MS3;401606
+Worship;USG;8954
+Worst Fears;JOU;153068
+Wort, Boggart Auntie;LRW;105464
+Wort, the Raidmother;MM3;111670
+Wort, the Raidmother;SHM;111670
+Worthy Cause;TMP;3297
+Wound Reflection;SHM;111659
+Wrack with Madness;DKA;139746
+Wrangle;AER;400310
+Wrap in Flames;MM2;127353
+Wrap in Flames;ROE;127353
+Wrap in Vigor;FUT;102377
+Wrath of God;10E;27870
+Wrath of God;2ED;294
+Wrath of God;3ED;294
+Wrath of God;4ED;294
+Wrath of God;5ED;294
+Wrath of God;6ED;294
+Wrath of God;7ED;27870
+Wrath of God;8ED;27870
+Wrath of God;9ED;27870
+Wrath of God;C13;27870
+Wrath of God;DPA;27870
+Wrath of God;EMA;27870
+Wrath of God;LEA;294
+Wrath of God;LEB;294
+Wrath of God;MS3;401607
+Wrath of God;POR;6763
+Wrath of God;PRM;100410
+Wrath of God;PZ1;27870
+Wrath of God;V14;156666
+Wrath of Marit Lage;8ED;49235
+Wrath of Marit Lage;ICE;1436
+Wreak Havoc;GPT;91883
+Wreath of Geists;DPA;138406
+Wreath of Geists;ISD;138406
+Wrecking Ball;CMD;94674
+Wrecking Ball;DIS;94674
+Wrecking Ball;DPA;94674
+Wrecking Ball;MM2;94674
+Wrecking Ogre;GTC;146555
+Wren's Run Packmaster;C14;106423
+Wren's Run Packmaster;LRW;106423
+Wren's Run Packmaster;PRM;107653
+Wren's Run Vanquisher;EVG;105482
+Wren's Run Vanquisher;LRW;105482
+Wren's Run Vanquisher;PRM;110132
+Wrench Mind;MRD;50203
+Wretched Anurid;ONS;43061
+Wretched Banquet;CON;118682
+Wretched Camel;HOU;401796
+Wretched Confluence;PZ1;160441
+Wretched Gryff;EMN;161929
+Wrexial, the Risen Deep;CMD;126521
+Wrexial, the Risen Deep;WWK;126521
+Wring Flesh;M12;137416
+Wring Flesh;M14;137416
+Writ of Passage;DIS;94474
+Write into Being;FRF;157171
+Write into Being;PRM;159384
+Wu Admiral;PTK;9078
+Wu Elite Cavalry;ME3;9023
+Wu Elite Cavalry;PTK;9023
+Wu Infantry;PTK;9012
+Wu Light Cavalry;PTK;9064
+Wu Longbowman;ME3;9013
+Wu Longbowman;PTK;9013
+Wu Scout;PTK;9029
+Wu Spy;PTK;9014
+Wu Warship;ME3;9186
+Wu Warship;PTK;9186
+Wurm;TOK;131552
+Wurm;TOK;131554
+Wurm;TOK;131617
+Wurm;TOK;143947
+Wurm;TOK;145994
+Wurm;TOK;33669
+Wurm;TOK;35343
+Wurm;TOK;400963
+Wurm;TOK;93489
+Wurm;TOK;99733
+Wurm's Tooth;10E;75222
+Wurm's Tooth;9ED;75222
+Wurm's Tooth;DPA;75222
+Wurm's Tooth;DST;75222
+Wurm's Tooth;M10;75222
+Wurm's Tooth;M11;75222
+Wurm's Tooth;M12;75222
+Wurmcalling;TSP;97460
+Wurmcoil Engine;C14;131040
+Wurmcoil Engine;DPA;131040
+Wurmcoil Engine;MS2;400943
+Wurmcoil Engine;PRM;131731
+Wurmcoil Engine;SOM;131040
+Wurmskin Forger;MRD;51092
+Wurmweaver Coil;DPA;91840
+Wurmweaver Coil;GPT;91840
+Wydwen, the Biting Gale;LRW;105542
+Wyluli Wolf;5ED;378
+Wyluli Wolf;6ED;378
+Wyluli Wolf;ARN;378
+Wyluli Wolf;MED;378
+Xanthic Statue;WTH;2861
+Xantid Swarm;EMA;48113
+Xantid Swarm;SCG;48113
+Xathrid Demon;C14;121564
+Xathrid Demon;DPA;121564
+Xathrid Demon;M10;121564
+Xathrid Gorgon;DPA;143875
+Xathrid Gorgon;M13;143875
+Xathrid Gorgon;PRM;143945
+Xathrid Necromancer;M14;147444
+Xathrid Necromancer;PRM;147444
+Xathrid Slyblade;M15;155249
+Xenagos, God of Revels;BNG;152103
+Xenagos, the Reveler;THS;149149
+Xenic Poltergeist;4ED;477
+Xenic Poltergeist;5ED;2515
+Xenic Poltergeist;ATQ;477
+Xenic Poltergeist;ME4;477
+Xenograft;NPH;134351
+Xiahou Dun, the One-Eyed;ME3;9144
+Xiahou Dun, the One-Eyed;PTK;9144
+Xira Arien;CH;726
+Xira Arien;LEG;726
+Xira Arien;ME3;726
+Xira Arien;TD0;726
+Xun Yu, Wei Advisor;PTK;10530
+Yahenni, Undying Partisan;AER;400300
+Yahenni's Expertise;AER;400303
+Yahenni's Expertise;PRM;400718
+Yamabushi's Flame;COK;80580
+Yamabushi's Storm;COK;80615
+Yare;MIR;2124
+Yasova Dragonclaw;FRF;157208
+Yavimaya Ancients;ALL;1778
+Yavimaya Ancients;ALL;1779
+Yavimaya Ancients;ME2;1779
+Yavimaya Ants;ALL;1780
+Yavimaya Ants;MED;1780
+Yavimaya Barbarian;INV;24004
+Yavimaya Coast;10E;31172
+Yavimaya Coast;9ED;31172
+Yavimaya Coast;APC;31172
+Yavimaya Coast;M15;31172
+Yavimaya Coast;ORI;31172
+Yavimaya Dryad;DPA;97511
+Yavimaya Dryad;TSP;97511
+Yavimaya Elder;CMD;127995
+Yavimaya Elder;DDE;127995
+Yavimaya Elder;DPA;127995
+Yavimaya Elder;TD0;15665
+Yavimaya Elder;UD;15665
+Yavimaya Elder;VMA;127995
+Yavimaya Enchantress;10E;27871
+Yavimaya Enchantress;7ED;27871
+Yavimaya Enchantress;8ED;15670
+Yavimaya Enchantress;9ED;15670
+Yavimaya Enchantress;EMA;27871
+Yavimaya Enchantress;TD0;15670
+Yavimaya Enchantress;UD;15670
+Yavimaya Gnats;ICE;1437
+Yavimaya Granger;UL;10544
+Yavimaya Hollow;UD;15703
+Yavimaya Hollow;VMA;15703
+Yavimaya Kavu;INV;24075
+Yavimaya Scion;UL;10350
+Yavimaya Wurm;M11;129163
+Yavimaya Wurm;UL;10340
+Yavimaya's Embrace;APC;31161
+Yavimaya's Embrace;DPA;31161
+Yawgmoth Demon;9ED;86952
+Yawgmoth Demon;ATQ;478
+Yawgmoth Demon;CH;478
+Yawgmoth's Agenda;INV;24191
+Yawgmoth's Bargain;UD;15640
+Yawgmoth's Bargain;VMA;15640
+Yawgmoth's Edict;7ED;27872
+Yawgmoth's Edict;USG;8793
+Yawgmoth's Will;PRM;8904
+Yawgmoth's Will;USG;8904
+Yawgmoth's Will;VMA;8904
+Yawning Fissure;M10;121668
+Ydwen Efreet;ARN;379
+Ydwen Efreet;MED;379
+Yellow Scarves Cavalry;PTK;9069
+Yellow Scarves General;PTK;9071
+Yellow Scarves Troops;PTK;9070
+Yeva, Nature's Herald;DPA;143881
+Yeva, Nature's Herald;M13;143881
+Yeva's Forcemage;DPA;143856
+Yeva's Forcemage;M13;143856
+Yeva's Forcemage;ORI;143856
+Yew Spirit;AVR;139828
+Yidris, Maelstrom Wielder;PZ2;162395
+Yisan, the Wanderer Bard;M15;155342
+Yixlid Jailer;FUT;102421
+Yixlid Jailer;PRM;103479
+Yoke of the Damned;CON;118719
+Yoke of the Damned;DDJ;118719
+Yoked Ox;ORI;149039
+Yoked Ox;THS;149039
+Yoked Plowbeast;ALA;115121
+Yomiji, Who Bars the Way;BOK;83893
+Yore-Tiller Nephilim;GPT;91863
+Yosei, the Morning Star;COK;80871
+Yosei, the Morning Star;DPA;80871
+Yosei, the Morning Star;MMA;80871
+Yotian Soldier;4ED;479
+Yotian Soldier;ATQ;479
+Yotian Soldier;ME4;479
+Yotian Soldier;MRD;50221
+Young Pyromancer;EMA;147404
+Young Pyromancer;M14;147404
+Young Wei Recruits;ME3;9082
+Young Wei Recruits;PTK;9082
+Young Wolf;DKA;139907
+Youthful Knight;10E;3807
+Youthful Knight;DPA;3807
+Youthful Knight;MM3;3807
+Youthful Knight;STH;3807
+Youthful Knight;TPR;3807
+Youthful Scholar;DTK;160047
+Yuan Shao, the Indecisive;PTK;9140
+Yuan Shao's Infantry;PTK;9153
+Yuki-Onna;SOK;86134
+Yukora, the Prisoner;BOK;83885
+Zada, Hedron Grinder;BFZ;160821
+Zada's Commando;OGW;161119
+Zameck Guildmage;GTC;146409
+Zameck Guildmage;PRM;147338
+Zanam Djinn;INV;24136
+Zanikev Locust;RTR;145173
+Zap;INV;24056
+Zarichi Tiger;GTC;146255
+Zealot il-Vec;TSP;97317
+Zealot of the God-Pharaoh;HOU;401726
+Zealots en-Dal;EXO;5656
+Zealous Conscripts;AVR;141663
+Zealous Conscripts;MM3;141663
+Zealous Guardian;SHM;111574
+Zealous Inquisitor;9ED;49046
+Zealous Inquisitor;SCG;49046
+Zealous Persecution;ARB;120977
+Zealous Persecution;DDK;120977
+Zealous Persecution;EMA;120977
+Zealous Strike;AVR;141564
+Zebra Unicorn;MIR;2125
+Zedruu the Greathearted;CMD;137545
+Zedruu the Greathearted;PZ1;137545
+Zektar Shrine Expedition;ZEN;123622
+Zelyon Sword;FEM;1038
+Zendikar Farguide;ZEN;123655
+Zendikar Incarnate;ORI;160336
+Zendikar Resurgent;OGW;161100
+Zendikar's Roil;ORI;160011
+Zenith Seeker;AKH;401295
+Zephid;USG;8646
+Zephid's Embrace;USG;8647
+Zephyr Charge;M14;147463
+Zephyr Falcon;4ED;727
+Zephyr Falcon;5ED;727
+Zephyr Falcon;LEG;727
+Zephyr Net;LRW;105599
+Zephyr Scribe;DTK;160060
+Zephyr Spirit;RAV;89003
+Zephyr Sprite;M10;121594
+Zerapa Minotaur;PCY;22001
+Zhalfirin Commander;DDG;2126
+Zhalfirin Commander;MIR;2126
+Zhalfirin Commander;TSB;2126
+Zhalfirin Crusader;VIS;2297
+Zhalfirin Crusader;VMA;2297
+Zhalfirin Knight;MIR;2127
+Zhang Fei, Fierce Warrior;ME3;9003
+Zhang Fei, Fierce Warrior;PTK;9003
+Zhang He, Wei General;PTK;9056
+Zhang Liao, Hero of Hefei;PTK;9044
+Zhao Zilong, Tiger General;PTK;9059
+Zhou Yu, Chief Commander;PTK;8997
+Zhuge Jin, Wu Strategist;PTK;9034
+Zhur-Taa Ancient;DGM;146876
+Zhur-Taa Druid;DDL;146726
+Zhur-Taa Druid;DGM;146726
+Zhur-Taa Swine;GTC;146296
+Zirilan of the Claw;MIR;2128
+Zo-Zu the Punisher;COK;81025
+Zodiac Dog;PRM;9183
+Zodiac Dog;PTK;9183
+Zodiac Dragon;ME3;9173
+Zodiac Dragon;PTK;9173
+Zodiac Goat;PRM;9171
+Zodiac Goat;PTK;9171
+Zodiac Horse;PRM;9114
+Zodiac Horse;PTK;9114
+Zodiac Monkey;9ED;86921
+Zodiac Monkey;PRM;9111
+Zodiac Monkey;PTK;9111
+Zodiac Ox;PRM;9115
+Zodiac Ox;PTK;9115
+Zodiac Pig;PRM;9181
+Zodiac Pig;PTK;9181
+Zodiac Rabbit;PRM;9112
+Zodiac Rabbit;PTK;9112
+Zodiac Rat;PRM;9166
+Zodiac Rat;PTK;9166
+Zodiac Rooster;PRM;9110
+Zodiac Rooster;PTK;9110
+Zodiac Snake;PRM;9168
+Zodiac Snake;PTK;9168
+Zodiac Tiger;PRM;9113
+Zodiac Tiger;PTK;9113
+Zoetic Cavern;C14;102430
+Zoetic Cavern;CMD;102430
+Zoetic Cavern;FUT;102430
+Zoetic Cavern;PRM;103478
+Zof Shade;M15;127340
+Zof Shade;ROE;127340
+Zombie Apocalypse;DKA;139826
+Zombie Apocalypse;PRM;140328
+Zombie Assassin;ODY;33440
+Zombie Boa;APC;31176
+Zombie Brute;LGN;46584
+Zombie Cannibal;ODY;33432
+Zombie Cutthroat;SCG;48572
+Zombie Giant;TOK;125090
+Zombie Goliath;M10;121625
+Zombie Goliath;M12;121625
+Zombie Goliath;M13;121625
+Zombie Horror;TOK;160130
+Zombie Infestation;M12;33392
+Zombie Infestation;ODY;33392
+Zombie Infestation;PD3;33392
+Zombie Master;2ED;295
+Zombie Master;3ED;295
+Zombie Master;4ED;295
+Zombie Master;5ED;2516
+Zombie Master;6ED;295
+Zombie Master;LEA;295
+Zombie Master;LEB;295
+Zombie Master;ME4;295
+Zombie Mob;MIR;2129
+Zombie Musher;CSP;96890
+Zombie Outlander;CON;118769
+Zombie Outlander;DPA;118769
+Zombie Scavengers;WTH;2789
+Zombie Trailblazer;TOR;36469
+Zombie Wizard;TOK;121082
+Zombie;TOK;103851
+Zombie;TOK;104573
+Zombie;TOK;117011
+Zombie;TOK;134065
+Zombie;TOK;138477
+Zombie;TOK;139310
+Zombie;TOK;139311
+Zombie;TOK;152108
+Zombie;TOK;155464
+Zombie;TOK;156416
+Zombie;TOK;156690
+Zombie;TOK;160052
+Zombie;TOK;160878
+Zombie;TOK;161607
+Zombie;TOK;162084
+Zombie;TOK;162085
+Zombie;TOK;162086
+Zombie;TOK;162087
+Zombie;TOK;33670
+Zombie;TOK;400961
+Zombie;TOK;44688
+Zombify;8ED;33408
+Zombify;9ED;33408
+Zombify;DPA;33408
+Zombify;ODY;33408
+Zombify;PRM;90394
+Zoologist;ODY;33289
+Zuberi, Golden Feather;MIR;2130
+Zulaport Chainmage;OGW;161085
+Zulaport Cutthroat;BFZ;160671
+Zulaport Enforcer;ROE;127384
+Zuo Ci, the Mocking Sage;PTK;9086
+Zur the Enchanter;CSP;96898
+Zur the Enchanter;MM3;96898
+Zur's Weirding;5ED;1438
+Zur's Weirding;6ED;1438
+Zur's Weirding;8ED;9401
+Zur's Weirding;9ED;86731
+Zur's Weirding;ICE;1438
+Zuran Enchanter;ICE;1439
+Zuran Orb;ICE;1440
+Zuran Orb;MED;1440
+Zuran Orb;PRM;1440
+Zuran Orb;V10;129508
+Zuran Spellcaster;ICE;1441
+Zuran Spellcaster;ME2;1441
+Zurgo Bellstriker;DTK;159784
+Zurgo Helmsmasher;KTK;156635
+Zurgo Helmsmasher;PRM;156852


### PR DESCRIPTION
This is for the Modern Card Renderer.  It alleviates some of the pixelation that occurs if the renderer uses just the scanned image.

The Utils/get_modo_artids.pl script creates (as long as you have the relevant .xml files copied into the same directory) a list of  'NAME;SET;ARTID' lines as output.

It also generates a way to download these images using lines such as the following:
echo "1" | cut.pl stdin "http://mtgoclientdepot.onlinegaming.wizards.com/Graphics/Cards/Pics/00020_typ_reg_sty_001.jpg" "LEA\Black Ward.jpg" wget_image

