### PR TITLE
[KHM] Implemented Burning-Rune Demon

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BurningRuneDemon.java
+++ b/Mage.Sets/src/mage/cards/b/BurningRuneDemon.java
@@ -1,0 +1,155 @@
+package mage.cards.b;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.*;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.abilities.keyword.FlyingAbility;
+import mage.constants.CardType;
+import mage.constants.Zone;
+import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.NamePredicate;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetCard;
+import mage.target.common.TargetCardInLibrary;
+import mage.target.common.TargetOpponent;
+import mage.util.CardUtil;
+
+/**
+ *
+ * @author weirddan455
+ */
+public final class BurningRuneDemon extends CardImpl {
+
+    public BurningRuneDemon(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{B}{B}");
+
+        this.subtype.add(SubType.DEMON);
+        this.subtype.add(SubType.BERSERKER);
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // When Burning-Rune Demon enters the battlefield, you may search your library for exactly two cards
+        // not named Burning-Rune Demon that have different names. If you do, reveal those cards.
+        // An opponent chooses one of them.
+        // Put the chosen card into your hand and the other into your graveyard, then shuffle your library.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new BurningRuneDemonEffect(), true));
+    }
+
+    private BurningRuneDemon(final BurningRuneDemon card) {
+        super(card);
+    }
+
+    @Override
+    public BurningRuneDemon copy() {
+        return new BurningRuneDemon(this);
+    }
+}
+
+class BurningRuneDemonEffect extends OneShotEffect {
+
+    public BurningRuneDemonEffect() {
+        super(Outcome.Benefit);
+        staticText = "search your library for exactly two cards "
+                + "not named Burning-Rune Demon that have different names. If you do, reveal those cards. "
+                + "An opponent chooses one of them. "
+                + "Put the chosen card into your hand and the other into your graveyard, then shuffle your library";
+    }
+
+    private BurningRuneDemonEffect(final BurningRuneDemonEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public BurningRuneDemonEffect copy() {
+        return new BurningRuneDemonEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            TargetCardInLibrary targetCardInLibrary = new BurningRuneDemonTarget();
+            if (controller.searchLibrary(targetCardInLibrary, source, game)) {
+                Cards cards = new CardsImpl(targetCardInLibrary.getTargets());
+                if (!cards.isEmpty()) {
+                    Player opponent;
+                    Set<UUID> opponents = game.getOpponents(controller.getId());
+                    if (opponents.size() == 1) {
+                        opponent = game.getPlayer(opponents.iterator().next());
+                    } else {
+                        TargetOpponent targetOpponent = new TargetOpponent(true);
+                        controller.chooseTarget(Outcome.Detriment, targetOpponent, source, game);
+                        opponent = game.getPlayer(targetOpponent.getFirstTarget());
+                    }
+                    if (opponent != null) {
+                        TargetCard targetCard = new TargetCard(Zone.LIBRARY, StaticFilters.FILTER_CARD);
+                        targetCard.withChooseHint("Card to go to opponent's hand (other goes to graveyard)");
+                        opponent.chooseTarget(outcome, cards, targetCard, source, game);
+                        Card cardToHand = game.getCard(targetCard.getFirstTarget());
+                        if (cardToHand != null) {
+                            controller.moveCards(cardToHand, Zone.HAND, source, game);
+                            cards.remove(cardToHand);
+                        }
+                        if (!cards.isEmpty()) {
+                            controller.moveCards(cards, Zone.GRAVEYARD, source, game);
+                        }
+                    }
+                }
+                controller.shuffleLibrary(source, game);
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+class BurningRuneDemonTarget extends TargetCardInLibrary {
+
+    private static final FilterCard filter
+            = new FilterCard("cards not named Burning-Rune Demon that have different names");
+
+    static {
+        filter.add(Predicates.not(new NamePredicate("Burning-Rune Demon")));
+    }
+
+    public BurningRuneDemonTarget() {
+        super(2, filter);
+    }
+
+    private BurningRuneDemonTarget(final BurningRuneDemonTarget target) {
+        super(target);
+    }
+
+    @Override
+    public BurningRuneDemonTarget copy() {
+        return new BurningRuneDemonTarget(this);
+    }
+
+    @Override
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
+            return false;
+        }
+        Card card = game.getCard(id);
+        return card != null
+                && this.getTargets()
+                .stream()
+                .map(game::getCard)
+                .filter(Objects::nonNull)
+                .map(Card::getName)
+                .noneMatch(n -> CardUtil.haveSameNames(card, n, game));
+    }
+}

--- a/Mage.Sets/src/mage/sets/Kaldheim.java
+++ b/Mage.Sets/src/mage/sets/Kaldheim.java
@@ -100,6 +100,7 @@ public final class Kaldheim extends ExpansionSet {
         cards.add(new SetCardInfo("Breakneck Berserker", 124, Rarity.COMMON, mage.cards.b.BreakneckBerserker.class));
         cards.add(new SetCardInfo("Bretagard Stronghold", 253, Rarity.UNCOMMON, mage.cards.b.BretagardStronghold.class));
         cards.add(new SetCardInfo("Broken Wings", 164, Rarity.COMMON, mage.cards.b.BrokenWings.class));
+        cards.add(new SetCardInfo("Burning-Rune Demon", 81, Rarity.MYTHIC, mage.cards.b.BurningRuneDemon.class));
         cards.add(new SetCardInfo("Calamity Bearer", 125, Rarity.RARE, mage.cards.c.CalamityBearer.class));
         cards.add(new SetCardInfo("Canopy Tactician", 378, Rarity.RARE, mage.cards.c.CanopyTactician.class));
         cards.add(new SetCardInfo("Cinderheart Giant", 126, Rarity.COMMON, mage.cards.c.CinderheartGiant.class));


### PR DESCRIPTION
Implemented Burning-Rune Demon for #7248 

A bug I ran into while testing this is that, for some reason, the AI is allowed to select two cards with the same name and does so even if there are two legal targets with different names.   I'm not sure if it's just a bug with the AI or something I should be doing differently in this code.

The human targeting interface appears to be working correctly.  I tested in a deck with only Grizzly Bears and it would not let me select 2 targets so only option was clicking Cancel and having the ability do nothing except look at the deck and then shuffle (which is expected behavior of the card if there are not 2 legal targets.)

Lastly, I think something like `TargetCardsInLibraryDifferentNames` could be made a common class as there are several cards currently using custom implementations of this already that are mostly doing the same thing.  I saw some variations though and I wasn't sure which of these two was correct (or if it really matters).  Ex.  Emergent Ultimatum and Deathbellow Warcry:

```
@Override
public boolean canTarget(UUID playerId, UUID id, Ability source, Game game)

@Override
public boolean canTarget(UUID playerId, UUID id, Ability source, Cards cards, Game game)
```

If someone could point me to maybe the best example of this class, I could look at making it a common class.