### PR TITLE
[WIP] Add OpenJDK 11 compatibility

### DIFF
--- a/Mage.Client/pom.xml
+++ b/Mage.Client/pom.xml
@@ -145,6 +145,12 @@
             <artifactId>balloontip</artifactId>
             <version>1.2.4.1</version>
         </dependency>
+        <dependency>
+  			<groupId>org.openjfx</groupId>
+  			<artifactId>javafx</artifactId>
+  			<version>14-ea+7</version>
+  			<type>pom</type>
+  		</dependency>
         <!-- svg support start -->
         <!--
             for "SAX2 driver class org.apache.crimson.parser.XMLReaderImpl not found" error looks here:


### PR DESCRIPTION
> There are plans to upgrade to OpenJDK (or same) instead oracle.
_Originally posted by @JayDi85 in https://github.com/magefree/mage/issues/5862#issuecomment-505714286_

A first step is replacing the few OpenJFX classes that were excluded from OpenJDK 11 by their replacement implementations...

I have just started doing exactly that.

Classes still to be replaced (all from `mage.client.dialog.WhatsNewDialog`):

- [ ] `javafx.application.Platform`
- [ ] `javafx.beans.value.ChangeListener`
- [ ] `javafx.beans.value.ObservableValue`
- [ ] `javafx.concurrent.Worker`
- [ ] `javafx.embed.swing.JFXPanel`
- [ ] `javafx.scene.Scene`
- [ ] `javafx.scene.web.WebEngine`
- [ ] `javafx.scene.web.WebView`
