### PR TITLE
SpellCastControllerTriggeredAbility - Check that source is in the correct zone

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/m14/YoungPyromancerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/m14/YoungPyromancerTest.java
@@ -1,0 +1,41 @@
+package org.mage.test.cards.single.m14;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author weirddan455
+ */
+public class YoungPyromancerTest extends CardTestPlayerBase {
+
+    // https://github.com/magefree/mage/issues/7095
+    // Cards that sacrifice Young Pyromancer as part of the cost should not trigger the ability.
+    // Result should be 1 token made from casting Lightning Bolt.  Village Rites should not make a token.
+    @Test
+    public void villageRitesTest() {
+        removeAllCardsFromHand(playerA);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Young Pyromancer");
+        addCard(Zone.HAND, playerA, "Lightning Bolt");
+        addCard(Zone.HAND, playerA, "Village Rites");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Village Rites");
+        setChoice(playerA, "Young Pyromancer");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertLife(playerB, 17);
+        assertHandCount(playerA, 2);
+        assertPermanentCount(playerA, "Elemental", 1);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/common/SpellCastControllerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/SpellCastControllerTriggeredAbility.java
@@ -68,7 +68,8 @@ public class SpellCastControllerTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         if (event.getPlayerId().equals(this.getControllerId())) {
             Spell spell = game.getStack().getSpell(event.getTargetId());
-            if (spell != null && filter.match(spell, getSourceId(), getControllerId(), game)) {
+            if (spell != null && filter.match(spell, getSourceId(), getControllerId(), game)
+                    && game.getState().getZone(this.getSourceId()) == zone) {
                 if (rememberSource) {
                     this.getEffects().setValue("spellCast", spell);
                     if (rememberSourceAsCard) {


### PR DESCRIPTION
Issue #7095 

Bug happens when sacrificing the source of the ability is a cost of casting the spell.  I thought there should be a zone check in lower level code for this case but I wasn't able to find it.  This just checks that the card is in the correct zone (battlefield in the case of Young Pyromance + Village Rites) at the time the spell is cast.