### PR TITLE
Text correction on UntapLandsEffect

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/UntapLandsEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/UntapLandsEffect.java
@@ -17,7 +17,7 @@ import mage.util.CardUtil;
  */
 public class UntapLandsEffect extends OneShotEffect {
 
-    private static final FilterLandPermanent filter = new FilterLandPermanent("untapped lands");
+    private static final FilterLandPermanent filter = new FilterLandPermanent("tapped lands");
 
     static {
         filter.add(TappedPredicate.instance);


### PR DESCRIPTION
UntapLandsEffect asks you to choose untapped lands to untap; by changing the fillter from "untapped lands" to "tapped lands" (technically you can choose already untapped lands but...) it will now ask you to choose tapped lands to untap.