### PR TITLE
Patron of the Nezumi

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PatronOfTheNezumi.java
+++ b/Mage.Sets/src/mage/cards/p/PatronOfTheNezumi.java
@@ -74,7 +74,7 @@ class PatronOfTheNezumiTriggeredAbility extends TriggeredAbilityImpl {
         if (zEvent.isDiesEvent()) {
             Permanent permanent = game.getPermanentOrLKIBattlefield(zEvent.getTargetId());
             if (permanent != null && game.getOpponents(controllerId).contains(permanent.getOwnerId())) {
-                this.getEffects().get(0).setTargetPointer(new FixedTarget(zEvent.getPlayerId()));
+                this.getEffects().get(0).setTargetPointer(new FixedTarget(permanent.getOwnerId()));
                 return true;
             }
         }


### PR DESCRIPTION
Patron of the Nezumi now correctly cares about whose graveyard a creature went to rather than who controlled it before dying. #5241