### PR TITLE
Fix Triumph Of Ferocity rule text

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TriumphOfFerocity.java
+++ b/Mage.Sets/src/mage/cards/t/TriumphOfFerocity.java
@@ -43,7 +43,7 @@ import mage.constants.TargetController;
  */
 public class TriumphOfFerocity extends CardImpl {
 
-    private static final String ruleText = "draw a card if you control the creature with the greatest power or tied for the greatest power";
+    private static final String ruleText = "At the beginning of your upkeep, draw a card if you control the creature with the greatest power or tied for the greatest power";
 
     public TriumphOfFerocity(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{2}{G}");


### PR DESCRIPTION
static ruleText passed to ConditionalTriggeredAbility was leaving off the initial triggering condition when building rule text.