### PR TITLE
Fixed Release to the Wind not allowing to cast the exiled permanent

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/asthought/PlayFromNotOwnHandZoneTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/asthought/PlayFromNotOwnHandZoneTargetEffect.java
@@ -159,7 +159,7 @@ public class PlayFromNotOwnHandZoneTargetEffect extends AsThoughEffectImpl {
             return false;
         }
         ContinuousEffect effect = new PlayFromNotOwnHandZoneTargetEffect(Zone.EXILED, allowedCaster, duration, withoutMana);
-        effect.setTargetPointer(new FixedTargets(cards, game));
+        effect.setTargetPointer(new FixedTargets(game.getExile().getExileZone(exileId), game));
         game.addEffect(effect, source);
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/asthought/PlayFromNotOwnHandZoneTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/asthought/PlayFromNotOwnHandZoneTargetEffect.java
@@ -159,7 +159,7 @@ public class PlayFromNotOwnHandZoneTargetEffect extends AsThoughEffectImpl {
             return false;
         }
         ContinuousEffect effect = new PlayFromNotOwnHandZoneTargetEffect(Zone.EXILED, allowedCaster, duration, withoutMana);
-        effect.setTargetPointer(new FixedTargets(game.getExile().getExileZone(exileId), game));
+        effect.setTargetPointer(new FixedTargets(cards, game));
         game.addEffect(effect, source);
         return true;
     }


### PR DESCRIPTION
Issue #7415 

I think this was a zone change counter issue.  Other cards using this method are cards that exile from top of library while Release to the Wind is passing it a Permanent.  I tested that this fixed it and didn't break other cards that use it (tested with Mind's Desire) but wanted to send a PR to double check this is the correct way to fix the problem.