### PR TITLE
Fixed Computer Player treating unprevented moves as unplayable.

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -1303,7 +1303,7 @@ public class ComputerPlayer extends PlayerImpl implements Player {
                     if (mana.enough(avail)) {
                         SpellAbility ability = card.getSpellAbility();
                         if (ability != null && ability.canActivate(playerId, game).canActivate()
-                                && game.getContinuousEffects().preventedByRuleModification(GameEvent.getEvent(GameEvent.EventType.CAST_SPELL, ability.getSourceId(), ability.getSourceId(), playerId), ability, game, true)) {
+                                && !game.getContinuousEffects().preventedByRuleModification(GameEvent.getEvent(GameEvent.EventType.CAST_SPELL, ability.getSourceId(), ability.getSourceId(), playerId), ability, game, true)) {
                             if (card.getCardType().contains(CardType.INSTANT)
                                     || card.hasAbility(FlashAbility.getInstance().getId(), game)) {
                                 playableInstant.add(card);


### PR DESCRIPTION
(First time contributing so please excuse my noobness) Card not prevented by an effect should be playable ("&& !prevented"), but currently AI says card not prevented is NOT playable ("&& prevented"). Also, not sure why AI doesn't add to unplayable even though its not contained by playableInstants or playableNonInstants. I'm not even sure if we're maintaining ComputerPlayer's decision logic (as opposed to Computer Player7).