### PR TITLE
[WIP] Implement Mutate.

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MetamorphicAlteration.java
+++ b/Mage.Sets/src/mage/cards/m/MetamorphicAlteration.java
@@ -99,7 +99,7 @@ class ChooseACreature extends OneShotEffect {
 class MetamorphicAlterationEffect extends ContinuousEffectImpl {
 
     public MetamorphicAlterationEffect() {
-        super(Duration.WhileOnBattlefield, Layer.CopyEffects_1, SubLayer.NA, Outcome.Copy);
+        super(Duration.WhileOnBattlefield, Layer.CopyEffects_1, SubLayer.CopyingMerging_1a, Outcome.Copy);
         this.staticText = "Enchanted creature is a copy of the chosen creature.";
     }
 

--- a/Mage.Sets/src/mage/sets/IkoriaLairOfBehemoths.java
+++ b/Mage.Sets/src/mage/sets/IkoriaLairOfBehemoths.java
@@ -9,46 +9,12 @@ import mage.constants.Rarity;
 import mage.constants.SetType;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
  * @author TheElk801
  */
 public final class IkoriaLairOfBehemoths extends ExpansionSet {
-
-    private static final List<String> mutateNames = Arrays.asList(
-            "Archipelagore",
-            "Auspicious Starrix",
-            "Boneyard Lurker",
-            "Brokkos, Apex of Forever",
-            "Cavern Whisperer",
-            "Chittering Harvester",
-            "Cloudpiercer",
-            "Cubwarden",
-            "Dirge Bat",
-            "Dreamtail Heron",
-            "Everquill Phoenix",
-            "Gemrazer",
-            "Glowstone Recluse",
-            "Huntmaster Liger",
-            "Illuna, Apex of Wishes",
-            "Insatiable Hemophage",
-            "Lore Drakkis",
-            "Majestic Auricorn",
-            "Migratory Greathorn",
-            "Necropanther",
-            "Nethroi, Apex of Death",
-            "Parcelbeast",
-            "Porcuparrot",
-            "Pouncing Shoreshark",
-            "Regal Leosaur",
-            "Sea-Dasher Octopus",
-            "Snapdax, Apex of the Hunt",
-            "Trumpeting Gnarr",
-            "Vadrok, Apex of Thunder",
-            "Vulpikeet"
-    );
 
     private static final IkoriaLairOfBehemoths instance = new IkoriaLairOfBehemoths();
 
@@ -457,8 +423,6 @@ public final class IkoriaLairOfBehemoths extends ExpansionSet {
         cards.add(new SetCardInfo("Zilortha, Strength Incarnate", 275, Rarity.MYTHIC, mage.cards.z.ZilorthaStrengthIncarnate.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Zirda, the Dawnwaker", 233, Rarity.RARE, mage.cards.z.ZirdaTheDawnwaker.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Zirda, the Dawnwaker", 360, Rarity.RARE, mage.cards.z.ZirdaTheDawnwaker.class, NON_FULL_USE_VARIOUS));
-
-        cards.removeIf(setCardInfo -> mutateNames.contains(setCardInfo.getName())); // remove when mutate is implemented
     }
 
     @Override
@@ -468,7 +432,7 @@ public final class IkoriaLairOfBehemoths extends ExpansionSet {
         }
         List<CardInfo> savedCardsInfos = savedCards.get(rarity);
         if (savedCardsInfos != null) {
-            return new ArrayList(savedCardsInfos);
+            return new ArrayList<CardInfo>(savedCardsInfos);
         }
         CardCriteria criteria = new CardCriteria();
         criteria.setCodes(this.code).notTypes(CardType.LAND);
@@ -482,7 +446,7 @@ public final class IkoriaLairOfBehemoths extends ExpansionSet {
         savedCardsInfos.addAll(CardRepository.instance.findCards(criteria));
         savedCards.put(rarity, savedCardsInfos);
         // Return a copy of the saved cards information, as not to modify the original.
-        return new ArrayList(savedCardsInfos);
+        return new ArrayList<CardInfo>(savedCardsInfos);
     }
 
     @Override
@@ -497,6 +461,6 @@ public final class IkoriaLairOfBehemoths extends ExpansionSet {
             savedSpecialLand.removeIf(cardInfo -> "Evolving Wilds".equals(cardInfo.getName()));
         }
 
-        return new ArrayList(savedSpecialLand);
+        return new ArrayList<CardInfo>(savedSpecialLand);
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
@@ -905,11 +905,18 @@ public class ContinuousEffects implements Serializable {
         removeInactiveEffects(game);
         List<ContinuousEffect> activeLayerEffects = getLayeredEffects(game);
 
+
         List<ContinuousEffect> layer = filterLayeredEffects(activeLayerEffects, Layer.CopyEffects_1);
         for (ContinuousEffect effect : layer) {
             Set<Ability> abilities = layeredEffects.getAbility(effect.getId());
             for (Ability ability : abilities) {
-                effect.apply(Layer.CopyEffects_1, SubLayer.NA, ability, game);
+                effect.apply(Layer.CopyEffects_1, SubLayer.CopyingMerging_1a, ability, game);
+            }
+        }
+        for (ContinuousEffect effect : layer) {
+            Set<Ability> abilities = layeredEffects.getAbility(effect.getId());
+            for (Ability ability : abilities) {
+                effect.apply(Layer.PTChangingEffects_7, SubLayer.ModifyFaceDown_1b, ability, game);
             }
         }
         //Reload layerEffect if copy effects were applied

--- a/Mage/src/main/java/mage/abilities/effects/common/CopyEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CopyEffect.java
@@ -32,7 +32,7 @@ public class CopyEffect extends ContinuousEffectImpl {
     }
 
     public CopyEffect(Duration duration, MageObject copyFromObject, UUID copyToObjectId) {
-        super(duration, Layer.CopyEffects_1, SubLayer.NA, Outcome.BecomeCreature);
+        super(duration, Layer.CopyEffects_1, SubLayer.CopyingMerging_1a, Outcome.BecomeCreature);
         this.copyFromObject = copyFromObject;
         this.copyToObjectId = copyToObjectId;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/CopyTokenEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CopyTokenEffect.java
@@ -12,7 +12,7 @@ public class CopyTokenEffect extends ContinuousEffectImpl {
     protected Token token;
 
     public CopyTokenEffect(Token token) {
-        super(Duration.WhileOnBattlefield, Layer.CopyEffects_1, SubLayer.NA, Outcome.BecomeCreature);
+        super(Duration.WhileOnBattlefield, Layer.CopyEffects_1, SubLayer.CopyingMerging_1a, Outcome.BecomeCreature);
         this.token = token.copy();
         staticText = "You may have {this} enter the battlefield as a copy of " + token.getDescription() + " on the battlefield";
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/MergeEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/MergeEffect.java
@@ -1,0 +1,129 @@
+package mage.abilities.effects.common;
+
+import mage.MageObject;
+import mage.MageObjectReference;
+import mage.abilities.Ability;
+import mage.abilities.effects.ContinuousEffectImpl;
+import mage.cards.Card;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.game.permanent.PermanentCard;
+import mage.game.permanent.PermanentToken;
+
+import java.util.UUID;
+
+/**
+ * @author BetaSteward_at_googlemail.com
+ */
+public class MergeEffect extends ContinuousEffectImpl {
+
+    /**
+     * Object we copy from
+     */
+    protected MageObject mergeSourceObject;
+    protected boolean onTop;
+
+    protected UUID mergeToObjectId;
+
+    public MergeEffect(MageObject mergeSourceObject, boolean onTop, UUID mergeToObjectId) {
+        this(Duration.Custom, mergeSourceObject, onTop, mergeToObjectId);
+    }
+
+    public MergeEffect(Duration duration, MageObject mergeSourceObject, boolean onTop, UUID mergeToObjectId) {
+        super(duration, Layer.CopyEffects_1, SubLayer.CopyingMerging_1a, Outcome.BecomeCreature);
+        this.mergeSourceObject = mergeSourceObject;
+        this.mergeToObjectId = mergeToObjectId;
+    }
+
+    public MergeEffect(final MergeEffect effect) {
+        super(effect);
+        this.mergeSourceObject = effect.mergeSourceObject.copy();
+        this.onTop = effect.onTop;
+        this.mergeToObjectId = effect.mergeToObjectId;
+    }
+
+    @Override
+    public void init(Ability source, Game game) {
+        super.init(source, game);
+        if (!(mergeSourceObject instanceof Permanent) && (mergeSourceObject instanceof Card)) {
+            this.mergeSourceObject = new PermanentCard((Card) mergeSourceObject, source.getControllerId(), game);
+        }
+        Permanent permanent = game.getPermanent(mergeToObjectId);
+        if (permanent != null) {
+            affectedObjectList.add(new MageObjectReference(permanent, game));
+        }
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        if (affectedObjectList.isEmpty()) {
+            this.discard();
+            return false;
+        }
+        Permanent permanent = affectedObjectList.get(0).getPermanent(game);
+        if (permanent == null) {
+            permanent = (Permanent) game.getLastKnownInformation(getSourceId(), Zone.BATTLEFIELD, source.getSourceObjectZoneChangeCounter());
+            // As long as the permanent is still in the LKI continue to copy to get triggered abilities to TriggeredAbilites for dies events.
+            if (permanent == null) {
+                discard();
+                return false;
+            }
+        }
+        return mergeToPermanent(permanent, game, source);
+    }
+
+    protected boolean mergeToPermanent(Permanent permanent, Game game, Ability source) {
+        if (onTop) {
+            permanent.setName(mergeSourceObject.getName());
+            permanent.getColor(game).setColor(mergeSourceObject.getColor(game));
+            permanent.getManaCost().clear();
+            permanent.getManaCost().add(mergeSourceObject.getManaCost());
+            permanent.getCardType().clear();
+            for (CardType type : mergeSourceObject.getCardType()) {
+                permanent.addCardType(type);
+            }
+            permanent.getSubtype(game).clear();
+            for (SubType type : mergeSourceObject.getSubtype(game)) {
+                permanent.getSubtype(game).add(type);
+            }
+            permanent.getSuperType().clear();
+            for (SuperType type : mergeSourceObject.getSuperType()) {
+                permanent.addSuperType(type);
+            }
+
+            // to get the image of the copied permanent copy number and expansionCode
+            if (mergeSourceObject instanceof PermanentCard) {
+                permanent.setCardNumber(((PermanentCard) mergeSourceObject).getCard().getCardNumber());
+                permanent.setExpansionSetCode(((PermanentCard) mergeSourceObject).getCard().getExpansionSetCode());
+            } else if (mergeSourceObject instanceof PermanentToken || mergeSourceObject instanceof Card) {
+                permanent.setCardNumber(((Card) mergeSourceObject).getCardNumber());
+                permanent.setExpansionSetCode(((Card) mergeSourceObject).getExpansionSetCode());
+            }
+        }
+
+        for (Ability ability : mergeSourceObject.getAbilities()) {
+            permanent.addAbility(ability, getSourceId(), game, false);
+        }
+
+        return true;
+    }
+
+    @Override
+    public MergeEffect copy() {
+        return new MergeEffect(this);
+    }
+
+    public MageObject getTarget() {
+        return mergeSourceObject;
+    }
+
+    public void setTarget(MageObject target) {
+        this.mergeSourceObject = target;
+    }
+
+    public UUID getSourceId() {
+        return mergeToObjectId;
+    }
+
+}

--- a/Mage/src/main/java/mage/abilities/keyword/MutateAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/MutateAbility.java
@@ -1,18 +1,56 @@
 package mage.abilities.keyword;
 
+import mage.MageObject;
+import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
+import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.ReplacementEffectImpl;
 import mage.cards.Card;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
 import mage.constants.SpellAbilityType;
-import mage.constants.TimingRule;
+import mage.constants.SubType;
+import mage.constants.Zone;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.Predicates;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.events.GameEvent.EventType;
+import mage.game.permanent.Permanent;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetCreaturePermanent;
 
 public class MutateAbility extends SpellAbility {
 
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("non-Human creature");
+
+    static {
+        filter.add(CardType.CREATURE.getPredicate());
+        filter.add(Predicates.not(SubType.HUMAN.getPredicate()));
+    }
+
     public MutateAbility(Card card, String manaString) {
-        super(new ManaCostsImpl(manaString), card.getName() + " using mutate");
-        this.spellAbilityType = SpellAbilityType.BASE_ALTERNATE;
-        this.timing = TimingRule.SORCERY;
-        // TODO: Implement this
+        super(card.getSpellAbility());
+        this.newId();
+        this.setCardName(card.getName() + " with mutate");
+        zone = Zone.HAND;
+        spellAbilityType = SpellAbilityType.BASE_ALTERNATE;
+
+        this.getManaCosts().clear();
+        this.getManaCostsToPay().clear();
+        this.addManaCost(new ManaCostsImpl(manaString));
+
+        this.setRuleAtTheTop(true);
+
+        TargetPermanent mutateTarget = new TargetCreaturePermanent(filter);
+        this.addTarget(mutateTarget);
+
+        Ability ability = new SimpleStaticAbility(Zone.BATTLEFIELD, new MutateEntersBattlefieldEffect());
+        ability.setRuleVisible(false);
+        addSubAbility(ability);
     }
 
     private MutateAbility(final MutateAbility ability) {
@@ -34,6 +72,53 @@ public class MutateAbility extends SpellAbility {
         return "Mutate " + getManaCostsToPay().getText() + " <i>(If you cast this spell for its mutate cost, " +
                 "put it over or under target non-Human creature you own. " +
                 "They mutate into the creature on top plus all abilities from under it.)</i>";
+    }
+
+}
+
+class MutateEntersBattlefieldEffect extends ReplacementEffectImpl {
+
+    public MutateEntersBattlefieldEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.Neutral);
+    }
+
+    public MutateEntersBattlefieldEffect(final MutateEntersBattlefieldEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return EventType.ENTERS_THE_BATTLEFIELD_SELF == event.getType();
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        return event.getTargetId().equals(source.getSourceId());
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        Permanent mutatePermanent = game.getPermanentEntering(source.getSourceId());
+        if (mutatePermanent != null) {
+            // I don't really know what this code does - copied from AttachEffect.
+            // Let me know if this is unneeded.
+            int zcc = game.getState().getZoneChangeCounter(mutatePermanent.getId());
+            if (zcc == source.getSourceObjectZoneChangeCounter()
+                    || zcc == source.getSourceObjectZoneChangeCounter() + 1
+                    || zcc == source.getSourceObjectZoneChangeCounter() + 2) {
+                Permanent permanent = game.getPermanent(getTargetPointer().getFirst(game, source));
+                if (permanent != null) {
+                    permanent.addMergedCard(source.getSourceId());
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public MutateEntersBattlefieldEffect copy() {
+        return new MutateEntersBattlefieldEffect(this);
     }
 
 }

--- a/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
@@ -74,7 +74,7 @@ public class TransformAbility extends SimpleStaticAbility {
 class TransformEffect extends ContinuousEffectImpl {
 
     public TransformEffect() {
-        super(Duration.WhileOnBattlefield, Layer.CopyEffects_1, SubLayer.NA, Outcome.BecomeCreature);
+        super(Duration.WhileOnBattlefield, Layer.CopyEffects_1, SubLayer.CopyingMerging_1a, Outcome.BecomeCreature);
         staticText = "";
     }
 

--- a/Mage/src/main/java/mage/constants/SubLayer.java
+++ b/Mage/src/main/java/mage/constants/SubLayer.java
@@ -5,6 +5,8 @@ package mage.constants;
  * @author North
  */
 public enum SubLayer {
+    CopyingMerging_1a,
+    ModifyFaceDown_1b,
     CharacteristicDefining_7a,
     SetPT_7b,
     ModifyPT_7c,

--- a/Mage/src/main/java/mage/game/ZoneChangeInfo.java
+++ b/Mage/src/main/java/mage/game/ZoneChangeInfo.java
@@ -3,7 +3,6 @@ package mage.game;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import mage.cards.MeldCard;
 import mage.game.events.ZoneChangeEvent;
 import mage.game.stack.Spell;
 
@@ -138,29 +137,23 @@ public class ZoneChangeInfo {
         }
     }
 
-    public static class Unmelded extends ZoneChangeInfo {
+    // This class records state changes for grouped cards like Meld and Mutate.
+    public static class Group extends ZoneChangeInfo {
 
+        ZoneChangeInfo topInfo;
         List<ZoneChangeInfo> subInfo = new ArrayList<>();
 
-        public Unmelded(ZoneChangeInfo info, Game game) {
-            super(info.event);
-            MeldCard meld = game.getMeldCard(info.event.getTargetId());
-            if (meld != null) {
-                if (meld.hasTopHalf(game)) {
-                    ZoneChangeEvent topEvent = new ZoneChangeEvent(meld.getTopHalfCard().getId(), event.getSourceId(),
-                            event.getPlayerId(), event.getFromZone(), event.getToZone(), event.getAppliedEffects());
-                    ZoneChangeInfo topInfo = info.copy();
-                    topInfo.event = topEvent;
-                    subInfo.add(topInfo);
-                }
-                if (meld.hasBottomHalf(game)) {
-                    ZoneChangeEvent bottomEvent = new ZoneChangeEvent(meld.getBottomHalfCard().getId(), event.getSourceId(),
-                            event.getPlayerId(), event.getFromZone(), event.getToZone(), event.getAppliedEffects());
-                    ZoneChangeInfo bottomInfo = info.copy();
-                    bottomInfo.event = bottomEvent;
-                    subInfo.add(bottomInfo);
-                }
-            }
+        public Group(ZoneChangeInfo parent, Game game) {
+            super(parent.event);
+            topInfo = parent;
+        }
+
+        public void addGroupedCard(UUID groupedCard) {
+            ZoneChangeEvent topEvent = new ZoneChangeEvent(groupedCard, event.getSourceId(),
+                    event.getPlayerId(), event.getFromZone(), event.getToZone(), event.getAppliedEffects());
+            ZoneChangeInfo newSubInfo = topInfo.copy();
+            newSubInfo.event = topEvent;
+            subInfo.add(newSubInfo);
         }
     }
 }

--- a/Mage/src/main/java/mage/game/permanent/Permanent.java
+++ b/Mage/src/main/java/mage/game/permanent/Permanent.java
@@ -355,6 +355,12 @@ public interface Permanent extends Card, Controllable {
 
     boolean isManifested();
 
+    void addMergedCard(UUID mergedCard);
+
+    List<UUID> getMergedCards();
+
+    void clearMergedCards();
+
     @Override
     Permanent copy();
 

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -94,6 +94,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
     protected int attachedToZoneChangeCounter;
     protected MageObjectReference pairedPermanent;
     protected List<UUID> bandedCards = new ArrayList<>();
+    protected List<UUID> mergedCards = new ArrayList<>();
     protected Counters counters;
     protected List<MarkedDamageInfo> markedDamage;
     protected int markedLifelink;
@@ -1515,6 +1516,21 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
     @Override
     public void setMorphed(boolean value) {
         morphed = value;
+    }
+
+    @Override
+    public void addMergedCard(UUID mergedCard) {
+        mergedCards.add(mergedCard);
+    }
+
+    @Override
+    public List<UUID> getMergedCards() {
+        return mergedCards;
+    }
+
+    @Override
+    public void clearMergedCards() {
+        mergedCards.clear();
     }
 
     @Override


### PR DESCRIPTION
This PR implements the Mutate mechanic. It creates a new MergeEffect that ties a card to the thing that it is mutated on top of; per the Comprehensive Rules, this is an effect that applies in layer 1a. The most recent update to the Rules split Layer 1 into 1a and 1b, which this PR reproduces in XMage's code.

Outstanding issues:
- [ ] Get zone change logic right.
- [ ] Write a bunch of tests and get them passing.

Test ideas:
- Basic (P/T, type, color)
- Mutate trigger
- Illegal target
- Move to graveyard
- Move to graveyard with dies trigger
- Move to library
- Move to graveyard with replacement effect (Blightsteel Colossus)
- Copy of mutate
- Mutate onto copy