### PR TITLE
Fix Irencrag Feat's spell casting effect.

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/IrencragFeatTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/IrencragFeatTest.java
@@ -1,0 +1,65 @@
+package org.mage.test.cards.continuous;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class IrencragFeatTest extends CardTestPlayerBase {
+    @Test
+    public void castFirst() {
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 10);
+        addCard(Zone.HAND, playerA, "Irencrag Feat", 1);
+        addCard(Zone.HAND, playerA, "Dwarven Trader", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Irencrag Feat");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Dwarven Trader");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Dwarven Trader");
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+
+        execute();
+
+        assertHandCount(playerA, "Dwarven Trader", 1);
+        assertPermanentCount(playerA, "Dwarven Trader", 1);
+    }
+
+
+    @Test
+    public void castThird() {
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 10);
+        addCard(Zone.HAND, playerA, "Irencrag Feat", 1);
+        addCard(Zone.HAND, playerA, "Dwarven Trader", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Dwarven Trader");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Dwarven Trader");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Irencrag Feat");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Dwarven Trader");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Dwarven Trader");
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+
+        execute();
+
+        assertHandCount(playerA, "Dwarven Trader", 1);
+        assertPermanentCount(playerA, "Dwarven Trader", 3);
+    }
+
+
+    @Test
+    public void nextTurn() {
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 10);
+        addCard(Zone.HAND, playerA, "Irencrag Feat", 1);
+        addCard(Zone.HAND, playerA, "Dwarven Trader", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Irencrag Feat");
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Dwarven Trader");
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Dwarven Trader");
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Dwarven Trader");
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Dwarven Trader");
+        setStopAt(3, PhaseStep.BEGIN_COMBAT);
+
+        execute();
+
+        assertHandCount(playerA, "Dwarven Trader", 0);
+        assertPermanentCount(playerA, "Dwarven Trader", 4);
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/magefree/mage/issues/6265.

Ensure that Irencrag Feat doesn't effect subsequent turns.
Ensure that Irencrag Feat only allows one spell to be cast after it.