### PR TITLE
Nacatl clone fix

### DIFF
--- a/Mage.Sets/src/mage/cards/n/NacatlWarPride.java
+++ b/Mage.Sets/src/mage/cards/n/NacatlWarPride.java
@@ -23,9 +23,10 @@ import mage.constants.Zone;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.token.EmptyToken;
 import mage.target.targetpointer.FixedTargets;
-import mage.util.CardUtil;
+import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
+import mage.players.Player;
+import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -92,20 +93,14 @@ class NacatlWarPrideEffect extends OneShotEffect {
             return false;
         }
 
-        List<Permanent> copies = new ArrayList<>();
-        for (int i = 0; i < count; i++) {
-            EmptyToken token = new EmptyToken();
-            CardUtil.copyTo(token).from(origNactalWarPride);
-            token.putOntoBattlefield(1, game, source.getSourceId(), source.getControllerId(), true, true);
-
-            for (UUID tokenId : token.getLastAddedTokenIds()) { // by cards like Doubling Season multiple tokens can be added to the battlefield
-                Permanent tokenPermanent = game.getPermanent(tokenId);
-                if (tokenPermanent != null) {
-                    copies.add(tokenPermanent);
-                }
-            }
-        }
-
+        List<Permanent> copies = new ArrayList<>();    
+        
+        Player controller = game.getPlayer(source.getControllerId());
+        CreateTokenCopyTargetEffect effect = new CreateTokenCopyTargetEffect(controller.getId(), null, false, count, true, true);
+        effect.setTargetPointer(new FixedTarget(origNactalWarPride, game));
+        effect.apply(game, source);
+        copies.addAll(effect.getAddedPermanent());
+        
         if (!copies.isEmpty()) {
             FixedTargets fixedTargets = new FixedTargets(copies, game);
             ExileTargetEffect exileEffect = new ExileTargetEffect();

--- a/Mage.Sets/src/mage/cards/n/NacatlWarPride.java
+++ b/Mage.Sets/src/mage/cards/n/NacatlWarPride.java
@@ -94,7 +94,6 @@ class NacatlWarPrideEffect extends OneShotEffect {
         }
 
         List<Permanent> copies = new ArrayList<>();    
-        
         Player controller = game.getPlayer(source.getControllerId());
         CreateTokenCopyTargetEffect effect = new CreateTokenCopyTargetEffect(controller.getId(), null, false, count, true, true);
         effect.setTargetPointer(new FixedTarget(origNactalWarPride, game));


### PR DESCRIPTION
When a creature clones Nacatl, such as Volrath the Shapestealer, and you attack with the Volrath as a copy of Nacatl. Nacatl's attack trigger creates tokens, but the tokens are all straight copies of Volrath, i.e. they are Legendary and are named Volrath therefore the Legendary rule triggers and all the Volrath tokens die. 

What should happen is that the tokens are direct copies of Volrath copying Nacatl, so the tokens should be 7/5 Nacatls with Vorlath's copy ability. This commit resolves that issue.

Please note this is my first commit on xmage, I've followed the Developer HOW TO but if there's anything missing that's expected please let me know.