### PR TITLE
Fix Llanowar Scout

### DIFF
--- a/Mage.Sets/src/mage/cards/l/LlanowarScout.java
+++ b/Mage.Sets/src/mage/cards/l/LlanowarScout.java
@@ -29,7 +29,7 @@ public final class LlanowarScout extends CardImpl {
 
         // {T}: You may put a land card from your hand onto the battlefield.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new PutCardFromHandOntoBattlefieldEffect(StaticFilters.FILTER_CARD_BASIC_LAND_A), new TapSourceCost()));
+                new PutCardFromHandOntoBattlefieldEffect(StaticFilters.FILTER_CARD_LAND_A), new TapSourceCost()));
     }
 
     public LlanowarScout(final LlanowarScout card) {


### PR DESCRIPTION
Llanowar Scout lets you put any land card from your hand onto the battlefield, not just a basic land card.

Reported on the Xmage subreddit.