### PR TITLE
Change the nimbus look and feel name (OpenJDK support)

### DIFF
--- a/Mage.Client/src/main/java/mage/client/MageFrame.java
+++ b/Mage.Client/src/main/java/mage/client/MageFrame.java
@@ -202,7 +202,7 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
         config.setAccessPreference(FsAccessOption.STORE, true);
         try {
             UIManager.put("desktop", new Color(0, 0, 0, 0));
-            UIManager.setLookAndFeel("com.sun.java.swing.plaf.nimbus.NimbusLookAndFeel");
+            UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
             //UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
             // stop JSplitPane from eating F6 and F8 or any other function keys
             {

--- a/Mage.Client/src/main/java/mage/client/components/MageJDesktop.java
+++ b/Mage.Client/src/main/java/mage/client/components/MageJDesktop.java
@@ -1,10 +1,5 @@
 package mage.client.components;
 
-//import com.sun.java.swing.Painter;
-
-import java.awt.Color;
-import java.awt.Graphics2D;
-
 import javax.swing.JDesktopPane;
 import javax.swing.UIDefaults;
 import javax.swing.UIManager;
@@ -22,7 +17,7 @@ public class MageJDesktop extends JDesktopPane {
     public void updateUI() {
         if ("Nimbus".equals(UIManager.getLookAndFeel().getName())) {
             UIDefaults map = new UIDefaults();
-            Painter painter = (g, c, w, h) -> {
+            Painter<?> painter = (g, c, w, h) -> {
                 g.setColor( UIManager.getDefaults().getColor("desktop") );
                 g.fillRect(0,0,w,h);
             };

--- a/Mage.Client/src/main/java/mage/client/components/ability/AbilityPicker.java
+++ b/Mage.Client/src/main/java/mage/client/components/ability/AbilityPicker.java
@@ -383,7 +383,7 @@ public class AbilityPicker extends JXPanel implements MouseWheelListener {
 
     public static void main(String[] argv) {
         try {
-            UIManager.setLookAndFeel("com.sun.java.swing.plaf.nimbus.NimbusLookAndFeel");
+            UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
         } catch (Exception ex) {
         }
 

--- a/Mage.Server.Console/src/main/java/mage/server/console/ConsoleFrame.java
+++ b/Mage.Server.Console/src/main/java/mage/server/console/ConsoleFrame.java
@@ -60,7 +60,7 @@ public class ConsoleFrame extends javax.swing.JFrame implements MageClient {
 
         initComponents();
         try {
-            UIManager.setLookAndFeel("com.sun.java.swing.plaf.nimbus.NimbusLookAndFeel");
+            UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
             session = new SessionImpl(this);
             connectDialog = new ConnectDialog();
         } catch (Exception ex) {


### PR DESCRIPTION
Mage.Client uses the deprecated name for the Nimbus look and feel, so it won't open on Java versions after 10 (https://www.oracle.com/technetwork/java/javase/10-relnote-issues-4108729.html#JDK-8185683). This change moves to the supported name which works on Java 7+.

A friend and I were poking at getting XMage up and running on Java 14, and this was the only code change necessary to get the client to run. It also requires adding JavaFX to run on Java 11+, but that's not a backwards compatible change.