### PR TITLE
Fix - Varchild, Betrayer of Kjeldor

### DIFF
--- a/Mage.Sets/src/mage/cards/v/VarchildBetrayerOfKjeldor.java
+++ b/Mage.Sets/src/mage/cards/v/VarchildBetrayerOfKjeldor.java
@@ -7,7 +7,7 @@ import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
 import mage.abilities.common.LeavesBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.CreateTokenTargetEffect;
 import mage.abilities.effects.common.combat.CantAttackYouOrPlaneswalkerAllEffect;
 import mage.abilities.effects.common.combat.CantBlockAllEffect;
 import mage.abilities.effects.common.continuous.GainControlAllEffect;
@@ -108,7 +108,7 @@ class VarchildBetrayerOfKjeldorEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         int damage = (int) this.getValue("damage");
         if (damage > 0) {
-            return new CreateTokenEffect(
+            return new CreateTokenTargetEffect(
                     new SurvivorToken(), damage
             ).apply(game, source);
         }

--- a/Mage.Sets/src/mage/cards/v/VarchildBetrayerOfKjeldor.java
+++ b/Mage.Sets/src/mage/cards/v/VarchildBetrayerOfKjeldor.java
@@ -108,9 +108,12 @@ class VarchildBetrayerOfKjeldorEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         int damage = (int) this.getValue("damage");
         if (damage > 0) {
-            return new CreateTokenTargetEffect(
+            CreateTokenTargetEffect createToken = new CreateTokenTargetEffect(
                     new SurvivorToken(), damage
-            ).apply(game, source);
+            );
+            //copy the target from this effect to other effect (actually a direct reference)
+            createToken.setTargetPointer(targetPointer);
+            return createToken.apply(game, source);
         }
         return false;
     }


### PR DESCRIPTION
The prior commit implemented some incorrect behavior. Varchild should now create tokens under the damaged player's control instead of its own controller's.