### PR TITLE
Implement Garbage Elemental

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GarbageElementalC.java
+++ b/Mage.Sets/src/mage/cards/g/GarbageElementalC.java
@@ -37,7 +37,7 @@ public final class GarbageElementalC extends CardImpl {
         this.addAbility(new BattleCryAbility());
 
         // When Garbage Elemental enters the battlefield, roll two six-sided dice. Create a number of 1/1 red Goblin creature tokens equal to the difference between those results.
-        this.addAbility(new EntersBattlefieldAbility(new GarbageElementalEffect(),
+        this.addAbility(new EntersBattlefieldAbility(new GarbageElementalCEffect(),
                 null,
                 "When {this} enters the battlefield, roll two six-sided dice. Create a number of 1/1 red Goblin creature tokens equal to the difference between those results",
                 null));
@@ -54,26 +54,20 @@ public final class GarbageElementalC extends CardImpl {
     }
 }
 
-class GarbageElementalEffect extends OneShotEffect {
+class GarbageElementalCEffect extends OneShotEffect {
 
-    private static final FilterPermanent filter = new FilterPermanent("permanent with a counter");
-
-    static {
-        filter.add(new CounterPredicate(null));
-    }
-
-    GarbageElementalEffect() {
+    GarbageElementalCEffect() {
         super(Outcome.PutCreatureInPlay);
         this.staticText = "roll two six-sided dice. Create a number of 1/1 red Goblin creature tokens equal to the difference between those results";
     }
 
-    GarbageElementalEffect(final GarbageElementalEffect effect) {
+    GarbageElementalCEffect(final GarbageElementalCEffect effect) {
         super(effect);
     }
 
     @Override
-    public GarbageElementalEffect copy() {
-        return new GarbageElementalEffect(this);
+    public GarbageElementalCEffect copy() {
+        return new GarbageElementalCEffect(this);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/g/GarbageElementalD.java
+++ b/Mage.Sets/src/mage/cards/g/GarbageElementalD.java
@@ -1,0 +1,81 @@
+
+package mage.cards.g;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.keyword.CascadeAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.common.TargetOpponent;
+
+/**
+ *
+ * @author spjspj
+ */
+public final class GarbageElementalD extends CardImpl {
+
+    public GarbageElementalD(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{R}");
+
+        this.subtype.add(SubType.ELEMENTAL);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(3);
+
+        // Cascade
+        this.addAbility(new CascadeAbility());
+
+        // When Garbage Elemental enters the battlefield, roll a six-sided die. Garbage Elemental deals damage equal to the result to target opponent.
+        Ability ability = new EntersBattlefieldAbility(new GarbageElementalDEffect(),
+            null,
+            "When {this} enters the battlefield, roll a six-sided die. {this} deals damage equal to the result to target opponent",
+            null);
+        ability.addTarget(new TargetOpponent());
+        this.addAbility(ability);
+
+    }
+
+    public GarbageElementalD(final GarbageElementalD card) {
+        super(card);
+    }
+
+    @Override
+    public GarbageElementalD copy() {
+        return new GarbageElementalD(this);
+    }
+}
+
+class GarbageElementalDEffect extends OneShotEffect {
+
+    GarbageElementalDEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "roll a six-sided die. {this} deals damage equal to the result to target opponent";
+    }
+
+    GarbageElementalDEffect(final GarbageElementalDEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public GarbageElementalDEffect copy() {
+        return new GarbageElementalDEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        Player opponent = game.getPlayer(source.getFirstTarget());
+        if (controller != null && opponent != null) {
+            int damage = controller.rollDice(game, 6);
+            return game.damagePlayerOrPlaneswalker(opponent.getId(), damage, source.getId(), game, false, true);
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/Unstable.java
+++ b/Mage.Sets/src/mage/sets/Unstable.java
@@ -45,6 +45,7 @@ public final class Unstable extends ExpansionSet {
         cards.add(new SetCardInfo("Forest", 216, Rarity.LAND, mage.cards.basiclands.Forest.class, new CardGraphicInfo(FrameStyle.UST_FULL_ART_BASIC, false)));
         cards.add(new SetCardInfo("GO TO JAIL", 8, Rarity.COMMON, mage.cards.g.GOTOJAIL.class));
         cards.add(new SetCardInfo("Garbage Elemental", "82c", Rarity.UNCOMMON, mage.cards.g.GarbageElementalC.class));
+        cards.add(new SetCardInfo("Garbage Elemental", "82d", Rarity.UNCOMMON, mage.cards.g.GarbageElementalD.class));
         cards.add(new SetCardInfo("Ground Pounder", 110, Rarity.COMMON, mage.cards.g.GroundPounder.class));
         cards.add(new SetCardInfo("Hammer Helper", 85, Rarity.COMMON, mage.cards.h.HammerHelper.class));
         cards.add(new SetCardInfo("Hammer Jammer", 86, Rarity.UNCOMMON, mage.cards.h.HammerJammer.class));


### PR DESCRIPTION
There may be a better way of implementing this since other damage-dealing ETBs like Cinder Hellion use `new EntersBattlefieldTriggeredAbility(new DamageTargetEffect(...))` with either a fixed integer or an implementation of `DynamicValue`, but I couldn't work out how to implement a `RollDiceCount` so I opted to use Garbage Elemental (c) as a template.