### PR TITLE
Fix tooltip on Stromkirk Condemned

### DIFF
--- a/Mage.Sets/src/mage/cards/s/StromkirkCondemned.java
+++ b/Mage.Sets/src/mage/cards/s/StromkirkCondemned.java
@@ -17,7 +17,7 @@ import mage.filter.common.FilterCreaturePermanent;
  */
 public final class StromkirkCondemned extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Vampires");
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Vampires you control");
 
     static {
         filter.add(SubType.VAMPIRE.getPredicate());


### PR DESCRIPTION
Should be 'Vampires you control' instead of 'Vampires'.

Right now, the tooltip in-game looks like [this](https://i.fiery.me/oN6uH.png), which does not match the [factual text](https://scryfall.com/card/emn/106/stromkirk-condemned).

