### PR TITLE
Tectonic giant doesn't trigger on attack

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TectonicGiant.java
+++ b/Mage.Sets/src/mage/cards/t/TectonicGiant.java
@@ -66,7 +66,7 @@ class TectonicGiantTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.DECLARED_ATTACKERS
-                && event.getType() == GameEvent.EventType.TARGETED;
+                || event.getType() == GameEvent.EventType.TARGETED;
     }
 
     @Override


### PR DESCRIPTION
The check just skips over it because of a misplaced boolean operator.