### PR TITLE
fix Ajani Adversary of Tyrants +1

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AjaniAdversaryOfTyrants.java
+++ b/Mage.Sets/src/mage/cards/a/AjaniAdversaryOfTyrants.java
@@ -41,7 +41,7 @@ public final class AjaniAdversaryOfTyrants extends CardImpl {
         this.addAbility(new PlanswalkerEntersWithLoyalityCountersAbility(4));
 
         // +1: Put a +1/+1 counter on each of up to two target creatures.
-        Ability ability = new LoyaltyAbility(new AddCountersTargetEffect(CounterType.P1P1.createInstance()));
+        Ability ability = new LoyaltyAbility(new AddCountersTargetEffect(CounterType.P1P1.createInstance()), 1);
         ability.addTarget(new TargetCreaturePermanent(0, 2));
         this.addAbility(ability);
 


### PR DESCRIPTION
Ajani, Adversary of Tyrants +1 was missing loyalty cost, defaults to -X