### PR TITLE
Add possibility to play less rounds of swiss than xmage suggests

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
@@ -913,7 +913,7 @@ public class NewTournamentDialog extends MageDialog {
         // set the number of minimum swiss rounds related to the number of players
         int minRounds = (int) Math.ceil(Math.log(numPlayers + 1) / Math.log(2));
         int newValue = Math.max((Integer) spnNumRounds.getValue(), minRounds);
-        this.spnNumRounds.setModel(new SpinnerNumberModel(newValue, 1, 10, 1));
+        this.spnNumRounds.setModel(new SpinnerNumberModel(newValue, 2, 10, 1));
         this.pack();
         this.revalidate();
         this.repaint();

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
@@ -913,7 +913,7 @@ public class NewTournamentDialog extends MageDialog {
         // set the number of minimum swiss rounds related to the number of players
         int minRounds = (int) Math.ceil(Math.log(numPlayers + 1) / Math.log(2));
         int newValue = Math.max((Integer) spnNumRounds.getValue(), minRounds);
-        this.spnNumRounds.setModel(new SpinnerNumberModel(newValue, minRounds, 10, 1));
+        this.spnNumRounds.setModel(new SpinnerNumberModel(newValue, 1, 10, 1));
         this.pack();
         this.revalidate();
         this.repaint();


### PR DESCRIPTION
This change preserves the functionality where Xmage raises the number of swiss rounds when the number of tournament participants increases, but now it's possible for the user to afterwards lower the number of rounds manually (to as down as 1).

Example of the new behavior: The tournament has 3 swiss rounds and 8 participants. The number of participants is raised to 10 and xmage sets the number of swiss rounds to 4. Afterwards the user can set the number of swiss rounds back to 3.

This is a common need in Xmage Draft Historical Society drafts where we'd like to play 3 swiss rounds even when we have 10 players. Fixes https://github.com/magefree/mage/issues/7470