### PR TITLE
replaced usage of ZoneChangeEvent with targetId param for permanent

### DIFF
--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -3987,7 +3987,7 @@ public abstract class PlayerImpl implements Player, Serializable {
                 for (Card card : cards) {
                     if (card instanceof Permanent) {
                         game.getBattlefield().removePermanent(card.getId());
-                        ZoneChangeEvent event = new ZoneChangeEvent(card.getId(),
+                        ZoneChangeEvent event = new ZoneChangeEvent((Permanent) card,
                                 (source == null ? null : source.getSourceId()),
                                 byOwner ? card.getOwnerId() : getId(), Zone.BATTLEFIELD, Zone.OUTSIDE, appliedEffects);
                         game.fireEvent(event);


### PR DESCRIPTION
This is the only occurrence that uses a targetId if it is a Permanent, all other occurrences where a ZoneChangeEvent is created  that use targetId do not have a permanent (e.g. in CardImpl).
#6499 