### PR TITLE
Implemented Blaze of Glory and Portal cards (& finished a todo in MustBlockAny checking)

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BlazeOfGlory.java
+++ b/Mage.Sets/src/mage/cards/b/BlazeOfGlory.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.b;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.CastOnlyDuringPhaseStepSourceAbility;
+import mage.abilities.condition.common.BeforeBlockersAreDeclaredCondition;
+import mage.abilities.effects.RequirementEffect;
+import mage.abilities.effects.common.combat.CanBlockAdditionalCreatureTargetEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.TurnPhase;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.ObjectPlayer;
+import mage.filter.predicate.ObjectPlayerPredicate;
+import mage.game.Controllable;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author L_J
+ */
+public class BlazeOfGlory extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature defending player controls");
+
+    static {
+        filter.add(new BlazeOfGloryDefendingPlayerControlsPredicate());
+    }
+
+    public BlazeOfGlory(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{W}");
+
+        // Cast Blaze of Glory only during combat before blockers are declared.
+        this.addAbility(new CastOnlyDuringPhaseStepSourceAbility(TurnPhase.COMBAT, BeforeBlockersAreDeclaredCondition.instance));
+
+        // Target creature defending player controls can block any number of creatures this turn. It blocks each attacking creature this turn if able.
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter));
+        this.getSpellAbility().addEffect(new CanBlockAdditionalCreatureTargetEffect(Duration.EndOfTurn, 0));
+        this.getSpellAbility().addEffect(new BlazeOfGloryRequirementEffect());
+    }
+
+    public BlazeOfGlory(final BlazeOfGlory card) {
+        super(card);
+    }
+
+    @Override
+    public BlazeOfGlory copy() {
+        return new BlazeOfGlory(this);
+    }
+}
+
+class BlazeOfGloryDefendingPlayerControlsPredicate implements ObjectPlayerPredicate<ObjectPlayer<Controllable>> {
+
+    @Override
+    public boolean apply(ObjectPlayer<Controllable> input, Game game) {
+        return game.getCombat().getPlayerDefenders(game).contains(input.getObject().getControllerId());
+    }
+}
+
+class BlazeOfGloryRequirementEffect extends RequirementEffect {
+
+    public BlazeOfGloryRequirementEffect() {
+        super(Duration.EndOfTurn);
+        this.staticText = "It blocks each attacking creature this turn if able";
+    }
+
+    public BlazeOfGloryRequirementEffect(final BlazeOfGloryRequirementEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean applies(Permanent permanent, Ability source, Game game) {
+        return permanent.getId().equals(targetPointer.getFirst(game, source));
+    }
+
+    @Override
+    public boolean mustAttack(Game game) {
+        return false;
+    }
+
+    @Override
+    public boolean mustBlock(Game game) {
+        return true;
+    }
+
+    @Override
+    public boolean mustBlockAllAttackers(Game game) {
+        return true;
+    }
+
+    @Override
+    public BlazeOfGloryRequirementEffect copy() {
+        return new BlazeOfGloryRequirementEffect(this);
+    }
+
+}

--- a/Mage.Sets/src/mage/cards/c/CruelFate.java
+++ b/Mage.Sets/src/mage/cards/c/CruelFate.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.c;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.cards.Cards;
+import mage.cards.CardsImpl;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Zone;
+import mage.filter.FilterCard;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetCard;
+import mage.target.common.TargetOpponent;
+
+/**
+ *
+ * @author TheElk801 & L_J
+ */
+public class CruelFate extends CardImpl {
+
+    public CruelFate(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{U}");
+
+        // Look at the top five cards of target opponent's library. Put one of those cards into that player's graveyard and the rest on top of his or her library in any order.
+        this.getSpellAbility().addEffect(new CruelFateEffect());
+        this.getSpellAbility().addTarget(new TargetOpponent());
+
+    }
+
+    public CruelFate(final CruelFate card) {
+        super(card);
+    }
+
+    @Override
+    public CruelFate copy() {
+        return new CruelFate(this);
+    }
+}
+
+class CruelFateEffect extends OneShotEffect {
+
+    public CruelFateEffect() {
+        super(Outcome.DrawCard);
+        this.staticText = "Look at the top five cards of target opponent's library. Put one of those cards into that player's graveyard and the rest on top of his or her library in any order";
+    }
+
+    public CruelFateEffect(final CruelFateEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public CruelFateEffect copy() {
+        return new CruelFateEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Card sourceCard = game.getCard(source.getSourceId());
+        if (sourceCard != null) {
+            Player you = game.getPlayer(source.getControllerId());
+            Player player = game.getPlayer(source.getFirstTarget());
+            if (player != null && you != null) {
+                Cards cards = new CardsImpl();
+                int count = Math.min(player.getLibrary().size(), 5);
+                for (int i = 0; i < count; i++) {
+                    Card card = player.getLibrary().removeFromTop(game);
+                    if (card != null) {
+                        cards.add(card);
+                    }
+                }
+
+                you.lookAtCards(sourceCard.getIdName(), cards, game);
+
+                // card to put into opponent's graveyard
+                TargetCard target = new TargetCard(Zone.LIBRARY, new FilterCard("card to put into target opponent's graveyard"));
+                if (player.canRespond()) {
+                    if (cards.size() > 1) {
+                        you.choose(Outcome.Detriment, cards, target, game);
+                        Card card = cards.get(target.getFirstTarget(), game);
+                        if (card != null) {
+                            cards.remove(card);
+                            card.moveToZone(Zone.GRAVEYARD, source.getSourceId(), game, true);
+                        }
+                    }
+                    else if (cards.size() == 1) {
+                        Card card = cards.get(cards.iterator().next(), game);
+                        card.moveToZone(Zone.GRAVEYARD, source.getSourceId(), game, true);
+                    }
+                }
+                // cards to put on the top of opponent's library
+                TargetCard target2 = new TargetCard(Zone.LIBRARY, new FilterCard("card to put on the top of target opponent's library"));
+                while (player.canRespond() && cards.size() > 1) {
+                    you.choose(Outcome.Neutral, cards, target2, game);
+                    Card card = cards.get(target2.getFirstTarget(), game);
+                    if (card != null) {
+                        cards.remove(card);
+                        card.moveToZone(Zone.LIBRARY, source.getSourceId(), game, true);
+                    }
+                    target2.clearChosen();
+                }
+                if (cards.size() == 1) {
+                    Card card = cards.get(cards.iterator().next(), game);
+                    card.moveToZone(Zone.LIBRARY, source.getSourceId(), game, true);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/d/DeepWood.java
+++ b/Mage.Sets/src/mage/cards/d/DeepWood.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.d;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.CastOnlyDuringPhaseStepSourceAbility;
+import mage.abilities.condition.common.AttackedThisStepCondition;
+import mage.abilities.effects.PreventionEffectImpl;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.PhaseStep;
+import mage.constants.TurnPhase;
+import mage.filter.common.FilterAttackingCreature;
+import mage.game.Game;
+import mage.game.events.DamagePlayerEvent;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.watchers.common.PlayerAttackedStepWatcher;
+
+/**
+ *
+ * @author L_J
+ */
+public class DeepWood extends CardImpl {
+
+    public DeepWood(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{G}");
+
+        // Cast Deep Wood only during the declare attackers step and only if you've been attacked this step.
+        Ability ability = new CastOnlyDuringPhaseStepSourceAbility(
+                TurnPhase.COMBAT, PhaseStep.DECLARE_ATTACKERS, AttackedThisStepCondition.instance,
+                "Cast {this} only during the declare attackers step and only if you've been attacked this step."
+        );
+        ability.addWatcher(new PlayerAttackedStepWatcher());
+        this.addAbility(ability);
+
+        // Prevent all damage that would be dealt to you this turn by attacking creatures.
+        this.getSpellAbility().addEffect(new DeepWoodEffect());
+    }
+
+    public DeepWood(final DeepWood card) {
+        super(card);
+    }
+
+    @Override
+    public DeepWood copy() {
+        return new DeepWood(this);
+    }
+}
+
+class DeepWoodEffect extends PreventionEffectImpl {
+
+    private static final FilterAttackingCreature filter = new FilterAttackingCreature();
+
+    DeepWoodEffect() {
+        super(Duration.EndOfTurn, Integer.MAX_VALUE, false);
+        staticText = "Prevent all damage that would be dealt to you this turn by attacking creatures";
+    }
+
+    DeepWoodEffect(final DeepWoodEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public DeepWoodEffect copy() {
+        return new DeepWoodEffect(this);
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (super.applies(event, source, game) && event instanceof DamagePlayerEvent && event.getAmount() > 0) {
+            DamagePlayerEvent damageEvent = (DamagePlayerEvent) event;
+            if (event.getTargetId().equals(source.getControllerId())) {
+                Permanent permanent = game.getPermanentOrLKIBattlefield(damageEvent.getSourceId());
+                if (permanent != null && filter.match(permanent, game)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/d/DreadCharge.java
+++ b/Mage.Sets/src/mage/cards/d/DreadCharge.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.d;
+
+import java.util.UUID;
+import mage.ObjectColor;
+import mage.abilities.effects.common.combat.CantBeBlockedByCreaturesAllEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.TargetController;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.ColorPredicate;
+import mage.filter.predicate.permanent.ControllerPredicate;
+
+/**
+ *
+ * @author L_J
+ */
+public class DreadCharge extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Black creatures you control");
+    private static final FilterCreaturePermanent filter2 = new FilterCreaturePermanent("except by black creatures");
+
+    static {
+        filter.add(new ColorPredicate(ObjectColor.BLACK));
+        filter2.add(Predicates.not(new ColorPredicate(ObjectColor.BLACK)));
+        filter.add(new ControllerPredicate(TargetController.YOU));
+    }
+
+    public DreadCharge(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{3}{B}");
+
+        // Black creatures you control can't be blocked this turn except by black creatures.
+        this.getSpellAbility().addEffect(new CantBeBlockedByCreaturesAllEffect(filter, filter2, Duration.EndOfTurn));
+    }
+
+    public DreadCharge(final DreadCharge card) {
+        super(card);
+    }
+
+    @Override
+    public DreadCharge copy() {
+        return new DreadCharge(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/e/EunuchsIntrigues.java
+++ b/Mage.Sets/src/mage/cards/e/EunuchsIntrigues.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.e;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.RestrictionEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.permanent.ControllerIdPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.Target;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetOpponent;
+
+/**
+ *
+ * @author TheElk801 & L_J
+ */
+public class EunuchsIntrigues extends CardImpl {
+
+    public EunuchsIntrigues(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{R}");
+
+        // Target opponent chooses a creature he or she controls. Other creatures he or she controls can't block this turn.
+        this.getSpellAbility().addEffect(new EunuchsIntriguesEffect());
+        this.getSpellAbility().addTarget(new TargetOpponent());
+    }
+
+    public EunuchsIntrigues(final EunuchsIntrigues card) {
+        super(card);
+    }
+
+    @Override
+    public EunuchsIntrigues copy() {
+        return new EunuchsIntrigues(this);
+    }
+}
+
+class EunuchsIntriguesEffect extends OneShotEffect {
+
+    EunuchsIntriguesEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "Target opponent chooses a creature he or she controls. Other creatures he or she controls can't block this turn.";
+    }
+
+    EunuchsIntriguesEffect(final EunuchsIntriguesEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public EunuchsIntriguesEffect copy() {
+        return new EunuchsIntriguesEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getFirstTarget());
+        if (player == null) {
+            return false;
+        }
+        FilterCreaturePermanent filter = new FilterCreaturePermanent("creature you control");
+        filter.add(new ControllerIdPredicate(player.getId()));
+        Target target = new TargetPermanent(1, 1, filter, true);
+        if (target.canChoose(source.getSourceId(), player.getId(), game)) {
+            while (!target.isChosen() && target.canChoose(player.getId(), game) && player.canRespond()) {
+                player.chooseTarget(Outcome.DestroyPermanent, target, source, game);
+            }
+            Permanent permanent = game.getPermanent(target.getFirstTarget());
+            if (permanent != null) {
+                game.informPlayers(player.getLogName() + " has chosen " + permanent.getLogName() + " as his only creature able to block this turn");
+            }
+        }
+        game.addEffect(new EunuchsIntriguesRestrictionEffect(target.getFirstTarget()), source);
+        return true;
+    }
+}
+
+class EunuchsIntriguesRestrictionEffect extends RestrictionEffect {
+    
+    protected UUID targetId;
+
+    public EunuchsIntriguesRestrictionEffect(UUID targetId) {
+        super(Duration.EndOfTurn);
+        this.targetId = targetId;
+    }
+
+    public EunuchsIntriguesRestrictionEffect(final EunuchsIntriguesRestrictionEffect effect) {
+        super(effect);
+        targetId = effect.targetId;
+    }
+
+    @Override
+    public EunuchsIntriguesRestrictionEffect copy() {
+        return new EunuchsIntriguesRestrictionEffect(this);
+    }
+
+    @Override
+    public boolean applies(Permanent permanent, Ability source, Game game) {
+        if (permanent.getControllerId().equals(source.getFirstTarget())) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean canBlock(Permanent attacker, Permanent blocker, Ability source, Game game) {
+        if (targetId != null && blocker.getId().equals(targetId)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/g/GoblinWarCry.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinWarCry.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.g;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.RestrictionEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.permanent.ControllerIdPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.Target;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetOpponent;
+
+/**
+ *
+ * @author TheElk801 & L_J
+ */
+public class GoblinWarCry extends CardImpl {
+
+    public GoblinWarCry(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{R}");
+
+        // Target opponent chooses a creature he or she controls. Other creatures he or she controls can't block this turn.
+        this.getSpellAbility().addEffect(new GoblinWarCryEffect());
+        this.getSpellAbility().addTarget(new TargetOpponent());
+    }
+
+    public GoblinWarCry(final GoblinWarCry card) {
+        super(card);
+    }
+
+    @Override
+    public GoblinWarCry copy() {
+        return new GoblinWarCry(this);
+    }
+}
+
+class GoblinWarCryEffect extends OneShotEffect {
+
+    GoblinWarCryEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "Target opponent chooses a creature he or she controls. Other creatures he or she controls can't block this turn.";
+    }
+
+    GoblinWarCryEffect(final GoblinWarCryEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public GoblinWarCryEffect copy() {
+        return new GoblinWarCryEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getFirstTarget());
+        if (player == null) {
+            return false;
+        }
+        FilterCreaturePermanent filter = new FilterCreaturePermanent("creature you control");
+        filter.add(new ControllerIdPredicate(player.getId()));
+        Target target = new TargetPermanent(1, 1, filter, true);
+        if (target.canChoose(source.getSourceId(), player.getId(), game)) {
+            while (!target.isChosen() && target.canChoose(player.getId(), game) && player.canRespond()) {
+                player.chooseTarget(Outcome.DestroyPermanent, target, source, game);
+            }
+            Permanent permanent = game.getPermanent(target.getFirstTarget());
+            if (permanent != null) {
+                game.informPlayers(player.getLogName() + " has chosen " + permanent.getLogName() + " as his only creature able to block this turn");
+            }
+        }
+        game.addEffect(new GoblinWarCryRestrictionEffect(target.getFirstTarget()), source);
+        return true;
+    }
+}
+
+class GoblinWarCryRestrictionEffect extends RestrictionEffect {
+    
+    protected UUID targetId;
+
+    public GoblinWarCryRestrictionEffect(UUID targetId) {
+        super(Duration.EndOfTurn);
+        this.targetId = targetId;
+    }
+
+    public GoblinWarCryRestrictionEffect(final GoblinWarCryRestrictionEffect effect) {
+        super(effect);
+        targetId = effect.targetId;
+    }
+
+    @Override
+    public GoblinWarCryRestrictionEffect copy() {
+        return new GoblinWarCryRestrictionEffect(this);
+    }
+
+    @Override
+    public boolean applies(Permanent permanent, Ability source, Game game) {
+        if (permanent.getControllerId().equals(source.getFirstTarget())) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean canBlock(Permanent attacker, Permanent blocker, Ability source, Game game) {
+        if (targetId != null && blocker.getId().equals(targetId)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/h/HarshJustice.java
+++ b/Mage.Sets/src/mage/cards/h/HarshJustice.java
@@ -1,0 +1,170 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.h;
+
+import java.util.UUID;
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.DelayedTriggeredAbility;
+import mage.abilities.common.CastOnlyDuringPhaseStepSourceAbility;
+import mage.abilities.condition.common.AttackedThisStepCondition;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.CreateDelayedTriggeredAbilityEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.PhaseStep;
+import mage.constants.TurnPhase;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.permanent.AttackingPredicate;
+import mage.game.Game;
+import mage.game.events.DamagedPlayerEvent;
+import mage.game.events.GameEvent;
+import mage.game.events.GameEvent.EventType;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.watchers.common.PlayerAttackedStepWatcher;
+
+/**
+ *
+ * @author LevelX2 & L_J
+ */
+public class HarshJustice extends CardImpl {
+
+    public HarshJustice(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{W}");
+
+        // Cast Harsh Justice only during the declare attackers step and only if you've been attacked this step.
+        Ability ability = new CastOnlyDuringPhaseStepSourceAbility(
+                TurnPhase.COMBAT, PhaseStep.DECLARE_ATTACKERS, AttackedThisStepCondition.instance,
+                "Cast {this} only during the declare attackers step and only if you've been attacked this step."
+        );
+        ability.addWatcher(new PlayerAttackedStepWatcher());
+        this.addAbility(ability);
+
+        // This turn, whenever an attacking creature deals combat damage to you, it deals that much damage to its controller.
+        this.getSpellAbility().addEffect(new CreateDelayedTriggeredAbilityEffect(new HarshJusticeTriggeredAbility()));
+    }
+
+    public HarshJustice(final HarshJustice card) {
+        super(card);
+    }
+
+    @Override
+    public HarshJustice copy() {
+        return new HarshJustice(this);
+    }
+}
+
+class HarshJusticeTriggeredAbility extends DelayedTriggeredAbility {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("attacking creature");
+
+    static {
+        filter.add(new AttackingPredicate());
+    }
+
+    public HarshJusticeTriggeredAbility() {
+        super(new HarshJusticeEffect(), Duration.EndOfTurn, false);
+    }
+
+    public HarshJusticeTriggeredAbility(final HarshJusticeTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public HarshJusticeTriggeredAbility copy() {
+        return new HarshJusticeTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == EventType.DAMAGED_PLAYER;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        Player controller = game.getPlayer(this.getControllerId());
+        DamagedPlayerEvent damageEvent = (DamagedPlayerEvent) event;
+        Permanent damagePermanent = game.getPermanentOrLKIBattlefield(damageEvent.getSourceId());
+        if (controller != null && damagePermanent != null) {
+            if (damageEvent.isCombatDamage() && controller.getId().equals(damageEvent.getTargetId()) && filter.match(damagePermanent, game)) {
+                for (Effect effect : this.getEffects()) {
+                    effect.setValue("damage", damageEvent.getAmount());
+                    effect.setValue("sourceId", damageEvent.getSourceId());
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String getRule() {
+        return "This turn, whenever an attacking creature deals combat damage to you, " + super.getRule();
+    }
+}
+
+class HarshJusticeEffect extends OneShotEffect {
+
+    public HarshJusticeEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "it deals that much damage to its controller";
+    }
+
+    public HarshJusticeEffect(final HarshJusticeEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public HarshJusticeEffect copy() {
+        return new HarshJusticeEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        int damage = (Integer) this.getValue("damage");
+        UUID sourceId = (UUID) this.getValue("sourceId");
+        MageObject sourceObject = game.getObject(source.getSourceId());
+        if (sourceObject != null && damage > 0 && sourceId != null) {
+            Permanent targetObject = game.getPermanentOrLKIBattlefield(sourceId);
+            if (targetObject != null) {
+                Player controller = game.getPlayer(targetObject.getControllerId());
+                if (controller != null) {
+                    game.informPlayers(sourceObject.getLogName() + ": " + targetObject.getLogName() + " deals " + damage + " damage to " + controller.getLogName());
+                    controller.damage(damage, sourceId, game, false, true);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/h/HeavyFog.java
+++ b/Mage.Sets/src/mage/cards/h/HeavyFog.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.h;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.CastOnlyDuringPhaseStepSourceAbility;
+import mage.abilities.condition.common.AttackedThisStepCondition;
+import mage.abilities.effects.PreventionEffectImpl;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.PhaseStep;
+import mage.constants.TurnPhase;
+import mage.filter.common.FilterAttackingCreature;
+import mage.game.Game;
+import mage.game.events.DamagePlayerEvent;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.watchers.common.PlayerAttackedStepWatcher;
+
+/**
+ *
+ * @author L_J
+ */
+public class HeavyFog extends CardImpl {
+
+    public HeavyFog(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{G}");
+
+        // Cast Deep Wood only during the declare attackers step and only if you've been attacked this step.
+        Ability ability = new CastOnlyDuringPhaseStepSourceAbility(
+                TurnPhase.COMBAT, PhaseStep.DECLARE_ATTACKERS, AttackedThisStepCondition.instance,
+                "Cast {this} only during the declare attackers step and only if you've been attacked this step."
+        );
+        ability.addWatcher(new PlayerAttackedStepWatcher());
+        this.addAbility(ability);
+
+        // Prevent all damage that would be dealt to you this turn by attacking creatures.
+        this.getSpellAbility().addEffect(new HeavyFogEffect());
+    }
+
+    public HeavyFog(final HeavyFog card) {
+        super(card);
+    }
+
+    @Override
+    public HeavyFog copy() {
+        return new HeavyFog(this);
+    }
+}
+
+class HeavyFogEffect extends PreventionEffectImpl {
+
+    private static final FilterAttackingCreature filter = new FilterAttackingCreature();
+
+    HeavyFogEffect() {
+        super(Duration.EndOfTurn, Integer.MAX_VALUE, false);
+        staticText = "Prevent all damage that would be dealt to you this turn by attacking creatures";
+    }
+
+    HeavyFogEffect(final HeavyFogEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public HeavyFogEffect copy() {
+        return new HeavyFogEffect(this);
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (super.applies(event, source, game) && event instanceof DamagePlayerEvent && event.getAmount() > 0) {
+            DamagePlayerEvent damageEvent = (DamagePlayerEvent) event;
+            if (event.getTargetId().equals(source.getControllerId())) {
+                Permanent permanent = game.getPermanentOrLKIBattlefield(damageEvent.getSourceId());
+                if (permanent != null && filter.match(permanent, game)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/j/JustFate.java
+++ b/Mage.Sets/src/mage/cards/j/JustFate.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.j;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.CastOnlyDuringPhaseStepSourceAbility;
+import mage.abilities.condition.common.AttackedThisStepCondition;
+import mage.abilities.effects.common.DestroyTargetEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.PhaseStep;
+import mage.constants.TurnPhase;
+import mage.target.common.TargetAttackingCreature;
+import mage.watchers.common.PlayerAttackedStepWatcher;
+
+/**
+ *
+ * @author TheElk801
+ */
+public class JustFate extends CardImpl {
+
+    public JustFate(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{W}");
+
+        // Cast Just Fate only during the declare attackers step and only if you've been attacked this step.
+        Ability ability = new CastOnlyDuringPhaseStepSourceAbility(
+                TurnPhase.COMBAT, PhaseStep.DECLARE_ATTACKERS, AttackedThisStepCondition.instance,
+                "Cast {this} only during the declare attackers step and only if you've been attacked this step."
+        );
+        ability.addWatcher(new PlayerAttackedStepWatcher());
+        this.addAbility(ability);
+
+        // Destroy target attacking creature.
+        this.getSpellAbility().addEffect(new DestroyTargetEffect());
+        this.getSpellAbility().addTarget(new TargetAttackingCreature());
+    }
+
+    public JustFate(final JustFate card) {
+        super(card);
+    }
+
+    @Override
+    public JustFate copy() {
+        return new JustFate(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/k/KongmingsContraptions.java
+++ b/Mage.Sets/src/mage/cards/k/KongmingsContraptions.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ * 
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ * 
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ * 
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ * 
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * 
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.k;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.condition.CompoundCondition;
+import mage.abilities.condition.common.AttackedThisStepCondition;
+import mage.abilities.condition.common.IsStepCondition;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.decorator.ConditionalActivatedAbility;
+import mage.abilities.effects.common.DamageTargetEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.filter.common.FilterAttackingCreature;
+import mage.target.TargetPermanent;
+import mage.watchers.common.PlayerAttackedStepWatcher;
+
+/**
+ *
+ * @author L_J
+ */
+public class KongmingsContraptions extends CardImpl {
+
+    public KongmingsContraptions(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{W}");
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.SOLDIER);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(4);
+
+        // {T}: Kongming's Contraptions deals 2 damage to target attacking creature. Activate this ability only during the declare attackers step and only if you've been attacked this step.
+        Ability ability = new ConditionalActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(2), new TapSourceCost(), 
+                new CompoundCondition("during the declare attackers step and only if you've been attacked this step", 
+                new IsStepCondition(PhaseStep.DECLARE_ATTACKERS, false), AttackedThisStepCondition.instance)
+        );
+        ability.addTarget(new TargetPermanent(new FilterAttackingCreature()));
+        this.addAbility(ability, new PlayerAttackedStepWatcher());
+    }
+
+    public KongmingsContraptions(final KongmingsContraptions card) {
+        super(card);
+    }
+
+    @Override
+    public KongmingsContraptions copy() {
+        return new KongmingsContraptions(this);
+    }
+
+}

--- a/Mage.Sets/src/mage/cards/t/TemporaryTruce.java
+++ b/Mage.Sets/src/mage/cards/t/TemporaryTruce.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.t;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.game.Game;
+import mage.players.Player;
+
+/**
+ *
+ * @author L_J
+ */
+public class TemporaryTruce extends CardImpl {
+
+    public TemporaryTruce(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{1}{W}");
+
+        // Each player may draw up to two cards. For each card less than two a player draws this way, that player gains 2 life.
+        this.getSpellAbility().addEffect(new TemporaryTruceEffect());
+    }
+
+    public TemporaryTruce(final TemporaryTruce card) {
+        super(card);
+    }
+
+    @Override
+    public TemporaryTruce copy() {
+        return new TemporaryTruce(this);
+    }
+}
+
+class TemporaryTruceEffect extends OneShotEffect {
+
+    TemporaryTruceEffect() {
+        super(Outcome.DrawCard);
+        this.staticText = "Each player may draw up to two cards. For each card less than two a player draws this way, that player gains 2 life";
+    }
+
+    TemporaryTruceEffect(final TemporaryTruceEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public TemporaryTruceEffect copy() {
+        return new TemporaryTruceEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {
+                Player player = game.getPlayer(playerId);
+                if (player != null) {
+                    int cardsToDraw = player.getAmount(0, 2, "Draw how many cards?", game);
+                    player.drawCards(cardsToDraw, game);
+                    player.gainLife((2 - cardsToDraw) * 2, game);
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/w/WarriorsStand.java
+++ b/Mage.Sets/src/mage/cards/w/WarriorsStand.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2010 BetaSteward_at_googlemail.com. All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification, are
+ *  permitted provided that the following conditions are met:
+ *
+ *     1. Redistributions of source code must retain the above copyright notice, this list of
+ *        conditions and the following disclaimer.
+ *
+ *     2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *        of conditions and the following disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY BetaSteward_at_googlemail.com ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ *  WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BetaSteward_at_googlemail.com OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ *  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  The views and conclusions contained in the software and documentation are those of the
+ *  authors and should not be interpreted as representing official policies, either expressed
+ *  or implied, of BetaSteward_at_googlemail.com.
+ */
+package mage.cards.w;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.CastOnlyDuringPhaseStepSourceAbility;
+import mage.abilities.condition.common.AttackedThisStepCondition;
+import mage.abilities.effects.common.continuous.BoostControlledEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.PhaseStep;
+import mage.constants.TurnPhase;
+import mage.filter.StaticFilters;
+import mage.watchers.common.PlayerAttackedStepWatcher;
+/**
+ *
+ * @author L_J
+ */
+public class WarriorsStand extends CardImpl {
+
+    public WarriorsStand(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{W}");
+
+        // Cast Warrior's Stand only during the declare attackers step and only if you've been attacked this step.
+        Ability ability = new CastOnlyDuringPhaseStepSourceAbility(
+                TurnPhase.COMBAT, PhaseStep.DECLARE_ATTACKERS, AttackedThisStepCondition.instance,
+                "Cast {this} only during the declare attackers step and only if you've been attacked this step."
+        );
+        ability.addWatcher(new PlayerAttackedStepWatcher());
+        this.addAbility(ability);
+
+        // Creatures you control get +2/+2 until end of turn.
+        this.getSpellAbility().addEffect(new BoostControlledEffect(2, 2, Duration.EndOfTurn, StaticFilters.FILTER_PERMANENT_CREATURE, false));
+    }
+
+    public WarriorsStand(final WarriorsStand card) {
+        super(card);
+    }
+
+    @Override
+    public WarriorsStand copy() {
+        return new WarriorsStand(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
@@ -44,6 +44,7 @@ public class LimitedEditionAlpha extends ExpansionSet {
         cards.add(new SetCardInfo("Black Lotus", 232, Rarity.RARE, mage.cards.b.BlackLotus.class));
         cards.add(new SetCardInfo("Black Vise", 233, Rarity.UNCOMMON, mage.cards.b.BlackVise.class));
         cards.add(new SetCardInfo("Black Ward", 189, Rarity.UNCOMMON, mage.cards.b.BlackWard.class));
+        cards.add(new SetCardInfo("Blaze of Glory", 190, Rarity.RARE, mage.cards.b.BlazeOfGlory.class));
         cards.add(new SetCardInfo("Blessing", 191, Rarity.RARE, mage.cards.b.Blessing.class));
         cards.add(new SetCardInfo("Blue Elemental Blast", 50, Rarity.COMMON, mage.cards.b.BlueElementalBlast.class));
         cards.add(new SetCardInfo("Blue Ward", 192, Rarity.UNCOMMON, mage.cards.b.BlueWard.class));

--- a/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
@@ -44,6 +44,7 @@ public class LimitedEditionBeta extends ExpansionSet {
         cards.add(new SetCardInfo("Black Lotus", 233, Rarity.RARE, mage.cards.b.BlackLotus.class));
         cards.add(new SetCardInfo("Black Vise", 234, Rarity.UNCOMMON, mage.cards.b.BlackVise.class));
         cards.add(new SetCardInfo("Black Ward", 5, Rarity.UNCOMMON, mage.cards.b.BlackWard.class));
+        cards.add(new SetCardInfo("Blaze of Glory", 6, Rarity.RARE, mage.cards.b.BlazeOfGlory.class));
         cards.add(new SetCardInfo("Blessing", 7, Rarity.RARE, mage.cards.b.Blessing.class));
         cards.add(new SetCardInfo("Blue Elemental Blast", 50, Rarity.COMMON, mage.cards.b.BlueElementalBlast.class));
         cards.add(new SetCardInfo("Blue Ward", 8, Rarity.UNCOMMON, mage.cards.b.BlueWard.class));

--- a/Mage.Sets/src/mage/sets/MastersEditionIII.java
+++ b/Mage.Sets/src/mage/sets/MastersEditionIII.java
@@ -137,6 +137,7 @@ public class MastersEditionIII extends ExpansionSet {
         cards.add(new SetCardInfo("Hammerheim", 207, Rarity.UNCOMMON, mage.cards.h.Hammerheim.class));
         cards.add(new SetCardInfo("Hazezon Tamar", 151, Rarity.RARE, mage.cards.h.HazezonTamar.class));
         cards.add(new SetCardInfo("Heal", 14, Rarity.COMMON, mage.cards.h.Heal.class));
+        cards.add(new SetCardInfo("Heavy Fog", 122, Rarity.COMMON, mage.cards.h.HeavyFog.class));
         cards.add(new SetCardInfo("Hellfire", 70, Rarity.RARE, mage.cards.h.Hellfire.class));
         cards.add(new SetCardInfo("Hua Tuo, Honored Physician", 123, Rarity.RARE, mage.cards.h.HuaTuoHonoredPhysician.class));
         cards.add(new SetCardInfo("Hunding Gjornersen", 152, Rarity.UNCOMMON, mage.cards.h.HundingGjornersen.class));

--- a/Mage.Sets/src/mage/sets/MastersEditionIV.java
+++ b/Mage.Sets/src/mage/sets/MastersEditionIV.java
@@ -91,6 +91,7 @@ public class MastersEditionIV extends ExpansionSet {
         cards.add(new SetCardInfo("Bee Sting", 144, Rarity.UNCOMMON, mage.cards.b.BeeSting.class));
         cards.add(new SetCardInfo("Bird Maiden", 110, Rarity.COMMON, mage.cards.b.BirdMaiden.class));
         cards.add(new SetCardInfo("Black Knight", 71, Rarity.UNCOMMON, mage.cards.b.BlackKnight.class));
+        cards.add(new SetCardInfo("Blaze of Glory", 7, Rarity.UNCOMMON, mage.cards.b.BlazeOfGlory.class));
         cards.add(new SetCardInfo("Blue Elemental Blast", 39, Rarity.UNCOMMON, mage.cards.b.BlueElementalBlast.class));
         cards.add(new SetCardInfo("Book of Rass", 183, Rarity.UNCOMMON, mage.cards.b.BookOfRass.class));
         cards.add(new SetCardInfo("Bottle of Suleiman", 184, Rarity.RARE, mage.cards.b.BottleOfSuleiman.class));

--- a/Mage.Sets/src/mage/sets/MastersEditionIV.java
+++ b/Mage.Sets/src/mage/sets/MastersEditionIV.java
@@ -170,6 +170,7 @@ public class MastersEditionIV extends ExpansionSet {
         cards.add(new SetCardInfo("Grapeshot Catapult", 204, Rarity.UNCOMMON, mage.cards.g.GrapeshotCatapult.class));
         cards.add(new SetCardInfo("Gravebind", 84, Rarity.COMMON, mage.cards.g.Gravebind.class));
         cards.add(new SetCardInfo("Guardian Beast", 85, Rarity.RARE, mage.cards.g.GuardianBeast.class));
+        cards.add(new SetCardInfo("Harsh Justice", 13, Rarity.RARE, mage.cards.h.HarshJustice.class));
         cards.add(new SetCardInfo("Hasran Ogress", 86, Rarity.COMMON, mage.cards.h.HasranOgress.class));
         cards.add(new SetCardInfo("Healing Salve", 14, Rarity.COMMON, mage.cards.h.HealingSalve.class));
         cards.add(new SetCardInfo("Horn of Deafening", 205, Rarity.UNCOMMON, mage.cards.h.HornOfDeafening.class));

--- a/Mage.Sets/src/mage/sets/MastersEditionIV.java
+++ b/Mage.Sets/src/mage/sets/MastersEditionIV.java
@@ -183,6 +183,7 @@ public class MastersEditionIV extends ExpansionSet {
         cards.add(new SetCardInfo("Jade Monolith", 208, Rarity.RARE, mage.cards.j.JadeMonolith.class));
         cards.add(new SetCardInfo("Juggernaut", 209, Rarity.UNCOMMON, mage.cards.j.Juggernaut.class));
         cards.add(new SetCardInfo("Junún Efreet", 88, Rarity.UNCOMMON, mage.cards.j.JununEfreet.class));
+        cards.add(new SetCardInfo("Just Fate", 16, Rarity.COMMON, mage.cards.j.JustFate.class));
         cards.add(new SetCardInfo("Kismet", 17, Rarity.RARE, mage.cards.k.Kismet.class));
         cards.add(new SetCardInfo("Kormus Bell", 210, Rarity.RARE, mage.cards.k.KormusBell.class));
         cards.add(new SetCardInfo("Kudzu", 159, Rarity.UNCOMMON, mage.cards.k.Kudzu.class));

--- a/Mage.Sets/src/mage/sets/Portal.java
+++ b/Mage.Sets/src/mage/sets/Portal.java
@@ -100,14 +100,17 @@ public class Portal extends ExpansionSet {
         cards.add(new SetCardInfo("Craven Giant", 126, Rarity.COMMON, mage.cards.c.CravenGiant.class));
         cards.add(new SetCardInfo("Craven Knight", 7, Rarity.COMMON, mage.cards.c.CravenKnight.class));
         cards.add(new SetCardInfo("Cruel Bargain", 8, Rarity.RARE, mage.cards.c.CruelBargain.class));
+        cards.add(new SetCardInfo("Cruel Fate", 51, Rarity.RARE, mage.cards.c.CruelFate.class));
         cards.add(new SetCardInfo("Cruel Tutor", 9, Rarity.RARE, mage.cards.c.CruelTutor.class));
         cards.add(new SetCardInfo("Deep-Sea Serpent", 52, Rarity.UNCOMMON, mage.cards.d.DeepSeaSerpent.class));
+        cards.add(new SetCardInfo("Deep Wood", 86, Rarity.UNCOMMON, mage.cards.d.DeepWood.class));
         cards.add(new SetCardInfo("Defiant Stand", 174, Rarity.UNCOMMON, mage.cards.d.DefiantStand.class));
         cards.add(new SetCardInfo("Deja Vu", 53, Rarity.COMMON, mage.cards.d.DejaVu.class));
         cards.add(new SetCardInfo("Desert Drake", 127, Rarity.UNCOMMON, mage.cards.d.DesertDrake.class));
         cards.add(new SetCardInfo("Devastation", 128, Rarity.RARE, mage.cards.d.Devastation.class));
         cards.add(new SetCardInfo("Devoted Hero", 175, Rarity.COMMON, mage.cards.d.DevotedHero.class));
         cards.add(new SetCardInfo("Djinn of the Lamp", 54, Rarity.RARE, mage.cards.d.DjinnOfTheLamp.class));
+        cards.add(new SetCardInfo("Dread Charge", 10, Rarity.RARE, mage.cards.d.DreadCharge.class));
         cards.add(new SetCardInfo("Dread Reaper", 11, Rarity.RARE, mage.cards.d.DreadReaper.class));
         cards.add(new SetCardInfo("Dry Spell", 12, Rarity.UNCOMMON, DrySpell.class));
         cards.add(new SetCardInfo("Earthquake", 129, Rarity.RARE, mage.cards.e.Earthquake.class));
@@ -246,6 +249,7 @@ public class Portal extends ExpansionSet {
         cards.add(new SetCardInfo("Sylvan Tutor", 114, Rarity.RARE, mage.cards.s.SylvanTutor.class));
         cards.add(new SetCardInfo("Symbol of Unsummoning", 71, Rarity.COMMON, mage.cards.s.SymbolOfUnsummoning.class));
         cards.add(new SetCardInfo("Taunt", 72, Rarity.RARE, mage.cards.t.Taunt.class));
+        cards.add(new SetCardInfo("Temporary Truce", 195, Rarity.RARE, mage.cards.t.TemporaryTruce.class));
         cards.add(new SetCardInfo("Theft of Dreams", 73, Rarity.UNCOMMON, mage.cards.t.TheftOfDreams.class));
         cards.add(new SetCardInfo("Thing from the Deep", 74, Rarity.RARE, mage.cards.t.ThingFromTheDeep.class));
         cards.add(new SetCardInfo("Thundering Wurm", 115, Rarity.RARE, mage.cards.t.ThunderingWurm.class));

--- a/Mage.Sets/src/mage/sets/Portal.java
+++ b/Mage.Sets/src/mage/sets/Portal.java
@@ -143,6 +143,7 @@ public class Portal extends ExpansionSet {
         cards.add(new SetCardInfo("Grizzly Bears", 94, Rarity.COMMON, mage.cards.g.GrizzlyBears.class));
         cards.add(new SetCardInfo("Hand of Death", 18, Rarity.COMMON, mage.cards.h.HandOfDeath.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Hand of Death", 19, Rarity.COMMON, mage.cards.h.HandOfDeath.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Harsh Justice", 180, Rarity.RARE, mage.cards.h.HarshJustice.class));
         cards.add(new SetCardInfo("Highland Giant", 137, Rarity.COMMON, mage.cards.h.HighlandGiant.class));
         cards.add(new SetCardInfo("Hill Giant", 138, Rarity.COMMON, mage.cards.h.HillGiant.class));
         cards.add(new SetCardInfo("Horned Turtle", 58, Rarity.COMMON, mage.cards.h.HornedTurtle.class));

--- a/Mage.Sets/src/mage/sets/PortalSecondAge.java
+++ b/Mage.Sets/src/mage/sets/PortalSecondAge.java
@@ -117,6 +117,7 @@ public class PortalSecondAge extends ExpansionSet {
         cards.add(new SetCardInfo("Goblin Mountaineer", 101, Rarity.COMMON, mage.cards.g.GoblinMountaineer.class));
         cards.add(new SetCardInfo("Goblin Piker", 102, Rarity.COMMON, mage.cards.g.GoblinPiker.class));
         cards.add(new SetCardInfo("Goblin Raider", 103, Rarity.COMMON, mage.cards.g.GoblinRaider.class));
+        cards.add(new SetCardInfo("Goblin War Cry", 104, Rarity.UNCOMMON, mage.cards.g.GoblinWarCry.class));
         cards.add(new SetCardInfo("Goblin War Strike", 105, Rarity.COMMON, mage.cards.g.GoblinWarStrike.class));
         cards.add(new SetCardInfo("Golden Bear", 67, Rarity.COMMON, mage.cards.g.GoldenBear.class));
         cards.add(new SetCardInfo("Hand of Death", 14, Rarity.COMMON, mage.cards.h.HandOfDeath.class));
@@ -128,6 +129,7 @@ public class PortalSecondAge extends ExpansionSet {
         cards.add(new SetCardInfo("Island", 155, Rarity.LAND, mage.cards.basiclands.Island.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Island", 156, Rarity.LAND, mage.cards.basiclands.Island.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Jagged Lightning", 106, Rarity.UNCOMMON, mage.cards.j.JaggedLightning.class));
+        cards.add(new SetCardInfo("Just Fate", 137, Rarity.RARE, mage.cards.j.JustFate.class));
         cards.add(new SetCardInfo("Kiss of Death", 16, Rarity.UNCOMMON, mage.cards.k.KissOfDeath.class));
         cards.add(new SetCardInfo("Lava Axe", 107, Rarity.COMMON, mage.cards.l.LavaAxe.class));
         cards.add(new SetCardInfo("Lone Wolf", 71, Rarity.UNCOMMON, mage.cards.l.LoneWolf.class));
@@ -213,6 +215,7 @@ public class PortalSecondAge extends ExpansionSet {
         cards.add(new SetCardInfo("Vengeance", 147, Rarity.UNCOMMON, mage.cards.v.Vengeance.class));
         cards.add(new SetCardInfo("Volcanic Hammer", 119, Rarity.COMMON, mage.cards.v.VolcanicHammer.class));
         cards.add(new SetCardInfo("Volunteer Militia", 148, Rarity.COMMON, mage.cards.v.VolunteerMilitia.class));
+        cards.add(new SetCardInfo("Warrior's Stand", 149, Rarity.UNCOMMON, mage.cards.w.WarriorsStand.class));
         cards.add(new SetCardInfo("Wildfire", 120, Rarity.RARE, mage.cards.w.Wildfire.class));
         cards.add(new SetCardInfo("Wild Griffin", 150, Rarity.COMMON, mage.cards.w.WildGriffin.class));
         cards.add(new SetCardInfo("Wild Ox", 90, Rarity.UNCOMMON, mage.cards.w.WildOx.class));

--- a/Mage.Sets/src/mage/sets/PortalSecondAge.java
+++ b/Mage.Sets/src/mage/sets/PortalSecondAge.java
@@ -95,6 +95,7 @@ public class PortalSecondAge extends ExpansionSet {
         cards.add(new SetCardInfo("Dakmor Sorceress", 11, Rarity.RARE, mage.cards.d.DakmorSorceress.class));
         cards.add(new SetCardInfo("Dark Offering", 12, Rarity.UNCOMMON, mage.cards.d.DarkOffering.class));
         cards.add(new SetCardInfo("Deathcoil Wurm", 65, Rarity.RARE, mage.cards.d.DeathcoilWurm.class));
+        cards.add(new SetCardInfo("Deep Wood", 66, Rarity.UNCOMMON, mage.cards.d.DeepWood.class));
         cards.add(new SetCardInfo("Deja Vu", 35, Rarity.COMMON, mage.cards.d.DejaVu.class));
         cards.add(new SetCardInfo("Denizen of the Deep", 36, Rarity.RARE, mage.cards.d.DenizenOfTheDeep.class));
         cards.add(new SetCardInfo("Earthquake", 94, Rarity.RARE, mage.cards.e.Earthquake.class));

--- a/Mage.Sets/src/mage/sets/PortalThreeKingdoms.java
+++ b/Mage.Sets/src/mage/sets/PortalThreeKingdoms.java
@@ -83,6 +83,7 @@ public class PortalThreeKingdoms extends ExpansionSet {
         cards.add(new SetCardInfo("Dong Zhou, the Tyrant", 109, Rarity.RARE, mage.cards.d.DongZhouTheTyrant.class));
         cards.add(new SetCardInfo("Eightfold Maze", 2, Rarity.RARE, mage.cards.e.EightfoldMaze.class));
         cards.add(new SetCardInfo("Empty City Ruse", 3, Rarity.UNCOMMON, mage.cards.e.EmptyCityRuse.class));
+        cards.add(new SetCardInfo("Eunuchs' Intrigues", 110, Rarity.UNCOMMON, mage.cards.e.EunuchsIntrigues.class));
         cards.add(new SetCardInfo("Exhaustion", 42, Rarity.RARE, mage.cards.e.Exhaustion.class));
         cards.add(new SetCardInfo("Extinguish", 43, Rarity.COMMON, mage.cards.e.Extinguish.class));
         cards.add(new SetCardInfo("False Defeat", 4, Rarity.COMMON, mage.cards.f.FalseDefeat.class));
@@ -99,6 +100,7 @@ public class PortalThreeKingdoms extends ExpansionSet {
         cards.add(new SetCardInfo("Ghostly Visit", 76, Rarity.COMMON, mage.cards.g.GhostlyVisit.class));
         cards.add(new SetCardInfo("Guan Yu's 1,000-Li March", 7, Rarity.RARE, mage.cards.g.GuanYus1000LiMarch.class));
         cards.add(new SetCardInfo("Guan Yu, Sainted Warrior", 6, Rarity.RARE, mage.cards.g.GuanYuSaintedWarrior.class));
+        cards.add(new SetCardInfo("Heavy Fog", 136, Rarity.UNCOMMON, mage.cards.h.HeavyFog.class));
         cards.add(new SetCardInfo("Huang Zhong, Shu General", 8, Rarity.RARE, mage.cards.h.HuangZhongShuGeneral.class));
         cards.add(new SetCardInfo("Hua Tuo, Honored Physician", 137, Rarity.RARE, mage.cards.h.HuaTuoHonoredPhysician.class));
         cards.add(new SetCardInfo("Hunting Cheetah", 138, Rarity.UNCOMMON, mage.cards.h.HuntingCheetah.class));
@@ -110,6 +112,7 @@ public class PortalThreeKingdoms extends ExpansionSet {
         cards.add(new SetCardInfo("Island", 170, Rarity.LAND, mage.cards.basiclands.Island.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Island", 171, Rarity.LAND, mage.cards.basiclands.Island.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Kongming, \"Sleeping Dragon\"", 9, Rarity.RARE, mage.cards.k.KongmingSleepingDragon.class));
+        cards.add(new SetCardInfo("Kongming's Contraptions", 10, Rarity.RARE, mage.cards.k.KongmingsContraptions.class));
         cards.add(new SetCardInfo("Lady Sun", 45, Rarity.RARE, mage.cards.l.LadySun.class));
         cards.add(new SetCardInfo("Lady Zhurong, Warrior Queen", 139, Rarity.RARE, mage.cards.l.LadyZhurongWarriorQueen.class));
         cards.add(new SetCardInfo("Liu Bei, Lord of Shu", 11, Rarity.RARE, mage.cards.l.LiuBeiLordOfShu.class));
@@ -185,6 +188,7 @@ public class PortalThreeKingdoms extends ExpansionSet {
         cards.add(new SetCardInfo("Virtuous Charge", 29, Rarity.COMMON, mage.cards.v.VirtuousCharge.class));
         cards.add(new SetCardInfo("Volunteer Militia", 30, Rarity.COMMON, mage.cards.v.VolunteerMilitia.class));
         cards.add(new SetCardInfo("Warrior's Oath", 124, Rarity.RARE, mage.cards.w.WarriorsOath.class));
+        cards.add(new SetCardInfo("Warrior's Stand", 31, Rarity.UNCOMMON, mage.cards.w.WarriorsStand.class));
         cards.add(new SetCardInfo("Wei Ambush Force", 85, Rarity.COMMON, mage.cards.w.WeiAmbushForce.class));
         cards.add(new SetCardInfo("Wei Assassins", 86, Rarity.UNCOMMON, mage.cards.w.WeiAssassins.class));
         cards.add(new SetCardInfo("Wei Elite Companions", 87, Rarity.UNCOMMON, mage.cards.w.WeiEliteCompanions.class));

--- a/Mage.Sets/src/mage/sets/UnlimitedEdition.java
+++ b/Mage.Sets/src/mage/sets/UnlimitedEdition.java
@@ -44,6 +44,7 @@ public class UnlimitedEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Black Lotus", 233, Rarity.RARE, mage.cards.b.BlackLotus.class));
         cards.add(new SetCardInfo("Black Vise", 234, Rarity.UNCOMMON, mage.cards.b.BlackVise.class));
         cards.add(new SetCardInfo("Black Ward", 189, Rarity.UNCOMMON, mage.cards.b.BlackWard.class));
+        cards.add(new SetCardInfo("Blaze of Glory", 190, Rarity.RARE, mage.cards.b.BlazeOfGlory.class));
         cards.add(new SetCardInfo("Blessing", 191, Rarity.RARE, mage.cards.b.Blessing.class));
         cards.add(new SetCardInfo("Blue Elemental Blast", 50, Rarity.COMMON, mage.cards.b.BlueElementalBlast.class));
         cards.add(new SetCardInfo("Blue Ward", 192, Rarity.UNCOMMON, mage.cards.b.BlueWard.class));


### PR DESCRIPTION
I've had lots of troubles implementing Blaze of Glory back when assigning multi-blockers was still bugged, but all that seems to work fine now, and at least in some of the more usual cases I've tested (nonflying vs flying, banded attackers, defending creature that cannot block) the card works fine. It still acts rather quirky when applied to an AI blocker, but that might only end up being a visual error, as damage appears to get assigned properly for both attackers and the Blazed AI blocker.