### PR TITLE
[KHM] Fixed Kardur, Doomscourge

### DIFF
--- a/Mage.Sets/src/mage/cards/k/KardurDoomscourge.java
+++ b/Mage.Sets/src/mage/cards/k/KardurDoomscourge.java
@@ -95,8 +95,6 @@ class KardurDoomscourgeEffect extends RestrictionEffect {
 
 class KardurDoomscourgeTriggeredAbility extends TriggeredAbilityImpl {
 
-    private List<UUID> attackers = null;
-
     public KardurDoomscourgeTriggeredAbility() {
         super(Zone.BATTLEFIELD, new LoseLifeOpponentsEffect(1), false);
         this.addEffect(new GainLifeEffect(1).concatBy("and"));
@@ -104,7 +102,6 @@ class KardurDoomscourgeTriggeredAbility extends TriggeredAbilityImpl {
 
     private KardurDoomscourgeTriggeredAbility(final KardurDoomscourgeTriggeredAbility ability) {
         super(ability);
-        this.attackers = ability.attackers;
     }
 
     @Override
@@ -128,13 +125,14 @@ class KardurDoomscourgeTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         switch (event.getType()) {
             case DECLARE_ATTACKERS_STEP:
-                attackers = game.getCombat().getAttackers();
+                game.getState().setValue(this.getId() + "Attackers", game.getCombat().getAttackers());
                 return false;
             case END_COMBAT_STEP_POST:
-                attackers = null;
+                game.getState().setValue(this.getId() + "Attackers", null);
                 return false;
             case ZONE_CHANGE:
                 ZoneChangeEvent zEvent = (ZoneChangeEvent) event;
+                List<UUID> attackers = (List<UUID>) game.getState().getValue(this.getId() + "Attackers");
                 return zEvent.isDiesEvent() && attackers != null && attackers.contains(zEvent.getTargetId());
             default:
                 return false;

--- a/Mage.Sets/src/mage/cards/k/KardurDoomscourge.java
+++ b/Mage.Sets/src/mage/cards/k/KardurDoomscourge.java
@@ -125,14 +125,14 @@ class KardurDoomscourgeTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         switch (event.getType()) {
             case DECLARE_ATTACKERS_STEP:
-                game.getState().setValue(this.getId() + "Attackers", game.getCombat().getAttackers());
+                game.getState().setValue(this.getSourceId() + "Attackers", game.getCombat().getAttackers());
                 return false;
             case END_COMBAT_STEP_POST:
-                game.getState().setValue(this.getId() + "Attackers", null);
+                game.getState().setValue(this.getSourceId() + "Attackers", null);
                 return false;
             case ZONE_CHANGE:
                 ZoneChangeEvent zEvent = (ZoneChangeEvent) event;
-                List<UUID> attackers = (List<UUID>) game.getState().getValue(this.getId() + "Attackers");
+                List<UUID> attackers = (List<UUID>) game.getState().getValue(this.getSourceId() + "Attackers");
                 return zEvent.isDiesEvent() && attackers != null && attackers.contains(zEvent.getTargetId());
             default:
                 return false;


### PR DESCRIPTION
Issue #7456 

First ability was just missing the watcher needed for `AttacksIfAbleAllEffect`

Second ability did not ever trigger because, by the time the creature changes zones, it's no longer attacking.  This code does not currently handle if a creature gets removed from combat.

I'm wondering if we should make this method fire an event that I can then check for or if there's a better way to handle this:

https://github.com/magefree/mage/blob/fb447d7740bc16e0da7fd83c361f77b1743ff02b/Mage/src/main/java/mage/game/combat/Combat.java#L1442