### PR TITLE
Fixed Conversion mana bug, issue #4664

### DIFF
--- a/Mage.Sets/src/mage/cards/c/Conversion.java
+++ b/Mage.Sets/src/mage/cards/c/Conversion.java
@@ -99,17 +99,11 @@ public class Conversion extends CardImpl {
         @Override
         public boolean apply(Layer layer, SubLayer sublayer, Ability source, Game game) {
             for (Permanent land : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), game)) {
-                switch (layer) {
-                    case AbilityAddingRemovingEffects_6:
-                        land.removeAllAbilities(source.getSourceId(), game);
-                        land.addAbility(new WhiteManaAbility(), source.getSourceId(), game);
-                        break;
-                    case TypeChangingEffects_4:
-                        land.getSubtype(game).clear();
-                        land.getSubtype(game).add(SubType.PLAINS);
-                        break;
+                land.removeAllAbilities(source.getSourceId(), game);
+                land.addAbility(new WhiteManaAbility(), source.getSourceId(), game);
+                land.getSubtype(game).clear();
+                land.getSubtype(game).add(SubType.PLAINS);
                 }
-            }
             return true;
         }
 


### PR DESCRIPTION
Switch case prevented the land from tapping for white mana.

Now when Conversion is on the battlefield, the land is converted into a plains while still retaining its name.
The card immediately returns to original state when Conversion leaves.