### PR TITLE
fixed #1219 - cavern of souls preventing counterspells even after permanent was bounced

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BoseijuWhoSheltersAll.java
+++ b/Mage.Sets/src/mage/cards/b/BoseijuWhoSheltersAll.java
@@ -1,10 +1,10 @@
 
 package mage.cards.b;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+
 import mage.MageObject;
+import mage.MageObjectReference;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTappedAbility;
@@ -58,7 +58,7 @@ public final class BoseijuWhoSheltersAll extends CardImpl {
 
 class BoseijuWhoSheltersAllWatcher extends Watcher {
 
-    private List<UUID> spells = new ArrayList<>();
+    private final Set<MageObjectReference> spells = new HashSet<>();
     private final UUID originalId;
 
     public BoseijuWhoSheltersAllWatcher(UUID originalId) {
@@ -69,17 +69,17 @@ class BoseijuWhoSheltersAllWatcher extends Watcher {
     @Override
     public void watch(GameEvent event, Game game) {
         if (event.getType() == GameEvent.EventType.MANA_PAID) {
-            if (event.getData() != null && event.getData().equals(originalId.toString())) {
+            if (event.getData() != null && event.getData().equals(originalId.toString()) && event.getTargetId() != null) {
                 Card spell = game.getSpell(event.getTargetId());
                 if (spell != null && (spell.isInstant() || spell.isSorcery())) {
-                    spells.add(event.getTargetId());
+                    spells.add(new MageObjectReference(game.getObject(event.getTargetId()), game));
                 }
             }
         }
     }
 
-    public boolean spellCantBeCountered(UUID spellId) {
-        return spells.contains(spellId);
+    public boolean spellCantBeCountered(MageObjectReference mor) {
+        return spells.contains(mor);
     }
 
     @Override
@@ -128,6 +128,6 @@ class BoseijuWhoSheltersAllCantCounterEffect extends ContinuousRuleModifyingEffe
     public boolean applies(GameEvent event, Ability source, Game game) {
         BoseijuWhoSheltersAllWatcher watcher = game.getState().getWatcher(BoseijuWhoSheltersAllWatcher.class, source.getSourceId());
         Spell spell = game.getStack().getSpell(event.getTargetId());
-        return spell != null && watcher != null && watcher.spellCantBeCountered(spell.getId());
+        return spell != null && watcher != null && watcher.spellCantBeCountered(new MageObjectReference(spell, game));
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/avr/CavernOfSoulsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/avr/CavernOfSoulsTest.java
@@ -296,5 +296,4 @@ public class CavernOfSoulsTest extends CardTestPlayerBase {
         assertGraveyardCount(playerB, "Counterspell", 2);
         assertGraveyardCount(playerB, "Unsummon", 1);
     }
-
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/avr/CavernOfSoulsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/avr/CavernOfSoulsTest.java
@@ -255,4 +255,46 @@ public class CavernOfSoulsTest extends CardTestPlayerBase {
 
     }
 
+    @Test
+    public void testBouncedCreatureNotCountered() {
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        addCard(Zone.HAND, playerA, "Forest");
+        addCard(Zone.HAND, playerA, "Cavern of Souls");
+        addCard(Zone.HAND, playerA, "Runeclaw Bear");
+
+        addCard(Zone.HAND, playerB, "Counterspell", 2);
+        addCard(Zone.HAND, playerB, "Unsummon");
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 5);
+
+        playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cavern of Souls");
+        setChoice(playerA, "Bear");
+
+        //wait for next turn, we'll need our next land drop
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Runeclaw Bear");
+
+        //make sure we used our cavern already and try to counter
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerB, "Counterspell");
+        waitStackResolved(3, PhaseStep.PRECOMBAT_MAIN);
+
+        checkPermanentCount("bear not countered", 3, PhaseStep.PRECOMBAT_MAIN, playerA, "Runeclaw Bear", 1);
+
+        //counterspell fizzled, return bear to hand to try countering it again
+        castSpell(3, PhaseStep.BEGIN_COMBAT, playerB, "Unsummon", "Runeclaw Bear");
+        waitStackResolved(3, PhaseStep.BEGIN_COMBAT);
+
+        //recast bear, without cavern of souls conditional mana
+        playLand(3, PhaseStep.POSTCOMBAT_MAIN, playerA, "Forest");
+        castSpell(3, PhaseStep.POSTCOMBAT_MAIN, playerA, "Runeclaw Bear");
+        castSpell(3, PhaseStep.POSTCOMBAT_MAIN, playerB, "Counterspell");
+
+        setStopAt(3, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerA, "Cavern of Souls", 1);
+        assertGraveyardCount(playerA, "Runeclaw Bear", 1);
+        assertGraveyardCount(playerB, "Counterspell", 2);
+        assertGraveyardCount(playerB, "Unsummon", 1);
+    }
+
 }


### PR DESCRIPTION
#1219 - cavern of souls watcher shouldn't track spell ids, it should track cast attempts of a given spell