### PR TITLE
Reworked and improved special mana abilities (Convoke, Delve, Assist, Improvise)

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -1533,10 +1533,34 @@ public class ComputerPlayer extends PlayerImpl implements Player {
                 }
             }
         }
+
         // pay phyrexian life costs
         if (cost instanceof PhyrexianManaCost) {
             return cost.pay(null, game, null, playerId, false, null) || permittingObject != null;
         }
+
+        // pay special mana like convoke cost (tap for pay)
+        // GUI: user see "special" button while pay spell's cost
+        // TODO: AI can't prioritize special mana types to pay, e.g. it will use first available
+        SpecialAction specialAction = game.getState().getSpecialActions().getControlledBy(this.getId(), true)
+                .values().stream().findFirst().orElse(null);
+        ManaOptions specialMana = specialAction == null ? null : specialAction.getManaOptions(ability, game, unpaid);
+        if (specialMana != null) {
+            for (Mana netMana : specialMana) {
+                if (cost.testPay(netMana) || permittingObject != null) {
+                    if (netMana instanceof ConditionalMana && !((ConditionalMana) netMana).apply(ability, game, getId(), cost)) {
+                        continue;
+                    }
+                    specialAction.setUnpaidMana(unpaid);
+                    if (activateAbility(specialAction, game)) {
+                        return true;
+                    }
+                    // only one time try to pay
+                    break;
+                }
+            }
+        }
+
         return false;
     }
 

--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -396,12 +396,16 @@ public class ComputerPlayer extends PlayerImpl implements Player {
                 }
             }
 
-            while ((outcome.isGood() ? target.getTargets().size() < target.getMaxNumberOfTargets() : !target.isChosen())
+            // exile cost workaround: exile is bad, but exile from graveyard in most cases is good (more exiled -- more good things you get, e.g. delve's pay)
+            boolean isRealGood = outcome.isGood() || outcome == Outcome.Exile;
+            while ((isRealGood ? target.getTargets().size() < target.getMaxNumberOfTargets() : !target.isChosen())
                     && !cards.isEmpty()) {
                 Card pick = pickTarget(abilityControllerId, cards, outcome, target, null, game);
                 if (pick != null) {
                     target.addTarget(pick.getId(), null, game);
                     cards.remove(pick);
+                } else {
+                    break;
                 }
             }
 

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -10,6 +10,7 @@ import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.RequirementEffect;
 import mage.abilities.hint.HintUtils;
 import mage.abilities.mana.ActivatedManaAbilityImpl;
+import mage.abilities.mana.ManaAbility;
 import mage.cards.Card;
 import mage.cards.Cards;
 import mage.cards.decks.Deck;
@@ -60,6 +61,8 @@ import static mage.constants.PlayerAction.TRIGGER_AUTO_ORDER_RESET_ALL;
  * @author BetaSteward_at_googlemail.com
  */
 public class HumanPlayer extends PlayerImpl {
+
+    private static final boolean ALLOW_USERS_TO_PUT_NON_PLAYABLE_SPELLS_ON_STACK_WORKAROUND = false; // warning, see workaround's info on usage
 
     private transient Boolean responseOpenedForAnswer = false; // can't get response until prepared target (e.g. until send all fire events to all players)
     private final transient PlayerResponse response = new PlayerResponse();
@@ -1039,7 +1042,7 @@ public class HumanPlayer extends PlayerImpl {
 
             if (response.getString() != null
                     && response.getString().equals("special")) {
-                specialAction(game);
+                activateSpecialAction(game, null);
             } else if (response.getUUID() != null) {
                 boolean result = false;
                 MageObject object = game.getObject(response.getUUID());
@@ -1057,6 +1060,24 @@ public class HumanPlayer extends PlayerImpl {
                         }
                         if (actingPlayer != null) {
                             useableAbilities = actingPlayer.getPlayableActivatedAbilities(object, zone, game);
+
+                            // GUI: workaround to enable users to put spells on stack without real available mana
+                            // (without highlighting, like it was in old versions before June 2020)
+                            // Reason: some gain ability adds cost modification and other things to spells on stack only,
+                            // e.g. xmage can't find playable ability before put that spell on stack (wtf example: Chief Engineer,
+                            // see ConvokeTest)
+                            // TODO: it's a BAD workaround  -- users can't see that card/ability is broken and will not report to us, AI can't play that ability too
+                            // Enable it on massive broken cards/abilities only or for manual tests
+                            if (ALLOW_USERS_TO_PUT_NON_PLAYABLE_SPELLS_ON_STACK_WORKAROUND) {
+                                if (object instanceof Card) {
+                                    for (Ability ability : ((Card) object).getAbilities(game)) {
+                                        if (ability instanceof SpellAbility && ((SpellAbility) ability).canActivate(actingPlayer.getId(), game).canActivate()
+                                                || ability instanceof PlayLandAbility) {
+                                            useableAbilities.putIfAbsent(ability.getId(), (ActivatedAbility) ability);
+                                        }
+                                    }
+                                }
+                            }
                         }
 
                         if (object instanceof Card
@@ -1221,7 +1242,7 @@ public class HumanPlayer extends PlayerImpl {
             } else if (response.getString() != null
                     && response.getString().equals("special")) {
                 if (unpaid instanceof ManaCostsImpl) {
-                    specialManaAction(unpaid, game);
+                    activateSpecialAction(game, unpaid);
                 }
             } else if (response.getManaType() != null) {
                 // this mana type can be paid once from pool
@@ -1336,14 +1357,26 @@ public class HumanPlayer extends PlayerImpl {
         if (object == null) {
             return;
         }
-        if (AbilityType.SPELL.equals(abilityToCast.getAbilityType())) {
+
+        // GUI: for user's information only - check if mana abilities allows to use here (getUseableManaAbilities already filter it)
+        // Reason: when you use special mana ability then normal mana abilities will be restricted to pay. Users
+        // can't see lands as playable and must know the reason (if they click on land then they get that message)
+        if (abilityToCast.getAbilityType() == AbilityType.SPELL) {
             Spell spell = game.getStack().getSpell(abilityToCast.getSourceId());
-            if (spell != null && !spell.isResolving()
-                    && spell.isDoneActivatingManaAbilities()) {
-                game.informPlayer(this, "You can no longer use activated mana abilities to pay for the current spell. Cancel and recast the spell and activate mana abilities first.");
-                return;
+            boolean haveManaAbilities = object.getAbilities().stream().anyMatch(a -> a instanceof ManaAbility);
+            if (spell != null && !spell.isResolving() && haveManaAbilities) {
+                switch (spell.getCurrentActivatingManaAbilitiesStep()) {
+                    // if you used special mana ability like convoke then normal mana abilities will be restricted to use, see Convoke for details
+                    case BEFORE:
+                    case NORMAL:
+                        break;
+                    case AFTER:
+                        game.informPlayer(this, "You can no longer use activated mana abilities to pay for the current spell (special mana pay already used). Cancel and recast the spell to activate mana abilities first.");
+                        return;
+                }
             }
         }
+
         Zone zone = game.getState().getZone(object.getId());
         if (zone != null) {
             LinkedHashMap<UUID, ActivatedManaAbilityImpl> useableAbilities = getUseableManaAbilities(object, zone, game);
@@ -1844,7 +1877,13 @@ public class HumanPlayer extends PlayerImpl {
         draft.firePickCardEvent(playerId);
     }
 
-    protected void specialAction(Game game) {
+    /**
+     * Activate special action (normal or mana)
+     *
+     * @param game
+     * @param unpaidForManaAction - set unpaid for mana actions like convoke
+     */
+    protected void activateSpecialAction(Game game, ManaCost unpaidForManaAction) {
         if (gameInCheckPlayableState(game)) {
             return;
         }
@@ -1853,35 +1892,9 @@ public class HumanPlayer extends PlayerImpl {
             return;
         }
 
-        Map<UUID, SpecialAction> specialActions = game.getState().getSpecialActions().getControlledBy(playerId, false);
+        Map<UUID, SpecialAction> specialActions = game.getState().getSpecialActions().getControlledBy(playerId, unpaidForManaAction != null);
         if (!specialActions.isEmpty()) {
 
-            updateGameStatePriority("specialAction", game);
-            prepareForResponse(game);
-            if (!isExecutingMacro()) {
-                game.fireGetChoiceEvent(playerId, name, null, new ArrayList<>(specialActions.values()));
-            }
-            waitForResponse(game);
-
-            if (response.getUUID() != null) {
-                if (specialActions.containsKey(response.getUUID())) {
-                    activateAbility(specialActions.get(response.getUUID()), game);
-                }
-            }
-        }
-    }
-
-    protected void specialManaAction(ManaCost unpaid, Game game) {
-        if (gameInCheckPlayableState(game)) {
-            return;
-        }
-
-        if (!canRespond()) {
-            return;
-        }
-
-        Map<UUID, SpecialAction> specialActions = game.getState().getSpecialActions().getControlledBy(playerId, true);
-        if (!specialActions.isEmpty()) {
             updateGameStatePriority("specialAction", game);
             prepareForResponse(game);
             if (!isExecutingMacro()) {
@@ -1892,10 +1905,10 @@ public class HumanPlayer extends PlayerImpl {
             if (response.getUUID() != null) {
                 if (specialActions.containsKey(response.getUUID())) {
                     SpecialAction specialAction = specialActions.get(response.getUUID());
-                    if (specialAction != null) {
-                        specialAction.setUnpaidMana(unpaid);
-                        activateAbility(specialActions.get(response.getUUID()), game);
+                    if (unpaidForManaAction != null) {
+                        specialAction.setUnpaidMana(unpaidForManaAction);
                     }
+                    activateAbility(specialAction, game);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/d/DigThroughTime.java
+++ b/Mage.Sets/src/mage/cards/d/DigThroughTime.java
@@ -1,7 +1,5 @@
-
 package mage.cards.d;
 
-import java.util.UUID;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.common.LookLibraryAndPickControllerEffect;
 import mage.abilities.keyword.DelveAbility;
@@ -11,19 +9,19 @@ import mage.constants.CardType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 
+import java.util.UUID;
+
 /**
- *
  * @author emerald000
  */
 public final class DigThroughTime extends CardImpl {
 
     public DigThroughTime(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{6}{U}{U}");
-
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{6}{U}{U}");
 
         // Delve
         this.addAbility(new DelveAbility());
-        
+
         // Look at the top seven cards of your library. Put two of them into your hand and the rest on the bottom of your library in any order.
         this.getSpellAbility().addEffect(new LookLibraryAndPickControllerEffect(StaticValue.get(7), false, StaticValue.get(2), new FilterCard(), Zone.LIBRARY, false, false));
     }

--- a/Mage.Sets/src/mage/cards/i/IllusionistsBracers.java
+++ b/Mage.Sets/src/mage/cards/i/IllusionistsBracers.java
@@ -1,7 +1,5 @@
-
 package mage.cards.i;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.costs.mana.GenericManaCost;
@@ -12,8 +10,8 @@ import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
@@ -22,18 +20,19 @@ import mage.game.permanent.Permanent;
 import mage.game.stack.StackAbility;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class IllusionistsBracers extends CardImpl {
 
     public IllusionistsBracers(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{2}");
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
         this.subtype.add(SubType.EQUIPMENT);
 
         // Whenever an ability of equipped creature is activated, if it isn't a mana ability, copy that ability. You may choose new targets for the copy.
-        this.addAbility(new AbilityActivatedTriggeredAbility());
+        this.addAbility(new IllusionistsBracersTriggeredAbility());
 
         // Equip 3
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(3)));
@@ -49,19 +48,19 @@ public final class IllusionistsBracers extends CardImpl {
     }
 }
 
-class AbilityActivatedTriggeredAbility extends TriggeredAbilityImpl {
+class IllusionistsBracersTriggeredAbility extends TriggeredAbilityImpl {
 
-    AbilityActivatedTriggeredAbility() {
+    IllusionistsBracersTriggeredAbility() {
         super(Zone.BATTLEFIELD, new CopyActivatedAbilityEffect());
     }
 
-    AbilityActivatedTriggeredAbility(final AbilityActivatedTriggeredAbility ability) {
+    IllusionistsBracersTriggeredAbility(final IllusionistsBracersTriggeredAbility ability) {
         super(ability);
     }
 
     @Override
-    public AbilityActivatedTriggeredAbility copy() {
-        return new AbilityActivatedTriggeredAbility(this);
+    public IllusionistsBracersTriggeredAbility copy() {
+        return new IllusionistsBracersTriggeredAbility(this);
     }
 
     @Override
@@ -72,7 +71,7 @@ class AbilityActivatedTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         Permanent equipment = game.getPermanent(this.getSourceId());
-        if (equipment != null  && equipment.isAttachedTo(event.getSourceId())) {
+        if (equipment != null && equipment.isAttachedTo(event.getSourceId())) {
             StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
             if (!(stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl)) {
                 Effect effect = this.getEffects().get(0);

--- a/Mage.Sets/src/mage/cards/s/StokeTheFlames.java
+++ b/Mage.Sets/src/mage/cards/s/StokeTheFlames.java
@@ -1,7 +1,5 @@
-
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.keyword.ConvokeAbility;
 import mage.cards.CardImpl;
@@ -9,19 +7,19 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.target.common.TargetAnyTarget;
 
+import java.util.UUID;
+
 /**
- *
  * @author Quercitron
  */
 public final class StokeTheFlames extends CardImpl {
 
     public StokeTheFlames(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{2}{R}{R}");
-
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{R}{R}");
 
         // Convoke
         this.addAbility(new ConvokeAbility());
-        
+
         // Stoke the Flames deals 4 damage to any target.
         this.getSpellAbility().addEffect(new DamageTargetEffect(4));
         this.getSpellAbility().addTarget(new TargetAnyTarget());

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/AssistTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/AssistTest.java
@@ -1,0 +1,138 @@
+package org.mage.test.cards.abilities.keywords;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBaseWithAIHelps;
+
+/**
+ * @author JayDi85
+ */
+
+public class AssistTest extends CardTestPlayerBaseWithAIHelps {
+
+    @Test
+    public void test_Playable_NoMana_NoAssist() {
+        // {7}{G}
+        // Assist (Another player can pay up to {7} of this spell's cost.)
+        addCard(Zone.HAND, playerA, "Charging Binox", 1);
+
+        checkPlayableAbility("all", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Charging Binox", false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+    }
+
+    @Test
+    public void test_Playable_Mana_NoAssist() {
+        // {7}{G}
+        // Assist (Another player can pay up to {7} of this spell's cost.)
+        addCard(Zone.HAND, playerA, "Charging Binox", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 8);
+
+        checkPlayableAbility("all", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Charging Binox", true);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+    }
+
+    @Test
+    public void test_Playable_NoMana_Assist() {
+        // {7}{G}
+        // Assist (Another player can pay up to {7} of this spell's cost.)
+        addCard(Zone.HAND, playerA, "Charging Binox", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 6);
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 2); // assist pay
+
+        checkPlayableAbility("all", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Charging Binox", true);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+    }
+
+    @Test
+    public void test_Playable_Mana_Assist() {
+        // {7}{G}
+        // Assist (Another player can pay up to {7} of this spell's cost.)
+        addCard(Zone.HAND, playerA, "Charging Binox", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 8);
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 2); // assist pay
+
+        checkPlayableAbility("all", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Charging Binox", true);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+    }
+
+    @Test
+    public void test_Playable_ManaPartly_AssistPartly() {
+        // {7}{G}
+        // Assist (Another player can pay up to {7} of this spell's cost.)
+        addCard(Zone.HAND, playerA, "Charging Binox", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 2); // assist pay
+
+        checkPlayableAbility("all", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Charging Binox", false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+    }
+
+    @Test
+    public void test_PlayAssist_Manual() {
+        // {7}{G}
+        // Assist (Another player can pay up to {7} of this spell's cost.)
+        addCard(Zone.HAND, playerA, "Charging Binox", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 8 - 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 2); // assist pay
+
+        // disabled auto-payment and prepare mana pool to control payment
+        disableManaAutoPayment(playerA);
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {G}", 6);
+        // cast and assist
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Charging Binox");
+        setChoice(playerA, "Green", 6); // normal pay x6
+        setChoice(playerA, "Assist"); // activate assist
+        addTarget(playerA, playerB); // player to assist
+        setChoice(playerB, "X=2"); // can pay (auto-pay from B to A's mana pool as colorless x2)
+        setChoice(playerA, "Colorless", 2 - 1); // assist pay x2, but 1 mana was unlocked in assist code (wtf)
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerA, "Charging Binox", 1);
+    }
+
+    @Test
+    public void test_PlayAssist_AI_MustIgnoreAssist() {
+        // {7}{G}
+        // Assist (Another player can pay up to {7} of this spell's cost.)
+        addCard(Zone.HAND, playerA, "Charging Binox", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 8 - 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 2); // assist pay
+
+        // AI must ignore assist
+        checkPlayableAbility("playable", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Charging Binox", true);
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertHandCount(playerA, "Charging Binox", 1);
+        assertTappedCount("Forest", false, 8); // no mana used
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ConvokeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ConvokeTest.java
@@ -1,145 +1,298 @@
-
-
 package org.mage.test.cards.abilities.keywords;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import mage.filter.common.FilterLandPermanent;
-import mage.game.permanent.Permanent;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mage.test.serverside.base.CardTestPlayerBase;
+import org.mage.test.serverside.base.CardTestPlayerBaseWithAIHelps;
 
 /**
- *
- * @author LevelX2
+ * @author JayDi85
  */
 
-public class ConvokeTest extends CardTestPlayerBase {
-
-    /*
-    Test are set to Ignore because the new way to handle this alternate mana payment methods 
-    are not supported yet from AI and getPlayable logic.
-    */
+public class ConvokeTest extends CardTestPlayerBaseWithAIHelps {
 
     @Test
-    @Ignore
-    public void testConvokeTwoCreatures() {
-        /**
-         * Ephemeral Shields   {1}{W}
-         * Instant
-         * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for or one mana of that creature's color.)
-         * Target creature gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)
-         */
+    public void test_Playable_NoMana_NoConvoke() {
+        // {2}{R}{R}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature’s color.)
+        // Stoke the Flames deals 4 damage to any target.
+        addCard(Zone.HAND, playerA, "Stoke the Flames", 1);
 
-        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2); // must be added because getPlayable does not take Convoke into account
-        
+        checkPlayableAbility("all", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Stoke the Flames", false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+    }
+
+    @Test
+    public void test_Playable_Mana_NoConvoke() {
+        // {2}{R}{R}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature’s color.)
+        // Stoke the Flames deals 4 damage to any target.
+        addCard(Zone.HAND, playerA, "Stoke the Flames", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
+
+        checkPlayableAbility("all", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Stoke the Flames", true);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+    }
+
+    @Test
+    public void test_Playable_NoMana_Convoke() {
+        // {2}{R}{R}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature’s color.)
+        // Stoke the Flames deals 4 damage to any target.
+        addCard(Zone.HAND, playerA, "Stoke the Flames", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Goblin Racketeer", 4); // convoke pay
+
+        checkPlayableAbility("all", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Stoke the Flames", true);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+    }
+
+    @Test
+    public void test_Playable_Mana_Convoke() {
+        // {2}{R}{R}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature’s color.)
+        // Stoke the Flames deals 4 damage to any target.
+        addCard(Zone.HAND, playerA, "Stoke the Flames", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Goblin Racketeer", 2); // convoke pay
+
+        checkPlayableAbility("all", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Stoke the Flames", true);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+    }
+
+    @Test
+    public void test_Playable_ManaPartly_ConvokePartly() {
+        // {2}{R}{R}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature’s color.)
+        // Stoke the Flames deals 4 damage to any target.
+        addCard(Zone.HAND, playerA, "Stoke the Flames", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2 - 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Goblin Racketeer", 2 - 1); // convoke pay
+
+        checkPlayableAbility("all", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Stoke the Flames", false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+    }
+
+    @Test
+    public void test_PlayConvoke_Manual() {
+        // {2}{R}{R}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature’s color.)
+        // Stoke the Flames deals 4 damage to any target.
+        addCard(Zone.HAND, playerA, "Stoke the Flames", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Goblin Racketeer", 2); // convoke pay
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {R}", 2);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Stoke the Flames", playerB);
+        setChoice(playerA, "Red"); // pay 1
+        setChoice(playerA, "Red"); // pay 2
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, "Goblin Racketeer"); // pay 3 as convoke
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, "Goblin Racketeer"); // pay 4 as convoke
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertLife(playerB, 20 - 4);
+    }
+
+    @Test
+    public void test_PlayConvoke_AI_AutoPay() {
+        // {2}{R}{R}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature’s color.)
+        // Stoke the Flames deals 4 damage to any target.
+        addCard(Zone.HAND, playerA, "Stoke the Flames", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Goblin Racketeer", 2); // convoke pay
+
+        // AI must use special actions to pay as convoke
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Stoke the Flames", playerB);
+
+        //setStrictChooseMode(true); AI must choose targets
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertLife(playerB, 20 - 4);
+    }
+
+    @Test
+    public void test_PlayConvoke_AI_AutoPayAsConvoke() {
+        // {2}{R}{R}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature’s color.)
+        // Stoke the Flames deals 4 damage to any target.
+        addCard(Zone.HAND, playerA, "Stoke the Flames", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Goblin Racketeer", 2); // convoke pay
+
+        // AI must use special actions to pay as convoke
+        // Current version uses special mana pay as last, after no normal mana available (it can be changed in the future, see playManaHandling)
+        // e.g. it must tap lands 2 times and convoke 2 times
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Stoke the Flames", playerB);
+        addTarget(playerA, "Goblin Racketeer"); // pay 1 as convoke
+        addTarget(playerA, "Goblin Racketeer"); // pay 2 as convoke
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertLife(playerB, 20 - 4);
+    }
+
+    @Test
+    public void test_PlayConvoke_AI_FullPlay() {
+        // {2}{R}{R}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creature’s color.)
+        // Stoke the Flames deals 4 damage to any target.
+        addCard(Zone.HAND, playerA, "Stoke the Flames", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Goblin Racketeer", 2); // convoke pay
+
+        // AI must use special actions to pay as convoke and play card
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertLife(playerB, 20 - 4);
+    }
+
+    @Test
+    public void test_Other_ConvokeTwoCreatures() {
+        // {1}{W}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for or one mana of that creature's color.)
+        // Target creature gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)
+        addCard(Zone.HAND, playerA, "Ephemeral Shields");
         addCard(Zone.BATTLEFIELD, playerA, "Silvercoat Lion", 1);
         addCard(Zone.BATTLEFIELD, playerA, "Oreskos Swiftclaw", 1);
 
-        addCard(Zone.HAND, playerA, "Ephemeral Shields");
-
-        addCard(Zone.BATTLEFIELD, playerB, "Mountain", 1);
-        addCard(Zone.HAND, playerB, "Lightning Bolt");
-
-
+        // AI automaticly use convoke to pay
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ephemeral Shields", "Silvercoat Lion");
-        setChoice(playerA, "Yes");
-        addTarget(playerA, "Silvercoat Lion^Oreskos Swiftclaw");
+        addTarget(playerA, "Silvercoat Lion"); // pay 1 as convoke
+        addTarget(playerA, "Oreskos Swiftclaw"); // pay 2 as convoke
 
-        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerB, "Lightning Bolt", "Silvercoat Lion");
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
+        assertAllCommandsUsed();
 
         assertLife(playerA, 20);
         assertLife(playerB, 20);
 
-        assertGraveyardCount(playerB, "Lightning Bolt", 1);
-
         assertGraveyardCount(playerA, "Ephemeral Shields", 1);
-        assertPermanentCount(playerA, "Silvercoat Lion", 1); // was indestructible
+        assertPermanentCount(playerA, "Silvercoat Lion", 1);
         assertPermanentCount(playerA, "Oreskos Swiftclaw", 1);
-
-        for (Permanent permanent: currentGame.getBattlefield().getAllActivePermanents(new FilterLandPermanent(), playerA.getId(), currentGame)) {
-            Assert.assertTrue(permanent.getName() + " may not be tapped", !permanent.isTapped());
-        }
     }
 
 
     @Test
-    @Ignore
-    public void testConvokeTwoCreaturesOneWithProtection() {
-        /**
-         * Ephemeral Shields   {1}{W}
-         * Instant
-         * Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for or one mana of that creature's color.)
-         * Target creature gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)
-         */
-
-        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2); // must be added because getPlayable does not take Convoke into account
-
+    public void test_Other_ConvokeProtection() {
+        // {1}{W}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for or one mana of that creature's color.)
+        // Target creature gains indestructible until end of turn. (Damage and effects that say "destroy" don't destroy it.)
+        addCard(Zone.HAND, playerA, "Ephemeral Shields");
         addCard(Zone.BATTLEFIELD, playerA, "Silvercoat Lion", 1);
+        // Protection from white
         addCard(Zone.BATTLEFIELD, playerA, "Black Knight", 1);
 
-        addCard(Zone.HAND, playerA, "Ephemeral Shields");
-
-        addCard(Zone.BATTLEFIELD, playerB, "Mountain", 1);
-        addCard(Zone.HAND, playerB, "Lightning Bolt");
-
-
+        // convoke must be able to target card with protection (it's no target)
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ephemeral Shields", "Silvercoat Lion");
-        setChoice(playerA, "Yes");
-        addTarget(playerA, "Silvercoat Lion^Black Knight");
+        addTarget(playerA, "Silvercoat Lion");
+        addTarget(playerA, "Black Knight");
 
-        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerB, "Lightning Bolt", "Silvercoat Lion");
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
+        assertAllCommandsUsed();
 
         assertLife(playerA, 20);
         assertLife(playerB, 20);
-
-        assertGraveyardCount(playerB, "Lightning Bolt", 1);
-
-        assertGraveyardCount(playerA, "Ephemeral Shields", 1);
-        assertPermanentCount(playerA, "Silvercoat Lion", 1); // was indestructible
-        assertPermanentCount(playerA, "Black Knight", 1);
-        assertTapped("Silvercoat Lion", true);
-        assertTapped("Black Knight", true);
-
-        for (Permanent permanent: currentGame.getBattlefield().getAllActivePermanents(new FilterLandPermanent(), playerA.getId(), currentGame)) {
-            Assert.assertTrue(permanent.getName() + " may not be tapped", !permanent.isTapped());
-        }
     }
 
     @Test
     @Ignore
-    public void testConvokeFromChiefEngineer() {
-        /**
-         * Chief Engineer   {1}{U}
-         * Creature - Vedalken, Artificer
-         * Artifact spells you cast have convoke.
-         */
-
-        // THIS TEST IS NOT FINISHED
-        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2); 
-        addCard(Zone.BATTLEFIELD, playerA, "Silvercoat Lion", 1); // creatures to use for convoek
+    // TODO: fix gain ability for spells to apply in all zones instead stack only or change getPlayable to look ahead and simulate spell on stack (wtf)
+    public void test_Other_ConvokeAsGains() {
+        // {1}{U}
+        // Artifact spells you cast have convoke.
         addCard(Zone.BATTLEFIELD, playerA, "Chief Engineer", 1);
-        
-        addCard(Zone.HAND, playerA, "ARTIFACT TO CAST", 1);
+        //
+        // {2}
+        addCard(Zone.HAND, playerA, "Alpha Myr", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Silvercoat Lion", 2);
 
-
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "ARTIFACT TO CAST");
-        setChoice(playerA, "Yes");
+        // Chief Engineer gives convoke to Alpha Myr and xmage must see it as playable before put real spell to stack
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Alpha Myr");
+        addTarget(playerA, "Silvercoat Lion");
         addTarget(playerA, "Silvercoat Lion");
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
+        assertAllCommandsUsed();
 
-        assertLife(playerA, 20);
-        assertLife(playerB, 20);
-
-
+        assertPermanentCount(playerA, "Alpha Myr", 1);
     }
 
+    @Test
+    @Ignore
+    // I don't know how to test it by framework - manual test works fine for HumanPlayer
+    // (he get warning message and can't activate mana abilities after convoke)
+    public void test_Other_CantUseConvokeBeforeManaAbilities() {
+        // https://github.com/magefree/mage/issues/768
+
+        // {6}
+        // Convoke
+        addCard(Zone.HAND, playerA, "Will-Forged Golem", 1);
+        //
+        // {2}{G}
+        // Create two 1/1 colorless Eldrazi Scion creature tokens. They have “Sacrifice this creature: Add {C}.”
+        addCard(Zone.HAND, playerA, "Call the Scions", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 3 * 2);
+
+        // prepare scions
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Call the Scions");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Call the Scions");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+        checkPermanentCount("scions", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Eldrazi Scion", 4);
+
+        // test case 1 - playable abilities must not show it as playable (not work, cause we don't known real payment order before payment)
+        //checkPlayableAbility("can't use convoke", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Will-Forged Golem", false);
+
+        // test case 2 - it's in playable list, but mana abilities can't be activated after convoke pay
+        //castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Will-Forged Golem");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DelveTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DelveTest.java
@@ -1,0 +1,84 @@
+package org.mage.test.cards.abilities.keywords;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBaseWithAIHelps;
+
+/**
+ * @author JayDi85
+ */
+
+public class DelveTest extends CardTestPlayerBaseWithAIHelps {
+
+    // no simple playable tests for delve, it's same as ConvokeTest
+
+    @Test
+    public void test_PlayDelve_Manual() {
+        // {4}{U}{U} creature
+        // Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)
+        addCard(Zone.HAND, playerA, "Ethereal Forager", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.GRAVEYARD, playerA, "Balduvian Bears", 4); // delve pay
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {U}", 2);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ethereal Forager");
+        setChoice(playerA, "Blue"); // pay 1
+        setChoice(playerA, "Blue"); // pay 2
+        // delve can be payed in test only by one card
+        setChoice(playerA, "Exile cards");
+        setChoice(playerA, "Balduvian Bears"); // pay 3 as delve
+        setChoice(playerA, "Exile cards");
+        setChoice(playerA, "Balduvian Bears"); // pay 4 as delve
+        setChoice(playerA, "Exile cards");
+        setChoice(playerA, "Balduvian Bears"); // pay 5 as delve
+        setChoice(playerA, "Exile cards");
+        setChoice(playerA, "Balduvian Bears"); // pay 6 as delve
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerA, "Ethereal Forager", 1);
+    }
+
+    @Test
+    public void test_PlayDelve_AI_AutoPay() {
+        // {4}{U}{U} creature
+        // Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)
+        addCard(Zone.HAND, playerA, "Ethereal Forager", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.GRAVEYARD, playerA, "Balduvian Bears", 4); // delve pay
+
+        // AI must use special actions to pay as delve
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ethereal Forager");
+
+        //setStrictChooseMode(true); AI must choose targets
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerA, "Ethereal Forager", 1);
+    }
+
+    @Test
+    public void test_PlayDelve_AI_FullPlay() {
+        // {4}{U}{U} creature
+        // Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)
+        addCard(Zone.HAND, playerA, "Ethereal Forager", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.GRAVEYARD, playerA, "Balduvian Bears", 4); // delve pay
+
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerA, "Ethereal Forager", 1);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ImproviseTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ImproviseTest.java
@@ -1,0 +1,79 @@
+package org.mage.test.cards.abilities.keywords;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBaseWithAIHelps;
+
+/**
+ * @author JayDi85
+ */
+
+public class ImproviseTest extends CardTestPlayerBaseWithAIHelps {
+
+    // no simple playable tests for improvise, it's same as ConvokeTest
+
+    @Test
+    public void test_PlayImprovise_Manual() {
+        // {5}{U} creature
+        // Improvise (Your artifacts can help cast this spell. Each artifact you tap after you’re done activating mana abilities pays for {1}.)
+        addCard(Zone.HAND, playerA, "Bastion Inventor", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+        addCard(Zone.BATTLEFIELD, playerA, "Alpha Myr", 2); // improvise pay
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {U}", 4);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Bastion Inventor");
+        setChoice(playerA, "Blue", 4); // pay 1-4
+        // improvise pay by one card
+        setChoice(playerA, "Improvise");
+        addTarget(playerA, "Alpha Myr"); // pay 5 as improvise
+        setChoice(playerA, "Improvise");
+        addTarget(playerA, "Alpha Myr"); // pay 6 as improvise
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerA, "Bastion Inventor", 1);
+    }
+
+    @Test
+    public void test_PlayImprovise_AI_AutoPay() {
+        // {5}{U} creature
+        // Improvise (Your artifacts can help cast this spell. Each artifact you tap after you’re done activating mana abilities pays for {1}.)
+        addCard(Zone.HAND, playerA, "Bastion Inventor", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+        addCard(Zone.BATTLEFIELD, playerA, "Alpha Myr", 2); // improvise pay
+
+        // AI must use special actions to pay as delve
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Bastion Inventor");
+
+        //setStrictChooseMode(true); AI must choose targets
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerA, "Bastion Inventor", 1);
+    }
+
+    @Test
+    public void test_PlayImprovise_AI_FullPlay() {
+        // {5}{U} creature
+        // Improvise (Your artifacts can help cast this spell. Each artifact you tap after you’re done activating mana abilities pays for {1}.)
+        addCard(Zone.HAND, playerA, "Bastion Inventor", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+        addCard(Zone.BATTLEFIELD, playerA, "Alpha Myr", 2); // improvise pay
+
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerA, "Bastion Inventor", 1);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/asthough/PlayFromNonHandZoneTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/asthough/PlayFromNonHandZoneTest.java
@@ -273,7 +273,7 @@ public class PlayFromNonHandZoneTest extends CardTestPlayerBase {
      * the discard was required. In the first log, when it was cast after
      * Angelic Purge the discard was not required.
      */
-    
+
     @Test
     public void castFromExileButWithAdditionalCostTest() {
         // Ninjutsu {2}{U}{B}
@@ -282,7 +282,7 @@ public class PlayFromNonHandZoneTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerB, "Fallen Shinobi", 1); // Creature 5/4
         addCard(Zone.BATTLEFIELD, playerB, "Silvercoat Lion");
         addCard(Zone.HAND, playerB, "Pillarfield Ox");
-        
+
         addCard(Zone.LIBRARY, playerB, "Pillarfield Ox"); // Card to draw on turn 2
         // As an additional cost to cast Tormenting Voice, discard a card.
         // Draw two cards.        
@@ -290,14 +290,14 @@ public class PlayFromNonHandZoneTest extends CardTestPlayerBase {
         // As an additional cost to cast this spell, sacrifice a creature.
         // Flying, Trample        
         addCard(Zone.LIBRARY, playerA, "Demon of Catastrophes"); // Creature {2}{B}{B}  6/6
-  
+
         skipInitShuffling();
 
         attack(2, playerB, "Fallen Shinobi");
-        
+
         castSpell(2, PhaseStep.POSTCOMBAT_MAIN, playerB, "Tormenting Voice");
         setChoice(playerB, "Pillarfield Ox"); // Discord for Tormenting Voice
-        
+
         castSpell(2, PhaseStep.POSTCOMBAT_MAIN, playerB, "Demon of Catastrophes");
         setChoice(playerB, "Silvercoat Lion"); // Sacrifice for Demon
 
@@ -309,20 +309,20 @@ public class PlayFromNonHandZoneTest extends CardTestPlayerBase {
 
         assertLife(playerA, 15);
         assertPermanentCount(playerB, "Fallen Shinobi", 1);
-        
-        assertGraveyardCount(playerA,  "Tormenting Voice", 1);
-        assertGraveyardCount(playerB,  "Pillarfield Ox", 1);  // Discarded for Tormenting Voice
-        
-        
+
+        assertGraveyardCount(playerA, "Tormenting Voice", 1);
+        assertGraveyardCount(playerB, "Pillarfield Ox", 1);  // Discarded for Tormenting Voice
+
+
         assertPermanentCount(playerB, "Demon of Catastrophes", 1);
-        assertGraveyardCount(playerB,  "Silvercoat Lion", 1);  // sacrificed for Demon
-        
+        assertGraveyardCount(playerB, "Silvercoat Lion", 1);  // sacrificed for Demon
+
         assertHandCount(playerB, "Pillarfield Ox", 1);
         assertHandCount(playerB, 3); // 2 from Tormenting Voice + 1 from Turn 2
         assertExileCount(playerA, 0); // Both exiled cards are cast
-    }    
-    
-    
+    }
+
+
     @Test
     public void castFromExileButWithAdditionalCost2Test() {
         // Ninjutsu {2}{U}{B}
@@ -331,7 +331,7 @@ public class PlayFromNonHandZoneTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerB, "Fallen Shinobi", 1); // Creature 5/4
         addCard(Zone.BATTLEFIELD, playerB, "Silvercoat Lion");
         addCard(Zone.HAND, playerB, "Pillarfield Ox");
-        
+
         addCard(Zone.BATTLEFIELD, playerA, "Amulet of Kroog"); // Just to exile for Angelic Purge
 
         // As an additional cost to cast Tormenting Voice, discard a card.
@@ -341,18 +341,18 @@ public class PlayFromNonHandZoneTest extends CardTestPlayerBase {
         // As an additional cost to cast Angelic Purge, sacrifice a permanent.
         // Exile target artifact, creature, or enchantment.      
         addCard(Zone.LIBRARY, playerA, "Angelic Purge"); // Sorcery {2}{W}
-  
+
         skipInitShuffling();
 
         attack(2, playerB, "Fallen Shinobi");
-        
+
         castSpell(2, PhaseStep.POSTCOMBAT_MAIN, playerB, "Angelic Purge");
         setChoice(playerB, "Silvercoat Lion"); // Sacrifice for Purge
         addTarget(playerB, "Amulet of Kroog"); // Exile with Purge
-        
+
         castSpell(2, PhaseStep.POSTCOMBAT_MAIN, playerB, "Tormenting Voice");
         setChoice(playerB, "Pillarfield Ox"); // Discord for Tormenting Voice
-        
+
         setStopAt(2, PhaseStep.END_TURN);
 
         setStrictChooseMode(true);
@@ -361,27 +361,27 @@ public class PlayFromNonHandZoneTest extends CardTestPlayerBase {
 
         assertLife(playerA, 15);
         assertPermanentCount(playerB, "Fallen Shinobi", 1);
-        
-        assertGraveyardCount(playerA, "Angelic Purge", 1);
-        assertGraveyardCount(playerB,  "Silvercoat Lion", 1);  // sacrificed for Purge
 
-        assertGraveyardCount(playerA,  "Tormenting Voice", 1);
-        assertGraveyardCount(playerB,  "Pillarfield Ox", 1);  // Discarded for Tormenting Voice
-                     
+        assertGraveyardCount(playerA, "Angelic Purge", 1);
+        assertGraveyardCount(playerB, "Silvercoat Lion", 1);  // sacrificed for Purge
+
+        assertGraveyardCount(playerA, "Tormenting Voice", 1);
+        assertGraveyardCount(playerB, "Pillarfield Ox", 1);  // Discarded for Tormenting Voice
+
         assertHandCount(playerB, 3); // 2 from Tormenting Voice + 1 from Turn 2 draw
-        
+
         assertExileCount(playerA, 1); // Both exiled cards are cast
         assertExileCount(playerA, "Amulet of Kroog", 1); // Exiled with Purge
-    }     
-    
-     @Test
-    public void castAdventureWithFallenShinobiTest() {     
+    }
+
+    @Test
+    public void castAdventureWithFallenShinobiTest() {
         // Ninjutsu {2}{U}{B}
         // Whenever Fallen Shinobi deals combat damage to a player, that player exiles the top two cards 
         // of their library. Until end of turn, you may play those cards without paying their mana cost.
         addCard(Zone.BATTLEFIELD, playerB, "Fallen Shinobi", 1); // Creature 5/4
         addCard(Zone.BATTLEFIELD, playerB, "Silvercoat Lion");
-        
+
         addCard(Zone.BATTLEFIELD, playerA, "Amulet of Kroog"); // Just to exile for Angelic Purge
 
         /* Curious Pair {1}{G}
@@ -391,23 +391,23 @@ public class PlayFromNonHandZoneTest extends CardTestPlayerBase {
          * Treats to Share {G}
          * Sorcery — Adventure
          * Create a Food token.
-         */        
-        addCard(Zone.LIBRARY, playerA, "Curious Pair");      
+         */
+        addCard(Zone.LIBRARY, playerA, "Curious Pair");
 
         // As an additional cost to cast Angelic Purge, sacrifice a permanent.
         // Exile target artifact, creature, or enchantment.      
         addCard(Zone.LIBRARY, playerA, "Angelic Purge"); // Sorcery {2}{W}
-  
+
         skipInitShuffling();
 
         attack(2, playerB, "Fallen Shinobi");
-        
+
         castSpell(2, PhaseStep.POSTCOMBAT_MAIN, playerB, "Angelic Purge");
         setChoice(playerB, "Silvercoat Lion"); // Sacrifice for Purge
         addTarget(playerB, "Amulet of Kroog"); // Exile with Purge
-        
+
         castSpell(2, PhaseStep.POSTCOMBAT_MAIN, playerB, "Treats to Share");
-        
+
         setStopAt(2, PhaseStep.END_TURN);
 
         setStrictChooseMode(true);
@@ -416,17 +416,46 @@ public class PlayFromNonHandZoneTest extends CardTestPlayerBase {
 
         assertLife(playerA, 15);
         assertPermanentCount(playerB, "Fallen Shinobi", 1);
-        
+
         assertGraveyardCount(playerA, "Angelic Purge", 1);
-        assertGraveyardCount(playerB,  "Silvercoat Lion", 1);  // sacrificed for Purge
+        assertGraveyardCount(playerB, "Silvercoat Lion", 1);  // sacrificed for Purge
 
         assertPermanentCount(playerB, "Food", 1);
         assertExileCount(playerA, "Curious Pair", 1);
-                     
+
         assertHandCount(playerB, 1); // 1 from Turn 2 draw
-        
+
         assertExileCount(playerA, 2); // Both exiled cards are cast 
         assertExileCount(playerA, "Amulet of Kroog", 1); // Exiled with Purge        
     }
-    
+
+    @Test
+    public void test_ActivateFromOpponentCreature() {
+        // Players can’t search libraries. Any player may pay {2} for that player to ignore this effect until end of turn.
+        addCard(Zone.BATTLEFIELD, playerB, "Leonin Arbiter", 1);
+        //
+        // {3}{U}{U}
+        // Search target opponent’s library for an artifact card and put that card onto the battlefield under your control. Then that player shuffles their library.
+        addCard(Zone.HAND, playerA, "Acquire", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5 * 2 + 2);
+        addCard(Zone.LIBRARY, playerB, "Alpha Myr", 1);
+
+        // first cast -- can't search library
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Acquire", playerB);
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        // second cast -- unlock library and search
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}: Any player may");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        //
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Acquire", playerB);
+        addTarget(playerA, "Alpha Myr");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerA, "Alpha Myr", 1);
+    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/CommandersCastTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/CommandersCastTest.java
@@ -17,7 +17,6 @@ public class CommandersCastTest extends CardTestCommander4Players {
         addCard(Zone.COMMAND, playerA, "Balduvian Bears", 1); // {1}{G}, 2/2, commander
         addCard(Zone.BATTLEFIELD, playerA, "Forest", 2);
 
-        // showCommand("commanders", 1, PhaseStep.PRECOMBAT_MAIN, playerA);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Balduvian Bears");
 
         setStopAt(1, PhaseStep.END_TURN);
@@ -70,9 +69,7 @@ public class CommandersCastTest extends CardTestCommander4Players {
     public void test_PlayAsLandOneTime() {
         addCard(Zone.COMMAND, playerA, "Academy Ruins", 1);
 
-        // showAvaileableAbilities("before", 1, PhaseStep.PRECOMBAT_MAIN, playerA);
         playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Academy Ruins");
-        //castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Academy Ruins");
 
         setStopAt(1, PhaseStep.END_TURN);
         setStrictChooseMode(true);
@@ -258,7 +255,6 @@ public class CommandersCastTest extends CardTestCommander4Players {
         addCard(Zone.BATTLEFIELD, playerA, "Balduvian Bears", 2);
 
         // cast overload
-        // showAvaileableAbilities("before", 1, PhaseStep.PRECOMBAT_MAIN, playerA);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Weapon Surge with overload");
         setChoice(playerA, "Yes"); // move to command zone
         checkAbility("after", 1, PhaseStep.BEGIN_COMBAT, playerA, "Balduvian Bears", FirstStrikeAbility.class, true);
@@ -267,5 +263,55 @@ public class CommandersCastTest extends CardTestCommander4Players {
         setStrictChooseMode(true);
         execute();
         assertAllCommandsUsed();
+    }
+
+    @Test
+    public void test_ExileWithDelvePayAndReturn() {
+        // https://github.com/magefree/mage/issues/5121
+        // Exiling your commander from your graveyard should give you the option to put it in command zone
+        // We were playing in a restarted-by-Karn game (if that mattered), and a player who exiled their
+        // commander from graveyard via Delve was not given the opportunity to place it in the command zone.
+        // Instead, it went directly to the exiled zone.
+
+        // disable auto-payment for delve test
+        disableManaAutoPayment(playerA);
+
+        // commander
+        addCard(Zone.COMMAND, playerA, "Balduvian Bears", 1); // {1}{G}, 2/2, commander
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 2);
+        //
+        addCard(Zone.HAND, playerA, "Lightning Bolt", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
+        //
+        // {4}{U}{U} creature
+        // Delve (Each card you exile from your graveyard while casting this spell pays for {1}.)
+        addCard(Zone.HAND, playerA, "Ethereal Forager", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5); // one from delve
+
+        // prepare commander and put it to graveyard
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {G}", 2);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Balduvian Bears");
+        setChoice(playerA, "Green", 2); // pay
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        //
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {R}");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", "Balduvian Bears");
+        setChoice(playerA, "Red"); // pay
+        setChoice(playerA, "No"); // leave in graveyard
+
+        // use commander as delve pay
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {U}", 5);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ethereal Forager");
+        setChoice(playerA, "Blue", 5); // pay normal
+        setChoice(playerA, "Exile cards"); // pay delve
+        setChoice(playerA, "Balduvian Bears");
+        setChoice(playerA, "Yes"); // move to command zone
+
+        setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
+        execute();
+        assertAllCommandsUsed();
+
+        assertCommandZoneCount(playerA, "Balduvian Bears", 1);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/copy/CleverImpersonatorTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/copy/CleverImpersonatorTest.java
@@ -1,4 +1,3 @@
-
 package org.mage.test.cards.copy;
 
 import mage.constants.CardType;
@@ -9,7 +8,6 @@ import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
- *
  * @author LevelX2
  */
 public class CleverImpersonatorTest extends CardTestPlayerBase {
@@ -54,22 +52,29 @@ public class CleverImpersonatorTest extends CardTestPlayerBase {
      */
     @Test
     public void testCopyPlaneswalker() {
-        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
-
         // You may have Clever Impersonator enter the battlefield as a copy of any nonland permanent on the battlefield.
         addCard(Zone.HAND, playerA, "Clever Impersonator", 1); // {2}{U}{U}
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
 
         // +2: Each player discards a card.
         // -X: Return target nonlegendary creature with converted mana cost X from your graveyard to the battlefield.
         // -8: You get an emblem with "Whenever a creature dies, return it to the battlefield under your control at the beginning of the next end step.";
         addCard(Zone.BATTLEFIELD, playerB, "Liliana, Defiant Necromancer", 1);
+        //
+        addCard(Zone.HAND, playerA, "Balduvian Bears", 1);
+        addCard(Zone.HAND, playerB, "Balduvian Bears", 1);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Clever Impersonator");
-        setChoice(playerA, "Liliana, Defiant Necromancer");
+        setChoice(playerA, "Yes"); // make copy
+        setChoice(playerA, "Liliana, Defiant Necromancer"); // copy target
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "+2: Each player discards a card");
+        addTarget(playerA, "Balduvian Bears"); // discard
+        addTarget(playerB, "Balduvian Bears"); // discard
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
+        assertAllCommandsUsed();
 
         assertHandCount(playerA, "Clever Impersonator", 0);
         assertCounterCount(playerB, "Liliana, Defiant Necromancer", CounterType.LOYALTY, 3);  // 3
@@ -157,8 +162,7 @@ public class CleverImpersonatorTest extends CardTestPlayerBase {
      * Reported bug: could not use Clever Impersonator to copy Dawn's Reflection
      */
     @Test
-    public void dawnsReflectionCopiedByImpersonator()
-    {
+    public void dawnsReflectionCopiedByImpersonator() {
         String impersonator = "Clever Impersonator";
         String dReflection = "Dawn's Reflection";
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/damage/SyrCarahTheBoldTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/damage/SyrCarahTheBoldTest.java
@@ -55,32 +55,31 @@ public class SyrCarahTheBoldTest extends CardTestPlayerBase {
     public void test_DamageWithCopyAbility() {
         removeAllCardsFromLibrary(playerA);
         removeAllCardsFromHand(playerA);
+
         // When Syr Carah, the Bold or an instant or sorcery spell you control deals damage to a player, exile the top card of your library. You may play that card this turn.
         // {T}: Syr Carah deals 1 damage to any target.
         addCard(Zone.BATTLEFIELD, playerA, "Syr Carah, the Bold", 1);
-        //
-        addCard(Zone.LIBRARY, playerA, "Swamp", 5);
-        //
-        // {T}: Embermage Goblin deals 1 damage to any target.
-        addCard(Zone.BATTLEFIELD, playerB, "Embermage Goblin", 1);
+        addCard(Zone.LIBRARY, playerA, "Balduvian Bears", 2);
         //
         // Whenever an ability of equipped creature is activated, if it isn't a mana ability, copy that ability. You may choose new targets for the copy.
         // Equip 3
-        addCard(Zone.BATTLEFIELD, playerB, "Illusionist's Bracers", 1);
-        addCard(Zone.BATTLEFIELD, playerB, "Island", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Illusionist's Bracers", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
 
-        // equip to copy abilities
-        // showAvaileableAbilities("abils", 2, PhaseStep.PRECOMBAT_MAIN, playerB);
-        activateAbility(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Equip {3}", "Embermage Goblin");
-        setChoice(playerB, "No"); // no new target
+        // prepare equip
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Equip {3}", "Syr Carah, the Bold");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        checkExileCount("before", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Balduvian Bears", 0);
 
-        // 3 - 2x damage (copy), but no trigger
-        // java.lang.ClassCastException: mage.game.stack.StackAbility cannot be cast to mage.game.stack.Spell
-        activateAbility(2, PhaseStep.POSTCOMBAT_MAIN, playerB, "{T}: {source} deals", playerA);
-        checkLife("damage 3", 2, PhaseStep.END_TURN, playerA, 20 - 1 - 1);
+        // activate damage - 2x damage with copy
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: {source} deals", playerB);
+        setChoice(playerA, "No"); // no new target for copy
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        checkLife("damage 2", 1, PhaseStep.PRECOMBAT_MAIN, playerB, 20 - 1 - 1);
+        checkExileCount("after", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Balduvian Bears", 2);
 
         setStrictChooseMode(true);
-        setStopAt(3, PhaseStep.END_TURN);
+        setStopAt(1, PhaseStep.END_TURN);
         execute();
         assertAllCommandsUsed();
     }

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/MageTestPlayerBase.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/MageTestPlayerBase.java
@@ -351,6 +351,13 @@ public abstract class MageTestPlayerBase {
         return new TestPlayer(new TestComputerPlayer(name, rangeOfInfluence));
     }
 
+    /**
+     * Raise error on any miss choices/targets setup in tests (if AI try to make decision itself instead of user defined actions)
+     * If you want to disable mana auto-payment (e.g. to simulate user clicks on mana pool or special mana) then call
+     * disableManaAutoPayment()
+     *
+     * @param enable
+     */
     protected void setStrictChooseMode(boolean enable) {
         if (playerA != null) playerA.setChooseStrictMode(enable);
         if (playerB != null) playerB.setChooseStrictMode(enable);
@@ -403,8 +410,8 @@ public abstract class MageTestPlayerBase {
 // custom card with global abilities list to init (can contains abilities per card name)
 class CustomTestCard extends CardImpl {
 
-    static private Map<String, Abilities<Ability>> abilitiesList = new HashMap<>(); // card name -> abilities
-    static private Map<String, SpellAbility> spellAbilitiesList = new HashMap<>(); // card name -> spell ability
+    static private final Map<String, Abilities<Ability>> abilitiesList = new HashMap<>(); // card name -> abilities
+    static private final Map<String, SpellAbility> spellAbilitiesList = new HashMap<>(); // card name -> spell ability
 
     static void addCustomAbility(String cardName, SpellAbility spellAbility, Ability ability) {
         if (!abilitiesList.containsKey(cardName)) {

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -1,13 +1,5 @@
 package org.mage.test.serverside.base.impl;
 
-import java.io.FileNotFoundException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import mage.MageObject;
 import mage.Mana;
 import mage.ObjectColor;
@@ -42,6 +34,15 @@ import org.mage.test.player.PlayerAction;
 import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestAPI;
 import org.mage.test.serverside.base.MageTestPlayerBase;
+
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * API for test initialization and asserting the test results.
@@ -273,7 +274,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
             }
         }
         Assert.assertFalse("Wrong stop command on " + this.stopOnTurn + " / " + this.stopAtStep + " (" + this.stopAtStep.getIndex() + ")"
-                + " (found actions after stop on " + maxTurn + " / " + maxPhase + ")",
+                        + " (found actions after stop on " + maxTurn + " / " + maxPhase + ")",
                 (maxTurn > this.stopOnTurn) || (maxTurn == this.stopOnTurn && maxPhase > this.stopAtStep.getIndex()));
 
         for (Player player : currentGame.getPlayers().values()) {
@@ -506,8 +507,8 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Add a card to specified zone of specified player.
      *
      * @param gameZone {@link mage.constants.Zone} to add cards to.
-     * @param player {@link Player} to add cards for. Use either playerA or
-     * playerB.
+     * @param player   {@link Player} to add cards for. Use either playerA or
+     *                 playerB.
      * @param cardName Card name in string format.
      */
     @Override
@@ -519,10 +520,10 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Add any amount of cards to specified zone of specified player.
      *
      * @param gameZone {@link mage.constants.Zone} to add cards to.
-     * @param player {@link Player} to add cards for. Use either playerA or
-     * playerB.
+     * @param player   {@link Player} to add cards for. Use either playerA or
+     *                 playerB.
      * @param cardName Card name in string format.
-     * @param count Amount of cards to be added.
+     * @param count    Amount of cards to be added.
      */
     @Override
     public void addCard(Zone gameZone, TestPlayer player, String cardName, int count) {
@@ -533,13 +534,13 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Add any amount of cards to specified zone of specified player.
      *
      * @param gameZone {@link mage.constants.Zone} to add cards to.
-     * @param player {@link Player} to add cards for. Use either playerA or
-     * playerB.
+     * @param player   {@link Player} to add cards for. Use either playerA or
+     *                 playerB.
      * @param cardName Card name in string format.
-     * @param count Amount of cards to be added.
-     * @param tapped In case gameZone is Battlefield, determines whether
-     * permanent should be tapped. In case gameZone is other than Battlefield,
-     * {@link IllegalArgumentException} is thrown
+     * @param count    Amount of cards to be added.
+     * @param tapped   In case gameZone is Battlefield, determines whether
+     *                 permanent should be tapped. In case gameZone is other than Battlefield,
+     *                 {@link IllegalArgumentException} is thrown
      */
     @Override
     public void addCard(Zone gameZone, TestPlayer player, String cardName, int count, boolean tapped) {
@@ -620,7 +621,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Set player's initial life count.
      *
      * @param player {@link Player} to set life count for.
-     * @param life Life count to set.
+     * @param life   Life count to set.
      */
     @Override
     public void setLife(TestPlayer player, int life) {
@@ -697,7 +698,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert player's life count after test execution.
      *
      * @param player {@link Player} to get life for comparison.
-     * @param life Expected player's life to compare with.
+     * @param life   Expected player's life to compare with.
      */
     @Override
     public void assertLife(Player player, int life) throws AssertionError {
@@ -714,14 +715,14 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * params 3b. all: there is at least one creature with the cardName with the
      * different p\t params
      *
-     * @param player {@link Player} to get creatures for comparison.
-     * @param cardName Card name to compare with.
-     * @param power Expected power to compare with.
+     * @param player    {@link Player} to get creatures for comparison.
+     * @param cardName  Card name to compare with.
+     * @param power     Expected power to compare with.
      * @param toughness Expected toughness to compare with.
-     * @param scope {@link mage.filter.Filter.ComparisonScope} Use ANY, if you
-     * want "at least one creature with given name should have specified p\t"
-     * Use ALL, if you want "all creature with gived name should have specified
-     * p\t"
+     * @param scope     {@link mage.filter.Filter.ComparisonScope} Use ANY, if you
+     *                  want "at least one creature with given name should have specified p\t"
+     *                  Use ALL, if you want "all creature with gived name should have specified
+     *                  p\t"
      */
     @Override
     public void assertPowerToughness(Player player, String cardName, int power, int toughness, Filter.ComparisonScope scope)
@@ -811,8 +812,8 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * @param cardName
      * @param ability
      * @param mustHave true if creature should contain ability, false if it
-     * should NOT contain it instead
-     * @param count number of permanents with that ability
+     *                 should NOT contain it instead
+     * @param count    number of permanents with that ability
      * @throws AssertionError
      */
     public void assertAbility(Player player, String cardName, Ability ability, boolean mustHave, int count) throws AssertionError {
@@ -845,7 +846,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert permanent count under player's control.
      *
      * @param player {@link Player} which permanents should be counted.
-     * @param count Expected count.
+     * @param count  Expected count.
      */
     @Override
     public void assertPermanentCount(Player player, int count) throws AssertionError {
@@ -861,9 +862,9 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     /**
      * Assert permanent count under player's control.
      *
-     * @param player {@link Player} which permanents should be counted.
+     * @param player   {@link Player} which permanents should be counted.
      * @param cardName Name of the cards that should be counted.
-     * @param count Expected count.
+     * @param count    Expected count.
      */
     @Override
     public void assertPermanentCount(Player player, String cardName, int count) throws AssertionError {
@@ -913,8 +914,8 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert counter count on a permanent
      *
      * @param cardName Name of the cards that should be counted.
-     * @param type Type of the counter that should be counted.
-     * @param count Expected count.
+     * @param type     Type of the counter that should be counted.
+     * @param count    Expected count.
      */
     public void assertCounterCount(String cardName, CounterType type, int count) throws AssertionError {
         this.assertCounterCount(null, cardName, type, count);
@@ -937,8 +938,8 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert counter count on a card in exile
      *
      * @param cardName Name of the cards that should be counted.
-     * @param type Type of the counter that should be counted.
-     * @param count Expected count.
+     * @param type     Type of the counter that should be counted.
+     * @param count    Expected count.
      */
     public void assertCounterOnExiledCardCount(String cardName, CounterType type, int count) throws AssertionError {
         //Assert.assertNotEquals("", cardName);
@@ -961,8 +962,8 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert counter count on a player
      *
      * @param player The player whos counters should be counted.
-     * @param type Type of the counter that should be counted.
-     * @param count Expected count.
+     * @param type   Type of the counter that should be counted.
+     * @param count  Expected count.
      */
     public void assertCounterCount(Player player, CounterType type, int count) throws AssertionError {
         Assert.assertEquals("(Battlefield) Counter counts are not equal (" + player.getName() + ':' + type + ')', count, player.getCounters().getCount(type));
@@ -972,7 +973,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert whether a permanent is a specified type or not
      *
      * @param cardName Name of the permanent that should be checked.
-     * @param type A type to test for
+     * @param type     A type to test for
      * @param mustHave true if creature should have type, false if it should not
      */
     public void assertType(String cardName, CardType type, boolean mustHave) throws AssertionError {
@@ -997,8 +998,8 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert whether a permanent is a specified type
      *
      * @param cardName Name of the permanent that should be checked.
-     * @param type A type to test for
-     * @param subType a subtype to test for
+     * @param type     A type to test for
+     * @param subType  a subtype to test for
      */
     public void assertType(String cardName, CardType type, SubType subType) throws AssertionError {
         //Assert.assertNotEquals("", cardName);
@@ -1013,7 +1014,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert whether a permanent is not a specified type
      *
      * @param cardName Name of the permanent that should be checked.
-     * @param type A type to test for
+     * @param type     A type to test for
      */
     public void assertNotType(String cardName, CardType type) throws AssertionError {
         //Assert.assertNotEquals("", cardName);
@@ -1025,7 +1026,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert whether a permanent is not a specified subtype
      *
      * @param cardName Name of the permanent that should be checked.
-     * @param subType a subtype to test for
+     * @param subType  a subtype to test for
      */
     public void assertNotSubtype(String cardName, SubType subType) throws AssertionError {
         //Assert.assertNotEquals("", cardName);
@@ -1038,10 +1039,10 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     /**
      * Assert permanent color
      *
-     * @param player player to check
-     * @param cardName card name on battlefield from player
+     * @param player       player to check
+     * @param cardName     card name on battlefield from player
      * @param searchColors colors list with searchable values
-     * @param mustHave must or not must have that colors
+     * @param mustHave     must or not must have that colors
      */
     public void assertColor(Player player, String cardName, ObjectColor searchColors, boolean mustHave) {
         //Assert.assertNotEquals("", cardName);
@@ -1076,7 +1077,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert whether a permanent is tapped or not
      *
      * @param cardName Name of the permanent that should be checked.
-     * @param tapped Whether the permanent is tapped or not
+     * @param tapped   Whether the permanent is tapped or not
      */
     public void assertTapped(String cardName, boolean tapped) throws AssertionError {
         //Assert.assertNotEquals("", cardName);
@@ -1103,8 +1104,8 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert whether X permanents of the same name are tapped or not.
      *
      * @param cardName Name of the permanent that should be checked.
-     * @param tapped Whether the permanent is tapped or not
-     * @param count The amount of this permanents that should be tapped
+     * @param tapped   Whether the permanent is tapped or not
+     * @param count    The amount of this permanents that should be tapped
      */
     public void assertTappedCount(String cardName, boolean tapped, int count) throws AssertionError {
         //Assert.assertNotEquals("", cardName);
@@ -1126,7 +1127,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     /**
      * Assert whether a permanent is attacking or not
      *
-     * @param cardName Name of the permanent that should be checked.
+     * @param cardName  Name of the permanent that should be checked.
      * @param attacking Whether the permanent is attacking or not
      */
     public void assertAttacking(String cardName, boolean attacking) throws AssertionError {
@@ -1148,7 +1149,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert card count in player's hand.
      *
      * @param player {@link Player} who's hand should be counted.
-     * @param count Expected count.
+     * @param count  Expected count.
      */
     public void assertHandCount(Player player, int count) throws AssertionError {
         int actual = currentGame.getPlayer(player.getId()).getHand().size();
@@ -1158,9 +1159,9 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     /**
      * Assert card count in player's hand.
      *
-     * @param player {@link Player} who's hand should be counted.
+     * @param player   {@link Player} who's hand should be counted.
      * @param cardName Name of the cards that should be counted.
-     * @param count Expected count.
+     * @param count    Expected count.
      */
     public void assertHandCount(Player player, String cardName, int count) throws AssertionError {
         //Assert.assertNotEquals("", cardName);
@@ -1208,7 +1209,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert card count in player's graveyard.
      *
      * @param player {@link Player} who's graveyard should be counted.
-     * @param count Expected count.
+     * @param count  Expected count.
      */
     public void assertGraveyardCount(Player player, int count) throws AssertionError {
         int actual = currentGame.getPlayer(player.getId()).getGraveyard().size();
@@ -1219,7 +1220,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert card count in exile.
      *
      * @param cardName Name of the cards that should be counted.
-     * @param count Expected count.
+     * @param count    Expected count.
      */
     public void assertExileCount(String cardName, int count) throws AssertionError {
         //Assert.assertNotEquals("", cardName);
@@ -1257,9 +1258,9 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     /**
      * Assert card count in player's exile.
      *
-     * @param owner {@link Player} who's exile should be counted.
+     * @param owner    {@link Player} who's exile should be counted.
      * @param cardName Name of the cards that should be counted.
-     * @param count Expected count.
+     * @param count    Expected count.
      */
     public void assertExileCount(Player owner, String cardName, int count) throws AssertionError {
         //Assert.assertNotEquals("", cardName);
@@ -1278,9 +1279,9 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     /**
      * Assert card count in player's graveyard.
      *
-     * @param player {@link Player} who's graveyard should be counted.
+     * @param player   {@link Player} who's graveyard should be counted.
      * @param cardName Name of the cards that should be counted.
-     * @param count Expected count.
+     * @param count    Expected count.
      */
     public void assertGraveyardCount(Player player, String cardName, int count) throws AssertionError {
         assertAliaseSupportInActivateCommand(cardName, true);
@@ -1299,7 +1300,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * Assert library card count.
      *
      * @param player {@link Player} who's library should be counted.
-     * @param count Expected count.
+     * @param count  Expected count.
      */
     public void assertLibraryCount(Player player, int count) throws AssertionError {
         List<Card> libraryList = player.getLibrary().getCards(currentGame);
@@ -1310,9 +1311,9 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     /**
      * Assert specific card count in player's library.
      *
-     * @param player {@link Player} who's library should be counted.
+     * @param player   {@link Player} who's library should be counted.
      * @param cardName Name of the cards that should be counted.
-     * @param count Expected count.
+     * @param count    Expected count.
      */
     public void assertLibraryCount(Player player, String cardName, int count) throws AssertionError {
         //Assert.assertNotEquals("", cardName);
@@ -1350,6 +1351,12 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
         Assert.assertEquals("(Targets of " + player.getName() + ") Count are not equal (found " + player.getTargets() + ")", count, player.getTargets().size());
     }
 
+    /**
+     * Raise error on any unused commands, choices or targets
+     * If you want to test that ability can't be activated then use call checkPlayableAbility()
+     *
+     * @throws AssertionError
+     */
     public void assertAllCommandsUsed() throws AssertionError {
         for (Player player : currentGame.getPlayers().values()) {
             TestPlayer testPlayer = (TestPlayer) player;
@@ -1493,8 +1500,8 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * @param player
      * @param cardName
      * @param targetName for modes you can add "mode=3" before target name,
-     * multiple targets can be seperated by ^, not target marks as
-     * TestPlayer.NO_TARGET
+     *                   multiple targets can be seperated by ^, not target marks as
+     *                   TestPlayer.NO_TARGET
      */
     public void castSpell(int turnNum, PhaseStep step, TestPlayer player, String cardName, String targetName) {
         //Assert.assertNotEquals("", cardName);
@@ -1517,8 +1524,8 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * @param step
      * @param player
      * @param cardName
-     * @param targetName for modal spells add the mode to the name e.g.
-     * "mode=2SilvercoatLion^mode3=PillarfieldOx"
+     * @param targetName   for modal spells add the mode to the name e.g.
+     *                     "mode=2SilvercoatLion^mode3=PillarfieldOx"
      * @param spellOnStack
      */
     public void castSpell(int turnNum, PhaseStep step, TestPlayer player, String cardName, String targetName, String spellOnStack) {
@@ -1605,7 +1612,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * @param step
      * @param player
      * @param ability
-     * @param targetName use NO_TARGET if there is no target to set
+     * @param targetName   use NO_TARGET if there is no target to set
      * @param spellOnStack
      */
     public void activateAbility(int turnNum, PhaseStep step, TestPlayer player, String ability, String targetName, String spellOnStack) {
@@ -1618,8 +1625,8 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * @param step
      * @param player
      * @param ability
-     * @param targetName if not target has to be defined use the constant
-     * NO_TARGET
+     * @param targetName   if not target has to be defined use the constant
+     *                     NO_TARGET
      * @param spellOnStack
      * @param clause
      */
@@ -1705,10 +1712,10 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      *
      * @param player
      * @param choice starting with "1" for mode 1, "2" for mode 2 and so on (to
-     * set multiple modes call the command multiple times). If a spell mode can
-     * be used only once like Demonic Pact, the value has to be set to the
-     * number of the remaining modes (e.g. if only 2 are left the number need to
-     * be 1 or 2).
+     *               set multiple modes call the command multiple times). If a spell mode can
+     *               be used only once like Demonic Pact, the value has to be set to the
+     *               number of the remaining modes (e.g. if only 2 are left the number need to
+     *               be 1 or 2).
      */
     public void setModeChoice(TestPlayer player, String choice) {
         player.addModeChoice(choice);
@@ -1719,12 +1726,12 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      *
      * @param player
      * @param target you can add multiple targets by separating them by the "^"
-     * character e.g. "creatureName1^creatureName2" you can qualify the target
-     * additional by setcode e.g. "creatureName-M15" you can add [no copy] to
-     * the end of the target name to prohibit targets that are copied you can
-     * add [only copy] to the end of the target name to allow only targets that
-     * are copies. For modal spells use a prefix with the mode number:
-     * mode=1Lightning Bolt^mode=2Silvercoat Lion
+     *               character e.g. "creatureName1^creatureName2" you can qualify the target
+     *               additional by setcode e.g. "creatureName-M15" you can add [no copy] to
+     *               the end of the target name to prohibit targets that are copied you can
+     *               add [only copy] to the end of the target name to allow only targets that
+     *               are copies. For modal spells use a prefix with the mode number:
+     *               mode=1Lightning Bolt^mode=2Silvercoat Lion
      */
     // TODO: mode options doesn't work here (see BrutalExpulsionTest)
     public void addTarget(TestPlayer player, String target) {
@@ -1744,7 +1751,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     /**
      * @param player
      * @param target use TestPlayer.TARGET_SKIP to 0 targets selects or to stop
-     * "up two xxx" selection
+     *               "up two xxx" selection
      * @param amount
      */
     public void addTargetAmount(TestPlayer player, String target, int amount) {

--- a/Mage/src/main/java/mage/abilities/SpecialAction.java
+++ b/Mage/src/main/java/mage/abilities/SpecialAction.java
@@ -1,18 +1,22 @@
-
-
 package mage.abilities;
 
+import mage.abilities.costs.mana.AlternateManaPaymentAbility;
 import mage.abilities.costs.mana.ManaCost;
+import mage.abilities.mana.ManaOptions;
 import mage.constants.AbilityType;
 import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.stack.Spell;
+import mage.game.stack.StackObject;
+
+import java.util.UUID;
 
 /**
- *
- * @author BetaSteward_at_googlemail.com
+ * @author BetaSteward_at_googlemail.com, JayDi85
  */
 public abstract class SpecialAction extends ActivatedAbilityImpl {
 
-    private boolean manaAction;
+    private final AlternateManaPaymentAbility manaAbility; // mana actions generates on every pay cycle, no need to copy it
     protected ManaCost unpaidMana;
 
     public SpecialAction() {
@@ -20,22 +24,23 @@ public abstract class SpecialAction extends ActivatedAbilityImpl {
     }
 
     public SpecialAction(Zone zone) {
-        this(zone, false);
+        this(zone, null);
     }
-    public SpecialAction(Zone zone, boolean manaAction) {
+
+    public SpecialAction(Zone zone, AlternateManaPaymentAbility manaAbility) {
         super(AbilityType.SPECIAL_ACTION, zone);
         this.usesStack = false;
-        this.manaAction = manaAction;
+        this.manaAbility = manaAbility;
     }
 
     public SpecialAction(final SpecialAction action) {
         super(action);
-        this.manaAction = action.manaAction;
         this.unpaidMana = action.unpaidMana;
+        this.manaAbility = action.manaAbility;
     }
 
     public boolean isManaAction() {
-        return manaAction;
+        return manaAbility != null;
     }
 
     public void setUnpaidMana(ManaCost manaCost) {
@@ -44,5 +49,30 @@ public abstract class SpecialAction extends ActivatedAbilityImpl {
 
     public ManaCost getUnpaidMana() {
         return unpaidMana;
+    }
+
+    public ManaOptions getManaOptions(Ability source, Game game, ManaCost unpaid) {
+        if (manaAbility != null) {
+            return manaAbility.getManaOptions(source, game, unpaid);
+        }
+        return null;
+    }
+
+    @Override
+    public ActivationStatus canActivate(UUID playerId, Game game) {
+        if (isManaAction()) {
+            // limit play mana abilities by steps
+            int currentStepOrder = 0;
+            if (!game.getStack().isEmpty()) {
+                StackObject stackObject = game.getStack().getFirst();
+                if (stackObject instanceof Spell) {
+                    currentStepOrder = ((Spell) stackObject).getCurrentActivatingManaAbilitiesStep().getStepOrder();
+                }
+            }
+            if (currentStepOrder > manaAbility.useOnActivationManaAbilityStep().getStepOrder()) {
+                return ActivationStatus.getFalse();
+            }
+        }
+        return super.canActivate(playerId, game);
     }
 }

--- a/Mage/src/main/java/mage/abilities/costs/mana/ActivationManaAbilityStep.java
+++ b/Mage/src/main/java/mage/abilities/costs/mana/ActivationManaAbilityStep.java
@@ -1,0 +1,25 @@
+package mage.abilities.costs.mana;
+
+/**
+ * Some special AlternateManaPaymentAbility must be restricted to pay before or after mana abilities.
+ * Game logic: if you use special mana ability then normal mana abilities must be restricted and vice versa,
+ * see Convoke for more info and rules
+ *
+ * @author JayDi85
+ */
+
+public enum ActivationManaAbilityStep {
+    BEFORE(0), // assist
+    NORMAL(1), // all activated mana abilities
+    AFTER(2); // convoke, delve, improvise
+
+    private final int stepOrder;
+
+    ActivationManaAbilityStep(int stepOrder) {
+        this.stepOrder = stepOrder;
+    }
+
+    public int getStepOrder() {
+        return stepOrder;
+    }
+}

--- a/Mage/src/main/java/mage/abilities/costs/mana/AlternateManaPaymentAbility.java
+++ b/Mage/src/main/java/mage/abilities/costs/mana/AlternateManaPaymentAbility.java
@@ -1,18 +1,17 @@
-
 package mage.abilities.costs.mana;
 
 import mage.abilities.Ability;
+import mage.abilities.mana.ManaOptions;
 import mage.game.Game;
 
 /**
  * Interface for abilities that allow the player to pay mana costs of a spell in alternate ways.
  * For the payment SpecialActions are used.
- *
+ * <p>
  * Example of such an alternate payment ability: {@link mage.abilities.keyword.DelveAbility}
  *
- * @author LevelX2
+ * @author LevelX2, JayDi85
  */
-@FunctionalInterface
 public interface AlternateManaPaymentAbility {
     /**
      * Adds the special action to the state, that allows the user to do the alternate mana payment
@@ -22,4 +21,21 @@ public interface AlternateManaPaymentAbility {
      * @param unpaid unapaid mana costs of the spell
      */
     void addSpecialAction(Ability source, Game game, ManaCost unpaid);
+
+    /**
+     * All possible mana payments that can make that ability (uses to find playable abilities)
+     *
+     * @param source
+     * @param game
+     * @param unpaid
+     * @return
+     */
+    ManaOptions getManaOptions(Ability source, Game game, ManaCost unpaid);
+
+    /**
+     * Mana payment step where you can use it
+     *
+     * @return
+     */
+    ActivationManaAbilityStep useOnActivationManaAbilityStep();
 }

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
@@ -1,10 +1,10 @@
 package mage.abilities.effects;
 
-import java.util.*;
 import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.CompoundAbility;
 import mage.abilities.MageSingleton;
+import mage.abilities.costs.mana.ActivationManaAbilityStep;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.DomainValue;
 import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
@@ -19,6 +19,8 @@ import mage.game.stack.Spell;
 import mage.game.stack.StackObject;
 import mage.players.Player;
 import mage.target.targetpointer.TargetPointer;
+
+import java.util.*;
 
 /**
  * @author BetaSteward_at_googlemail.com, JayDi85
@@ -416,7 +418,7 @@ public abstract class ContinuousEffectImpl extends EffectImpl implements Continu
             StackObject stackObject = game.getStack().getFirst();
             return !(stackObject instanceof Spell)
                     || !Zone.LIBRARY.equals(((Spell) stackObject).getFromZone())
-                    || ((Spell) stackObject).isDoneActivatingManaAbilities();
+                    || ((Spell) stackObject).getCurrentActivatingManaAbilitiesStep() == ActivationManaAbilityStep.AFTER; // mana payment finished
         }
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/keyword/AssistAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/AssistAbility.java
@@ -5,21 +5,37 @@ import mage.abilities.Ability;
 import mage.abilities.SpecialAction;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.Cost;
+import mage.abilities.costs.mana.ActivationManaAbilityStep;
 import mage.abilities.costs.mana.AlternateManaPaymentAbility;
 import mage.abilities.costs.mana.ManaCost;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.mana.ManaOptions;
 import mage.constants.*;
 import mage.filter.FilterPlayer;
 import mage.game.Game;
+import mage.game.stack.Spell;
 import mage.players.ManaPool;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.TargetPlayer;
 import mage.util.ManaUtil;
 
-/*
- * @author emerald000
+import java.util.UUID;
+
+/**
+ * 702.131. Assist
+ * <p>
+ * 702.131a Assist is a static ability that modifies the rules of paying for the spell with assist (see rules 601.2g-h).
+ * If the total cost to cast a spell with assist includes a generic mana component, before you activate mana
+ * abilities while casting it, you may choose another player. That player has a chance to activate mana abilities.
+ * Once that player chooses not to activate any more mana abilities, you have a chance to activate mana abilities.
+ * Before you begin to pay the total cost of the spell, the player you chose may pay for any amount of the generic
+ * mana in the spell’s total cost.
+ *
+ * @author emerald000, JayDi85
  */
+
+
 public class AssistAbility extends SimpleStaticAbility implements AlternateManaPaymentAbility {
 
     private static final FilterPlayer filter = new FilterPlayer("another player");
@@ -29,7 +45,7 @@ public class AssistAbility extends SimpleStaticAbility implements AlternateManaP
     }
 
     public AssistAbility() {
-        super(Zone.STACK, null);
+        super(Zone.ALL, null);
         this.setRuleAtTheTop(true);
     }
 
@@ -43,13 +59,23 @@ public class AssistAbility extends SimpleStaticAbility implements AlternateManaP
     }
 
     @Override
+    public String getRule() {
+        return "Assist <i>(Another player can help pay the generic mana of this spell's cost.)</i>";
+    }
+
+    @Override
+    public ActivationManaAbilityStep useOnActivationManaAbilityStep() {
+        return ActivationManaAbilityStep.BEFORE;
+    }
+
+    @Override
     public void addSpecialAction(Ability source, Game game, ManaCost unpaid) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null
                 && source.getAbilityType() == AbilityType.SPELL
                 && unpaid.getMana().getGeneric() >= 1
-                && game.getState().getValue(source.getSourceId().toString() + game.getState().getZoneChangeCounter(source.getSourceId())) == null) {
-            SpecialAction specialAction = new AssistSpecialAction(unpaid);
+                && game.getState().getValue(source.getSourceId().toString() + game.getState().getZoneChangeCounter(source.getSourceId()) + "_assisted") == null) {
+            SpecialAction specialAction = new AssistSpecialAction(unpaid, this);
             specialAction.setControllerId(source.getControllerId());
             specialAction.setSourceId(source.getSourceId());
             Target target = new TargetPlayer(1, 1, true, filter);
@@ -61,15 +87,47 @@ public class AssistAbility extends SimpleStaticAbility implements AlternateManaP
     }
 
     @Override
-    public String getRule() {
-        return "Assist <i>(Another player can help pay the generic mana of this spell's cost.)</i>";
+    public ManaOptions getManaOptions(Ability source, Game game, ManaCost unpaid) {
+        ManaOptions options = new ManaOptions();
+        if (unpaid.getMana().getGeneric() == 0) {
+            // nothing to pay
+            return options;
+        }
+
+        // AI can't use assist (can't ask another player to help), maybe in teammode it can be enabled, but tests must works all the time
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null && !controller.isTestMode() && !controller.isHuman()) {
+            return options;
+        }
+
+        // search opponents who can help with generic pay
+        int opponentCanPayMax = 0;
+        for (UUID opponentId : game.getOpponents(source.getControllerId())) {
+            Player opponent = game.getPlayer(opponentId);
+            if (opponent != null) {
+                // basic and pool, but no coditional mana
+                ManaOptions availableMana = opponent.getManaAvailable(game);
+                availableMana.addMana(opponent.getManaPool().getMana());
+                for (Mana mana : availableMana) {
+                    if (mana.count() > 0) {
+                        opponentCanPayMax = Math.max(opponentCanPayMax, mana.count());
+                    }
+                }
+            }
+        }
+
+        if (opponentCanPayMax > 0) {
+            options.addMana(Mana.GenericMana(Math.min(unpaid.getMana().getGeneric(), opponentCanPayMax)));
+        }
+
+        return options;
     }
 }
 
 class AssistSpecialAction extends SpecialAction {
 
-    AssistSpecialAction(ManaCost unpaid) {
-        super(Zone.ALL, true);
+    AssistSpecialAction(ManaCost unpaid, AlternateManaPaymentAbility manaAbility) {
+        super(Zone.ALL, manaAbility);
         setRuleVisible(false);
         this.addEffect(new AssistEffect(unpaid));
     }
@@ -108,17 +166,28 @@ class AssistEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         Player targetPlayer = game.getPlayer(this.getTargetPointer().getFirst(game, source));
-        if (controller != null && targetPlayer != null) {
-            int amountToPay = targetPlayer.announceXMana(0, unpaid.getMana().getGeneric(), "How much mana to pay?", game, source);
+        Spell spell = game.getStack().getSpell(source.getSourceId());
+        if (controller != null && spell != null && targetPlayer != null) {
+            // AI can't assist other players, maybe for teammates only (but tests must work as normal)
+            int amountToPay = 0;
+            if (targetPlayer.isHuman() || targetPlayer.isTestMode()) {
+                amountToPay = targetPlayer.announceXMana(0, unpaid.getMana().getGeneric(),
+                        "How much mana to pay as assist for " + controller.getName() + "?", game, source);
+            }
+
             if (amountToPay > 0) {
                 Cost cost = ManaUtil.createManaCost(amountToPay, false);
                 if (cost.pay(source, game, source.getSourceId(), targetPlayer.getId(), false)) {
                     ManaPool manaPool = controller.getManaPool();
                     manaPool.addMana(Mana.ColorlessMana(amountToPay), game, source);
-                    manaPool.unlockManaType(ManaType.COLORLESS);
-                    game.informPlayers(targetPlayer.getLogName() + " paid {" + amountToPay + "}.");
-                    game.getState().setValue(source.getSourceId().toString() + game.getState().getZoneChangeCounter(source.getSourceId()), true);
+                    manaPool.unlockManaType(ManaType.COLORLESS); // it's unlock mana for one use/click, but it can gives more
+                    game.informPlayers(targetPlayer.getLogName() + " paid {" + amountToPay + "} for " + controller.getLogName());
+                    game.getState().setValue(source.getSourceId().toString() + game.getState().getZoneChangeCounter(source.getSourceId()) + "_assisted", true);
                 }
+
+                // assist must be used before activating mana abilities, so no need to switch step after usage
+                // (mana and other special abilities can be used after assist)
+                //spell.setCurrentActivatingManaAbilitiesStep(ActivationManaAbilityStep.NORMAL);
             }
             return true;
         }

--- a/Mage/src/main/java/mage/abilities/keyword/DelveAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/DelveAbility.java
@@ -5,9 +5,14 @@ import mage.abilities.Ability;
 import mage.abilities.SpecialAction;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.ExileFromGraveCost;
+import mage.abilities.costs.mana.ActivationManaAbilityStep;
 import mage.abilities.costs.mana.AlternateManaPaymentAbility;
 import mage.abilities.costs.mana.ManaCost;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.CardsInControllerGraveyardCount;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.hint.ValueHint;
+import mage.abilities.mana.ManaOptions;
 import mage.cards.Card;
 import mage.cards.Cards;
 import mage.cards.CardsImpl;
@@ -17,6 +22,7 @@ import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.game.Game;
+import mage.game.stack.Spell;
 import mage.players.ManaPool;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
@@ -25,35 +31,42 @@ import mage.util.CardUtil;
 import java.util.List;
 
 /**
- * 702.65. Delve 702.65a Delve is a static ability that functions while the
- * spell with delve is on the stack. “Delve” means “For each generic mana in
- * this spell's total cost, you may exile a card from your graveyard rather than
- * pay that mana.” The delve ability isn't an additional or alternative cost and
- * applies only after the total cost of the spell with delve is determined.
- * 702.65b Multiple instances of delve on the same spell are redundant.
+ * 702.65. Delve
  * <p>
- * The rules for delve have changed slightly since it was last in an expansion.
- * Previously, delve reduced the cost to cast a spell. Under the current rules,
- * you exile cards from your graveyard at the same time you pay the spell's
- * cost. Exiling a card this way is simply another way to pay that cost. * Delve
- * doesn't change a spell's mana cost or converted mana cost. For example, Dead
- * Drop's converted mana cost is 10 even if you exiled three cards to cast it. *
- * You can't exile cards to pay for the colored mana requirements of a spell
- * with delve. * You can't exile more cards than the generic mana requirement of
- * a spell with delve. For example, you can't exile more than nine cards from
- * your graveyard to cast Dead Drop. * Because delve isn't an alternative cost,
- * it can be used in conjunction with alternative costs.
+ * 702.65a Delve is a static ability that functions while the spell with delve is on the stack. “Delve” means “For
+ * each generic mana in this spell’s total cost, you may exile a card from your graveyard rather than pay that mana.”
+ * <p>
+ * 702.65b The delve ability isn’t an additional or alternative cost and applies only after the total cost of the spell
+ * with delve is determined.
+ * <p>
+ * 702.65c Multiple instances of delve on the same spell are redundant.
+ * <p>
+ * The rules for delve have changed slightly since it was last in an expansion. Previously, delve reduced the cost
+ * to cast a spell. Under the current rules, you exile cards from your graveyard at the same time you pay the spell’s
+ * cost. Exiling a card this way is simply another way to pay that cost. (This is similar to the change made to
+ * convoke for the Magic 2015 Core Set.)
+ * <p>
+ * You can’t exile cards to pay for the colored mana requirements of a spell with delve.
+ * <p>
+ * You can’t exile more cards than the generic mana requirement of a spell with delve. For example, you can’t exile more
+ * than nine cards from your graveyard to cast Dead Drop.
+ * <p>
+ * Because delve isn’t an alternative cost, it can be used in conjunction with alternative costs.
  *
- * @author LevelX2
+ * @author LevelX2, JayDi85
  * <p>
  * TODO: Change card exiling to a way to pay mana costs, now it's maybe not
  * possible to pay costs from effects that increase the mana costs.
+ * If it real bug then possible fix: choose cards on apply like convoke and improvise, not as cost
  */
 public class DelveAbility extends SimpleStaticAbility implements AlternateManaPaymentAbility {
 
+    private static final DynamicValue cardsInGraveyard = new CardsInControllerGraveyardCount();
+
     public DelveAbility() {
-        super(Zone.STACK, null);
+        super(Zone.ALL, null);
         this.setRuleAtTheTop(true);
+        this.addHint(new ValueHint("Cards in your graveyard", cardsInGraveyard));
     }
 
     public DelveAbility(final DelveAbility ability) {
@@ -71,11 +84,16 @@ public class DelveAbility extends SimpleStaticAbility implements AlternateManaPa
     }
 
     @Override
+    public ActivationManaAbilityStep useOnActivationManaAbilityStep() {
+        return ActivationManaAbilityStep.AFTER;
+    }
+
+    @Override
     public void addSpecialAction(Ability source, Game game, ManaCost unpaid) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && !controller.getGraveyard().isEmpty()) {
-            if (unpaid.getMana().getGeneric() > 0 && source.getAbilityType() == AbilityType.SPELL) {
-                SpecialAction specialAction = new DelveSpecialAction();
+            if (source.getAbilityType() == AbilityType.SPELL && unpaid.getMana().getGeneric() > 0) {
+                SpecialAction specialAction = new DelveSpecialAction(this);
                 specialAction.setControllerId(source.getControllerId());
                 specialAction.setSourceId(source.getSourceId());
                 int unpaidAmount = unpaid.getMana().getGeneric();
@@ -84,19 +102,30 @@ public class DelveAbility extends SimpleStaticAbility implements AlternateManaPa
                 }
                 specialAction.addCost(new ExileFromGraveCost(new TargetCardInYourGraveyard(
                         0, Math.min(controller.getGraveyard().size(), unpaidAmount),
-                        new FilterCard("cards to exile for delve's pay from your graveyard"), true)));
+                        new FilterCard("cards from your graveyard"), true)));
                 if (specialAction.canActivate(source.getControllerId(), game).canActivate()) {
                     game.getState().getSpecialActions().add(specialAction);
                 }
             }
         }
     }
+
+    @Override
+    public ManaOptions getManaOptions(Ability source, Game game, ManaCost unpaid) {
+        ManaOptions options = new ManaOptions();
+        Player controller = game.getPlayer(source.getControllerId());
+        int graveCount = cardsInGraveyard.calculate(game, source, null);
+        if (controller != null && graveCount > 0) {
+            options.addMana(Mana.GenericMana(Math.min(unpaid.getMana().getGeneric(), graveCount)));
+        }
+        return options;
+    }
 }
 
 class DelveSpecialAction extends SpecialAction {
 
-    public DelveSpecialAction() {
-        super(Zone.ALL, true);
+    public DelveSpecialAction(AlternateManaPaymentAbility manaAbility) {
+        super(Zone.ALL, manaAbility);
         this.addEffect(new DelveEffect());
     }
 
@@ -129,9 +158,9 @@ class DelveEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null) {
+        Spell spell = game.getStack().getSpell(source.getSourceId());
+        if (controller != null && spell != null) {
             ExileFromGraveCost exileFromGraveCost = (ExileFromGraveCost) source.getCosts().get(0);
-
             List<Card> exiledCards = exileFromGraveCost.getExiledCards();
             if (!exiledCards.isEmpty()) {
                 Cards toDelve = new CardsImpl();
@@ -139,7 +168,7 @@ class DelveEffect extends OneShotEffect {
                     toDelve.add(card);
                 }
                 ManaPool manaPool = controller.getManaPool();
-                manaPool.addMana(new Mana(0, 0, 0, 0, 0, 0, 0, toDelve.size()), game, source);
+                manaPool.addMana(Mana.ColorlessMana(toDelve.size()), game, source);
                 manaPool.unlockManaType(ManaType.COLORLESS);
                 String keyString = CardUtil.getCardZoneString("delvedCards", source.getSourceId(), game);
                 @SuppressWarnings("unchecked")
@@ -149,6 +178,9 @@ class DelveEffect extends OneShotEffect {
                 } else {
                     delvedCards.addAll(toDelve);
                 }
+
+                // can't use mana abilities after that (delve cost must be payed after mana abilities only)
+                spell.setCurrentActivatingManaAbilitiesStep(ActivationManaAbilityStep.AFTER);
             }
             return true;
         }

--- a/Mage/src/main/java/mage/abilities/mana/ActivatedManaAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/mana/ActivatedManaAbilityImpl.java
@@ -10,6 +10,8 @@ import mage.constants.AsThoughEffectType;
 import mage.constants.TimingRule;
 import mage.constants.Zone;
 import mage.game.Game;
+import mage.game.stack.Spell;
+import mage.game.stack.StackObject;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,10 +56,24 @@ public abstract class ActivatedManaAbilityImpl extends ActivatedAbilityImpl impl
                 && null == game.getContinuousEffects().asThough(sourceId, AsThoughEffectType.ACTIVATE_AS_INSTANT, this, controllerId, game)) {
             return ActivationStatus.getFalse();
         }
-        // check if player is in the process of playing spell costs and they are no longer allowed to use activated mana abilities (e.g. because they started to use improvise)
+
+        // check if player is in the process of playing spell costs and they are no longer allowed to use
+        // activated mana abilities (e.g. because they started to use improvise or convoke)
+        if (!game.getStack().isEmpty()) {
+            StackObject stackObject = game.getStack().getFirst();
+            if (stackObject instanceof Spell) {
+                switch (((Spell) stackObject).getCurrentActivatingManaAbilitiesStep()) {
+                    case BEFORE:
+                    case NORMAL:
+                        break;
+                    case AFTER:
+                        return ActivationStatus.getFalse();
+                }
+            }
+        }
+
         //20091005 - 605.3a
         return new ActivationStatus(costs.canPay(this, sourceId, controllerId, game), null);
-
     }
 
     /**

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -1,9 +1,5 @@
 package mage.game;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.*;
-import java.util.Map.Entry;
 import mage.MageException;
 import mage.MageObject;
 import mage.abilities.*;
@@ -70,6 +66,11 @@ import mage.util.RandomUtil;
 import mage.util.functions.ApplyToPermanent;
 import mage.watchers.common.*;
 import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.*;
+import java.util.Map.Entry;
 
 public abstract class GameImpl implements Game, Serializable {
 
@@ -1548,7 +1549,7 @@ public abstract class GameImpl implements Game, Serializable {
     /**
      * @param emblem
      * @param sourceObject
-     * @param toPlayerId controller and owner of the emblem
+     * @param toPlayerId   controller and owner of the emblem
      */
     @Override
     public void addEmblem(Emblem emblem, MageObject sourceObject, UUID toPlayerId) {
@@ -1566,8 +1567,8 @@ public abstract class GameImpl implements Game, Serializable {
     /**
      * @param plane
      * @param sourceObject
-     * @param toPlayerId controller and owner of the plane (may only be one per
-     * game..)
+     * @param toPlayerId   controller and owner of the plane (may only be one per
+     *                     game..)
      * @return boolean - whether the plane was added successfully or not
      */
     @Override
@@ -1803,7 +1804,7 @@ public abstract class GameImpl implements Game, Serializable {
                     break;
                 }
                 // triggered abilities that don't use the stack have to be executed first (e.g. Banisher Priest Return exiled creature
-                for (Iterator<TriggeredAbility> it = abilities.iterator(); it.hasNext();) {
+                for (Iterator<TriggeredAbility> it = abilities.iterator(); it.hasNext(); ) {
                     TriggeredAbility triggeredAbility = it.next();
                     if (!triggeredAbility.isUsesStack()) {
                         state.removeTriggeredAbility(triggeredAbility);
@@ -2594,7 +2595,7 @@ public abstract class GameImpl implements Game, Serializable {
         }
         //20100423 - 800.4a
         Set<Card> toOutside = new HashSet<>();
-        for (Iterator<Permanent> it = getBattlefield().getAllPermanents().iterator(); it.hasNext();) {
+        for (Iterator<Permanent> it = getBattlefield().getAllPermanents().iterator(); it.hasNext(); ) {
             Permanent perm = it.next();
             if (perm.isOwnedBy(playerId)) {
                 if (perm.getAttachedTo() != null) {
@@ -2639,7 +2640,7 @@ public abstract class GameImpl implements Game, Serializable {
         player.moveCards(toOutside, Zone.OUTSIDE, null, this);
         // triggered abilities that don't use the stack have to be executed
         List<TriggeredAbility> abilities = state.getTriggered(player.getId());
-        for (Iterator<TriggeredAbility> it = abilities.iterator(); it.hasNext();) {
+        for (Iterator<TriggeredAbility> it = abilities.iterator(); it.hasNext(); ) {
             TriggeredAbility triggeredAbility = it.next();
             if (!triggeredAbility.isUsesStack()) {
                 state.removeTriggeredAbility(triggeredAbility);
@@ -2659,7 +2660,7 @@ public abstract class GameImpl implements Game, Serializable {
 
         // Remove cards from the player in all exile zones
         for (ExileZone exile : this.getExile().getExileZones()) {
-            for (Iterator<UUID> it = exile.iterator(); it.hasNext();) {
+            for (Iterator<UUID> it = exile.iterator(); it.hasNext(); ) {
                 Card card = this.getCard(it.next());
                 if (card != null && card.isOwnedBy(playerId)) {
                     it.remove();
@@ -2669,7 +2670,7 @@ public abstract class GameImpl implements Game, Serializable {
 
         //Remove all commander/emblems/plane the player controls
         boolean addPlaneAgain = false;
-        for (Iterator<CommandObject> it = this.getState().getCommand().iterator(); it.hasNext();) {
+        for (Iterator<CommandObject> it = this.getState().getCommand().iterator(); it.hasNext(); ) {
             CommandObject obj = it.next();
             if (obj.isControlledBy(playerId)) {
                 if (obj instanceof Emblem) {

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -1875,7 +1875,11 @@ public abstract class GameImpl implements Game, Serializable {
                     .forEach(commanders::add);
             commanders.removeIf(card -> state.checkCommanderShouldStay(card, this));
             for (Card card : commanders) {
-                if (player.chooseUse(Outcome.Benefit, "Move " + card.getIdName() + " to the command zone or leave it in its current zone?", "You can only make this choice once", "Move to command", "Leave in current zone", null, this)) {
+                Zone currentZone = this.getState().getZone(card.getId());
+                String currentZoneInfo = (currentZone == null ? "(error)" : "(" + currentZone.name() + ")");
+                if (player.chooseUse(Outcome.Benefit, "Move " + card.getIdName()
+                                + " to the command zone or leave it in current zone " + currentZoneInfo + "?", "You can only make this choice once per object",
+                        "Move to command", "Leave in current zone " + currentZoneInfo, null, this)) {
                     toMove.add(card);
                 } else {
                     state.setCommanderShouldStay(card, this);

--- a/Mage/src/main/java/mage/game/stack/Spell.java
+++ b/Mage/src/main/java/mage/game/stack/Spell.java
@@ -1,6 +1,5 @@
 package mage.game.stack;
 
-import java.util.*;
 import mage.MageInt;
 import mage.MageObject;
 import mage.Mana;
@@ -11,6 +10,7 @@ import mage.abilities.Mode;
 import mage.abilities.SpellAbility;
 import mage.abilities.costs.AlternativeSourceCosts;
 import mage.abilities.costs.Cost;
+import mage.abilities.costs.mana.ActivationManaAbilityStep;
 import mage.abilities.costs.mana.ManaCost;
 import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.keyword.BestowAbility;
@@ -31,6 +31,11 @@ import mage.game.permanent.PermanentCard;
 import mage.players.Player;
 import mage.util.GameLog;
 import mage.util.SubTypeList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * @author BetaSteward_at_googlemail.com
@@ -62,7 +67,7 @@ public class Spell extends StackObjImpl implements Card {
     private boolean resolving = false;
     private UUID commandedBy = null; // for Word of Command
 
-    private boolean doneActivatingManaAbilities; // if this is true, the player is no longer allowed to pay the spell costs with activating of mana abilies
+    private ActivationManaAbilityStep currentActivatingManaAbilitiesStep = ActivationManaAbilityStep.BEFORE;
 
     public Spell(Card card, SpellAbility ability, UUID controllerId, Zone fromZone) {
         this.card = card;
@@ -118,12 +123,12 @@ public class Spell extends StackObjImpl implements Card {
         this.resolving = spell.resolving;
         this.commandedBy = spell.commandedBy;
 
-        this.doneActivatingManaAbilities = spell.doneActivatingManaAbilities;
+        this.currentActivatingManaAbilitiesStep = spell.currentActivatingManaAbilitiesStep;
         this.targetChanged = spell.targetChanged;
     }
 
     public boolean activate(Game game, boolean noMana) {
-        setDoneActivatingManaAbilities(false); // used for e.g. improvise
+        setCurrentActivatingManaAbilitiesStep(ActivationManaAbilityStep.BEFORE); // mana payment step started, can use any mana abilities, see AlternateManaPaymentAbility
 
         if (!ability.activate(game, noMana)) {
             return false;
@@ -147,7 +152,7 @@ public class Spell extends StackObjImpl implements Card {
                 return false;
             }
         }
-        setDoneActivatingManaAbilities(true); // can be activated again maybe during the resolution of the spell (e.g. Metallic Rebuke)
+        setCurrentActivatingManaAbilitiesStep(ActivationManaAbilityStep.NORMAL);
         return true;
     }
 
@@ -401,12 +406,12 @@ public class Spell extends StackObjImpl implements Card {
         }
     }
 
-    public boolean isDoneActivatingManaAbilities() {
-        return doneActivatingManaAbilities;
+    public ActivationManaAbilityStep getCurrentActivatingManaAbilitiesStep() {
+        return this.currentActivatingManaAbilitiesStep;
     }
 
-    public void setDoneActivatingManaAbilities(boolean doneActivatingManaAbilities) {
-        this.doneActivatingManaAbilities = doneActivatingManaAbilities;
+    public void setCurrentActivatingManaAbilitiesStep(ActivationManaAbilityStep currentActivatingManaAbilitiesStep) {
+        this.currentActivatingManaAbilitiesStep = currentActivatingManaAbilitiesStep;
     }
 
     @Override

--- a/Mage/src/main/java/mage/util/ManaUtil.java
+++ b/Mage/src/main/java/mage/util/ManaUtil.java
@@ -1,6 +1,5 @@
 package mage.util;
 
-import java.util.*;
 import mage.MageObject;
 import mage.Mana;
 import mage.ManaSymbol;
@@ -18,6 +17,8 @@ import mage.constants.ColoredManaSymbol;
 import mage.filter.FilterMana;
 import mage.game.Game;
 import mage.players.Player;
+
+import java.util.*;
 
 /**
  * @author noxx
@@ -46,7 +47,7 @@ public final class ManaUtil {
      * In case we can't auto choose we'll simply return the useableAbilities map
      * back to caller without any modification.
      *
-     * @param unpaid Mana we need to pay. Can be null (it is for X costs now).
+     * @param unpaid           Mana we need to pay. Can be null (it is for X costs now).
      * @param useableAbilities List of mana abilities permanent may produce
      * @return List of mana abilities permanent may produce and are reasonable
      * for unpaid mana
@@ -403,7 +404,7 @@ public final class ManaUtil {
     }
 
     /**
-     * This activates the special button inthe feedback panel of the client if
+     * This activates the special button in the feedback panel of the client if
      * there exists special ways to pay the mana (e.g. Delve, Convoke)
      *
      * @param source ability the mana costs have to be paid for


### PR DESCRIPTION
Detailed information is available in the commits. Below information for what's new.

Special mana abilities improved:
* Cards with Convoke, Delve, Assist and Improvise abilities calculates available mana and are visible as playable;
* AI can play that cards and use special mana as pay (except for Assist);
* Added mtg's rules and restrictions support for activation order of normal and special mana abilities (rule 601.2f, see #768);
* Added hints and improved messages;