### PR TITLE
Add methods to get information about potential spells.

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AnimarSoulOfElements.java
+++ b/Mage.Sets/src/mage/cards/a/AnimarSoulOfElements.java
@@ -11,6 +11,7 @@ import mage.abilities.common.SpellCastControllerTriggeredAbility;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.ProtectionAbility;
+import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
@@ -85,7 +86,7 @@ class AnimarCostReductionEffect extends CostModificationEffectImpl {
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
         if (abilityToModify instanceof SpellAbility) {
             if (abilityToModify.isControlledBy(source.getControllerId())) {
-                Spell spell = (Spell) game.getStack().getStackObject(abilityToModify.getId());
+                Card spell = ((SpellAbility) abilityToModify).getCharachteristics(game);
                 if (spell != null) {
                     return spell.isCreature();
                 }

--- a/Mage.Sets/src/mage/cards/a/AnimarSoulOfElements.java
+++ b/Mage.Sets/src/mage/cards/a/AnimarSoulOfElements.java
@@ -19,7 +19,6 @@ import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.stack.Spell;
 import mage.util.CardUtil;
 
 /**
@@ -86,7 +85,7 @@ class AnimarCostReductionEffect extends CostModificationEffectImpl {
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
         if (abilityToModify instanceof SpellAbility) {
             if (abilityToModify.isControlledBy(source.getControllerId())) {
-                Card spell = ((SpellAbility) abilityToModify).getCharachteristics(game);
+                Card spell = ((SpellAbility) abilityToModify).getCharacteristics(game);
                 if (spell != null) {
                     return spell.isCreature();
                 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/modification/CostModificationTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/modification/CostModificationTest.java
@@ -219,8 +219,7 @@ public class CostModificationTest extends CardTestPlayerBase {
     }
 
     /**
-     * Zoetic Cavern's cast as creature cost is not modified as Animar, Soul of
-     * Elements gains counters.
+     * Confirm that Animar's cost reduction allows you to play spells that you wouldn't have enough mana for without it.
      */
     @Test
     public void AnimarSoulOfElementsTest() {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/modification/CostModificationTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/modification/CostModificationTest.java
@@ -217,4 +217,34 @@ public class CostModificationTest extends CardTestPlayerBase {
         assertTappedCount("Plains", false, 2); // 2 for 1st Lion 1 for 2nd lion and only 1 mana needed to cast face down Zoetic
 
     }
+
+    /**
+     * Zoetic Cavern's cast as creature cost is not modified as Animar, Soul of
+     * Elements gains counters.
+     */
+    @Test
+    public void AnimarSoulOfElementsTest() {
+
+        // Protection from white and from black
+        // Whenever you cast a creature spell, put a +1/+1 counter on Animar, Soul of Elements.
+        // Creature spells you cast cost {1} less to cast for each +1/+1 counter on Animar.
+        addCard(Zone.BATTLEFIELD, playerA, "Animar, Soul of Elements");
+
+        addCard(Zone.HAND, playerA, "Silvercoat Lion", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 3);
+
+        addCard(Zone.HAND, playerA, "Zoetic Cavern");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Silvercoat Lion");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Silvercoat Lion");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "Silvercoat Lion", 2);
+        assertCounterCount(playerA, "Animar, Soul of Elements", CounterType.P1P1, 2);
+
+        assertTappedCount("Plains", true, 3);
+
+    }
 }

--- a/Mage/src/main/java/mage/abilities/SpellAbility.java
+++ b/Mage/src/main/java/mage/abilities/SpellAbility.java
@@ -212,7 +212,7 @@ public class SpellAbility extends ActivatedAbilityImpl {
         return this;
     }
 
-    public Card getCharachteristics(Game game) {
+    public Card getCharacteristics(Game game) {
         Spell spell = game.getSpell(this.getId());
         if (spell != null) {
             return spell;

--- a/Mage/src/main/java/mage/abilities/SpellAbility.java
+++ b/Mage/src/main/java/mage/abilities/SpellAbility.java
@@ -1,6 +1,7 @@
 
 package mage.abilities;
 
+import java.util.Optional;
 import java.util.UUID;
 import mage.MageObject;
 import mage.MageObjectReference;
@@ -19,6 +20,7 @@ import mage.constants.TimingRule;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
+import mage.game.stack.Spell;
 import mage.players.Player;
 
 /**
@@ -208,6 +210,26 @@ public class SpellAbility extends ActivatedAbilityImpl {
 
     public SpellAbility getSpellAbilityToResolve(Game game) {
         return this;
+    }
+
+    public Card getCharachteristics(Game game) {
+        Spell spell = game.getSpell(this.getId());
+        if (spell != null) {
+            return spell;
+        }
+        return game.getCard(this.getSourceId());
+    }
+
+    public static SpellAbility getSpellAbilityFromEvent(GameEvent event, Game game) {
+        if (event.getType() != GameEvent.EventType.CAST_SPELL) {
+            return null;
+        }
+        Card card = game.getCard(event.getSourceId());
+        Optional<Ability> ability = card.getAbilities(game).get(event.getTargetId());
+        if (ability.isPresent() && ability.get() instanceof SpellAbility) {
+            return (SpellAbility) ability.get();
+        }
+        return card.getSpellAbility();
     }
 
     public void setId(UUID idToUse) {


### PR DESCRIPTION
Adds methods to standardize getting information about spells not yet on the stack.
This also uses one of the new methods to fix a bug with Animar, Soul of Elements.

The reasoning for this new api is to be able to override them for spell abilities that modify the charachteristics of the card.