### PR TITLE
Duplicated code in "return to its owner's hand" effect

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandTargetEffect.java
@@ -102,7 +102,7 @@ public class ReturnToHandTargetEffect extends OneShotEffect {
         }
         sb.append(target.getTargetName());
         if(target.getMaxNumberOfTargets() > 1) {
-            sb.append(" to their owners' hand");
+            sb.append(" to their owners' hands");
         }
         else {
             sb.append(" to its owner's hand");

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandTargetEffect.java
@@ -109,7 +109,7 @@ public class ReturnToHandTargetEffect extends OneShotEffect {
             sb.append(" to their owners' hand");
         }
         else {
-            sb.append(target.getTargetName()).append(" to its owner's hand");
+            sb.append(" to its owner's hand");
         }
         return sb.toString();
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandTargetEffect.java
@@ -90,21 +90,17 @@ public class ReturnToHandTargetEffect extends OneShotEffect {
         }
         Target target = mode.getTargets().get(0);
         StringBuilder sb = new StringBuilder("return ");
-        if (target.getMinNumberOfTargets() == 0 && target.getMaxNumberOfTargets() > 0) {
+        if (target.getMinNumberOfTargets() == 0 && target.getMaxNumberOfTargets() >= 1) {
             sb.append("up to ");
-            sb.append(CardUtil.numberToText(target.getMaxNumberOfTargets()));
-            if (!target.getTargetName().contains("target")) {
-                sb.append(" target ");
-            }
-            sb.append(target.getTargetName());
-        } else {
-            if (target.getNumberOfTargets() > 1) {
-                sb.append(CardUtil.numberToText(target.getNumberOfTargets())).append(' ');
-            }
-            if (!target.getTargetName().startsWith("another")) {
-                sb.append("target ");
-            }
+            sb.append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(" ");
         }
+        else if (!(target.getMinNumberOfTargets() == 1 || target.getMaxNumberOfTargets() == 1)) {
+            sb.append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(" ");
+        }
+        if (!target.getTargetName().contains("target")) {
+            sb.append("target ");
+        }
+        sb.append(target.getTargetName());
         if(target.getMaxNumberOfTargets() > 1) {
             sb.append(" to their owners' hand");
         }


### PR DESCRIPTION
This code was causing cards like Roaming Ghostlight and Teferi, Time Raveler to have the target duplicated in the ability.
After removed, it's all back to normal.

Fixes Roaming Ghostlight in #6643

Signed-off-by: Andre Cabaca <andre.cabaca24@gmail.com>