### PR TITLE
fix verbiage for ShredMemory card filter

### DIFF
--- a/Mage.Common/src/main/java/mage/view/AbilityPickerView.java
+++ b/Mage.Common/src/main/java/mage/view/AbilityPickerView.java
@@ -49,7 +49,9 @@ public class AbilityPickerView implements Serializable {
         if (rule.isEmpty()) {
             rule = ability.toString();
         }
-        rule = Character.toUpperCase(rule.charAt(0)) + rule.substring(1);
+        if (!rule.isEmpty()) {
+            rule = Character.toUpperCase(rule.charAt(0)) + rule.substring(1);
+        }
         return rule;
     }
 

--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -1896,27 +1896,6 @@ public class ComputerPlayer extends PlayerImpl implements Player {
     }
 
     @Override
-    public SpellAbility chooseSpellAbilityForCast(SpellAbility ability, Game game, boolean noMana) {
-        switch (ability.getSpellAbilityType()) {
-            case SPLIT:
-            case SPLIT_FUSED:
-            case SPLIT_AFTERMATH:
-                MageObject object = game.getObject(ability.getSourceId());
-                if (object != null) {
-                    LinkedHashMap<UUID, ActivatedAbility> useableAbilities = getSpellAbilities(playerId, object, game.getState().getZone(object.getId()), game);
-                    if (useableAbilities != null && !useableAbilities.isEmpty()) {
-                        // game.fireGetChoiceEvent(playerId, name, object, new ArrayList<>(useableAbilities.values()));
-                        // TODO: Improve this
-                        return (SpellAbility) useableAbilities.values().iterator().next();
-                    }
-                }
-                return null;
-            default:
-                return ability;
-        }
-    }
-
-    @Override
     public Mode chooseMode(Modes modes, Ability source, Game game) {
         log.debug("chooseMode");
         if (modes.getMode() != null && modes.getMaxModes() == modes.getSelectedModes().size()) {

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -1974,51 +1974,6 @@ public class HumanPlayer extends PlayerImpl {
     }
 
     @Override
-    public SpellAbility chooseSpellAbilityForCast(SpellAbility ability, Game game, boolean noMana) {
-        if (gameInCheckPlayableState(game)) {
-            return null;
-        }
-
-        // TODO: add canRespond cycle?
-        if (!canRespond()) {
-            return null;
-        }
-
-        switch (ability.getSpellAbilityType()) {
-            case SPLIT:
-            case SPLIT_FUSED:
-            case SPLIT_AFTERMATH:
-                MageObject object = game.getObject(ability.getSourceId());
-                if (object != null) {
-                    String message = "Choose ability to cast" + (noMana ? " for FREE" : "") + "<br>" + object.getLogName();
-                    LinkedHashMap<UUID, ActivatedAbility> useableAbilities = getSpellAbilities(playerId, object, game.getState().getZone(object.getId()), game);
-                    if (useableAbilities != null
-                            && useableAbilities.size() == 1) {
-                        return (SpellAbility) useableAbilities.values().iterator().next();
-                    } else if (useableAbilities != null
-                            && !useableAbilities.isEmpty()) {
-
-                        updateGameStatePriority("chooseSpellAbilityForCast", game);
-                        prepareForResponse(game);
-                        if (!isExecutingMacro()) {
-                            game.fireGetChoiceEvent(playerId, message, object, new ArrayList<>(useableAbilities.values()));
-                        }
-                        waitForResponse(game);
-
-                        if (response.getUUID() != null) {
-                            if (useableAbilities.containsKey(response.getUUID())) {
-                                return (SpellAbility) useableAbilities.get(response.getUUID());
-                            }
-                        }
-                    }
-                }
-                return null;
-            default:
-                return ability;
-        }
-    }
-
-    @Override
     public SpellAbility chooseAbilityForCast(Card card, Game game, boolean nonMana) {
         if (gameInCheckPlayableState(game)) {
             return null;

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -2096,6 +2096,9 @@ public class HumanPlayer extends PlayerImpl {
                             modeText = "(selected " + timesSelected + "x) " + modeText;
                         }
                     }
+                    if (!modeText.isEmpty()) {
+                        modeText = Character.toUpperCase(modeText.charAt(0)) + modeText.substring(1);
+                    }
                     modeMap.put(mode.getId(), modeIndex + ". " + modeText);
                 }
             }

--- a/Mage.Sets/src/mage/cards/d/DriverOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/d/DriverOfTheDead.java
@@ -21,7 +21,7 @@ import mage.target.common.TargetCardInYourGraveyard;
  */
 public final class DriverOfTheDead extends CardImpl {
 
-    private static final FilterCreatureCard filter = new FilterCreatureCard("creature card with converted mana cost 2 or less from your graveyard to the battlefield");
+    private static final FilterCreatureCard filter = new FilterCreatureCard("creature card with converted mana cost 2 or less from your graveyard");
 
     static {
         filter.add(new ConvertedManaCostPredicate(ComparisonType.FEWER_THAN, 3));

--- a/Mage.Sets/src/mage/cards/s/ShredMemory.java
+++ b/Mage.Sets/src/mage/cards/s/ShredMemory.java
@@ -21,7 +21,7 @@ public final class ShredMemory extends CardImpl {
 
         // Exile up to four target cards from a single graveyard.
         this.getSpellAbility().addEffect(new ExileTargetEffect());
-        this.getSpellAbility().addTarget(new TargetCardInASingleGraveyard(0, 4, new FilterCard("cards")));
+        this.getSpellAbility().addTarget(new TargetCardInASingleGraveyard(0, 4, new FilterCard("cards from a single graveyard")));
         // Transmute {1}{B}{B}
         this.addAbility(new TransmuteAbility("{1}{B}{B}"));
     }

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestComputerPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestComputerPlayer.java
@@ -30,39 +30,6 @@ public class TestComputerPlayer extends ComputerPlayer {
     }
 
     @Override
-    public SpellAbility chooseSpellAbilityForCast(SpellAbility ability, Game game, boolean noMana) {
-        // copy-paste for TestComputerXXX
-
-        // workaround to cast fused cards in tests by it's NAMES (Wear, Tear, Wear // Tear)
-        // reason: TestPlayer uses outer computerPlayer to cast, not TestPlayer
-        switch (ability.getSpellAbilityType()) {
-            case SPLIT:
-            case SPLIT_FUSED:
-            case SPLIT_AFTERMATH:
-                if (!this.testPlayerLink.getChoices().isEmpty()) {
-                    MageObject object = game.getObject(ability.getSourceId());
-                    if (object != null) {
-                        LinkedHashMap<UUID, ActivatedAbility> useableAbilities = getSpellAbilities(playerId, object, game.getState().getZone(object.getId()), game);
-
-                        // left, right or fused cast
-                        for (String choose : this.testPlayerLink.getChoices()) {
-                            for (ActivatedAbility activatedAbility : useableAbilities.values()) {
-                                if (activatedAbility instanceof SpellAbility) {
-                                    if (((SpellAbility) activatedAbility).getCardName().equals(choose)) {
-                                        return (SpellAbility) activatedAbility;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-        }
-
-        // default implementation by AI
-        return super.chooseSpellAbilityForCast(ability, game, noMana);
-    }
-
-    @Override
     public boolean choose(Outcome outcome, Target target, UUID sourceId, Game game) {
         // copy-paste for TestComputerXXX
 

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestComputerPlayer7.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestComputerPlayer7.java
@@ -30,39 +30,6 @@ public class TestComputerPlayer7 extends ComputerPlayer7 {
     }
 
     @Override
-    public SpellAbility chooseSpellAbilityForCast(SpellAbility ability, Game game, boolean noMana) {
-        // copy-paste for TestComputerXXX
-
-        // workaround to cast fused cards in tests by it's NAMES (Wear, Tear, Wear // Tear)
-        // reason: TestPlayer uses outer computerPlayer to cast, not TestPlayer
-        switch (ability.getSpellAbilityType()) {
-            case SPLIT:
-            case SPLIT_FUSED:
-            case SPLIT_AFTERMATH:
-                if (!this.testPlayerLink.getChoices().isEmpty()) {
-                    MageObject object = game.getObject(ability.getSourceId());
-                    if (object != null) {
-                        LinkedHashMap<UUID, ActivatedAbility> useableAbilities = getSpellAbilities(playerId, object, game.getState().getZone(object.getId()), game);
-
-                        // left, right or fused cast
-                        for (String choose : this.testPlayerLink.getChoices()) {
-                            for (ActivatedAbility activatedAbility : useableAbilities.values()) {
-                                if (activatedAbility instanceof SpellAbility) {
-                                    if (((SpellAbility) activatedAbility).getCardName().equals(choose)) {
-                                        return (SpellAbility) activatedAbility;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-        }
-
-        // default implementation by AI
-        return super.chooseSpellAbilityForCast(ability, game, noMana);
-    }
-
-    @Override
     public boolean choose(Outcome outcome, Target target, UUID sourceId, Game game) {
         // copy-paste for TestComputerXXX
 

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestComputerPlayerMonteCarlo.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestComputerPlayerMonteCarlo.java
@@ -30,39 +30,6 @@ public class TestComputerPlayerMonteCarlo extends ComputerPlayerMCTS {
     }
 
     @Override
-    public SpellAbility chooseSpellAbilityForCast(SpellAbility ability, Game game, boolean noMana) {
-        // copy-paste for TestComputerXXX
-
-        // workaround to cast fused cards in tests by it's NAMES (Wear, Tear, Wear // Tear)
-        // reason: TestPlayer uses outer computerPlayer to cast, not TestPlayer
-        switch (ability.getSpellAbilityType()) {
-            case SPLIT:
-            case SPLIT_FUSED:
-            case SPLIT_AFTERMATH:
-                if (!this.testPlayerLink.getChoices().isEmpty()) {
-                    MageObject object = game.getObject(ability.getSourceId());
-                    if (object != null) {
-                        LinkedHashMap<UUID, ActivatedAbility> useableAbilities = getSpellAbilities(playerId, object, game.getState().getZone(object.getId()), game);
-
-                        // left, right or fused cast
-                        for (String choose : this.testPlayerLink.getChoices()) {
-                            for (ActivatedAbility activatedAbility : useableAbilities.values()) {
-                                if (activatedAbility instanceof SpellAbility) {
-                                    if (((SpellAbility) activatedAbility).getCardName().equals(choose)) {
-                                        return (SpellAbility) activatedAbility;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-        }
-
-        // default implementation by AI
-        return super.chooseSpellAbilityForCast(ability, game, noMana);
-    }
-
-    @Override
     public boolean choose(Outcome outcome, Target target, UUID sourceId, Game game) {
         // copy-paste for TestComputerXXX
 

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -3457,12 +3457,6 @@ public class TestPlayer implements Player {
     }
 
     @Override
-    public SpellAbility chooseSpellAbilityForCast(SpellAbility ability, Game game, boolean noMana) {
-        Assert.fail("That's method must calls only from computerPlayer->cast(), see TestComputerPlayerXXX");
-        return computerPlayer.chooseSpellAbilityForCast(ability, game, noMana);
-    }
-
-    @Override
     public void skip() {
         computerPlayer.skip();
     }

--- a/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
+++ b/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
@@ -544,11 +544,6 @@ public class PlayerStub implements Player {
     }
 
     @Override
-    public SpellAbility chooseSpellAbilityForCast(SpellAbility ability, Game game, boolean noMana) {
-        return null;
-    }
-
-    @Override
     public boolean putInHand(Card card, Game game) {
         return false;
     }

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -317,8 +317,6 @@ public interface Player extends MageItem, Copyable<Player> {
 
     boolean cast(SpellAbility ability, Game game, boolean noMana, MageObjectReference reference);
 
-    SpellAbility chooseSpellAbilityForCast(SpellAbility ability, Game game, boolean noMana);
-
     SpellAbility chooseAbilityForCast(Card card, Game game, boolean noMana);
 
     boolean putInHand(Card card, Game game);

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1120,13 +1120,7 @@ public abstract class PlayerImpl implements Player, Serializable {
         SpellAbility ability = originalAbility.copy();
         ability.setControllerId(getId());
         ability.setSourceObjectZoneChangeCounter(game.getState().getZoneChangeCounter(ability.getSourceId()));
-        if (ability.getSpellAbilityType() != SpellAbilityType.BASE) {
-            ability = chooseSpellAbilityForCast(ability, game, noMana);
-            if (ability == null) {
-                // No ability could be cast (selected), probably because of no valid targets (happens often if a card can be cast by an effect).
-                return false;
-            }
-        }
+
         //20091005 - 601.2a
         if (ability.getSourceId() == null) {
             logger.error("Ability without sourceId turn " + game.getTurnNum() + ". Ability: " + ability.getRule());
@@ -1187,11 +1181,6 @@ public abstract class PlayerImpl implements Player, Serializable {
             }
         }
         return false;
-    }
-
-    @Override
-    public SpellAbility chooseSpellAbilityForCast(SpellAbility ability, Game game, boolean noMana) {
-        return ability;
     }
 
     @Override


### PR DESCRIPTION
Updating verbiage to match other cards which use ExileTargetEffect effect along with TargetCardInASingleGraveyard target, and do NOT use static text.

Other cards using similar verbiage are Decompose, Famished Ghoul, Martyr of Bones for example.