### PR TITLE
Fix ManaTypeInManaPoolCount to include conditional mana (Fixes #5458)

### DIFF
--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/ManaTypeInManaPoolCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/ManaTypeInManaPoolCount.java
@@ -1,5 +1,6 @@
 package mage.abilities.dynamicvalue.common;
 
+import mage.ConditionalMana;
 import mage.abilities.Ability;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
@@ -29,6 +30,9 @@ public class ManaTypeInManaPoolCount implements DynamicValue {
         Player player = game.getPlayer(sourceAbility.getControllerId());
         if (player != null) {
             amount = player.getManaPool().get(manaType);
+            for (ConditionalMana mana : player.getManaPool().getConditionalMana()) {
+                amount += mana.get(manaType);
+            }
         }
         return amount;
     }


### PR DESCRIPTION
Allows conditional mana to be counted in addition to regular mana. Fixes Omnath not getting the number of +1/+1 counters he should be getting per the rule "3/1/2010 | If a green mana you add to your mana pool has certain restrictions or riders associated with it (for example, if it was produced by Ancient Ziggurat), they’ll apply to that mana no matter when you spend it." (Fixes #5458)