### PR TITLE
fix: Zurzoth attack ability trigger for opponent creatures

### DIFF
--- a/Mage.Sets/src/mage/cards/z/ZurzothChaosRider.java
+++ b/Mage.Sets/src/mage/cards/z/ZurzothChaosRider.java
@@ -121,6 +121,7 @@ class ZurzothChaosRiderAttackAbility extends TriggeredAbilityImpl {
                 .stream()
                 .map(game::getPermanent)
                 .filter(Objects::nonNull)
+                .filter(permanent -> permanent.isControlledBy(this.getControllerId()))
                 .filter(permanent -> permanent.hasSubtype(SubType.DEVIL, game))
                 .map(MageItem::getId)
                 .map(game.getCombat()::getDefenderId)
@@ -131,7 +132,7 @@ class ZurzothChaosRiderAttackAbility extends TriggeredAbilityImpl {
         if (playerIds.isEmpty()) {
             return false;
         }
-        playerIds.add(getControllerId());
+        playerIds.add(this.getControllerId());
         this.getEffects().clear();
         this.addEffect(new ZurzothChaosRiderEffect(playerIds));
         return true;


### PR DESCRIPTION
The checkTrigger of ZurzothChaosRiderAttackAbility wasn't filtering creatures controlled by Zurzoth's controller