### PR TITLE
Add detrimental P/T counter types from older sets

### DIFF
--- a/Mage.Sets/src/mage/cards/e/EssenceFlare.java
+++ b/Mage.Sets/src/mage/cards/e/EssenceFlare.java
@@ -16,7 +16,7 @@ import mage.constants.SubType;
 import mage.constants.Outcome;
 import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.counters.BoostCounter;
+import mage.counters.CounterType;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -39,7 +39,7 @@ public final class EssenceFlare extends CardImpl {
         // Enchanted creature gets +2/+0.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(2, 0)));
         // At the beginning of the upkeep of enchanted creature's controller, put a -0/-1 counter on that creature.
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersAttachedEffect(new BoostCounter(0, -1), "that creature"),
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersAttachedEffect(CounterType.M0M1.createInstance(), "that creature"),
             TargetController.CONTROLLER_ATTACHED_TO, false));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GreaterWerewolf.java
+++ b/Mage.Sets/src/mage/cards/g/GreaterWerewolf.java
@@ -13,7 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Outcome;
-import mage.counters.BoostCounter;
+import mage.counters.CounterType;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.permanent.BlockedByIdPredicate;
@@ -71,7 +71,7 @@ class GreaterWerewolfEffect extends OneShotEffect {
             FilterCreaturePermanent filter = new FilterCreaturePermanent();
             filter.add(Predicates.or(new BlockedByIdPredicate(sourcePermanent.getId()), new BlockingAttackerIdPredicate(sourcePermanent.getId())));
             for (Permanent permanent : game.getBattlefield().getAllActivePermanents(filter, game)) {
-                Effect effect = new AddCountersTargetEffect(new BoostCounter(0, -2), Outcome.UnboostCreature);
+                Effect effect = new AddCountersTargetEffect(CounterType.M0M2.createInstance(), Outcome.UnboostCreature);
                 effect.setTargetPointer(new FixedTarget(permanent, game));
                 effect.apply(game, source);
             }

--- a/Mage.Sets/src/mage/cards/k/KjeldoranHomeGuard.java
+++ b/Mage.Sets/src/mage/cards/k/KjeldoranHomeGuard.java
@@ -13,7 +13,7 @@ import mage.constants.SubType;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.counters.BoostCounter;
+import mage.counters.CounterType;
 import mage.game.permanent.token.DeserterToken;
 import mage.watchers.common.AttackedOrBlockedThisCombatWatcher;
 
@@ -33,7 +33,7 @@ public final class KjeldoranHomeGuard extends CardImpl {
 
         // At end of combat, if Kjeldoran Home Guard attacked or blocked this combat, put a -0/-1 counter on Kjeldoran Home Guard and put a 0/1 white Deserter creature token onto the battlefield.
         Ability ability = new ConditionalInterveningIfTriggeredAbility(
-                new EndOfCombatTriggeredAbility(new AddCountersSourceEffect(new BoostCounter(0, -1)), false),
+                new EndOfCombatTriggeredAbility(new AddCountersSourceEffect(CounterType.M0M1.createInstance()), false),
                 AttackedOrBlockedThisCombatSourceCondition.instance,
                 "At end of combat, if {this} attacked or blocked this combat, put a -0/-1 counter on {this} and create a 0/1 white Deserter creature token.");
         ability.addEffect(new CreateTokenEffect(new DeserterToken()).setText("and create a 0/1 white Deserter creature token."));

--- a/Mage.Sets/src/mage/cards/k/KrovikanPlague.java
+++ b/Mage.Sets/src/mage/cards/k/KrovikanPlague.java
@@ -21,7 +21,7 @@ import mage.constants.SubType;
 import mage.constants.Outcome;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.counters.BoostCounter;
+import mage.counters.CounterType;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicates;
@@ -66,7 +66,7 @@ public final class KrovikanPlague extends CardImpl {
         // Tap enchanted creature: Tap enchanted creature: Krovikan Plague deals 1 damage to any target. Put a -0/-1 counter on enchanted creature. Activate this ability only if enchanted creature is untapped.
         Ability ability2 = new ActivateIfConditionActivatedAbility(Zone.BATTLEFIELD,
                 new DamageTargetEffect(1), new TapAttachedCost(), new AttachedToMatchesFilterCondition(filter));
-        ability2.addEffect(new AddCountersAttachedEffect(new BoostCounter(0, -1),"enchanted creature"));
+        ability2.addEffect(new AddCountersAttachedEffect(CounterType.M0M1.createInstance(),"enchanted creature"));
         ability2.addTarget(new TargetAnyTarget());
         this.addAbility(ability2);
 

--- a/Mage.Sets/src/mage/cards/s/ShieldSphere.java
+++ b/Mage.Sets/src/mage/cards/s/ShieldSphere.java
@@ -10,7 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.counters.BoostCounter;
+import mage.counters.CounterType;
 
 /**
  *
@@ -27,7 +27,7 @@ public final class ShieldSphere extends CardImpl {
         // Defender
         this.addAbility(DefenderAbility.getInstance());
         // Whenever Shield Sphere blocks, put a -0/-1 counter on it.
-        this.addAbility(new BlocksSourceTriggeredAbility(new AddCountersSourceEffect(new BoostCounter(0, -1)), false));
+        this.addAbility(new BlocksSourceTriggeredAbility(new AddCountersSourceEffect(CounterType.M0M1.createInstance()), false));
     }
 
     public ShieldSphere(final ShieldSphere card) {

--- a/Mage.Sets/src/mage/cards/s/SpiritShackle.java
+++ b/Mage.Sets/src/mage/cards/s/SpiritShackle.java
@@ -12,7 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Outcome;
-import mage.counters.BoostCounter;
+import mage.counters.CounterType;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -35,7 +35,7 @@ public final class SpiritShackle extends CardImpl {
         this.addAbility(ability);
 
         // Whenever enchanted creature becomes tapped, put a -0/-2 counter on it.
-        this.addAbility(new BecomesTappedAttachedTriggeredAbility(new AddCountersAttachedEffect(new BoostCounter(0, -2), "it"), "enchanted creature"));
+        this.addAbility(new BecomesTappedAttachedTriggeredAbility(new AddCountersAttachedEffect(CounterType.M0M2.createInstance(), "it"), "enchanted creature"));
 
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfRoots.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfRoots.java
@@ -13,7 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.counters.BoostCounter;
+import mage.counters.CounterType;
 
 /**
  *
@@ -32,7 +32,7 @@ public final class WallOfRoots extends CardImpl {
         // Defender
         this.addAbility(DefenderAbility.getInstance());
         // Put a -0/-1 counter on Wall of Roots: Add {G}. Activate this ability only once each turn.
-        this.addAbility(new ActivateOncePerTurnManaAbility(Zone.BATTLEFIELD, new BasicManaEffect(Mana.GreenMana(1)), new PutCountersSourceCost(new BoostCounter(0, -1))));
+        this.addAbility(new ActivateOncePerTurnManaAbility(Zone.BATTLEFIELD, new BasicManaEffect(Mana.GreenMana(1)), new PutCountersSourceCost(CounterType.M0M1.createInstance())));
     }
 
     public WallOfRoots(final WallOfRoots card) {

--- a/Mage/src/main/java/mage/counters/CounterType.java
+++ b/Mage/src/main/java/mage/counters/CounterType.java
@@ -96,7 +96,10 @@ public enum CounterType {
     MANNEQUIN("mannequin"),
     MATRIX("matrix"),
     MENACE("menace"),
+    M0M1(new BoostCounter(-0, -1).name),
+    M0M2(new BoostCounter(-0, -2).name),
     M1M1(new BoostCounter(-1, -1).name),
+    M1M0(new BoostCounter(-1, -0).name),
     M2M1(new BoostCounter(-2, -1).name),
     M2M2(new BoostCounter(-2, -2).name),
     MINE("mine"),
@@ -211,6 +214,12 @@ public enum CounterType {
                 return new BoostCounter(1, 2, amount);
             case P2P2:
                 return new BoostCounter(2, 2, amount);
+            case M0M1:
+                return new BoostCounter(0, -1, amount);
+            case M0M2:
+                return new BoostCounter(0, -2, amount);
+            case M1M0:
+                return new BoostCounter(-1, 0, amount);
             case M1M1:
                 return new BoostCounter(-1, -1, amount);
             case M2M1:


### PR DESCRIPTION
Adds some detrimental P/T counter types from older sets (LEG, FEM, ICE, ALL, MIR).
Currently only the BoostCounter(P,T) was used.
These shorthands can be used in card implementations and for Outcome logic.