### PR TITLE
[KHM] Implemented Halvar, God of Battle

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HalvarGodOfBattle.java
+++ b/Mage.Sets/src/mage/cards/h/HalvarGodOfBattle.java
@@ -21,8 +21,9 @@ import mage.cards.CardSetInfo;
 import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.ObjectSourcePlayer;
+import mage.filter.predicate.ObjectSourcePlayerPredicate;
 import mage.filter.predicate.Predicates;
-import mage.filter.predicate.permanent.AttachedToPredicate;
 import mage.filter.predicate.permanent.EnchantedPredicate;
 import mage.filter.predicate.permanent.EquippedPredicate;
 import mage.game.Game;
@@ -43,7 +44,7 @@ public final class HalvarGodOfBattle extends ModalDoubleFacesCard {
     static {
         filter.add(Predicates.or(EnchantedPredicate.instance, EquippedPredicate.instance));
         filter2.add(Predicates.or(SubType.AURA.getPredicate(), SubType.EQUIPMENT.getPredicate()));
-        filter2.add(new AttachedToPredicate(StaticFilters.FILTER_CONTROLLED_CREATURE));
+        filter2.add(new HalvarGodOfBattlePredicate(StaticFilters.FILTER_CONTROLLED_CREATURE));
     }
 
     public HalvarGodOfBattle(UUID ownerId, CardSetInfo setInfo) {
@@ -174,5 +175,25 @@ class SwordOfTheRealmsEffect extends OneShotEffect {
             }
         }
         return false;
+    }
+}
+
+class HalvarGodOfBattlePredicate implements ObjectSourcePlayerPredicate<ObjectSourcePlayer<Permanent>> {
+
+    private final FilterPermanent filter;
+
+    public HalvarGodOfBattlePredicate(FilterPermanent filter) {
+        this.filter=filter;
+    }
+
+    @Override
+    public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
+        UUID attachedTo = input.getObject().getAttachedTo();
+        return attachedTo != null && filter.match(game.getPermanent(attachedTo), input.getSourceId(), input.getPlayerId(), game);
+    }
+
+    @Override
+    public String toString() {
+        return "attached to " + filter.getMessage();
     }
 }

--- a/Mage.Sets/src/mage/cards/h/HalvarGodOfBattle.java
+++ b/Mage.Sets/src/mage/cards/h/HalvarGodOfBattle.java
@@ -1,0 +1,178 @@
+package mage.cards.h;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.BeginningOfCombatTriggeredAbility;
+import mage.abilities.common.DiesAttachedTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.BoostEquippedEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
+import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
+import mage.abilities.keyword.DoubleStrikeAbility;
+import mage.abilities.keyword.EquipAbility;
+import mage.abilities.keyword.VigilanceAbility;
+import mage.cards.Card;
+import mage.cards.ModalDoubleFacesCard;
+import mage.constants.*;
+import mage.cards.CardSetInfo;
+import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.permanent.AttachedToPredicate;
+import mage.filter.predicate.permanent.EnchantedPredicate;
+import mage.filter.predicate.permanent.EquippedPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.Target;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetControlledCreaturePermanent;
+
+/**
+ *
+ * @author weirddan455
+ */
+public final class HalvarGodOfBattle extends ModalDoubleFacesCard {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent();
+    private static final FilterPermanent filter2 = new FilterPermanent("aura or equipment attached to a creature you control");
+    static {
+        filter.add(Predicates.or(EnchantedPredicate.instance, EquippedPredicate.instance));
+        filter2.add(Predicates.or(SubType.AURA.getPredicate(), SubType.EQUIPMENT.getPredicate()));
+        filter2.add(new AttachedToPredicate(StaticFilters.FILTER_CONTROLLED_CREATURE));
+    }
+
+    public HalvarGodOfBattle(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo,
+                new CardType[]{CardType.CREATURE}, new SubType[]{SubType.GOD}, "{2}{W}{W}",
+                "Sword of the Realms", new CardType[]{CardType.ARTIFACT}, new SubType[]{SubType.EQUIPMENT}, "{1}{W}"
+        );
+
+        // 1.
+        // Halvar, God of Battle
+        // Legendary Creature - God
+        this.getLeftHalfCard().addSuperType(SuperType.LEGENDARY);
+        this.getLeftHalfCard().setPT(new MageInt(4), new MageInt(4));
+
+        // Creatures you control that are enchanted or equipped have double strike.
+        this.getLeftHalfCard().addAbility(new SimpleStaticAbility(
+                new GainAbilityControlledEffect(DoubleStrikeAbility.getInstance(), Duration.WhileOnBattlefield, filter
+                ).setText("Creatures you control that are enchanted or equipped have double strike")
+        ));
+
+        // At the beginning of each combat, you may attach target Aura or Equipment attached to a creature you control to target creature you control.
+        Ability ability = new BeginningOfCombatTriggeredAbility(new HalvarGodOfBattleEffect(), TargetController.ANY, false);
+        ability.addTarget(new TargetPermanent(filter2));
+        ability.addTarget(new TargetControlledCreaturePermanent());
+        this.getLeftHalfCard().addAbility(ability);
+
+        // 2.
+        // Sword of the Realms
+        // Legendary Artifact - Equipment
+        this.getRightHalfCard().addSuperType(SuperType.LEGENDARY);
+
+        // Equipped creature gets +2/+0 and has vigilance
+        ability = new SimpleStaticAbility(new BoostEquippedEffect(2, 0));
+        ability.addEffect(new GainAbilityAttachedEffect(VigilanceAbility.getInstance(), AttachmentType.EQUIPMENT
+        ).setText("and has vigilance"));
+        this.getRightHalfCard().addAbility(ability);
+
+        // Whenever equipped creature dies, return it to its owners hand
+        this.getRightHalfCard().addAbility(new DiesAttachedTriggeredAbility(
+                new SwordOfTheRealmsEffect(), "equipped creature"
+        ));
+
+        // Equip {1}{W}
+        this.getRightHalfCard().addAbility(new EquipAbility(Outcome.AddAbility, new ManaCostsImpl<>("{1}{W}")));
+    }
+
+    private HalvarGodOfBattle(final HalvarGodOfBattle card) {
+        super(card);
+    }
+
+    @Override
+    public HalvarGodOfBattle copy() {
+        return new HalvarGodOfBattle(this);
+    }
+}
+
+class HalvarGodOfBattleEffect extends OneShotEffect {
+
+    public HalvarGodOfBattleEffect() {
+        super(Outcome.BoostCreature);
+        staticText = "you may attach target Aura or Equipment attached to a creature you control to target creature you control";
+    }
+
+    private HalvarGodOfBattleEffect(final HalvarGodOfBattleEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public HalvarGodOfBattleEffect copy() {
+        return new HalvarGodOfBattleEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        Permanent attachment = game.getPermanent(source.getTargets().get(0).getFirstTarget());
+        Permanent creature = game.getPermanent(source.getTargets().get(1).getFirstTarget());
+        if (controller != null && attachment != null && creature != null && creature.isControlledBy(controller.getId())) {
+            Permanent oldCreature = game.getPermanent(attachment.getAttachedTo());
+            if (oldCreature != null && oldCreature.isControlledBy(controller.getId()) && !oldCreature.equals(creature)) {
+                boolean canAttach = true;
+                if (attachment.hasSubtype(SubType.AURA, game)) {
+                    Target auraTarget = attachment.getSpellAbility().getTargets().get(0);
+                    if (!auraTarget.canTarget(creature.getId(), game)) {
+                        canAttach = false;
+                    }
+                }
+                if (!canAttach) {
+                    game.informPlayers(attachment.getLogName() + " was not attached to " + creature.getLogName()
+                            + " because it's not a legal target for the aura");
+                } else if (controller.chooseUse(Outcome.BoostCreature, "Attach " + attachment.getLogName()
+                        + " to " + creature.getLogName() + "?", source, game)) {
+                    oldCreature.removeAttachment(attachment.getId(), source, game);
+                    creature.addAttachment(attachment.getId(), source, game);
+                    game.informPlayers(attachment.getLogName() + " was unattached from " + oldCreature.getLogName()
+                            + " and attached to " + creature.getLogName());
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}
+
+class SwordOfTheRealmsEffect extends OneShotEffect {
+
+    public SwordOfTheRealmsEffect() {
+        super(Outcome.ReturnToHand);
+        staticText = "return it to its owner's hand";
+    }
+
+    private SwordOfTheRealmsEffect(final SwordOfTheRealmsEffect effect) {
+        super (effect);
+    }
+
+    @Override
+    public SwordOfTheRealmsEffect copy() {
+        return new SwordOfTheRealmsEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            Card creature = (Card) getValue("attachedTo");
+            if (creature != null) {
+                return controller.moveCards(creature, Zone.HAND, source, game);
+            }
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/Kaldheim.java
+++ b/Mage.Sets/src/mage/sets/Kaldheim.java
@@ -42,6 +42,7 @@ public final class Kaldheim extends ExpansionSet {
         cards.add(new SetCardInfo("Giant's Grasp", 384, Rarity.UNCOMMON, mage.cards.g.GiantsGrasp.class));
         cards.add(new SetCardInfo("Gilded Assault Cart", 390, Rarity.UNCOMMON, mage.cards.g.GildedAssaultCart.class));
         cards.add(new SetCardInfo("Gladewalker Ritualist", 392, Rarity.UNCOMMON, mage.cards.g.GladewalkerRitualist.class));
+        cards.add(new SetCardInfo("Halvar, God of Battle", 15, Rarity.MYTHIC, mage.cards.h.HalvarGodOfBattle.class));
         cards.add(new SetCardInfo("Hengegate Pathway", 260, Rarity.RARE, mage.cards.h.HengegatePathway.class));
         cards.add(new SetCardInfo("Kaya the Inexorable", 218, Rarity.MYTHIC, mage.cards.k.KayaTheInexorable.class));
         cards.add(new SetCardInfo("Magda, Brazen Outlaw", 142, Rarity.RARE, mage.cards.m.MagdaBrazenOutlaw.class));


### PR DESCRIPTION
Implemented Halvar, God of Battle for #7248 

Issue I ran into is that `filter2.add(new AttachedToPredicate(StaticFilters.FILTER_CONTROLLED_CREATURE));` is not working.  If I use Pacifism on an opponent's creature, it allows me to select Pacifism as a target when it shouldn't.  I think the issue is similar to what @JayDi85 fixed in [a307e59](https://github.com/magefree/mage/commit/a307e5934f850b8936774a95787d4978d69ee179) where it's not checking the full filter but I'm not sure the correct way to fix this predicate.