### PR TITLE
Fix Unesh, Criosphinx Sovereign

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SphinxOfUthuun.java
+++ b/Mage.Sets/src/mage/cards/s/SphinxOfUthuun.java
@@ -23,7 +23,9 @@ import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.game.Game;
 import mage.players.Player;
+import mage.target.Target;
 import mage.target.TargetCard;
+import mage.target.common.TargetOpponent;
 
 /**
  *
@@ -81,6 +83,13 @@ class SphinxOfUthuunEffect extends OneShotEffect {
         Set<UUID> opponents = game.getOpponents(source.getControllerId());
         if (!opponents.isEmpty()) {
             Player opponent = game.getPlayer(opponents.iterator().next());
+            if (opponents.size() > 1) {
+                Target targetOpponent = new TargetOpponent(true);
+                if (controller.chooseTarget(Outcome.Neutral, targetOpponent, source, game)) {
+                    opponent = game.getPlayer(targetOpponent.getFirstTarget());
+                    game.informPlayers(controller.getLogName() + " chose " + opponent.getLogName() + " to separate the revealed cards");
+                }
+            }
 
             TargetCard target = new TargetCard(0, cards.size(), Zone.LIBRARY, new FilterCard("cards to put in the first pile"));
             target.setRequired(false);

--- a/Mage.Sets/src/mage/cards/u/UneshCriosphinxSovereign.java
+++ b/Mage.Sets/src/mage/cards/u/UneshCriosphinxSovereign.java
@@ -15,6 +15,7 @@ import mage.filter.FilterPermanent;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetCard;
+import mage.target.common.TargetOpponent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -93,9 +94,16 @@ class UneshCriosphinxSovereignEffect extends OneShotEffect {
         Set<UUID> opponents = game.getOpponents(source.getControllerId());
         if (!opponents.isEmpty()) {
             Player opponent = game.getPlayer(opponents.iterator().next());
+            if (opponents.size() > 1) {
+                Target targetOpponent = new TargetOpponent(true);
+                if (controller.chooseTarget(Outcome.Neutral, targetOpponent, source, game)) {
+                    opponent = game.getPlayer(targetOpponent.getFirstTarget());
+                    game.informPlayers(controller.getLogName() + " chose " + opponent.getLogName() + " to separate the revealed cards");
+                }
+            }
             TargetCard target = new TargetCard(0, cards.size(), Zone.LIBRARY, new FilterCard("cards to put in the first pile"));
             List<Card> pile1 = new ArrayList<>();
-            if (opponent != null && opponent.choose(Outcome.Neutral, cards, target, game)) {
+            if (opponent.choose(Outcome.Neutral, cards, target, game)) {
                 List<UUID> targets = target.getTargets();
                 for (UUID targetId : targets) {
                     Card card = cards.get(targetId, game);

--- a/Mage.Sets/src/mage/cards/u/UneshCriosphinxSovereign.java
+++ b/Mage.Sets/src/mage/cards/u/UneshCriosphinxSovereign.java
@@ -14,6 +14,7 @@ import mage.filter.FilterCard;
 import mage.filter.FilterPermanent;
 import mage.game.Game;
 import mage.players.Player;
+import mage.target.Target;
 import mage.target.TargetCard;
 import mage.target.common.TargetOpponent;
 


### PR DESCRIPTION
Unesh incorrectly defaulted to the first opponent in multiplayer rather than letting its controller choose. Since the effect is exactly the same except for the number of cards, I copied the implementation from Fact or Fiction to fix it.