### PR TITLE
Additions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,9 @@ Utils/*implemented.txt
 .metadata
 .project
 .settings
-.idea
+.idea/
+.vscode/
+.factorypath
 syntax: regexp
 \.class
 \.jar


### PR DESCRIPTION
Added Visual Studio Code (vscode) and .factorypath maven files to .gitignore.
Also the .idea pattern is now restricted to folders.