### PR TITLE
Fix for Herald's Horn's spell reduction

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/cost/SpellsCostReductionAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/cost/SpellsCostReductionAllEffect.java
@@ -142,7 +142,7 @@ public class SpellsCostReductionAllEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (onlyControlled && abilityToModify.getControllerId().equals(source.getControllerId())) {
+        if (onlyControlled && !abilityToModify.getControllerId().equals(source.getControllerId())) {
             return false;
         }
         if (abilityToModify instanceof SpellAbility) {


### PR DESCRIPTION
Correctly reduces chosen type of controlled spells again after change in last release.
As mentioned multiple times in #4895.