### PR TITLE
Implemented Crown of Fury

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CrownOfFury.java
+++ b/Mage.Sets/src/mage/cards/c/CrownOfFury.java
@@ -1,0 +1,104 @@
+
+package mage.cards.c;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.common.SacrificeSourceCost;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.effects.common.continuous.BoostAllEffect;
+import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
+import mage.abilities.keyword.EnchantAbility;
+import mage.abilities.keyword.FirstStrikeAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.common.FilterOtherCreatureSharingCreatureSubtype;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetCreaturePermanent;
+
+/**
+ *
+ * @author t-schroeder
+ */
+public final class CrownOfFury extends CardImpl {
+
+    public CrownOfFury(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{R}");
+        this.subtype.add(SubType.AURA);
+        
+        TargetPermanent auraTarget = new TargetCreaturePermanent();
+        this.getSpellAbility().addTarget(auraTarget);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.BoostCreature));
+        Ability ability = new EnchantAbility(auraTarget.getTargetName());
+        this.addAbility(ability);
+
+        // Enchanted creature gets +1/+0 and has first strike.
+        Effect effect = new BoostEnchantedEffect(1, 0, Duration.WhileOnBattlefield);
+        effect.setText("enchanted creature gets +1/+0");
+        ability = new SimpleStaticAbility(Zone.BATTLEFIELD, effect);
+        effect = new GainAbilityAttachedEffect(FirstStrikeAbility.getInstance(), AttachmentType.AURA);
+        effect.setText("and has first strike");
+        ability.addEffect(effect);
+        this.addAbility(ability);
+
+        // Sacrifice Crown of Fury: Enchanted creature and other creatures that share a creature type with it get +1/+0 and gain first strike until end of turn.
+        ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new CrownOfFuryEffect(), new SacrificeSourceCost());
+        this.addAbility(ability);
+    }
+
+    public CrownOfFury(final CrownOfFury card) {
+        super(card);
+    }
+
+    @Override
+    public CrownOfFury copy() {
+        return new CrownOfFury(this);
+    }
+}
+
+class CrownOfFuryEffect extends OneShotEffect {
+
+    public CrownOfFuryEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "Enchanted creature and other creatures that share a creature type with it get +1/+0 and gain first strike until end of turn.";
+    }
+
+    public CrownOfFuryEffect(final CrownOfFuryEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public CrownOfFuryEffect copy() {
+        return new CrownOfFuryEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+
+        // Enchanted creature ...
+        ContinuousEffect effect = new BoostEnchantedEffect(1, 0, Duration.EndOfTurn);
+        game.addEffect(effect, source);
+        effect = new GainAbilityAttachedEffect(FirstStrikeAbility.getInstance(), AttachmentType.AURA, Duration.EndOfTurn);
+        game.addEffect(effect, source);
+
+        // ... and other creatures that share a creature type with it ...
+        Permanent enchantedCreature = game.getPermanent(source.getSourcePermanentOrLKI(game).getAttachedTo());
+        FilterCreaturePermanent filter = new FilterOtherCreatureSharingCreatureSubtype(enchantedCreature, game);
+        game.addEffect(new BoostAllEffect(1, 0, Duration.EndOfTurn, filter, false), source);
+        game.addEffect(new GainAbilityAllEffect(FirstStrikeAbility.getInstance(), Duration.EndOfTurn, filter), source);
+
+        // ... get +1/+0 and gain first strike until end of turn.
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/sets/Onslaught.java
+++ b/Mage.Sets/src/mage/sets/Onslaught.java
@@ -86,6 +86,7 @@ public final class Onslaught extends ExpansionSet {
         cards.add(new SetCardInfo("Cover of Darkness", 133, Rarity.RARE, mage.cards.c.CoverOfDarkness.class));
         cards.add(new SetCardInfo("Crafty Pathmage", 77, Rarity.COMMON, mage.cards.c.CraftyPathmage.class));
         cards.add(new SetCardInfo("Crowd Favorites", 15, Rarity.UNCOMMON, mage.cards.c.CrowdFavorites.class));
+        cards.add(new SetCardInfo("Crown of Fury", 196, Rarity.COMMON, mage.cards.c.CrownOfFury.class));
         cards.add(new SetCardInfo("Crude Rampart", 17, Rarity.UNCOMMON, mage.cards.c.CrudeRampart.class));
         cards.add(new SetCardInfo("Cruel Revival", 135, Rarity.COMMON, mage.cards.c.CruelRevival.class));
         cards.add(new SetCardInfo("Cryptic Gateway", 306, Rarity.RARE, mage.cards.c.CrypticGateway.class));

--- a/Mage/src/main/java/mage/filter/common/FilterOtherCreatureSharingCreatureSubtype.java
+++ b/Mage/src/main/java/mage/filter/common/FilterOtherCreatureSharingCreatureSubtype.java
@@ -1,0 +1,45 @@
+
+package mage.filter.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import mage.constants.SubType;
+import mage.constants.SubTypeSet;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.SubtypePredicate;
+import mage.filter.predicate.permanent.PermanentIdPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+/**
+ *
+ * @author tschroeder
+ */
+
+public class FilterOtherCreatureSharingCreatureSubtype extends FilterCreaturePermanent {
+
+    public FilterOtherCreatureSharingCreatureSubtype(Permanent creature, Game game) {
+        super("creature sharing a creature type with " + creature.toString());
+
+        List<SubtypePredicate> subtypePredicates = new ArrayList<>();
+        for (SubType subtype : creature.getSubtype(game)) {
+            if (subtype.getSubTypeSet() == SubTypeSet.CreatureType) {
+                subtypePredicates.add(new SubtypePredicate(subtype));
+            }
+        }
+        this.add(Predicates.and(
+            Predicates.or(subtypePredicates),
+            Predicates.not(new PermanentIdPredicate(creature.getId()))
+        ));
+    }
+
+    public FilterOtherCreatureSharingCreatureSubtype(final FilterOtherCreatureSharingCreatureSubtype filter) {
+        super(filter);
+    }
+
+    @Override
+    public FilterOtherCreatureSharingCreatureSubtype copy() {
+        return new FilterOtherCreatureSharingCreatureSubtype(this);
+    }
+}


### PR DESCRIPTION
Here's my reasoning behind this implementation: The card text says when you sacrifice it "enchanted creature and other creatures that share a creature type with it" get the bonus. At first I just wanted to use one filter that matches all creatures having any of the creatures types of the enchanted one. That would match both the enchanted creature and the others. But what if the enchanted creature had no creature type? (I don't know that many Magic cards. Is this possible?) Then the enchanted creature itself wouldn't get the effect. But since the card text says "enchanted creature and other creatures [...]" I thought we need to add the effect(s) to the enchanted creature independent of whether it even has a creature type. Therefore I added a new Filter class for matching all creatures that have a creature type in common with a given creature permanent, except for that creature permanent itself.