### PR TITLE
Make draft logs compatible with MTGO format #5450

### DIFF
--- a/Mage.Client/src/main/java/mage/client/draft/DraftPickLogger.java
+++ b/Mage.Client/src/main/java/mage/client/draft/DraftPickLogger.java
@@ -1,0 +1,85 @@
+package mage.client.draft;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.UUID;
+
+import org.apache.log4j.Logger;
+
+import mage.view.DraftView;
+
+public class DraftPickLogger {
+
+  private static final Logger LOGGER = Logger.getLogger(DraftPickLogger.class);
+
+  private final Path logPath;
+  private final boolean logging;
+  private boolean headerWritten = false;
+
+  public DraftPickLogger(File directory, String logFilename) {
+    this.logging = true;
+    if (!directory.exists()) {
+      directory.mkdirs();
+    }
+    this.logPath = new File(directory, logFilename).toPath();
+    try {
+      Files.write(logPath, new byte[0], StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    } catch (IOException ex) {
+      LOGGER.error(null, ex);
+    }
+  }
+
+  public DraftPickLogger() {
+    this.logging = false;
+    this.logPath = null;
+  }
+
+  public void updateDraft(UUID draftId, DraftView draftView) {
+    if (headerWritten) {
+      return;
+    }
+    headerWritten = true;
+    Date now = new Date();
+    SimpleDateFormat formatter = new SimpleDateFormat("M/d/yyyy h:mm:ss a");
+    StringBuilder buffer = new StringBuilder()
+      .append("Event #: ").append(draftId).append("\n")
+      .append("Time:    ").append(formatter.format(now)).append('\n');
+    buffer.append("Players:\n");
+    for (String player : draftView.getPlayers()) {
+      buffer.append("    ").append(player).append('\n');
+    }
+    buffer.append('\n');
+    appendToDraftLog(buffer.toString());
+  }
+
+  public void logPick(String setCode, int packNo, int pickNo, String pick, String[] currentBooster) {
+    StringBuilder b = new StringBuilder();
+    if (pickNo == 1) {
+      b.append("------ ").append(setCode).append(" ------\n\n");
+    }
+    b.append("Pack ").append(packNo).append(" pick ").append(pickNo).append(":\n");
+    for (String name : currentBooster) {
+      b.append(pick.equals(name) ? "--> " : "    ");
+      b.append(name);
+      b.append('\n');
+    }
+    b.append('\n');
+    appendToDraftLog(b.toString());
+  }
+
+  private void appendToDraftLog(String data) {
+    if (logging) {
+      try {
+        Files.write(logPath, data.getBytes(), StandardOpenOption.APPEND);
+      } catch (IOException ex) {
+        LOGGER.error(null, ex);
+      }
+    }
+  }
+
+}

--- a/Mage.Client/src/main/java/mage/client/remote/CallbackClientImpl.java
+++ b/Mage.Client/src/main/java/mage/client/remote/CallbackClientImpl.java
@@ -353,8 +353,9 @@ public class CallbackClientImpl implements CallbackClient {
                     }
                     case DRAFT_UPDATE: {
                         DraftPanel panel = MageFrame.getDraft(callback.getObjectId());
+                        DraftClientMessage message = (DraftClientMessage) callback.getData();
                         if (panel != null) {
-                            panel.updateDraft((DraftView) callback.getData());
+                            panel.updateDraft(message.getDraftView());
                         }
                         break;
                     }

--- a/Mage.Common/src/main/java/mage/view/DraftClientMessage.java
+++ b/Mage.Common/src/main/java/mage/view/DraftClientMessage.java
@@ -13,19 +13,10 @@ public class DraftClientMessage implements Serializable {
 
     private DraftView draftView;
     private DraftPickView draftPickView;
-    private String message;
 
-    public DraftClientMessage(DraftView draftView) {
+    public DraftClientMessage(DraftView draftView, DraftPickView draftPickView) {
         this.draftView = draftView;
-    }
-
-    public DraftClientMessage(DraftPickView draftPickView) {
         this.draftPickView = draftPickView;
-    }
-
-    public DraftClientMessage(DraftView draftView, String message) {
-        this.message = message;
-        this.draftView = draftView;
     }
 
     public DraftPickView getDraftPickView() {

--- a/Mage.Common/src/main/java/mage/view/DraftView.java
+++ b/Mage.Common/src/main/java/mage/view/DraftView.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import mage.cards.ExpansionSet;
 import mage.game.draft.Draft;
+import mage.game.draft.DraftCube;
 import mage.game.draft.DraftPlayer;
 
 /**
@@ -17,6 +18,7 @@ public class DraftView implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final List<String> sets = new ArrayList<>();
+    private final List<String> setCodes = new ArrayList<>();
     private final int boosterNum;
     private final int cardNum;
     private final List<String> players = new ArrayList<>();
@@ -24,11 +26,14 @@ public class DraftView implements Serializable {
     public DraftView(Draft draft) {
         if (draft.getDraftCube() != null) {
             for (int i = 0; i < draft.getNumberBoosters(); i++) {
-                sets.add(draft.getDraftCube().getName());
+                DraftCube cube = draft.getDraftCube();
+                sets.add(cube.getName());
+                setCodes.add(cube.getCode());
             }
         } else {
             for (ExpansionSet set: draft.getSets()) {
                 sets.add(set.getName());
+                setCodes.add(set.getCode());
             }
         }
         this.boosterNum = draft.getBoosterNum();
@@ -40,6 +45,10 @@ public class DraftView implements Serializable {
 
     public List<String> getSets() {
         return sets;
+    }
+
+    public List<String> getSetCodes() {
+        return setCodes;
     }
 
     public List<String> getPlayers() {

--- a/Mage.Server/src/main/java/mage/server/draft/DraftSession.java
+++ b/Mage.Server/src/main/java/mage/server/draft/DraftSession.java
@@ -48,7 +48,8 @@ public class DraftSession {
             if (user.isPresent()) {
                 if (futureTimeout != null && !futureTimeout.isDone()) {
                     int remaining = (int) futureTimeout.getDelay(TimeUnit.SECONDS);
-                    user.get().fireCallback(new ClientCallback(ClientCallbackMethod.DRAFT_INIT, draft.getId(), new DraftClientMessage(getDraftPickView(remaining))));
+                    user.get().fireCallback(new ClientCallback(ClientCallbackMethod.DRAFT_INIT, draft.getId(),
+                        new DraftClientMessage(getDraftView(), getDraftPickView(remaining))));
                 }
                 return true;
             }
@@ -60,8 +61,8 @@ public class DraftSession {
         if (!killed) {
             UserManager.instance
                     .getUser(userId).
-                    ifPresent(user -> user.fireCallback(
-                    new ClientCallback(ClientCallbackMethod.DRAFT_UPDATE, draft.getId(), getDraftView())));
+                    ifPresent(user -> user.fireCallback(new ClientCallback(ClientCallbackMethod.DRAFT_UPDATE, draft.getId(),
+                        new DraftClientMessage(getDraftView(), null))));
         }
     }
 
@@ -70,7 +71,6 @@ public class DraftSession {
             UserManager.instance
                     .getUser(userId)
                     .ifPresent(user -> user.fireCallback(new ClientCallback(ClientCallbackMethod.DRAFT_OVER, draft.getId())));
-
         }
     }
 
@@ -79,7 +79,8 @@ public class DraftSession {
             setupTimeout(timeout);
             UserManager.instance
                     .getUser(userId)
-                    .ifPresent(user -> user.fireCallback(new ClientCallback(ClientCallbackMethod.DRAFT_PICK, draft.getId(), new DraftClientMessage(getDraftPickView(timeout)))));
+                    .ifPresent(user -> user.fireCallback(new ClientCallback(ClientCallbackMethod.DRAFT_PICK, draft.getId(),
+                        new DraftClientMessage(getDraftView(), getDraftPickView(timeout)))));
 
         }
     }

--- a/Mage/src/main/java/mage/game/draft/DraftCube.java
+++ b/Mage/src/main/java/mage/game/draft/DraftCube.java
@@ -46,6 +46,7 @@ public abstract class DraftCube {
     private static final Logger logger = Logger.getLogger(DraftCube.class);
 
     private final String name;
+    private final String code;
     private static final int boosterSize = 15;
 
     protected List<CardIdentity> cubeCards = new ArrayList<>();
@@ -53,10 +54,15 @@ public abstract class DraftCube {
 
     public DraftCube(String name) {
         this.name = name;
+        this.code = getClass().getSimpleName();
     }
 
     public String getName() {
         return name;
+    }
+
+    public String getCode() {
+        return code;
     }
 
     public List<CardIdentity> getCubeCards() {


### PR DESCRIPTION
See: https://github.com/magefree/mage/issues/5450

I'm fairly certain that the changes I needed to get access to the set code would break the client/server protocol, so I made a few other refactors at the same time.    An alternative approach would be to do a reverse lookup from the set's name to the set's code, but I think this is cleaner as long as the breaking change is acceptable.