### PR TITLE
Fix a bug with clones of Adaptive Automaton and Metallic Mimic

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AdaptiveAutomaton.java
+++ b/Mage.Sets/src/mage/cards/a/AdaptiveAutomaton.java
@@ -38,7 +38,7 @@ public final class AdaptiveAutomaton extends CardImpl {
 
         // As Adaptive Automaton enters the battlefield, choose a creature type.
         // Adaptive Automaton is the chosen type in addition to its other types.
-        AsEntersBattlefieldAbility ability = new AsEntersBattlefieldAbility(new ChooseCreatureTypeEffect(Outcome.BoostCreature), null, EnterEventType.SELF);
+        AsEntersBattlefieldAbility ability = new AsEntersBattlefieldAbility(new ChooseCreatureTypeEffect(Outcome.BoostCreature));
         ability.addEffect(new EnterAttributeAddChosenSubtypeEffect());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/m/MetallicMimic.java
+++ b/Mage.Sets/src/mage/cards/m/MetallicMimic.java
@@ -32,7 +32,7 @@ public final class MetallicMimic extends CardImpl {
         this.toughness = new MageInt(1);
 
         // As Metallic Mimic enters the battlefield, choose a creature type.
-        AsEntersBattlefieldAbility ability = new AsEntersBattlefieldAbility(new ChooseCreatureTypeEffect(Outcome.BoostCreature), null, EnterEventType.SELF);
+        AsEntersBattlefieldAbility ability = new AsEntersBattlefieldAbility(new ChooseCreatureTypeEffect(Outcome.BoostCreature));
         // Metallic Mimic is the chosen type in addition to its other types.
         ability.addEffect(new EnterAttributeAddChosenSubtypeEffect());
         this.addAbility(ability);


### PR DESCRIPTION
Copies of Adaptive Automaton and Metallic Mimic don't get to choose a creature type.