### PR TITLE
Fixed rule text on BecomesTappedSourceTriggeredAbility

### DIFF
--- a/Mage/src/main/java/mage/abilities/common/BecomesTappedSourceTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/BecomesTappedSourceTriggeredAbility.java
@@ -42,6 +42,6 @@ public class BecomesTappedSourceTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public String getRule() {
-        return "When {this} becomes tapped, " + super.getRule();
+        return "Whenever {this} becomes tapped, " + super.getRule();
     }
 }


### PR DESCRIPTION
All cards with this ability are worded "Whenever", not "When":  https://scryfall.com/search?as=grid&order=name&q=oracle%3A%22whenever+~+becomes+tapped%22