### PR TITLE
Vivien, Monsters' Advocate - Make the choice for counter on token required (fixes #7264)

### DIFF
--- a/Mage.Sets/src/mage/cards/v/VivienMonstersAdvocate.java
+++ b/Mage.Sets/src/mage/cards/v/VivienMonstersAdvocate.java
@@ -107,7 +107,8 @@ class VivienMonstersAdvocateTokenEffect extends OneShotEffect {
             if (permanent == null) {
                 continue;
             }
-            Choice choice = new ChoiceImpl();
+            Choice choice = new ChoiceImpl(true);
+            choice.setMessage("Choose vigilance, reach, or trample counter");
             choice.setChoices(choices);
             player.choose(outcome, choice, game);
             String chosen = choice.getChoice();


### PR DESCRIPTION
Fixes #7264 

According to the wording on the card, it should not be possible to make a token without a counter on it.  Made the choice required and also added a message to the choice dialog.