### PR TITLE
Fix Verix Bladewing kicker ability text

### DIFF
--- a/Mage.Sets/src/mage/cards/v/VerixBladewing.java
+++ b/Mage.Sets/src/mage/cards/v/VerixBladewing.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.condition.common.KickedCondition;
-import mage.abilities.decorator.ConditionalOneShotEffect;
+import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.KickerAbility;
@@ -37,10 +37,13 @@ public final class VerixBladewing extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // When Verix Bladewing enters the battlefield, if it was kicked, create Karox Bladewing,
-        //  a legendary 4/4 red Dragon creature token with flying.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new ConditionalOneShotEffect(
-                new CreateTokenEffect(new KaroxBladewingDragonToken()), KickedCondition.instance,
-                "create Karox Bladewing, a legendary 4/4 red Dragon creature token with flying.")));
+        // a legendary 4/4 red Dragon creature token with flying.
+        EntersBattlefieldTriggeredAbility ability = new EntersBattlefieldTriggeredAbility(
+                new CreateTokenEffect(new KaroxBladewingDragonToken()));
+
+        this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, KickedCondition.instance,
+                "When {this} enters the battlefield, if it was kicked, create Karox Bladewing, " +
+                        "a legendary 4/4 red Dragon creature token with flying."));
     }
 
     public VerixBladewing(final VerixBladewing card) {


### PR DESCRIPTION
Text before:
"When Verix Bladewing enters the battlefield, create Karox Bladewing, a legendary 4/4 red Dragon creature token with flying."

Text after:
"When Verix Bladewing enters the battlefield, if it was kicked, create Karox Bladewing, a legendary 4/4 red Dragon creature token with flying."