### PR TITLE
Fix filtering bug in Leyline of Abundance.

### DIFF
--- a/Mage.Sets/src/mage/cards/l/LeylineOfAbundance.java
+++ b/Mage.Sets/src/mage/cards/l/LeylineOfAbundance.java
@@ -15,7 +15,7 @@ import mage.constants.SetTargetPointer;
 import mage.counters.CounterType;
 import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.common.FilterControlledCreaturePermanent;
 
 import java.util.UUID;
 
@@ -24,7 +24,7 @@ import java.util.UUID;
  */
 public final class LeylineOfAbundance extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterCreaturePermanent("you tap a creature");
+    private static final FilterPermanent filter = new FilterControlledCreaturePermanent("you tap a creature");
 
     public LeylineOfAbundance(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{G}{G}");

--- a/Mage.Tests/src/test/java/org/mage/test/cards/mana/LeylineOfAbundanceTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/mana/LeylineOfAbundanceTest.java
@@ -1,0 +1,37 @@
+
+package org.mage.test.cards.mana;
+
+import mage.constants.ManaType;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author apetresc
+ */
+public class LeylineOfAbundanceTest extends CardTestPlayerBase {
+
+    /**
+     * Creatures an opponent controls shouldn't trigger Leyline's ability to
+     * generate additional mana.
+     */
+    @Test
+    public void testOpponentsManaCreatures() {
+        addCard(Zone.BATTLEFIELD, playerA, "Upwelling", 1);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Leyline of Abundance");
+        addCard(Zone.BATTLEFIELD, playerB, "Llanowar Elves");
+        addCard(Zone.BATTLEFIELD, playerB, "Leyline of Abundance");
+
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerB, "{T}: Add {G}");
+        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertManaPool(playerB, ManaType.GREEN, 2);
+        assertManaPool(playerA, ManaType.GREEN, 0);
+    }
+}
+


### PR DESCRIPTION
Basically the abundance effect was triggering on your opponents' mana creatures too. Now it should only trigger on your own. Added previously-failing test as well.

Fixes #6052.