### PR TITLE
Some early groundwork for banding support & (semi)implemented Icatian Infantry

### DIFF
--- a/Mage.Sets/src/mage/cards/i/IcatianInfantry.java
+++ b/Mage.Sets/src/mage/cards/i/IcatianInfantry.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ * 
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ * 
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ * 
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ * 
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+
+package mage.cards.i;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
+import mage.abilities.keyword.BandingAbility;
+import mage.abilities.keyword.FirstStrikeAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.Duration;
+import mage.constants.Zone;
+
+/**
+ *
+ * @author L_J
+ */
+public class IcatianInfantry extends CardImpl {
+
+    public IcatianInfantry(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{W}");
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.SOLDIER);
+
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(1);
+
+        // {1}: Icatian Infantry gains first strike until end of turn.
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilitySourceEffect(FirstStrikeAbility.getInstance(), Duration.EndOfTurn), new ManaCostsImpl("{1}")));
+
+        // {1}: Icatian Infantry gains banding until end of turn.
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilitySourceEffect(BandingAbility.getInstance(), Duration.EndOfTurn), new ManaCostsImpl("{1}")));
+    }
+
+    public IcatianInfantry(final IcatianInfantry card) {
+        super(card);
+    }
+
+    @Override
+    public IcatianInfantry copy() {
+        return new IcatianInfantry(this);
+    }
+
+}

--- a/Mage.Sets/src/mage/sets/FallenEmpires.java
+++ b/Mage.Sets/src/mage/sets/FallenEmpires.java
@@ -44,6 +44,7 @@ import mage.cards.h.HighTide;
 import mage.cards.h.Homarid;
 import mage.cards.h.HomaridWarrior;
 import mage.cards.h.HymnToTourach;
+import mage.cards.i.IcatianInfantry;
 import mage.cards.i.IcatianJavelineers;
 import mage.cards.i.IcatianMoneychanger;
 import mage.cards.i.IcatianScout;
@@ -170,6 +171,10 @@ public class FallenEmpires extends ExpansionSet {
         cards.add(new SetCardInfo("Hymn to Tourach", 13, Rarity.COMMON, HymnToTourach.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Hymn to Tourach", 14, Rarity.COMMON, HymnToTourach.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Hymn to Tourach", 15, Rarity.COMMON, HymnToTourach.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Icatian Infantry", 144, Rarity.COMMON, IcatianInfantry.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Icatian Infantry", 145, Rarity.COMMON, IcatianInfantry.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Icatian Infantry", 146, Rarity.COMMON, IcatianInfantry.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Icatian Infantry", 147, Rarity.COMMON, IcatianInfantry.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Icatian Javelineers", 148, Rarity.COMMON, IcatianJavelineers.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Icatian Javelineers", 149, Rarity.COMMON, IcatianJavelineers.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Icatian Javelineers", 150, Rarity.COMMON, IcatianJavelineers.class, NON_FULL_USE_VARIOUS));

--- a/Mage/src/main/java/mage/abilities/keyword/BandingAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/BandingAbility.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and should not be interpreted as representing official policies, either expressed
+ * or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.abilities.keyword;
+
+import java.io.ObjectStreamException;
+import mage.abilities.MageSingleton;
+import mage.abilities.StaticAbility;
+import mage.constants.Zone;
+
+/**
+ *
+ * @author L_J
+ */
+public class BandingAbility extends StaticAbility implements MageSingleton {
+
+    private static final BandingAbility instance = new BandingAbility();
+
+    private Object readResolve() throws ObjectStreamException {
+        return instance;
+    }
+
+    public static BandingAbility getInstance() {
+        return instance;
+    }
+
+    private BandingAbility() {
+        super(Zone.BATTLEFIELD, null);
+    }
+
+    @Override
+    public String getRule() {
+        return "banding";
+    }
+
+    @Override
+    public BandingAbility copy() {
+        return instance;
+    }
+
+}


### PR DESCRIPTION
I'm been doing some work on banding recently, and here are some early changes that appeared to be functioning correctly in the little testing I've been able to do so far. I have to emphasize that this PR does _not_ fully implement banding; I've decided to submit these changes early so any possible new combat bugs/issues would be easier to trace back and fix.

**This PR aims to implement the following:**
- 702.21j - if a creature is blocked by at least one blocker with banding, the defending player distributes the creature's combat damage. (similar to Defensive Formation)
- 702.21k - if a creature blocks multiple attackers and one of the attackers has banding, the attacking player distributes the creature's combat damage.
- made singleBlockerDamage and multiBlockerDamage iterate over all attackers in the combat group instead of just attackers.get(0) (under normal circumstances this shouldn't change anything - right now, an attacking combat group only has 1 attacker); similar changes also made for addBlockerToGroup and checkBlockRestrictions - this is to support bands in the future (see below).
- include a card to test drive all this.

**What this PR doesn't implement:**
- the whole action of actually forming attacking bands (thus currently single-blocker creatures have no influence on banding at all). I intend to implement bands as attacking CombatGroups with multiple entries in the attackers list, while creatures forming a band will be traced by a list in PermanentImpl. Client-side this will be working in a manner similar to Soulbond, with yellow pointer arrows marking which creatures are banded to each other.
- damage distribution for single blockers blocking bands - this will be necessary to include in the singleBlockerDamage and multiBlockerDamage methods.

The reason I've also included Icatian Infantry in this PR is because it's a low-profile card that won't get seriously used in a constructed format, it only has banding conditionally (as an activated ability), but can serve as a "preview" for the keyword and thus allows multiple people to troubleshoot potential problems with banding in advance if they wish to do so. **I have no plans to implement further cards with banding until everything else (i.e. bands and bug fixing) is implemented as proper.**