### PR TITLE
Refactor: make plane and emblem implement Controllable

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CelestialDawn.java
+++ b/Mage.Sets/src/mage/cards/c/CelestialDawn.java
@@ -135,7 +135,7 @@ class CelestialDawnToWhiteEffect extends ContinuousEffectImpl {
             // Command
             for (CommandObject commandObject : game.getState().getCommand()) {
                 if (commandObject instanceof Commander) {
-                    if (commandObject.getControllerId().equals(controller.getId())) {
+                    if (commandObject.isControlledBy(controller.getId())) {
                         setColor(commandObject.getColor(game), game);
                     }
                 }

--- a/Mage.Sets/src/mage/cards/c/CoverOfWinter.java
+++ b/Mage.Sets/src/mage/cards/c/CoverOfWinter.java
@@ -88,7 +88,7 @@ class CoverOfWinterEffect extends PreventionEffectImpl {
 
         if (event.getType() == GameEvent.EventType.DAMAGE_CREATURE) {
             Permanent permanent = game.getPermanent(event.getTargetId());
-            if (permanent != null && permanent.getControllerId().equals(source.getControllerId())) {
+            if (permanent != null && permanent.isControlledBy(source.getControllerId())) {
                 return super.applies(event, source, game);
             }
         }

--- a/Mage.Sets/src/mage/cards/e/EmissaryOfGrudges.java
+++ b/Mage.Sets/src/mage/cards/e/EmissaryOfGrudges.java
@@ -94,11 +94,11 @@ class EmissaryOfGrudgesEffect extends OneShotEffect {
                         Mode mode = stackObject.getStackAbility().getModes().get(modeId);
                         for (Target target : mode.getTargets()) {
                             for (UUID targetId : target.getTargets()) {
-                                if (source.getControllerId().equals(targetId)) {
+                                if (source.isControlledBy(targetId)) {
                                     targetsYouOrAPermanentYouControl = true;
                                 }
                                 Permanent permanent = game.getPermanent(targetId);
-                                if (permanent != null && source.getControllerId().equals(permanent.getControllerId())) {
+                                if (permanent != null && source.isControlledBy(permanent.getControllerId())) {
                                     targetsYouOrAPermanentYouControl = true;
                                 }
                             }

--- a/Mage.Sets/src/mage/cards/s/SavageSummoning.java
+++ b/Mage.Sets/src/mage/cards/s/SavageSummoning.java
@@ -100,7 +100,7 @@ class SavageSummoningAsThoughEffect extends AsThoughEffectImpl {
             MageObject mageObject = game.getBaseObject(objectId);
             if (mageObject instanceof Commander) {
                 Commander commander = (Commander) mageObject;
-                if (commander.isCreature() && commander.getControllerId().equals(source.getControllerId())) {
+                if (commander.isCreature() && commander.isControlledBy(source.getControllerId())) {
                     return true;
                 }
             } else if (mageObject instanceof Card) {

--- a/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
@@ -219,9 +219,9 @@ public abstract class ActivatedAbilityImpl extends AbilityImpl implements Activa
         } else {
             MageObject mageObject = game.getObject(this.sourceId);
             if (mageObject instanceof Emblem) {
-                return ((Emblem) mageObject).getControllerId().equals(playerId);
+                return ((Emblem) mageObject).isControlledBy(playerId);
             } else if (mageObject instanceof Plane) {
-                return ((Plane) mageObject).getControllerId().equals(playerId);
+                return ((Plane) mageObject).isControlledBy(playerId);
             } else if (game.getState().getZone(this.sourceId) != Zone.BATTLEFIELD) {
                 return ((Card) mageObject).isOwnedBy(playerId);
             }

--- a/Mage/src/main/java/mage/game/Controllable.java
+++ b/Mage/src/main/java/mage/game/Controllable.java
@@ -12,6 +12,9 @@ public interface Controllable {
     UUID getId();
 
     default boolean isControlledBy(UUID controllerID){
+        if(getControllerId() == null){
+            return false;
+        }
         return getControllerId().equals(controllerID);
     }
 }

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -2594,7 +2594,7 @@ public abstract class GameImpl implements Game, Serializable {
         boolean addPlaneAgain = false;
         for (Iterator<CommandObject> it = this.getState().getCommand().iterator(); it.hasNext();) {
             CommandObject obj = it.next();
-            if (obj.getControllerId().equals(playerId)) {
+            if (obj.isControlledBy(playerId)) {
                 if (obj instanceof Emblem) {
                     ((Emblem) obj).discardEffects();// This may not be the best fix but it works
                 }

--- a/Mage/src/main/java/mage/game/command/CommandObject.java
+++ b/Mage/src/main/java/mage/game/command/CommandObject.java
@@ -3,16 +3,15 @@ package mage.game.command;
 
 import java.util.UUID;
 import mage.MageObject;
+import mage.game.Controllable;
 
 /**
  *
  * @author Viserion, nantuko
  */
-public interface CommandObject extends MageObject {
+public interface CommandObject extends MageObject, Controllable {
 
     UUID getSourceId();
-
-    UUID getControllerId();
 
     void assignNewId();
 


### PR DESCRIPTION
make plane and emblem implement Controllable to give access to the isControlledBy method.

That way we can remove some of the getControllerId().equals(.....) calls