### PR TITLE
Archon clone null exception

### DIFF
--- a/Mage.Sets/src/mage/cards/a/ArchonOfValorsReach.java
+++ b/Mage.Sets/src/mage/cards/a/ArchonOfValorsReach.java
@@ -169,6 +169,11 @@ class ArchonOfValorsReachReplacementEffect extends ContinuousRuleModifyingEffect
 
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
+        
+        if ((String) game.getState().getValue(source.getSourceId().toString() + "_cardtype") == null){
+            return false;
+        }
+        
         CardType cardType = ArchonOfValorsReachChoice.getType((String) game.getState().getValue(source.getSourceId().toString() + "_cardtype"));
         // spell is not on the stack yet, so we have to check the card
         Card card = game.getCard(event.getSourceId());


### PR DESCRIPTION
When a creature copies Archon of Valor's Reach that is already on the battlefield (Volrath the Shapestealer as an example). The choice for what card type the Archon stops from been able to cast never happens, therefore errors with a null exception and rolls back when it tries to apply the restriction.

This commit merely stops the null exception error, which allows the game to continue allowing the creature to copy the Archon.

I would suggest that this needs looking into further (by someone who has more knowledge than I). As really it shouldn't try to apply the Archon restrict ability if a choice hasn't been made. But I'm not sure how to remove the ability.