### PR TITLE
removed some of unused dependencies

### DIFF
--- a/Mage.Client/pom.xml
+++ b/Mage.Client/pom.xml
@@ -44,11 +44,6 @@
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.sf.trove4j</groupId>
-            <artifactId>trove4j</artifactId>
-            <version>3.0.3</version>
-        </dependency>
-        <dependency>
             <groupId>com.mortennobel</groupId>
             <artifactId>java-image-scaling</artifactId>
             <version>0.8.6</version>
@@ -71,16 +66,6 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>1.11.498</version>
-        </dependency>
-        <dependency>
-            <groupId>com.jgoodies</groupId>
-            <artifactId>forms</artifactId>
-            <version>1.2.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.intellij</groupId>
-            <artifactId>forms_rt</artifactId>
-            <version>7.0.3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -124,16 +109,6 @@
                     <groupId>net.java.truecommons</groupId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.googlecode.soundlibs</groupId>
-            <artifactId>mp3spi</artifactId>
-            <version>1.9.5.4</version>
-        </dependency>
-        <dependency>
-            <groupId>javazoom</groupId>
-            <artifactId>jlayer</artifactId>
-            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.mobicents.external.tritonus</groupId>

--- a/Mage.Common/pom.xml
+++ b/Mage.Common/pom.xml
@@ -47,11 +47,6 @@
             <version>1.3.4</version>
         </dependency>
         <dependency>
-            <groupId>trove</groupId>
-            <artifactId>trove</artifactId>
-            <version>1.0.2</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.5</version>

--- a/Mage.Sets/pom.xml
+++ b/Mage.Sets/pom.xml
@@ -26,12 +26,6 @@
             <artifactId>log4j</artifactId>
             <type>jar</type>
         </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/Mage/pom.xml
+++ b/Mage/pom.xml
@@ -62,8 +62,10 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
-
-
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>


### PR DESCRIPTION
Removing some of dependencies that does not seem to be used. I've used maven dependency plugin, while its super unreliable and produces a lot of false positives, it allowed to find most of these. You can run the analysis using:

`mvn dependency:analyze`

I've quickly checked how xmage works without them and frankly speaking haven't found any problems. Although there almost were, see comment [here](https://github.com/magefree/mage/pull/6796#issuecomment-654993687). Some deps might be used on different platforms, some might be loaded only in some runtime and used in one particular place. For that reason, please let me know if you think some of these should stay.