### PR TITLE
Fix Accursed Witch to avoid duplicated card

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AccursedWitch.java
+++ b/Mage.Sets/src/mage/cards/a/AccursedWitch.java
@@ -56,8 +56,8 @@ public class AccursedWitch extends CardImpl {
 
     public AccursedWitch(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{B}");
-        this.subtype.add(SubType.SHAMAN);
         this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.SHAMAN);
         this.power = new MageInt(4);
         this.toughness = new MageInt(2);
 

--- a/Mage.Sets/src/mage/cards/a/AccursedWitch.java
+++ b/Mage.Sets/src/mage/cards/a/AccursedWitch.java
@@ -37,11 +37,15 @@ import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.abilities.keyword.TransformAbility;
+import mage.cards.i.InfectiousCurse;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.cards.i.InfectiousCurse;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.CostModificationType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -56,8 +60,8 @@ public class AccursedWitch extends CardImpl {
 
     public AccursedWitch(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{B}");
-        this.subtype.add(SubType.HUMAN);
-        this.subtype.add(SubType.SHAMAN);
+        this.subtype.add("Human");
+        this.subtype.add("Shaman");
         this.power = new MageInt(4);
         this.toughness = new MageInt(2);
 
@@ -106,6 +110,7 @@ class AccursedWitchReturnTransformedEffect extends OneShotEffect {
                 //note: should check for null after game.getCard
                 Card card = game.getCard(source.getSourceId());
                 if (card != null) {
+                    card.removeFromZone(game, Zone.GRAVEYARD, source.getSourceId());
                     card.putOntoBattlefield(game, Zone.BATTLEFIELD, source.getSourceId(), source.getControllerId(), false);
                 }
             }

--- a/Mage.Sets/src/mage/cards/a/AccursedWitch.java
+++ b/Mage.Sets/src/mage/cards/a/AccursedWitch.java
@@ -41,11 +41,7 @@ import mage.cards.i.InfectiousCurse;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.CostModificationType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -60,8 +56,8 @@ public class AccursedWitch extends CardImpl {
 
     public AccursedWitch(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{B}");
-        this.subtype.add("Human");
-        this.subtype.add("Shaman");
+        this.subtype.add(SubType.SHAMAN);
+        this.subtype.add(SubType.HUMAN);
         this.power = new MageInt(4);
         this.toughness = new MageInt(2);
 


### PR DESCRIPTION
Saw this bug on a Commander match:

I Play Accursed Witch -> someone kills her -> active ability and came back transformed BUT the non-flipped cards stills on grave (now having two cards in game).

Is the same card because they have same ID.

A look to the code and find a way to solve, adding:
```
card.removeFromZone(game, Zone.GRAVEYARD, source.getSourceId());
``` 
![screenshot from 2017-12-13 00-17-19](https://user-images.githubusercontent.com/8901883/33918703-110de3de-df9c-11e7-9d9c-46f9a4f314ee.png)
