### PR TITLE
Allow 'Gonti, Lord of Luxury', 'Nightveil Specter' and 'Thief of Sanity' to cast adventures from exile

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GontiLordOfLuxury.java
+++ b/Mage.Sets/src/mage/cards/g/GontiLordOfLuxury.java
@@ -147,6 +147,12 @@ class GontiLordOfLuxuryCastFromExileEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Card theCard = game.getCard(objectId);
+        if (theCard == null) {
+            return false;
+        }
+        objectId = theCard.getMainCard().getId(); // for split cards
+
         UUID targetId = getTargetPointer().getFirst(game, source);
         if (targetId == null) {
             this.discard();
@@ -194,7 +200,7 @@ class GontiLordOfLuxurySpendAnyManaEffect extends AsThoughEffectImpl implements 
             // if the card moved from exile to spell the zone change counter is increased by 1 (effect must applies before and on stack, use isCheckPlayableMode?)
             return source.isControlledBy(affectedControllerId);
         } else if (((FixedTarget) getTargetPointer()).getTarget().equals(objectId)) {
-            // object has moved zone so effect can be discarted
+            // object has moved zone so effect can be discarded
             this.discard();
         }
         return false;

--- a/Mage.Sets/src/mage/cards/n/NightveilSpecter.java
+++ b/Mage.Sets/src/mage/cards/n/NightveilSpecter.java
@@ -119,6 +119,12 @@ class NightveilSpecterEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Card theCard = game.getCard(objectId);
+        if (theCard == null) {
+            return false;
+        }
+        objectId = theCard.getMainCard().getId();// for split cards
+
         if (affectedControllerId.equals(source.getControllerId()) && game.getState().getZone(objectId) == Zone.EXILED) {
             ExileZone zone = game.getExile().getExileZone(CardUtil.getCardExileZoneId(game, source));
             return zone != null && zone.contains(objectId);

--- a/Mage.Sets/src/mage/cards/t/ThiefOfSanity.java
+++ b/Mage.Sets/src/mage/cards/t/ThiefOfSanity.java
@@ -147,6 +147,12 @@ class ThiefOfSanityCastFromExileEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Card theCard = game.getCard(objectId);
+        if (theCard == null) {
+            return false;
+        }
+        objectId = theCard.getMainCard().getId();// for split cards
+
         UUID cardId = getTargetPointer().getFirst(game, source);
         if (cardId == null) {
             this.discard(); // card is no longer in the origin zone, effect can be discarded


### PR DESCRIPTION
Updated effects for 'Gonti, Lord of Luxury', 'Nightveil Specter' and 'Thief of Sanity' to allow the player to cast the adventure part of cards