### PR TITLE
add unit test for hapatra vizier of poisons + fix issue #5886

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CorrosiveMentor.java
+++ b/Mage.Sets/src/mage/cards/c/CorrosiveMentor.java
@@ -14,6 +14,7 @@ import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
+import mage.filter.predicate.mageobject.CardTypePredicate;
 import mage.filter.predicate.mageobject.ColorPredicate;
 
 /**
@@ -26,6 +27,7 @@ public final class CorrosiveMentor extends CardImpl {
 
     static {
         filter.add(new ColorPredicate(ObjectColor.BLACK));
+        filter.add(new CardTypePredicate(CardType.CREATURE));
     }
 
     public CorrosiveMentor(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/akh/HapatraVizierOfPoisonsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/akh/HapatraVizierOfPoisonsTest.java
@@ -110,6 +110,7 @@ public class HapatraVizierOfPoisonsTest extends CardTestPlayerBase {
         String krakenHatchling = "Kraken Hatchling"; //Arbitrary creature to defend
         String triumphOfTheHordes = "Triumph of the Hordes"; //Creatures you control gain infect
         String sprout = "Sprout"; //Create a 1/1 Saproling creature token
+        
         addCard(Zone.HAND, playerA, sprout, 1);
         addCard(Zone.HAND, playerA, triumphOfTheHordes, 1);
 
@@ -124,10 +125,12 @@ public class HapatraVizierOfPoisonsTest extends CardTestPlayerBase {
         attack(1, playerA, "Saproling");
         block(1, playerB, krakenHatchling, "Saproling");
         setStopAt(1, PhaseStep.END_COMBAT);
+        setStrictChooseMode(true);
         execute();
 
         assertPowerToughness(playerB, krakenHatchling, -2, 2);
         assertCounterCount(playerB, krakenHatchling, CounterType.M1M1, 2);
         assertPermanentCount(playerA, "Snake", 1); //Should have triggered when Saproling added -1/-1 counter
+        assertAllCommandsUsed();
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/akh/HapatraVizierOfPoisonsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/akh/HapatraVizierOfPoisonsTest.java
@@ -98,4 +98,36 @@ public class HapatraVizierOfPoisonsTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Snake", 1);
         assertAbility(playerA, "Snake", DeathtouchAbility.getInstance(), true);
     }
+
+    /**
+     * Testing fix for issue #5886
+     * Tokens with wither/infect that deal damage were not triggering Hapatra's snake creating ability
+     * @author jgray1206
+     */
+    @Test
+    public void testTokensWithInfectTriggerHapatra() {
+        String concordantCrossroads = "Concordant Crossroads"; //All creatures have haste
+        String krakenHatchling = "Kraken Hatchling"; //Arbitrary creature to defend
+        String triumphOfTheHordes = "Triumph of the Hordes"; //Creatures you control gain infect
+        String sprout = "Sprout"; //Create a 1/1 Saproling creature token
+        addCard(Zone.HAND, playerA, sprout, 1);
+        addCard(Zone.HAND, playerA, triumphOfTheHordes, 1);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 6);
+        addCard(Zone.BATTLEFIELD, playerA, hapatra, 1);
+        addCard(Zone.BATTLEFIELD, playerA, concordantCrossroads, 1);
+        addCard(Zone.BATTLEFIELD, playerB, krakenHatchling, 1);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, sprout);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, triumphOfTheHordes);
+
+        attack(1, playerA, "Saproling");
+        block(1, playerB, krakenHatchling, "Saproling");
+        setStopAt(1, PhaseStep.END_COMBAT);
+        execute();
+
+        assertPowerToughness(playerB, krakenHatchling, -2, 2);
+        assertCounterCount(playerB, krakenHatchling, CounterType.M1M1, 2);
+        assertPermanentCount(playerA, "Snake", 1); //Should have triggered when Saproling added -1/-1 counter
+    }
 }

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -5,6 +5,7 @@ import mage.MageObjectReference;
 import mage.ObjectColor;
 import mage.abilities.Abilities;
 import mage.abilities.Ability;
+import mage.abilities.SpellAbility;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.RestrictionEffect;
@@ -888,7 +889,13 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
         }
         for (MarkedDamageInfo mdi : markedDamage) {
             Ability source = null;
-            if (mdi.sourceObject instanceof Permanent) {
+            if (mdi.sourceObject instanceof PermanentToken) {
+                /* Tokens dont have a spellAbility. We must make a phony one as the source so the events in addCounters
+                 * can trace the source back to an object/controller.
+                 */
+                source = new SpellAbility(null, ((PermanentToken) mdi.sourceObject).name);
+                source.setSourceId(((PermanentToken) mdi.sourceObject).objectId);
+            } else if (mdi.sourceObject instanceof Permanent) {
                 source = ((Permanent) mdi.sourceObject).getSpellAbility();
             }
             addCounters(mdi.counter, source, game);


### PR DESCRIPTION
also noticed that Corrosive Mentor was giving wither to non-creature cards. Added a quick fix for that, too.