### PR TITLE
Targeting interface now says "Select up to one..." when the target is optional (bug #7046).

### DIFF
--- a/Mage/src/main/java/mage/target/TargetImpl.java
+++ b/Mage/src/main/java/mage/target/TargetImpl.java
@@ -117,7 +117,11 @@ public abstract class TargetImpl implements Target {
                 || targetName.startsWith("an ")
                 || targetName.startsWith("any ")) {
             return "Select " + targetName + suffix;
-        } else if (targetName.startsWith("a") || targetName.startsWith("e") || targetName.startsWith("i") || targetName.startsWith("o") || targetName.startsWith("u")) {
+        }
+        if (getMinNumberOfTargets() == 0 && getMaxNumberOfTargets() == 1) {
+            return "Select up to one " + targetName + suffix;
+        }
+        if (targetName.startsWith("a") || targetName.startsWith("e") || targetName.startsWith("i") || targetName.startsWith("o") || targetName.startsWith("u")) {
             return "Select an " + targetName + suffix;
         }
         return "Select a " + targetName + suffix;


### PR DESCRIPTION
I added some logic to check if to check if there are 0 required targets and if so to update the UI's text to "Select up to one <creature, enchantment, etc>"  This was a request made for the card "Scale the Heights" on bug #7046  but it also works for other cards (tested with Basri Ket's +1 ability.)