### PR TITLE
GUI: added render option to hide ability text in card's info

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.form
@@ -98,7 +98,7 @@
                       <Component id="main_gamelog" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="main_battlefield" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace pref="23" max="32767" attributes="0"/>
+                      <EmptySpace max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -4469,6 +4469,7 @@
                               <Component id="cbCardRenderImageFallback" min="-2" max="-2" attributes="0"/>
                               <Component id="cbCardRenderShowReminderText" min="-2" max="-2" attributes="0"/>
                               <Component id="cbCardRenderHideSetSymbol" min="-2" max="-2" attributes="0"/>
+                              <Component id="cbCardRenderShowAbilityTextOverlay" min="-2" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                       </Group>
@@ -4480,6 +4481,8 @@
                           <Component id="cbCardRenderImageFallback" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="cbCardRenderShowReminderText" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="cbCardRenderShowAbilityTextOverlay" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="cbCardRenderHideSetSymbol" min="-2" max="-2" attributes="0"/>
                           <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
@@ -4510,6 +4513,14 @@
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cbCardRenderHideSetSymbolActionPerformed"/>
+                  </Events>
+                </Component>
+                <Component class="javax.swing.JCheckBox" name="cbCardRenderShowAbilityTextOverlay">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="Show ability text as overlay in big card view"/>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cbCardRenderShowAbilityTextOverlayActionPerformed"/>
                   </Events>
                 </Component>
               </SubComponents>
@@ -5744,7 +5755,7 @@
                       <Group type="102" attributes="0">
                           <Group type="103" groupAlignment="0" max="-2" attributes="0">
                               <Component id="lblURLServerList" max="32767" attributes="0"/>
-                              <Component id="txtURLServerList" max="32767" attributes="0"/>
+                              <Component id="txtURLServerList" pref="26" max="32767" attributes="0"/>
                           </Group>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="jLabel17" min="-2" max="-2" attributes="0"/>

--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
@@ -85,6 +85,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
 
     public static final String KEY_CARD_RENDERING_FALLBACK = "cardRenderingFallback";
     public static final String KEY_CARD_RENDERING_REMINDER_TEXT = "cardRenderingReminderText";
+    public static final String KEY_CARD_RENDERING_ABILITY_TEXT_OVERLAY = "cardRenderingAbilityTextOverlay";
     public static final String KEY_CARD_RENDERING_SET_SYMBOL = "cardRenderingSetSymbol";
 
     public static final String KEY_BACKGROUND_IMAGE = "backgroundImage";
@@ -500,6 +501,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
         cbCardRenderImageFallback = new javax.swing.JCheckBox();
         cbCardRenderShowReminderText = new javax.swing.JCheckBox();
         cbCardRenderHideSetSymbol = new javax.swing.JCheckBox();
+        cbCardRenderShowAbilityTextOverlay = new javax.swing.JCheckBox();
         panelBackgroundImages = new javax.swing.JPanel();
         cbUseDefaultBackground = new javax.swing.JCheckBox();
         txtBackgroundImagePath = new javax.swing.JTextField();
@@ -867,7 +869,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
                                 .add(main_gamelog, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                                 .add(main_battlefield, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                                .addContainerGap(23, Short.MAX_VALUE))
+                                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         main_card.getAccessibleContext().setAccessibleName("Game panel");
@@ -1645,6 +1647,13 @@ public class PreferencesDialog extends javax.swing.JDialog {
             }
         });
 
+        cbCardRenderShowAbilityTextOverlay.setText("Show ability text as overlay in big card view");
+        cbCardRenderShowAbilityTextOverlay.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                cbCardRenderShowAbilityTextOverlayActionPerformed(evt);
+            }
+        });
+
         org.jdesktop.layout.GroupLayout jPanel1Layout = new org.jdesktop.layout.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
         jPanel1Layout.setHorizontalGroup(
@@ -1653,7 +1662,8 @@ public class PreferencesDialog extends javax.swing.JDialog {
                                 .add(jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
                                         .add(cbCardRenderImageFallback)
                                         .add(cbCardRenderShowReminderText)
-                                        .add(cbCardRenderHideSetSymbol))
+                                        .add(cbCardRenderHideSetSymbol)
+                                        .add(cbCardRenderShowAbilityTextOverlay))
                                 .add(0, 0, Short.MAX_VALUE))
         );
         jPanel1Layout.setVerticalGroup(
@@ -1662,6 +1672,8 @@ public class PreferencesDialog extends javax.swing.JDialog {
                                 .add(cbCardRenderImageFallback)
                                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                                 .add(cbCardRenderShowReminderText)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(cbCardRenderShowAbilityTextOverlay)
                                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                                 .add(cbCardRenderHideSetSymbol)
                                 .add(0, 0, Short.MAX_VALUE))
@@ -2394,7 +2406,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
                         .add(connection_serversLayout.createSequentialGroup()
                                 .add(connection_serversLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING, false)
                                         .add(lblURLServerList, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                        .add(txtURLServerList, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                                        .add(txtURLServerList, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 26, Short.MAX_VALUE))
                                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                                 .add(jLabel17))
         );
@@ -2936,6 +2948,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
         save(prefs, dialog.cbCardRenderImageFallback, KEY_CARD_RENDERING_FALLBACK, "true", "false", UPDATE_CACHE_POLICY);
         save(prefs, dialog.cbCardRenderHideSetSymbol, KEY_CARD_RENDERING_SET_SYMBOL, "true", "false", UPDATE_CACHE_POLICY);
         save(prefs, dialog.cbCardRenderShowReminderText, KEY_CARD_RENDERING_REMINDER_TEXT, "true", "false", UPDATE_CACHE_POLICY);
+        save(prefs, dialog.cbCardRenderShowAbilityTextOverlay, KEY_CARD_RENDERING_ABILITY_TEXT_OVERLAY, "true", "false", UPDATE_CACHE_POLICY);
 
         // sounds
         save(prefs, dialog.cbEnableGameSounds, KEY_SOUNDS_GAME_ON, "true", "false", UPDATE_CACHE_POLICY);
@@ -3282,6 +3295,10 @@ public class PreferencesDialog extends javax.swing.JDialog {
         // TODO add your handling code here:
     }//GEN-LAST:event_cbThemeActionPerformed
 
+    private void cbCardRenderShowAbilityTextOverlayActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cbCardRenderShowAbilityTextOverlayActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_cbCardRenderShowAbilityTextOverlayActionPerformed
+
     private void showProxySettings() {
         Connection.ProxyType proxyType = (Connection.ProxyType) cbProxyType.getSelectedItem();
         switch (proxyType) {
@@ -3477,6 +3494,8 @@ public class PreferencesDialog extends javax.swing.JDialog {
         load(prefs, dialog.cbCardRenderImageFallback, KEY_CARD_RENDERING_FALLBACK, "true", "false");
         load(prefs, dialog.cbCardRenderHideSetSymbol, KEY_CARD_RENDERING_SET_SYMBOL, "true");
         load(prefs, dialog.cbCardRenderShowReminderText, KEY_CARD_RENDERING_REMINDER_TEXT, "true");
+        load(prefs, dialog.cbCardRenderShowAbilityTextOverlay, KEY_CARD_RENDERING_ABILITY_TEXT_OVERLAY, "true");
+
 
         //add background load precedure
         prop = prefs.get(KEY_BACKGROUND_IMAGE_DEFAULT, "true");
@@ -3996,6 +4015,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
     private javax.swing.JComboBox cbBattlefieldFeedbackColorizingMode;
     private javax.swing.JCheckBox cbCardRenderHideSetSymbol;
     private javax.swing.JCheckBox cbCardRenderImageFallback;
+    private javax.swing.JCheckBox cbCardRenderShowAbilityTextOverlay;
     private javax.swing.JCheckBox cbCardRenderShowReminderText;
     private javax.swing.JCheckBox cbConfirmEmptyManaPool;
     private javax.swing.JCheckBox cbDraftLogAutoSave;

--- a/Mage.Client/src/main/java/mage/client/plugins/adapters/MageActionCallback.java
+++ b/Mage.Client/src/main/java/mage/client/plugins/adapters/MageActionCallback.java
@@ -610,7 +610,7 @@ public class MageActionCallback implements ActionCallback {
             // XXX: scaled to fit width
             bigCard.setCard(mageCard.getOriginal().getId(), enlargeMode, image, mageCard.getOriginal().getRules(), mageCard.getOriginal().isToRotate());
             // if it's an ability, show only the ability text as overlay
-            if (mageCard.getOriginal().isAbility() && enlargeMode == EnlargeMode.NORMAL) {
+            if (mageCard.getOriginal().isAbility() && enlargeMode == EnlargeMode.NORMAL && isAbilityTextOverlayEnabled()) {
                 bigCard.showTextComponent();
             } else {
                 bigCard.hideTextComponent();
@@ -622,6 +622,10 @@ public class MageActionCallback implements ActionCallback {
             bigCard.addJXPanel(mageCard.getOriginal().getId(), panel);
         }
         enlargeredViewOpened = new Date();
+    }
+
+    private boolean isAbilityTextOverlayEnabled() {
+        return PreferencesDialog.getCachedValue(PreferencesDialog.KEY_CARD_RENDERING_ABILITY_TEXT_OVERLAY, "true").equals("true");
     }
 
     private synchronized void startHideTimeout() {


### PR DESCRIPTION
Adds an option to hide the ability text overlay in the big card view.
When playing with images in foreign languages the overlay can be annoying for some players.
The default is that the overlay is enabled.