### PR TITLE
initial rewrite for copy method

### DIFF
--- a/Mage/src/main/java/mage/watchers/Watcher.java
+++ b/Mage/src/main/java/mage/watchers/Watcher.java
@@ -2,6 +2,8 @@
 package mage.watchers;
 
 import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.UUID;
 import mage.constants.WatcherScope;
 import mage.game.Game;
@@ -76,6 +78,15 @@ public abstract class Watcher implements Serializable {
 
     public abstract void watch(GameEvent event, Game game);
 
-    public abstract Watcher copy();
+    public <T extends Watcher> T copy(){
+        try {
+            Constructor<? extends Watcher> constructor = this.getClass().getDeclaredConstructor(getClass());
+            constructor.setAccessible(true);
+            return (T) constructor.newInstance(this);
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
 
 }

--- a/Mage/src/main/java/mage/watchers/common/BlockedAttackerWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/BlockedAttackerWatcher.java
@@ -34,10 +34,10 @@ public class BlockedAttackerWatcher extends Watcher {
         }
     }
 
-    @Override
-    public BlockedAttackerWatcher copy() {
-        return new BlockedAttackerWatcher(this);
-    }
+//    @Override
+//    public BlockedAttackerWatcher copy() {
+//        return new BlockedAttackerWatcher(this);
+//    }
 
     @Override
     public void watch(GameEvent event, Game game) {

--- a/Mage/src/main/java/mage/watchers/common/BloodthirstWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/BloodthirstWatcher.java
@@ -36,9 +36,4 @@ public class BloodthirstWatcher extends Watcher {
             }
         }
     }
-
-    @Override
-    public BloodthirstWatcher copy() {
-        return new BloodthirstWatcher(this);
-    }
 }

--- a/Mage/src/main/java/mage/watchers/common/CastSpellLastTurnWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/CastSpellLastTurnWatcher.java
@@ -81,10 +81,10 @@ public class CastSpellLastTurnWatcher extends Watcher {
         }
         return 0;
     }
-
-    @Override
-    public CastSpellLastTurnWatcher copy() {
-        return new CastSpellLastTurnWatcher(this);
-    }
+//
+//    @Override
+//    public CastSpellLastTurnWatcher copy() {
+//        return new CastSpellLastTurnWatcher(this);
+//    }
 
 }

--- a/Mage/src/main/java/mage/watchers/common/CastSpellYourLastTurnWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/CastSpellYourLastTurnWatcher.java
@@ -60,9 +60,9 @@ public class CastSpellYourLastTurnWatcher extends Watcher {
     public Integer getAmountOfSpellsCastOnPlayersTurn(UUID playerId) {
         return amountOfSpellsCastOnPrevTurn.getOrDefault(playerId, 0);
     }
-
-    @Override
-    public CastSpellYourLastTurnWatcher copy() {
-        return new CastSpellYourLastTurnWatcher(this);
-    }
+//
+//    @Override
+//    public CastSpellYourLastTurnWatcher copy() {
+//        return new CastSpellYourLastTurnWatcher(this);
+//    }
 }

--- a/Mage/src/main/java/mage/watchers/common/DamageDoneWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/DamageDoneWatcher.java
@@ -47,11 +47,6 @@ public class DamageDoneWatcher extends Watcher {
     }
 
     @Override
-    public DamageDoneWatcher copy() {
-        return new DamageDoneWatcher(this);
-    }
-
-    @Override
     public void watch(GameEvent event, Game game) {
         switch (event.getType()) {
             case DAMAGED_CREATURE:

--- a/Mage/src/main/java/mage/watchers/common/MorbidWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/MorbidWatcher.java
@@ -33,9 +33,9 @@ public class MorbidWatcher extends Watcher {
         }
     }
 
-    @Override
-    public MorbidWatcher copy() {
-        return new MorbidWatcher(this);
-    }
+//    @Override
+//    public MorbidWatcher copy() {
+//        return new MorbidWatcher(this);
+//    }
 
 }

--- a/Mage/src/main/java/mage/watchers/common/PlanarRollWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/PlanarRollWatcher.java
@@ -56,8 +56,4 @@ public class PlanarRollWatcher extends Watcher {
         numberTimesPlanarDieRolled.clear();
     }
 
-    @Override
-    public PlanarRollWatcher copy() {
-        return new PlanarRollWatcher(this);
-    }
 }

--- a/Mage/src/main/java/mage/watchers/common/PlayerDamagedBySourceWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/PlayerDamagedBySourceWatcher.java
@@ -30,10 +30,6 @@ public class PlayerDamagedBySourceWatcher extends Watcher {
         this.damageSourceIds.addAll(watcher.damageSourceIds);
     }
 
-    @Override
-    public PlayerDamagedBySourceWatcher copy() {
-        return new PlayerDamagedBySourceWatcher(this);
-    }
 
     @Override
     public void watch(GameEvent event, Game game) {

--- a/Mage/src/main/java/mage/watchers/common/PlayerLostLifeNonCombatWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/PlayerLostLifeNonCombatWatcher.java
@@ -77,8 +77,8 @@ public class PlayerLostLifeNonCombatWatcher extends Watcher {
         amountOfLifeLostThisTurn.clear();
     }
 
-    @Override
-    public PlayerLostLifeNonCombatWatcher copy() {
-        return new PlayerLostLifeNonCombatWatcher(this);
-    }
+//    @Override
+//    public PlayerLostLifeNonCombatWatcher copy() {
+//        return new PlayerLostLifeNonCombatWatcher(this);
+//    }
 }

--- a/Mage/src/main/java/mage/watchers/common/PlayerLostLifeWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/PlayerLostLifeWatcher.java
@@ -75,8 +75,8 @@ public class PlayerLostLifeWatcher extends Watcher {
         amountOfLifeLostThisTurn.clear();
     }
 
-    @Override
-    public PlayerLostLifeWatcher copy() {
-        return new PlayerLostLifeWatcher(this);
-    }
+//    @Override
+//    public PlayerLostLifeWatcher copy() {
+//        return new PlayerLostLifeWatcher(this);
+//    }
 }

--- a/Mage/src/main/java/mage/watchers/common/PlayersAttackedThisTurnWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/PlayersAttackedThisTurnWatcher.java
@@ -35,10 +35,6 @@ public class PlayersAttackedThisTurnWatcher extends Watcher {
         }
     }
 
-    @Override
-    public PlayersAttackedThisTurnWatcher copy() {
-        return new PlayersAttackedThisTurnWatcher(this);
-    }
 
     @Override
     public void watch(GameEvent event, Game game) {


### PR DESCRIPTION
This pull request is an example to replace all copy methods with a generic method. 
Currently, each class that implements the isCopyable interface, overrides an abstract copy() method that calls the private constructor. All of those copy methods do the same.

This pull request contains an initial rewrite, changing the copy() method in the Watcher class to be non-abstract, and removing all overriding copy() methods in the default GameWatchers. 

If this works out well, then we could move the new copy method to be the default method of the isCopyable interface. 

This could lead in a big reduction of the codebase