### PR TITLE
Allow Temporal Aperture to play lands off the top of the library (bug #7141)

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TemporalAperture.java
+++ b/Mage.Sets/src/mage/cards/t/TemporalAperture.java
@@ -120,7 +120,7 @@ class TemporalApertureTopCardCastEffect extends AsThoughEffectImpl {
                 if (controller != null
                         && game.getState().getZone(objectId) == Zone.LIBRARY) {
                     if (controller.getLibrary().getFromTop(game).equals(card)) {
-                        if (objectCard == card && objectCard.getSpellAbility() != null) { // only if castable
+                        if (objectCard == card && (objectCard.getSpellAbility() != null || objectCard.isLand())) { // only if castable or land
                             allowCardToPlayWithoutMana(objectId, source, affectedControllerId, game);
                             return true;
                         }


### PR DESCRIPTION
Added a check to see if the top card is a land.  This fixes bug #7141 