### PR TITLE
Make the type checking on predicates added to filters stricter

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DustOfMoments.java
+++ b/Mage.Sets/src/mage/cards/d/DustOfMoments.java
@@ -18,6 +18,7 @@ import mage.counters.Counter;
 import mage.counters.CounterType;
 import mage.filter.Filter;
 import mage.filter.FilterCard;
+import mage.filter.FilterPermanent;
 import mage.filter.predicate.permanent.CardCounterPredicate;
 import mage.filter.predicate.permanent.CounterPredicate;
 import mage.game.Game;
@@ -59,13 +60,13 @@ public final class DustOfMoments extends CardImpl {
     public abstract static class DustOfMomentsEffect extends OneShotEffect {
 
         private final Counter counter;
-        private final Filter<Card> permFilter;
+        private final Filter<Permanent> permFilter;
         private final Filter<Card> exiledFilter;
 
         public DustOfMomentsEffect() {
             super(Outcome.Benefit);
             this.counter = new Counter(CounterType.TIME.getName(), 2);
-            this.permFilter = new FilterCard("permanent and each suspended card");
+            this.permFilter = new FilterPermanent("permanent and each suspended card");
             permFilter.add(new CounterPredicate(CounterType.TIME));
 
             this.exiledFilter = new FilterCard("permanent and each suspended card");

--- a/Mage.Sets/src/mage/cards/i/Interdict.java
+++ b/Mage.Sets/src/mage/cards/i/Interdict.java
@@ -55,15 +55,15 @@ public final class Interdict extends CardImpl {
     }
 }
 
-class InterdictPredicate implements Predicate<Ability> {
+class InterdictPredicate implements Predicate<StackObject> {
 
     public InterdictPredicate() {
     }
 
     @Override
-    public boolean apply(Ability input, Game game) {
-        if (input instanceof StackAbility && input.getAbilityType() == AbilityType.ACTIVATED) {
-            MageObject sourceObject = input.getSourceObject(game);
+    public boolean apply(StackObject input, Game game) {
+        if (input instanceof StackAbility && ((StackAbility) input).getAbilityType() == AbilityType.ACTIVATED) {
+            MageObject sourceObject = ((StackAbility) input).getSourceObject(game);
             if (sourceObject != null) {
                 return (sourceObject.isArtifact()
                         || sourceObject.isEnchantment()

--- a/Mage.Sets/src/mage/cards/o/OupheVandals.java
+++ b/Mage.Sets/src/mage/cards/o/OupheVandals.java
@@ -61,15 +61,16 @@ public final class OupheVandals extends CardImpl {
     }
 }
 
-class ArtifactSourcePredicate implements Predicate<Ability> {
+class ArtifactSourcePredicate implements Predicate<StackObject> {
 
     public ArtifactSourcePredicate() {
     }
 
     @Override
-    public boolean apply(Ability input, Game game) {
+    public boolean apply(StackObject input, Game game) {
         if (input instanceof StackAbility) {
-            return input.getSourceObject(game).isArtifact() && input.getAbilityType() == AbilityType.ACTIVATED;
+            StackAbility ability = (StackAbility) input;
+            return ability.getSourceObject(game).isArtifact() && ability.getAbilityType() == AbilityType.ACTIVATED;
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/s/SecondGuess.java
+++ b/Mage.Sets/src/mage/cards/s/SecondGuess.java
@@ -10,7 +10,7 @@ import mage.constants.CardType;
 import mage.filter.FilterSpell;
 import mage.filter.predicate.Predicate;
 import mage.game.Game;
-import mage.game.stack.Spell;
+import mage.game.stack.StackObject;
 import mage.target.TargetSpell;
 import mage.watchers.common.CastSpellLastTurnWatcher;
 
@@ -45,10 +45,10 @@ public final class SecondGuess extends CardImpl {
     }
 }
 
-class SecondSpellPredicate implements Predicate<Spell> {
+class SecondSpellPredicate implements Predicate<StackObject> {
 
     @Override
-    public boolean apply(Spell input, Game game) {
+    public boolean apply(StackObject input, Game game) {
         CastSpellLastTurnWatcher watcher = (CastSpellLastTurnWatcher) game.getState().getWatchers().get(CastSpellLastTurnWatcher.class.getSimpleName());
 
         if (watcher.getSpellOrder(new MageObjectReference(input.getId(), game), game) == 2) {

--- a/Mage.Sets/src/mage/cards/s/SecretsOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/s/SecretsOfTheDead.java
@@ -12,6 +12,7 @@ import mage.filter.FilterSpell;
 import mage.filter.predicate.Predicate;
 import mage.game.Game;
 import mage.game.stack.Spell;
+import mage.game.stack.StackObject;
 
 /**
  *
@@ -43,7 +44,7 @@ public final class SecretsOfTheDead extends CardImpl {
     }
 }
 
-class SpellZonePredicate implements Predicate<Spell> {
+class SpellZonePredicate implements Predicate<StackObject> {
 
     private final Zone zone;
 
@@ -52,8 +53,8 @@ class SpellZonePredicate implements Predicate<Spell> {
     }
 
     @Override
-    public boolean apply(Spell input, Game game) {
-        return input.getFromZone().match(zone);
+    public boolean apply(StackObject input, Game game) {
+        return input instanceof Spell && ((Spell) input).getFromZone().match(zone);
     }
 
     @Override

--- a/Mage/src/main/java/mage/filter/Filter.java
+++ b/Mage/src/main/java/mage/filter/Filter.java
@@ -18,7 +18,7 @@ public interface Filter<E> extends Serializable {
 
     boolean match(E o, Game game);
 
-    Filter<E> add(Predicate predicate);
+    Filter<E> add(Predicate<? super E> predicate);
 
     boolean checkObjectClass(Object object);
 

--- a/Mage/src/main/java/mage/filter/FilterImpl.java
+++ b/Mage/src/main/java/mage/filter/FilterImpl.java
@@ -14,9 +14,9 @@ import mage.game.Game;
  */
 public abstract class FilterImpl<E> implements Filter<E> {
 
-    protected List<Predicate<Object>> predicates = new ArrayList<>();
+    protected List<Predicate<? super E>> predicates = new ArrayList<>();
     protected String message;
-    protected boolean lockedFilter; // Helps to prevent to "accidently" modify the StaticFilters objects
+    protected boolean lockedFilter; // Helps to prevent "accidentally" modifying the StaticFilters objects
 
     @Override
     public abstract FilterImpl<E> copy();
@@ -41,7 +41,7 @@ public abstract class FilterImpl<E> implements Filter<E> {
     }
 
     @Override
-    public final Filter add(Predicate predicate) {
+    public final Filter add(Predicate<? super E> predicate) {
         if (isLockedFilter()) {
             throw new UnsupportedOperationException("You may not modify a locked filter");
         }

--- a/Mage/src/main/java/mage/filter/common/FilterPermanentOrSuspendedCard.java
+++ b/Mage/src/main/java/mage/filter/common/FilterPermanentOrSuspendedCard.java
@@ -30,6 +30,8 @@
 package mage.filter.common;
 
 import java.util.UUID;
+
+import mage.MageObject;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.Card;
 import mage.counters.CounterType;
@@ -46,7 +48,7 @@ import mage.game.permanent.Permanent;
  *
  * @author emerald000
  */
-public class FilterPermanentOrSuspendedCard extends FilterImpl<Object> implements FilterInPlay<Object> {
+public class FilterPermanentOrSuspendedCard extends FilterImpl<MageObject> implements FilterInPlay<MageObject> {
 
     protected FilterCard cardFilter;
     protected FilterPermanent permanentFilter;
@@ -71,11 +73,11 @@ public class FilterPermanentOrSuspendedCard extends FilterImpl<Object> implement
 
     @Override
     public boolean checkObjectClass(Object object) {
-        return true;
+        return object instanceof MageObject;
     }
 
     @Override
-    public boolean match(Object o, Game game) {
+    public boolean match(MageObject o, Game game) {
         if (o instanceof Permanent) {
             return permanentFilter.match((Permanent) o, game);
         } else if (o instanceof Card) {
@@ -85,7 +87,7 @@ public class FilterPermanentOrSuspendedCard extends FilterImpl<Object> implement
     }
 
     @Override
-    public boolean match(Object o, UUID sourceId, UUID playerId, Game game) {
+    public boolean match(MageObject o, UUID sourceId, UUID playerId, Game game) {
         if (o instanceof Permanent) {
             return permanentFilter.match((Permanent) o, sourceId, playerId, game);
         } else if (o instanceof Card) {
@@ -106,7 +108,7 @@ public class FilterPermanentOrSuspendedCard extends FilterImpl<Object> implement
         this.permanentFilter = permanentFilter;
     }
 
-    public void setSpellFilter(FilterCard cardFilter) {
+    public void setCardFilter(FilterCard cardFilter) {
         this.cardFilter = cardFilter;
     }
 

--- a/Mage/src/main/java/mage/filter/common/FilterSpellOrPermanent.java
+++ b/Mage/src/main/java/mage/filter/common/FilterSpellOrPermanent.java
@@ -30,10 +30,14 @@
 package mage.filter.common;
 
 import java.util.UUID;
+
+import mage.MageObject;
 import mage.filter.FilterImpl;
 import mage.filter.FilterInPlay;
 import mage.filter.FilterPermanent;
 import mage.filter.FilterSpell;
+import mage.filter.predicate.ObjectPlayer;
+import mage.filter.predicate.ObjectPlayerPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.game.stack.Spell;
@@ -42,7 +46,7 @@ import mage.game.stack.Spell;
  *
  * @author LevelX
  */
-public class FilterSpellOrPermanent extends FilterImpl<Object> implements FilterInPlay<Object> {
+public class FilterSpellOrPermanent extends FilterImpl<MageObject> implements FilterInPlay<MageObject> {
 
     protected FilterPermanent permanentFilter;
     protected FilterSpell spellFilter;
@@ -65,11 +69,11 @@ public class FilterSpellOrPermanent extends FilterImpl<Object> implements Filter
 
     @Override
     public boolean checkObjectClass(Object object) {
-        return true;
+        return object instanceof MageObject;
     }
 
     @Override
-    public boolean match(Object o, Game game) {
+    public boolean match(MageObject o, Game game) {
         if (o instanceof Spell) {
             return spellFilter.match((Spell) o, game);
         } else if (o instanceof Permanent) {
@@ -79,7 +83,7 @@ public class FilterSpellOrPermanent extends FilterImpl<Object> implements Filter
     }
 
     @Override
-    public boolean match(Object o, UUID sourceId, UUID playerId, Game game) {
+    public boolean match(MageObject o, UUID sourceId, UUID playerId, Game game) {
         if (o instanceof Spell) {
             return spellFilter.match((Spell) o, sourceId, playerId, game);
         } else if (o instanceof Permanent) {
@@ -88,11 +92,19 @@ public class FilterSpellOrPermanent extends FilterImpl<Object> implements Filter
         return false;
     }
 
+    public final void add(ObjectPlayerPredicate<? extends ObjectPlayer> predicate) {
+        if (isLockedFilter()) {
+            throw new UnsupportedOperationException("You may not modify a locked filter");
+        }
+        spellFilter.add(predicate);
+        permanentFilter.add(predicate);
+    }
+
     public FilterPermanent getPermanentFilter() {
         return this.permanentFilter;
     }
 
-    public FilterSpell getspellFilter() {
+    public FilterSpell getSpellFilter() {
         return this.spellFilter;
     }
 

--- a/Mage/src/main/java/mage/filter/predicate/mageobject/NumberOfTargetsPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/mageobject/NumberOfTargetsPredicate.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Mode;
 import mage.filter.predicate.Predicate;
+import mage.game.Controllable;
 import mage.game.Game;
 import mage.game.stack.StackObject;
 import mage.target.Target;
@@ -13,7 +14,7 @@ import mage.target.Target;
  *
  * @author jeffwadsworth
  */
-public class NumberOfTargetsPredicate implements Predicate<MageObject> {
+public class NumberOfTargetsPredicate implements Predicate<Controllable> {
 
     private final int targets;
 
@@ -22,7 +23,7 @@ public class NumberOfTargetsPredicate implements Predicate<MageObject> {
     }
 
     @Override
-    public boolean apply(MageObject input, Game game) {
+    public boolean apply(Controllable input, Game game) {
         StackObject stackObject = game.getState().getStack().getStackObject(input.getId());
         if (stackObject != null) {
             int numberOfTargets = 0;

--- a/Mage/src/main/java/mage/target/common/TargetPermanentOrSuspendedCard.java
+++ b/Mage/src/main/java/mage/target/common/TargetPermanentOrSuspendedCard.java
@@ -69,7 +69,7 @@ public class TargetPermanentOrSuspendedCard extends TargetImpl {
     }
     
     @Override
-    public Filter<Object> getFilter() {
+    public Filter<MageObject> getFilter() {
         return this.filter;
     }
     


### PR DESCRIPTION
This is largely useful because of ObjectPlayer predicates.
Prior to this change you could add them to filters that didn't have support for them.