### PR TITLE
filter missing zombie on SOTW

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SlayerOfTheWicked.java
+++ b/Mage.Sets/src/mage/cards/s/SlayerOfTheWicked.java
@@ -27,7 +27,7 @@ public final class SlayerOfTheWicked extends CardImpl {
         filter.add(Predicates.or(
                 new SubtypePredicate(SubType.VAMPIRE),
                 new SubtypePredicate(SubType.WEREWOLF),
-                new SubtypePredicate(SubType.WEREWOLF)));
+                new SubtypePredicate(SubType.ZOMBIE)));
     }
 
     public SlayerOfTheWicked(UUID ownerId, CardSetInfo setInfo) {


### PR DESCRIPTION
zombie predicate missing in SOTW filter

When Slayer of the Wicked enters the battlefield, you may destroy target Vampire, Werewolf, or Zombie.