### PR TITLE
Fixed Killian, Ink Duelist's cost reduction not applying for getPlayable

### DIFF
--- a/Mage.Sets/src/mage/cards/k/KillianInkDuelist.java
+++ b/Mage.Sets/src/mage/cards/k/KillianInkDuelist.java
@@ -69,9 +69,18 @@ class KillianInkDuelistEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean apply(Game game, Ability source, Ability abilityToModify) {
-        // Always apply cost reduction for getPlayable and get real cost reduction once player has selected targets
         // Bug #7762: https://github.com/magefree/mage/issues/7762
-        if (game.inCheckPlayableState() || CardUtil.getAllSelectedTargets(abilityToModify, game)
+        // Check possible targets for getPlayable
+        if (game.inCheckPlayableState()) {
+            if (CardUtil.getAllPossibleTargets(abilityToModify, game)
+                    .stream()
+                    .map(game::getPermanent)
+                    .filter(Objects::nonNull)
+                    .anyMatch(MageObject::isCreature)) {
+                CardUtil.reduceCost(abilityToModify, 2);
+            }
+        // Check selected targets on actual cast
+        } else if (CardUtil.getAllSelectedTargets(abilityToModify, game)
                 .stream()
                 .map(game::getPermanent)
                 .filter(Objects::nonNull)

--- a/Mage.Sets/src/mage/cards/k/KillianInkDuelist.java
+++ b/Mage.Sets/src/mage/cards/k/KillianInkDuelist.java
@@ -69,19 +69,21 @@ class KillianInkDuelistEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean apply(Game game, Ability source, Ability abilityToModify) {
-        CardUtil.reduceCost(abilityToModify, 2);
+        // Always apply cost reduction for getPlayable and get real cost reduction once player has selected targets
+        // Bug #7762: https://github.com/magefree/mage/issues/7762
+        if (game.inCheckPlayableState() || CardUtil.getAllSelectedTargets(abilityToModify, game)
+                .stream()
+                .map(game::getPermanent)
+                .filter(Objects::nonNull)
+                .anyMatch(MageObject::isCreature)) {
+            CardUtil.reduceCost(abilityToModify, 2);
+        }
         return true;
     }
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
         return abilityToModify instanceof SpellAbility
-                && abilityToModify.isControlledBy(source.getControllerId())
-                && CardUtil
-                .getAllSelectedTargets(abilityToModify, game)
-                .stream()
-                .map(game::getPermanent)
-                .filter(Objects::nonNull)
-                .anyMatch(MageObject::isCreature);
+                && abilityToModify.isControlledBy(source.getControllerId());
     }
 }


### PR DESCRIPTION
Issue #7762

Cards that could have cost reduction were not being marked as playable.  Cost reduction can't be known until the player selects targets so this patch just always applies the cost reduction for the getPlayable check similar to how to we're handling Torgaar and Dargo.