### PR TITLE
Verbiage fixes

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DriverOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/d/DriverOfTheDead.java
@@ -21,7 +21,7 @@ import mage.target.common.TargetCardInYourGraveyard;
  */
 public final class DriverOfTheDead extends CardImpl {
 
-    private static final FilterCreatureCard filter = new FilterCreatureCard("creature card with converted mana cost 2 or less from your graveyard to the battlefield");
+    private static final FilterCreatureCard filter = new FilterCreatureCard("creature card with converted mana cost 2 or less from your graveyard");
 
     static {
         filter.add(new ConvertedManaCostPredicate(ComparisonType.FEWER_THAN, 3));

--- a/Mage.Sets/src/mage/cards/s/ShredMemory.java
+++ b/Mage.Sets/src/mage/cards/s/ShredMemory.java
@@ -21,7 +21,7 @@ public final class ShredMemory extends CardImpl {
 
         // Exile up to four target cards from a single graveyard.
         this.getSpellAbility().addEffect(new ExileTargetEffect());
-        this.getSpellAbility().addTarget(new TargetCardInASingleGraveyard(0, 4, new FilterCard("cards")));
+        this.getSpellAbility().addTarget(new TargetCardInASingleGraveyard(0, 4, new FilterCard("cards from a single graveyard")));
         // Transmute {1}{B}{B}
         this.addAbility(new TransmuteAbility("{1}{B}{B}"));
     }


### PR DESCRIPTION
Updating verbiage for Shred Memory to match other cards which use ExileTargetEffect effect along with TargetCardInASingleGraveyard target, and do NOT use static text. Other cards using similar verbiage are Decompose, Famished Ghoul, Martyr of Bones for example. This is a quick fix; ideally the mage.abilities.effects.common.ExileTargetEffect.getText(Mode) function should be responsible for appending "from a single graveyard" when the TargetCardInASingleGraveyard target is used.

Adding fix for driver of the dead verbiage. Similar issue where the card filter is including verbiage which is meant to be handled by the effect's getText() function. I would argue that 'from your graveyard' text should also be included in the getText() function for ReturnFromGraveyardToBattlefieldTargetEffect, but that would require a pretty large change to many cards.