### PR TITLE
[STX] Fixed Verdant Mastery targeting issues (fixes #7971)

### DIFF
--- a/Mage.Sets/src/mage/cards/v/VerdantMastery.java
+++ b/Mage.Sets/src/mage/cards/v/VerdantMastery.java
@@ -70,7 +70,7 @@ class VerdantMasteryEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        TargetCardInLibrary target = new TargetCardInLibrary(4, StaticFilters.FILTER_CARD_BASIC_LAND);
+        TargetCardInLibrary target = new TargetCardInLibrary(0, 4, StaticFilters.FILTER_CARD_BASIC_LAND);
         player.searchLibrary(target, source, game);
         Cards cards = new CardsImpl(target.getTargets());
         player.revealCards(source, cards, game);
@@ -86,6 +86,7 @@ class VerdantMasteryEffect extends OneShotEffect {
             Player opponent = game.getPlayer(targetOpponent.getFirstTarget());
             if (opponent != null) {
                 target = new TargetCardInLibrary(1, StaticFilters.FILTER_CARD_BASIC_LAND);
+                target.setRequired(true);
                 target.withChooseHint("to give to " + opponent.getName());
                 player.choose(outcome, cards, target, game);
                 Card card = game.getCard(target.getFirstTarget());
@@ -100,7 +101,8 @@ class VerdantMasteryEffect extends OneShotEffect {
             player.shuffleLibrary(source, game);
             return true;
         }
-        target = new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LAND);
+        target = new TargetCardInLibrary(Math.min(cards.size(), 2), StaticFilters.FILTER_CARD_BASIC_LAND);
+        target.setRequired(true);
         player.choose(outcome, cards, target, game);
         player.moveCards(
                 new CardsImpl(target.getTargets()).getCards(game), Zone.BATTLEFIELD, source,


### PR DESCRIPTION
Issue #7971 

- Initial Targeting from library changed to "up to" 4 cards
- Set required on target to give land to opponent (previously it would allow the player to hit cancel and not give a land to the opponent)
- Lands to controller's battlefield also set to required and must be 2 (or 1 if the player did not find 4 lands in library)