### PR TITLE
Bolas's Citadel + Split cards fix

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -1726,7 +1726,7 @@ public class HumanPlayer extends PlayerImpl {
             if (ability instanceof PlayLandAbility) {
                 return true;
             }
-            if (!ability.getSourceId().equals(getCastSourceIdWithAlternateMana())
+            if (!getCastSourceIdWithAlternateManaMap().containsKey(ability.getSourceId())
                     && ability.getManaCostsToPay().convertedManaCost() > 0) {
                 return true;
             }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/BolassCitadelTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/BolassCitadelTest.java
@@ -37,13 +37,14 @@ public class BolassCitadelTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Revival", snubhorn);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        setStrictChooseMode(true);
         execute();
 
         assertLife(playerA, 18);
         assertGraveyardCount(playerA, snubhorn, 0);
         assertPermanentCount(playerA, snubhorn, 1);
         assertGraveyardCount(playerA, revivalRevenge, 1);
-
+        assertAllCommandsUsed();
     }
 
     /*
@@ -58,10 +59,12 @@ public class BolassCitadelTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, krakenHatchling);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        setStrictChooseMode(true);
         execute();
 
         assertLife(playerA, 19);
         assertPermanentCount(playerA, krakenHatchling, 1);
+        assertAllCommandsUsed();
     }
 
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/BolassCitadelTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/BolassCitadelTest.java
@@ -7,45 +7,61 @@ import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
- *
  * @author jgray1206
  */
 public class BolassCitadelTest extends CardTestPlayerBase {
 
+    /*Bolas's Citadel {3}{B}{B}{B}
+     *You may look at the top card of your library any time.
+     *You may play the top card of your library. If you cast a spell this way, pay life equal to its converted mana cost rather than pay its mana cost.
+     *{T}, Sacrifice ten nonland permanents: Each opponent loses 10 life.
+     */
     private String bolass = "Bolas's Citadel";
 
+    /*
+     * Issue #5912: Bolas's is not able to cast split cards off top of deck with life.
+     */
     @Test
     public void testBolassCastSplitCardOffTopOfDeckWithLife() {
 
+        /* Arbitrary split card
+         * Return target creature card with converted mana cost 3 or less from your graveyard to the battlefield
+         */
+        String revivalRevenge = "Revival // Revenge";
+        String snubhorn = "Snubhorn Sentry"; //Arbitrary creature with converted mana cost < 3
+
         addCard(Zone.BATTLEFIELD, playerA, bolass, 1);
-        addCard(Zone.LIBRARY, playerA, "Revival // Revenge");
-        addCard(Zone.GRAVEYARD, playerA, "Snubhorn Sentry");
+        addCard(Zone.LIBRARY, playerA, revivalRevenge);
+        addCard(Zone.GRAVEYARD, playerA, snubhorn);
         skipInitShuffling();
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Revival", "Snubhorn Sentry");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Revival", snubhorn);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
         assertLife(playerA, 18);
-        assertGraveyardCount(playerA, "Snubhorn Sentry", 0);
-        assertPermanentCount(playerA, "Snubhorn Sentry", 1);
-        assertGraveyardCount(playerA, "Revival // Revenge", 1);
+        assertGraveyardCount(playerA, snubhorn, 0);
+        assertPermanentCount(playerA, snubhorn, 1);
+        assertGraveyardCount(playerA, revivalRevenge, 1);
 
     }
 
+    /*
+     * Test basic functionality of Bolas's
+     */
     @Test
     public void testBolassCastCardOffTopOfDeckWithLife() {
-
+        String krakenHatchling = "Kraken Hatchling"; //Arbitrary creature to cast using life
         addCard(Zone.BATTLEFIELD, playerA, bolass, 1);
-        addCard(Zone.LIBRARY, playerA, "Kraken Hatchling");
+        addCard(Zone.LIBRARY, playerA, krakenHatchling);
         skipInitShuffling();
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Kraken Hatchling");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, krakenHatchling);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
         assertLife(playerA, 19);
-        assertPermanentCount(playerA, "Kraken Hatchling", 1);
+        assertPermanentCount(playerA, krakenHatchling, 1);
     }
 
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/BolassCitadelTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/BolassCitadelTest.java
@@ -1,0 +1,51 @@
+
+package org.mage.test.cards.single;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author jgray1206
+ */
+public class BolassCitadelTest extends CardTestPlayerBase {
+
+    private String bolass = "Bolas's Citadel";
+
+    @Test
+    public void testBolassCastSplitCardOffTopOfDeckWithLife() {
+
+        addCard(Zone.BATTLEFIELD, playerA, bolass, 1);
+        addCard(Zone.LIBRARY, playerA, "Revival // Revenge");
+        addCard(Zone.GRAVEYARD, playerA, "Snubhorn Sentry");
+        skipInitShuffling();
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Revival", "Snubhorn Sentry");
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertLife(playerA, 18);
+        assertGraveyardCount(playerA, "Snubhorn Sentry", 0);
+        assertPermanentCount(playerA, "Snubhorn Sentry", 1);
+        assertGraveyardCount(playerA, "Revival // Revenge", 1);
+
+    }
+
+    @Test
+    public void testBolassCastCardOffTopOfDeckWithLife() {
+
+        addCard(Zone.BATTLEFIELD, playerA, bolass, 1);
+        addCard(Zone.LIBRARY, playerA, "Kraken Hatchling");
+        skipInitShuffling();
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Kraken Hatchling");
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertLife(playerA, 19);
+        assertPermanentCount(playerA, "Kraken Hatchling", 1);
+    }
+
+}

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -2341,19 +2341,10 @@ public class TestPlayer implements Player {
         computerPlayer.setCastSourceIdWithAlternateMana(sourceId, manaCosts, costs);
     }
 
-    @Override
-    public UUID getCastSourceIdWithAlternateMana() {
-        return computerPlayer.getCastSourceIdWithAlternateMana();
-    }
 
     @Override
-    public ManaCosts getCastSourceIdManaCosts() {
-        return computerPlayer.getCastSourceIdManaCosts();
-    }
-
-    @Override
-    public Costs<Cost> getCastSourceIdCosts() {
-        return computerPlayer.getCastSourceIdCosts();
+    public Map<UUID, AlternateManaCosts> getCastSourceIdWithAlternateManaMap() {
+        return computerPlayer.getCastSourceIdWithAlternateManaMap();
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
+++ b/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
@@ -1207,24 +1207,15 @@ public class PlayerStub implements Player {
     }
 
     @Override
-    public UUID getCastSourceIdWithAlternateMana() {
-        return null;
-    }
-
-    @Override
     public void setCastSourceIdWithAlternateMana(UUID sourceId, ManaCosts<ManaCost> manaCosts, Costs<Cost> costs) {
 
     }
 
     @Override
-    public ManaCosts getCastSourceIdManaCosts() {
+    public Map<UUID, AlternateManaCosts> getCastSourceIdWithAlternateManaMap() {
         return null;
     }
 
-    @Override
-    public Costs<Cost> getCastSourceIdCosts() {
-        return null;
-    }
 
     @Override
     public void addPermissionToShowHandCards(UUID watcherUserId) {

--- a/Mage/src/main/java/mage/abilities/SpellAbility.java
+++ b/Mage/src/main/java/mage/abilities/SpellAbility.java
@@ -93,7 +93,7 @@ public class SpellAbility extends ActivatedAbilityImpl {
             // Alternate spell abilities (Flashback, Overload) can't be cast with no mana to pay option
             if (getSpellAbilityType() == SpellAbilityType.BASE_ALTERNATE) {
                 Player player = game.getPlayer(playerId);
-                if (player != null && getSourceId().equals(player.getCastSourceIdWithAlternateMana())) {
+                if (player != null && player.getCastSourceIdWithAlternateManaMap().containsKey(getSourceId())) {
                     return ActivationStatus.getFalse();
                 }
             }

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -846,11 +846,12 @@ public interface Player extends MageItem, Copyable<Player> {
      */
     void setCastSourceIdWithAlternateMana(UUID sourceId, ManaCosts<ManaCost> manaCosts, Costs<Cost> costs);
 
-    UUID getCastSourceIdWithAlternateMana();
+    class AlternateManaCosts {
+        ManaCosts<ManaCost> castSourceIdManaCosts;
+        Costs<Cost> castSourceIdCosts;
+    }
 
-    ManaCosts<ManaCost> getCastSourceIdManaCosts();
-
-    Costs<Cost> getCastSourceIdCosts();
+    Map<UUID, AlternateManaCosts> getCastSourceIdWithAlternateManaMap();
 
     // permission handling to show hand cards
     void addPermissionToShowHandCards(UUID watcherUserId);


### PR DESCRIPTION
Split cards were not being source-id-cost-modified by Bolas's correctly. This is because the way Bolas sets the modification (on the controller) only allowed it to modify one card cost at a time. I have replaced that one at a time system with a map that will allow multiple cards (which should only ever be the two cards in a split card or one card). This fixes the original issue, and will perhaps solve this issue for other cards that modify split card costs like this. 