### PR TITLE
Fix Estrid the Masked's filters

### DIFF
--- a/Mage.Sets/src/mage/cards/e/EstridTheMasked.java
+++ b/Mage.Sets/src/mage/cards/e/EstridTheMasked.java
@@ -123,7 +123,7 @@ class EstridTheMaskedGraveyardEffect extends OneShotEffect {
 
     static {
         filter.add(Predicates.not(SubType.AURA.getPredicate()));
-        filter.add(SubType.AURA.getPredicate());
+        filter2.add(SubType.AURA.getPredicate());
     }
 
     public EstridTheMaskedGraveyardEffect() {


### PR DESCRIPTION
At some point a typographical error snuck into the code; this caused Estrid's ultimate ability to no longer function properly with auras. It instead put all auras into play at the same time as your non-aura enchantments, causing you to be forced to attach your auras to targets already in play.