### PR TITLE
6079 - Fixing conditional damage order, conditions

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BrimstoneVolley.java
+++ b/Mage.Sets/src/mage/cards/b/BrimstoneVolley.java
@@ -1,7 +1,7 @@
 
 package mage.cards.b;
 
-import mage.abilities.condition.common.HellbentCondition;
+import mage.abilities.condition.common.MorbidCondition;
 import mage.abilities.decorator.ConditionalOneShotEffect;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.cards.CardImpl;
@@ -23,7 +23,7 @@ public final class BrimstoneVolley extends CardImpl {
         // Brimstone Volley deals 3 damage to any target.
         // <i>Morbid</i> &mdash; Brimstone Volley deals 5 damage to that creature or player instead if a creature died this turn.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new DamageTargetEffect(3), new DamageTargetEffect(5), HellbentCondition.instance,
+                new DamageTargetEffect(5), new DamageTargetEffect(3), MorbidCondition.instance,
                 "{this} deals 3 damage to any target." +
                         "<br><i>Morbid</i> &mdash; {this} deals 5 damage instead if a creature died this turn."
         ));

--- a/Mage.Sets/src/mage/cards/c/CacklingFlames.java
+++ b/Mage.Sets/src/mage/cards/c/CacklingFlames.java
@@ -21,7 +21,7 @@ public final class CacklingFlames extends CardImpl {
         // Cackling Flames deals 3 damage to any target.
         // Hellbent - Cackling Flames deals 5 damage to that creature or player instead if you have no cards in hand.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new DamageTargetEffect(3), new DamageTargetEffect(5), HellbentCondition.instance,
+                new DamageTargetEffect(5), new DamageTargetEffect(3), HellbentCondition.instance,
                 "{this} deals 3 damage to any target<br><i>Hellbent</i> " +
                         "&mdash; {this} deals 5 damage instead if you have no cards in hand."
         ));

--- a/Mage.Sets/src/mage/cards/f/FirecannonBlast.java
+++ b/Mage.Sets/src/mage/cards/f/FirecannonBlast.java
@@ -26,7 +26,7 @@ public final class FirecannonBlast extends CardImpl {
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
                 new DamageTargetEffect(6),
                 new DamageTargetEffect(3),
-                new InvertCondition(RaidCondition.instance),
+                RaidCondition.instance,
                 "{this} deals 3 damage to target creature.<br><i>Raid</i> &mdash; {this} deals 6 damage instead if you attacked with a creature this turn"));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addWatcher(new PlayerAttackedWatcher());

--- a/Mage.Sets/src/mage/cards/f/FirecannonBlast.java
+++ b/Mage.Sets/src/mage/cards/f/FirecannonBlast.java
@@ -24,8 +24,8 @@ public final class FirecannonBlast extends CardImpl {
         // Firecannon Blast deals 3 damage to target creature.
         // Raid - Firecannon Blast deals 6 damage to that creature instead if you attacked with a creature this turn.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new DamageTargetEffect(3),
                 new DamageTargetEffect(6),
+                new DamageTargetEffect(3),
                 new InvertCondition(RaidCondition.instance),
                 "{this} deals 3 damage to target creature.<br><i>Raid</i> &mdash; {this} deals 6 damage instead if you attacked with a creature this turn"));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());


### PR DESCRIPTION
As of c482fad, a number of spells had their conditional damage
reworded in oracle text. As a part of these changes, some of the
spells had their order of effects inverted, with the damage
after the condition was happening before the condition was met.
In addition, Brimstone volley was changed from a Morbid condition
to a Hellbent condition. This commit corrects those typos.