### PR TITLE
Fixed compression on callback (#5340)

### DIFF
--- a/Mage.Common/src/main/java/mage/interfaces/callback/ClientCallback.java
+++ b/Mage.Common/src/main/java/mage/interfaces/callback/ClientCallback.java
@@ -56,8 +56,6 @@ public class ClientCallback implements Serializable {
         } else {
             this.data = CompressUtil.compress(data);
         }
-
-        this.data = data;
     }
 
     public void decompressData() {


### PR DESCRIPTION
The callbacks are not being compressed =/ 

I am working on a different approach to compression of small data (zstd + dictionary) [1], and I noticed that callbacks are not currently being compressed.

Related to the #5340

[1] https://facebook.github.io/zstd/