### PR TITLE
Fix: multiple token copies of Aurelia didn't trigger additional combat

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AureliaTheWarleader.java
+++ b/Mage.Sets/src/mage/cards/a/AureliaTheWarleader.java
@@ -48,6 +48,7 @@ import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.GameEvent.EventType;
+import mage.game.permanent.Permanent;
 
 /**
 *
@@ -118,7 +119,7 @@ class AureliaAttacksTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
        if (event.getSourceId().equals(this.getSourceId()) ) {
-           Card sourceCard = game.getCard(getSourceId());
+           Permanent sourceCard = game.getPermanent(getSourceId());
            Integer amountAttacks = (Integer) game.getState().getValue(getValueKey(sourceCard, game));
            if (amountAttacks == null || amountAttacks < 1) {
                if (amountAttacks == null) {


### PR DESCRIPTION
Cause: the checkTrigger was trying to find the source as a card but if the source was a token, getCard wouldn't find anything, causing sourceCard to be null. The first token copy would trigger, but additional copies attacking for the first time were using the same counter in game.getState because sourceCard was null. By using getPermanent, checkTrigger can now find the token that was the source of the trigger and can accurately track amountAttacks for each Aurelia permanent.