### PR TITLE
Fixed Odric, Master Tactician (fixes #7266)

### DIFF
--- a/Mage.Sets/src/mage/cards/o/OdricMasterTactician.java
+++ b/Mage.Sets/src/mage/cards/o/OdricMasterTactician.java
@@ -128,9 +128,6 @@ class OdricMasterTacticianChooseBlockersEffect extends ContinuousRuleModifyingEf
 
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
-        if (source.isControlledBy(event.getPlayerId())) {
-            return false; // Don't replace the own call to selectBlockers
-        }
         ChooseBlockersRedundancyWatcher watcher = game.getState().getWatcher(ChooseBlockersRedundancyWatcher.class);
         if (watcher == null) {
             return false;


### PR DESCRIPTION
Fixes #7266 

These lines got added in a big refactor commit c16fb756683fcbdee1cc562bb6f81051e9cfe924 and I'm not sure what it's trying to do.  `event.getPlayerId()` should return the attacker.  Since Odric only ever triggers when he's attacking, this just always makes the effect do nothing (although for some reason it still works in an AI game, oddly enough.)

The rest of this code looks nearly identical to the card Melee which does not include this if statement (and works correctly.)  I tested this change and it now lets the Odric controller choose blocks in a Human match and in an AI match.