### PR TITLE
Add freeform brawl deck type

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.java
@@ -660,6 +660,7 @@ public class NewTableDialog extends MageDialog {
                 break;
             case "Variant Magic - Brawl":
             case "Variant Magic - Duel Brawl":
+            case "Variant Magic - Freeform Brawl":
                 if (!options.getGameType().startsWith("Brawl")) {
                     JOptionPane.showMessageDialog(MageFrame.getDesktop(), "Deck type Brawl needs also a Brawl game type", "Error", JOptionPane.ERROR_MESSAGE);
                     return false;
@@ -715,7 +716,8 @@ public class NewTableDialog extends MageDialog {
             case "Brawl Two Player Duel":
             case "Brawl Free For All":
                 if (!options.getDeckType().equals("Variant Magic - Brawl")
-                        && !options.getDeckType().equals("Variant Magic - Duel Brawl")) {
+                        && !options.getDeckType().equals("Variant Magic - Duel Brawl")
+                        && !options.getDeckType().equals("Variant Magic - Freeform Brawl")) {
                     JOptionPane.showMessageDialog(MageFrame.getDesktop(), "Deck type Brawl needs also a Brawl game type", "Error", JOptionPane.ERROR_MESSAGE);
                     return false;
                 }

--- a/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
+++ b/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
@@ -884,7 +884,7 @@ public class TablesPanel extends javax.swing.JPanel {
             formatFilterList.add(RowFilter.regexFilter("^Constructed - Premodern", TablesTableModel.COLUMN_DECK_TYPE));
         }
         if (btnFormatCommander.isSelected()) {
-            formatFilterList.add(RowFilter.regexFilter("^Commander|^Duel Commander|^Centurion Commander|^Penny Dreadful Commander|^Freeform Commander|^Freeform Unlimited Commander|^MTGO 1v1 Commander|^Duel Brawl|^Brawl", TablesTableModel.COLUMN_DECK_TYPE));
+            formatFilterList.add(RowFilter.regexFilter("^Commander|^Duel Commander|^Centurion Commander|^Penny Dreadful Commander|^Freeform Commander|^Freeform Unlimited Commander|^MTGO 1v1 Commander|^Duel Brawl|^Freeform Brawl|^Brawl", TablesTableModel.COLUMN_DECK_TYPE));
         }
         if (btnFormatTinyLeader.isSelected()) {
             formatFilterList.add(RowFilter.regexFilter("^Tiny", TablesTableModel.COLUMN_DECK_TYPE));

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/FreeformBrawl.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/FreeformBrawl.java
@@ -1,0 +1,137 @@
+package mage.deck;
+
+import mage.abilities.Ability;
+import mage.abilities.common.CanBeYourCommanderAbility;
+import mage.abilities.keyword.CompanionAbility;
+import mage.cards.Card;
+import mage.cards.ExpansionSet;
+import mage.cards.Sets;
+import mage.cards.decks.Constructed;
+import mage.cards.decks.Deck;
+import mage.cards.decks.DeckValidatorErrorType;
+import mage.filter.FilterMana;
+import mage.util.ManaUtil;
+
+import java.util.*;
+
+/**
+ * @author Tosh94
+ */
+public class FreeformBrawl extends Constructed {
+
+    public FreeformBrawl() {
+        super("Freeform Brawl");
+        
+        // all sets available
+        for (ExpansionSet set : Sets.getInstance().values()) {
+            setCodes.add(set.getCode());
+        }
+
+        // no banned cards
+        this.banned.clear();
+    }
+
+    @Override
+    public int getSideboardMinSize() {
+        return 1;
+    }
+
+    @Override
+    public boolean validate(Deck deck) {
+        boolean valid = true;
+        errorsList.clear();
+        Card brawler = null;
+        Card companion = null;
+        FilterMana colorIdentity = new FilterMana();
+
+        if (deck.getSideboard().size() == 1) {
+            for (Card card : deck.getSideboard()) {
+                brawler = card;
+            }
+        } else if (deck.getSideboard().size() == 2) {
+            Iterator<Card> iter = deck.getSideboard().iterator();
+            Card card1 = iter.next();
+            Card card2 = iter.next();
+            if (card1.getAbilities().stream().anyMatch(ability -> ability instanceof CompanionAbility)) {
+                companion = card1;
+                brawler = card2;
+            } else if (card2.getAbilities().stream().anyMatch(ability -> ability instanceof CompanionAbility)) {
+                companion = card2;
+                brawler = card1;
+            } else {
+                addError(DeckValidatorErrorType.PRIMARY, "Freeform Brawl", "Sideboard must contain only the brawler and up to 1 companion");
+                valid = false;
+            }
+        } else {
+            addError(DeckValidatorErrorType.PRIMARY, "Freeform Brawl", "Sideboard must contain only the brawler and up to 1 companion");
+            valid = false;
+        }
+
+        if (brawler != null) {
+            ManaUtil.collectColorIdentity(colorIdentity, brawler.getColorIdentity());
+            if (!((brawler.isCreature() && brawler.isLegendary())
+                    || brawler.isPlaneswalker() || brawler.getAbilities().contains(CanBeYourCommanderAbility.getInstance()))) {
+                addError(DeckValidatorErrorType.PRIMARY, brawler.getName(), "Brawler Invalid (" + brawler.getName() + ')', true);
+                valid = false;
+            }
+        }
+
+        if (companion != null && deck.getCards().size() + deck.getSideboard().size() != getDeckMinSize() + 1) {
+            addError(DeckValidatorErrorType.DECK_SIZE, "Deck", "Must contain " + (getDeckMinSize() + 1) + " cards (companion doesn't count in deck size requirement): has " + (deck.getCards().size() + deck.getSideboard().size()) + " cards");
+            valid = false;
+        } else if (companion == null && deck.getCards().size() + deck.getSideboard().size() != getDeckMinSize()) {
+            addError(DeckValidatorErrorType.DECK_SIZE, "Deck", "Must contain " + getDeckMinSize() + " cards: has " + (deck.getCards().size() + deck.getSideboard().size()) + " cards");
+            valid = false;
+        }
+
+        Map<String, Integer> counts = new HashMap<>();
+        countCards(counts, deck.getCards());
+        countCards(counts, deck.getSideboard());
+        valid = checkCounts(1, counts) && valid;
+
+        Set<String> basicsInDeck = new HashSet<>();
+        if (colorIdentity.isColorless()) {
+            for (Card card : deck.getCards()) {
+                if (basicLandNames.contains(card.getName())) {
+                    basicsInDeck.add(card.getName());
+                }
+            }
+        }
+        for (Card card : deck.getCards()) {
+            if (!ManaUtil.isColorIdentityCompatible(colorIdentity, card.getColorIdentity())
+                    && !(colorIdentity.isColorless()
+                    && basicsInDeck.size() == 1
+                    && basicsInDeck.contains(card.getName()))) {
+                addError(DeckValidatorErrorType.OTHER, card.getName(), "Invalid color (" + colorIdentity.toString() + ')', true);
+                valid = false;
+            }
+        }
+        for (Card card : deck.getSideboard()) {
+            if (!ManaUtil.isColorIdentityCompatible(colorIdentity, card.getColorIdentity())
+                    && !(colorIdentity.isColorless()
+                    && basicsInDeck.size() == 1
+                    && basicsInDeck.contains(card.getName()))) {
+                addError(DeckValidatorErrorType.OTHER, card.getName(), "Invalid color (" + colorIdentity.toString() + ')', true);
+                valid = false;
+            }
+        }
+        
+        // Check for companion legality
+        if (companion != null) {
+            Set<Card> cards = new HashSet<>(deck.getCards());
+            cards.add(brawler);
+            for (Ability ability : companion.getAbilities()) {
+                if (ability instanceof CompanionAbility) {
+                    CompanionAbility companionAbility = (CompanionAbility) ability;
+                    if (!companionAbility.isLegal(cards, getDeckMinSize())) {
+                        addError(DeckValidatorErrorType.PRIMARY, companion.getName(), "Brawl Companion Invalid", true);
+                        valid = false;
+                    }
+                    break;
+                }
+            }
+        }
+
+        return valid;
+    }
+}

--- a/Mage.Server/config/config.xml
+++ b/Mage.Server/config/config.xml
@@ -190,6 +190,7 @@
         <deckType name="Variant Magic - Freeform Commander" jar="mage-deck-constructed.jar" className="mage.deck.FreeformCommander"/>
         <deckType name="Variant Magic - Freeform Unlimited Commander" jar="mage-deck-constructed.jar" className="mage.deck.FreeformUnlimitedCommander"/>
         <deckType name="Variant Magic - Brawl" jar="mage-deck-constructed.jar" className="mage.deck.Brawl"/>
+        <deckType name="Variant Magic - Freeform Brawl" jar="mage-deck-constructed.jar" className="mage.deck.FreeformBrawl"/>
         <deckType name="Variant Magic - Oathbreaker" jar="mage-deck-constructed.jar" className="mage.deck.Oathbreaker"/>
         <deckType name="Block Constructed - Amonkhet" jar="mage-deck-constructed.jar" className="mage.deck.AmonkhetBlock"/>
         <deckType name="Block Constructed - Battle for Zendikar" jar="mage-deck-constructed.jar" className="mage.deck.BattleForZendikarBlock"/>

--- a/Mage.Server/release/config/config.xml
+++ b/Mage.Server/release/config/config.xml
@@ -182,6 +182,7 @@
         <deckType name="Variant Magic - Freeform Commander" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.FreeformCommander"/>
         <deckType name="Variant Magic - Freeform Unlimited Commander" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.FreeformUnlimitedCommander"/>
         <deckType name="Variant Magic - Brawl" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.Brawl"/>
+        <deckType name="Variant Magic - Freeform Brawl" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.FreeformBrawl"/>
         <deckType name="Variant Magic - Oathbreaker" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.Oathbreaker"/>
         <deckType name="Block Constructed - Amonkhet" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.AmonkhetBlock"/>
         <deckType name="Block Constructed - Battle for Zendikar" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.BattleForZendikarBlock"/>

--- a/Mage.Server/src/test/resources/config_error.xml
+++ b/Mage.Server/src/test/resources/config_error.xml
@@ -152,6 +152,7 @@
         <deckType name="Variant Magic - Freeform Commander" jar="mage-deck-constructed.jar" className="mage.deck.FreeformCommander"/>
         <deckType name="Variant Magic - Freeform Unlimited Commander" jar="mage-deck-constructed.jar" className="mage.deck.FreeformUnlimitedCommander"/>
         <deckType name="Variant Magic - Brawl" jar="mage-deck-constructed.jar" className="mage.deck.Brawl"/>
+        <deckType name="Variant Magic - Freeform Brawl" jar="mage-deck-constructed.jar" className="mage.deck.FreeformBrawl"/>
         <deckType name="Variant Magic - Oathbreaker" jar="mage-deck-constructed.jar" className="mage.deck.Oathbreaker"/>
         <deckType name="Block Constructed - Amonkhet" jar="mage-deck-constructed.jar" className="mage.deck.AmonkhetBlock"/>
         <deckType name="Block Constructed - Battle for Zendikar" jar="mage-deck-constructed.jar" className="mage.deck.BattleForZendikarBlock"/>


### PR DESCRIPTION
When I wanted to play Brawl using cards from an older Standard environment, I noticed there was no such option, so I added a Freeform Brawl deck type.

It's mostly copied from regular Brawl, but without banned cards or set restrictions.
Since there's no changes in gameplay, it should work fine with the regular brawl game types.