### PR TITLE
Fixed Magma Opus tap effect

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MagmaOpus.java
+++ b/Mage.Sets/src/mage/cards/m/MagmaOpus.java
@@ -75,10 +75,7 @@ class MagmaOpusTapEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        for (UUID targetId : getTargetPointer().getTargets(game, source)) {
-            if (!source.getTargets().get(1).getTargets().contains(targetId)) {
-                continue;
-            }
+        for (UUID targetId : source.getTargets().get(1).getTargets()) {
             Permanent permanent = game.getPermanent(targetId);
             if (permanent != null) {
                 permanent.tap(source, game);


### PR DESCRIPTION
Issue #7787 

TargetPointer only contains targets from the first (damage) effect.  I think this is the correct fix unless there's some reason we need to use the target pointer that I'm not thinking of.