### PR TITLE
add missing quotes in rule text

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HeliodsPunishment.java
+++ b/Mage.Sets/src/mage/cards/h/HeliodsPunishment.java
@@ -62,7 +62,7 @@ class HeliodsPunishmentLoseAllAbilitiesEnchantedEffect extends ContinuousEffectI
 
     public HeliodsPunishmentLoseAllAbilitiesEnchantedEffect() {
         super(Duration.WhileOnBattlefield, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.LoseAbility);
-        staticText = "It loses all abilities and has \"{T}: Remove a task counter from {this}. Then if it has no task counters on it, destroy {this}.\" ";
+        staticText = "It loses all abilities and has \"{T}: Remove a task counter from {this}. Then if it has no task counters on it, destroy {this}.\"";
     }
 
     public HeliodsPunishmentLoseAllAbilitiesEnchantedEffect(final HeliodsPunishmentLoseAllAbilitiesEnchantedEffect effect) {

--- a/Mage.Sets/src/mage/cards/i/InevitableEnd.java
+++ b/Mage.Sets/src/mage/cards/i/InevitableEnd.java
@@ -1,5 +1,6 @@
 package mage.cards.i;
 
+import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -14,36 +15,38 @@ import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
-import java.util.UUID;
-
 /**
  * @author TheElk801
  */
 public final class InevitableEnd extends CardImpl {
 
     public InevitableEnd(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{B}");
+        super(ownerId, setInfo, new CardType[] {CardType.ENCHANTMENT},
+              "{2}{B}");
 
         this.subtype.add(SubType.AURA);
 
         // Enchant creature
         TargetPermanent auraTarget = new TargetCreaturePermanent();
         this.getSpellAbility().addTarget(auraTarget);
-        this.getSpellAbility().addEffect(new AttachEffect(Outcome.BoostCreature));
+        this.getSpellAbility().addEffect(
+            new AttachEffect(Outcome.BoostCreature));
         Ability ability = new EnchantAbility(auraTarget.getTargetName());
         this.addAbility(ability);
 
-        // Enchanted creature has "At the beginning of your upkeep, sacrifice a creature."
+        // Enchanted creature has "At the beginning of your upkeep, sacrifice a
+        // creature."
+        BeginningOfUpkeepTriggeredAbility triggeredAbility =
+            new BeginningOfUpkeepTriggeredAbility(
+                new SacrificeControllerEffect(
+                    StaticFilters.FILTER_PERMANENT_CREATURE, 1, null),
+                TargetController.YOU, false);
         this.addAbility(new SimpleStaticAbility(new GainAbilityAttachedEffect(
-                new BeginningOfUpkeepTriggeredAbility(new SacrificeControllerEffect(
-                        StaticFilters.FILTER_PERMANENT_CREATURE, 1, null
-                ), TargetController.YOU, false), AttachmentType.AURA
-        )));
+            triggeredAbility, AttachmentType.AURA, Duration.WhileOnBattlefield,
+            "Enchanted creature has \"" + triggeredAbility.getRule() + "\"")));
     }
 
-    private InevitableEnd(final InevitableEnd card) {
-        super(card);
-    }
+    private InevitableEnd(final InevitableEnd card) { super(card); }
 
     @Override
     public InevitableEnd copy() {


### PR DESCRIPTION
As a follow up to pr #6494 and issue #6477 I checked all cards that might use the `GainAbilityAttachedEffect` ( [these are the cards I checked](https://scryfall.com/search?as=grid&order=name&q=o%3D%27%22%27+%28o%3Dequiped+or+o%3Denchanted%29&unique=cards) ) and only found [heliods punishment](https://scryfall.com/card/thb/21/heliods-punishment) and [inevitable end](https://scryfall.com/card/thb/102/inevitable-end) in the output of the test log.