### PR TITLE
Fix various hints and warnings on many set & block classes (via Intel…

### DIFF
--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/AmonkhetBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/AmonkhetBlock.java
@@ -12,7 +12,7 @@ public class AmonkhetBlock extends Constructed {
 
     public AmonkhetBlock() {
         super("Constructed - Amonkhet Block");
-        setCodes.add("AKH");
-        setCodes.add("HOU");
+        setCodes.add(mage.sets.Amonkhet.getInstance().getCode());
+        setCodes.add(mage.sets.HourOfDevastation.getInstance().getCode());
     }
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/BattleForZendikarBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/BattleForZendikarBlock.java
@@ -12,7 +12,7 @@ public class BattleForZendikarBlock extends Constructed {
 
     public BattleForZendikarBlock() {
         super("Constructed - Battle for Zendikar Block");
-        setCodes.add("BFZ");
-        setCodes.add("OGW");
+        setCodes.add(mage.sets.BattleForZendikar.getInstance().getCode());
+        setCodes.add(mage.sets.OathOfTheGatewatch.getInstance().getCode());
     }
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/InnistradBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/InnistradBlock.java
@@ -12,9 +12,9 @@ public class InnistradBlock extends Constructed {
 
     public InnistradBlock() {
         super("Constructed - Innistrad Block");
-        setCodes.add("ISD");
-        setCodes.add("DKA");
-        setCodes.add("AVR");
+        setCodes.add(mage.sets.Innistrad.getInstance().getCode());
+        setCodes.add(mage.sets.DarkAscension.getInstance().getCode());
+        setCodes.add(mage.sets.AvacynRestored.getInstance().getCode());
     }
 
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/IxalanBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/IxalanBlock.java
@@ -11,7 +11,7 @@ public class IxalanBlock extends Constructed {
 
     public IxalanBlock() {
         super("Constructed - Ixalan Block");
-        setCodes.add("XLN");
-        setCodes.add("RIX");
+        setCodes.add(mage.sets.Ixalan.getInstance().getCode());
+        setCodes.add(mage.sets.RivalsOfIxalan.getInstance().getCode());
     }
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/KaladeshBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/KaladeshBlock.java
@@ -12,7 +12,7 @@ public class KaladeshBlock extends Constructed {
 
     public KaladeshBlock() {
         super("Constructed - Kaladesh Block");
-        setCodes.add("KLD");
-        setCodes.add("AER");
+        setCodes.add(mage.sets.Kaladesh.getInstance().getCode());
+        setCodes.add(mage.sets.AetherRevolt.getInstance().getCode());
     }
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/KamigawaBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/KamigawaBlock.java
@@ -12,9 +12,9 @@ public class KamigawaBlock extends Constructed {
 
     public KamigawaBlock() {
         super("Constructed - Kamigawa Block");
-        setCodes.add("CHK");
-        setCodes.add("BOK");
-        setCodes.add("SOK");
+        setCodes.add(mage.sets.ChampionsOfKamigawa.getInstance().getCode());
+        setCodes.add(mage.sets.BetrayersOfKamigawa.getInstance().getCode());
+        setCodes.add(mage.sets.SaviorsOfKamigawa.getInstance().getCode());
     }
 
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/KhansOfTarkirBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/KhansOfTarkirBlock.java
@@ -12,9 +12,9 @@ public class KhansOfTarkirBlock extends Constructed {
 
     public KhansOfTarkirBlock() {
         super("Constructed - Khans of Tarkir Block");
-        setCodes.add("KTK");
-        setCodes.add("FRF");
-        setCodes.add("DTK");
+        setCodes.add(mage.sets.KhansOfTarkir.getInstance().getCode());
+        setCodes.add(mage.sets.FateReforged.getInstance().getCode());
+        setCodes.add(mage.sets.DragonsOfTarkir.getInstance().getCode());
     }
 
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/LorwynBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/LorwynBlock.java
@@ -11,7 +11,7 @@ public class LorwynBlock extends Constructed {
 
     public LorwynBlock() {
         super("Constructed - Lorwyn Block");
-        setCodes.add("LRW");
-        setCodes.add("MOR");
+        setCodes.add(mage.sets.Lorwyn.getInstance().getCode());
+        setCodes.add(mage.sets.Morningtide.getInstance().getCode());
     }
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/ReturnToRavnicaBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/ReturnToRavnicaBlock.java
@@ -12,9 +12,9 @@ public class ReturnToRavnicaBlock extends Constructed {
 
     public ReturnToRavnicaBlock() {
         super("Constructed - Return to Ravnica Block");
-        setCodes.add("RTR");
-        setCodes.add("GTC");
-        setCodes.add("DGM");
+        setCodes.add(mage.sets.ReturnToRavnica.getInstance().getCode());
+        setCodes.add(mage.sets.Gatecrash.getInstance().getCode());
+        setCodes.add(mage.sets.DragonsMaze.getInstance().getCode());
     }
 
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/ScarsOfMirrodinBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/ScarsOfMirrodinBlock.java
@@ -12,9 +12,9 @@ public class ScarsOfMirrodinBlock extends Constructed {
 
     public ScarsOfMirrodinBlock() {
         super("Constructed - Scars of Mirrodin Block");
-        setCodes.add("SOM");
-        setCodes.add("MBS");
-        setCodes.add("NPH");
+        setCodes.add(mage.sets.ScarsOfMirrodin.getInstance().getCode());
+        setCodes.add(mage.sets.MirrodinBesieged.getInstance().getCode());
+        setCodes.add(mage.sets.NewPhyrexia.getInstance().getCode());
     }
 
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/ShadowmoorBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/ShadowmoorBlock.java
@@ -12,8 +12,8 @@ public class ShadowmoorBlock extends Constructed {
 
     public ShadowmoorBlock() {
         super("Constructed - Shadowmoor Block");
-        setCodes.add("SHM");
-        setCodes.add("EVE");
+        setCodes.add(mage.sets.Shadowmoor.getInstance().getCode());
+        setCodes.add(mage.sets.Eventide.getInstance().getCode());
     }
 
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/ShadowsOverInnistradBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/ShadowsOverInnistradBlock.java
@@ -12,7 +12,7 @@ public class ShadowsOverInnistradBlock extends Constructed {
 
     public ShadowsOverInnistradBlock() {
         super("Constructed - Shadows over Innistrad Block");
-        setCodes.add("SOI");
-        setCodes.add("EDM");
+        setCodes.add(mage.sets.ShadowsOverInnistrad.getInstance().getCode());
+        setCodes.add(mage.sets.EldritchMoon.getInstance().getCode());
     }
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/ShardsOfAlaraBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/ShardsOfAlaraBlock.java
@@ -12,9 +12,9 @@ public class ShardsOfAlaraBlock extends Constructed {
 
     public ShardsOfAlaraBlock() {
         super("Constructed - Shards of Alara Block");
-        setCodes.add("ALA");
-        setCodes.add("CON");
-        setCodes.add("ARB");
+        setCodes.add(mage.sets.ShardsOfAlara.getInstance().getCode());
+        setCodes.add(mage.sets.Conflux.getInstance().getCode());
+        setCodes.add(mage.sets.AlaraReborn.getInstance().getCode());
     }
 
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/StarWarsBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/StarWarsBlock.java
@@ -15,7 +15,7 @@ public class StarWarsBlock extends Constructed {
 
     public StarWarsBlock() {
         super("Constructed Custom - Star Wars Block");
-        setCodes.add("SWS");
+        setCodes.add(mage.sets.StarWars.getInstance().getCode());
     }
 
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/SuperType2.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/SuperType2.java
@@ -26,7 +26,7 @@ public class SuperType2 extends Constructed {
      * Kamigawa/Ravnica standard, where rotation stabilized.
      * Data taken from http://thattournament.website/historic-tournament.php
      */
-    protected static final String[][] standards = {
+    private static final String[][] standards = {
             // 11th Standard
             {"7ED", "INV", "APC", "PLS", "ODY", "TOR", "JUD"},
             // 12th Standard
@@ -72,7 +72,7 @@ public class SuperType2 extends Constructed {
      * regular validation function to test validity.
      *
      * @param deck - the deck to validate.
-     * @return
+     * @return boolean if valid deck
      */
     @Override
     public boolean validate(Deck deck) {

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/TherosBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/TherosBlock.java
@@ -12,9 +12,9 @@ public class TherosBlock extends Constructed {
 
     public TherosBlock() {
         super("Constructed - Theros Block");
-        setCodes.add("THS");
-        setCodes.add("BNG");
-        setCodes.add("JOU");
+        setCodes.add(mage.sets.Theros.getInstance().getCode());
+        setCodes.add(mage.sets.BornOfTheGods.getInstance().getCode());
+        setCodes.add(mage.sets.JourneyIntoNyx.getInstance().getCode());
     }
 
 }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/ZendikarBlock.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/ZendikarBlock.java
@@ -15,9 +15,9 @@ public class ZendikarBlock extends Constructed {
 
     public ZendikarBlock() {
         super("Constructed - Zendikar Block");
-        setCodes.add("ZEN");
-        setCodes.add("WWK");
-        setCodes.add("ROE");
+        setCodes.add(mage.sets.Zendikar.getInstance().getCode());
+        setCodes.add(mage.sets.Worldwake.getInstance().getCode());
+        setCodes.add(mage.sets.RiseOfTheEldrazi.getInstance().getCode());
     }
 
 }

--- a/Mage.Sets/src/mage/sets/AetherRevolt.java
+++ b/Mage.Sets/src/mage/sets/AetherRevolt.java
@@ -22,7 +22,7 @@ public final class AetherRevolt extends ExpansionSet {
         return instance;
     }
 
-    protected final List<CardInfo> savedSpecialLand = new ArrayList<>();
+    private final List<CardInfo> savedSpecialLand = new ArrayList<>();
 
     private AetherRevolt() {
         super("Aether Revolt", "AER", ExpansionSet.buildDate(2017, 1, 20), SetType.EXPANSION);

--- a/Mage.Sets/src/mage/sets/Amonkhet.java
+++ b/Mage.Sets/src/mage/sets/Amonkhet.java
@@ -23,7 +23,7 @@ public final class Amonkhet extends ExpansionSet {
         return instance;
     }
 
-    protected final List<CardInfo> savedSpecialLand = new ArrayList<>();
+    private final List<CardInfo> savedSpecialLand = new ArrayList<>();
 
     private Amonkhet() {
         super("Amonkhet", "AKH", ExpansionSet.buildDate(2017, 4, 28), SetType.EXPANSION);

--- a/Mage.Sets/src/mage/sets/BattleForZendikar.java
+++ b/Mage.Sets/src/mage/sets/BattleForZendikar.java
@@ -21,7 +21,7 @@ public final class BattleForZendikar extends ExpansionSet {
         return instance;
     }
 
-    protected final List<CardInfo> savedSpecialLand = new ArrayList<>();
+    private final List<CardInfo> savedSpecialLand = new ArrayList<>();
 
     private BattleForZendikar() {
         super("Battle for Zendikar", "BFZ", ExpansionSet.buildDate(2015, 10, 2), SetType.EXPANSION);

--- a/Mage.Sets/src/mage/sets/CoreSet2019.java
+++ b/Mage.Sets/src/mage/sets/CoreSet2019.java
@@ -1,9 +1,7 @@
 package mage.sets;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import mage.cards.Card;
 import mage.cards.ExpansionSet;
 import mage.cards.repository.CardCriteria;
 import mage.cards.repository.CardInfo;
@@ -23,8 +21,8 @@ public final class CoreSet2019 extends ExpansionSet {
     public static CoreSet2019 getInstance() {
         return instance;
     }
-    List<CardInfo> savedSpecialCommon = new ArrayList<>();
-    protected final List<CardInfo> savedSpecialLand = new ArrayList<>();
+
+    private final List<CardInfo> savedSpecialLand = new ArrayList<>();
 
     private CoreSet2019() {
         super("Core Set 2019", "M19", ExpansionSet.buildDate(2018, 7, 13), SetType.CORE);
@@ -372,7 +370,7 @@ public final class CoreSet2019 extends ExpansionSet {
                 criteria.setCodes(this.code).notTypes(CardType.LAND);
                 savedCardsInfos = CardRepository.instance.findCards(criteria);
                 if (maxCardNumberInBooster != Integer.MAX_VALUE) {
-                    savedCardsInfos.removeIf(next -> next.getCardNumberAsInt() > maxCardNumberInBooster && rarity != Rarity.LAND);
+                    savedCardsInfos.removeIf(next -> next.getCardNumberAsInt() > maxCardNumberInBooster);
                 }
                 savedCards.put(rarity, savedCardsInfos);
             }

--- a/Mage.Sets/src/mage/sets/CoreSet2020.java
+++ b/Mage.Sets/src/mage/sets/CoreSet2020.java
@@ -22,7 +22,6 @@ public final class CoreSet2020 extends ExpansionSet {
         return instance;
     }
 
-    private final List<CardInfo> savedSpecialCommon = new ArrayList<>();
     private final List<CardInfo> savedSpecialLand = new ArrayList<>();
 
     private CoreSet2020() {
@@ -106,7 +105,7 @@ public final class CoreSet2020 extends ExpansionSet {
         cards.add(new SetCardInfo("Chandra, Novice Pyromancer", 128, Rarity.UNCOMMON, mage.cards.c.ChandraNovicePyromancer.class));
         cards.add(new SetCardInfo("Cloudkin Seer", 54, Rarity.COMMON, mage.cards.c.CloudkinSeer.class));
         cards.add(new SetCardInfo("Colossus Hammer", 223, Rarity.UNCOMMON, mage.cards.c.ColossusHammer.class));
-        cards.add(new SetCardInfo("Concordia Pegasus", 304, Rarity.UNCOMMON, mage.cards.c.ConcordiaPegasus.class));
+        cards.add(new SetCardInfo("Concordia Pegasus", 304, Rarity.COMMON, mage.cards.c.ConcordiaPegasus.class));
         cards.add(new SetCardInfo("Convolute", 55, Rarity.COMMON, mage.cards.c.Convolute.class));
         cards.add(new SetCardInfo("Coral Merfolk", 315, Rarity.COMMON, mage.cards.c.CoralMerfolk.class));
         cards.add(new SetCardInfo("Corpse Knight", 206, Rarity.UNCOMMON, mage.cards.c.CorpseKnight.class));
@@ -399,7 +398,7 @@ public final class CoreSet2020 extends ExpansionSet {
                 criteria.setCodes(this.code).notTypes(CardType.LAND);
                 savedCardsInfos = CardRepository.instance.findCards(criteria);
                 if (maxCardNumberInBooster != Integer.MAX_VALUE) {
-                    savedCardsInfos.removeIf(next -> next.getCardNumberAsInt() > maxCardNumberInBooster && rarity != Rarity.LAND);
+                    savedCardsInfos.removeIf(next -> next.getCardNumberAsInt() > maxCardNumberInBooster);
                 }
                 savedCards.put(rarity, savedCardsInfos);
             }

--- a/Mage.Sets/src/mage/sets/DragonsMaze.java
+++ b/Mage.Sets/src/mage/sets/DragonsMaze.java
@@ -23,10 +23,10 @@ public final class DragonsMaze extends ExpansionSet {
         return instance;
     }
 
-    List<CardInfo> savedSpecialRares = new ArrayList<>();
+    private List<CardInfo> savedSpecialRares = new ArrayList<>();
 
     private DragonsMaze() {
-        super("Dragon's Maze", "DGM", ExpansionSet.buildDate(2013, 5, 03), SetType.EXPANSION);
+        super("Dragon's Maze", "DGM", ExpansionSet.buildDate(2013, 5, 3), SetType.EXPANSION);
         this.blockName = "Return to Ravnica";
         this.hasBoosters = true;
         this.numBoosterSpecial = 1;
@@ -204,7 +204,7 @@ public final class DragonsMaze extends ExpansionSet {
                 criteria.rarities(rarity).doubleFaced(false);
                 savedCardsInfos = CardRepository.instance.findCards(criteria);
                 if (maxCardNumberInBooster != Integer.MAX_VALUE) {
-                    savedCardsInfos.removeIf(next -> next.getCardNumberAsInt() > maxCardNumberInBooster && rarity != Rarity.LAND);
+                    savedCardsInfos.removeIf(next -> next.getCardNumberAsInt() > maxCardNumberInBooster);
                 }
                 savedCards.put(rarity, savedCardsInfos);
             }
@@ -224,7 +224,6 @@ public final class DragonsMaze extends ExpansionSet {
 
     @Override
     public List<CardInfo> getSpecialRare() {
-        List<CardInfo> specialRares = new ArrayList<>();
         if (savedSpecialRares == null) {
             CardCriteria criteria = new CardCriteria();
             criteria.setCodes("GTC").name("Breeding Pool");
@@ -258,8 +257,7 @@ public final class DragonsMaze extends ExpansionSet {
             criteria.setCodes("RTR").name("Temple Garden");
             savedSpecialRares.addAll(CardRepository.instance.findCards(criteria));
         }
-        specialRares.addAll(savedSpecialRares);
-        return specialRares;
+        return new ArrayList<>(savedSpecialRares);
     }
 
     @Override

--- a/Mage.Sets/src/mage/sets/DuelDecksDivineVsDemonic.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksDivineVsDemonic.java
@@ -16,7 +16,7 @@ public final class DuelDecksDivineVsDemonic extends ExpansionSet {
     }
 
     private DuelDecksDivineVsDemonic() {
-        super("Duel Decks: Divine vs. Demonic", "DDC", ExpansionSet.buildDate(2009, 04, 10), SetType.SUPPLEMENTAL);
+        super("Duel Decks: Divine vs. Demonic", "DDC", ExpansionSet.buildDate(2009, 4, 10), SetType.SUPPLEMENTAL);
         this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/DuelDecksJaceVsChandra.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksJaceVsChandra.java
@@ -21,7 +21,7 @@ public final class DuelDecksJaceVsChandra extends ExpansionSet {
     }
 
     private DuelDecksJaceVsChandra() {
-        super("Duel Decks: Jace vs. Chandra", "DD2", ExpansionSet.buildDate(2008, 11, 07), SetType.SUPPLEMENTAL);
+        super("Duel Decks: Jace vs. Chandra", "DD2", ExpansionSet.buildDate(2008, 11, 7), SetType.SUPPLEMENTAL);
         this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/FateReforged.java
+++ b/Mage.Sets/src/mage/sets/FateReforged.java
@@ -19,8 +19,8 @@ public final class FateReforged extends ExpansionSet {
 
     private static final FateReforged instance = new FateReforged();
 
-    List<CardInfo> savedSpecialRares = new ArrayList<>();
-    List<CardInfo> savedSpecialCommon = new ArrayList<>();
+    private List<CardInfo> savedSpecialRares = new ArrayList<>();
+    private List<CardInfo> savedSpecialCommon = new ArrayList<>();
 
     public static FateReforged getInstance() {
         return instance;
@@ -238,7 +238,7 @@ public final class FateReforged extends ExpansionSet {
                 criteria.setCodes(this.code).notTypes(CardType.LAND);
                 savedCardsInfos = CardRepository.instance.findCards(criteria);
                 if (maxCardNumberInBooster != Integer.MAX_VALUE) {
-                    savedCardsInfos.removeIf(next -> next.getCardNumberAsInt() > maxCardNumberInBooster && rarity != Rarity.LAND);
+                    savedCardsInfos.removeIf(next -> next.getCardNumberAsInt() > maxCardNumberInBooster);
                 }
                 savedCards.put(rarity, savedCardsInfos);
             }
@@ -251,7 +251,6 @@ public final class FateReforged extends ExpansionSet {
 
     @Override
     public List<CardInfo> getSpecialCommon() {
-        List<CardInfo> specialCommons = new ArrayList<>();
         if (savedSpecialCommon.isEmpty()) {
             // the 10 common lands from Fate Reforged can show up in the basic lands slot
             // http://magic.wizards.com/en/articles/archive/feature/fetching-look-fate-reforged-2014-12-24
@@ -261,13 +260,11 @@ public final class FateReforged extends ExpansionSet {
             criteria.rarities(Rarity.LAND).setCodes(this.code);
             savedSpecialCommon.addAll(CardRepository.instance.findCards(criteria));
         }
-        specialCommons.addAll(savedSpecialCommon);
-        return specialCommons;
+        return new ArrayList<>(savedSpecialCommon);
     }
 
     @Override
     public List<CardInfo> getSpecialRare() {
-        List<CardInfo> specialRares = new ArrayList<>();
         if (savedSpecialRares.isEmpty()) {
             CardCriteria criteria = new CardCriteria();
             criteria.setCodes("KTK").name("Bloodstained Mire");
@@ -285,7 +282,6 @@ public final class FateReforged extends ExpansionSet {
             criteria.setCodes("KTK").name("Wooded Foothills");
             savedSpecialRares.addAll(CardRepository.instance.findCards(criteria));
         }
-        specialRares.addAll(savedSpecialRares);
-        return specialRares;
+        return new ArrayList<>(savedSpecialRares);
     }
 }

--- a/Mage.Sets/src/mage/sets/HourOfDevastation.java
+++ b/Mage.Sets/src/mage/sets/HourOfDevastation.java
@@ -22,7 +22,7 @@ public final class HourOfDevastation extends ExpansionSet {
         return instance;
     }
 
-    protected final List<CardInfo> savedSpecialLand = new ArrayList<>();
+    private final List<CardInfo> savedSpecialLand = new ArrayList<>();
 
     private HourOfDevastation() {
         super("Hour of Devastation", "HOU", ExpansionSet.buildDate(2017, 7, 14), SetType.EXPANSION);

--- a/Mage.Sets/src/mage/sets/Kaladesh.java
+++ b/Mage.Sets/src/mage/sets/Kaladesh.java
@@ -23,7 +23,7 @@ public final class Kaladesh extends ExpansionSet {
         return instance;
     }
 
-    protected final List<CardInfo> savedSpecialLand = new ArrayList<>();
+    private final List<CardInfo> savedSpecialLand = new ArrayList<>();
 
     private Kaladesh() {
         super("Kaladesh", "KLD", ExpansionSet.buildDate(2016, 9, 30), SetType.EXPANSION);

--- a/Mage.Sets/src/mage/sets/Masters25.java
+++ b/Mage.Sets/src/mage/sets/Masters25.java
@@ -1,14 +1,13 @@
 
 package mage.sets;
 
-/**
- *
- * @author JayDi85
- */
 import mage.cards.ExpansionSet;
 import mage.constants.Rarity;
 import mage.constants.SetType;
 
+/**
+ * @author JayDi85
+ */
 public final class Masters25 extends ExpansionSet {
 
     private static final Masters25 instance = new Masters25();

--- a/Mage.Sets/src/mage/sets/MastersEditionIV.java
+++ b/Mage.Sets/src/mage/sets/MastersEditionIV.java
@@ -22,7 +22,7 @@ public final class MastersEditionIV extends ExpansionSet {
         return instance;
     }
 
-    protected final List<CardInfo> savedSpecialLand = new ArrayList<>();
+    private final List<CardInfo> savedSpecialLand = new ArrayList<>();
 
     private MastersEditionIV() {
         super("Masters Edition IV", "ME4", ExpansionSet.buildDate(2011, 1, 10), SetType.MAGIC_ONLINE);

--- a/Mage.Sets/src/mage/sets/OathOfTheGatewatch.java
+++ b/Mage.Sets/src/mage/sets/OathOfTheGatewatch.java
@@ -26,7 +26,7 @@ public final class OathOfTheGatewatch extends ExpansionSet {
         return instance;
     }
 
-    protected final List<CardInfo> savedSpecialLand = new ArrayList<>();
+    private final List<CardInfo> savedSpecialLand = new ArrayList<>();
 
     private OathOfTheGatewatch() {
         super("Oath of the Gatewatch", "OGW", ExpansionSet.buildDate(2016, 1, 22), SetType.EXPANSION);

--- a/Mage.Sets/src/mage/sets/Portal.java
+++ b/Mage.Sets/src/mage/sets/Portal.java
@@ -12,9 +12,6 @@ public final class Portal extends ExpansionSet {
 
     private static final Portal instance = new Portal();
 
-    /**
-     * @return
-     */
     public static Portal getInstance() {
         return instance;
     }

--- a/Mage.Sets/src/mage/sets/PortalSecondAge.java
+++ b/Mage.Sets/src/mage/sets/PortalSecondAge.java
@@ -13,10 +13,6 @@ public final class PortalSecondAge extends ExpansionSet {
 
     private static final PortalSecondAge instance = new PortalSecondAge();
 
-    /**
-     *
-     * @return
-     */
     public static PortalSecondAge getInstance() {
         return instance;
     }

--- a/Mage.Sets/src/mage/sets/ShadowsOverInnistrad.java
+++ b/Mage.Sets/src/mage/sets/ShadowsOverInnistrad.java
@@ -25,7 +25,7 @@ public final class ShadowsOverInnistrad extends ExpansionSet {
         return instance;
     }
 
-    protected final EnumMap<Rarity, List<CardInfo>> savedDoubleFacedCards;
+    private final EnumMap<Rarity, List<CardInfo>> savedDoubleFacedCards;
 
     private ShadowsOverInnistrad() {
         super("Shadows over Innistrad", "SOI", ExpansionSet.buildDate(2016, 4, 8), SetType.EXPANSION);
@@ -387,7 +387,7 @@ public final class ShadowsOverInnistrad extends ExpansionSet {
         }
     }
 
-    public List<CardInfo> getDoubleFacedCardsByRarity(Rarity rarity) {
+    private List<CardInfo> getDoubleFacedCardsByRarity(Rarity rarity) {
         List<CardInfo> savedCardsInfos = savedDoubleFacedCards.get(rarity);
         if (savedCardsInfos == null) {
             CardCriteria criteria = new CardCriteria();

--- a/Mage.Sets/src/mage/sets/Starter2000.java
+++ b/Mage.Sets/src/mage/sets/Starter2000.java
@@ -13,10 +13,6 @@ public final class Starter2000 extends ExpansionSet {
 
     private static final Starter2000 instance = new Starter2000();
 
-    /**
-     *
-     * @return
-     */
     public static Starter2000 getInstance() {
         return instance;
     }

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/deck/DeckValidatorTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/deck/DeckValidatorTest.java
@@ -28,14 +28,14 @@ public class DeckValidatorTest extends MageTestBase {
 
         int number;
 
-        public CardNameAmount(String setCode, int cardNumber, int number) {
+        CardNameAmount(String setCode, int cardNumber, int number) {
             this.name = "";
             this.setCode = setCode;
             this.cardNumber = String.valueOf(cardNumber);
             this.number = number;
         }
 
-        public CardNameAmount(String name, int number) {
+        CardNameAmount(String name, int number) {
             this.name = name;
             this.number = number;
         }
@@ -48,11 +48,11 @@ public class DeckValidatorTest extends MageTestBase {
             return number;
         }
 
-        public String getSetCode() {
+        String getSetCode() {
             return setCode;
         }
 
-        public String getCardNumber() {
+        String getCardNumber() {
             return cardNumber;
         }
 
@@ -359,6 +359,7 @@ public class DeckValidatorTest extends MageTestBase {
                     cardinfo = CardRepository.instance.findCard(cardNameAmount.getName());
                 }
                 for (int i = 0; i < cardNameAmount.getNumber(); i++) {
+                    assert cardinfo != null;
                     deckToTest.getCards().add(cardinfo.getCard());
                 }
             }
@@ -372,6 +373,7 @@ public class DeckValidatorTest extends MageTestBase {
                     cardinfo = CardRepository.instance.findCard(cardNameAmount.getName());
                 }
                 for (int i = 0; i < cardNameAmount.getNumber(); i++) {
+                    assert cardinfo != null;
                     deckToTest.getSideboard().add(cardinfo.getCard());
                 }
             }

--- a/Mage.Tests/src/test/java/org/mage/test/sets/BoosterGenerationTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/sets/BoosterGenerationTest.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.keyword.PartnerWithAbility;
 import mage.cards.Card;
@@ -144,6 +145,15 @@ public class BoosterGenerationTest extends MageTestBase {
     }
 
     @Test
+    public void testWarOfTheSpark_EveryBoosterContainsPlaneswalker() {
+        for (int i = 0; i < 10; i++) {
+            List<Card> booster = WarOfTheSpark.getInstance().createBooster();
+            // check that booster contains a planeswalker
+            assertTrue(booster.stream().anyMatch(MageObject::isPlaneswalker));
+        }
+    }
+
+    @Test
     public void testDominaria_EveryBoosterContainsLegendaryCreature() {
         for (int i = 0; i < 10; i++) {
             List<Card> booster = Dominaria.getInstance().createBooster();
@@ -161,6 +171,14 @@ public class BoosterGenerationTest extends MageTestBase {
     }
 
     @Test
+    public void testModernHorizons_BoosterMustHaveOneSnowLand() {
+        for (int i = 0; i < 10; i++) {
+            List<Card> booster = ModernHorizons.getInstance().createBooster();
+            assertTrue("Modern Horizon's booster must contain 1 snow covered land", booster.stream().anyMatch(card -> card.isBasic() && card.getName().startsWith("Snow-Covered ")));
+        }
+    }
+
+    @Test
     public void testMastersEditionII_BoosterMustHaveOneSnowLand() {
         for (int i = 0; i < 10; i++) {
             List<Card> booster = MastersEditionII.getInstance().createBooster();
@@ -171,7 +189,7 @@ public class BoosterGenerationTest extends MageTestBase {
     @Test
     public void testBattlebond_BoosterMustHaveOneLand() {
         for (int i = 0; i < 10; i++) {
-            List<Card> booster = Coldsnap.getInstance().createBooster();
+            List<Card> booster = Battlebond.getInstance().createBooster();
             assertTrue("battlebond's booster must contain 1 land", booster.stream().anyMatch(card -> card.isBasic() && card.isLand()));
         }
     }


### PR DESCRIPTION
Fix various hints and warnings on many set & block classes (via IntelliJ IDEA linting):
- replacing hard coded strings of set codes with reference to 'mage.sets.<set>.getInstance().getCode()' allows for set class names to no longer show as unreferenced & adds for more consistence between other block units
- various protected variables were able to be changed to private to clean up additional warnings
- some JavaDoc comments were generating warnings due to missing documentation
- removed some unused imports and unused variables
- there were multiple conditional logic checks for 'rarity != Rarity.LAND' within an if block where the outer condition was 'if rarity == Rarity.COMMON' rendering the inner condition always true and thus redundant
- a few ExpansionSet.buildDate parameters wer using octal values (eg. '03' instead of '3') which triggered some warnings
- added a booster generation test for WarOfTheSparks to make sure every booster contains a planeswalker
- added a booster generation test for ModernHorizons to make sure every booster contains a snow land
- booster generation test for Battlbond set referenced the Coldsnap set class instead of Battlebond