### PR TITLE
Fix line break tags in effect text

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AgonyWarp.java
+++ b/Mage.Sets/src/mage/cards/a/AgonyWarp.java
@@ -32,7 +32,7 @@ public final class AgonyWarp extends CardImpl {
 
         // Target creature gets -0/-3 until end of turn.
         Effect effect2 = new BoostTargetEffect(-0,-3, Duration.EndOfTurn);
-        effect2.setText("<br></br>Target creature gets -0/-3 until end of turn");
+        effect2.setText("<br><br>Target creature gets -0/-3 until end of turn");
         effect2.setTargetPointer(SecondTargetPointer.getInstance());
         this.getSpellAbility().addEffect(effect2);
         target = new TargetCreaturePermanent(new FilterCreaturePermanent("second creature (can be the same as the first)"));

--- a/Mage.Sets/src/mage/cards/a/AzoriusPloy.java
+++ b/Mage.Sets/src/mage/cards/a/AzoriusPloy.java
@@ -33,7 +33,7 @@ public final class AzoriusPloy extends CardImpl {
 
         // Prevent all combat damage that would be dealt to target creature this turn.
         Effect effect2 = new PreventDamageToTargetEffect(Duration.EndOfTurn, true);
-        effect2.setText("<br></br>Prevent all combat damage that would be dealt to target creature this turn.");
+        effect2.setText("<br><br>Prevent all combat damage that would be dealt to target creature this turn.");
         effect2.setTargetPointer(SecondTargetPointer.getInstance());
         this.getSpellAbility().addEffect(effect2);
         target = new TargetCreaturePermanent(new FilterCreaturePermanent("second creature (can be the same as the first)"));

--- a/Mage.Sets/src/mage/cards/m/MartialGlory.java
+++ b/Mage.Sets/src/mage/cards/m/MartialGlory.java
@@ -32,7 +32,7 @@ public final class MartialGlory extends CardImpl {
         
         // Target creature gets +0/+3 until end of turn.
         Effect effect2 = new BoostTargetEffect(0,3, Duration.EndOfTurn);
-        effect2.setText("<br></br>Target creature gets +0/+3 until end of turn");
+        effect2.setText("<br><br>Target creature gets +0/+3 until end of turn");
         effect2.setTargetPointer(SecondTargetPointer.getInstance());
         target = new TargetCreaturePermanent(new FilterCreaturePermanent("second creature (can be the same as the first)"));
         this.getSpellAbility().addEffect(effect2);


### PR DESCRIPTION
Three cards had broken line break html tags:
- Agony Warp
- Azorius Ploy
- Martial Glory