### PR TITLE
Fix Field of Ruin search logic

### DIFF
--- a/Mage.Sets/src/mage/cards/f/FieldOfRuin.java
+++ b/Mage.Sets/src/mage/cards/f/FieldOfRuin.java
@@ -91,7 +91,7 @@ class FieldOfRuinEffect extends OneShotEffect {
                 if (player != null) {
                     TargetCardInLibrary target = new TargetCardInLibrary(0, 1, StaticFilters.FILTER_CARD_BASIC_LAND);
                     if (player.searchLibrary(target, game)) {
-                        player.moveCards(new CardsImpl(target.getTargets()), Zone.BATTLEFIELD, source, game);
+                        player.moveCards(new CardsImpl(target.getTargets()).getCards(game), Zone.BATTLEFIELD, source, game);
                         player.shuffleLibrary(source, game);
                     }
                 }


### PR DESCRIPTION
Per #5126:
field of ruin bugged: doesn't let u search for a land. (reported by vespel / 2018-07-15 03:18:09.356).

Changed search logic to match the search from CollectiveVoyage.java.