### PR TITLE
Fix pass with mana in pool message when activating macro

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -911,7 +911,7 @@ public class HumanPlayer extends PlayerImpl {
                 }
                 if (response.getBoolean() != null
                         || response.getInteger() != null) {
-                    if (passWithManaPoolCheck(game) && !activatingMacro) {
+                    if (!activatingMacro && passWithManaPoolCheck(game)) {
                         return false;
                     } else {
                         if (activatingMacro) {


### PR DESCRIPTION
Suppress the pass with mana in pool question when activating a macro with mana in the pool.
For example now you are able to make a macro producing mana with Devoted Druid and Vizier of Remedies.