### PR TITLE
make jboss remoting2 work with openjdk11 in xmage

### DIFF
--- a/Mage.Common/src/main/java/mage/interfaces/MageServer.java
+++ b/Mage.Common/src/main/java/mage/interfaces/MageServer.java
@@ -16,7 +16,6 @@ import mage.utils.MageVersion;
 import mage.view.*;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -84,7 +83,7 @@ public interface MageServer {
 
     boolean isTableOwner(String sessionId, UUID roomId, UUID tableId) throws MageException;
 
-    Optional<TableView> getTable(UUID roomId, UUID tableId) throws MageException;
+    TableView getTable(UUID roomId, UUID tableId) throws MageException;
 
     List<TableView> getTables(UUID roomId) throws MageException;
 
@@ -95,13 +94,13 @@ public interface MageServer {
 
     void leaveChat(UUID chatId, String sessionId) throws MageException;
 
-    Optional<UUID> getTableChatId(UUID tableId) throws MageException;
+    UUID getTableChatId(UUID tableId) throws MageException;
 
-    Optional<UUID> getGameChatId(UUID gameId) throws MageException;
+    UUID getGameChatId(UUID gameId) throws MageException;
 
-    Optional<UUID> getRoomChatId(UUID roomId) throws MageException;
+    UUID getRoomChatId(UUID roomId) throws MageException;
 
-    Optional<UUID> getTournamentChatId(UUID tournamentId) throws MageException;
+    UUID getTournamentChatId(UUID tournamentId) throws MageException;
 
     //room methods
     UUID getMainRoomId() throws MageException;

--- a/Mage.Common/src/main/java/mage/remote/Connection.java
+++ b/Mage.Common/src/main/java/mage/remote/Connection.java
@@ -42,6 +42,7 @@ public class Connection {
 //    private UserSkipPrioritySteps userSkipPrioritySteps;
     private static final String serialization = "?serializationtype=jboss";
     private static final String transport = "bisocket";
+    private static final String threadpool = "onewayThreadPool=mage.remote.CustomThreadPool";
 
     private final String parameter;
 
@@ -78,13 +79,13 @@ public class Connection {
             try {
                 InetAddress inet = getLocalAddress();
                 if (inet != null) {
-                    return transport + "://" + inet.getHostAddress() + ':' + port + '/' + serialization + parameter;
+                    return transport + "://" + inet.getHostAddress() + ':' + port + '/' + serialization + "&" + threadpool + parameter;
                 }
             } catch (SocketException ex) {
                 // just use localhost if can't find local ip
             }
         }
-        return transport + "://" + host + ':' + port + '/' + serialization + parameter;
+        return transport + "://" + host + ':' + port + '/' + serialization + "&" + threadpool + parameter;
     }
 
     public ProxyType getProxyType() {

--- a/Mage.Common/src/main/java/mage/remote/CustomThreadPool.java
+++ b/Mage.Common/src/main/java/mage/remote/CustomThreadPool.java
@@ -1,0 +1,32 @@
+package mage.remote;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.apache.log4j.Logger;
+import org.jboss.util.threadpool.BasicThreadPool;
+
+public class CustomThreadPool extends BasicThreadPool {
+    private static final Logger logger = Logger.getLogger(SessionImpl.class);
+
+    @Override
+    public void setMaximumPoolSize(int size) {
+        /*
+         * I really don't want to implement a whole new threadpool
+         * just to fix this and the executor is private
+         */
+        try {
+            Field executorField = BasicThreadPool.class.getField("executor");
+            executorField.setAccessible(true);
+            ThreadPoolExecutor executor = (ThreadPoolExecutor) executorField.get(this);
+            synchronized (executor) {
+                executor.setMaximumPoolSize(size);
+                executor.setCorePoolSize(size);
+            }
+        } catch (NoSuchFieldException | SecurityException e) {
+            logger.error("Failed to get field executor from BasicThreadPool", e);
+        } catch (IllegalArgumentException | IllegalAccessException e) {
+            logger.error("Failed to get executor object from BasicThreadPool", e);
+        }
+    }
+}

--- a/Mage.Common/src/main/java/mage/remote/SessionImpl.java
+++ b/Mage.Common/src/main/java/mage/remote/SessionImpl.java
@@ -647,7 +647,7 @@ public class SessionImpl implements Session {
     public Optional<UUID> getRoomChatId(UUID roomId) {
         try {
             if (isConnected()) {
-                return server.getRoomChatId(roomId);
+                return Optional.of(server.getRoomChatId(roomId));
             }
         } catch (MageException ex) {
             handleMageException(ex);
@@ -659,7 +659,7 @@ public class SessionImpl implements Session {
     public Optional<UUID> getTableChatId(UUID tableId) {
         try {
             if (isConnected()) {
-                return server.getTableChatId(tableId);
+                return Optional.of(server.getTableChatId(tableId));
             }
         } catch (MageException ex) {
             handleMageException(ex);
@@ -671,7 +671,7 @@ public class SessionImpl implements Session {
     public Optional<UUID> getGameChatId(UUID gameId) {
         try {
             if (isConnected()) {
-                return server.getGameChatId(gameId);
+                return Optional.of(server.getGameChatId(gameId));
             }
         } catch (MageException ex) {
             handleMageException(ex);
@@ -685,7 +685,7 @@ public class SessionImpl implements Session {
     public Optional<TableView> getTable(UUID roomId, UUID tableId) {
         try {
             if (isConnected()) {
-                return server.getTable(roomId, tableId);
+                return Optional.of(server.getTable(roomId, tableId));
             }
         } catch (MageException ex) {
             handleMageException(ex);
@@ -829,7 +829,7 @@ public class SessionImpl implements Session {
     public Optional<UUID> getTournamentChatId(UUID tournamentId) {
         try {
             if (isConnected()) {
-                return server.getTournamentChatId(tournamentId);
+                return Optional.of(server.getTournamentChatId(tournamentId));
             }
         } catch (MageException ex) {
             handleMageException(ex);

--- a/Mage.Server/src/main/java/mage/server/MageServerImpl.java
+++ b/Mage.Server/src/main/java/mage/server/MageServerImpl.java
@@ -397,15 +397,15 @@ public class MageServerImpl implements MageServer {
 
     @Override
     //FIXME: why no sessionId here???
-    public Optional<TableView> getTable(UUID roomId, UUID tableId) throws MageException {
+    public TableView getTable(UUID roomId, UUID tableId) throws MageException {
         try {
             Optional<GamesRoom> room = GamesRoomManager.instance.getRoom(roomId);
-            return room.flatMap(r -> r.getTable(tableId));
+            return room.flatMap(r -> r.getTable(tableId)).orElse(null);
 
         } catch (Exception ex) {
             handleException(ex);
         }
-        return Optional.empty();
+        return null;
     }
 
     @Override
@@ -536,18 +536,18 @@ public class MageServerImpl implements MageServer {
 
     @Override
     //FIXME: why no sessionId here???
-    public Optional<UUID> getRoomChatId(UUID roomId) throws MageException {
+    public UUID getRoomChatId(UUID roomId) throws MageException {
         try {
             Optional<GamesRoom> room = GamesRoomManager.instance.getRoom(roomId);
             if (!room.isPresent()) {
                 logger.error("roomId not found : " + roomId);
-                return Optional.empty();
+                return null;
             }
-            return Optional.of(room.get().getChatId());
+            return room.get().getChatId();
         } catch (Exception ex) {
             handleException(ex);
         }
-        return Optional.empty();
+        return null;
     }
 
     @Override
@@ -602,13 +602,13 @@ public class MageServerImpl implements MageServer {
 
     @Override
     //FIXME: why no sessionId here???
-    public Optional<UUID> getTableChatId(UUID tableId) throws MageException {
+    public UUID getTableChatId(UUID tableId) throws MageException {
         try {
-            return TableManager.instance.getChatId(tableId);
+            return TableManager.instance.getChatId(tableId).orElse(null);
         } catch (Exception ex) {
             handleException(ex);
         }
-        return Optional.empty();
+        return null;
     }
 
     @Override
@@ -646,24 +646,24 @@ public class MageServerImpl implements MageServer {
 
     @Override
     //FIXME: why no sessionId here???
-    public Optional<UUID> getGameChatId(UUID gameId) throws MageException {
+    public UUID getGameChatId(UUID gameId) throws MageException {
         try {
-            return GameManager.instance.getChatId(gameId);
+            return GameManager.instance.getChatId(gameId).orElse(null);
         } catch (Exception ex) {
             handleException(ex);
         }
-        return Optional.empty();
+        return null;
     }
 
     @Override
     //FIXME: why no sessionId here???
-    public Optional<UUID> getTournamentChatId(UUID tournamentId) throws MageException {
+    public UUID getTournamentChatId(UUID tournamentId) throws MageException {
         try {
-            return TournamentManager.instance.getChatId(tournamentId);
+            return TournamentManager.instance.getChatId(tournamentId).orElse(null);
         } catch (Exception ex) {
             handleException(ex);
         }
-        return Optional.empty();
+        return null;
     }
 
     @Override


### PR DESCRIPTION
If you use this together with #6394 you can run xmage server and client on openjdk11 (+openjfx11 for the client)
kind of solves #6514 (it doesn't update the jboss remoting since there doesn't really exist a new version that does the same)
Also relevant for #6197