### PR TITLE
Update deps (except H2)

### DIFF
--- a/Mage.Client/pom.xml
+++ b/Mage.Client/pom.xml
@@ -194,8 +194,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
-            </plugin>
+<!--            <version>3.0.0-M1</version>
+ -->            </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <configuration>

--- a/Mage.Common/pom.xml
+++ b/Mage.Common/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.googlecode.jspf</groupId>
             <artifactId>jspf-core</artifactId>
-            <version>0.9.1</version>            
+            <version>0.9.1</version>
         </dependency>
 
         <dependency>

--- a/Mage.Verify/pom.xml
+++ b/Mage.Verify/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.9.9.1,)</version>
+            <version>[2.11.1,)</version>
         </dependency>
 
         <dependency>
@@ -60,6 +60,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M5</version>
                     <configuration>
                         <argLine>-Dfile.encoding=UTF-8</argLine>
                     </configuration>

--- a/Mage/pom.xml
+++ b/Mage/pom.xml
@@ -25,10 +25,11 @@
             <type>jar</type>
         </dependency>
         <dependency>
-            <!-- WARNING, do not update db engine (stable: 1.4.197) cause compatibility issues, see https://github.com/h2database/h2database/issues/2078 -->
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.200</version>
+            <!-- WARNING, do NOT update h2 (stable: 1.4.197). Version 1.4.200 is buggy.
+            See https://github.com/h2database/h2database/issues/2078 -->
+            <version>1.4.197</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/Mage/pom.xml
+++ b/Mage/pom.xml
@@ -15,9 +15,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
+            <groupId>com.github.cliftonlabs</groupId>
             <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>

--- a/Mage/pom.xml
+++ b/Mage/pom.xml
@@ -28,7 +28,7 @@
             <!-- WARNING, do not update db engine (stable: 1.4.197) cause compatibility issues, see https://github.com/h2database/h2database/issues/2078 -->
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.197</version>
+            <version>1.4.200</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -75,7 +75,7 @@
 			<goals>
 				<goal>run</goal>
 			</goals>
-                        
+
 			<configuration>
                                 <protocArtifact>com.google.protobuf:protoc:3.0.0</protocArtifact>
 				<inputDirectories>
@@ -88,7 +88,7 @@
 						<outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
 					</outputTarget>
 				</outputTargets>
-			</configuration>                        
+			</configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -111,7 +111,7 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>            
+            </plugin>
         </plugins>
 
         <finalName>mage</finalName>

--- a/Mage/src/main/java/mage/cards/decks/importer/JsonDeckImporter.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/JsonDeckImporter.java
@@ -1,67 +1,69 @@
 package mage.cards.decks.importer;
 
-import mage.cards.decks.DeckCardLists;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
-
 import java.io.File;
 import java.io.FileReader;
+
+import com.github.cliftonlabs.json_simple.JsonException;
+import com.github.cliftonlabs.json_simple.JsonObject;
+import com.github.cliftonlabs.json_simple.Jsoner;
+
+import mage.cards.decks.DeckCardLists;
 
 /**
  * @author github: timhae
  */
 public abstract class JsonDeckImporter extends DeckImporter {
 
-    protected StringBuilder sbMessage = new StringBuilder();
+	protected StringBuilder sbMessage = new StringBuilder();
 
-    /**
-     * @param file              file to import
-     * @param errorMessages     you can setup output messages to showup to user
-     * @param saveAutoFixedFile do not supported for that format
-     * @return decks list
-     */
-    public DeckCardLists importDeck(String file, StringBuilder errorMessages, boolean saveAutoFixedFile) {
-        File f = new File(file);
-        DeckCardLists deckList = new DeckCardLists();
-        if (!f.exists()) {
-            logger.warn("Deckfile " + file + " not found.");
-            return deckList;
-        }
+	/**
+	 * @param file              file to import
+	 * @param errorMessages     you can setup output messages to showup to user
+	 * @param saveAutoFixedFile do not supported for that format
+	 * @return decks list
+	 */
+	public DeckCardLists importDeck(String file, StringBuilder errorMessages, boolean saveAutoFixedFile) {
+		File f = new File(file);
+		DeckCardLists deckList = new DeckCardLists();
+		if (!f.exists()) {
+			logger.warn("Deckfile " + file + " not found.");
+			return deckList;
+		}
 
-        sbMessage.setLength(0);
-        try {
-            try (FileReader reader = new FileReader(f)) {
-                try { // Json parsing
-                    JSONParser parser = new JSONParser();
-                    JSONObject rootObj = (JSONObject) parser.parse(reader);
-                    readJson(rootObj, deckList);
+		sbMessage.setLength(0);
+		try {
+			try (FileReader reader = new FileReader(f)) {
+				try {
+					// Json parsing
+					JsonObject rootObj = (JsonObject) Jsoner.deserialize(reader);
 
-                    if (sbMessage.length() > 0) {
-                        if (errorMessages != null) {
-                            // normal output for user
-                            errorMessages.append(sbMessage);
-                        } else {
-                            // fatal error
-                            logger.fatal(sbMessage);
-                        }
-                    }
-                } catch (ParseException ex) {
-                    logger.fatal(null, ex);
-                }
-            } catch (Exception ex) {
-                logger.fatal(null, ex);
-            }
-        } catch (Exception ex) {
-            logger.fatal(null, ex);
-        }
-        return deckList;
-    }
+					readJson(rootObj, deckList);
 
-    @Override
-    public DeckCardLists importDeck(String file, boolean saveAutoFixedFile) {
-        return importDeck(file, null, saveAutoFixedFile);
-    }
+					if (sbMessage.length() > 0) {
+						if (errorMessages != null) {
+							// normal output for user
+							errorMessages.append(sbMessage);
+						} else {
+							// fatal error
+							logger.fatal(sbMessage);
+						}
+					}
+				} catch (JsonException ex) {
+					logger.fatal(null, ex);
+				}
+			} catch (Exception ex) {
+				logger.fatal(null, ex);
+			}
+		} catch (Exception ex) {
+			logger.fatal(null, ex);
+		}
+		return deckList;
+	}
 
-    protected abstract void readJson(JSONObject line, DeckCardLists decklist);
+	@Override
+	public DeckCardLists importDeck(String file, boolean saveAutoFixedFile) {
+		return importDeck(file, null, saveAutoFixedFile);
+	}
+
+	protected abstract void readJson(JsonObject line, DeckCardLists decklist);
 }

--- a/Mage/src/main/java/mage/cards/decks/importer/MtgjsonDeckImporter.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/MtgjsonDeckImporter.java
@@ -1,63 +1,63 @@
 package mage.cards.decks.importer;
 
-import mage.cards.decks.DeckCardInfo;
-import mage.cards.decks.DeckCardLists;
-import mage.cards.repository.CardInfo;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-
 import java.util.List;
 import java.util.Optional;
 
+import com.github.cliftonlabs.json_simple.JsonArray;
+import com.github.cliftonlabs.json_simple.JsonObject;
+
+import mage.cards.decks.DeckCardInfo;
+import mage.cards.decks.DeckCardLists;
+import mage.cards.repository.CardInfo;
 
 /**
  * @author github: timhae
  */
 public class MtgjsonDeckImporter extends JsonDeckImporter {
 
-    @Override
-    protected void readJson(JSONObject rootObj, DeckCardLists deckList) {
-        JSONObject data = (JSONObject) rootObj.get("data");
-        if (data == null) {
-            sbMessage.append("Could not find data in json").append("'\n");
-            return;
-        }
+	@Override
+	protected void readJson(JsonObject rootObj, DeckCardLists deckList) {
+		JsonObject data = (JsonObject) rootObj.get("data");
+		if (data == null) {
+			sbMessage.append("Could not find data in json").append("'\n");
+			return;
+		}
 
-        // info
-        String deckSet = (String) data.get("code");
-        String name = (String) data.get("name");
-        if (name != null) {
-            deckList.setName(name);
-        }
-        // mainboard
-        JSONArray mainBoard = (JSONArray) data.get("mainBoard");
-        List<mage.cards.decks.DeckCardInfo> mainDeckList = deckList.getCards();
-        addBoardToList(mainBoard, mainDeckList, deckSet);
-        // sideboard
-        JSONArray sideBoard = (JSONArray) data.get("sideBoard");
-        List<mage.cards.decks.DeckCardInfo> sideDeckList = deckList.getSideboard();
-        addBoardToList(sideBoard, sideDeckList, deckSet);
-    }
+		// info
+		String deckSet = (String) data.get("code");
+		String name = (String) data.get("name");
+		if (name != null) {
+			deckList.setName(name);
+		}
+		// mainboard
+		JsonArray mainBoard = (JsonArray) data.get("mainBoard");
+		List<mage.cards.decks.DeckCardInfo> mainDeckList = deckList.getCards();
+		addBoardToList(mainBoard, mainDeckList, deckSet);
+		// sideboard
+		JsonArray sideBoard = (JsonArray) data.get("sideBoard");
+		List<mage.cards.decks.DeckCardInfo> sideDeckList = deckList.getSideboard();
+		addBoardToList(sideBoard, sideDeckList, deckSet);
+	}
 
-    private void addBoardToList(JSONArray board, List<mage.cards.decks.DeckCardInfo> list, String deckSet) {
-        board.forEach(arrayCard -> {
-            JSONObject card = (JSONObject) arrayCard;
-            String name = (String) card.get("name");
-            String setCode = (String) card.get("setCode");
-            if (setCode == null || setCode.isEmpty()) {
-                setCode = deckSet;
-            }
+	private void addBoardToList(JsonArray board, List<mage.cards.decks.DeckCardInfo> list, String deckSet) {
+		board.forEach(arrayCard -> {
+			JsonObject card = (JsonObject) arrayCard;
+			String name = (String) card.get("name");
+			String setCode = (String) card.get("setCode");
+			if (setCode == null || setCode.isEmpty()) {
+				setCode = deckSet;
+			}
 
-            int num = ((Number) card.get("count")).intValue();
-            Optional<CardInfo> cardLookup = getCardLookup().lookupCardInfo(name, setCode);
-            if (!cardLookup.isPresent()) {
-                sbMessage.append("Could not find card: '").append(name).append("'\n");
-            } else {
-                CardInfo cardInfo = cardLookup.get();
-                for (int i = 0; i < num; i++) {
-                    list.add(new DeckCardInfo(cardInfo.getName(), cardInfo.getCardNumber(), cardInfo.getSetCode()));
-                }
-            }
-        });
-    }
+			int num = ((Number) card.get("count")).intValue();
+			Optional<CardInfo> cardLookup = getCardLookup().lookupCardInfo(name, setCode);
+			if (!cardLookup.isPresent()) {
+				sbMessage.append("Could not find card: '").append(name).append("'\n");
+			} else {
+				CardInfo cardInfo = cardLookup.get();
+				for (int i = 0; i < num; i++) {
+					list.add(new DeckCardInfo(cardInfo.getName(), cardInfo.getCardNumber(), cardInfo.getSetCode()));
+				}
+			}
+		});
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                     <encoding>UTF-8</encoding>
                     <!--
                     Because of known error in maven-compiler-plugin 3.2 useIncrementalCompilation is inverted
@@ -41,7 +41,7 @@
             <!-- default manifest settings (parent) -->
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -106,7 +106,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.8.0-beta2</version>
+                <version>1.8.0-beta4</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
@JayDi85 I have just reverted the H2 dep update from #7128, and also moved the warning closer to the version number (I hadn't seen it in the first place.)

What about the other, non-H2 deps? (For instance, dependabot won't be able to update the JSON deps, since they changed their API and require a small code change.)

@JayDi85 In any case, I think the specific problem you mention does not apply here, since the game does not update the DB, but rebuilds it from scratch. Or am I mistaken in this?