### PR TITLE
Fix Turbulent Dreams.

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TurbulentDreams.java
+++ b/Mage.Sets/src/mage/cards/t/TurbulentDreams.java
@@ -52,7 +52,7 @@ enum TurbulentDreamsAdjuster implements TargetAdjuster {
 
     @Override
     public void adjustTargets(Ability ability, Game game) {
-        Target target = new TargetPermanent(0, ability.getManaCostsToPay().getX(), filter, false);
+        Target target = new TargetPermanent(ability.getCosts().getVariableCosts().get(0).getAmount(), filter);
         ability.addTarget(target);
     }
 }


### PR DESCRIPTION
More specifically get the value of X from the discard cost not the mana cost and correctly set it to target exactly x permanents.
Fixes https://github.com/magefree/mage/issues/6264