### PR TITLE
Added method to SupportAbility class to allow for removal of 'other' …

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TogetherForever.java
+++ b/Mage.Sets/src/mage/cards/t/TogetherForever.java
@@ -41,7 +41,7 @@ public final class TogetherForever extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{W}{W}");
 
         // When Together Forever enters the battlefield, support 2. (Put a +1/+1 counter on each of up to two other target creatures.)
-        this.addAbility(new SupportAbility(this, 2));
+        this.addAbility(new SupportAbility(this, 2, false));
 
         // {1}: Choose target creature with a counter on it. When that creature dies this turn, return that card to its owner's hand.
         Ability ability = new SimpleActivatedAbility(new TogetherForeverEffect(), new GenericManaCost(1));

--- a/Mage/src/main/java/mage/abilities/keyword/SupportAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SupportAbility.java
@@ -19,22 +19,9 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public class SupportAbility extends EntersBattlefieldTriggeredAbility {
 
-    public SupportAbility(Card card, int amount) {
-        super(new SupportEffect(card, amount, true));
-        if (!card.isInstant() && !card.isSorcery()) {
-            FilterCreaturePermanent filter = new FilterCreaturePermanent("creatures");
-            if (card.isCreature()) {
-                filter.add(AnotherPredicate.instance);
-                filter.setMessage("other target creatures");
-            }
-            addTarget(new TargetCreaturePermanent(0, amount, filter, false));
-        }
-    }
-
     /*
-     * For enchanments, the text should not include the word "other". This method
-     * allows the otherPermanent choice to be selected in the call to SupportAbility
-     * and removes the "other" text from rule creation.
+     * For enchantments, the text should not include the word "other".
+     * The otherPermanent choice removes the word "other" from rule text creation.
      */
     public SupportAbility(Card card, int amount, boolean otherPermanent) {
         super(new SupportEffect(card, amount, otherPermanent));
@@ -47,6 +34,9 @@ public class SupportAbility extends EntersBattlefieldTriggeredAbility {
             addTarget(new TargetCreaturePermanent(0, amount, filter, false));
         }
     }
+
+
+    public SupportAbility(Card card, int amount){ this( card, amount, true); }
 
 
     public SupportAbility(final SupportAbility ability) {

--- a/Mage/src/main/java/mage/abilities/keyword/SupportAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SupportAbility.java
@@ -31,6 +31,24 @@ public class SupportAbility extends EntersBattlefieldTriggeredAbility {
         }
     }
 
+    /*
+     * For enchanments, the text should not include the word "other". This method
+     * allows the otherPermanent choice to be selected in the call to SupportAbility
+     * and removes the "other" text from rule creation.
+     */
+    public SupportAbility(Card card, int amount, boolean otherPermanent) {
+        super(new SupportEffect(card, amount, otherPermanent));
+        if (!card.isInstant() && !card.isSorcery()) {
+            FilterCreaturePermanent filter = new FilterCreaturePermanent("creatures");
+            if (card.isCreature()) {
+                filter.add(AnotherPredicate.instance);
+                filter.setMessage("other target creatures");
+            }
+            addTarget(new TargetCreaturePermanent(0, amount, filter, false));
+        }
+    }
+
+
     public SupportAbility(final SupportAbility ability) {
         super(ability);
     }


### PR DESCRIPTION
…text in rule generation

This addresses the text error in Together Forever from issue #6471 .

This does not seem like a very elegant solution. Perhaps someone with more knowledge could make it a bit better. 