### PR TITLE
CreateTokenAttachSourceEffect - Remove redundant setText

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/CreateTokenAttachSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CreateTokenAttachSourceEffect.java
@@ -13,7 +13,6 @@ public class CreateTokenAttachSourceEffect extends CreateTokenEffect {
 
     public CreateTokenAttachSourceEffect(Token token) {
         super(token);
-        setText();
         staticText = staticText.concat(", then attach {this} to it");
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/CreateTokenEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CreateTokenEffect.java
@@ -111,7 +111,7 @@ public class CreateTokenEffect extends OneShotEffect {
         }
     }
 
-    void setText() {
+    private void setText() {
         StringBuilder sb = new StringBuilder("create ");
         if (amount.toString().equals("1")) {
             sb.append("a ");


### PR DESCRIPTION
I had another look at #7393 and realized I didn't need to call `setText()` since that was being done in the `CreateTokenEffect` constructor.