### PR TITLE
[READY] Add GitHub Actions bot that fetches cards in comments (through one little GitHub Action)

### DIFF
--- a/.github/workflows/mtg-fetch-cards.yml
+++ b/.github/workflows/mtg-fetch-cards.yml
@@ -16,5 +16,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: ldeluigi/mtg-fetch-action@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mtg-fetch-cards.yml
+++ b/.github/workflows/mtg-fetch-cards.yml
@@ -1,0 +1,20 @@
+name: Mtg Card Fetch Bot
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+  pull_request_review:
+    type: [submitted]
+
+jobs:
+  fetch-card-references:
+    name: Fetch MTG Card
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ldeluigi/mtg-fetch-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### WTF?
This GitHub Action workflow enables and runs an action which I developed: https://github.com/marketplace/actions/mtg-fetch-action.
Generally speaking this action is extremely useless. **But**, inspired by the issues that normally are raised here and the Reddit MtgFetcher bot I thought it would be great to have it on GitHub too.

For example, you will be able to comment an issue with `[[Island]]` to make the bot fetch an Island and paste the links (well formatted) as answer in the issue thread.

### Improvement
Feel free to ask questions, suggest features and complain about it in the future. I'll stay as maintainer of it.

### Why GitHub Actions
I see that XMage currently uses Travis CI for CI/CD, but Travis recently changed its policies and now its substantially a must-pay platform. Travis can't react to events outside the push/pr scope so there is no more convenient way to implement this bot. GitHub refuels your monthly CPU linux minutes so that u/magefree won't run out (this is an Open Source project so cpu time could even be infinite if I remember correctly).

------------------
If you like my idea: _you are welcome, my pleasure to help._