### PR TITLE
Issue 4952 fix touranment lobby column width and order

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
@@ -203,6 +203,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
     public static final String KEY_TABLES_DIVIDER_LOCATION_1 = "tablePanelDividerLocation1";
     public static final String KEY_TABLES_DIVIDER_LOCATION_2 = "tablePanelDividerLocation2";
     public static final String KEY_TABLES_DIVIDER_LOCATION_3 = "tablePanelDividerLocation3";
+    public static final String KEY_TABLES_DIVIDER_LOCATION_4 = "tablePanelDividerLocation4";
 
     // Positions of deck editor divider bars
     public static final String KEY_EDITOR_HORIZONTAL_DIVIDER_LOCATION = "editorHorizontalDividerLocation";

--- a/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.java
@@ -154,6 +154,7 @@ public class TableWaitingDialog extends MageDialog {
     public void showDialog(UUID roomId, UUID tableId, boolean isTournament) {
         Rectangle currentBounds = MageFrame.getDesktop().getBounds();
         Optional<UUID> chatId = SessionHandler.getTableChatId(tableId);
+        String tournamentChatDivider = PreferencesDialog.getCachedValue(KEY_TABLES_DIVIDER_LOCATION_4, null);
         updateTask = new UpdateSeatsTask(SessionHandler.getSession(), roomId, tableId, this);
 
         this.roomId = roomId;
@@ -176,7 +177,7 @@ public class TableWaitingDialog extends MageDialog {
             this.setModal(false);
             this.setLocation(100, 100);
             this.setVisible(true);
-            String tournamentChatDivider = PreferencesDialog.getCachedValue(KEY_TABLES_DIVIDER_LOCATION_4, null);
+
             GuiDisplayUtil.restoreDividerLocations(currentBounds, tournamentChatDivider, jSplitPane1);
         } else {
             closeDialog();
@@ -193,7 +194,7 @@ public class TableWaitingDialog extends MageDialog {
         this.removeDialog();
         TableUtil.saveColumnWidthAndOrderToPrefs(jTableSeats, KEY_TABLE_WAITING_COLUMNS_WIDTH, KEY_TABLE_WAITING_COLUMNS_ORDER);
         GuiDisplayUtil.saveCurrentBoundsToPrefs();
-        GuiDisplayUtil.setDividerLocation(KEY_TABLES_DIVIDER_LOCATION_4, this.jSplitPane1.getDividerLocation());
+        GuiDisplayUtil.saveDividerLocationToPrefs(KEY_TABLES_DIVIDER_LOCATION_4, this.jSplitPane1.getDividerLocation());
     }
 
     /**

--- a/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.java
@@ -34,6 +34,7 @@
 package mage.client.dialog;
 
 import java.awt.Dimension;
+import java.awt.Rectangle;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -54,6 +55,7 @@ import mage.client.util.GUISizeHelper;
 import mage.client.util.audio.AudioManager;
 import mage.client.util.gui.TableUtil;
 import mage.client.util.gui.countryBox.CountryCellRenderer;
+import mage.client.util.gui.GuiDisplayUtil;
 import mage.players.PlayerType;
 import mage.remote.Session;
 import mage.view.SeatView;
@@ -61,6 +63,7 @@ import mage.view.TableView;
 
 import static mage.client.dialog.PreferencesDialog.KEY_TABLE_WAITING_COLUMNS_ORDER;
 import static mage.client.dialog.PreferencesDialog.KEY_TABLE_WAITING_COLUMNS_WIDTH;
+import static mage.client.dialog.PreferencesDialog.KEY_TABLES_DIVIDER_LOCATION_4;
 
 /**
  * @author BetaSteward_at_googlemail.com
@@ -154,6 +157,9 @@ public class TableWaitingDialog extends MageDialog {
         this.roomId = roomId;
         this.tableId = tableId;
         this.isTournament = isTournament;
+
+        Rectangle currentBounds = MageFrame.getDesktop().getBounds();
+
         updateTask = new UpdateSeatsTask(SessionHandler.getSession(), roomId, tableId, this);
         if (SessionHandler.isTableOwner(roomId, tableId)) {
             this.btnStart.setVisible(true);
@@ -171,6 +177,8 @@ public class TableWaitingDialog extends MageDialog {
             this.setModal(false);
             this.setLocation(100, 100);
             this.setVisible(true);
+            String tournamentChatDivider = PreferencesDialog.getCachedValue(KEY_TABLES_DIVIDER_LOCATION_4, null);
+            GuiDisplayUtil.restoreDividerLocations(currentBounds, tournamentChatDivider, jSplitPane1);
         } else {
             closeDialog();
         }
@@ -185,6 +193,8 @@ public class TableWaitingDialog extends MageDialog {
         MageFrame.getUI().removeButton(MageComponents.TABLE_WAITING_START_BUTTON);
         this.removeDialog();
         TableUtil.saveColumnWidthAndOrderToPrefs(jTableSeats, KEY_TABLE_WAITING_COLUMNS_WIDTH, KEY_TABLE_WAITING_COLUMNS_ORDER);
+        GuiDisplayUtil.saveCurrentBoundsToPrefs();
+        GuiDisplayUtil.setDividerLocation(KEY_TABLES_DIVIDER_LOCATION_4, this.jSplitPane1.getDividerLocation());
     }
 
     /**

--- a/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.java
@@ -96,6 +96,7 @@ public class TableWaitingDialog extends MageDialog {
 
         setGUISize();
         jTableSeats.createDefaultColumnsFromModel();
+        jTableSeats.setAutoCreateColumnsFromModel(false);
         jTableSeats.setDefaultRenderer(Icon.class, new CountryCellRenderer());
         TableUtil.setColumnWidthAndOrder(jTableSeats, DEFAULT_COLUMNS_WIDTH, KEY_TABLE_WAITING_COLUMNS_WIDTH, KEY_TABLE_WAITING_COLUMNS_ORDER);
         chatPanel.useExtendedView(ChatPanelBasic.VIEW_MODE.NONE);

--- a/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.java
@@ -71,7 +71,7 @@ import static mage.client.dialog.PreferencesDialog.KEY_TABLES_DIVIDER_LOCATION_4
 public class TableWaitingDialog extends MageDialog {
 
     private static final Logger LOGGER = Logger.getLogger(TableWaitingDialog.class);
-    private static final int[] DEFAULT_COLUMNS_WIDTH = {20, 50, 100, 100, 100};
+    private static final int[] DEFAULT_COLUMNS_WIDTH = {20, 50, 100, 100, 100, 100};
 
     private UUID tableId;
     private UUID roomId;

--- a/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.java
@@ -95,12 +95,10 @@ public class TableWaitingDialog extends MageDialog {
         }
 
         setGUISize();
-
-        chatPanel.useExtendedView(ChatPanelBasic.VIEW_MODE.NONE);
         jTableSeats.createDefaultColumnsFromModel();
-        TableUtil.setColumnWidthAndOrder(jTableSeats, DEFAULT_COLUMNS_WIDTH, KEY_TABLE_WAITING_COLUMNS_WIDTH, KEY_TABLE_WAITING_COLUMNS_ORDER);
         jTableSeats.setDefaultRenderer(Icon.class, new CountryCellRenderer());
-
+        TableUtil.setColumnWidthAndOrder(jTableSeats, DEFAULT_COLUMNS_WIDTH, KEY_TABLE_WAITING_COLUMNS_WIDTH, KEY_TABLE_WAITING_COLUMNS_ORDER);
+        chatPanel.useExtendedView(ChatPanelBasic.VIEW_MODE.NONE);
         MageFrame.getUI().addButton(MageComponents.TABLE_WAITING_START_BUTTON, btnStart);
     }
 
@@ -154,13 +152,14 @@ public class TableWaitingDialog extends MageDialog {
     }
 
     public void showDialog(UUID roomId, UUID tableId, boolean isTournament) {
+        Rectangle currentBounds = MageFrame.getDesktop().getBounds();
+        Optional<UUID> chatId = SessionHandler.getTableChatId(tableId);
+        updateTask = new UpdateSeatsTask(SessionHandler.getSession(), roomId, tableId, this);
+
         this.roomId = roomId;
         this.tableId = tableId;
         this.isTournament = isTournament;
 
-        Rectangle currentBounds = MageFrame.getDesktop().getBounds();
-
-        updateTask = new UpdateSeatsTask(SessionHandler.getSession(), roomId, tableId, this);
         if (SessionHandler.isTableOwner(roomId, tableId)) {
             this.btnStart.setVisible(true);
             this.btnMoveDown.setVisible(true);
@@ -170,7 +169,7 @@ public class TableWaitingDialog extends MageDialog {
             this.btnMoveDown.setVisible(false);
             this.btnMoveUp.setVisible(false);
         }
-        Optional<UUID> chatId = SessionHandler.getTableChatId(tableId);
+
         if (chatId.isPresent()) {
             this.chatPanel.connect(chatId.get());
             updateTask.execute();

--- a/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
+++ b/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
@@ -231,7 +231,7 @@ public class TablesPanel extends javax.swing.JPanel {
         jScrollPaneTablesActive.getViewport().setBackground(new Color(255, 255, 255, 50));
         jScrollPaneTablesFinished.getViewport().setBackground(new Color(255, 255, 255, 50));
 
-        saveActiveFiltersToPrefs();
+        restoreFilters();
         setGUISize();
 
         Action openTableAction;
@@ -411,12 +411,12 @@ public class TablesPanel extends javax.swing.JPanel {
     private void saveDividerLocations() {
         // save divider locations and divider saveDividerLocations
         GuiDisplayUtil.saveCurrentBoundsToPrefs();
-        GuiDisplayUtil.setDividerLocation(KEY_TABLES_DIVIDER_LOCATION_1, this.jSplitPane1.getDividerLocation());
-        GuiDisplayUtil.setDividerLocation(KEY_TABLES_DIVIDER_LOCATION_2, this.jSplitPaneTables.getDividerLocation());
-        GuiDisplayUtil.setDividerLocation(KEY_TABLES_DIVIDER_LOCATION_3, chatPanelMain.getSplitDividerLocation());
+        GuiDisplayUtil.saveDividerLocationToPrefs(KEY_TABLES_DIVIDER_LOCATION_1, this.jSplitPane1.getDividerLocation());
+        GuiDisplayUtil.saveDividerLocationToPrefs(KEY_TABLES_DIVIDER_LOCATION_2, this.jSplitPaneTables.getDividerLocation());
+        GuiDisplayUtil.saveDividerLocationToPrefs(KEY_TABLES_DIVIDER_LOCATION_3, chatPanelMain.getSplitDividerLocation());
     }
 
-    private void saveActiveFiltersToPrefs() {
+    private void restoreFilters() {
         TableUtil.setActiveFilters(KEY_TABLES_FILTER_SETTINGS, filterButtons);
         setTableFilter();
     }

--- a/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
+++ b/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
@@ -410,10 +410,8 @@ public class TablesPanel extends javax.swing.JPanel {
     }
 
     private void saveDividerLocations() {
-        // save desktop bounds and divider locations
-        Rectangle rec = MageFrame.getDesktop().getBounds();
-        String currentBounds = Double.toString(rec.getWidth()) + 'x' + Double.toString(rec.getHeight());
-        PreferencesDialog.saveValue(KEY_MAGE_PANEL_LAST_SIZE, currentBounds);
+        // save divider locations and divider saveDividerLocations
+        GuiDisplayUtil.saveCurrentBoundsToPrefs();
         GuiDisplayUtil.setDividerLocation(KEY_TABLES_DIVIDER_LOCATION_1, this.jSplitPane1.getDividerLocation());
         GuiDisplayUtil.setDividerLocation(KEY_TABLES_DIVIDER_LOCATION_2, this.jSplitPaneTables.getDividerLocation());
         GuiDisplayUtil.setDividerLocation(KEY_TABLES_DIVIDER_LOCATION_3, chatPanelMain.getSplitDividerLocation());
@@ -432,9 +430,9 @@ public class TablesPanel extends javax.swing.JPanel {
     private void restoreDividers() {
       Rectangle currentBounds = MageFrame.getDesktop().getBounds();
       if (currentBounds != null) {
-        String firstDivider = PreferencesDialog.getCachedValue(PreferencesDialog.KEY_TABLES_DIVIDER_LOCATION_1, null);
-        String tableDivider = PreferencesDialog.getCachedValue(PreferencesDialog.KEY_TABLES_DIVIDER_LOCATION_2, null);
-        String chatDivider = PreferencesDialog.getCachedValue(PreferencesDialog.KEY_TABLES_DIVIDER_LOCATION_3, null);
+        String firstDivider = PreferencesDialog.getCachedValue(KEY_TABLES_DIVIDER_LOCATION_1, null);
+        String tableDivider = PreferencesDialog.getCachedValue(KEY_TABLES_DIVIDER_LOCATION_2, null);
+        String chatDivider = PreferencesDialog.getCachedValue(KEY_TABLES_DIVIDER_LOCATION_3, null);
         GuiDisplayUtil.restoreDividerLocations(currentBounds, firstDivider, jSplitPane1);
         GuiDisplayUtil.restoreDividerLocations(currentBounds, tableDivider, jSplitPaneTables);
         GuiDisplayUtil.restoreDividerLocations(currentBounds, chatDivider, chatPanelMain);

--- a/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
+++ b/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
@@ -196,8 +196,7 @@ public class TablesPanel extends javax.swing.JPanel {
         list.add(new RowSorter.SortKey(TableTableModel.COLUMN_CREATED, SortOrder.DESCENDING));
         activeTablesSorter.setSortKeys(list);
 
-        TableUtil.setColumnWidthAndOrder(tableTables, DEFAULT_COLUMNS_WIDTH,
-                PreferencesDialog.KEY_TABLES_COLUMNS_WIDTH, PreferencesDialog.KEY_TABLES_COLUMNS_ORDER);
+        TableUtil.setColumnWidthAndOrder(tableTables, DEFAULT_COLUMNS_WIDTH, KEY_TABLES_COLUMNS_WIDTH, KEY_TABLES_COLUMNS_ORDER);
 
         // 2. TABLE COMPLETED
         completedTablesSorter = new MageTableRowSorter(matchesModel);

--- a/Mage.Client/src/main/java/mage/client/util/gui/GuiDisplayUtil.java
+++ b/Mage.Client/src/main/java/mage/client/util/gui/GuiDisplayUtil.java
@@ -48,6 +48,12 @@ public final class GuiDisplayUtil {
       }
     }
 
+    public static void saveCurrentBoundsToPrefs() {
+      Rectangle rec = MageFrame.getDesktop().getBounds();
+      String currentBounds = Double.toString(rec.getWidth()) + 'x' + Double.toString(rec.getHeight());
+      PreferencesDialog.saveValue(KEY_MAGE_PANEL_LAST_SIZE, currentBounds);
+    }
+
     public static void setDividerLocation(String dividerPrefKey, int position) {
       PreferencesDialog.saveValue(dividerPrefKey, Integer.toString(position));
     }

--- a/Mage.Client/src/main/java/mage/client/util/gui/GuiDisplayUtil.java
+++ b/Mage.Client/src/main/java/mage/client/util/gui/GuiDisplayUtil.java
@@ -4,8 +4,11 @@ import java.awt.*;
 import java.util.ArrayList;
 import java.util.Locale;
 import javax.swing.*;
+import mage.client.dialog.PreferencesDialog;
+import static mage.client.dialog.PreferencesDialog.KEY_MAGE_PANEL_LAST_SIZE;
 import mage.client.MageFrame;
 import mage.client.util.GUISizeHelper;
+import mage.client.table.*;
 import mage.constants.*;
 import mage.view.CardView;
 import mage.view.CounterView;
@@ -24,6 +27,29 @@ public final class GuiDisplayUtil {
 
         public int basicTextLength;
         public ArrayList<String> lines;
+    }
+
+    public static void restoreDividerLocations(Rectangle bounds, String lastDividerLocation, JComponent component) {
+      String currentBounds = Double.toString(bounds.getWidth()) + 'x' + Double.toString(bounds.getHeight());
+      String savedBounds = PreferencesDialog.getCachedValue(KEY_MAGE_PANEL_LAST_SIZE, null);
+      // use divider positions only if screen size is the same as it was the time the settings were saved
+      if (savedBounds != null && savedBounds.equals(currentBounds)) {
+        if (lastDividerLocation != null && component != null) {
+          if (component instanceof JSplitPane) {
+            JSplitPane jSplitPane = (JSplitPane) component;
+            jSplitPane.setDividerLocation(Integer.parseInt(lastDividerLocation));
+          }
+
+          if (component instanceof PlayersChatPanel) {
+            PlayersChatPanel playerChatPanel = (PlayersChatPanel) component;
+            playerChatPanel.setSplitDividerLocation(Integer.parseInt(lastDividerLocation));
+          }
+        }
+      }
+    }
+
+    public static void setDividerLocation(String dividerPrefKey, int position) {
+      PreferencesDialog.saveValue(dividerPrefKey, Integer.toString(position));
     }
 
     public static JXPanel getDescription(CardView card, int width, int height) {

--- a/Mage.Client/src/main/java/mage/client/util/gui/GuiDisplayUtil.java
+++ b/Mage.Client/src/main/java/mage/client/util/gui/GuiDisplayUtil.java
@@ -54,7 +54,7 @@ public final class GuiDisplayUtil {
       PreferencesDialog.saveValue(KEY_MAGE_PANEL_LAST_SIZE, currentBounds);
     }
 
-    public static void setDividerLocation(String dividerPrefKey, int position) {
+    public static void saveDividerLocationToPrefs(String dividerPrefKey, int position) {
       PreferencesDialog.saveValue(dividerPrefKey, Integer.toString(position));
     }
 

--- a/Mage.Client/src/main/java/mage/client/util/gui/TableUtil.java
+++ b/Mage.Client/src/main/java/mage/client/util/gui/TableUtil.java
@@ -55,7 +55,6 @@ public final class TableUtil {
 
         // set the column width from saved value or defaults
         int[] widths = getIntArrayFromString(PreferencesDialog.getCachedValue(widthPrefKey, null));
-        LOGGER.info("loading stored widths: " + Arrays.toString(widths));
         int i = 0;
         for (int width : defaultColumnsWidth) {
             if (widths != null && widths.length > i) {
@@ -72,7 +71,6 @@ public final class TableUtil {
 
         // set the column order
         int[] order = getIntArrayFromString(PreferencesDialog.getCachedValue(orderPrefKey, null));
-        LOGGER.info("loading column order: " + Arrays.toString(order));
         if (order != null && order.length == table.getColumnCount()) {
             for (int j = 0; j < table.getColumnCount(); j++) {
                 table.moveColumn(table.convertColumnIndexToView(order[j]), j);
@@ -100,8 +98,6 @@ public final class TableUtil {
 
         PreferencesDialog.saveValue(widthPrefKey, columnWidthSettings.toString());
         PreferencesDialog.saveValue(orderPrefKey, columnOrderSettings.toString());
-        LOGGER.info("saving column widths: " + columnWidthSettings.toString());
-        LOGGER.info("saving column order: " + columnOrderSettings.toString());
     }
 
     private static int[] getIntArrayFromString(String stringData) {

--- a/Mage.Client/src/main/java/mage/client/util/gui/TableUtil.java
+++ b/Mage.Client/src/main/java/mage/client/util/gui/TableUtil.java
@@ -7,6 +7,7 @@ package mage.client.util.gui;
 
 import java.util.Arrays;
 import javax.swing.JTable;
+import javax.swing.JToggleButton;
 import javax.swing.table.TableColumn;
 import org.apache.log4j.Logger;
 import mage.client.dialog.PreferencesDialog;
@@ -27,7 +28,29 @@ public final class TableUtil {
 
     private static final Logger LOGGER = Logger.getLogger(TableUtil.class);
 
-    static public void setColumnWidthAndOrder(JTable table, int[] defaultColumnsWidth, String widthPrefKey, String orderPrefKey) {
+    public static void saveActiveFiltersToPrefs(String filterPrefKey, JToggleButton[] buttons) {
+      StringBuilder currentFilters = new StringBuilder();
+      for (JToggleButton component : buttons) {
+          currentFilters.append(component.isSelected() ? "x" : "-");
+      }
+
+      PreferencesDialog.saveValue(filterPrefKey, currentFilters.toString());
+    }
+
+    public static void setActiveFilters(String filterPrefKey, JToggleButton[] buttons) {
+        String formatSettings = PreferencesDialog.getCachedValue(filterPrefKey, "");
+        int i = 0;
+        for (JToggleButton component : buttons) {
+            if (formatSettings.length() > i) {
+                component.setSelected(formatSettings.substring(i, i + 1).equals("x"));
+            } else {
+                component.setSelected(true);
+            }
+            i++;
+        }
+    }
+
+    public static void setColumnWidthAndOrder(JTable table, int[] defaultColumnsWidth, String widthPrefKey, String orderPrefKey) {
         table.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
 
         // set the column width from saved value or defaults
@@ -58,11 +81,11 @@ public final class TableUtil {
 
     }
 
-    static public void saveColumnWidthAndOrderToPrefs(JTable table, String widthPrefKey, String orderPrefKey) {
-        // Column width
+    public static void saveColumnWidthAndOrderToPrefs(JTable table, String widthPrefKey, String orderPrefKey) {
         StringBuilder columnWidthSettings = new StringBuilder();
         StringBuilder columnOrderSettings = new StringBuilder();
         boolean firstValue = true;
+
         for (int i = 0; i < table.getColumnModel().getColumnCount(); i++) {
             TableColumn column = table.getColumnModel().getColumn(table.convertColumnIndexToView(i));
             if (!firstValue) {
@@ -74,14 +97,14 @@ public final class TableUtil {
             columnWidthSettings.append(column.getWidth());
             columnOrderSettings.append(table.convertColumnIndexToModel(i));
         }
+
         PreferencesDialog.saveValue(widthPrefKey, columnWidthSettings.toString());
         PreferencesDialog.saveValue(orderPrefKey, columnOrderSettings.toString());
-
         LOGGER.info("saving column widths: " + columnWidthSettings.toString());
         LOGGER.info("saving column order: " + columnOrderSettings.toString());
     }
 
-    public static int[] getIntArrayFromString(String stringData) {
+    private static int[] getIntArrayFromString(String stringData) {
         int[] intArray = null;
         if (stringData != null && !stringData.isEmpty()) {
             String[] items = stringData.split(",");


### PR DESCRIPTION
Need a bit of help with this one - the chat divider is being properly saved and restored for the tournament waiting lobby but the column widths and order refuse to work!

What this does:
- [x] refactors the divider location saving and setting into utility functions
- [x] refactors the applied filter saving and setting into utility functions
- [x] adds the ability for the pre-game tournament window to remember chat divider positioning
- [x] fixes the pre-game tournament column width and order not being displayed