### PR TITLE
Allow morph lands to be cast face down at instant speed

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/CastAsThoughItHadFlashAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/CastAsThoughItHadFlashAllEffect.java
@@ -5,8 +5,10 @@ package mage.abilities.effects.common.continuous;
 import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.AsThoughEffectImpl;
+import mage.abilities.keyword.MorphAbility;
 import mage.cards.Card;
 import mage.constants.AsThoughEffectType;
+import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.filter.FilterCard;
@@ -53,7 +55,25 @@ public class CastAsThoughItHadFlashAllEffect extends AsThoughEffectImpl {
     public boolean applies(UUID affectedSpellId, Ability source, UUID affectedControllerId, Game game) {
         if (anyPlayer || source.isControlledBy(affectedControllerId)) {
             Card card = game.getCard(affectedSpellId);
-            return card != null && filter.match(card, game);
+            if (card != null) {
+                //Allow lands with morph to be played at instant speed
+                if (card.isLand()) {
+                    boolean morphAbility = false;
+                    for (Ability checkAbility : card.getAbilities()) {
+                        if (checkAbility instanceof MorphAbility) {
+                            morphAbility = true;
+                            break;
+                        }
+                    }
+                    if (morphAbility) {
+                        Card cardCopy = card.copy();
+                        cardCopy.getCardType().clear();
+                        cardCopy.addCardType(CardType.CREATURE);
+                        return filter.match(cardCopy, game);
+                    }
+                }
+                return filter.match(card, game);
+            }
         }
         return false;
     }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -3393,7 +3393,8 @@ public abstract class PlayerImpl implements Player, Serializable {
             // Even mana cost can't be checked here without lookahead
             // So make it available all the time
             boolean canUse;
-            if (ability instanceof MorphAbility && object instanceof Card && game.canPlaySorcery(getId())) {
+            if (ability instanceof MorphAbility && object instanceof Card && (game.canPlaySorcery(getId()) ||
+                    (null != game.getContinuousEffects().asThough(object.getId(), AsThoughEffectType.CAST_AS_INSTANT, playAbility, this.getId(), game)))) {
                 canUse = canPlayCardByAlternateCost((Card) object, availableMana, playAbility, game);
             } else {
                 canUse = canPlay(playAbility, availableMana, object, game); // canPlay already checks alternative source costs and all conditions


### PR DESCRIPTION
This is for bug #7160 I went into more detail on the bug thread but I ran into some more bugs with morph while testing this fix.  It may be possible to code in workarounds to those bugs (similar to what I did here) but the bugs are all related to the way the morph ability is implemented.

Morph is implemented as an alternate casting cost and I'm wondering if it would be best to re-work morph to act more like a split card or MDFC card.  I couldn't find a clean way to handle non-creature morph cards since there's no "split card" object.  I'd like to hear some feedback before I pursue this any further.