### PR TITLE
Deck import's performance improved (fixes #7126)

### DIFF
--- a/Mage/src/main/java/mage/cards/repository/CardInfo.java
+++ b/Mage/src/main/java/mage/cards/repository/CardInfo.java
@@ -33,6 +33,12 @@ public class CardInfo {
 
     @DatabaseField(indexName = "name_index")
     protected String name;
+    /**
+     * lower_name exists to speed up importing decks, specifically to provide an indexed column.
+     * H2 does not support expressions in indices, so we need a physical column.
+     */
+    @DatabaseField(indexName = "lower_name_index")
+    protected String lower_name;
     @DatabaseField(indexName = "setCode_cardNumber_index")
     protected String cardNumber;
     @DatabaseField(indexName = "setCode_cardNumber_index")
@@ -107,6 +113,7 @@ public class CardInfo {
 
     public CardInfo(Card card) {
         this.name = card.getName();
+        this.lower_name = name.toLowerCase();
         this.cardNumber = card.getCardNumber();
         this.setCode = card.getExpansionSetCode();
         this.className = card.getClass().getCanonicalName();

--- a/Mage/src/main/java/mage/cards/repository/CardRepository.java
+++ b/Mage/src/main/java/mage/cards/repository/CardRepository.java
@@ -58,7 +58,6 @@ public enum CardRepository {
 
             TableUtils.createTableIfNotExists(connectionSource, CardInfo.class);
             cardDao = DaoManager.createDao(connectionSource, CardInfo.class);
-
             eventSource.fireRepositoryDbLoaded();
         } catch (SQLException ex) {
             Logger.getLogger(CardRepository.class).error("Error creating card repository - ", ex);
@@ -490,7 +489,7 @@ public enum CardRepository {
         try {
             String sqlName = name.toLowerCase(Locale.ENGLISH).replaceAll("'", "''");
             GenericRawResults<CardInfo> rawResults = cardDao.queryRaw(
-                    "select * from " + CardRepository.VERSION_ENTITY_NAME + " where lower(name) = '" + sqlName + '\'',
+                    "select * from " + CardRepository.VERSION_ENTITY_NAME + " where lower_name = '" + sqlName + '\'',
                     cardDao.getRawRowMapper());
             List<CardInfo> result = new ArrayList<>();
             for (CardInfo cardinfo : rawResults) {


### PR DESCRIPTION
I'm not incredibly satisfied with creating a new column; I'm also unclear how this impacts existing databases.

Could a maintainer provide guidance on how to modify this change without breaking compatibility with existing DBs? As-is, using this change with an older DB will cause import to fail as the column doesn't exist.

----

Profiling deck import revealed we spend most of the time running sql.
The specific query compared against `lower(name)` which is not under an index.
As a result, importing a deck could be quite slow since we were looking at
every single card in the game.

This change introduces a new indexed column, `lower_name`, and swaps
findCardsCaseInsensitive to run against it.

Optimally, we'd introduce an index here on `lower(name)` to avoid the
unnecessary column. ie,
`CREATE INDEX IF NOT EXISTS lower_name_index ON card (lower(name))`
However, H2 does not currently support indices on expressions.

----

Here's an example of the import after introducing the new column. From ~10 seconds to instant.

![fast_import](https://user-images.githubusercontent.com/2524459/95668214-65439700-0b36-11eb-85aa-7bbbeac2d6d2.gif)

