### PR TITLE
Removed Planeswalker deck cards

### DIFF
--- a/Mage.Sets/src/mage/sets/Dominaria.java
+++ b/Mage.Sets/src/mage/sets/Dominaria.java
@@ -53,6 +53,7 @@ public class Dominaria extends ExpansionSet {
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
         this.needsLegends = true;
+        this.maxCardNumberInBooster = 269;
 
         cards.add(new SetCardInfo("Academy Drake", 40, Rarity.UNCOMMON, mage.cards.a.AcademyDrake.class));
         cards.add(new SetCardInfo("Academy Journeymage", 41, Rarity.COMMON, mage.cards.a.AcademyJourneymage.class));


### PR DESCRIPTION
Took the Planeswalker deck cards out of Dominaria Packs. To clarify, I just made them not come up in packs for limited. Although playing Teferi, Timebender in my sealed deck was pretty fun.