### PR TITLE
Fix equip and fortify abilities

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/EquipEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/EquipEffect.java
@@ -1,0 +1,39 @@
+package mage.abilities.effects;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.common.AttachEffect;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+public class EquipEffect extends AttachEffect {
+
+    public EquipEffect(Outcome outcome) {
+        super(outcome, "Equip");
+    }
+
+    public EquipEffect(EquipEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent sourcePermanent = game.getPermanent(source.getSourceId());
+        //301.5c An Equipment that’s also a creature can’t equip a creature. An Equipment that loses the subtype
+        // “Equipment” can’t equip a creature. An Equipment can’t equip itself. An Equipment that equips an illegal or
+        // nonexistent permanent becomes unattached from that permanent but remains on the battlefield. (This is a
+        // state-based action. See rule 704.) An Equipment can’t equip more than one creature. If a spell or ability
+        // would cause an Equipment to equip more than one creature, the Equipment’s controller chooses which creature
+        // it equips.
+        if (sourcePermanent != null && sourcePermanent.hasSubtype(SubType.EQUIPMENT, game) && !sourcePermanent.isCreature()) {
+            return super.apply(game, source);
+        }
+        return false;
+    }
+
+    @Override
+    public EquipEffect copy(){
+        return new EquipEffect(this);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/FortifyEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/FortifyEffect.java
@@ -1,0 +1,38 @@
+package mage.abilities.effects.common;
+
+import mage.abilities.Ability;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+public class FortifyEffect extends AttachEffect{
+
+    public FortifyEffect(Outcome outcome) {
+        super(outcome, "Fortify");
+    }
+
+    public FortifyEffect(FortifyEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent sourcePermanent = game.getPermanent(source.getSourceId());
+        //Some artifacts have the subtype “Fortification.” A Fortification can be attached to a land. It can’t legally
+        // be attached to an object that isn’t a land. Fortification’s analog to the equip keyword ability is the
+        // fortify keyword ability. Rules 301.5a–e apply to Fortifications in relation to lands just as they apply to
+        // Equipment in relation to creatures, with one clarification relating to rule 301.5c: a Fortification that’s
+        // also a creature (not a land) can’t fortify a land. (See rule 702.66, “Fortify.”)
+        if (sourcePermanent != null && sourcePermanent.hasSubtype(SubType.FORTIFICATION, game) && !sourcePermanent.isCreature()
+                && !sourcePermanent.isLand()) {
+            return super.apply(game, source);
+        }
+        return false;
+    }
+
+    @Override
+    public FortifyEffect copy(){
+        return new FortifyEffect(this);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/keyword/EquipAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/EquipAbility.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 import mage.abilities.ActivatedAbilityImpl;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.effects.EquipEffect;
 import mage.abilities.effects.common.AttachEffect;
 import mage.constants.Outcome;
 import mage.constants.SubType;
@@ -28,19 +29,9 @@ public class EquipAbility extends ActivatedAbilityImpl {
     }
 
     public EquipAbility(Outcome outcome, Cost cost, Target target) {
-        super(Zone.BATTLEFIELD, new AttachEffect(outcome, "Equip"), cost);
+        super(Zone.BATTLEFIELD, new EquipEffect(outcome), cost);
         this.addTarget(target);
         this.timing = TimingRule.SORCERY;
-    }
-
-    @Override
-    public ActivationStatus canActivate(UUID playerId, Game game) {
-        Permanent permanent = game.getPermanent(sourceId);
-        if (permanent != null && permanent.hasSubtype(SubType.EQUIPMENT, game) && !permanent.isCreature()) {
-            return super.canActivate(playerId, game);
-        } else {
-            return ActivationStatus.getFalse();
-        }
     }
 
     public EquipAbility(final EquipAbility ability) {

--- a/Mage/src/main/java/mage/abilities/keyword/FortifyAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/FortifyAbility.java
@@ -3,6 +3,7 @@
 package mage.abilities.keyword;
 
 import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.effects.common.FortifyEffect;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.TimingRule;
@@ -36,19 +37,9 @@ public class FortifyAbility extends ActivatedAbilityImpl {
     }
 
     public FortifyAbility(Outcome outcome, Cost cost, Target target) {
-        super(Zone.BATTLEFIELD, new AttachEffect(outcome, "Fortify"), cost);
+        super(Zone.BATTLEFIELD, new FortifyEffect(outcome), cost);
         this.addTarget(target);
         this.timing = TimingRule.SORCERY;
-    }
-
-    @Override
-    public ActivationStatus canActivate(UUID playerId, Game game) {
-        Permanent permanent = game.getPermanent(sourceId);
-        if (permanent != null && permanent.hasSubtype(SubType.FORTIFICATION, game) && !permanent.isCreature() && !permanent.isLand()) {
-            return super.canActivate(playerId, game);
-        } else {
-            return ActivationStatus.getFalse();
-        }
     }
 
     public FortifyAbility(final FortifyAbility ability) {


### PR DESCRIPTION
According to Judge Chat, when a permanent with the equip ability is a creature or a nonequipment permanent, you can still activate the ability, it just doesn't do anything. This makes that happen, versus the previous behavior of not being able to activate at all.