### PR TITLE
Fixed Cavern of Souls and similar cards spamming the game logs (bug #7079)

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CavernOfSouls.java
+++ b/Mage.Sets/src/mage/cards/c/CavernOfSouls.java
@@ -68,7 +68,7 @@ class CavernOfSoulsManaBuilder extends ConditionalManaBuilder {
         }
         Player controller = game.getPlayer(source.getControllerId());
         MageObject sourceObject = game.getObject(source.getSourceId());
-        if (game.inCheckPlayableState() && controller != null && sourceObject != null) {
+        if (controller != null && sourceObject != null && mana.getAny() == 0) {
             game.informPlayers(controller.getLogName() + " produces " + mana.toString() + " with " + sourceObject.getLogName()
                     + " (can only be spend to cast for creatures of type " + creatureType + " and that spell can't be countered)");
         }

--- a/Mage.Sets/src/mage/cards/p/PillarOfOrigins.java
+++ b/Mage.Sets/src/mage/cards/p/PillarOfOrigins.java
@@ -56,7 +56,7 @@ class PillarOfOriginsManaBuilder extends ConditionalManaBuilder {
         creatureType = ChooseCreatureTypeEffect.getChosenCreatureType(source.getSourceId(), game);
         Player controller = game.getPlayer(source.getControllerId());
         MageObject sourceObject = game.getObject(source.getSourceId());
-        if (controller != null && sourceObject != null) {
+        if (controller != null && sourceObject != null && mana.getAny() == 0) {
             game.informPlayers(controller.getLogName() + " produces " + mana.toString() + " with " + sourceObject.getLogName()
                     + " (can only be spent to cast creatures of type " + creatureType + ")");
         }

--- a/Mage.Sets/src/mage/cards/u/UnclaimedTerritory.java
+++ b/Mage.Sets/src/mage/cards/u/UnclaimedTerritory.java
@@ -63,7 +63,7 @@ class UnclaimedTerritoryManaBuilder extends ConditionalManaBuilder {
         }
         Player controller = game.getPlayer(source.getControllerId());
         MageObject sourceObject = game.getObject(source.getSourceId());
-        if (controller != null && sourceObject != null) {
+        if (controller != null && sourceObject != null && mana.getAny() == 0) {
             game.informPlayers(controller.getLogName() + " produces " + mana.toString() + " with " + sourceObject.getLogName()
                     + " (can only be spent to cast creatures of type " + creatureType + ")");
         }


### PR DESCRIPTION
This is a fix for bug #7079 The symbol it was spamming was for "Any mana" (not entirely sure what that is since it appears to be neither colored nor colorless mana.)  I added a check so it will now only report to the log when it actually gets tapped for colored mana (and technically colorless but that is done in a different ability for all of these cards.)

This bug was also affecting Unclaimed Territory and Pillar of Origins.  Lastly, for Cavern of Souls, there was a check not present in the other two cards that was breaking functionality (before I changed anything, Cavern was not correctly reporting to logs when it was tapped for mana) so that has been removed.

Note that this change only affects what is reported to the logs.  The actual functionality of these cards is not affected by this change.