### PR TITLE
Fixed the Ghostly Pilferer triggered ability

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GhostlyPilferer.java
+++ b/Mage.Sets/src/mage/cards/g/GhostlyPilferer.java
@@ -85,7 +85,7 @@ class GhostlyPilfererTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         Spell spell = game.getStack().getSpell(event.getTargetId());
-        return (this.controllerId != spell.getControllerId()
+        return (game.getOpponents(getControllerId()).contains(spell.getControllerId())
                 && event.getZone() != Zone.HAND);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GhostlyPilferer.java
+++ b/Mage.Sets/src/mage/cards/g/GhostlyPilferer.java
@@ -41,6 +41,10 @@ public final class GhostlyPilferer extends CardImpl {
 
         // Whenever an opponent casts a spell from anywhere other than their hand, draw a card.
         this.addAbility(new GhostlyPilfererTriggeredAbility());
+        /*TODO: I think this way is the optimal way(copied from counter balance):
+         * this.addAbility(new SpellCastOpponentTriggeredAbility(Zone.BATTLEFIELD,
+         * new CounterbalanceEffect(), StaticFilters.FILTER_SPELL, true, SetTargetPointer.SPELL));
+         */
 
         // Discard a card: Ghostly Pilferer can't be blocked this turn.
         this.addAbility(new SimpleActivatedAbility(
@@ -80,11 +84,9 @@ class GhostlyPilfererTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        if (event.getZone() == Zone.HAND) {
-            return false;
-        }
         Spell spell = game.getStack().getSpell(event.getTargetId());
-        return spell != null;
+        return (this.controllerId != spell.getControllerId()
+                && event.getZone() != Zone.HAND);
     }
 
     @Override


### PR DESCRIPTION
Trigger ability: Whenever an opponent casts a spell from anywhere other than their hand, draw a card.
issue #6951

The only problem was that the trigger wasn't checking for opponents only, I added a quick check to make sure it doesn't trigger if the spell's controller is the same as ghostly pilferer controller.

Although I still think we can do better if we use the same code that is being used in Counterbalance, so we don't need to validate the controller and the zone every time a spell is being cast.

I've tested the bug with faithless looting casting from my graveyard with both me and my opponent having a ghostly pilferer in play.
Then tested the same with my opponent casting a faithless looting from their graveyard.

Both work just fine.