### PR TITLE
Fix Mudbutton Clanger

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MudbuttonClanger.java
+++ b/Mage.Sets/src/mage/cards/m/MudbuttonClanger.java
@@ -4,7 +4,7 @@ package mage.cards.m;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.abilityword.KinshipAbility;
-import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;

--- a/Mage.Sets/src/mage/cards/m/MudbuttonClanger.java
+++ b/Mage.Sets/src/mage/cards/m/MudbuttonClanger.java
@@ -27,7 +27,7 @@ public final class MudbuttonClanger extends CardImpl {
 
         // Kinship - At the beginning of your upkeep, you may look at the top card of your library. If it shares a creature type with Mudbutton Clanger, you may reveal it. 
         // If you do, Mudbutton Clanger gets +1/+1 until end of turn.
-        this.addAbility(new KinshipAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance())));
+        this.addAbility(new KinshipAbility(new BoostSourceEffect(1, 1, Duration.EndOfTurn)));
     }
 
     public MudbuttonClanger(final MudbuttonClanger card) {

--- a/Mage.Sets/src/mage/cards/m/MudbuttonClanger.java
+++ b/Mage.Sets/src/mage/cards/m/MudbuttonClanger.java
@@ -8,8 +8,8 @@ import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.counters.CounterType;
 
 /**
  *


### PR DESCRIPTION
Should get +1/+1 until end of turn, not +1/+1 counters.