### PR TITLE
Fix Krark, the Thumbless

### DIFF
--- a/Mage.Sets/src/mage/cards/k/KrarkTheThumbless.java
+++ b/Mage.Sets/src/mage/cards/k/KrarkTheThumbless.java
@@ -82,6 +82,6 @@ class KrarkTheThumblessEffect extends OneShotEffect {
             game.getStack().remove(spell, game);
             return true;
         }
-        return game.getSpell(spell.getId()) == null && player.moveCards(spell, Zone.HAND, source, game);
+        return game.getSpell(spell.getId()) != null && player.moveCards(spell, Zone.HAND, source, game);
     }
 }


### PR DESCRIPTION
This is for #7167 (1 of 3 cards reported as bugged)

Incorrect comparison to null was causing the return statement to short circuit before it returned the spell to hand.