### PR TITLE
Satyr Firedancer doesn't triggers for each opponent

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SatyrFiredancer.java
+++ b/Mage.Sets/src/mage/cards/s/SatyrFiredancer.java
@@ -26,7 +26,9 @@ import mage.target.targetadjustment.TargetAdjuster;
 import mage.target.targetpointer.FixedTarget;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -57,8 +59,6 @@ public final class SatyrFiredancer extends CardImpl {
 
 class SatyrFiredancerTriggeredAbility extends TriggeredAbilityImpl {
 
-    private List<UUID> handledStackObjects = new ArrayList<>();
-
     public SatyrFiredancerTriggeredAbility() {
         super(Zone.BATTLEFIELD, new SatyrFiredancerDamageEffect(), false);
         targetAdjuster = SatyrFiredancerAdjuster.instance;
@@ -74,38 +74,33 @@ class SatyrFiredancerTriggeredAbility extends TriggeredAbilityImpl {
     }
 
     @Override
-    public void reset(Game game) {
-        handledStackObjects.clear();
-    }
-
-    @Override
     public boolean checkEventType(GameEvent event, Game game) {
         return event.getType() == EventType.DAMAGED_PLAYER;
     }
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        if (isControlledBy(game.getControllerId(event.getSourceId()))) {
-            MageObject damageSource = game.getObject(event.getSourceId());
-            if (damageSource != null) {
-                if (game.getOpponents(getControllerId()).contains(event.getTargetId())) {
-                    MageObject object = game.getObject(event.getSourceId());
-                    if (object != null && (object.isInstant() || object.isSorcery())) {
-                        if (!(damageSource instanceof StackObject) || !handledStackObjects.contains(damageSource.getId())) {
-                            if (damageSource instanceof StackObject) {
-                                handledStackObjects.add(damageSource.getId());
-                            }
-                            for (Effect effect : this.getEffects()) {
-                                effect.setTargetPointer(new FixedTarget(event.getTargetId())); // used by adjust targets
-                                effect.setValue("damage", event.getAmount());
-                            }
-                            return true;
-                        }
-                    }
-                }
-            }
+        boolean controlledBy = isControlledBy(game.getControllerId(event.getSourceId()));
+        if (!controlledBy) {
+            return false;
         }
-        return false;
+        MageObject damageSource = game.getObject(event.getSourceId());
+        if (damageSource == null) {
+            return false;
+        }
+        UUID damageTarget = event.getTargetId();
+        if (!game.getOpponents(getControllerId()).contains(damageTarget)) {
+            return false;
+        }
+        MageObject sourceObject = game.getObject(event.getSourceId());
+        if (sourceObject == null || !(sourceObject.isInstant() || sourceObject.isSorcery())) {
+            return false;
+        }
+        for (Effect effect : this.getEffects()) {
+            effect.setTargetPointer(new FixedTarget(damageTarget)); // used by adjust targets
+            effect.setValue("damage", event.getAmount());
+        }
+        return true;
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/damage/SatyrFiredancerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/damage/SatyrFiredancerTest.java
@@ -3,6 +3,7 @@ package org.mage.test.cards.abilities.oneshot.damage;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
+import mage.game.GameException;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -74,5 +75,64 @@ public class SatyrFiredancerTest extends CardTestPlayerBase {
         assertLife(playerA, 20);
         assertLife(playerB, 19);
         
+    }
+
+    @Test
+    public void testPriceOfProgressMultiplayer() throws GameException {
+        playerC = createPlayer(currentGame, playerC, "PlayerC");
+        addCard(Zone.BATTLEFIELD, playerA, "Satyr Firedancer", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        addCard(Zone.HAND, playerA, "Price of Progress", 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Taiga", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Swab Goblin", 1);
+        addCard(Zone.BATTLEFIELD, playerC, "Savannah", 1);
+        addCard(Zone.BATTLEFIELD, playerC, "Grizzly Bears", 1);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Price of Progress");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        execute();
+
+        assertPermanentCount(playerB, "Swab Goblin", 0);
+        assertGraveyardCount(playerB, "Swab Goblin", 1);
+
+        assertPermanentCount(playerC, "Grizzly Bears", 0);
+        assertGraveyardCount(playerC, "Grizzly Bears", 1);
+    }
+
+    @Test
+    public void testMultipleInstanceOfDamage() {
+        addCard(Zone.BATTLEFIELD, playerA, "Satyr Firedancer", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
+        addCard(Zone.HAND, playerA, "Fiery Confluence", 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Taiga", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Grizzly Bears", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Bear Cub", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Forest Bear", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Runeclaw Bear", 1);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Fiery Confluence");
+        setModeChoice(playerA, "2");
+        setModeChoice(playerA, "2");
+        setModeChoice(playerA, "2");
+
+        addTarget(playerA, "Grizzly Bears");
+        addTarget(playerA, "Bear Cub");
+        addTarget(playerA, "Forest Bear");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        execute();
+
+        assertPermanentCount(playerB, "Grizzly Bears", 0);
+        assertPermanentCount(playerB, "Bear Cub", 0);
+        assertPermanentCount(playerB, "Forest Bear", 0);
+        assertPermanentCount(playerB, "Runeclaw Bear", 1);
+
+        assertGraveyardCount(playerB, "Grizzly Bears", 1);
+        assertGraveyardCount(playerB, "Bear Cub", 1);
+        assertGraveyardCount(playerB, "Forest Bear", 1);
+        assertGraveyardCount(playerB, "Runeclaw Bear", 0);
     }
 }


### PR DESCRIPTION
Satyr Firedancer should trigger multiple times when single Instant or Sorcery deals damage to multiple opponents, once for each opponent. Cards like Price of Progress currently triggered first time for first opponent in turn order, but not for others.

I confirmed with a judge on https://chat.magicjudges.org/mtgrules/ that this is how it should work, but if somebody could verify it, I would be grateful.

Requested commit changes how the ability handles multiple damage by single source: instances of damage dealt to a opponent are temporarily stored in a map - source to opponents. If a instant would deal damage to an opponent twice, the second instance will also trigger the Satyr twice, because that's two instances of damage dealt.