### PR TITLE
Refactoring methods which add counters to track which player adds the counters (ready for review)

### DIFF
--- a/Mage.Server/src/main/java/mage/server/util/SystemUtil.java
+++ b/Mage.Server/src/main/java/mage/server/util/SystemUtil.java
@@ -518,7 +518,7 @@ public final class SystemUtil {
                 } else if ("loyalty".equalsIgnoreCase(command.zone)) {
                     for (Permanent perm : game.getBattlefield().getAllActivePermanents(player.getId())) {
                         if (perm.getName().equals(command.cardName) && perm.getCardType().contains(CardType.PLANESWALKER)) {
-                            perm.addCounters(CounterType.LOYALTY.createInstance(command.Amount), source.getControllerId(), fakeSourceAbility, game);
+                            perm.addCounters(CounterType.LOYALTY.createInstance(command.Amount), fakeSourceAbility.getControllerId(), fakeSourceAbility, game);
                         }
                     }
                     continue;

--- a/Mage.Server/src/main/java/mage/server/util/SystemUtil.java
+++ b/Mage.Server/src/main/java/mage/server/util/SystemUtil.java
@@ -518,7 +518,7 @@ public final class SystemUtil {
                 } else if ("loyalty".equalsIgnoreCase(command.zone)) {
                     for (Permanent perm : game.getBattlefield().getAllActivePermanents(player.getId())) {
                         if (perm.getName().equals(command.cardName) && perm.getCardType().contains(CardType.PLANESWALKER)) {
-                            perm.addCounters(CounterType.LOYALTY.createInstance(command.Amount), fakeSourceAbility, game);
+                            perm.addCounters(CounterType.LOYALTY.createInstance(command.Amount), source.getControllerId(), fakeSourceAbility, game);
                         }
                     }
                     continue;

--- a/Mage.Sets/src/mage/cards/a/Aboroth.java
+++ b/Mage.Sets/src/mage/cards/a/Aboroth.java
@@ -52,7 +52,7 @@ class AborothCost extends CostImpl {
     public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null) {
-            permanent.addCounters(CounterType.M1M1.createInstance(), ability, game);
+            permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), ability, game);
             this.paid = true;
             return true;
         }

--- a/Mage.Sets/src/mage/cards/a/Aboroth.java
+++ b/Mage.Sets/src/mage/cards/a/Aboroth.java
@@ -52,7 +52,7 @@ class AborothCost extends CostImpl {
     public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null) {
-            permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), ability, game);
+            permanent.addCounters(CounterType.M1M1.createInstance(), controllerId, ability, game);
             this.paid = true;
             return true;
         }

--- a/Mage.Sets/src/mage/cards/a/AetherbornMarauder.java
+++ b/Mage.Sets/src/mage/cards/a/AetherbornMarauder.java
@@ -93,7 +93,7 @@ class AetherbornMarauderEffect extends OneShotEffect {
                             }
                             if (numberToMove > 0) {
                                 fromPermanent.removeCounters(CounterType.P1P1.createInstance(numberToMove), source, game);
-                                sourceObject.addCounters(CounterType.P1P1.createInstance(numberToMove), source, game);
+                                sourceObject.addCounters(CounterType.P1P1.createInstance(numberToMove), source.getControllerId(), source, game);
                             }
                         }
                     }

--- a/Mage.Sets/src/mage/cards/a/AfiyaGrove.java
+++ b/Mage.Sets/src/mage/cards/a/AfiyaGrove.java
@@ -77,7 +77,7 @@ class MoveCounterToTargetFromSourceEffect extends OneShotEffect {
             Permanent toPermanent = game.getPermanent(getTargetPointer().getFirst(game, source));
             if (toPermanent != null && sourceObject.getCounters(game).getCount(CounterType.P1P1) > 0) {
                 sourceObject.removeCounters(CounterType.P1P1.createInstance(), source, game);
-                toPermanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                toPermanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 game.informPlayers("Moved a +1/+1 counter from " + sourceObject.getLogName() + " to " + toPermanent.getLogName());
             }
             return true;

--- a/Mage.Sets/src/mage/cards/a/AgitatorAnt.java
+++ b/Mage.Sets/src/mage/cards/a/AgitatorAnt.java
@@ -88,7 +88,7 @@ class AgitatorAntEffect extends OneShotEffect {
             targetPermanent.setNotTarget(true);
             player.choose(Outcome.BoostCreature, targetPermanent, source.getSourceId(), game);
             Permanent permanent = game.getPermanent(targetPermanent.getFirstTarget());
-            if (permanent == null || !permanent.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game)) {
+            if (permanent == null || !permanent.addCounters(CounterType.P1P1.createInstance(2), player.getId(), source, game)) {
                 continue;
             }
             new GoadTargetEffect().setTargetPointer(new FixedTarget(permanent, game)).apply(game, source);

--- a/Mage.Sets/src/mage/cards/a/AgitatorAnt.java
+++ b/Mage.Sets/src/mage/cards/a/AgitatorAnt.java
@@ -88,7 +88,7 @@ class AgitatorAntEffect extends OneShotEffect {
             targetPermanent.setNotTarget(true);
             player.choose(Outcome.BoostCreature, targetPermanent, source.getSourceId(), game);
             Permanent permanent = game.getPermanent(targetPermanent.getFirstTarget());
-            if (permanent == null || !permanent.addCounters(CounterType.P1P1.createInstance(2), source, game)) {
+            if (permanent == null || !permanent.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game)) {
                 continue;
             }
             new GoadTargetEffect().setTargetPointer(new FixedTarget(permanent, game)).apply(game, source);

--- a/Mage.Sets/src/mage/cards/a/AngelheartVial.java
+++ b/Mage.Sets/src/mage/cards/a/AngelheartVial.java
@@ -19,7 +19,6 @@ import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 
 /**
@@ -106,7 +105,7 @@ class AngelheartVialEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null) {
-            permanent.addCounters(CounterType.CHARGE.createInstance((Integer) this.getValue("damageAmount")), source, game);
+            permanent.addCounters(CounterType.CHARGE.createInstance((Integer) this.getValue("damageAmount")), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/a/AnimationModule.java
+++ b/Mage.Sets/src/mage/cards/a/AnimationModule.java
@@ -151,7 +151,7 @@ class AnimationModuleEffect extends OneShotEffect {
                         if (player.getCounters().size() == 1) {
                             for (Counter counter : player.getCounters().values()) {
                                 Counter newCounter = new Counter(counter.getName());
-                                player.addCounters(newCounter, source, game);
+                                player.addCounters(newCounter, source.getControllerId(), source, game);
                             }
                         } else {
                             Choice choice = new ChoiceImpl(true);
@@ -165,7 +165,7 @@ class AnimationModuleEffect extends OneShotEffect {
                                 for (Counter counter : player.getCounters().values()) {
                                     if (counter.getName().equals(choice.getChoice())) {
                                         Counter newCounter = new Counter(counter.getName());
-                                        player.addCounters(newCounter, source, game);
+                                        player.addCounters(newCounter, source.getControllerId(), source, game);
                                         break;
                                     }
                                 }

--- a/Mage.Sets/src/mage/cards/a/AnimationModule.java
+++ b/Mage.Sets/src/mage/cards/a/AnimationModule.java
@@ -121,7 +121,7 @@ class AnimationModuleEffect extends OneShotEffect {
                     if (permanent.getCounters(game).size() == 1) {
                         for (Counter counter : permanent.getCounters(game).values()) {
                             Counter newCounter = new Counter(counter.getName());
-                            permanent.addCounters(newCounter, source, game);
+                            permanent.addCounters(newCounter, source.getControllerId(), source, game);
                         }
                     } else {
                         Choice choice = new ChoiceImpl(true);
@@ -135,7 +135,7 @@ class AnimationModuleEffect extends OneShotEffect {
                             for (Counter counter : permanent.getCounters(game).values()) {
                                 if (counter.getName().equals(choice.getChoice())) {
                                     Counter newCounter = new Counter(counter.getName());
-                                    permanent.addCounters(newCounter, source, game);
+                                    permanent.addCounters(newCounter, source.getControllerId(), source, game);
                                     break;
                                 }
                             }

--- a/Mage.Sets/src/mage/cards/a/Anthroplasm.java
+++ b/Mage.Sets/src/mage/cards/a/Anthroplasm.java
@@ -75,7 +75,7 @@ class AnthroplasmEffect extends OneShotEffect {
             //Remove all +1/+1 counters
             permanent.removeCounters(permanent.getCounters(game).get(CounterType.P1P1.getName()), source, game);
             //put X +1/+1 counters
-            permanent.addCounters(CounterType.P1P1.createInstance(source.getManaCostsToPay().getX()), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(source.getManaCostsToPay().getX()), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/a/ApocalypseHydra.java
+++ b/Mage.Sets/src/mage/cards/a/ApocalypseHydra.java
@@ -82,9 +82,9 @@ class ApocalypseHydraEffect extends OneShotEffect {
         int amount = spellAbility.getManaCostsToPay().getX();
         if (amount > 0) {
             if (amount < 5) {
-                permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             } else {
-                permanent.addCounters(CounterType.P1P1.createInstance(amount * 2), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(amount * 2), source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/a/ArbiterOfTheIdeal.java
+++ b/Mage.Sets/src/mage/cards/a/ArbiterOfTheIdeal.java
@@ -89,7 +89,7 @@ class ArbiterOfTheIdealEffect extends OneShotEffect {
                 controller.moveCards(card, Zone.BATTLEFIELD, source, game);
                 Permanent permanent = game.getPermanent(card.getId());
                 if (permanent != null) {
-                    permanent.addCounters(CounterType.MANIFESTATION.createInstance(), source, game);
+                    permanent.addCounters(CounterType.MANIFESTATION.createInstance(), source.getControllerId(), source, game);
                     ContinuousEffect effect = new AddCardTypeTargetEffect(Duration.Custom, CardType.ENCHANTMENT);
                     effect.setTargetPointer(new FixedTarget(permanent, game));
                     game.addEffect(effect, source);

--- a/Mage.Sets/src/mage/cards/a/ArcboundFiend.java
+++ b/Mage.Sets/src/mage/cards/a/ArcboundFiend.java
@@ -80,7 +80,7 @@ class MoveCounterFromTargetToSourceEffect extends OneShotEffect {
             Permanent fromPermanent = game.getPermanent(getTargetPointer().getFirst(game, source));
             if (fromPermanent != null && fromPermanent.getCounters(game).getCount(CounterType.P1P1) > 0) {
                 fromPermanent.removeCounters(CounterType.P1P1.createInstance(), source, game);
-                sourceObject.addCounters(CounterType.P1P1.createInstance(), source, game);
+                sourceObject.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 game.informPlayers("Moved a +1/+1 counter from " + fromPermanent.getLogName() + " to " + sourceObject.getLogName());
             }
             return true;

--- a/Mage.Sets/src/mage/cards/a/ArlinnVoiceOfThePack.java
+++ b/Mage.Sets/src/mage/cards/a/ArlinnVoiceOfThePack.java
@@ -77,7 +77,7 @@ class ArlinnVoiceOfThePackReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/a/ArsenalThresher.java
+++ b/Mage.Sets/src/mage/cards/a/ArsenalThresher.java
@@ -87,7 +87,7 @@ class ArsenalThresherEffect extends OneShotEffect {
                     if (arsenalThresher != null) {
                         controller.revealCards(arsenalThresher.getIdName(), cards, game);
                         List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects"); // the basic event is the EntersBattlefieldEvent, so use already applied replacement effects from that event
-                        arsenalThresher.addCounters(CounterType.P1P1.createInstance(cards.size()), source, game, appliedEffects);
+                        arsenalThresher.addCounters(CounterType.P1P1.createInstance(cards.size()), source.getControllerId(), source, game, appliedEffects);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/a/AsLuckWouldHaveIt.java
+++ b/Mage.Sets/src/mage/cards/a/AsLuckWouldHaveIt.java
@@ -106,7 +106,7 @@ class AsLuckWouldHaveItEffect extends OneShotEffect {
         if (controller != null && permanent != null) {
             if (getValue("rolled") != null) {
                 int amount = (Integer) getValue("rolled");
-                permanent.addCounters(new Counter("luck", amount), source, game);
+                permanent.addCounters(new Counter("luck", amount), source.getControllerId(), source, game);
 
                 if (permanent.getCounters(game).getCount("luck") >= 100) {
                     Player player = game.getPlayer(permanent.getControllerId());

--- a/Mage.Sets/src/mage/cards/a/AscendantSpirit.java
+++ b/Mage.Sets/src/mage/cards/a/AscendantSpirit.java
@@ -85,7 +85,7 @@ class AscendantSpiritWarriorEffect extends OneShotEffect {
         if (permanent == null || !permanent.hasSubtype(SubType.WARRIOR, game)) {
             return false;
         }
-        permanent.addCounters(CounterType.FLYING.createInstance(), source, game);
+        permanent.addCounters(CounterType.FLYING.createInstance(), source.getControllerId(), source, game);
         game.addEffect(new AddCardSubTypeSourceEffect(
                 Duration.Custom, SubType.SPIRIT, SubType.WARRIOR, SubType.ANGEL
         ), source);
@@ -119,7 +119,7 @@ class AscendantSpiritAngelEffect extends OneShotEffect {
         if (permanent == null || !permanent.hasSubtype(SubType.ANGEL, game)) {
             return false;
         }
-        permanent.addCounters(CounterType.P1P1.createInstance(2), source, game);
+        permanent.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
         game.addEffect(new GainAbilitySourceEffect(new DealsCombatDamageToAPlayerTriggeredAbility(
                 new DrawCardSourceControllerEffect(1), false
         ), Duration.Custom), source);

--- a/Mage.Sets/src/mage/cards/a/AscentOfTheWorthy.java
+++ b/Mage.Sets/src/mage/cards/a/AscentOfTheWorthy.java
@@ -171,7 +171,7 @@ class AscentOfTheWorthyReturnEffect extends OneShotEffect {
         if (permanent == null) {
             return false;
         }
-        permanent.addCounters(CounterType.FLYING.createInstance(), source, game);
+        permanent.addCounters(CounterType.FLYING.createInstance(), source.getControllerId(), source, game);
         game.addEffect(new AddCardSubTypeTargetEffect(
                 SubType.ANGEL, Duration.Custom
         ).setTargetPointer(new FixedTarget(permanent, game)), source);

--- a/Mage.Sets/src/mage/cards/a/AzorsElocutors.java
+++ b/Mage.Sets/src/mage/cards/a/AzorsElocutors.java
@@ -14,7 +14,6 @@ import mage.constants.*;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
@@ -96,7 +95,7 @@ class AzorsElocutorsEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null) {
-            permanent.addCounters(CounterType.FILIBUSTER.createInstance(), source, game);
+            permanent.addCounters(CounterType.FILIBUSTER.createInstance(), source.getControllerId(), source, game);
             if (permanent.getCounters(game).getCount(CounterType.FILIBUSTER) > 4) {
                 Player player = game.getPlayer(permanent.getControllerId());
                 if (player != null) {

--- a/Mage.Sets/src/mage/cards/b/Bioshift.java
+++ b/Mage.Sets/src/mage/cards/b/Bioshift.java
@@ -90,7 +90,7 @@ class MoveCounterFromTargetToTargetEffect extends OneShotEffect {
                 int amountToMove = controller.getAmount(0, amountCounters, "How many counters do you want to move?", game);
                 if (amountToMove > 0) {
                     fromPermanent.removeCounters(CounterType.P1P1.createInstance(amountToMove), source, game);
-                    toPermanent.addCounters(CounterType.P1P1.createInstance(amountToMove), source, game);
+                    toPermanent.addCounters(CounterType.P1P1.createInstance(amountToMove), source.getControllerId(), source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/b/BlackSunsZenith.java
+++ b/Mage.Sets/src/mage/cards/b/BlackSunsZenith.java
@@ -54,7 +54,7 @@ class BlackSunsZenithEffect extends OneShotEffect {
         int amount = source.getManaCostsToPay().getX();
         for (Permanent permanent : game.getBattlefield().getAllActivePermanents()) {
             if (permanent != null && permanent.isCreature()) {
-                permanent.addCounters(CounterType.M1M1.createInstance(amount), source, game);
+                permanent.addCounters(CounterType.M1M1.createInstance(amount), source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/b/BladeOfTheBloodchief.java
+++ b/Mage.Sets/src/mage/cards/b/BladeOfTheBloodchief.java
@@ -62,9 +62,9 @@ class BladeOfTheBloodchiefEffect extends OneShotEffect {
             Permanent creature = game.getPermanent(enchantment.getAttachedTo());
             if (creature != null) {
                 if (creature.hasSubtype(SubType.VAMPIRE, game)) {
-                    creature.addCounters(CounterType.P1P1.createInstance(2), source, game);
+                    creature.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
                 } else {
-                    creature.addCounters(CounterType.P1P1.createInstance(), source, game);
+                    creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/b/BlessingOfFrost.java
+++ b/Mage.Sets/src/mage/cards/b/BlessingOfFrost.java
@@ -84,7 +84,7 @@ class BlessingOfFrostEffect extends OneShotEffect {
                 if (permanent == null) {
                     continue;
                 }
-                permanent.addCounters(CounterType.P1P1.createInstance(target.getTargetAmount(targetId)), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(target.getTargetAmount(targetId)), source.getControllerId(), source, game);
             }
         }
         game.applyEffects();

--- a/Mage.Sets/src/mage/cards/b/BloodCurdle.java
+++ b/Mage.Sets/src/mage/cards/b/BloodCurdle.java
@@ -72,6 +72,6 @@ class BloodCurdleEffect extends OneShotEffect {
         if (permanent == null) {
             return false;
         }
-        return permanent.addCounters(CounterType.MENACE.createInstance(), source, game);
+        return permanent.addCounters(CounterType.MENACE.createInstance(), source.getControllerId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/b/BloodTyrant.java
+++ b/Mage.Sets/src/mage/cards/b/BloodTyrant.java
@@ -16,7 +16,6 @@ import mage.constants.*;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
@@ -119,7 +118,7 @@ class BloodTyrantEffect extends OneShotEffect {
             }
             Permanent bloodTyrant = game.getPermanent(source.getSourceId());
             if (bloodTyrant != null && counters > 0) {
-                bloodTyrant.addCounters(CounterType.P1P1.createInstance(counters), source, game);
+                bloodTyrant.addCounters(CounterType.P1P1.createInstance(counters), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/b/BloodsporeThrinax.java
+++ b/Mage.Sets/src/mage/cards/b/BloodsporeThrinax.java
@@ -15,7 +15,6 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 
 /**
@@ -78,7 +77,7 @@ class BloodsporeThrinaxEntersBattlefieldEffect extends ReplacementEffectImpl {
         if (sourceCreature != null && creature != null) {
             int amount = sourceCreature.getCounters(game).getCount(CounterType.P1P1);
             if (amount > 0) {
-                creature.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                creature.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/b/BlowflyInfestation.java
+++ b/Mage.Sets/src/mage/cards/b/BlowflyInfestation.java
@@ -84,7 +84,7 @@ class BlowflyInfestationEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent creature = game.getPermanent(source.getFirstTarget());
         if (creature != null) {
-            creature.addCounters(CounterType.M1M1.createInstance(), source, game);
+            creature.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/b/BombSquad.java
+++ b/Mage.Sets/src/mage/cards/b/BombSquad.java
@@ -17,7 +17,6 @@ import mage.counters.CounterType;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCreaturePermanent;
@@ -175,7 +174,7 @@ class BombSquadBeginningEffect extends OneShotEffect {
             return false;
         }
         for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), game)) {
-            permanent.addCounters(CounterType.FUSE.createInstance(), source, game);
+            permanent.addCounters(CounterType.FUSE.createInstance(), source.getControllerId(), source, game);
 
             game.informPlayers(card.getName() + " puts a fuse counter on " + permanent.getName());
         }

--- a/Mage.Sets/src/mage/cards/b/BorealOutrider.java
+++ b/Mage.Sets/src/mage/cards/b/BorealOutrider.java
@@ -98,7 +98,7 @@ class BorealOutriderEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
             discard();
         }
         return false;

--- a/Mage.Sets/src/mage/cards/b/BraceForImpact.java
+++ b/Mage.Sets/src/mage/cards/b/BraceForImpact.java
@@ -83,7 +83,7 @@ class BraceForImpactPreventDamageTargetEffect extends PreventionEffectImpl {
             if (prevented > 0) {
                 Permanent targetPermanent = game.getPermanent(source.getTargets().getFirstTarget());
                 if (targetPermanent != null) {
-                    targetPermanent.addCounters(CounterType.P1P1.createInstance(prevented), source, game);
+                    targetPermanent.addCounters(CounterType.P1P1.createInstance(prevented), source.getControllerId(), source, game);
                     game.informPlayers("Brace for Impact: Prevented " + prevented + " damage ");
                     game.informPlayers("Brace for Impact: Adding " + prevented + " +1/+1 counters to " + targetPermanent.getName());
                 }

--- a/Mage.Sets/src/mage/cards/b/BramblewoodParagon.java
+++ b/Mage.Sets/src/mage/cards/b/BramblewoodParagon.java
@@ -88,7 +88,7 @@ class BramblewoodParagonReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/c/CallOfTheDeathDweller.java
+++ b/Mage.Sets/src/mage/cards/c/CallOfTheDeathDweller.java
@@ -99,7 +99,7 @@ class CallOfTheDeathDwellerEffect extends OneShotEffect {
         if (player.choose(outcome, target, source.getSourceId(), game)) {
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
-                permanent.addCounters(CounterType.DEATHTOUCH.createInstance(), source, game);
+                permanent.addCounters(CounterType.DEATHTOUCH.createInstance(), source.getControllerId(), source, game);
             }
         }
         filter.setMessage("creature to put a menace counter on");
@@ -107,7 +107,7 @@ class CallOfTheDeathDwellerEffect extends OneShotEffect {
         if (player.choose(outcome, target, source.getSourceId(), game)) {
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
-                permanent.addCounters(CounterType.MENACE.createInstance(), source, game);
+                permanent.addCounters(CounterType.MENACE.createInstance(), source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/c/CankerAbomination.java
+++ b/Mage.Sets/src/mage/cards/c/CankerAbomination.java
@@ -78,7 +78,7 @@ class CankerAbominationEffect extends OneShotEffect {
                 game.informPlayers(cankerAbomination.getName() + ": " + controller.getLogName() + " has chosen " + opponent.getLogName());
                 int amount = game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, opponent.getId(), game).size();
                 if (amount > 0) {
-                    cankerAbomination.addCounters(CounterType.M1M1.createInstance(amount), source, game);
+                    cankerAbomination.addCounters(CounterType.M1M1.createInstance(amount), source.getControllerId(), source, game);
                 }
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/c/Cannibalize.java
+++ b/Mage.Sets/src/mage/cards/c/Cannibalize.java
@@ -72,7 +72,7 @@ class CannibalizeEffect extends OneShotEffect {
                         controller.moveCardToExileWithInfo(creature, null, "", source, game, Zone.BATTLEFIELD, true);
                         exileDone = true;
                     } else {
-                        creature.addCounters(CounterType.P1P1.createInstance(2), source, game);
+                        creature.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
                         game.informPlayers("Added two +1/+1 counters on " + creature.getLogName());
                     }
                     count++;

--- a/Mage.Sets/src/mage/cards/c/CauldronsGift.java
+++ b/Mage.Sets/src/mage/cards/c/CauldronsGift.java
@@ -84,7 +84,7 @@ class CauldronsGiftEffect extends OneShotEffect {
         }
         Permanent permanent = game.getPermanent(card.getId());
         if (permanent != null) {
-            permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/ChargingCinderhorn.java
+++ b/Mage.Sets/src/mage/cards/c/ChargingCinderhorn.java
@@ -85,7 +85,7 @@ class ChargingCinderhornDamageTargetEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent chargingCinderhoof = game.getPermanent(source.getSourceId());
         if (chargingCinderhoof != null) {
-            chargingCinderhoof.addCounters(CounterType.FURY.createInstance(), source, game);
+            chargingCinderhoof.addCounters(CounterType.FURY.createInstance(), source.getControllerId(), source, game);
         } else {
             chargingCinderhoof = game.getPermanentOrLKIBattlefield(source.getSourceId());
         }

--- a/Mage.Sets/src/mage/cards/c/ChorusOfTheConclave.java
+++ b/Mage.Sets/src/mage/cards/c/ChorusOfTheConclave.java
@@ -151,7 +151,7 @@ class ChorusOfTheConclaveReplacementEffect2 extends ReplacementEffectImpl {
             String key = event.getSourceId().toString() + (game.getState().getZoneChangeCounter(event.getSourceId()) - 1);
             int xValue = spellX.get(key);
             if (xValue > 0) {
-                creature.addCounters(CounterType.P1P1.createInstance(xValue), source, game, event.getAppliedEffects());
+                creature.addCounters(CounterType.P1P1.createInstance(xValue), source.getControllerId(), source, game, event.getAppliedEffects());
                 game.informPlayers(sourceObject.getLogName() + ": " + creature.getLogName() + " enters the battlefield with " + xValue + " +1/+1 counter" + (xValue > 1 ? "s" : "") + " on it");
             }
             spellX.remove(key);

--- a/Mage.Sets/src/mage/cards/c/CollectiveEffort.java
+++ b/Mage.Sets/src/mage/cards/c/CollectiveEffort.java
@@ -106,7 +106,7 @@ class CollectiveEffortEffect extends OneShotEffect {
         Player target = game.getPlayer(source.getFirstTarget());
         if (target != null) {
             for (Permanent p : game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, target.getId(), game)) {
-                p.addCounters(CounterType.P1P1.createInstance(), source, game);
+                p.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/c/CombineGuildmage.java
+++ b/Mage.Sets/src/mage/cards/c/CombineGuildmage.java
@@ -100,7 +100,7 @@ class CombineGuildmageReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent target = ((EntersTheBattlefieldEvent) event).getTarget();
         if (target != null) {
-            target.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            target.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }
@@ -136,7 +136,7 @@ class CombineGuildmageCounterEffect extends OneShotEffect {
         }
         if (fromPermanent.getCounters(game).getCount(CounterType.P1P1) > 0) {
             fromPermanent.removeCounters(CounterType.P1P1.createInstance(), source, game);
-            toPermanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+            toPermanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/CommonBond.java
+++ b/Mage.Sets/src/mage/cards/c/CommonBond.java
@@ -57,12 +57,12 @@ class CommonBondEffect extends OneShotEffect {
         int affectedTargets = 0;
         Permanent permanent = game.getPermanent(source.getTargets().get(0).getFirstTarget());
         if (permanent != null) {
-            permanent.addCounters(CounterType.P1P1.createInstance(1), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(1), source.getControllerId(), source, game);
             affectedTargets ++;
         }
         permanent = game.getPermanent(source.getTargets().get(1).getFirstTarget());
         if (permanent != null) {
-            permanent.addCounters(CounterType.P1P1.createInstance(1), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(1), source.getControllerId(), source, game);
             affectedTargets ++;
         }
         return affectedTargets > 0;

--- a/Mage.Sets/src/mage/cards/c/ContagionEngine.java
+++ b/Mage.Sets/src/mage/cards/c/ContagionEngine.java
@@ -68,7 +68,7 @@ class ContagionEngineEffect extends OneShotEffect {
         Player targetPlayer = game.getPlayer(getTargetPointer().getFirst(game, source));
         if (targetPlayer != null) {
             for (Permanent creature : game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, targetPlayer.getId(), game)) {
-                creature.addCounters(CounterType.M1M1.createInstance(), source, game);
+                creature.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/c/Corrosion.java
+++ b/Mage.Sets/src/mage/cards/c/Corrosion.java
@@ -78,7 +78,7 @@ class CorrosionUpkeepEffect extends OneShotEffect {
             // put a rust counter on each artifact target opponent controls
             if (targetPlayer != null) {
                 for (Permanent permanent : game.getBattlefield().getAllActivePermanents(filter, targetPlayer.getId(), game)) {
-                    permanent.addCounters(CounterType.RUST.createInstance(), source, game);
+                    permanent.addCounters(CounterType.RUST.createInstance(), source.getControllerId(), source, game);
                 }
             }
             // destroy each artifact with converted mana cost less than or equal to the number of rust counters on it

--- a/Mage.Sets/src/mage/cards/c/CradleOfVitality.java
+++ b/Mage.Sets/src/mage/cards/c/CradleOfVitality.java
@@ -66,6 +66,6 @@ class CradleOfVitalityEffect extends OneShotEffect {
             lifeGained = (Integer) this.getValue("gainedLife");
         }
         return permanent != null && lifeGained > 0
-                && permanent.addCounters(CounterType.P1P1.createInstance(lifeGained), source, game);
+                && permanent.addCounters(CounterType.P1P1.createInstance(lifeGained), source.getControllerId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CrazedFirecat.java
+++ b/Mage.Sets/src/mage/cards/c/CrazedFirecat.java
@@ -73,7 +73,7 @@ class CrazedFirecatEffect extends OneShotEffect {
                     break;
                 }
             }
-            sourceObject.addCounters(CounterType.P1P1.createInstance(flipsWon), source, game);
+            sourceObject.addCounters(CounterType.P1P1.createInstance(flipsWon), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/c/CrovaxTheCursed.java
+++ b/Mage.Sets/src/mage/cards/c/CrovaxTheCursed.java
@@ -82,7 +82,7 @@ class CrovaxTheCursedEffect extends OneShotEffect {
             if (creatures > 0 && controller.chooseUse(outcome, "Sacrifice a creature?", source, game)) {
                 if (new SacrificeControllerEffect(StaticFilters.FILTER_PERMANENT_CREATURES, 1, "").apply(game, source)) {
                     if (sourceObject != null) {
-                        sourceObject.addCounters(CounterType.P1P1.createInstance(), source, game);
+                        sourceObject.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                         game.informPlayers(controller.getLogName() + " puts a +1/+1 counter on " + sourceObject.getName());
                     }
                 }

--- a/Mage.Sets/src/mage/cards/c/CryptbornHorror.java
+++ b/Mage.Sets/src/mage/cards/c/CryptbornHorror.java
@@ -65,7 +65,7 @@ class CryptbornHorrorEffect extends OneShotEffect {
         if (permanent != null) {
             int oll = OpponentsLostLifeCount.instance.calculate(game, source, this);
             if (oll > 0) {
-                permanent.addCounters(CounterType.P1P1.createInstance(oll), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(oll), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/c/CrystallineGiant.java
+++ b/Mage.Sets/src/mage/cards/c/CrystallineGiant.java
@@ -97,6 +97,6 @@ class CrystallineGiantEffect extends OneShotEffect {
         }
         return permanent.addCounters(counterTypes.get(
                 RandomUtil.nextInt(counterTypes.size())
-        ).createInstance(), source, game);
+        ).createInstance(), source.getControllerId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CytoplastRootKin.java
+++ b/Mage.Sets/src/mage/cards/c/CytoplastRootKin.java
@@ -89,7 +89,7 @@ class CytoplastRootKinEffect extends OneShotEffect {
                 && !sourcePermanent.getId().equals(targetPermanent.getId())
                 && targetPermanent.getCounters(game).getCount(CounterType.P1P1) > 0) {
             targetPermanent.removeCounters(CounterType.P1P1.createInstance(), source, game);
-            sourcePermanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+            sourcePermanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/d/DaghatarTheAdamant.java
+++ b/Mage.Sets/src/mage/cards/d/DaghatarTheAdamant.java
@@ -90,7 +90,7 @@ class MoveCounterFromTargetToTargetEffect extends OneShotEffect {
                 Permanent toPermanent = game.getPermanent(source.getTargets().get(1).getFirstTarget());
                 if (toPermanent != null) {
                     fromPermanent.removeCounters(CounterType.P1P1.createInstance(), source, game);
-                    toPermanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                    toPermanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                     game.informPlayers(sourceObject.getLogName() + ": Moved a +1/+1 counter from " + fromPermanent.getLogName() +" to " + toPermanent.getLogName());
                 }
             }

--- a/Mage.Sets/src/mage/cards/d/DaredevilDragster.java
+++ b/Mage.Sets/src/mage/cards/d/DaredevilDragster.java
@@ -76,7 +76,7 @@ class DaredevilDragsterEffect extends OneShotEffect {
         Permanent permanent = game.getPermanent(source.getSourceId());
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && permanent != null) {
-            permanent.addCounters(CounterType.VELOCITY.createInstance(), source, game);
+            permanent.addCounters(CounterType.VELOCITY.createInstance(), source.getControllerId(), source, game);
             if (permanent.getCounters(game).getCount(CounterType.VELOCITY) >= 2) {
                 permanent.sacrifice(source, game);
                 controller.drawCards(2, source, game);

--- a/Mage.Sets/src/mage/cards/d/DarigaazReincarnated.java
+++ b/Mage.Sets/src/mage/cards/d/DarigaazReincarnated.java
@@ -98,7 +98,7 @@ class DarigaazReincarnatedDiesEffect extends ReplacementEffectImpl {
                 return false;
             }
             return controller.moveCardToExileWithInfo(permanent, null, null, source, game, Zone.BATTLEFIELD, true)
-                    && permCard.addCounters(CounterType.EGG.createInstance(3), source, game);
+                    && permCard.addCounters(CounterType.EGG.createInstance(3), source.getControllerId(), source, game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/d/DarkIntimations.java
+++ b/Mage.Sets/src/mage/cards/d/DarkIntimations.java
@@ -201,7 +201,7 @@ class DarkIntimationsReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.LOYALTY.createInstance(), source, game);
+            creature.addCounters(CounterType.LOYALTY.createInstance(), source.getControllerId(), source, game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/d/DearlyDeparted.java
+++ b/Mage.Sets/src/mage/cards/d/DearlyDeparted.java
@@ -14,7 +14,6 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 
 /**
@@ -74,7 +73,7 @@ class DearlyDepartedEntersBattlefieldEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent target = ((EntersTheBattlefieldEvent) event).getTarget();
         if (target != null) {
-            target.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            target.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/d/DeepglowSkate.java
+++ b/Mage.Sets/src/mage/cards/d/DeepglowSkate.java
@@ -73,7 +73,7 @@ class DeepglowSkateEffect extends OneShotEffect {
                 if (permanent != null) {
                     for (Counter counter : permanent.getCounters(game).values()) {
                         Counter newCounter = new Counter(counter.getName(), counter.getCount());
-                        permanent.addCounters(newCounter, source, game);
+                        permanent.addCounters(newCounter, source.getControllerId(), source, game);
                         didOne = true;
                     }
                 }

--- a/Mage.Sets/src/mage/cards/d/DefiantGreatmaw.java
+++ b/Mage.Sets/src/mage/cards/d/DefiantGreatmaw.java
@@ -1,7 +1,5 @@
-
 package mage.cards.d;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.TriggeredAbilityImpl;
@@ -22,8 +20,9 @@ import mage.game.events.GameEvent;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.common.TargetCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author fireshoes
  */
 public final class DefiantGreatmaw extends CardImpl {
@@ -44,7 +43,7 @@ public final class DefiantGreatmaw extends CardImpl {
         this.addAbility(new DefiantGreatmawTriggeredAbility());
     }
 
-    public DefiantGreatmaw(final DefiantGreatmaw card) {
+    private DefiantGreatmaw(final DefiantGreatmaw card) {
         super(card);
     }
 
@@ -68,7 +67,7 @@ class DefiantGreatmawTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetCreaturePermanent(filter));
     }
 
-    DefiantGreatmawTriggeredAbility(final DefiantGreatmawTriggeredAbility ability) {
+    private DefiantGreatmawTriggeredAbility(final DefiantGreatmawTriggeredAbility ability) {
         super(ability);
     }
 
@@ -79,12 +78,9 @@ class DefiantGreatmawTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        boolean weAreDoingIt = isControlledBy(game.getControllerId(event.getSourceId()));
-        boolean isM1M1Counters = event.getData().equals(CounterType.M1M1.getName());
-        if (weAreDoingIt && isM1M1Counters && event.getTargetId().equals(this.getSourceId())) {
-                return true;
-            }
-        return false;
+        return event.getData().equals(CounterType.M1M1.getName())
+                && isControlledBy(event.getPlayerId())
+                && event.getTargetId().equals(getSourceId());
     }
 
     @Override
@@ -94,6 +90,7 @@ class DefiantGreatmawTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public String getRule() {
-        return "Whenever you put one or more -1/-1 counters on {this}, remove a -1/-1 counter from another target creature you control.";
+        return "Whenever you put one or more -1/-1 counters on {this}, " +
+                "remove a -1/-1 counter from another target creature you control.";
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DefyDeath.java
+++ b/Mage.Sets/src/mage/cards/d/DefyDeath.java
@@ -60,7 +60,7 @@ class DefyDeathEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent permanent = game.getPermanent(source.getFirstTarget());
         if (permanent != null && permanent.hasSubtype(SubType.ANGEL, game)) {
-            permanent.addCounters(CounterType.P1P1.createInstance(2), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/d/Delay.java
+++ b/Mage.Sets/src/mage/cards/d/Delay.java
@@ -72,7 +72,7 @@ class DelayEffect extends OneShotEffect {
                 boolean hasSuspend = card.getAbilities(game).containsClass(SuspendAbility.class);
                 UUID exileId = SuspendAbility.getSuspendExileId(controller.getId(), game);
                 if (controller.moveCardToExileWithInfo(card, exileId, "Suspended cards of " + controller.getLogName(), source, game, Zone.HAND, true)) {
-                    card.addCounters(CounterType.TIME.createInstance(3), source, game);
+                    card.addCounters(CounterType.TIME.createInstance(3), source.getControllerId(), source, game);
                     if (!hasSuspend) {
                         game.addEffect(new GainSuspendEffect(new MageObjectReference(card, game)), source);
                     }

--- a/Mage.Sets/src/mage/cards/d/DelifsCube.java
+++ b/Mage.Sets/src/mage/cards/d/DelifsCube.java
@@ -86,7 +86,7 @@ class DelifsCubeEffect extends OneShotEffect{
     public boolean apply(Game game, Ability source) {
         Permanent perm = game.getPermanent(cubeId);
         if (perm == null) return false;
-        perm.addCounters(CounterType.CUBE.createInstance(), source, game);
+        perm.addCounters(CounterType.CUBE.createInstance(), source.getControllerId(), source, game);
         return true;         
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DescentIntoMadness.java
+++ b/Mage.Sets/src/mage/cards/d/DescentIntoMadness.java
@@ -86,7 +86,7 @@ class DescentIntoMadnessEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         Permanent sourcePermanent = game.getPermanent(source.getSourceId());
         if (sourcePermanent != null && controller != null) {
-            sourcePermanent.addCounters(CounterType.DESPAIR.createInstance(), source, game);
+            sourcePermanent.addCounters(CounterType.DESPAIR.createInstance(), source.getControllerId(), source, game);
         }
         if (sourcePermanent == null) {
             sourcePermanent = (Permanent) game.getLastKnownInformation(source.getSourceId(), Zone.BATTLEFIELD);

--- a/Mage.Sets/src/mage/cards/d/DesecrationDemon.java
+++ b/Mage.Sets/src/mage/cards/d/DesecrationDemon.java
@@ -82,7 +82,7 @@ class DesecrationDemonEffect extends OneShotEffect {
                                 permanent.sacrifice(source, game);
                                 game.informPlayers(opponent.getLogName() + " sacrifices " + permanent.getLogName() + " to tap " + descrationDemon.getLogName() + ". A +1/+1 counter was put on it");
                                 descrationDemon.tap(source, game);
-                                descrationDemon.addCounters(CounterType.P1P1.createInstance(), source, game);
+                                descrationDemon.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                             }
                         }
                     }

--- a/Mage.Sets/src/mage/cards/d/DiregrafColossus.java
+++ b/Mage.Sets/src/mage/cards/d/DiregrafColossus.java
@@ -83,7 +83,7 @@ class DiregrafColossusEffect extends OneShotEffect {
             int amount = 0;
             amount += player.getGraveyard().count(filter, game);
             if (amount > 0) {
-                permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/d/Dismantle.java
+++ b/Mage.Sets/src/mage/cards/d/Dismantle.java
@@ -82,7 +82,7 @@ class DismantleEffect extends OneShotEffect {
                             counter = CounterType.CHARGE.createInstance(counterCount);
                         }
                         if (artifact != null) {
-                            artifact.addCounters(counter, source, game);
+                            artifact.addCounters(counter, source.getControllerId(), source, game);
                         }
                     }
                 }

--- a/Mage.Sets/src/mage/cards/d/DranaTheLastBloodchief.java
+++ b/Mage.Sets/src/mage/cards/d/DranaTheLastBloodchief.java
@@ -175,7 +175,7 @@ class DranaTheLastBloodchiefCounterEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null && mor.refersTo(creature, game)) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
             discard();
         }
         return false;

--- a/Mage.Sets/src/mage/cards/d/DraugrNecromancer.java
+++ b/Mage.Sets/src/mage/cards/d/DraugrNecromancer.java
@@ -81,7 +81,7 @@ class DraugrNecromancerReplacementEffect extends ReplacementEffectImpl {
         }
         controller.moveCards(permanent, Zone.EXILED, source, game);
         Card card = game.getCard(permanent.getId());
-        card.addCounters(CounterType.ICE.createInstance(), source, game);
+        card.addCounters(CounterType.ICE.createInstance(), source.getControllerId(), source, game);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/d/DustOfMoments.java
+++ b/Mage.Sets/src/mage/cards/d/DustOfMoments.java
@@ -114,7 +114,7 @@ public final class DustOfMoments extends CardImpl {
                         final Counter modifiedCounter = new Counter(counterName, countersToRemove);
                         card.removeCounters(modifiedCounter, source, game);
                     } else {
-                        card.addCounters(counter, source, game);
+                        card.addCounters(counter, source.getControllerId(), source, game);
                     }
                     if (!game.isSimulation()) {
                         game.informPlayers(sourceObject.getName() + ": " +
@@ -139,7 +139,7 @@ public final class DustOfMoments extends CardImpl {
                         final Counter modifiedCounter = new Counter(counterName, countersToRemove);
                         card.removeCounters(modifiedCounter, source, game);
                     } else {
-                        card.addCounters(counter, source, game);
+                        card.addCounters(counter, source.getControllerId(), source, game);
                     }
                     if (!game.isSimulation()) {
                         game.informPlayers(sourceObject.getName() + ": " +

--- a/Mage.Sets/src/mage/cards/e/EbonPraetor.java
+++ b/Mage.Sets/src/mage/cards/e/EbonPraetor.java
@@ -85,7 +85,7 @@ class EbonPraetorEffect extends OneShotEffect {
                 Permanent sacrificedCreature = ((SacrificeTargetCost) cost).getPermanents().get(0);
                 Permanent sourceCreature = game.getPermanent(source.getSourceId());
                 if (sacrificedCreature.hasSubtype(SubType.THRULL, game) && sourceCreature != null) {
-                    sourceCreature.addCounters(CounterType.P1P0.createInstance(), source, game);
+                    sourceCreature.addCounters(CounterType.P1P0.createInstance(), source.getControllerId(), source, game);
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/e/ElderCathar.java
+++ b/Mage.Sets/src/mage/cards/e/ElderCathar.java
@@ -70,9 +70,9 @@ class ElderCatharAddCountersTargetEffect extends OneShotEffect {
         if (permanent != null) {
             if (counter != null) {
                 if (permanent.hasSubtype(SubType.HUMAN, game)) {
-                    permanent.addCounters(counter2.copy(), source, game);
+                    permanent.addCounters(counter2.copy(), source.getControllerId(), source, game);
                 } else {
-                    permanent.addCounters(counter.copy(), source, game);
+                    permanent.addCounters(counter.copy(), source.getControllerId(), source, game);
                 }
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/e/ElspethConquersDeath.java
+++ b/Mage.Sets/src/mage/cards/e/ElspethConquersDeath.java
@@ -147,7 +147,7 @@ class ElspethConquersDeathReturnEffect extends OneShotEffect {
                 outcome, "Choose a type of counter to add",
                 null, "+1/+1", "Loyalty", source, game
         ) ? CounterType.P1P1.createInstance() : CounterType.LOYALTY.createInstance();
-        permanent.addCounters(counter, source, game);
+        permanent.addCounters(counter, source.getControllerId(), source, game);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmielTheBlessed.java
+++ b/Mage.Sets/src/mage/cards/e/EmielTheBlessed.java
@@ -92,6 +92,6 @@ class EmielTheBlessedEffect extends OneShotEffect {
             return false;
         }
         int counters = permanent.hasSubtype(SubType.UNICORN, game) ? 2 : 1;
-        return permanent.addCounters(CounterType.P1P1.createInstance(counters), source, game);
+        return permanent.addCounters(CounterType.P1P1.createInstance(counters), source.getControllerId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/e/EmpoweredAutogenerator.java
+++ b/Mage.Sets/src/mage/cards/e/EmpoweredAutogenerator.java
@@ -94,7 +94,7 @@ class EmpoweredAutogeneratorManaEffect extends ManaEffect {
             return mana;
         }
 
-        sourcePermanent.addCounters(CounterType.CHARGE.createInstance(), source, game);
+        sourcePermanent.addCounters(CounterType.CHARGE.createInstance(), source.getControllerId(), source, game);
         int counters = sourcePermanent.getCounters(game).getCount(CounterType.CHARGE);
         if (counters == 0) {
             return mana;

--- a/Mage.Sets/src/mage/cards/e/EntrailsFeaster.java
+++ b/Mage.Sets/src/mage/cards/e/EntrailsFeaster.java
@@ -76,7 +76,7 @@ class EntrailsFeasterEffect extends OneShotEffect {
                     if (cardChosen != null) {
                         controller.moveCardsToExile(cardChosen, source, game, true, null, "");
                         if (sourceObject != null) {
-                            sourceObject.addCounters(CounterType.P1P1.createInstance(), source, game);
+                            sourceObject.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                             game.informPlayers(controller.getLogName() + " puts a +1/+1 counter on " + sourceObject.getLogName());
                         }
                     }

--- a/Mage.Sets/src/mage/cards/e/Epochrasite.java
+++ b/Mage.Sets/src/mage/cards/e/Epochrasite.java
@@ -83,7 +83,7 @@ class EpochrasiteEffect extends OneShotEffect {
             if (game.getState().getZone(card.getId()) == Zone.GRAVEYARD) {
                 UUID exileId = SuspendAbility.getSuspendExileId(controller.getId(), game);
                 controller.moveCardToExileWithInfo(card, exileId, "Suspended cards of " + controller.getName(), source, game, Zone.GRAVEYARD, true);
-                card.addCounters(CounterType.TIME.createInstance(3), source, game);
+                card.addCounters(CounterType.TIME.createInstance(3), source.getControllerId(), source, game);
                 game.addEffect(new GainSuspendEffect(new MageObjectReference(card, game)), source);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/e/EternityVessel.java
+++ b/Mage.Sets/src/mage/cards/e/EternityVessel.java
@@ -60,7 +60,7 @@ class EternityVesselEffect extends OneShotEffect {
         if (vessel != null && controller != null) {
             int amount = controller.getLife();
             if (amount > 0) {
-                vessel.addCounters(CounterType.CHARGE.createInstance(amount), source, game);
+                vessel.addCounters(CounterType.CHARGE.createInstance(amount), source.getControllerId(), source, game);
 
             }
             return true;

--- a/Mage.Sets/src/mage/cards/e/EtrataTheSilencer.java
+++ b/Mage.Sets/src/mage/cards/e/EtrataTheSilencer.java
@@ -140,7 +140,7 @@ class EtrataTheSilencerEffect extends OneShotEffect {
         controller.moveCards(creature, Zone.EXILED, source, game);
         Card card = game.getCard(source.getFirstTarget());
         if (card != null) {
-            card.addCounters(CounterType.HIT.createInstance(), source, game);
+            card.addCounters(CounterType.HIT.createInstance(), source.getControllerId(), source, game);
         }
         int cardsFound = 0;
         cardsFound = game.getExile().getAllCards(game).stream().filter((exiledCard) -> (exiledCard.getCounters(game).getCount(CounterType.HIT) >= 1

--- a/Mage.Sets/src/mage/cards/e/EverlastingTorment.java
+++ b/Mage.Sets/src/mage/cards/e/EverlastingTorment.java
@@ -17,7 +17,6 @@ import mage.counters.Counter;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 
 /**
@@ -79,7 +78,7 @@ class DamageDealtAsIfSourceHadWitherEffect extends ReplacementEffectImpl {
             Counter counter = CounterType.M1M1.createInstance(damageAmount);
             Permanent creatureDamaged = game.getPermanent(event.getTargetId());
             if (creatureDamaged != null) {
-                creatureDamaged.addCounters(counter, source, game);
+                creatureDamaged.addCounters(counter, source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/e/EvolutionaryEscalation.java
+++ b/Mage.Sets/src/mage/cards/e/EvolutionaryEscalation.java
@@ -69,7 +69,7 @@ class EvolutionaryEscalationEffect extends OneShotEffect {
         for (Target target: source.getTargets()) {
             Permanent targetPermanent = game.getPermanent(target.getFirstTarget());
             if (targetPermanent != null) {
-                targetPermanent.addCounters(counter.copy(), source, game);
+                targetPermanent.addCounters(counter.copy(), source.getControllerId(), source, game);
                 addedCounters = true;
             }
         }

--- a/Mage.Sets/src/mage/cards/e/EyeOfDoom.java
+++ b/Mage.Sets/src/mage/cards/e/EyeOfDoom.java
@@ -22,9 +22,7 @@ import mage.players.PlayerList;
 import mage.target.Target;
 import mage.target.common.TargetNonlandPermanent;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * @author LevelX2
@@ -78,7 +76,7 @@ class EyeOfDoomEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        List<Permanent> permanents = new ArrayList<>();
+        Map<UUID,Permanent>permanents=new HashMap<>();
         Target target = new TargetNonlandPermanent();
         target.setNotTarget(true);
         PlayerList playerList = game.getPlayerList().copy();
@@ -89,15 +87,15 @@ class EyeOfDoomEffect extends OneShotEffect {
             if (player != null && player.chooseTarget(outcome, target, source, game)) {
                 Permanent permanent = game.getPermanent(target.getFirstTarget());
                 if (permanent != null) {
-                    permanents.add(permanent);
+                    permanents.put(player.getId(),permanent);
                     game.informPlayers(player.getLogName() + " chooses " + permanent.getName());
                 }
             }
             player = playerList.getNext(game, false);
         } while (player != null && !player.getId().equals(game.getActivePlayerId()));
 
-        for (Permanent permanent : permanents) {
-            permanent.addCounters(CounterType.DOOM.createInstance(), source.getControllerId(), source, game);
+        for (Map.Entry<UUID,Permanent> entry : permanents.entrySet()) {
+            entry.getValue().addCounters(CounterType.DOOM.createInstance(), entry.getKey(), source, game);
         }
 
         return true;

--- a/Mage.Sets/src/mage/cards/e/EyeOfDoom.java
+++ b/Mage.Sets/src/mage/cards/e/EyeOfDoom.java
@@ -97,7 +97,7 @@ class EyeOfDoomEffect extends OneShotEffect {
         } while (player != null && !player.getId().equals(game.getActivePlayerId()));
 
         for (Permanent permanent : permanents) {
-            permanent.addCounters(CounterType.DOOM.createInstance(), source, game);
+            permanent.addCounters(CounterType.DOOM.createInstance(), source.getControllerId(), source, game);
         }
 
         return true;

--- a/Mage.Sets/src/mage/cards/e/EzuriClawOfProgress.java
+++ b/Mage.Sets/src/mage/cards/e/EzuriClawOfProgress.java
@@ -87,7 +87,7 @@ class EzuriClawOfProgressEffect extends OneShotEffect {
             Permanent target = game.getPermanent(getTargetPointer().getFirst(game, source));
             if (target != null) {
                 int amount = controller.getCounters().getCount(CounterType.EXPERIENCE);
-                target.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                target.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/f/FalkenrathAristocrat.java
+++ b/Mage.Sets/src/mage/cards/f/FalkenrathAristocrat.java
@@ -78,7 +78,7 @@ class FalkenrathAristocratEffect extends OneShotEffect {
                 Permanent sacrificedCreature = ((SacrificeTargetCost) cost).getPermanents().get(0);
                 Permanent sourceCreature = game.getPermanent(source.getSourceId());
                 if (sacrificedCreature.hasSubtype(SubType.HUMAN, game) && sourceCreature != null) {
-                    sourceCreature.addCounters(CounterType.P1P1.createInstance(), source, game);
+                    sourceCreature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                     break;
                 }
             }

--- a/Mage.Sets/src/mage/cards/f/FalkenrathTorturer.java
+++ b/Mage.Sets/src/mage/cards/f/FalkenrathTorturer.java
@@ -74,7 +74,7 @@ class FalkenrathTorturerEffect extends OneShotEffect {
                 Permanent sacrificedCreature = ((SacrificeTargetCost) cost).getPermanents().get(0);
                 Permanent sourceCreature = game.getPermanent(source.getSourceId());
                 if (sacrificedCreature.hasSubtype(SubType.HUMAN, game) && sourceCreature != null) {
-                    sourceCreature.addCounters(CounterType.P1P1.createInstance(), source, game);
+                    sourceCreature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/f/FateTransfer.java
+++ b/Mage.Sets/src/mage/cards/f/FateTransfer.java
@@ -77,7 +77,7 @@ class FateTransferEffect extends OneShotEffect {
             Permanent copyCreature = creatureToMoveCountersFrom.copy();
             for (Counter counter : copyCreature.getCounters(game).values()) {
                 creatureToMoveCountersFrom.removeCounters(counter, source, game);
-                creatureToMoveCountersTo.addCounters(counter, source, game);
+                creatureToMoveCountersTo.addCounters(counter, source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/f/FearsomeAwakening.java
+++ b/Mage.Sets/src/mage/cards/f/FearsomeAwakening.java
@@ -61,7 +61,7 @@ class FearsomeAwakeningEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent permanent = game.getPermanent(source.getFirstTarget());
         if (permanent != null && permanent.hasSubtype(SubType.DRAGON, game)) {
-            permanent.addCounters(CounterType.P1P1.createInstance(2), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/f/FleshBlood.java
+++ b/Mage.Sets/src/mage/cards/f/FleshBlood.java
@@ -72,7 +72,7 @@ class FleshEffect extends OneShotEffect {
             if (power > 0) {
                 Permanent targetCreature = game.getPermanent(source.getTargets().get(1).getFirstTarget());
                 if (targetCreature != null) {
-                    targetCreature.addCounters(CounterType.P1P1.createInstance(power), source, game);
+                    targetCreature.addCounters(CounterType.P1P1.createInstance(power), source.getControllerId(), source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/f/ForgottenAncient.java
+++ b/Mage.Sets/src/mage/cards/f/ForgottenAncient.java
@@ -131,7 +131,7 @@ public final class ForgottenAncient extends CardImpl {
             //Move all the counters for each chosen creature
             for (CounterMovement cm : counterMovements) {
                 sourcePermanent.removeCounters(CounterType.P1P1.createInstance(cm.counters), source, game);
-                game.getPermanent(cm.target).addCounters(CounterType.P1P1.createInstance(cm.counters), source, game);
+                game.getPermanent(cm.target).addCounters(CounterType.P1P1.createInstance(cm.counters), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/f/FulfillContract.java
+++ b/Mage.Sets/src/mage/cards/f/FulfillContract.java
@@ -77,7 +77,7 @@ class FulfillContractEffect extends OneShotEffect {
         if (controller != null) {
             if (permanentToDestroy != null && permanentToDestroy.destroy(source, game, false)) {
                 if (permanentToPutCounter != null) {
-                    permanentToPutCounter.addCounters(CounterType.P1P1.createInstance(), source, game);
+                    permanentToPutCounter.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/g/GenerousPatron.java
+++ b/Mage.Sets/src/mage/cards/g/GenerousPatron.java
@@ -1,21 +1,21 @@
 package mage.cards.g;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.keyword.SupportAbility;
-import mage.constants.SubType;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author TheElk801
  */
 public final class GenerousPatron extends CardImpl {
@@ -47,11 +47,11 @@ public final class GenerousPatron extends CardImpl {
 
 class GenerousPatronTriggeredAbility extends TriggeredAbilityImpl {
 
-    public GenerousPatronTriggeredAbility() {
+    GenerousPatronTriggeredAbility() {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
     }
 
-    public GenerousPatronTriggeredAbility(GenerousPatronTriggeredAbility ability) {
+    private GenerousPatronTriggeredAbility(GenerousPatronTriggeredAbility ability) {
         super(ability);
     }
 
@@ -62,7 +62,7 @@ class GenerousPatronTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        if (!isControlledBy(game.getControllerId(event.getSourceId()))) {
+        if (!isControlledBy(event.getPlayerId())) {
             return false;
         }
         Permanent permanent = game.getPermanentOrLKIBattlefield(event.getTargetId());

--- a/Mage.Sets/src/mage/cards/g/GideonTheOathsworn.java
+++ b/Mage.Sets/src/mage/cards/g/GideonTheOathsworn.java
@@ -139,7 +139,7 @@ class GideonTheOathswornEffect extends OneShotEffect {
         for (MageObjectReference mor : attackers) {
             Permanent permanent = mor.getPermanent(game);
             if (permanent != null) {
-                permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/g/GilderBairn.java
+++ b/Mage.Sets/src/mage/cards/g/GilderBairn.java
@@ -72,7 +72,7 @@ class GilderBairnEffect extends OneShotEffect {
         if (target != null) {
             for (Counter counter : target.getCounters(game).values()) {
                 Counter newCounter = new Counter(counter.getName(), counter.getCount());
-                target.addCounters(newCounter, source, game);
+                target.addCounters(newCounter, source.getControllerId(), source, game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/g/GlisteningOil.java
+++ b/Mage.Sets/src/mage/cards/g/GlisteningOil.java
@@ -75,7 +75,7 @@ class GlisteningOilEffect extends OneShotEffect {
         if (enchantment != null && enchantment.getAttachedTo() != null) {
             Permanent creature = game.getPermanent(enchantment.getAttachedTo());
             if (creature != null) {
-                creature.addCounters(CounterType.M1M1.createInstance(), source, game);
+                creature.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/g/GlyphOfDelusion.java
+++ b/Mage.Sets/src/mage/cards/g/GlyphOfDelusion.java
@@ -127,7 +127,7 @@ class GlyphOfDelusionEffect extends OneShotEffect {
         if (source.getTargets().get(1) != null) {
             Permanent targetPermanent = game.getPermanent(source.getTargets().get(1).getFirstTarget());
             if (targetPermanent != null) {
-                targetPermanent.addCounters(CounterType.GLYPH.createInstance(targetPermanent.getPower().getValue()), source, game);
+                targetPermanent.addCounters(CounterType.GLYPH.createInstance(targetPermanent.getPower().getValue()), source.getControllerId(), source, game);
 
                 SimpleStaticAbility ability = new SimpleStaticAbility(Zone.BATTLEFIELD, new ConditionalContinuousRuleModifyingEffect(new DontUntapInControllersUntapStepSourceEffect(),
                         new SourceHasCounterCondition(CounterType.GLYPH)).setText("This creature doesn't untap during your untap step if it has a glyph counter on it"));

--- a/Mage.Sets/src/mage/cards/g/GolgariGraveTroll.java
+++ b/Mage.Sets/src/mage/cards/g/GolgariGraveTroll.java
@@ -73,7 +73,7 @@ class GolgariGraveTrollEffect extends OneShotEffect {
         if (permanent != null && player != null) {
             int amount = player.getGraveyard().count(StaticFilters.FILTER_CARD_CREATURE, game);
             if (amount > 0) {
-                permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/g/GraveBetrayal.java
+++ b/Mage.Sets/src/mage/cards/g/GraveBetrayal.java
@@ -19,7 +19,6 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.events.ZoneChangeEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -158,7 +157,7 @@ class GraveBetrayalReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
             ContinuousEffect effect = new BecomesBlackZombieAdditionEffect();
             effect.setTargetPointer(new FixedTarget(creature.getId(), creature.getZoneChangeCounter(game) + 1));
             game.addEffect(effect, source);

--- a/Mage.Sets/src/mage/cards/g/GreenbeltRampager.java
+++ b/Mage.Sets/src/mage/cards/g/GreenbeltRampager.java
@@ -65,7 +65,7 @@ public final class GreenbeltRampager extends CardImpl {
                 Permanent sourceObject = source.getSourcePermanentIfItStillExists(game);
                 if (sourceObject != null) {
                     controller.moveCards(sourceObject, Zone.HAND, source, game);
-                    controller.addCounters(CounterType.ENERGY.createInstance(), source, game);
+                    controller.addCounters(CounterType.ENERGY.createInstance(), source.getControllerId(), source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/g/GriefTyrant.java
+++ b/Mage.Sets/src/mage/cards/g/GriefTyrant.java
@@ -72,7 +72,7 @@ class GriefTyrantEffect extends OneShotEffect {
         Permanent griefTyrant = game.getPermanentOrLKIBattlefield(source.getSourceId());
         int countersOnGriefTyrant = griefTyrant.getCounters(game).getCount(CounterType.M1M1);
         if (targetCreature != null) {
-            targetCreature.addCounters(CounterType.M1M1.createInstance(countersOnGriefTyrant), source, game);
+            targetCreature.addCounters(CounterType.M1M1.createInstance(countersOnGriefTyrant), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/g/Grimdancer.java
+++ b/Mage.Sets/src/mage/cards/g/Grimdancer.java
@@ -100,8 +100,8 @@ class GrimdancerEffect extends OneShotEffect {
                 counter2 = CounterType.LIFELINK.createInstance();
                 break;
         }
-        permanent.addCounters(counter1, source, game);
-        permanent.addCounters(counter2, source, game);
+        permanent.addCounters(counter1, source.getControllerId(), source, game);
+        permanent.addCounters(counter2, source.getControllerId(), source, game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/g/GrumgullyTheGenerous.java
+++ b/Mage.Sets/src/mage/cards/g/GrumgullyTheGenerous.java
@@ -74,7 +74,7 @@ class GrumgullyTheGenerousReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/g/GuildmagesForum.java
+++ b/Mage.Sets/src/mage/cards/g/GuildmagesForum.java
@@ -19,7 +19,6 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.game.stack.Spell;
 import mage.watchers.Watcher;
@@ -115,7 +114,7 @@ class GuildmagesForumEntersBattlefieldEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent target = ((EntersTheBattlefieldEvent) event).getTarget();
         if (target != null) {
-            target.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            target.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/g/GwafaHazidProfiteer.java
+++ b/Mage.Sets/src/mage/cards/g/GwafaHazidProfiteer.java
@@ -70,7 +70,7 @@ class GwafaHazidProfiteerEffect1 extends OneShotEffect {
         Permanent targetCreature = game.getPermanent(source.getFirstTarget());
         if (targetCreature != null) {
             Player controller = game.getPlayer(targetCreature.getControllerId());
-            targetCreature.addCounters(CounterType.BRIBERY.createInstance(), source, game);
+            targetCreature.addCounters(CounterType.BRIBERY.createInstance(), source.getControllerId(), source, game);
             if (controller != null) {
                 controller.drawCards(1, source, game);
             }

--- a/Mage.Sets/src/mage/cards/h/HamletbackGoliath.java
+++ b/Mage.Sets/src/mage/cards/h/HamletbackGoliath.java
@@ -15,7 +15,6 @@ import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.target.targetpointer.FixedTarget;
 
@@ -102,7 +101,7 @@ class HamletbackGoliathEffect extends OneShotEffect {
         Permanent creature = getTargetPointer().getFirstTargetPermanentOrLKI(game, source);
         Permanent sourceObject = game.getPermanent(source.getSourceId());
         if (creature != null && sourceObject != null) {
-            sourceObject.addCounters(CounterType.P1P1.createInstance(creature.getPower().getValue()), source, game);
+            sourceObject.addCounters(CounterType.P1P1.createInstance(creature.getPower().getValue()), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/h/HammerJammer.java
+++ b/Mage.Sets/src/mage/cards/h/HammerJammer.java
@@ -72,7 +72,7 @@ class HammerJammerEntersEffect extends EntersBattlefieldWithXCountersEffect {
         if (controller != null && permanent != null) {
             int amount = controller.rollDice(source, game, 6);
             List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects"); // the basic event is the EntersBattlefieldEvent, so use already applied replacement effects from that event
-            permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game, appliedEffects);
+            permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game, appliedEffects);
             return super.apply(game, source);
         }
         return false;
@@ -145,7 +145,7 @@ class HammerJammerEffect extends OneShotEffect {
             if (getValue("rolled") != null) {
                 int amount = (Integer) getValue("rolled");
                 permanent.removeCounters(CounterType.P1P1.createInstance(permanent.getCounters(game).getCount(CounterType.P1P1)), source, game);
-                permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/h/Hankyu.java
+++ b/Mage.Sets/src/mage/cards/h/Hankyu.java
@@ -76,7 +76,7 @@ class HankyuAddCounterEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent equipment = game.getPermanent(this.effectGivingEquipmentId);
         if (equipment != null) {
-            equipment.addCounters(CounterType.AIM.createInstance(), source, game);
+            equipment.addCounters(CounterType.AIM.createInstance(), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/h/HapatraVizierOfPoisons.java
+++ b/Mage.Sets/src/mage/cards/h/HapatraVizierOfPoisons.java
@@ -73,7 +73,7 @@ class HapatraVizierOfPoisonsTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         if (!event.getData().equals(CounterType.M1M1.getName())
-                || !controllerId.equals(event.getPlayerId())) {
+                || !isControlledBy(event.getPlayerId())) {
             return false;
         }
         Permanent permanent = game.getPermanentOrLKIBattlefield(event.getTargetId());

--- a/Mage.Sets/src/mage/cards/h/HapatraVizierOfPoisons.java
+++ b/Mage.Sets/src/mage/cards/h/HapatraVizierOfPoisons.java
@@ -1,12 +1,10 @@
 
 package mage.cards.h;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.counter.AddCountersTargetEffect;
 import mage.cards.CardImpl;
@@ -22,8 +20,9 @@ import mage.game.permanent.Permanent;
 import mage.game.permanent.token.DeathtouchSnakeToken;
 import mage.target.common.TargetCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author Styxo
  */
 public final class HapatraVizierOfPoisons extends CardImpl {
@@ -43,8 +42,7 @@ public final class HapatraVizierOfPoisons extends CardImpl {
         this.addAbility(ability);
 
         // Whenever you put one or more -1/-1 counters on a creature, create a 1/1 green Snake creature token with deathtouch.
-        this.addAbility(new HapatraVizierOfPoisonsTriggeredAbility(new CreateTokenEffect(new DeathtouchSnakeToken()), false));
-
+        this.addAbility(new HapatraVizierOfPoisonsTriggeredAbility());
     }
 
     public HapatraVizierOfPoisons(final HapatraVizierOfPoisons card) {
@@ -59,11 +57,11 @@ public final class HapatraVizierOfPoisons extends CardImpl {
 
 class HapatraVizierOfPoisonsTriggeredAbility extends TriggeredAbilityImpl {
 
-    public HapatraVizierOfPoisonsTriggeredAbility(Effect effect, boolean optional) {
-        super(Zone.BATTLEFIELD, effect, optional);
+    HapatraVizierOfPoisonsTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new CreateTokenEffect(new DeathtouchSnakeToken()), false);
     }
 
-    public HapatraVizierOfPoisonsTriggeredAbility(HapatraVizierOfPoisonsTriggeredAbility ability) {
+    private HapatraVizierOfPoisonsTriggeredAbility(HapatraVizierOfPoisonsTriggeredAbility ability) {
         super(ability);
     }
 
@@ -74,16 +72,15 @@ class HapatraVizierOfPoisonsTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        if (event.getData().equals(CounterType.M1M1.getName())
-                && controllerId.equals(game.getControllerId(event.getSourceId()))) {
-            Permanent permanent = game.getPermanentOrLKIBattlefield(event.getTargetId());
-            if (permanent == null) {
-                permanent = game.getPermanentEntering(event.getTargetId());
-            }
-            return (permanent != null
-                    && permanent.isCreature());
+        if (!event.getData().equals(CounterType.M1M1.getName())
+                || !controllerId.equals(event.getPlayerId())) {
+            return false;
         }
-        return false;
+        Permanent permanent = game.getPermanentOrLKIBattlefield(event.getTargetId());
+        if (permanent == null) {
+            permanent = game.getPermanentEntering(event.getTargetId());
+        }
+        return permanent != null && permanent.isCreature();
 
     }
 

--- a/Mage.Sets/src/mage/cards/h/HaphazardBombardment.java
+++ b/Mage.Sets/src/mage/cards/h/HaphazardBombardment.java
@@ -92,7 +92,7 @@ class HaphazardBombardmentEffect extends OneShotEffect {
                 }
             }
             for (Permanent permanent : permanents) {
-                permanent.addCounters(CounterType.AIM.createInstance(), source, game);
+                permanent.addCounters(CounterType.AIM.createInstance(), source.getControllerId(), source, game);
             }
             return true;
 

--- a/Mage.Sets/src/mage/cards/h/HatchetBully.java
+++ b/Mage.Sets/src/mage/cards/h/HatchetBully.java
@@ -78,7 +78,7 @@ class HatchetBullyCost extends CostImpl {
     public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
         Permanent permanent = game.getPermanent(ability.getTargets().get(1).getFirstTarget());
         if (permanent != null) {
-            permanent.addCounters(CounterType.M1M1.createInstance(), ability, game);
+            permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), ability, game);
             this.paid = true;
         }
         return paid;

--- a/Mage.Sets/src/mage/cards/h/HatchetBully.java
+++ b/Mage.Sets/src/mage/cards/h/HatchetBully.java
@@ -78,7 +78,7 @@ class HatchetBullyCost extends CostImpl {
     public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
         Permanent permanent = game.getPermanent(ability.getTargets().get(1).getFirstTarget());
         if (permanent != null) {
-            permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), ability, game);
+            permanent.addCounters(CounterType.M1M1.createInstance(), controllerId, ability, game);
             this.paid = true;
         }
         return paid;

--- a/Mage.Sets/src/mage/cards/h/HuntedNightmare.java
+++ b/Mage.Sets/src/mage/cards/h/HuntedNightmare.java
@@ -80,6 +80,6 @@ class HuntedNightmareEffect extends OneShotEffect {
         target.setNotTarget(true);
         player.choose(outcome, target, source.getSourceId(), game);
         Permanent permanent = game.getPermanent(target.getFirstTarget());
-        return permanent != null && permanent.addCounters(CounterType.DEATHTOUCH.createInstance(), source.getControllerId(), source, game);
+        return permanent != null && permanent.addCounters(CounterType.DEATHTOUCH.createInstance(), player.getId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/h/HuntedNightmare.java
+++ b/Mage.Sets/src/mage/cards/h/HuntedNightmare.java
@@ -80,6 +80,6 @@ class HuntedNightmareEffect extends OneShotEffect {
         target.setNotTarget(true);
         player.choose(outcome, target, source.getSourceId(), game);
         Permanent permanent = game.getPermanent(target.getFirstTarget());
-        return permanent != null && permanent.addCounters(CounterType.DEATHTOUCH.createInstance(), source, game);
+        return permanent != null && permanent.addCounters(CounterType.DEATHTOUCH.createInstance(), source.getControllerId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/h/Hydradoodle.java
+++ b/Mage.Sets/src/mage/cards/h/Hydradoodle.java
@@ -97,7 +97,7 @@ class HydradoodleEffect extends OneShotEffect {
                         total += thisRoll;
                     }
 
-                    permanent.addCounters(CounterType.P1P1.createInstance(total), source, game);
+                    permanent.addCounters(CounterType.P1P1.createInstance(total), source.getControllerId(), source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/h/HydrasGrowth.java
+++ b/Mage.Sets/src/mage/cards/h/HydrasGrowth.java
@@ -76,7 +76,7 @@ class HydrasGrowthDoubleEffect extends OneShotEffect {
             if (attachedTo != null) {
                 int amount = attachedTo.getCounters(game).getCount(CounterType.P1P1);
                 if (amount > 0) {
-                    attachedTo.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                    attachedTo.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
                 }
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/i/IchorRats.java
+++ b/Mage.Sets/src/mage/cards/i/IchorRats.java
@@ -59,7 +59,7 @@ class IchorRatsEffect extends OneShotEffect {
         for (UUID playerId : game.getState().getPlayerList(source.getControllerId())) {
             Player player = game.getPlayer(playerId);
             if (player != null) {
-                player.addCounters(CounterType.POISON.createInstance(), source, game);
+                player.addCounters(CounterType.POISON.createInstance(), source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/i/ImmaculateMagistrate.java
+++ b/Mage.Sets/src/mage/cards/i/ImmaculateMagistrate.java
@@ -76,7 +76,7 @@ class ImmaculateMagistrateEffect extends OneShotEffect {
         if (permanent != null) {
             int count = game.getBattlefield().count(filter, source.getSourceId(), source.getControllerId(), game);
             if (count > 0) {
-                permanent.addCounters(CounterType.P1P1.createInstance(count), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(count), source.getControllerId(), source, game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/i/ImminentDoom.java
+++ b/Mage.Sets/src/mage/cards/i/ImminentDoom.java
@@ -114,7 +114,7 @@ class ImminentDoomEffect extends OneShotEffect {
         if (imminentDoom != null) {
             Effect effect = new DamageTargetEffect((int) game.getState().getValue("ImminentDoomCount" + source.getSourceId().toString()));
             effect.apply(game, source);
-            imminentDoom.addCounters(CounterType.DOOM.createInstance(), source, game);
+            imminentDoom.addCounters(CounterType.DOOM.createInstance(), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/i/IncreasingSavagery.java
+++ b/Mage.Sets/src/mage/cards/i/IncreasingSavagery.java
@@ -64,7 +64,7 @@ class IncreasingSavageryEffect extends OneShotEffect {
             }
             Permanent permanent = game.getPermanent(targetPointer.getFirst(game, source));
             if (permanent != null) {
-                permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/i/IncrementalBlight.java
+++ b/Mage.Sets/src/mage/cards/i/IncrementalBlight.java
@@ -105,7 +105,7 @@ class IncrementalBlightEffect extends OneShotEffect {
             i++;
             Permanent creature = game.getPermanent(target.getFirstTarget());
             if (creature != null) {
-                creature.addCounters(CounterType.M1M1.createInstance(i), source, game);
+                creature.addCounters(CounterType.M1M1.createInstance(i), source.getControllerId(), source, game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/i/IncrementalGrowth.java
+++ b/Mage.Sets/src/mage/cards/i/IncrementalGrowth.java
@@ -81,7 +81,7 @@ class IncrementalGrowthEffect extends OneShotEffect {
             i++;
             Permanent creature = game.getPermanent(target.getFirstTarget());
             if (creature != null) {
-                creature.addCounters(CounterType.P1P1.createInstance(i), source, game);
+                creature.addCounters(CounterType.P1P1.createInstance(i), source.getControllerId(), source, game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/i/Inhumaniac.java
+++ b/Mage.Sets/src/mage/cards/i/Inhumaniac.java
@@ -66,9 +66,9 @@ class InhumaniacEffect extends OneShotEffect {
         if (controller != null && permanent != null) {
             int amount = controller.rollDice(source, game, 6);
             if (amount >= 3 && amount <= 4) {
-                permanent.addCounters(CounterType.P1P1.createInstance(1), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(1), source.getControllerId(), source, game);
             } else if (amount >= 5) {
-                permanent.addCounters(CounterType.P1P1.createInstance(2), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
             } else if (amount == 1) {
                 int numToRemove = permanent.getCounters(game).getCount(CounterType.P1P1);
                 if (numToRemove > 0) {

--- a/Mage.Sets/src/mage/cards/i/InsatiableRakghoul.java
+++ b/Mage.Sets/src/mage/cards/i/InsatiableRakghoul.java
@@ -66,7 +66,7 @@ class InsatiableRakghoulEffect extends OneShotEffect {
             if (watcher != null && watcher.conditionMet()) {
                 Permanent permanent = game.getPermanentEntering(source.getSourceId());
                 if (permanent != null) {
-                    permanent.addCounters(CounterType.P1P1.createInstance(1), source, game);
+                    permanent.addCounters(CounterType.P1P1.createInstance(1), source.getControllerId(), source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/i/InvigoratingSurge.java
+++ b/Mage.Sets/src/mage/cards/i/InvigoratingSurge.java
@@ -61,6 +61,6 @@ class InvigoratingSurgeEffect extends OneShotEffect {
             return false;
         }
         int counterCount = permanent.getCounters(game).getCount(CounterType.P1P1);
-        return counterCount > 0 && permanent.addCounters(CounterType.P1P1.createInstance(counterCount), source, game);
+        return counterCount > 0 && permanent.addCounters(CounterType.P1P1.createInstance(counterCount), source.getControllerId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/j/JaredCarthalionTrueHeir.java
+++ b/Mage.Sets/src/mage/cards/j/JaredCarthalionTrueHeir.java
@@ -108,7 +108,7 @@ class JaredCarthalionTrueHeirPreventionEffect extends PreventionEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null) {
-            permanent.addCounters(CounterType.P1P1.createInstance(event.getAmount()), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(event.getAmount()), source.getControllerId(), source, game);
         }
         return super.replaceEvent(event, source, game);
     }

--- a/Mage.Sets/src/mage/cards/j/JhoiraOfTheGhitu.java
+++ b/Mage.Sets/src/mage/cards/j/JhoiraOfTheGhitu.java
@@ -92,7 +92,7 @@ class JhoiraOfTheGhituSuspendEffect extends OneShotEffect {
 
             UUID exileId = SuspendAbility.getSuspendExileId(controller.getId(), game);
             if (controller.moveCardToExileWithInfo(card, exileId, "Suspended cards of " + controller.getName(), source, game, Zone.HAND, true)) {
-                card.addCounters(CounterType.TIME.createInstance(4), source, game);
+                card.addCounters(CounterType.TIME.createInstance(4), source.getControllerId(), source, game);
                 if (!hasSuspend) {
                     game.addEffect(new GainSuspendEffect(new MageObjectReference(card, game)), source);
                 }

--- a/Mage.Sets/src/mage/cards/j/JhoirasTimebug.java
+++ b/Mage.Sets/src/mage/cards/j/JhoirasTimebug.java
@@ -79,7 +79,7 @@ class JhoirasTimebugEffect extends OneShotEffect {
             Permanent permanent = game.getPermanent(this.getTargetPointer().getFirst(game, source));
             if (permanent != null && permanent.getCounters(game).containsKey(CounterType.TIME)) {
                 if (controller.chooseUse(Outcome.Benefit, "Add a time counter? (Otherwise remove one)", source, game)) {
-                    permanent.addCounters(CounterType.TIME.createInstance(), source, game);
+                    permanent.addCounters(CounterType.TIME.createInstance(), source.getControllerId(), source, game);
                 }
                 else {
                     permanent.removeCounters(CounterType.TIME.createInstance(), source, game);
@@ -89,7 +89,7 @@ class JhoirasTimebugEffect extends OneShotEffect {
                 Card card = game.getExile().getCard(this.getTargetPointer().getFirst(game, source), game);
                 if (card != null) {
                     if (controller.chooseUse(Outcome.Detriment, "Add a time counter? (Otherwise remove one)", source, game)) {
-                        card.addCounters(CounterType.TIME.createInstance(), source, game);
+                        card.addCounters(CounterType.TIME.createInstance(), source.getControllerId(), source, game);
                     }
                     else {
                         card.removeCounters(CounterType.TIME.createInstance(), source, game);

--- a/Mage.Sets/src/mage/cards/j/JinxedChoker.java
+++ b/Mage.Sets/src/mage/cards/j/JinxedChoker.java
@@ -1,7 +1,5 @@
-
 package mage.cards.j;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.BeginningOfYourEndStepTriggeredAbility;
 import mage.abilities.common.OnEventTriggeredAbility;
@@ -24,23 +22,21 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetOpponent;
 
+import java.util.UUID;
+
 /**
- *
  * @author andyfries
  */
 
 public final class JinxedChoker extends CardImpl {
 
     public JinxedChoker(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{3}");
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
 
         // At the beginning of your end step, target opponent gains control of Jinxed Choker and puts a charge counter on it.
         Ability endStepAbility = new BeginningOfYourEndStepTriggeredAbility(new JinxedChokerChangeControllerEffect(), false);
+        endStepAbility.addEffect(new JinxedChokerAddCounterEffect());
         endStepAbility.addTarget(new TargetOpponent());
-
-        AddCountersSourceEffect addCountersSourceEffect = new AddCountersSourceEffect(CounterType.CHARGE.createInstance());
-        addCountersSourceEffect.setText("");
-        endStepAbility.addEffect(addCountersSourceEffect);
         this.addAbility(endStepAbility);
 
         // At the beginning of your upkeep, Jinxed Choker deals damage to you equal to the number of charge counters on it.
@@ -66,7 +62,7 @@ class JinxedChokerChangeControllerEffect extends ContinuousEffectImpl {
 
     public JinxedChokerChangeControllerEffect() {
         super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
-        staticText = "target opponent gains control of {this} and puts a charge counter on it";
+        staticText = "target opponent gains control of {this}";
     }
 
     public JinxedChokerChangeControllerEffect(final JinxedChokerChangeControllerEffect effect) {
@@ -91,6 +87,32 @@ class JinxedChokerChangeControllerEffect extends ContinuousEffectImpl {
 
 }
 
+class JinxedChokerAddCounterEffect extends OneShotEffect {
+
+    JinxedChokerAddCounterEffect() {
+        super(Outcome.Benefit);
+        staticText = "and puts a charge counter on it";
+    }
+
+    private JinxedChokerAddCounterEffect(final JinxedChokerAddCounterEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public JinxedChokerAddCounterEffect copy() {
+        return new JinxedChokerAddCounterEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = source.getSourcePermanentIfItStillExists(game);
+        return permanent != null && permanent.addCounters(
+                CounterType.CHARGE.createInstance(), source.getFirstTarget(), source, game
+        );
+    }
+}
+
+
 class JinxedChokerDynamicValue implements DynamicValue {
 
     @Override
@@ -98,7 +120,7 @@ class JinxedChokerDynamicValue implements DynamicValue {
         Permanent permanent = game.getPermanent(sourceAbility.getSourceId());
 
         int count = 0;
-        if (permanent != null){
+        if (permanent != null) {
             count = permanent.getCounters(game).getCount(CounterType.CHARGE);
         }
         return count;

--- a/Mage.Sets/src/mage/cards/j/JumboImp.java
+++ b/Mage.Sets/src/mage/cards/j/JumboImp.java
@@ -80,7 +80,7 @@ class JumboImpEffect extends EntersBattlefieldWithXCountersEffect {
         if (controller != null && permanent != null) {
             int amount = controller.rollDice(source, game, 6);
             List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects"); // the basic event is the EntersBattlefieldEvent, so use already applied replacement effects from that event
-            permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game, appliedEffects);
+            permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game, appliedEffects);
             return super.apply(game, source);
         }
         return false;
@@ -115,7 +115,7 @@ class JumboImpAddCountersEffect extends OneShotEffect {
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (controller != null && permanent != null) {
             int amount = controller.rollDice(source, game, 6);
-            permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/k/KalonianHydra.java
+++ b/Mage.Sets/src/mage/cards/k/KalonianHydra.java
@@ -82,7 +82,7 @@ class KalonianHydraEffect extends OneShotEffect {
         for (Permanent permanent : permanents) {
             int existingCounters = permanent.getCounters(game).getCount(CounterType.P1P1);
             if (existingCounters > 0) {
-                permanent.addCounters(CounterType.P1P1.createInstance(existingCounters), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(existingCounters), source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/k/KarnScionOfUrza.java
+++ b/Mage.Sets/src/mage/cards/k/KarnScionOfUrza.java
@@ -109,7 +109,7 @@ class KarnPlus1Effect extends OneShotEffect {
                 if (!cards.isEmpty()) {
                     controller.moveCards(cards, Zone.EXILED, source, game);
                     for (Card c : cards.getCards(game)) {
-                        c.addCounters(CounterType.SILVER.createInstance(1), source, game);
+                        c.addCounters(CounterType.SILVER.createInstance(1), source.getControllerId(), source, game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/k/KathrilAspectWarper.java
+++ b/Mage.Sets/src/mage/cards/k/KathrilAspectWarper.java
@@ -109,7 +109,7 @@ class KathrilAspectWarperEffect extends OneShotEffect {
             if (permanent == null) {
                 continue;
             }
-            if (permanent.addCounters(counterType.createInstance(), source, game)) {
+            if (permanent.addCounters(counterType.createInstance(), source.getControllerId(), source, game)) {
                 countersAdded++;
             }
         }
@@ -120,7 +120,7 @@ class KathrilAspectWarperEffect extends OneShotEffect {
         if (permanent == null) {
             return true;
         }
-        permanent.addCounters(CounterType.P1P1.createInstance(countersAdded), source, game);
+        permanent.addCounters(CounterType.P1P1.createInstance(countersAdded), source.getControllerId(), source, game);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/k/KavuPredator.java
+++ b/Mage.Sets/src/mage/cards/k/KavuPredator.java
@@ -16,7 +16,6 @@ import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
@@ -106,7 +105,7 @@ class KavuPredatorEffect extends OneShotEffect {
         if (permanent != null) {
             Integer gainedLife  = (Integer) this.getValue("gainedLife");
             if (gainedLife != null) {
-                permanent.addCounters(CounterType.P1P1.createInstance(gainedLife), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(gainedLife), source.getControllerId(), source, game);
                 Player player = game.getPlayer(source.getControllerId());
                 if (player != null) {
                     game.informPlayers(player.getLogName() + " puts " + gainedLife + " +1/+1 counter on " + permanent.getName());

--- a/Mage.Sets/src/mage/cards/k/KreshTheBloodbraided.java
+++ b/Mage.Sets/src/mage/cards/k/KreshTheBloodbraided.java
@@ -62,7 +62,7 @@ class KreshTheBloodbraidedEffect extends OneShotEffect {
         if (permanent != null && kreshTheBloodbraided != null) {
             int amount = permanent.getPower().getValue();
             if (amount > 0) {
-                kreshTheBloodbraided.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                kreshTheBloodbraided.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/l/LavabrinkFloodgates.java
+++ b/Mage.Sets/src/mage/cards/l/LavabrinkFloodgates.java
@@ -87,7 +87,7 @@ class LavabrinkFloodgatesEffect extends OneShotEffect {
         player.choose(outcome, choice, game);
         switch (choice.getChoice()) {
             case "Add a doom counter":
-                permanent.addCounters(CounterType.DOOM.createInstance(), source, game);
+                permanent.addCounters(CounterType.DOOM.createInstance(), source.getControllerId(), source, game);
                 break;
             case "Remove a doom counter":
                 permanent.removeCounters(CounterType.DOOM.createInstance(), source, game);

--- a/Mage.Sets/src/mage/cards/l/LavabrinkFloodgates.java
+++ b/Mage.Sets/src/mage/cards/l/LavabrinkFloodgates.java
@@ -87,7 +87,7 @@ class LavabrinkFloodgatesEffect extends OneShotEffect {
         player.choose(outcome, choice, game);
         switch (choice.getChoice()) {
             case "Add a doom counter":
-                permanent.addCounters(CounterType.DOOM.createInstance(), source.getControllerId(), source, game);
+                permanent.addCounters(CounterType.DOOM.createInstance(), player.getId(), source, game);
                 break;
             case "Remove a doom counter":
                 permanent.removeCounters(CounterType.DOOM.createInstance(), source, game);

--- a/Mage.Sets/src/mage/cards/l/LeechBonder.java
+++ b/Mage.Sets/src/mage/cards/l/LeechBonder.java
@@ -114,7 +114,7 @@ class LeechBonderEffect extends OneShotEffect {
                 if (counterType != null) {
                     Counter counter = counterType.createInstance();
                     fromPermanent.removeCounters(counterType.getName(), 1, source, game);
-                    toPermanent.addCounters(counter, source, game);
+                    toPermanent.addCounters(counter, source.getControllerId(), source, game);
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/l/LethalSting.java
+++ b/Mage.Sets/src/mage/cards/l/LethalSting.java
@@ -73,7 +73,7 @@ class LethalStingCost extends CostImpl {
             controller.chooseTarget(Outcome.UnboostCreature, target, ability, game);
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
-                permanent.addCounters(CounterType.M1M1.createInstance(), ability, game);
+                permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), ability, game);
                 game.informPlayers(controller.getLogName() + " puts a -1/-1 counter on " + permanent.getLogName());
                 this.paid = true;
             }

--- a/Mage.Sets/src/mage/cards/l/LethalSting.java
+++ b/Mage.Sets/src/mage/cards/l/LethalSting.java
@@ -73,7 +73,7 @@ class LethalStingCost extends CostImpl {
             controller.chooseTarget(Outcome.UnboostCreature, target, ability, game);
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
-                permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), ability, game);
+                permanent.addCounters(CounterType.M1M1.createInstance(), controllerId, ability, game);
                 game.informPlayers(controller.getLogName() + " puts a -1/-1 counter on " + permanent.getLogName());
                 this.paid = true;
             }

--- a/Mage.Sets/src/mage/cards/l/Lichenthrope.java
+++ b/Mage.Sets/src/mage/cards/l/Lichenthrope.java
@@ -69,7 +69,7 @@ class LichenthropeEffect extends ReplacementEffectImpl {
         DamageCreatureEvent damageEvent = (DamageCreatureEvent) event;
         Permanent p = game.getPermanent(source.getSourceId());
         if (p != null) {
-            p.addCounters(CounterType.M1M1.createInstance(damageEvent.getAmount()), source, game);
+            p.addCounters(CounterType.M1M1.createInstance(damageEvent.getAmount()), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/l/LieutenantsOfTheGuard.java
+++ b/Mage.Sets/src/mage/cards/l/LieutenantsOfTheGuard.java
@@ -75,7 +75,7 @@ class LieutenantsOfTheGuardDilemmaEffect extends CouncilsDilemmaVoteEffect {
         //Strength Votes
         //If strength received zero votes or the permanent is no longer on the battlefield, do not attempt to put P1P1 counters on it.
         if (voteOneCount > 0 && permanent != null) {
-            permanent.addCounters(CounterType.P1P1.createInstance(voteOneCount), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(voteOneCount), source.getControllerId(), source, game);
         }
 
         //Numbers Votes

--- a/Mage.Sets/src/mage/cards/l/LifecraftersGift.java
+++ b/Mage.Sets/src/mage/cards/l/LifecraftersGift.java
@@ -70,7 +70,7 @@ class LifecraftersGiftEffect extends OneShotEffect {
         MageObject sourceObject = source.getSourceObject(game);
         if (controller != null && sourceObject != null) {
             for(Permanent permanent: game.getState().getBattlefield().getAllActivePermanents(filter , controller.getId(), game)) {
-                permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 game.informPlayers(sourceObject.getName() + ": Put a +1/+1 counter on " + permanent.getLogName());
             }
         }

--- a/Mage.Sets/src/mage/cards/l/LightOfPromise.java
+++ b/Mage.Sets/src/mage/cards/l/LightOfPromise.java
@@ -80,6 +80,6 @@ class LightOfPromiseEffect extends OneShotEffect {
             return false;
         }
         int gainedLife = (int) this.getValue("gainedLife");
-        return permanent.addCounters(CounterType.P1P1.createInstance(gainedLife), source, game);
+        return permanent.addCounters(CounterType.P1P1.createInstance(gainedLife), source.getControllerId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LightningStorm.java
+++ b/Mage.Sets/src/mage/cards/l/LightningStorm.java
@@ -114,7 +114,7 @@ class LightningStormAddCounterEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Spell spell = game.getStack().getSpell(source.getSourceId());
         if (spell != null) {
-            spell.addCounters(CounterType.CHARGE.createInstance(2), source, game);
+            spell.addCounters(CounterType.CHARGE.createInstance(2), source.getControllerId(), source, game);
             spell.chooseNewTargets(game, ((ActivatedAbilityImpl) source).getActivatorId(), false, false, null);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/l/LilianasScrounger.java
+++ b/Mage.Sets/src/mage/cards/l/LilianasScrounger.java
@@ -85,6 +85,6 @@ class LilianasScroungerEffect extends OneShotEffect {
         TargetPermanent target = new TargetPermanent(0, 1, filter, true);
         player.choose(outcome, target, source.getSourceId(), game);
         Permanent permanent = game.getPermanent(target.getFirstTarget());
-        return permanent != null && permanent.addCounters(CounterType.LOYALTY.createInstance(), source, game);
+        return permanent != null && permanent.addCounters(CounterType.LOYALTY.createInstance(), source.getControllerId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LittjaraMirrorlake.java
+++ b/Mage.Sets/src/mage/cards/l/LittjaraMirrorlake.java
@@ -81,7 +81,7 @@ class LittjaraMirrorlakeEffect extends OneShotEffect {
             if (permanent == null) {
                 continue;
             }
-            permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/l/LivingArmor.java
+++ b/Mage.Sets/src/mage/cards/l/LivingArmor.java
@@ -63,7 +63,7 @@ public final class LivingArmor extends CardImpl {
             Permanent creature = game.getPermanent(source.getTargets().getFirstTarget());
             if (creature != null) {
                 int amount = creature.getConvertedManaCost();
-                creature.addCounters(new BoostCounter(0, 1, amount), source, game);
+                creature.addCounters(new BoostCounter(0, 1, amount), source.getControllerId(), source, game);
                 return true;
             }
             return false;

--- a/Mage.Sets/src/mage/cards/l/LivioOathswornSentinel.java
+++ b/Mage.Sets/src/mage/cards/l/LivioOathswornSentinel.java
@@ -104,7 +104,7 @@ class LivioOathswornSentinelExileEffect extends OneShotEffect {
         if (card == null || game.getState().getZone(card.getId()) != Zone.EXILED) {
             return false;
         }
-        card.addCounters(CounterType.AEGIS.createInstance(), source, game);
+        card.addCounters(CounterType.AEGIS.createInstance(), source.getControllerId(), source, game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LockjawSnapper.java
+++ b/Mage.Sets/src/mage/cards/l/LockjawSnapper.java
@@ -73,7 +73,7 @@ class LockjawSnapperEffect extends OneShotEffect {
         }
         for (Permanent creature : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), game)) {
             if (creature != null) {
-                creature.addCounters(CounterType.M1M1.createInstance(), source, game);
+                creature.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), source, game);
                 applied = true;
             }
         }

--- a/Mage.Sets/src/mage/cards/l/LongRoadHome.java
+++ b/Mage.Sets/src/mage/cards/l/LongRoadHome.java
@@ -20,7 +20,6 @@ import mage.game.ExileZone;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCreaturePermanent;
@@ -162,7 +161,7 @@ class LongRoadHomeEntersBattlefieldEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent permanent = ((EntersTheBattlefieldEvent) event).getTarget();
         if (permanent != null) {
-            permanent.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
             discard(); // use only once
         }
         return false;

--- a/Mage.Sets/src/mage/cards/l/LuminousBroodmoth.java
+++ b/Mage.Sets/src/mage/cards/l/LuminousBroodmoth.java
@@ -128,7 +128,7 @@ class LuminousBroodmothEffect extends OneShotEffect {
         if (permanent == null) {
             return false;
         }
-        permanent.addCounters(CounterType.FLYING.createInstance(), source, game);
+        permanent.addCounters(CounterType.FLYING.createInstance(), source.getControllerId(), source, game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/m/MairsilThePretender.java
+++ b/Mage.Sets/src/mage/cards/m/MairsilThePretender.java
@@ -97,7 +97,7 @@ class MairsilThePretenderExileEffect extends OneShotEffect {
                 Card card = controller.getHand().get(target.getFirstTarget(), game);
                 if (card != null) {
                     controller.moveCards(card, Zone.EXILED, source, game);
-                    card.addCounters(CounterType.CAGE.createInstance(), source, game);
+                    card.addCounters(CounterType.CAGE.createInstance(), source.getControllerId(), source, game);
                 }
             } else {
                 Target target = new TargetCardInYourGraveyard(0, 1, filter);
@@ -105,7 +105,7 @@ class MairsilThePretenderExileEffect extends OneShotEffect {
                 Card card = controller.getGraveyard().get(target.getFirstTarget(), game);
                 if (card != null) {
                     controller.moveCards(card, Zone.EXILED, source, game);
-                    card.addCounters(CounterType.CAGE.createInstance(), source, game);
+                    card.addCounters(CounterType.CAGE.createInstance(), source.getControllerId(), source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/m/ManaCache.java
+++ b/Mage.Sets/src/mage/cards/m/ManaCache.java
@@ -78,7 +78,7 @@ class ManaCacheEffect extends OneShotEffect {
         Permanent sourcePermanent = game.getPermanent(source.getSourceId());
         if (player != null && sourcePermanent != null) {
             int controlledUntappedLands = game.getBattlefield().countAll(filter, game.getActivePlayerId(), game);
-            sourcePermanent.addCounters(CounterType.CHARGE.createInstance(controlledUntappedLands), source, game);
+            sourcePermanent.addCounters(CounterType.CHARGE.createInstance(controlledUntappedLands), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/m/MasterBiomancer.java
+++ b/Mage.Sets/src/mage/cards/m/MasterBiomancer.java
@@ -17,7 +17,6 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.target.targetpointer.FixedTarget;
 
@@ -81,7 +80,7 @@ class MasterBiomancerEntersBattlefieldEffect extends ReplacementEffectImpl {
         if (sourceCreature != null && creature != null) {
             int power = sourceCreature.getPower().getValue();
             if (power > 0) {
-                creature.addCounters(CounterType.P1P1.createInstance(power), source, game);
+                creature.addCounters(CounterType.P1P1.createInstance(power), source.getControllerId(), source, game);
             }
             ContinuousEffect effect = new AddCardSubTypeTargetEffect(SubType.MUTANT, Duration.Custom);
             effect.setTargetPointer(new FixedTarget(creature.getId(), creature.getZoneChangeCounter(game) + 1));

--- a/Mage.Sets/src/mage/cards/m/MaulfistRevolutionary.java
+++ b/Mage.Sets/src/mage/cards/m/MaulfistRevolutionary.java
@@ -81,7 +81,7 @@ class MaulfistRevolutionaryEffect extends OneShotEffect {
                     } else {
                         counterToAdd = new Counter(counter.getName());
                     }
-                    player.addCounters(counterToAdd, source, game);
+                    player.addCounters(counterToAdd, source.getControllerId(), source, game);
                 }
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/m/MaulfistRevolutionary.java
+++ b/Mage.Sets/src/mage/cards/m/MaulfistRevolutionary.java
@@ -96,7 +96,7 @@ class MaulfistRevolutionaryEffect extends OneShotEffect {
                     } else {
                         counterToAdd = new Counter(counter.getName());
                     }
-                    permanent.addCounters(counterToAdd, source, game);
+                    permanent.addCounters(counterToAdd, source.getControllerId(), source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/m/MayaelsAria.java
+++ b/Mage.Sets/src/mage/cards/m/MayaelsAria.java
@@ -72,7 +72,7 @@ class MayaelsAriaEffect extends OneShotEffect {
         filter.add(new PowerPredicate(ComparisonType.MORE_THAN, 4));
         if (game.getState().getBattlefield().countAll(filter, controller.getId(), game) > 0) {
             for (Permanent creature : game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, source.getControllerId(), game)) {
-                creature.addCounters(CounterType.P1P1.createInstance(), source, game);
+                creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
             }
         }
         game.getState().processAction(game); // needed because otehrwise the +1/+1 counters wouldn't be taken into account

--- a/Mage.Sets/src/mage/cards/m/Meadowboon.java
+++ b/Mage.Sets/src/mage/cards/m/Meadowboon.java
@@ -66,7 +66,7 @@ class MeadowboonEffect extends OneShotEffect {
         Player target = game.getPlayer(source.getFirstTarget());
         if (target != null) {
             for (Permanent p : game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, target.getId(), game)) {
-                p.addCounters(CounterType.P1P1.createInstance(), source, game);
+                p.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/m/MenacingOgre.java
+++ b/Mage.Sets/src/mage/cards/m/MenacingOgre.java
@@ -99,7 +99,7 @@ class MenacingOgreEffect extends OneShotEffect {
                     player.loseLife(highestNumber, game, source, false);
                     if (player.getId().equals(source.getControllerId())
                             && menacingOgre != null) {
-                        menacingOgre.addCounters(CounterType.P1P1.createInstance(2), source, game);
+                        menacingOgre.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/m/MessengerJays.java
+++ b/Mage.Sets/src/mage/cards/m/MessengerJays.java
@@ -73,7 +73,7 @@ class MessengerJaysDilemmaEffect extends CouncilsDilemmaVoteEffect {
         //Feathers Votes
         //If feathers received zero votes or the permanent is no longer on the battlefield, do not attempt to put P1P1 counter on it.
         if (voteOneCount > 0 && permanent != null)
-            permanent.addCounters(CounterType.P1P1.createInstance(voteOneCount), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(voteOneCount), source.getControllerId(), source, game);
 
         //Quill Votes
         //Only let the controller loot the appropriate amount of cards if it was voted for.

--- a/Mage.Sets/src/mage/cards/m/MetallicMimic.java
+++ b/Mage.Sets/src/mage/cards/m/MetallicMimic.java
@@ -95,7 +95,7 @@ class MetallicMimicReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/m/MindMaggots.java
+++ b/Mage.Sets/src/mage/cards/m/MindMaggots.java
@@ -77,7 +77,7 @@ class MindMaggotsEffect extends OneShotEffect {
         if (permanent == null || counters < 1) {
             return true;
         }
-        permanent.addCounters(CounterType.P1P1.createInstance(counters), source, game);
+        permanent.addCounters(CounterType.P1P1.createInstance(counters), source.getControllerId(), source, game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/m/MiraculousRecovery.java
+++ b/Mage.Sets/src/mage/cards/m/MiraculousRecovery.java
@@ -62,7 +62,7 @@ class MiraculousRecoveryEffect extends OneShotEffect {
         // targetPointer can't be used because target moved from graveyard to battlefield
         Permanent permanent = game.getPermanent(source.getFirstTarget());
         if (permanent != null) {
-            permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/m/MysteriousPathlighter.java
+++ b/Mage.Sets/src/mage/cards/m/MysteriousPathlighter.java
@@ -85,7 +85,7 @@ class MysteriousPathlighterEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent target = ((EntersTheBattlefieldEvent) event).getTarget();
         if (target != null) {
-            target.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            target.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/n/NantukoCultivator.java
+++ b/Mage.Sets/src/mage/cards/n/NantukoCultivator.java
@@ -71,7 +71,7 @@ class NantukoCultivatorEffect extends OneShotEffect {
         }
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null) {
-            permanent.addCounters(CounterType.P1P1.createInstance(count), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(count), source.getControllerId(), source, game);
         }
         player.drawCards(count, source, game);
         return true;

--- a/Mage.Sets/src/mage/cards/n/NaturesBlessing.java
+++ b/Mage.Sets/src/mage/cards/n/NaturesBlessing.java
@@ -101,7 +101,7 @@ class NaturesBlessingEffect extends OneShotEffect {
             if (gainedAbility != null) {
                 game.addEffect(new GainAbilityTargetEffect(gainedAbility, Duration.Custom), source);
             } else {
-                targetPermanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                targetPermanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 game.informPlayers(controller.getLogName() + " puts a +1/+1 counter on " + targetPermanent.getLogName());
             }
             return true;

--- a/Mage.Sets/src/mage/cards/n/NayaSoulbeast.java
+++ b/Mage.Sets/src/mage/cards/n/NayaSoulbeast.java
@@ -21,7 +21,6 @@ import mage.constants.Outcome;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
@@ -127,7 +126,7 @@ class NayaSoulbeastReplacementEffect extends ReplacementEffectImpl {
         Permanent permanent = game.getPermanentEntering(source.getSourceId());
         if (permanent != null && object instanceof Integer) {
             int amount = ((Integer) object);
-            permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/n/NecromanticSummons.java
+++ b/Mage.Sets/src/mage/cards/n/NecromanticSummons.java
@@ -82,7 +82,7 @@ class NecromanticSummoningReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(2), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game, event.getAppliedEffects());
             discard();
         }
         return false;

--- a/Mage.Sets/src/mage/cards/n/Neoform.java
+++ b/Mage.Sets/src/mage/cards/n/Neoform.java
@@ -137,7 +137,7 @@ class NeoformReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         discard();
         return false;

--- a/Mage.Sets/src/mage/cards/n/NestOfScarabs.java
+++ b/Mage.Sets/src/mage/cards/n/NestOfScarabs.java
@@ -55,7 +55,7 @@ class NestOfScarabsTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        boolean weAreDoingIt = isControlledBy(game.getControllerId(event.getSourceId()));
+        boolean weAreDoingIt = isControlledBy(event.getPlayerId());
         boolean isM1M1Counters = event.getData().equals(CounterType.M1M1.getName());
         if (weAreDoingIt && isM1M1Counters && event.getAmount() > 0) {
             Permanent permanent = game.getPermanentOrLKIBattlefield(event.getTargetId());
@@ -63,7 +63,7 @@ class NestOfScarabsTriggeredAbility extends TriggeredAbilityImpl {
                 permanent = game.getPermanentEntering(event.getTargetId());
             }
             if (permanent != null && permanent.isCreature()) {
-                getEffects().forEach(effect -> effect.setValue("countersAdded", event.getAmount()));
+                getEffects().setValue("countersAdded", event.getAmount());
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/n/NestingGrounds.java
+++ b/Mage.Sets/src/mage/cards/n/NestingGrounds.java
@@ -107,7 +107,7 @@ class NestingGroundsEffect extends OneShotEffect {
                 if (counterType != null) {
                     Counter counter = counterType.createInstance();
                     fromPermanent.removeCounters(counterType.getName(), 1, source, game);
-                    toPermanent.addCounters(counter, source, game);
+                    toPermanent.addCounters(counter, source.getControllerId(), source, game);
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/n/NightDealings.java
+++ b/Mage.Sets/src/mage/cards/n/NightDealings.java
@@ -113,7 +113,7 @@ public final class NightDealings extends CardImpl {
             if (damageAmount != null) {
                 Permanent permanent = game.getPermanent(source.getSourceId());
                 if (permanent != null) {
-                    permanent.addCounters(CounterType.THEFT.createInstance(damageAmount), source, game);
+                    permanent.addCounters(CounterType.THEFT.createInstance(damageAmount), source.getControllerId(), source, game);
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/n/NineLives.java
+++ b/Mage.Sets/src/mage/cards/n/NineLives.java
@@ -81,7 +81,7 @@ class NineLivesPreventionEffect extends PreventionEffectImpl {
             if (player != null) {
                 Permanent nineLives = source.getSourcePermanentIfItStillExists(game);
                 if (nineLives != null) {
-                    nineLives.addCounters(CounterType.INCARNATION.createInstance(1), source, game);
+                    nineLives.addCounters(CounterType.INCARNATION.createInstance(1), source.getControllerId(), source, game);
                 }
             }
             event.setAmount(0);

--- a/Mage.Sets/src/mage/cards/n/NissaOfShadowedBoughs.java
+++ b/Mage.Sets/src/mage/cards/n/NissaOfShadowedBoughs.java
@@ -153,7 +153,7 @@ class NissaOfShadowedBoughsCreatureEffect extends OneShotEffect {
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
         Permanent permanent = game.getPermanent(card.getId());
         if (permanent != null) {
-            permanent.addCounters(CounterType.P1P1.createInstance(2), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/n/NovijenHeartOfProgress.java
+++ b/Mage.Sets/src/mage/cards/n/NovijenHeartOfProgress.java
@@ -71,7 +71,7 @@ class NovijenHeartOfProgressEffect extends OneShotEffect {
         if (controller != null && sourceObject != null) {
             for (Permanent permanent : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, source.getControllerId(), game)) {
                 if (permanent.getTurnsOnBattlefield() == 0) {
-                    permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                    permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                     game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts a +1/+1 counter on " + permanent.getLogName());
                 }
             }

--- a/Mage.Sets/src/mage/cards/o/OathOfGideon.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfGideon.java
@@ -77,7 +77,7 @@ class OathOfGideonReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.LOYALTY.createInstance(), source, game);
+            creature.addCounters(CounterType.LOYALTY.createInstance(), source.getControllerId(), source, game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/o/ObeliskSpider.java
+++ b/Mage.Sets/src/mage/cards/o/ObeliskSpider.java
@@ -76,7 +76,7 @@ class ObeliskSpiderTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         if (event.getData().equals(CounterType.M1M1.getName())
-                && controllerId.equals(game.getControllerId(event.getSourceId()))) {
+                && isControlledBy(event.getPlayerId())) {
             Permanent permanent = game.getPermanentOrLKIBattlefield(event.getTargetId());
             if (permanent == null) {
                 permanent = game.getPermanentEntering(event.getTargetId());

--- a/Mage.Sets/src/mage/cards/o/OonasBlackguard.java
+++ b/Mage.Sets/src/mage/cards/o/OonasBlackguard.java
@@ -18,7 +18,6 @@ import mage.game.Game;
 import mage.game.events.DamagedPlayerEvent;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.target.targetpointer.FixedTarget;
 
@@ -92,7 +91,7 @@ class OonasBlackguardReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/o/OpalPalace.java
+++ b/Mage.Sets/src/mage/cards/o/OpalPalace.java
@@ -15,7 +15,6 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.game.stack.Spell;
 import mage.players.Player;
@@ -130,7 +129,7 @@ class OpalPalaceEntersBattlefieldEffect extends ReplacementEffectImpl {
             CommanderPlaysCountWatcher watcher = game.getState().getWatcher(CommanderPlaysCountWatcher.class);
             int castCount = watcher.getPlaysCount(permanent.getId());
             if (castCount > 0) {
-                permanent.addCounters(CounterType.P1P1.createInstance(castCount), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(castCount), source.getControllerId(), source, game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/o/OranRiefHydra.java
+++ b/Mage.Sets/src/mage/cards/o/OranRiefHydra.java
@@ -125,9 +125,9 @@ class OranRiefHydraEffect extends OneShotEffect {
                 && landLKI != null
                 && sourcePermanent != null) {
             if (landLKI.hasSubtype(SubType.FOREST, game)) {
-                sourcePermanent.addCounters(CounterType.P1P1.createInstance(2), source, game);
+                sourcePermanent.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
             } else {
-                sourcePermanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                sourcePermanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/o/OranRiefTheVastwood.java
+++ b/Mage.Sets/src/mage/cards/o/OranRiefTheVastwood.java
@@ -68,7 +68,7 @@ class OranRiefTheVastwoodEffect extends OneShotEffect {
         filter.add(new ColorPredicate(ObjectColor.GREEN));
         for (Permanent permanent: game.getBattlefield().getActivePermanents(filter, source.getControllerId(), game)) {
             if (permanent.getTurnsOnBattlefield() == 0) {
-                permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/o/OrchardElemental.java
+++ b/Mage.Sets/src/mage/cards/o/OrchardElemental.java
@@ -69,7 +69,7 @@ class OrchardElementalDilemmaEffect extends CouncilsDilemmaVoteEffect {
         //Sprout Votes
         //If sprout received zero votes or the permanent is no longer on the battlefield, do not attempt to put P1P1 counter on it.
         if (voteOneCount > 0 && permanent != null)
-            permanent.addCounters(CounterType.P1P1.createInstance(voteOneCount * 2), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(voteOneCount * 2), source.getControllerId(), source, game);
 
         //Harvest Votes
         if (voteTwoCount > 0) {

--- a/Mage.Sets/src/mage/cards/o/OrmosArchiveKeeper.java
+++ b/Mage.Sets/src/mage/cards/o/OrmosArchiveKeeper.java
@@ -90,7 +90,7 @@ class OrmosArchiveKeeperEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null) {
-            permanent.addCounters(CounterType.P1P1.createInstance(5), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(5), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/o/OrzhovAdvokist.java
+++ b/Mage.Sets/src/mage/cards/o/OrzhovAdvokist.java
@@ -95,7 +95,7 @@ class OrzhovAdvokistEffect extends OneShotEffect {
             for (UUID creatureId : creatures) {
                 Permanent creature = game.getPermanent(creatureId);
                 if (creature != null) {
-                    creature.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
+                    creature.addCounters(CounterType.P1P1.createInstance(2), creature.getControllerId(), source, game);
                 }
             }
             for (UUID playerId : players) {

--- a/Mage.Sets/src/mage/cards/o/OrzhovAdvokist.java
+++ b/Mage.Sets/src/mage/cards/o/OrzhovAdvokist.java
@@ -95,7 +95,7 @@ class OrzhovAdvokistEffect extends OneShotEffect {
             for (UUID creatureId : creatures) {
                 Permanent creature = game.getPermanent(creatureId);
                 if (creature != null) {
-                    creature.addCounters(CounterType.P1P1.createInstance(2), source, game);
+                    creature.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
                 }
             }
             for (UUID playerId : players) {

--- a/Mage.Sets/src/mage/cards/o/OtherworldlyJourney.java
+++ b/Mage.Sets/src/mage/cards/o/OtherworldlyJourney.java
@@ -159,7 +159,7 @@ class OtherworldlyJourneyEntersBattlefieldEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent permanent = ((EntersTheBattlefieldEvent) event).getTarget();
         if (permanent != null) {
-            permanent.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
             discard(); // use only once
         }
         return false;

--- a/Mage.Sets/src/mage/cards/o/Outmuscle.java
+++ b/Mage.Sets/src/mage/cards/o/Outmuscle.java
@@ -78,7 +78,7 @@ class OutmuscleEffect extends OneShotEffect {
             effect.setTargetPointer(new FixedTarget(permanent, game));
             game.addEffect(effect, source);
         }
-        permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+        permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         Permanent creature = game.getPermanent(source.getTargets().get(1).getFirstTarget());
         if (creature == null) {
             return true;

--- a/Mage.Sets/src/mage/cards/p/PakoArcaneRetriever.java
+++ b/Mage.Sets/src/mage/cards/p/PakoArcaneRetriever.java
@@ -100,14 +100,14 @@ class PakoArcaneRetrieverEffect extends OneShotEffect {
         }
         cards.getCards(game)
                 .stream()
-                .filter(card -> card.addCounters(CounterType.FETCH.createInstance(), source, game))
+                .filter(card -> card.addCounters(CounterType.FETCH.createInstance(), source.getControllerId(), source, game))
                 .filter(card -> !card.isCreature())
                 .forEach(card -> watcher.addCard(controller.getId(), card, game));
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent == null || counters == 0) {
             return true;
         }
-        return permanent.addCounters(CounterType.P1P1.createInstance(counters), source, game);
+        return permanent.addCounters(CounterType.P1P1.createInstance(counters), source.getControllerId(), source, game);
     }
 }
 

--- a/Mage.Sets/src/mage/cards/p/PardicDragon.java
+++ b/Mage.Sets/src/mage/cards/p/PardicDragon.java
@@ -83,7 +83,7 @@ class PardicDragonEffect extends OneShotEffect {
         Card sourceCard = game.getCard(source.getSourceId());
         if (opponent != null && sourceCard != null) {
             if (opponent.chooseUse(outcome, "Put a time counter on " + sourceCard.getName() + '?', source, game)) {
-                sourceCard.addCounters(CounterType.TIME.createInstance(), source, game);
+                sourceCard.addCounters(CounterType.TIME.createInstance(), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/p/PardicDragon.java
+++ b/Mage.Sets/src/mage/cards/p/PardicDragon.java
@@ -83,7 +83,7 @@ class PardicDragonEffect extends OneShotEffect {
         Card sourceCard = game.getCard(source.getSourceId());
         if (opponent != null && sourceCard != null) {
             if (opponent.chooseUse(outcome, "Put a time counter on " + sourceCard.getName() + '?', source, game)) {
-                sourceCard.addCounters(CounterType.TIME.createInstance(), source.getControllerId(), source, game);
+                sourceCard.addCounters(CounterType.TIME.createInstance(), opponent.getId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/p/PatronOfTheValiant.java
+++ b/Mage.Sets/src/mage/cards/p/PatronOfTheValiant.java
@@ -76,7 +76,7 @@ class PatronOfTheValiantEffect extends OneShotEffect {
         MageObject sourceObject = source.getSourceObject(game);
         if (controller != null && sourceObject != null) {
             for(Permanent permanent: game.getState().getBattlefield().getAllActivePermanents(filter , controller.getId(), game)) {
-                permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 game.informPlayers(sourceObject.getName() + ": Put a +1/+1 counter on " + permanent.getLogName());
             }
         }

--- a/Mage.Sets/src/mage/cards/p/PatronOfTheVein.java
+++ b/Mage.Sets/src/mage/cards/p/PatronOfTheVein.java
@@ -24,7 +24,6 @@ import mage.counters.CounterType;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
-import mage.game.events.GameEvent.EventType;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
 import mage.game.permanent.Permanent;
@@ -155,7 +154,7 @@ class PatronOfTheVeinExileCreatureEffect extends OneShotEffect {
         }
 
         for (Permanent permanent : game.getState().getBattlefield().getAllActivePermanents(filter, controller.getId(), game)) {
-            permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
             game.informPlayers(sourceObject.getName() + ": Put a +1/+1 counter on " + permanent.getLogName());
         }
         return true;

--- a/Mage.Sets/src/mage/cards/p/PetrifiedWoodKin.java
+++ b/Mage.Sets/src/mage/cards/p/PetrifiedWoodKin.java
@@ -93,7 +93,7 @@ class PetrifiedWoodKinEffect extends OneShotEffect {
             MageObjectReference mor = new MageObjectReference(opponentId, game);
             amount += watcher.getDamagedObjects().getOrDefault(mor, 0);
         }
-        permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game, appliedEffects);
+        permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game, appliedEffects);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhylacteryLich.java
+++ b/Mage.Sets/src/mage/cards/p/PhylacteryLich.java
@@ -115,7 +115,7 @@ class PhylacteryLichEffect extends OneShotEffect {
                 if (player.choose(Outcome.Neutral, target, source.getSourceId(), game)) {
                     Permanent permanent = game.getPermanent(target.getFirstTarget());
                     if (permanent != null) {
-                        permanent.addCounters(CounterType.PHYLACTERY.createInstance(), source, game);
+                        permanent.addCounters(CounterType.PHYLACTERY.createInstance(), source.getControllerId(), source, game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/p/PhyrexianHydra.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianHydra.java
@@ -81,7 +81,7 @@ class PhyrexianHydraEffect extends PreventionEffectImpl {
         }
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null) {
-            permanent.addCounters(CounterType.M1M1.createInstance(damage), source, game);
+            permanent.addCounters(CounterType.M1M1.createInstance(damage), source.getControllerId(), source, game);
         }
         return retValue;
     }

--- a/Mage.Sets/src/mage/cards/p/PhyrexianUnlife.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianUnlife.java
@@ -18,7 +18,6 @@ import mage.game.Game;
 import mage.game.events.DamagePlayerEvent;
 import mage.game.events.DamagedPlayerEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
@@ -78,7 +77,7 @@ class PhyrexianUnlifeEffect2 extends ReplacementEffectImpl {
         if (actualDamage > 0) {
             Player player = game.getPlayer(damageEvent.getPlayerId());
             Permanent damageSource = game.getPermanent(damageEvent.getSourceId());
-            player.addCounters(CounterType.POISON.createInstance(actualDamage), source, game);
+            player.addCounters(CounterType.POISON.createInstance(actualDamage), source.getControllerId(), source, game);
             if (damageSource != null && damageSource.getAbilities().containsKey(LifelinkAbility.getInstance().getId())) {
                 Player controlPlayer = game.getPlayer(damageSource.getControllerId());
                 controlPlayer.gainLife(actualDamage, game, source);

--- a/Mage.Sets/src/mage/cards/p/PhyrexianVatmother.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianVatmother.java
@@ -66,7 +66,7 @@ class PoisonControllerEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            player.addCounters(CounterType.POISON.createInstance(), source, game);
+            player.addCounters(CounterType.POISON.createInstance(), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/p/Phytohydra.java
+++ b/Mage.Sets/src/mage/cards/p/Phytohydra.java
@@ -13,7 +13,6 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.DamageCreatureEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 
 /**
@@ -59,7 +58,7 @@ class PhytohydraEffect extends ReplacementEffectImpl {
         DamageCreatureEvent damageEvent = (DamageCreatureEvent) event;
         Permanent p = game.getPermanent(source.getSourceId());
         if (p != null) {
-            p.addCounters(CounterType.P1P1.createInstance(damageEvent.getAmount()), source, game);
+            p.addCounters(CounterType.P1P1.createInstance(damageEvent.getAmount()), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/p/PistusStrike.java
+++ b/Mage.Sets/src/mage/cards/p/PistusStrike.java
@@ -70,7 +70,7 @@ class PoisonControllerTargetCreatureEffect extends OneShotEffect {
         if (permanent != null) {
             Player player = game.getPlayer(permanent.getControllerId());
             if (player != null) {
-                player.addCounters(CounterType.POISON.createInstance(), source, game);
+                player.addCounters(CounterType.POISON.createInstance(), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/p/PolukranosUnchained.java
+++ b/Mage.Sets/src/mage/cards/p/PolukranosUnchained.java
@@ -101,7 +101,7 @@ class PolukranosUnchainedEffect extends OneShotEffect {
             counters = 6;
         }
         List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects");
-        permanent.addCounters(CounterType.P1P1.createInstance(counters), source, game, appliedEffects);
+        permanent.addCounters(CounterType.P1P1.createInstance(counters), source.getControllerId(), source, game, appliedEffects);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalAmulet.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalAmulet.java
@@ -83,7 +83,7 @@ class PrimalAmuletEffect extends OneShotEffect {
         Player player = game.getPlayer(source.getControllerId());
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null && player != null) {
-            permanent.addCounters(CounterType.CHARGE.createInstance(), source, game);
+            permanent.addCounters(CounterType.CHARGE.createInstance(), source.getControllerId(), source, game);
             int counters = permanent.getCounters(game).getCount(CounterType.CHARGE);
             if (counters > 3 && player.chooseUse(Outcome.Benefit, "Transform this?", source, game)) {
                 permanent.removeCounters("charge", counters, source, game);

--- a/Mage.Sets/src/mage/cards/p/PrimalEmpathy.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalEmpathy.java
@@ -91,6 +91,6 @@ class PrimalEmpathyEffect extends OneShotEffect {
             return false;
         }
         Permanent permanent = game.getPermanent(target.getFirstTarget());
-        return permanent != null && permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+        return permanent != null && permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PrimalInstinct.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalInstinct.java
@@ -55,10 +55,10 @@ class PrimalInstictEffect extends OneShotEffect {
         if (controller != null) {
             Permanent target = game.getPermanent(getTargetPointer().getFirst(game, source));
             if (target != null) {
-                target.addCounters(CounterType.P1P1.createInstance(), source, game);
+                target.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 int addCounterCount = target.getCounters(game).getCount(CounterType.P1P1);
                 game.informPlayers("Counters " + addCounterCount);
-                target.addCounters(CounterType.P1P1.createInstance(addCounterCount), source, game);
+                target.addCounters(CounterType.P1P1.createInstance(addCounterCount), source.getControllerId(), source, game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/p/PrimordialHydra.java
+++ b/Mage.Sets/src/mage/cards/p/PrimordialHydra.java
@@ -79,7 +79,7 @@ class PrimordialHydraDoubleEffect extends OneShotEffect {
         if (sourcePermanent != null) {
             int amount = sourcePermanent.getCounters(game).getCount(CounterType.P1P1);
             if (amount > 0) {
-                sourcePermanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                sourcePermanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/q/QuarryHauler.java
+++ b/Mage.Sets/src/mage/cards/q/QuarryHauler.java
@@ -82,7 +82,7 @@ class QuarryHaulerEffect extends OneShotEffect {
                         } else {
                             counterToAdd = new Counter(counter.getName());
                         }
-                        permanent.addCounters(counterToAdd, source, game);
+                        permanent.addCounters(counterToAdd, source.getControllerId(), source, game);
                     } else {
                         counterType = CounterType.findByName(counter.getName());
                         if (counterType != null) {

--- a/Mage.Sets/src/mage/cards/q/QuestForUlasTemple.java
+++ b/Mage.Sets/src/mage/cards/q/QuestForUlasTemple.java
@@ -19,7 +19,6 @@ import mage.filter.common.FilterCreatureCard;
 import mage.filter.predicate.Predicates;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
@@ -84,7 +83,7 @@ class QuestForUlasTempleEffect extends OneShotEffect {
                     controller.revealCards(sourcePermanent.getName(), cards, game);
                     Permanent questForUlasTemple = game.getPermanent(source.getSourceId());
                     if (questForUlasTemple != null) {
-                        questForUlasTemple.addCounters(CounterType.QUEST.createInstance(), source, game);
+                        questForUlasTemple.addCounters(CounterType.QUEST.createInstance(), source.getControllerId(), source, game);
                         return true;
                     }
                 }

--- a/Mage.Sets/src/mage/cards/q/QuicksilverFountain.java
+++ b/Mage.Sets/src/mage/cards/q/QuicksilverFountain.java
@@ -99,7 +99,7 @@ class QuicksilverFountainEffect extends OneShotEffect {
         Player player = game.getPlayer(game.getActivePlayerId());
         if (player != null) {
             Permanent landChosen = game.getPermanent(source.getFirstTarget());
-            landChosen.addCounters(CounterType.FLOOD.createInstance(), source, game);
+            landChosen.addCounters(CounterType.FLOOD.createInstance(), source.getControllerId(), source, game);
             ContinuousEffect becomesBasicLandTargetEffect
                     = new BecomesBasicLandTargetEffect(Duration.Custom, false, SubType.ISLAND);
             ConditionalContinuousEffect effect

--- a/Mage.Sets/src/mage/cards/q/QuicksilverFountain.java
+++ b/Mage.Sets/src/mage/cards/q/QuicksilverFountain.java
@@ -1,6 +1,5 @@
 package mage.cards.q;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.BeginningOfEndStepTriggeredAbility;
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
@@ -12,12 +11,7 @@ import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.continuous.BecomesBasicLandTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.counters.CounterType;
 import mage.filter.common.FilterLandPermanent;
 import mage.filter.predicate.Predicates;
@@ -27,8 +21,9 @@ import mage.players.Player;
 import mage.target.common.TargetLandPermanent;
 import mage.target.targetadjustment.TargetAdjuster;
 
+import java.util.UUID;
+
 /**
- *
  * @author jeffwadsworth
  */
 public final class QuicksilverFountain extends CardImpl {
@@ -99,12 +94,12 @@ class QuicksilverFountainEffect extends OneShotEffect {
         Player player = game.getPlayer(game.getActivePlayerId());
         if (player != null) {
             Permanent landChosen = game.getPermanent(source.getFirstTarget());
-            landChosen.addCounters(CounterType.FLOOD.createInstance(), source.getControllerId(), source, game);
+            landChosen.addCounters(CounterType.FLOOD.createInstance(), player.getId(), source, game);
             ContinuousEffect becomesBasicLandTargetEffect
                     = new BecomesBasicLandTargetEffect(Duration.Custom, false, SubType.ISLAND);
             ConditionalContinuousEffect effect
                     = new ConditionalContinuousEffect(becomesBasicLandTargetEffect,
-                            new LandHasFloodCounterCondition(), staticText);
+                    new LandHasFloodCounterCondition(), staticText);
             // Bug #6885 Fixed when owner/controller leaves the game the effect still applies
             SimpleStaticAbility gainAbility = new SimpleStaticAbility(Zone.BATTLEFIELD, effect);
             gainAbility.setSourceId(landChosen.getId());

--- a/Mage.Sets/src/mage/cards/r/RakdosRiteknife.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosRiteknife.java
@@ -87,7 +87,7 @@ class RakdosRiteKnifeEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent equipment = game.getPermanent(this.effectGivingEquipmentId);
         if (equipment != null) {
-            equipment.addCounters(CounterType.BLOOD.createInstance(), source, game);
+            equipment.addCounters(CounterType.BLOOD.createInstance(), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/r/RamosDragonEngine.java
+++ b/Mage.Sets/src/mage/cards/r/RamosDragonEngine.java
@@ -94,7 +94,7 @@ class RamosDragonEngineAddCountersEffect extends OneShotEffect {
                     ++amount;
                 }
                 if (amount > 0) {
-                    permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                    permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/r/RayamiFirstOfTheFallen.java
+++ b/Mage.Sets/src/mage/cards/r/RayamiFirstOfTheFallen.java
@@ -130,7 +130,7 @@ class RayamiFirstOfTheFallenReplacementEffect extends ReplacementEffectImpl {
         }
         controller.moveCards(permanent, Zone.EXILED, source, game);
         Card card = game.getCard(permanent.getId());
-        card.addCounters(CounterType.BLOOD.createInstance(), source, game);
+        card.addCounters(CounterType.BLOOD.createInstance(), source.getControllerId(), source, game);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/r/RegnasSanction.java
+++ b/Mage.Sets/src/mage/cards/r/RegnasSanction.java
@@ -1,25 +1,27 @@
 package mage.cards.r;
 
-import java.util.UUID;
-
+import mage.MageItem;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.TapAllEffect;
-import mage.abilities.effects.common.counter.AddCountersAllEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.choices.ChooseFriendsAndFoes;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.counters.CounterType;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.filter.predicate.permanent.PermanentIdPredicate;
 import mage.filter.predicate.permanent.TappedPredicate;
 import mage.game.Game;
+import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
+
+import java.util.UUID;
 
 /**
  * @author TheElk801
@@ -81,11 +83,12 @@ class RegnasSanctionEffect extends OneShotEffect {
                 filterToTap.add(Predicates.not(new PermanentIdPredicate(target.getFirstTarget())));
             }
         }
-        for (Player player : choice.getFriends()) {
-            FilterCreaturePermanent filter = new FilterCreaturePermanent();
-            filter.add(new ControllerIdPredicate(player.getId()));
-            new AddCountersAllEffect(CounterType.P1P1.createInstance(), filter).apply(game, source);
-            filterToTap.add(Predicates.not(new ControllerIdPredicate(player.getId())));
+        for (Permanent permanent : game.getBattlefield().getActivePermanents(
+                StaticFilters.FILTER_PERMANENT_CREATURE, source.getControllerId(), source.getSourceId(), game
+        )) {
+            if (choice.getFriends().stream().map(MageItem::getId).anyMatch(permanent::isControlledBy)) {
+                permanent.addCounters(CounterType.P1P1.createInstance(), permanent.getControllerId(), source, game);
+            }
         }
         return new TapAllEffect(filterToTap).apply(game, source);
     }

--- a/Mage.Sets/src/mage/cards/r/RenataCalledToTheHunt.java
+++ b/Mage.Sets/src/mage/cards/r/RenataCalledToTheHunt.java
@@ -80,7 +80,7 @@ class RenataCalledToTheHuntReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/r/ReplicatingRing.java
+++ b/Mage.Sets/src/mage/cards/r/ReplicatingRing.java
@@ -68,7 +68,7 @@ class ReplicatingRingEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent permanent = source.getSourcePermanentIfItStillExists(game);
         if (permanent != null) {
-            permanent.addCounters(CounterType.NIGHT.createInstance(), source, game);
+            permanent.addCounters(CounterType.NIGHT.createInstance(), source.getControllerId(), source, game);
         }
         permanent = source.getSourcePermanentOrLKI(game);
         if (permanent == null || permanent.getCounters(game).getCount(CounterType.NIGHT) < 8) {

--- a/Mage.Sets/src/mage/cards/r/ResplendentMarshal.java
+++ b/Mage.Sets/src/mage/cards/r/ResplendentMarshal.java
@@ -95,7 +95,7 @@ class ResplendentMarshalEffect extends OneShotEffect {
             for (Permanent permanent : game.getBattlefield().getActivePermanents(
                     StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, source.getControllerId(), source.getSourceId(), game)) {
                 if (permanent.shareCreatureTypes(game, exiledCard)) {
-                    permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                    permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                     if (!game.isSimulation()) {
                         game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName()
                                 + " puts a +1/+1 counter on " + permanent.getLogName());

--- a/Mage.Sets/src/mage/cards/r/Retribution.java
+++ b/Mage.Sets/src/mage/cards/r/Retribution.java
@@ -75,7 +75,7 @@ class RetributionEffect extends OneShotEffect {
                         creature.sacrifice(source, game);
                         sacrificeDone = true;
                     } else {
-                        creature.addCounters(CounterType.M1M1.createInstance(), source, game);
+                        creature.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), source, game);
                     }
                     count++;
                 }

--- a/Mage.Sets/src/mage/cards/r/RhythmOfTheWild.java
+++ b/Mage.Sets/src/mage/cards/r/RhythmOfTheWild.java
@@ -111,7 +111,7 @@ class RhythmOfTheWildEffect extends ReplacementEffectImpl {
                 null, "+1/+1 counter", "Haste", source, game
         )) {
             game.informPlayers(player.getLogName() + " choose to put a +1/+1 counter on " + creature.getName());
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         } else {
             ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);
             effect.setTargetPointer(new FixedTarget(creature.getId(), creature.getZoneChangeCounter(game) + 1));

--- a/Mage.Sets/src/mage/cards/r/RowdyCrew.java
+++ b/Mage.Sets/src/mage/cards/r/RowdyCrew.java
@@ -90,7 +90,7 @@ class RowdyCrewEffect extends OneShotEffect {
                         if (game.getCard(cardId).getCardType().contains(type)) {
                             count++;
                             if (count > 1) {
-                                creature.addCounters(CounterType.P1P1.createInstance(2), source, game);
+                                creature.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
                                 return true;
                             }
                         }

--- a/Mage.Sets/src/mage/cards/s/SageOfFables.java
+++ b/Mage.Sets/src/mage/cards/s/SageOfFables.java
@@ -86,7 +86,7 @@ class SageOfFablesReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/s/SavageSummoning.java
+++ b/Mage.Sets/src/mage/cards/s/SavageSummoning.java
@@ -16,7 +16,6 @@ import mage.game.Game;
 import mage.game.command.Commander;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.game.stack.Spell;
 import mage.watchers.Watcher;
@@ -265,7 +264,7 @@ class SavageSummoningEntersBattlefieldEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         discard();
         return false;

--- a/Mage.Sets/src/mage/cards/s/ScaleBlessing.java
+++ b/Mage.Sets/src/mage/cards/s/ScaleBlessing.java
@@ -72,7 +72,7 @@ class ScaleBlessingEffect extends OneShotEffect {
         MageObject sourceObject = source.getSourceObject(game);
         if (controller != null && sourceObject != null) {
             for (Permanent permanent : game.getState().getBattlefield().getAllActivePermanents(filter, controller.getId(), game)) {
-                permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 game.informPlayers(sourceObject.getName() + ": Put a +1/+1 counter on " + permanent.getLogName());
             }
         }

--- a/Mage.Sets/src/mage/cards/s/ScarscaleRitual.java
+++ b/Mage.Sets/src/mage/cards/s/ScarscaleRitual.java
@@ -72,7 +72,7 @@ class ScarscaleRitualCost extends CostImpl {
             controller.chooseTarget(Outcome.UnboostCreature, target, ability, game);
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
-                permanent.addCounters(CounterType.M1M1.createInstance(), ability, game);
+                permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), ability, game);
                 game.informPlayers(controller.getLogName() + " puts a -1/-1 counter on " + permanent.getLogName());
                 this.paid = true;
             }

--- a/Mage.Sets/src/mage/cards/s/ScarscaleRitual.java
+++ b/Mage.Sets/src/mage/cards/s/ScarscaleRitual.java
@@ -72,7 +72,7 @@ class ScarscaleRitualCost extends CostImpl {
             controller.chooseTarget(Outcome.UnboostCreature, target, ability, game);
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
-                permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), ability, game);
+                permanent.addCounters(CounterType.M1M1.createInstance(), controllerId, ability, game);
                 game.informPlayers(controller.getLogName() + " puts a -1/-1 counter on " + permanent.getLogName());
                 this.paid = true;
             }

--- a/Mage.Sets/src/mage/cards/s/ScavengingOoze.java
+++ b/Mage.Sets/src/mage/cards/s/ScavengingOoze.java
@@ -74,7 +74,7 @@ class ScavengingOozeEffect extends OneShotEffect {
             if (card.isCreature()) {
                 Permanent sourcePermanent = game.getPermanent(source.getSourceId());
                 if (sourcePermanent != null) {
-                    sourcePermanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                    sourcePermanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 }
                 controller.gainLife(1, game, source);
             }

--- a/Mage.Sets/src/mage/cards/s/ScroungingBandar.java
+++ b/Mage.Sets/src/mage/cards/s/ScroungingBandar.java
@@ -91,7 +91,7 @@ class ScroungingBandarEffect extends OneShotEffect {
                     int amountToMove = controller.getAmount(0, amountCounters, "How many counters do you want to move?", game);
                     if (amountToMove > 0) {
                         fromPermanent.removeCounters(CounterType.P1P1.createInstance(amountToMove), source, game);
-                        toPermanent.addCounters(CounterType.P1P1.createInstance(amountToMove), source, game);
+                        toPermanent.addCounters(CounterType.P1P1.createInstance(amountToMove), source.getControllerId(), source, game);
                     }
                 }
                 return true;

--- a/Mage.Sets/src/mage/cards/s/SelvalasEnforcer.java
+++ b/Mage.Sets/src/mage/cards/s/SelvalasEnforcer.java
@@ -75,7 +75,7 @@ class SelvalasEnforcerEffect extends OneShotEffect {
             if (parley > 0) {
                 Permanent sourcePermanent = game.getPermanent(source.getSourceId());
                 if (sourcePermanent != null) {
-                    sourcePermanent.addCounters(CounterType.P1P1.createInstance(parley), source, game);
+                    sourcePermanent.addCounters(CounterType.P1P1.createInstance(parley), source.getControllerId(), source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/s/SettleTheScore.java
+++ b/Mage.Sets/src/mage/cards/s/SettleTheScore.java
@@ -74,7 +74,7 @@ class SettleTheScoreEffect extends OneShotEffect {
         if (target.choose(Outcome.Benefit, player.getId(), source.getSourceId(), game)) {
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
-                permanent.addCounters(CounterType.LOYALTY.createInstance(2), source, game);
+                permanent.addCounters(CounterType.LOYALTY.createInstance(2), source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/s/ShelteringAncient.java
+++ b/Mage.Sets/src/mage/cards/s/ShelteringAncient.java
@@ -70,7 +70,7 @@ class ShelteringAncientCost extends CostImpl {
             if (target.choose(Outcome.BoostCreature, controllerId, source.getSourceId(), game)) {
                 Permanent permanent = game.getPermanent(target.getFirstTarget());
                 if (permanent != null) {
-                    permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), ability, game);
+                    permanent.addCounters(CounterType.P1P1.createInstance(), controllerId, ability, game);
                     this.paid = true;
                     return true;
                 }

--- a/Mage.Sets/src/mage/cards/s/ShelteringAncient.java
+++ b/Mage.Sets/src/mage/cards/s/ShelteringAncient.java
@@ -70,7 +70,7 @@ class ShelteringAncientCost extends CostImpl {
             if (target.choose(Outcome.BoostCreature, controllerId, source.getSourceId(), game)) {
                 Permanent permanent = game.getPermanent(target.getFirstTarget());
                 if (permanent != null) {
-                    permanent.addCounters(CounterType.P1P1.createInstance(), ability, game);
+                    permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), ability, game);
                     this.paid = true;
                     return true;
                 }

--- a/Mage.Sets/src/mage/cards/s/ShimatsuTheBloodcloaked.java
+++ b/Mage.Sets/src/mage/cards/s/ShimatsuTheBloodcloaked.java
@@ -93,7 +93,7 @@ class ShimatsuTheBloodcloakedEffect extends ReplacementEffectImpl {
                         return false;
                     }
                 }
-                creature.addCounters(CounterType.P1P1.createInstance(sacrificedCreatures), source, game);
+                creature.addCounters(CounterType.P1P1.createInstance(sacrificedCreatures), source.getControllerId(), source, game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/ShivanSandMage.java
+++ b/Mage.Sets/src/mage/cards/s/ShivanSandMage.java
@@ -89,7 +89,7 @@ class ShivanSandMageEffect extends OneShotEffect {
         Permanent permanent = game.getPermanent(this.getTargetPointer().getFirst(game, source));
         if (permanent != null) {
             if (addCounters) {
-                permanent.addCounters(CounterType.TIME.createInstance(2), source, game);
+                permanent.addCounters(CounterType.TIME.createInstance(2), source.getControllerId(), source, game);
             } else {
                 permanent.removeCounters(CounterType.TIME.getName(), 2, source, game);
             }
@@ -98,7 +98,7 @@ class ShivanSandMageEffect extends OneShotEffect {
         Card card = game.getCard(this.getTargetPointer().getFirst(game, source));
         if (card != null) {
             if (addCounters) {
-                card.addCounters(CounterType.TIME.createInstance(2), source, game);
+                card.addCounters(CounterType.TIME.createInstance(2), source.getControllerId(), source, game);
             } else {
                 card.removeCounters(CounterType.TIME.getName(), 2, source, game);
             }

--- a/Mage.Sets/src/mage/cards/s/SimicFluxmage.java
+++ b/Mage.Sets/src/mage/cards/s/SimicFluxmage.java
@@ -78,7 +78,7 @@ class MoveCounterFromSourceToTargetEffect extends OneShotEffect {
             Permanent targetPermanent = game.getPermanent(targetPointer.getFirst(game, source));
             if (targetPermanent != null) {
                 sourcePermanent.removeCounters(CounterType.P1P1.createInstance(), source, game);
-                targetPermanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                targetPermanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/s/SimicGuildmage.java
+++ b/Mage.Sets/src/mage/cards/s/SimicGuildmage.java
@@ -112,7 +112,7 @@ class MoveCounterFromTargetToTargetEffect extends OneShotEffect {
                 return false;
             }
             fromPermanent.removeCounters(CounterType.P1P1.createInstance(1), source, game);
-            toPermanent.addCounters(CounterType.P1P1.createInstance(1), source, game);
+            toPermanent.addCounters(CounterType.P1P1.createInstance(1), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/SithLord.java
+++ b/Mage.Sets/src/mage/cards/s/SithLord.java
@@ -63,7 +63,7 @@ public final class SithLord extends CardImpl {
             if (permanent != null) {
                 int oll = OpponentsLostLifeCount.instance.calculate(game, source, this);
                 if (oll > 0) {
-                    permanent.addCounters(CounterType.P1P1.createInstance(oll), source, game);
+                    permanent.addCounters(CounterType.P1P1.createInstance(oll), source.getControllerId(), source, game);
                 }
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/s/SixyBeast.java
+++ b/Mage.Sets/src/mage/cards/s/SixyBeast.java
@@ -68,7 +68,7 @@ class SixyBeastEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (permanent != null && controller != null) {
             int counterAmount = controller.getAmount(0, 6, "Secretly put up to six counters on " + permanent.getName(), game);
-            permanent.addCounters(CounterType.P1P1.createInstance(counterAmount), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(counterAmount), source.getControllerId(), source, game);
             Player opponent = null;
             Set<UUID> opponents = game.getOpponents(source.getControllerId());
             if (!opponents.isEmpty()) {

--- a/Mage.Sets/src/mage/cards/s/SkyshipPlunderer.java
+++ b/Mage.Sets/src/mage/cards/s/SkyshipPlunderer.java
@@ -95,7 +95,7 @@ class SkyshipPlundererEffect extends OneShotEffect {
                     } else {
                         counterToAdd = new Counter(counter.getName());
                     }
-                    permanent.addCounters(counterToAdd, source, game);
+                    permanent.addCounters(counterToAdd, source.getControllerId(), source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/s/SkyshipPlunderer.java
+++ b/Mage.Sets/src/mage/cards/s/SkyshipPlunderer.java
@@ -80,7 +80,7 @@ class SkyshipPlundererEffect extends OneShotEffect {
                     } else {
                         counterToAdd = new Counter(counter.getName());
                     }
-                    player.addCounters(counterToAdd, source, game);
+                    player.addCounters(counterToAdd, source.getControllerId(), source, game);
                 }
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/s/SlipperyBogbonder.java
+++ b/Mage.Sets/src/mage/cards/s/SlipperyBogbonder.java
@@ -134,7 +134,7 @@ class SlipperyBogbonderEffect extends OneShotEffect {
                     .stream()
                     .filter(entry -> entry.getValue() > 0)
                     .map(entry -> CounterType.findByName(entry.getKey()).createInstance(entry.getValue()))
-                    .filter(counter -> creature.addCounters(counter, source, game))
+                    .filter(counter -> creature.addCounters(counter, source.getControllerId(), source, game))
                     .forEach(counter -> permanent.removeCounters(counter, source, game));
         }
         return true;

--- a/Mage.Sets/src/mage/cards/s/SolidarityOfHeroes.java
+++ b/Mage.Sets/src/mage/cards/s/SolidarityOfHeroes.java
@@ -66,7 +66,7 @@ class SolidarityOfHeroesEffect extends OneShotEffect {
                 if (permanent != null) {
                     int existingCounters = permanent.getCounters(game).getCount(CounterType.P1P1);
                     if (existingCounters > 0) {
-                        permanent.addCounters(CounterType.P1P1.createInstance(existingCounters), source, game);
+                        permanent.addCounters(CounterType.P1P1.createInstance(existingCounters), source.getControllerId(), source, game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/s/SorinImperiousBloodlord.java
+++ b/Mage.Sets/src/mage/cards/s/SorinImperiousBloodlord.java
@@ -110,7 +110,7 @@ class SorinImperiousBloodlordEffect extends OneShotEffect {
             return false;
         }
         if (permanent.hasSubtype(SubType.VAMPIRE, game)) {
-            permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         }
         game.addEffect(new GainAbilityTargetEffect(DeathtouchAbility.getInstance(), Duration.EndOfTurn), source);
         game.addEffect(new GainAbilityTargetEffect(LifelinkAbility.getInstance(), Duration.EndOfTurn), source);

--- a/Mage.Sets/src/mage/cards/s/SoulExchange.java
+++ b/Mage.Sets/src/mage/cards/s/SoulExchange.java
@@ -77,7 +77,7 @@ class SoulExchangeEffect extends OneShotEffect {
                 for (Permanent exiled : ((ExileTargetCost) c).getPermanents()) {
                     if (exiled != null) {
                         if (exiled.hasSubtype(SubType.THRULL, game)) {
-                            game.getPermanent(source.getFirstTarget()).addCounters(CounterType.P2P2.createInstance(), source, game);
+                            game.getPermanent(source.getFirstTarget()).addCounters(CounterType.P2P2.createInstance(), source.getControllerId(), source, game);
                             return true;
                         }
                     } else {

--- a/Mage.Sets/src/mage/cards/s/SoulsMight.java
+++ b/Mage.Sets/src/mage/cards/s/SoulsMight.java
@@ -58,7 +58,7 @@ class SoulsMightEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent permanent = game.getPermanent(source.getFirstTarget());
         if (permanent != null && permanent.getPower().getValue() > 0) {
-            permanent.addCounters(CounterType.P1P1.createInstance(permanent.getPower().getValue()), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(permanent.getPower().getValue()), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/SphinxBoneWand.java
+++ b/Mage.Sets/src/mage/cards/s/SphinxBoneWand.java
@@ -69,7 +69,7 @@ class SphinxBoneWandEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent sourcePermanent = game.getPermanent(source.getSourceId());
         if (sourcePermanent != null) {
-            sourcePermanent.addCounters(CounterType.CHARGE.createInstance(), source, game);
+            sourcePermanent.addCounters(CounterType.CHARGE.createInstance(), source.getControllerId(), source, game);
             int amount = sourcePermanent.getCounters(game).getCount(CounterType.CHARGE);
 
             Permanent permanent = game.getPermanent(source.getFirstTarget());

--- a/Mage.Sets/src/mage/cards/s/SpikeCannibal.java
+++ b/Mage.Sets/src/mage/cards/s/SpikeCannibal.java
@@ -87,7 +87,7 @@ class SpikeCannibalEffect extends OneShotEffect {
             }
 
             if (countersRemoved > 0) {
-                sourcePermanent.addCounters(CounterType.P1P1.createInstance(countersRemoved), source, game);
+                sourcePermanent.addCounters(CounterType.P1P1.createInstance(countersRemoved), source.getControllerId(), source, game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/s/StormwildCapridor.java
+++ b/Mage.Sets/src/mage/cards/s/StormwildCapridor.java
@@ -78,7 +78,7 @@ class StormwildCapridorEffect extends PreventionEffectImpl {
         if (preventionEffectData.getPreventedDamage() > 0) {
             Permanent permanent = game.getPermanent(source.getSourceId());
             if (permanent != null) {
-                permanent.addCounters(CounterType.P1P1.createInstance(preventionEffectData.getPreventedDamage()), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(preventionEffectData.getPreventedDamage()), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/s/StrengthOfTheTajuru.java
+++ b/Mage.Sets/src/mage/cards/s/StrengthOfTheTajuru.java
@@ -73,7 +73,7 @@ class StrengthOfTheTajuruAddCountersTargetEffect extends OneShotEffect {
         for (UUID uuid : targetPointer.getTargets(game, source)) {
             Permanent permanent = game.getPermanent(uuid);
             if (permanent != null) {
-                permanent.addCounters(counter.copy(), source, game);
+                permanent.addCounters(counter.copy(), source.getControllerId(), source, game);
                 affectedTargets++;
             }
         }

--- a/Mage.Sets/src/mage/cards/s/StumpsquallHydra.java
+++ b/Mage.Sets/src/mage/cards/s/StumpsquallHydra.java
@@ -110,7 +110,7 @@ class StumpsquallHydraEffect extends OneShotEffect {
             if (permanent == null) {
                 continue;
             }
-            permanent.addCounters(CounterType.P1P1.createInstance(targetAmount.getTargetAmount(targetId)), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(targetAmount.getTargetAmount(targetId)), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/s/SupremeLeaderSnoke.java
+++ b/Mage.Sets/src/mage/cards/s/SupremeLeaderSnoke.java
@@ -137,7 +137,7 @@ class SupremeLeaderSnokeCounterEffect extends OneShotEffect {
             if (amount > 0) {
                 Counter counterToAdd = counter.copy();
                 counterToAdd.add(amount - counter.getCount());
-                permanent.addCounters(counterToAdd, source, game);
+                permanent.addCounters(counterToAdd, source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/s/SwallowWhole.java
+++ b/Mage.Sets/src/mage/cards/s/SwallowWhole.java
@@ -87,6 +87,6 @@ class SwallowWholeEffect extends OneShotEffect {
                 .map(game::getPermanent)
                 .findFirst()
                 .orElse(null);
-        return permanent != null && permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+        return permanent != null && permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SwordOfTruthAndJustice.java
+++ b/Mage.Sets/src/mage/cards/s/SwordOfTruthAndJustice.java
@@ -89,7 +89,7 @@ class SwordOfTruthAndJusticeEffect extends OneShotEffect {
         if (player.choose(outcome, target, source.getSourceId(), game)) {
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
-                permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
             }
         }
         return new ProliferateEffect().apply(game, source);

--- a/Mage.Sets/src/mage/cards/s/SzadekLordOfSecrets.java
+++ b/Mage.Sets/src/mage/cards/s/SzadekLordOfSecrets.java
@@ -69,7 +69,7 @@ class SzadekLordOfSecretsEffect extends ReplacementEffectImpl {
         if (damageEvent.isCombatDamage()) {
             Permanent permanent = game.getPermanent(source.getSourceId());
             if (permanent != null) {
-                permanent.addCounters(CounterType.P1P1.createInstance(damageEvent.getAmount()), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(damageEvent.getAmount()), source.getControllerId(), source, game);
                 if (damagedPlayer != null) {
                     damagedPlayer.millCards(damageEvent.getAmount(), source, game);
                 }

--- a/Mage.Sets/src/mage/cards/t/TalusPaladin.java
+++ b/Mage.Sets/src/mage/cards/t/TalusPaladin.java
@@ -15,7 +15,6 @@ import mage.counters.CounterType;
 import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
@@ -116,7 +115,7 @@ class TalusPaladinEffect extends OneShotEffect {
             if (!player.chooseUse(Outcome.Benefit, question, source, game)) {
                 return false;
             }
-            taluspPaladin.addCounters(CounterType.P1P1.createInstance(), source, game);
+            taluspPaladin.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/t/TayamLuminousEnigma.java
+++ b/Mage.Sets/src/mage/cards/t/TayamLuminousEnigma.java
@@ -224,7 +224,7 @@ class TayamLuminousEnigmaReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.VIGILANCE.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.VIGILANCE.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/t/TeferisTimeTwist.java
+++ b/Mage.Sets/src/mage/cards/t/TeferisTimeTwist.java
@@ -116,7 +116,7 @@ class TeferisTimeTwistReturnEffect extends OneShotEffect {
             // TODO: This is technically wrong as it should enter with the counters,
             // however there's currently no way to know that for sure
             // this is similar to the blood moon issue
-            permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/t/Temper.java
+++ b/Mage.Sets/src/mage/cards/t/Temper.java
@@ -99,7 +99,7 @@ class TemperPreventDamageTargetEffect extends PreventionEffectImpl {
             if (prevented > 0) {
                 Permanent targetPermanent = game.getPermanent(source.getTargets().getFirstTarget());
                 if (targetPermanent != null) {
-                    targetPermanent.addCounters(CounterType.P1P1.createInstance(prevented), source, game);
+                    targetPermanent.addCounters(CounterType.P1P1.createInstance(prevented), source.getControllerId(), source, game);
                     game.informPlayers("Temper: Prevented " + prevented + " damage ");
                     game.informPlayers("Temper: Adding " + prevented + " +1/+1 counters to " + targetPermanent.getName());
                 }

--- a/Mage.Sets/src/mage/cards/t/TemptWithGlory.java
+++ b/Mage.Sets/src/mage/cards/t/TemptWithGlory.java
@@ -84,7 +84,7 @@ class TemptWithGloryEffect extends OneShotEffect {
 
     private void addCounterToEachCreature(UUID playerId, Counter counter, Ability source, Game game) {
         for (Permanent permanent : game.getBattlefield().getAllActivePermanents(filter, playerId, game)) {
-            permanent.addCounters(counter, source, game);
+            permanent.addCounters(counter, source.getControllerId(), source, game);
         }
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TemptWithGlory.java
+++ b/Mage.Sets/src/mage/cards/t/TemptWithGlory.java
@@ -84,7 +84,7 @@ class TemptWithGloryEffect extends OneShotEffect {
 
     private void addCounterToEachCreature(UUID playerId, Counter counter, Ability source, Game game) {
         for (Permanent permanent : game.getBattlefield().getAllActivePermanents(filter, playerId, game)) {
-            permanent.addCounters(counter, source.getControllerId(), source, game);
+            permanent.addCounters(counter, playerId, source, game);
         }
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TestOfFaith.java
+++ b/Mage.Sets/src/mage/cards/t/TestOfFaith.java
@@ -87,7 +87,7 @@ class TestOfFaithPreventDamageTargetEffect extends PreventionEffectImpl {
             if (prevented > 0) {
                 Permanent targetPermanent = game.getPermanent(source.getTargets().getFirstTarget());
                 if (targetPermanent != null) {
-                    targetPermanent.addCounters(CounterType.P1P1.createInstance(prevented), source, game);
+                    targetPermanent.addCounters(CounterType.P1P1.createInstance(prevented), source.getControllerId(), source, game);
                     game.informPlayers("Test of Faith: Prevented " + prevented + " damage ");
                     game.informPlayers("Test of Faith: Adding " + prevented + " +1/+1 counters to " + targetPermanent.getName());
                 }

--- a/Mage.Sets/src/mage/cards/t/TheBattleOfEndor.java
+++ b/Mage.Sets/src/mage/cards/t/TheBattleOfEndor.java
@@ -78,7 +78,7 @@ class TheBattleOfEndorEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             for (Permanent permanent : game.getBattlefield().getActivePermanents(new FilterControlledCreaturePermanent(), source.getControllerId(), source.getSourceId(), game)) {
-                permanent.addCounters(CounterType.P1P1.createInstance(source.getManaCostsToPay().getX()), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(source.getManaCostsToPay().getX()), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/t/TheElderspell.java
+++ b/Mage.Sets/src/mage/cards/t/TheElderspell.java
@@ -82,6 +82,6 @@ class TheElderspellEffect extends OneShotEffect {
         if (permanent == null) {
             return false;
         }
-        return permanent.addCounters(CounterType.LOYALTY.createInstance(2 * count), source, game);
+        return permanent.addCounters(CounterType.LOYALTY.createInstance(2 * count), source.getControllerId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TheMimeoplasm.java
+++ b/Mage.Sets/src/mage/cards/t/TheMimeoplasm.java
@@ -87,7 +87,7 @@ class TheMimeoplasmEffect extends OneShotEffect {
                                     controller.moveCards(cardsToExile, Zone.EXILED, source, game);
                                     CopyEffect copyEffect = new CopyEffect(Duration.Custom, cardToCopy, source.getSourceId());
                                     game.addEffect(copyEffect, source);
-                                    permanent.addCounters(CounterType.P1P1.createInstance(cardForCounters.getPower().getValue()), source, game);
+                                    permanent.addCounters(CounterType.P1P1.createInstance(cardForCounters.getPower().getValue()), source.getControllerId(), source, game);
                                 }
                             }
                         }

--- a/Mage.Sets/src/mage/cards/t/TheOzolith.java
+++ b/Mage.Sets/src/mage/cards/t/TheOzolith.java
@@ -123,7 +123,7 @@ class TheOzolithLeaveEffect extends OneShotEffect {
         }
         counters.values()
                 .stream()
-                .forEach(counter -> permanent.addCounters(counter, source, game));
+                .forEach(counter -> permanent.addCounters(counter, source.getControllerId(), source, game));
         return true;
     }
 }
@@ -174,7 +174,7 @@ class TheOzolithMoveCountersEffect extends OneShotEffect {
                 .copy()
                 .values()
                 .stream()
-                .filter(counter -> creature.addCounters(counter, source, game))
+                .filter(counter -> creature.addCounters(counter, source.getControllerId(), source, game))
                 .forEach(counter -> permanent.removeCounters(counter, source, game));
         return true;
     }

--- a/Mage.Sets/src/mage/cards/t/ThelonsChant.java
+++ b/Mage.Sets/src/mage/cards/t/ThelonsChant.java
@@ -78,7 +78,7 @@ class ThelonsChantEffect extends OneShotEffect {
                     && player.choose(Outcome.UnboostCreature, target, source.getSourceId(), game)) {
                 Permanent permanent = game.getPermanent(target.getFirstTarget());
                 if (permanent != null) {
-                    permanent.addCounters(CounterType.M1M1.createInstance(), source, game);
+                    permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), source, game);
                     paid = true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/t/ThelonsChant.java
+++ b/Mage.Sets/src/mage/cards/t/ThelonsChant.java
@@ -78,7 +78,7 @@ class ThelonsChantEffect extends OneShotEffect {
                     && player.choose(Outcome.UnboostCreature, target, source.getSourceId(), game)) {
                 Permanent permanent = game.getPermanent(target.getFirstTarget());
                 if (permanent != null) {
-                    permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), source, game);
+                    permanent.addCounters(CounterType.M1M1.createInstance(), player.getId(), source, game);
                     paid = true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/t/ThiefOfBlood.java
+++ b/Mage.Sets/src/mage/cards/t/ThiefOfBlood.java
@@ -83,7 +83,7 @@ class ThiefOfBloodEffect extends OneShotEffect {
         if (countersRemoved > 0) {
             Permanent sourcePermanent = game.getPermanentEntering(source.getSourceId());
             if (sourcePermanent != null) {
-                sourcePermanent.addCounters(CounterType.P1P1.createInstance(countersRemoved), source, game);
+                sourcePermanent.addCounters(CounterType.P1P1.createInstance(countersRemoved), source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/t/ThoughtGorger.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtGorger.java
@@ -75,7 +75,7 @@ class ThoughtGorgerEffectEnters extends OneShotEffect {
                 || player.getHand().isEmpty()
                 || thoughtGorger == null
                 || !thoughtGorger.addCounters(
-                CounterType.P1P1.createInstance(player.getHand().size()), source, game
+                CounterType.P1P1.createInstance(player.getHand().size()), source.getControllerId(), source, game
         )) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/t/Timebender.java
+++ b/Mage.Sets/src/mage/cards/t/Timebender.java
@@ -90,7 +90,7 @@ class TimebenderEffect extends OneShotEffect {
         Permanent permanent = game.getPermanent(this.getTargetPointer().getFirst(game, source));
         if (permanent != null) {
             if (addCounters) {
-                permanent.addCounters(CounterType.TIME.createInstance(2), source, game);
+                permanent.addCounters(CounterType.TIME.createInstance(2), source.getControllerId(), source, game);
             } else {
                 permanent.removeCounters(CounterType.TIME.getName(), 2, source, game);
             }
@@ -99,7 +99,7 @@ class TimebenderEffect extends OneShotEffect {
         Card card = game.getCard(this.getTargetPointer().getFirst(game, source));
         if (card != null) {
             if (addCounters) {
-                card.addCounters(CounterType.TIME.createInstance(2), source, game);
+                card.addCounters(CounterType.TIME.createInstance(2), source.getControllerId(), source, game);
             } else {
                 card.removeCounters(CounterType.TIME.getName(), 2, source, game);
             }

--- a/Mage.Sets/src/mage/cards/t/Timecrafting.java
+++ b/Mage.Sets/src/mage/cards/t/Timecrafting.java
@@ -112,12 +112,12 @@ class TimecraftingAddEffect extends OneShotEffect {
             int xValue = source.getManaCostsToPay().getX();
             Permanent permanent = game.getPermanent(this.getTargetPointer().getFirst(game, source));
             if (permanent != null) {
-                permanent.addCounters(CounterType.TIME.createInstance(xValue), source, game);
+                permanent.addCounters(CounterType.TIME.createInstance(xValue), source.getControllerId(), source, game);
             }
             else {
                 Card card = game.getExile().getCard(this.getTargetPointer().getFirst(game, source), game);
                 if (card != null) {
-                    card.addCounters(CounterType.TIME.createInstance(xValue), source, game);
+                    card.addCounters(CounterType.TIME.createInstance(xValue), source.getControllerId(), source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/t/TourachsChant.java
+++ b/Mage.Sets/src/mage/cards/t/TourachsChant.java
@@ -78,7 +78,7 @@ class TourachsChantEffect extends OneShotEffect {
                     && player.choose(Outcome.UnboostCreature, target, source.getSourceId(), game)) {
                 Permanent permanent = game.getPermanent(target.getFirstTarget());
                 if (permanent != null) {
-                    permanent.addCounters(CounterType.M1M1.createInstance(), source, game);
+                    permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), source, game);
                     paid = true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/t/TourachsChant.java
+++ b/Mage.Sets/src/mage/cards/t/TourachsChant.java
@@ -78,7 +78,7 @@ class TourachsChantEffect extends OneShotEffect {
                     && player.choose(Outcome.UnboostCreature, target, source.getSourceId(), game)) {
                 Permanent permanent = game.getPermanent(target.getFirstTarget());
                 if (permanent != null) {
-                    permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), source, game);
+                    permanent.addCounters(CounterType.M1M1.createInstance(), player.getId(), source, game);
                     paid = true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/t/TreasureMap.java
+++ b/Mage.Sets/src/mage/cards/t/TreasureMap.java
@@ -75,7 +75,7 @@ class TreasureMapEffect extends OneShotEffect {
         if (player != null) {
             player.scry(1, source, game);
             if (permanent != null) {
-                permanent.addCounters(CounterType.LANDMARK.createInstance(), source, game);
+                permanent.addCounters(CounterType.LANDMARK.createInstance(), source.getControllerId(), source, game);
                 int counters = permanent.getCounters(game).getCount(CounterType.LANDMARK);
                 if (counters > 2) {
                     permanent.removeCounters("landmark", counters, source, game);

--- a/Mage.Sets/src/mage/cards/t/TurntimberSymbiosis.java
+++ b/Mage.Sets/src/mage/cards/t/TurntimberSymbiosis.java
@@ -108,7 +108,7 @@ class TurntimberSymbiosisEffect extends OneShotEffect {
         if (permanent == null || !small) {
             return true;
         }
-        permanent.addCounters(CounterType.P1P1.createInstance(3), source, game);
+        permanent.addCounters(CounterType.P1P1.createInstance(3), source.getControllerId(), source, game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/u/UlashtTheHateSeed.java
+++ b/Mage.Sets/src/mage/cards/u/UlashtTheHateSeed.java
@@ -101,7 +101,7 @@ class UlashtTheHateSeedEffect extends OneShotEffect {
             int amount = game.getBattlefield().count(filterRed, source.getSourceId(), source.getControllerId(), game);
             amount += game.getBattlefield().count(filterGreen, source.getSourceId(), source.getControllerId(), game);
             if (amount > 0) {
-                permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/u/UnbreakableBond.java
+++ b/Mage.Sets/src/mage/cards/u/UnbreakableBond.java
@@ -75,7 +75,7 @@ class UnbreakableBondReplacementEffect extends ReplacementEffectImpl {
         if (creature == null) {
             return false;
         }
-        creature.addCounters(CounterType.LIFELINK.createInstance(), source, game, event.getAppliedEffects());
+        creature.addCounters(CounterType.LIFELINK.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         discard();
         return false;
     }

--- a/Mage.Sets/src/mage/cards/u/UnbreathingHorde.java
+++ b/Mage.Sets/src/mage/cards/u/UnbreathingHorde.java
@@ -78,7 +78,7 @@ class UnbreathingHordeEffect1 extends OneShotEffect {
             int amount = game.getBattlefield().countAll(filter1, source.getControllerId(), game);
             amount += player.getGraveyard().count(filter2, game);
             if (amount > 0) {
-                permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/u/UrgeToFeed.java
+++ b/Mage.Sets/src/mage/cards/u/UrgeToFeed.java
@@ -69,7 +69,7 @@ class UrgeToFeedEffect extends OneShotEffect {
                 Permanent vampire = game.getPermanent(vampireId);
                 if (vampire != null) {
                     vampire.tap(source, game);
-                    vampire.addCounters(CounterType.P1P1.createInstance(), source, game);
+                    vampire.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/v/VastwoodHydra.java
+++ b/Mage.Sets/src/mage/cards/v/VastwoodHydra.java
@@ -83,7 +83,7 @@ class VastwoodHydraDistributeEffect extends OneShotEffect {
             for (UUID target : multiTarget.getTargets()) {
                 Permanent permanent = game.getPermanent(target);
                 if (permanent != null) {
-                    permanent.addCounters(CounterType.P1P1.createInstance(multiTarget.getTargetAmount(target)), source, game);
+                    permanent.addCounters(CounterType.P1P1.createInstance(multiTarget.getTargetAmount(target)), source.getControllerId(), source, game);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/v/VeneratedLoxodon.java
+++ b/Mage.Sets/src/mage/cards/v/VeneratedLoxodon.java
@@ -81,7 +81,7 @@ class VeneratedLoxodonEffect extends OneShotEffect {
                 for (MageObjectReference creatureMOR : creatures) {
                     Permanent creature = creatureMOR.getPermanent(game);
                     if (creature != null) {
-                        creature.addCounters(CounterType.P1P1.createInstance(), source, game);
+                        creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/v/VeneratedTeacher.java
+++ b/Mage.Sets/src/mage/cards/v/VeneratedTeacher.java
@@ -66,7 +66,7 @@ class VeneratedTeacherEffect extends OneShotEffect {
             for (Permanent permanent : permanents) {
                 for (Ability ability : permanent.getAbilities()) {
                     if (ability instanceof LevelUpAbility) {
-                        permanent.addCounters(CounterType.LEVEL.createInstance(2), source, game);
+                        permanent.addCounters(CounterType.LEVEL.createInstance(2), source.getControllerId(), source, game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/v/Vigor.java
+++ b/Mage.Sets/src/mage/cards/v/Vigor.java
@@ -72,7 +72,7 @@ class VigorReplacementEffect extends ReplacementEffectImpl {
             event.setAmount(0);
             Permanent permanent = game.getPermanent(event.getTargetId());
             if (permanent != null) {
-                permanent.addCounters(CounterType.P1P1.createInstance(preventedDamage), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(preventedDamage), source.getControllerId(), source, game);
             }
             game.fireEvent(new PreventedDamageEvent(event.getTargetId(), source.getSourceId(), source, source.getControllerId(), preventedDamage));
             return true;

--- a/Mage.Sets/src/mage/cards/v/VigorMortis.java
+++ b/Mage.Sets/src/mage/cards/v/VigorMortis.java
@@ -79,7 +79,7 @@ class VigorMortisReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {
-            creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
             discard();
         }
         return false;

--- a/Mage.Sets/src/mage/cards/v/VirulentWound.java
+++ b/Mage.Sets/src/mage/cards/v/VirulentWound.java
@@ -15,7 +15,6 @@ import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.events.ZoneChangeEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -136,7 +135,7 @@ class VirulentWoundDelayedEffect extends OneShotEffect {
         if (permanent != null) {
             Player player = game.getPlayer(permanent.getControllerId());
             if (player != null) {
-                player.addCounters(CounterType.POISON.createInstance(1), source, game);
+                player.addCounters(CounterType.POISON.createInstance(1), source.getControllerId(), source, game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/v/VivienMonstersAdvocate.java
+++ b/Mage.Sets/src/mage/cards/v/VivienMonstersAdvocate.java
@@ -114,7 +114,7 @@ class VivienMonstersAdvocateTokenEffect extends OneShotEffect {
             String chosen = choice.getChoice();
             if (chosen != null) {
                 permanent.addCounters(CounterType.findByName(chosen.toLowerCase(
-                        Locale.ENGLISH)).createInstance(), source, game);
+                        Locale.ENGLISH)).createInstance(), source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/v/VoraciousHydra.java
+++ b/Mage.Sets/src/mage/cards/v/VoraciousHydra.java
@@ -90,6 +90,6 @@ class VoraciousHydraEffect extends OneShotEffect {
         }
         return permanent.addCounters(CounterType.P1P1.createInstance(
                 permanent.getCounters(game).getCount(CounterType.P1P1)
-        ), source, game);
+        ), source.getControllerId(), source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/v/VorelOfTheHullClade.java
+++ b/Mage.Sets/src/mage/cards/v/VorelOfTheHullClade.java
@@ -83,7 +83,7 @@ class VorelOfTheHullCladeEffect extends OneShotEffect {
         }
         for (Counter counter : target.getCounters(game).values()) {
             Counter newCounter = new Counter(counter.getName(), counter.getCount());
-            target.addCounters(newCounter, source, game);
+            target.addCounters(newCounter, source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/v/VorinclexMonstrousRaider.java
+++ b/Mage.Sets/src/mage/cards/v/VorinclexMonstrousRaider.java
@@ -1,0 +1,101 @@
+package mage.cards.v;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.common.InfoEffect;
+import mage.abilities.keyword.HasteAbility;
+import mage.abilities.keyword.TrampleAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+
+import java.util.UUID;
+
+/**
+ * @author TheElk801
+ */
+public final class VorinclexMonstrousRaider extends CardImpl {
+
+    public VorinclexMonstrousRaider(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{G}{G}");
+
+        this.addSuperType(SuperType.LEGENDARY);
+        this.subtype.add(SubType.PHYREXIAN);
+        this.subtype.add(SubType.PRAETOR);
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Trample
+        this.addAbility(TrampleAbility.getInstance());
+
+        // Haste
+        this.addAbility(HasteAbility.getInstance());
+
+        // If you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.
+        this.addAbility(new SimpleStaticAbility(new VorinclexMonstrousRaiderEffect()));
+
+        // If an opponent would put one or more counters on a permanent or player, they put half that many of each of those kinds of counters on that permanent or player instead, rounded down.
+        this.addAbility(new SimpleStaticAbility(new InfoEffect(
+                "if an opponent would put one or more counters on a permanent or player, " +
+                        "they put half that many of each of those kinds of counters " +
+                        "on that permanent or player instead, rounded down"
+        )));
+    }
+
+    private VorinclexMonstrousRaider(final VorinclexMonstrousRaider card) {
+        super(card);
+    }
+
+    @Override
+    public VorinclexMonstrousRaider copy() {
+        return new VorinclexMonstrousRaider(this);
+    }
+}
+
+class VorinclexMonstrousRaiderEffect extends ReplacementEffectImpl {
+
+    VorinclexMonstrousRaiderEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.BoostCreature, false);
+        staticText = "if you would put one or more counters on a permanent or player, " +
+                "put twice that many of each of those kinds of counters on that permanent or player instead";
+    }
+
+    private VorinclexMonstrousRaiderEffect(final VorinclexMonstrousRaiderEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        if (source.isControlledBy(event.getPlayerId())) {
+            event.setAmountForCounters(2 * event.getAmount(), true);
+        } else if (game.getOpponents(event.getPlayerId()).contains(source.getControllerId())) {
+            event.setAmountForCounters(Math.floorDiv(event.getAmount(), 2), true);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.ADD_COUNTERS;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        return source.isControlledBy(event.getPlayerId())
+                || game.getOpponents(event.getPlayerId()).contains(source.getControllerId());
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return true;
+    }
+
+    @Override
+    public VorinclexMonstrousRaiderEffect copy() {
+        return new VorinclexMonstrousRaiderEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/w/WanderingMage.java
+++ b/Mage.Sets/src/mage/cards/w/WanderingMage.java
@@ -101,7 +101,7 @@ class WanderingMageCost extends CostImpl {
     public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
         Permanent permanent = game.getPermanent(ability.getTargets().get(1).getFirstTarget());
         if (permanent != null) {
-            permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), ability, game);
+            permanent.addCounters(CounterType.M1M1.createInstance(), controllerId, ability, game);
             this.paid = true;
         }
         return paid;

--- a/Mage.Sets/src/mage/cards/w/WanderingMage.java
+++ b/Mage.Sets/src/mage/cards/w/WanderingMage.java
@@ -101,7 +101,7 @@ class WanderingMageCost extends CostImpl {
     public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
         Permanent permanent = game.getPermanent(ability.getTargets().get(1).getFirstTarget());
         if (permanent != null) {
-            permanent.addCounters(CounterType.M1M1.createInstance(), ability, game);
+            permanent.addCounters(CounterType.M1M1.createInstance(), source.getControllerId(), ability, game);
             this.paid = true;
         }
         return paid;

--- a/Mage.Sets/src/mage/cards/w/WeaponRack.java
+++ b/Mage.Sets/src/mage/cards/w/WeaponRack.java
@@ -73,7 +73,7 @@ class WeaponRackEffect extends OneShotEffect {
             return false;
         }
         Permanent permanent = game.getPermanent(source.getFirstTarget());
-        if (permanent == null || !permanent.addCounters(CounterType.P1P1.createInstance(), source, game)) {
+        if (permanent == null || !permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game)) {
             return false;
         }
         sourcePermanent.removeCounters(CounterType.P1P1.createInstance(), source, game);

--- a/Mage.Sets/src/mage/cards/w/WillOfTheAllHunter.java
+++ b/Mage.Sets/src/mage/cards/w/WillOfTheAllHunter.java
@@ -66,7 +66,7 @@ class WillOfTheAllHunterEffect extends OneShotEffect {
             return false;
         }
         if (permanent.getBlocking() > 0) {
-            return permanent.addCounters(CounterType.P1P1.createInstance(2), source, game);
+            return permanent.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
         }
         game.addEffect(new BoostTargetEffect(2, 2), source);
         return true;

--- a/Mage.Sets/src/mage/cards/w/WookieeMystic.java
+++ b/Mage.Sets/src/mage/cards/w/WookieeMystic.java
@@ -115,7 +115,7 @@ class WookieeMysticWatcher extends Watcher {
         if (event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD) {
             if (creatures.contains(event.getSourceId())) {
                 Permanent creature = game.getPermanent(event.getSourceId());
-                creature.addCounters(CounterType.P1P1.createInstance(), source, game);
+                creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 creatures.remove(event.getSourceId());
             }
         }

--- a/Mage.Sets/src/mage/cards/w/WorldheartPhoenix.java
+++ b/Mage.Sets/src/mage/cards/w/WorldheartPhoenix.java
@@ -116,7 +116,7 @@ public final class WorldheartPhoenix extends CardImpl {
                         && permanent.getZoneChangeCounter(game) == spellAbility.getSourceObjectZoneChangeCounter()) {
                     // TODO: No perfect solution because there could be other effects that allow to cast the card for this mana cost
                     if (spellAbility.getManaCosts().getText().equals("{W}{U}{B}{R}{G}")) {
-                        permanent.addCounters(CounterType.P1P1.createInstance(2), source, game);
+                        permanent.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/y/YorvoLordOfGarenbrig.java
+++ b/Mage.Sets/src/mage/cards/y/YorvoLordOfGarenbrig.java
@@ -87,14 +87,14 @@ class YorvoLordOfGarenbrigEffect extends OneShotEffect {
         if (sourcePerm == null) {
             return false;
         }
-        sourcePerm.addCounters(CounterType.P1P1.createInstance(), source, game);
+        sourcePerm.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         Permanent permanent = getTargetPointer().getFirstTargetPermanentOrLKI(game, source);
         if (permanent == null) {
             return true;
         }
         game.getState().processAction(game);
         if (permanent.getPower().getValue() > sourcePerm.getPower().getValue()) {
-            sourcePerm.addCounters(CounterType.P1P1.createInstance(), source, game);
+            sourcePerm.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/z/ZameckGuildmage.java
+++ b/Mage.Sets/src/mage/cards/z/ZameckGuildmage.java
@@ -81,7 +81,7 @@ class ZameckGuildmageEntersBattlefieldEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent target = ((EntersTheBattlefieldEvent) event).getTarget();
         if (target != null) {
-            target.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+            target.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/z/ZaxaraTheExemplary.java
+++ b/Mage.Sets/src/mage/cards/z/ZaxaraTheExemplary.java
@@ -136,7 +136,7 @@ class ZaxaraTheExemplaryHydraTokenEffect extends OneShotEffect {
                 for (UUID tokenId : hydraToken.getLastAddedTokenIds()) {
                     Permanent permanent = game.getPermanent(tokenId);
                     if (permanent != null)
-                        permanent.addCounters(CounterType.P1P1.createInstance(xValue), source, game);
+                        permanent.addCounters(CounterType.P1P1.createInstance(xValue), source.getControllerId(), source, game);
                 }
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/z/ZombieMob.java
+++ b/Mage.Sets/src/mage/cards/z/ZombieMob.java
@@ -70,7 +70,7 @@ class ZombieMobEffect extends OneShotEffect {
             int amount = 0;
             amount += controller.getGraveyard().count(filter, game);
             if (amount > 0) {
-                permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             }
             Cards cards = new CardsImpl(controller.getGraveyard().getCards(filter, game));
             controller.moveCards(cards, Zone.EXILED, source, game);

--- a/Mage.Sets/src/mage/sets/Kaldheim.java
+++ b/Mage.Sets/src/mage/sets/Kaldheim.java
@@ -315,6 +315,7 @@ public final class Kaldheim extends ExpansionSet {
         cards.add(new SetCardInfo("Vengeful Reaper", 116, Rarity.UNCOMMON, mage.cards.v.VengefulReaper.class));
         cards.add(new SetCardInfo("Village Rites", 117, Rarity.COMMON, mage.cards.v.VillageRites.class));
         cards.add(new SetCardInfo("Volatile Fjord", 273, Rarity.COMMON, mage.cards.v.VolatileFjord.class));
+        cards.add(new SetCardInfo("Vorinclex, Monstrous Raider", 199, Rarity.MYTHIC, mage.cards.v.VorinclexMonstrousRaider.class));
         cards.add(new SetCardInfo("Waking the Trolls", 234, Rarity.RARE, mage.cards.w.WakingTheTrolls.class));
         cards.add(new SetCardInfo("Warchanter Skald", 381, Rarity.UNCOMMON, mage.cards.w.WarchanterSkald.class));
         cards.add(new SetCardInfo("Warhorn Blast", 38, Rarity.COMMON, mage.cards.w.WarhornBlast.class));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/khm/VorinclexMonstrousRaiderTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/khm/VorinclexMonstrousRaiderTest.java
@@ -1,0 +1,120 @@
+package org.mage.test.cards.single.khm;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author TheElk801
+ */
+public class VorinclexMonstrousRaiderTest extends CardTestPlayerBase {
+
+    private static final String vorinclex = "Vorinclex, Monstrous Raider";
+    private static final String boon = "Dragonscale Boon";
+    private static final String bear = "Grizzly Bears";
+    private static final String rats = "Ichor Rats";
+
+    @Test
+    public void testIDoubleCountersOnMyStuff() {
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 4);
+        addCard(Zone.BATTLEFIELD, playerA, vorinclex);
+        addCard(Zone.BATTLEFIELD, playerA, bear);
+        addCard(Zone.HAND, playerA, boon);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, boon, bear);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertCounterCount(bear, CounterType.P1P1, 4);
+    }
+
+    @Test
+    public void testIDoubleCountersOnTheirStuff() {
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 4);
+        addCard(Zone.BATTLEFIELD, playerA, vorinclex);
+        addCard(Zone.BATTLEFIELD, playerB, bear);
+        addCard(Zone.HAND, playerA, boon);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, boon, bear);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertCounterCount(bear, CounterType.P1P1, 4);
+    }
+
+    @Test
+    public void testIDoubleCountersOnMyself() {
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+        addCard(Zone.BATTLEFIELD, playerA, vorinclex);
+        addCard(Zone.HAND, playerA, rats);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, rats);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertCounterCount(playerA, CounterType.POISON, 2);
+        assertCounterCount(playerB, CounterType.POISON, 2);
+    }
+
+    @Test
+    public void testTheyHalveCountersOnTheirStuff() {
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 4);
+        addCard(Zone.BATTLEFIELD, playerA, vorinclex);
+        addCard(Zone.BATTLEFIELD, playerB, bear);
+        addCard(Zone.HAND, playerB, boon);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, boon, bear);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertCounterCount(bear, CounterType.P1P1, 1);
+    }
+
+    @Test
+    public void testTheyHalveCountersOnMyStuff() {
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 4);
+        addCard(Zone.BATTLEFIELD, playerA, vorinclex);
+        addCard(Zone.BATTLEFIELD, playerA, bear);
+        addCard(Zone.HAND, playerB, boon);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, boon, bear);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertCounterCount(bear, CounterType.P1P1, 1);
+    }
+
+    @Test
+    public void testTheyHalveCountersOnMyself() {
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+        addCard(Zone.BATTLEFIELD, playerB, vorinclex);
+        addCard(Zone.HAND, playerA, rats);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, rats);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertCounterCount(playerA, CounterType.POISON, 0);
+        assertCounterCount(playerB, CounterType.POISON, 0);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -673,7 +673,7 @@ public class TestPlayer implements Player {
                             CounterType counterType = CounterType.findByName(groups[1]);
                             Assert.assertNotNull("Invalid counter type " + groups[1], counterType);
                             Counter counter = counterType.createInstance(Integer.parseInt(groups[2]));
-                            permanent.addCounters(counter, source, game);
+                            permanent.addCounters(counter, source.getControllerId(), source, game);
                             actions.remove(action);
                             return true;
                         }

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -3135,8 +3135,8 @@ public class TestPlayer implements Player {
     }
 
     @Override
-    public boolean addCounters(Counter counter, Ability source, Game game) {
-        return computerPlayer.addCounters(counter, source, game);
+    public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game) {
+        return computerPlayer.addCounters(counter, source.getControllerId(), source, game);
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
+++ b/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
@@ -1070,7 +1070,7 @@ public class PlayerStub implements Player {
     }
 
     @Override
-    public boolean addCounters(Counter counter, Ability source, Game game) {
+    public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game) {
         return true;
     }
 

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -110,6 +110,7 @@ public class VerifyCardDataTest {
         // subtype
         skipListCreate(SKIP_LIST_SUBTYPE);
         skipListAddName(SKIP_LIST_SUBTYPE, "UGL", "Miss Demeanor");
+        subtypesToIgnore.add("Phyrexian"); // large errata incoming, adding this for now
 
         // number
         skipListCreate(SKIP_LIST_NUMBER);

--- a/Mage/src/main/java/mage/abilities/common/EscapesWithAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EscapesWithAbility.java
@@ -88,7 +88,7 @@ class EscapesWithEffect extends OneShotEffect {
             return false;
         }
         List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects");
-        permanent.addCounters(CounterType.P1P1.createInstance(counter), source, game, appliedEffects);
+        permanent.addCounters(CounterType.P1P1.createInstance(counter), source.getControllerId(), source, game, appliedEffects);
         if (this.delayedTriggeredAbility != null) {
             game.addDelayedTriggeredAbility(this.delayedTriggeredAbility, source);
         }

--- a/Mage/src/main/java/mage/abilities/common/TurnFaceUpAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/TurnFaceUpAbility.java
@@ -82,7 +82,7 @@ class TurnFaceUpEffect extends OneShotEffect {
             if (sourcePermanent != null) {
                 if (sourcePermanent.turnFaceUp(source, game, source.getControllerId())) {
                     if (megamorph) {
-                        sourcePermanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                        sourcePermanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                     }
                     game.getState().setValue(source.getSourceId().toString() + "TurnFaceUpX", source.getManaCostsToPay().getX());
                     return true;

--- a/Mage/src/main/java/mage/abilities/costs/common/PayLoyaltyCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/PayLoyaltyCost.java
@@ -50,7 +50,7 @@ public class PayLoyaltyCost extends CostImpl {
         Permanent planeswalker = game.getPermanent(source.getSourceId());
         if (planeswalker != null && planeswalker.getCounters(game).getCount(CounterType.LOYALTY) + amount >= 0 && planeswalker.canLoyaltyBeUsed(game)) {
             if (amount > 0) {
-                planeswalker.addCounters(CounterType.LOYALTY.createInstance(amount), ability, game, false);
+                planeswalker.addCounters(CounterType.LOYALTY.createInstance(amount), source.getControllerId(), ability, game, false);
             } else if (amount < 0) {
                 planeswalker.removeCounters(CounterType.LOYALTY.getName(), Math.abs(amount), source, game);
             }

--- a/Mage/src/main/java/mage/abilities/costs/common/PutCountersSourceCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/PutCountersSourceCost.java
@@ -46,7 +46,7 @@ public class PutCountersSourceCost extends CostImpl {
     public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null) {
-            this.paid = permanent.addCounters(counter, source.getControllerId(), ability, game, false);
+            this.paid = permanent.addCounters(counter, controllerId, ability, game, false);
         }
         return paid;
     }

--- a/Mage/src/main/java/mage/abilities/costs/common/PutCountersSourceCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/PutCountersSourceCost.java
@@ -46,7 +46,7 @@ public class PutCountersSourceCost extends CostImpl {
     public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null) {
-            this.paid = permanent.addCounters(counter, ability, game, false);
+            this.paid = permanent.addCounters(counter, source.getControllerId(), ability, game, false);
         }
         return paid;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/AmplifyEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/AmplifyEffect.java
@@ -132,7 +132,7 @@ public class AmplifyEffect extends ReplacementEffectImpl {
             Cards cards = new CardsImpl();
             cards.addAll(target.getTargets());
             int amountCounters = cards.size() * amplifyFactor.getFactor();
-            sourceCreature.addCounters(CounterType.P1P1.createInstance(amountCounters), source, game);
+            sourceCreature.addCounters(CounterType.P1P1.createInstance(amountCounters), source.getControllerId(), source, game);
             controller.revealCards(sourceCreature.getIdName(), cards, game);
         }
         return false;

--- a/Mage/src/main/java/mage/abilities/effects/common/DevourEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DevourEffect.java
@@ -106,7 +106,7 @@ public class DevourEffect extends ReplacementEffectImpl {
                     } else {
                         amountCounters = devouredCreatures * devourFactor.getFactor();
                     }
-                    creature.addCounters(CounterType.P1P1.createInstance(amountCounters), source, game);
+                    creature.addCounters(CounterType.P1P1.createInstance(amountCounters), source.getControllerId(), source, game);
                     game.getState().setValue(creature.getId().toString() + "devoured", creaturesDevoured);
                 }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/EntersBattlefieldWithXCountersEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/EntersBattlefieldWithXCountersEffect.java
@@ -54,7 +54,7 @@ public class EntersBattlefieldWithXCountersEffect extends OneShotEffect {
                         Counter counterToAdd = counter.copy();
                         counterToAdd.add(amount - counter.getCount());
                         List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects");
-                        permanent.addCounters(counterToAdd, source, game, appliedEffects);
+                        permanent.addCounters(counterToAdd, source.getControllerId(), source, game, appliedEffects);
                     }
                 }
             }

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCounterChoiceSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCounterChoiceSourceEffect.java
@@ -48,7 +48,7 @@ public class AddCounterChoiceSourceEffect extends OneShotEffect {
         } else {
             counter = counterType2.createInstance();
         }
-        return permanent.addCounters(counter, source, game);
+        return permanent.addCounters(counter, source.getControllerId(), source, game);
     }
 
     private static final String cap(String string) {

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersAllEffect.java
@@ -42,7 +42,7 @@ public class AddCountersAllEffect extends OneShotEffect {
         if (controller != null && sourceObject != null) {
             if (counter != null) {
                 for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source.getSourceId(), game)) {
-                    permanent.addCounters(counter.copy(), source, game);
+                    permanent.addCounters(counter.copy(), source.getControllerId(), source, game);
                     if (!game.isSimulation()) {
                         game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts " + counter.getCount() + ' ' + counter.getName().toLowerCase(Locale.ENGLISH)
                                 + " counter on " + permanent.getLogName());

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersAttachedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersAttachedEffect.java
@@ -59,7 +59,7 @@ public class AddCountersAttachedEffect extends OneShotEffect {
                 if (countersToAdd > 0) {
                     countersToAdd--;
                     newCounter.add(countersToAdd);
-                    attachedTo.addCounters(newCounter, source, game);
+                    attachedTo.addCounters(newCounter, source.getControllerId(), source, game);
                 }
             }
             return true;

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersControllerEffect.java
@@ -59,7 +59,7 @@ public class AddCountersControllerEffect extends OneShotEffect {
         }
         Player player = game.getPlayer(uuid);
         if (player != null) {
-            player.addCounters(counter, source, game);
+            player.addCounters(counter, source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersSourceEffect.java
@@ -81,7 +81,7 @@ public class AddCountersSourceEffect extends OneShotEffect {
                         }
                         newCounter.add(countersToAdd);
                         List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects");
-                        card.addCounters(newCounter, source, game, appliedEffects);
+                        card.addCounters(newCounter, source.getControllerId(), source, game, appliedEffects);
                         if (informPlayers && !game.isSimulation()) {
                             Player player = game.getPlayer(source.getControllerId());
                             if (player != null) {
@@ -109,7 +109,7 @@ public class AddCountersSourceEffect extends OneShotEffect {
                             newCounter.add(countersToAdd);
                             int before = permanent.getCounters(game).getCount(newCounter.getName());
                             List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects");
-                            permanent.addCounters(newCounter, source, game, appliedEffects); // if used from a replacement effect, the basic event determines if an effect was already applied to an event
+                            permanent.addCounters(newCounter, source.getControllerId(), source, game, appliedEffects); // if used from a replacement effect, the basic event determines if an effect was already applied to an event
                             if (informPlayers && !game.isSimulation()) {
                                 int amountAdded = permanent.getCounters(game).getCount(newCounter.getName()) - before;
                                 Player player = game.getPlayer(source.getControllerId());

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersTargetEffect.java
@@ -81,7 +81,7 @@ public class AddCountersTargetEffect extends OneShotEffect {
                     game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts "
                         + newCounter.getCount() + ' ' + newCounter.getName().toLowerCase(Locale.ENGLISH) + " counters on " + permanent.getLogName());
                 } else if (player != null) {
-                    player.addCounters(newCounter, source, game);
+                    player.addCounters(newCounter, source.getControllerId(), source, game);
                     affectedTargets++;
                     game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts "
                         + newCounter.getCount() + ' ' + newCounter.getName().toLowerCase(Locale.ENGLISH) + " counters on " + player.getLogName());

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersTargetEffect.java
@@ -76,7 +76,7 @@ public class AddCountersTargetEffect extends OneShotEffect {
                 Player player = game.getPlayer(uuid);
                 Card card = game.getCard(targetPointer.getFirst(game, source));
                 if (permanent != null) {
-                    permanent.addCounters(newCounter, source, game);
+                    permanent.addCounters(newCounter, source.getControllerId(), source, game);
                     affectedTargets++;
                     game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts "
                         + newCounter.getCount() + ' ' + newCounter.getName().toLowerCase(Locale.ENGLISH) + " counters on " + permanent.getLogName());
@@ -86,7 +86,7 @@ public class AddCountersTargetEffect extends OneShotEffect {
                     game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts "
                         + newCounter.getCount() + ' ' + newCounter.getName().toLowerCase(Locale.ENGLISH) + " counters on " + player.getLogName());
                 } else if (card != null) {
-                    card.addCounters(newCounter, source, game);
+                    card.addCounters(newCounter, source.getControllerId(), source, game);
                     affectedTargets++;
                     game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts "
                             + newCounter.getCount() + ' ' + newCounter.getName().toLowerCase(Locale.ENGLISH) + " counters on " + card.getLogName());

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddPlusOneCountersAttachedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddPlusOneCountersAttachedEffect.java
@@ -44,7 +44,7 @@ public class AddPlusOneCountersAttachedEffect extends OneShotEffect {
         if (enchantment != null && enchantment.getAttachedTo() != null) {
             Permanent creature = game.getPermanent(enchantment.getAttachedTo());
             if (creature != null) {
-                creature.addCounters(CounterType.P1P1.createInstance(amount), source, game);
+                creature.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game);
             }
         }
         return true;

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddPoisonCounterTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddPoisonCounterTargetEffect.java
@@ -40,7 +40,7 @@ public class AddPoisonCounterTargetEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(targetPointer.getFirst(game, source));
         if (player != null) {
-            player.addCounters(CounterType.POISON.createInstance(amount), source, game);
+            player.addCounters(CounterType.POISON.createInstance(amount), source.getControllerId(), source, game);
             return true;
         }
         return false;

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddRemoveAllTimeSuspentCountersEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddRemoveAllTimeSuspentCountersEffect.java
@@ -68,7 +68,7 @@ public class AddRemoveAllTimeSuspentCountersEffect extends OneShotEffect {
                     final Counter modifiedCounter = new Counter(counterName, countersToRemove);
                     card.removeCounters(modifiedCounter, source, game);
                 } else {
-                    card.addCounters(counter, source, game);
+                    card.addCounters(counter, source.getControllerId(), source, game);
                 }
                 if (!game.isSimulation()) {
                     game.informPlayers(new StringBuilder(sourceObject.getName()).append(": ")

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/DistributeCountersEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/DistributeCountersEffect.java
@@ -53,7 +53,7 @@ public class DistributeCountersEffect extends OneShotEffect {
             for (UUID target : multiTarget.getTargets()) {
                 Permanent permanent = game.getPermanent(target);
                 if (permanent != null) {
-                    permanent.addCounters(counterType.createInstance(multiTarget.getTargetAmount(target)), source, game);
+                    permanent.addCounters(counterType.createInstance(multiTarget.getTargetAmount(target)), source.getControllerId(), source, game);
                 }
             }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/GetEnergyCountersControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/GetEnergyCountersControllerEffect.java
@@ -37,7 +37,7 @@ public class GetEnergyCountersControllerEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            return controller.addCounters(CounterType.ENERGY.createInstance(value.calculate(game, source, this)), source, game);
+            return controller.addCounters(CounterType.ENERGY.createInstance(value.calculate(game, source, this)), source.getControllerId(), source, game);
         }
         return false;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/MoveCountersTargetsEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/MoveCountersTargetsEffect.java
@@ -42,7 +42,7 @@ public class MoveCountersTargetsEffect extends OneShotEffect {
         Permanent addTargetCreature = game.getPermanent(targetPointer.getTargets(game, source).get(1));
         if (removeTargetCreature != null && addTargetCreature != null && removeTargetCreature.getCounters(game).getCount(counterType) >= amount) {
             removeTargetCreature.removeCounters(counterType.createInstance(amount), source, game);
-            addTargetCreature.addCounters(counterType.createInstance(amount), source, game);
+            addTargetCreature.addCounters(counterType.createInstance(amount), source.getControllerId(), source, game);
             if (!game.isSimulation()) {
                 game.informPlayers("Moved " + amount + ' ' + counterType.getName() + " counter" + (amount > 1 ? "s" : "") + " from " + removeTargetCreature.getLogName() + " to " + addTargetCreature.getLogName());
             }

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/ProliferateEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/ProliferateEffect.java
@@ -59,7 +59,7 @@ public class ProliferateEffect extends OneShotEffect {
                 if (!permanent.getCounters(game).isEmpty()) {
                     for (Counter counter : permanent.getCounters(game).values()) {
                         newCounter = new Counter(counter.getName());
-                        permanent.addCounters(newCounter, source, game);
+                        permanent.addCounters(newCounter, source.getControllerId(), source, game);
                     }
                     if (newCounter != null) {
                         game.informPlayers(permanent.getName()

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/ProliferateEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/ProliferateEffect.java
@@ -74,7 +74,7 @@ public class ProliferateEffect extends OneShotEffect {
                     if (!player.getCounters().isEmpty()) {
                         for (Counter counter : player.getCounters().values()) {
                             newCounter = new Counter(counter.getName());
-                            player.addCounters(newCounter, source, game);
+                            player.addCounters(newCounter, source.getControllerId(), source, game);
                         }
                         if (newCounter != null) {
                             game.informPlayers(player.getLogName()

--- a/Mage/src/main/java/mage/abilities/effects/keyword/AdaptEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/AdaptEffect.java
@@ -60,7 +60,7 @@ public class AdaptEffect extends OneShotEffect {
         }
         if (permanent.getCounters(game).getCount(CounterType.P1P1) == 0
                 || event.getFlag()) {
-            permanent.addCounters(CounterType.P1P1.createInstance(event.getAmount()), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(event.getAmount()), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/effects/keyword/AmassEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/AmassEffect.java
@@ -79,7 +79,7 @@ public class AmassEffect extends OneShotEffect {
         if (permanent == null) {
             return false;
         }
-        permanent.addCounters(CounterType.P1P1.createInstance(xValue), source, game);
+        permanent.addCounters(CounterType.P1P1.createInstance(xValue), source.getControllerId(), source, game);
         this.amassedCreatureId = permanent.getId();
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/effects/keyword/ExploreSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/ExploreSourceEffect.java
@@ -110,7 +110,7 @@ public class ExploreSourceEffect extends OneShotEffect {
                     permanentController.moveCards(card, Zone.HAND, source, game);
                 } else {
                     if (game.getState().getZone(permanentId) == Zone.BATTLEFIELD) { // needed in case LKI object is used
-                        permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+                        permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                     }
                     if (permanentController.chooseUse(Outcome.Neutral, "Put " + card.getLogName() + " in your graveyard?", source, game)) {
                         permanentController.moveCards(card, Zone.GRAVEYARD, source, game);
@@ -124,7 +124,7 @@ public class ExploreSourceEffect extends OneShotEffect {
                 && game.getState().getZone(permanentId) == Zone.BATTLEFIELD) {
             // If no card is revealed, most likely because that player's library is empty,
             // the exploring creature receives a +1/+1 counter.
-            permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
+            permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         }
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/keyword/BloodthirstAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/BloodthirstAbility.java
@@ -75,7 +75,7 @@ class BloodthirstEffect extends OneShotEffect {
                 Permanent permanent = game.getPermanentEntering(source.getSourceId());
                 if (permanent != null) {
                     List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects"); // the basic event is the EntersBattlefieldEvent, so use already applied replacement effects from that event
-                    permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game, appliedEffects);
+                    permanent.addCounters(CounterType.P1P1.createInstance(amount), source.getControllerId(), source, game, appliedEffects);
                 }
                 return true;
             }

--- a/Mage/src/main/java/mage/abilities/keyword/EvolveAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/EvolveAbility.java
@@ -139,7 +139,7 @@ class EvolveEffect extends OneShotEffect {
         if (triggeringCreature != null) {
             Permanent sourceCreature = game.getPermanent(source.getSourceId());
             if (sourceCreature != null && EvolveAbility.isPowerOrThoughnessGreater(sourceCreature, triggeringCreature)) {
-                sourceCreature.addCounters(CounterType.P1P1.createInstance(), source, game);
+                sourceCreature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 game.fireEvent(GameEvent.getEvent(GameEvent.EventType.EVOLVED_CREATURE, sourceCreature.getId(), source, source.getControllerId()));
             }
             return true;

--- a/Mage/src/main/java/mage/abilities/keyword/FabricateAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/FabricateAbility.java
@@ -67,7 +67,7 @@ class FabricateEffect extends OneShotEffect {
                     "Create " + CardUtil.numberToText(value, "a") + " 1/1 token" + (value > 1 ? "s" : ""),
                     source,
                     game)) {
-                ((Card) sourceObject).addCounters(CounterType.P1P1.createInstance(value), source, game);
+                ((Card) sourceObject).addCounters(CounterType.P1P1.createInstance(value), source.getControllerId(), source, game);
             }
             else {
                 new ServoToken().putOntoBattlefield(value, game, source, controller.getId());

--- a/Mage/src/main/java/mage/abilities/keyword/GraftAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/GraftAbility.java
@@ -147,7 +147,7 @@ class GraftDistributeCounterEffect extends OneShotEffect {
                 Permanent targetCreature = game.getPermanent(targetPointer.getFirst(game, source));
                 if (targetCreature != null) {
                     sourcePermanent.removeCounters(CounterType.P1P1.getName(), 1, source, game);
-                    targetCreature.addCounters(CounterType.P1P1.createInstance(1), source, game);
+                    targetCreature.addCounters(CounterType.P1P1.createInstance(1), source.getControllerId(), source, game);
                     if (!game.isSimulation()) {
                         game.informPlayers("Moved one +1/+1 counter from " + sourcePermanent.getLogName() + " to " + targetCreature.getLogName());
                     }

--- a/Mage/src/main/java/mage/abilities/keyword/ModularAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ModularAbility.java
@@ -162,7 +162,7 @@ class ModularDistributeCounterEffect extends OneShotEffect {
             int numberOfCounters = sourcePermanent.getCounters(game).getCount(CounterType.P1P1);
             if (numberOfCounters > 0) {
                 List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects"); // the basic event is the EntersBattlefieldEvent, so use already applied replacement effects from that event
-                targetArtifact.addCounters(CounterType.P1P1.createInstance(numberOfCounters), source, game, appliedEffects);
+                targetArtifact.addCounters(CounterType.P1P1.createInstance(numberOfCounters), source.getControllerId(), source, game, appliedEffects);
             }
             return true;
         }

--- a/Mage/src/main/java/mage/abilities/keyword/RiotAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/RiotAbility.java
@@ -13,7 +13,6 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
@@ -73,7 +72,7 @@ class RiotReplacementEffect extends ReplacementEffectImpl {
         if (creature != null && controller != null) {
             if (controller.chooseUse(outcome, "Have " + creature.getLogName() + " enter the battlefield with a +1/+1 counter on it or with haste?", null, "+1/+1 counter", "Haste", source, game)) {
                 game.informPlayers(controller.getLogName() + " choose to put a +1/+1 counter on " + creature.getName());
-                creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+                creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
             } else {
                 game.addEffect(new GainAbilitySourceEffect(HasteAbility.getInstance(), Duration.Custom), source);
             }

--- a/Mage/src/main/java/mage/abilities/keyword/SunburstAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SunburstAbility.java
@@ -74,7 +74,7 @@ class SunburstEffect extends OneShotEffect {
                     counter = CounterType.CHARGE.createInstance(countersAmount);
                 }
                 List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects"); // the basic event is the EntersBattlefieldEvent, so use already applied replacement effects from that event
-                permanent.addCounters(counter, source, game, appliedEffects);
+                permanent.addCounters(counter, source.getControllerId(), source, game, appliedEffects);
                 if (!game.isSimulation()) {
                     Player player = game.getPlayer(source.getControllerId());
                     if (player != null) {

--- a/Mage/src/main/java/mage/abilities/keyword/SuspendAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SuspendAbility.java
@@ -266,7 +266,7 @@ class SuspendExileEffect extends OneShotEffect {
                 if (suspend == Integer.MAX_VALUE) {
                     suspend = source.getManaCostsToPay().getX();
                 }
-                card.addCounters(CounterType.TIME.createInstance(suspend), source, game);
+                card.addCounters(CounterType.TIME.createInstance(suspend), source.getControllerId(), source, game);
                 if (!game.isSimulation()) {
                     game.informPlayers(controller.getLogName()
                             + " suspends (" + suspend + ") " + card.getLogName());

--- a/Mage/src/main/java/mage/abilities/keyword/TributeAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/TributeAbility.java
@@ -89,7 +89,7 @@ class TributeEffect extends OneShotEffect {
                             game.informPlayers(opponent.getLogName() + " pays tribute to " + sourcePermanent.getLogName());
                         }
                         game.getState().setValue("tributeValue" + source.getSourceId(), "yes");
-                        return new AddCountersSourceEffect(CounterType.P1P1.createInstance(tributeValue), true).apply(game, source);
+                        return sourcePermanent.addCounters(CounterType.P1P1.createInstance(tributeValue),opponent.getId(),source,game);
                     } else {
                         if (!game.isSimulation()) {
                             game.informPlayers(opponent.getLogName() + " does not pay tribute to " + sourcePermanent.getLogName());

--- a/Mage/src/main/java/mage/abilities/keyword/UnleashAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/UnleashAbility.java
@@ -12,7 +12,6 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
@@ -78,7 +77,7 @@ class UnleashReplacementEffect extends ReplacementEffectImpl {
                 if (!game.isSimulation()) {
                     game.informPlayers(controller.getLogName() + " unleashes " + creature.getName());
                 }
-                creature.addCounters(CounterType.P1P1.createInstance(), source, game, event.getAppliedEffects());
+                creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
             }
         }
         return false;

--- a/Mage/src/main/java/mage/cards/Card.java
+++ b/Mage/src/main/java/mage/cards/Card.java
@@ -142,13 +142,13 @@ public interface Card extends MageObject {
 
     void looseAllAbilities(Game game);
 
-    boolean addCounters(Counter counter, Ability source, Game game);
+    boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game);
 
-    boolean addCounters(Counter counter, Ability source, Game game, boolean isEffect);
+    boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, boolean isEffect);
 
-    boolean addCounters(Counter counter, Ability source, Game game, List<UUID> appliedEffects);
+    boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, List<UUID> appliedEffects);
 
-    boolean addCounters(Counter counter, Ability source, Game game, List<UUID> appliedEffects, boolean isEffect);
+    boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, List<UUID> appliedEffects, boolean isEffect);
 
     void removeCounters(String name, int amount, Ability source, Game game);
 

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -602,7 +602,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
         Counters countersToAdd = game.getEnterWithCounters(permanent.getId());
         if (countersToAdd != null) {
             for (Counter counter : countersToAdd.values()) {
-                permanent.addCounters(counter, source, game);
+                permanent.addCounters(counter, source.getControllerId(), source, game);
             }
             game.setEnterWithCounters(permanent.getId(), null);
         }
@@ -715,22 +715,22 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
     }
 
     @Override
-    public boolean addCounters(Counter counter, Ability source, Game game) {
-        return addCounters(counter, source, game, null, true);
+    public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game) {
+        return addCounters(counter, playerAddingCounters, source, game, null, true);
     }
 
     @Override
-    public boolean addCounters(Counter counter, Ability source, Game game, boolean isEffect) {
-        return addCounters(counter, source, game, null, isEffect);
+    public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, boolean isEffect) {
+        return addCounters(counter, playerAddingCounters, source, game, null, isEffect);
     }
 
     @Override
-    public boolean addCounters(Counter counter, Ability source, Game game, List<UUID> appliedEffects) {
-        return addCounters(counter, source, game, appliedEffects, true);
+    public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, List<UUID> appliedEffects) {
+        return addCounters(counter, playerAddingCounters, source, game, appliedEffects, true);
     }
 
     @Override
-    public boolean addCounters(Counter counter, Ability source, Game game, List<UUID> appliedEffects, boolean isEffect) {
+    public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, List<UUID> appliedEffects, boolean isEffect) {
         boolean returnCode = true;
         GameEvent addingAllEvent = GameEvent.getEvent(GameEvent.EventType.ADD_COUNTERS, objectId, source, getControllerOrOwner(), counter.getName(), counter.getCount());
         addingAllEvent.setAppliedEffects(appliedEffects);

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -732,7 +732,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
     @Override
     public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, List<UUID> appliedEffects, boolean isEffect) {
         boolean returnCode = true;
-        GameEvent addingAllEvent = GameEvent.getEvent(GameEvent.EventType.ADD_COUNTERS, objectId, source, getControllerOrOwner(), counter.getName(), counter.getCount());
+        GameEvent addingAllEvent = GameEvent.getEvent(GameEvent.EventType.ADD_COUNTERS, objectId, source, playerAddingCounters, counter.getName(), counter.getCount());
         addingAllEvent.setAppliedEffects(appliedEffects);
         addingAllEvent.setFlag(isEffect);
         if (!game.replaceEvent(addingAllEvent)) {
@@ -742,12 +742,12 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
             for (int i = 0; i < amount; i++) {
                 Counter eventCounter = counter.copy();
                 eventCounter.remove(eventCounter.getCount() - 1);
-                GameEvent addingOneEvent = GameEvent.getEvent(GameEvent.EventType.ADD_COUNTER, objectId, source, getControllerOrOwner(), counter.getName(), 1);
+                GameEvent addingOneEvent = GameEvent.getEvent(GameEvent.EventType.ADD_COUNTER, objectId, source, playerAddingCounters, counter.getName(), 1);
                 addingOneEvent.setAppliedEffects(appliedEffects);
                 addingOneEvent.setFlag(isEffectFlag);
                 if (!game.replaceEvent(addingOneEvent)) {
                     getCounters(game).addCounter(eventCounter);
-                    GameEvent addedOneEvent = GameEvent.getEvent(GameEvent.EventType.COUNTER_ADDED, objectId, source, getControllerOrOwner(), counter.getName(), 1);
+                    GameEvent addedOneEvent = GameEvent.getEvent(GameEvent.EventType.COUNTER_ADDED, objectId, source, playerAddingCounters, counter.getName(), 1);
                     addedOneEvent.setFlag(addingOneEvent.getFlag());
                     game.fireEvent(addedOneEvent);
                 } else {
@@ -756,7 +756,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
                 }
             }
             if (finalAmount > 0) {
-                GameEvent addedAllEvent = GameEvent.getEvent(GameEvent.EventType.COUNTERS_ADDED, objectId, source, getControllerOrOwner(), counter.getName(), amount);
+                GameEvent addedAllEvent = GameEvent.getEvent(GameEvent.EventType.COUNTERS_ADDED, objectId, source, playerAddingCounters, counter.getName(), amount);
                 addedAllEvent.setFlag(isEffectFlag);
                 game.fireEvent(addedAllEvent);
             }

--- a/Mage/src/main/java/mage/cards/MeldCard.java
+++ b/Mage/src/main/java/mage/cards/MeldCard.java
@@ -1,7 +1,5 @@
 package mage.cards;
 
-import java.util.List;
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.constants.CardType;
 import mage.constants.Zone;
@@ -9,6 +7,9 @@ import mage.counters.Counter;
 import mage.game.Game;
 import mage.game.events.ZoneChangeEvent;
 import mage.game.permanent.Permanent;
+
+import java.util.List;
+import java.util.UUID;
 
 /**
  * @author emerald000
@@ -103,17 +104,17 @@ public abstract class MeldCard extends CardImpl {
     }
 
     @Override
-    public boolean addCounters(Counter counter, Ability source, Game game, List<UUID> appliedEffects) {
+    public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, List<UUID> appliedEffects) {
         if (this.isMelded(game)) {
-            return super.addCounters(counter, source, game, appliedEffects);
+            return super.addCounters(counter, playerAddingCounters, source, game, appliedEffects);
         } else {
             // can this really happen?
             boolean returnState = true;
             if (hasTopHalf(game)) {
-                returnState |= topHalfCard.addCounters(counter, source, game, appliedEffects);
+                returnState |= topHalfCard.addCounters(counter, playerAddingCounters, source, game, appliedEffects);
             }
             if (hasBottomHalf(game)) {
-                returnState |= bottomHalfCard.addCounters(counter, source, game, appliedEffects);
+                returnState |= bottomHalfCard.addCounters(counter, playerAddingCounters, source, game, appliedEffects);
             }
             return returnState;
         }

--- a/Mage/src/main/java/mage/constants/SubType.java
+++ b/Mage/src/main/java/mage/constants/SubType.java
@@ -269,6 +269,7 @@ public enum SubType {
     PEST("Pest", SubTypeSet.CreatureType),
     PHELDDAGRIF("Phelddagrif", SubTypeSet.CreatureType),
     PHOENIX("Phoenix", SubTypeSet.CreatureType),
+    PHYREXIAN("Phyrexian", SubTypeSet.CreatureType),
     PILOT("Pilot", SubTypeSet.CreatureType),
     PINCHER("Pincher", SubTypeSet.CreatureType),
     PIRATE("Pirate", SubTypeSet.CreatureType),

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -960,7 +960,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
             } else if (mdi.sourceObject instanceof Permanent) {
                 source = ((Permanent) mdi.sourceObject).getSpellAbility();
             }
-            addCounters(mdi.counter, source.getControllerId(), source, game);
+            addCounters(mdi.counter, game.getControllerId(mdi.sourceObject.getId()), source, game);
         }
         markedDamage.clear();
         return 0;
@@ -1023,7 +1023,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                     damageSourceAbility = ((Permanent) attacker).getSpellAbility();
                 }
                 // deal damage immediately
-                addCounters(CounterType.M1M1.createInstance(actualDamage), damageSourceAbility.getControllerId(), damageSourceAbility, game);
+                addCounters(CounterType.M1M1.createInstance(actualDamage), game.getControllerId(attackerId), damageSourceAbility, game);
             }
         } else {
             this.damage = CardUtil.addWithOverflowCheck(this.damage, actualDamage);

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -960,7 +960,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
             } else if (mdi.sourceObject instanceof Permanent) {
                 source = ((Permanent) mdi.sourceObject).getSpellAbility();
             }
-            addCounters(mdi.counter, source, game);
+            addCounters(mdi.counter, source.getControllerId(), source, game);
         }
         markedDamage.clear();
         return 0;
@@ -1023,7 +1023,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                     damageSourceAbility = ((Permanent) attacker).getSpellAbility();
                 }
                 // deal damage immediately
-                addCounters(CounterType.M1M1.createInstance(actualDamage), damageSourceAbility, game);
+                addCounters(CounterType.M1M1.createInstance(actualDamage), damageSourceAbility.getControllerId(), damageSourceAbility, game);
             }
         } else {
             this.damage = CardUtil.addWithOverflowCheck(this.damage, actualDamage);

--- a/Mage/src/main/java/mage/game/stack/Spell.java
+++ b/Mage/src/main/java/mage/game/stack/Spell.java
@@ -1,6 +1,5 @@
 package mage.game.stack;
 
-import java.util.*;
 import mage.MageInt;
 import mage.MageObject;
 import mage.Mana;
@@ -35,6 +34,8 @@ import mage.players.Player;
 import mage.util.CardUtil;
 import mage.util.GameLog;
 import mage.util.SubTypes;
+
+import java.util.*;
 
 /**
  * @author BetaSteward_at_googlemail.com
@@ -593,7 +594,7 @@ public class Spell extends StackObjImpl implements Card {
             if (mageObjectAttribute != null) {
                 return mageObjectAttribute.getColor();
             }
-        }                
+        }
         return color;
     }
 
@@ -959,23 +960,23 @@ public class Spell extends StackObjImpl implements Card {
     }
 
     @Override
-    public boolean addCounters(Counter counter, Ability source, Game game) {
-        return card.addCounters(counter, source, game);
+    public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game) {
+        return card.addCounters(counter, playerAddingCounters, source, game);
     }
 
     @Override
-    public boolean addCounters(Counter counter, Ability source, Game game, boolean isEffect) {
-        return card.addCounters(counter, source, game, isEffect);
+    public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, boolean isEffect) {
+        return card.addCounters(counter, playerAddingCounters, source, game, isEffect);
     }
 
     @Override
-    public boolean addCounters(Counter counter, Ability source, Game game, List<UUID> appliedEffects) {
-        return card.addCounters(counter, source, game, appliedEffects);
+    public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, List<UUID> appliedEffects) {
+        return card.addCounters(counter, playerAddingCounters, source, game, appliedEffects);
     }
 
     @Override
-    public boolean addCounters(Counter counter, Ability source, Game game, List<UUID> appliedEffects, boolean isEffect) {
-        return card.addCounters(counter, source, game, appliedEffects, isEffect);
+    public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, List<UUID> appliedEffects, boolean isEffect) {
+        return card.addCounters(counter, playerAddingCounters, source, game, appliedEffects, isEffect);
     }
 
     @Override

--- a/Mage/src/main/java/mage/game/turn/PreCombatMainStep.java
+++ b/Mage/src/main/java/mage/game/turn/PreCombatMainStep.java
@@ -1,7 +1,5 @@
-
 package mage.game.turn;
 
-import java.util.UUID;
 import mage.constants.PhaseStep;
 import mage.constants.SubType;
 import mage.counters.CounterType;
@@ -10,8 +8,9 @@ import mage.game.Game;
 import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public class PreCombatMainStep extends Step {
@@ -29,7 +28,7 @@ public class PreCombatMainStep extends Step {
         this.postStepEvent = EventType.PRECOMBAT_MAIN_STEP_POST;
     }
 
-    public PreCombatMainStep(final PreCombatMainStep step) {
+    private PreCombatMainStep(final PreCombatMainStep step) {
         super(step);
     }
 
@@ -38,7 +37,7 @@ public class PreCombatMainStep extends Step {
         super.beginStep(game, activePlayerId);
         for (Permanent saga : game.getBattlefield().getAllActivePermanents(filter, activePlayerId, game)) {
             if (saga != null) {
-                saga.addCounters(CounterType.LORE.createInstance(), null, game);
+                saga.addCounters(CounterType.LORE.createInstance(), activePlayerId, null, game);
             }
         }
     }

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -709,7 +709,7 @@ public interface Player extends MageItem, Copyable<Player> {
 
     LinkedHashMap<UUID, ActivatedAbility> getPlayableActivatedAbilities(MageObject object, Zone zone, Game game);
 
-    boolean addCounters(Counter counter, Ability source, Game game);
+    boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game);
 
     void removeCounters(String name, int amount, Ability source, Game game);
 

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2112,7 +2112,7 @@ public abstract class PlayerImpl implements Player, Serializable {
                             sourceControllerId = ((Permanent) attacker).getControllerId();
                         }
                         if (sourceAbilities != null && sourceAbilities.containsKey(InfectAbility.getInstance().getId())) {
-                            addCounters(CounterType.POISON.createInstance(actualDamage), source, game);
+                            addCounters(CounterType.POISON.createInstance(actualDamage), source.getControllerId(), source, game);
                         } else {
                             GameEvent damageToLifeLossEvent = new GameEvent(GameEvent.EventType.DAMAGE_CAUSES_LIFE_LOSS,
                                     playerId, source, playerId, actualDamage, combatDamage);
@@ -2151,7 +2151,7 @@ public abstract class PlayerImpl implements Player, Serializable {
     }
 
     @Override
-    public boolean addCounters(Counter counter, Ability source, Game game) {
+    public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game) {
         boolean returnCode = true;
         GameEvent addingAllEvent = GameEvent.getEvent(GameEvent.EventType.ADD_COUNTERS, playerId, source,
                 playerId, counter.getName(), counter.getCount());

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2153,8 +2153,10 @@ public abstract class PlayerImpl implements Player, Serializable {
     @Override
     public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game) {
         boolean returnCode = true;
-        GameEvent addingAllEvent = GameEvent.getEvent(GameEvent.EventType.ADD_COUNTERS, playerId, source,
-                playerId, counter.getName(), counter.getCount());
+        GameEvent addingAllEvent = GameEvent.getEvent(
+                GameEvent.EventType.ADD_COUNTERS, playerId, source,
+                playerAddingCounters, counter.getName(), counter.getCount()
+        );
         if (!game.replaceEvent(addingAllEvent)) {
             int amount = addingAllEvent.getAmount();
             int finalAmount = amount;
@@ -2162,13 +2164,17 @@ public abstract class PlayerImpl implements Player, Serializable {
             for (int i = 0; i < amount; i++) {
                 Counter eventCounter = counter.copy();
                 eventCounter.remove(eventCounter.getCount() - 1);
-                GameEvent addingOneEvent = GameEvent.getEvent(GameEvent.EventType.ADD_COUNTER, playerId, source,
-                        playerId, counter.getName(), 1);
+                GameEvent addingOneEvent = GameEvent.getEvent(
+                        GameEvent.EventType.ADD_COUNTER, playerId, source,
+                        playerAddingCounters, counter.getName(), 1
+                );
                 addingOneEvent.setFlag(isEffectFlag);
                 if (!game.replaceEvent(addingOneEvent)) {
                     getCounters().addCounter(eventCounter);
-                    GameEvent addedOneEvent = GameEvent.getEvent(GameEvent.EventType.COUNTER_ADDED, playerId, source,
-                            playerId, counter.getName(), 1);
+                    GameEvent addedOneEvent = GameEvent.getEvent(
+                            GameEvent.EventType.COUNTER_ADDED, playerId, source,
+                            playerAddingCounters, counter.getName(), 1
+                    );
                     addedOneEvent.setFlag(addingOneEvent.getFlag());
                     game.fireEvent(addedOneEvent);
                 } else {
@@ -2177,8 +2183,10 @@ public abstract class PlayerImpl implements Player, Serializable {
                 }
             }
             if (finalAmount > 0) {
-                GameEvent addedAllEvent = GameEvent.getEvent(GameEvent.EventType.COUNTERS_ADDED, playerId, source,
-                        playerId, counter.getName(), amount);
+                GameEvent addedAllEvent = GameEvent.getEvent(
+                        GameEvent.EventType.COUNTERS_ADDED, playerId, source,
+                        playerAddingCounters, counter.getName(), amount
+                );
                 addedAllEvent.setFlag(addingAllEvent.getFlag());
                 game.fireEvent(addedAllEvent);
             }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2112,7 +2112,7 @@ public abstract class PlayerImpl implements Player, Serializable {
                             sourceControllerId = ((Permanent) attacker).getControllerId();
                         }
                         if (sourceAbilities != null && sourceAbilities.containsKey(InfectAbility.getInstance().getId())) {
-                            addCounters(CounterType.POISON.createInstance(actualDamage), source.getControllerId(), source, game);
+                            addCounters(CounterType.POISON.createInstance(actualDamage), sourceControllerId, source, game);
                         } else {
                             GameEvent damageToLifeLossEvent = new GameEvent(GameEvent.EventType.DAMAGE_CAUSES_LIFE_LOSS,
                                     playerId, source, playerId, actualDamage, combatDamage);


### PR DESCRIPTION
Effects like [Vorinclex, Monstrous Raider](https://scryfall.com/card/khm/199/vorinclex-monstrous-raider) and [Nest of Scarabs](https://scryfall.com/card/akh/101/nest-of-scarabs) require tracking which player added counters which isn't currently supported but matters in the case of cards like [Hunted Nightmare](https://scryfall.com/card/iko/92/hunted-nightmare). This shouldn't be too much work since I'm pretty sure I've tracked down all the cards that need to be changed individually.