### PR TITLE
Venomspout Brackus ability damage doesn't match card text

### DIFF
--- a/Mage.Sets/src/mage/cards/v/VenomspoutBrackus.java
+++ b/Mage.Sets/src/mage/cards/v/VenomspoutBrackus.java
@@ -40,7 +40,7 @@ public final class VenomspoutBrackus extends CardImpl {
         this.toughness = new MageInt(5);
 
         // {1}{G}, {tap}: Venomspout Brackus deals 5 damage to target attacking or blocking creature with flying.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(1), new ManaCostsImpl("{1}{G}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(5), new ManaCostsImpl("{1}{G}"));
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetCreaturePermanent(filter));
         this.addAbility(ability);


### PR DESCRIPTION
Activated ability for Venomspout Brackus was doing incorrect amount of damage from card.