### PR TITLE
Fix creature type on Rekindling Phoenix token.

### DIFF
--- a/Mage/src/main/java/mage/game/permanent/token/RekindlingPhoenixToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/RekindlingPhoenixToken.java
@@ -27,7 +27,7 @@ public final class RekindlingPhoenixToken extends TokenImpl {
         super("Elemental", "0/1 red Elemental creature token with \"At the beginning of your upkeep, sacrifice this creature and return target card named Rekindling Phoenix from your graveyard to the battlefield. It gains haste until end of turn.\"");
         setTokenType(1);
         cardType.add(CardType.CREATURE);
-        subtype.add(SubType.THRULL);
+        subtype.add(SubType.ELEMENTAL);
         color.setRed(true);
         power = new MageInt(0);
         toughness = new MageInt(1);


### PR DESCRIPTION
Type should be Elemental, not Thrull.