### PR TITLE
Fix NPE when using Nicol Bolas, God-Pharaoh's +1

### DIFF
--- a/Mage.Sets/src/mage/cards/n/NicolBolasGodPharaoh.java
+++ b/Mage.Sets/src/mage/cards/n/NicolBolasGodPharaoh.java
@@ -98,11 +98,17 @@ class NicolBolasGodPharaohPlusOneEffect extends OneShotEffect {
             Player opponent = game.getPlayer(opponentId);
             if (opponent != null) {
                 int numberOfCardsToExile = Math.min(2, opponent.getHand().size());
-                Target target = new TargetCardInHand(numberOfCardsToExile, new FilterCard());
-                target.setRequired(true);
-                if (opponent.chooseTarget(Outcome.Exile, target, source, game)) {
-                    Cards cards = new CardsImpl(target.getTargets());
-                    cardsToExile.put(opponentId, cards);
+                if(numberOfCardsToExile > 0) {
+                	Target target = new TargetCardInHand(numberOfCardsToExile, new FilterCard());
+                	target.setRequired(true);
+                	if (opponent.chooseTarget(Outcome.Exile, target, source, game)) {
+                		Cards cards = new CardsImpl(target.getTargets());
+                		cardsToExile.put(opponentId, cards);
+                	}
+                }
+                else
+                {
+                	cardsToExile.put(opponentId, new CardsImpl());
                 }
             }
         }


### PR DESCRIPTION
Fix NPE when using Nicol Bolas, God-Pharaoh's +1 when an opponent has no cards in hand. 

Add empty card selection to map to avoid accessing null later on.