### PR TITLE
Fixed NullPointerException when Accursed Witch transforms

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/AuraReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/AuraReplacementEffect.java
@@ -64,7 +64,9 @@ public class AuraReplacementEffect extends ReplacementEffectImpl {
             return false;
         }
 
+        Card firstCardFace = null;
         if (game.getState().getValue(TransformAbility.VALUE_KEY_ENTER_TRANSFORMED + card.getId()) != null) {
+            firstCardFace = card;
             card = card.getSecondCardFace();
             if (!card.isEnchantment() || !card.hasSubtype(SubType.AURA, game)) {
                 return false;
@@ -129,7 +131,7 @@ public class AuraReplacementEffect extends ReplacementEffectImpl {
             enchantCardInGraveyard = target instanceof TargetCardInGraveyard;
             if (target != null) {
                 target.setNotTarget(true); // always not target because this way it's not handled targeted
-                target.clearChosen(); // neccessary if e.g. aura is blinked multiple times
+                target.clearChosen(); // necessary if e.g. aura is blinked multiple times
             }
 
             if (event.getPlayerId() != null) {
@@ -152,7 +154,12 @@ public class AuraReplacementEffect extends ReplacementEffectImpl {
         }
         Player targetPlayer = game.getPlayer(targetId);
         if (targetCard != null || targetPermanent != null || targetPlayer != null) {
-            card.removeFromZone(game, fromZone, sourceId);
+            if (firstCardFace != null) {
+                // transforming card. remove first face (original card) from old zone
+                firstCardFace.removeFromZone(game, fromZone, sourceId);
+            } else {
+                card.removeFromZone(game, fromZone, sourceId);
+            }
             PermanentCard permanent = new PermanentCard(card, (controllingPlayer == null ? card.getOwnerId() : controllingPlayer.getId()), game);
             ZoneChangeEvent zoneChangeEvent = new ZoneChangeEvent(permanent, controllerId, fromZone, Zone.BATTLEFIELD);
             permanent.updateZoneChangeCounter(game, zoneChangeEvent);

--- a/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
@@ -18,7 +18,7 @@ public class TransformAbility extends SimpleStaticAbility {
     public static final String NO_SPELLS_TRANSFORM_RULE = "At the beginning of each upkeep, if no spells were cast last turn, transform {this}.";
     public static final String TWO_OR_MORE_SPELLS_TRANSFORM_RULE = "At the beginning of each upkeep, if a player cast two or more spells last turn, transform {this}.";
 
-    // this state value controlls if a permanent enters the battlefield already transformed
+    // this state value controls if a permanent enters the battlefield already transformed
     public static final String VALUE_KEY_ENTER_TRANSFORMED = "EnterTransformed";
 
     public TransformAbility() {


### PR DESCRIPTION
Feedback issue: #5529
Aura replacement code tried to remove the second face from the original zone which had ownerId == null. Now, we remember the first face (the original card) and remove it from the old zone before creating a permanent out of the second face.