### PR TITLE
Updated implementation of Unpredictable Cyclone

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AkoumFlameseeker.java
+++ b/Mage.Sets/src/mage/cards/a/AkoumFlameseeker.java
@@ -80,7 +80,7 @@ class AkoumFlameseekerEffect extends OneShotEffect {
         if (controller != null) {
             Cards cards = controller.discard(1, false, source, game);
             if (!cards.isEmpty()) {
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/a/AladdinsLamp.java
+++ b/Mage.Sets/src/mage/cards/a/AladdinsLamp.java
@@ -75,7 +75,7 @@ class AladdinsLampEffect extends ReplacementEffectImpl {
         }
         controller.putCardsOnBottomOfLibrary(cards, game, source, false);
         game.applyEffects();
-        controller.drawCards(1, game, event.getAppliedEffects());
+        controller.drawCards(1, event.getSourceId(), game, event.getAppliedEffects());
         discard();
         return true;
     }

--- a/Mage.Sets/src/mage/cards/a/AlhammarretsArchive.java
+++ b/Mage.Sets/src/mage/cards/a/AlhammarretsArchive.java
@@ -98,7 +98,7 @@ class AlhammarretsArchiveReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            controller.drawCards(2, game, event.getAppliedEffects());
+            controller.drawCards(2, event.getSourceId(), game, event.getAppliedEffects());
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/a/AlmsCollector.java
+++ b/Mage.Sets/src/mage/cards/a/AlmsCollector.java
@@ -74,8 +74,8 @@ class AlmsCollectorReplacementEffect extends ReplacementEffectImpl {
         Player controller = game.getPlayer(source.getControllerId());
         Player opponent = game.getPlayer(event.getPlayerId());
         if (controller != null && opponent != null) {
-            controller.drawCards(1, game, event.getAppliedEffects());
-            opponent.drawCards(1, game, event.getAppliedEffects());
+            controller.drawCards(1, source.getSourceId(), game, event.getAppliedEffects());
+            opponent.drawCards(1, source.getSourceId(), game, event.getAppliedEffects());
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/a/AmassTheComponents.java
+++ b/Mage.Sets/src/mage/cards/a/AmassTheComponents.java
@@ -63,7 +63,7 @@ class AmassTheComponentsEffect extends OneShotEffect {
             return false;
         }
 
-        player.drawCards(3, game);
+        player.drawCards(3, source.getSourceId(), game);
         if (!player.getHand().isEmpty()) {
             FilterCard filter = new FilterCard("card from your hand to put on the bottom of your library");
             TargetCard target = new TargetCard(Zone.HAND, filter);

--- a/Mage.Sets/src/mage/cards/a/AminatouTheFateshifter.java
+++ b/Mage.Sets/src/mage/cards/a/AminatouTheFateshifter.java
@@ -98,7 +98,7 @@ class AminatouPlusEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
             putOnLibrary(player, source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/a/AncientExcavation.java
+++ b/Mage.Sets/src/mage/cards/a/AncientExcavation.java
@@ -63,7 +63,7 @@ class AncientExcavationEffect extends OneShotEffect {
         if (player != null) {
             DynamicValue numCards = CardsInControllerHandCount.instance;
             int amount = numCards.calculate(game, source, this);
-            player.drawCards(amount, game);
+            player.drawCards(amount, source.getSourceId(), game);
             player.discard(amount, false, source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/a/AnvilOfBogardan.java
+++ b/Mage.Sets/src/mage/cards/a/AnvilOfBogardan.java
@@ -57,7 +57,7 @@ class AnvilOfBogardanEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player targetPlayer = game.getPlayer(targetPointer.getFirst(game, source));
         if (targetPlayer != null) {
-            targetPlayer.drawCards(1, game);
+            targetPlayer.drawCards(1, source.getSourceId(), game);
             targetPlayer.discard(1, false, source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/a/ArcaneArtisan.java
+++ b/Mage.Sets/src/mage/cards/a/ArcaneArtisan.java
@@ -90,7 +90,7 @@ class ArcaneArtisanCreateTokenEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        player.drawCards(1, game);
+        player.drawCards(1, source.getSourceId(), game);
         TargetCard target = new TargetCardInHand(1, StaticFilters.FILTER_CARD);
         if (!player.chooseTarget(Outcome.Exile, player.getHand(), target, source, game)) {
             return false;

--- a/Mage.Sets/src/mage/cards/a/ArjunTheShiftingFlame.java
+++ b/Mage.Sets/src/mage/cards/a/ArjunTheShiftingFlame.java
@@ -64,7 +64,7 @@ class ArjunTheShiftingFlameEffect extends OneShotEffect {
         if (you != null) {
             int count = you.getHand().size();
             you.putCardsOnBottomOfLibrary(you.getHand(), game, source, true);
-            you.drawCards(count, game);
+            you.drawCards(count, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/a/AzorTheLawbringer.java
+++ b/Mage.Sets/src/mage/cards/a/AzorTheLawbringer.java
@@ -168,7 +168,7 @@ class AzorTheLawbringerAttacksEffect extends OneShotEffect {
                 if (cost.pay(source, game, source.getSourceId(), source.getControllerId(), false, null)) {
                     controller.resetStoredBookmark(game); // otherwise you can undo the payment
                     controller.gainLife(costX, game, source);
-                    controller.drawCards(costX, game);
+                    controller.drawCards(costX, source.getSourceId(), game);
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/a/AzorsGateway.java
+++ b/Mage.Sets/src/mage/cards/a/AzorsGateway.java
@@ -78,7 +78,7 @@ class AzorsGatewayEffect extends OneShotEffect {
         UUID exileId = CardUtil.getCardExileZoneId(game, source);
         MageObject sourceObject = source.getSourceObject(game);
         if (controller != null && exileId != null && sourceObject != null) {
-            controller.drawCards(1, game);
+            controller.drawCards(1, source.getSourceId(), game);
             TargetCardInHand target = new TargetCardInHand();
             controller.choose(outcome, target, source.getSourceId(), game);
             Card cardToExile = game.getCard(target.getFirstTarget());

--- a/Mage.Sets/src/mage/cards/a/AzraBladeseeker.java
+++ b/Mage.Sets/src/mage/cards/a/AzraBladeseeker.java
@@ -84,7 +84,7 @@ class AzraBladeseekerEffect extends OneShotEffect {
         }
         for (PlayerCard playerCard : playerCardList) {
             if (playerCard.getPlayer().discard(playerCard.getCard(), source, game)) {
-                playerCard.getPlayer().drawCards(1, game);
+                playerCard.getPlayer().drawCards(1, source.getSourceId(), game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/b/BalanceOfPower.java
+++ b/Mage.Sets/src/mage/cards/b/BalanceOfPower.java
@@ -59,7 +59,7 @@ class BalanceOfPowerEffect extends OneShotEffect {
         Player opponent = game.getPlayer(source.getFirstTarget());
 
         if (opponent != null && player != null && opponent.getHand().size() > player.getHand().size()) {
-            player.drawCards(opponent.getHand().size() - player.getHand().size(), game);
+            player.drawCards(opponent.getHand().size() - player.getHand().size(), source.getSourceId(), game);
             return true;
         }
 

--- a/Mage.Sets/src/mage/cards/b/BalefulStare.java
+++ b/Mage.Sets/src/mage/cards/b/BalefulStare.java
@@ -70,7 +70,7 @@ class BalefulStareEffect extends OneShotEffect {
                    count++;
                }
             }
-            controller.drawCards(count, game);
+            controller.drawCards(count, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/b/BaneAlleyBroker.java
+++ b/Mage.Sets/src/mage/cards/b/BaneAlleyBroker.java
@@ -106,7 +106,7 @@ class BaneAlleyBrokerDrawExileEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            controller.drawCards(1, game);
+            controller.drawCards(1, source.getSourceId(), game);
             Target target = new TargetCardInHand(new FilterCard("card to exile"));
             if (controller.chooseTarget(outcome, target, source, game)) {
                 Card card = game.getCard(target.getFirstTarget());

--- a/Mage.Sets/src/mage/cards/b/BarbedShocker.java
+++ b/Mage.Sets/src/mage/cards/b/BarbedShocker.java
@@ -70,7 +70,7 @@ class BarbedShockerEffect extends OneShotEffect {
                 for (Card card : targetPlayer.getHand().getCards(game)) {
                     targetPlayer.discard(card, source, game);
                 }
-                targetPlayer.drawCards(count, game);
+                targetPlayer.drawCards(count, source.getSourceId(), game);
                 return false;
             }
         return true;

--- a/Mage.Sets/src/mage/cards/b/BiomanticMastery.java
+++ b/Mage.Sets/src/mage/cards/b/BiomanticMastery.java
@@ -63,7 +63,7 @@ class BiomanticMasteryEffect extends OneShotEffect {
                 Player player = game.getPlayer(playerId);
                 if (player != null) {
                     int creatures = game.getBattlefield().countAll(StaticFilters.FILTER_PERMANENT_CREATURE, playerId, game);
-                    controller.drawCards(creatures, game);
+                    controller.drawCards(creatures, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/b/BlastOfGenius.java
+++ b/Mage.Sets/src/mage/cards/b/BlastOfGenius.java
@@ -59,7 +59,7 @@ class BlastOfGeniusEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(3, game);
+            player.drawCards(3, source.getSourceId(), game);
             TargetDiscard target = new TargetDiscard(player.getId());
             if (target.canChoose(source.getSourceId(), player.getId(), game)) {
                 player.choose(Outcome.Discard, target, source.getSourceId(), game);

--- a/Mage.Sets/src/mage/cards/b/BloodScrivener.java
+++ b/Mage.Sets/src/mage/cards/b/BloodScrivener.java
@@ -70,7 +70,7 @@ class BloodScrivenerReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player != null) {
-            player.drawCards(2, game, event.getAppliedEffects());
+            player.drawCards(2, event.getSourceId(), game, event.getAppliedEffects());
             player.loseLife(1, game, false);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/b/BondersOrnament.java
+++ b/Mage.Sets/src/mage/cards/b/BondersOrnament.java
@@ -73,7 +73,7 @@ class BondersOrnamentEffect extends OneShotEffect {
                     .noneMatch("Bonder's Ornament"::equals)) {
                 continue;
             }
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/b/BountyOfTheLuxa.java
+++ b/Mage.Sets/src/mage/cards/b/BountyOfTheLuxa.java
@@ -80,7 +80,7 @@ class BountyOfTheLuxaEffect extends OneShotEffect {
                 if (bountyOfLuxa != null) {
                     new AddCountersSourceEffect(CounterType.FLOOD.createInstance()).apply(game, source);
                 }
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/b/BrainPry.java
+++ b/Mage.Sets/src/mage/cards/b/BrainPry.java
@@ -67,7 +67,7 @@ class BrainPryEffect extends OneShotEffect {
                 }
             }
             if (!hasDiscarded) {
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             }
             controller.lookAtCards(sourceObject.getName() + " Hand", targetPlayer.getHand(), game);
         }

--- a/Mage.Sets/src/mage/cards/b/BreathstealersCrypt.java
+++ b/Mage.Sets/src/mage/cards/b/BreathstealersCrypt.java
@@ -68,7 +68,7 @@ class BreathstealersCryptEffect extends ReplacementEffectImpl {
         Player player = game.getPlayer(event.getPlayerId());
         if (player != null) {
             Cards oldHand = player.getHand().copy();
-            if (player.drawCards(1, game, event.getAppliedEffects()) > 0) {
+            if (player.drawCards(1, event.getSourceId(), game, event.getAppliedEffects()) > 0) {
                 Cards drawnCards = player.getHand().copy();
                 drawnCards.removeAll(oldHand);
                 player.revealCards(source, "The card drawn from " + player.getName() + "'s library.", drawnCards, game);

--- a/Mage.Sets/src/mage/cards/b/Browbeat.java
+++ b/Mage.Sets/src/mage/cards/b/Browbeat.java
@@ -80,7 +80,7 @@ class BrowbeatDrawEffect extends OneShotEffect {
                 if (targetPlayer != null) {
                     Player player = game.getPlayer(targetPlayer);
                     if (player != null) {
-                        player.drawCards(3, game);
+                        player.drawCards(3, source.getSourceId(), game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/b/BushmeatPoacher.java
+++ b/Mage.Sets/src/mage/cards/b/BushmeatPoacher.java
@@ -98,6 +98,6 @@ class BushmeatPoacherEffect extends OneShotEffect {
         if (amount > 0) {
             player.gainLife(amount, game, source);
         }
-        return player.drawCards(1, game) > 0;
+        return player.drawCards(1, source.getSourceId(), game) > 0;
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CallToHeel.java
+++ b/Mage.Sets/src/mage/cards/c/CallToHeel.java
@@ -67,7 +67,7 @@ class CallToHeelEffect extends OneShotEffect {
         if (permanent != null) {
             Player controller = game.getPlayer(permanent.getControllerId());
             if (controller != null) {
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/c/Camaraderie.java
+++ b/Mage.Sets/src/mage/cards/c/Camaraderie.java
@@ -67,7 +67,7 @@ class CamaraderieEffect extends OneShotEffect {
                 source.getSourceId(), source.getControllerId(), game
         );
         player.gainLife(xValue, game, source);
-        player.drawCards(xValue, game);
+        player.drawCards(xValue, source.getSourceId(), game);
         game.addEffect(new BoostControlledEffect(1, 1, Duration.EndOfTurn), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/CavalierOfFlame.java
+++ b/Mage.Sets/src/mage/cards/c/CavalierOfFlame.java
@@ -109,7 +109,7 @@ class CavalierOfFlameEffect extends OneShotEffect {
                     .map(uuid -> game.getCard(uuid))
                     .mapToInt(card -> card != null && player.discard(card, source, game) ? 1 : 0)
                     .sum();
-            player.drawCards(counter, game);
+            player.drawCards(counter, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/CemeteryRecruitment.java
+++ b/Mage.Sets/src/mage/cards/c/CemeteryRecruitment.java
@@ -64,7 +64,7 @@ class CemeteryRecruitmentEffect extends OneShotEffect {
             if (card != null) {
                 if (controller.moveCards(card, Zone.HAND, source, game)
                         && card.hasSubtype(SubType.ZOMBIE, game)) {
-                    controller.drawCards(1, game);
+                    controller.drawCards(1, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/c/ChandraFlamecaller.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraFlamecaller.java
@@ -112,7 +112,7 @@ class ChandraDrawEffect extends OneShotEffect {
             for (Card card : cardsInHand) {
                 player.discard(card, source, game);
             }
-            player.drawCards(amount + 1, game);
+            player.drawCards(amount + 1, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/c/ChandrasDefeat.java
+++ b/Mage.Sets/src/mage/cards/c/ChandrasDefeat.java
@@ -84,7 +84,7 @@ class ChandrasDefeatEffect extends OneShotEffect {
             if (filter.match(permanent, game) && controller != null
                     && controller.chooseUse(outcome, "Discard a card and draw a card?", source, game)) {
                 controller.discard(1, false, source, game);
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/c/ChanneledForce.java
+++ b/Mage.Sets/src/mage/cards/c/ChanneledForce.java
@@ -67,7 +67,7 @@ class ChanneledForceEffect extends OneShotEffect {
         }
         Player player = game.getPlayer(source.getTargets().get(0).getFirstTarget());
         if (player != null) {
-            player.drawCards(xValue, game);
+            player.drawCards(xValue, source.getSourceId(), game);
         }
         game.damagePlayerOrPlaneswalker(
                 source.getTargets().get(1).getFirstTarget(), xValue,

--- a/Mage.Sets/src/mage/cards/c/ChroniclerOfHeroes.java
+++ b/Mage.Sets/src/mage/cards/c/ChroniclerOfHeroes.java
@@ -75,7 +75,7 @@ class ChroniclerOfHeroesEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             if (new PermanentsOnTheBattlefieldCondition(filter).apply(game, source)) {
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/c/CivilizedScholar.java
+++ b/Mage.Sets/src/mage/cards/c/CivilizedScholar.java
@@ -16,13 +16,10 @@ import mage.cards.h.HomicidalBruteWatcher;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Outcome;
-import mage.constants.WatcherScope;
 import mage.constants.Zone;
 import mage.game.Game;
-import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
-import mage.watchers.Watcher;
 
 /**
  * @author nantuko
@@ -77,7 +74,7 @@ class CivilizedScholarEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
             Card card = player.discardOne(false, source, game);
             if (card != null && card.isCreature()) {
                 Permanent permanent = game.getPermanent(source.getSourceId());

--- a/Mage.Sets/src/mage/cards/c/ClackbridgeTroll.java
+++ b/Mage.Sets/src/mage/cards/c/ClackbridgeTroll.java
@@ -114,7 +114,7 @@ class ClackbridgeTrollEffect extends OneShotEffect {
                 sourcePerm.tap(game);
             }
             controller.gainLife(3, game, source);
-            controller.drawCards(1, game);
+            controller.drawCards(1, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/ClingToDust.java
+++ b/Mage.Sets/src/mage/cards/c/ClingToDust.java
@@ -72,7 +72,7 @@ class ClingToDustEffect extends OneShotEffect {
         if (isCreature) {
             player.gainLife(3, game, source);
         } else {
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/CoercedConfession.java
+++ b/Mage.Sets/src/mage/cards/c/CoercedConfession.java
@@ -69,7 +69,7 @@ class CoercedConfessionMillEffect extends OneShotEffect {
             if (foundCreatures > 0) {
                 Player controller = game.getPlayer(source.getControllerId());
                 if (controller != null) {
-                    controller.drawCards(foundCreatures, game);
+                    controller.drawCards(foundCreatures, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/c/CoercivePortal.java
+++ b/Mage.Sets/src/mage/cards/c/CoercivePortal.java
@@ -77,7 +77,7 @@ class CoercivePortalEffect extends OneShotEffect {
                 new SacrificeSourceEffect().apply(game, source);
                 new DestroyAllEffect(new FilterNonlandPermanent()).apply(game, source);
             } else {
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/c/ColdEyedSelkie.java
+++ b/Mage.Sets/src/mage/cards/c/ColdEyedSelkie.java
@@ -68,7 +68,7 @@ class ColdEyeSelkieEffect extends OneShotEffect {
         if (amount > 0) {
             Player controller = game.getPlayer(source.getControllerId());
             if (controller != null) {
-                controller.drawCards(amount, game);
+                controller.drawCards(amount, source.getSourceId(), game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/c/CollectiveDefiance.java
+++ b/Mage.Sets/src/mage/cards/c/CollectiveDefiance.java
@@ -95,7 +95,7 @@ class CollectiveDefianceEffect extends OneShotEffect {
             for (Card card : targetPlayer.getHand().getCards(game)) {
                 targetPlayer.discard(card, source, game);
             }
-            targetPlayer.drawCards(count, game);
+            targetPlayer.drawCards(count, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/c/CommenceTheEndgame.java
+++ b/Mage.Sets/src/mage/cards/c/CommenceTheEndgame.java
@@ -60,7 +60,7 @@ class CommenceTheEndgameEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        player.drawCards(2, game);
+        player.drawCards(2, source.getSourceId(), game);
         return new AmassEffect(player.getHand().size()).apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/ConchHorn.java
+++ b/Mage.Sets/src/mage/cards/c/ConchHorn.java
@@ -64,7 +64,7 @@ class ConchHornEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(2, game);
+            player.drawCards(2, source.getSourceId(), game);
             putOnLibrary(player, source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/c/CovenantOfMinds.java
+++ b/Mage.Sets/src/mage/cards/c/CovenantOfMinds.java
@@ -74,12 +74,12 @@ class CovenantOfMindsEffect extends OneShotEffect {
                 player.moveCards(cards, Zone.HAND, source, game);
             } else {
                 player.moveCards(cards, Zone.GRAVEYARD, source, game);
-                player.drawCards(5, game);
+                player.drawCards(5, source.getSourceId(), game);
             }
 
         } else {
             if (!opponent.chooseUse(Outcome.Benefit, player.getLogName() + "'s library is empty? Do you want them to draw five cards?", source, game)) {
-                player.drawCards(5, game);
+                player.drawCards(5, source.getSourceId(), game);
             }
         }
 

--- a/Mage.Sets/src/mage/cards/c/CranialArchive.java
+++ b/Mage.Sets/src/mage/cards/c/CranialArchive.java
@@ -71,7 +71,7 @@ class CranialArchiveEffect extends OneShotEffect {
                 }
                 targetPlayer.shuffleLibrary(source, game);
             }
-            controller.drawCards(1, game);
+            controller.drawCards(1, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/c/CreditVoucher.java
+++ b/Mage.Sets/src/mage/cards/c/CreditVoucher.java
@@ -79,7 +79,7 @@ class CreditVoucherEffect extends OneShotEffect {
             }
             controller.shuffleLibrary(source, game);
             if (amountShuffled > 0) {
-                controller.drawCards(amountShuffled, game);
+                controller.drawCards(amountShuffled, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/c/CullingDais.java
+++ b/Mage.Sets/src/mage/cards/c/CullingDais.java
@@ -66,7 +66,7 @@ class CullingDaisEffect extends OneShotEffect {
         Player player = game.getPlayer(source.getControllerId());
         if (p != null && player != null) {
             int count = p.getCounters(game).getCount(CounterType.CHARGE);
-            player.drawCards(count, game);
+            player.drawCards(count, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/c/CurseOfChaos.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfChaos.java
@@ -115,7 +115,7 @@ class CurseOfChaosEffect extends OneShotEffect {
         if (attacker != null) {
             if (!attacker.getHand().isEmpty() && attacker.chooseUse(outcome, "Discard a card and draw a card?", source, game)) {
                 attacker.discard(1, false, source, game);
-                attacker.drawCards(1, game);
+                attacker.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/c/CurseOfVengeance.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfVengeance.java
@@ -157,7 +157,7 @@ class CurseOfVengeanceDrawLifeEffect extends OneShotEffect {
         Permanent sourceObject = game.getPermanentOrLKIBattlefield(source.getSourceId());
         if (sourceObject != null && controller != null) {
             if (sourceObject.getCounters(game).containsKey(CounterType.SPITE)) {
-                controller.drawCards(sourceObject.getCounters(game).getCount(CounterType.SPITE), game);
+                controller.drawCards(sourceObject.getCounters(game).getCount(CounterType.SPITE), source.getSourceId(), game);
                 controller.gainLife(sourceObject.getCounters(game).getCount(CounterType.SPITE), game, source);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/d/DamnablePact.java
+++ b/Mage.Sets/src/mage/cards/d/DamnablePact.java
@@ -52,7 +52,7 @@ class DamnablePactEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player targetPlayer = game.getPlayer(targetPointer.getFirst(game, source));
         if (targetPlayer != null) {
-            targetPlayer.drawCards(source.getManaCostsToPay().getX(), game);
+            targetPlayer.drawCards(source.getManaCostsToPay().getX(), source.getSourceId(), game);
             targetPlayer.loseLife(source.getManaCostsToPay().getX(), game, false);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/d/DaredevilDragster.java
+++ b/Mage.Sets/src/mage/cards/d/DaredevilDragster.java
@@ -79,7 +79,7 @@ class DaredevilDragsterEffect extends OneShotEffect {
             permanent.addCounters(CounterType.VELOCITY.createInstance(), source, game);
             if (permanent.getCounters(game).getCount(CounterType.VELOCITY) >= 2) {
                 permanent.sacrifice(source.getSourceId(), game);
-                controller.drawCards(2, game);
+                controller.drawCards(2, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/d/DarettiScrapSavant.java
+++ b/Mage.Sets/src/mage/cards/d/DarettiScrapSavant.java
@@ -101,7 +101,7 @@ class DarettiDiscardDrawEffect extends OneShotEffect {
                     count++;
                 }
             }
-            controller.drawCards(count, game);
+            controller.drawCards(count, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/d/DarkDeal.java
+++ b/Mage.Sets/src/mage/cards/d/DarkDeal.java
@@ -5,7 +5,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import com.j256.ormlite.stmt.query.In;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
@@ -72,7 +71,7 @@ class DarkDealEffect extends OneShotEffect {
             for (Map.Entry<UUID, Integer> toDrawByPlayer : cardsToDraw.entrySet()) {
                 Player player = game.getPlayer(toDrawByPlayer.getKey());
                 if (player != null) {
-                    player.drawCards(toDrawByPlayer.getValue(), game);
+                    player.drawCards(toDrawByPlayer.getValue(), source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/d/DarkIntimations.java
+++ b/Mage.Sets/src/mage/cards/d/DarkIntimations.java
@@ -128,7 +128,7 @@ class DarkIntimationsEffect extends OneShotEffect {
             }
             controller.moveCards(card, Zone.HAND, source, game);
         }
-        controller.drawCards(1, game);
+        controller.drawCards(1, source.getSourceId(), game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DecreeOfPain.java
+++ b/Mage.Sets/src/mage/cards/d/DecreeOfPain.java
@@ -73,7 +73,7 @@ class DecreeOfPainEffect extends OneShotEffect {
                 }
             }
             if (destroyedCreature > 0) {
-                controller.drawCards(destroyedCreature, game);
+                controller.drawCards(destroyedCreature, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/d/DesperateRavings.java
+++ b/Mage.Sets/src/mage/cards/d/DesperateRavings.java
@@ -62,7 +62,7 @@ class DesperateRavingsEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(2, game);
+            player.drawCards(2, source.getSourceId(), game);
             Cards hand = player.getHand();
             Card card = hand.getRandom(game);
             player.discard(card, source, game);

--- a/Mage.Sets/src/mage/cards/d/DiminishingReturns.java
+++ b/Mage.Sets/src/mage/cards/d/DiminishingReturns.java
@@ -72,7 +72,7 @@ class DiminishingReturnsEffect extends OneShotEffect {
                 Player player = game.getPlayer(playerId);
                 if (player != null) {
                     int cardsToDrawCount = player.getAmount(0, 7, "How many cards to draw (up to 7)?", game);
-                    player.drawCards(cardsToDrawCount, game);
+                    player.drawCards(cardsToDrawCount, source.getSourceId(), game);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/d/DimirCutpurse.java
+++ b/Mage.Sets/src/mage/cards/d/DimirCutpurse.java
@@ -59,7 +59,7 @@ class DimirCutpurseEffect extends OneShotEffect {
             damagedPlayer.discard(1, false,source, game);
         }
         if (you != null) {
-            you.drawCards(1, game);
+            you.drawCards(1, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/d/DiscipleOfBolas.java
+++ b/Mage.Sets/src/mage/cards/d/DiscipleOfBolas.java
@@ -75,7 +75,7 @@ class DiscipleOfBolasEffect extends OneShotEffect {
                     sacrificed.sacrifice(source.getSourceId(), game);
                     int power = sacrificed.getPower().getValue();
                     controller.gainLife(power, game, source);
-                    controller.drawCards(power, game);
+                    controller.drawCards(power, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/d/DistantMemories.java
+++ b/Mage.Sets/src/mage/cards/d/DistantMemories.java
@@ -85,7 +85,7 @@ class DistantMemoriesEffect extends OneShotEffect {
                 if (putInHand) {
                     controller.moveCards(card, Zone.HAND, source, game);
                 } else {
-                    controller.drawCards(3, game);
+                    controller.drawCards(3, source.getSourceId(), game);
                 }
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/d/DivinerSpirit.java
+++ b/Mage.Sets/src/mage/cards/d/DivinerSpirit.java
@@ -64,8 +64,8 @@ class DivinerSpiritEffect extends OneShotEffect {
         if (sourceController != null && damagedPlayer != null) {
             int amount = (Integer) getValue("damage");
             if (amount > 0) {
-                sourceController.drawCards(amount, game);
-                damagedPlayer.drawCards(amount, game);
+                sourceController.drawCards(amount, source.getSourceId(), game);
+                damagedPlayer.drawCards(amount, source.getSourceId(), game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/d/DivinersLockbox.java
+++ b/Mage.Sets/src/mage/cards/d/DivinersLockbox.java
@@ -84,7 +84,7 @@ class DivinersLockboxEffect extends OneShotEffect {
         player.revealCards(source, new CardsImpl(card), game);
         if (choice.getChoice().equals(card.getName())) {
             sacEffect.apply(game, source);
-            player.drawCards(3, game);
+            player.drawCards(3, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/d/DoomForetold.java
+++ b/Mage.Sets/src/mage/cards/d/DoomForetold.java
@@ -96,7 +96,7 @@ class DoomForetoldEffect extends OneShotEffect {
         }
         player.discard(1, false, source, game);
         player.loseLife(2, game, false);
-        controller.drawCards(1, game);
+        controller.drawCards(1, source.getSourceId(), game);
         controller.gainLife(2, game, source);
         effect1.apply(game, source);
         effect2.apply(game, source);

--- a/Mage.Sets/src/mage/cards/d/DrasticRevelation.java
+++ b/Mage.Sets/src/mage/cards/d/DrasticRevelation.java
@@ -51,7 +51,7 @@ class DrasticRevelationEffect extends OneShotEffect {
         Player you = game.getPlayer(source.getControllerId());
         if (you != null) {
             you.discard(you.getHand().size(), false, source, game);
-            you.drawCards(7, game);
+            you.drawCards(7, source.getSourceId(), game);
             Cards hand = you.getHand();
             for (int i = 0; i < 3; i++) {
                 Card card = hand.getRandom(game);

--- a/Mage.Sets/src/mage/cards/d/DreamCache.java
+++ b/Mage.Sets/src/mage/cards/d/DreamCache.java
@@ -58,7 +58,7 @@ class DreamCacheEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            controller.drawCards(3, game);
+            controller.drawCards(3, source.getSourceId(), game);
             boolean putOnTop = controller.chooseUse(Outcome.Neutral, "Put cards on top?", source, game);
             TargetCardInHand target = new TargetCardInHand(2, 2, new FilterCard());
             controller.chooseTarget(Outcome.Detriment, target, source, game);

--- a/Mage.Sets/src/mage/cards/d/DreamFracture.java
+++ b/Mage.Sets/src/mage/cards/d/DreamFracture.java
@@ -70,7 +70,7 @@ class DreamFractureEffect extends OneShotEffect {
             countered = true;
         }
         if (controller != null) {
-            controller.drawCards(1, game);
+            controller.drawCards(1, source.getSourceId(), game);
         }
         return countered;
     }

--- a/Mage.Sets/src/mage/cards/d/DreamSalvage.java
+++ b/Mage.Sets/src/mage/cards/d/DreamSalvage.java
@@ -3,7 +3,6 @@ package mage.cards.d;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
@@ -97,7 +96,7 @@ class DreamSalvageEffect extends OneShotEffect {
                 && controller != null
                 && watcher != null
                 && watcher.getAmountCardsDiscarded(targetOpponent.getId()) > 0) {
-            controller.drawCards(watcher.getAmountCardsDiscarded(targetOpponent.getId()), game);
+            controller.drawCards(watcher.getAmountCardsDiscarded(targetOpponent.getId()), source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/e/Excavation.java
+++ b/Mage.Sets/src/mage/cards/e/Excavation.java
@@ -67,7 +67,7 @@ class ExcavationEffect extends OneShotEffect {
         if (source instanceof ActivatedAbilityImpl) {
             Player activator = game.getPlayer(((ActivatedAbilityImpl) source).getActivatorId());
             if (activator != null) {
-                activator.drawCards(1, game);
+                activator.drawCards(1, source.getSourceId(), game);
                 return true;
             }
 

--- a/Mage.Sets/src/mage/cards/e/ExpansionExplosion.java
+++ b/Mage.Sets/src/mage/cards/e/ExpansionExplosion.java
@@ -85,7 +85,7 @@ class ExplosionEffect extends OneShotEffect {
         effect.apply(game, source);
         Player player = game.getPlayer(source.getTargets().get(1).getFirstTarget());
         if (player != null) {
-            player.drawCards(xValue, game);
+            player.drawCards(xValue, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/f/FaadiyahSeer.java
+++ b/Mage.Sets/src/mage/cards/f/FaadiyahSeer.java
@@ -71,7 +71,7 @@ class FaadiyahSeerEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Card card = controller.getLibrary().getFromTop(game);
-            controller.drawCards(1, game);
+            controller.drawCards(1, source.getSourceId(), game);
             controller.revealCards("Fa'adiyah Seer", new CardsImpl(card), game);
             if (!filter.match(card, game)) {
                 controller.discard(card, source, game);

--- a/Mage.Sets/src/mage/cards/f/FatalLore.java
+++ b/Mage.Sets/src/mage/cards/f/FatalLore.java
@@ -67,7 +67,7 @@ class FatalLoreEffect extends OneShotEffect {
         if (controller != null
                 && chosenOpponent != null) {
             if (chosenOpponent.chooseUse(Outcome.Neutral, "If you choose Yes, the controller draws three cards.  If no, the controller gets to destroy up to two target creatures that you control and you get to draw up to 3 cards.  Those creatures can't be regenerated.", source, game)) {
-                controller.drawCards(3, game);
+                controller.drawCards(3, source.getSourceId(), game);
             } else {
                 FilterCreaturePermanent filter = new FilterCreaturePermanent("chosen opponent's creature");
                 filter.add(new ControllerIdPredicate(chosenOpponent.getId()));

--- a/Mage.Sets/src/mage/cards/f/Fecundity.java
+++ b/Mage.Sets/src/mage/cards/f/Fecundity.java
@@ -60,7 +60,7 @@ class FecundityEffect extends OneShotEffect {
             Player controller = game.getPlayer(permanent.getControllerId());
             if (controller != null) {
                 if (controller.chooseUse(outcome, "Draw a card?", source, game)) {
-                    controller.drawCards(1, game);
+                    controller.drawCards(1, source.getSourceId(), game);
                 }
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/f/FeveredVisions.java
+++ b/Mage.Sets/src/mage/cards/f/FeveredVisions.java
@@ -54,7 +54,7 @@ class FeveredVisionsEffect extends OneShotEffect {
         UUID activePlayerId = game.getActivePlayerId();
         Player player = game.getPlayer(activePlayerId);
         if (controller != null && player != null) {
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
             Set<UUID> opponents = game.getOpponents(source.getControllerId());
             if (opponents.contains(player.getId()) && player.getHand().size() > 3) {
                 player.damage(2, source.getSourceId(), game);

--- a/Mage.Sets/src/mage/cards/f/FieryGambit.java
+++ b/Mage.Sets/src/mage/cards/f/FieryGambit.java
@@ -81,7 +81,7 @@ class FieryGambitEffect extends OneShotEffect {
                     new DamagePlayersEffect(6, TargetController.OPPONENT).apply(game, source);
                 }
                 if (flipsWon > 2) {
-                    controller.drawCards(9, game);
+                    controller.drawCards(9, source.getSourceId(), game);
                     new UntapAllLandsControllerEffect().apply(game, source);
                 }
             } else {

--- a/Mage.Sets/src/mage/cards/f/FiligreeFracture.java
+++ b/Mage.Sets/src/mage/cards/f/FiligreeFracture.java
@@ -63,7 +63,7 @@ class FiligreeFractureEffect extends OneShotEffect {
             permanent.destroy(source.getSourceId(), game, true);
             game.applyEffects();
             if (permanent.getColor(game).isBlack() || permanent.getColor(game).isBlue()) {
-                player.drawCards(1, game);
+                player.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/f/FinaleOfRevelation.java
+++ b/Mage.Sets/src/mage/cards/f/FinaleOfRevelation.java
@@ -66,11 +66,11 @@ class FinaleOfRevelationEffect extends OneShotEffect {
         int xValue = source.getManaCostsToPay().getX();
 
         if (xValue < 10) {
-            player.drawCards(xValue, game);
+            player.drawCards(xValue, source.getSourceId(), game);
         } else {
             player.putCardsOnTopOfLibrary(player.getGraveyard(), game, source, false);
             player.shuffleLibrary(source, game);
-            player.drawCards(xValue, game);
+            player.drawCards(xValue, source.getSourceId(), game);
             new UntapLandsEffect(5).apply(game, source);
             game.addEffect(new MaximumHandSizeControllerEffect(
                     Integer.MAX_VALUE, Duration.EndOfGame,

--- a/Mage.Sets/src/mage/cards/f/FireProphecy.java
+++ b/Mage.Sets/src/mage/cards/f/FireProphecy.java
@@ -74,7 +74,7 @@ class FireProphecyEffect extends OneShotEffect {
             return false;
         }
         player.getLibrary().putOnBottom(card, game);
-        player.drawCards(1, game);
+        player.drawCards(1, source.getSourceId(), game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/f/Flux.java
+++ b/Mage.Sets/src/mage/cards/f/Flux.java
@@ -61,7 +61,7 @@ class FluxEffect extends OneShotEffect {
             if (player != null) {
                 int numToDiscard = player.getAmount(0, player.getHand().size(), "Discard how many cards?", game);
                 player.discard(numToDiscard, false, source, game);
-                player.drawCards(numToDiscard, game);
+                player.drawCards(numToDiscard, source.getSourceId(), game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/f/Foreshadow.java
+++ b/Mage.Sets/src/mage/cards/f/Foreshadow.java
@@ -73,7 +73,7 @@ class ForeshadowEffect extends OneShotEffect {
             if (card != null) {
                 controller.moveCards(card, Zone.GRAVEYARD, source, game);
                 if (CardUtil.haveSameNames(card.getName(), cardName)) {
-                    controller.drawCards(1, game);
+                    controller.drawCards(1, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/f/Forget.java
+++ b/Mage.Sets/src/mage/cards/f/Forget.java
@@ -57,7 +57,7 @@ class ForgetEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player targetPlayer = game.getPlayer(source.getFirstTarget());
         if (targetPlayer != null) {
-            targetPlayer.drawCards(targetPlayer.discard(2, false, source, game).size(), game);
+            targetPlayer.drawCards(targetPlayer.discard(2, false, source, game).size(), source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/f/ForgottenCreation.java
+++ b/Mage.Sets/src/mage/cards/f/ForgottenCreation.java
@@ -67,7 +67,7 @@ class ForgottenCreationEffect extends OneShotEffect {
         if (controller != null) {
             int cardsInHand = controller.getHand().size();
             controller.discard(cardsInHand, false, source, game);
-            controller.drawCards(cardsInHand, game);
+            controller.drawCards(cardsInHand, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/f/FruitOfTheFirstTree.java
+++ b/Mage.Sets/src/mage/cards/f/FruitOfTheFirstTree.java
@@ -71,7 +71,7 @@ class FruitOfTheFirstTreeEffect extends OneShotEffect {
         Permanent creature = (Permanent) getValue("attachedTo");
         if (controller != null && creature != null) {
             controller.gainLife(creature.getToughness().getValue(), game, source);
-            controller.drawCards(creature.getToughness().getValue(), game);
+            controller.drawCards(creature.getToughness().getValue(), source.getSourceId(), game);
             return true;            
         }
         return false;

--- a/Mage.Sets/src/mage/cards/g/GarrukPrimalHunter.java
+++ b/Mage.Sets/src/mage/cards/g/GarrukPrimalHunter.java
@@ -80,7 +80,7 @@ class GarrukPrimalHunterEffect extends OneShotEffect {
                     amount = p.getPower().getValue();
                 }
             }
-            player.drawCards(amount, game);
+            player.drawCards(amount, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/g/GhastlyDiscovery.java
+++ b/Mage.Sets/src/mage/cards/g/GhastlyDiscovery.java
@@ -58,7 +58,7 @@ class GhastlyDiscoveryEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            controller.drawCards(2, game);
+            controller.drawCards(2, source.getSourceId(), game);
             controller.discard(1, false, source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/g/GiveTake.java
+++ b/Mage.Sets/src/mage/cards/g/GiveTake.java
@@ -72,7 +72,7 @@ class TakeEffect extends OneShotEffect {
                 creature.removeCounters(CounterType.P1P1.getName(), numberCounters, game);
                 Player controller = game.getPlayer(source.getControllerId());
                 if (controller != null) {
-                    controller.drawCards(numberCounters, game);
+                    controller.drawCards(numberCounters, source.getSourceId(), game);
                 } else {
                     throw new UnsupportedOperationException("Controller missing");
                 }

--- a/Mage.Sets/src/mage/cards/g/GlintEyeNephilim.java
+++ b/Mage.Sets/src/mage/cards/g/GlintEyeNephilim.java
@@ -74,7 +74,7 @@ class GlintEyeNephilimEffect extends OneShotEffect {
         if (amount > 0) {
             Player controller = game.getPlayer(source.getControllerId());
             if (controller != null) {
-                controller.drawCards(amount, game);
+                controller.drawCards(amount, source.getSourceId(), game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/g/GoblinArtisans.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinArtisans.java
@@ -79,7 +79,7 @@ class GoblinArtisansEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             if (controller.flipCoin(source, game, true)) {
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             } else {
                 List<Permanent> artifacts = game.getBattlefield().getActivePermanents(new FilterControlledArtifactPermanent(), source.getControllerId(), game);
                 if (artifacts.isEmpty()) {//Don't even bother if there is no artifact to 'counter'/sacrifice

--- a/Mage.Sets/src/mage/cards/g/GodEternalBontu.java
+++ b/Mage.Sets/src/mage/cards/g/GodEternalBontu.java
@@ -96,6 +96,6 @@ class GodEternalBontuEffect extends OneShotEffect {
                 counter++;
             }
         }
-        return player.drawCards(counter, game) > 0;
+        return player.drawCards(counter, source.getSourceId(), game) > 0;
     }
 }

--- a/Mage.Sets/src/mage/cards/g/GrandMoffTarkin.java
+++ b/Mage.Sets/src/mage/cards/g/GrandMoffTarkin.java
@@ -137,7 +137,7 @@ class GrandMoffTarkinEffect extends OneShotEffect {
             game.informPlayers(player.getLogName() + " pays 2 life to prevent " + targetCreature.getName() + " being destroyed");
             Player sourceController = game.getPlayer(source.getControllerId());
             if (sourceController != null) {
-                sourceController.drawCards(1, game);
+                sourceController.drawCards(1, source.getSourceId(), game);
             }
 
             return true;

--- a/Mage.Sets/src/mage/cards/g/Gravestorm.java
+++ b/Mage.Sets/src/mage/cards/g/Gravestorm.java
@@ -79,7 +79,7 @@ class GravestormEffect extends OneShotEffect {
             
             if (!opponentExilesACard) {                
                 if (you.chooseUse(Outcome.DrawCard, "Draw a card?", source, game)) {
-                    you.drawCards(1, game);                            
+                    you.drawCards(1, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/g/GrevenPredatorCaptain.java
+++ b/Mage.Sets/src/mage/cards/g/GrevenPredatorCaptain.java
@@ -124,7 +124,7 @@ class GrevenPredatorCaptainEffect extends OneShotEffect {
         if (!permanent.sacrifice(source.getSourceId(), game)) {
             return false;
         }
-        player.drawCards(power, game);
+        player.drawCards(power, source.getSourceId(), game);
         player.loseLife(toughness, game, false);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/g/GrothamaAllDevouring.java
+++ b/Mage.Sets/src/mage/cards/g/GrothamaAllDevouring.java
@@ -158,7 +158,7 @@ class GrothamaAllDevouringDrawCardsEffect extends OneShotEffect {
             if (player != null) {
                 int toDraw = damageMap.getOrDefault(player.getId(), 0);
                 if (toDraw > 0) {
-                    player.drawCards(toDraw, game);
+                    player.drawCards(toDraw, source.getSourceId(), game);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/g/GuardianProject.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianProject.java
@@ -21,7 +21,6 @@ import mage.filter.predicate.permanent.TokenPredicate;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.ZoneChangeEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
@@ -145,7 +144,7 @@ class GuardianProjectEffect extends OneShotEffect {
         if (GuardianProjectTriggeredAbility.checkCondition(
                 mor.getPermanentOrLKIBattlefield(game), source.getControllerId(), game)
         ) {
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/g/GuildSummit.java
+++ b/Mage.Sets/src/mage/cards/g/GuildSummit.java
@@ -90,7 +90,7 @@ class GuildSummitEffect extends OneShotEffect {
             }
         }
         if (tappedAmount > 0) {
-            you.drawCards(tappedAmount, game);
+            you.drawCards(tappedAmount, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/g/GwafaHazidProfiteer.java
+++ b/Mage.Sets/src/mage/cards/g/GwafaHazidProfiteer.java
@@ -79,7 +79,7 @@ class GwafaHazidProfiteerEffect1 extends OneShotEffect {
             Player controller = game.getPlayer(targetCreature.getControllerId());
             targetCreature.addCounters(CounterType.BRIBERY.createInstance(), source, game);
             if (controller != null) {
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/h/HappilyEverAfter.java
+++ b/Mage.Sets/src/mage/cards/h/HappilyEverAfter.java
@@ -80,7 +80,7 @@ class HappilyEverAfterEffect extends OneShotEffect {
                 .filter(Objects::nonNull)
                 .forEachOrdered(player -> {
                     player.gainLife(5, game, source);
-                    player.drawCards(1, game);
+                    player.drawCards(1, source.getSourceId(), game);
                 });
         return true;
     }

--- a/Mage.Sets/src/mage/cards/h/HarborGuardian.java
+++ b/Mage.Sets/src/mage/cards/h/HarborGuardian.java
@@ -67,7 +67,7 @@ class HarborGuardianEffect extends OneShotEffect {
         Player defender = game.getPlayer(defenderId);
         if (defender != null) {
             if (defender.chooseUse(outcome, "Draw a card?", source, game)) {
-                defender.drawCards(1, game);
+                defender.drawCards(1, source.getSourceId(), game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/h/HeartwarmingRedemption.java
+++ b/Mage.Sets/src/mage/cards/h/HeartwarmingRedemption.java
@@ -57,7 +57,7 @@ class HeartwarmingRedemptionEffect extends OneShotEffect {
             return false;
         }
         int discarded = player.discard(player.getHand().size(), false, source, game).size();
-        player.drawCards(discarded + 1, game);
+        player.drawCards(discarded + 1, source.getSourceId(), game);
         player.gainLife(player.getHand().size(), game, source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/h/HeartwoodStoryteller.java
+++ b/Mage.Sets/src/mage/cards/h/HeartwoodStoryteller.java
@@ -106,7 +106,7 @@ class HeartwoodStorytellerEffect extends OneShotEffect {
             Player player = game.getPlayer(playerId);
             if (player != null) {
                 if (player.chooseUse(outcome, "Draw a card?", source, game)) {
-                    player.drawCards(1, game);
+                    player.drawCards(1, source.getSourceId(), game);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/h/HeedTheMists.java
+++ b/Mage.Sets/src/mage/cards/h/HeedTheMists.java
@@ -57,7 +57,7 @@ public final class HeedTheMists extends CardImpl {
                 if (card != null) {
                     int cmc = card.getConvertedManaCost();
                     controller.moveCards(card, Zone.GRAVEYARD, source, game);
-                    controller.drawCards(cmc, game);
+                    controller.drawCards(cmc, source.getSourceId(), game);
                 }
             }
             return result;

--- a/Mage.Sets/src/mage/cards/h/HoardersGreed.java
+++ b/Mage.Sets/src/mage/cards/h/HoardersGreed.java
@@ -58,7 +58,7 @@ class HoardersGreedEffect extends OneShotEffect {
         if (controller != null) {
             do {
                 controller.loseLife(2, game, false);
-                controller.drawCards(2, game);
+                controller.drawCards(2, source.getSourceId(), game);
             } while (controller.canRespond() && ClashEffect.getInstance().apply(game, source));
             return true;
         }

--- a/Mage.Sets/src/mage/cards/h/HumbleDefector.java
+++ b/Mage.Sets/src/mage/cards/h/HumbleDefector.java
@@ -69,7 +69,7 @@ class HumbleDefectorEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            controller.drawCards(2, game);
+            controller.drawCards(2, source.getSourceId(), game);
         }
         Permanent humbleDefector = (Permanent) source.getSourceObjectIfItStillExists(game);
         Player targetOpponent = game.getPlayer(getTargetPointer().getFirst(game, source));

--- a/Mage.Sets/src/mage/cards/h/HuntersProwess.java
+++ b/Mage.Sets/src/mage/cards/h/HuntersProwess.java
@@ -73,7 +73,7 @@ class HuntersProwessDrawEffect extends OneShotEffect {
         if (controller != null) {
             int damage = (Integer) this.getValue("damage");
             if (damage > 0) {
-                controller.drawCards(damage, game);
+                controller.drawCards(damage, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/h/HydroidKrasis.java
+++ b/Mage.Sets/src/mage/cards/h/HydroidKrasis.java
@@ -86,7 +86,7 @@ class HydroidKrasisEffect extends OneShotEffect {
             return false;
         }
         int halfCost = Math.floorDiv(((SpellAbility) obj).getManaCostsToPay().getX(), 2);
-        player.drawCards(halfCost, game);
+        player.drawCards(halfCost, source.getSourceId(), game);
         player.gainLife(halfCost, game, source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/i/IllusoryAmbusher.java
+++ b/Mage.Sets/src/mage/cards/i/IllusoryAmbusher.java
@@ -67,7 +67,7 @@ class IllusoryAmbusherDealtDamageEffect extends OneShotEffect {
         if (player != null) {
             int amount = (Integer) getValue("damage");
             if (amount > 0) {
-                player.drawCards(amount, game);
+                player.drawCards(amount, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/i/ImpulsiveWager.java
+++ b/Mage.Sets/src/mage/cards/i/ImpulsiveWager.java
@@ -68,7 +68,7 @@ class ImpulsiveWagerEffect extends OneShotEffect {
                     effect.setTargetPointer(getTargetPointer());
                     effect.apply(game, source);
                 } else {
-                    player.drawCards(2, game);
+                    player.drawCards(2, source.getSourceId(), game);
                 }
 
             }

--- a/Mage.Sets/src/mage/cards/i/IncendiaryCommand.java
+++ b/Mage.Sets/src/mage/cards/i/IncendiaryCommand.java
@@ -95,7 +95,7 @@ class IncendiaryCommandDrawEffect extends OneShotEffect {
             for (Map.Entry<UUID, Integer> toDrawByPlayer : cardsToDraw.entrySet()) {
                 Player player = game.getPlayer(toDrawByPlayer.getKey());
                 if (player != null) {
-                    player.drawCards(toDrawByPlayer.getValue(), game);
+                    player.drawCards(toDrawByPlayer.getValue(), source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/i/InducedAmnesia.java
+++ b/Mage.Sets/src/mage/cards/i/InducedAmnesia.java
@@ -77,7 +77,7 @@ class InducedAmnesiaExileEffect extends OneShotEffect {
                 }
                 game.informPlayers(sourcePermanent.getLogName() + ": " + targetPlayer.getLogName() + " exiles their hand face down (" + numberOfCards + "card" + (numberOfCards > 1 ? "s" : "") + ')');
                 game.applyEffects();
-                targetPlayer.drawCards(numberOfCards, game);
+                targetPlayer.drawCards(numberOfCards, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/i/IndulgentTormentor.java
+++ b/Mage.Sets/src/mage/cards/i/IndulgentTormentor.java
@@ -88,7 +88,7 @@ class IndulgentTormentorEffect extends OneShotEffect {
                     return true;
                 }
             }
-            game.getPlayer(source.getControllerId()).drawCards(1, game);
+            game.getPlayer(source.getControllerId()).drawCards(1, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/i/InfernalOffering.java
+++ b/Mage.Sets/src/mage/cards/i/InfernalOffering.java
@@ -99,7 +99,7 @@ class InfernalOfferingSacrificeEffect extends OneShotEffect {
                 for (UUID playerId : toDraw) {
                     Player playerToDraw = game.getPlayer(playerId);
                     if (playerToDraw != null) {
-                        playerToDraw.drawCards(2, game);
+                        playerToDraw.drawCards(2, source.getSourceId(), game);
                     }
                 }
                 return true;

--- a/Mage.Sets/src/mage/cards/i/InspiredUltimatum.java
+++ b/Mage.Sets/src/mage/cards/i/InspiredUltimatum.java
@@ -65,7 +65,7 @@ class InspiredUltimatumEffect extends OneShotEffect {
         );
         player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(5, game);
+            player.drawCards(5, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/i/IntellectualOffering.java
+++ b/Mage.Sets/src/mage/cards/i/IntellectualOffering.java
@@ -64,10 +64,10 @@ class IntellectualOfferingDrawEffect extends OneShotEffect {
         if (player != null) {
             Target target = new TargetOpponent(true);
             target.choose(Outcome.DrawCard, source.getControllerId(), source.getSourceId(), game);
-            player.drawCards(3, game);
+            player.drawCards(3, source.getSourceId(), game);
             Player opponent = game.getPlayer(target.getFirstTarget());
             if (opponent != null) {
-                opponent.drawCards(3, game);
+                opponent.drawCards(3, source.getSourceId(), game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/i/InterpretTheSigns.java
+++ b/Mage.Sets/src/mage/cards/i/InterpretTheSigns.java
@@ -64,7 +64,7 @@ class InterpretTheSignsEffect extends OneShotEffect {
             Card card = controller.getLibrary().getFromTop(game);
             if (card != null) {
                 controller.revealCards(sourceCard.getName(), new CardsImpl(card), game);
-                controller.drawCards(card.getConvertedManaCost(), game);
+                controller.drawCards(card.getConvertedManaCost(), source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/i/IzzetKeyrune.java
+++ b/Mage.Sets/src/mage/cards/i/IzzetKeyrune.java
@@ -20,7 +20,6 @@ import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.permanent.token.TokenImpl;
-import mage.game.permanent.token.Token;
 import mage.players.Player;
 
 /**
@@ -71,7 +70,7 @@ public final class IzzetKeyrune extends CardImpl {
         public boolean apply(Game game, Ability source) {
             Player player = game.getPlayer(source.getControllerId());
             if (player != null && player.chooseUse(Outcome.DrawCard, "Do you wish to draw a card? If you do, discard a card.", source, game)) {
-                if (player.drawCards(1, game) > 0) {
+                if (player.drawCards(1, source.getSourceId(), game) > 0) {
                     player.discard(1, false, source, game);
                 }
                 return true;

--- a/Mage.Sets/src/mage/cards/j/JaceMemoryAdept.java
+++ b/Mage.Sets/src/mage/cards/j/JaceMemoryAdept.java
@@ -73,7 +73,7 @@ class JaceMemoryAdeptEffect extends DrawCardTargetEffect {
         for (UUID target : targetPointer.getTargets(game, source)) {
             Player player = game.getPlayer(target);
             if (player != null) {
-                player.drawCards(amount.calculate(game, source, this), game);
+                player.drawCards(amount.calculate(game, source, this), source.getSourceId(), game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/j/JaceWielderOfMysteries.java
+++ b/Mage.Sets/src/mage/cards/j/JaceWielderOfMysteries.java
@@ -127,7 +127,7 @@ class JaceWielderOfMysteriesEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        player.drawCards(7, game);
+        player.drawCards(7, source.getSourceId(), game);
         if (!player.getLibrary().hasCards()) {
             player.won(game);
         }

--- a/Mage.Sets/src/mage/cards/j/JacesArchivist.java
+++ b/Mage.Sets/src/mage/cards/j/JacesArchivist.java
@@ -77,7 +77,7 @@ class JacesArchivistEffect extends OneShotEffect {
             for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
                 Player player = game.getPlayer(playerId);
                 if (player != null) {
-                    player.drawCards(maxDiscarded, game);
+                    player.drawCards(maxDiscarded, source.getSourceId(), game);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/j/JandorsRing.java
+++ b/Mage.Sets/src/mage/cards/j/JandorsRing.java
@@ -82,7 +82,7 @@ class JandorsRingEffect extends OneShotEffect {
                 if (effect.apply(game, source)) {//Conditional was already checked, card should be in hand, but if for some weird reason it fails, the card won't be drawn, although the cost will already be paid
                     Player controller = game.getPlayer(source.getControllerId());
                     if(controller != null) {
-                        controller.drawCards(1, game);
+                        controller.drawCards(1, source.getSourceId(), game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/j/JayaBallard.java
+++ b/Mage.Sets/src/mage/cards/j/JayaBallard.java
@@ -87,7 +87,7 @@ class JayaBallardDiscardDrawEffect extends OneShotEffect {
                     count++;
                 }
             }
-            controller.drawCards(count, game);
+            controller.drawCards(count, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/k/KefnetTheMindful.java
+++ b/Mage.Sets/src/mage/cards/k/KefnetTheMindful.java
@@ -115,7 +115,7 @@ class KefnetTheMindfulEffect extends OneShotEffect {
         filterControlledLand.add(CardType.LAND.getPredicate());
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            controller.drawCards(1, game);
+            controller.drawCards(1, source.getSourceId(), game);
             if (controller.chooseUse(Outcome.AIDontUseIt, "Do you want to return a land you control to its owner's hand?", null, "Yes", "No", source, game)) {
                 Effect effect = new ReturnToHandChosenControlledPermanentEffect(filterControlledLand);
                 effect.apply(game, source);

--- a/Mage.Sets/src/mage/cards/k/KhorvathsFury.java
+++ b/Mage.Sets/src/mage/cards/k/KhorvathsFury.java
@@ -75,7 +75,7 @@ class KhorvathsFuryEffect extends OneShotEffect {
         }
         for (Player player : choice.getFriends()) {
             if (player != null) {
-                player.drawCards(cardsToDraw.get(player.getId()) + 1, game);
+                player.drawCards(cardsToDraw.get(player.getId()) + 1, source.getSourceId(), game);
             }
         }
         for (Player player : choice.getFoes()) {

--- a/Mage.Sets/src/mage/cards/k/KnollspineDragon.java
+++ b/Mage.Sets/src/mage/cards/k/KnollspineDragon.java
@@ -71,7 +71,7 @@ class KnollspineDragonEffect extends OneShotEffect {
                 AmountOfDamageAPlayerReceivedThisTurnWatcher watcher = game.getState().getWatcher(AmountOfDamageAPlayerReceivedThisTurnWatcher.class);
                 if (watcher != null) {
                     int drawAmount = watcher.getAmountOfDamageReceivedThisTurn(targetOpponent.getId());
-                    controller.drawCards(drawAmount, game);
+                    controller.drawCards(drawAmount, source.getSourceId(), game);
                     game.informPlayers(controller.getLogName() + "draws " + drawAmount + " cards");
                     return true;
                 }

--- a/Mage.Sets/src/mage/cards/k/KozilekTheGreatDistortion.java
+++ b/Mage.Sets/src/mage/cards/k/KozilekTheGreatDistortion.java
@@ -91,7 +91,7 @@ class KozilekDrawEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            controller.drawCards(7 - controller.getHand().size(), game);
+            controller.drawCards(7 - controller.getHand().size(), source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/k/KynaiosAndTiroOfMeletis.java
+++ b/Mage.Sets/src/mage/cards/k/KynaiosAndTiroOfMeletis.java
@@ -70,7 +70,7 @@ class KynaiosAndTirosEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            controller.drawCards(1, game);
+            controller.drawCards(1, source.getSourceId(), game);
             PlayerList playerList = game.getState().getPlayerList().copy();
 
             while (!playerList.get().equals(source.getControllerId()) && controller.canRespond()) {
@@ -113,7 +113,7 @@ class KynaiosAndTirosEffect extends OneShotEffect {
             for (UUID playerId : noLandPlayers) {
                 Player player = game.getPlayer(playerId);
                 if (player != null) {
-                    player.drawCards(1, game);
+                    player.drawCards(1, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/l/LaquatussCreativity.java
+++ b/Mage.Sets/src/mage/cards/l/LaquatussCreativity.java
@@ -59,7 +59,7 @@ class LaquatussCreativityEffect extends OneShotEffect {
         Player player = game.getPlayer(source.getFirstTarget());
         if(player != null) {
             int handCount = player.getHand().count(new FilterCard(), game);
-            player.drawCards(handCount, game);
+            player.drawCards(handCount, source.getSourceId(), game);
             player.discard(handCount, false, source, game);
         }
         return false;

--- a/Mage.Sets/src/mage/cards/l/LastStand.java
+++ b/Mage.Sets/src/mage/cards/l/LastStand.java
@@ -101,7 +101,7 @@ class LastStandEffect extends OneShotEffect {
             // Draw a card for each Island you control, then discard that many cards
             int islands = game.getBattlefield().count(filterIsland, source.getSourceId(), source.getControllerId(), game);
             if (islands > 0) {
-                controller.drawCards(islands, game);
+                controller.drawCards(islands, source.getSourceId(), game);
                 controller.discard(islands, false, source, game);
             }
 

--- a/Mage.Sets/src/mage/cards/l/LeaveChance.java
+++ b/Mage.Sets/src/mage/cards/l/LeaveChance.java
@@ -87,7 +87,7 @@ class ChanceEffect extends OneShotEffect {
                     }
                 }
                 game.applyEffects();
-                controller.drawCards(target.getTargets().size(), game);
+                controller.drawCards(target.getTargets().size(), source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/l/LiarsPendulum.java
+++ b/Mage.Sets/src/mage/cards/l/LiarsPendulum.java
@@ -102,7 +102,7 @@ class LiarsPendulumEffect extends OneShotEffect {
             if (controller.chooseUse(outcome, "Reveal your hand?", source, game)) {
                 controller.revealCards("hand of " + controller.getName(), controller.getHand(), game);
                 if (!rightGuess) {
-                    controller.drawCards(1, game);
+                    controller.drawCards(1, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/l/Lich.java
+++ b/Mage.Sets/src/mage/cards/l/Lich.java
@@ -86,7 +86,7 @@ class LichLifeGainReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(event.getPlayerId());
         if (controller != null) {
-            controller.drawCards(event.getAmount(), game);
+            controller.drawCards(event.getAmount(), source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/l/LichsMirror.java
+++ b/Mage.Sets/src/mage/cards/l/LichsMirror.java
@@ -85,7 +85,7 @@ class LichsMirrorEffect extends ReplacementEffectImpl {
             }
             player.shuffleLibrary(source, game);
             
-            player.drawCards(7, game);
+            player.drawCards(7, source.getSourceId(), game);
             
             player.setLife(20, game, source);
         }

--- a/Mage.Sets/src/mage/cards/l/LifebloodHydra.java
+++ b/Mage.Sets/src/mage/cards/l/LifebloodHydra.java
@@ -76,7 +76,7 @@ class LifebloodHydraEffect extends OneShotEffect {
             Permanent diedPermanent = (Permanent) getValue("permanentLeftBattlefield");
             if (diedPermanent != null) {
                 controller.gainLife(diedPermanent.getPower().getValue(), game, source);
-                controller.drawCards(diedPermanent.getPower().getValue(), game);
+                controller.drawCards(diedPermanent.getPower().getValue(), source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/l/LifesLegacy.java
+++ b/Mage.Sets/src/mage/cards/l/LifesLegacy.java
@@ -66,7 +66,7 @@ class LifesLegacyEffect extends OneShotEffect {
             }
         }
         if (power > 0) {
-            controller.drawCards(power, game);
+            controller.drawCards(power, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/l/LordWindgrace.java
+++ b/Mage.Sets/src/mage/cards/l/LordWindgrace.java
@@ -103,9 +103,9 @@ class LordWindgraceEffect extends OneShotEffect {
         }
         Card card = player.discardOne(false, source, game);
         if (card == null || !card.isLand()) {
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
         } else {
-            player.drawCards(2, game);
+            player.drawCards(2, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/l/LostLegacy.java
+++ b/Mage.Sets/src/mage/cards/l/LostLegacy.java
@@ -61,7 +61,7 @@ class LostLegacyEffect extends SearchTargetGraveyardHandLibraryForCardNameAndExi
             boolean result = super.applySearchAndExile(game, source, cardName, targetPointer.getFirst(game, source));
             int cardsExiled = cardsInHandBefore - targetPlayer.getHand().count(filter, game);
             if (cardsExiled > 0) {
-                targetPlayer.drawCards(cardsExiled, game);
+                targetPlayer.drawCards(cardsExiled, source.getSourceId(), game);
             }
             return result;
         }

--- a/Mage.Sets/src/mage/cards/l/LudevicNecroAlchemist.java
+++ b/Mage.Sets/src/mage/cards/l/LudevicNecroAlchemist.java
@@ -103,7 +103,7 @@ class LudevicNecroAlchemistEffect extends OneShotEffect {
         Player player = game.getPlayer(game.getActivePlayerId());
         if (player != null
                 && player.chooseUse(Outcome.DrawCard, "Draw a card?", source, game)) {
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/l/LumengridAugur.java
+++ b/Mage.Sets/src/mage/cards/l/LumengridAugur.java
@@ -71,7 +71,7 @@ class LumengridAugurEffect extends OneShotEffect {
         Player player = game.getPlayer(getTargetPointer().getFirst(game, source));
         Permanent sourcePermanent = game.getPermanent(source.getSourceId());
         if (player != null) {
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
             Card discardedCard = player.discardOne(false, source, game);
             if (discardedCard != null && discardedCard.isArtifact()) {
                 if (sourcePermanent != null) {

--- a/Mage.Sets/src/mage/cards/m/MagusOfTheJar.java
+++ b/Mage.Sets/src/mage/cards/m/MagusOfTheJar.java
@@ -83,7 +83,7 @@ class MagusoftheJarEffect extends OneShotEffect {
         for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {
             Player player = game.getPlayer(playerId);
             if (player != null) {
-                player.drawCards(7, game);
+                player.drawCards(7, source.getSourceId(), game);
             }
         }
         //Delayed ability

--- a/Mage.Sets/src/mage/cards/m/MalignantGrowth.java
+++ b/Mage.Sets/src/mage/cards/m/MalignantGrowth.java
@@ -80,6 +80,6 @@ class MalignantGrowthEffect extends OneShotEffect {
         if (counters == 0) {
             return true;
         }
-        return player.damage(player.drawCards(counters, game), source.getSourceId(), game) > 0;
+        return player.damage(player.drawCards(counters, source.getSourceId(), game), source.getSourceId(), game) > 0;
     }
 }

--- a/Mage.Sets/src/mage/cards/m/ManipulateFate.java
+++ b/Mage.Sets/src/mage/cards/m/ManipulateFate.java
@@ -69,7 +69,7 @@ class ManipulateFateEffect extends SearchEffect {
                 }
             }
             player.shuffleLibrary(source, game);
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/m/MartyrsCry.java
+++ b/Mage.Sets/src/mage/cards/m/MartyrsCry.java
@@ -67,7 +67,7 @@ class MartyrsCryEffect extends OneShotEffect {
         for (UUID playerId : game.getPlayerList().toList()) {
             Player player = game.getPlayer(playerId);
             if (player != null) {
-                player.drawCards(playerCrtCount.getOrDefault(playerId, 0), game);
+                player.drawCards(playerCrtCount.getOrDefault(playerId, 0), source.getSourceId(), game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/m/MemoryJar.java
+++ b/Mage.Sets/src/mage/cards/m/MemoryJar.java
@@ -79,7 +79,7 @@ class MemoryJarEffect extends OneShotEffect {
         for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {
             Player player = game.getPlayer(playerId);
             if (player != null) {
-                player.drawCards(7, game);
+                player.drawCards(7, source.getSourceId(), game);
             }
         }
         //Delayed ability

--- a/Mage.Sets/src/mage/cards/m/MidnightClock.java
+++ b/Mage.Sets/src/mage/cards/m/MidnightClock.java
@@ -135,7 +135,7 @@ class MidnightClockEffect extends OneShotEffect {
         cards.addAll(player.getGraveyard());
         player.putCardsOnTopOfLibrary(cards, game, source, false);
         player.shuffleLibrary(source, game);
-        player.drawCards(7, game);
+        player.drawCards(7, source.getSourceId(), game);
         return effect.apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/m/Mindmoil.java
+++ b/Mage.Sets/src/mage/cards/m/Mindmoil.java
@@ -53,7 +53,7 @@ class MindmoilEffect extends OneShotEffect {
         if (you != null) {
             int count = you.getHand().size();
             you.putCardsOnBottomOfLibrary(you.getHand(), game, source, true);
-            you.drawCards(count, game);
+            you.drawCards(count, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/m/MindsAglow.java
+++ b/Mage.Sets/src/mage/cards/m/MindsAglow.java
@@ -70,7 +70,7 @@ class MindsAglowEffect extends OneShotEffect {
                 for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
                     Player player = game.getPlayer(playerId);
                     if (player != null) {
-                        player.drawCards(xSum, game);
+                        player.drawCards(xSum, source.getSourceId(), game);
                     }
                 }
 

--- a/Mage.Sets/src/mage/cards/m/MindstormCrown.java
+++ b/Mage.Sets/src/mage/cards/m/MindstormCrown.java
@@ -65,7 +65,7 @@ class MindstormCrownEffect extends OneShotEffect {
         MindstormCrownWatcher watcher = game.getState().getWatcher(MindstormCrownWatcher.class);
         if (watcher != null
                 && watcher.getCardsInHandCount() == 0) {
-            controller.drawCards(1, game);
+            controller.drawCards(1, source.getSourceId(), game);
         } else {
             if (permanent != null) {
                 controller.damage(1, permanent.getId(), game);

--- a/Mage.Sets/src/mage/cards/m/MinionsMurmurs.java
+++ b/Mage.Sets/src/mage/cards/m/MinionsMurmurs.java
@@ -56,7 +56,7 @@ public final class MinionsMurmurs extends CardImpl {
             Player controller = game.getPlayer(source.getControllerId());
             if (controller != null) {
                 int creaturesControlled = game.getBattlefield().countAll(StaticFilters.FILTER_PERMANENT_CREATURE, controller.getId(), game);
-                controller.drawCards(creaturesControlled, game);
+                controller.drawCards(creaturesControlled, source.getSourceId(), game);
                 controller.loseLife(creaturesControlled, game, false);
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/m/Mise.java
+++ b/Mage.Sets/src/mage/cards/m/Mise.java
@@ -60,7 +60,7 @@ class MiseEffect extends OneShotEffect {
             if (card != null) {
                 player.revealCards("Mise", cards, game, true);
                 if (card.getName().equals(namedCard)) {
-                    player.drawCards(3, game);
+                    player.drawCards(3, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/m/MoltenPsyche.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenPsyche.java
@@ -78,7 +78,7 @@ class MoltenPsycheEffect extends OneShotEffect {
             for (UUID playerId : cardsToDraw.keySet()) {
                 Player player = game.getPlayer(playerId);
                 if (player != null) {
-                    player.drawCards(cardsToDraw.get(playerId), game);
+                    player.drawCards(cardsToDraw.get(playerId), source.getSourceId(), game);
                 }
             }
             if (MetalcraftCondition.instance.apply(game, source)) {

--- a/Mage.Sets/src/mage/cards/m/MomentousFall.java
+++ b/Mage.Sets/src/mage/cards/m/MomentousFall.java
@@ -68,7 +68,7 @@ class MomentousFallEffect extends OneShotEffect {
                 }
             }
             if (power > 0) {
-                controller.drawCards(power, game);
+                controller.drawCards(power, source.getSourceId(), game);
             }
             if (toughness > 0) {
                 controller.gainLife(toughness, game, source);

--- a/Mage.Sets/src/mage/cards/m/MurderOfCrows.java
+++ b/Mage.Sets/src/mage/cards/m/MurderOfCrows.java
@@ -63,7 +63,7 @@ class MurderOfCrowsEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null && player.chooseUse(Outcome.DrawCard, "Do you wish to draw a card? If you do, discard a card.", source, game)) {
-            if (player.drawCards(1, game) > 0) {
+            if (player.drawCards(1, source.getSourceId(), game) > 0) {
                 player.discard(1, false, source, game);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/m/MysticRemora.java
+++ b/Mage.Sets/src/mage/cards/m/MysticRemora.java
@@ -123,7 +123,7 @@ class MysticRemoraEffect extends OneShotEffect {
                         && cost.pay(source, game, source.getSourceId(), opponent.getId(), false, null)) {
                     return true;
                 }
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/n/NantukoCultivator.java
+++ b/Mage.Sets/src/mage/cards/n/NantukoCultivator.java
@@ -68,7 +68,7 @@ class NantukoCultivatorEffect extends OneShotEffect {
                 if(permanent != null) {
                     permanent.addCounters(CounterType.P1P1.createInstance(count), source, game);
                 }
-                player.drawCards(count, game);
+                player.drawCards(count, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/n/NarsetOfTheAncientWay.java
+++ b/Mage.Sets/src/mage/cards/n/NarsetOfTheAncientWay.java
@@ -133,7 +133,7 @@ class NarsetOfTheAncientWayDrawEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        player.drawCards(1, game);
+        player.drawCards(1, source.getSourceId(), game);
         if (player.getHand().isEmpty() || !player.chooseUse(Outcome.Discard, "Discard a card?", source, game)) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/n/NaturesResurgence.java
+++ b/Mage.Sets/src/mage/cards/n/NaturesResurgence.java
@@ -63,7 +63,7 @@ class NaturesResurgenceEffect extends OneShotEffect {
                 Player player = game.getPlayer(playerId);
                 if (player != null) {
                     int amount = player.getGraveyard().count(filter, game);
-                    player.drawCards(amount, game);
+                    player.drawCards(amount, source.getSourceId(), game);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/n/NefariousLich.java
+++ b/Mage.Sets/src/mage/cards/n/NefariousLich.java
@@ -130,7 +130,7 @@ class NefariousLichLifeGainReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(event.getPlayerId());
         if (controller != null) {
-            controller.drawCards(event.getAmount(), game);
+            controller.drawCards(event.getAmount(), source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/n/NehebDreadhordeChampion.java
+++ b/Mage.Sets/src/mage/cards/n/NehebDreadhordeChampion.java
@@ -92,7 +92,7 @@ class NehebDreadhordeChampionEffect extends OneShotEffect {
         if (counter == 0) {
             return true;
         }
-        player.drawCards(counter, game);
+        player.drawCards(counter, source.getSourceId(), game);
         player.getManaPool().addMana(mana, game, source, true);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/n/NessianBoar.java
+++ b/Mage.Sets/src/mage/cards/n/NessianBoar.java
@@ -69,6 +69,6 @@ class NessianBoarEffect extends OneShotEffect {
             return false;
         }
         Player player = game.getPlayer(permanent.getControllerId());
-        return player != null && player.drawCards(1, game) > 0;
+        return player != null && player.drawCards(1, source.getSourceId(), game) > 0;
     }
 }

--- a/Mage.Sets/src/mage/cards/n/NicolBolasDragonGod.java
+++ b/Mage.Sets/src/mage/cards/n/NicolBolasDragonGod.java
@@ -129,7 +129,7 @@ class NicolBolasDragonGodPlusOneEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        player.drawCards(1, game);
+        player.drawCards(1, source.getSourceId(), game);
         Set<Card> cardsOnBattlefield = new LinkedHashSet<>();
         Set<Card> cards = new LinkedHashSet<>();
         for (UUID opponentId : game.getState().getPlayersInRange(player.getId(), game)) {

--- a/Mage.Sets/src/mage/cards/n/NinThePainArtist.java
+++ b/Mage.Sets/src/mage/cards/n/NinThePainArtist.java
@@ -75,7 +75,7 @@ class NinThePainArtistEffect extends OneShotEffect {
             permanent.damage(source.getManaCostsToPay().getX(), source.getSourceId(), game, false, true);
             Player player = game.getPlayer(permanent.getControllerId());
             if (player != null) {
-                player.drawCards(source.getManaCostsToPay().getX(), game);
+                player.drawCards(source.getManaCostsToPay().getX(), source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/n/NissasDefeat.java
+++ b/Mage.Sets/src/mage/cards/n/NissasDefeat.java
@@ -83,7 +83,7 @@ class NissasDefeatEffect extends OneShotEffect {
 
             // If it was a Nissa planeswalker, draw a card
             if (filter.match(permanent, game) && controller != null) {
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/n/NissasRevelation.java
+++ b/Mage.Sets/src/mage/cards/n/NissasRevelation.java
@@ -69,7 +69,7 @@ class NissasRevelationEffect extends OneShotEffect {
                 cards.add(card);
                 controller.revealCards(sourceObject.getIdName(), cards, game);
                 if (card.isCreature()) {
-                    controller.drawCards(card.getPower().getValue(), game);
+                    controller.drawCards(card.getPower().getValue(), source.getSourceId(), game);
                     controller.gainLife(card.getToughness().getValue(), game, source);
                 }
             }

--- a/Mage.Sets/src/mage/cards/n/NotionThief.java
+++ b/Mage.Sets/src/mage/cards/n/NotionThief.java
@@ -76,7 +76,7 @@ class NotionThiefReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(1, game, event.getAppliedEffects());
+            player.drawCards(1, event.getSourceId(), game, event.getAppliedEffects());
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/o/OathOfScholars.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfScholars.java
@@ -107,7 +107,7 @@ class OathOfScholarsEffect extends OneShotEffect {
         }
         if (firstPlayer.chooseUse(Outcome.AIDontUseIt, "Discard your hand and draw 3 cards?", source, game)) {
             firstPlayer.discard(firstPlayer.getHand().size(), true, source, game);
-            firstPlayer.drawCards(3, game);
+            firstPlayer.drawCards(3, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/o/ObNixilisTheHateTwisted.java
+++ b/Mage.Sets/src/mage/cards/o/ObNixilisTheHateTwisted.java
@@ -79,7 +79,7 @@ class ObNixilisTheHateTwistedEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        player.drawCards(2, game);
+        player.drawCards(2, source.getSourceId(), game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/o/Oblation.java
+++ b/Mage.Sets/src/mage/cards/o/Oblation.java
@@ -65,7 +65,7 @@ class OblationEffect extends OneShotEffect {
 
                 game.applyEffects(); // so effects from creatures that were on the battlefield won't trigger from draw 
 
-                player.drawCards(2, game);
+                player.drawCards(2, source.getSourceId(), game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/o/OratorOfOjutai.java
+++ b/Mage.Sets/src/mage/cards/o/OratorOfOjutai.java
@@ -136,7 +136,7 @@ class OratorOfOjutaiEffect extends OneShotEffect {
             if (sourcePermanent != null) {
                 DragonOnTheBattlefieldWhileSpellWasCastWatcher watcher = game.getState().getWatcher(DragonOnTheBattlefieldWhileSpellWasCastWatcher.class);
                 if (watcher != null && watcher.castWithConditionTrue(sourcePermanent.getSpellAbility().getId())) {
-                    controller.drawCards(1, game);
+                    controller.drawCards(1, source.getSourceId(), game);
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/o/OtherworldAtlas.java
+++ b/Mage.Sets/src/mage/cards/o/OtherworldAtlas.java
@@ -68,7 +68,7 @@ class OtherworldAtlasDrawEffect extends OneShotEffect {
                 for (UUID playerId : game.getState().getPlayersInRange(sourcePlayer.getId(), game)) {
                     Player player = game.getPlayer(playerId);
                     if (player != null) {
-                        player.drawCards(amount, game);
+                        player.drawCards(amount, source.getSourceId(), game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/o/OverwhelmingIntellect.java
+++ b/Mage.Sets/src/mage/cards/o/OverwhelmingIntellect.java
@@ -61,7 +61,7 @@ class OverwhelmingIntellectEffect extends OneShotEffect {
         Spell spell = game.getStack().getSpell(getTargetPointer().getFirst(game, source));
         if (controller != null && spell != null) {
             game.getStack().counter(source.getFirstTarget(), source.getSourceId(), game);
-            controller.drawCards(spell.getConvertedManaCost(), game);
+            controller.drawCards(spell.getConvertedManaCost(), source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/p/PainsReward.java
+++ b/Mage.Sets/src/mage/cards/p/PainsReward.java
@@ -81,7 +81,7 @@ class PainsRewardEffect extends OneShotEffect {
 
             game.informPlayers(winner.getLogName() + " won the auction with a bid of " + highBid + " life" + (highBid > 1 ? "s" : ""));
             winner.loseLife(highBid, game, false);
-            winner.drawCards(4, game);
+            winner.drawCards(4, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/p/PartingThoughts.java
+++ b/Mage.Sets/src/mage/cards/p/PartingThoughts.java
@@ -66,7 +66,7 @@ class PartingThoughtsEffect extends OneShotEffect {
                     numberOfCounters += counter.getCount();
                 }
                 if (numberOfCounters > 0) {
-                    controller.drawCards(numberOfCounters, game);
+                    controller.drawCards(numberOfCounters, source.getSourceId(), game);
                     controller.loseLife(numberOfCounters, game, false);
                 }
             }

--- a/Mage.Sets/src/mage/cards/p/PatientRebuilding.java
+++ b/Mage.Sets/src/mage/cards/p/PatientRebuilding.java
@@ -77,7 +77,7 @@ class PatientRebuildingEffect extends OneShotEffect {
             }
         }
         if (numberOfLandCards > 0) {
-            return controller.drawCards(numberOfLandCards, game) > 0;
+            return controller.drawCards(numberOfLandCards, source.getSourceId(), game) > 0;
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/p/PendantOfProsperity.java
+++ b/Mage.Sets/src/mage/cards/p/PendantOfProsperity.java
@@ -5,25 +5,19 @@ import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.common.PutCardFromHandOntoBattlefieldEffect;
-import mage.abilities.effects.common.continuous.GainControlTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.cards.CardsImpl;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
-import mage.target.Target;
 import mage.target.common.TargetCardInHand;
-import mage.target.common.TargetOpponent;
-import mage.target.targetpointer.FixedTarget;
 
 import java.util.UUID;
 import mage.abilities.effects.common.EntersBattlefieldUnderControlOfOpponentOfChoiceEffect;
@@ -85,7 +79,7 @@ class PendantOfProsperityEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        player.drawCards(1, game);
+        player.drawCards(1, source.getSourceId(), game);
         if (!player.chooseUse(outcome, "Put a land into play from your hand?", source, game)) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/p/PetalsOfInsight.java
+++ b/Mage.Sets/src/mage/cards/p/PetalsOfInsight.java
@@ -71,7 +71,7 @@ class PetalsOfInsightEffect extends OneShotEffect {
                 controller.moveCards(spellCard, Zone.HAND, source, game);
             }
         } else {
-            controller.drawCards(3, game);
+            controller.drawCards(3, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/p/Plagiarize.java
+++ b/Mage.Sets/src/mage/cards/p/Plagiarize.java
@@ -64,7 +64,7 @@ class PlagiarizeEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(1, game, event.getAppliedEffects());
+            player.drawCards(1, event.getSourceId(), game, event.getAppliedEffects());
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/p/PleaForPower.java
+++ b/Mage.Sets/src/mage/cards/p/PleaForPower.java
@@ -72,7 +72,7 @@ class PleaForPowerEffect extends OneShotEffect {
             if (timeCount > knowledgeCount) {
                 new AddExtraTurnControllerEffect().apply(game, source);
             } else {
-                controller.drawCards(3, game);
+                controller.drawCards(3, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/p/PrecognitivePerception.java
+++ b/Mage.Sets/src/mage/cards/p/PrecognitivePerception.java
@@ -62,7 +62,7 @@ class PrecognitivePerceptionEffect extends OneShotEffect {
         if (AddendumCondition.instance.apply(game, source)) {
             controller.scry(3, source, game);
         }
-        controller.drawCards(3, game);
+        controller.drawCards(3, source.getSourceId(), game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/p/Predict.java
+++ b/Mage.Sets/src/mage/cards/p/Predict.java
@@ -71,7 +71,7 @@ class PredictEffect extends OneShotEffect {
                     amount = 2;
                 }
             }
-            controller.drawCards(amount, game);
+            controller.drawCards(amount, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/p/PrimalEmpathy.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalEmpathy.java
@@ -83,7 +83,7 @@ class PrimalEmpathyEffect extends OneShotEffect {
                 .mapToInt(MageInt::getValue)
                 .anyMatch(i -> i >= highestPower);
         if (flag) {
-            return player.drawCards(1, game) > 0;
+            return player.drawCards(1, source.getSourceId(), game) > 0;
         }
         Target target = new TargetControlledCreaturePermanent();
         target.setNotTarget(true);

--- a/Mage.Sets/src/mage/cards/p/PsychicVortex.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicVortex.java
@@ -62,7 +62,7 @@ class PsychicVortexCost extends CostImpl {
     public boolean pay(Ability ability, Game game, UUID sourceId, UUID controllerId, boolean noMana, Cost costToPay) {
         Player controller = game.getPlayer(controllerId);
         if (controller != null) {
-            controller.drawCards(1, game);
+            controller.drawCards(1, sourceId, game);
             this.paid = true;
             return true;
             }

--- a/Mage.Sets/src/mage/cards/r/ReadTheRunes.java
+++ b/Mage.Sets/src/mage/cards/r/ReadTheRunes.java
@@ -59,7 +59,7 @@ class ReadTheRunesEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            int drawnCards = controller.drawCards(source.getManaCostsToPay().getX(), game);
+            int drawnCards = controller.drawCards(source.getManaCostsToPay().getX(), source.getSourceId(), game);
             Target target = new TargetControlledPermanent(0, drawnCards, new FilterControlledPermanent(), true);
             controller.chooseTarget(Outcome.Sacrifice, target, source, game);
             int sacrificedPermanents = 0;

--- a/Mage.Sets/src/mage/cards/r/RecurringInsight.java
+++ b/Mage.Sets/src/mage/cards/r/RecurringInsight.java
@@ -57,7 +57,7 @@ class RecurringInsightEffect extends OneShotEffect {
         if (controller != null) {
             Player opponent = game.getPlayer(getTargetPointer().getFirst(game, source));
             if (opponent != null) {
-                controller.drawCards(opponent.getHand().size(), game);
+                controller.drawCards(opponent.getHand().size(), source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/r/Reprocess.java
+++ b/Mage.Sets/src/mage/cards/r/Reprocess.java
@@ -78,7 +78,7 @@ class ReprocessEffect extends OneShotEffect {
                     amount++;
                 }
             }
-            player.drawCards(amount, game);
+            player.drawCards(amount, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/r/ResearchDevelopment.java
+++ b/Mage.Sets/src/mage/cards/r/ResearchDevelopment.java
@@ -146,7 +146,7 @@ class DevelopmentEffect extends OneShotEffect {
                     if (opponent != null && opponent.chooseUse(Outcome.Detriment,
                             "Allow " + player.getLogName() + " to draw a card instead? (" + Integer.toString(i + 1) + ')', source, game)) {
                         game.informPlayers(opponent.getLogName() + " had chosen to let " + player.getLogName() + " draw a card.");
-                        player.drawCards(1, game);
+                        player.drawCards(1, source.getSourceId(), game);
                         putToken = false;
                         break;
                     }

--- a/Mage.Sets/src/mage/cards/r/RhysticStudy.java
+++ b/Mage.Sets/src/mage/cards/r/RhysticStudy.java
@@ -69,7 +69,7 @@ class RhysticStudyDrawEffect extends OneShotEffect {
                         && cost.pay(source, game, source.getSourceId(), opponent.getId(), false, null)) {
                     return true;
                 }
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/r/RiskFactor.java
+++ b/Mage.Sets/src/mage/cards/r/RiskFactor.java
@@ -67,7 +67,7 @@ class RiskFactorEffect extends OneShotEffect {
         if (opponent.chooseUse(outcome, "Do you choose to take the damage?", source, game)) {
             opponent.damage(4, source.getSourceId(), game);
         } else {
-            controller.drawCards(3, game);
+            controller.drawCards(3, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/r/RixMaadiReveler.java
+++ b/Mage.Sets/src/mage/cards/r/RixMaadiReveler.java
@@ -73,10 +73,10 @@ class RixMaadiRevelerEffect extends OneShotEffect {
         }
         if (SpectacleCondition.instance.apply(game, source)) {
             player.discard(player.getHand().size(), false, source, game);
-            player.drawCards(3, game);
+            player.drawCards(3, source.getSourceId(), game);
         } else {
             player.discard(1, false, source, game);
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/r/RowdyCrew.java
+++ b/Mage.Sets/src/mage/cards/r/RowdyCrew.java
@@ -71,7 +71,7 @@ class RowdyCrewEffect extends OneShotEffect {
         Permanent creature = game.getPermanent(source.getSourceId());
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(3, game);
+            player.drawCards(3, source.getSourceId(), game);
             Cards cards = new CardsImpl();
             int cardsInHand = player.getHand().size();
             switch (cardsInHand) {

--- a/Mage.Sets/src/mage/cards/r/Rumination.java
+++ b/Mage.Sets/src/mage/cards/r/Rumination.java
@@ -56,7 +56,7 @@ public final class Rumination extends CardImpl {
         public boolean apply(Game game, Ability source) {
             Player player = game.getPlayer(source.getControllerId());
             if (player != null) {
-                player.drawCards(3, game);
+                player.drawCards(3, source.getSourceId(), game);
                 putOnLibrary(player, source, game);
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/s/SandstoneOracle.java
+++ b/Mage.Sets/src/mage/cards/s/SandstoneOracle.java
@@ -74,7 +74,7 @@ class SandstoneOracleEffect extends OneShotEffect {
                     game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " has chosen " + opponent.getLogName());
                     int cardsDiff = opponent.getHand().size() - controller.getHand().size();
                     if (cardsDiff > 0) {
-                        controller.drawCards(cardsDiff, game);
+                        controller.drawCards(cardsDiff, source.getSourceId(), game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/s/SarkhanUnbroken.java
+++ b/Mage.Sets/src/mage/cards/s/SarkhanUnbroken.java
@@ -82,7 +82,7 @@ class SarkhanUnbrokenAbility1 extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            controller.drawCards(1, game);
+            controller.drawCards(1, source.getSourceId(), game);
 
             game.fireUpdatePlayersEvent();
 

--- a/Mage.Sets/src/mage/cards/s/SawtoothLoon.java
+++ b/Mage.Sets/src/mage/cards/s/SawtoothLoon.java
@@ -84,7 +84,7 @@ class SawtoothLoonEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            controller.drawCards(2, game);
+            controller.drawCards(2, source.getSourceId(), game);
             TargetCardInHand target = new TargetCardInHand(2, 2, new FilterCard());
             controller.chooseTarget(Outcome.Detriment, target, source, game);
             Cards cardsToLibrary = new CardsImpl(target.getTargets());

--- a/Mage.Sets/src/mage/cards/s/ScryingGlass.java
+++ b/Mage.Sets/src/mage/cards/s/ScryingGlass.java
@@ -71,7 +71,7 @@ class ScryingGlassEffect extends OneShotEffect {
             targetOpponent.revealCards(source, targetOpponent.getHand(), game);
             if (targetOpponent.getHand().count(filter, game) == amount) {
                 game.informPlayers(controller.getName() + " has chosen the exact number and color of the revealed cards from " + targetOpponent.getName() + "'s hand.  They draw a card.");
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
                 return true;
             } else {
                 game.informPlayers(controller.getName() + " has chosen incorrectly and will not draw a card.");

--- a/Mage.Sets/src/mage/cards/s/SeasonedPyromancer.java
+++ b/Mage.Sets/src/mage/cards/s/SeasonedPyromancer.java
@@ -84,7 +84,7 @@ class SeasonedPyromancerEffect extends OneShotEffect {
         int nonlands = player
                 .discard(2, false, source, game)
                 .count(StaticFilters.FILTER_CARD_NON_LAND, game);
-        player.drawCards(2, game);
+        player.drawCards(2, source.getSourceId(), game);
         if (nonlands == 0) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/s/SeeBeyond.java
+++ b/Mage.Sets/src/mage/cards/s/SeeBeyond.java
@@ -53,7 +53,7 @@ class SeeBeyondEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if(controller != null) {
-            controller.drawCards(2, game);
+            controller.drawCards(2, source.getSourceId(), game);
             if (!controller.getHand().isEmpty()) {
                 TargetCard target = new TargetCard(Zone.HAND, new FilterCard("card to shuffle into your library"));
                 controller.choose(Outcome.Detriment, controller.getHand(), target, game);

--- a/Mage.Sets/src/mage/cards/s/SelvalaHeartOfTheWilds.java
+++ b/Mage.Sets/src/mage/cards/s/SelvalaHeartOfTheWilds.java
@@ -7,9 +7,7 @@ import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.GreatestPowerAmongControlledCreaturesValue;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.ManaEffect;
 import mage.abilities.effects.mana.AddManaInAnyCombinationEffect;
@@ -18,7 +16,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicate;
 import mage.filter.predicate.permanent.AnotherPredicate;
@@ -102,7 +99,7 @@ class SelvalaHeartOfTheWildsEffect extends OneShotEffect {
                 Player permanentController = game.getPlayer(permanent.getControllerId());
                 if (permanentController != null
                         && permanentController.chooseUse(Outcome.DrawCard, "Would you like to draw a card?", source, game)) {
-                    permanentController.drawCards(1, game);
+                    permanentController.drawCards(1, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/s/SerumPowder.java
+++ b/Mage.Sets/src/mage/cards/s/SerumPowder.java
@@ -69,7 +69,7 @@ class SerumPowderReplaceEffect extends ReplacementEffectImpl {
                 for (Card card: cards.getCards(game)) {
                     card.moveToExile(null, null, source.getSourceId(), game);
                 }
-                controller.drawCards(cardsHand, game);
+                controller.drawCards(cardsHand, source.getSourceId(), game);
             }
             game.informPlayers(sourceCard.getLogName() +": " + controller.getLogName() + " exiles hand and draws " + cardsHand + " card(s)");
             return true;

--- a/Mage.Sets/src/mage/cards/s/ShahOfNaarIsle.java
+++ b/Mage.Sets/src/mage/cards/s/ShahOfNaarIsle.java
@@ -106,7 +106,7 @@ class ShahOfNaarIsleEffect extends OneShotEffect {
                 Player opponent = game.getPlayer(playerId);
                 if (opponent != null) {
                     int number = opponent.getAmount(0, 3, "Draw how many cards?", game);
-                    opponent.drawCards(number, game);
+                    opponent.drawCards(number, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/s/ShatterTheSky.java
+++ b/Mage.Sets/src/mage/cards/s/ShatterTheSky.java
@@ -75,7 +75,7 @@ class ShatterTheSkyEffect extends OneShotEffect {
                 .distinct()
                 .map(game::getPlayer)
                 .filter(Objects::nonNull)
-                .forEach(player -> player.drawCards(1, game));
+                .forEach(player -> player.drawCards(1, source.getSourceId(), game));
         effect.apply(game, source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/s/Shocker.java
+++ b/Mage.Sets/src/mage/cards/s/Shocker.java
@@ -64,7 +64,7 @@ class ShockerEffect extends OneShotEffect {
                 for (Card card : targetPlayer.getHand().getCards(game)) {
                     targetPlayer.discard(card, source, game);
                 }
-                targetPlayer.drawCards(count, game);
+                targetPlayer.drawCards(count, source.getSourceId(), game);
                 return false;
             }
         return true;

--- a/Mage.Sets/src/mage/cards/s/SibilantSpirit.java
+++ b/Mage.Sets/src/mage/cards/s/SibilantSpirit.java
@@ -66,7 +66,7 @@ class SibilantSpiritEffect extends OneShotEffect {
         Player defender = game.getPlayer(defenderId);
         if (defender != null) {
             if (defender.chooseUse(outcome, "Draw a card?", source, game)) {
-                defender.drawCards(1, game);
+                defender.drawCards(1, source.getSourceId(), game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/Sindbad.java
+++ b/Mage.Sets/src/mage/cards/s/Sindbad.java
@@ -69,7 +69,7 @@ class SindbadEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Card card = controller.getLibrary().getFromTop(game);
-            controller.drawCards(1, game);
+            controller.drawCards(1, source.getSourceId(), game);
             controller.revealCards("Sindbad", new CardsImpl(card), game);
             if (!filter.match(card, game)) {
                 controller.discard(card, source, game);

--- a/Mage.Sets/src/mage/cards/s/SirensRuse.java
+++ b/Mage.Sets/src/mage/cards/s/SirensRuse.java
@@ -66,7 +66,7 @@ class SirensRuseEffect extends ExileTargetForSourceEffect {
         if (super.apply(game, source)) {
             new ReturnToBattlefieldUnderYourControlTargetEffect(true).apply(game, source);
             if (isPirate && player != null) {
-                player.drawCards(1, game);
+                player.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/s/SkeletalScrying.java
+++ b/Mage.Sets/src/mage/cards/s/SkeletalScrying.java
@@ -105,7 +105,7 @@ class SkeletalScryingEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
             if ( controller != null ) {
-                controller.drawCards(amount.calculate(game, source, this), game);
+                controller.drawCards(amount.calculate(game, source, this), source.getSourceId(), game);
                 controller.loseLife(amount.calculate(game, source, this), game, false);
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/s/SkullknockerOgre.java
+++ b/Mage.Sets/src/mage/cards/s/SkullknockerOgre.java
@@ -65,7 +65,7 @@ class SkullknockerOgreEffect extends OneShotEffect {
             return false;
         }
         if (player.discard(1, true, source, game).size() > 0) {
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/s/Slithermuse.java
+++ b/Mage.Sets/src/mage/cards/s/Slithermuse.java
@@ -83,7 +83,7 @@ class SlithermuseEffect extends OneShotEffect {
                     game.informPlayers(permanent.getName() + ": " + player.getLogName() + " has chosen " + chosenPlayer.getLogName());
                     int diff = chosenPlayer.getHand().size() - player.getHand().size();
                     if (diff > 0) {
-                        player.drawCards(diff, game);
+                        player.drawCards(diff, source.getSourceId(), game);
                     }
                     return true;
                 }

--- a/Mage.Sets/src/mage/cards/s/SoldeviSentry.java
+++ b/Mage.Sets/src/mage/cards/s/SoldeviSentry.java
@@ -56,7 +56,7 @@ class SoldeviSentryEffect extends RegenerateSourceEffect {
         if (permanent != null && permanent.regenerate(this.getId(), game)) {
             if (opponent != null) {
                 if (opponent.chooseUse(Outcome.DrawCard, "Draw a card?", source, game)) {
-                    opponent.drawCards(1, game);
+                    opponent.drawCards(1, source.getSourceId(), game);
                 }
             }
             this.used = true;

--- a/Mage.Sets/src/mage/cards/s/SoulOfRavnica.java
+++ b/Mage.Sets/src/mage/cards/s/SoulOfRavnica.java
@@ -95,7 +95,7 @@ class SoulOfRavnicaEffect extends OneShotEffect {
                     colors.add(ObjectColor.WHITE);
                 }
             }
-            controller.drawCards(colors.size(), game);
+            controller.drawCards(colors.size(), source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/SoulRansom.java
+++ b/Mage.Sets/src/mage/cards/s/SoulRansom.java
@@ -94,7 +94,7 @@ class SoulRansomEffect extends OneShotEffect {
         if (controller == null) {
             return false;
         }
-        controller.drawCards(2, game);
+        controller.drawCards(2, source.getSourceId(), game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SoulsMajesty.java
+++ b/Mage.Sets/src/mage/cards/s/SoulsMajesty.java
@@ -52,7 +52,7 @@ public final class SoulsMajesty extends CardImpl {
             Permanent target = game.getPermanent(source.getFirstTarget());
             Player player = game.getPlayer(source.getControllerId());
         if (player != null && target != null) {
-            player.drawCards(target.getPower().getValue(), game);
+            player.drawCards(target.getPower().getValue(), source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/SpellboundDragon.java
+++ b/Mage.Sets/src/mage/cards/s/SpellboundDragon.java
@@ -71,7 +71,7 @@ class SpellboundDragonEffect extends OneShotEffect {
         Player you = game.getPlayer(source.getControllerId());
         Permanent dragon = game.getPermanent(source.getSourceId());
         if(you != null) {
-            you.drawCards(1, game);
+            you.drawCards(1, source.getSourceId(), game);
             TargetDiscard target = new TargetDiscard(you.getId());
             you.choose(Outcome.Discard, target, source.getSourceId(), game);
             Card card = you.getHand().get(target.getFirstTarget(), game);

--- a/Mage.Sets/src/mage/cards/s/SpiritualFocus.java
+++ b/Mage.Sets/src/mage/cards/s/SpiritualFocus.java
@@ -106,7 +106,7 @@ class SpiritualFocusDrawCardEffect extends OneShotEffect {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null && permanent != null) {
             if (player.chooseUse(outcome, "Draw a card (" + permanent.getLogName() + ')', source, game)) {
-                player.drawCards(1, game);
+                player.drawCards(1, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/s/SqueesRevenge.java
+++ b/Mage.Sets/src/mage/cards/s/SqueesRevenge.java
@@ -60,7 +60,7 @@ class SqueesRevengeEffect extends OneShotEffect {
                     return true;
                 }
             }
-            player.drawCards(2 * number, game);
+            player.drawCards(2 * number, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/Standstill.java
+++ b/Mage.Sets/src/mage/cards/s/Standstill.java
@@ -97,7 +97,7 @@ class StandstillEffect extends OneShotEffect {
                 for (UUID uuid : game.getOpponents(this.getTargetPointer().getFirst(game, source))) {
                     Player player = game.getPlayer(uuid);
                     if (player != null) {
-                        player.drawCards(3, game);
+                        player.drawCards(3, source.getSourceId(), game);
                     }
                 }
                 return true;

--- a/Mage.Sets/src/mage/cards/s/StunningReversal.java
+++ b/Mage.Sets/src/mage/cards/s/StunningReversal.java
@@ -65,7 +65,7 @@ class StunningReversalEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player != null) {
-            player.drawCards(7, game);
+            player.drawCards(7, source.getSourceId(), game);
             player.setLife(1, game, source);
             this.discard();
         }

--- a/Mage.Sets/src/mage/cards/s/SurvivalCache.java
+++ b/Mage.Sets/src/mage/cards/s/SurvivalCache.java
@@ -62,7 +62,7 @@ class SurvivalCacheEffect extends OneShotEffect {
                 }
             }
             if (haveMoreLife)
-                sourcePlayer.drawCards(1, game);
+                sourcePlayer.drawCards(1, source.getSourceId(), game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/s/SurvivorOfTheUnseen.java
+++ b/Mage.Sets/src/mage/cards/s/SurvivorOfTheUnseen.java
@@ -71,7 +71,7 @@ class SurvivorOfTheUnseenEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(2, game);
+            player.drawCards(2, source.getSourceId(), game);
             putOnLibrary(player, source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/s/SwansOfBrynArgoll.java
+++ b/Mage.Sets/src/mage/cards/s/SwansOfBrynArgoll.java
@@ -80,21 +80,21 @@ class SwansOfBrynArgollEffect extends PreventionEffectImpl {
                 if (spell != null) {
                     Player controllerOfSpell = game.getPlayer(spell.getControllerId());
                     if(controllerOfSpell != null) {
-                        controllerOfSpell.drawCards(preventionEffectData.getPreventedDamage(), game);
+                        controllerOfSpell.drawCards(preventionEffectData.getPreventedDamage(), source.getSourceId(), game);
                         passed = true;
                     }
                 }
                 if (permanent != null) {
                     Player controllerOfPermanent = game.getPlayer(permanent.getControllerId());
                     if(controllerOfPermanent != null) {
-                        controllerOfPermanent.drawCards(preventionEffectData.getPreventedDamage(), game);
+                        controllerOfPermanent.drawCards(preventionEffectData.getPreventedDamage(), source.getSourceId(), game);
                         passed = true;
                     }
                 }
                 if (emblem != null) {
                     Player controllerOfEmblem = game.getPlayer(emblem.getControllerId());
                     if(controllerOfEmblem != null) {
-                        controllerOfEmblem.drawCards(preventionEffectData.getPreventedDamage(), game);
+                        controllerOfEmblem.drawCards(preventionEffectData.getPreventedDamage(), source.getSourceId(), game);
                     }
                     passed = true;
                 }
@@ -104,7 +104,7 @@ class SwansOfBrynArgollEffect extends PreventionEffectImpl {
                     if (cardSource != null) {
                         Player owner = game.getPlayer(cardSource.getOwnerId());
                         if (owner != null) {
-                            owner.drawCards(preventionEffectData.getPreventedDamage(), game);
+                            owner.drawCards(preventionEffectData.getPreventedDamage(), source.getSourceId(), game);
                         }
                     }
                 }

--- a/Mage.Sets/src/mage/cards/s/SwiftSilence.java
+++ b/Mage.Sets/src/mage/cards/s/SwiftSilence.java
@@ -66,7 +66,7 @@ class SwiftSilenceEffect extends OneShotEffect {
         }
         Player controller = game.getPlayer(source.getControllerId());
         if (toDraw > 0 && controller != null){
-            controller.drawCards(toDraw, game);
+            controller.drawCards(toDraw, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/s/SylvanLibrary.java
+++ b/Mage.Sets/src/mage/cards/s/SylvanLibrary.java
@@ -71,7 +71,7 @@ class SylvanLibraryEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            controller.drawCards(2, game);
+            controller.drawCards(2, source.getSourceId(), game);
             SylvanLibraryCardsDrawnThisTurnWatcher watcher = game.getState().getWatcher(SylvanLibraryCardsDrawnThisTurnWatcher.class);
             if (watcher != null) {
                 Cards cards = new CardsImpl();

--- a/Mage.Sets/src/mage/cards/s/SyphonMind.java
+++ b/Mage.Sets/src/mage/cards/s/SyphonMind.java
@@ -76,7 +76,7 @@ class SyphonMindEffect extends OneShotEffect {
                     }
                 }
             }
-            you.drawCards(amount, game);
+            you.drawCards(amount, source.getSourceId(), game);
         }
         return result;
     }

--- a/Mage.Sets/src/mage/cards/t/TeferisPuzzleBox.java
+++ b/Mage.Sets/src/mage/cards/t/TeferisPuzzleBox.java
@@ -55,7 +55,7 @@ class TeferisPuzzleBoxEffect extends OneShotEffect {
         if (player != null) {
             int count = player.getHand().size();
             player.putCardsOnBottomOfLibrary(player.getHand(), game, source, true);
-            player.drawCards(count, game);
+            player.drawCards(count, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/t/TemporalCascade.java
+++ b/Mage.Sets/src/mage/cards/t/TemporalCascade.java
@@ -63,7 +63,7 @@ class TemporalCascadeDrawEffect extends OneShotEffect {
         for (UUID playerId : game.getState().getPlayersInRange(sourcePlayer.getId(), game)) {
             Player player = game.getPlayer(playerId);
             if (player != null) {
-                player.drawCards(7, game);
+                player.drawCards(7, source.getSourceId(), game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/t/TemporaryTruce.java
+++ b/Mage.Sets/src/mage/cards/t/TemporaryTruce.java
@@ -58,7 +58,7 @@ class TemporaryTruceEffect extends OneShotEffect {
                 Player player = game.getPlayer(playerId);
                 if (player != null) {
                     int cardsToDraw = player.getAmount(0, 2, "Draw how many cards?", game);
-                    player.drawCards(cardsToDraw, game);
+                    player.drawCards(cardsToDraw, source.getSourceId(), game);
                     player.gainLife((2 - cardsToDraw) * 2, game, source);
                 }
             }

--- a/Mage.Sets/src/mage/cards/t/TheBattleOfNaboo.java
+++ b/Mage.Sets/src/mage/cards/t/TheBattleOfNaboo.java
@@ -74,7 +74,7 @@ class TheBattleOfNabooEffect extends OneShotEffect {
         if (player != null) {
             int x = source.getManaCostsToPay().getX();
             if (x > 0) {
-                player.drawCards(2 * x, game);
+                player.drawCards(2 * x, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/t/TheGreatAurora.java
+++ b/Mage.Sets/src/mage/cards/t/TheGreatAurora.java
@@ -98,7 +98,7 @@ class TheGreatAuroraEffect extends OneShotEffect {
                 if (player != null) {
                     int count = permanentsCount.get(playerId);
                     if (count > 0) {
-                        player.drawCards(count, game);
+                        player.drawCards(count, source.getSourceId(), game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/t/ThoughtGorger.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtGorger.java
@@ -106,7 +106,7 @@ class ThoughtGorgerEffectLeaves extends OneShotEffect {
         Permanent thoughtGorgerLastState = (Permanent) game.getLastKnownInformation(source.getSourceId(), Zone.BATTLEFIELD);
         int numberCounters = thoughtGorgerLastState.getCounters(game).getCount(CounterType.P1P1);
         if (player != null) {
-            player.drawCards(numberCounters, game);
+            player.drawCards(numberCounters, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/t/ThoughtReflection.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtReflection.java
@@ -75,7 +75,7 @@ class ThoughtReflectionReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player you = game.getPlayer(event.getPlayerId());
         if (you != null) {
-            you.drawCards(2, game, event.getAppliedEffects());
+            you.drawCards(2, event.getSourceId(), game, event.getAppliedEffects());
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/t/ThrasiosTritonHero.java
+++ b/Mage.Sets/src/mage/cards/t/ThrasiosTritonHero.java
@@ -89,7 +89,7 @@ class ThrasiosTritonHeroEffect extends OneShotEffect {
             if (card.isLand()) {
                 controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
             } else {
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/t/TibaltTheFiendBlooded.java
+++ b/Mage.Sets/src/mage/cards/t/TibaltTheFiendBlooded.java
@@ -86,7 +86,7 @@ class TibaltTheFiendBloodedFirstEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
             Card card = player.getHand().getRandom(game);
             player.discard(card, source, game);
             return true;

--- a/Mage.Sets/src/mage/cards/t/TriadOfFates.java
+++ b/Mage.Sets/src/mage/cards/t/TriadOfFates.java
@@ -108,7 +108,7 @@ class DrawCardControllerTargetEffect extends OneShotEffect {
         if (creature != null) {
             Player controllerOfTarget = game.getPlayer(creature.getControllerId());
             if (controllerOfTarget != null) {
-                controllerOfTarget.drawCards(2, game);
+                controllerOfTarget.drawCards(2, source.getSourceId(), game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/t/Truce.java
+++ b/Mage.Sets/src/mage/cards/t/Truce.java
@@ -58,7 +58,7 @@ class TruceEffect extends OneShotEffect {
                 Player player = game.getPlayer(playerId);
                 if (player != null) {
                     int cardsToDraw = player.getAmount(0, 2, "Draw how many cards?", game);
-                    player.drawCards(cardsToDraw, game);
+                    player.drawCards(cardsToDraw, source.getSourceId(), game);
                     player.gainLife((2 - cardsToDraw) * 2, game, source);
                 }
             }

--- a/Mage.Sets/src/mage/cards/t/TwistedJustice.java
+++ b/Mage.Sets/src/mage/cards/t/TwistedJustice.java
@@ -69,7 +69,7 @@ class TwistedJusticeEffect extends OneShotEffect {
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
                 permanent.sacrifice(source.getSourceId(), game);
-                controller.drawCards(permanent.getPower().getValue(), game);
+                controller.drawCards(permanent.getPower().getValue(), source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/t/TymnaTheWeaver.java
+++ b/Mage.Sets/src/mage/cards/t/TymnaTheWeaver.java
@@ -82,7 +82,7 @@ class TymnaTheWeaverEffect extends OneShotEffect {
                 Cost cost = new PayLifeCost(cardsToDraw);
                 if (cost.canPay(source, source.getSourceId(), source.getControllerId(), game)
                         && cost.pay(source, game, source.getSourceId(), source.getControllerId(), false)) {
-                    controller.drawCards(cardsToDraw, game);
+                    controller.drawCards(cardsToDraw, source.getSourceId(), game);
                 }
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/u/UginTheSpiritDragon.java
+++ b/Mage.Sets/src/mage/cards/u/UginTheSpiritDragon.java
@@ -129,7 +129,7 @@ class UginTheSpiritDragonEffect3 extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             controller.gainLife(7, game, source);
-            controller.drawCards(7, game);
+            controller.drawCards(7, source.getSourceId(), game);
             TargetCardInHand target = new TargetCardInHand(0, 7, new FilterPermanentCard("permanent cards"));
             if (controller.choose(Outcome.PutCardInPlay, target, source.getSourceId(), game)) {
                 controller.moveCards(new CardsImpl(target.getTargets()), Zone.BATTLEFIELD, source, game);

--- a/Mage.Sets/src/mage/cards/u/UginsInsight.java
+++ b/Mage.Sets/src/mage/cards/u/UginsInsight.java
@@ -59,7 +59,7 @@ class UginsInsightEffect extends OneShotEffect {
             if (highCMC > 0) {
                 controller.scry(highCMC, source, game);
             }
-            controller.drawCards(3, game);
+            controller.drawCards(3, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/u/UnifyingTheory.java
+++ b/Mage.Sets/src/mage/cards/u/UnifyingTheory.java
@@ -64,7 +64,7 @@ class UnifyingTheoryEffect extends OneShotEffect {
             if (caster.chooseUse(Outcome.DrawCard, "Pay {2} to draw a card?", source, game)) {
                 Cost cost = new ManaCostsImpl("{2}");
                 if (cost.pay(source, game, source.getSourceId(), caster.getId(), false, null)) {
-                    caster.drawCards(1, game);
+                    caster.drawCards(1, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/u/UnmooredEgo.java
+++ b/Mage.Sets/src/mage/cards/u/UnmooredEgo.java
@@ -111,7 +111,7 @@ class UnmooredEgoEffect extends OneShotEffect {
 
                 if (numberOfCardsExiledFromHand > 0) {
                     game.getState().applyEffects(game);
-                    targetPlayer.drawCards(numberOfCardsExiledFromHand, game);
+                    targetPlayer.drawCards(numberOfCardsExiledFromHand, source.getSourceId(), game);
                 }
             }
 

--- a/Mage.Sets/src/mage/cards/u/UnpredictableCyclone.java
+++ b/Mage.Sets/src/mage/cards/u/UnpredictableCyclone.java
@@ -13,6 +13,7 @@ import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
+import mage.game.stack.StackObject;
 import mage.players.Player;
 
 import java.util.UUID;
@@ -26,7 +27,7 @@ public final class UnpredictableCyclone extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{R}{R}");
 
         // If a cycling ability of another nonland card would cause you to draw a card, instead exile cards from the top of your library until you exile a card that shares a card type with the cycled card. You may cast that card without paying its mana cost. Then put the exiled cards that weren't cast this way on the bottom of your library in a random order.
-        this.addAbility(new SimpleStaticAbility(new ArchmageAscensionReplacementEffect()));
+        this.addAbility(new SimpleStaticAbility(new UnpredictableCycloneReplacementEffect()));
 
         // Cycling {2}
         this.addAbility(new CyclingAbility(new ManaCostsImpl("{2}")));
@@ -42,9 +43,9 @@ public final class UnpredictableCyclone extends CardImpl {
     }
 }
 
-class ArchmageAscensionReplacementEffect extends ReplacementEffectImpl {
+class UnpredictableCycloneReplacementEffect extends ReplacementEffectImpl {
 
-    ArchmageAscensionReplacementEffect() {
+    UnpredictableCycloneReplacementEffect() {
         super(Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "If a cycling ability of another nonland card would cause you to draw a card, " +
                 "instead exile cards from the top of your library until you exile a card " +
@@ -52,13 +53,13 @@ class ArchmageAscensionReplacementEffect extends ReplacementEffectImpl {
                 "Then put the exiled cards that weren't cast this way on the bottom of your library in a random order.";
     }
 
-    private ArchmageAscensionReplacementEffect(final ArchmageAscensionReplacementEffect effect) {
+    private UnpredictableCycloneReplacementEffect(final UnpredictableCycloneReplacementEffect effect) {
         super(effect);
     }
 
     @Override
-    public ArchmageAscensionReplacementEffect copy() {
-        return new ArchmageAscensionReplacementEffect(this);
+    public UnpredictableCycloneReplacementEffect copy() {
+        return new UnpredictableCycloneReplacementEffect(this);
     }
 
     @Override
@@ -69,8 +70,12 @@ class ArchmageAscensionReplacementEffect extends ReplacementEffectImpl {
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
-        Card sourceCard = game.getCard(event.getSourceId());
-        if (player == null || sourceCard == null || sourceCard.isLand()) {
+        StackObject stackObject = game.getStack().getStackObject(event.getSourceId());
+        if (player == null || stackObject == null) {
+            return false;
+        }
+        Card sourceCard = game.getCard(stackObject.getSourceId());
+        if (sourceCard == null ) {
             return false;
         }
         Cards cards = new CardsImpl();
@@ -98,11 +103,22 @@ class ArchmageAscensionReplacementEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.CYCLE_DRAW;
+        return event.getType() == GameEvent.EventType.DRAW_CARD;
     }
 
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
-        return event.getPlayerId().equals(source.getControllerId());
+        if (event.getPlayerId().equals(source.getControllerId())) {
+            return false;
+        }
+        Player player = game.getPlayer(event.getPlayerId());
+        StackObject stackObject = game.getStack().getStackObject(event.getSourceId());
+        if (player == null || stackObject == null
+                || stackObject.getStackAbility() == null
+                || !(stackObject.getStackAbility() instanceof CyclingAbility)) {
+            return false;
+        }
+        Card sourceCard = game.getCard(stackObject.getSourceId());
+        return sourceCard == null || sourceCard.isLand();
     }
 }

--- a/Mage.Sets/src/mage/cards/u/UnpredictableCyclone.java
+++ b/Mage.Sets/src/mage/cards/u/UnpredictableCyclone.java
@@ -75,7 +75,7 @@ class UnpredictableCycloneReplacementEffect extends ReplacementEffectImpl {
             return false;
         }
         Card sourceCard = game.getCard(stackObject.getSourceId());
-        if (sourceCard == null ) {
+        if (sourceCard == null) {
             return false;
         }
         Cards cards = new CardsImpl();
@@ -108,7 +108,7 @@ class UnpredictableCycloneReplacementEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
-        if (event.getPlayerId().equals(source.getControllerId())) {
+        if (!event.getPlayerId().equals(source.getControllerId())) {
             return false;
         }
         Player player = game.getPlayer(event.getPlayerId());
@@ -119,6 +119,6 @@ class UnpredictableCycloneReplacementEffect extends ReplacementEffectImpl {
             return false;
         }
         Card sourceCard = game.getCard(stackObject.getSourceId());
-        return sourceCard == null || sourceCard.isLand();
+        return sourceCard != null && !sourceCard.isLand();
     }
 }

--- a/Mage.Sets/src/mage/cards/u/UrgorosTheEmptyOne.java
+++ b/Mage.Sets/src/mage/cards/u/UrgorosTheEmptyOne.java
@@ -69,7 +69,7 @@ class UrgorosTheEmptyOneEffect extends OneShotEffect {
         Player attackedPlayer = game.getPlayer(getTargetPointer().getFirst(game, source));
         if (controller != null && attackedPlayer != null) {
             if (attackedPlayer.getHand().isEmpty()) {
-                controller.drawCards(1, game);
+                controller.drawCards(1, source.getSourceId(), game);
             } else {
                 attackedPlayer.discardOne(true, source, game);
             }

--- a/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
+++ b/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
@@ -550,7 +550,7 @@ class UrzaAcademyHeadmasterBrainstormEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(3, game);
+            player.drawCards(3, source.getSourceId(), game);
             putOnLibrary(player, source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/v/VanishIntoMemory.java
+++ b/Mage.Sets/src/mage/cards/v/VanishIntoMemory.java
@@ -72,7 +72,7 @@ class VanishIntoMemoryEffect extends OneShotEffect {
         MageObject sourceObject = game.getObject(source.getSourceId());
         if (controller != null && permanent != null && sourceObject != null) {
             if (controller.moveCardsToExile(permanent, source, game, true, source.getSourceId(), sourceObject.getIdName())) {
-                controller.drawCards(permanent.getPower().getValue(), game);
+                controller.drawCards(permanent.getPower().getValue(), source.getSourceId(), game);
                 ExileZone exile = game.getExile().getExileZone(source.getSourceId());
                 // only if permanent is in exile (tokens would be stop to exist)
                 if (exile != null && !exile.isEmpty()) {

--- a/Mage.Sets/src/mage/cards/v/VendilionClique.java
+++ b/Mage.Sets/src/mage/cards/v/VendilionClique.java
@@ -85,7 +85,7 @@ class VendilionCliqueEffect extends OneShotEffect {
                     cards.add(card);
                     player.revealCards(sourceObject.getIdName(), cards, game);
                     player.putCardsOnBottomOfLibrary(cards, game, source, true);
-                    player.drawCards(1, game);
+                    player.drawCards(1, source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/v/Vex.java
+++ b/Mage.Sets/src/mage/cards/v/Vex.java
@@ -65,7 +65,7 @@ class VexEffect extends OneShotEffect {
             countered = true;
         }
         if (controller != null) {
-            controller.drawCards(1, game);
+            controller.drawCards(1, source.getSourceId(), game);
         }
         return countered;
     }

--- a/Mage.Sets/src/mage/cards/v/VisionsOfBeyond.java
+++ b/Mage.Sets/src/mage/cards/v/VisionsOfBeyond.java
@@ -59,7 +59,7 @@ class VisionsOfBeyondEffect extends OneShotEffect {
                 }
             }
         }
-        sourcePlayer.drawCards(count, game);
+        sourcePlayer.drawCards(count, source.getSourceId(), game);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/w/WellOfKnowledge.java
+++ b/Mage.Sets/src/mage/cards/w/WellOfKnowledge.java
@@ -105,7 +105,7 @@ class WellOfKnowledgeEffect extends OneShotEffect {
         if (source instanceof ActivatedAbilityImpl) {
             Player activator = game.getPlayer(((ActivatedAbilityImpl) source).getActivatorId());
             if (activator != null) {
-                activator.drawCards(1, game);
+                activator.drawCards(1, source.getSourceId(), game);
                 return true;
             }
 

--- a/Mage.Sets/src/mage/cards/w/WellOfLostDreams.java
+++ b/Mage.Sets/src/mage/cards/w/WellOfLostDreams.java
@@ -62,7 +62,7 @@ class WellOfLostDreamsEffect extends OneShotEffect {
                 if (xValue > 0) {
                     if (new GenericManaCost(xValue).pay(source, game, source.getSourceId(), controller.getId(), false)) {
                         game.informPlayers(controller.getLogName() + " payed {" + xValue + '}');
-                        controller.drawCards(xValue, game);
+                        controller.drawCards(xValue, source.getSourceId(), game);
                     } else {
                         return false;
                     }

--- a/Mage.Sets/src/mage/cards/w/WhirlpoolWarrior.java
+++ b/Mage.Sets/src/mage/cards/w/WhirlpoolWarrior.java
@@ -90,7 +90,7 @@ class WhirlpoolWarriorActivatedEffect extends OneShotEffect {
             for (Entry<UUID, Integer> entry : playerCards.entrySet()) {
                 Player player = game.getPlayer(entry.getKey());
                 if (player != null) {
-                    player.drawCards(entry.getValue(), game);
+                    player.drawCards(entry.getValue(), source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/w/WhisperingMadness.java
+++ b/Mage.Sets/src/mage/cards/w/WhisperingMadness.java
@@ -73,7 +73,7 @@ class WhisperingMadnessEffect extends OneShotEffect {
         for (UUID playerId : game.getState().getPlayersInRange(sourcePlayer.getId(), game)) {
             Player player = game.getPlayer(playerId);
             if (player != null) {
-                player.drawCards(maxDiscarded, game);
+                player.drawCards(maxDiscarded, source.getSourceId(), game);
             }
         }
 

--- a/Mage.Sets/src/mage/cards/w/WickedGuardian.java
+++ b/Mage.Sets/src/mage/cards/w/WickedGuardian.java
@@ -87,6 +87,6 @@ class WickedGuardianEffect extends OneShotEffect {
             return false;
         }
         permanent.damage(2, source.getSourceId(), game);
-        return player.drawCards(1, game) > 0;
+        return player.drawCards(1, source.getSourceId(), game) > 0;
     }
 }

--- a/Mage.Sets/src/mage/cards/w/Windfall.java
+++ b/Mage.Sets/src/mage/cards/w/Windfall.java
@@ -70,7 +70,7 @@ class WindfallEffect extends OneShotEffect {
         for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
             Player player = game.getPlayer(playerId);
             if (player != null) {
-                player.drawCards(maxDiscarded, game);
+                player.drawCards(maxDiscarded, source.getSourceId(), game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/w/WindsOfChange.java
+++ b/Mage.Sets/src/mage/cards/w/WindsOfChange.java
@@ -69,7 +69,7 @@ class WindsOfChangeEffect extends OneShotEffect {
             for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {
                 Player player = game.getPlayer(playerId);
                 if (player != null && permanentsCount.containsKey(playerId)) {
-                    player.drawCards(permanentsCount.get(playerId), game);
+                    player.drawCards(permanentsCount.get(playerId), source.getSourceId(), game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/w/WitheringGaze.java
+++ b/Mage.Sets/src/mage/cards/w/WitheringGaze.java
@@ -70,7 +70,7 @@ class WitheringGazeEffect extends OneShotEffect {
                    count++;
                }
             }
-            controller.drawCards(count, game);
+            controller.drawCards(count, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/w/WordsOfWisdom.java
+++ b/Mage.Sets/src/mage/cards/w/WordsOfWisdom.java
@@ -62,7 +62,7 @@ class WordsOfWisdomEffect extends OneShotEffect {
                 if (!playerId.equals(controller.getId())) {
                     Player player = game.getPlayer(playerId);
                     if (player != null) {
-                        player.drawCards(1, game);
+                        player.drawCards(1, source.getSourceId(), game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/y/YennettCrypticSovereign.java
+++ b/Mage.Sets/src/mage/cards/y/YennettCrypticSovereign.java
@@ -99,10 +99,10 @@ class YennettCrypticSovereignEffect extends OneShotEffect {
                 choose not to cast it, you draw a card. Keep in mind that revealing a card doesn’t cause it to change 
                 zones. This means that the card you draw will be the card you revealed.
                  */
-                player.drawCards(1, game);
+                player.drawCards(1, source.getSourceId(), game);
             }
         } else {
-            player.drawCards(1, game);
+            player.drawCards(1, source.getSourceId(), game);
         }
         return true;
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/UnpredictableCycloneTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/UnpredictableCycloneTest.java
@@ -1,0 +1,114 @@
+package org.mage.test.cards.single;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author TheElk801
+ */
+public class UnpredictableCycloneTest extends CardTestPlayerBase {
+
+    @Test
+    public void testCyclone() {
+        // Make sure the card works normally
+
+        addCard(Zone.LIBRARY, playerA, "Goblin Piker");
+        addCard(Zone.LIBRARY, playerA, "Swamp", 10);
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.BATTLEFIELD, playerA, "Unpredictable Cyclone");
+        addCard(Zone.HAND, playerA, "Desert Cerodon");
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cycling");
+        setChoice(playerA, "Yes");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+        assertPermanentCount(playerA, "Goblin Piker", 1);
+    }
+
+    @Test
+    public void testLandCycle() {
+        // Make sure it doesn't apply to cycling lands
+
+        addCard(Zone.LIBRARY, playerA, "Swamp", 10);
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.BATTLEFIELD, playerA, "Unpredictable Cyclone");
+        addCard(Zone.HAND, playerA, "Forgotten Cave");
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cycling");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+        assertHandCount(playerA, "Swamp", 1);
+    }
+
+    @Test
+    public void testModifiedDraw() {
+        // If a draw is increased, the ability will apply additional times
+
+        addCard(Zone.LIBRARY, playerA, "Goblin Piker", 2);
+        addCard(Zone.LIBRARY, playerA, "Swamp", 10);
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.BATTLEFIELD, playerA, "Unpredictable Cyclone");
+        addCard(Zone.BATTLEFIELD, playerA, "Thought Reflection");
+        addCard(Zone.HAND, playerA, "Desert Cerodon");
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cycling");
+        setChoice(playerA, "Thought Reflection"); // apply doubling first
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+        assertPermanentCount(playerA, "Goblin Piker", 2);
+    }
+
+    @Test
+    public void testModifiedDraw2() {
+        // Make sure the effect works with multiple stacked replacement effects
+
+        addCard(Zone.LIBRARY, playerA, "Goblin Piker", 4);
+        addCard(Zone.LIBRARY, playerA, "Swamp", 10);
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.BATTLEFIELD, playerA, "Unpredictable Cyclone");
+        addCard(Zone.BATTLEFIELD, playerA, "Thought Reflection", 2);
+        addCard(Zone.HAND, playerA, "Desert Cerodon");
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cycling");
+        setChoice(playerA, "Thought Reflection", 3); // apply doubling first
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+        assertPermanentCount(playerA, "Goblin Piker", 4);
+    }
+
+    @Test
+    public void testStolenDraw() {
+        // if your opponent cycles a card and you steal that draw with Notion Thief, the draw will still be replaced
+
+        addCard(Zone.LIBRARY, playerA, "Goblin Piker", 1);
+        addCard(Zone.LIBRARY, playerA, "Swamp", 10);
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain");
+        addCard(Zone.BATTLEFIELD, playerA, "Unpredictable Cyclone");
+        addCard(Zone.HAND, playerB, "Desert Cerodon");
+        addCard(Zone.HAND, playerA, "Plagiarize");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Plagiarize", playerB);
+        activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerB, "Cycling");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+        assertPermanentCount(playerA, "Goblin Piker", 1);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/UnpredictableCycloneTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/UnpredictableCycloneTest.java
@@ -25,6 +25,7 @@ public class UnpredictableCycloneTest extends CardTestPlayerBase {
         setChoice(playerA, "Yes");
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
         assertAllCommandsUsed();
         assertPermanentCount(playerA, "Goblin Piker", 1);
@@ -43,6 +44,7 @@ public class UnpredictableCycloneTest extends CardTestPlayerBase {
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cycling");
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
         assertAllCommandsUsed();
         assertHandCount(playerA, "Swamp", 1);
@@ -64,6 +66,7 @@ public class UnpredictableCycloneTest extends CardTestPlayerBase {
         setChoice(playerA, "Thought Reflection"); // apply doubling first
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
         assertAllCommandsUsed();
         assertPermanentCount(playerA, "Goblin Piker", 2);
@@ -85,6 +88,7 @@ public class UnpredictableCycloneTest extends CardTestPlayerBase {
         setChoice(playerA, "Thought Reflection", 3); // apply doubling first
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
         assertAllCommandsUsed();
         assertPermanentCount(playerA, "Goblin Piker", 4);
@@ -107,6 +111,7 @@ public class UnpredictableCycloneTest extends CardTestPlayerBase {
         activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerB, "Cycling");
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
         assertAllCommandsUsed();
         assertPermanentCount(playerA, "Goblin Piker", 1);

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -2511,13 +2511,13 @@ public class TestPlayer implements Player {
     }
 
     @Override
-    public int drawCards(int num, Game game) {
-        return computerPlayer.drawCards(num, game);
+    public int drawCards(int num, UUID sourceId, Game game) {
+        return computerPlayer.drawCards(num, sourceId, game);
     }
 
     @Override
-    public int drawCards(int num, Game game, List<UUID> appliedEffects) {
-        return computerPlayer.drawCards(num, game, appliedEffects);
+    public int drawCards(int num, UUID sourceId, Game game, List<UUID> appliedEffects) {
+        return computerPlayer.drawCards(num, sourceId, game, appliedEffects);
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
+++ b/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
@@ -528,12 +528,12 @@ public class PlayerStub implements Player {
     }
 
     @Override
-    public int drawCards(int num, Game game) {
+    public int drawCards(int num, UUID sourceId, Game game) {
         return 0;
     }
 
     @Override
-    public int drawCards(int num, Game game, List<UUID> appliedEffects) {
+    public int drawCards(int num, UUID sourceId, Game game, List<UUID> appliedEffects) {
         return 0;
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/BrainstormEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/BrainstormEffect.java
@@ -29,7 +29,7 @@ public class BrainstormEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.drawCards(3, game);
+            player.drawCards(3, source.getSourceId(), game);
             putOnLibrary(player, source, game);
             putOnLibrary(player, source, game);
             return true;

--- a/Mage/src/main/java/mage/abilities/effects/common/DrawCardAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DrawCardAllEffect.java
@@ -59,7 +59,7 @@ public class DrawCardAllEffect extends OneShotEffect {
                 for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
                     Player player = game.getPlayer(playerId);
                     if (player != null) {
-                        player.drawCards(amount.calculate(game, source, this), game);
+                        player.drawCards(amount.calculate(game, source, this), source.getSourceId(), game);
                     }
                 }
                 break;
@@ -67,7 +67,7 @@ public class DrawCardAllEffect extends OneShotEffect {
                 for (UUID playerId : game.getOpponents(controller.getId())) {
                     Player player = game.getPlayer(playerId);
                     if (player != null) {
-                        player.drawCards(amount.calculate(game, source, this), game);
+                        player.drawCards(amount.calculate(game, source, this), source.getSourceId(), game);
                     }
                 }
                 break;

--- a/Mage/src/main/java/mage/abilities/effects/common/DrawCardSourceControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DrawCardSourceControllerEffect.java
@@ -54,7 +54,7 @@ public class DrawCardSourceControllerEffect extends OneShotEffect {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null
                 && player.canRespond()) {
-            player.drawCards(amount.calculate(game, source, this), game);
+            player.drawCards(amount.calculate(game, source, this), source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage/src/main/java/mage/abilities/effects/common/DrawCardTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DrawCardTargetEffect.java
@@ -70,7 +70,7 @@ public class DrawCardTargetEffect extends OneShotEffect {
                 }
                 if (!optional
                         || player.chooseUse(outcome, "Use draw effect?", source, game)) {
-                    player.drawCards(cardsToDraw, game);
+                    player.drawCards(cardsToDraw, source.getSourceId(), game);
                 }
             }
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/DrawDiscardControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DrawDiscardControllerEffect.java
@@ -58,7 +58,7 @@ public class DrawDiscardControllerEffect extends OneShotEffect {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
             if (!optional || player.chooseUse(outcome, "Use draw, then discard effect?", source, game)) {
-                player.drawCards(cardsToDraw, game);
+                player.drawCards(cardsToDraw, source.getSourceId(), game);
                 player.discard(cardsToDiscard, false, source, game);
             }
             return true;

--- a/Mage/src/main/java/mage/abilities/effects/common/DrawDiscardOneOfThemEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DrawDiscardOneOfThemEffect.java
@@ -46,7 +46,7 @@ public class DrawDiscardOneOfThemEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Cards initialHand = controller.getHand().copy();
-            controller.drawCards(cardsToDraw, game);
+            controller.drawCards(cardsToDraw, source.getSourceId(), game);
             Cards drawnCards = new CardsImpl(controller.getHand().copy());
             drawnCards.removeAll(initialHand);
             if (!drawnCards.isEmpty()) {

--- a/Mage/src/main/java/mage/abilities/effects/common/DrawDiscardTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DrawDiscardTargetEffect.java
@@ -49,7 +49,7 @@ public class DrawDiscardTargetEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(getTargetPointer().getFirst(game, source));
         if (player != null) {
-            player.drawCards(cardsToDraw, game);
+            player.drawCards(cardsToDraw, source.getSourceId(), game);
             player.discard(cardsToDiscard, false, source, game);
             return true;
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/ShuffleHandIntoLibraryDrawThatManySourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ShuffleHandIntoLibraryDrawThatManySourceEffect.java
@@ -37,7 +37,7 @@ public class ShuffleHandIntoLibraryDrawThatManySourceEffect extends OneShotEffec
                 controller.moveCards(controller.getHand(), Zone.LIBRARY, source, game);
                 controller.shuffleLibrary(source, game);
                 game.applyEffects(); // then
-                controller.drawCards(cardsHand, game);
+                controller.drawCards(cardsHand, source.getSourceId(), game);
             }
             return true;
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardHandDrawSameNumberSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardHandDrawSameNumberSourceEffect.java
@@ -28,7 +28,7 @@ public class DiscardHandDrawSameNumberSourceEffect extends OneShotEffect {
         if (player != null) {
             int amount = player.getHand().getCards(game).size();
             player.discard(amount, false, source, game);
-            player.drawCards(amount, game);
+            player.drawCards(amount, source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage/src/main/java/mage/abilities/keyword/CyclingAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/CyclingAbility.java
@@ -1,18 +1,13 @@
 package mage.abilities.keyword;
 
-import mage.abilities.Ability;
 import mage.abilities.ActivatedAbilityImpl;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.CyclingDiscardCost;
 import mage.abilities.costs.mana.ManaCost;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.common.search.SearchLibraryPutInHandEffect;
-import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
 
 /**
@@ -24,7 +19,7 @@ public class CyclingAbility extends ActivatedAbilityImpl {
     private final String text;
 
     public CyclingAbility(Cost cost) {
-        super(Zone.HAND, new CyclingDrawEffect(), cost);
+        super(Zone.HAND, new DrawCardSourceControllerEffect(1), cost);
         this.addCost(new CyclingDiscardCost());
         this.cost = cost;
         this.text = "Cycling";
@@ -58,39 +53,5 @@ public class CyclingAbility extends ActivatedAbilityImpl {
         }
         rule.append(cost.getText()).append(" <i>(").append(super.getRule(true)).append(")</i>");
         return rule.toString();
-    }
-}
-
-class CyclingDrawEffect extends OneShotEffect {
-
-    CyclingDrawEffect() {
-        super(Outcome.Benefit);
-        staticText = "draw a card";
-    }
-
-    private CyclingDrawEffect(final CyclingDrawEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public CyclingDrawEffect copy() {
-        return new CyclingDrawEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player player = game.getPlayer(source.getSourceId());
-        if (player == null) {
-            return false;
-        }
-        GameEvent event = GameEvent.getEvent(
-                GameEvent.EventType.CYCLE_DRAW, source.getSourceId(),
-                source.getSourceId(), source.getControllerId()
-        );
-        if (game.replaceEvent(event)) {
-            return true;
-        }
-        player.drawCards(1, game);
-        return true;
     }
 }

--- a/Mage/src/main/java/mage/actions/MageDrawAction.java
+++ b/Mage/src/main/java/mage/actions/MageDrawAction.java
@@ -1,8 +1,5 @@
 package mage.actions;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import mage.actions.impl.MageAction;
 import mage.actions.score.ArtificialScoringSystem;
 import mage.cards.Card;
@@ -11,6 +8,10 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.players.Player;
 import mage.util.CardUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * Action for drawing cards.
@@ -37,11 +38,12 @@ public class MageDrawAction extends MageAction {
     /**
      * Draw and set action score.
      *
-     * @param game Game context.
+     * @param sourceId
+     * @param game     Game context.
      * @return
      */
     @Override
-    public int doAction(Game game) {
+    public int doAction(UUID sourceId, Game game) {
         int numDrawn = 0;
         int score = 0;
         GameEvent event = GameEvent.getEvent(GameEvent.EventType.DRAW_CARDS, player.getId(), null, player.getId(), null, amount);
@@ -49,7 +51,7 @@ public class MageDrawAction extends MageAction {
         if (amount < 2 || !game.replaceEvent(event)) {
             amount = event.getAmount();
             for (int i = 0; i < amount; i++) {
-                int value = drawCard(game);
+                int value = drawCard(sourceId, game);
                 if (value == NEGATIVE_VALUE) {
                     continue;
                 }
@@ -62,7 +64,7 @@ public class MageDrawAction extends MageAction {
             if (player.isEmptyDraw()) {
                 event = GameEvent.getEvent(GameEvent.EventType.EMPTY_DRAW, player.getId(), player.getId());
                 if (!game.replaceEvent(event)) {
-                    game.doAction(new MageLoseGameAction(player, MageLoseGameAction.DRAW_REASON));
+                    game.doAction(new MageLoseGameAction(player, MageLoseGameAction.DRAW_REASON), sourceId);
                 }
             }
 
@@ -76,11 +78,12 @@ public class MageDrawAction extends MageAction {
      * Draw a card if possible (there is no replacement effect that prevent us
      * from drawing). Fire event about card drawn.
      *
+     * @param sourceId
      * @param game
      * @return
      */
-    protected int drawCard(Game game) {
-        GameEvent event = GameEvent.getEvent(GameEvent.EventType.DRAW_CARD, player.getId(), player.getId());
+    protected int drawCard(UUID sourceId, Game game) {
+        GameEvent event = GameEvent.getEvent(GameEvent.EventType.DRAW_CARD, player.getId(), sourceId, player.getId());
         event.addAppliedEffects(appliedEffects);
         if (!game.replaceEvent(event)) {
             Card card = player.getLibrary().removeFromTop(game);

--- a/Mage/src/main/java/mage/actions/MageLoseGameAction.java
+++ b/Mage/src/main/java/mage/actions/MageLoseGameAction.java
@@ -5,6 +5,8 @@ import mage.actions.score.ArtificialScoringSystem;
 import mage.game.Game;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
  * Lose game action.
  *
@@ -26,7 +28,7 @@ public class MageLoseGameAction extends MageAction {
     }
 
     @Override
-    public int doAction(final Game game) {
+    public int doAction(UUID sourceId, final Game game) {
         oldLosingPlayer = game.getLosingPlayer();
         if (oldLosingPlayer == null && player.canLose(game)) {
             setScore(player, ArtificialScoringSystem.inst.getLoseGameScore(game));

--- a/Mage/src/main/java/mage/actions/impl/MageAction.java
+++ b/Mage/src/main/java/mage/actions/impl/MageAction.java
@@ -3,6 +3,8 @@ package mage.actions.impl;
 import mage.game.Game;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
  * Base class for mage actions.
  *
@@ -52,10 +54,12 @@ public abstract class MageAction {
     /**
      * Execute action.
      *
+     *
+     * @param sourceId
      * @param game Game context.
      * @return
      */
-    public abstract int doAction(final Game game);
+    public abstract int doAction(UUID sourceId, final Game game);
 
     /**
      * Undo action.

--- a/Mage/src/main/java/mage/game/Game.java
+++ b/Mage/src/main/java/mage/game/Game.java
@@ -408,7 +408,7 @@ public interface Game extends MageItem, Serializable {
 
     boolean endTurn(Ability source);
 
-    int doAction(MageAction action);
+    int doAction(MageAction action, UUID sourceId);
 
     //game transaction methods
     void saveState(boolean bookmark);

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -1026,7 +1026,7 @@ public abstract class GameImpl implements Game, Serializable {
                 player.initLife(this.getLife());
             }
             if (!gameOptions.testMode) {
-                player.drawCards(startingHandSize, this);
+                player.drawCards(startingHandSize, null, this);
             }
         }
 
@@ -3021,9 +3021,9 @@ public abstract class GameImpl implements Game, Serializable {
     }
 
     @Override
-    public int doAction(MageAction action) {
+    public int doAction(MageAction action, UUID sourceId) {
         //actions.add(action);
-        int value = action.doAction(this);
+        int value = action.doAction(sourceId, this);
 //        score += action.getScore(scorePlayer);
         return value;
     }

--- a/Mage/src/main/java/mage/game/command/planes/AcademyAtTolariaWestPlane.java
+++ b/Mage/src/main/java/mage/game/command/planes/AcademyAtTolariaWestPlane.java
@@ -93,7 +93,7 @@ class DrawCardsActivePlayerEffect extends OneShotEffect {
         }
         Player player = game.getPlayer(game.getActivePlayerId());
         if (player != null) {
-            player.drawCards(amount.calculate(game, source, this), game);
+            player.drawCards(amount.calculate(game, source, this), source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage/src/main/java/mage/game/mulligan/CanadianHighlanderMulligan.java
+++ b/Mage/src/main/java/mage/game/mulligan/CanadianHighlanderMulligan.java
@@ -118,7 +118,7 @@ public class CanadianHighlanderMulligan extends VancouverMulligan {
                 .append(" mulligans to ")
                 .append(Integer.toString(numToMulliganTo))
                 .append(numToMulliganTo == 1 ? " card" : " cards").toString());
-        player.drawCards(numToMulliganTo, game);
+        player.drawCards(numToMulliganTo, null, game);
     }
 
 }

--- a/Mage/src/main/java/mage/game/mulligan/LondonMulligan.java
+++ b/Mage/src/main/java/mage/game/mulligan/LondonMulligan.java
@@ -103,7 +103,7 @@ public class LondonMulligan extends Mulligan {
                     .append(newHandSize)
                     .append(newHandSize == 1 ? " card" : " cards").toString());
         }
-        player.drawCards(numCards, game);
+        player.drawCards(numCards, null, game);
 
         if (player.getHand().size() > newHandSize) {
             int cardsToDiscard = player.getHand().size() - newHandSize;

--- a/Mage/src/main/java/mage/game/mulligan/ParisMulligan.java
+++ b/Mage/src/main/java/mage/game/mulligan/ParisMulligan.java
@@ -53,7 +53,7 @@ public class ParisMulligan extends Mulligan {
                 .append(deduction == 0 ? " for free and draws " : " down to ")
                 .append((numCards - deduction))
                 .append(numCards - deduction == 1 ? " card" : " cards").toString());
-        player.drawCards(numCards - deduction, game);
+        player.drawCards(numCards - deduction, null, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/game/turn/DrawStep.java
+++ b/Mage/src/main/java/mage/game/turn/DrawStep.java
@@ -1,15 +1,13 @@
-
-
 package mage.game.turn;
 
-import java.util.UUID;
 import mage.constants.PhaseStep;
 import mage.game.Game;
 import mage.game.events.GameEvent.EventType;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public class DrawStep extends Step {
@@ -29,7 +27,7 @@ public class DrawStep extends Step {
     public void beginStep(Game game, UUID activePlayerId) {
         Player activePlayer = game.getPlayer(activePlayerId);
         //20091005 - 504.1/703.4c
-        activePlayer.drawCards(1, game);
+        activePlayer.drawCards(1, null, game);
 //        game.saveState();
         game.applyEffects();
         super.beginStep(game, activePlayerId);

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -311,9 +311,9 @@ public interface Player extends MageItem, Copyable<Player> {
 
     void shuffleLibrary(Ability source, Game game);
 
-    int drawCards(int num, Game game);
+    int drawCards(int num, UUID sourceId, Game game);
 
-    int drawCards(int num, Game game, List<UUID> appliedEffects);
+    int drawCards(int num, UUID sourceId, Game game, List<UUID> appliedEffects);
 
     boolean cast(SpellAbility ability, Game game, boolean noMana, MageObjectReference reference);
 

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -673,16 +673,16 @@ public abstract class PlayerImpl implements Player, Serializable {
     }
 
     @Override
-    public int drawCards(int num, Game game) {
+    public int drawCards(int num, UUID sourceId, Game game) {
         if (num > 0) {
-            return game.doAction(new MageDrawAction(this, num, null));
+            return game.doAction(new MageDrawAction(this, num, null), sourceId);
         }
         return 0;
     }
 
     @Override
-    public int drawCards(int num, Game game, List<UUID> appliedEffects) {
-        return game.doAction(new MageDrawAction(this, num, appliedEffects));
+    public int drawCards(int num, UUID sourceId, Game game, List<UUID> appliedEffects) {
+        return game.doAction(new MageDrawAction(this, num, appliedEffects), sourceId);
     }
 
     @Override


### PR DESCRIPTION
The previous implementation didn't really interact properly with drawing cards, now card draw events include the source id. I should probably write some tests for this too.