### PR TITLE
Update CI infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@ git:
   depth: 3
   submodules: false
 sudo: false
-dist: trusty
+dist: focal
 language: java
+jdk:
+  - openjdk11
+  - openjdk-ea
+matrix:
+  allow_failures:
+    - jdk: openjdk-ea
 before_install:
   - echo "MAVEN_OPTS='-Xmx2g'" > ~/.mavenrc
 cache:


### PR DESCRIPTION
@LevelX2 @jeffwadsworth @JayDi85 

This allows compiling XMage 1.4.43V0 under OpenJDK 11+
Tested with both currently supported OpenJDK versions: 11 (LTS) and 14.

All projects but one build fine. The only exception is Verify (the last one). I would appreciate help with that.

Output and logs below:

### Output

```
Results :

Failed tests:   verifyCards(mage.verify.VerifyCardDataTest): 24 errors in verify

Tests run: 13, Failures: 1, Errors: 0, Skipped: 2

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Mage Root 1.4.43 ................................... SUCCESS [  0.269 s]
[INFO] Mage Framework 1.4.43 .............................. SUCCESS [ 15.357 s]
[INFO] Mage Common Classes 1.4.43 ......................... SUCCESS [  0.717 s]
[INFO] Mage Sets 1.4.43 ................................... SUCCESS [01:00 min]
[INFO] Mage Server Plugins 1.4.43 ......................... SUCCESS [  0.076 s]
[INFO] Mage Player AI 1.4.43 .............................. SUCCESS [  0.382 s]
[INFO] Mage Deck Constructed 1.4.43 ....................... SUCCESS [  0.412 s]
[INFO] Mage Deck Limited 1.4.43 ........................... SUCCESS [  0.097 s]
[INFO] Mage Game Commander Two Player 1.4.43 .............. SUCCESS [  0.097 s]
[INFO] Mage Game Brawl Two Player 1.4.43 .................. SUCCESS [  0.108 s]
[INFO] Mage Game Commander Free For All 1.4.43 ............ SUCCESS [  0.088 s]
[INFO] Mage Game Brawl Free For All 1.4.43 ................ SUCCESS [  0.085 s]
[INFO] Mage Game Free For All 1.4.43 ...................... SUCCESS [  0.070 s]
[INFO] Mage Game Two Player 1.4.43 ........................ SUCCESS [  0.067 s]
[INFO] Mage Player Human 1.4.43 ........................... SUCCESS [  0.198 s]
[INFO] Mage Player AI Minimax 1.4.43 ...................... SUCCESS [  0.204 s]
[INFO] Mage Player AI.MA 1.4.43 ........................... SUCCESS [  0.255 s]
[INFO] Mage Player AI MCTS 1.4.43 ......................... SUCCESS [  0.235 s]
[INFO] Mage Tournament Booster Draft 1.4.43 ............... SUCCESS [  0.641 s]
[INFO] Mage Tournament Sealed 1.4.43 ...................... SUCCESS [  0.056 s]
[INFO] Mage Tournament Constructed 1.4.43 ................. SUCCESS [  0.081 s]
[INFO] Mage Player AI.DraftBot 1.4.43 ..................... SUCCESS [  0.092 s]
[INFO] Mage Game Tiny Leaders Two Player 1.4.43 ........... SUCCESS [  0.054 s]
[INFO] Mage Game Canadian Highlander Two Player 1.4.43 .... SUCCESS [  0.064 s]
[INFO] Mage Game Penny Dreadful Commander Free For All 1.4.43 SUCCESS [  0.052 s]
[INFO] Mage Game Freeform Commander Free For All 1.4.43 ... SUCCESS [  0.070 s]
[INFO] Mage Game Freeform Unlimited Commander 1.4.43 ...... SUCCESS [  0.057 s]
[INFO] Mage Game Freeform Commander Two Player 1.4.43 ..... SUCCESS [  0.056 s]
[INFO] Mage Game Oathbreaker Free For All 1.4.43 .......... SUCCESS [  0.074 s]
[INFO] Mage Game Oathbreaker Two Player 1.4.43 ............ SUCCESS [  0.063 s]
[INFO] Mage Game Momir Basic Two Player 1.4.43 ............ SUCCESS [  0.069 s]
[INFO] Mage Game Momir Basic Free for All 1.4.43 .......... SUCCESS [  0.076 s]
[INFO] Mage Server 1.4.43 ................................. SUCCESS [  1.882 s]
[INFO] Mage Plugins 1.4.43 ................................ SUCCESS [  0.006 s]
[INFO] Mage Counter Plugin 0.1 ............................ SUCCESS [  0.120 s]
[INFO] Mage Client 1.4.43 ................................. SUCCESS [  6.126 s]
[INFO] Mage Server Console 1.4.43 ......................... SUCCESS [  0.479 s]
[INFO] Mage Tests 1.4.43 .................................. SUCCESS [02:21 min]
[INFO] Mage Verify 1.4.43 ................................. FAILURE [ 33.703 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:24 min
[INFO] Finished at: 2020-06-22T16:41:17-03:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test (default-test) on project mage-verify: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/allentiak/devel/projects/magic-engines/xmage--java/Mage.Verify/target/surefire-reports for the individual test results.
```
### Logs
[openjdk-11.0.7+10-post-Debian-3--mage.verify.VerifyCardDataTest.txt](https://github.com/magefree/mage/files/4815297/openjdk-11.0.7%2B10-post-Debian-3--mage.verify.VerifyCardDataTest.txt)
[openjdk-11.0.7+10-post-Debian-3--TEST-mage.verify.VerifyCardDataTest.xml.txt](https://github.com/magefree/mage/files/4815298/openjdk-11.0.7%2B10-post-Debian-3--TEST-mage.verify.VerifyCardDataTest.xml.txt)

[openjdk-14.0.1+7-Debian-1--TEST-mage.verify.VerifyCardDataTest.xml.txt](https://github.com/magefree/mage/files/4815300/openjdk-14.0.1%2B7-Debian-1--TEST-mage.verify.VerifyCardDataTest.xml.txt)
[openjdk-14.0.1+7-Debian-1--mage.verify.VerifyCardDataTest.txt](https://github.com/magefree/mage/files/4815299/openjdk-14.0.1%2B7-Debian-1--mage.verify.VerifyCardDataTest.txt)
