### PR TITLE
Refactor Ugin's Conjurant, Protean Hydra with a new ability. Fixed Ashiok, Dream Renderer

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AshiokDreamRender.java
+++ b/Mage.Sets/src/mage/cards/a/AshiokDreamRender.java
@@ -7,7 +7,6 @@ import mage.abilities.common.PlaneswalkerEntersWithLoyaltyCountersAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.common.ExileGraveyardAllPlayersEffect;
-import mage.abilities.effects.common.PutTopCardOfLibraryIntoGraveTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
@@ -17,6 +16,8 @@ import mage.game.events.GameEvent;
 import mage.players.Player;
 
 import java.util.UUID;
+import mage.abilities.effects.common.PutLibraryIntoGraveTargetEffect;
+import mage.target.TargetPlayer;
 
 /**
  * @author TheElk801
@@ -34,7 +35,8 @@ public final class AshiokDreamRender extends CardImpl {
         this.addAbility(new SimpleStaticAbility(new AshiokDreamRenderEffect()));
 
         // -1: Target player puts the top four cards of their library into their graveyard. Then exile each opponent's graveyard.
-        Ability ability = new LoyaltyAbility(new PutTopCardOfLibraryIntoGraveTargetEffect(4), -1);
+        Ability ability = new LoyaltyAbility(new PutLibraryIntoGraveTargetEffect(4), -1);
+        ability.addTarget(new TargetPlayer());
         ability.addEffect(new ExileGraveyardAllPlayersEffect(StaticFilters.FILTER_CARD, TargetController.OPPONENT).setText("Then exile each opponent's graveyard."));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/p/ProteanHydra.java
+++ b/Mage.Sets/src/mage/cards/p/ProteanHydra.java
@@ -3,12 +3,11 @@ package mage.cards.p;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.DelayedTriggeredAbility;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.PreventionEffectImpl;
+import mage.abilities.effects.PreventDamageAndRemoveCountersEffect;
 import mage.abilities.effects.common.CreateDelayedTriggeredAbilityEffect;
 import mage.abilities.effects.common.EntersBattlefieldWithXCountersEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
@@ -16,13 +15,11 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.GameEvent.EventType;
-import mage.game.permanent.Permanent;
 
 /**
  *
@@ -41,7 +38,7 @@ public final class ProteanHydra extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(new EntersBattlefieldWithXCountersEffect(CounterType.P1P1.createInstance())));
 
         // If damage would be dealt to Protean Hydra, prevent that damage and remove that many +1/+1 counters from it.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new ProteanHydraEffect2()));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PreventDamageAndRemoveCountersEffect()));
 
         // Whenever a +1/+1 counter is removed from Protean Hydra, put two +1/+1 counters on it at the beginning of the next end step.
         this.addAbility(new ProteanHydraAbility());
@@ -55,50 +52,6 @@ public final class ProteanHydra extends CardImpl {
     @Override
     public ProteanHydra copy() {
         return new ProteanHydra(this);
-    }
-
-    static class ProteanHydraEffect2 extends PreventionEffectImpl {
-
-        public ProteanHydraEffect2() {
-            super(Duration.WhileOnBattlefield, Integer.MAX_VALUE, false, false);
-            staticText = "If damage would be dealt to {this}, prevent that damage and remove that many +1/+1 counters from it";
-        }
-
-        public ProteanHydraEffect2(final ProteanHydraEffect2 effect) {
-            super(effect);
-        }
-
-        @Override
-        public ProteanHydraEffect2 copy() {
-            return new ProteanHydraEffect2(this);
-        }
-
-        @Override
-        public boolean apply(Game game, Ability source) {
-            return true;
-        }
-
-        @Override
-        public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-            int damage = event.getAmount();
-            preventDamageAction(event, source, game);
-            Permanent permanent = game.getPermanent(source.getSourceId());
-            if (permanent != null) {
-                permanent.removeCounters(CounterType.P1P1.createInstance(damage), game); //MTG ruling Protean Hydra loses counters even if the damage isn't prevented
-            }
-            return false;
-        }
-
-        @Override
-        public boolean applies(GameEvent event, Ability source, Game game) {
-            if (super.applies(event, source, game)) {
-                if (event.getTargetId().equals(source.getSourceId())) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
     }
 
     class ProteanHydraAbility extends TriggeredAbilityImpl {

--- a/Mage.Sets/src/mage/cards/u/UginsConjurant.java
+++ b/Mage.Sets/src/mage/cards/u/UginsConjurant.java
@@ -9,18 +9,10 @@ import mage.constants.CardType;
 
 import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.effects.common.EntersBattlefieldWithXCountersEffect;
+import mage.abilities.effects.PreventDamageAndRemoveCountersEffect;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.counters.CounterType;
-import mage.abilities.Ability;
-import mage.abilities.effects.PreventionEffectImpl;
-import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.game.permanent.Permanent;
-import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 
 /**
  *
@@ -39,7 +31,7 @@ public final class UginsConjurant extends CardImpl {
         // Ugin’s Conjurant enters the battlefield with X +1/+1 counters on it.
         this.addAbility(new EntersBattlefieldAbility(new EntersBattlefieldWithXCountersEffect(CounterType.P1P1.createInstance())));
         // If damage would be dealt to Ugin’s Conjurant while it has a +1/+1 counter on it, prevent that damage and remove that many +1/+1 counters from Ugin’s Conjurant.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new UginsConjurantPrevention()));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PreventDamageAndRemoveCountersEffect()));
     }
 
     private UginsConjurant(final UginsConjurant card) {
@@ -49,49 +41,5 @@ public final class UginsConjurant extends CardImpl {
     @Override
     public UginsConjurant copy() {
         return new UginsConjurant(this);
-    }
-
-    static class UginsConjurantPrevention extends PreventionEffectImpl {
-
-        public UginsConjurantPrevention() {
-            super(Duration.WhileOnBattlefield, Integer.MAX_VALUE, false, false);
-            staticText = "If damage would be dealt to {this}, prevent that damage and remove that many +1/+1 counters from it";
-        }
-
-        public UginsConjurantPrevention(final UginsConjurantPrevention effect) {
-            super(effect);
-        }
-
-        @Override
-        public UginsConjurantPrevention copy() {
-            return new UginsConjurantPrevention(this);
-        }
-
-        @Override
-        public boolean apply(Game game, Ability source) {
-            return true;
-        }
-
-        @Override
-        public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-            int damage = event.getAmount();
-            preventDamageAction(event, source, game);
-            Permanent permanent = game.getPermanent(source.getSourceId());
-            if (permanent != null) {
-                permanent.removeCounters(CounterType.P1P1.createInstance(damage), game); //MTG ruling Protean Hydra loses counters even if the damage isn't prevented
-            }
-            return false;
-        }
-
-        @Override
-        public boolean applies(GameEvent event, Ability source, Game game) {
-            if (super.applies(event, source, game)) {
-                if (event.getTargetId().equals(source.getSourceId())) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/PreventDamageAndRemoveCountersEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/PreventDamageAndRemoveCountersEffect.java
@@ -1,0 +1,60 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package mage.abilities.effects;
+
+import mage.abilities.Ability;
+import mage.constants.Duration;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+
+/**
+ *
+ * @author antoni-g
+ */
+public class PreventDamageAndRemoveCountersEffect extends PreventionEffectImpl {
+
+    public PreventDamageAndRemoveCountersEffect() {
+        super(Duration.WhileOnBattlefield, Integer.MAX_VALUE, false, false);
+        staticText = "If damage would be dealt to {this}, prevent that damage and remove that many +1/+1 counters from it";
+    }
+
+    public PreventDamageAndRemoveCountersEffect(final PreventDamageAndRemoveCountersEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public PreventDamageAndRemoveCountersEffect copy() {
+        return new PreventDamageAndRemoveCountersEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return true;
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        int damage = event.getAmount();
+        preventDamageAction(event, source, game);
+        Permanent permanent = game.getPermanent(source.getSourceId());
+        if (permanent != null) {
+            permanent.removeCounters(CounterType.P1P1.createInstance(damage), game); //MTG ruling (this) loses counters even if the damage isn't prevented
+        }
+        return false;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (super.applies(event, source, game)) {
+            if (event.getTargetId().equals(source.getSourceId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Originally, the "prevent that damage and remove that many +1/+1 counters instead" ability on Protean Hydra was unique to that card. This refactors and floats the ability up to a new class the abilities/effects directory and refactors both Ugin's Conjurant and Protean Hydra to use it.