### PR TITLE
Fixed Valakut Exploration not allowing exiled card to be played if land ETB'd on opponent's turn

### DIFF
--- a/Mage.Sets/src/mage/cards/v/ValakutExploration.java
+++ b/Mage.Sets/src/mage/cards/v/ValakutExploration.java
@@ -5,7 +5,6 @@ import mage.abilities.common.BeginningOfEndStepTriggeredAbility;
 import mage.abilities.common.LandfallAbility;
 import mage.abilities.condition.Condition;
 import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
-import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.asthought.PlayFromNotOwnHandZoneTargetEffect;

--- a/Mage.Sets/src/mage/cards/v/ValakutExploration.java
+++ b/Mage.Sets/src/mage/cards/v/ValakutExploration.java
@@ -99,38 +99,10 @@ class ValakutExplorationExileEffect extends OneShotEffect {
                         game, source.getSourceId(), source.getSourceObjectZoneChangeCounter()
                 ), sourcePermanent.getIdName()
         );
-        ContinuousEffect effect = new PlayFromNotOwnHandZoneTargetEffect(Duration.EndOfTurn);
+        ContinuousEffect effect = new PlayFromNotOwnHandZoneTargetEffect(Duration.EndOfGame);
         effect.setTargetPointer(new FixedTarget(card, game));
         game.addEffect(effect, source);
         return true;
-    }
-}
-
-class ValakutExplorationCastFromExileEffect extends AsThoughEffectImpl {
-
-    ValakutExplorationCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
-        staticText = "You may play the card from exile";
-    }
-
-    private ValakutExplorationCastFromExileEffect(final ValakutExplorationCastFromExileEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
-    public ValakutExplorationCastFromExileEffect copy() {
-        return new ValakutExplorationCastFromExileEffect(this);
-    }
-
-    @Override
-    public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        return source.isControlledBy(affectedControllerId)
-                && objectId.equals(getTargetPointer().getFirst(game, source));
     }
 }
 


### PR DESCRIPTION
Fixes #7309 

- Changed duration from EndOfTurn to EndOfGame
- Removed dead code - `ValakutExplorationCastFromExileEffect` was never used