### PR TITLE
fixed #1072 - fixed Meddling Mage and Isochron Scepter interaction

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CouncilOfTheAbsolute.java
+++ b/Mage.Sets/src/mage/cards/c/CouncilOfTheAbsolute.java
@@ -76,7 +76,7 @@ class CouncilOfTheAbsoluteReplacementEffect extends ContinuousRuleModifyingEffec
 
     @Override
     public String getInfoMessage(Ability source, GameEvent event, Game game) {
-        MageObject mageObject = game.getObject(source.getSourceId());
+        MageObject mageObject = game.getObject(event.getSourceId());
         if (mageObject != null) {
             return "You can't cast a spell with that name (" + mageObject.getName() + " in play).";
         }

--- a/Mage.Sets/src/mage/cards/m/MeddlingMage.java
+++ b/Mage.Sets/src/mage/cards/m/MeddlingMage.java
@@ -70,7 +70,7 @@ class MeddlingMageReplacementEffect extends ContinuousRuleModifyingEffectImpl {
 
     @Override
     public String getInfoMessage(Ability source, GameEvent event, Game game) {
-        MageObject mageObject = game.getObject(source.getSourceId());
+        MageObject mageObject = game.getObject(event.getSourceId());
         if (mageObject != null) {
             return "You can't cast a spell with that name (" + mageObject.getName() + " in play).";
         }
@@ -86,9 +86,8 @@ class MeddlingMageReplacementEffect extends ContinuousRuleModifyingEffectImpl {
     public boolean applies(GameEvent event, Ability source, Game game) {
         MageObject object = game.getObject(event.getSourceId());
         String cardName = (String) game.getState().getValue(source.getSourceId().toString() + ChooseACardNameEffect.INFO_KEY);
-        return object != null
-                && !object.isCopy()
-                && CardUtil.haveSameNames(object, cardName, game);
+
+        return object != null && CardUtil.haveSameNames(object, cardName, game);
 
     }
 }

--- a/Mage.Sets/src/mage/cards/n/NullChamber.java
+++ b/Mage.Sets/src/mage/cards/n/NullChamber.java
@@ -135,7 +135,7 @@ class NullChamberReplacementEffect extends ContinuousRuleModifyingEffectImpl {
 
     @Override
     public String getInfoMessage(Ability source, GameEvent event, Game game) {
-        MageObject mageObject = game.getObject(source.getSourceId());
+        MageObject mageObject = game.getObject(event.getSourceId());
         if (mageObject != null) {
             return "You can't cast a spell with that name (" + mageObject.getName() + " in play).";
         }

--- a/Mage.Sets/src/mage/cards/v/VoidstoneGargoyle.java
+++ b/Mage.Sets/src/mage/cards/v/VoidstoneGargoyle.java
@@ -73,7 +73,7 @@ class VoidstoneGargoyleReplacementEffect1 extends ContinuousRuleModifyingEffectI
 
     @Override
     public String getInfoMessage(Ability source, GameEvent event, Game game) {
-        MageObject mageObject = game.getObject(source.getSourceId());
+        MageObject mageObject = game.getObject(event.getSourceId());
         if (mageObject != null) {
             return "You can't cast a spell with that name (" + mageObject.getName() + ").";
         }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/restriction/MeddlingMageTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/restriction/MeddlingMageTest.java
@@ -1,0 +1,169 @@
+package org.mage.test.cards.restriction;
+
+import mage.constants.EmptyNames;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class MeddlingMageTest extends CardTestPlayerBase {
+
+    //As Meddling Mage enters the battlefield, choose a nonland card name. Spells with the chosen name can't be cast.
+
+    @Test
+    public void testMeddlingMageDefaultScenario() {
+        addCard(Zone.HAND, playerA, "Meddling Mage");
+        addCard(Zone.HAND, playerA, "Savannah Lions");
+
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Meddling Mage");
+        setChoice(playerA, "Savannah Lions"); // name a spell that can't be cast
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Savannah Lions");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Meddling Mage", 1);
+        assertPermanentCount(playerA, "Savannah Lions", 0);
+        assertHandCount(playerA, "Meddling Mage", 0);
+        assertHandCount(playerA, "Savannah Lions", 1);
+    }
+
+    @Test
+    public void testMeddlingMageIsochronScepterScenario() {
+        addCard(Zone.HAND, playerA, "Meddling Mage");
+        addCard(Zone.HAND, playerA, "Isochron Scepter");
+        addCard(Zone.HAND, playerA, "Lightning Bolt");
+
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Meddling Mage");
+        setChoice(playerA, "Lightning Bolt"); // name a spell that can't be cast
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Isochron Scepter");
+        setChoice(playerA, "Yes"); // use imprint
+        setChoice(playerA, "Lightning Bolt"); // target for imprint
+
+        // copy and cast imprinted card
+        activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{2}, {T}:");
+        setChoice(playerA, "Yes");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "Meddling Mage", 1);
+        assertPermanentCount(playerA, "Isochron Scepter", 1);
+        assertExileCount("Lightning Bolt", 1);
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+
+    }
+
+    @Test
+    public void testMeddlingMageFaceDownCreature() {
+        addCard(Zone.HAND, playerA, "Meddling Mage");
+        addCard(Zone.HAND, playerA, "Ainok Tracker"); // red morph creature to prevent it casting from Islands and Plains
+
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Meddling Mage");
+        setChoice(playerA, "Ainok Tracker"); // name a spell that can't be cast
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ainok Tracker");
+        setChoice(playerA, "Yes"); // cast it face down as 2/2 creature
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Meddling Mage", 1);
+        assertPermanentCount(playerA, EmptyNames.FACE_DOWN_CREATURE.toString(), 1);
+        assertHandCount(playerA, "Meddling Mage", 0);
+        assertHandCount(playerA, "Ainok Tracker", 0);
+    }
+
+    @Test
+    public void testMeddlingMageFuseCardStopAndCastWell() {
+        addCard(Zone.HAND, playerA, "Meddling Mage");
+
+        // Create a 3/3 green Centaur creature token.
+        // You gain 2 life for each creature you control.
+        addCard(Zone.HAND, playerA, "Alive // Well"); // {3}{G} // {W}
+
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Meddling Mage");
+        setChoice(playerA, "Well"); // name a spell that can't be cast
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Well");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "Meddling Mage", 1);
+        assertHandCount(playerA, "Meddling Mage", 0);
+        assertHandCount(playerA, "Alive // Well", 1);
+        assertLife(playerA, 20);
+
+    }
+
+    @Test
+    public void testMeddlingMageFuseCardStopAliveAndCastWell() {
+        addCard(Zone.HAND, playerA, "Meddling Mage");
+
+        // Create a 3/3 green Centaur creature token.
+        // You gain 2 life for each creature you control.
+        addCard(Zone.HAND, playerA, "Alive // Well"); // {3}{G} // {W}
+
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Meddling Mage");
+        setChoice(playerA, "Alive"); // name a spell that can't be cast
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Well");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "Meddling Mage", 1);
+        assertHandCount(playerA, "Meddling Mage", 0);
+        assertHandCount(playerA, "Alive // Well", 0);
+        assertLife(playerA, 22);
+    }
+
+    @Test
+    public void testMeddlingMageFuseCardStopAliveAndCastFused() {
+        addCard(Zone.HAND, playerA, "Meddling Mage");
+
+        // Create a 3/3 green Centaur creature token.
+        // You gain 2 life for each creature you control.
+        addCard(Zone.HAND, playerA, "Alive // Well"); // {3}{G} // {W}
+
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Meddling Mage");
+        setChoice(playerA, "Alive"); // name a spell that can't be cast
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "fused Alive // Well");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "Meddling Mage", 1);
+        assertHandCount(playerA, "Meddling Mage", 0);
+
+        assertHandCount(playerA, "Alive // Well", 1);
+        assertLife(playerA, 20);
+    }
+}


### PR DESCRIPTION
- fixed interaction with copied spells - it should stop them, because functional errata from few years ago, it stops spells with chosen name instead of cards with chosen name from being cast.
- fixed interactions with fused spells. If any half of the spell is named by MM, you cannot cast that half and a fused spell. The second half can be casted.