### PR TITLE
[AFR] Fixed Pack Tactics not triggering correctly

### DIFF
--- a/Mage/src/main/java/mage/abilities/keyword/PackTacticsAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/PackTacticsAbility.java
@@ -3,15 +3,11 @@ package mage.abilities.keyword;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
 import mage.constants.AbilityWord;
-import mage.constants.WatcherScope;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
-import mage.watchers.Watcher;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -21,7 +17,6 @@ public class PackTacticsAbility extends TriggeredAbilityImpl {
 
     public PackTacticsAbility(Effect effect) {
         super(Zone.BATTLEFIELD, effect, false);
-        this.addWatcher(new PackTacticsAbilityWatcher());
     }
 
     private PackTacticsAbility(final PackTacticsAbility ability) {
@@ -35,12 +30,17 @@ public class PackTacticsAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        return getSourceId().equals(event.getSourceId());
-    }
-
-    @Override
-    public boolean checkInterveningIfClause(Game game) {
-        return PackTacticsAbilityWatcher.checkPlayer(getControllerId(), game);
+        if (getSourceId().equals(event.getSourceId())) {
+            int power = 0;
+            for (UUID attackerId : game.getCombat().getAttackers()) {
+                Permanent attacker = game.getPermanent(attackerId);
+                if (attacker != null) {
+                    power += attacker.getPower().getValue();
+                }
+            }
+            return power >= 6;
+        }
+        return false;
     }
 
     @Override
@@ -53,39 +53,5 @@ public class PackTacticsAbility extends TriggeredAbilityImpl {
         return AbilityWord.PACK_TACTICS.formatWord() +
                 "Whenever {this} attacks, if you attacked with creatures " +
                 "with total power 6 or greater this combat, " + super.getRule();
-    }
-}
-
-class PackTacticsAbilityWatcher extends Watcher {
-
-    private final Map<UUID, Integer> playerMap = new HashMap<>();
-
-    PackTacticsAbilityWatcher() {
-        super(WatcherScope.GAME);
-    }
-
-    @Override
-    public void watch(GameEvent event, Game game) {
-        switch (event.getType()) {
-            case BEGIN_COMBAT_STEP_PRE:
-                playerMap.clear();
-                return;
-            case ATTACKER_DECLARED:
-                Permanent permanent = game.getPermanent(event.getSourceId());
-                if (permanent == null) {
-                    return;
-                }
-                playerMap.compute(
-                        permanent.getControllerId(),
-                        (u, i) -> i == null ?
-                                permanent.getPower().getValue() :
-                                Integer.sum(permanent.getPower().getValue(), i)
-                );
-        }
-    }
-
-    static boolean checkPlayer(UUID playerId, Game game) {
-        PackTacticsAbilityWatcher watcher = game.getState().getWatcher(PackTacticsAbilityWatcher.class);
-        return watcher != null && watcher.playerMap.getOrDefault(playerId, 0) >= 6;
     }
 }


### PR DESCRIPTION
Issue #7949 

The problem with the watcher is that the creature's power is getting added one at a time.  The first creature only sees its own power so it doesn't trigger if it's less than 6 (even though you may have a total power of 6, that first creature won't see it.)

I've tested this solution and it seems to work correctly even accounting for extra combat phases.

Let me know if this will work or if there's something I'm missing here.