### PR TITLE
Updated commander zone change rules (ready for review)

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/commander/duel/CastBRGCommanderTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/commander/duel/CastBRGCommanderTest.java
@@ -160,7 +160,7 @@ public class CastBRGCommanderTest extends CardTestCommanderDuelBase {
         assertGraveyardCount(playerA, "Mogg Infestation", 1);
         assertCommandZoneCount(playerB, "Daxos of Meletis", 1);
 
-        assertPermanentCount(playerB, "Goblin", 0);
+        assertPermanentCount(playerB, "Goblin", 2);
 
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/commander/duel/CommanderReplaceEffectTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/commander/duel/CommanderReplaceEffectTest.java
@@ -110,8 +110,8 @@ public class CommanderReplaceEffectTest extends CardTestCommanderDuelBase {
         execute();
 
         assertPermanentCount(playerA, "Soulherder", 1);
-        assertPermanentCount(playerA, "Daxos of Meletis", 0);
-        assertCommandZoneCount(playerA, "Daxos of Meletis", 1);
+        assertPermanentCount(playerA, "Daxos of Meletis", 1);
+        assertCommandZoneCount(playerA, "Daxos of Meletis", 0);
         assertPowerToughness(playerA, "Soulherder", 2, 2);
 
     }

--- a/Mage.Tests/src/test/java/org/mage/test/commander/duel/MythUnboundTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/commander/duel/MythUnboundTest.java
@@ -52,7 +52,6 @@ public class MythUnboundTest extends CardTestCommanderDuelBase {
         assertPermanentCount(playerA, "Myth Unbound", 1);
         assertGraveyardCount(playerB, "Lightning Bolt", 1);
         assertPermanentCount(playerA, "Oviya Pashiri, Sage Lifecrafter", 1);
-        assertHandCount(playerA, 1);
         assertTappedCount("Forest", false, 4 - 3); // 1 for first, 2 for second cast
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/commander/duel/NorinTheWaryTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/commander/duel/NorinTheWaryTest.java
@@ -72,7 +72,7 @@ public class NorinTheWaryTest extends CardTestCommanderDuelBase {
     }
 
     @Test
-    public void castNorinTheWaryToCommandAndReturn() {
+    public void castNorinTheWaryToCommandAndNotReturn() {
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
         addCard(Zone.HAND, playerA, "Lightning Bolt", 1);
 
@@ -85,7 +85,7 @@ public class NorinTheWaryTest extends CardTestCommanderDuelBase {
         assertGraveyardCount(playerA, "Lightning Bolt", 1);
         assertPermanentCount(playerA, "Norin the Wary", 0);
         assertExileCount("Norin the Wary", 0);
-        assertCommandZoneCount(playerA,"Norin the Wary",1);
+        assertCommandZoneCount(playerA, "Norin the Wary", 1);
 
         assertLife(playerB, 37);
 

--- a/Mage.Tests/src/test/java/org/mage/test/commander/duel/NorinTheWaryTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/commander/duel/NorinTheWaryTest.java
@@ -83,8 +83,9 @@ public class NorinTheWaryTest extends CardTestCommanderDuelBase {
         execute();
 
         assertGraveyardCount(playerA, "Lightning Bolt", 1);
-        assertPermanentCount(playerA, "Norin the Wary", 1);
+        assertPermanentCount(playerA, "Norin the Wary", 0);
         assertExileCount("Norin the Wary", 0);
+        assertCommandZoneCount(playerA,"Norin the Wary",1);
 
         assertLife(playerB, 37);
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/CommanderReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/CommanderReplacementEffect.java
@@ -106,8 +106,6 @@ public class CommanderReplacementEffect extends ReplacementEffectImpl {
         switch (zEvent.getToZone()) {
             case LIBRARY:
             case HAND:
-            case GRAVEYARD:
-            case EXILED:
                 if (commanderId.equals(zEvent.getTargetId())) {
                     return true;
                 }

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -1874,12 +1874,12 @@ public abstract class GameImpl implements Game, Serializable {
                     .map(uuid -> getExile().getCard(uuid, this))
                     .filter(Objects::nonNull)
                     .forEach(commanders::add);
-            commanders.removeIf(card -> state.checkCommander(card, this));
+            commanders.removeIf(card -> state.checkCommanderShouldStay(card, this));
             for (Card card : commanders) {
                 if (player.chooseUse(Outcome.Benefit, "Move " + card.getIdName() + " to the command zone or leave it in its current zone?", "You can only make this choice once", "Move to command", "Leave in current zone", null, this)) {
                     toMove.add(card);
                 } else {
-                    state.stickCommander(card, this);
+                    state.setCommanderShouldStay(card, this);
                 }
             }
             if (toMove.isEmpty()) {

--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -1,6 +1,7 @@
 package mage.game;
 
 import mage.MageObject;
+import mage.MageObjectReference;
 import mage.abilities.*;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.ContinuousEffects;
@@ -100,6 +101,7 @@ public class GameState implements Serializable, Copyable<GameState> {
     private Map<UUID, Card> copiedCards = new HashMap<>();
     private int permanentOrderNumber;
     private Map<UUID, FilterCreaturePermanent> usePowerInsteadOfToughnessForDamageLethalityFilters = new HashMap<>();
+    private final Set<MageObjectReference> stuckCommanders = new HashSet<>();
 
     private int applyEffectsCounter; // Upcounting number of each applyEffects execution
 
@@ -1228,5 +1230,13 @@ public class GameState implements Serializable, Copyable<GameState> {
                 .filter(usePowerInsteadOfToughnessForDamageLethalityFilters::containsKey)
                 .map(usePowerInsteadOfToughnessForDamageLethalityFilters::get)
                 .collect(Collectors.toList());
+    }
+
+    boolean checkCommander(Card card, Game game) {
+        return stuckCommanders.stream().anyMatch(mor -> mor.refersTo(card, game));
+    }
+
+    void stickCommander(Card card, Game game) {
+        stuckCommanders.add(new MageObjectReference(card, game));
     }
 }

--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -101,7 +101,7 @@ public class GameState implements Serializable, Copyable<GameState> {
     private Map<UUID, Card> copiedCards = new HashMap<>();
     private int permanentOrderNumber;
     private Map<UUID, FilterCreaturePermanent> usePowerInsteadOfToughnessForDamageLethalityFilters = new HashMap<>();
-    private final Set<MageObjectReference> stuckCommanders = new HashSet<>();
+    private final Set<MageObjectReference> commandersToStay = new HashSet<>();
 
     private int applyEffectsCounter; // Upcounting number of each applyEffects execution
 
@@ -1232,11 +1232,11 @@ public class GameState implements Serializable, Copyable<GameState> {
                 .collect(Collectors.toList());
     }
 
-    boolean checkCommander(Card card, Game game) {
-        return stuckCommanders.stream().anyMatch(mor -> mor.refersTo(card, game));
+    boolean checkCommanderShouldStay(Card card, Game game) {
+        return commandersToStay.stream().anyMatch(mor -> mor.refersTo(card, game));
     }
 
-    void stickCommander(Card card, Game game) {
-        stuckCommanders.add(new MageObjectReference(card, game));
+    void setCommanderShouldStay(Card card, Game game) {
+        commandersToStay.add(new MageObjectReference(card, game));
     }
 }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -3882,7 +3882,7 @@ public abstract class PlayerImpl implements Player, Serializable {
                 break;
             case COMMAND:
                 for (Card card : cards) {
-                    if (moveCardToCommandWithInfo(card, source.getSourceId(), game, fromZone)) {
+                    if (moveCardToCommandWithInfo(card, source == null ? null : source.getSourceId(), game, fromZone)) {
                         successfulMovedCards.add(card);
                     }
                 }


### PR DESCRIPTION
Commanders go to the graveyard and exile zone the same way everything else does but will be able to go to the command zone as a state-based action. Going to other zones is still the same as before.