### PR TITLE
#6256: Fixed Watcher copy method for JDK11

### DIFF
--- a/Mage/src/main/java/mage/watchers/Watcher.java
+++ b/Mage/src/main/java/mage/watchers/Watcher.java
@@ -112,11 +112,11 @@ public abstract class Watcher implements Serializable {
 
                     field.setAccessible(true);
                     if (field.getType() == Set.class) {
-                        field.set(watcher, new HashSet<>());
+                        ((Set) field.get(watcher)).clear();
                         ((Set) field.get(watcher)).addAll((Set) field.get(this));
                     } else if (field.getType() == Map.class) {
-                        HashMap<Object, Object> target = new HashMap<>();
-                        field.set(watcher, target);
+                        Map target = ((Map) field.get(watcher));
+                        target.clear();
                         Map source = (Map) field.get(this);
 
                         ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();

--- a/Mage/src/main/java/mage/watchers/Watcher.java
+++ b/Mage/src/main/java/mage/watchers/Watcher.java
@@ -5,7 +5,6 @@ import mage.constants.WatcherScope;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import org.apache.log4j.Logger;
-import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl;
 
 import java.io.Serializable;
 import java.lang.reflect.*;
@@ -113,16 +112,16 @@ public abstract class Watcher implements Serializable {
 
                     field.setAccessible(true);
                     if (field.getType() == Set.class) {
-                        ((Set) field.get(watcher)).clear();
+                        field.set(watcher, new HashSet<>());
                         ((Set) field.get(watcher)).addAll((Set) field.get(this));
                     } else if (field.getType() == Map.class) {
-                        Map target = ((Map) field.get(watcher));
-                        target.clear();
+                        HashMap<Object, Object> target = new HashMap<>();
+                        field.set(watcher, target);
                         Map source = (Map) field.get(this);
 
                         ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
                         Type valueType = parameterizedType.getActualTypeArguments()[1];
-                        if (valueType instanceof ParameterizedTypeImpl && ((ParameterizedTypeImpl) valueType).getRawType().getSimpleName().contains("Set")) {
+                        if (valueType.getClass().getSimpleName().contains("Set")) {
                             source.entrySet().forEach(kv -> {
                                 Object key = ((Map.Entry) kv).getKey();
                                 Set value = (Set) ((Map.Entry) kv).getValue();

--- a/Mage/src/test/java/mage/WatcherTest.java
+++ b/Mage/src/test/java/mage/WatcherTest.java
@@ -4,9 +4,12 @@ import static mage.constants.WatcherScope.GAME;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import mage.constants.WatcherScope;
 import mage.game.Game;
 import mage.game.events.GameEvent;
@@ -18,24 +21,36 @@ public class WatcherTest {
   @Test
   public void test() {
     // Given
+    Map<String, String> mapField = new HashMap<>();
+    mapField.put("mapFieldKey1", "mapFieldValue1");
+    mapField.put("mapFieldKey2", "mapFieldValue2");
+
     TestWatcher testWatcher = new TestWatcher(GAME);
     testWatcher.setStringField("stringField");
-    testWatcher.setSetField(ImmutableSet.of("setField1, setField2"));
-    testWatcher.setMapField(ImmutableMap.of("mapFieldKey1, mapFieldValue1", "mapFieldKey2, mapFieldValue2"));
+    testWatcher.setSetField(set("setField1", "setField2"));
+    testWatcher.setMapField(mapField);
 
     // When
     TestWatcher copy = testWatcher.copy();
 
+    // And
+    testWatcher.getSetField().add("setField3");
+    mapField.put("mapFieldKey3", "mapFieldValue3");
+
     // Then
-    assertEquals(testWatcher.getStringField(), copy.getStringField());
-    assertEquals(testWatcher.getSetField(), copy.getSetField());
-    assertEquals(testWatcher.getMapField(), copy.getMapField());
+    assertEquals("stringField", copy.getStringField());
+    assertEquals(set("setField1", "setField2"), copy.getSetField());
+    assertEquals(ImmutableMap.of("mapFieldKey1", "mapFieldValue1", "mapFieldKey2", "mapFieldValue2"), copy.getMapField());
+  }
+
+  private Set<String> set(String... values) {
+    return Stream.of(values).collect(Collectors.toSet());
   }
 
   public static class TestWatcher extends Watcher {
     private String stringField;
-    private Set<String> setField;
-    private Map<String, String> mapField;
+    private Set<String> setField = new HashSet<>();
+    private Map<String, String> mapField = new HashMap<>();
 
     public TestWatcher(WatcherScope scope) {
       super(scope);

--- a/Mage/src/test/java/mage/WatcherTest.java
+++ b/Mage/src/test/java/mage/WatcherTest.java
@@ -1,4 +1,73 @@
 package mage;
 
+import static mage.constants.WatcherScope.GAME;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.Set;
+import mage.constants.WatcherScope;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.watchers.Watcher;
+import org.junit.Test;
+
 public class WatcherTest {
+
+  @Test
+  public void test() {
+    // Given
+    TestWatcher testWatcher = new TestWatcher(GAME);
+    testWatcher.setStringField("stringField");
+    testWatcher.setSetField(ImmutableSet.of("setField1, setField2"));
+    testWatcher.setMapField(ImmutableMap.of("mapFieldKey1, mapFieldValue1", "mapFieldKey2, mapFieldValue2"));
+
+    // When
+    TestWatcher copy = testWatcher.copy();
+
+    // Then
+    assertEquals(testWatcher.getStringField(), copy.getStringField());
+    assertEquals(testWatcher.getSetField(), copy.getSetField());
+    assertEquals(testWatcher.getMapField(), copy.getMapField());
+  }
+
+  public static class TestWatcher extends Watcher {
+    private String stringField;
+    private Set<String> setField;
+    private Map<String, String> mapField;
+
+    public TestWatcher(WatcherScope scope) {
+      super(scope);
+    }
+
+    @Override
+    public void watch(GameEvent event, Game game) {
+      System.out.println("watch");
+    }
+
+    public String getStringField() {
+      return stringField;
+    }
+
+    public void setStringField(String stringField) {
+      this.stringField = stringField;
+    }
+
+    public Set<String> getSetField() {
+      return setField;
+    }
+
+    public void setSetField(Set<String> setField) {
+      this.setField = setField;
+    }
+
+    public Map<String, String> getMapField() {
+      return mapField;
+    }
+
+    public void setMapField(Map<String, String> mapField) {
+      this.mapField = mapField;
+    }
+  }
 }


### PR DESCRIPTION
So, there were two problems with it:
 1. ParameterizedTypeImpl has been deprecated in JDK11 so the code would not compile
 2. Actually the code for copying Sets and Maps was broken.
        At line 119 `((Set) field.get(watcher)).clear();` was always getting null as the watcher object was just created and its fields was null. Same was for Map

Fixed both problems and added a test that verifies that the code is working.