### PR TITLE
[KHM] Implemented Weathered Runestone

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WeatheredRunestone.java
+++ b/Mage.Sets/src/mage/cards/w/WeatheredRunestone.java
@@ -1,0 +1,107 @@
+package mage.cards.w;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.events.ZoneChangeEvent;
+
+/**
+ *
+ * @author weirddan455
+ */
+public final class WeatheredRunestone extends CardImpl {
+
+    public WeatheredRunestone(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
+
+        // Nonland permanent cards in graveyards and libraries can't enter the battlefield.
+        this.addAbility(new SimpleStaticAbility(new WeatheredRunestoneEffect()));
+
+        // Players can't cast spells from graveyards or libraries.
+        this.addAbility(new SimpleStaticAbility(new WeatheredRunestoneEffect2()));
+    }
+
+    private WeatheredRunestone(final WeatheredRunestone card) {
+        super(card);
+    }
+
+    @Override
+    public WeatheredRunestone copy() {
+        return new WeatheredRunestone(this);
+    }
+}
+
+class WeatheredRunestoneEffect extends ContinuousRuleModifyingEffectImpl {
+
+    public WeatheredRunestoneEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.Benefit);
+        staticText = "Nonland permanent cards in graveyards and libraries can't enter the battlefield";
+    }
+
+    private WeatheredRunestoneEffect(final WeatheredRunestoneEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public WeatheredRunestoneEffect copy() {
+        return new WeatheredRunestoneEffect(this);
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return GameEvent.EventType.ZONE_CHANGE == event.getType();
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        ZoneChangeEvent zEvent = (ZoneChangeEvent) event;
+        if (zEvent.getToZone() == Zone.BATTLEFIELD && (zEvent.getFromZone() == Zone.GRAVEYARD || zEvent.getFromZone() == Zone.LIBRARY)) {
+            Card card = game.getCard(zEvent.getTargetId());
+            return card != null && !card.isLand() && card.isPermanent();
+        }
+        return false;
+    }
+}
+
+class WeatheredRunestoneEffect2 extends ContinuousRuleModifyingEffectImpl {
+
+    public WeatheredRunestoneEffect2() {
+        super(Duration.WhileOnBattlefield, Outcome.Benefit);
+        staticText = "Players can't cast spells from graveyards or libraries";
+    }
+
+    private WeatheredRunestoneEffect2(final WeatheredRunestoneEffect2 effect) {
+        super(effect);
+    }
+
+    @Override
+    public WeatheredRunestoneEffect2 copy() {
+        return new WeatheredRunestoneEffect2(this);
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.CAST_SPELL;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        Card card = game.getCard(event.getSourceId());
+        if (card != null) {
+            Zone zone = game.getState().getZone(card.getId());
+            return zone == Zone.GRAVEYARD || zone == Zone.LIBRARY;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/Kaldheim.java
+++ b/Mage.Sets/src/mage/sets/Kaldheim.java
@@ -177,6 +177,7 @@ public final class Kaldheim extends ExpansionSet {
         cards.add(new SetCardInfo("Volatile Fjord", 273, Rarity.COMMON, mage.cards.v.VolatileFjord.class));
         cards.add(new SetCardInfo("Waking the Trolls", 234, Rarity.RARE, mage.cards.w.WakingTheTrolls.class));
         cards.add(new SetCardInfo("Warchanter Skald", 381, Rarity.UNCOMMON, mage.cards.w.WarchanterSkald.class));
+        cards.add(new SetCardInfo("Weathered Runestone", 247, Rarity.UNCOMMON, mage.cards.w.WeatheredRunestone.class));
         cards.add(new SetCardInfo("Woodland Chasm", 274, Rarity.COMMON, mage.cards.w.WoodlandChasm.class));
         cards.add(new SetCardInfo("Youthful Valkyrie", 382, Rarity.UNCOMMON, mage.cards.y.YouthfulValkyrie.class));
 


### PR DESCRIPTION
Implemented Weathered Runestone for #7248 

Code is mostly the same as Grafdigger's Cage.  Just needed to change affected cards from creature to nonland permanent for the first effect.