### PR TITLE
Add AIMCTS Sources to Maven (missing srcDirectory)

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.AIMCTS/pom.xml
+++ b/Mage.Server.Plugins/Mage.Player.AIMCTS/pom.xml
@@ -38,6 +38,7 @@
     </dependencies>
 
     <build>
+        <sourceDirectory>src</sourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
No Maven expert, but the sources of every other Server.Plugin is included in Maven project EXCEPT for Mage.Player.AIMCTS (which seems necessary to actually be used/ran, imported, indexed, etc). I doubt this is intentional and it's the only way to get those sources working for IntelliJ IDEA.
This should add some more development support for anyone else poking around the code base, like in #6114