### PR TITLE
Fix Psychic Surgery putting cards on bottom of library

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PsychicSurgery.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicSurgery.java
@@ -114,7 +114,7 @@ class PsychicSurgeryEffect extends OneShotEffect {
                     }
                 }
             }
-            controller.putCardsOnBottomOfLibrary(cards, game, source, true);
+            controller.putCardsOnTopOfLibrary(cards, game, source, true);
             return true;
         }
         return false;


### PR DESCRIPTION
#5126
Effect now properly puts cards on top of opponent's library.