### PR TITLE
[KHM] Toralf, God of Fury - Fixed null pointer exception

### DIFF
--- a/Mage.Sets/src/mage/cards/t/ToralfGodOfFury.java
+++ b/Mage.Sets/src/mage/cards/t/ToralfGodOfFury.java
@@ -69,7 +69,7 @@ public final class ToralfGodOfFury extends ModalDoubleFacesCard {
         // Equipped creature has "{1}{R}, {T}, Unattach Toralf's Hammer: It deals 3 damage to any target. Return Toralf's Hammer to its owner's hand."
         this.getRightHalfCard().addAbility(new SimpleStaticAbility(new GainAbilityWithAttachmentEffect(
                 "equipped creature has \"{tap}, Unattach {this}: It deals 3 damage to any target. Return {this} to its owner's hand.\"",
-                new TapTargetEffect(), new TargetAnyTarget(), new UnattachCost(), new ManaCostsImpl<>("{1]{R}"), new TapSourceCost()
+                new TapTargetEffect(), new TargetAnyTarget(), new UnattachCost(), new ManaCostsImpl<>("{1}{R}"), new TapSourceCost()
         )));
 
         // Equipped creature get +3/+0 as long as its legendary.

--- a/Mage.Sets/src/mage/sets/Kaldheim.java
+++ b/Mage.Sets/src/mage/sets/Kaldheim.java
@@ -182,8 +182,8 @@ public final class Kaldheim extends ExpansionSet {
         cards.add(new SetCardInfo("The Trickster-God's Heist", 232, Rarity.UNCOMMON, mage.cards.t.TheTricksterGodsHeist.class));
         cards.add(new SetCardInfo("The World Tree", 275, Rarity.RARE, mage.cards.t.TheWorldTree.class));
         cards.add(new SetCardInfo("Thornmantle Striker", 387, Rarity.UNCOMMON, mage.cards.t.ThornmantleStriker.class));
-        cards.add(new SetCardInfo("Tormentor's Helm", 155, Rarity.COMMON, mage.cards.t.TormentorsHelm.class));
         cards.add(new SetCardInfo("Toralf, God of Fury", 154, Rarity.MYTHIC, mage.cards.t.ToralfGodOfFury.class));
+        cards.add(new SetCardInfo("Tormentor's Helm", 155, Rarity.COMMON, mage.cards.t.TormentorsHelm.class));
         cards.add(new SetCardInfo("Toski, Bearer of Secrets", 197, Rarity.RARE, mage.cards.t.ToskiBearerOfSecrets.class));
         cards.add(new SetCardInfo("Tyvar Kell", 198, Rarity.MYTHIC, mage.cards.t.TyvarKell.class));
         cards.add(new SetCardInfo("Undersea Invader", 78, Rarity.COMMON, mage.cards.u.UnderseaInvader.class));


### PR DESCRIPTION
Typo in Toralf was causing a null pointer exception when building the card database.  Was probably responsible for the build failures too.  Also fixed ordering in KHM cards file.