### PR TITLE
Fix Tectonic Hellion's ability crashing

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TectonicHellion.java
+++ b/Mage.Sets/src/mage/cards/t/TectonicHellion.java
@@ -70,9 +70,8 @@ class TectonicHellionEffect extends OneShotEffect {
         Map<UUID, Integer> landMap = new HashMap<>();
         game.getState()
                 .getPlayersInRange(source.getControllerId(), game)
-                .stream()
-                .map(uuid -> landMap.put(uuid, game.getBattlefield().getActivePermanents(
-                        StaticFilters.FILTER_LAND, uuid, source.getSourceId(), game
+                .forEach(uuid -> landMap.put(uuid, game.getBattlefield().getActivePermanents(
+                        StaticFilters.FILTER_CONTROLLED_PERMANENT_LAND, uuid, source.getSourceId(), game
                 ).size()));
         int max = landMap
                 .values()


### PR DESCRIPTION
Fix NoSuchElementException when resolving Tectonic Hellion's triggered ability.

Also fix filtering, so that only a player's controlled lands are counted, not every land in a player's range of influence.