### PR TITLE
[DON'T MERGE] Apply Chief Engineer's effect to commanders

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilityControlledSpellsEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilityControlledSpellsEffect.java
@@ -3,16 +3,15 @@ package mage.abilities.effects.common.continuous;
 import mage.abilities.Ability;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.cards.Card;
-import mage.constants.Duration;
-import mage.constants.Layer;
-import mage.constants.Outcome;
-import mage.constants.SubLayer;
+import mage.constants.*;
 import mage.filter.FilterCard;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.game.stack.Spell;
 import mage.game.stack.StackObject;
 import mage.players.Player;
+
+import java.util.UUID;
 
 /**
  * @author Styxo
@@ -65,6 +64,14 @@ public class GainAbilityControlledSpellsEffect extends ContinuousEffectImpl {
             for (Card card : player.getGraveyard().getCards(game)) {
                 if (filter.match(card, game)) {
                     game.getState().addOtherAbility(card, ability);
+                }
+            }
+            for (UUID commanderId : game.getCommandersIds(player)) {
+                if (game.getState().getZone(commanderId) == Zone.COMMAND) {
+                    Card commander = game.getCard(commanderId);
+                    if (filter.match(commander, game)) {
+                        game.getState().addOtherAbility(commander, ability);
+                    }
                 }
             }
             for (StackObject stackObject : game.getStack()) {

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -46,6 +46,7 @@ import mage.filter.predicate.permanent.PermanentIdPredicate;
 import mage.game.*;
 import mage.game.combat.CombatGroup;
 import mage.game.command.CommandObject;
+import mage.game.command.Commander;
 import mage.game.events.*;
 import mage.game.events.GameEvent.EventType;
 import mage.game.match.MatchPlayer;
@@ -3346,7 +3347,14 @@ public abstract class PlayerImpl implements Player, Serializable {
         // special mana to pay spell cost
         ManaOptions manaFull = availableMana.copy();
         if (ability instanceof SpellAbility) {
-            for (AlternateManaPaymentAbility altAbility : CardUtil.getAbilities(object, game).stream()
+            // For commanders, we need to check alternate mana against the real card (not CommanderObject)
+            MageObject checkObject;
+            if (object instanceof Commander){
+                checkObject = game.getCard(((Commander) object).getSourceId());
+            } else {
+                checkObject = object;
+            }
+            for (AlternateManaPaymentAbility altAbility : CardUtil.getAbilities(checkObject, game).stream()
                     .filter(a -> a instanceof AlternateManaPaymentAbility)
                     .map(a -> (AlternateManaPaymentAbility) a)
                     .collect(Collectors.toList())) {


### PR DESCRIPTION
Fixes #7171 

Applied the GainAbilityControlledSpellsEffect to commanders and added a check in PlayerImpl to check the alternate mana for commanders against the real card object (rather than the CommandObject that method was getting passed.)