### PR TITLE
Detection Tower and Witchbane Orb interaction bug confirmed for #5796

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/curses/CursesTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/curses/CursesTest.java
@@ -426,7 +426,7 @@ public class CursesTest extends CardTestPlayerBase {
     }
 
     /*
-     * Reported bug issue #3326 (NOTE test is failing due to bug in code)
+     * Reported bug issue #3326
      * When {Witchbane Orb} triggers when entering the field and there IS a curse attached to you, an error message (I sadly skipped) appears and your turn is reset.
         This happened to me in a 4-player Commander game with {Curse of the Shallow Graves} on the field.
      */

--- a/Mage.Tests/src/test/java/org/mage/test/cards/asthough/DidNotHaveHexproofTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/asthough/DidNotHaveHexproofTest.java
@@ -41,14 +41,15 @@ public class DidNotHaveHexproofTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerB, wOrb);
         
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}");
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Shock", playerB);
+        castSpell(1, PhaseStep.BEGIN_COMBAT, playerA, "Shock", playerB);
         
-        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        setStopAt(1, PhaseStep.END_COMBAT);
         execute();
-        
+                
         assertTappedCount("Mountain", true, 2);
         assertTapped(dTower, true);
         assertGraveyardCount(playerA, "Shock", 1);
         assertLife(playerB, 18);
+        assertAllCommandsUsed();
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/asthough/DidNotHaveHexproofTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/asthough/DidNotHaveHexproofTest.java
@@ -1,0 +1,54 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package org.mage.test.cards.asthough;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author drmDev
+ */
+public class DidNotHaveHexproofTest extends CardTestPlayerBase {
+
+    /*
+     Witchbane Orb (4)
+    When Witchbane Orb enters the battlefield, destroy all Curses attached to you.
+    You have hexproof. (You can't be the target of spells or abilities your opponents control, including Aura spells.)
+    */
+    public static final String wOrb = "Witchbane Orb";
+
+    /*
+    Detection Tower (Land)
+    {T}: Add Colorless.
+    1, {T}: Until end of turn, your opponents and creatures your opponents control with hexproof can be the targets of spells and abilities you control 
+    as though they didn't have hexproof.
+    */
+    public static final String dTower = "Detection Tower";
+
+    @Test
+    public void detectionTowerAllowsTargettingPlayerWithWitchbaneOrb() {
+        
+        addCard(Zone.BATTLEFIELD, playerA, dTower);        
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        addCard(Zone.HAND, playerA, "Shock"); // {R} 2 dmg to any target
+        addCard(Zone.BATTLEFIELD, playerB, wOrb);
+        
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Shock", playerB);
+        
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+        
+        assertTappedCount("Mountain", true, 2);
+        assertTapped(dTower, true);
+        assertGraveyardCount(playerA, "Shock", 1);
+        assertLife(playerB, 18);
+    }
+}


### PR DESCRIPTION
Tried to debug the issue, but for some reason when executing the test, it never hits the Detection Tower applies method with a breakpoint there. Either way, the test confirms the issue mentioned. I would guess its in the Detection Tower applies method with a conditional not checking on the opponent ID correctly:
