### PR TITLE
Fix rules text for abilities with up to one target

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/text/WrennAndSixTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/text/WrennAndSixTest.java
@@ -1,0 +1,17 @@
+package org.mage.test.cards.text;
+
+import mage.cards.Card;
+import mage.cards.repository.CardRepository;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class WrennAndSixTest {
+
+    @Test
+    public void testFirstLoyaltyAbilityRulesText() {
+        Card wrennAndSix = CardRepository.instance.findCard("Wrenn and Six").getCard();
+        String firstLoyaltyAbilityRulesText = wrennAndSix.getRules().get(0);
+
+        Assert.assertEquals(firstLoyaltyAbilityRulesText, "+1: Return up to one target land card from your graveyard to your hand.");
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnFromGraveyardToHandTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnFromGraveyardToHandTargetEffect.java
@@ -56,10 +56,10 @@ public class ReturnFromGraveyardToHandTargetEffect extends OneShotEffect {
         StringBuilder sb = new StringBuilder();
         Target target = mode.getTargets().get(0);
         sb.append("return ");
-        if (target.getMaxNumberOfTargets() > 1) {
-            if (target.getMaxNumberOfTargets() != target.getNumberOfTargets()) {
-                sb.append("up to ");
-            }
+        if (target.getMaxNumberOfTargets() != target.getNumberOfTargets()) {
+            sb.append("up to ");
+            sb.append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(' ');
+        } else if (target.getMaxNumberOfTargets() > 1) {
             sb.append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(' ');
         }
         if (!mode.getTargets().get(0).getTargetName().startsWith("another")) {


### PR DESCRIPTION
Wrenn and Six's first loyalty ability currently reads "+1: Return target land card from your graveyard to your hand", missing the "up to one". The target is in fact optional; it's just that the rules text is being generated incorrectly.