### PR TITLE
Fix Commander Ninjutsu (fixes #5395)

### DIFF
--- a/Mage/src/main/java/mage/abilities/keyword/NinjutsuAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/NinjutsuAbility.java
@@ -199,8 +199,8 @@ class RevealNinjutsuCardCost extends CostImpl {
             for (CommandObject coj : game.getState().getCommand()) {
                 if (coj != null && coj.getId().equals(ability.getSourceId())) {
                     card = game.getCard(ability.getSourceId());
+                    break;
                 }
-                break;
             }
         }
         if (card != null) {


### PR DESCRIPTION
When trying to activate Commander Ninjutsu from the command zone, RevealNinjutsuCardCost only checked the first card in the Command Zone.