### PR TITLE
Fixed Thousand-Year Storm and Mirari and added hint to Aetherflux Res…

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AetherfluxReservoir.java
+++ b/Mage.Sets/src/mage/cards/a/AetherfluxReservoir.java
@@ -10,6 +10,7 @@ import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.GainLifeEffect;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -28,12 +29,14 @@ public final class AetherfluxReservoir extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{4}");
 
         // Whenever you cast a spell, you gain 1 life for each spell you've cast this turn.
-        this.addAbility(new SpellCastControllerTriggeredAbility(new GainLifeEffect(new AetherfluxReservoirDynamicValue()), false));
+        Ability abilityGainLife = new SpellCastControllerTriggeredAbility(new GainLifeEffect(new AetherfluxReservoirDynamicValue()), false);
+        abilityGainLife.addHint(new ValueHint("You've cast spells this turn", new AetherfluxReservoirDynamicValue()));
+        this.addAbility(abilityGainLife);
 
         // Pay 50 life: Aetherflux Reservoir deals 50 damage to any target.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(50), new PayLifeCost(50));
-        ability.addTarget(new TargetAnyTarget());
-        this.addAbility(ability);
+        Ability abilityPayLife = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(50), new PayLifeCost(50));
+        abilityPayLife.addTarget(new TargetAnyTarget());
+        this.addAbility(abilityPayLife);
     }
 
     public AetherfluxReservoir(final AetherfluxReservoir card) {

--- a/Mage.Sets/src/mage/cards/s/SentinelTower.java
+++ b/Mage.Sets/src/mage/cards/s/SentinelTower.java
@@ -2,10 +2,13 @@ package mage.cards.s;
 
 import mage.MageObject;
 import mage.MageObjectReference;
+import mage.abilities.Ability;
 import mage.abilities.common.SpellCastAllTriggeredAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -44,13 +47,18 @@ public final class SentinelTower extends CardImpl {
 
 class SentinelTowerTriggeredAbility extends SpellCastAllTriggeredAbility {
 
+    private String damageInfo;
+
     SentinelTowerTriggeredAbility() {
         super(new DamageTargetEffect(0), StaticFilters.FILTER_SPELL_AN_INSTANT_OR_SORCERY, false);
         this.addTarget(new TargetAnyTarget());
+        this.addHint(new ValueHint("There were cast instant and sorcery this turn", SentinelTowerSpellsCastValue.instance));
+        this.damageInfo = null;
     }
 
     SentinelTowerTriggeredAbility(final SentinelTowerTriggeredAbility effect) {
         super(effect);
+        this.damageInfo = effect.damageInfo;
     }
 
     @Override
@@ -78,6 +86,7 @@ class SentinelTowerTriggeredAbility extends SpellCastAllTriggeredAbility {
                     break;
                 }
             }
+            damageInfo = " (<b>" + damageToDeal + " damage</b>)";
             for (Effect effect : this.getEffects()) {
                 if (effect instanceof DamageTargetEffect) {
                     ((DamageTargetEffect) effect).setAmount(StaticValue.get(damageToDeal));
@@ -92,7 +101,8 @@ class SentinelTowerTriggeredAbility extends SpellCastAllTriggeredAbility {
     public String getRule() {
         return "Whenever an instant or sorcery spell is cast during your turn, "
                 + "{this} deals damage to any target equal to 1 "
-                + "plus the number of instant and sorcery spells cast before that spell this turn.";
+                + "plus the number of instant and sorcery spells cast before that spell this turn."
+                + ((damageInfo == null) ? "" : damageInfo);
     }
 }
 
@@ -122,5 +132,38 @@ class SentinelTowerWatcher extends Watcher {
 
     public List<MageObjectReference> getSpellsThisTurn() {
         return spellsThisTurn;
+    }
+}
+
+enum SentinelTowerSpellsCastValue implements DynamicValue {
+
+    instance;
+
+    @Override
+    public int calculate(Game game, Ability sourceAbility, Effect effect) {
+        SentinelTowerWatcher watcher = game.getState().getWatcher(SentinelTowerWatcher.class);
+        if (watcher == null) {
+            return 0;
+        }
+        List<MageObjectReference> spellsCast = watcher.getSpellsThisTurn();
+        if (spellsCast == null) {
+            return 0;
+        }
+        return spellsCast.size();
+    }
+
+    @Override
+    public SentinelTowerSpellsCastValue copy() {
+        return instance;
+    }
+
+    @Override
+    public String toString() {
+        return "X";
+    }
+
+    @Override
+    public String getMessage() {
+        return "There was an instant or sorcery spell in this turn";
     }
 }

--- a/Mage.Sets/src/mage/cards/t/ThousandYearStorm.java
+++ b/Mage.Sets/src/mage/cards/t/ThousandYearStorm.java
@@ -156,26 +156,10 @@ class ThousandYearStormEffect extends OneShotEffect {
 
 class ThousandYearStormWatcher extends Watcher {
 
-    private final HashMap<UUID, List<MageObjectReference>> spellsThisTurn;
+    private final Map<UUID, List<MageObjectReference>> spellsThisTurn = new HashMap<>();
 
     public ThousandYearStormWatcher() {
         super(WatcherScope.GAME);
-        this.spellsThisTurn = new HashMap<>();
-    }
-
-    public ThousandYearStormWatcher(final ThousandYearStormWatcher watcher) {
-        super(watcher);
-        // deep copy HashMap
-        this.spellsThisTurn = new HashMap<UUID, List<MageObjectReference>>();
-        for (Map.Entry<UUID, List<MageObjectReference>> entry : watcher.spellsThisTurn.entrySet())
-        {
-            this.spellsThisTurn.put(entry.getKey(), new ArrayList<MageObjectReference>(entry.getValue()));
-        }
-    }
-
-    @Override
-    public ThousandYearStormWatcher copy() {
-        return new ThousandYearStormWatcher(this);
     }
 
     @Override

--- a/Mage/src/main/java/mage/watchers/Watcher.java
+++ b/Mage/src/main/java/mage/watchers/Watcher.java
@@ -115,26 +115,33 @@ public abstract class Watcher implements Serializable {
                         ((Set) field.get(watcher)).clear();
                         ((Set) field.get(watcher)).addAll((Set) field.get(this));
                     } else if (field.getType() == Map.class) {
-                        Map target = ((Map) field.get(watcher));
-                        target.clear();
-                        Map source = (Map) field.get(this);
-
                         ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
                         Type valueType = parameterizedType.getActualTypeArguments()[1];
-                        if (valueType.getClass().getSimpleName().contains("Set")) {
-                            source.entrySet().forEach(kv -> {
-                                Object key = ((Map.Entry) kv).getKey();
-                                Set value = (Set) ((Map.Entry) kv).getValue();
-                                target.put(key, new HashSet<>(value));
-                            });
+                        if (valueType.getTypeName().contains("Set")) {
+                            Map<Object, Set<Object>> target = (Map<Object, Set<Object>>) field.get(watcher);
+                            Map<Object, Set<Object>> source = (Map<Object, Set<Object>>) field.get(this);
+                            target.clear();
+                            for (Map.Entry<Object, Set<Object>> e : source.entrySet()) {
+                                Set<Object> set = new HashSet<>();
+                                set.addAll(e.getValue());
+                                target.put(e.getKey(), set);
+                            }
                         }
-                        else {
+                        else if (valueType.getTypeName().contains("List")) {
+                            Map<Object, List<Object>> target = (Map<Object, List<Object>>) field.get(watcher);
+                            Map<Object, List<Object>> source = (Map<Object, List<Object>>) field.get(this);
+                            target.clear();
+                            for (Map.Entry<Object, List<Object>> e : source.entrySet()) {
+                                List<Object> list = new ArrayList<>();
+                                list.addAll(e.getValue());
+                                target.put(e.getKey(), list);
+                            }
+                        } else {
                             ((Map) field.get(watcher)).putAll((Map) field.get(this));
                         }
                     } else if (field.getType() == List.class) {
                         ((List) field.get(watcher)).clear();
                         ((List) field.get(watcher)).addAll((List) field.get(this));
-
                     } else {
                         field.set(watcher, field.get(this));
                     }

--- a/Mage/src/test/java/mage/WatcherTest.java
+++ b/Mage/src/test/java/mage/WatcherTest.java
@@ -1,15 +1,17 @@
 package mage;
 
 import static mage.constants.WatcherScope.GAME;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableSet;
 import mage.constants.WatcherScope;
 import mage.game.Game;
 import mage.game.events.GameEvent;
@@ -19,7 +21,7 @@ import org.junit.Test;
 public class WatcherTest {
 
   @Test
-  public void test() {
+  public void testShallowCopy() {
     // Given
     Map<String, String> mapField = new HashMap<>();
     mapField.put("mapFieldKey1", "mapFieldValue1");
@@ -43,6 +45,60 @@ public class WatcherTest {
     assertEquals(ImmutableMap.of("mapFieldKey1", "mapFieldValue1", "mapFieldKey2", "mapFieldValue2"), copy.getMapField());
   }
 
+  @Test
+  public void testDeepCopy() {
+    // Given
+    Map<String, List<String>> listInMapField = new HashMap<>();
+    List<String> list1 = new ArrayList<>();
+    list1.add("v1");
+    list1.add("v1.1");
+    List<String> list2 = new ArrayList<>();
+    list2.add("v2");
+    listInMapField.put("k1", list1);
+    listInMapField.put("k2", list2);
+
+    Map<String, Set<String>> setInMapField = new HashMap<>();
+    Set<String> set1 = new HashSet<>();
+    set1.add("v3");
+    Set<String> set2 = new HashSet<>();
+    set2.add("v4");
+    set2.add("v4.1");
+    setInMapField.put("k3", set1);
+    setInMapField.put("k4", set2);
+    setInMapField.put("k", new HashSet<String>());
+
+    TestWatcher testWatcher = new TestWatcher(GAME);
+    testWatcher.setListInMapField(listInMapField);
+    testWatcher.setSetInMapField(setInMapField);
+
+    // When
+    TestWatcher copy = testWatcher.copy();
+
+    // And
+    testWatcher.getListInMapField().get("k1").add("v1.2");
+    List<String> list3 = new ArrayList<>();
+    list3.add("v5");
+    testWatcher.getListInMapField().put("k5", list3);
+    testWatcher.getSetInMapField().get("k3").add("v3.1");
+
+    // Then
+    Map<String, List<String>> copyListInMap = copy.getListInMapField();
+    assertEquals(2, copyListInMap.size());
+    assertTrue(copyListInMap.containsKey("k1"));
+    assertEquals(ImmutableList.of("v1", "v1.1"), copyListInMap.get("k1"));
+    assertTrue(copyListInMap.containsKey("k2"));
+    assertEquals(ImmutableList.of("v2"), copyListInMap.get("k2"));
+
+    Map<String, Set<String>> copySetInMap = copy.getSetInMapField();
+    assertEquals(3, copySetInMap.size());
+    assertTrue(copySetInMap.containsKey("k3"));
+    assertEquals(ImmutableSet.of("v3"), copySetInMap.get("k3"));
+    assertTrue(copySetInMap.containsKey("k4"));
+    assertEquals(ImmutableSet.of("v4", "v4.1"), copySetInMap.get("k4"));
+    assertTrue(copySetInMap.containsKey("k"));
+    assertEquals(ImmutableSet.of(), copySetInMap.get("k"));
+  }
+
   private Set<String> set(String... values) {
     return Stream.of(values).collect(Collectors.toSet());
   }
@@ -51,6 +107,8 @@ public class WatcherTest {
     private String stringField;
     private Set<String> setField = new HashSet<>();
     private Map<String, String> mapField = new HashMap<>();
+    private Map<String, List<String>> listInMapField = new HashMap<>();
+    private Map<String, Set<String>> setInMapField = new HashMap<>();
 
     public TestWatcher(WatcherScope scope) {
       super(scope);
@@ -83,6 +141,22 @@ public class WatcherTest {
 
     public void setMapField(Map<String, String> mapField) {
       this.mapField = mapField;
+    }
+
+    public Map<String, List<String>> getListInMapField() {
+      return listInMapField;
+    }
+
+    public void setListInMapField(Map<String, List<String>> listInMapField) {
+      this.listInMapField = listInMapField;
+    }
+
+    public Map<String, Set<String>> getSetInMapField() {
+      return setInMapField;
+    }
+
+    public void setSetInMapField(Map<String, Set<String>> setInMapField) {
+      this.setInMapField = setInMapField;
     }
   }
 }


### PR DESCRIPTION
This addresses the issue of Thousand-Year Storm copying spells incorrectly or not at all #5698 #6076 and Mirari not copying stuff #5844 #6291 #6338

I reimplemented the Thousand-Year Storm ability to function simular to the Sentinel Tower abiliy. This fixes the error of only one copy of the card working properly in the deck and the other ones doing nothing.
With this change it now also calculates the right number of copies when:
Cast a Shock -> (with Thousand-Year Storm trigger on the stack) -> Narset's Reversal the Shock -> Cast the same Shock again
Previous to this change the Thousand-Year Storm trigger of the Shock at the beginning copied it 2 times instead of making no copies (as no spells have been cast before this turn)

I also replaced Miraris custom triggerd ability with ```SpellCastControllerTriggeredAbility``` due to the custom ability not working properly.

While doing this changes I noticed that Aetherflux Resovoir and Sentinel Tower are missing hints although it would be nice to have them here as well. I added hints simular to the one on Thousand Year-Storm.