### PR TITLE
AI updates, more cards will have the isRemoval bonus to their card ra…

### DIFF
--- a/Mage.Sets/src/mage/cards/j/JusticeStrike.java
+++ b/Mage.Sets/src/mage/cards/j/JusticeStrike.java
@@ -38,7 +38,7 @@ public final class JusticeStrike extends CardImpl {
 class JusticeStrikeEffect extends OneShotEffect {
 
     public JusticeStrikeEffect() {
-        super(Outcome.Removal);
+        super(Outcome.Damage);
         this.staticText = "Target creature deals damage to itself equal to its power.";
     }
 

--- a/Mage.Sets/src/mage/cards/j/JusticeStrike.java
+++ b/Mage.Sets/src/mage/cards/j/JusticeStrike.java
@@ -38,7 +38,7 @@ public final class JusticeStrike extends CardImpl {
 class JusticeStrikeEffect extends OneShotEffect {
 
     public JusticeStrikeEffect() {
-        super(Outcome.Benefit);
+        super(Outcome.Removal);
         this.staticText = "Target creature deals damage to itself equal to its power.";
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/DontUntapInControllersUntapStepEnchantedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DontUntapInControllersUntapStepEnchantedEffect.java
@@ -19,7 +19,7 @@ public class DontUntapInControllersUntapStepEnchantedEffect extends ContinuousRu
     }
 
     public DontUntapInControllersUntapStepEnchantedEffect(String description) {
-        super(Duration.WhileOnBattlefield, Outcome.Detriment, false, true);
+        super(Duration.WhileOnBattlefield, Outcome.Removal, false, true);
         staticText = "Enchanted " + description + " doesn't untap during its controller's untap step";
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/ExileAndGainLifeEqualPowerTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ExileAndGainLifeEqualPowerTargetEffect.java
@@ -14,7 +14,7 @@ import mage.players.Player;
 public class ExileAndGainLifeEqualPowerTargetEffect extends OneShotEffect {
 
     public ExileAndGainLifeEqualPowerTargetEffect() {
-        super(Outcome.GainLife);
+        super(Outcome.Removal);
         staticText = "Exile target creature. Its controller gains life equal to its power";
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/ExileUntilSourceLeavesEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ExileUntilSourceLeavesEffect.java
@@ -19,7 +19,7 @@ import mage.util.CardUtil;
 public class ExileUntilSourceLeavesEffect extends OneShotEffect {
 
     public ExileUntilSourceLeavesEffect(String targetName) {
-        super(Outcome.Benefit);
+        super(Outcome.Removal);
         this.staticText = "exile target " + targetName + " an opponent controls until {this} leaves the battlefield";
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/combat/CantAttackBlockAttachedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/combat/CantAttackBlockAttachedEffect.java
@@ -5,6 +5,7 @@ import mage.constants.AttachmentType;
 import mage.constants.Duration;
 import mage.abilities.Ability;
 import mage.abilities.effects.RestrictionEffect;
+import mage.constants.Outcome;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 
@@ -14,7 +15,7 @@ import mage.game.permanent.Permanent;
 public class CantAttackBlockAttachedEffect extends RestrictionEffect {
 
     public CantAttackBlockAttachedEffect(AttachmentType attachmentType) {
-        super(Duration.WhileOnBattlefield);
+        super(Duration.WhileOnBattlefield, Outcome.Removal);
         this.staticText = attachmentType.verb() + " creature can't attack or block";
     }
 


### PR DESCRIPTION
…ting

these weren't being picked up as removal spells and now are:
* modal spells where one mode is a removal spell
* spells that do a dynamic amount of damage, such as fireball
* cards that reduce the toughness temporarily or permanently
* cards that keep a creature tapped down
* cards that exile a creature
* cards that damage creatures that are attacking or blocking
* enchantments that exile a creature when they etb
* fight cards, and one sided fight cards

the ai will now rate those types of cards higher as they are removal