### PR TITLE
Fix #5821 by finding in preferred set

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/images/DownloadPicturesService.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/images/DownloadPicturesService.java
@@ -439,7 +439,7 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
                             throw new IllegalStateException("Second side card can't have empty name.");
                         }
 
-                        CardInfo secondSideCard = CardRepository.instance.findCard(card.getSecondSideName());
+                        CardInfo secondSideCard = CardRepository.instance.findCardWPreferredSet(card.getSecondSideName(), card.getSetCode(), false);
                         if (secondSideCard == null) {
                             throw new IllegalStateException("Can''t find second side card in database: " + card.getSecondSideName());
                         }


### PR DESCRIPTION
Fixes #5821.

Finding in preferred set tries to get the second face from the same set as the first face, thus ensuring we have the correct card number for that set.