### PR TITLE
HashMap is not thread safe.  The existing synchronized(map) is too small, should be extended to cover the surrounding code.

### DIFF
--- a/Mage.Client/src/main/java/mage/client/util/gui/ArrowBuilder.java
+++ b/Mage.Client/src/main/java/mage/client/util/gui/ArrowBuilder.java
@@ -112,10 +112,11 @@ public class ArrowBuilder {
      * Removes all arrows from the screen.
      */
     public void removeAllArrows(UUID gameId) {
-        if (map.containsKey(gameId)) {
-            Map<Type, List<Arrow>> innerMap = map.get(gameId);
-            JPanel p = getArrowsPanel(gameId);
-            synchronized (map) {
+        synchronized (map) {
+            if (map.containsKey(gameId)) {
+                Map<Type, List<Arrow>> innerMap = map.get(gameId);
+                JPanel p = getArrowsPanel(gameId);
+
                 if (p != null && p.getComponentCount() > 0) {
                     p.removeAll();
                     p.revalidate();


### PR DESCRIPTION
The current 

```synchronized (map) {```

https://github.com/magefree/mage/blob/master/Mage.Client/src/main/java/mage/client/util/gui/ArrowBuilder.java#L118-L126

does not also protect

```map.containsKey()``` and ```map.get()```

https://github.com/magefree/mage/blob/master/Mage.Client/src/main/java/mage/client/util/gui/ArrowBuilder.java#L115-L117

```map``` is a ```HashMap```, which is not thread-safe.


The ```synchronized (map)``` should be extended to cover
```map.containsKey()``` and ```map.get()``` too.

# Testing Done

```mvn test```

passed

