### PR TITLE
Fix Marrow-Gnawer sacrifice cost

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MarrowGnawer.java
+++ b/Mage.Sets/src/mage/cards/m/MarrowGnawer.java
@@ -51,8 +51,8 @@ public final class MarrowGnawer extends CardImpl {
 
         // {T}, Sacrifice a Rat: create X 1/1 black Rat creature tokens, where X is the number of Rats you control.
         Ability ability;
-        ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new CreateTokenEffect(new RatToken(),new PermanentsOnBattlefieldCount(filter3)), new SacrificeTargetCost(new TargetControlledPermanent(filterSacrifice)));
-        ability.addCost(new TapSourceCost());
+        ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new CreateTokenEffect(new RatToken(),new PermanentsOnBattlefieldCount(filter3)), new TapSourceCost());
+        ability.addCost(new SacrificeTargetCost(new TargetControlledPermanent(filterSacrifice)));
         this.addAbility(ability);
     }
 


### PR DESCRIPTION
Hello,
At the moment, Marrow-Gnawer is unable to sacrifice itself. See https://github.com/magefree/mage/issues/5879
Marrow-Gnawer's text, as printed on the card, is:
> Tap, Sacrifice a Rat: Create X 1/1 black Rat creature tokens, where X is the number of Rats you control.

However, on XMage, Marrow-Gnawer's text currently is:
> Sacrifice a Rat, Tap: Create X 1/1 black Rat creature tokens, where X is the number of Rats you control.

XMage doesn't let Marrow-Gnawer sacrifice itself because "Sacrifice a Rat" is put before the tap (contrary to the original text).

I have never touched XMage code, so this is only an attempt to solve the issue. I took inspiration from Bloodshot Cyclops, which has a similar ability. I am unable to test this fix, I am sorry about that.

Cheers