### PR TITLE
Fixed Court of Ambition incorrectly causing you to discard cards (fixes #7263)

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CourtOfAmbition.java
+++ b/Mage.Sets/src/mage/cards/c/CourtOfAmbition.java
@@ -70,7 +70,7 @@ class CourtOfAmbitionEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         int discardCount = source.isControlledBy(game.getMonarchId()) ? 2 : 1;
         String message = "Discard " + CardUtil.numberToText(discardCount, "a")
-                + "card" + (discardCount > 1 ? 's' : "") + "? If not you lose " + (discardCount * 3) + " life";
+                + " card" + (discardCount > 1 ? 's' : "") + "? If not you lose " + (discardCount * 3) + " life";
         Map<UUID, Cards> discardMap = new HashMap<>();
         for (UUID playerId : game.getOpponents(source.getControllerId())) {
             Player player = game.getPlayer(playerId);
@@ -79,6 +79,7 @@ class CourtOfAmbitionEffect extends OneShotEffect {
             }
             if (player.getHand().size() < discardCount || !player.chooseUse(outcome, message, source, game)) {
                 player.loseLife(discardCount * 3, game, source, false);
+                continue;
             }
             TargetDiscard target = new TargetDiscard(discardCount, StaticFilters.FILTER_CARD, playerId);
             player.choose(outcome, target, source.getSourceId(), game);


### PR DESCRIPTION
Fixes #7263 

Break out of the loop if player chooses to lose life so they don't also discard cards.  Also added a space to the string (was showing "discard acard" with no space.)