### PR TITLE
Implemented "explores, then it explores again"

### DIFF
--- a/Mage.Sets/src/mage/cards/j/JadelightRanger.java
+++ b/Mage.Sets/src/mage/cards/j/JadelightRanger.java
@@ -26,8 +26,8 @@ public final class JadelightRanger extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Jadelight Ranger enters the battlefield, it explores, then it explores again.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new ExploreSourceEffect().setText("it explores"), false);
-        ability.addEffect(new ExploreSourceEffect().setText(", then it explores again. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard. Then repeat this process.) "));
+        Ability ability = new EntersBattlefieldTriggeredAbility(new ExploreSourceEffect(false));
+        ability.addEffect(new ExploreSourceEffect(true, (byte) 1));
         this.addAbility(ability);
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/keyword/ExploreSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/ExploreSourceEffect.java
@@ -27,19 +27,31 @@ public class ExploreSourceEffect extends OneShotEffect {
     private static final String RULE_TEXT_HINT = "<i>(Reveal the top card of your library. "
             + "Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on "
             + "this creature, then put the card back or put it into your graveyard.)</i>";
+    private static final String RULE_TEXT_AGAIN = ", then %s explores again."; //So far the only card that uses this is Jadelight Ranger
 
     public static String getRuleText(boolean showAbilityHint) {
         return getRuleText(showAbilityHint, null);
     }
 
     public static String getRuleText(boolean showAbilityHint, String whosExplores) {
+        return getRuleText(showAbilityHint, whosExplores, (byte) 0);
+    }
+
+    public static String getRuleText(boolean showAbilityHint, String whosExplores, byte numTimesExplored) {
 
         String res = whosExplores;
         if (res == null) {
             res = "it";
         }
 
-        res += " " + RULE_TEXT_START;
+        if (numTimesExplored > 0)
+        {
+            res = String.format(RULE_TEXT_AGAIN, res);
+        }
+        else
+        {
+            res += " " + RULE_TEXT_START;
+        }
 
         if (showAbilityHint) {
             res += " " + RULE_TEXT_HINT;
@@ -49,6 +61,7 @@ public class ExploreSourceEffect extends OneShotEffect {
 
     private String sourceName = "it";
     private boolean showAbilityHint = true;
+    private byte numTimesExplored = 0;
 
     public ExploreSourceEffect() {
         this(true);
@@ -58,12 +71,22 @@ public class ExploreSourceEffect extends OneShotEffect {
         this(showAbilityHint, null);
     }
 
+    public ExploreSourceEffect(boolean showAbilityHint, byte numTimesExplored) {
+        this(showAbilityHint, null, numTimesExplored);
+    }
+
     public ExploreSourceEffect(boolean showAbilityHint, String whosExplores) {
+        this(showAbilityHint, whosExplores, (byte) 0);
+    }
+
+    public ExploreSourceEffect(boolean showAbilityHint, String whosExplores, byte numTimesExplored) {
         super(Outcome.Benefit);
 
         if (whosExplores != null) {
             this.sourceName = whosExplores;
         }
+        this.showAbilityHint = showAbilityHint;
+        this.numTimesExplored = numTimesExplored;
         setText();
     }
 
@@ -71,11 +94,12 @@ public class ExploreSourceEffect extends OneShotEffect {
         super(effect);
         this.showAbilityHint = effect.showAbilityHint;
         this.sourceName = effect.sourceName;
+        this.numTimesExplored = effect.numTimesExplored;
         setText();
     }
 
     private void setText() {
-        this.staticText = getRuleText(this.showAbilityHint, this.sourceName);
+        this.staticText = getRuleText(this.showAbilityHint, this.sourceName, this.numTimesExplored);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/keyword/ExploreSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/ExploreSourceEffect.java
@@ -44,12 +44,10 @@ public class ExploreSourceEffect extends OneShotEffect {
             res = "it";
         }
 
-        if (numTimesExplored > 0)
-        {
+        if (numTimesExplored > 0) {
             res = String.format(RULE_TEXT_AGAIN, res);
         }
-        else
-        {
+        else {
             res += " " + RULE_TEXT_START;
         }
 


### PR DESCRIPTION
Before we could only get "it explores. It explores." or write the text ourselves

Now when creating the ability we can reference the number of explores done(guess that can be changed in the future, that's why it's a byte instead of a bool).

For more info see issue #6958