### PR TITLE
Unlicensed disintegration no damage

### DIFF
--- a/Mage.Sets/src/mage/cards/u/UnlicensedDisintegration.java
+++ b/Mage.Sets/src/mage/cards/u/UnlicensedDisintegration.java
@@ -25,10 +25,10 @@ public final class UnlicensedDisintegration extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addEffect(new DestroyTargetEffect());
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new DamageTargetControllerEffect(3),
+                new DamageTargetControllerEffect(3,false,true),
                 new PermanentsOnTheBattlefieldCondition(new FilterControlledArtifactPermanent()),
                 "If you control an artifact, Unlicensed Disintegration deals 3 damage to that creature's controller"));
-
+        
     }
 
     public UnlicensedDisintegration(final UnlicensedDisintegration card) {

--- a/Mage.Sets/src/mage/cards/u/UnlicensedDisintegration.java
+++ b/Mage.Sets/src/mage/cards/u/UnlicensedDisintegration.java
@@ -25,7 +25,7 @@ public final class UnlicensedDisintegration extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addEffect(new DestroyTargetEffect());
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new DamageTargetControllerEffect(3,false,true),
+                new DamageTargetControllerEffect(3),
                 new PermanentsOnTheBattlefieldCondition(new FilterControlledArtifactPermanent()),
                 "If you control an artifact, Unlicensed Disintegration deals 3 damage to that creature's controller"));
         

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/destroy/UnlicensedDisintegrationTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/destroy/UnlicensedDisintegrationTest.java
@@ -1,0 +1,115 @@
+package org.mage.test.cards.abilities.oneshot.destroy;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+
+/*
+Unlicensed Disintigration - Hi! Noticed that everytime that i succesfully cast 
+Unlicensed Disintigration with an artifact on the board the opponent wont lose 3 life. 
+The creature dies but the last piece of text does not work (teM, 2020-02-24 15:17:36)
+*/
+public class UnlicensedDisintegrationTest extends CardTestPlayerBase{
+    
+    @Test
+    public void testDestroyCreatureLifeLoss(){
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.HAND, playerA, "Unlicensed Disintegration");
+        addCard(Zone.BATTLEFIELD, playerB, "Volrath, the Shapestealer");
+        
+        // Need an artifact to trigger the damage
+        addCard(Zone.BATTLEFIELD, playerA, "Sol Ring");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unlicensed Disintegration", "Volrath, the Shapestealer");
+        
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        
+        setStrictChooseMode(true);
+        execute();
+        assertAllCommandsUsed();
+        
+        assertLife(playerA, 20);
+        assertGraveyardCount(playerA, "Unlicensed Disintegration", 1);
+        assertLife(playerB, 17);
+        assertGraveyardCount(playerB, "Volrath, the Shapestealer", 1);
+    }
+  
+    @Test
+    public void testDestroyCreatureLifeLossIndestructible(){
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.HAND, playerA, "Unlicensed Disintegration");
+        addCard(Zone.BATTLEFIELD, playerB, "Volrath, the Shapestealer");
+        addCard(Zone.BATTLEFIELD, playerB, "Avacyn, Angel of Hope");
+        
+        // Need an artifact to trigger the damage
+        addCard(Zone.BATTLEFIELD, playerA, "Sol Ring");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unlicensed Disintegration", "Volrath, the Shapestealer");
+        
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        
+        setStrictChooseMode(true);
+        execute();
+        assertAllCommandsUsed();
+        
+        assertLife(playerA, 20);
+        assertGraveyardCount(playerA, "Unlicensed Disintegration", 1);
+        
+        assertLife(playerB, 17);
+        assertPermanentCount(playerB, "Volrath, the Shapestealer", 1);
+        assertPermanentCount(playerB, "Avacyn, Angel of Hope", 1);
+    }
+
+    @Test
+    public void testDestroyCreatureNoLifeLossNoArtifact(){
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.HAND, playerA, "Unlicensed Disintegration");
+        addCard(Zone.BATTLEFIELD, playerB, "Volrath, the Shapestealer");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unlicensed Disintegration", "Volrath, the Shapestealer");
+        
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        
+        setStrictChooseMode(true);
+        execute();
+        assertAllCommandsUsed();
+        
+        assertLife(playerA, 20);
+        assertGraveyardCount(playerA, "Unlicensed Disintegration", 1);
+        assertLife(playerB, 20);
+        assertGraveyardCount(playerB, "Volrath, the Shapestealer", 1);
+    }
+
+    @Test
+    public void testDestroyCreatureNoLifeLossNoArtifactIndestructible(){
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.HAND, playerA, "Unlicensed Disintegration");
+        addCard(Zone.BATTLEFIELD, playerB, "Volrath, the Shapestealer");
+        addCard(Zone.BATTLEFIELD, playerB, "Avacyn, Angel of Hope");
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unlicensed Disintegration", "Volrath, the Shapestealer");
+        
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        
+        setStrictChooseMode(true);
+        execute();
+        assertAllCommandsUsed();
+        
+        assertLife(playerA, 20);
+        assertGraveyardCount(playerA, "Unlicensed Disintegration", 1);
+        
+        assertLife(playerB, 20);
+        assertPermanentCount(playerB, "Volrath, the Shapestealer", 1);
+        assertPermanentCount(playerB, "Avacyn, Angel of Hope", 1);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/destroy/UnlicensedDisintegrationTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/destroy/UnlicensedDisintegrationTest.java
@@ -13,18 +13,31 @@ The creature dies but the last piece of text does not work (teM, 2020-02-24 15:1
 */
 public class UnlicensedDisintegrationTest extends CardTestPlayerBase{
     
+    /*
+    Unlicensed Disintegration {1}{B}{R}
+    
+    Destroy target creature. If you control an artifact, 
+    Unlicensed Disintegration deals 3 damage to that creature's controller.
+    
+    
+    Avacyn, Angel of Hope {5}{W}{W}
+    
+    Flying, vigilance, indestructible
+    Other permanents you control have indestructible.
+    */
+    
     @Test
     public void testDestroyCreatureLifeLoss(){
-        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
-        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
-        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
         addCard(Zone.HAND, playerA, "Unlicensed Disintegration");
-        addCard(Zone.BATTLEFIELD, playerB, "Volrath, the Shapestealer");
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp",2);
         
         // Need an artifact to trigger the damage
         addCard(Zone.BATTLEFIELD, playerA, "Sol Ring");
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unlicensed Disintegration", "Volrath, the Shapestealer");
+        // Play Unlicensed Disintegration, targeting Balduvian Bears
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unlicensed Disintegration", "Balduvian Bears");
         
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         
@@ -35,22 +48,22 @@ public class UnlicensedDisintegrationTest extends CardTestPlayerBase{
         assertLife(playerA, 20);
         assertGraveyardCount(playerA, "Unlicensed Disintegration", 1);
         assertLife(playerB, 17);
-        assertGraveyardCount(playerB, "Volrath, the Shapestealer", 1);
+        assertGraveyardCount(playerB, "Balduvian Bears", 1);
     }
   
     @Test
     public void testDestroyCreatureLifeLossIndestructible(){
-        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
-        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
-        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
         addCard(Zone.HAND, playerA, "Unlicensed Disintegration");
-        addCard(Zone.BATTLEFIELD, playerB, "Volrath, the Shapestealer");
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears");
         addCard(Zone.BATTLEFIELD, playerB, "Avacyn, Angel of Hope");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp",2);
         
         // Need an artifact to trigger the damage
         addCard(Zone.BATTLEFIELD, playerA, "Sol Ring");
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unlicensed Disintegration", "Volrath, the Shapestealer");
+        // Play Unlicensed Disintegration, targeting Balduvian Bears
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unlicensed Disintegration", "Balduvian Bears");
         
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         
@@ -62,19 +75,19 @@ public class UnlicensedDisintegrationTest extends CardTestPlayerBase{
         assertGraveyardCount(playerA, "Unlicensed Disintegration", 1);
         
         assertLife(playerB, 17);
-        assertPermanentCount(playerB, "Volrath, the Shapestealer", 1);
+        assertPermanentCount(playerB, "Balduvian Bears", 1);
         assertPermanentCount(playerB, "Avacyn, Angel of Hope", 1);
     }
 
     @Test
     public void testDestroyCreatureNoLifeLossNoArtifact(){
-        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
-        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
-        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
         addCard(Zone.HAND, playerA, "Unlicensed Disintegration");
-        addCard(Zone.BATTLEFIELD, playerB, "Volrath, the Shapestealer");
-
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unlicensed Disintegration", "Volrath, the Shapestealer");
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp",2);
+        
+        // Play Unlicensed Disintegration, targeting Balduvian Bears
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unlicensed Disintegration", "Balduvian Bears");
         
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         
@@ -85,19 +98,19 @@ public class UnlicensedDisintegrationTest extends CardTestPlayerBase{
         assertLife(playerA, 20);
         assertGraveyardCount(playerA, "Unlicensed Disintegration", 1);
         assertLife(playerB, 20);
-        assertGraveyardCount(playerB, "Volrath, the Shapestealer", 1);
+        assertGraveyardCount(playerB, "Balduvian Bears", 1);
     }
 
     @Test
     public void testDestroyCreatureNoLifeLossNoArtifactIndestructible(){
         addCard(Zone.BATTLEFIELD, playerA, "Mountain");
-        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
-        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp",2);  
         addCard(Zone.HAND, playerA, "Unlicensed Disintegration");
-        addCard(Zone.BATTLEFIELD, playerB, "Volrath, the Shapestealer");
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears");
         addCard(Zone.BATTLEFIELD, playerB, "Avacyn, Angel of Hope");
         
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unlicensed Disintegration", "Volrath, the Shapestealer");
+        // Play Unlicensed Disintegration, targeting Balduvian Bears
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Unlicensed Disintegration", "Balduvian Bears");
         
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         
@@ -109,7 +122,7 @@ public class UnlicensedDisintegrationTest extends CardTestPlayerBase{
         assertGraveyardCount(playerA, "Unlicensed Disintegration", 1);
         
         assertLife(playerB, 20);
-        assertPermanentCount(playerB, "Volrath, the Shapestealer", 1);
+        assertPermanentCount(playerB, "Balduvian Bears", 1);
         assertPermanentCount(playerB, "Avacyn, Angel of Hope", 1);
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/DamageTargetControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DamageTargetControllerEffect.java
@@ -5,9 +5,7 @@ import mage.abilities.Mode;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.OneShotEffect;
-import mage.cards.Card;
 import mage.constants.Outcome;
-import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -19,7 +17,6 @@ public class DamageTargetControllerEffect extends OneShotEffect {
 
     protected DynamicValue amount;
     protected boolean preventable;
-    protected boolean useLastKnownInfo;
 
     public DamageTargetControllerEffect(int amount) {
         this(StaticValue.get(amount), true);
@@ -27,11 +24,6 @@ public class DamageTargetControllerEffect extends OneShotEffect {
 
     public DamageTargetControllerEffect(int amount, boolean preventable) {
         this(StaticValue.get(amount), preventable);
-    }
-    
-    public DamageTargetControllerEffect(int amount, boolean preventable, boolean useLastKnownInfo) {
-        this(StaticValue.get(amount), preventable);
-        this.useLastKnownInfo = useLastKnownInfo;
     }
 
     public DamageTargetControllerEffect(DynamicValue amount) {
@@ -48,7 +40,6 @@ public class DamageTargetControllerEffect extends OneShotEffect {
         super(effect);
         amount = effect.amount.copy();
         preventable = effect.preventable;
-        useLastKnownInfo = effect.useLastKnownInfo;
     }
 
     @Override
@@ -58,16 +49,7 @@ public class DamageTargetControllerEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Permanent permanent = game.getPermanent(getTargetPointer().getFirst(game, source));
-
-        if (permanent == null && useLastKnownInfo){
-            Card card = game.getCard(targetPointer.getFirst(game, source));
-
-            if (card != null) {
-                permanent = (Permanent) game.getLastKnownInformation(card.getId(), Zone.BATTLEFIELD);
-            }
-        }
-        
+        Permanent permanent = game.getPermanentOrLKIBattlefield(getTargetPointer().getFirst(game, source));
         if (permanent != null) {
             Player targetController = game.getPlayer(permanent.getControllerId());
             if (targetController != null) {

--- a/Mage/src/main/java/mage/abilities/effects/common/DamageTargetControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DamageTargetControllerEffect.java
@@ -5,7 +5,9 @@ import mage.abilities.Mode;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.OneShotEffect;
+import mage.cards.Card;
 import mage.constants.Outcome;
+import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -17,6 +19,7 @@ public class DamageTargetControllerEffect extends OneShotEffect {
 
     protected DynamicValue amount;
     protected boolean preventable;
+    protected boolean useLastKnownInfo;
 
     public DamageTargetControllerEffect(int amount) {
         this(StaticValue.get(amount), true);
@@ -24,6 +27,11 @@ public class DamageTargetControllerEffect extends OneShotEffect {
 
     public DamageTargetControllerEffect(int amount, boolean preventable) {
         this(StaticValue.get(amount), preventable);
+    }
+    
+    public DamageTargetControllerEffect(int amount, boolean preventable, boolean useLastKnownInfo) {
+        this(StaticValue.get(amount), preventable);
+        this.useLastKnownInfo = useLastKnownInfo;
     }
 
     public DamageTargetControllerEffect(DynamicValue amount) {
@@ -40,6 +48,7 @@ public class DamageTargetControllerEffect extends OneShotEffect {
         super(effect);
         amount = effect.amount.copy();
         preventable = effect.preventable;
+        useLastKnownInfo = effect.useLastKnownInfo;
     }
 
     @Override
@@ -50,6 +59,15 @@ public class DamageTargetControllerEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Permanent permanent = game.getPermanent(getTargetPointer().getFirst(game, source));
+
+        if (permanent == null && useLastKnownInfo){
+            Card card = game.getCard(targetPointer.getFirst(game, source));
+
+            if (card != null) {
+                permanent = (Permanent) game.getLastKnownInformation(card.getId(), Zone.BATTLEFIELD);
+            }
+        }
+        
         if (permanent != null) {
             Player targetController = game.getPlayer(permanent.getControllerId());
             if (targetController != null) {


### PR DESCRIPTION
This issue is one of defects listed in: 
#6291 v5 04.03.2020

and someone mentioned this issue on Reddit:
https://www.reddit.com/r/XMage/comments/fzys43/unlicenced_disintegration_bug/

When Unlicensed Disintegration successfully destroys a creature the opponent doesn't lose the 3 life as expected. In this scenario, DamageTargetControllerEffect's apply method, the permanent object is null. (If the creature isn't destroyed, because it's indestructible, then the code works fine).