### PR TITLE
Check Archfiend of Spite trigger on CREATURE_DAMAGED

### DIFF
--- a/Mage.Sets/src/mage/cards/a/ArchfiendOfSpite.java
+++ b/Mage.Sets/src/mage/cards/a/ArchfiendOfSpite.java
@@ -73,7 +73,7 @@ class ArchfiendOfSpiteAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.DAMAGED_PLAYER;
+        return event.getType() == GameEvent.EventType.DAMAGED_CREATURE;
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ArchfiendOfSpiteTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ArchfiendOfSpiteTest.java
@@ -1,0 +1,32 @@
+package org.mage.test.cards.single;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class ArchfiendOfSpiteTest extends CardTestPlayerBase {
+
+    @Test
+    public void damageTriggerTest() {
+        addCard(Zone.BATTLEFIELD, playerA, "Archfiend of Spite");
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain", 1);
+        addCard(Zone.HAND, playerB, "Lightning Bolt", 1);
+        setStopAt(1, PhaseStep.UNTAP);
+        execute();
+
+        assertPermanentCount(playerA, "Archfiend of Spite", 1);
+        assertLife(playerB, 20);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Lightning Bolt", "Archfiend of Spite");
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        setStrictChooseMode(true);
+        execute();
+
+        assertPermanentCount(playerA, "Archfiend of Spite", 1);
+        assertPermanentCount(playerB, "Mountain", 1);
+        assertDamageReceived(playerA, "Archfiend of Spite", 3);
+        assertLife(playerB, 17);
+    }
+}


### PR DESCRIPTION
Currently, it ignored the trigger unless a player was also damaged (by other unblocked attacking creatures, for example), so there are plenty of situations where it will fail to occur.

The included test fails against current master, but passes with the patch.

Fixes #5971.

**NOTE:** This is my first non-trivial patch to Xmage so please be gentle :) Trying to figure out this code base as best as I can.