### PR TITLE
fixed card text

### DIFF
--- a/Mage.Sets/src/mage/cards/s/ShredMemory.java
+++ b/Mage.Sets/src/mage/cards/s/ShredMemory.java
@@ -21,7 +21,7 @@ public final class ShredMemory extends CardImpl {
 
         // Exile up to four target cards from a single graveyard.
         this.getSpellAbility().addEffect(new ExileTargetEffect());
-        this.getSpellAbility().addTarget(new TargetCardInASingleGraveyard(0, 4, new FilterCard("cards")));
+        this.getSpellAbility().addTarget(new TargetCardInASingleGraveyard(0, 4, new FilterCard("cards from a single graveyard")));
         // Transmute {1}{B}{B}
         this.addAbility(new TransmuteAbility("{1}{B}{B}"));
     }


### PR DESCRIPTION
Fixed the missing part of the text.
I think the Class "TargetCardInASingleGraveyard" should have a method that append the text by itself. 