### PR TITLE
Unit Tests for Merfolk Trickster, confirming #5825

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/MerfolkTricksterTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/MerfolkTricksterTest.java
@@ -1,0 +1,158 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.mage.test.cards.continuous;
+
+import mage.abilities.Abilities;
+import mage.abilities.AbilitiesImpl;
+import mage.abilities.Ability;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+import org.junit.Test;
+import mage.abilities.keyword.FlashAbility;
+import mage.counters.CounterType;
+
+/**
+ *
+ * @author drmDev
+ */
+public class MerfolkTricksterTest extends CardTestPlayerBase {
+    
+    /*
+     Merfolk Trickster (UU)
+    Creature Merfolk Wizard
+    Flash
+    When Merfolk Trickster enters the battlefield, tap target creature an opponent controls. It loses all abilities until end of turn.
+    */
+    public final String mTrickster = "Merfolk Trickster";
+    
+    @Test
+    public void test_TricksterAndFlyer_FlyingRemoved()
+    {
+        addCard(Zone.BATTLEFIELD, playerA, "Flying Men"); // (U) 1/1 flyer
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+        addCard(Zone.HAND, playerB, mTrickster);
+        
+        attack(1, playerA, "Flying Men");
+        castSpell(1, PhaseStep.DECLARE_BLOCKERS, playerB, mTrickster);
+        
+        setStopAt(1, PhaseStep.END_COMBAT);
+        execute();
+        
+        assertLife(playerA, 20);
+        assertLife(playerB, 19);
+        assertTappedCount("Island", true, 2);
+        assertTapped("Flying Men", true);
+        
+        Abilities<Ability> noAbilities = new AbilitiesImpl<>();
+        assertAbilities(playerA, "Flying Men", noAbilities); // no abilities, empty list
+        
+        Abilities<Ability> flashAbility = new AbilitiesImpl<>();
+        flashAbility.add(FlashAbility.getInstance());
+        assertAbilities(playerB, mTrickster, flashAbility); // has flash        
+        
+        assertAllCommandsUsed();
+    }
+    
+    @Test
+    public void test_TricksterAndFlyerBlocked_FlyingRemovedAndBlocked()
+    {
+        addCard(Zone.BATTLEFIELD, playerA, "Flying Men"); // (U) 1/1 flyer
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+        addCard(Zone.HAND, playerB, mTrickster);
+        
+        attack(1, playerA, "Flying Men");
+        castSpell(1, PhaseStep.DECLARE_ATTACKERS, playerB, mTrickster);
+        block(1, playerB, mTrickster, "Flying Men");
+        
+        setStopAt(1, PhaseStep.END_COMBAT);
+        execute();
+        
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+        assertTappedCount("Island", true, 2);
+        assertGraveyardCount(playerA, "Flying Men", 1);
+        assertPermanentCount(playerB, mTrickster, 1);
+        assertDamageReceived(playerB, mTrickster, 1);
+        assertAllCommandsUsed();
+    }
+    
+    @Test
+    public void test_TricksterBlocksFootlightFiend_Survives()
+    {
+        addCard(Zone.BATTLEFIELD, playerA, "Footlight Fiend"); // (R/B) 1/1 on death pings any target for 1
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+        addCard(Zone.HAND, playerB, mTrickster);
+        
+        attack(1, playerA, "Footlight Fiend");
+        castSpell(1, PhaseStep.DECLARE_ATTACKERS, playerB, mTrickster);
+        block(1, playerB, mTrickster, "Footlight Fiend");
+        addTarget(playerA, mTrickster);
+        
+        setStopAt(1, PhaseStep.END_COMBAT);
+        execute();
+        
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+        assertTappedCount("Island", true, 2);
+        assertPermanentCount(playerB, mTrickster, 1);
+        assertDamageReceived(playerB, mTrickster, 1);
+        //assertAllCommandsUsed(); // uncommenting this will force a failure since PlayerA cannot do a command to target Trickster, as expected
+    }
+    
+    // Making sure Footlight Fiend working correctly here first...    
+    @Test
+    public void test_GrizzlyBearBlocksFootlightFiend_BothDie()
+    {
+        addCard(Zone.BATTLEFIELD, playerA, "Footlight Fiend"); // (R/B) 1/1 on death pings any target for 1
+        addCard(Zone.BATTLEFIELD, playerB, "Grizzly Bears"); // (G) 2/2
+        
+        attack(1, playerA, "Footlight Fiend");
+        block(1, playerB, "Grizzly Bears", "Footlight Fiend");
+        addTarget(playerA, "Grizzly Bears");
+        
+        setStopAt(1, PhaseStep.END_COMBAT);
+        execute();
+        
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+        assertGraveyardCount(playerA, "Footlight Fiend", 1);
+        assertGraveyardCount(playerB, "Grizzly Bears", 1);
+        assertAllCommandsUsed();
+    }
+    
+    @Test
+    public void test_TricksterBlocksTibaltToken_Survives()
+    {
+        /*        
+        Tibalt, Rakish Instigator (2R)
+        Legendary Planeswalker Tibalt
+        Your opponents can't gain life.
+        -2: Create a 1/1 red Devil creature token with "When this creature dies, it deals 1 damage to any target."
+        */
+        addCard(Zone.BATTLEFIELD, playerA, "Tibalt, Rakish Instigator");
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+        addCard(Zone.HAND, playerB, mTrickster);
+        
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "-2:");
+        
+        attack(3, playerA, "Devil");
+        castSpell(3, PhaseStep.DECLARE_ATTACKERS, playerB, mTrickster);
+        block(3, playerB, mTrickster, "Devil");
+        addTarget(playerA, mTrickster);
+        
+        setStopAt(3, PhaseStep.END_COMBAT);
+        execute();
+        
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+        assertCounterCount("Tibalt, Rakish Instigator", CounterType.LOYALTY, 3);
+        assertTappedCount("Island", true, 2);
+        assertPermanentCount(playerB, mTrickster, 1);
+        assertDamageReceived(playerB, mTrickster, 1);
+        assertAllCommandsUsed(); // uncommenting this should force a failure since PlayerA cannot do a command to target Trickster, as expected
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/MerfolkTricksterTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/MerfolkTricksterTest.java
@@ -38,6 +38,7 @@ public class MerfolkTricksterTest extends CardTestPlayerBase {
         
         attack(1, playerA, "Flying Men");
         castSpell(1, PhaseStep.DECLARE_BLOCKERS, playerB, mTrickster);
+        addTarget(playerB, "Flying Men");
         
         setStopAt(1, PhaseStep.END_COMBAT);
         execute();
@@ -66,6 +67,7 @@ public class MerfolkTricksterTest extends CardTestPlayerBase {
         
         attack(1, playerA, "Flying Men");
         castSpell(1, PhaseStep.DECLARE_ATTACKERS, playerB, mTrickster);
+        addTarget(playerB, "Flying Men");
         block(1, playerB, mTrickster, "Flying Men");
         
         setStopAt(1, PhaseStep.END_COMBAT);
@@ -89,6 +91,7 @@ public class MerfolkTricksterTest extends CardTestPlayerBase {
         
         attack(1, playerA, "Footlight Fiend");
         castSpell(1, PhaseStep.DECLARE_ATTACKERS, playerB, mTrickster);
+        addTarget(playerB, "Footlight Fiend");
         block(1, playerB, mTrickster, "Footlight Fiend");
         addTarget(playerA, mTrickster);
         
@@ -141,6 +144,7 @@ public class MerfolkTricksterTest extends CardTestPlayerBase {
         
         attack(3, playerA, "Devil");
         castSpell(3, PhaseStep.DECLARE_ATTACKERS, playerB, mTrickster);
+        addTarget(playerB, "Devil");
         block(3, playerB, mTrickster, "Devil");
         addTarget(playerA, mTrickster);
         

--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/MerfolkTricksterTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/MerfolkTricksterTest.java
@@ -106,27 +106,6 @@ public class MerfolkTricksterTest extends CardTestPlayerBase {
         //assertAllCommandsUsed(); // uncommenting this will force a failure since PlayerA cannot do a command to target Trickster, as expected
     }
     
-    // Making sure Footlight Fiend working correctly here first...    
-    @Test
-    public void test_GrizzlyBearBlocksFootlightFiend_BothDie()
-    {
-        addCard(Zone.BATTLEFIELD, playerA, "Footlight Fiend"); // (R/B) 1/1 on death pings any target for 1
-        addCard(Zone.BATTLEFIELD, playerB, "Grizzly Bears"); // (G) 2/2
-        
-        attack(1, playerA, "Footlight Fiend");
-        block(1, playerB, "Grizzly Bears", "Footlight Fiend");
-        addTarget(playerA, "Grizzly Bears");
-        
-        setStopAt(1, PhaseStep.END_COMBAT);
-        execute();
-        
-        assertLife(playerA, 20);
-        assertLife(playerB, 20);
-        assertGraveyardCount(playerA, "Footlight Fiend", 1);
-        assertGraveyardCount(playerB, "Grizzly Bears", 1);
-        assertAllCommandsUsed();
-    }
-    
     @Test
     public void test_TricksterBlocksTibaltToken_Survives()
     {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/dies/FootlightFiendTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/dies/FootlightFiendTest.java
@@ -1,0 +1,33 @@
+package org.mage.test.cards.triggers.dies;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author drmDev
+ */
+public class FootlightFiendTest extends CardTestPlayerBase {
+    
+    @Test
+    public void test_GrizzlyBearBlocksFootlightFiend_BothDie()
+    {
+        addCard(Zone.BATTLEFIELD, playerA, "Footlight Fiend"); // (R/B) 1/1 on death pings any target for 1
+        addCard(Zone.BATTLEFIELD, playerB, "Grizzly Bears"); // (G) 2/2
+        
+        attack(1, playerA, "Footlight Fiend");
+        block(1, playerB, "Grizzly Bears", "Footlight Fiend");
+        addTarget(playerA, "Grizzly Bears");
+        
+        setStopAt(1, PhaseStep.END_COMBAT);
+        execute();
+        
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+        assertGraveyardCount(playerA, "Footlight Fiend", 1);
+        assertGraveyardCount(playerB, "Grizzly Bears", 1);
+        assertAllCommandsUsed();
+    }
+}


### PR DESCRIPTION
Added a small batch of unit tests for Merfolk Trickster interactions, and seems to confirm #5825  - the Devil token kills Trickster. Footlight Fiend does not however, so I suspect this is an issue related to Tokens. Maybe I'll add more tests with Trickster interacting with other tokens to confirm those work correctly?