### PR TITLE
Enable dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'java:maven'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
Dependabot keeps dependencies up to date. 

The result of this is that dependabot will create PRs weekly (probably immediately after the merge for the first run) telling us what dependencies are out of date.

Background: https://dependabot.com/
Source: https://github.com/dependabot