### PR TITLE
Fix nonbasic land counting in singleton mode

### DIFF
--- a/Mage.Client/src/main/java/mage/client/deck/generator/DeckGeneratorPool.java
+++ b/Mage.Client/src/main/java/mage/client/deck/generator/DeckGeneratorPool.java
@@ -136,7 +136,7 @@ public class DeckGeneratorPool
         int cardCount = getCardCount((card.getName()));
         // No need to check if the land is valid for the colors chosen
         // They are all filtered before searching for lands to include in the deck.
-        return (cardCount < 4);
+        return (cardCount < (isSingleton ? 1 : 4));
     }
 
 


### PR DESCRIPTION
Nonbasic lands weren't being checked against the singleton restriction, leading to decks with multiple copies of the same nonbasic land (e.g. I generated one with two Crumbling Necropolis).