### PR TITLE
Implemented updated Cascade ruling 702.84a

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -2782,6 +2782,12 @@ public class ComputerPlayer extends PlayerImpl implements Player {
     }
 
     @Override
+    public SpellAbility chooseAbilityForCast(Card card, Game game, boolean noMana) {
+        Map<UUID, ActivatedAbility> useable = PlayerImpl.getSpellAbilities(this.getId(), card, game.getState().getZone(card.getId()), game);
+        return (SpellAbility) useable.values().stream().findFirst().orElse(null);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/Mage.Sets/src/mage/cards/g/GodEternalKefnet.java
+++ b/Mage.Sets/src/mage/cards/g/GodEternalKefnet.java
@@ -90,7 +90,6 @@ class GodEternalKefnetDrawCardReplacementEffect extends ReplacementEffectImpl {
         you.setTopCardRevealed(true);
 
         // cast copy
-
         if (topCard.isInstantOrSorcery()
                 && you.chooseUse(outcome, "Would you like to copy " + topCard.getName() + " and cast it for {2} less?", source, game)) {
             Card blueprint = topCard.copy();
@@ -105,7 +104,9 @@ class GodEternalKefnetDrawCardReplacementEffect extends ReplacementEffectImpl {
             }
             Card copiedCard = game.copyCard(blueprint, source, source.getControllerId());
             you.moveCardToHandWithInfo(copiedCard, source, game, true); // The copy is created in and cast from your hand. (2019-05-03)
+            game.getState().setValue("PlayFromNotOwnHandZone" + copiedCard.getId(), Boolean.TRUE);
             you.cast(you.chooseAbilityForCast(copiedCard, game, false), game, false, new ApprovingObject(source, game));
+            game.getState().setValue("PlayFromNotOwnHandZone" + copiedCard.getId(), null);
         }
 
         // draw (return false for default draw)

--- a/Mage.Sets/src/mage/cards/j/JestersScepter.java
+++ b/Mage.Sets/src/mage/cards/j/JestersScepter.java
@@ -156,7 +156,8 @@ class JestersScepterCost extends CostImpl {
             TargetCardInExile target = new TargetCardInExile(new FilterCard(), CardUtil.getCardExileZoneId(game, ability));
             target.setNotTarget(true);
             Cards cards = game.getExile().getExileZone(CardUtil.getCardExileZoneId(game, ability));
-            if (!cards.isEmpty()
+            if (cards != null
+                    && !cards.isEmpty()
                     && controller.choose(Outcome.Benefit, cards, target, game)) {
                 Card card = game.getCard(target.getFirstTarget());
                 if (card != null) {

--- a/Mage.Sets/src/mage/cards/k/KahoMinamoHistorian.java
+++ b/Mage.Sets/src/mage/cards/k/KahoMinamoHistorian.java
@@ -130,7 +130,8 @@ class KahoMinamoHistorianCastEffect extends OneShotEffect {
             filter.add(new ConvertedManaCostPredicate(ComparisonType.EQUAL_TO, source.getManaCostsToPay().getX()));
             TargetCardInExile target = new TargetCardInExile(filter, CardUtil.getCardExileZoneId(game, source));
             Cards cards = game.getExile().getExileZone(CardUtil.getCardExileZoneId(game, source));
-            if (!cards.isEmpty()
+            if (cards != null
+                    && !cards.isEmpty()
                     && controller.choose(Outcome.PlayForFree, cards, target, game)) {
                 Card card = game.getCard(target.getFirstTarget());
                 if (card != null) {

--- a/Mage.Sets/src/mage/cards/m/MesmericFiend.java
+++ b/Mage.Sets/src/mage/cards/m/MesmericFiend.java
@@ -122,7 +122,7 @@ class MesmericFiendLeaveEffect extends OneShotEffect {
             UUID exileId = (UUID) game.getState().getValue(source.getSourceId().toString() + zoneChangeMinusOne);
             if (exileId != null) {
                 Cards cards = game.getExile().getExileZone(exileId);
-                if (!cards.isEmpty()) {
+                if (cards != null && !cards.isEmpty()) {
                     return controller.moveCards(cards, Zone.HAND, source, game);
                 }
             }

--- a/Mage.Sets/src/mage/cards/v/ValkiGodOfLies.java
+++ b/Mage.Sets/src/mage/cards/v/ValkiGodOfLies.java
@@ -124,6 +124,7 @@ class ValkiGodOfLiesRevealExileEffect extends OneShotEffect {
                 if (opponent != null) {
                     opponent.revealCards(source, opponent.getHand(), game);
                     TargetCard targetToExile = new TargetCard(Zone.HAND, StaticFilters.FILTER_CARD_CREATURE);
+                    targetToExile.withChooseHint("card to exile");
                     targetToExile.setNotTarget(true);
                     if (controller.choose(Outcome.Exile, opponent.getHand(), targetToExile, game)) {
                         Card targetedCardToExile = game.getCard(targetToExile.getFirstTarget());
@@ -240,7 +241,8 @@ class ValkiGodOfLiesCopyExiledEffect extends OneShotEffect {
             filter.add(new ConvertedManaCostPredicate(ComparisonType.EQUAL_TO, source.getManaCostsToPay().getX()));
             TargetCardInExile target = new TargetCardInExile(filter, exileId);
             Cards cards = game.getExile().getExileZone(exileId);
-            if (!cards.isEmpty()
+            if (cards != null
+                    && !cards.isEmpty()
                     && controller.choose(Outcome.Benefit, cards, target, game)) {
                 Card chosenExiledCard = game.getCard(target.getFirstTarget());
                 if (chosenExiledCard != null) {

--- a/Mage.Sets/src/mage/cards/v/VoidMaw.java
+++ b/Mage.Sets/src/mage/cards/v/VoidMaw.java
@@ -138,7 +138,8 @@ class VoidMawCost extends CostImpl {
             TargetCardInExile target = new TargetCardInExile(new FilterCard(), CardUtil.getCardExileZoneId(game, ability));
             target.setNotTarget(true);
             Cards cards = game.getExile().getExileZone(CardUtil.getCardExileZoneId(game, ability));
-            if (!cards.isEmpty()
+            if (cards != null
+                    && !cards.isEmpty()
                     && controller.choose(Outcome.Benefit, cards, target, game)) {
                 Card card = game.getCard(target.getFirstTarget());
                 if (card != null) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/modaldoublefaces/ModalDoubleFacesCardsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/modaldoublefaces/ModalDoubleFacesCardsTest.java
@@ -10,6 +10,7 @@ import mage.util.CardUtil;
 import mage.util.ManaUtil;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -796,5 +797,70 @@ public class ModalDoubleFacesCardsTest extends CardTestPlayerBase {
         setStopAt(1, PhaseStep.END_TURN);
         execute();
         assertAllCommandsUsed();
+    }
+
+    @Test
+    public void test_Cascade_ValkiGodOfLies() {
+        // https://magic.wizards.com/en/articles/archive/news/february-15-2021-banned-and-restricted-announcement
+        // For example, if you cast Bloodbraid Elf and exile Valki, God of Lies from your library,
+        // you'll be able to cast Valki but not Tibalt, Cosmic Impostor. On the other hand, if you
+        // exile Cosima, God of the Voyage, you may cast either Cosima or The Omenkeel, as each face
+        // has a lesser converted mana cost than Bloodbraid Elf.
+        removeAllCardsFromLibrary(playerA);
+        skipInitShuffling();
+
+        // Cascade
+        addCard(Zone.HAND, playerA, "Bloodbraid Elf"); // {2}{R}{G}
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 1);
+        //
+        addCard(Zone.LIBRARY, playerA, "Swamp", 2);
+        addCard(Zone.LIBRARY, playerA, "Valki, God of Lies", 1);
+        addCard(Zone.LIBRARY, playerA, "Island", 2);
+
+        // play elf with cascade
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Bloodbraid Elf");
+        setChoice(playerA, "Yes"); // use free cast
+        //setChoice(playerA, "Cast Valki, God of Lies"); possible bug: you can see two spell abilities to choose, but only one allows here
+        setChoice(playerA, TestPlayer.CHOICE_SKIP); // no choices for valki's etb exile
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerA, "Valki, God of Lies", 1);
+    }
+
+    @Test
+    public void test_Cascade_CosimaGodOfTheVoyage() {
+        // https://magic.wizards.com/en/articles/archive/news/february-15-2021-banned-and-restricted-announcement
+        // For example, if you cast Bloodbraid Elf and exile Valki, God of Lies from your library,
+        // you'll be able to cast Valki but not Tibalt, Cosmic Impostor. On the other hand, if you
+        // exile Cosima, God of the Voyage, you may cast either Cosima or The Omenkeel, as each face
+        // has a lesser converted mana cost than Bloodbraid Elf.
+        removeAllCardsFromLibrary(playerA);
+        skipInitShuffling();
+
+        // Cascade
+        addCard(Zone.HAND, playerA, "Bloodbraid Elf"); // {2}{R}{G}
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 1);
+        //
+        addCard(Zone.LIBRARY, playerA, "Swamp", 2);
+        addCard(Zone.LIBRARY, playerA, "Cosima, God of the Voyage", 1);
+        addCard(Zone.LIBRARY, playerA, "Island", 2);
+
+        // play elf with cascade
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Bloodbraid Elf");
+        setChoice(playerA, "Yes"); // use free cast
+        setChoice(playerA, "Cast The Omenkeel"); // can cast any side here
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerA, "The Omenkeel", 1);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -3777,6 +3777,21 @@ public class TestPlayer implements Player {
     ) {
         assertAliasSupportInChoices(false);
         if (!choices.isEmpty()) {
+
+            // skip choices
+            if (choices.get(0).equals(CHOICE_SKIP)) {
+                choices.remove(0);
+                if (cards.isEmpty()) {
+                    // cancel button forced in GUI on no possible choices
+                    return false;
+                } else {
+                    Assert.assertTrue("found skip choice, but it require more choices, needs "
+                                    + (target.getMinNumberOfTargets() - target.getTargets().size()) + " more",
+                            target.getTargets().size() >= target.getMinNumberOfTargets());
+                    return true;
+                }
+            }
+
             for (String choose2 : choices) {
                 // TODO: More targetting to fix
                 String[] targetList = choose2.split("\\^");

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -365,6 +365,20 @@ public interface Player extends MageItem, Copyable<Player> {
 
     boolean cast(SpellAbility ability, Game game, boolean noMana, ApprovingObject approvingObject);
 
+    /**
+     * Force player to choose spell ability to cast. Use it in effects while casting cards.
+     *
+     * Commands order in all use cases:
+     * - PlayFromNotOwnHandZone - true
+     * - chooseAbilityForCast
+     * - cast
+     * - PlayFromNotOwnHandZone - false
+     *
+     * @param card
+     * @param game
+     * @param noMana
+     * @return
+     */
     SpellAbility chooseAbilityForCast(Card card, Game game, boolean noMana);
 
     boolean putInHand(Card card, Game game);

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1519,14 +1519,26 @@ public abstract class PlayerImpl implements Player, Serializable {
         return false;
     }
 
+    /**
+     * Return spells for possible cast
+     * Uses in GUI to show only playable spells for choosing from the card
+     * (example: effect allow to cast card and player must choose the spell ability)
+     *
+     * @param playerId
+     * @param object
+     * @param zone
+     * @param game
+     * @return
+     */
     public static LinkedHashMap<UUID, ActivatedAbility> getSpellAbilities(UUID playerId, MageObject object, Zone zone, Game game) {
+        // it uses simple check from spellCanBeActivatedRegularlyNow
+        // reason: no approved info here (e.g. forced to choose spell ability from cast card)
         LinkedHashMap<UUID, ActivatedAbility> useable = new LinkedHashMap<>();
         for (Ability ability : object.getAbilities()) {
             if (ability instanceof SpellAbility) {
                 switch (((SpellAbility) ability).getSpellAbilityType()) {
                     case BASE_ALTERNATE:
-                        ActivationStatus as = ((SpellAbility) ability).canActivate(playerId, game);
-                        if (as.canActivate()) {
+                        if (((SpellAbility) ability).spellCanBeActivatedRegularlyNow(playerId, game)) {
                             useable.put(ability.getId(), (SpellAbility) ability);  // example: Chandra, Torch of Defiance +1 loyal ability
                         }
                         return useable;
@@ -1560,7 +1572,9 @@ public abstract class PlayerImpl implements Player, Serializable {
                         }
                         return useable;
                     default:
-                        useable.put(ability.getId(), (SpellAbility) ability);
+                        if (((SpellAbility) ability).spellCanBeActivatedRegularlyNow(playerId, game)) {
+                            useable.put(ability.getId(), (SpellAbility) ability);
+                        }
                 }
             }
         }
@@ -2713,7 +2727,9 @@ public abstract class PlayerImpl implements Player, Serializable {
 
             // casting selected card
             // TODO: fix costs (why is Panglacial Wurm automatically accepting payment?)
+            game.getState().setValue("PlayFromNotOwnHandZone" + card.getId(), Boolean.TRUE);
             targetPlayer.cast(targetPlayer.chooseAbilityForCast(card, game, false), game, false, null);
+            game.getState().setValue("PlayFromNotOwnHandZone" + card.getId(), null);
             castableCards.remove(card.getId());
             casted = true;
         }


### PR DESCRIPTION
Issue #7583 

Cascade now needs to check if you are allowed to cast the back half of MDFCs or the spell half of adventure cards.  While I was in here, I also cleaned up some code (changed variable names to be more clear and moved all cards to exile at once.)

For adventure cards, there is no "creature half" so I couldn't call `controller.chooseAbilityForCast` in the case that the player is unable to cast the spell half.  Currently, it's just going to cast the main spell ability in that case.  Let me know if that will be an issue.

I tested with WotC's examples in the B&R announcement.  With Bloodbraid Elf, you can no longer cast Tibalt (only Valki.)  You can no longer cast Granted (only creature side of Fae of Wishes.)  Bonecrusher Giant and Cosima, God of the Voyage allow either side to be cast.