### PR TITLE
Changed Shadrix Silverquill to fix issue #7874

### DIFF
--- a/Mage.Sets/src/mage/cards/s/ShadrixSilverquill.java
+++ b/Mage.Sets/src/mage/cards/s/ShadrixSilverquill.java
@@ -56,11 +56,10 @@ public final class ShadrixSilverquill extends CardImpl {
         this.addAbility(DoubleStrikeAbility.getInstance());
 
         // At the beginning of combat on your turn, you may choose two. Each mode must target a different player.
-        Ability ability = new BeginningOfCombatTriggeredAbility(null, TargetController.YOU, false);
+        Ability ability = new BeginningOfCombatTriggeredAbility(null, TargetController.YOU, true);
         ability.getModes().setMinModes(2);
         ability.getModes().setMaxModes(2);
         ability.getModes().setMaxModesFilter(filter0);
-        ability.getModes().setMayChooseNone(true);
 
         // • Target player creates a 2/1 white and black Inkling creature token with flying.
         ability.addEffect(new CreateTokenTargetEffect(new SilverquillToken()));


### PR DESCRIPTION
 #7874 
Changed the ability on [[Shadrix Silverquill] so that instead of it being min 2 modes max 2 modes can choose none (which didn't work), the ability is now optional (which it should be as a may ability) and if you use it and you have to pick 2 modes (min 2 max 2). Should fix the problem as far as I'm aware (this is my first edit though).