### PR TITLE
Epitaph Golem puts card on top, rather than bottom

### DIFF
--- a/Mage.Sets/src/mage/cards/e/EpitaphGolem.java
+++ b/Mage.Sets/src/mage/cards/e/EpitaphGolem.java
@@ -33,7 +33,7 @@ public final class EpitaphGolem extends CardImpl {
         // {2}: Put target card from your graveyard on the bottom of your library.
         Ability ability = new SimpleActivatedAbility(
                 Zone.BATTLEFIELD,
-                new PutOnLibraryTargetEffect(true),
+                new PutOnLibraryTargetEffect(false),
                 new ManaCostsImpl("{2}"));
         ability.addTarget(new TargetCardInYourGraveyard());
         this.addAbility(ability);


### PR DESCRIPTION
PutOnLibraryTargetEffect's parameter is "onTop", it should be false (for putting the cards on the bottom) rather than true (for putting the cards on top.)