### PR TITLE
Fix Mana#containsAny to account for Any mana

### DIFF
--- a/Mage/src/main/java/mage/Mana.java
+++ b/Mage/src/main/java/mage/Mana.java
@@ -934,6 +934,8 @@ public class Mana implements Comparable<Mana>, Serializable, Copyable<Mana> {
             return true;
         } else if (mana.colorless > 0 && this.colorless > 0 && includeColorless) {
             return true;
+        } else if (mana.any > 0 && this.count() > 0){
+            return true;
         }
 
         return false;


### PR DESCRIPTION
This fixes a bug where the containsAny method was not accounting for {Any} mana. I noticed this with the interaction between Mana Web and Chromatic lantern. For example, if a player has a Mana Web and an opponent has a Chromatic Lantern, the opponent tapping any land should cause all their lands to be tapped, but doesn't.