### PR TITLE
Update EtrataTheSilencer.java

### DIFF
--- a/Mage.Sets/src/mage/cards/e/EtrataTheSilencer.java
+++ b/Mage.Sets/src/mage/cards/e/EtrataTheSilencer.java
@@ -145,7 +145,7 @@ class EtrataTheSilencerEffect extends OneShotEffect {
         }
         int cardsFound = 0;
         for (Card exiledCard : game.getExile().getAllCards(game)) {
-            if (exiledCard.getCounters(game).getCount(CounterType.HIT) > 1 && exiledCard.getOwnerId().equals(player.getId())) {
+            if (exiledCard.getCounters(game).getCount(CounterType.HIT) >= 1 && exiledCard.getOwnerId().equals(player.getId())) {
                 cardsFound++;
             }
         }


### PR DESCRIPTION
**Bug:**
https://www.reddit.com/r/XMage/comments/9kx3h4/bug_report_etrata_the_silencer/
> Etrata The Silencer does not cause a game loss when a player has three cards with Hit counters.

**Assessment:**
My assessment is that the filter is not finding the right number of cards. The code indicates that the filter criteria is >1 Hit counter, so 1 Hit counter will not pass the filter.

**Fix:**
Make the filter for cardsFound trigger on "greater than or equal to" rather than just "greater than".