### PR TITLE
refactor of moveCard usage

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AbundantHarvest.java
+++ b/Mage.Sets/src/mage/cards/a/AbundantHarvest.java
@@ -74,10 +74,8 @@ class AbundantHarvestEffect extends OneShotEffect {
             }
         }
         player.revealCards(source, toReveal, game);
-        if (toHand != null) {
-            toReveal.remove(toHand);
-            player.moveCards(toHand, Zone.HAND, source, game);
-        }
+        toReveal.remove(toHand);
+        player.moveCards(toHand, Zone.HAND, source, game);
         player.putCardsOnBottomOfLibrary(toReveal, game, source, false);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/a/AccursedWitch.java
+++ b/Mage.Sets/src/mage/cards/a/AccursedWitch.java
@@ -83,10 +83,8 @@ class AccursedWitchReturnTransformedEffect extends OneShotEffect {
         game.getState().setValue("attachTo:" + secondFaceId, attachTo.getId());
         //note: should check for null after game.getCard
         Card card = game.getCard(source.getSourceId());
-        if (card != null) {
-            if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                attachTo.addAttachment(card.getId(), source, game);
-            }
+        if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
+            attachTo.addAttachment(card.getId(), source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/a/AcolyteOfAffliction.java
+++ b/Mage.Sets/src/mage/cards/a/AcolyteOfAffliction.java
@@ -77,10 +77,6 @@ class AcolyteOfAfflictionEffect extends OneShotEffect {
             return true;
         }
         Card card = game.getCard(target.getFirstTarget());
-        if (card == null) {
-            return true;
-        }
-        player.moveCards(card, Zone.HAND, source, game);
-        return true;
+        return player.moveCards(card, Zone.HAND, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/a/Acquire.java
+++ b/Mage.Sets/src/mage/cards/a/Acquire.java
@@ -1,6 +1,5 @@
 package mage.cards.a;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
@@ -15,13 +14,15 @@ import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetOpponent;
 
+import java.util.UUID;
+
 /**
  * @author andyfries
  */
 public final class Acquire extends CardImpl {
 
     public Acquire(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{3}{U}{U}");
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{U}{U}");
 
         // Search target opponent's library for an artifact card and put that card onto the battlefield under your control.
         // Then that player shuffles their library.
@@ -64,9 +65,7 @@ class AcquireEffect extends OneShotEffect {
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
             controller.searchLibrary(target, source, game, opponent.getId());
             Card targetCard = game.getCard(target.getFirstTarget());
-            if (targetCard != null) {
-                controller.moveCards(targetCard, Zone.BATTLEFIELD, source, game);
-            }
+            controller.moveCards(targetCard, Zone.BATTLEFIELD, source, game);
             opponent.shuffleLibrary(source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/a/AetherVial.java
+++ b/Mage.Sets/src/mage/cards/a/AetherVial.java
@@ -92,9 +92,7 @@ class AetherVialEffect extends OneShotEffect {
         TargetCardInHand target = new TargetCardInHand(filter);
         if (controller.choose(this.outcome, target, source.getSourceId(), game)) {
             Card card = game.getCard(target.getFirstTarget());
-            if (card != null) {
                 return controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-            }
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/a/AleshaWhoSmilesAtDeath.java
+++ b/Mage.Sets/src/mage/cards/a/AleshaWhoSmilesAtDeath.java
@@ -1,7 +1,6 @@
 
 package mage.cards.a;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
@@ -19,8 +18,9 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class AleshaWhoSmilesAtDeath extends CardImpl {
@@ -32,7 +32,7 @@ public final class AleshaWhoSmilesAtDeath extends CardImpl {
     }
 
     public AleshaWhoSmilesAtDeath(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{R}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{R}");
         addSuperType(SuperType.LEGENDARY);
         this.subtype.add(SubType.HUMAN);
         this.subtype.add(SubType.WARRIOR);
@@ -75,10 +75,8 @@ class AleshaWhoSmilesAtDeathEffect extends OneShotEffect {
 
         if (controller != null) {
             Card card = game.getCard(getTargetPointer().getFirst(game, source));
-            if (card != null) {
-                if (controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null)) {
-                    game.getCombat().addAttackingCreature(card.getId(), game);
-                }
+            if (controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null)) {
+                game.getCombat().addAttackingCreature(card.getId(), game);
             }
             return true;
 

--- a/Mage.Sets/src/mage/cards/a/AllureOfTheUnknown.java
+++ b/Mage.Sets/src/mage/cards/a/AllureOfTheUnknown.java
@@ -80,7 +80,6 @@ class AllureOfTheUnknownEffect extends OneShotEffect {
         opponent.choose(Outcome.Exile, cards, targetCard, game);
         Card card = game.getCard(targetCard.getFirstTarget());
         if (player.moveCards(card, Zone.EXILED, source, game)
-                && card != null
                 && game.getState().getZone(card.getId()) == Zone.EXILED) {
             cards.remove(card);
         }

--- a/Mage.Sets/src/mage/cards/a/AltarOfTheLost.java
+++ b/Mage.Sets/src/mage/cards/a/AltarOfTheLost.java
@@ -70,23 +70,19 @@ class AltarOfTheLostManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
+        if(game == null){
+            return false;
+        }
         MageObject object = game.getObject(source.getSourceId());
-        if (game != null && game.inCheckPlayableState()) {
-            if (object instanceof Card && game.getState().getZone(source.getSourceId()).equals(Zone.GRAVEYARD)) {
-                for (Ability ability : ((Card) object).getAbilities(game)) {
-                    if (ability instanceof FlashbackAbility) {
-                        return true;
-                    }
-                }
+        if (game.inCheckPlayableState()) {
+            if (object instanceof Card && game.getState().getZone(source.getSourceId())== Zone.GRAVEYARD) {
+                return ((Card) object).getAbilities(game).stream().anyMatch(ability -> ability instanceof FlashbackAbility);
             }
 
         }
         if (object instanceof Spell && ((Spell) object).getFromZone() == Zone.GRAVEYARD) {
-            for (Ability ability : ((Spell) object).getAbilities(game)) {
-                if (ability instanceof FlashbackAbility) {
-                    return true;
-                }
-            }
+            return ((Spell)object).getAbilities(game).stream().anyMatch(ability -> ability instanceof FlashbackAbility);
+
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/a/AnafenzaTheForemost.java
+++ b/Mage.Sets/src/mage/cards/a/AnafenzaTheForemost.java
@@ -97,9 +97,7 @@ class AnafenzaTheForemostEffect extends ReplacementEffectImpl {
                 }
             } else {
                 Card card = game.getCard(event.getTargetId());
-                if (card != null) {
-                    return controller.moveCards(card, Zone.EXILED, source, game);
-                }
+                return controller.moveCards(card, Zone.EXILED, source, game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/a/AnimalMagnetism.java
+++ b/Mage.Sets/src/mage/cards/a/AnimalMagnetism.java
@@ -1,7 +1,5 @@
 package mage.cards.a;
 
-import java.util.Set;
-import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
@@ -16,8 +14,10 @@ import mage.target.Target;
 import mage.target.TargetCard;
 import mage.target.common.TargetOpponent;
 
+import java.util.Set;
+import java.util.UUID;
+
 /**
- *
  * @author fenhl
  */
 public final class AnimalMagnetism extends CardImpl {
@@ -79,10 +79,8 @@ class AnimalMagnetismEffect extends OneShotEffect {
                     opponent.chooseTarget(outcome, cards, target, source, game);
                     cardToBattlefield = game.getCard(target.getFirstTarget());
                 }
-                if (cardToBattlefield != null) {
-                    controller.moveCards(cardToBattlefield, Zone.BATTLEFIELD, source, game);
-                    cards.remove(cardToBattlefield);
-                }
+                controller.moveCards(cardToBattlefield, Zone.BATTLEFIELD, source, game);
+                cards.remove(cardToBattlefield);
                 controller.moveCards(cards, Zone.GRAVEYARD, source, game);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/a/ArchmageAscension.java
+++ b/Mage.Sets/src/mage/cards/a/ArchmageAscension.java
@@ -94,9 +94,7 @@ class ArchmageAscensionReplacementEffect extends ReplacementEffectImpl {
         TargetCardInLibrary target = new TargetCardInLibrary();
         player.searchLibrary(target, source, game);
         Card card = player.getLibrary().getCard(target.getFirstTarget(), game);
-        if (card != null) {
-            player.moveCards(card, Zone.HAND, source, game);
-        }
+        player.moveCards(card, Zone.HAND, source, game);
         player.shuffleLibrary(source, game);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/a/ArcumDagsson.java
+++ b/Mage.Sets/src/mage/cards/a/ArcumDagsson.java
@@ -1,7 +1,6 @@
 
 package mage.cards.a;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -22,8 +21,9 @@ import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInLibrary;
 
+import java.util.UUID;
+
 /**
- *
  * @author emerald000
  */
 public final class ArcumDagsson extends CardImpl {
@@ -35,7 +35,7 @@ public final class ArcumDagsson extends CardImpl {
     }
 
     public ArcumDagsson(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{U}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{U}");
         addSuperType(SuperType.LEGENDARY);
         this.subtype.add(SubType.HUMAN);
         this.subtype.add(SubType.ARTIFICER);
@@ -91,9 +91,7 @@ class ArcumDagssonEffect extends OneShotEffect {
                     TargetCardInLibrary target = new TargetCardInLibrary(filter);
                     if (player.searchLibrary(target, source, game)) {
                         Card card = game.getCard(target.getFirstTarget());
-                        if (card != null) {
-                            player.moveCards(card, Zone.BATTLEFIELD, source, game);
-                        }
+                        player.moveCards(card, Zone.BATTLEFIELD, source, game);
                     }
                     player.shuffleLibrary(source, game);
                 }

--- a/Mage.Sets/src/mage/cards/a/AssassinsTrophy.java
+++ b/Mage.Sets/src/mage/cards/a/AssassinsTrophy.java
@@ -1,7 +1,5 @@
 package mage.cards.a;
 
-import java.util.UUID;
-
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DestroyTargetEffect;
@@ -19,6 +17,8 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInLibrary;
+
+import java.util.UUID;
 
 /**
  * @author TheElk801
@@ -78,9 +78,7 @@ class AssassinsTrophyEffect extends OneShotEffect {
                     TargetCardInLibrary target = new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND);
                     if (controller.searchLibrary(target, source, game)) {
                         Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
-                        if (card != null) {
-                            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                        }
+                        controller.moveCards(card, Zone.BATTLEFIELD, source, game);
                     }
                     controller.shuffleLibrary(source, game);
                 }

--- a/Mage.Sets/src/mage/cards/a/AtlaPalaniNestTender.java
+++ b/Mage.Sets/src/mage/cards/a/AtlaPalaniNestTender.java
@@ -95,9 +95,7 @@ class AtlaPalaniNestTenderEffect extends OneShotEffect {
                 break;
             }
         }
-        if (toBattlefield != null) {
-            player.moveCards(toBattlefield, Zone.BATTLEFIELD, source, game);
-        }
+        player.moveCards(toBattlefield, Zone.BATTLEFIELD, source, game);
         player.revealCards(source, cards, game);
         cards.remove(toBattlefield);
         if (!cards.isEmpty()) {

--- a/Mage.Sets/src/mage/cards/a/AudaciousReshapers.java
+++ b/Mage.Sets/src/mage/cards/a/AudaciousReshapers.java
@@ -76,9 +76,6 @@ class AudaciousReshapersEffect extends OneShotEffect {
         Cards cards = new CardsImpl();
         Card artifact = null;
         for (Card card : player.getLibrary().getCards(game)) {
-            if (card == null) {
-                continue;
-            }
             cards.add(card);
             if (card.isArtifact()) {
                 artifact = card;
@@ -87,9 +84,7 @@ class AudaciousReshapersEffect extends OneShotEffect {
         }
         int size = cards.size();
         player.revealCards(source, cards, game);
-        if (artifact != null) {
-            player.moveCards(artifact, Zone.BATTLEFIELD, source, game);
-        }
+        player.moveCards(artifact, Zone.BATTLEFIELD, source, game);
         cards.removeIf(uuid -> game.getState().getZone(uuid) != Zone.LIBRARY);
         player.putCardsOnBottomOfLibrary(cards, game, source, false);
         player.damage(size, source.getSourceId(), source, game);

--- a/Mage.Sets/src/mage/cards/a/AugurOfBolas.java
+++ b/Mage.Sets/src/mage/cards/a/AugurOfBolas.java
@@ -92,11 +92,10 @@ class AugurOfBolasEffect extends OneShotEffect {
                             controller.chooseTarget(outcome, topCards, target, source, game);
                             card = topCards.get(target.getFirstTarget(), game);
                         }
-                        if (card != null) {
-                            controller.moveCards(card, Zone.HAND, source, game);
-                            controller.revealCards(sourceObject.getIdName(), new CardsImpl(card), game);
-                            topCards.remove(card);
-                        }
+                        controller.moveCards(card, Zone.HAND, source, game);
+                        controller.revealCards(sourceObject.getIdName(), new CardsImpl(card), game);
+                        topCards.remove(card);
+
                     }
                 }
                 controller.putCardsOnBottomOfLibrary(topCards, game, source, true);

--- a/Mage.Sets/src/mage/cards/b/BaneAlleyBroker.java
+++ b/Mage.Sets/src/mage/cards/b/BaneAlleyBroker.java
@@ -164,7 +164,7 @@ class BaneAlleyBrokerReturnToHandEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        return card != null && player.moveCards(card, Zone.HAND, source, game);
+        return player.moveCards(card, Zone.HAND, source, game);
     }
 }
 

--- a/Mage.Sets/src/mage/cards/b/BenefactionOfRhonas.java
+++ b/Mage.Sets/src/mage/cards/b/BenefactionOfRhonas.java
@@ -1,15 +1,10 @@
 
 package mage.cards.b;
 
-import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
-import mage.cards.Card;
-import mage.cards.CardImpl;
-import mage.cards.CardSetInfo;
-import mage.cards.Cards;
-import mage.cards.CardsImpl;
+import mage.cards.*;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
@@ -19,8 +14,9 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetCard;
 
+import java.util.UUID;
+
 /**
- *
  * @author fireshoes
  */
 public final class BenefactionOfRhonas extends CardImpl {
@@ -83,7 +79,7 @@ class BenefactionOfRhonasEffect extends OneShotEffect {
                 controller.revealCards(sourceObject.getName(), cards, game);
                 if ((creatureCardFound || enchantmentCardFound)
                         && controller.chooseUse(Outcome.DrawCard,
-                                "Put a creature card and/or enchantment card into your hand?", source, game)) {
+                        "Put a creature card and/or enchantment card into your hand?", source, game)) {
                     TargetCard target = new TargetCard(Zone.LIBRARY, new FilterCreatureCard("creature card to put into your hand"));
                     if (creatureCardFound && controller.chooseTarget(Outcome.DrawCard, cards, target, source, game)) {
                         Card card = cards.get(target.getFirstTarget(), game);
@@ -96,10 +92,9 @@ class BenefactionOfRhonasEffect extends OneShotEffect {
                     target = new TargetCard(Zone.LIBRARY, new FilterEnchantmentCard("enchantment card to put into your hand"));
                     if (enchantmentCardFound && controller.chooseTarget(Outcome.DrawCard, cards, target, source, game)) {
                         Card card = cards.get(target.getFirstTarget(), game);
-                        if (card != null) {
-                            cards.remove(card);
-                            controller.moveCards(card, Zone.HAND, source, game);
-                        }
+                        cards.remove(card);
+                        controller.moveCards(card, Zone.HAND, source, game);
+
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/b/Bioplasm.java
+++ b/Mage.Sets/src/mage/cards/b/Bioplasm.java
@@ -73,9 +73,6 @@ class BioplasmEffect extends OneShotEffect {
             return false;
         }
         Card card = library.getFromTop(game);
-        if (card == null) {
-            return false;
-        }
         if (player.moveCards(card, Zone.EXILED, source, game) && card.isCreature()) {
             game.addEffect(new BoostSourceEffect(card.getPower().getValue(), card.getToughness().getValue(), Duration.EndOfTurn), source);
         }

--- a/Mage.Sets/src/mage/cards/b/BlizzardSpecter.java
+++ b/Mage.Sets/src/mage/cards/b/BlizzardSpecter.java
@@ -1,7 +1,6 @@
 
 package mage.cards.b;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.Mode;
@@ -19,14 +18,15 @@ import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetControlledPermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author anonymous
  */
 public final class BlizzardSpecter extends CardImpl {
 
     public BlizzardSpecter(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{U}{B}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}{B}");
         addSuperType(SuperType.SNOW);
         this.subtype.add(SubType.SPECTER);
         this.power = new MageInt(2);
@@ -83,9 +83,8 @@ class ReturnToHandEffect extends OneShotEffect {
         if (target.canChoose(source.getSourceId(), targetPlayer.getId(), game)) {
             targetPlayer.chooseTarget(Outcome.ReturnToHand, target, source, game);
             Permanent permanent = game.getPermanent(target.getFirstTarget());
-            if (permanent != null) {
-                targetPlayer.moveCards(permanent, Zone.HAND, source, game);
-            }
+            targetPlayer.moveCards(permanent, Zone.HAND, source, game);
+
 
         }
         return true;

--- a/Mage.Sets/src/mage/cards/b/BloodClock.java
+++ b/Mage.Sets/src/mage/cards/b/BloodClock.java
@@ -78,9 +78,6 @@ class BloodClockEffect extends OneShotEffect {
             return false;
         }
         Permanent permanent = game.getPermanent(target.getFirstTarget());
-        if (permanent == null) {
-            return false;
-        }
         return player.moveCards(permanent, Zone.HAND, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/b/BloodOath.java
+++ b/Mage.Sets/src/mage/cards/b/BloodOath.java
@@ -80,40 +80,21 @@ class BloodOathEffect extends OneShotEffect {
             Choice choiceImpl = new ChoiceImpl();
             choiceImpl.setChoices(choice);
             if (player.choose(Outcome.Neutral, choiceImpl, game)) {
-                CardType type = null;
-                String choosenType = choiceImpl.getChoice();
-
-                if (choosenType.equals(CardType.ARTIFACT.toString())) {
-                    type = CardType.ARTIFACT;
-                } else if (choosenType.equals(CardType.LAND.toString())) {
-                    type = CardType.LAND;
-                } else if (choosenType.equals(CardType.CREATURE.toString())) {
-                    type = CardType.CREATURE;
-                } else if (choosenType.equals(CardType.ENCHANTMENT.toString())) {
-                    type = CardType.ENCHANTMENT;
-                } else if (choosenType.equals(CardType.INSTANT.toString())) {
-                    type = CardType.INSTANT;
-                } else if (choosenType.equals(CardType.SORCERY.toString())) {
-                    type = CardType.SORCERY;
-                } else if (choosenType.equals(CardType.PLANESWALKER.toString())) {
-                    type = CardType.PLANESWALKER;
-                } else if (choosenType.equals(CardType.TRIBAL.toString())) {
-                    type = CardType.TRIBAL;
-                }
-                if (type != null) {
-                    Cards hand = opponent.getHand();
-                    opponent.revealCards(sourceObject.getIdName(), hand, game);
-                    Set<Card> cards = hand.getCards(game);
-                    int damageToDeal = 0;
-                    for (Card card : cards) {
-                        if (card != null && card.getCardType().contains(type)) {
-                            damageToDeal += 3;
-                        }
+                String chosenType = choiceImpl.getChoice();
+                CardType cardType = CardType.fromString(chosenType);
+                Cards hand = opponent.getHand();
+                opponent.revealCards(sourceObject.getIdName(), hand, game);
+                Set<Card> cards = hand.getCards(game);
+                int damageToDeal = 0;
+                for (Card card : cards) {
+                    if (card != null && card.getCardType().contains(cardType)) {
+                        damageToDeal += 3;
                     }
-                    game.informPlayers(sourceObject.getLogName() + " deals " + (damageToDeal == 0 ? "no" : "" + damageToDeal) + " damage to " + opponent.getLogName());
-                    opponent.damage(damageToDeal, source.getSourceId(), source, game);
-                    return true;
                 }
+                game.informPlayers(sourceObject.getLogName() + " deals " + (damageToDeal == 0 ? "no" : "" + damageToDeal) + " damage to " + opponent.getLogName());
+                opponent.damage(damageToDeal, source.getSourceId(), source, game);
+                return true;
+
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/b/BloodOnTheSnow.java
+++ b/Mage.Sets/src/mage/cards/b/BloodOnTheSnow.java
@@ -83,10 +83,9 @@ class BloodOnTheSnowEffect extends OneShotEffect {
             TargetCardInYourGraveyard target = new TargetCardInYourGraveyard(1, 1, filter, true);
             controller.chooseTarget(outcome, target, source, game);
             Card card = game.getCard(target.getFirstTarget());
-            if (card != null) {
-                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                return true;
-            }
+            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+            return true;
+
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/b/BoneDancer.java
+++ b/Mage.Sets/src/mage/cards/b/BoneDancer.java
@@ -1,7 +1,6 @@
 
 package mage.cards.b;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksAndIsNotBlockedTriggeredAbility;
@@ -14,14 +13,15 @@ import mage.constants.*;
 import mage.game.Game;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
- *
  * @author LoneFox
  */
 public final class BoneDancer extends CardImpl {
 
     public BoneDancer(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{B}{B}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{B}{B}");
         this.subtype.add(SubType.ZOMBIE);
         this.power = new MageInt(2);
         this.toughness = new MageInt(2);
@@ -69,9 +69,7 @@ class BoneDancerEffect extends OneShotEffect {
                     lastCreatureCard = card;
                 }
             }
-            if (lastCreatureCard != null) {
-                controller.moveCards(lastCreatureCard, Zone.BATTLEFIELD, source, game);
-            }
+            controller.moveCards(lastCreatureCard, Zone.BATTLEFIELD, source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/b/BoosterTutor.java
+++ b/Mage.Sets/src/mage/cards/b/BoosterTutor.java
@@ -1,19 +1,10 @@
 
 package mage.cards.b;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.List;
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.ChooseExpansionSetEffect;
-import mage.cards.Card;
-import mage.cards.CardImpl;
-import mage.cards.CardSetInfo;
-import mage.cards.CardsImpl;
-import mage.cards.ExpansionSet;
-import mage.cards.Sets;
+import mage.cards.*;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
@@ -22,8 +13,12 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetCard;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
 /**
- *
  * @author spjspj & L_J
  */
 public final class BoosterTutor extends CardImpl {
@@ -93,9 +88,8 @@ class BoosterTutorEffect extends OneShotEffect {
                     cards.addAll(boosterPack);
                     if (controller.choose(Outcome.Benefit, cards, targetCard, game)) {
                         Card card = game.getCard(targetCard.getFirstTarget());
-                        if (card != null) {
-                            controller.moveCards(card, Zone.HAND, source, game);
-                        }
+                        controller.moveCards(card, Zone.HAND, source, game);
+
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/b/BountyOfSkemfar.java
+++ b/Mage.Sets/src/mage/cards/b/BountyOfSkemfar.java
@@ -83,9 +83,7 @@ class BountyOfSkemfarEffect extends OneShotEffect {
         target = new TargetCardInLibrary(0, 1, filter);
         player.choose(outcome, cards, target, game);
         Card elf = cards.get(target.getFirstTarget(), game);
-        if (elf != null) {
-            player.moveCards(elf, Zone.HAND, source, game);
-        }
+        player.moveCards(elf, Zone.HAND, source, game);
         cards.removeIf(uuid -> game.getState().getZone(uuid) != Zone.LIBRARY);
         player.putCardsOnBottomOfLibrary(cards, game, source, false);
         return true;

--- a/Mage.Sets/src/mage/cards/b/BringToLight.java
+++ b/Mage.Sets/src/mage/cards/b/BringToLight.java
@@ -1,6 +1,5 @@
 package mage.cards.b;
 
-import java.util.UUID;
 import mage.ApprovingObject;
 import mage.abilities.Ability;
 import mage.abilities.dynamicvalue.common.ColorsOfManaSpentToCastCount;
@@ -18,6 +17,8 @@ import mage.filter.predicate.mageobject.ManaValuePredicate;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
+
+import java.util.UUID;
 
 /**
  * @author LevelX2
@@ -74,9 +75,7 @@ class BringToLightEffect extends OneShotEffect {
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
             controller.searchLibrary(target, source, game);
             Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
-            if (card != null) {
-                controller.moveCards(card, Zone.EXILED, source, game);
-            }
+            controller.moveCards(card, Zone.EXILED, source, game);
             controller.shuffleLibrary(source, game);
             if (card != null) {
                 if (controller.chooseUse(Outcome.PlayForFree, "Cast " + card.getName()

--- a/Mage.Sets/src/mage/cards/b/Browse.java
+++ b/Mage.Sets/src/mage/cards/b/Browse.java
@@ -1,7 +1,6 @@
 
 package mage.cards.b;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
@@ -15,8 +14,9 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetCard;
 
+import java.util.UUID;
+
 /**
- *
  * @author Quercitron
  */
 public final class Browse extends CardImpl {
@@ -65,10 +65,8 @@ class BrowseEffect extends OneShotEffect {
                 TargetCard target = new TargetCard(Zone.LIBRARY, new FilterCard("card to put in your hand"));
                 if (controller.choose(Outcome.Benefit, cards, target, game)) {
                     Card card = cards.get(target.getFirstTarget(), game);
-                    if (card != null) {
-                        controller.moveCards(card, Zone.HAND, source, game);
-                        cards.remove(card);
-                    }
+                    controller.moveCards(card, Zone.HAND, source, game);
+                    cards.remove(card);
                 }
                 controller.moveCards(cards, Zone.EXILED, source, game);
             }

--- a/Mage.Sets/src/mage/cards/b/BurningRuneDemon.java
+++ b/Mage.Sets/src/mage/cards/b/BurningRuneDemon.java
@@ -1,17 +1,14 @@
 package mage.cards.b;
 
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.keyword.FlyingAbility;
 import mage.cards.*;
+import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.abilities.keyword.FlyingAbility;
-import mage.constants.CardType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
@@ -24,8 +21,11 @@ import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetOpponent;
 import mage.util.CardUtil;
 
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
 /**
- *
  * @author weirddan455
  */
 public final class BurningRuneDemon extends CardImpl {
@@ -99,13 +99,10 @@ class BurningRuneDemonEffect extends OneShotEffect {
                         targetCard.withChooseHint("Card to go to opponent's hand (other goes to graveyard)");
                         opponent.chooseTarget(outcome, cards, targetCard, source, game);
                         Card cardToHand = game.getCard(targetCard.getFirstTarget());
-                        if (cardToHand != null) {
-                            controller.moveCards(cardToHand, Zone.HAND, source, game);
-                            cards.remove(cardToHand);
-                        }
-                        if (!cards.isEmpty()) {
-                            controller.moveCards(cards, Zone.GRAVEYARD, source, game);
-                        }
+                        controller.moveCards(cardToHand, Zone.HAND, source, game);
+                        cards.remove(cardToHand);
+                        controller.moveCards(cards, Zone.GRAVEYARD, source, game);
+
                     }
                 }
                 controller.shuffleLibrary(source, game);

--- a/Mage.Sets/src/mage/cards/c/CallToTheKindred.java
+++ b/Mage.Sets/src/mage/cards/c/CallToTheKindred.java
@@ -94,10 +94,9 @@ class CallToTheKindredEffect extends OneShotEffect {
             TargetCard target = new TargetCardInLibrary(0, 1, filter);
             controller.choose(Outcome.PutCreatureInPlay, cards, target, game);
             Card card = cards.get(target.getFirstTarget(), game);
-            if (card != null) {
-                cards.remove(card);
-                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-            }
+            cards.remove(card);
+            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+
         }
         controller.putCardsOnBottomOfLibrary(cards, game, source, true);
         return true;

--- a/Mage.Sets/src/mage/cards/c/CavalierOfThorns.java
+++ b/Mage.Sets/src/mage/cards/c/CavalierOfThorns.java
@@ -96,10 +96,9 @@ class CavalierOfThornsEffect extends OneShotEffect {
         if (cards.getCards(game).stream().anyMatch(Card::isLand)
                 && controller.choose(Outcome.PutCardInPlay, cards, target, game)) {
             Card card = cards.get(target.getFirstTarget(), game);
-            if (card != null) {
-                cards.remove(card);
-                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-            }
+            cards.remove(card);
+            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+
         }
         controller.moveCards(cards, Zone.GRAVEYARD, source, game);
         return true;

--- a/Mage.Sets/src/mage/cards/c/CerebralEruption.java
+++ b/Mage.Sets/src/mage/cards/c/CerebralEruption.java
@@ -66,9 +66,8 @@ class CerebralEruptionEffect extends OneShotEffect {
             }
             if (card.isLand()) {
                 Card spellCard = game.getStack().getSpell(source.getSourceId()).getCard();
-                if (spellCard != null) {
-                    player.moveCards(spellCard, Zone.HAND, source, game);
-                }
+                player.moveCards(spellCard, Zone.HAND, source, game);
+
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/c/CharmbreakerDevils.java
+++ b/Mage.Sets/src/mage/cards/c/CharmbreakerDevils.java
@@ -79,6 +79,6 @@ class CharmbreakerDevilsEffect extends OneShotEffect {
         target.setNotTarget(true);
         player.choose(outcome, target, source.getSourceId(), game);
         Card card = game.getCard(target.getFirstTarget());
-        return card != null && player.moveCards(card, Zone.HAND, source, game);
+        return player.moveCards(card, Zone.HAND, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CitanulFlute.java
+++ b/Mage.Sets/src/mage/cards/c/CitanulFlute.java
@@ -78,10 +78,8 @@ class CitanulFluteSearchEffect extends OneShotEffect {
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
         player.searchLibrary(target, source, game);
         Card card = player.getLibrary().getCard(target.getFirstTarget(), game);
-        if (card != null) {
-            player.revealCards(source, new CardsImpl(card), game);
-            player.moveCards(card, Zone.HAND, source, game);
-        }
+        player.revealCards(source, new CardsImpl(card), game);
+        player.moveCards(card, Zone.HAND, source, game);
         player.shuffleLibrary(source, game);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/ClearTheStage.java
+++ b/Mage.Sets/src/mage/cards/c/ClearTheStage.java
@@ -75,9 +75,6 @@ class ClearTheStageEffect extends OneShotEffect {
             return false;
         }
         Card card = game.getCard(source.getTargets().get(1).getFirstTarget());
-        if (card == null) {
-            return false;
-        }
         return player.moveCards(card, Zone.HAND, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CommuneWithTheGods.java
+++ b/Mage.Sets/src/mage/cards/c/CommuneWithTheGods.java
@@ -1,7 +1,6 @@
 
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.*;
@@ -14,8 +13,9 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetCard;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class CommuneWithTheGods extends CardImpl {
@@ -67,10 +67,9 @@ class CommuneWithTheGodsEffect extends OneShotEffect {
                     TargetCard target = new TargetCard(0, 1, Zone.LIBRARY, filterPutInHand);
                     if (controller.choose(Outcome.DrawCard, cards, target, game)) {
                         Card card = game.getCard(target.getFirstTarget());
-                        if (card != null) {
-                            cards.remove(card);
-                            controller.moveCards(card, Zone.HAND, source, game);
-                        }
+                        cards.remove(card);
+                        controller.moveCards(card, Zone.HAND, source, game);
+
 
                     }
                 }

--- a/Mage.Sets/src/mage/cards/c/ConspiracyTheorist.java
+++ b/Mage.Sets/src/mage/cards/c/ConspiracyTheorist.java
@@ -125,7 +125,7 @@ class ConspiracyTheoristEffect extends OneShotEffect {
             if (validTarget && controller.chooseUse(Outcome.Benefit, "Exile a card?", source, game)) {
                 if (controller.choose(Outcome.Benefit, cards, target, game)) {
                     Card card = cards.get(target.getFirstTarget(), game);
-                    if (card != null && controller.moveCards(card, Zone.EXILED, source, game)) {
+                    if (controller.moveCards(card, Zone.EXILED, source, game)) {
                         // you may cast it this turn
                         CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
                     }

--- a/Mage.Sets/src/mage/cards/c/CorpseChurn.java
+++ b/Mage.Sets/src/mage/cards/c/CorpseChurn.java
@@ -1,7 +1,6 @@
 
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.MillCardsControllerEffect;
@@ -16,8 +15,9 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class CorpseChurn extends CardImpl {
@@ -68,9 +68,8 @@ class CorpseChurnEffect extends OneShotEffect {
                 && controller.chooseUse(outcome, "Return a creature card from your graveyard to hand?", source, game)
                 && controller.choose(Outcome.ReturnToHand, target, source.getSourceId(), game)) {
             Card card = game.getCard(target.getFirstTarget());
-            if (card != null) {
-                controller.moveCards(card, Zone.HAND, source, game);
-            }
+            controller.moveCards(card, Zone.HAND, source, game);
+
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/CorpseConnoisseur.java
+++ b/Mage.Sets/src/mage/cards/c/CorpseConnoisseur.java
@@ -1,6 +1,5 @@
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
@@ -19,8 +18,9 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
 
+import java.util.UUID;
+
 /**
- *
  * @author Plopman
  */
 public final class CorpseConnoisseur extends CardImpl {
@@ -72,9 +72,8 @@ class SearchLibraryPutInGraveyard extends SearchEffect {
             if (controller.searchLibrary(target, source, game)) {
                 if (!target.getTargets().isEmpty()) {
                     Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
-                    if (card != null) {
-                        controller.moveCards(card, Zone.GRAVEYARD, source, game);
-                    }
+                    controller.moveCards(card, Zone.GRAVEYARD, source, game);
+
                 }
             }
             controller.shuffleLibrary(source, game);

--- a/Mage.Sets/src/mage/cards/c/CreativeTechnique.java
+++ b/Mage.Sets/src/mage/cards/c/CreativeTechnique.java
@@ -74,9 +74,7 @@ class CreativeTechniqueEffect extends OneShotEffect {
         }
         player.revealCards(source, cards, game);
         cards.remove(toCast);
-        if (toCast != null) {
-            player.moveCards(toCast, Zone.EXILED, source, game);
-        }
+        player.moveCards(toCast, Zone.EXILED, source, game);
         player.putCardsOnBottomOfLibrary(cards, game, source, false);
         if (toCast == null || !player.chooseUse(
                 Outcome.PlayForFree, "Cast " + toCast.getIdName()

--- a/Mage.Sets/src/mage/cards/c/CruelFate.java
+++ b/Mage.Sets/src/mage/cards/c/CruelFate.java
@@ -71,10 +71,8 @@ class CruelFateEffect extends OneShotEffect {
         TargetCard targetCard = new TargetCardInLibrary();
         controller.choose(outcome, cards, targetCard, game);
         Card card = game.getCard(targetCard.getFirstTarget());
-        if (card != null) {
-            controller.moveCards(card, Zone.GRAVEYARD, source, game);
-            cards.remove(card);
-        }
+        controller.moveCards(card, Zone.GRAVEYARD, source, game);
+        cards.remove(card);
         return controller.putCardsOnTopOfLibrary(card, game, source, true);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CruelRevival.java
+++ b/Mage.Sets/src/mage/cards/c/CruelRevival.java
@@ -74,7 +74,7 @@ class CruelRevivalEffect extends OneShotEffect {
 
         Player player = game.getPlayer(source.getControllerId());
         Card targetRetrieve = game.getCard(source.getTargets().get(1).getFirstTarget());
-        if (player != null && targetRetrieve != null) {
+        if (player != null) {
             player.moveCards(targetRetrieve, Zone.HAND, source, game);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/c/Cultivate.java
+++ b/Mage.Sets/src/mage/cards/c/Cultivate.java
@@ -82,15 +82,13 @@ class CultivateEffect extends OneShotEffect {
                     }
                     Set<Card> cards = revealed.getCards(game);
                     card = cards.isEmpty() ? null : cards.iterator().next();
-                    if (card != null) {
-                        controller.moveCards(card, Zone.HAND, source, game);
-                    }
+                    controller.moveCards(card, Zone.HAND, source, game);
+
                 } else if (target.getTargets().size() == 1) {
                     Set<Card> cards = revealed.getCards(game);
                     Card card = cards.isEmpty() ? null : cards.iterator().next();
-                    if (card != null) {
-                        controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
-                    }
+                    controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
+
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/c/Curfew.java
+++ b/Mage.Sets/src/mage/cards/c/Curfew.java
@@ -1,7 +1,6 @@
 
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
@@ -16,8 +15,9 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetControlledCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author maxlebedev
  */
 public final class Curfew extends CardImpl {
@@ -55,9 +55,7 @@ class CurfewEffect extends OneShotEffect {
                 TargetControlledCreaturePermanent target = new TargetControlledCreaturePermanent(1, 1, StaticFilters.FILTER_CONTROLLED_CREATURE, true);
                 player.choose(Outcome.ReturnToHand, target, source.getSourceId(), game);
                 Permanent permanent = game.getPermanent(target.getFirstTarget());
-                if (permanent != null) {
-                    player.moveCards(permanent, Zone.HAND, source, game);
-                }
+                player.moveCards(permanent, Zone.HAND, source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/d/DarettiScrapSavant.java
+++ b/Mage.Sets/src/mage/cards/d/DarettiScrapSavant.java
@@ -92,6 +92,6 @@ class DarettiSacrificeEffect extends OneShotEffect {
             return true;
         }
         Card card = game.getCard(getTargetPointer().getFirst(game, source));
-        return card == null || controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+        return controller.moveCards(card, Zone.BATTLEFIELD, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DarkIntimations.java
+++ b/Mage.Sets/src/mage/cards/d/DarkIntimations.java
@@ -1,9 +1,6 @@
 
 package mage.cards.d;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SpellCastControllerTriggeredAbility;
 import mage.abilities.effects.ContinuousEffect;
@@ -28,8 +25,11 @@ import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class DarkIntimations extends CardImpl {
@@ -120,7 +120,7 @@ class DarkIntimationsEffect extends OneShotEffect {
             }
         }
         TargetCardInYourGraveyard target = new TargetCardInYourGraveyard(filterCard);
-        if (target.canChoose(source.getSourceId(), source.getControllerId(), game) 
+        if (target.canChoose(source.getSourceId(), source.getControllerId(), game)
                 && controller.choose(Outcome.ReturnToHand, target, source.getSourceId(), game)) {
             Card card = game.getCard(target.getFirstTarget());
             if (card == null) {
@@ -154,9 +154,7 @@ class DarkIntimationsGraveyardEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Card sourceCard = controller.getGraveyard().get(source.getSourceId(), game);
-            if (sourceCard != null) {
-                controller.moveCards(sourceCard, Zone.EXILED, source, game);
-            }
+            controller.moveCards(sourceCard, Zone.EXILED, source, game);
             Spell spell = game.getStack().getSpell(getTargetPointer().getFirst(game, source));
             if (spell != null) {
                 ContinuousEffect effect = new DarkIntimationsReplacementEffect();
@@ -188,7 +186,7 @@ class DarkIntimationsReplacementEffect extends ReplacementEffectImpl {
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
-        return creature != null 
+        return creature != null
                 && event.getTargetId().equals(getTargetPointer().getFirst(game, source));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkSupplicant.java
+++ b/Mage.Sets/src/mage/cards/d/DarkSupplicant.java
@@ -1,7 +1,6 @@
 
 package mage.cards.d;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -25,8 +24,9 @@ import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.common.TargetControlledPermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author jeffwadsworth
  */
 public final class DarkSupplicant extends CardImpl {
@@ -116,9 +116,7 @@ class DarkSupplicantEffect extends OneShotEffect {
             }
 
         }
-        if (selectedCard != null) {
-            controller.moveCards(selectedCard, Zone.BATTLEFIELD, source, game);
-        }
+        controller.moveCards(selectedCard, Zone.BATTLEFIELD, source, game);
         if (librarySearched) {
             controller.shuffleLibrary(source, game);
         }

--- a/Mage.Sets/src/mage/cards/d/DarthTyranusCountOfSerenno.java
+++ b/Mage.Sets/src/mage/cards/d/DarthTyranusCountOfSerenno.java
@@ -1,7 +1,6 @@
 
 package mage.cards.d;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.LoyaltyAbility;
 import mage.abilities.common.PlaneswalkerEntersWithLoyaltyCountersAbility;
@@ -12,12 +11,7 @@ import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.SuperType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.filter.common.FilterArtifactCard;
 import mage.filter.common.FilterControlledArtifactPermanent;
 import mage.game.Game;
@@ -28,14 +22,15 @@ import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetControlledPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author Styxo
  */
 public final class DarthTyranusCountOfSerenno extends CardImpl {
 
     public DarthTyranusCountOfSerenno(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.PLANESWALKER},"{1}{W}{U}{B}");
+        super(ownerId, setInfo, new CardType[]{CardType.PLANESWALKER}, "{1}{W}{U}{B}");
         this.addSuperType(SuperType.LEGENDARY);
         this.subtype.add(SubType.DOOKU);
 
@@ -125,15 +120,11 @@ class TransmuteArtifactEffect extends SearchEffect {
                 }
             }
             if (sacrifice && controller.searchLibrary(target, source, game)) {
-                if (!target.getTargets().isEmpty()) {
-                    for (UUID cardId : target.getTargets()) {
-                        Card card = controller.getLibrary().getCard(cardId, game);
-                        if (card != null) {
-                            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                            controller.shuffleLibrary(source, game);
-                            return true;
-                        }
-                    }
+                for (UUID cardId : target.getTargets()) {
+                    Card card = controller.getLibrary().getCard(cardId, game);
+                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+                    controller.shuffleLibrary(source, game);
+                    return true;
                 }
                 controller.shuffleLibrary(source, game);
             }

--- a/Mage.Sets/src/mage/cards/d/DeadlyBrew.java
+++ b/Mage.Sets/src/mage/cards/d/DeadlyBrew.java
@@ -111,9 +111,7 @@ class DeadlyBrewEffect extends OneShotEffect {
         );
         controller.choose(outcome, yourGrave, target, game);
         Card card = controller.getGraveyard().get(target.getFirstTarget(), game);
-        if (card != null) {
-            controller.moveCards(card, Zone.HAND, source, game);
-        }
+        controller.moveCards(card, Zone.HAND, source, game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DereviEmpyrialTactician.java
+++ b/Mage.Sets/src/mage/cards/d/DereviEmpyrialTactician.java
@@ -157,10 +157,6 @@ class PutCommanderOnBattlefieldEffect extends OneShotEffect {
             return false;
         }
         Card card = game.getCard(source.getSourceId());
-        if (card != null) {
-            player.moveCards(card, Zone.BATTLEFIELD, source, game);
-            return true;
-        }
-        return false;
+        return player.moveCards(card, Zone.BATTLEFIELD, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DesecratorHag.java
+++ b/Mage.Sets/src/mage/cards/d/DesecratorHag.java
@@ -89,9 +89,8 @@ class DesecratorHagEffect extends OneShotEffect {
                     && you.choose(Outcome.DrawCard, cards, target, game)) {
                 if (target != null) {
                     Card card = game.getCard(target.getFirstTarget());
-                    if (card != null) {
-                        return you.moveCards(card, Zone.HAND, source, game);
-                    }
+                    return you.moveCards(card, Zone.HAND, source, game);
+
                 }
             } else {
                 return you.moveCards(cards, Zone.HAND, source, game);

--- a/Mage.Sets/src/mage/cards/d/DireFleetDaredevil.java
+++ b/Mage.Sets/src/mage/cards/d/DireFleetDaredevil.java
@@ -127,7 +127,7 @@ class DireFleetDaredevilReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Card card = game.getCard(event.getTargetId());
         Player controller = game.getPlayer(source.getControllerId());
-        if (card != null && controller != null) {
+        if (controller != null) {
             return controller.moveCards(card, Zone.EXILED, source, game);
         }
         return false;

--- a/Mage.Sets/src/mage/cards/d/Disappear.java
+++ b/Mage.Sets/src/mage/cards/d/Disappear.java
@@ -77,9 +77,7 @@ class DisappearEffect extends OneShotEffect {
                 && aura.getAttachedTo() != null) {
             Permanent enchantedCreature = game.getPermanent(aura.getAttachedTo());
             controller.moveCards(aura, Zone.HAND, source, game);
-            if (enchantedCreature != null) {
-                controller.moveCards(enchantedCreature, Zone.HAND, source, game);
-            }
+            controller.moveCards(enchantedCreature, Zone.HAND, source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/d/DivineGambit.java
+++ b/Mage.Sets/src/mage/cards/d/DivineGambit.java
@@ -1,7 +1,5 @@
 package mage.cards.d;
 
-import java.util.UUID;
-
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.ExileTargetEffect;
@@ -21,8 +19,9 @@ import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInHand;
 
+import java.util.UUID;
+
 /**
- *
  * @author weirddan455
  */
 public final class DivineGambit extends CardImpl {
@@ -85,9 +84,7 @@ class DivineGambitEffect extends OneShotEffect {
                     TargetCardInHand target = new TargetCardInHand(StaticFilters.FILTER_CARD_PERMANENT);
                     if (player.chooseTarget(outcome, target, source, game)) {
                         Card card = game.getCard(target.getFirstTarget());
-                        if (card != null) {
-                            return player.moveCards(card, Zone.BATTLEFIELD, source, game);
-                        }
+                        return player.moveCards(card, Zone.BATTLEFIELD, source, game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/d/DrakeFamiliar.java
+++ b/Mage.Sets/src/mage/cards/d/DrakeFamiliar.java
@@ -70,9 +70,7 @@ class DrakeFamiliarEffect extends OneShotEffect {
                 && controller.chooseUse(outcome, "Return an enchantment to its owner's hand?", source, game)) {
             controller.chooseTarget(Outcome.ReturnToHand, target, source, game);
             Permanent permanent = game.getPermanent(target.getFirstTarget());
-            if (permanent != null) {
-                return controller.moveCards(permanent, Zone.HAND, source, game);
-            }
+            return controller.moveCards(permanent, Zone.HAND, source, game);
         }
         Permanent permanent = source.getSourcePermanentIfItStillExists(game);
         return permanent != null && permanent.sacrifice(source, game);

--- a/Mage.Sets/src/mage/cards/e/EaterOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/e/EaterOfTheDead.java
@@ -66,9 +66,8 @@ class EaterOfTheDeadEffect extends OneShotEffect {
             return false;
         }
         Card card = game.getCard(source.getFirstTarget());
-        if (card != null) {
-            player.moveCards(card, Zone.EXILED, source, game);
-        }
+
+        player.moveCards(card, Zone.EXILED, source, game);
         permanent.untap(game);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/e/EsikaGodOfTheTree.java
+++ b/Mage.Sets/src/mage/cards/e/EsikaGodOfTheTree.java
@@ -107,10 +107,9 @@ class PrismaticBridgeEffect extends OneShotEffect {
             }
         }
         controller.revealCards(source, toReveal, game);
-        if (toBattlefield != null) {
-            toReveal.remove(toBattlefield);
-            controller.moveCards(toBattlefield, Zone.BATTLEFIELD, source, game);
-        }
+        toReveal.remove(toBattlefield);
+        controller.moveCards(toBattlefield, Zone.BATTLEFIELD, source, game);
+
         controller.putCardsOnBottomOfLibrary(toReveal, game, source, false);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/e/EternalDominion.java
+++ b/Mage.Sets/src/mage/cards/e/EternalDominion.java
@@ -1,7 +1,6 @@
 
 package mage.cards.e;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.EpicEffect;
@@ -18,10 +17,10 @@ import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetOpponent;
 
+import java.util.UUID;
+
 /**
- *
  * @author jeffwadsworth
- *
  */
 public final class EternalDominion extends CardImpl {
 
@@ -78,9 +77,7 @@ class EternalDominionEffect extends OneShotEffect {
             TargetCardInLibrary target = new TargetCardInLibrary(FILTER);
             controller.searchLibrary(target, source, game, opponent.getId());
             Card targetCard = game.getCard(target.getFirstTarget());
-            if (targetCard != null) {
-                applied = controller.moveCards(targetCard, Zone.BATTLEFIELD, source, game);
-            }
+            applied = controller.moveCards(targetCard, Zone.BATTLEFIELD, source, game);
             opponent.shuffleLibrary(source, game);
         }
         return applied;

--- a/Mage.Sets/src/mage/cards/e/EtherealForager.java
+++ b/Mage.Sets/src/mage/cards/e/EtherealForager.java
@@ -87,7 +87,7 @@ class EtherealForagerEffect extends OneShotEffect {
         ;
         player.choose(Outcome.DrawCard, delvedCards, targetCard, game);
         Card card = game.getCard(targetCard.getFirstTarget());
-        if (card == null || !player.moveCards(card, Zone.HAND, source, game)) {
+        if (!player.moveCards(card, Zone.HAND, source, game)) {
             return false;
         }
         delvedCards.remove(card);

--- a/Mage.Sets/src/mage/cards/e/ExplosiveRevelation.java
+++ b/Mage.Sets/src/mage/cards/e/ExplosiveRevelation.java
@@ -89,11 +89,9 @@ class ExplosiveRevelationEffect extends OneShotEffect {
                         }
                     }
                 }
-                if (nonLandCard != null) {
-                    // move nonland card to hand
-                    controller.moveCards(nonLandCard, Zone.HAND, source, game);
-                    toReveal.remove(nonLandCard);
-                }
+                // move nonland card to hand
+                controller.moveCards(nonLandCard, Zone.HAND, source, game);
+                toReveal.remove(nonLandCard);
                 // put the rest of the cards on the bottom of the library in any order
                 return controller.putCardsOnBottomOfLibrary(toReveal, game, source, true);
             }

--- a/Mage.Sets/src/mage/cards/e/ExpressiveIteration.java
+++ b/Mage.Sets/src/mage/cards/e/ExpressiveIteration.java
@@ -74,10 +74,8 @@ class ExpressiveIterationEffect extends OneShotEffect {
         target.withChooseHint("To put into your hand");
         player.choose(outcome, cards, target, game);
         Card card = game.getCard(target.getFirstTarget());
-        if (card != null) {
-            player.moveCards(card, Zone.HAND, source, game);
-            cards.remove(card);
-        }
+        player.moveCards(card, Zone.HAND, source, game);
+        cards.remove(card);
         if (cards.isEmpty()) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/e/EyeOfYawgmoth.java
+++ b/Mage.Sets/src/mage/cards/e/EyeOfYawgmoth.java
@@ -85,10 +85,8 @@ class EyeOfYawgmothEffect extends OneShotEffect {
             TargetCard target = new TargetCard(Zone.LIBRARY, new FilterCard("card to put into your hand"));
             if (controller.choose(Outcome.DrawCard, cards, target, game)) {
                 Card card = cards.get(target.getFirstTarget(), game);
-                if (card != null) {
-                    controller.moveCards(card, Zone.HAND, source, game);
-                    cards.remove(card);
-                }
+                controller.moveCards(card, Zone.HAND, source, game);
+                cards.remove(card);
             }
             controller.moveCards(cards, Zone.EXILED, source, game);
         }

--- a/Mage.Sets/src/mage/cards/f/FathomFeeder.java
+++ b/Mage.Sets/src/mage/cards/f/FathomFeeder.java
@@ -1,7 +1,6 @@
 
 package mage.cards.f;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -16,20 +15,21 @@ import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
- *
  * @author fireshoes
  */
 public final class FathomFeeder extends CardImpl {
 
     public FathomFeeder(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{U}{B}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{U}{B}");
         this.subtype.add(SubType.ELDRAZI);
         this.subtype.add(SubType.DRONE);
         this.power = new MageInt(1);
@@ -78,13 +78,12 @@ class FathomFeederEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        for (UUID opponentId: game.getOpponents(source.getControllerId())) {
+        for (UUID opponentId : game.getOpponents(source.getControllerId())) {
             Player player = game.getPlayer(opponentId);
             if (player != null) {
                 Card card = player.getLibrary().getFromTop(game);
-                if (card != null) {
-                    player.moveCards(card, Zone.EXILED, source, game);
-                }
+                player.moveCards(card, Zone.EXILED, source, game);
+
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/f/FinaleOfPromise.java
+++ b/Mage.Sets/src/mage/cards/f/FinaleOfPromise.java
@@ -189,9 +189,8 @@ class FinaleOfPromiseReplacementEffect extends ReplacementEffectImpl {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Card card = game.getCard(getTargetPointer().getFirst(game, source));
-            if (card != null) {
-                return controller.moveCards(card, Zone.EXILED, source, game);
-            }
+            return controller.moveCards(card, Zone.EXILED, source, game);
+
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/f/FlayingTendrils.java
+++ b/Mage.Sets/src/mage/cards/f/FlayingTendrils.java
@@ -65,7 +65,7 @@ class FlayingTendrilsReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent permanent = ((ZoneChangeEvent) event).getTarget();
         Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null && permanent != null) {
+        if (controller != null) {
             return controller.moveCards(permanent, Zone.EXILED, source, game);
         }
         return false;

--- a/Mage.Sets/src/mage/cards/f/FoldIntoAether.java
+++ b/Mage.Sets/src/mage/cards/f/FoldIntoAether.java
@@ -71,9 +71,8 @@ class FoldIntoAetherEffect extends OneShotEffect {
                     && spellController.chooseUse(Outcome.Neutral, "Put a creature card from your hand in play?", source, game)
                     && spellController.choose(Outcome.PutCreatureInPlay, target, source.getSourceId(), game)) {
                 Card card = game.getCard(target.getFirstTarget());
-                if (card != null) {
-                    spellController.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                spellController.moveCards(card, Zone.BATTLEFIELD, source, game);
+
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/f/ForkInTheRoad.java
+++ b/Mage.Sets/src/mage/cards/f/ForkInTheRoad.java
@@ -80,21 +80,17 @@ class ForkInTheRoadEffect extends OneShotEffect {
                     TargetCard target2 = new TargetCard(Zone.LIBRARY, filter);
                     controller.choose(Outcome.Benefit, revealed, target2, game);
                     Card card = revealed.get(target2.getFirstTarget(), game);
-                    if (card != null) {
-                        controller.moveCards(card, Zone.HAND, source, game);
-                        revealed.remove(card);
-                    }
+                    controller.moveCards(card, Zone.HAND, source, game);
+                    revealed.remove(card);
                     if (!revealed.isEmpty()) {
                         card = revealed.getCards(game).iterator().next();
-                        if (card != null) {
-                            controller.moveCards(card, Zone.GRAVEYARD, source, game);
-                        }
+                        controller.moveCards(card, Zone.GRAVEYARD, source, game);
+
                     }
                 } else if (target.getTargets().size() == 1 && !revealed.isEmpty()) {
                     Card card = revealed.getCards(game).iterator().next();
-                    if (card != null) {
-                        controller.moveCards(card, Zone.HAND, source, game);
-                    }
+                    controller.moveCards(card, Zone.HAND, source, game);
+
                 }
 
             }

--- a/Mage.Sets/src/mage/cards/f/FossilFind.java
+++ b/Mage.Sets/src/mage/cards/f/FossilFind.java
@@ -1,7 +1,6 @@
 
 package mage.cards.f;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
@@ -13,14 +12,15 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
- *
  * @author North
  */
 public final class FossilFind extends CardImpl {
 
     public FossilFind(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{R/G}");
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{R/G}");
 
         // Return a card at random from your graveyard to your hand, then reorder your graveyard as you choose.
         this.getSpellAbility().addEffect(new FossilFindEffect());
@@ -57,10 +57,7 @@ class FossilFindEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && !controller.getGraveyard().isEmpty()) {
             Card card = controller.getGraveyard().getRandom(game);
-            if (card != null) {
-                controller.moveCards(card, Zone.HAND, source, game);
-                return true;
-            }
+            controller.moveCards(card, Zone.HAND, source, game);
             controller.moveCards(controller.getGraveyard(), Zone.GRAVEYARD, source, game);
         }
         return false;

--- a/Mage.Sets/src/mage/cards/g/GateToTheAfterlife.java
+++ b/Mage.Sets/src/mage/cards/g/GateToTheAfterlife.java
@@ -126,9 +126,8 @@ class GateToTheAfterlifeEffect extends OneShotEffect {
             }
             controller.shuffleLibrary(source, game);
         }
-        if (card != null) {
-            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-        }
+        controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+
         if (librarySearched) {
             controller.shuffleLibrary(source, game);
         }

--- a/Mage.Sets/src/mage/cards/g/GeomancersGambit.java
+++ b/Mage.Sets/src/mage/cards/g/GeomancersGambit.java
@@ -80,9 +80,8 @@ class GeomancersGambitEffect extends OneShotEffect {
         TargetCardInLibrary target = new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND);
         if (controller.searchLibrary(target, source, game)) {
             Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
-            if (card != null) {
-                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-            }
+            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+
         }
         controller.shuffleLibrary(source, game);
         return true;

--- a/Mage.Sets/src/mage/cards/g/GhastlordOfFugue.java
+++ b/Mage.Sets/src/mage/cards/g/GhastlordOfFugue.java
@@ -85,9 +85,7 @@ class GhastlordOfFugueEffect extends OneShotEffect {
             if (controller.chooseTarget(Outcome.Benefit, targetPlayer.getHand(), target, source, game)) {
                 chosenCard = game.getCard(target.getFirstTarget());
             }
-            if (chosenCard != null) {
-                controller.moveCards(chosenCard, Zone.EXILED, source, game);
-            }
+            controller.moveCards(chosenCard, Zone.EXILED, source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/g/GhostQuarter.java
+++ b/Mage.Sets/src/mage/cards/g/GhostQuarter.java
@@ -75,9 +75,7 @@ class GhostQuarterEffect extends OneShotEffect {
                 TargetCardInLibrary target = new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND);
                 if (controller.searchLibrary(target, source, game)) {
                     Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
-                    if (card != null) {
-                        controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                    }
+                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
                 }
                 controller.shuffleLibrary(source, game);
             }

--- a/Mage.Sets/src/mage/cards/g/GhostlyWings.java
+++ b/Mage.Sets/src/mage/cards/g/GhostlyWings.java
@@ -84,9 +84,7 @@ class GhostlyWingsReturnEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && permanent != null && permanent.getAttachedTo() != null) {
             Permanent enchantedCreature = game.getPermanent(permanent.getAttachedTo());
-            if (enchantedCreature != null) {
-                controller.moveCards(enchantedCreature, Zone.HAND, source, game);
-            }
+            controller.moveCards(enchantedCreature, Zone.HAND, source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/g/Gigantiform.java
+++ b/Mage.Sets/src/mage/cards/g/Gigantiform.java
@@ -115,9 +115,7 @@ class GigantiformEffect extends OneShotEffect {
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
         if (controller != null && controller.searchLibrary(target, source, game)) {
             Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
-            if (card != null) {
-                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-            }
+            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             controller.shuffleLibrary(source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/g/GlacianPowerstoneEngineer.java
+++ b/Mage.Sets/src/mage/cards/g/GlacianPowerstoneEngineer.java
@@ -97,9 +97,9 @@ class GlacianPowerstoneEngineerEffect extends OneShotEffect {
         TargetCard targetCard = new TargetCardInLibrary(1, StaticFilters.FILTER_CARD);
         player.choose(outcome, cards, targetCard, game);
         Card card = game.getCard(targetCard.getFirstTarget());
-        if (card != null && player.moveCards(card, Zone.HAND, source, game)) {
-            cards.remove(card);
-        }
+        player.moveCards(card, Zone.HAND, source, game);
+        cards.remove(card);
+
         player.moveCards(cards, Zone.GRAVEYARD, source, game);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/g/GoldenGuardian.java
+++ b/Mage.Sets/src/mage/cards/g/GoldenGuardian.java
@@ -156,9 +156,7 @@ class GoldenGuardianReturnTransformedEffect extends OneShotEffect {
             if (game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD) {
                 game.getState().setValue(TransformAbility.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
                 Card card = game.getCard(source.getSourceId());
-                if (card != null) {
-                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/g/GrappleWithThePast.java
+++ b/Mage.Sets/src/mage/cards/g/GrappleWithThePast.java
@@ -76,9 +76,7 @@ class GrappleWithThePastEffect extends OneShotEffect {
                 && controller.chooseUse(outcome, "Return a creature or land card from your graveyard to hand?", source, game)
                 && controller.choose(Outcome.ReturnToHand, target, source.getSourceId(), game)) {
             Card card = game.getCard(target.getFirstTarget());
-            if (card != null) {
-                controller.moveCards(card, Zone.HAND, source, game);
-            }
+            controller.moveCards(card, Zone.HAND, source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/g/GrimCaptainsCall.java
+++ b/Mage.Sets/src/mage/cards/g/GrimCaptainsCall.java
@@ -75,9 +75,7 @@ class GrimCaptainsCallEffect extends OneShotEffect {
         if (target.canChoose(source.getSourceId(), source.getControllerId(), game)) {
             if (controller.chooseTarget(outcome, target, source, game)) {
                 Card card = game.getCard(target.getFirstTarget());
-                if (card != null) {
-                    controller.moveCards(card, Zone.HAND, source, game);
-                }
+                controller.moveCards(card, Zone.HAND, source, game);
             }
         }
     }

--- a/Mage.Sets/src/mage/cards/g/GrislySalvage.java
+++ b/Mage.Sets/src/mage/cards/g/GrislySalvage.java
@@ -71,10 +71,8 @@ class GrislySalvageEffect extends OneShotEffect {
                 if (properCardFound && controller.chooseUse(outcome, "Put a creature or land card from the revealed cards into your hand?", source, game)
                         && controller.choose(Outcome.DrawCard, cards, target, game)) {
                     Card card = game.getCard(target.getFirstTarget());
-                    if (card != null) {
-                        controller.moveCards(card, Zone.HAND, source, game);
-                        cards.remove(card);
-                    }
+                    controller.moveCards(card, Zone.HAND, source, game);
+                    cards.remove(card);
                 }
                 controller.moveCards(cards, Zone.GRAVEYARD, source, game);
             }

--- a/Mage.Sets/src/mage/cards/g/GruesomeEncore.java
+++ b/Mage.Sets/src/mage/cards/g/GruesomeEncore.java
@@ -117,7 +117,7 @@ class GruesomeEncoreReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(source.getSourceId());
         Card card = game.getCard(source.getFirstTarget());
-        return player != null && card != null && player.moveCards(card, Zone.EXILED, source, game);
+        return player != null && player.moveCards(card, Zone.EXILED, source, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/g/GyrudaDoomOfDepths.java
+++ b/Mage.Sets/src/mage/cards/g/GyrudaDoomOfDepths.java
@@ -116,6 +116,6 @@ class GyrudaDoomOfDepthsEffect extends OneShotEffect {
         targetCard.setNotTarget(true);
         controller.choose(outcome, cards, targetCard, game);
         Card card = game.getCard(targetCard.getFirstTarget());
-        return card != null && controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+        return controller.moveCards(card, Zone.BATTLEFIELD, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/h/HalvarGodOfBattle.java
+++ b/Mage.Sets/src/mage/cards/h/HalvarGodOfBattle.java
@@ -170,9 +170,8 @@ class SwordOfTheRealmsEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Card creature = (Card) getValue("attachedTo");
-            if (creature != null) {
-                return controller.moveCards(creature, Zone.HAND, source, game);
-            }
+            return controller.moveCards(creature, Zone.HAND, source, game);
+
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/h/HaraldUnitesTheElves.java
+++ b/Mage.Sets/src/mage/cards/h/HaraldUnitesTheElves.java
@@ -107,9 +107,7 @@ class HaraldUnitesTheElvesEffect extends OneShotEffect {
         TargetCard targetCard = new TargetCardInYourGraveyard(0, 1, filter, true);
         player.choose(outcome, targetCard, source.getSourceId(), game);
         Card card = player.getGraveyard().get(targetCard.getFirstTarget(), game);
-        if (card != null) {
-            player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        }
+        player.moveCards(card, Zone.BATTLEFIELD, source, game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/h/HarvestHand.java
+++ b/Mage.Sets/src/mage/cards/h/HarvestHand.java
@@ -70,9 +70,7 @@ class HarvestHandReturnTransformedEffect extends OneShotEffect {
             if (game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD) {
                 game.getState().setValue(TransformAbility.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
                 Card card = game.getCard(source.getSourceId());
-                if (card != null) {
-                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/h/HatcherySpider.java
+++ b/Mage.Sets/src/mage/cards/h/HatcherySpider.java
@@ -106,10 +106,8 @@ class HatcherySpiderEffect extends OneShotEffect {
         if (player.chooseUse(outcome, "Put a card onto the battlefield?", source, game)
                 && player.choose(outcome, cards, target, game)) {
             Card card = game.getCard(target.getFirstTarget());
-            if (card != null
-                    && player.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                cards.remove(card);
-            }
+            player.moveCards(card, Zone.BATTLEFIELD, source, game);
+            cards.remove(card);
         }
         while (!cards.isEmpty()) {
             Card card = cards.getRandom(game);

--- a/Mage.Sets/src/mage/cards/h/HeroesPodium.java
+++ b/Mage.Sets/src/mage/cards/h/HeroesPodium.java
@@ -135,10 +135,8 @@ class HeroesPodiumEffect extends OneShotEffect {
                 TargetCard target = new TargetCard(Zone.LIBRARY, filter);
                 if (controller.choose(outcome, cards, target, game)) {
                     Card card = cards.get(target.getFirstTarget(), game);
-                    if (card != null) {
-                        cards.remove(card);
-                        controller.moveCards(card, Zone.HAND, source, game);
-                    }
+                    cards.remove(card);
+                    controller.moveCards(card, Zone.HAND, source, game);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/h/HiredGiant.java
+++ b/Mage.Sets/src/mage/cards/h/HiredGiant.java
@@ -74,10 +74,8 @@ class HiredGiantEffect extends OneShotEffect {
                         TargetCardInLibrary target = new TargetCardInLibrary(new FilterLandCard());
                         if (player.searchLibrary(target, source, game)) {
                             Card targetCard = player.getLibrary().getCard(target.getFirstTarget(), game);
-                            if (targetCard != null) {
-                                player.moveCards(targetCard, Zone.BATTLEFIELD, source, game);
-                                playersThatSearched.add(player);
-                            }
+                            player.moveCards(targetCard, Zone.BATTLEFIELD, source, game);
+                            playersThatSearched.add(player);
                         }
                     }
                 }

--- a/Mage.Sets/src/mage/cards/h/HofriGhostforge.java
+++ b/Mage.Sets/src/mage/cards/h/HofriGhostforge.java
@@ -142,6 +142,6 @@ class HofriGhostforgeReturnEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         Card card = mor.getCard(game);
-        return player != null && card != null && player.moveCards(card, Zone.GRAVEYARD, source, game);
+        return player != null && player.moveCards(card, Zone.GRAVEYARD, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/i/ImagesOfThePast.java
+++ b/Mage.Sets/src/mage/cards/i/ImagesOfThePast.java
@@ -64,10 +64,9 @@ class ImagesOfThePastEffect extends OneShotEffect {
             List<UUID> targets = source.getTargets().get(0).getTargets();
             for (UUID targetId : targets) {
                 Card card = game.getCard(targetId);
-                if (card != null) {
-                    player.moveCards(card, Zone.BATTLEFIELD, source, game);
-                    player.moveCards(card, Zone.EXILED, source, game);
-                }
+                player.moveCards(card, Zone.BATTLEFIELD, source, game);
+                player.moveCards(card, Zone.EXILED, source, game);
+
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/i/IncandescentSoulstoke.java
+++ b/Mage.Sets/src/mage/cards/i/IncandescentSoulstoke.java
@@ -95,19 +95,18 @@ class IncandescentSoulstokeEffect extends OneShotEffect {
                 TargetCardInHand target = new TargetCardInHand(filter);
                 if (controller.choose(Outcome.PutCreatureInPlay, target, source.getSourceId(), game)) {
                     Card card = game.getCard(target.getFirstTarget());
-                    if (card != null) {
-                        if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                            Permanent permanent = game.getPermanent(card.getId());
-                            if (permanent != null) {
-                                ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);
-                                effect.setTargetPointer(new FixedTarget(permanent, game));
-                                game.addEffect(effect, source);
-                                SacrificeTargetEffect sacrificeEffect = new SacrificeTargetEffect("sacrifice " + card.getName(), source.getControllerId());
-                                sacrificeEffect.setTargetPointer(new FixedTarget(permanent, game));
-                                game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(sacrificeEffect), source);
-                            }
+                    if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
+                        Permanent permanent = game.getPermanent(card.getId());
+                        if (permanent != null) {
+                            ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);
+                            effect.setTargetPointer(new FixedTarget(permanent, game));
+                            game.addEffect(effect, source);
+                            SacrificeTargetEffect sacrificeEffect = new SacrificeTargetEffect("sacrifice " + card.getName(), source.getControllerId());
+                            sacrificeEffect.setTargetPointer(new FixedTarget(permanent, game));
+                            game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(sacrificeEffect), source);
                         }
                     }
+
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/i/InfernalOffering.java
+++ b/Mage.Sets/src/mage/cards/i/InfernalOffering.java
@@ -143,9 +143,7 @@ class InfernalOfferingReturnEffect extends OneShotEffect {
                 target = new TargetCardInYourGraveyard(new FilterCreatureCard("creature card in your graveyard"));
                 if (target.choose(Outcome.PutCreatureInPlay, opponent.getId(), source.getSourceId(), game)) {
                     Card card = opponent.getGraveyard().get(target.getFirstTarget(), game);
-                    if (card != null) {
-                        opponent.moveCards(card, Zone.BATTLEFIELD, source, game);
-                    }
+                    opponent.moveCards(card, Zone.BATTLEFIELD, source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/i/Intuition.java
+++ b/Mage.Sets/src/mage/cards/i/Intuition.java
@@ -90,10 +90,8 @@ class IntuitionEffect extends SearchEffect {
                     }
                 }
                 Card card = cards.get(targetCard.getFirstTarget(), game);
-                if (card != null) {
-                    cards.remove(card);
-                    controller.moveCards(card, Zone.HAND, source, game);
-                }
+                cards.remove(card);
+                controller.moveCards(card, Zone.HAND, source, game);
                 controller.moveCards(cards, Zone.GRAVEYARD, source, game);
             }
             controller.shuffleLibrary(source, game);

--- a/Mage.Sets/src/mage/cards/j/JungleWayfinder.java
+++ b/Mage.Sets/src/mage/cards/j/JungleWayfinder.java
@@ -75,10 +75,8 @@ class JungleWayfinderEffect extends OneShotEffect {
                         player.searchLibrary(target, source, game);
                         for (UUID cardId : target.getTargets()) {
                             Card card = player.getLibrary().getCard(cardId, game);
-                            if (card != null) {
-                                player.revealCards(source, new CardsImpl(card), game);
-                                player.moveCards(card, Zone.HAND, source, game);
-                            }
+                            player.revealCards(source, new CardsImpl(card), game);
+                            player.moveCards(card, Zone.HAND, source, game);
                         }
                         player.shuffleLibrary(source, game);
                     }

--- a/Mage.Sets/src/mage/cards/k/KarnScionOfUrza.java
+++ b/Mage.Sets/src/mage/cards/k/KarnScionOfUrza.java
@@ -178,9 +178,7 @@ class KarnMinus1Effect extends OneShotEffect {
         if (card == null) {
             card = game.getCard(target.getFirstTarget());
         }
-        if (card != null) {
-            controller.moveCards(card, Zone.HAND, source, game);
-        }
+        controller.moveCards(card, Zone.HAND, source, game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/k/KasminaEnigmaSage.java
+++ b/Mage.Sets/src/mage/cards/k/KasminaEnigmaSage.java
@@ -137,9 +137,7 @@ class KasminaEnigmaSageSearchEffect extends OneShotEffect {
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
         controller.searchLibrary(target, source, game);
         Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
-        if (card != null) {
-            controller.moveCards(card, Zone.EXILED, source, game);
-        }
+        controller.moveCards(card, Zone.EXILED, source, game);
         controller.shuffleLibrary(source, game);
         if (card == null || !controller.chooseUse(
                 Outcome.PlayForFree, "Cast " + card.getName() + " without paying its mana cost?", source, game

--- a/Mage.Sets/src/mage/cards/k/KessDissidentMage.java
+++ b/Mage.Sets/src/mage/cards/k/KessDissidentMage.java
@@ -118,8 +118,7 @@ class KessDissidentMageReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         Card card = game.getCard(event.getTargetId());
-        if (controller != null
-                && card != null) {
+        if (controller != null) {
             return controller.moveCards(card, Zone.EXILED, source, game);
         }
         return false;

--- a/Mage.Sets/src/mage/cards/k/KianneDeanOfSubstance.java
+++ b/Mage.Sets/src/mage/cards/k/KianneDeanOfSubstance.java
@@ -218,9 +218,7 @@ class ImbrahamDeanOfTheoryEffect extends OneShotEffect {
         targetCard.setNotTarget(true);
         player.choose(outcome, targetCard, source.getSourceId(), game);
         Card card = game.getCard(targetCard.getFirstTarget());
-        if (card != null) {
-            player.moveCards(card, Zone.HAND, source, game);
-        }
+        player.moveCards(card, Zone.HAND, source, game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/k/KodamasReach.java
+++ b/Mage.Sets/src/mage/cards/k/KodamasReach.java
@@ -85,15 +85,13 @@ class KodamasReachEffect extends OneShotEffect {
                     }
                     Set<Card> cards = revealed.getCards(game);
                     card = cards.isEmpty() ? null : cards.iterator().next();
-                    if (card != null) {
-                        controller.moveCards(card, Zone.HAND, source, game);
-                    }
+                    controller.moveCards(card, Zone.HAND, source, game);
+
                 } else if (target.getTargets().size() == 1) {
                     Set<Card> cards = revealed.getCards(game);
                     Card card = cards.isEmpty() ? null : cards.iterator().next();
-                    if (card != null) {
-                        controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
-                    }
+                    controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
+
                 }
 
             }

--- a/Mage.Sets/src/mage/cards/l/LegionsEnd.java
+++ b/Mage.Sets/src/mage/cards/l/LegionsEnd.java
@@ -80,7 +80,7 @@ class LegionsEndEffect extends OneShotEffect {
             return false;
         }
         String name = permanent.getName();
-        if (name == null || name.equals("")) {
+        if (name == null || name.isEmpty()) {
             player.revealCards(source, player.getHand(), game);
             return player.moveCards(permanent, Zone.EXILED, source, game);
         }

--- a/Mage.Sets/src/mage/cards/l/LichsMastery.java
+++ b/Mage.Sets/src/mage/cards/l/LichsMastery.java
@@ -212,9 +212,7 @@ class LichsMasteryLoseLifeEffect extends OneShotEffect {
                 Target target = new TargetCardInYourGraveyard(1, 1, new FilterCard(), true);
                 target.choose(Outcome.Exile, source.getControllerId(), source.getSourceId(), game);
                 Card card = controller.getGraveyard().get(target.getFirstTarget(), game);
-                if (card != null) {
-                    controller.moveCards(card, Zone.EXILED, source, game);
-                }
+                controller.moveCards(card, Zone.EXILED, source, game);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/l/LilianaTheLastHope.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaTheLastHope.java
@@ -94,9 +94,7 @@ class LilianaTheLastHopeEffect extends OneShotEffect {
                 && controller.chooseUse(outcome, "Return a creature card from your graveyard to hand?", source, game)
                 && controller.choose(Outcome.ReturnToHand, target, source.getSourceId(), game)) {
             Card card = game.getCard(target.getFirstTarget());
-            if (card != null) {
-                controller.moveCards(card, Zone.HAND, source, game);
-            }
+            controller.moveCards(card, Zone.HAND, source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/l/LinSivviDefiantHero.java
+++ b/Mage.Sets/src/mage/cards/l/LinSivviDefiantHero.java
@@ -100,9 +100,7 @@ class LinSivviDefiantHeroEffect extends OneShotEffect {
 
         if (controller.searchLibrary(target, source, game)) {
             Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
-            if (card != null) {
-                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-            }
+            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             controller.shuffleLibrary(source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/l/LostInTheMist.java
+++ b/Mage.Sets/src/mage/cards/l/LostInTheMist.java
@@ -62,7 +62,6 @@ class LostInTheMistEffect extends OneShotEffect {
         Player player = game.getPlayer(source.getControllerId());
         Permanent permanent = game.getPermanent(source.getTargets().get(1).getFirstTarget());
         return player != null
-                && permanent != null
                 && player.moveCards(permanent, Zone.HAND, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/m/MangarasTome.java
+++ b/Mage.Sets/src/mage/cards/m/MangarasTome.java
@@ -108,9 +108,7 @@ class MangarasTomeReplacementEffect extends ReplacementEffectImpl {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Card card = game.getExile().getExileZone(CardUtil.getCardExileZoneId(game, source)).getRandom(game);
-            if (card != null) {
-                controller.moveCards(card, Zone.HAND, source, game);
-            }
+            controller.moveCards(card, Zone.HAND, source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/m/MausoleumTurnkey.java
+++ b/Mage.Sets/src/mage/cards/m/MausoleumTurnkey.java
@@ -87,9 +87,7 @@ class MausoleumTurnkeyEffect extends OneShotEffect {
                     Target target = new TargetCardInGraveyard(filter);
                     opponent.chooseTarget(outcome, target, source, game);
                     Card card = game.getCard(target.getFirstTarget());
-                    if (card != null) {
-                        controller.moveCards(card, Zone.HAND, source, game);
-                    }
+                    controller.moveCards(card, Zone.HAND, source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/m/MemoryLeak.java
+++ b/Mage.Sets/src/mage/cards/m/MemoryLeak.java
@@ -87,9 +87,7 @@ class MemoryLeakEffect extends OneShotEffect {
         }
         if (controller.choose(outcome, cards, target, game)) {
             Card card = game.getCard(target.getFirstTarget());
-            if (card != null) {
-                controller.moveCards(card, Zone.EXILED, source, game);
-            }
+            controller.moveCards(card, Zone.EXILED, source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/m/MercadianLift.java
+++ b/Mage.Sets/src/mage/cards/m/MercadianLift.java
@@ -90,9 +90,7 @@ class MercadianLiftEffect extends OneShotEffect {
                     && controller.choose(Outcome.PutCardInPlay, target, source.getSourceId(), game)) {
                 target.setRequired(false);
                 Card card = game.getCard(target.getFirstTarget());
-                if (card != null) {
-                    return controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                return controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/m/MerchantsDockhand.java
+++ b/Mage.Sets/src/mage/cards/m/MerchantsDockhand.java
@@ -100,10 +100,8 @@ class MerchantsDockhandEffect extends OneShotEffect {
         target.setNotTarget(true);
         if (controller.chooseTarget(Outcome.DrawCard, cards, target, source, game)) {
             Card card = cards.get(target.getFirstTarget(), game);
-            if (card != null) {
-                controller.moveCards(card, Zone.HAND, source, game);
-                cards.remove(card);
-            }
+            controller.moveCards(card, Zone.HAND, source, game);
+            cards.remove(card);
         }
         controller.putCardsOnBottomOfLibrary(cards, game, source, true);
         return true;

--- a/Mage.Sets/src/mage/cards/m/Metamorphose.java
+++ b/Mage.Sets/src/mage/cards/m/Metamorphose.java
@@ -82,9 +82,7 @@ class MetamorphoseEffect extends OneShotEffect {
                 target.clearChosen();
                 if (controller.chooseTarget(outcome, target, source, game)) {
                     Card card = game.getCard(target.getFirstTarget());
-                    if (card != null) {
-                        controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                    }
+                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
                 }
             }
 

--- a/Mage.Sets/src/mage/cards/m/MirrorMadPhantasm.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorMadPhantasm.java
@@ -80,10 +80,8 @@ class MirrorMadPhantasmEffect extends OneShotEffect {
                     }
                 }
                 owner.revealCards(source, cards, game);
-                if (phantasmCard != null) {
-                    owner.moveCards(phantasmCard, Zone.BATTLEFIELD, source, game);
-                    cards.remove(phantasmCard);
-                }
+                owner.moveCards(phantasmCard, Zone.BATTLEFIELD, source, game);
+                cards.remove(phantasmCard);
                 owner.moveCards(cards, Zone.GRAVEYARD, source, game);
             }
         }

--- a/Mage.Sets/src/mage/cards/m/MishraArtificerProdigy.java
+++ b/Mage.Sets/src/mage/cards/m/MishraArtificerProdigy.java
@@ -141,9 +141,7 @@ class MishraArtificerProdigyEffect extends OneShotEffect {
                 controller.shuffleLibrary(source, game);
             }
             // Put on battlefield
-            if (card != null) {
-                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-            }
+            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/m/MistmoonGriffin.java
+++ b/Mage.Sets/src/mage/cards/m/MistmoonGriffin.java
@@ -76,10 +76,7 @@ class MistmoonGriffinEffect extends OneShotEffect {
                     lastCreatureCard = card;
                 }
             }
-            if (lastCreatureCard != null) {
-                return controller.moveCards(lastCreatureCard, Zone.BATTLEFIELD, source, game);
-            }
-            return true;
+            return controller.moveCards(lastCreatureCard, Zone.BATTLEFIELD, source, game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/m/MitoticManipulation.java
+++ b/Mage.Sets/src/mage/cards/m/MitoticManipulation.java
@@ -84,10 +84,8 @@ class MitoticManipulationEffect extends OneShotEffect {
                         && controller.chooseUse(Outcome.PutCardInPlay, "Put a card on the battlefield?", source, game)) {
                     if (controller.choose(Outcome.PutCardInPlay, cardsFromTop, target, game)) {
                         Card card = cardsFromTop.get(target.getFirstTarget(), game);
-                        if (card != null) {
-                            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                            cardsFromTop.remove(card);
-                        }
+                        controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+                        cardsFromTop.remove(card);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/m/MoxDiamond.java
+++ b/Mage.Sets/src/mage/cards/m/MoxDiamond.java
@@ -80,10 +80,8 @@ class MoxDiamondReplacementEffect extends ReplacementEffectImpl {
                 return false;
             } else {
                 Permanent permanent = game.getPermanentEntering(event.getTargetId());
-                if (permanent != null) {
-                    player.moveCards(permanent, Zone.GRAVEYARD, source, game);
-                }
-                return true;
+                return player.moveCards(permanent, Zone.GRAVEYARD, source, game);
+
             }
 
         }

--- a/Mage.Sets/src/mage/cards/m/MurmursFromBeyond.java
+++ b/Mage.Sets/src/mage/cards/m/MurmursFromBeyond.java
@@ -84,10 +84,8 @@ class MurmursFromBeyondEffect extends OneShotEffect {
                     opponent.chooseTarget(outcome, cards, target, source, game);
                     cardToGraveyard = game.getCard(target.getFirstTarget());
                 }
-                if (cardToGraveyard != null) {
-                    controller.moveCards(cardToGraveyard, Zone.GRAVEYARD, source, game);
-                    cards.remove(cardToGraveyard);
-                }
+                controller.moveCards(cardToGraveyard, Zone.GRAVEYARD, source, game);
+                cards.remove(cardToGraveyard);
                 controller.moveCards(cards, Zone.HAND, source, game);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/m/MuzzioVisionaryArchitect.java
+++ b/Mage.Sets/src/mage/cards/m/MuzzioVisionaryArchitect.java
@@ -92,11 +92,9 @@ class MuzzioVisionaryArchitectEffect extends OneShotEffect {
             TargetCard target = new TargetCard(Zone.LIBRARY, new FilterArtifactCard("artifact card to put onto the battlefield"));
             if (target.canChoose(source.getSourceId(), controller.getId(), game) && controller.choose(Outcome.Benefit, cards, target, game)) {
                 Card card = cards.get(target.getFirstTarget(), game);
-                if (card != null) {
-                    controller.revealCards(source, new CardsImpl(card), game);
-                    cards.remove(card);
-                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                controller.revealCards(source, new CardsImpl(card), game);
+                cards.remove(card);
+                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             }
         }
         controller.putCardsOnBottomOfLibrary(cards, game, source, true);

--- a/Mage.Sets/src/mage/cards/m/MythosOfBrokkos.java
+++ b/Mage.Sets/src/mage/cards/m/MythosOfBrokkos.java
@@ -79,9 +79,7 @@ class MythosOfBrokkosEffect extends OneShotEffect {
             TargetCardInLibrary targetCardInLibrary = new TargetCardInLibrary();
             if (player.searchLibrary(targetCardInLibrary, source, game)) {
                 Card card = game.getCard(targetCardInLibrary.getFirstTarget());
-                if (card != null) {
-                    player.moveCards(card, Zone.GRAVEYARD, source, game);
-                }
+                player.moveCards(card, Zone.GRAVEYARD, source, game);
                 player.shuffleLibrary(source, game);
             }
         }

--- a/Mage.Sets/src/mage/cards/n/NahiriTheLithomancer.java
+++ b/Mage.Sets/src/mage/cards/n/NahiriTheLithomancer.java
@@ -154,16 +154,12 @@ class NahiriTheLithomancerSecondAbilityEffect extends OneShotEffect {
                 Target target = new TargetCardInHand(0, 1, filter);
                 controller.choose(outcome, target, source.getSourceId(), game);
                 Card card = controller.getHand().get(target.getFirstTarget(), game);
-                if (card != null) {
-                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             } else {
                 Target target = new TargetCardInYourGraveyard(0, 1, filter);
                 target.choose(Outcome.PutCardInPlay, source.getControllerId(), source.getSourceId(), game);
                 Card card = controller.getGraveyard().get(target.getFirstTarget(), game);
-                if (card != null) {
-                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/n/NecromancersMagemark.java
+++ b/Mage.Sets/src/mage/cards/n/NecromancersMagemark.java
@@ -94,10 +94,7 @@ class NecromancersMagemarkEffect extends ReplacementEffectImpl {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Permanent permanent = ((ZoneChangeEvent) event).getTarget();
-            if (permanent != null) {
-                controller.moveCards(permanent, Zone.HAND, source, game);
-                return true;
-            }
+            return controller.moveCards(permanent, Zone.HAND, source, game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/n/NessianGameWarden.java
+++ b/Mage.Sets/src/mage/cards/n/NessianGameWarden.java
@@ -89,11 +89,9 @@ class NessianGameWardenEffect extends OneShotEffect {
             TargetCard target = new TargetCard(Zone.LIBRARY, new FilterCreatureCard("creature card to put into your hand"));
             if (target.canChoose(source.getSourceId(), controller.getId(), game) && controller.choose(Outcome.DrawCard, cards, target, game)) {
                 Card card = cards.get(target.getFirstTarget(), game);
-                if (card != null) {
-                    controller.revealCards(sourcePermanent.getName(), new CardsImpl(card), game);
-                    cards.remove(card);
-                    controller.moveCards(card, Zone.HAND, source, game);
-                }
+                controller.revealCards(sourcePermanent.getName(), new CardsImpl(card), game);
+                cards.remove(card);
+                controller.moveCards(card, Zone.HAND, source, game);
             }
         }
 

--- a/Mage.Sets/src/mage/cards/n/NeverHappened.java
+++ b/Mage.Sets/src/mage/cards/n/NeverHappened.java
@@ -82,9 +82,7 @@ class NeverHappenedEffect extends OneShotEffect {
         }
         if (controller.choose(outcome, cards, target, game)) {
             Card card = game.getCard(target.getFirstTarget());
-            if (card != null) {
-                controller.moveCards(card, Zone.EXILED, source, game);
-            }
+            controller.moveCards(card, Zone.EXILED, source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/n/NightDealings.java
+++ b/Mage.Sets/src/mage/cards/n/NightDealings.java
@@ -157,10 +157,8 @@ public final class NightDealings extends CardImpl {
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
             player.searchLibrary(target, source, game);
             Card card = player.getLibrary().getCard(target.getFirstTarget(), game);
-            if (card != null) {
-                player.revealCards(source, new CardsImpl(card), game);
-                player.moveCards(card, Zone.HAND, source, game);
-            }
+            player.revealCards(source, new CardsImpl(card), game);
+            player.moveCards(card, Zone.HAND, source, game);
             player.shuffleLibrary(source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/n/NobleBenefactor.java
+++ b/Mage.Sets/src/mage/cards/n/NobleBenefactor.java
@@ -74,9 +74,7 @@ class NobleBenefactorEffect extends OneShotEffect {
                         player.searchLibrary(target, source, game);
                         for (UUID cardId : target.getTargets()) {
                             Card card = player.getLibrary().getCard(cardId, game);
-                            if (card != null) {
-                                player.moveCards(card, Zone.HAND, source, game);
-                            }
+                            player.moveCards(card, Zone.HAND, source, game);
                         }
                         player.shuffleLibrary(source, game);
                     }

--- a/Mage.Sets/src/mage/cards/o/OathOfDruids.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfDruids.java
@@ -132,9 +132,7 @@ class OathOfDruidsEffect extends OneShotEffect {
         controller.revealCards(source, revealed, game);
 
         //If they do, that player puts that card onto the battlefield
-        if (selectedCard != null) {
-            controller.moveCards(selectedCard, Zone.BATTLEFIELD, source, game);
-        }
+        controller.moveCards(selectedCard, Zone.BATTLEFIELD, source, game);
         // and all other cards revealed this way into their graveyard
         controller.moveCards(notSelectedCards, Zone.GRAVEYARD, source, game);
         return true;

--- a/Mage.Sets/src/mage/cards/o/OathOfGhouls.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfGhouls.java
@@ -121,9 +121,8 @@ class OathOfGhoulsEffect extends OneShotEffect {
                 && firstPlayer.chooseUse(outcome, "Return a creature card from your graveyard to your hand?", source, game)
                 && firstPlayer.chooseTarget(Outcome.ReturnToHand, target, source, game)) {
             Card card = game.getCard(target.getFirstTarget());
-            if (card != null) {
-                firstPlayer.moveCards(card, Zone.HAND, source, game);
-            }
+            firstPlayer.moveCards(card, Zone.HAND, source, game);
+
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/o/OathOfNissa.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfNissa.java
@@ -91,11 +91,10 @@ class OathOfNissaEffect extends OneShotEffect {
                             controller.choose(outcome, topCards, target, game);
                             card = topCards.get(target.getFirstTarget(), game);
                         }
-                        if (card != null) {
-                            controller.moveCards(card, Zone.HAND, source, game);
-                            controller.revealCards(sourceObject.getIdName(), new CardsImpl(card), game);
-                            topCards.remove(card);
-                        }
+                        controller.moveCards(card, Zone.HAND, source, game);
+                        controller.revealCards(sourceObject.getIdName(), new CardsImpl(card), game);
+                        topCards.remove(card);
+
                     }
                 }
                 controller.putCardsOnBottomOfLibrary(topCards, game, source, true);

--- a/Mage.Sets/src/mage/cards/o/ObzedatGhostCouncil.java
+++ b/Mage.Sets/src/mage/cards/o/ObzedatGhostCouncil.java
@@ -80,8 +80,7 @@ class ObzedatGhostCouncilExileSourceEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         Permanent permanent = game.getPermanent(source.getSourceId());
-        if (permanent == null
-                || controller == null
+        if (controller == null
                 || !controller.moveCards(permanent, Zone.EXILED, source, game)) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/p/ParallelThoughts.java
+++ b/Mage.Sets/src/mage/cards/p/ParallelThoughts.java
@@ -134,9 +134,7 @@ class ParallelThoughtsReplacementEffect extends ReplacementEffectImpl {
         if (controller != null && cards != null && !cards.isEmpty()) {
             if (controller.chooseUse(outcome, "Draw a card from the pile you exiled instead drawing from your library?", source, game)) {
                 Card card = cards.iterator().next();
-                if (card != null) {
-                    controller.moveCards(card, Zone.HAND, source, game);
-                }
+                controller.moveCards(card, Zone.HAND, source, game);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/p/PetalsOfInsight.java
+++ b/Mage.Sets/src/mage/cards/p/PetalsOfInsight.java
@@ -67,9 +67,7 @@ class PetalsOfInsightEffect extends OneShotEffect {
         if (controller.chooseUse(outcome, "Put the cards on the bottom of your library in any order?", source, game)) {
             controller.putCardsOnBottomOfLibrary(cards, game, source, true);
             Card spellCard = game.getStack().getSpell(source.getSourceId()).getCard();
-            if (spellCard != null) {
-                controller.moveCards(spellCard, Zone.HAND, source, game);
-            }
+            controller.moveCards(spellCard, Zone.HAND, source, game);
         } else {
             controller.drawCards(3, source, game);
         }

--- a/Mage.Sets/src/mage/cards/p/PhantomWings.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomWings.java
@@ -78,7 +78,7 @@ public final class PhantomWings extends CardImpl {
                 return false;
             }
             Permanent enchantedCreature = game.getPermanent(permanent.getAttachedTo());
-            return enchantedCreature != null && player.moveCards(enchantedCreature, Zone.HAND, source, game);
+            return player.moveCards(enchantedCreature, Zone.HAND, source, game);
         }
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PhyrexianDevourer.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianDevourer.java
@@ -138,9 +138,8 @@ class ExileTopCardLibraryCost extends CostImpl {
         Player controller = game.getPlayer(controllerId);
         if (controller != null) {
             card = controller.getLibrary().getFromTop(game);
-            if (card != null) {
-                paid = controller.moveCards(card, Zone.EXILED, ability, game);
-            }
+            paid = controller.moveCards(card, Zone.EXILED, ability, game);
+
         }
         return paid;
     }

--- a/Mage.Sets/src/mage/cards/p/PhyrexianGrimoire.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianGrimoire.java
@@ -93,16 +93,11 @@ class PhyrexianGrimoireEffect extends OneShotEffect {
                 {
                     Card card = game.getCard(target.getFirstTarget()); 
                     cards.remove(target.getFirstTarget());
-                    if (card != null) {
-                        controller.moveCards(card, Zone.EXILED, source, game);
-                    }
-                    
-                    if(!cards.isEmpty())
-                    {
+                    controller.moveCards(card, Zone.EXILED, source, game);
+                    if(!cards.isEmpty()){
                         card = game.getCard(cards.iterator().next()); 
-                        if (card != null) {
-                            controller.moveCards(card, Zone.HAND, source, game);
-                        }
+                        controller.moveCards(card, Zone.HAND, source, game);
+
                     }
                     
                 }

--- a/Mage.Sets/src/mage/cards/p/PhyrexianPortal.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianPortal.java
@@ -102,9 +102,7 @@ class PhyrexianPortalEffect extends OneShotEffect {
                 TargetCard target2 = new TargetCard(Zone.HAND, new FilterCard("card to put into your hand"));
                 if (controller.choose(outcome, chosenPile, target2, game)) {
                     Card card = chosenPile.get(target2.getFirstTarget(), game);
-                    if (card != null) {
-                        controller.moveCards(card, Zone.HAND, source, game);
-                    }
+                    controller.moveCards(card, Zone.HAND, source, game);
                 }
                 controller.shuffleLibrary(source, game);
             }

--- a/Mage.Sets/src/mage/cards/p/PlagueReaver.java
+++ b/Mage.Sets/src/mage/cards/p/PlagueReaver.java
@@ -184,7 +184,6 @@ class PlagueReaverReturnEffect extends OneShotEffect {
         Player player = game.getPlayer(playerId);
         Card card = game.getCard(targetPointer.getFirst(game, source));
         return player != null
-                && card != null
                 && player.moveCards(card, Zone.BATTLEFIELD, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PlungeIntoDarkness.java
+++ b/Mage.Sets/src/mage/cards/p/PlungeIntoDarkness.java
@@ -127,10 +127,8 @@ class PlungeIntoDarknessSearchEffect extends OneShotEffect {
             TargetCard target = new TargetCard(Zone.LIBRARY, new FilterCard("card to put into your hand"));
             if (controller.choose(Outcome.DrawCard, cards, target, game)) {
                 Card card = cards.get(target.getFirstTarget(), game);
-                if (card != null) {
-                    cards.remove(card);
-                    controller.moveCards(card, Zone.HAND, source, game);
-                }
+                cards.remove(card);
+                controller.moveCards(card, Zone.HAND, source, game);
             }
             controller.moveCards(cards, Zone.EXILED, source, game);
             return true;

--- a/Mage.Sets/src/mage/cards/p/Polymorph.java
+++ b/Mage.Sets/src/mage/cards/p/Polymorph.java
@@ -79,9 +79,7 @@ class PolymorphEffect extends OneShotEffect {
                             break;
                         }
                     }
-                    if (toBattlefield != null) {
-                        player.moveCards(toBattlefield, Zone.BATTLEFIELD, source, game);
-                    }
+                    player.moveCards(toBattlefield, Zone.BATTLEFIELD, source, game);
                     player.revealCards(source, cards, game);
                     cards.remove(toBattlefield);
                     if (!cards.isEmpty()) {

--- a/Mage.Sets/src/mage/cards/p/PrecognitionField.java
+++ b/Mage.Sets/src/mage/cards/p/PrecognitionField.java
@@ -78,9 +78,7 @@ class PrecognitionFieldExileEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Card card = controller.getLibrary().getFromTop(game);
-            if (card != null) {
-                controller.moveCards(card, Zone.EXILED, source, game);
-            }
+            controller.moveCards(card, Zone.EXILED, source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/p/PsychicMiasma.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicMiasma.java
@@ -57,9 +57,8 @@ class PsychicMiasmaEffect extends OneShotEffect {
             Card discardedCard = player.discardOne(false, false, source, game);
             if (discardedCard != null && discardedCard.isLand()) {
                 Card spellCard = game.getStack().getSpell(source.getSourceId()).getCard();
-                if (spellCard != null) {
-                    player.moveCards(spellCard, Zone.HAND, source, game);
-                }
+                player.moveCards(spellCard, Zone.HAND, source, game);
+
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/p/PsychicSurgery.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicSurgery.java
@@ -108,10 +108,8 @@ class PsychicSurgeryEffect extends OneShotEffect {
                 TargetCard target = new TargetCard(Zone.LIBRARY, new FilterCard("card to exile"));
                 if (controller.choose(Outcome.Exile, cards, target, game)) {
                     Card card = cards.get(target.getFirstTarget(), game);
-                    if (card != null) {
-                        controller.moveCards(card, Zone.EXILED, source, game);
-                        cards.remove(card);
-                    }
+                    controller.moveCards(card, Zone.EXILED, source, game);
+                    cards.remove(card);
                 }
             }
             controller.putCardsOnTopOfLibrary(cards, game, source, true);

--- a/Mage.Sets/src/mage/cards/p/PullFromEternity.java
+++ b/Mage.Sets/src/mage/cards/p/PullFromEternity.java
@@ -70,9 +70,7 @@ class PullFromEternityEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Card card = game.getCard(getTargetPointer().getFirst(game, source));
-            if (card != null) {
-                controller.moveCards(card, Zone.GRAVEYARD, source, game);
-            }
+            controller.moveCards(card, Zone.GRAVEYARD, source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/p/PulsemageAdvocate.java
+++ b/Mage.Sets/src/mage/cards/p/PulsemageAdvocate.java
@@ -89,9 +89,7 @@ class PulsemageAdvocateEffect extends OneShotEffect {
             }
             controller.moveCards(cards, Zone.HAND, source, game);
             Card card = controller.getGraveyard().get(source.getTargets().get(1).getFirstTarget(), game);
-            if (card != null) {
-                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-            }
+            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/p/Purgatory.java
+++ b/Mage.Sets/src/mage/cards/p/Purgatory.java
@@ -165,15 +165,13 @@ class PurgatoryReturnEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         UUID exileId = CardUtil.getCardExileZoneId(game, source);
         MageObject sourceObject = source.getSourceObject(game);
-        if (controller != null && exileId != null && sourceObject != null) {
+        if (controller != null && sourceObject != null) {
             ExileZone exileZone = game.getExile().getExileZone(exileId);
             if (exileZone != null) {
                 TargetCard targetCard = new TargetCard(Zone.EXILED, new FilterCard());
                 controller.chooseTarget(outcome, exileZone, targetCard, source, game);
                 Card card = game.getCard(targetCard.getFirstTarget());
-                if (card != null) {
-                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/p/PurphorosBronzeBlooded.java
+++ b/Mage.Sets/src/mage/cards/p/PurphorosBronzeBlooded.java
@@ -111,7 +111,7 @@ class PurphurosBronzeBloodedEffect extends OneShotEffect {
             return true;
         }
         Card card = game.getCard(target.getFirstTarget());
-        if (card == null || !controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
+        if (!controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             return false;
         }
         Permanent permanent = game.getPermanent(card.getId());

--- a/Mage.Sets/src/mage/cards/q/QuillmaneBaku.java
+++ b/Mage.Sets/src/mage/cards/q/QuillmaneBaku.java
@@ -104,9 +104,7 @@ class QuillmaneBakuReturnEffect extends OneShotEffect {
             return false;
         }
         Permanent permanent = game.getPermanent(this.getTargetPointer().getFirst(game, source));
-        if (permanent != null) {
-            controller.moveCards(permanent, Zone.HAND, source, game);
-        }
+        controller.moveCards(permanent, Zone.HAND, source, game);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RealityScramble.java
+++ b/Mage.Sets/src/mage/cards/r/RealityScramble.java
@@ -105,10 +105,8 @@ class RealityScrambleEffect extends OneShotEffect {
             }
         }
         controller.revealCards(source, toReveal, game);
-        if (cardToPlay != null) {
-            controller.moveCards(cardToPlay, Zone.BATTLEFIELD, source, game);
-            toReveal.remove(cardToPlay);
-        }
+        controller.moveCards(cardToPlay, Zone.BATTLEFIELD, source, game);
+        toReveal.remove(cardToPlay);
         controller.putCardsOnBottomOfLibrary(toReveal, game, source, false);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/r/RelentlessDead.java
+++ b/Mage.Sets/src/mage/cards/r/RelentlessDead.java
@@ -83,9 +83,7 @@ class RelentlessDeadEffect extends OneShotEffect {
                 TargetCardInYourGraveyard target = new TargetCardInYourGraveyard(filter);
                 if (controller.chooseTarget(outcome, target, source, game)) {
                     Card card = game.getCard(target.getFirstTarget());
-                    if (card != null) {
-                        controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                    }
+                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
                 }
 
             }

--- a/Mage.Sets/src/mage/cards/r/RescueFromTheUnderworld.java
+++ b/Mage.Sets/src/mage/cards/r/RescueFromTheUnderworld.java
@@ -205,9 +205,8 @@ class RescueFromTheUnderworldReturnEffect extends OneShotEffect {
             // Target card comes only back if in graveyard
             for (UUID targetId : getTargetPointer().getTargets(game, source)) {
                 Card card = game.getCard(targetId);
-                if (card != null) {
-                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+
             }
             // However, if the sacrificed creature is put into another public zone instead of the graveyard,
             // perhaps because it's your commander or because of another replacement effect, it will return

--- a/Mage.Sets/src/mage/cards/r/RescuerSphinx.java
+++ b/Mage.Sets/src/mage/cards/r/RescuerSphinx.java
@@ -91,7 +91,7 @@ class RescuerSphinxEffect extends OneShotEffect {
             return false;
         }
         Permanent permanent = game.getPermanent(target.getFirstTarget());
-        if (permanent == null || !player.moveCards(permanent, Zone.HAND, source, game)) {
+        if (!player.moveCards(permanent, Zone.HAND, source, game)) {
             return false;
         }
         return new AddCountersSourceEffect(CounterType.P1P1.createInstance()).apply(game, source);

--- a/Mage.Sets/src/mage/cards/r/Reweave.java
+++ b/Mage.Sets/src/mage/cards/r/Reweave.java
@@ -90,9 +90,7 @@ class ReweaveEffect extends OneShotEffect {
                             }
                         }
                         permanentController.revealCards(source, cards, game);
-                        if (permanentCard != null) {
-                            permanentController.moveCards(permanentCard, Zone.BATTLEFIELD, source, game);
-                        }
+                        permanentController.moveCards(permanentCard, Zone.BATTLEFIELD, source, game);
                         permanentController.shuffleLibrary(source, game);
 
                     }

--- a/Mage.Sets/src/mage/cards/r/RootsOfWisdom.java
+++ b/Mage.Sets/src/mage/cards/r/RootsOfWisdom.java
@@ -78,7 +78,7 @@ class RootsOfWisdomEffect extends OneShotEffect {
         if (targetCard.canChoose(source.getSourceId(), source.getControllerId(), game)
                 && player.choose(outcome, targetCard, source.getSourceId(), game)) {
             Card card = player.getGraveyard().get(targetCard.getFirstTarget(), game);
-            if (card != null && player.moveCards(card, Zone.HAND, source, game)) {
+            if (player.moveCards(card, Zone.HAND, source, game)) {
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/s/SatyrWayfinder.java
+++ b/Mage.Sets/src/mage/cards/s/SatyrWayfinder.java
@@ -80,11 +80,8 @@ class SatyrWayfinderEffect extends OneShotEffect {
                         && controller.chooseUse(outcome, "Put a land card into your hand?", source, game)
                         && controller.choose(Outcome.DrawCard, cards, target, game)) {
                     Card card = game.getCard(target.getFirstTarget());
-                    if (card != null) {
-                        cards.remove(card);
-                        controller.moveCards(card, Zone.HAND, source, game);
-                    }
-
+                    cards.remove(card);
+                    controller.moveCards(card, Zone.HAND, source, game);
                 }
                 controller.moveCards(cards, Zone.GRAVEYARD, source, game);
             }

--- a/Mage.Sets/src/mage/cards/s/ScarabOfTheUnseen.java
+++ b/Mage.Sets/src/mage/cards/s/ScarabOfTheUnseen.java
@@ -85,7 +85,7 @@ class ScarabOfTheUnseenEffect extends OneShotEffect {
                 attachments.addAll(targetPermanent.getAttachments());
                 for (UUID attachedId : attachments) {
                     Permanent attachedPerm = game.getPermanent(attachedId);
-                    if (attachedPerm != null && filter.match(attachedPerm, game)) {
+                    if (filter.match(attachedPerm, game)) {
                         controller.moveCards(attachedPerm, Zone.HAND, source, game);
                     }
                 }

--- a/Mage.Sets/src/mage/cards/s/ScoutTheBorders.java
+++ b/Mage.Sets/src/mage/cards/s/ScoutTheBorders.java
@@ -74,11 +74,8 @@ class ScoutTheBordersEffect extends OneShotEffect {
                 TargetCard target = new TargetCard(Zone.LIBRARY, filterPutInHand);
                 if (properCardFound && controller.choose(Outcome.DrawCard, cards, target, game)) {
                     Card card = game.getCard(target.getFirstTarget());
-                    if (card != null) {
-                        controller.moveCards(card, Zone.HAND, source, game);
-                        cards.remove(card);
-                    }
-
+                    controller.moveCards(card, Zone.HAND, source, game);
+                    cards.remove(card);
                 }
                 controller.moveCards(cards, Zone.GRAVEYARD, source, game);
             }

--- a/Mage.Sets/src/mage/cards/s/ScrabblingClaws.java
+++ b/Mage.Sets/src/mage/cards/s/ScrabblingClaws.java
@@ -92,6 +92,6 @@ class ScrabblingClawsEffect extends OneShotEffect {
             return false;
         }
         Card card = game.getCard(target.getFirstTarget());
-        return card != null && targetPlayer.moveCards(card, Zone.EXILED, source, game);
+        return targetPlayer.moveCards(card, Zone.EXILED, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SeeBeyond.java
+++ b/Mage.Sets/src/mage/cards/s/SeeBeyond.java
@@ -58,8 +58,7 @@ class SeeBeyondEffect extends OneShotEffect {
                 TargetCard target = new TargetCard(Zone.HAND, new FilterCard("card to shuffle into your library"));
                 controller.choose(Outcome.Detriment, controller.getHand(), target, game);
                 Card card = controller.getHand().get(target.getFirstTarget(), game);
-                if (card != null) {
-                    controller.moveCards(card, Zone.LIBRARY, source, game);
+                if(controller.moveCards(card, Zone.LIBRARY, source, game)){
                     controller.shuffleLibrary(source, game);
                 }
                 return true;

--- a/Mage.Sets/src/mage/cards/s/SengirNosferatu.java
+++ b/Mage.Sets/src/mage/cards/s/SengirNosferatu.java
@@ -92,9 +92,6 @@ class ReturnSengirNosferatuEffect extends OneShotEffect {
         }
         controller.chooseTarget(Outcome.PutCreatureInPlay, target, source, game);
         Card card = game.getCard(target.getTargets().get(0));
-        if (card != null) {
-            return controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-        }
-        return false;
+        return controller.moveCards(card, Zone.BATTLEFIELD, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SequesteredStash.java
+++ b/Mage.Sets/src/mage/cards/s/SequesteredStash.java
@@ -80,9 +80,7 @@ class SequesteredStashEffect extends OneShotEffect {
                 && controller.chooseUse(outcome, "Put an artifact card from your graveyard to library?", source, game)
                 && controller.choose(outcome, target, source.getSourceId(), game)) {
             Card card = game.getCard(target.getFirstTarget());
-            if (card != null) {
-                controller.moveCards(card, Zone.LIBRARY, source, game);
-            }
+            controller.moveCards(card, Zone.LIBRARY, source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/s/ShapeAnew.java
+++ b/Mage.Sets/src/mage/cards/s/ShapeAnew.java
@@ -71,9 +71,7 @@ public final class ShapeAnew extends CardImpl {
                 }
             }
             targetController.revealCards(source, revealed, game);
-            if (artifactCard != null) {
-                targetController.moveCards(artifactCard, Zone.BATTLEFIELD, source, game);
-            }
+            targetController.moveCards(artifactCard, Zone.BATTLEFIELD, source, game);
             // 1/1/2011: If the first card the player reveals is an artifact card, they will still have to shuffle their library even though no other cards were revealed this way.
             targetController.shuffleLibrary(source, game);
             return true;

--- a/Mage.Sets/src/mage/cards/s/ShiftyDoppelganger.java
+++ b/Mage.Sets/src/mage/cards/s/ShiftyDoppelganger.java
@@ -85,11 +85,9 @@ class ShiftyDoppelgangerExileEffect extends OneShotEffect {
             TargetCardInHand target = new TargetCardInHand(filter);
             if (player.choose(Outcome.PutCreatureInPlay, target, source.getSourceId(), game)) {
                 Card card = game.getCard(target.getFirstTarget());
-                if (card != null) {
-                    putCreature = player.moveCards(card, Zone.BATTLEFIELD, source, game);
-                    if (putCreature) {
-                        creatureId = card.getId();
-                    }
+                putCreature = player.moveCards(card, Zone.BATTLEFIELD, source, game);
+                if (putCreature) {
+                    creatureId = card.getId();
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/s/ShrineOfPiercingVision.java
+++ b/Mage.Sets/src/mage/cards/s/ShrineOfPiercingVision.java
@@ -96,10 +96,8 @@ class ShrineOfPiercingVisionEffect extends OneShotEffect {
             TargetCard target = new TargetCard(Zone.LIBRARY, new FilterCard("card to put into your hand"));
             if (player.choose(Outcome.DrawCard, cards, target, game)) {
                 Card card = cards.get(target.getFirstTarget(), game);
-                if (card != null) {
-                    cards.remove(card);
-                    player.moveCards(card, Zone.HAND, source, game);
-                }
+                cards.remove(card);
+                player.moveCards(card, Zone.HAND, source, game);
             }
             player.putCardsOnBottomOfLibrary(cards, game, source, true);
         }

--- a/Mage.Sets/src/mage/cards/s/Skullwinder.java
+++ b/Mage.Sets/src/mage/cards/s/Skullwinder.java
@@ -85,9 +85,7 @@ class SkullwinderEffect extends OneShotEffect {
                     targetCard.setNotTarget(true);
                     if (opponent.choose(outcome, targetCard, source.getSourceId(), game)) {
                         Card card = game.getCard(targetCard.getFirstTarget());
-                        if (card != null) {
-                            opponent.moveCards(card, Zone.HAND, source, game);
-                        }
+                        opponent.moveCards(card, Zone.HAND, source, game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/s/SneakAttack.java
+++ b/Mage.Sets/src/mage/cards/s/SneakAttack.java
@@ -77,7 +77,7 @@ class SneakAttackEffect extends OneShotEffect {
             return true;
         }
         Card card = game.getCard(target.getFirstTarget());
-        if (card == null || !controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
+        if (!controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             return false;
         }
         Permanent permanent = game.getPermanent(card.getId());

--- a/Mage.Sets/src/mage/cards/s/Spelltwine.java
+++ b/Mage.Sets/src/mage/cards/s/Spelltwine.java
@@ -81,12 +81,8 @@ class SpelltwineEffect extends OneShotEffect {
         Card cardOne = game.getCard(source.getTargets().get(0).getFirstTarget());
         Card cardTwo = game.getCard(source.getTargets().get(1).getFirstTarget());
         if (controller != null) {
-            if (cardOne != null) {
-                controller.moveCards(cardOne, Zone.EXILED, source, game);
-            }
-            if (cardTwo != null) {
-                controller.moveCards(cardTwo, Zone.EXILED, source, game);
-            }
+            controller.moveCards(cardOne, Zone.EXILED, source, game);
+            controller.moveCards(cardTwo, Zone.EXILED, source, game);
             boolean castCardOne = true;
             ApprovingObject approvingObject = new ApprovingObject(source, game);
             if (cardOne != null 

--- a/Mage.Sets/src/mage/cards/s/StartledAwake.java
+++ b/Mage.Sets/src/mage/cards/s/StartledAwake.java
@@ -74,9 +74,7 @@ class StartledAwakeReturnTransformedEffect extends OneShotEffect {
             if (game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD) {
                 game.getState().setValue(TransformAbility.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
                 Card card = game.getCard(source.getSourceId());
-                if (card != null) {
-                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/s/StormElemental.java
+++ b/Mage.Sets/src/mage/cards/s/StormElemental.java
@@ -127,9 +127,7 @@ class ExileTopCardLibraryCost extends CostImpl {
         Player controller = game.getPlayer(controllerId);
         if (controller != null) {
             card = controller.getLibrary().getFromTop(game);
-            if (card != null) {
-                paid = controller.moveCards(card, Zone.EXILED, ability, game);
-            }
+            paid = controller.moveCards(card, Zone.EXILED, ability, game);
         }
         return paid;
     }

--- a/Mage.Sets/src/mage/cards/s/SummoningTrap.java
+++ b/Mage.Sets/src/mage/cards/s/SummoningTrap.java
@@ -130,10 +130,8 @@ class SummoningTrapEffect extends OneShotEffect {
                             "creature card to put on the battlefield"));
             if (controller.choose(Outcome.PutCreatureInPlay, cards, target, game)) {
                 Card card = cards.get(target.getFirstTarget(), game);
-                if (card != null) {
-                    cards.remove(card);
-                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                cards.remove(card);
+                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             }
             if (!cards.isEmpty()) {
                 controller.putCardsOnBottomOfLibrary(cards, game, source, true);

--- a/Mage.Sets/src/mage/cards/s/SunClasp.java
+++ b/Mage.Sets/src/mage/cards/s/SunClasp.java
@@ -75,9 +75,7 @@ class SunClaspReturnEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && permanent != null && permanent.getAttachedTo() != null) {
             Permanent enchantedCreature = game.getPermanent(permanent.getAttachedTo());
-            if (enchantedCreature != null) {
-                controller.moveCards(enchantedCreature, Zone.HAND, source, game);
-            }
+            controller.moveCards(enchantedCreature, Zone.HAND, source, game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/SunkenHope.java
+++ b/Mage.Sets/src/mage/cards/s/SunkenHope.java
@@ -74,9 +74,7 @@ class SunkenHopeReturnToHandEffect extends OneShotEffect {
 
             for (UUID targetId : target.getTargets()) {
                 Permanent permanent = game.getPermanent(targetId);
-                if (permanent != null) {
-                    result |= player.moveCards(permanent, Zone.HAND, source, game);
-                }
+                result |= player.moveCards(permanent, Zone.HAND, source, game);
             }
         }
         return result;

--- a/Mage.Sets/src/mage/cards/s/SurrealMemoir.java
+++ b/Mage.Sets/src/mage/cards/s/SurrealMemoir.java
@@ -64,8 +64,7 @@ class SurrealMemoirEffect extends OneShotEffect {
             Card[] cards = controller.getGraveyard().getCards(filter, game).toArray(new Card[0]);
             if (cards.length > 0) {
                 Card card = cards[RandomUtil.nextInt(cards.length)];
-                if (card != null
-                        && controller.moveCards(card, Zone.HAND, source, game)) {
+                if (controller.moveCards(card, Zone.HAND, source, game)) {
                     game.informPlayers(card.getName() + "returned to the hand of" + controller.getLogName());
                     return true;
                 }

--- a/Mage.Sets/src/mage/cards/s/SwordOfLightAndShadow.java
+++ b/Mage.Sets/src/mage/cards/s/SwordOfLightAndShadow.java
@@ -124,11 +124,7 @@ class SwordOfLightAndShadowReturnToHandTargetEffect extends OneShotEffect {
                     switch (game.getState().getZone(targetId)) {
                         case GRAVEYARD:
                             Card card = game.getCard(targetId);
-                            if (card != null) {
-                                controller.moveCards(card, Zone.HAND, source, game);
-                            } else {
-                                result = false;
-                            }
+                            result = controller.moveCards(card, Zone.HAND, source, game);
                             break;
                     }
                 }

--- a/Mage.Sets/src/mage/cards/t/TajuruParagon.java
+++ b/Mage.Sets/src/mage/cards/t/TajuruParagon.java
@@ -93,10 +93,8 @@ class TajuruParagonEffect extends OneShotEffect {
             TargetCard target = new TargetCardInLibrary(0, 1, filter);
             player.choose(outcome, cards, target, game);
             Card card = game.getCard(target.getFirstTarget());
-            if (card != null) {
-                player.moveCards(card, Zone.HAND, source, game);
-                cards.remove(card);
-            }
+            player.moveCards(card, Zone.HAND, source, game);
+            cards.remove(card);
         }
         player.putCardsOnBottomOfLibrary(cards, game, source, false);
         return true;

--- a/Mage.Sets/src/mage/cards/t/TasigurTheGoldenFang.java
+++ b/Mage.Sets/src/mage/cards/t/TasigurTheGoldenFang.java
@@ -91,9 +91,7 @@ class TasigurTheGoldenFangEffect extends OneShotEffect {
                     target.setNotTarget(true);
                     opponent.chooseTarget(outcome, target, source, game);
                     Card card = game.getCard(target.getFirstTarget());
-                    if (card != null) {
-                        controller.moveCards(card, Zone.HAND, source, game);
-                    }
+                    controller.moveCards(card, Zone.HAND, source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/t/TellingTime.java
+++ b/Mage.Sets/src/mage/cards/t/TellingTime.java
@@ -81,13 +81,10 @@ class TellingTimeEffect extends OneShotEffect {
         }
 
         card = pickCard(game, controller, cards, "card to put on top of your library");
-        if (card != null) {
-            controller.moveCards(card, Zone.LIBRARY, source, game);
-            cards.remove(card);
-        }
-        if (!cards.isEmpty()) {
-            controller.putCardsOnBottomOfLibrary(cards, game, source, false);
-        }
+        controller.moveCards(card, Zone.LIBRARY, source, game);
+        cards.remove(card);
+
+        controller.putCardsOnBottomOfLibrary(cards, game, source, false);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemptWithDiscovery.java
+++ b/Mage.Sets/src/mage/cards/t/TemptWithDiscovery.java
@@ -69,9 +69,7 @@ class TemptWithDiscoveryEffect extends OneShotEffect {
             if (controller.searchLibrary(target, source, game)) {
                 for (UUID cardId : target.getTargets()) {
                     Card card = game.getCard(cardId);
-                    if (card != null) {
-                        controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                    }
+                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
                 }
             }
             int opponentsUsedSearch = 0;
@@ -85,9 +83,7 @@ class TemptWithDiscoveryEffect extends OneShotEffect {
                         if (opponent.searchLibrary(target, source, game)) {
                             for (UUID cardId : target.getTargets()) {
                                 Card card = game.getCard(cardId);
-                                if (card != null) {
-                                    opponent.moveCards(card, Zone.BATTLEFIELD, source, game);
-                                }
+                                opponent.moveCards(card, Zone.BATTLEFIELD, source, game);
                             }
                         }
                     }
@@ -98,9 +94,7 @@ class TemptWithDiscoveryEffect extends OneShotEffect {
                 if (controller.searchLibrary(target, source, game)) {
                     for (UUID cardId : target.getTargets()) {
                         Card card = game.getCard(cardId);
-                        if (card != null) {
-                            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                        }
+                        controller.moveCards(card, Zone.BATTLEFIELD, source, game);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/t/TemptWithImmortality.java
+++ b/Mage.Sets/src/mage/cards/t/TemptWithImmortality.java
@@ -77,10 +77,8 @@ class TemptWithImmortalityEffect extends OneShotEffect {
                         if (opponent.chooseUse(outcome, "Return a creature card from your graveyard to the battlefield?", source, game)) {
                             if (opponent.chooseTarget(outcome, targetCardOpponent, source, game)) {
                                 Card card = game.getCard(targetCardOpponent.getFirstTarget());
-                                if (card != null) {
-                                    opponentsReturnedCreatures++;
-                                    opponent.moveCards(card, Zone.BATTLEFIELD, source, game);
-                                }
+                                opponentsReturnedCreatures++;
+                                opponent.moveCards(card, Zone.BATTLEFIELD, source, game);
                             }
                         }
                     }
@@ -103,9 +101,7 @@ class TemptWithImmortalityEffect extends OneShotEffect {
         if (target.canChoose(source.getSourceId(), source.getControllerId(), game)) {
             if (player.chooseTarget(outcome, target, source, game)) {
                 Card card = game.getCard(target.getFirstTarget());
-                if (card != null) {
-                    return player.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                return player.moveCards(card, Zone.BATTLEFIELD, source, game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/t/TemurSabertooth.java
+++ b/Mage.Sets/src/mage/cards/t/TemurSabertooth.java
@@ -82,9 +82,7 @@ class TemurSabertoothEffect extends OneShotEffect {
                 if (controller.chooseUse(outcome, "Return another creature to hand?", source, game)
                         && controller.chooseTarget(outcome, target, source, game)) {
                     Permanent toHand = game.getPermanent(target.getFirstTarget());
-                    if (toHand != null) {
-                        controller.moveCards(toHand, Zone.HAND, source, game);
-                    }
+                    controller.moveCards(toHand, Zone.HAND, source, game);
                     game.addEffect(new GainAbilitySourceEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn), source);
                 }
             }

--- a/Mage.Sets/src/mage/cards/t/TergridGodOfFright.java
+++ b/Mage.Sets/src/mage/cards/t/TergridGodOfFright.java
@@ -156,11 +156,8 @@ class TergridGodOfFrightEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Card card = game.getCard(targetPointer.getFirst(game, source));
-            if (card != null) {
                 // controller gets to choose the order in which the cards enter the battlefield
-                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-            }
-            return true;
+               return controller.moveCards(card, Zone.BATTLEFIELD, source, game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/t/TezzeretTheSeeker.java
+++ b/Mage.Sets/src/mage/cards/t/TezzeretTheSeeker.java
@@ -93,9 +93,7 @@ class TezzeretTheSeekerEffect2 extends OneShotEffect {
 
         if (controller.searchLibrary(target, source, game)) {
             Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
-            if (card != null) {
-                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-            }
+            controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             controller.shuffleLibrary(source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/t/TheMendingOfDominaria.java
+++ b/Mage.Sets/src/mage/cards/t/TheMendingOfDominaria.java
@@ -81,9 +81,7 @@ class TheMendingOfDominariaFirstEffect extends OneShotEffect {
                 && controller.chooseUse(outcome, "Return a creature card from your graveyard to hand?", source, game)
                 && controller.choose(Outcome.ReturnToHand, target, source.getSourceId(), game)) {
             Card card = game.getCard(target.getFirstTarget());
-            if (card != null) {
-                controller.moveCards(card, Zone.HAND, source, game);
-            }
+            controller.moveCards(card, Zone.HAND, source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/t/ThoughtpickerWitch.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtpickerWitch.java
@@ -83,10 +83,8 @@ class ThoughtpickerWitchEffect extends OneShotEffect {
                 TargetCard target = new TargetCardInLibrary(new FilterCard("card to exile"));
                 if (controller.choose(Outcome.Exile, cards, target, game)) {
                     Card card = cards.get(target.getFirstTarget(), game);
-                    if (card != null) {
-                        cards.remove(card);
-                        opponent.moveCards(card, Zone.EXILED, source, game);
-                    }
+                    cards.remove(card);
+                    opponent.moveCards(card, Zone.EXILED, source, game);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/t/ThranTome.java
+++ b/Mage.Sets/src/mage/cards/t/ThranTome.java
@@ -101,10 +101,9 @@ class ThranTomeEffect extends OneShotEffect {
         }
 
         // put the chosen card in the graveyard
-        if (cardToGraveyard != null) {
-            controller.moveCards(cardToGraveyard, Zone.GRAVEYARD, source, game);
-            cards.remove(cardToGraveyard);
-        }
+        controller.moveCards(cardToGraveyard, Zone.GRAVEYARD, source, game);
+        cards.remove(cardToGraveyard);
+
 
         // draw 2
         controller.drawCards(2, source, game);

--- a/Mage.Sets/src/mage/cards/t/TimeWipe.java
+++ b/Mage.Sets/src/mage/cards/t/TimeWipe.java
@@ -65,9 +65,7 @@ class TimeWipeEffect extends OneShotEffect {
         target.setNotTarget(true);
         if (player.choose(outcome, target, source.getSourceId(), game)) {
             Permanent permanent = game.getPermanent(target.getFirstTarget());
-            if (permanent != null) {
-                player.moveCards(permanent, Zone.HAND, source, game);
-            }
+            player.moveCards(permanent, Zone.HAND, source, game);
         }
         return new DestroyAllEffect(StaticFilters.FILTER_PERMANENT_A_CREATURE).apply(game, source);
     }

--- a/Mage.Sets/src/mage/cards/t/TombOfTheDuskRose.java
+++ b/Mage.Sets/src/mage/cards/t/TombOfTheDuskRose.java
@@ -82,15 +82,13 @@ class TombOfTheDuskRoseEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         UUID exileId = CardUtil.getCardExileZoneId(game, source);
         MageObject sourceObject = source.getSourceObject(game);
-        if (controller != null && exileId != null && sourceObject != null) {
+        if (controller != null && sourceObject != null) {
             ExileZone exileZone = game.getExile().getExileZone(exileId);
             if (exileZone != null) {
                 TargetCard targetCard = new TargetCard(Zone.EXILED, StaticFilters.FILTER_CARD_CREATURE);
                 controller.chooseTarget(outcome, exileZone, targetCard, source, game);
                 Card card = game.getCard(targetCard.getFirstTarget());
-                if (card != null) {
-                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                }
+                controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/t/TrackersInstincts.java
+++ b/Mage.Sets/src/mage/cards/t/TrackersInstincts.java
@@ -73,10 +73,8 @@ class TrackersInstinctsEffect extends OneShotEffect {
                 TargetCard target = new TargetCard(Zone.LIBRARY, new FilterCreatureCard("creature card to put in hand"));
                 if (creaturesFound && controller.choose(Outcome.DrawCard, cards, target, game)) {
                     Card card = game.getCard(target.getFirstTarget());
-                    if (card != null) {
-                        controller.moveCards(card, Zone.HAND, source, game);
-                        cards.remove(card);
-                    }
+                    controller.moveCards(card, Zone.HAND, source, game);
+                    cards.remove(card);
                 }
                 controller.moveCards(cards, Zone.GRAVEYARD, source, game);
             }

--- a/Mage.Sets/src/mage/cards/t/Transmogrify.java
+++ b/Mage.Sets/src/mage/cards/t/Transmogrify.java
@@ -75,9 +75,8 @@ class TransmogrifyEffect extends OneShotEffect {
                             break;
                         }
                     }
-                    if (toBattlefield != null) {
-                        player.moveCards(toBattlefield, Zone.BATTLEFIELD, source, game);
-                    }
+                    player.moveCards(toBattlefield, Zone.BATTLEFIELD, source, game);
+
                     player.revealCards(source, cards, game);
                     cards.remove(toBattlefield);
                     if (!cards.isEmpty()) {

--- a/Mage.Sets/src/mage/cards/u/UnexpectedResults.java
+++ b/Mage.Sets/src/mage/cards/u/UnexpectedResults.java
@@ -108,7 +108,7 @@ class UnexpectedResultEffect extends OneShotEffect {
                 if (controller.chooseUse(outcome, "Cast " + card.getName() 
                         + " without paying its mana cost?", source, game)) {
                     game.getState().setValue("PlayFromNotOwnHandZone" + card.getId(), Boolean.TRUE);
-                    Boolean cardWasCast = controller.cast(controller.chooseAbilityForCast(card, game, true),
+                    boolean cardWasCast = controller.cast(controller.chooseAbilityForCast(card, game, true),
                             game, true, new ApprovingObject(source, game));
                     game.getState().setValue("PlayFromNotOwnHandZone" + card.getId(), null);
                     return cardWasCast;

--- a/Mage.Sets/src/mage/cards/v/VerdantSuccession.java
+++ b/Mage.Sets/src/mage/cards/v/VerdantSuccession.java
@@ -130,8 +130,7 @@ class VerdantSuccessionEffect extends OneShotEffect {
                     controller.searchLibrary(target, source, game);
                     if (!target.getTargets().isEmpty()) {
                         Card card = game.getCard(target.getFirstTarget());
-                        if (card != null
-                                && controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
+                        if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
                             controller.shuffleLibrary(source, game);
                         }
                         return true;

--- a/Mage.Sets/src/mage/cards/v/VesselOfNascency.java
+++ b/Mage.Sets/src/mage/cards/v/VesselOfNascency.java
@@ -89,11 +89,8 @@ class VesselOfNascencyEffect extends OneShotEffect {
                         && controller.chooseUse(outcome, "Put an artifact, creature, enchantment, land, or planeswalker card into your hand?", source, game)
                         && controller.choose(Outcome.DrawCard, cards, target, game)) {
                     Card card = game.getCard(target.getFirstTarget());
-                    if (card != null) {
-                        cards.remove(card);
-                        controller.moveCards(card, Zone.HAND, source, game);
-                    }
-
+                    cards.remove(card);
+                    controller.moveCards(card, Zone.HAND, source, game);
                 }
                 controller.moveCards(cards, Zone.GRAVEYARD, source, game);
             }

--- a/Mage.Sets/src/mage/cards/v/VizierOfTheAnointed.java
+++ b/Mage.Sets/src/mage/cards/v/VizierOfTheAnointed.java
@@ -152,9 +152,7 @@ class SearchLibraryPutInGraveyard extends SearchEffect {
             if (controller.searchLibrary(target, source, game)) {
                 if (!target.getTargets().isEmpty()) {
                     Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
-                    if (card != null) {
-                        controller.moveCards(card, Zone.GRAVEYARD, source, game);
-                    }
+                    controller.moveCards(card, Zone.GRAVEYARD, source, game);
                 }
             }
             controller.shuffleLibrary(source, game);

--- a/Mage.Sets/src/mage/cards/w/WildResearch.java
+++ b/Mage.Sets/src/mage/cards/w/WildResearch.java
@@ -84,11 +84,9 @@ class WildResearchEffect extends OneShotEffect {
             if (controller.searchLibrary(target, source, game)) {
                 if (!target.getTargets().isEmpty()) {
                     Card card = controller.getLibrary().remove(target.getFirstTarget(), game);
-                    if (card != null) {
-                        controller.moveCards(card, Zone.HAND, source, game);
-                        Cards cards = new CardsImpl(card);
-                        controller.revealCards(sourceObject.getIdName(), cards, game, true);
-                    }
+                    controller.moveCards(card, Zone.HAND, source, game);
+                    Cards cards = new CardsImpl(card);
+                    controller.revealCards(sourceObject.getIdName(), cards, game, true);
                 }
             }
             controller.discardOne(true, false, source, game);

--- a/Mage.Sets/src/mage/cards/w/WildfireDevils.java
+++ b/Mage.Sets/src/mage/cards/w/WildfireDevils.java
@@ -107,7 +107,7 @@ class WildfireDevilsEffect extends OneShotEffect {
             return false;
         }
         game.getState().setValue("PlayFromNotOwnHandZone" + copiedCard.getId(), Boolean.TRUE);
-        Boolean cardWasCast = controller.cast(controller.chooseAbilityForCast(copiedCard, game, true), game, true,
+        boolean cardWasCast = controller.cast(controller.chooseAbilityForCast(copiedCard, game, true), game, true,
                 new ApprovingObject(source, game));
         game.getState().setValue("PlayFromNotOwnHandZone" + copiedCard.getId(), null);
         return cardWasCast;

--- a/Mage.Sets/src/mage/cards/w/WitherbloomCommand.java
+++ b/Mage.Sets/src/mage/cards/w/WitherbloomCommand.java
@@ -112,6 +112,6 @@ class WitherbloomCommandEffect extends OneShotEffect {
         }
         player.choose(outcome, target, source.getSourceId(), game);
         Card card = game.getCard(target.getFirstTarget());
-        return card != null && player.moveCards(card, Zone.HAND, source, game);
+        return player.moveCards(card, Zone.HAND, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/w/WordsOfWind.java
+++ b/Mage.Sets/src/mage/cards/w/WordsOfWind.java
@@ -74,9 +74,7 @@ class WordsOfWindEffect extends ReplacementEffectImpl {
                         }
                     }
                     Permanent permanent = game.getPermanent(target.getFirstTarget());
-                    if (permanent != null) {
-                        player.moveCards(permanent, Zone.HAND, source, game);
-                    }
+                    player.moveCards(permanent, Zone.HAND, source, game);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/w/WorldlyCounsel.java
+++ b/Mage.Sets/src/mage/cards/w/WorldlyCounsel.java
@@ -74,10 +74,8 @@ class WorldlyCounselEffect extends OneShotEffect {
                 TargetCard target = new TargetCard(Zone.LIBRARY, new FilterCard("card to put into your hand"));
                 if (controller.choose(Outcome.DrawCard, cards, target, game)) {
                     Card card = cards.get(target.getFirstTarget(), game);
-                    if (card != null) {
-                        cards.remove(card);
-                        controller.moveCards(card, Zone.HAND, source, game);
-                    }
+                    cards.remove(card);
+                    controller.moveCards(card, Zone.HAND, source, game);
                 }
                 controller.putCardsOnBottomOfLibrary(cards, game, source, true);
             }

--- a/Mage.Sets/src/mage/cards/w/WrexialTheRisenDeep.java
+++ b/Mage.Sets/src/mage/cards/w/WrexialTheRisenDeep.java
@@ -183,7 +183,7 @@ class WrexialReplacementEffect extends ReplacementEffectImpl {
         UUID eventObject = event.getTargetId();
         StackObject card = game.getStack().getStackObject(eventObject);
         Player controller = game.getPlayer(source.getControllerId());
-        if (card != null && controller != null) {
+        if (controller != null) {
             if (card instanceof Card) {
                 return controller.moveCards((Card) card, Zone.EXILED, source, game);
             }

--- a/Mage.Sets/src/mage/cards/w/WuSpy.java
+++ b/Mage.Sets/src/mage/cards/w/WuSpy.java
@@ -79,10 +79,8 @@ class WuSpyEffect extends OneShotEffect {
                 TargetCard target = new TargetCardInLibrary(new FilterCard("card to put into graveyard"));
                 controller.choose(Outcome.Benefit, cards, target, game);
                 Card card = cards.get(target.getFirstTarget(), game);
-                if (card != null) {
-                    cards.remove(card);
-                    controller.moveCards(card, Zone.GRAVEYARD, source, game);
-                }
+                cards.remove(card);
+                controller.moveCards(card, Zone.GRAVEYARD, source, game);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/y/YawgmothsVileOffering.java
+++ b/Mage.Sets/src/mage/cards/y/YawgmothsVileOffering.java
@@ -80,9 +80,7 @@ class YawgmothsVileOfferingEffect extends OneShotEffect {
         }
 
         Card returnCard = game.getCard(source.getTargets().getFirstTarget());
-        if (returnCard != null) {
-            controller.moveCards(returnCard, Zone.BATTLEFIELD, source, game);
-        }
+        controller.moveCards(returnCard, Zone.BATTLEFIELD, source, game);
 
         Permanent permanent = game.getPermanent(source.getTargets().get(1).getFirstTarget());
 

--- a/Mage/src/main/java/mage/abilities/costs/common/ExileSourceFromHandCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/ExileSourceFromHandCost.java
@@ -27,7 +27,7 @@ public class ExileSourceFromHandCost extends CostImpl {
     public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
         Player player = game.getPlayer(controllerId);
         Card card = game.getCard(source.getSourceId());
-        if (player != null && player.getHand().contains(source.getSourceId()) && card != null) {
+        if (player != null && player.getHand().contains(source.getSourceId())) {
             paid = player.moveCards(card, Zone.EXILED, source, game);
         }
         return paid;

--- a/Mage/src/main/java/mage/abilities/effects/CastCardFromGraveyardThenExileItEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/CastCardFromGraveyardThenExileItEffect.java
@@ -97,7 +97,6 @@ class ExileReplacementEffect extends ReplacementEffectImpl {
         Player controller = game.getPlayer(source.getControllerId());
         Card card = game.getCard(this.cardId);
         return controller != null
-                && card != null
                 && controller.moveCards(card, Zone.EXILED, source, game);
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/EnterBattlefieldPayCostOrPutGraveyardEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/EnterBattlefieldPayCostOrPutGraveyardEffect.java
@@ -1,7 +1,6 @@
 
 package mage.abilities.effects.common;
 
-import java.util.Locale;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.costs.Cost;
@@ -15,8 +14,9 @@ import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
 import mage.players.Player;
 
+import java.util.Locale;
+
 /**
- *
  * @author LevelX2
  */
 public class EnterBattlefieldPayCostOrPutGraveyardEffect extends ReplacementEffectImpl {
@@ -53,16 +53,14 @@ public class EnterBattlefieldPayCostOrPutGraveyardEffect extends ReplacementEffe
             if (cost.canPay(source, source, player.getId(), game)) {
                 if (player.chooseUse(outcome,
                         cost.getText().substring(0, 1).toUpperCase(Locale.ENGLISH) + cost.getText().substring(1)
-                        + "? (otherwise " + sourceObject.getLogName() + " is put into graveyard)", source, game)) {
+                                + "? (otherwise " + sourceObject.getLogName() + " is put into graveyard)", source, game)) {
                     cost.clearPaid();
                     replace = !cost.pay(source, game, source, source.getControllerId(), false, null);
                 }
             }
             if (replace) {
                 Card card = game.getCard(event.getTargetId());
-                if (card != null) {
-                    player.moveCards(card, Zone.GRAVEYARD, source, game);
-                }
+                player.moveCards(card, Zone.GRAVEYARD, source, game);
                 return true;
             }
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/ExileAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ExileAllEffect.java
@@ -52,7 +52,7 @@ public class ExileAllEffect extends OneShotEffect {
         Cards cards = new CardsImpl();
         game.getBattlefield().getActivePermanents(
                 filter, source.getControllerId(), source.getSourceId(), game
-        ).stream().forEach(cards::add);
+        ).forEach(cards::add);
         if (forSource) {
             return controller.moveCardsToExile(cards.getCards(game), source, game, true, CardUtil.getExileZoneId(game, source), sourceObject.getName());
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnSourceFromGraveyardToHandEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnSourceFromGraveyardToHandEffect.java
@@ -33,10 +33,8 @@ public class ReturnSourceFromGraveyardToHandEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         Card card = controller.getGraveyard().get(source.getSourceId(), game);
-        if (card != null) {
-            return controller.moveCards(card, Zone.HAND, source, game);
-        }
-        return false;
+        return controller.moveCards(card, Zone.HAND, source, game);
+
     }
 
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnToBattlefieldUnderYourControlSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnToBattlefieldUnderYourControlSourceEffect.java
@@ -42,12 +42,8 @@ public class ReturnToBattlefieldUnderYourControlSourceEffect extends OneShotEffe
         ExileZone exileZone = game.getExile().getExileZone(exileZoneId);
         if (exileZone != null && exileZone.contains(source.getSourceId())) {
             Card card = game.getCard(source.getSourceId());
-            if (card != null
-                    && controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                return true;
-            }
+            return controller.moveCards(card, Zone.BATTLEFIELD, source, game);
         }
         return false;
     }
-
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandSourceEffect.java
@@ -68,10 +68,7 @@ public class ReturnToHandSourceEffect extends OneShotEffect {
                 switch (game.getState().getZone(mageObject.getId())) {
                     case BATTLEFIELD:
                         Permanent permanent = game.getPermanent(source.getSourceId());
-                        if (permanent != null) {
-                            return controller.moveCards(permanent, Zone.HAND, source, game);
-                        }
-                        break;
+                        return controller.moveCards(permanent, Zone.HAND, source, game);
                     case GRAVEYARD:
                         Card card = (Card) mageObject;
                         if (!fromBattlefieldOnly) {

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandSpellEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandSpellEffect.java
@@ -31,8 +31,7 @@ public class ReturnToHandSpellEffect extends OneShotEffect implements MageSingle
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Card spellCard = game.getStack().getSpell(source.getSourceId()).getCard();
-            controller.moveCards(spellCard, Zone.HAND, source, game);
-            return true;
+            return controller.moveCards(spellCard, Zone.HAND, source, game);
         }
         return false;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
@@ -16,6 +16,7 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetCard;
 import mage.util.CardUtil;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -72,8 +73,8 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
         this(StaticValue.get(1), filter, targetController);
     }
 
-    public DiscardCardYouChooseTargetEffect(DynamicValue numberCardsToDiscard, 
-            FilterCard filter, TargetController targetController) {
+    public DiscardCardYouChooseTargetEffect(DynamicValue numberCardsToDiscard,
+                                            FilterCard filter, TargetController targetController) {
         super(Outcome.Discard);
         this.targetController = targetController;
         this.filter = filter;
@@ -111,7 +112,7 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
         Cards revealedCards = new CardsImpl();
         numberToReveal = Math.min(player.getHand().size(), numberToReveal);
         if (player.getHand().size() > numberToReveal) {
-            TargetCard chosenCards = new TargetCard(numberToReveal, numberToReveal, 
+            TargetCard chosenCards = new TargetCard(numberToReveal, numberToReveal,
                     Zone.HAND, new FilterCard("card in " + player.getName() + "'s hand"));
             chosenCards.setNotTarget(true);
             if (chosenCards.canChoose(source.getSourceId(), player.getId(), game)
@@ -120,9 +121,8 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
                     List<UUID> targets = chosenCards.getTargets();
                     for (UUID targetid : targets) {
                         Card card = game.getCard(targetid);
-                        if (card != null) {
-                            revealedCards.add(card);
-                        }
+                        revealedCards.add(card);
+
                     }
                 }
             }
@@ -131,7 +131,7 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
         }
 
         Card sourceCard = game.getCard(source.getSourceId());
-        player.revealCards(sourceCard != null ? sourceCard.getIdName() + " (" 
+        player.revealCards(sourceCard != null ? sourceCard.getIdName() + " ("
                 + sourceCard.getZoneChangeCounter(game) + ')' : "Discard", revealedCards, game);
 
         boolean result = true;
@@ -144,7 +144,7 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
         if (!controller.choose(Outcome.Benefit, revealedCards, target, game)) {
             return result;
         }
-        result=!player.discard(new CardsImpl(target.getTargets()),false, source,game).isEmpty();
+        result = !player.discard(new CardsImpl(target.getTargets()), false, source, game).isEmpty();
         return result;
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/replacement/DiesReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/replacement/DiesReplacementEffect.java
@@ -46,7 +46,7 @@ public class DiesReplacementEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent permanent = ((ZoneChangeEvent) event).getTarget();
         Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null && permanent != null) {
+        if (controller != null) {
             return controller.moveCards(permanent, Zone.EXILED, source, game);
         }
         return false;

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryGraveyardPutInHandEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryGraveyardPutInHandEffect.java
@@ -78,10 +78,8 @@ public class SearchLibraryGraveyardPutInHandEffect extends OneShotEffect {
                 }
             }
 
-            if (cardFound != null) {
-                controller.revealCards(sourceObject.getIdName(), new CardsImpl(cardFound), game);
-                controller.moveCards(cardFound, Zone.HAND, source, game);
-            }
+            controller.revealCards(sourceObject.getIdName(), new CardsImpl(cardFound), game);
+            controller.moveCards(cardFound, Zone.HAND, source, game);
 
             if (needShuffle) {
                 controller.shuffleLibrary(source, game);

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryGraveyardPutOntoBattlefieldEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryGraveyardPutOntoBattlefieldEffect.java
@@ -76,9 +76,7 @@ public class SearchLibraryGraveyardPutOntoBattlefieldEffect extends OneShotEffec
                 }
             }
 
-            if (cardFound != null) {
-                controller.moveCards(cardFound, Zone.BATTLEFIELD, source, game);
-            }
+            controller.moveCards(cardFound, Zone.BATTLEFIELD, source, game);
 
             if (needShuffle) {
                 controller.shuffleLibrary(source, game);

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryGraveyardWithLessMVPutIntoPlay.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryGraveyardWithLessMVPutIntoPlay.java
@@ -2,10 +2,10 @@ package mage.abilities.effects.common.search;
 
 import mage.MageObject;
 import mage.abilities.Ability;
-import mage.constants.ComparisonType;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
 import mage.cards.CardsImpl;
+import mage.constants.ComparisonType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
@@ -16,7 +16,6 @@ import mage.target.TargetCard;
 import mage.target.common.TargetCardInLibrary;
 
 /**
- *
  * @author antoni-g
  */
 public class SearchLibraryGraveyardWithLessMVPutIntoPlay extends OneShotEffect {
@@ -48,7 +47,7 @@ public class SearchLibraryGraveyardWithLessMVPutIntoPlay extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         MageObject sourceObject = source.getSourceObject(game);
         Card cardFound = null;
-        if (controller != null  && sourceObject != null) {
+        if (controller != null && sourceObject != null) {
             // create x cost filter
             FilterCard advancedFilter = filter.copy(); // never change static objects so copy the object here before
             advancedFilter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, source.getManaCostsToPay().getX() + 1));
@@ -74,10 +73,8 @@ public class SearchLibraryGraveyardWithLessMVPutIntoPlay extends OneShotEffect {
                 }
             }
 
-            if (cardFound != null) {
-                controller.revealCards(sourceObject.getIdName(), new CardsImpl(cardFound), game);
-                controller.moveCards(cardFound, Zone.BATTLEFIELD, source, game);
-            }
+            controller.revealCards(sourceObject.getIdName(), new CardsImpl(cardFound), game);
+            controller.moveCards(cardFound, Zone.BATTLEFIELD, source, game);
 
             return true;
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryWithLessCMCPutInPlayEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryWithLessCMCPutInPlayEffect.java
@@ -2,9 +2,9 @@
 package mage.abilities.effects.common.search;
 
 import mage.abilities.Ability;
-import mage.constants.ComparisonType;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
+import mage.constants.ComparisonType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
@@ -14,7 +14,6 @@ import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
 
 /**
- *
  * @author Styxo
  */
 public class SearchLibraryWithLessCMCPutInPlayEffect extends OneShotEffect {
@@ -46,9 +45,8 @@ public class SearchLibraryWithLessCMCPutInPlayEffect extends OneShotEffect {
             if (controller.searchLibrary(target, source, game)) {
                 if (!target.getTargets().isEmpty()) {
                     Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
-                    if (card != null) {
-                        controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                    }
+                    controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+
                 }
                 controller.shuffleLibrary(source, game);
             }

--- a/Mage/src/main/java/mage/abilities/keyword/IngestAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/IngestAbility.java
@@ -10,7 +10,6 @@ import mage.game.Game;
 import mage.players.Player;
 
 /**
- *
  * @author LevelX2
  */
 public class IngestAbility extends DealsCombatDamageToAPlayerTriggeredAbility {
@@ -56,10 +55,8 @@ class IngestEffect extends OneShotEffect {
         Player targetPlayer = game.getPlayer(getTargetPointer().getFirst(game, source));
         if (targetPlayer != null) {
             Card card = targetPlayer.getLibrary().getFromTop(game);
-            if (card != null) {
-                targetPlayer.moveCards(card, Zone.EXILED, source, game);
-            }
-            return true;
+            return targetPlayer.moveCards(card, Zone.EXILED, source, game);
+
         }
         return false;
     }

--- a/Mage/src/main/java/mage/abilities/keyword/PartnerWithAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/PartnerWithAbility.java
@@ -1,7 +1,6 @@
 
 package mage.abilities.keyword;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
@@ -16,8 +15,9 @@ import mage.players.Player;
 import mage.target.TargetPlayer;
 import mage.target.common.TargetCardInLibrary;
 
+import java.util.UUID;
+
 /**
- *
  * @author TheElk801
  */
 public class PartnerWithAbility extends EntersBattlefieldTriggeredAbility {
@@ -119,10 +119,9 @@ class PartnersWithSearchEffect extends OneShotEffect {
                     player.searchLibrary(target, source, game);
                     for (UUID cardId : target.getTargets()) {
                         Card card = player.getLibrary().getCard(cardId, game);
-                        if (card != null) {
-                            player.revealCards(source, new CardsImpl(card), game);
-                            player.moveCards(card, Zone.HAND, source, game);
-                        }
+                        player.revealCards(source, new CardsImpl(card), game);
+                        player.moveCards(card, Zone.HAND, source, game);
+
                     }
                     player.shuffleLibrary(source, game);
                 }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -4129,7 +4129,7 @@ public abstract class PlayerImpl implements Player, Serializable {
     @Override
     public boolean moveCards(Set<? extends Card> cards, Zone toZone, Ability source, Game game, boolean tapped, boolean faceDown, boolean byOwner, List<UUID> appliedEffects) {
         if (cards.isEmpty()) {
-            return true;
+            return false;
         }
         Set<Card> successfulMovedCards = new LinkedHashSet<>();
         Zone fromZone = null;


### PR DESCRIPTION
This PR is to refactor slightly the use of Player::moveCard. Since this is part of core project, I do not push directly :) 
This method seems to be used inconsitently around the project. Sometimes it used the return value, sometimes it was used as a step ignoring the return value (which is OK too). 
Player.moveCards used to return a true on null or empty cards, which leads to weird boolean comparisons. 
There were also snippets like this:

return card != null && player.moveCards(card, Zone.EXILED, source, game);

so suppose the card was null, the first statement got valuated to false, and the player.moveCards would not. Even though it would return a true. That makes no sense, so we can merge these checks and make moveCards return false on null or empty

other snippet:

if(permanent == null || !player.moveCards(permanent, Zone.HAND, source, game))

So suppose the permanent was null, the first statement is true, then the second part is not evaluated. But if the permanent==null check was not there, the previously player.moveCards would have returned true, then the ! operator would make it a false, so the if statement fails. That makes no sense, so we can merge these checks and make moveCards return false on null or empty

Also, there were a lot of if(card!=null) checks before calling player.moveCards. This is not needed since the moveCards method handles null itself.

		