### PR TITLE
Fix Unified Strike 2

### DIFF
--- a/Mage.Sets/src/mage/cards/u/UnifiedStrike.java
+++ b/Mage.Sets/src/mage/cards/u/UnifiedStrike.java
@@ -76,7 +76,7 @@ class UnifiedStrikeEffect extends OneShotEffect {
 
     UnifiedStrikeEffect() {
         super(Outcome.Exile);
-        this.staticText = "Exile target attacking creature if its power is less than or equal to the number of Soldiers on the battlefield.";
+        this.staticText = "Exile target attacking creature if its power is less than or equal to the number of Soldiers on the battlefield";
     }
 
     UnifiedStrikeEffect(final UnifiedStrikeEffect effect) {
@@ -102,6 +102,10 @@ class UnifiedStrikeEffect extends OneShotEffect {
                         source.getSourceId(),
                         game
                 ).size();
-        return creature.getPower().getValue() <= soldierCount;
+        boolean successful = creature.getPower().getValue() <= soldierCount;
+        if (successful) {
+            player.moveCards(creature, Zone.EXILED, source, game);
+        }
+        return successful;
     }
 }


### PR DESCRIPTION
@Zzooouhh informed me in [my previous pull request](https://github.com/magefree/mage/pull/4441) that my understanding was incorrect and that the Outcome enum only matters to the AI (which is really the sort of thing that should be documented) so I did my best to actually address the problem of Unified Strike not actually doing anything.

I'm much more out of my depth than before - I don't use Java myself, and Xmage is a giant undocumented codebase which I've had to feel my way around because I had trouble finding cards with a close enough effect to Unified Strike to use as a template. The ideal response to this is "thanks, I did it myself better because I have a better understanding of the codebase" followed by closing the PR.