### PR TITLE
copy chainer triggered ability when used as commander

### DIFF
--- a/Mage.Sets/src/mage/cards/c/ChainerNightmareAdept.java
+++ b/Mage.Sets/src/mage/cards/c/ChainerNightmareAdept.java
@@ -177,6 +177,15 @@ class ChainerNightmareAdeptTriggeredAbility extends EntersBattlefieldAllTriggere
         super(Zone.BATTLEFIELD, gainHasteUntilNextTurnEffect, filter, false, SetTargetPointer.PERMANENT, abilityText);
     }
 
+    ChainerNightmareAdeptTriggeredAbility(final ChainerNightmareAdeptTriggeredAbility effect) {
+        super(effect);
+    }
+
+    @Override
+    public ChainerNightmareAdeptTriggeredAbility copy() {
+        return new ChainerNightmareAdeptTriggeredAbility(this);
+    }
+
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         if (!super.checkTrigger(event, game)) {


### PR DESCRIPTION
There was a constructor and copy function missing so the triggered ability was not copied to the commander entity