### PR TITLE
Fixed Rankle's triggered ability

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -1830,6 +1830,11 @@ public class HumanPlayer extends PlayerImpl {
                             }
                         }
                     }
+                    else if (modes.getSelectedModes().size() >= modes.getMinModes() &&
+                             modes.getSelectedModes().size() <= modes.getMaxModes()) {
+                        /* let the player cancel mode selection if they do not need to select any further modes */
+                        done = true;
+                    }
                     if (source.getAbilityType() != AbilityType.TRIGGERED) {
                         done = true;
                     }

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -1830,8 +1830,7 @@ public class HumanPlayer extends PlayerImpl {
                             }
                         }
                     }
-                    else if (modes.getSelectedModes().size() >= modes.getMinModes() &&
-                             modes.getSelectedModes().size() <= modes.getMaxModes()) {
+                    else if (modes.getSelectedModes().size() >= modes.getMinModes()) {
                         /* let the player cancel mode selection if they do not need to select any further modes */
                         done = true;
                     }

--- a/Mage.Sets/src/mage/cards/r/RankleMasterOfPranks.java
+++ b/Mage.Sets/src/mage/cards/r/RankleMasterOfPranks.java
@@ -51,7 +51,7 @@ public final class RankleMasterOfPranks extends CardImpl {
         // • Each player sacrifices a creature.
         ability.addMode(new Mode(new SacrificeAllEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
 
-        ability.getModes().setMinModes(1);
+        ability.getModes().setMinModes(0);
         ability.getModes().setMaxModes(3);
         ability.getModes().setChooseText("choose any number &mdash;");
         this.addAbility(ability);

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -229,6 +229,7 @@ public abstract class AbilityImpl implements Ability {
         if (!getModes().choose(game, this)) {
             return false;
         }
+        
 
         MageObject sourceObject = getSourceObject(game);
         if (getSourceObjectZoneChangeCounter() == 0) {
@@ -1192,7 +1193,7 @@ public abstract class AbilityImpl implements Ability {
 
     protected String getTargetDescriptionForLog(Targets targets, Game game) {
         StringBuilder sb = new StringBuilder(); // threadLocal StringBuilder can't be used because calling method already uses it
-        if (!targets.isEmpty()) {
+        if (targets != null && !targets.isEmpty()) {
             String usedVerb = null;
             for (Target target : targets) {
                 if (!target.getTargets().isEmpty()) {

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -229,7 +229,6 @@ public abstract class AbilityImpl implements Ability {
         if (!getModes().choose(game, this)) {
             return false;
         }
-        
 
         MageObject sourceObject = getSourceObject(game);
         if (getSourceObjectZoneChangeCounter() == 0) {

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -924,7 +924,7 @@ public abstract class AbilityImpl implements Ability {
         if (getModes().getMode() != null) {
             return getModes().getMode().getTargets();
         }
-        return null;
+        return new Targets();
     }
 
     @Override
@@ -1192,7 +1192,7 @@ public abstract class AbilityImpl implements Ability {
 
     protected String getTargetDescriptionForLog(Targets targets, Game game) {
         StringBuilder sb = new StringBuilder(); // threadLocal StringBuilder can't be used because calling method already uses it
-        if (targets != null && !targets.isEmpty()) {
+        if (!targets.isEmpty()) {
             String usedVerb = null;
             for (Target target : targets) {
                 if (!target.getTargets().isEmpty()) {

--- a/Mage/src/main/java/mage/game/stack/StackAbility.java
+++ b/Mage/src/main/java/mage/game/stack/StackAbility.java
@@ -81,13 +81,7 @@ public class StackAbility extends StackObjImpl implements Ability {
 
     @Override
     public boolean resolve(Game game) {
-        Targets targets = ability.getTargets();
-        if (targets == null) {
-            boolean result = ability.resolve(game);
-            game.getStack().remove(this, game);
-            return result;
-        }
-        if (targets.stillLegal(ability, game) || !canFizzle()) {
+        if (ability.getTargets().stillLegal(ability, game) || !canFizzle()) {
             boolean result = ability.resolve(game);
             game.getStack().remove(this, game);
             return result;

--- a/Mage/src/main/java/mage/game/stack/StackAbility.java
+++ b/Mage/src/main/java/mage/game/stack/StackAbility.java
@@ -81,7 +81,13 @@ public class StackAbility extends StackObjImpl implements Ability {
 
     @Override
     public boolean resolve(Game game) {
-        if (ability.getTargets().stillLegal(ability, game) || !canFizzle()) {
+        Targets targets = ability.getTargets();
+        if (targets == null) {
+            boolean result = ability.resolve(game);
+            game.getStack().remove(this, game);
+            return result;
+        }
+        if (targets.stillLegal(ability, game) || !canFizzle()) {
             boolean result = ability.resolve(game);
             game.getStack().remove(this, game);
             return result;


### PR DESCRIPTION
Any number of available modes can now be selected, including zero.

#5979

HumanPlayer::chooseMode() did not break out of the loop while processing a TriggeredAbility's Modes until all abilities were selected. There is now a stop condition for these abilities that triggers when the user clicks Cancel. This can have the added effect of making targets = null where they would otherwise be expected. Some null checks were added where necessary in the Ability/Stack resolution tree.