### PR TITLE
Added remaining 2011 Commander pre-constructed decks

### DIFF
--- a/Mage.Client/release/sample-decks/Commander/Commander 2011/Devour for Power.dck
+++ b/Mage.Client/release/sample-decks/Commander/Commander 2011/Devour for Power.dck
@@ -1,0 +1,87 @@
+1 [CMD:193] Desecrator Hag
+1 [CMD:270] Dimir Aqueduct
+1 [CMD:62] Slipstream Eel
+1 [CMD:63] Spell Crumple
+1 [CMD:271] Dreadship Reef
+1 [CMD:152] Eternal Witness
+1 [CMD:275] Golgari Rot Farm
+1 [CMD:68] Vow of Flight
+2 [CMD:310] Swamp
+1 [CMD:236] Vulturous Zombie
+1 [CMD:235] Vorosh, the Hunter
+1 [CMD:279] Jwar Isle Refuge
+2 [CMD:315] Forest
+2 [CMD:317] Forest
+1 [CMD:239] Wrexial, the Risen Deep
+2 [CMD:316] Forest
+3 [CMD:308] Swamp
+3 [CMD:307] Swamp
+3 [CMD:309] Swamp
+1 [CMD:191] Damia, Sage of Stone
+1 [CMD:71] Wonder
+1 [CMD:140] Acidic Slime
+1 [CMD:73] Avatar of Woe
+1 [CMD:261] Sol Ring
+1 [CMD:74] Buried Alive
+1 [CMD:263] Triskelavus
+1 [CMD:262] Solemn Simulacrum
+1 [CMD:70] Windfall
+1 [CMD:102] Stitch Together
+1 [CMD:145] Brawn
+1 [CMD:101] Sign in Blood
+1 [CMD:266] Barren Moor
+1 [CMD:148] Cultivate
+1 [CMD:104] Syphon Mind
+1 [CMD:269] Command Tower
+1 [CMD:103] Syphon Flesh
+1 [CMD:75] Butcher of Malakir
+1 [CMD:227] Skullbriar, the Walking Grave
+2 [CMD:304] Island
+1 [CMD:76] Dark Hatchling
+1 [CMD:105] Unnerve
+2 [CMD:303] Island
+2 [CMD:306] Island
+1 [CMD:228] Szadek, Lord of Secrets
+1 [CMD:107] Vow of Malice
+2 [CMD:305] Island
+1 [CMD:292] Tranquil Thicket
+1 [CMD:83] Fleshbag Marauder
+1 [CMD:291] Terramorphic Expanse
+1 [CMD:85] Grave Pact
+1 [CMD:175] Tribute to the Wild
+1 [CMD:254] Oblivion Stone
+1 [CMD:81] Extractor Demon
+1 [CMD:176] Troll Ascetic
+1 [CMD:253] Lightning Greaves
+1 [CMD:1] Artisan of Kozilek
+1 [CMD:179] Yavimaya Elder
+1 [CMD:178] Vow of Wildness
+1 [CMD:86] Gravedigger
+1 [CMD:259] Simic Signet
+1 [CMD:44] Dreamborn Muse
+1 [CMD:88] Living Death
+1 [CMD:89] Mortivore
+1 [CMD:45] Fact or Fiction
+1 [CMD:290] Temple of the False God
+1 [CMD:93] Patron of the Nezumi
+1 [CMD:281] Lonely Sandbar
+1 [CMD:50] Memory Erosion
+1 [CMD:51] Minds Aglow
+1 [CMD:52] Mulldrifter
+1 [CMD:96] Rise from the Grave
+1 [CMD:285] Rupture Spire
+1 [CMD:165] Lhurgoyf
+1 [CMD:92] Nezumi Graverobber
+1 [CMD:168] Relic Crush
+1 [CMD:289] Svogthos, the Restless Tomb
+1 [CMD:288] Simic Growth Chamber
+1 [CMD:59] Riddlekeeper
+1 [CMD:246] Dimir Signet
+1 [CMD:97] Scythe Specter
+1 [CMD:249] Golgari Signet
+1 [CMD:98] Sewer Nemesis
+1 [CMD:99] Shared Trauma
+2 [CMD:318] Forest
+SB: 1 [CMD:210] The Mimeoplasm
+LAYOUT MAIN:(2,10)(CMC,true,50)|()()([CMD:92],[CMD:227])([CMD:152],[CMD:83],[CMD:59],[CMD:176],[CMD:179])([CMD:145],[CMD:193],[CMD:44],[CMD:86],[CMD:165],[CMD:89],[CMD:98],[CMD:262],[CMD:71])([CMD:140],[CMD:52],[CMD:236])([CMD:76],[CMD:81],[CMD:97],[CMD:235],[CMD:239])([CMD:75],[CMD:191],[CMD:93],[CMD:62],[CMD:228],[CMD:263])([CMD:73])([CMD:1])([CMD:266],[CMD:269],[CMD:270],[CMD:271],[CMD:315],[CMD:315],[CMD:316],[CMD:316],[CMD:317],[CMD:317],[CMD:318],[CMD:318],[CMD:275],[CMD:303],[CMD:303],[CMD:304],[CMD:304],[CMD:305],[CMD:305],[CMD:306],[CMD:306],[CMD:279],[CMD:281],[CMD:285],[CMD:288],[CMD:289],[CMD:307],[CMD:307],[CMD:307],[CMD:308],[CMD:308],[CMD:308],[CMD:309],[CMD:309],[CMD:309],[CMD:310],[CMD:310],[CMD:290],[CMD:291],[CMD:292])([CMD:51],[CMD:99],[CMD:261])([CMD:101],[CMD:102],[CMD:175],[CMD:246],[CMD:249],[CMD:253],[CMD:259])([CMD:74],[CMD:148],[CMD:70],[CMD:63],[CMD:254],[CMD:50],[CMD:68],[CMD:107],[CMD:178])([CMD:104],[CMD:105],[CMD:45],[CMD:85])([CMD:88],[CMD:96],[CMD:103],[CMD:168])()()()()
+LAYOUT SIDEBOARD:(1,1)(NONE,false,50)|([CMD:210])

--- a/Mage.Client/release/sample-decks/Commander/Commander 2011/Heavenly Inferno.dck
+++ b/Mage.Client/release/sample-decks/Commander/Commander 2011/Heavenly Inferno.dck
@@ -1,0 +1,90 @@
+1 [CMD:272] Evolving Wilds
+1 [CMD:195] Duergar Hedge-Mage
+1 [CMD:273] Forgotten Cave
+1 [CMD:111] Avatar of Slaughter
+1 [CMD:231] Terminate
+2 [CMD:311] Mountain
+1 [CMD:24] Orim's Thunder
+2 [CMD:310] Swamp
+1 [CMD:25] Path to Exile
+2 [CMD:313] Mountain
+2 [CMD:312] Mountain
+1 [CMD:117] Comet Storm
+1 [CMD:238] Wrecking Ball
+2 [CMD:314] Mountain
+1 [CMD:21] Mother of Runes
+1 [CMD:116] Cleansing Beam
+1 [CMD:118] Death by Dragons
+2 [CMD:308] Swamp
+2 [CMD:307] Swamp
+1 [CMD:109] Anger
+2 [CMD:309] Swamp
+1 [CMD:18] Lightkeeper of Emeria
+1 [CMD:184] Basandra, Battle Seraph
+1 [CMD:261] Sol Ring
+1 [CMD:30] Serra Angel
+1 [CMD:186] Boros Guildmage
+1 [CMD:185] Bladewing the Risen
+1 [CMD:264] Akoum Refuge
+1 [CMD:267] Bojuka Bog
+2 [CMD:300] Plains
+1 [CMD:79] Dread Cacodemon
+1 [CMD:35] Voice of All
+1 [CMD:266] Barren Moor
+1 [CMD:36] Vow of Duty
+1 [CMD:269] Command Tower
+2 [CMD:302] Plains
+1 [CMD:104] Syphon Mind
+1 [CMD:268] Boros Garrison
+2 [CMD:301] Plains
+1 [CMD:103] Syphon Flesh
+1 [CMD:31] Shattered Angel
+1 [CMD:32] Soul Snare
+1 [CMD:108] Akroma, Angel of Fury
+1 [CMD:229] Tariel, Reckoner of Souls
+1 [CMD:77] Diabolic Tutor
+1 [CMD:107] Vow of Malice
+1 [CMD:28] Return to Dust
+1 [CMD:29] Righteous Cause
+1 [CMD:180] Angel of Despair
+1 [CMD:82] Fallen Angel
+1 [CMD:9] Bathe in Light
+1 [CMD:7] Archangel of Strife
+1 [CMD:5] Angelic Arbiter
+1 [CMD:130] Oni of Wild Places
+1 [CMD:298] Zoetic Cavern
+1 [CMD:3] Akroma's Vengeance
+1 [CMD:80] Evincar's Justice
+1 [CMD:297] Vivid Meadow
+1 [CMD:253] Lightning Greaves
+1 [CMD:132] Pyrohemia
+2 [CMD:299] Plains
+1 [CMD:211] Mortify
+1 [CMD:255] Orzhov Signet
+1 [CMD:137] Sulfurous Blast
+1 [CMD:257] Rakdos Signet
+1 [CMD:136] Stranglehold
+1 [CMD:216] Oros, the Avenger
+1 [CMD:138] Vow of Lightning
+1 [CMD:217] Orzhov Guildmage
+1 [CMD:209] Master Warcraft
+1 [CMD:208] Malfegor
+1 [CMD:94] Razorjaw Oni
+1 [CMD:283] Orzhov Basilica
+1 [CMD:95] Reiver Demon
+1 [CMD:282] Molten Slagheap
+1 [CMD:285] Rupture Spire
+1 [CMD:120] Dragon Whelp
+1 [CMD:284] Rakdos Carnarium
+1 [CMD:243] Boros Signet
+1 [CMD:286] Secluded Steppe
+1 [CMD:242] Armillary Sphere
+1 [CMD:121] Earthquake
+1 [CMD:124] Furnace Whelp
+1 [CMD:245] Darksteel Ingot
+1 [CMD:202] Gwyllion Hedge-Mage
+1 [CMD:11] Congregate
+1 [CMD:129] Mana-Charged Dragon
+SB: 1 [CMD:206] Kaalia of the Vast
+LAYOUT MAIN:(2,10)(CMC,true,50)|()([CMD:21])([CMD:186],[CMD:217])([CMD:195],[CMD:202])([CMD:109],[CMD:120],[CMD:124],[CMD:18],[CMD:94],[CMD:35])([CMD:184],[CMD:82],[CMD:30],[CMD:31])([CMD:208],[CMD:129],[CMD:130],[CMD:216])([CMD:180],[CMD:5],[CMD:7],[CMD:185],[CMD:229])([CMD:108],[CMD:111],[CMD:95])([CMD:79])([CMD:264],[CMD:266],[CMD:267],[CMD:268],[CMD:269],[CMD:272],[CMD:273],[CMD:282],[CMD:311],[CMD:311],[CMD:312],[CMD:312],[CMD:313],[CMD:313],[CMD:314],[CMD:314],[CMD:283],[CMD:299],[CMD:299],[CMD:300],[CMD:300],[CMD:301],[CMD:301],[CMD:302],[CMD:302],[CMD:284],[CMD:285],[CMD:286],[CMD:307],[CMD:307],[CMD:308],[CMD:308],[CMD:309],[CMD:309],[CMD:310],[CMD:310],[CMD:297],[CMD:298])([CMD:121],[CMD:25],[CMD:261],[CMD:32])([CMD:242],[CMD:9],[CMD:243],[CMD:117],[CMD:253],[CMD:255],[CMD:257],[CMD:231])([CMD:245],[CMD:211],[CMD:24],[CMD:36],[CMD:138],[CMD:107])([CMD:11],[CMD:77],[CMD:80],[CMD:209],[CMD:132],[CMD:28],[CMD:136],[CMD:137],[CMD:104],[CMD:238])([CMD:116],[CMD:29],[CMD:103])([CMD:3],[CMD:118])()()()
+LAYOUT SIDEBOARD:(1,1)(NONE,false,50)|([CMD:206])

--- a/Mage.Client/release/sample-decks/Commander/Commander 2011/Political Puppets.dck
+++ b/Mage.Client/release/sample-decks/Commander/Commander 2011/Political Puppets.dck
@@ -1,0 +1,86 @@
+1 [CMD:60] Scattering Stroke
+1 [CMD:61] Skyscribing
+1 [CMD:272] Evolving Wilds
+1 [CMD:194] Dominus of Fealty
+1 [CMD:63] Spell Crumple
+1 [CMD:278] Izzet Boilerworks
+2 [CMD:311] Mountain
+1 [CMD:68] Vow of Flight
+1 [CMD:112] Breath of Darigaaz
+1 [CMD:69] Whirlpool Whelm
+2 [CMD:313] Mountain
+1 [CMD:26] Pollen Lullaby
+2 [CMD:312] Mountain
+1 [CMD:114] Chaos Warp
+1 [CMD:27] Prison Term
+1 [CMD:64] Trade Secrets
+2 [CMD:314] Mountain
+1 [CMD:237] Wall of Denial
+1 [CMD:66] Vedalken Plotter
+1 [CMD:22] Oblation
+1 [CMD:118] Death by Dragons
+1 [CMD:67] Vision Skeins
+1 [CMD:17] Journey to Nowhere
+1 [CMD:19] Martyr's Bond
+1 [CMD:261] Sol Ring
+1 [CMD:183] Azorius Guildmage
+1 [CMD:265] Azorius Chancery
+1 [CMD:221] Ruhan of the Fomori
+1 [CMD:187] Brion Stoutarm
+2 [CMD:300] Plains
+1 [CMD:36] Vow of Duty
+1 [CMD:269] Command Tower
+2 [CMD:302] Plains
+1 [CMD:37] Wall of Omens
+1 [CMD:268] Boros Garrison
+2 [CMD:301] Plains
+1 [CMD:38] Windborn Muse
+3 [CMD:304] Island
+3 [CMD:303] Island
+1 [CMD:32] Soul Snare
+3 [CMD:306] Island
+1 [CMD:33] Spurnmage Advocate
+3 [CMD:305] Island
+1 [CMD:291] Terramorphic Expanse
+1 [CMD:8] Austere Command
+1 [CMD:40] Brainstorm
+1 [CMD:6] Arbiter of Knollridge
+1 [CMD:41] Chromeshell Crab
+1 [CMD:131] Punishing Fire
+1 [CMD:251] Howling Mine
+1 [CMD:133] Rapacious One
+1 [CMD:253] Lightning Greaves
+1 [CMD:46] Flusterstorm
+1 [CMD:256] Prophetic Prism
+2 [CMD:299] Plains
+1 [CMD:47] Fog Bank
+1 [CMD:48] Gomazoa
+1 [CMD:49] Guard Gomazoa
+1 [CMD:213] Nin, the Pain Artist
+1 [CMD:139] Wild Ricochet
+1 [CMD:43] Court Hussar
+1 [CMD:215] Numot, the Devastator
+1 [CMD:138] Vow of Lightning
+1 [CMD:218] Plumeveil
+1 [CMD:242] Armillary Sphere
+1 [CMD:13] False Prophet
+1 [CMD:245] Darksteel Ingot
+1 [CMD:57] Reins of Power
+1 [CMD:123] Flametongue Kavu
+1 [CMD:244] Champion's Helm
+1 [CMD:14] Ghostly Prison
+1 [CMD:58] Repulse
+1 [CMD:247] Dreamstone Hedron
+1 [CMD:126] Insurrection
+1 [CMD:125] Goblin Cadets
+1 [CMD:16] Jotun Grunt
+1 [CMD:205] Izzet Chronarch
+1 [CMD:53] Murmurs from Beyond
+1 [CMD:248] Fellwar Stone
+1 [CMD:127] Lash Out
+1 [CMD:54] Perilous Research
+1 [CMD:55] Propaganda
+1 [CMD:12] Crescendo of War
+SB: 1 [CMD:240] Zedruu the Greathearted
+LAYOUT MAIN:(2,9)(CMC,true,50)|()([CMD:125],[CMD:33])([CMD:183],[CMD:47],[CMD:16],[CMD:213],[CMD:37])([CMD:43],[CMD:48],[CMD:49],[CMD:218],[CMD:66],[CMD:237])([CMD:187],[CMD:13],[CMD:123],[CMD:221],[CMD:38])([CMD:41],[CMD:194],[CMD:205])([CMD:215],[CMD:133])([CMD:6])()([CMD:265],[CMD:268],[CMD:269],[CMD:272],[CMD:303],[CMD:303],[CMD:303],[CMD:304],[CMD:304],[CMD:304],[CMD:305],[CMD:305],[CMD:305],[CMD:306],[CMD:306],[CMD:306],[CMD:278],[CMD:311],[CMD:311],[CMD:312],[CMD:312],[CMD:313],[CMD:313],[CMD:314],[CMD:314],[CMD:299],[CMD:299],[CMD:300],[CMD:300],[CMD:301],[CMD:301],[CMD:302],[CMD:302],[CMD:291])([CMD:40],[CMD:46],[CMD:261],[CMD:32])([CMD:242],[CMD:112],[CMD:248],[CMD:251],[CMD:17],[CMD:127],[CMD:253],[CMD:54],[CMD:26],[CMD:256],[CMD:131],[CMD:61],[CMD:67],[CMD:69])([CMD:244],[CMD:114],[CMD:245],[CMD:14],[CMD:53],[CMD:22],[CMD:27],[CMD:55],[CMD:58],[CMD:63],[CMD:64],[CMD:36],[CMD:68],[CMD:138])([CMD:12],[CMD:57],[CMD:60],[CMD:139])()([CMD:8],[CMD:118],[CMD:247],[CMD:19])()([CMD:126])
+LAYOUT SIDEBOARD:(1,1)(NONE,false,50)|([CMD:240])


### PR DESCRIPTION
Devour for Power is one of the new Commander Anthology 2 decks so will likely see some play soon.