### PR TITLE
fix for Reflecting Pool and SylvokExplorer

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/mana/ReflectingPoolTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/mana/ReflectingPoolTest.java
@@ -133,7 +133,6 @@ public class ReflectingPoolTest extends CardTestPlayerBase {
      * producing mana
      */
     @Test
-    @Ignore
     public void testWithDifferentLands() {
         addCard(Zone.BATTLEFIELD, playerA, "Silvercoat Lion", 1);
 
@@ -215,7 +214,6 @@ public class ReflectingPoolTest extends CardTestPlayerBase {
     }
 
     @Test
-    @Ignore
     public void testReflectingPoolAnyManaNeedWithoutCondition() {
         // any mana source without conditions (use any mana at any time)
         addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
@@ -233,7 +231,6 @@ public class ReflectingPoolTest extends CardTestPlayerBase {
     }
 
     @Test
-    @Ignore
     public void testReflectingPoolAnyManaNeedWithCondition() {
         // any mana source have condition to use (Reflecting Pool must ignore that condition)
         addCard(Zone.BATTLEFIELD, playerA, "Cavern of Souls", 1); // {C} or {any}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/mana/SylvokExplorerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/mana/SylvokExplorerTest.java
@@ -32,7 +32,6 @@ public class SylvokExplorerTest extends CardTestPlayerBase {
      * mage.abilities.mana.AnyColorLandsProduceManaEffect.getNetMana(AnyColorLandsProduceManaAbility.java:181)
      */
     @Test
-    @Ignore
     public void testOneInstance() {
         addCard(Zone.BATTLEFIELD, playerB, "Island", 1);
         addCard(Zone.BATTLEFIELD, playerB, "Mountain", 1);

--- a/Mage/src/main/java/mage/abilities/mana/ManaOptions.java
+++ b/Mage/src/main/java/mage/abilities/mana/ManaOptions.java
@@ -53,7 +53,7 @@ public class ManaOptions extends ArrayList<Mana> {
                     boolean hasTapCost = hasTapCost(abilities.get(0));
                     for (Mana netMana : netManas) {
                         for (Mana mana : copy) {
-                            if (!hasTapCost /* || checkTappedForManaReplacement(abilities.get(0), game, netMana) */) { // Seems to produce endless iterations so deactivated for now:  https://github.com/magefree/mage/issues/5023
+                            if (hasTapCost /* || checkTappedForManaReplacement(abilities.get(0), game, netMana) */) { // Seems to produce endless iterations so deactivated for now:  https://github.com/magefree/mage/issues/5023
                                 Mana newMana = new Mana();
                                 newMana.add(mana);
                                 newMana.add(netMana);


### PR DESCRIPTION
I looked into the ignored tests for Reflecting Pool and Sylvok Explorer, especially at ManaOptions::addMana. I saw that , besides an odd way to calculate a union, I did not quite understand the !hasTapCost. I changed the line to hasTapCost, and all tests for Reflecting Pool and Sylvok Explorer started to pass, and all other tests also still passed. 

Since this is core of XMage I leave it first as a PR for you to review.