### PR TITLE
Aminatou fix

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -44,9 +44,6 @@ public class AminatousAugury extends CardImpl {
         // Until end of turn, for each nonland card type, you may cast a card of that type from among the exiled cards
         // without paying its mana cost.
         this.getSpellAbility().addEffect(new AminatousAuguryPlayLandAndExileEffect());
-        //this.getSpellAbility().addEffect(new AminatousAuguryCastFromExileEffect());
-
-        //Ability ability =
     }
 
     public AminatousAugury(final AminatousAugury card) {
@@ -60,8 +57,6 @@ public class AminatousAugury extends CardImpl {
 }
 
 class AminatousAuguryPlayLandAndExileEffect extends OneShotEffect {
-
-    //private static final FilterCard filter = new FilterLandCard("land card to put on the battlefield");
 
     public AminatousAuguryPlayLandAndExileEffect() {
         super(Outcome.PlayForFree);
@@ -81,6 +76,8 @@ class AminatousAuguryPlayLandAndExileEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
+
+
         Player player = game.getPlayer(source.getControllerId());
         MageObject sourceObject = game.getObject(source.getSourceId());
         if (player != null && sourceObject != null) {
@@ -107,35 +104,18 @@ class AminatousAuguryPlayLandAndExileEffect extends OneShotEffect {
                 }
             }
 
-            //if (cards.size()>1) {
-             //  ContinuousRuleModifyingEffect effect = new AminatousAuguryCastFromExileEffect();
-            //}
-
-            /*
-            // Track all non-land cards put into exile with Aminatou
-            Set<Card> aminatouCards = new HashSet<>();
-            for (Card card : cards) {
-                if (game.getState().getZone(card.getId()) == Zone.EXILED && !card.isLand()) {
-                    aminatouCards.add(card);
-                }
-            }
-            //use unique id in case of multiple Aminatou's
-            //game.getState().setValue(source.getSourceId().toString() + "Cards", aminatouCards);
-
-             */
-
-            //set list of unused card types -- TODO: Use exile zone id for unique identifier
+            //create list of unused card types
             EnumSet<CardType> unusedCardTypes = EnumSet.allOf(CardType.class);
-            unusedCardTypes.remove(CardType.LAND); //untested
-            //game.getState().setValue(source.getSourceId().toString() + "_unusedCardTypes", unusedCardTypes);
-            game.getState().setValue("AA_unusedCardTypes", unusedCardTypes);
-            System.out.println("ID:" + source.getSourceId().toString());
+            unusedCardTypes.remove(CardType.LAND);
+
+            //use unique id in case of multiple Aminatou's Augury cast
+            game.getState().setValue(exileId.toString() +"_unusedCardTypes", unusedCardTypes);
+            System.out.println("EXID1: " + exileId.toString());
 
             //apply effect to each card
             for (Card card : cards) {
                 if (game.getState().getZone(card.getId()) == Zone.EXILED && !card.isLand()) {
-                    AsThoughEffect effect = new AminatousAuguryCastFromExileEffectTwo(exileId);
-                    //ContinuousRuleModifyingEffect effect = new AminatousAuguryCastFromExileEffect();
+                    AsThoughEffect effect = new AminatousAuguryCastFromExileEffect(exileId);
                     effect.setTargetPointer(new FixedTarget(card, game));
                     game.addEffect(effect, source);
                 }
@@ -146,64 +126,17 @@ class AminatousAuguryPlayLandAndExileEffect extends OneShotEffect {
     }
 }
 
+class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
 
-class AminatousAuguryCastFromExileEffect extends ContinuousRuleModifyingEffectImpl{
+    private static UUID aminatouExileId;
 
-    AminatousAuguryCastFromExileEffect() {
-        super(Duration.EndOfTurn, Outcome.Benefit);
-        staticText = "for each nonland cardtype, you may cast a card of that type from among the exiled cards without paying its mana cost";
-    }
-
-    private AminatousAuguryCastFromExileEffect(final AminatousAuguryCastFromExileEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        System.out.println("Game Event: " + GameEvent.EventType.SPELL_CAST);
-        return event.getType() == GameEvent.EventType.CAST_SPELL;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        //CardType cardType = ArchonOfValorsReachChoice.getType((String) game.getState().getValue(source.getSourceId().toString() + "_cardtype"));
-        // spell is not on the stack yet, so we have to check the card
-        Card card = game.getCard(event.getSourceId());
-        System.out.println("Card name: " + card.getName());
-        if (card.getCardType().size()>1){
-            System.out.println("This card has mutliple types");
-            //ask which type to cast the card
-        }
-        //check if card type contains a type already cast. If card type has two types, prompt for choice.
-        //return cardType != null && card != null && card.getCardType().contains(cardType);
-        return card != null; //&& card.getCardType().contains(cardType);
-    }
-
-    @Override
-    public AminatousAuguryCastFromExileEffect copy() {
-        return new AminatousAuguryCastFromExileEffect(this);
-    }
-
-}
-
-
-
-
-
-
-
-
-class AminatousAuguryCastFromExileEffectTwo extends AsThoughEffectImpl {
-
-    private UUID exileZoneId;
-
-    public AminatousAuguryCastFromExileEffectTwo(UUID exileId) {
+    public AminatousAuguryCastFromExileEffect(UUID exileId) {
         super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.PlayForFree);
-        exileZoneId = exileId;
+        this.aminatouExileId = exileId;
         staticText = "Cast this card without paying its mana cost";
     }
 
-    public AminatousAuguryCastFromExileEffectTwo(final AminatousAuguryCastFromExileEffectTwo effect) {
+    public AminatousAuguryCastFromExileEffect(final AminatousAuguryCastFromExileEffect effect) {
         super(effect);
     }
 
@@ -213,8 +146,8 @@ class AminatousAuguryCastFromExileEffectTwo extends AsThoughEffectImpl {
     }
 
     @Override
-    public AminatousAuguryCastFromExileEffectTwo copy() {
-        return new AminatousAuguryCastFromExileEffectTwo(this);
+    public AminatousAuguryCastFromExileEffect copy() {
+        return new AminatousAuguryCastFromExileEffect(this);
     }
 
     @Override
@@ -222,9 +155,9 @@ class AminatousAuguryCastFromExileEffectTwo extends AsThoughEffectImpl {
         return applies(objectId, null, source, game, affectedControllerId);
     }
 
-
     @Override
     public boolean applies(UUID objectId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
+
 
         Card cardToCheck = game.getCard(objectId);
         objectId = CardUtil.getMainCardId(game, objectId); // for split cards
@@ -244,60 +177,35 @@ class AminatousAuguryCastFromExileEffectTwo extends AsThoughEffectImpl {
         }
         */
 
-        // c
-
-        EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue("AA_unusedCardTypes" );
-        if (unusedCardTypes == null){
-            return false;
-        }
 
 
-
-        if (objectId.equals(getTargetPointer().getFirst(game, source))
-                && playerId.equals(source.getControllerId())) {
-
-            // Determine which card types from Aminatou cards were cast
-            /*
-            Iterator<Card> chkCardCastIterator = aminatouCards.iterator();
-            while(chkCardCastIterator.hasNext()){
-                Card chkCardCast = chkCardCastIterator.next();
-                //check if spell was cast
-                Spell spell = game.getStack().getSpell(chkCardCast.getId());
-                if (spell != null) {
-                    usedCardTypes.addAll(chkCardCast.getCardType());
-                }
-            }
-            //save changes to used card types
-            game.getState().setValue(source.getSourceId().toString() + "UsedCardTypes", usedCardTypes);
+        if (objectId.equals(getTargetPointer().getFirst(game, source)) && playerId.equals(source.getControllerId())) {
 
 
-             */
 
             // make all eligible cards types zero mana cost
-            Card card = game.getCard(objectId);
+            //Card card = game.getCard(objectId);
+            Player player = game.getPlayer(playerId);
+            if (cardToCheck != null && player !=null ) {
+            //if (card != null && !Collections.disjoint(unusedCardTypes,card.getCardType()) ) {
 
-            //if ( unusedCardTypes.contains(card.getCardType())){
-                //allow casting
-            //}
+                System.out.println("EXID2: " + aminatouExileId.toString());  //This goes to null pointer exception
+                //load set that tracks which card types are available to cast
+                EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue(aminatouExileId.toString() + "_unusedCardTypes" );
+                if (unusedCardTypes == null){
+                    return false;
+                }
 
-            //if (card != null && Collections.disjoint(usedCardTypes,card.getCardType())) {
-            if (card != null && !Collections.disjoint(unusedCardTypes,card.getCardType()) ) {
-                    Player player = game.getPlayer(playerId);
-                    if (player != null) {
 
-                        //PayLifeCost cost = new PayLifeCost(affectedAbility.getManaCosts().convertedManaCost());
-                        AminatousAuguryCost cost = new AminatousAuguryCost(exileZoneId);
-                        Costs costs = new CostsImpl();
-                        costs.add(cost);
-                        costs.addAll(affectedAbility.getCosts());
-                        //controller.setCastSourceIdWithAlternateMana(affectedAbility.getSourceId(), null, costs);
-
-                        //player.setCastSourceIdWithAlternateMana(affectedAbility.getSourceId(), null, affectedAbility.getCosts());
-                        player.setCastSourceIdWithAlternateMana(affectedAbility.getSourceId(), null, costs);
-
-                        return true;
-                    }
-
+                if (!Collections.disjoint(unusedCardTypes,cardToCheck.getCardType())) {
+                        //if (player != null)
+                    AminatousAuguryCost aminatouCost = new AminatousAuguryCost(aminatouExileId);
+                    Costs costs = new CostsImpl();
+                    costs.add(aminatouCost);
+                    costs.addAll(affectedAbility.getCosts());
+                    player.setCastSourceIdWithAlternateMana(affectedAbility.getSourceId(), null, costs);
+                    return true;
+                }
             }
         }
         return false;
@@ -307,15 +215,10 @@ class AminatousAuguryCastFromExileEffectTwo extends AsThoughEffectImpl {
 
 class AminatousAuguryCost extends CostImpl {
 
-    private UUID exileZoneId;
+    private static UUID aminatouExileId;
 
     AminatousAuguryCost(UUID exileId) {
-        //take card type as input, if card has more that one type, need to choose it here.
-        //
-        exileZoneId = exileId;
-
-        //this.addTarget(sourceInExile.getSourceId());
-        //give one of each type to spend, remove as types are cast
+        this.aminatouExileId = exileId;
         this.text = "for each nonland cardtype, you may cast a card of that type from among the exiled cards without paying its mana cost";
     }
 
@@ -327,11 +230,11 @@ class AminatousAuguryCost extends CostImpl {
     @Override
     public boolean pay(Ability ability, Game game, UUID sourceId, UUID controllerId, boolean noMana, Cost costToPay) {
 
-        //available card types to cast
-        System.out.println("ID:" + sourceId.toString());
-        System.out.println("Name: " + ability.getSourceObject(game).getName());
-        //EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue(sourceId.toString() + "_unusedCardTypes");
-        EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue("AA_unusedCardTypes");
+
+        System.out.println("EXID3: " + aminatouExileId.toString());
+        System.out.println("Ability Name: " + ability.getSourceObject(game).getName());
+        //load card types available for castings
+        EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue(aminatouExileId.toString() + "_unusedCardTypes");
         if (unusedCardTypes == null){
             System.out.println("Failed to load cast type list");
             return false;
@@ -339,23 +242,16 @@ class AminatousAuguryCost extends CostImpl {
             System.out.println("Castable types: " + unusedCardTypes.toString());
         }
 
-        // if card has type that matches a type on the unused list, allow casting
-        // at least one element in common.
 
 
-        //Player controller = game.getPlayer(source.getControllerId());
-        Player controller = game.getPlayer(controllerId);
-
-        Set<CardType> cardTypes = ability.getSourceObject(game).getCardType();
+        Set<CardType> castCardTypes = ability.getSourceObject(game).getCardType();
 
 
-        if (cardTypes != null) {
-            //for card with multiple types allow selection of type
-            //when both types are available
-
+        if (castCardTypes != null) {
+            //count matching available card types
             CardType useType = null;
             int numAvailTypes = 0;
-            for (CardType chkType : cardTypes){
+            for (CardType chkType : castCardTypes){
                 if (unusedCardTypes.contains(chkType)){
                     numAvailTypes++;
                     useType = chkType;
@@ -364,69 +260,53 @@ class AminatousAuguryCost extends CostImpl {
 
             System.out.println("Num avialble types " + numAvailTypes);
 
+            /*
+             * numAvailTypes==0
+             * If no available types, then do not cast.
+             * numAvailTypes==1
+             * If card has multiple types, and only one is unused,
+             * then cast using that type OR if card has only one type
+             * and it is available, then cast.
+             * numAvailTypes>=2
+             * If card has multiple types, and more than one has not yet been used,
+             * then show dialog to select which type to use for cast.
+             */
+
             if (numAvailTypes == 0){
+                //If no available types, then do not cast.
                 paid = false;
             } else if (numAvailTypes == 1){
+                // If card has multiple types, and only one is unused,
+                // then cast using that type OR if card has only one type
+                // and it is available, then cast.
                 unusedCardTypes.remove(useType);
                 paid = true;
             } else if (numAvailTypes >= 2){
-                //choose type
-                AminatousAuguryCardTypeChoice choices = new AminatousAuguryCardTypeChoice(cardTypes);
+                //If card has multiple types, and more than one has not yet been used,
+                //then show dialog to select which type to use for cast.
+                AminatousAuguryCardTypeChoice choices = new AminatousAuguryCardTypeChoice(castCardTypes);
+                Player controller = game.getPlayer(controllerId);
                 if (controller.choose(Outcome.Neutral, choices, game)) {
                     CardType choiceType = CardType.fromString(choices.getChoice());
                     unusedCardTypes.remove(choiceType);
                     paid = true;
                 }
             }
-
-
-            /*
-            if ( unusedCardTypes.containsAll(cardTypes) && cardTypes.size() > 1) {
-                AminatousAuguryCardTypeChoice choices = new AminatousAuguryCardTypeChoice(cardTypes);
-                if (controller.choose(Outcome.Neutral, choices, game)) {
-                    CardType choiceType = CardType.fromString(choices.getChoice());
-                    cardTypes.clear();
-                    cardTypes.add(choiceType);
-                }
-            } else {
-                for (CardType chkType : cardTypes){
-                    if (unusedCardTypes.contains(chkType)){
-
-                    }
-                }
-            }
-            */
-
-            /*
-            for (CardType chkType : cardTypes){
-                System.out.println("chkType: " + chkType.toString());
-                if (unusedCardTypes.contains(chkType)){
-                    unusedCardTypes.remove(chkType);
-                    paid = true;
-                }
-                break;
-            }
-
-             */
-
         } else {
             System.out.println("CardType returned null");
         }
 
-        //save changes to used card types
-        game.getState().setValue( "AA_unusedCardTypes", unusedCardTypes);
+        //save changes to unused card types
+        game.getState().setValue( aminatouExileId.toString() + "_unusedCardTypes", unusedCardTypes);
         System.out.println("Castable types: " + unusedCardTypes.toString());
 
         return paid;
     }
 
+
     @Override
     public boolean canPay(Ability ability, UUID sourceId, UUID controllerId, Game game) {
-
-        //System.out.println( "EZID: " + game.getExile().getExileZone(exileZoneId));
-        //System.out.println( "S ID: " + game.getState().getZone(sourceId));
         return targets.canChoose(controllerId, game);
-
     }
 
     @Override
@@ -436,6 +316,14 @@ class AminatousAuguryCost extends CostImpl {
 }
 
 class AminatousAuguryCardTypeChoice extends ChoiceImpl {
+
+    //20180713 -- notes and rules via Scryfall: https://scryfall.com/card/mb1/285/aminatous-augury#rulings
+    /*
+     * If a nonland card has multiple types, such as an artifact creature, you
+     * may cast it as either of those types. For example, you could cast one
+     * artifact creature as your artifact card and another artifact creature
+     * as your creature card.
+     */
 
     AminatousAuguryCardTypeChoice(Set<CardType> selectFromTypes) {
         super(true);

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -1,36 +1,29 @@
 package mage.cards.a;
 
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.effects.AsThoughEffectImpl;
+import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.cards.Cards;
-import mage.cards.CardsImpl;
-import mage.choices.Choice;
-import mage.choices.ChoiceImpl;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
-import mage.filter.StaticFilters;
-import mage.game.ExileZone;
+import mage.constants.*;
+import mage.filter.FilterCard;
+import mage.filter.common.FilterLandCard;
 import mage.game.Game;
 import mage.players.Player;
-import mage.target.TargetCard;
 import mage.target.targetpointer.FixedTarget;
-import mage.util.CardUtil;
+
+import java.util.Set;
+import java.util.UUID;
 
 /**
  *
  * @author credman0
+ *
+ * Comparing to cards like Narset and Emrakul, the Promised End.
+ *
  */
 public class AminatousAugury extends CardImpl {
 
@@ -56,6 +49,8 @@ public class AminatousAugury extends CardImpl {
 
 class AminatousAuguryEffect extends OneShotEffect {
 
+    private static final FilterCard filter = new FilterLandCard("land card to put on the battlefield");
+
     public AminatousAuguryEffect() {
         super(Outcome.PlayForFree);
         staticText = "Exile the top eight cards of your library. You may put a land card from among them onto the"
@@ -74,7 +69,118 @@ class AminatousAuguryEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getControllerId());
+        MageObject sourceObject = game.getObject(source.getSourceId());
+        if (player != null && sourceObject != null) {
+            //Cards cards = new CardsImpl(controller.getLibrary().getTopCards(game, 5));
+            Set<Card> cards = player.getLibrary().getTopCards(game, 8);
+            //Cards cards = new CardsImpl(player.getLibrary().getTopCards(game, 8));
 
+
+            player.moveCards(cards, Zone.EXILED, source, game);
+
+            /*
+            if (player.chooseUse(Outcome.PutCardInPlay, "Put a land from among the exiled cards into play?", source, game)) {
+                TargetCardInExile target = new TargetCardInExile(StaticFilters.FILTER_CARD_LAND_A);
+                if (player.choose(Outcome.PutCardInPlay, target, source.getSourceId(), game)) {
+                    Card card = game.getCard(target.getFirstTarget());
+                    if (card != null) {
+                        return player.moveCards(card, Zone.BATTLEFIELD, source, game, false, false, false, null);
+                    }
+                }
+            }
+
+             */
+
+
+            for (Card card : cards) {
+                if (game.getState().getZone(card.getId()) == Zone.EXILED && !card.isLand()) {
+                    ContinuousEffect effect = new AminatousAuguryCastFromExileEffect();
+                    effect.setTargetPointer(new FixedTarget(card, game));
+                    game.addEffect(effect, source);
+                }
+            }
+            return true;
+
+            //ContinuousEffect effect = new AminatousAuguryCastFromExileEffect();
+            //effect.setTargetPointer(new FixedTargets(cards.getCards(StaticFilters.FILTER_CARD_NON_LAND, game), game));
+            //game.addEffect(effect, source);
+
+            //return true;
+
+        }
+        return false;
+
+        /*
+        Player player = game.getPlayer(source.getControllerId());
+        if (player == null) {
+            return false;
+        }
+        MageObject sourceObject = game.getObject(source.getSourceId());
+        if (player != null && sourceObject != null) {
+            Set<Card> cards = player.getLibrary().getTopCards(game, 8);
+
+            Cards aminatouExileSet = new CardsImpl();
+            aminatouExileSet.addAll(cards);
+
+            player.moveCards(cards, Zone.EXILED, source, game);
+
+            TargetCard target = new TargetCard(Zone.EXILED, StaticFilters.FILTER_CARD_LAND);
+
+
+            //check for land card
+
+            //for (Card xCard : cards){
+           //    System.out.println("Card name -- " + xCard.toString());
+            //}
+
+
+            if (aminatouExileSet.count(StaticFilters.FILTER_CARD_LAND, game) > 0) {
+                //System.out.println("Exile set contains land!");
+                if (player.chooseUse(Outcome.PutCardInPlay, "Put a land from among the exiled cards into play?", source, game)) {
+                    if (player.choose(Outcome.PutCardInPlay, target, source.getSourceId(), game)) {
+                        Card card = game.getCard(target.getFirstTarget());
+                        if (card != null) {
+                                return player.moveCards(card, Zone.BATTLEFIELD, source, game, false, false, false, null);
+                        }
+                    }
+                }
+            }
+            Cards canBeCast = new CardsImpl();
+            for (Card card : cards) {
+                if (!card.isLand()) {
+                    canBeCast.add(card);
+                }
+            }
+
+            ContinuousEffect effect = new AminatousAuguryCastFromExileEffect();
+            effect.setTargetPointer(new FixedTargets(canBeCast, game));
+            game.addEffect(effect, source);
+
+            for (Card card : cards) {
+                if (game.getState().getZone(card.getId()) == Zone.EXILED) {
+
+                }
+            }
+
+
+            ExileZone auguryExileZone = game.getExile().getExileZone(source.getSourceId());
+            Cards cardsToCast = new CardsImpl();
+            cardsToCast.addAll(auguryExileZone.getCards(game));
+
+
+
+        }
+
+        return false;
+
+         */
+    }
+
+    /*
+    @Override
+    public boolean apply(Game game, Ability source) {
+        System.out.println("Aminatou Apply Override");
         Player controller = game.getPlayer(source.getControllerId());
         MageObject sourceObject = source.getSourceObject(game);
         if (controller != null && sourceObject != null) {
@@ -91,6 +197,7 @@ class AminatousAuguryEffect extends OneShotEffect {
                     Zone.EXILED,
                     StaticFilters.FILTER_CARD_LAND_A
             );
+
             if (cardsToCast.count(StaticFilters.FILTER_CARD_LAND, game) > 0) {
                 if (controller.chooseUse(Outcome.PutLandInPlay, "Put a land from among the exiled cards into play?", source, game)) {
                     if (controller.choose(Outcome.PutLandInPlay, cardsToCast, target, game)) {
@@ -103,6 +210,7 @@ class AminatousAuguryEffect extends OneShotEffect {
                 }
             }
             for (Card card : cardsToCast.getCards(StaticFilters.FILTER_CARD_NON_LAND, game)) {
+                System.out.println("Card -- " + card.toString());
                 AminatousAuguryCastFromExileEffect effect = new AminatousAuguryCastFromExileEffect();
                 effect.setTargetPointer(new FixedTarget(card.getId(), card.getZoneChangeCounter(game)));
                 game.addEffect(effect, source);
@@ -110,6 +218,8 @@ class AminatousAuguryEffect extends OneShotEffect {
         }
         return false;
     }
+    */
+
 }
 
 class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
@@ -133,41 +243,144 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
         return new AminatousAuguryCastFromExileEffect(this);
     }
 
+    //track each card type -- 5 types
+    //allow casting if not already cast from the 8 cards moved to exile
+
+    @Override
+    public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+
+        if (objectId.equals(getTargetPointer().getFirst(game, source))
+                && affectedControllerId.equals(source.getControllerId())) {
+            Card card = game.getCard(objectId);
+            if (card != null) {
+                Player player = game.getPlayer(affectedControllerId);
+                if (player != null) {
+                    player.setCastSourceIdWithAlternateMana(objectId, null, card.getSpellAbility().getCosts());
+                    return true;
+                }
+            }
+        }
+        return false;
+
+        /*
+
+        //EnumSet<CardType> usedCardTypesOutside = EnumSet.noneOf(CardType.class);
+        //EnumSet<CardType> unusedCardTypesOutside = EnumSet.noneOf(CardType.class);
+
+
+
+
+        if (objectId.equals(getTargetPointer().getFirst(game, source))
+                && affectedControllerId.equals(source.getControllerId())) {
+            Card card = game.getCard(objectId);
+            //System.out.println("card type -- " + card.getSuperType().toString());
+            if (card != null) {
+
+
+
+                Thread t = Thread.currentThread();
+                System.out.println("Thread ID --  " + t.getId());
+
+
+                EnumSet<CardType> usedCardTypes = EnumSet.noneOf(CardType.class);
+                EnumSet<CardType> unusedCardTypes = EnumSet.noneOf(CardType.class);
+
+                for (CardType cardT : card.getCardType()) {
+                    //System.out.println("Card Types -- " +  card.getCardType().toString());
+                    if (!usedCardTypes.contains(cardT)) {
+                        unusedCardTypes.add(cardT);
+                    }
+                    if (!usedCardTypesOutside.contains(cardT)) {
+                        unusedCardTypesOutside.add(cardT);
+                    }
+                }
+
+                System.out.print("Used Card Types: ");
+                for ( CardType pCard : usedCardTypes){
+                    System.out.print(pCard.toString() + " ");
+                }
+                System.out.println();
+                System.out.print("Unused Card Types: ");
+                for ( CardType pCard : unusedCardTypes){
+                    System.out.print(pCard.toString() + " ");
+                }
+                System.out.println();
+                System.out.print("UOed Card Types: ");
+                for ( CardType pCard : usedCardTypesOutside){
+                    System.out.print(pCard.toString() + " ");
+                }
+                System.out.println();
+                System.out.print("UOused Card Types: ");
+                for ( CardType pCard : unusedCardTypesOutside){
+                    System.out.print(pCard.toString() + " ");
+                }
+                System.out.println();
+
+
+                Player player = game.getPlayer(affectedControllerId);
+                if (player != null) {
+                    player.setCastSourceIdWithAlternateMana(objectId, null, card.getSpellAbility().getCosts());
+                    return true;
+                }
+            }
+        }
+        return false;
+
+         */
+    }
+
+    /*
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+
+        //System.out.println("Aminatou Applies Override");
+
         Player player = game.getPlayer(affectedControllerId);
         EnumSet<CardType> usedCardTypes = EnumSet.noneOf(CardType.class);
 
         if (game.getState().getValue(source.getSourceId().toString() + "cardTypes") != null) {
             usedCardTypes = (EnumSet<CardType>) game.getState().getValue(source.getSourceId().toString() + "cardTypes");
         }
+
+        for ( CardType xCard : usedCardTypes){
+            System.out.println("Used card types -xx- " + xCard.toString());
+        }
+
+
         //TODO add code for adding additional costs to the card
         if (player != null
                 && sourceId != null
                 && sourceId.equals(getTargetPointer().getFirst(game, source))
                 && affectedControllerId.equals(source.getControllerId())) {
             Card card = game.getCard(sourceId);
-            if (card != null
-                    && game.getState().getZone(sourceId) == Zone.EXILED) {
+            if (card != null  && game.getState().getZone(sourceId) == Zone.EXILED) {
                 EnumSet<CardType> unusedCardTypes = EnumSet.noneOf(CardType.class);
                 for (CardType cardT : card.getCardType()) {
+                    System.out.println("Card Types -- " +  card.getCardType().toString());
                     if (!usedCardTypes.contains(cardT)) {
                         unusedCardTypes.add(cardT);
                     }
                 }
+
+                for ( CardType xCard : unusedCardTypes){
+                    System.out.println("Unused card types -- " + xCard.toString());
+                }
+
                 if (!unusedCardTypes.isEmpty()) {
                     if (!game.inCheckPlayableState()) { // some actions may not be done while the game only checks if a card can be cast
-                        // Select the card type to consume and remove all not seleczted card types
+                        // Select the card type to consume and remove all not selected card types
                         if (unusedCardTypes.size() > 1) {
                             Choice choice = new ChoiceImpl(true);
                             choice.setMessage("Which card type do you want to consume?");
                             Set<String> choices = choice.getChoices();
                             for (CardType cardType : unusedCardTypes) {
                                 choices.add(cardType.toString());
+                                System.out.println("Aminatou adds type: ");
                             }
                             player.choose(Outcome.Detriment, choice, game);
                             for (Iterator<CardType> iterator = unusedCardTypes.iterator(); iterator.hasNext();) {
                                 CardType next = iterator.next();
+                                System.out.println("Aminatou selects: ");
                                 if (!next.toString().equals(choice.getChoice())) {
                                     iterator.remove();
                                 }
@@ -184,4 +397,6 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
         }
         return false;
     }
+    */
+
 }

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -2,23 +2,32 @@ package mage.cards.a;
 
 import mage.MageObject;
 import mage.abilities.Ability;
-import mage.abilities.effects.AsThoughEffectImpl;
-import mage.abilities.effects.ContinuousEffect;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.costs.Cost;
+import mage.abilities.costs.CostImpl;
+import mage.abilities.costs.Costs;
+import mage.abilities.costs.CostsImpl;
+import mage.abilities.effects.*;
 import mage.cards.*;
+import mage.choices.ChoiceImpl;
 import mage.constants.*;
 import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterLandCard;
 import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
 import mage.game.stack.Spell;
 import mage.players.Player;
 import mage.target.TargetCard;
+
+import mage.target.common.TargetCardInExile;
 import mage.target.targetpointer.FixedTarget;
 import mage.util.CardUtil;
 
 
 import java.util.*;
+
+import static mage.filter.predicate.permanent.ControllerControlsIslandPredicate.filter;
 
 /**
  *
@@ -34,7 +43,10 @@ public class AminatousAugury extends CardImpl {
         // Exile the top eight cards of your library. You may put a land card from among them onto the battlefield.
         // Until end of turn, for each nonland card type, you may cast a card of that type from among the exiled cards
         // without paying its mana cost.
-        this.getSpellAbility().addEffect(new AminatousAuguryEffect());
+        this.getSpellAbility().addEffect(new AminatousAuguryPlayLandAndExileEffect());
+        //this.getSpellAbility().addEffect(new AminatousAuguryCastFromExileEffect());
+
+        //Ability ability =
     }
 
     public AminatousAugury(final AminatousAugury card) {
@@ -47,24 +59,24 @@ public class AminatousAugury extends CardImpl {
     }
 }
 
-class AminatousAuguryEffect extends OneShotEffect {
+class AminatousAuguryPlayLandAndExileEffect extends OneShotEffect {
 
-    private static final FilterCard filter = new FilterLandCard("land card to put on the battlefield");
+    //private static final FilterCard filter = new FilterLandCard("land card to put on the battlefield");
 
-    public AminatousAuguryEffect() {
+    public AminatousAuguryPlayLandAndExileEffect() {
         super(Outcome.PlayForFree);
         staticText = "Exile the top eight cards of your library. You may put a land card from among them onto the"
                 + " battlefield. Until end of turn, for each nonland card type, you may cast a card of that type from"
                 + " among the exiled cards without paying its mana cost.";
     }
 
-    public AminatousAuguryEffect(final AminatousAuguryEffect effect) {
+    public AminatousAuguryPlayLandAndExileEffect(final AminatousAuguryPlayLandAndExileEffect effect) {
         super(effect);
     }
 
     @Override
-    public AminatousAuguryEffect copy() {
-        return new AminatousAuguryEffect(this);
+    public AminatousAuguryPlayLandAndExileEffect copy() {
+        return new AminatousAuguryPlayLandAndExileEffect(this);
     }
 
     @Override
@@ -72,8 +84,13 @@ class AminatousAuguryEffect extends OneShotEffect {
         Player player = game.getPlayer(source.getControllerId());
         MageObject sourceObject = game.getObject(source.getSourceId());
         if (player != null && sourceObject != null) {
+            //Exile the top eight cards of your library.
             Set<Card> cards = player.getLibrary().getTopCards(game, 8);
-            player.moveCards(cards, Zone.EXILED, source, game);
+            UUID exileId = CardUtil.getCardExileZoneId(game, source);
+            for (Card card : cards) {
+                card.moveToExile(exileId,source.getSourceObject(game).getName(), source.getSourceId(), game);
+             }
+
 
             //you may put a land card from among them onto the battlefield
             Cards aminatouExileGroup = new CardsImpl(cards);
@@ -82,13 +99,17 @@ class AminatousAuguryEffect extends OneShotEffect {
                     TargetCard targetLandCard = new TargetCard(1, Zone.EXILED, StaticFilters.FILTER_CARD_LAND);
                     if (player.choose(Outcome.PutCardInPlay, aminatouExileGroup, targetLandCard, game)) {
                         Card landCard = game.getCard(targetLandCard.getFirstTarget());
-                        if (landCard == null) {
+                        if (landCard != null) {
                             player.moveCards(landCard, Zone.BATTLEFIELD, source, game, false, false, false, null);
                             aminatouExileGroup.remove(landCard);
                         }
                     }
                 }
             }
+
+            //if (cards.size()>1) {
+             //  ContinuousRuleModifyingEffect effect = new AminatousAuguryCastFromExileEffect();
+            //}
 
             // Track all non-land cards put into exile with Aminatou
             Set<Card> aminatouCards = new HashSet<>();
@@ -100,10 +121,17 @@ class AminatousAuguryEffect extends OneShotEffect {
             //use unique id in case of multiple Aminatou's
             game.getState().setValue(source.getSourceId().toString() + "Cards", aminatouCards);
 
+            //set list of unused card types -- TODO: Use exile zone id for unique identifier
+            EnumSet<CardType> unusedCardTypes = EnumSet.allOf(CardType.class);
+            //game.getState().setValue(source.getSourceId().toString() + "_unusedCardTypes", unusedCardTypes);
+            game.getState().setValue("AA_unusedCardTypes", unusedCardTypes);
+            System.out.println("ID:" + source.getSourceId().toString());
+
             //apply effect to each card
             for (Card card : cards) {
                 if (game.getState().getZone(card.getId()) == Zone.EXILED && !card.isLand()) {
-                    ContinuousEffect effect = new AminatousAuguryCastFromExileEffect();
+                    AsThoughEffect effect = new AminatousAuguryCastFromExileEffectTwo(exileId);
+                    //ContinuousRuleModifyingEffect effect = new AminatousAuguryCastFromExileEffect();
                     effect.setTargetPointer(new FixedTarget(card, game));
                     game.addEffect(effect, source);
                 }
@@ -114,14 +142,64 @@ class AminatousAuguryEffect extends OneShotEffect {
     }
 }
 
-class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
 
-    public AminatousAuguryCastFromExileEffect() {
+class AminatousAuguryCastFromExileEffect extends ContinuousRuleModifyingEffectImpl{
+
+    AminatousAuguryCastFromExileEffect() {
+        super(Duration.EndOfTurn, Outcome.Benefit);
+        staticText = "for each nonland cardtype, you may cast a card of that type from among the exiled cards without paying its mana cost";
+    }
+
+    private AminatousAuguryCastFromExileEffect(final AminatousAuguryCastFromExileEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        System.out.println("Game Event: " + GameEvent.EventType.SPELL_CAST);
+        return event.getType() == GameEvent.EventType.CAST_SPELL;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        //CardType cardType = ArchonOfValorsReachChoice.getType((String) game.getState().getValue(source.getSourceId().toString() + "_cardtype"));
+        // spell is not on the stack yet, so we have to check the card
+        Card card = game.getCard(event.getSourceId());
+        System.out.println("Card name: " + card.getName());
+        if (card.getCardType().size()>1){
+            System.out.println("This card has mutliple types");
+            //ask which type to cast the card
+        }
+        //check if card type contains a type already cast. If card type has two types, prompt for choice.
+        //return cardType != null && card != null && card.getCardType().contains(cardType);
+        return card != null; //&& card.getCardType().contains(cardType);
+    }
+
+    @Override
+    public AminatousAuguryCastFromExileEffect copy() {
+        return new AminatousAuguryCastFromExileEffect(this);
+    }
+
+}
+
+
+
+
+
+
+
+
+class AminatousAuguryCastFromExileEffectTwo extends AsThoughEffectImpl {
+
+    private UUID exileZoneId;
+
+    public AminatousAuguryCastFromExileEffectTwo(UUID exileId) {
         super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.PlayForFree);
+        exileZoneId = exileId;
         staticText = "Cast this card without paying its mana cost";
     }
 
-    public AminatousAuguryCastFromExileEffect(final AminatousAuguryCastFromExileEffect effect) {
+    public AminatousAuguryCastFromExileEffectTwo(final AminatousAuguryCastFromExileEffectTwo effect) {
         super(effect);
     }
 
@@ -131,8 +209,8 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public AminatousAuguryCastFromExileEffect copy() {
-        return new AminatousAuguryCastFromExileEffect(this);
+    public AminatousAuguryCastFromExileEffectTwo copy() {
+        return new AminatousAuguryCastFromExileEffectTwo(this);
     }
 
     @Override
@@ -178,12 +256,24 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
 
             // make all eligible cards types zero mana cost
             Card card = game.getCard(objectId);
-            if (card != null && Collections.disjoint(usedCardTypes,card.getCardType())) {
-                Player player = game.getPlayer(playerId);
-                if (player != null) {
-                    player.setCastSourceIdWithAlternateMana(affectedAbility.getSourceId(), null, affectedAbility.getCosts());
-                    return true;
-                }
+            //if (card != null && Collections.disjoint(usedCardTypes,card.getCardType())) {
+            if (card != null ) {
+                    Player player = game.getPlayer(playerId);
+                    if (player != null) {
+
+                        //PayLifeCost cost = new PayLifeCost(affectedAbility.getManaCosts().convertedManaCost());
+                        AminatousAuguryCost cost = new AminatousAuguryCost(exileZoneId);
+                        Costs costs = new CostsImpl();
+                        costs.add(cost);
+                        costs.addAll(affectedAbility.getCosts());
+                        //controller.setCastSourceIdWithAlternateMana(affectedAbility.getSourceId(), null, costs);
+
+                        //player.setCastSourceIdWithAlternateMana(affectedAbility.getSourceId(), null, affectedAbility.getCosts());
+                        player.setCastSourceIdWithAlternateMana(affectedAbility.getSourceId(), null, costs);
+
+                        return true;
+                    }
+
             }
         }
         return false;
@@ -191,5 +281,159 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
 }
 
 
+class AminatousAuguryCost extends CostImpl {
+
+    private UUID exileZoneId;
+
+    AminatousAuguryCost(UUID exileId) {
+        //take card type as input, if card has more that one type, need to choose it here.
+        //
+        exileZoneId = exileId;
+
+        //this.addTarget(sourceInExile.getSourceId());
+        //give one of each type to spend, remove as types are cast
+        this.text = "for each nonland cardtype, you may cast a card of that type from among the exiled cards without paying its mana cost";
+    }
 
 
+    AminatousAuguryCost(final AminatousAuguryCost cost) {
+        super(cost);
+    }
+
+    @Override
+    public boolean pay(Ability ability, Game game, UUID sourceId, UUID controllerId, boolean noMana, Cost costToPay) {
+
+        //available card types to cast
+        System.out.println("ID:" + sourceId.toString());
+        System.out.println("Name: " + ability.getSourceObject(game).getName());
+        //EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue(sourceId.toString() + "_unusedCardTypes");
+        EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue("AA_unusedCardTypes");
+        if (unusedCardTypes == null){
+            System.out.println("Failed to load cast type list");
+            return false;
+        } else {
+            System.out.println("Castable types: " + unusedCardTypes.toString());
+        }
+
+        // if card has type that matches a type on the unused list, allow casting
+        // at least one element in common.
+
+
+        //Player controller = game.getPlayer(source.getControllerId());
+        Player controller = game.getPlayer(controllerId);
+
+        Set<CardType> cardTypes = ability.getSourceObject(game).getCardType();
+
+
+        if (cardTypes != null) {
+            //for card with multiple types allow selection of type
+            //when both types are available
+
+            CardType useType = null;
+            int numAvailTypes = 0;
+            for (CardType chkType : cardTypes){
+                if (unusedCardTypes.contains(chkType)){
+                    numAvailTypes++;
+                    useType = chkType;
+                }
+            }
+
+            System.out.println("Num avialble types " + numAvailTypes);
+
+            if (numAvailTypes == 0){
+                paid = false;
+            } else if (numAvailTypes == 1){
+                unusedCardTypes.remove(useType);
+                paid = true;
+            } else if (numAvailTypes >= 2){
+                //choose type
+                AminatousAuguryCardTypeChoice choices = new AminatousAuguryCardTypeChoice(cardTypes);
+                if (controller.choose(Outcome.Neutral, choices, game)) {
+                    CardType choiceType = CardType.fromString(choices.getChoice());
+                    unusedCardTypes.remove(choiceType);
+                    paid = true;
+                }
+            }
+
+
+            /*
+            if ( unusedCardTypes.containsAll(cardTypes) && cardTypes.size() > 1) {
+                AminatousAuguryCardTypeChoice choices = new AminatousAuguryCardTypeChoice(cardTypes);
+                if (controller.choose(Outcome.Neutral, choices, game)) {
+                    CardType choiceType = CardType.fromString(choices.getChoice());
+                    cardTypes.clear();
+                    cardTypes.add(choiceType);
+                }
+            } else {
+                for (CardType chkType : cardTypes){
+                    if (unusedCardTypes.contains(chkType)){
+
+                    }
+                }
+            }
+            */
+
+            /*
+            for (CardType chkType : cardTypes){
+                System.out.println("chkType: " + chkType.toString());
+                if (unusedCardTypes.contains(chkType)){
+                    unusedCardTypes.remove(chkType);
+                    paid = true;
+                }
+                break;
+            }
+
+             */
+
+        } else {
+            System.out.println("CardType returned null");
+        }
+
+        //save changes to used card types
+        game.getState().setValue( "AA_unusedCardTypes", unusedCardTypes);
+        System.out.println("Castable types: " + unusedCardTypes.toString());
+
+        return paid;
+    }
+
+
+    /*
+     * Cards that share types with types on the unused list should be listed
+     *  as canPay targets.
+     */
+
+    @Override
+    public boolean canPay(Ability ability, UUID sourceId, UUID controllerId, Game game) {
+
+        System.out.println( "EZID: " + game.getExile().getExileZone(exileZoneId));
+        System.out.println( "S ID: " + game.getState().getZone(sourceId));
+        return targets.canChoose(controllerId, game);
+    }
+
+    @Override
+    public AminatousAuguryCost copy() {
+        return new AminatousAuguryCost(this);
+    }
+}
+
+class AminatousAuguryCardTypeChoice extends ChoiceImpl {
+
+    AminatousAuguryCardTypeChoice(Set<CardType> selectFromTypes) {
+        super(true);
+
+        for (CardType cType : selectFromTypes ){
+            this.choices.add(cType.toString());
+        }
+        this.message = "Choose a single type for casting";
+    }
+
+    private AminatousAuguryCardTypeChoice(final AminatousAuguryCardTypeChoice choice) {
+        super(choice);
+    }
+
+    @Override
+    public AminatousAuguryCardTypeChoice copy() {
+        return new AminatousAuguryCardTypeChoice(this);
+    }
+
+}

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -169,6 +169,7 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
             if (card != null && Collections.disjoint(usedCardTypes,card.getCardType())) {
                 Player player = game.getPlayer(affectedControllerId);
                 if (player != null) {
+                    //TODO: Bolass Citadel seems to work, try fix based on that 
                     player.setCastSourceIdWithAlternateMana(objectId, null, card.getSpellAbility().getCosts());
                     return true;
                 }

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -1,7 +1,11 @@
 package mage.cards.a;
 
 import mage.MageObject;
+import mage.abilities.Abilities;
 import mage.abilities.Ability;
+import mage.abilities.costs.CostImpl;
+import mage.abilities.costs.Costs;
+import mage.abilities.costs.CostsImpl;
 import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
@@ -15,6 +19,7 @@ import mage.game.stack.Spell;
 import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 
 import java.util.*;
@@ -139,6 +144,21 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        return applies(objectId, null, source, game, affectedControllerId);
+    }
+
+
+    @Override
+    public boolean applies(UUID objectId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
+
+    //@Override
+    //public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Card cardToCheck = game.getCard(objectId);
+        objectId = CardUtil.getMainCardId(game, objectId); // for split cards
+
+        if (!isAbilityAppliedForAlternateCast(cardToCheck, affectedAbility, playerId, source)) {
+            return false;
+        }
 
         //cards put into exile using Aminatou -- created in AminatouAuguryEffect -> Apply
         Set<Card> aminatouCards = (Set<Card>) game.getState().getValue(source.getSourceId().toString() + "Cards");
@@ -150,7 +170,7 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
         }
 
         if (objectId.equals(getTargetPointer().getFirst(game, source))
-                && affectedControllerId.equals(source.getControllerId())) {
+                && playerId.equals(source.getControllerId())) {
 
             // Determine which card types from Aminatou cards were cast
             Iterator<Card> chkCardCastIterator = aminatouCards.iterator();
@@ -167,11 +187,17 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
             // make all eligible cards types zero mana cost
             Card card = game.getCard(objectId);
             if (card != null && Collections.disjoint(usedCardTypes,card.getCardType())) {
-                Player player = game.getPlayer(affectedControllerId);
+                Player player = game.getPlayer(playerId);
                 if (player != null) {
-                    //TODO: Bolass Citadel seems to work, try fix based on that 
-                    player.setCastSourceIdWithAlternateMana(objectId, null, source.getCosts());
+                    //TODO: Bolass Citadel seems to work, try fix based on that
+                    //Costs cost = new CostsImpl();
+                    //Abilities<Ability> cardAbilities = card.getAbilities(game);
+                    //cost.addAll(card.getAbilities(game). getCosts());
+                    System.out.println("Card costs:" + card.getSpellAbility().getCosts().getText());
+                    System.out.println("Source costs:" + source.getCosts().getText());
+                    //player.setCastSourceIdWithAlternateMana(objectId, null, cost);
                     //player.setCastSourceIdWithAlternateMana(objectId, null, card.getSpellAbility().getCosts());
+                    player.setCastSourceIdWithAlternateMana(affectedAbility.getSourceId(), null, affectedAbility.getCosts());
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -10,12 +10,10 @@ import mage.constants.*;
 import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterLandCard;
-import mage.game.ExileZone;
 import mage.game.Game;
 import mage.game.stack.Spell;
 import mage.players.Player;
 import mage.target.TargetCard;
-import mage.target.common.TargetCardInExile;
 import mage.target.targetpointer.FixedTarget;
 
 

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -1,11 +1,7 @@
 package mage.cards.a;
 
 import mage.MageObject;
-import mage.abilities.Abilities;
 import mage.abilities.Ability;
-import mage.abilities.costs.CostImpl;
-import mage.abilities.costs.Costs;
-import mage.abilities.costs.CostsImpl;
 import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
@@ -49,7 +45,6 @@ public class AminatousAugury extends CardImpl {
     public AminatousAugury copy() {
         return new AminatousAugury(this);
     }
-
 }
 
 class AminatousAuguryEffect extends OneShotEffect {
@@ -117,8 +112,6 @@ class AminatousAuguryEffect extends OneShotEffect {
         }
         return false;
     }
-
-
 }
 
 class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
@@ -151,8 +144,6 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
     @Override
     public boolean applies(UUID objectId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
 
-    //@Override
-    //public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         Card cardToCheck = game.getCard(objectId);
         objectId = CardUtil.getMainCardId(game, objectId); // for split cards
 
@@ -160,7 +151,7 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
             return false;
         }
 
-        //cards put into exile using Aminatou -- created in AminatouAuguryEffect -> Apply
+        //cards put into exile using Aminatou -- created in AminatouAuguryEffect - Apply
         Set<Card> aminatouCards = (Set<Card>) game.getState().getValue(source.getSourceId().toString() + "Cards");
 
         //Set to track which card types from the Aminatou cards have already been cast
@@ -176,27 +167,20 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
             Iterator<Card> chkCardCastIterator = aminatouCards.iterator();
             while(chkCardCastIterator.hasNext()){
                 Card chkCardCast = chkCardCastIterator.next();
-                Spell spell = game.getStack().getSpell(chkCardCast.getId()); //check if spell was cast
+                //check if spell was cast
+                Spell spell = game.getStack().getSpell(chkCardCast.getId());
                 if (spell != null) {
                     usedCardTypes.addAll(chkCardCast.getCardType());
                 }
             }
-            game.getState().setValue(source.getSourceId().toString() + "UsedCardTypes", usedCardTypes); //update changes
-
+            //save changes to used card types
+            game.getState().setValue(source.getSourceId().toString() + "UsedCardTypes", usedCardTypes);
 
             // make all eligible cards types zero mana cost
             Card card = game.getCard(objectId);
             if (card != null && Collections.disjoint(usedCardTypes,card.getCardType())) {
                 Player player = game.getPlayer(playerId);
                 if (player != null) {
-                    //TODO: Bolass Citadel seems to work, try fix based on that
-                    //Costs cost = new CostsImpl();
-                    //Abilities<Ability> cardAbilities = card.getAbilities(game);
-                    //cost.addAll(card.getAbilities(game). getCosts());
-                    System.out.println("Card costs:" + card.getSpellAbility().getCosts().getText());
-                    System.out.println("Source costs:" + source.getCosts().getText());
-                    //player.setCastSourceIdWithAlternateMana(objectId, null, cost);
-                    //player.setCastSourceIdWithAlternateMana(objectId, null, card.getSpellAbility().getCosts());
                     player.setCastSourceIdWithAlternateMana(affectedAbility.getSourceId(), null, affectedAbility.getCosts());
                     return true;
                 }
@@ -205,4 +189,7 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
         return false;
     }
 }
+
+
+
 

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -170,7 +170,8 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
                 Player player = game.getPlayer(affectedControllerId);
                 if (player != null) {
                     //TODO: Bolass Citadel seems to work, try fix based on that 
-                    player.setCastSourceIdWithAlternateMana(objectId, null, card.getSpellAbility().getCosts());
+                    player.setCastSourceIdWithAlternateMana(objectId, null, source.getCosts());
+                    //player.setCastSourceIdWithAlternateMana(objectId, null, card.getSpellAbility().getCosts());
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -230,7 +230,13 @@ class AminatousAuguryCost extends CostImpl {
             throw new UnsupportedOperationException("Could not load unused card types for Aminatou's Augury");
         }
 
-        Set<CardType> castCardTypes = ability.getSourceObject(game).getCardType();
+        MageObject sourceObject = ability.getSourceObject(game);
+        if (sourceObject!=null) {
+            Set<CardType> castCardTypes = sourceObject.getCardType();
+        } else {
+            throw new UnsupportedOperationException("Mage source object returned null.");
+        }
+
         if (castCardTypes != null) {
 
             // Count matching available card types
@@ -276,6 +282,7 @@ class AminatousAuguryCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, UUID sourceId, UUID controllerId, Game game) {
+        //need to check which cards can be paid or not here. 
         return targets.canChoose(controllerId, game);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -82,25 +82,38 @@ class AminatousAuguryPlayLandAndExileEffect extends OneShotEffect {
         Player player = game.getPlayer(source.getControllerId());
         MageObject sourceObject = game.getObject(source.getSourceId());
         if (player != null && sourceObject != null) {
-            //Exile the top eight cards of your library.
-            Set<Card> cards = player.getLibrary().getTopCards(game, 8);
-            UUID exileId = CardUtil.getCardExileZoneId(game, source);
-            for (Card card : cards) {
-                card.moveToExile(exileId,source.getSourceObject(game).getName(), source.getSourceId(), game);
-             }
 
-            //HACK
-            //create game state hash map, to map each mage object to each aminatou's augury card.
-            HashMap<UUID, UUID> cardIdToAminatouIdMap = new HashMap <UUID, UUID>();
+            // Map each card's ID to Aminatou's Augury card ID that was used to exile it.
+            HashMap<UUID, UUID> cardIdToAminatouIdMap = new HashMap <>();
             if (game.getState().getValue("cardToAminatouIdMap")!=null) {
                 cardIdToAminatouIdMap = (HashMap<UUID,UUID>) game.getState().getValue("cardToAminatouIdMap");
             }
+
+
+            //Exile the top eight cards of your library.
+            Set<Card> cards = player.getLibrary().getTopCards(game, 8);
+            UUID exileId = CardUtil.getCardExileZoneId(game, source);
+
+
             for (Card card : cards) {
+                card.moveToExile(exileId,source.getSourceObject(game).getName(), source.getSourceId(), game);
                 cardIdToAminatouIdMap.put(card.getId(), source.getSourceId());
-            }
-            System.out.println("HMap: " + cardIdToAminatouIdMap.toString());
+             }
 
             game.getState().setValue("cardToAminatouIdMap", cardIdToAminatouIdMap);
+
+            //HACK
+            //create game state hash map, to map each mage object to each aminatou's augury card.
+            //HashMap<UUID, UUID> cardIdToAminatouIdMap = new HashMap <UUID, UUID>();
+            //if (game.getState().getValue("cardToAminatouIdMap")!=null) {
+            //    cardIdToAminatouIdMap = (HashMap<UUID,UUID>) game.getState().getValue("cardToAminatouIdMap");
+           // }
+            //for (Card card : cards) {
+            //    cardIdToAminatouIdMap.put(card.getId(), source.getSourceId());
+            //}
+            //System.out.println("HMap: " + cardIdToAminatouIdMap.toString());
+
+
 
 
             //you may put a land card from among them onto the battlefield
@@ -182,63 +195,35 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
             return false;
         }
 
-        /*
-        //cards put into exile using Aminatou -- created in AminatouAuguryEffect - Apply
-        Set<Card> aminatouCards = (Set<Card>) game.getState().getValue(source.getSourceId().toString() + "Cards");
-
-        //Set to track which card types from the Aminatou cards have already been cast
-        Set<CardType> usedCardTypes = new HashSet<>();
-        if (game.getState().getValue(source.getSourceId().toString() + "UsedCardTypes") != null){
-            usedCardTypes = (Set<CardType>) game.getState().getValue(source.getSourceId().toString() + "UsedCardTypes");
-        }
-        */
-
-
-
         if (objectId.equals(getTargetPointer().getFirst(game, source)) && playerId.equals(source.getControllerId())) {
-
-
 
             // make all eligible cards types zero mana cost
             //Card card = game.getCard(objectId);
             Player player = game.getPlayer(playerId);
             if (cardToCheck != null && player !=null ) {
-            //if (card != null && !Collections.disjoint(unusedCardTypes,card.getCardType()) ) {
-
-                //System.out.println("E: " + aminatouId);  //This goes to null pointer exception
-                //System.out.println("E: " + source.getSourceId());  //This goes to null pointer exception
-
-                //if ( !aminatouId.equals(source.getSourceId().toString() + "_unusedCardTypes") ){
-                //    System.out.println("Mismatch ID!");
-                //    System.out.println("E: " + aminatouId);  //This goes to null pointer exception
-                //    System.out.println("E: " + source.getSourceId().toString() + "_unusedCardTypes");  //This goes to null pointer exception
-                //}
-
-                //System.out.println("CardToCheck: "  + cardToCheck.getId().toString());
-                //System.out.println("CardToCheck ID for " + cardToCheck.getName() + " from Applies: " + cardToCheck.getId().toString());
 
 
                 HashMap<UUID,UUID> setLocater = (HashMap<UUID, UUID>) game.getState().getValue("cardToAminatouIdMap");
                 String aminatouId = setLocater.get(cardToCheck.getId()).toString() + "_unusedCardTypes";
-
-
-                //load set that tracks which card types are available to cast
-                EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue(aminatouId);
-
-                if (!aminatouId.equals(source.getSourceId().toString() + "_unusedCardTypes")){
-                    System.out.println("Mismatch: " + aminatouId + " AND " + source.getSourceId().toString());
-                }
-
-                System.out.println("From Applies ID: " + source.getSourceId().toString() + "_unusedCardTypes " + " Castable types: " + unusedCardTypes.toString());
+                //EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue(aminatouId);
+                //load unused card types using Aminatou card Id
+                EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue(source.getSourceId().toString() + "_unusedCardTypes");
                 if (unusedCardTypes == null){
                     return false;  //return false or null on error?
                 }
 
+                if (!aminatouId.equals(source.getSourceId().toString() + "_unusedCardTypes")){
+                    System.out.println("Mismatch: " + aminatouId + " AND " + source.getSourceId().toString());
+                }
+                //if (!aminatouId.equals(source.getSourceId().toString() + "_unusedCardTypes")){
+                //    System.out.println("Mismatch: " + aminatouId + " AND " + source.getSourceId().toString());
+                //}
 
+
+                //System.out.println("From Applies ID: " + source.getSourceId().toString() + "_unusedCardTypes " + " Castable types: " + unusedCardTypes.toString());
 
 
                 if (!Collections.disjoint(unusedCardTypes,cardToCheck.getCardType())) {
-                        //if (player != null)
                     AminatousAuguryCost aminatouCost = new AminatousAuguryCost();
                     Costs costs = new CostsImpl();
                     costs.add(aminatouCost);
@@ -255,13 +240,9 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
 
 class AminatousAuguryCost extends CostImpl {
 
-    //private static String aminatouId;
-
     AminatousAuguryCost() {
-
         this.text = "for each nonland cardtype, you may cast a card of that type from among the exiled cards without paying its mana cost";
     }
-
 
     AminatousAuguryCost(final AminatousAuguryCost cost) {
         super(cost);
@@ -270,36 +251,25 @@ class AminatousAuguryCost extends CostImpl {
     @Override
     public boolean pay(Ability ability, Game game, UUID sourceId, UUID controllerId, boolean noMana, Cost costToPay) {
 
-
-        //System.out.println("EXID3: " + aminatouId);
-        //System.out.println("Ability Name: " + ability.getSourceObject(game).getName());
-        //load card types available for castings
-
-        System.out.println("Source ID for " + game.getCard(sourceId).getName() + " from Pay: " + sourceId.toString());
-
-        //load correct unusedCardType game state variable
+        /*
+         use map to match card to Aminatou card used to exile it. Then use Aminatou card Id, to load
+         castable card types
+        */
         HashMap<UUID,UUID> setLocater = (HashMap<UUID, UUID>) game.getState().getValue("cardToAminatouIdMap");
         String aminatouId = setLocater.get(sourceId).toString() + "_unusedCardTypes";
+        EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue(aminatouId);
 
-        //System.out.println("EXID3: " + aminatouId);
-        //System.out.println("Ability Name: " + ability.getSourceObject(game).getName());
-
-
-
-        EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue(aminatouId); //this one isn't changing
         if (unusedCardTypes == null){
             System.out.println("Failed to load cast type list");
-            return false;
+            return false; //return false, null or paid??
         } else {
             System.out.println("From Pay ID: " + aminatouId + " Castable types: " + unusedCardTypes.toString());
         }
 
 
-
         Set<CardType> castCardTypes = ability.getSourceObject(game).getCardType();
-
-
         if (castCardTypes != null) {
+
             //count matching available card types
             CardType useType = null;
             int numAvailTypes = 0;
@@ -310,7 +280,6 @@ class AminatousAuguryCost extends CostImpl {
                 }
             }
 
-            //System.out.println("Num avialble types " + numAvailTypes);
 
             if (numAvailTypes == 0){
                 //If no available types, then do not cast.
@@ -338,7 +307,6 @@ class AminatousAuguryCost extends CostImpl {
 
         //save changes to unused card types
         game.getState().setValue( aminatouId, unusedCardTypes);
-        System.out.println("From Exit Pay ID: " + aminatouId + " Castable types: " + unusedCardTypes.toString());
 
         return paid;
     }
@@ -359,10 +327,10 @@ class AminatousAuguryCardTypeChoice extends ChoiceImpl {
 
     //20180713 -- notes and rules via Scryfall: https://scryfall.com/card/mb1/285/aminatous-augury#rulings
     /*
-     * If a nonland card has multiple types, such as an artifact creature, you
-     * may cast it as either of those types. For example, you could cast one
-     * artifact creature as your artifact card and another artifact creature
-     * as your creature card.
+       If a nonland card has multiple types, such as an artifact creature, you
+       may cast it as either of those types. For example, you could cast one
+       artifact creature as your artifact card and another artifact creature
+       as your creature card.
      */
 
     AminatousAuguryCardTypeChoice(Set<CardType> selectFromTypes) {

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -171,7 +171,6 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
             if (card != null && Collections.disjoint(usedCardTypes,card.getCardType())) {
                 Player player = game.getPlayer(affectedControllerId);
                 if (player != null) {
-                    //This still has bug where you can cast spells that require additional non-mana costs
                     player.setCastSourceIdWithAlternateMana(objectId, null, card.getSpellAbility().getCosts());
                     return true;
                 }

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -111,6 +111,7 @@ class AminatousAuguryPlayLandAndExileEffect extends OneShotEffect {
              //  ContinuousRuleModifyingEffect effect = new AminatousAuguryCastFromExileEffect();
             //}
 
+            /*
             // Track all non-land cards put into exile with Aminatou
             Set<Card> aminatouCards = new HashSet<>();
             for (Card card : cards) {
@@ -119,10 +120,13 @@ class AminatousAuguryPlayLandAndExileEffect extends OneShotEffect {
                 }
             }
             //use unique id in case of multiple Aminatou's
-            game.getState().setValue(source.getSourceId().toString() + "Cards", aminatouCards);
+            //game.getState().setValue(source.getSourceId().toString() + "Cards", aminatouCards);
+
+             */
 
             //set list of unused card types -- TODO: Use exile zone id for unique identifier
             EnumSet<CardType> unusedCardTypes = EnumSet.allOf(CardType.class);
+            unusedCardTypes.remove(CardType.LAND); //untested
             //game.getState().setValue(source.getSourceId().toString() + "_unusedCardTypes", unusedCardTypes);
             game.getState().setValue("AA_unusedCardTypes", unusedCardTypes);
             System.out.println("ID:" + source.getSourceId().toString());
@@ -229,6 +233,7 @@ class AminatousAuguryCastFromExileEffectTwo extends AsThoughEffectImpl {
             return false;
         }
 
+        /*
         //cards put into exile using Aminatou -- created in AminatouAuguryEffect - Apply
         Set<Card> aminatouCards = (Set<Card>) game.getState().getValue(source.getSourceId().toString() + "Cards");
 
@@ -237,11 +242,22 @@ class AminatousAuguryCastFromExileEffectTwo extends AsThoughEffectImpl {
         if (game.getState().getValue(source.getSourceId().toString() + "UsedCardTypes") != null){
             usedCardTypes = (Set<CardType>) game.getState().getValue(source.getSourceId().toString() + "UsedCardTypes");
         }
+        */
+
+        // c
+
+        EnumSet<CardType> unusedCardTypes = (EnumSet<CardType>) game.getState().getValue("AA_unusedCardTypes" );
+        if (unusedCardTypes == null){
+            return false;
+        }
+
+
 
         if (objectId.equals(getTargetPointer().getFirst(game, source))
                 && playerId.equals(source.getControllerId())) {
 
             // Determine which card types from Aminatou cards were cast
+            /*
             Iterator<Card> chkCardCastIterator = aminatouCards.iterator();
             while(chkCardCastIterator.hasNext()){
                 Card chkCardCast = chkCardCastIterator.next();
@@ -254,10 +270,18 @@ class AminatousAuguryCastFromExileEffectTwo extends AsThoughEffectImpl {
             //save changes to used card types
             game.getState().setValue(source.getSourceId().toString() + "UsedCardTypes", usedCardTypes);
 
+
+             */
+
             // make all eligible cards types zero mana cost
             Card card = game.getCard(objectId);
+
+            //if ( unusedCardTypes.contains(card.getCardType())){
+                //allow casting
+            //}
+
             //if (card != null && Collections.disjoint(usedCardTypes,card.getCardType())) {
-            if (card != null ) {
+            if (card != null && !Collections.disjoint(unusedCardTypes,card.getCardType()) ) {
                     Player player = game.getPlayer(playerId);
                     if (player != null) {
 
@@ -396,18 +420,13 @@ class AminatousAuguryCost extends CostImpl {
         return paid;
     }
 
-
-    /*
-     * Cards that share types with types on the unused list should be listed
-     *  as canPay targets.
-     */
-
     @Override
     public boolean canPay(Ability ability, UUID sourceId, UUID controllerId, Game game) {
 
-        System.out.println( "EZID: " + game.getExile().getExileZone(exileZoneId));
-        System.out.println( "S ID: " + game.getState().getZone(sourceId));
+        //System.out.println( "EZID: " + game.getExile().getExileZone(exileZoneId));
+        //System.out.println( "S ID: " + game.getState().getZone(sourceId));
         return targets.canChoose(controllerId, game);
+
     }
 
     @Override


### PR DESCRIPTION
This addresses the issue of not being able to cast spells exiled with Aminatou's Augury. See issues
 #5876, #5859, #6076, #6461 and #5683. 

While working on this I noticed that other cards using the line:
`setCastSourceIdWithAlternateMana(objectId, null, card.getSpellAbility().getCosts());`
do not require non-mana costs, such as sacrifice or discard, when cast in this way. I believe this is incorrect so I will follow up with a separate issue. However, I left the line as is in the current code. 

Finally, since I'm still very new to all this, I would appreciate any feedback. In particular, when I cast the card, it seems to take the computer awhile to process. Perhaps this code could be better optimized. 

Thanks! 
