### PR TITLE
Fixes ChooseCardTypeEffect always showing all card types

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/ChooseCardTypeEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ChooseCardTypeEffect.java
@@ -52,7 +52,7 @@ public class ChooseCardTypeEffect extends OneShotEffect {
             mageObject = game.getObject(source.getSourceId());
         }
         if (controller != null && mageObject != null) {
-            Choice typeChoice = new ChoiceCardType();
+            Choice typeChoice = new ChoiceCardType(true, cardTypes);
             if (controller.choose(outcome, typeChoice, game)) {
                 game.informPlayers(mageObject.getLogName() + ": " + controller.getLogName() + " has chosen: " + typeChoice.getChoice());
                 game.getState().setValue(source.getSourceId() + "_type", typeChoice.getChoice());


### PR DESCRIPTION
While fixing Archon of Valors Reach I discovered that ChooseCardTypeEffect displays all Card Types and not only the ones it got passed in the constructor.