### PR TITLE
Test framework and cheat engine improves

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/ComputerPlayer7.java
+++ b/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/ComputerPlayer7.java
@@ -108,7 +108,7 @@ public class ComputerPlayer7 extends ComputerPlayer6 {
     protected void calculateActions(Game game) {
         if (!getNextAction(game)) {
             Date startTime = new Date();
-            currentScore = GameStateEvaluator2.evaluate(playerId, game);
+            currentScore = GameStateEvaluator2.evaluate(playerId, game).getTotalScore();
             Game sim = createSimulation(game);
             SimulationNode2.resetCount();
             root = new SimulationNode2(null, sim, maxDepth, playerId);

--- a/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/SimulatedPlayer2.java
+++ b/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/SimulatedPlayer2.java
@@ -264,6 +264,8 @@ public class SimulatedPlayer2 extends ComputerPlayer {
         Iterator<Ability> iterator = options.iterator();
         boolean bad = true;
         boolean good = true;
+
+        // TODO: add custom outcome from ability?
         for (Effect effect : ability.getEffects()) {
             if (effect.getOutcome().isGood()) {
                 bad = false;

--- a/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/ma/MagicAbility.java
+++ b/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/ma/MagicAbility.java
@@ -38,13 +38,13 @@ public final class MagicAbility {
         // gatecrash
         put(new EvolveAbility().getRule(), 50);
         put(new ExtortAbility().getRule(), 30);
-        
+
 
     }};
 
     public static int getAbilityScore(Ability ability) {
         if (!scores.containsKey(ability.getRule())) {
-            //System.err.println("Couldn't find ability score: " + ability.getRule());
+            //System.err.println("Couldn't find ability score: " + ability.getClass().getSimpleName() + " - " + ability.toString());
             //TODO: add handling protection from ..., levelup, kicker, etc. abilities
             return 0;
         }

--- a/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/ma/optimizers/impl/OutcomeOptimizer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/ma/optimizers/impl/OutcomeOptimizer.java
@@ -6,24 +6,25 @@
 
 package mage.player.ai.ma.optimizers.impl;
 
-import java.util.List;
 import mage.abilities.Ability;
 import mage.abilities.effects.Effect;
 import mage.constants.Outcome;
 import mage.game.Game;
 
+import java.util.List;
+
 /**
  * Removes abilities that require only discard a card for activation.
  *
-  * @author LevelX2
+ * @author LevelX2
  */
 public class OutcomeOptimizer extends BaseTreeOptimizer {
 
     @Override
     public void filter(Game game, List<Ability> actions) {
         for (Ability ability : actions) {
-            for (Effect effect: ability.getEffects()) {
-                if (effect.getOutcome() == Outcome.AIDontUseIt) {
+            for (Effect effect : ability.getEffects()) {
+                if (ability.getCustomOutcome() == Outcome.AIDontUseIt || effect.getOutcome() == Outcome.AIDontUseIt) {
                     removeAbility(ability);
                     break;
                 }

--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -1160,12 +1160,12 @@ public class ComputerPlayer extends PlayerImpl implements Player {
                     if (!playableAbilities.isEmpty()) {
                         for (ActivatedAbility ability : playableAbilities) {
                             if (ability.canActivate(playerId, game).canActivate()) {
-                                if (ability.getEffects().hasOutcome(Outcome.PutLandInPlay)) {
+                                if (ability.getEffects().hasOutcome(ability, Outcome.PutLandInPlay)) {
                                     if (this.activateAbility(ability, game)) {
                                         return true;
                                     }
                                 }
-                                if (ability.getEffects().hasOutcome(Outcome.PutCreatureInPlay)) {
+                                if (ability.getEffects().hasOutcome(ability, Outcome.PutCreatureInPlay)) {
                                     if (getOpponentBlockers(opponentId, game).size() <= 1) {
                                         if (this.activateAbility(ability, game)) {
                                             return true;

--- a/Mage.Sets/src/mage/cards/k/KaaliaOfTheVast.java
+++ b/Mage.Sets/src/mage/cards/k/KaaliaOfTheVast.java
@@ -1,7 +1,5 @@
-
 package mage.cards.k;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.TriggeredAbilityImpl;
@@ -20,8 +18,9 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
 
+import java.util.UUID;
+
 /**
- *
  * @author Backfir3
  */
 public final class KaaliaOfTheVast extends CardImpl {
@@ -73,9 +72,7 @@ class KaaliaOfTheVastAttacksAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         if (event.getSourceId().equals(this.getSourceId())) {
             Player opponent = game.getPlayer(event.getTargetId());
-            if (opponent != null) {
-                return true;
-            }
+            return opponent != null;
         }
         return false;
     }
@@ -123,7 +120,7 @@ class KaaliaOfTheVastEffect extends OneShotEffect {
             return false;
         }
         TargetCardInHand target = new TargetCardInHand(filter);
-        if (target.canChoose(controller.getId(), game) && target.choose(getOutcome(), controller.getId(), source.getSourceId(), game)) {
+        if (target.canChoose(controller.getId(), game) && target.choose(outcome, controller.getId(), source.getSourceId(), game)) {
             if (!target.getTargets().isEmpty()) {
                 UUID cardId = target.getFirstTarget();
                 Card card = game.getCard(cardId);

--- a/Mage.Sets/src/mage/cards/m/MiresGrasp.java
+++ b/Mage.Sets/src/mage/cards/m/MiresGrasp.java
@@ -28,7 +28,7 @@ public final class MiresGrasp extends CardImpl {
         // Enchant creature
         TargetPermanent auraTarget = new TargetCreaturePermanent();
         this.getSpellAbility().addTarget(auraTarget);
-        this.getSpellAbility().addEffect(new AttachEffect(Outcome.BoostCreature));
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.UnboostCreature));
         Ability ability = new EnchantAbility(auraTarget.getTargetName());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/p/PreeminentCaptain.java
+++ b/Mage.Sets/src/mage/cards/p/PreeminentCaptain.java
@@ -1,6 +1,5 @@
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
@@ -19,8 +18,9 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
 
+import java.util.UUID;
+
 /**
- *
  * @author Rafbill
  */
 public final class PreeminentCaptain extends CardImpl {
@@ -71,7 +71,7 @@ class PreeminentCaptainEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         TargetCardInHand target = new TargetCardInHand(filter);
         if (controller != null && target.canChoose(controller.getId(), game)
-                && target.choose(getOutcome(), controller.getId(), source.getSourceId(), game)) {
+                && target.choose(outcome, controller.getId(), source.getSourceId(), game)) {
             if (!target.getTargets().isEmpty()) {
                 UUID cardId = target.getFirstTarget();
                 Card card = controller.getHand().get(cardId, game);

--- a/Mage.Sets/src/mage/cards/r/RescueFromTheUnderworld.java
+++ b/Mage.Sets/src/mage/cards/r/RescueFromTheUnderworld.java
@@ -1,7 +1,5 @@
-
 package mage.cards.r;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.DelayedTriggeredAbility;
 import mage.abilities.Mode;
@@ -29,34 +27,34 @@ import mage.target.common.TargetCardInGraveyard;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.common.TargetControlledCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
  * Once you announce you're casting Rescue from the Underworld, no player may
  * attempt to stop you from casting the spell by removing the creature you want
  * to sacrifice.
- *
+ * <p>
  * If you sacrifice a creature token to cast Rescue from the Underworld, it
  * won't return to the battlefield, although the target creature card will.
- *
+ * <p>
  * If either the sacrificed creature or the target creature card leaves the
  * graveyard before the delayed triggered ability resolves during your next
  * upkeep, it won't return.
- *
+ * <p>
  * However, if the sacrificed creature is put into another public zone instead
  * of the graveyard, perhaps because it's your commander or because of another
  * replacement effect, it will return to the battlefield from the zone it went
  * to.
- *
+ * <p>
  * Rescue from the Underworld is exiled as it resolves, not later as its delayed
  * trigger resolves.
- *
  *
  * @author LevelX2
  */
 public final class RescueFromTheUnderworld extends CardImpl {
 
     public RescueFromTheUnderworld(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{4}{B}");
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{4}{B}");
 
         // As an additional cost to cast Rescue from the Underworld, sacrifice a creature.
         this.getSpellAbility().addCost(new SacrificeTargetCost(new TargetControlledCreaturePermanent(1, 1, new FilterControlledCreaturePermanent("a creature"), false)));
@@ -106,7 +104,7 @@ class RescueFromTheUnderworldCreateDelayedTriggeredAbilityEffect extends OneShot
     protected DelayedTriggeredAbility ability;
 
     public RescueFromTheUnderworldCreateDelayedTriggeredAbilityEffect(DelayedTriggeredAbility ability) {
-        super(ability.getEffects().get(0).getOutcome());
+        super(ability.getEffects().getOutcome(ability));
         this.ability = ability;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/TestFrameworkCanPlayAITest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/TestFrameworkCanPlayAITest.java
@@ -1,0 +1,77 @@
+package org.mage.test.AI.basic;
+
+import mage.constants.CardType;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.game.permanent.Permanent;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBaseWithAIHelps;
+
+/**
+ * @author JayDi85
+ */
+public class TestFrameworkCanPlayAITest extends CardTestPlayerBaseWithAIHelps {
+
+    @Test
+    public void test_AI_PlayOnePriorityAction() {
+        addCard(Zone.HAND, playerA, "Lightning Bolt", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 3);
+        //
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears", 5);
+
+        // AI must play one time
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
+        execute();
+        assertAllCommandsUsed();
+
+        assertGraveyardCount(playerA, "Lightning Bolt", 1);
+        assertPermanentCount(playerB, "Balduvian Bears", 5 - 1);
+    }
+
+    @Test
+    public void test_AI_PlayManyActionsInOneStep() {
+        addCard(Zone.HAND, playerA, "Lightning Bolt", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 3);
+        //
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears", 5);
+
+        // AI must play all step actions
+        aiPlayStep(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
+        execute();
+        assertAllCommandsUsed();
+
+        assertGraveyardCount(playerA, "Lightning Bolt", 3);
+        assertPermanentCount(playerB, "Balduvian Bears", 5 - 3);
+    }
+
+    @Test
+    @Ignore // AI can't play blade cause score system give priority for boost instead restriction effects like goad
+    public void test_AI_GoadedByBloodthirstyBlade_Normal() {
+        // Equipped creature gets +2/+0 and is goaded
+        // {1}: Attach Bloodthirsty Blade to target creature an opponent controls. Activate this ability only any time you could cast a sorcery.
+        addCard(Zone.BATTLEFIELD, playerA, "Bloodthirsty Blade", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 1);
+        //
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears", 1);
+
+        // AI must play
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
+        execute();
+        assertAllCommandsUsed();
+
+        Assert.assertEquals(1, currentGame.getBattlefield().getAllActivePermanents(CardType.CREATURE).size());
+        Permanent permanent = currentGame.getBattlefield().getAllActivePermanents(CardType.CREATURE).get(0);
+        Assert.assertEquals(1, permanent.getAttachments().size());
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/OutcomesTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/OutcomesTest.java
@@ -1,0 +1,99 @@
+package org.mage.test.cards.abilities;
+
+import mage.abilities.Ability;
+import mage.abilities.common.LeavesBattlefieldTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.GainLifeEffect;
+import mage.abilities.effects.common.continuous.BoostSourceEffect;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBaseWithAIHelps;
+
+/**
+ * @author JayDi85
+ */
+public class OutcomesTest extends CardTestPlayerBaseWithAIHelps {
+
+    /**
+     * Normal outcome from effects
+     */
+
+    @Test
+    public void test_FromEffects_Single() {
+        Ability abilityGood = new SimpleStaticAbility(new GainLifeEffect(10));
+        Assert.assertEquals(1, abilityGood.getEffects().getOutcomeScore(abilityGood));
+
+        Ability abilityBad = new SimpleStaticAbility(new DamageTargetEffect(10));
+        Assert.assertEquals(-1, abilityBad.getEffects().getOutcomeScore(abilityBad));
+    }
+
+    @Test
+    public void test_FromEffects_Multi() {
+        Ability abilityGood = new SimpleStaticAbility(new GainLifeEffect(10));
+        abilityGood.addEffect(new BoostSourceEffect(10, 10, Duration.EndOfTurn));
+        Assert.assertEquals(1 + 1, abilityGood.getEffects().getOutcomeScore(abilityGood));
+
+        Ability abilityBad = new SimpleStaticAbility(new DamageTargetEffect(10));
+        abilityBad.addEffect(new ExileTargetEffect());
+        Assert.assertEquals(-1 + -1, abilityBad.getEffects().getOutcomeScore(abilityBad));
+    }
+
+    @Test
+    public void test_FromEffects_MultiCombine() {
+        Ability ability = new SimpleStaticAbility(new GainLifeEffect(10));
+        ability.addEffect(new BoostSourceEffect(10, 10, Duration.EndOfTurn));
+        ability.addEffect(new ExileTargetEffect());
+        Assert.assertEquals(1 + 1 + -1, ability.getEffects().getOutcomeScore(ability));
+    }
+
+    @Test
+    public void test_FromEffects_Default() {
+        Ability ability = new LeavesBattlefieldTriggeredAbility(null, false);
+        Assert.assertEquals(0, ability.getEffects().getOutcomeScore(ability));
+        Assert.assertEquals(Outcome.Detriment, ability.getEffects().getOutcome(ability));
+        Assert.assertEquals(Outcome.BoostCreature, ability.getEffects().getOutcome(ability, Outcome.BoostCreature));
+    }
+
+    /**
+     * Special outcome from ability (AI activates only good abilities)
+     */
+
+    @Test
+    public void test_FromAbility_Single() {
+        Ability abilityGood = new SimpleStaticAbility(new GainLifeEffect(10));
+        abilityGood.addCustomOutcome(Outcome.Detriment);
+        Assert.assertEquals(-1, abilityGood.getEffects().getOutcomeScore(abilityGood));
+        Assert.assertEquals(Outcome.Detriment, abilityGood.getEffects().getOutcome(abilityGood));
+
+        Ability abilityBad = new SimpleStaticAbility(new DamageTargetEffect(10));
+        abilityBad.addCustomOutcome(Outcome.Neutral);
+        Assert.assertEquals(1, abilityBad.getEffects().getOutcomeScore(abilityBad));
+        Assert.assertEquals(Outcome.Neutral, abilityBad.getEffects().getOutcome(abilityBad));
+    }
+
+    @Test
+    public void test_FromAbility_Multi() {
+        Ability abilityGood = new SimpleStaticAbility(new GainLifeEffect(10));
+        abilityGood.addEffect(new BoostSourceEffect(10, 10, Duration.EndOfTurn));
+        abilityGood.addCustomOutcome(Outcome.Detriment);
+        Assert.assertEquals(-1 + -1, abilityGood.getEffects().getOutcomeScore(abilityGood));
+
+        Ability abilityBad = new SimpleStaticAbility(new DamageTargetEffect(10));
+        abilityBad.addEffect(new ExileTargetEffect());
+        abilityBad.addCustomOutcome(Outcome.Neutral);
+        Assert.assertEquals(1 + 1, abilityBad.getEffects().getOutcomeScore(abilityBad));
+    }
+
+    @Test
+    public void test_FromAbility_MultiCombine() {
+        Ability ability = new SimpleStaticAbility(new GainLifeEffect(10));
+        ability.addEffect(new BoostSourceEffect(10, 10, Duration.EndOfTurn));
+        ability.addEffect(new ExileTargetEffect());
+        ability.addCustomOutcome(Outcome.Neutral); // must "convert" all effects to good
+        Assert.assertEquals(1 + 1 + 1, ability.getEffects().getOutcomeScore(ability));
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestPlayerBaseWithAIHelps.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestPlayerBaseWithAIHelps.java
@@ -1,0 +1,22 @@
+package org.mage.test.serverside.base;
+
+import mage.constants.RangeOfInfluence;
+import org.mage.test.player.TestComputerPlayer7;
+import org.mage.test.player.TestPlayer;
+
+/**
+ * Base class but with latest computer player to test single AI commands (it's different from full AI simulation from CardTestPlayerBaseAI):
+ * 1. AI don't play normal priorities (you must use ai*** commands to play it);
+ * 2. AI will choose in non strict mode (it's simulated ComputerPlayer7, not simple ComputerPlayer from basic tests)
+ *
+ * @author JayDi85
+ */
+public abstract class CardTestPlayerBaseWithAIHelps extends CardTestPlayerBase {
+
+    @Override
+    protected TestPlayer createPlayer(String name, RangeOfInfluence rangeOfInfluence) {
+        TestPlayer testPlayer = new TestPlayer(new TestComputerPlayer7(name, RangeOfInfluence.ONE, 6));
+        testPlayer.setAIPlayer(false); // AI can't play it by itself, use AI commands
+        return testPlayer;
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -22,6 +22,7 @@ import mage.game.GameOptions;
 import mage.game.command.CommandObject;
 import mage.game.permanent.Permanent;
 import mage.game.permanent.PermanentCard;
+import mage.player.ai.ComputerPlayer7;
 import mage.players.ManaPool;
 import mage.players.Player;
 import mage.util.CardUtil;
@@ -53,6 +54,8 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     public static final String ALIAS_PREFIX = "@"; // don't change -- it uses in user's tests
     public static final String CHECK_PARAM_DELIMETER = "#";
     public static final String CHECK_PREFIX = "check:"; // prefix for all check commands
+    public static final String SHOW_PREFIX = "show:"; // prefix for all show commands
+    public static final String AI_PREFIX = "ai:"; // prefix for all ai commands
 
     static {
         // aliases can be used in check commands, so all prefixes and delimeters must be unique
@@ -66,6 +69,10 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     public static final String ACTIVATE_ABILITY = "activate:";
     public static final String ACTIVATE_PLAY = "activate:Play ";
     public static final String ACTIVATE_CAST = "activate:Cast ";
+
+    // commands for AI
+    public static final String AI_COMMAND_PLAY_PRIORITY = "play priority";
+    public static final String AI_COMMAND_PLAY_STEP = "play step";
 
     static {
         // cards can be played/casted by activate ability command too
@@ -1389,6 +1396,28 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
         //Assert.assertNotEquals("", cardName);
         assertAliaseSupportInActivateCommand(cardName, false);
         player.addAction(turnNum, step, ACTIVATE_CAST + cardName + "$targetPlayer=" + target.getName() + "$manaInPool=" + manaInPool);
+    }
+
+    /**
+     * AI play one PRIORITY with multi game simulations (calcs and play ONE best action, can be called with stack)
+     */
+    public void aiPlayPriority(int turnNum, PhaseStep step, TestPlayer player) {
+        assertAiPlayAndGameCompatible(player);
+        player.addAction(turnNum, step, AI_PREFIX + AI_COMMAND_PLAY_PRIORITY);
+    }
+
+    /**
+     * AI play STEP to the end with multi game simulations (calcs and play best actions until step ends, can be called in the middle of the step)
+     */
+    public void aiPlayStep(int turnNum, PhaseStep step, TestPlayer player) {
+        assertAiPlayAndGameCompatible(player);
+        player.addAction(turnNum, step, AI_PREFIX + AI_COMMAND_PLAY_STEP);
+    }
+
+    private void assertAiPlayAndGameCompatible(TestPlayer player) {
+        if (player.isAIPlayer() || !(player.getComputerPlayer() instanceof ComputerPlayer7)) {
+            Assert.fail("AI commands supported by CardTestPlayerBaseWithAIHelps only");
+        }
     }
 
     public void waitStackResolved(int turnNum, PhaseStep step, TestPlayer player) {

--- a/Mage/src/main/java/mage/abilities/AbilitiesImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilitiesImpl.java
@@ -1,8 +1,5 @@
-
 package mage.abilities;
 
-import java.util.*;
-import java.util.stream.Collectors;
 import mage.abilities.common.ZoneChangeTriggeredAbility;
 import mage.abilities.costs.Cost;
 import mage.abilities.keyword.ProtectionAbility;
@@ -12,6 +9,9 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.util.ThreadLocalStringBuilder;
 import org.apache.log4j.Logger;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @param <T>
@@ -220,7 +220,7 @@ public class AbilitiesImpl<T extends Ability> extends ArrayList<T> implements Ab
 
     @Override
     public boolean contains(T ability) {
-        for (Iterator<T> iterator = this.iterator(); iterator.hasNext();) { // simple loop can cause java.util.ConcurrentModificationException
+        for (Iterator<T> iterator = this.iterator(); iterator.hasNext(); ) { // simple loop can cause java.util.ConcurrentModificationException
             T test = iterator.next();
             // Checking also by getRule() without other restrictions is a problem when a triggered ability will be copied to a permanent that had the same ability
             // already before the copy. Because then it keeps the triggered ability twice and it triggers twice.
@@ -273,7 +273,7 @@ public class AbilitiesImpl<T extends Ability> extends ArrayList<T> implements Ab
 
     @Override
     public int getOutcomeTotal() {
-        return stream().mapToInt(ability -> ability.getEffects().getOutcomeTotal()).sum();
+        return stream().mapToInt(ability -> ability.getEffects().getOutcomeScore(ability)).sum();
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/Ability.java
+++ b/Mage/src/main/java/mage/abilities/Ability.java
@@ -1,8 +1,5 @@
 package mage.abilities;
 
-import java.io.Serializable;
-import java.util.List;
-import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.CostAdjuster;
@@ -12,10 +9,7 @@ import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.Effects;
 import mage.abilities.hint.Hint;
-import mage.constants.AbilityType;
-import mage.constants.AbilityWord;
-import mage.constants.EffectType;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.game.Controllable;
 import mage.game.Game;
 import mage.game.events.GameEvent;
@@ -25,6 +19,10 @@ import mage.target.Target;
 import mage.target.Targets;
 import mage.target.targetadjustment.TargetAdjuster;
 import mage.watchers.Watcher;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * Practically everything in the game is started from an Ability. This interface
@@ -46,10 +44,8 @@ public interface Ability extends Controllable, Serializable {
      *
      * @see mage.players.PlayerImpl#playAbility(mage.abilities.ActivatedAbility,
      * mage.game.Game)
-     * @see
-     * mage.game.GameImpl#addTriggeredAbility(mage.abilities.TriggeredAbility)
-     * @see
-     * mage.game.GameImpl#addDelayedTriggeredAbility(mage.abilities.DelayedTriggeredAbility)
+     * @see mage.game.GameImpl#addTriggeredAbility(mage.abilities.TriggeredAbility)
+     * @see mage.game.GameImpl#addDelayedTriggeredAbility(mage.abilities.DelayedTriggeredAbility)
      */
     void newId();
 
@@ -58,10 +54,8 @@ public interface Ability extends Controllable, Serializable {
      *
      * @see mage.players.PlayerImpl#playAbility(mage.abilities.ActivatedAbility,
      * mage.game.Game)
-     * @see
-     * mage.game.GameImpl#addTriggeredAbility(mage.abilities.TriggeredAbility)
-     * @see
-     * mage.game.GameImpl#addDelayedTriggeredAbility(mage.abilities.DelayedTriggeredAbility)
+     * @see mage.game.GameImpl#addTriggeredAbility(mage.abilities.TriggeredAbility)
+     * @see mage.game.GameImpl#addDelayedTriggeredAbility(mage.abilities.DelayedTriggeredAbility)
      */
     void newOriginalId();
 
@@ -267,16 +261,15 @@ public interface Ability extends Controllable, Serializable {
     /**
      * Activates this ability prompting the controller to pay any mandatory
      *
-     * @param game A reference the {@link Game} for which this ability should be
-     * activated within.
+     * @param game   A reference the {@link Game} for which this ability should be
+     *               activated within.
      * @param noMana Whether or not {@link ManaCosts} have to be paid.
      * @return True if this ability was successfully activated.
      * @see mage.players.PlayerImpl#cast(mage.abilities.SpellAbility,
      * mage.game.Game, boolean)
      * @see mage.players.PlayerImpl#playAbility(mage.abilities.ActivatedAbility,
      * mage.game.Game)
-     * @see
-     * mage.players.PlayerImpl#triggerAbility(mage.abilities.TriggeredAbility,
+     * @see mage.players.PlayerImpl#triggerAbility(mage.abilities.TriggeredAbility,
      * mage.game.Game)
      */
     boolean activate(Game game, boolean noMana);
@@ -290,8 +283,7 @@ public interface Ability extends Controllable, Serializable {
      *
      * @param game The {@link Game} for which this ability resolves within.
      * @return Whether or not this ability successfully resolved.
-     * @see
-     * mage.players.PlayerImpl#playManaAbility(mage.abilities.mana.ManaAbility,
+     * @see mage.players.PlayerImpl#playManaAbility(mage.abilities.mana.ManaAbility,
      * mage.game.Game)
      * @see mage.players.PlayerImpl#specialAction(mage.abilities.SpecialAction,
      * mage.game.Game)
@@ -526,4 +518,8 @@ public interface Ability extends Controllable, Serializable {
     List<Hint> getHints();
 
     Ability addHint(Hint hint);
+
+    Ability addCustomOutcome(Outcome customOutcome);
+
+    Outcome getCustomOutcome();
 }

--- a/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
@@ -3,7 +3,6 @@ package mage.abilities;
 import mage.MageObject;
 import mage.abilities.effects.Effect;
 import mage.constants.AbilityType;
-import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
@@ -61,7 +60,7 @@ public abstract class TriggeredAbilityImpl extends AbilityImpl implements Trigge
             MageObject object = game.getObject(getSourceId());
             Player player = game.getPlayer(this.getControllerId());
             if (player != null && object != null) {
-                if (!player.chooseUse(getEffects().isEmpty() ? Outcome.Detriment : getEffects().get(0).getOutcome(), this.getRule(object.getLogName()), this, game)) {
+                if (!player.chooseUse(getEffects().getOutcome(this), this.getRule(object.getLogName()), this, game)) {
                     return false;
                 }
             } else {

--- a/Mage/src/main/java/mage/abilities/effects/common/CopyPermanentEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CopyPermanentEffect.java
@@ -1,4 +1,3 @@
-
 package mage.abilities.effects.common;
 
 import mage.MageObject;
@@ -103,11 +102,11 @@ public class CopyPermanentEffect extends OneShotEffect {
                     // attach - search effect in spell ability (example: cast Utopia Sprawl, cast Estrid's Invocation on it)
                     for (Ability ability : bluePrintPermanent.getAbilities()) {
                         if (ability instanceof SpellAbility) {
+                            auraOutcome = ability.getEffects().getOutcome(ability);
                             for (Effect effect : ability.getEffects()) {
                                 if (effect instanceof AttachEffect) {
                                     if (bluePrintPermanent.getSpellAbility().getTargets().size() > 0) {
                                         auraTarget = bluePrintPermanent.getSpellAbility().getTargets().get(0);
-                                        auraOutcome = effect.getOutcome();
                                     }
                                 }
                             }
@@ -118,12 +117,9 @@ public class CopyPermanentEffect extends OneShotEffect {
                     if (auraTarget == null) {
                         for (Ability ability : bluePrintPermanent.getAbilities()) {
                             if (ability instanceof EnchantAbility) {
+                                auraOutcome = ability.getEffects().getOutcome(ability);
                                 if (ability.getTargets().size() > 0) { // Animate Dead don't have targets
                                     auraTarget = ability.getTargets().get(0);
-                                    for (Effect effect : ability.getEffects()) {
-                                        // first outcome
-                                        auraOutcome = effect.getOutcome();
-                                    }
                                 }
                             }
                         }

--- a/Mage/src/main/java/mage/abilities/effects/common/CreateDelayedTriggeredAbilityEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CreateDelayedTriggeredAbilityEffect.java
@@ -1,4 +1,3 @@
-
 package mage.abilities.effects.common;
 
 import mage.abilities.Ability;
@@ -6,11 +5,9 @@ import mage.abilities.DelayedTriggeredAbility;
 import mage.abilities.Mode;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
-import mage.constants.Outcome;
 import mage.game.Game;
 
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public class CreateDelayedTriggeredAbilityEffect extends OneShotEffect {
@@ -28,7 +25,7 @@ public class CreateDelayedTriggeredAbilityEffect extends OneShotEffect {
     }
 
     public CreateDelayedTriggeredAbilityEffect(DelayedTriggeredAbility ability, boolean copyTargets, boolean initAbility) {
-        super(ability.getEffects().isEmpty() ? Outcome.Detriment : ability.getEffects().get(0).getOutcome());
+        super(ability.getEffects().getOutcome(ability));
         this.ability = ability;
         this.copyTargets = copyTargets;
         this.initAbility = initAbility;

--- a/Mage/src/main/java/mage/abilities/effects/common/CreateSpecialActionEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CreateSpecialActionEffect.java
@@ -1,15 +1,12 @@
-
 package mage.abilities.effects.common;
 
 import mage.abilities.Ability;
 import mage.abilities.Mode;
 import mage.abilities.SpecialAction;
 import mage.abilities.effects.OneShotEffect;
-import mage.constants.Outcome;
 import mage.game.Game;
 
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public class CreateSpecialActionEffect extends OneShotEffect {
@@ -17,7 +14,7 @@ public class CreateSpecialActionEffect extends OneShotEffect {
     protected SpecialAction action;
 
     public CreateSpecialActionEffect(SpecialAction action) {
-        super(action.getEffects().isEmpty() ? Outcome.Detriment : action.getEffects().get(0).getOutcome());
+        super(action.getEffects().getOutcome(action));
         this.action = action;
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/DoIfCostPaid.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DoIfCostPaid.java
@@ -91,7 +91,7 @@ public class DoIfCostPaid extends OneShotEffect {
             }
             message = CardUtil.replaceSourceName(message, mageObject.getLogName());
             boolean result = true;
-            Outcome payOutcome = executingEffects.size() > 0 ? executingEffects.get(0).getOutcome() : this.outcome;
+            Outcome payOutcome = executingEffects.getOutcome(source, this.outcome);
             if (cost.canPay(source, source.getSourceId(), player.getId(), game)
                     && (!optional || player.chooseUse(payOutcome, message, source, game))) {
                 cost.clearPaid();

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilityTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilityTargetEffect.java
@@ -39,8 +39,7 @@ public class GainAbilityTargetEffect extends ContinuousEffectImpl {
     }
 
     public GainAbilityTargetEffect(Ability ability, Duration duration, String rule, boolean onCard, Layer layer, SubLayer subLayer) {
-        super(duration, layer, subLayer,
-                !ability.getEffects().isEmpty() ? ability.getEffects().get(0).getOutcome() : Outcome.AddAbility);
+        super(duration, layer, subLayer, ability.getEffects().getOutcome(ability, Outcome.AddAbility));
         this.ability = ability;
         staticText = rule;
         this.onCard = onCard;

--- a/Mage/src/main/java/mage/game/draft/RateCard.java
+++ b/Mage/src/main/java/mage/game/draft/RateCard.java
@@ -132,6 +132,7 @@ public final class RateCard {
     }
 
     private static int isEffectRemoval(Card card, Ability ability, Effect effect) {
+        // it's effect relates score, do not use custom outcome from ability
         if (effect.getOutcome() == Outcome.Removal) {
             // found removal
             return 1;

--- a/Mage/src/main/java/mage/game/stack/StackAbility.java
+++ b/Mage/src/main/java/mage/game/stack/StackAbility.java
@@ -1,9 +1,5 @@
 package mage.game.stack;
 
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.UUID;
 import mage.MageInt;
 import mage.MageObject;
 import mage.ObjectColor;
@@ -33,6 +29,11 @@ import mage.target.targetadjustment.TargetAdjuster;
 import mage.util.GameLog;
 import mage.util.SubTypeList;
 import mage.watchers.Watcher;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * @author BetaSteward_at_googlemail.com
@@ -578,7 +579,7 @@ public class StackAbility extends StackObjImpl implements Ability {
         game.getStack().push(newStackAbility);
         if (chooseNewTargets && !newAbility.getTargets().isEmpty()) {
             Player controller = game.getPlayer(newControllerId);
-            Outcome outcome = newAbility.getEffects().isEmpty() ? Outcome.Detriment : newAbility.getEffects().get(0).getOutcome();
+            Outcome outcome = newAbility.getEffects().getOutcome(newAbility);
             if (controller.chooseUse(outcome, "Choose new targets?", source, game)) {
                 newAbility.getTargets().clearChosen();
                 newAbility.getTargets().chooseTargets(outcome, newControllerId, newAbility, false, game, false);
@@ -648,7 +649,16 @@ public class StackAbility extends StackObjImpl implements Ability {
 
     @Override
     public Ability addHint(Hint hint) {
-        // only abilities supports addhint
-        return null;
+        throw new IllegalArgumentException("Stack ability is not supports hint adding");
+    }
+
+    @Override
+    public Ability addCustomOutcome(Outcome customOutcome) {
+        throw new IllegalArgumentException("Stack ability is not supports custom outcome adding");
+    }
+
+    @Override
+    public Outcome getCustomOutcome() {
+        return this.ability.getCustomOutcome();
     }
 }

--- a/Mage/src/main/java/mage/game/stack/StackObjImpl.java
+++ b/Mage/src/main/java/mage/game/stack/StackObjImpl.java
@@ -163,7 +163,7 @@ public abstract class StackObjImpl implements StackObject {
                 targetAmount = " (amount: " + target.getTargetAmount(targetId) + ")";
             }
             // change the target?
-            Outcome outcome = mode.getEffects().isEmpty() ? Outcome.Detriment : mode.getEffects().get(0).getOutcome();
+            Outcome outcome = mode.getEffects().getOutcome(ability);
 
             if (targetNames != null
                     && (forceChange || targetController.chooseUse(outcome, "Change this target: " + targetNames + targetAmount + '?', ability, game))) {


### PR DESCRIPTION
## Test framework: added AI support in basic card tests

The original problem -- devs can't test AI bugs or reproduce user's use cases. Old test framework allows AI testing, but it was limited by full playable games only (e.g. you haven't control on AI actions or battlefield prepare -- AI will play all cards by it own). Default tests uses simple AI (for choose dialogs only) and can't run simulations.

The new test framework are more flexible. You can setup test and run AI for specific situations only. Even more -- now you can take your manual test, replace only one basic class and insert AI command to test (e.g. to check is it able to play some card or ability correctly).

What's new in test framework:
* Added new command to play one best action on priority by AI (`aiPlayPriority`);
* Added new command to play all best actions on step by AI (`aiPlayStep`);
* Now you can setup battlefield by standard commands and run AI simulations for single priority/step;
* `CardTestPlayerBase` - old default class for card tests, it uses simple AI for choosing, but do not play/simulate games;
* `CardTestPlayerBaseAI` - old default class for AI game tests; auto-playable playerA; you can control only playerB;
* `CardTestPlayerBaseWithAIHelps` - new improved class for card tests, it uses controllable and real AI with game simulations;

## Cheat engine: added command to activate opponent's playable ability

Another problem -- if you manually test game by cheat engine (play real game in test mode) AI opponents do not make actions as you want. Example: you need test counter effect, but AI don't want to cast. 

In old days you must run multiple clients, but now new command available: activate opponent's playable ability. You can call it from cheat dialog at any time. That's activate dialog will show you only playable abilities to activate. Just select one of it and opponent try to activate it. It's little tricky and can be buggy (as all cheat commands).

How to use:
 * Insert special command in `init.txt` file to enable it: `[@activate opponent ability]`

![shot_200128_144509](https://user-images.githubusercontent.com/8344157/73327424-67e3b200-426f-11ea-8940-9b97a20872a5.png)