### PR TITLE
Fixed major bug with Charmed Griffin

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CharmedGriffin.java
+++ b/Mage.Sets/src/mage/cards/c/CharmedGriffin.java
@@ -79,7 +79,7 @@ class CharmedGriffinEffect extends OneShotEffect {
                                 && player.choose(Outcome.PutCardInPlay, target, source.getSourceId(), game)) {
                             Card card = game.getCard(target.getFirstTarget());
                             if (card != null) {
-                                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+                                player.moveCards(card, Zone.BATTLEFIELD, source, game);
                             }
                         }
                     }


### PR DESCRIPTION
Currently Charmed Griffin puts all cards from each other player into play under Charmed Griffin's CONTROLLER'S control. The card is supposed to put the cards into play under their owners' control. Simple fix to update controller.moveCards to player.moveCards on line 82 to make it work properly.