### PR TITLE
Fix cards which incorrectly target rather than choose

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DawnbreakReclaimer.java
+++ b/Mage.Sets/src/mage/cards/d/DawnbreakReclaimer.java
@@ -90,6 +90,7 @@ class DawnbreakReclaimerEffect extends OneShotEffect {
         MageObject sourceObject = source.getSourceObject(game);
         if (controller != null && sourceObject != null) {
             TargetCardInOpponentsGraveyard targetOpponentGraveyard = new TargetCardInOpponentsGraveyard(new FilterCreatureCard("a creature card in an opponent's graveyard"));
+            targetOpponentGraveyard.setNotTarget(true);
             Player opponent = null;
             Card cardOpponentGraveyard = null;
             if (targetOpponentGraveyard.canChoose(source.getSourceId(), source.getControllerId(), game)) {
@@ -103,6 +104,7 @@ class DawnbreakReclaimerEffect extends OneShotEffect {
             if (opponent == null) {
                 // if no card from opponent was available controller has to chose an opponent to select a creature card in controllers graveyard
                 TargetOpponent targetOpponent = new TargetOpponent(true);
+                targetOpponent.setNotTarget(true);
                 controller.choose(outcome, targetOpponent, source.getSourceId(), game);
                 opponent = game.getPlayer(targetOpponent.getFirstTarget());
                 if (opponent != null) {

--- a/Mage.Sets/src/mage/cards/g/GruesomeMenagerie.java
+++ b/Mage.Sets/src/mage/cards/g/GruesomeMenagerie.java
@@ -84,6 +84,7 @@ class GruesomeMenagerieEffect extends OneShotEffect {
         Cards cards = new CardsImpl();
         Target target;
         target = new TargetCardInYourGraveyard(filter1);
+        target.setNotTarget(true);
         if (player.choose(outcome, target, source.getSourceId(), game)) {
             Card card = game.getCard(target.getFirstTarget());
             if (card != null) {
@@ -91,6 +92,7 @@ class GruesomeMenagerieEffect extends OneShotEffect {
             }
         }
         target = new TargetCardInYourGraveyard(filter2);
+        target.setNotTarget(true);
         if (player.choose(outcome, target, source.getSourceId(), game)) {
             Card card = game.getCard(target.getFirstTarget());
             if (card != null) {
@@ -98,6 +100,7 @@ class GruesomeMenagerieEffect extends OneShotEffect {
             }
         }
         target = new TargetCardInYourGraveyard(filter3);
+        target.setNotTarget(true);
         if (player.choose(outcome, target, source.getSourceId(), game)) {
             Card card = game.getCard(target.getFirstTarget());
             if (card != null) {


### PR DESCRIPTION
 bd6bb7b fixed a bug where The Mimeoplasm was incorrectly prevented from reanimating cards by Silent Gravestone; however, Dawnbreak Reclaimer and Gruesome Menagerie also had similar bugs. This commit fixes these cards.