### PR TITLE
Fixed Fleet Swallower + Bruvac interaction (fixes #7223)

### DIFF
--- a/Mage.Sets/src/mage/cards/f/FleetSwallower.java
+++ b/Mage.Sets/src/mage/cards/f/FleetSwallower.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.Zone;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetPlayer;
@@ -61,7 +60,8 @@ class FleetSwallowerEffect extends OneShotEffect {
         Player player = game.getPlayer(source.getFirstTarget());
         if (player != null) {
             int amount = (int) Math.ceil(player.getLibrary().size() * .5);
-            return player.moveCards(player.getLibrary().getTopCards(game, amount), Zone.GRAVEYARD, source, game);
+            player.millCards(amount, source, game);
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
Fixes #7223 

Changed Fleet Swallower to use `player.millCards` instead of `player.moveCards` so that Bruvac's replacement effect works.