### PR TITLE
Enhancement/Autoconnect by Argument 

### DIFF
--- a/Mage.Client/src/main/java/mage/client/MageFrame.java
+++ b/Mage.Client/src/main/java/mage/client/MageFrame.java
@@ -740,7 +740,7 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
     }
 
     public boolean autoConnect() {
-        boolean autoConnectParamValue = Boolean.parseBoolean(PREFS.get("autoConnect", "false"));
+        boolean autoConnectParamValue = startUser != null || Boolean.parseBoolean(PREFS.get("autoConnect", "false"));
         boolean status = false;
         if (autoConnectParamValue) {
             status = performConnect(false);
@@ -1238,26 +1238,20 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
                 }
             }
             instance = new MageFrame();
-            instance.setVisible(true);
+            
             if( startUser != null){
-                //instance.connectDialog.
-                Connection startConnection = new Connection();
-                startConnection.setUsername(startUser);
-                startConnection.setHost(startServer);
+                instance.currentConnection = new Connection();
+                instance.currentConnection.setUsername(startUser);
+                instance.currentConnection.setHost(startServer);
                 if (startPort > 0){
-                    startConnection.setPort(startPort);
+                    instance.currentConnection.setPort(startPort);
                 }else {
-                    startConnection.setPort(MagePreferences.getServerPortWithDefault(Config.port));
+                    instance.currentConnection.setPort(MagePreferences.getServerPortWithDefault(Config.port));
                 }
-                PreferencesDialog.setProxyInformation(startConnection);
-                startConnection.setPassword(startPassword);
-                boolean connectSuccess = connect(startConnection);
-                if (connectSuccess){
-                    instance.connectDialog.hideDialog();
-                } else {
-                    
-                }
+                PreferencesDialog.setProxyInformation(instance.currentConnection);
+                instance.currentConnection.setPassword(startPassword);
             }
+            instance.setVisible(true);
 
         });
     }

--- a/Mage.Client/src/main/java/mage/client/MageFrame.java
+++ b/Mage.Client/src/main/java/mage/client/MageFrame.java
@@ -105,6 +105,10 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
     private static final String GRAY_MODE_ARG = "-gray";
     private static final String FILL_SCREEN_ARG = "-fullscreen";
     private static final String SKIP_DONE_SYMBOLS = "-skipDoneSymbols";
+    private static final String USER_ARG = "-user";
+    private static final String PASSWORD_ARG = "-pw";
+    private static final String SERVER_ARG = "-server";
+    private static final String PORT_ARG = "-port";
 
     private static final String NOT_CONNECTED_TEXT = "<not connected>";
     private static MageFrame instance;
@@ -123,6 +127,10 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
     private static boolean grayMode = false;
     private static boolean fullscreenMode = false;
     private static boolean skipSmallSymbolGenerationForExisting = false;
+    private static String startUser = null;
+    private static String startPassword = "";
+    private static String startServer = "localhost";
+    private static int startPort = -1;
 
     private static final Map<UUID, ChatPanelBasic> CHATS = new HashMap<>();
     private static final Map<UUID, GamePanel> GAMES = new HashMap<>();
@@ -1186,8 +1194,10 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
 
         startTime = System.currentTimeMillis();
         Thread.setDefaultUncaughtExceptionHandler((t, e) -> LOGGER.fatal(null, e));
+        
         SwingUtilities.invokeLater(() -> {
-            for (String arg : args) {
+            for (int i = 0; i < args.length; i++) {
+                String arg = args[i];
                 if (arg.startsWith(LITE_MODE_ARG)) {
                     liteMode = true;
                 }
@@ -1199,6 +1209,22 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
                 }
                 if (arg.startsWith(SKIP_DONE_SYMBOLS)) {
                     skipSmallSymbolGenerationForExisting = true;
+                }
+                if (arg.startsWith(USER_ARG)){
+                    startUser = args[i+1];
+                    i++;
+                }
+                if (arg.startsWith(PASSWORD_ARG)){
+                    startPassword = args[i+1];
+                    i++;
+                }
+                if (arg.startsWith(SERVER_ARG)){
+                    startServer = args[i+1];
+                    i++;
+                }
+                if (arg.startsWith(PORT_ARG)){
+                    startPort = Integer.valueOf(args[i+1]);
+                    i++;
                 }
             }
             if (!liteMode) {
@@ -1213,6 +1239,25 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
             }
             instance = new MageFrame();
             instance.setVisible(true);
+            if( startUser != null){
+                //instance.connectDialog.
+                Connection startConnection = new Connection();
+                startConnection.setUsername(startUser);
+                startConnection.setHost(startServer);
+                if (startPort > 0){
+                    startConnection.setPort(startPort);
+                }else {
+                    startConnection.setPort(MagePreferences.getServerPortWithDefault(Config.port));
+                }
+                PreferencesDialog.setProxyInformation(startConnection);
+                startConnection.setPassword(startPassword);
+                boolean connectSuccess = connect(startConnection);
+                if (connectSuccess){
+                    instance.connectDialog.hideDialog();
+                } else {
+                    
+                }
+            }
 
         });
     }


### PR DESCRIPTION
 #4878
Allows xmage to take in server, user, password and port by argument. 

As of now, it is somewhat limited use because I can't figure out how to launch the development version of mage-client from command line (Seems to be not supported #900), which means you can't put 2-4 launches in a .sh/.cmd script. That would be possible with the release jars, but I can't find instructions for building those either. It would be nice to test this on a redistributable build instead of just in netbeans. 

## Instructions
pass parameters with a launch configuration in netbeans/intellij
("<>" indicates replace with your value and shouldn't be literally typed.)
-user <username> sets the username and tells xmage to autoconnect with these parameters on start. 
-server <server> specifies a server, defaults to localhost. 
-port <port> defaults to the port set in MagePreferences. 
-pw <pw> defaults to "" 

## Notes
I Should add something to the wiki about this if it gets added. 

I considered using a library(such as argparse4j) for nicer command line option handling, but figured it wouldn't be worth the extra dependency. None of the other main methods I found in mage seemed to use one. 