### PR TITLE
Fix ChromeMox produceMana

### DIFF
--- a/Mage.Sets/src/mage/cards/c/ChromeMox.java
+++ b/Mage.Sets/src/mage/cards/c/ChromeMox.java
@@ -200,22 +200,19 @@ class ChromeMoxManaEffect extends ManaEffect {
                         }
                         switch (choice.getChoice()) {
                             case "Black":
-                                player.getManaPool().addMana(Mana.BlackMana(1), game, source);
+                                mana.add(Mana.BlackMana(1));
                                 break;
                             case "Blue":
-                                player.getManaPool().addMana(Mana.BlueMana(1), game, source);
+                                mana.add(Mana.BlueMana(1));
                                 break;
                             case "Red":
-                                player.getManaPool().addMana(Mana.RedMana(1), game, source);
+                                mana.add(Mana.RedMana(1));
                                 break;
                             case "Green":
-                                player.getManaPool().addMana(Mana.GreenMana(1), game, source);
+                                mana.add(Mana.GreenMana(1));
                                 break;
                             case "White":
-                                player.getManaPool().addMana(Mana.WhiteMana(1), game, source);
-                                break;
-                            case "Colorless":
-                                player.getManaPool().addMana(Mana.ColorlessMana(1), game, source);
+                                mana.add(Mana.WhiteMana(1));
                                 break;
                             default:
                                 break;


### PR DESCRIPTION
I just ran into a bug while playing Chrome Mox. Too much mana was added to the mana pool.

Here I propose two changes:

* Add the mana to the Mana object and not directly to the mana pool.
* Remove the colorless choice which shall not happen anyway.

I have not tested or compiled these changes in any way.