### PR TITLE
Correcting some M21 text issues

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BarrinTolarianArchmage.java
+++ b/Mage.Sets/src/mage/cards/b/BarrinTolarianArchmage.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 public final class BarrinTolarianArchmage extends CardImpl {
 
     private static final FilterCreatureOrPlaneswalkerPermanent filter
-            = new FilterCreatureOrPlaneswalkerPermanent("other target creature or planeswalker");
+            = new FilterCreatureOrPlaneswalkerPermanent(" other target creature or planeswalker");
 
     static {
         filter.add(AnotherPredicate.instance);

--- a/Mage.Sets/src/mage/cards/k/KaervekTheSpiteful.java
+++ b/Mage.Sets/src/mage/cards/k/KaervekTheSpiteful.java
@@ -29,7 +29,7 @@ public final class KaervekTheSpiteful extends CardImpl {
         // Other creatures get -1/-1.
         this.addAbility(new SimpleStaticAbility(new BoostAllEffect(
                 -1, -1, Duration.WhileOnBattlefield, true
-        ).setText("other creatures get +1/+1")));
+        ).setText("other creatures get -1/-1")));
     }
 
     private KaervekTheSpiteful(final KaervekTheSpiteful card) {

--- a/Mage/src/main/java/mage/abilities/common/ActivateIfConditionActivatedAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/ActivateIfConditionActivatedAbility.java
@@ -37,7 +37,8 @@ public class ActivateIfConditionActivatedAbility extends ActivatedAbilityImpl {
             sb.append(" Activate this ability only ");
         }
         if (!condition.toString().startsWith("during")
-                && !condition.toString().startsWith("before")) {
+                && !condition.toString().startsWith("before")
+                && !condition.toString().startsWith("if")) {
             sb.append("if ");
         }
         sb.append(condition.toString()).append('.');

--- a/Mage/src/main/java/mage/abilities/decorator/ConditionalActivatedAbility.java
+++ b/Mage/src/main/java/mage/abilities/decorator/ConditionalActivatedAbility.java
@@ -73,7 +73,9 @@ public class ConditionalActivatedAbility extends ActivatedAbilityImpl {
         }
         String conditionText = condition.toString();
         String additionalText = "if ";
-        if (conditionText.startsWith("during")) {
+        if (conditionText.startsWith("during")
+                || conditionText.startsWith("before")
+                || conditionText.startsWith("if")) {
             additionalText = "";
         }
         return super.getRule() + " Activate this ability only " + additionalText + condition.toString() + ".";

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandTargetEffect.java
@@ -90,15 +90,13 @@ public class ReturnToHandTargetEffect extends OneShotEffect {
         }
         Target target = mode.getTargets().get(0);
         StringBuilder sb = new StringBuilder("return ");
-        if (target.getNumberOfTargets() == 0 && target.getMaxNumberOfTargets() > 0) {
+        if (target.getMinNumberOfTargets() == 0 && target.getMaxNumberOfTargets() > 0) {
             sb.append("up to ");
             sb.append(CardUtil.numberToText(target.getMaxNumberOfTargets()));
             if (!target.getTargetName().contains("target")) {
                 sb.append(" target ");
             }
             sb.append(target.getTargetName());
-            sb.append(" to their owners' hand");
-            return sb.toString();
         } else {
             if (target.getNumberOfTargets() > 1) {
                 sb.append(CardUtil.numberToText(target.getNumberOfTargets())).append(' ');
@@ -106,9 +104,14 @@ public class ReturnToHandTargetEffect extends OneShotEffect {
             if (!target.getTargetName().startsWith("another")) {
                 sb.append("target ");
             }
-            sb.append(target.getTargetName()).append(" to its owner's hand");
-            return sb.toString();
         }
+        if(target.getMaxNumberOfTargets() > 1) {
+            sb.append(" to their owners' hand");
+        }
+        else {
+            sb.append(target.getTargetName()).append(" to its owner's hand");
+        }
+        return sb.toString();
     }
 
 }


### PR DESCRIPTION
This fixes(in #6643):
-Barrin, Tolarian Archmage - missing a space
-Barrin, Tolarian Archmage - their owners' > it's owner's(also Teferi's Time raveler, although not reported)
-Roaming Ghostlight - "their owners'" > "its owner's"
-Caged Zombie - remove extra "if"
-Kaervek, the Spiteful - should be -1/-1 instead of +1/+1
