### PR TITLE
Card hint window now disappears for all cards

### DIFF
--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanel.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanel.java
@@ -625,9 +625,7 @@ public abstract class CardPanel extends MagePermanent implements MouseListener, 
         if (gameCard.hideInfo()) {
             return;
         }
-        if (this.contains(e.getPoint())) {
-            return;
-        }
+        
         if (tooltipShowing) {
             synchronized (this) {
                 if (tooltipShowing) {


### PR DESCRIPTION
Proposed fix for issue #4692 

Swing already informs the UI that the mouse has exited the UI element, so we are not required to check if the mouse is inside of the element