### PR TITLE
Scenario I was testing for this fix:

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -151,11 +151,13 @@ public class HumanPlayer extends PlayerImpl {
 
     protected void waitResponseOpen() {
         // wait response open for answer process
-        while (!responseOpenedForAnswer && canRespond()) {
+        int numTimesWaiting = 0;
+        while (!responseOpenedForAnswer && canRespond() && numTimesWaiting < 300) {
+            numTimesWaiting ++;
             try {
                 Thread.sleep(100);
             } catch (InterruptedException e) {
-                logger.warn("Response waiting interrapted for " + getId());
+                logger.warn("Response waiting interrupted for " + getId());
             }
         }
     }

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -2452,6 +2452,9 @@ public abstract class GameImpl implements Game, Serializable {
 
     @Override
     public UUID getPriorityPlayerId() {
+        if (state.getPriorityPlayerId() == null) {
+            return state.getActivePlayerId();
+        }
         return state.getPriorityPlayerId();
     }
 


### PR DESCRIPTION
Local Server, EDH game with Player1, Player2, Player3.
Player1 has 2 mana reflections out, cast Torment of Hailfire for 15 and is tapping mana for it.
The 'choose replacement effect' popup comes up.
Whilst the popup (aka 'Choose Mana Reflection#1' or 'Choose Mana Reflection#2') is present for Player1, Player2 concedes.
This will currently lock up the game and sits forever in waitResponseOpen.
 (With the time out now added in in this pull, it will time out after 30 seconds or so).