### PR TITLE
UI: fix for </font> in card renders at end of ToolTipMarkTags

### DIFF
--- a/Mage.Client/src/main/java/org/mage/card/arcane/TextboxRule.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/TextboxRule.java
@@ -7,6 +7,7 @@ package org.mage.card.arcane;
 
 import java.awt.Font;
 import java.awt.Image;
+import java.awt.Paint;
 import java.awt.font.GraphicAttribute;
 import java.awt.font.ImageGraphicAttribute;
 import java.awt.font.TextAttribute;
@@ -43,6 +44,25 @@ public class TextboxRule {
         public void applyToAttributedString(AttributedString str, Font normal, Font italic) {
             if (end > start + 1) {
                 str.addAttribute(TextAttribute.FONT, italic, start, end);
+            }
+        }
+    }
+
+    public static class ColorRegion implements AttributeRegion {
+
+        ColorRegion(int start, int end, Paint color) {
+            this.start = start;
+            this.end = end;
+            this.color = color;
+        }
+        private final int start;
+        private final int end;
+        private final Paint color;
+
+        @Override
+        public void applyToAttributedString(AttributedString str, Font normal, Font italic) {
+            if (end > start + 1) {
+                str.addAttribute(TextAttribute.FOREGROUND, color, start, end);
             }
         }
     }

--- a/Mage.Client/src/main/java/org/mage/card/arcane/TextboxRuleParser.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/TextboxRuleParser.java
@@ -23,6 +23,7 @@ public final class TextboxRuleParser {
     private static final Pattern LevelAbilityPattern = Pattern.compile("Level (\\d+)-?(\\d*)(\\+?)");
     private static final Pattern LoyaltyAbilityPattern = Pattern.compile("^(\\+|\\-)(\\d+|X): ");
     private static final Pattern SimpleKeywordPattern = Pattern.compile("^(\\w+( \\w+)?)\\s*(\\([^\\)]*\\))?\\s*$");
+    private static final Pattern FontColorValuePattern = Pattern.compile("color\\s*=\\s*[\"'](\\w+)[\"']");
 
     // Parse a given rule (given as a string) into a TextboxRule, replacing
     // symbol annotations, italics, etc, parsing out information such as
@@ -199,6 +200,11 @@ public final class TextboxRuleParser {
                                             LOGGER.error("Bad leveler levels in rule `" + rule + "`.");
                                         }
                                     }
+                                    break;
+                                case "/font":
+                                    // Font it is an additional info of a card
+                                    // lets make it blue like it is in tooltip
+                                    regions.add(new TextboxRule.ColorRegion(openingIndex, outputIndex, Color.BLUE));
                                     break;
                                 default:
                                     // Unknown


### PR DESCRIPTION
Currently the client does remove the <font> but not the </font> from CardUtil.addToolTipMarkTags rules.
![2020-05-01-175210_398x391_scrot](https://user-images.githubusercontent.com/926223/80819044-8d68ba80-8bd4-11ea-9522-1532f612fbba.png)
I changed the render code so it makes the text blue, like it is in the tooltips.