### PR TITLE
Fix Light up the Stage and Escape to the Wilds not being able to cast adventures

### DIFF
--- a/Mage.Sets/src/mage/cards/e/EscapeToTheWilds.java
+++ b/Mage.Sets/src/mage/cards/e/EscapeToTheWilds.java
@@ -10,6 +10,7 @@ import mage.constants.*;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -113,7 +114,8 @@ class EscapeToTheWildsMayPlayEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        UUID objectIdToCast = CardUtil.getMainCardId(game, sourceId);
         return source.isControlledBy(affectedControllerId)
-                && getTargetPointer().getTargets(game, source).contains(sourceId);
+                && getTargetPointer().getTargets(game, source).contains(objectIdToCast);
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LightUpTheStage.java
+++ b/Mage.Sets/src/mage/cards/l/LightUpTheStage.java
@@ -119,7 +119,8 @@ class LightUpTheStageMayPlayEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        UUID objectIdToCast = CardUtil.getMainCardId(game, sourceId);
         return source.isControlledBy(affectedControllerId)
-                && getTargetPointer().getTargets(game, source).contains(sourceId);
+                && getTargetPointer().getTargets(game, source).contains(objectIdToCast);
     }
 }


### PR DESCRIPTION
Fixes #7074 This same code is used in the PlayFromNotOwnHandZoneTargetEffect class and is mentioned as a TODO in AsThoughEffectType:

    // PLAY_FROM_NOT_OWN_HAND_ZONE + CAST_AS_INSTANT:
    // 1. Do not use dialogs in "applies" method for that type of effect (it calls multiple times and will freeze the game)
    // 2. All effects in "applies" must checks affectedControllerId.equals(source.getControllerId()) (if not then all players will be able to play it)
    // 3. Target points to mainCard, but card's characteristics from objectId (split, adventure)
    // TODO: search all PLAY_FROM_NOT_OWN_HAND_ZONE and CAST_AS_INSTANT effects and add support of mainCard and objectId