### PR TITLE
Make watcher copy method deep copy Maps

### DIFF
--- a/Mage/src/main/java/mage/watchers/Watcher.java
+++ b/Mage/src/main/java/mage/watchers/Watcher.java
@@ -115,18 +115,38 @@ public abstract class Watcher implements Serializable {
                         ((Set) field.get(watcher)).clear();
                         ((Set) field.get(watcher)).addAll((Set) field.get(this));
                     } else if (field.getType() == Map.class) {
-                        Map target = ((Map) field.get(watcher));
-                        target.clear();
-                        Map source = (Map) field.get(this);
-
                         ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
                         Type valueType = parameterizedType.getActualTypeArguments()[1];
-                        if (valueType.getClass().getSimpleName().contains("Set")) {
-                            source.entrySet().forEach(kv -> {
-                                Object key = ((Map.Entry) kv).getKey();
-                                Set value = (Set) ((Map.Entry) kv).getValue();
-                                target.put(key, new HashSet<>(value));
-                            });
+                        if (valueType.getTypeName().contains("Set")) {
+                            Map<Object, Set<Object>> source = (Map<Object, Set<Object>>) field.get(this);
+                            Map<Object, Set<Object>> target = (Map<Object, Set<Object>>) field.get(watcher);
+                            target.clear();
+                            for (Map.Entry<Object, Set<Object>> e : source.entrySet()) {
+                                Set<Object> set = new HashSet<>();
+                                set.addAll(e.getValue());
+                                target.put(e.getKey(), set);
+                            }
+                        }
+                        else if (valueType.getTypeName().contains("List")) {
+                            Map<Object, List<Object>> source = (Map<Object, List<Object>>) field.get(this);
+                            Map<Object, List<Object>> target = (Map<Object, List<Object>>) field.get(watcher);
+                            target.clear();
+                            for (Map.Entry<Object, List<Object>> e : source.entrySet()) {
+                                List<Object> list = new ArrayList<>();
+                                list.addAll(e.getValue());
+                                target.put(e.getKey(), list);
+                            }
+                        }
+                        else if (valueType.getTypeName().contains("Map")) {
+                            Map<Object, Map<Object, Object>> source = (Map<Object, Map<Object, Object>>) field.get(this);
+                            Map<Object, Map<Object, Object>> target = (Map<Object, Map<Object, Object>>) field.get(watcher);
+                            target.clear();
+                            for (Map.Entry<Object, Map<Object, Object>> e : source.entrySet()) {
+                                Map<Object, Object> map = new HashMap<>();
+                                map.putAll(e.getValue());
+                                target.put(e.getKey(), map);
+                            }
+
                         }
                         else {
                             ((Map) field.get(watcher)).putAll((Map) field.get(this));

--- a/Mage/src/test/java/mage/WatcherTest.java
+++ b/Mage/src/test/java/mage/WatcherTest.java
@@ -1,13 +1,17 @@
 package mage;
 
 import static mage.constants.WatcherScope.GAME;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import mage.constants.WatcherScope;
@@ -19,7 +23,7 @@ import org.junit.Test;
 public class WatcherTest {
 
   @Test
-  public void test() {
+  public void testShallowCopy() {
     // Given
     Map<String, String> mapField = new HashMap<>();
     mapField.put("mapFieldKey1", "mapFieldValue1");
@@ -43,6 +47,104 @@ public class WatcherTest {
     assertEquals(ImmutableMap.of("mapFieldKey1", "mapFieldValue1", "mapFieldKey2", "mapFieldValue2"), copy.getMapField());
   }
 
+  @Test
+  public void testDeepCopyMapOfList() {
+    // Given
+    Map<String, List<String>> listInMapField = new HashMap<>();
+    List<String> list1 = new ArrayList<>();
+    list1.add("v1");
+    list1.add("v1.1");
+    List<String> list2 = new ArrayList<>();
+    list2.add("v2");
+    listInMapField.put("k1", list1);
+    listInMapField.put("k2", list2);
+
+    TestWatcher testWatcher = new TestWatcher(GAME);
+    testWatcher.setListInMapField(listInMapField);
+
+    // When
+    TestWatcher copy = testWatcher.copy();
+
+    // And
+    testWatcher.getListInMapField().get("k1").add("v1.2");
+    List<String> list3 = new ArrayList<>();
+    list3.add("v5");
+    testWatcher.getListInMapField().put("k5", list3);
+
+    // Then
+    Map<String, List<String>> copyListInMap = copy.getListInMapField();
+    assertEquals(2, copyListInMap.size());
+    assertTrue(copyListInMap.containsKey("k1"));
+    assertEquals(ImmutableList.of("v1", "v1.1"), copyListInMap.get("k1"));
+    assertTrue(copyListInMap.containsKey("k2"));
+    assertEquals(ImmutableList.of("v2"), copyListInMap.get("k2"));
+  }
+
+  @Test
+  public void testDeepCopyMapOfSet() {
+    // Given
+    Map<String, Set<String>> setInMapField = new HashMap<>();
+    Set<String> set1 = new HashSet<>();
+    set1.add("v3");
+    Set<String> set2 = new HashSet<>();
+    set2.add("v4");
+    set2.add("v4.1");
+    setInMapField.put("k3", set1);
+    setInMapField.put("k4", set2);
+    setInMapField.put("k", new HashSet<String>());
+
+    TestWatcher testWatcher = new TestWatcher(GAME);
+    testWatcher.setSetInMapField(setInMapField);
+
+    // When
+    TestWatcher copy = testWatcher.copy();
+
+    // And
+    testWatcher.getSetInMapField().get("k3").add("v3.1");
+
+    // Then
+    Map<String, Set<String>> copySetInMap = copy.getSetInMapField();
+    assertEquals(3, copySetInMap.size());
+    assertTrue(copySetInMap.containsKey("k3"));
+    assertEquals(ImmutableSet.of("v3"), copySetInMap.get("k3"));
+    assertTrue(copySetInMap.containsKey("k4"));
+    assertEquals(ImmutableSet.of("v4", "v4.1"), copySetInMap.get("k4"));
+    assertTrue(copySetInMap.containsKey("k"));
+    assertEquals(ImmutableSet.of(), copySetInMap.get("k"));
+  }
+
+  @Test
+  public void testDeepCopyMapOfMap() {
+    // Given
+    Map<String, Map<String, String>> mapInMapField = new HashMap<>();
+    Map<String, String> map1 = new HashMap<>();
+    map1.put("k1.1", "v1.1");
+    map1.put("k1.2", "v1.2");
+    Map<String, String> map2 = new HashMap<>();
+    map2.put("k2.1", "v2.1");
+    mapInMapField.put("k1", map1);
+    mapInMapField.put("k2", map2);
+
+    TestWatcher testWatcher = new TestWatcher(GAME);
+    testWatcher.setMapInMapField(mapInMapField);
+
+    // When
+    TestWatcher copy = testWatcher.copy();
+
+    // And
+    testWatcher.getMapInMapField().get("k2").put("k2.2", "v2.2");
+    testWatcher.getMapInMapField().put("k3", new HashMap<>());
+
+    // Then
+    Map<String, Map<String, String>> copyMapInMap = copy.getMapInMapField();
+    assertEquals(2, copyMapInMap.size());
+    assertTrue(copyMapInMap.containsKey("k1"));
+    assertEquals(ImmutableMap.of("k1.1", "v1.1", "k1.2", "v1.2"), copyMapInMap.get("k1"));
+    assertTrue(copyMapInMap.containsKey("k2"));
+    assertEquals(ImmutableMap.of("k2.1", "v2.1"), copyMapInMap.get("k2"));
+    assertFalse(copyMapInMap.containsKey("k3"));
+  }
+
   private Set<String> set(String... values) {
     return Stream.of(values).collect(Collectors.toSet());
   }
@@ -51,6 +153,9 @@ public class WatcherTest {
     private String stringField;
     private Set<String> setField = new HashSet<>();
     private Map<String, String> mapField = new HashMap<>();
+    private Map<String, List<String>> listInMapField = new HashMap<>();
+    private Map<String, Set<String>> setInMapField = new HashMap<>();
+    private Map<String, Map<String, String>> mapInMapField = new HashMap<>();
 
     public TestWatcher(WatcherScope scope) {
       super(scope);
@@ -83,6 +188,30 @@ public class WatcherTest {
 
     public void setMapField(Map<String, String> mapField) {
       this.mapField = mapField;
+    }
+
+    public Map<String, List<String>> getListInMapField() {
+      return listInMapField;
+    }
+
+    public void setListInMapField(Map<String, List<String>> listInMapField) {
+      this.listInMapField = listInMapField;
+    }
+
+    public Map<String, Set<String>> getSetInMapField() {
+      return setInMapField;
+    }
+
+    public void setSetInMapField(Map<String, Set<String>> setInMapField) {
+      this.setInMapField = setInMapField;
+    }
+
+    public Map<String, Map<String, String>> getMapInMapField() {
+      return mapInMapField;
+    }
+
+    public void setMapInMapField(Map<String, Map<String, String>> mapInMapField) {
+      this.mapInMapField = mapInMapField;
     }
   }
 }


### PR DESCRIPTION
https://github.com/magefree/mage/blob/fe3c2cc386f4f9ccd37d7a4e30043c22f3bd8752/Mage/src/main/java/mage/watchers/Watcher.java#L124

This line makes problems as ```valueType.getClass()``` is some class implementing ParameterizedType and not the generic of the map you are looking to copy. Thus the if above is never executed

I also expanded the code method to copy ```Map<Object, List<Object>>``` and ```Map<Object, Map<Object, Object>>``` in a similar way to ```Map<Object, Set<Object>>``` as those are also used in sub classes of the watcher class