### PR TITLE
Fix incorrect trigger for Syr Konrad (READY FOR REVIEW/MERGING)

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SyrKonradTheGrim.java
+++ b/Mage.Sets/src/mage/cards/s/SyrKonradTheGrim.java
@@ -72,6 +72,7 @@ class SyrKonradTheGrimTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         ZoneChangeEvent zEvent = (ZoneChangeEvent) event;
+        // Whenever another creature dies
         if (zEvent.isDiesEvent()
                 && zEvent.getTarget() != null
                 && !zEvent.getTargetId().equals(this.getSourceId())
@@ -79,6 +80,7 @@ class SyrKonradTheGrimTriggeredAbility extends TriggeredAbilityImpl {
             return true;
         }
         Card card = game.getCard(zEvent.getTargetId());
+        // Or a creature card is put into a graveyard from anywhere other than the battlefield
         if (card == null || !card.isCreature()) {
             return false;
         }
@@ -86,7 +88,9 @@ class SyrKonradTheGrimTriggeredAbility extends TriggeredAbilityImpl {
                 && zEvent.getFromZone() != Zone.BATTLEFIELD) {
             return true;
         }
-        return zEvent.getFromZone() == Zone.GRAVEYARD;
+        // Or a creature card leaves your graveyard
+        return zEvent.getFromZone() == Zone.GRAVEYARD
+                && zEvent.getPlayerId() == this.getControllerId();
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ArchfiendOfSpiteTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ArchfiendOfSpiteTest.java
@@ -2,7 +2,6 @@ package org.mage.test.cards.single;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/SyrKonradTheGrimTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/SyrKonradTheGrimTest.java
@@ -8,11 +8,13 @@ import org.mage.test.serverside.base.CardTestPlayerBase;
 public class SyrKonradTheGrimTest extends CardTestPlayerBase {
 
     @Test
-    public void ownGraveyardTriggerTest() {
+    public void leavesOwnGraveyardTriggerTest() {
         addCard(Zone.HAND, playerA, "Rest in Peace");
         addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
         addCard(Zone.BATTLEFIELD, playerA, "Syr Konrad, the Grim");
+        // These leaving the graveyard *should* cause loss of life
         addCard(Zone.GRAVEYARD, playerA, "Grizzly Bears", 2);
+        // These ones *shouldn't*
         addCard(Zone.GRAVEYARD, playerB, "Grizzly Bears");
         setStopAt(1, PhaseStep.UNTAP);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/SyrKonradTheGrimTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/SyrKonradTheGrimTest.java
@@ -1,0 +1,31 @@
+package org.mage.test.cards.single;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class SyrKonradTheGrimTest extends CardTestPlayerBase {
+
+    @Test
+    public void ownGraveyardTriggerTest() {
+        addCard(Zone.HAND, playerA, "Rest in Peace");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Syr Konrad, the Grim");
+        addCard(Zone.GRAVEYARD, playerA, "Grizzly Bears", 2);
+        addCard(Zone.GRAVEYARD, playerB, "Grizzly Bears");
+        setStopAt(1, PhaseStep.UNTAP);
+        execute();
+
+        assertLife(playerB, 20);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Rest in Peace");
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertGraveyardCount(playerA, 0);
+        assertGraveyardCount(playerB, 0);
+        assertLife(playerA, 20);
+        assertLife(playerB, 18);
+    }
+}


### PR DESCRIPTION
His ability should only trigger on creatures leaving the controller's graveyard, not any graveyard. Thanks to [OvenmittsMTG](https://www.reddit.com/r/XMage/comments/dgajw2/syr_konrad_coded_wrong/) on Reddit for reporting.

  - [x] Add a failing test that higlights the issue
  - [x] Implement a fix