### PR TITLE
Curfew - Fix targeting/protection issue

### DIFF
--- a/Mage.Sets/src/mage/cards/c/Curfew.java
+++ b/Mage.Sets/src/mage/cards/c/Curfew.java
@@ -79,8 +79,9 @@ class CurfewEffect extends OneShotEffect{
         for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {
             Player player = game.getPlayer(playerId);
             if (player != null) {
-                TargetControlledCreaturePermanent target = new TargetControlledCreaturePermanent();
-                List<Permanent> liste = game.getBattlefield().getActivePermanents(new FilterControlledCreaturePermanent(), playerId, game);
+                FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent();
+                TargetControlledCreaturePermanent target = new TargetControlledCreaturePermanent(1, 1, filter, true);
+                List<Permanent> liste = game.getBattlefield().getActivePermanents(filter, playerId, game);
                 if(!liste.isEmpty()){
                     player.choose(Outcome.ReturnToHand, target, source.getSourceId(), game);
 


### PR DESCRIPTION
This is my first not-just-a-typo-fix PR, so if there's a better way to do this please let me know.

I discovered an issue where Curfew would not require (or even let) a player to bounce a creature if it had protection from blue (or monocolored).

For some reason, when I tried to test this against an AI, they bounced the creature with protection. But two human clients and the player was never even prompted.