### PR TITLE
Fixed Firesong and Sunspeaker's first ability staying active through Frogify effects (bug# 7137)

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/GainAbilitySpellsEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/GainAbilitySpellsEffect.java
@@ -18,7 +18,7 @@ public class GainAbilitySpellsEffect extends ContinuousEffectImpl {
     private final FilterObject filter;
 
     public GainAbilitySpellsEffect(Ability ability, FilterObject filter) {
-        super(Duration.Custom, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
+        super(Duration.WhileOnBattlefield, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
         this.ability = ability;
         this.filter = filter;
         staticText = filter.getMessage() + " have " + ability.getRule();


### PR DESCRIPTION
Fix for bug #7137 This was affecting all cards that used GainAbilitySpellsEffect class (Firesong and Sunspeaker, Soulfire Grand Master, and Pestilent Spirit.)  I looked at Teferi, Mage of Zhalfir as a card that was implemented in a similar way and was not affected by this bug (may want to have that card use this class as well if this commit gets merged) and noticed duration was set to WhileOnBattlefield.  Made the change and it fixed the issue.  Now, cards like Frogify and Lignify correctly disable abilities that use this class.