### PR TITLE
Perform the action on double click in the game list.

### DIFF
--- a/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
+++ b/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
@@ -9,6 +9,8 @@ package mage.client.table;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.beans.PropertyVetoException;
 import java.io.File;
 import java.text.DateFormat;
@@ -316,6 +318,20 @@ public class TablesPanel extends javax.swing.JPanel {
         actionButton1 = new ButtonColumn(tableTables, openTableAction, tableTables.convertColumnIndexToView(TableTableModel.ACTION_COLUMN));
         actionButton2 = new ButtonColumn(tableCompleted, closedTableAction, tableCompleted.convertColumnIndexToView(MatchesTableModel.COLUMN_ACTION));
         // !!!!
+        addTableDoubleClickListener(tableTables, openTableAction);
+        addTableDoubleClickListener(tableCompleted, closedTableAction);
+    }
+
+    private void addTableDoubleClickListener(JTable table, Action action) {
+        table.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                int row = table.rowAtPoint(e.getPoint());
+                if (e.getClickCount() == 2 && row != -1) {
+                    action.actionPerformed(new ActionEvent(e.getSource(), e.getID(), "" + row));
+                }
+            }
+        });
     }
 
     public void cleanUp() {


### PR DESCRIPTION
Fixed the inability to join a game with a doubleclick as it's currently not used for anything there. If the columns are wide enough, the join button is not visible and new players have no idea how to join. Same for reviewing the completed games.