### PR TITLE
Force Scryfall URL enconding

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
@@ -13,6 +13,7 @@ import org.mage.plugins.card.images.CardDownloadData;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
@@ -93,6 +94,12 @@ public enum ScryfallImageSource implements CardImageSource {
                 } else if (card.getSet().matches("PLS")) {
                     scryfallCollectorId += "★";
                 }
+            }
+
+            try {
+                scryfallCollectorId = URLEncoder.encode(scryfallCollectorId, "utf-8");
+            } catch (UnsupportedEncodingException e) {
+                // URL failed to encode, this will cause download to miss in certain environments
             }
 
             baseUrl = "https://api.scryfall.com/cards/" + formatSetName(card.getSet(), isToken) + "/"


### PR DESCRIPTION
This increases compatibility in the default JRE distribution bundled with the XMage launcher, which does not properly encode some Unicode characters used in Scryfall card numbers (like the character `†`), causing these requests to return a 400 error code reply.