### PR TITLE
Add new fallback card render with round corners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ syntax: glob
 Mage.Client/*.dck
 Mage.Client/db
 Mage.Client/gamelogs
-Mage.Client/mageclient.log
+Mage.Client/*.log
 Mage.Client/plugins/images
 Mage.Client/plugins/plugin.data
 Mage.Client/target

--- a/Mage.Client/src/main/java/mage/client/cards/Card.java
+++ b/Mage.Client/src/main/java/mage/client/cards/Card.java
@@ -562,7 +562,7 @@ public class Card extends MagePermanent implements MouseMotionListener, MouseLis
     }
 
     @Override
-    public void setTextOffset(int yOffset) {
+    public void setCardCaptionTopOffset(int yOffsetPercent) {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 

--- a/Mage.Client/src/main/java/mage/client/cards/CardArea.java
+++ b/Mage.Client/src/main/java/mage/client/cards/CardArea.java
@@ -53,7 +53,7 @@ public class CardArea extends JPanel implements MouseListener {
     private boolean reloaded = false;
     private final javax.swing.JLayeredPane cardArea;
     private final javax.swing.JScrollPane scrollPane;
-    private int yTextOffset;
+    private int yCardCaptionOffsetPercent = 0; // card caption offset (use for moving card caption view center, below mana icons -- for more good UI)
     private Dimension cardDimension;
     private int verticalCardOffset;
 
@@ -68,8 +68,6 @@ public class CardArea extends JPanel implements MouseListener {
         setGUISize();
         cardArea = new JLayeredPane();
         scrollPane.setViewportView(cardArea);
-        yTextOffset = 10;
-
     }
 
     public void cleanUp() {
@@ -103,10 +101,10 @@ public class CardArea extends JPanel implements MouseListener {
         this.reloaded = true;
         cardArea.removeAll();
         if (showCards != null && showCards.size() < 10) {
-            yTextOffset = 10;
+            yCardCaptionOffsetPercent = 8; // TODO: need to test
             loadCardsFew(showCards, bigCard, gameId);
         } else {
-            yTextOffset = 0;
+            yCardCaptionOffsetPercent = 0;
             loadCardsMany(showCards, bigCard, gameId);
         }
         cardArea.revalidate();
@@ -118,8 +116,10 @@ public class CardArea extends JPanel implements MouseListener {
     public void loadCardsNarrow(CardsView showCards, BigCard bigCard, UUID gameId) {
         this.reloaded = true;
         cardArea.removeAll();
-        yTextOffset = 0;
+
+        yCardCaptionOffsetPercent = 0; // TODO: need to test
         loadCardsMany(showCards, bigCard, gameId);
+
         cardArea.revalidate();
 
         this.revalidate();
@@ -152,7 +152,10 @@ public class CardArea extends JPanel implements MouseListener {
         cardArea.moveToFront(cardPanel);
         cardPanel.update(card);
         cardPanel.setCardBounds(rectangle.x, rectangle.y, cardDimension.width, cardDimension.height);
-        cardPanel.setTextOffset(yTextOffset);
+
+        // new card have same settings as current view
+        cardPanel.setCardCaptionTopOffset(yCardCaptionOffsetPercent);
+
         cardPanel.showCardTitle();
     }
 

--- a/Mage.Client/src/main/java/mage/client/cards/DragCardGrid.java
+++ b/Mage.Client/src/main/java/mage/client/cards/DragCardGrid.java
@@ -1726,7 +1726,7 @@ public class DragCardGrid extends JPanel implements DragCardSource, DragCardTarg
         // Create the card view
         final MageCard cardPanel = Plugins.instance.getMageCard(card, lastBigCard, new Dimension(getCardWidth(), getCardHeight()), null, true, true);
         cardPanel.update(card);
-        cardPanel.setTextOffset(0);
+        cardPanel.setCardCaptionTopOffset(0);
 
         // Remove mouse wheel listeners so that scrolling works
         // Scrolling works on all areas without cards or by using the scroll bar, that's enough

--- a/Mage.Client/src/main/java/mage/client/deckeditor/collection/viewer/MageBook.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/collection/viewer/MageBook.java
@@ -236,6 +236,7 @@ public class MageBook extends JComponent {
         for (int i = 0; i < Math.min(conf.CARDS_PER_PAGE / 2, size); i++) {
             Card card = cards.get(i).getMockCard();
             addCard(new CardView(card), bigCard, null, rectangle);
+
             rectangle = CardPosition.translatePosition(i, rectangle, conf);
         }
 
@@ -340,6 +341,8 @@ public class MageBook extends JComponent {
         jLayeredPane.add(cardImg, JLayeredPane.DEFAULT_LAYER, 10);
         cardImg.update(card);
         cardImg.setCardBounds(rectangle.x, rectangle.y, cardDimensions.frameWidth, cardDimensions.frameHeight);
+
+        cardImg.setCardCaptionTopOffset(8); // card caption below real card caption to see full name even with mana icons
 
         boolean implemented = card.getRarity() != Rarity.NA;
 

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanel.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanel.java
@@ -91,7 +91,7 @@ public abstract class CardPanel extends MagePermanent implements MouseListener, 
 
     private JPanel cardArea;
 
-    private int yTextOffset = 10;
+    private int yCardCaptionOffsetPercent = 0; // card caption offset (use for moving card caption view center, below mana icons -- for more good UI)
 
     // if this is set, it's opened if the user right clicks on the card panel
     private JPopupMenu popupMenu;
@@ -819,12 +819,12 @@ public abstract class CardPanel extends MagePermanent implements MouseListener, 
     }
 
     @Override
-    public void setTextOffset(int yOffset) {
-        yTextOffset = yOffset;
+    public void setCardCaptionTopOffset(int yOffsetPercent) {
+        yCardCaptionOffsetPercent = yOffsetPercent;
     }
 
-    public int getTextOffset() {
-        return yTextOffset;
+    public int getCardCaptionTopOffset() {
+        return yCardCaptionOffsetPercent;
     }
 
     @Override

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanel.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanel.java
@@ -91,7 +91,8 @@ public abstract class CardPanel extends MagePermanent implements MouseListener, 
 
     private JPanel cardArea;
 
-    private int yCardCaptionOffsetPercent = 0; // card caption offset (use for moving card caption view center, below mana icons -- for more good UI)
+    // default offset, e.g. for battlefield
+    private int yCardCaptionOffsetPercent = 8; // card caption offset (use for moving card caption view center, below mana icons -- for more good UI)
 
     // if this is set, it's opened if the user right clicks on the card panel
     private JPopupMenu popupMenu;

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelComponentImpl.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelComponentImpl.java
@@ -34,7 +34,7 @@ import static org.mage.plugins.card.constants.Constants.THUMBNAIL_SIZE_FULL;
  * Class for drawing the mage card object by using a form based JComponent
  * approach
  *
- * @author arcane, nantuko, noxx, stravant
+ * @author arcane, nantuko, noxx, stravant, JayDi85
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class CardPanelComponentImpl extends CardPanel {
@@ -47,8 +47,13 @@ public class CardPanelComponentImpl extends CardPanel {
 
     private static final float ROUNDED_CORNER_SIZE = 0.1f;
     private static final float BLACK_BORDER_SIZE = 0.03f;
+    private static final float SELECTION_BORDER_SIZE = 0.03f;
     private static final int TEXT_GLOW_SIZE = 6;
     private static final float TEXT_GLOW_INTENSITY = 3f;
+
+    // size to show icons and text (help to see full size card without text)
+    private static final int CARD_MIN_SIZE_FOR_ICONS = 60;
+    private static final int CARD_MAX_SIZE_FOR_ICONS = 200;
 
     public final ScaledImagePanel imagePanel;
     public ImagePanel overlayPanel;
@@ -175,6 +180,31 @@ public class CardPanelComponentImpl extends CardPanel {
 
     static {
         IMAGE_CACHE = ImageCaches.register(new MapMaker().softValues().makeComputingMap((Function<Key, BufferedImage>) key -> createImage(key)));
+    }
+
+    static private boolean canShowCardIcons(int fullWidth){
+        return (fullWidth > 60) && (fullWidth < 200);
+    }
+
+    private static class CardSizes{
+        Rectangle rectFull;
+        Rectangle rectSelection;
+        Rectangle rectBorder;
+        Rectangle rectCard;
+
+        CardSizes(int offsetX, int offsetY, int fullWidth, int fullHeight){
+
+            int realBorderSizeX = Math.round(fullWidth * BLACK_BORDER_SIZE);
+            int realBorderSizeY = Math.round(fullWidth * BLACK_BORDER_SIZE);
+            int realSelectionSizeX = Math.round(fullWidth * SELECTION_BORDER_SIZE);
+            int realSelectionSizeY = Math.round(fullWidth * SELECTION_BORDER_SIZE);
+
+            // card full size = select border + black border + real card
+            rectFull = new Rectangle(offsetX, offsetY, fullWidth, fullHeight);
+            rectSelection = new Rectangle(rectFull.x, rectFull.y, rectFull.width, rectFull.height);
+            rectBorder = new Rectangle(rectSelection.x + realSelectionSizeX, rectSelection.y + realSelectionSizeY, rectSelection.width - 2 * realSelectionSizeX, rectSelection.height - 2 * realSelectionSizeY);
+            rectCard = new Rectangle(rectBorder.x + realBorderSizeX, rectBorder.y + realBorderSizeY, rectBorder.width - 2 * realBorderSizeX, rectBorder.height - 2 * realBorderSizeY);
+        }
     }
 
     public CardPanelComponentImpl(CardView newGameCard, UUID gameId, final boolean loadImage, ActionCallback callback, final boolean foil, Dimension dimension) {
@@ -368,31 +398,44 @@ public class CardPanelComponentImpl extends CardPanel {
         Graphics2D g2d = image.createGraphics();
         g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
-        if (!key.hasImage) {
-            g2d.setColor(new Color(30, 200, 200, 120));
-        } else {
-            g2d.setColor(new Color(0, 0, 0, 0));
-        }
+        // card full size = select border + black border + real card
+        CardSizes sizes = new CardSizes(cardXOffset, cardYOffset, cardWidth, cardHeight);
 
-        int cornerSize = Math.max(4, Math.round(cardWidth * ROUNDED_CORNER_SIZE));
-        g2d.fillRoundRect(cardXOffset, cardYOffset, cardWidth, cardHeight, cornerSize, cornerSize);
+        // corners for selection and for border
+        int cornerSizeSelection = Math.max(4, Math.round(sizes.rectSelection.width * ROUNDED_CORNER_SIZE));
+        int cornerSizeBorder = Math.max(4, Math.round(sizes.rectBorder.width * ROUNDED_CORNER_SIZE));
 
+        // DRAW ORDER from big to small: select -> select info -> border -> card
+
+        // draw selection
         if (key.isSelected) {
             g2d.setColor(Color.green);
-            g2d.fillRoundRect(cardXOffset + 1, cardYOffset + 1, cardWidth - 2, cardHeight - 2, cornerSize, cornerSize);
+            g2d.fillRoundRect(sizes.rectSelection.x + 1, sizes.rectSelection.y + 1, sizes.rectSelection.width - 2, sizes.rectSelection.height - 2, cornerSizeSelection, cornerSizeSelection);
         } else if (key.isChoosable) {
             g2d.setColor(new Color(250, 250, 0, 230));
-            g2d.fillRoundRect(cardXOffset + 1, cardYOffset + 1, cardWidth - 2, cardHeight - 2, cornerSize, cornerSize);
+            g2d.fillRoundRect(sizes.rectSelection.x + 1, sizes.rectSelection.y + 1, sizes.rectSelection.width - 2, sizes.rectSelection.height - 2, cornerSizeSelection, cornerSizeSelection);
         } else if (key.isPlayable) {
             g2d.setColor(new Color(153, 102, 204, 200));
-            //g2d.fillRoundRect(cardXOffset + 1, cardYOffset + 1, cardWidth - 2, cardHeight - 2, cornerSize, cornerSize);
-            g2d.fillRoundRect(cardXOffset, cardYOffset, cardWidth, cardHeight, cornerSize, cornerSize);
+            g2d.fillRoundRect(sizes.rectSelection.x, sizes.rectSelection.y, sizes.rectSelection.width, sizes.rectSelection.height, cornerSizeSelection, cornerSizeSelection);
         }
 
+        // draw empty card with border
+        if (!key.hasImage) {
+            // gray 1 px border
+            g2d.setColor(new Color(125, 125, 125, 255));
+            g2d.fillRoundRect(sizes.rectBorder.x, sizes.rectBorder.y, sizes.rectBorder.width, sizes.rectBorder.height, cornerSizeBorder, cornerSizeBorder);
+            // color plate
+            g2d.setColor(new Color(30, 200, 200, 200));
+            g2d.fillRoundRect(sizes.rectBorder.x + 1, sizes.rectBorder.y + 1, sizes.rectBorder.width - 2, sizes.rectBorder.height - 2, cornerSizeBorder, cornerSizeBorder);
+        }
+
+        // draw attack border (inner part of border, not selection -- must always show attack)
         if (key.canAttack) {
             g2d.setColor(new Color(0, 0, 255, 230));
-            g2d.fillRoundRect(cardXOffset + 1, cardYOffset + 1, cardWidth - 2, cardHeight - 2, cornerSize, cornerSize);
+            g2d.fillRoundRect(sizes.rectBorder.x + 1, sizes.rectBorder.y + 1, sizes.rectBorder.width - 2, sizes.rectBorder.height - 2, cornerSizeBorder, cornerSizeBorder);
         }
+
+        // draw real card by component (see imagePanel and other layout's items)
 
         //TODO:uncomment
         /*
@@ -409,18 +452,54 @@ public class CardPanelComponentImpl extends CardPanel {
     protected void paintChildren(Graphics g) {
         super.paintChildren(g);
 
-        if (getShowCastingCost() && !isAnimationPanel() && getCardWidth() < 200 && getCardWidth() > 60) {
+        CardSizes realCard = new CardSizes(getCardXOffset(), getCardYOffset(), getCardWidth(), getCardHeight());
+
+        /*
+        // draw recs for debug
+
+        // full card
+        g.setColor(new Color(255, 0, 0));
+        g.drawRect(realCard.rectFull.x, realCard.rectFull.y, realCard.rectFull.width, realCard.rectFull.height);
+
+        // real card - image
+        g.setColor(new Color(0, 0, 255));
+        g.drawRect(imagePanel.getX(), imagePanel.getY(), imagePanel.getBounds().width, imagePanel.getBounds().height);
+
+        // caption
+        g.setColor(new Color(0, 255, 255));
+        g.drawRect(titleText.getX(), titleText.getY(), titleText.getBounds().width, titleText.getBounds().height);
+
+        // life points
+        g.setColor(new Color(120, 0, 120));
+        g.drawRect(ptText.getX(), ptText.getY(), ptText.getBounds().width, ptText.getBounds().height);
+        //*/
+
+        if (getShowCastingCost() && !isAnimationPanel() && canShowCardIcons(getCardWidth())) {
+
             String manaCost = ManaSymbols.getStringManaCost(gameCard.getManaCost());
-            int width = getWidth(manaCost);
+            int manaWidth = getManaWidth(manaCost);
+
+            // right top corner with margin (sizes from any sample card, length from black border to mana icon)
+            int manaMarginRight = Math.round(22f / 672f * getCardWidth());
+            int manaMarginTop = Math.round(24f / 936f * getCardHeight());
+
+            int manaX = getCardXOffset() + getCardWidth() - manaMarginRight - manaWidth;
+            int manaY = getCardYOffset() + manaMarginTop;
+
             if (hasImage) {
-                ManaSymbols.draw(g, manaCost, getCardXOffset() + getCardWidth() - width - 5, getCardYOffset() + 5, getSymbolWidth());
+                // top right corner if have image like real card
+                ManaSymbols.draw(g, manaCost, manaX, manaY, getSymbolWidth());
             } else {
-                ManaSymbols.draw(g, manaCost, getCardXOffset() + 8, getCardHeight() - 9, getSymbolWidth());
+                // old version - bottom left corner if haven't card
+                // ManaSymbols.draw(g, manaCost, getCardXOffset() + manaMarginRight, getCardYOffset() + getCardHeight() - manaMarginTop - getSymbolWidth(), getSymbolWidth());
+
+                // new version - like a normal image (it's best to view and construct decks)
+                ManaSymbols.draw(g, manaCost, manaX, manaY, getSymbolWidth());
             }
         }
     }
 
-    private int getWidth(String manaCost) {
+    private int getManaWidth(String manaCost) {
         int width = 0;
         manaCost = manaCost.replace("\\", "");
         StringTokenizer tok = new StringTokenizer(manaCost, " ");
@@ -439,24 +518,28 @@ public class CardPanelComponentImpl extends CardPanel {
         int cardHeight = getCardHeight();
         int cardXOffset = getCardXOffset();
         int cardYOffset = getCardYOffset();
-        int borderSize = Math.round(cardWidth * BLACK_BORDER_SIZE);
-        imagePanel.setLocation(cardXOffset + borderSize, cardYOffset + borderSize);
-        imagePanel.setSize(cardWidth - borderSize * 2, cardHeight - borderSize * 2);
+
+        CardSizes sizes = new CardSizes(cardXOffset, cardYOffset, cardWidth, cardHeight);
+
+        // origin card without selection
+        Rectangle realCardSize = sizes.rectBorder;
+        imagePanel.setLocation(realCardSize.x, realCardSize.y);
+        imagePanel.setSize(realCardSize.width, realCardSize.height);
 
         if (hasSickness() && gameCard.isCreature() && isPermanent()) {
-            overlayPanel.setLocation(cardXOffset + borderSize, cardYOffset + borderSize);
-            overlayPanel.setSize(cardWidth - borderSize * 2, cardHeight - borderSize * 2);
+            overlayPanel.setLocation(realCardSize.x, realCardSize.y);
+            overlayPanel.setSize(realCardSize.width, realCardSize.height);
         } else {
             overlayPanel.setVisible(false);
         }
 
         if (iconPanel != null) {
-            iconPanel.setLocation(cardXOffset + borderSize, cardYOffset + borderSize);
-            iconPanel.setSize(cardWidth - borderSize * 2, cardHeight - borderSize * 2);
+            iconPanel.setLocation(realCardSize.x, realCardSize.y);
+            iconPanel.setSize(realCardSize.width, realCardSize.height);
         }
         if (counterPanel != null) {
-            counterPanel.setLocation(cardXOffset + borderSize, cardYOffset + borderSize);
-            counterPanel.setSize(cardWidth - borderSize * 2, cardHeight - borderSize * 2);
+            counterPanel.setLocation(realCardSize.x, realCardSize.y);
+            counterPanel.setSize(realCardSize.width, realCardSize.height);
             int size = cardWidth > WIDTH_LIMIT ? 40 : 20;
 
             minusCounterLabel.setLocation(counterPanel.getWidth() - size, counterPanel.getHeight() - size * 2);
@@ -472,32 +555,52 @@ public class CardPanelComponentImpl extends CardPanel {
             otherCounterLabel.setSize(size, size);
 
         }
-        int fontHeight = Math.round(cardHeight * (27f / 680));
-        boolean showText = (!isAnimationPanel() && fontHeight < 12);
+
+        // TITLE
+
+        //old version - text hide on small fonts, why?
+        //int fontHeight = Math.round(cardHeight * (26f / 672));
+        //boolean showText = (!isAnimationPanel() && fontHeight < 12);
+
+        boolean showText = !isAnimationPanel() && canShowCardIcons(cardWidth);
         titleText.setVisible(showText);
         ptText.setVisible(showText);
         fullImageText.setVisible(fullImagePath != null);
 
         if (showText) {
-            int fontSize = cardHeight / 11;
+            int fontSize = cardHeight / 13; // startup font size (it same size on all zoom levels)
             titleText.setFont(getFont().deriveFont(Font.BOLD, fontSize));
 
-            int titleX = Math.round(cardWidth * (20f / 480));
-            int titleY = Math.round(cardHeight * (9f / 680)) + getTextOffset();
-            titleText.setBounds(cardXOffset + titleX, cardYOffset + titleY, cardWidth - titleX, cardHeight - titleY);
+            // margins from card black border to text, not need? text show up good without margins
+            int titleMarginLeft = 0; //Math.round(28f / 672f * cardWidth);
+            int titleMarginRight = 0;
+            int titleMarginTop = 0 + Math.round(getCardCaptionTopOffset() / 100f * cardHeight);//Math.round(28f / 936f * cardHeight);
+            int titleMarginBottom = 0;
+            titleText.setBounds(
+                    imagePanel.getX() + titleMarginLeft,
+                    imagePanel.getY() + titleMarginTop,
+                    imagePanel.getBounds().width - titleMarginLeft - titleMarginRight,
+                    imagePanel.getBounds().height - titleMarginTop - titleMarginBottom
+            );
 
             fullImageText.setFont(getFont().deriveFont(Font.PLAIN, 10));
-            fullImageText.setBounds(cardXOffset, cardYOffset + titleY, cardWidth, cardHeight - titleY);
+            fullImageText.setBounds(titleText.getX(), titleText.getY(), titleText.getBounds().width, titleText.getBounds().height);
 
+            // life points location (font as title)
             ptText.setFont(getFont().deriveFont(Font.BOLD, fontSize));
             Dimension ptSize = ptText.getPreferredSize();
             ptText.setSize(ptSize.width, ptSize.height);
-            int ptX = Math.round(cardWidth * (420f / 480)) - ptSize.width / 2;
-            int ptY = Math.round(cardHeight * (675f / 680)) - ptSize.height;
 
-            int offsetX = Math.round((CARD_SIZE_FULL.width - cardWidth) / 10.0f);
+            // right bottom corner with margin (sizes from any sample card)
+            int ptMarginRight = Math.round(64f / 672f * cardWidth);
+            int ptMarginBottom = Math.round(62f / 936f * cardHeight);
 
-            ptText.setLocation(cardXOffset + ptX - TEXT_GLOW_SIZE / 2 - offsetX, cardYOffset + ptY - TEXT_GLOW_SIZE / 2);
+            int ptX = cardXOffset + cardWidth - ptMarginRight - ptSize.width;
+            int ptY = cardYOffset + cardHeight - ptMarginBottom - ptSize.height;
+            ptText.setLocation(ptX, ptY);
+
+            // old version was with TEXT_GLOW_SIZE
+            //ptText.setLocation(cardXOffset + ptX - TEXT_GLOW_SIZE / 2 - offsetX, cardYOffset + ptY - TEXT_GLOW_SIZE / 2);
         }
     }
 
@@ -581,7 +684,7 @@ public class CardPanelComponentImpl extends CardPanel {
         } else if (this.gameCard instanceof StackAbilityView) {
             return ImageCache.getMorphImage();
         } else {
-            return ImageCache.loadImage(new TFile(DirectLinksForDownload.outDir + File.separator + DirectLinksForDownload.cardbackFilename));
+            return ImageCache.getCardbackImage();
         }
     }
 

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelComponentImpl.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelComponentImpl.java
@@ -182,8 +182,11 @@ public class CardPanelComponentImpl extends CardPanel {
         IMAGE_CACHE = ImageCaches.register(new MapMaker().softValues().makeComputingMap((Function<Key, BufferedImage>) key -> createImage(key)));
     }
 
-    static private boolean canShowCardIcons(int fullWidth){
-        return (fullWidth > 60) && (fullWidth < 200);
+    static private boolean canShowCardIcons(int cardFullWidth, boolean cardHasImage){
+        // cards without images show icons and text always
+        // TODO: apply "card names on card" setting to icon too?
+        // TODO: fix card min-max size to hide (compare to settings size, not direct 60 and 200)
+        return ((cardFullWidth > 60) && (cardFullWidth < 200)) || (!cardHasImage);
     }
 
     private static class CardSizes{
@@ -474,7 +477,7 @@ public class CardPanelComponentImpl extends CardPanel {
         g.drawRect(ptText.getX(), ptText.getY(), ptText.getBounds().width, ptText.getBounds().height);
         //*/
 
-        if (getShowCastingCost() && !isAnimationPanel() && canShowCardIcons(getCardWidth())) {
+        if (getShowCastingCost() && !isAnimationPanel() && canShowCardIcons(getCardWidth(), hasImage)) {
 
             String manaCost = ManaSymbols.getStringManaCost(gameCard.getManaCost());
             int manaWidth = getManaWidth(manaCost);
@@ -562,7 +565,7 @@ public class CardPanelComponentImpl extends CardPanel {
         //int fontHeight = Math.round(cardHeight * (26f / 672));
         //boolean showText = (!isAnimationPanel() && fontHeight < 12);
 
-        boolean showText = !isAnimationPanel() && canShowCardIcons(cardWidth);
+        boolean showText = !isAnimationPanel() && canShowCardIcons(cardWidth, hasImage);
         titleText.setVisible(showText);
         ptText.setVisible(showText);
         fullImageText.setVisible(fullImagePath != null);

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelComponentImpl.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelComponentImpl.java
@@ -429,10 +429,10 @@ public class CardPanelComponentImpl extends CardPanel {
             g2d.fillRoundRect(sizes.rectBorder.x + 1, sizes.rectBorder.y + 1, sizes.rectBorder.width - 2, sizes.rectBorder.height - 2, cornerSizeBorder, cornerSizeBorder);
         }
 
-        // draw attack border (inner part of border, not selection -- must always show attack)
+        // draw attack border (inner part of selection)
         if (key.canAttack) {
             g2d.setColor(new Color(0, 0, 255, 230));
-            g2d.fillRoundRect(sizes.rectBorder.x - 1, sizes.rectBorder.y - 1, sizes.rectBorder.width + 2, sizes.rectBorder.height + 2, cornerSizeBorder, cornerSizeBorder);
+            g2d.fillRoundRect(sizes.rectBorder.x + 1, sizes.rectBorder.y + 1, sizes.rectBorder.width - 2, sizes.rectBorder.height - 2, cornerSizeBorder, cornerSizeBorder);
         }
 
         // draw real card by component (see imagePanel and other layout's items)

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelComponentImpl.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelComponentImpl.java
@@ -432,7 +432,7 @@ public class CardPanelComponentImpl extends CardPanel {
         // draw attack border (inner part of border, not selection -- must always show attack)
         if (key.canAttack) {
             g2d.setColor(new Color(0, 0, 255, 230));
-            g2d.fillRoundRect(sizes.rectBorder.x + 1, sizes.rectBorder.y + 1, sizes.rectBorder.width - 2, sizes.rectBorder.height - 2, cornerSizeBorder, cornerSizeBorder);
+            g2d.fillRoundRect(sizes.rectBorder.x - 1, sizes.rectBorder.y - 1, sizes.rectBorder.width + 2, sizes.rectBorder.height + 2, cornerSizeBorder, cornerSizeBorder);
         }
 
         // draw real card by component (see imagePanel and other layout's items)

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderImpl.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderImpl.java
@@ -398,7 +398,7 @@ public class CardPanelRenderImpl extends CardPanel {
         } else if (this.gameCard instanceof StackAbilityView) {
             return ImageCache.getMorphImage();
         } else {
-            return ImageCache.loadImage(new TFile(DirectLinksForDownload.outDir + File.separator + DirectLinksForDownload.cardbackFilename));
+            return ImageCache.getCardbackImage();
         }
     }
 

--- a/Mage.Common/src/main/java/mage/cards/MageCard.java
+++ b/Mage.Common/src/main/java/mage/cards/MageCard.java
@@ -25,8 +25,8 @@ public abstract class MageCard extends JPanel {
 
     public abstract CardView getOriginal();
 
-    // sets the vertical text offset for the card name on the image
-    public abstract void setTextOffset(int yOffset);
+    // sets the vertical text offset for the card name on the image, use to move caption to card center
+    public abstract void setCardCaptionTopOffset(int yOffsetPercent);
 
     public abstract void setCardBounds(int x, int y, int width, int height);
 


### PR DESCRIPTION
See #4168 for bugs of old origin card render with "before" screenshots.

New features:
 - fixed text, mana and life text's position (viewer, deck editor and battle mode);
 - fixed wrong card sizes, icons position and draw of empty card (without image);
 - added round corners to all cards and tokens (if you see white corners -- clear images cash by deleting all `*.thumb.zip` files in game folder);
 - new round corners apply to all cards on image load -- this should not affect performance or memory resources consumption (if you get OutOfMemoryException -- tell me).

Examples:

1. Before-after animation:
![mtg---render---before-after](https://user-images.githubusercontent.com/8344157/32980843-5776fcd4-cc87-11e7-83c1-35749bf4cecf.gif)

2. Battlefield render:
![shot_171118_063831](https://user-images.githubusercontent.com/8344157/32976229-818ce274-cc2b-11e7-91f6-c7d19e180b18.png)


3. Viewer render:
![shot_171118_035957](https://user-images.githubusercontent.com/8344157/32975472-d936e660-cc20-11e7-8ec4-9d96c70db954.png)

4. Deck editor render:
![shot_171118_035934](https://user-images.githubusercontent.com/8344157/32975480-ec370542-cc20-11e7-8021-8c49c0649320.png)
