### PR TITLE
[AFR] Implemented Skullport Merchant

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SkullportMerchant.java
+++ b/Mage.Sets/src/mage/cards/s/SkullportMerchant.java
@@ -1,0 +1,61 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.SacrificeTargetCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.constants.SubType;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.Predicate;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.game.permanent.token.TreasureToken;
+import mage.target.common.TargetControlledPermanent;
+
+/**
+ *
+ * @author weirddan455
+ */
+public final class SkullportMerchant extends CardImpl {
+
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent("another creature or a Treasure");
+
+    static {
+        Predicate anotherCreaturePredicate = Predicates.and(CardType.CREATURE.getPredicate(), AnotherPredicate.instance);
+        filter.add(Predicates.or(anotherCreaturePredicate, SubType.TREASURE.getPredicate()));
+    }
+
+    public SkullportMerchant(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{B}");
+
+        this.subtype.add(SubType.DWARF);
+        this.subtype.add(SubType.CITIZEN);
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(4);
+
+        // When Skullport Merchant enters the battlefield, create a Treasure token.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new CreateTokenEffect(new TreasureToken())));
+
+        // {1}{B}, Sacrifice another creature or a Treasure: Draw a card.
+        Ability ability = new SimpleActivatedAbility(new DrawCardSourceControllerEffect(1), new ManaCostsImpl("{1}{B}"));
+        ability.addCost(new SacrificeTargetCost(new TargetControlledPermanent(filter)));
+        this.addAbility(ability);
+    }
+
+    private SkullportMerchant(final SkullportMerchant card) {
+        super(card);
+    }
+
+    @Override
+    public SkullportMerchant copy() {
+        return new SkullportMerchant(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SkullportMerchant.java
+++ b/Mage.Sets/src/mage/cards/s/SkullportMerchant.java
@@ -2,6 +2,7 @@ package mage.cards.s;
 
 import java.util.UUID;
 import mage.MageInt;
+import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -14,9 +15,9 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.common.FilterControlledPermanent;
-import mage.filter.predicate.Predicate;
-import mage.filter.predicate.Predicates;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.predicate.ObjectSourcePlayer;
+import mage.filter.predicate.ObjectSourcePlayerPredicate;
+import mage.game.Game;
 import mage.game.permanent.token.TreasureToken;
 import mage.target.common.TargetControlledPermanent;
 
@@ -29,8 +30,7 @@ public final class SkullportMerchant extends CardImpl {
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("another creature or a Treasure");
 
     static {
-        Predicate anotherCreaturePredicate = Predicates.and(CardType.CREATURE.getPredicate(), AnotherPredicate.instance);
-        filter.add(Predicates.or(anotherCreaturePredicate, SubType.TREASURE.getPredicate()));
+        filter.add(SkullportMerchantPredicate.instance);
     }
 
     public SkullportMerchant(UUID ownerId, CardSetInfo setInfo) {
@@ -57,5 +57,20 @@ public final class SkullportMerchant extends CardImpl {
     @Override
     public SkullportMerchant copy() {
         return new SkullportMerchant(this);
+    }
+}
+
+enum SkullportMerchantPredicate implements ObjectSourcePlayerPredicate<ObjectSourcePlayer<MageObject>> {
+    instance;
+
+    @Override
+    public boolean apply(ObjectSourcePlayer<MageObject> input, Game game) {
+        if (input.getObject().hasSubtype(SubType.TREASURE, game)) {
+            return true;
+        }
+        if (input.getObject().getId().equals(input.getSourceId())) {
+            return false;
+        }
+        return input.getObject().isCreature();
     }
 }

--- a/Mage.Sets/src/mage/sets/AdventuresInTheForgottenRealms.java
+++ b/Mage.Sets/src/mage/sets/AdventuresInTheForgottenRealms.java
@@ -148,6 +148,7 @@ public final class AdventuresInTheForgottenRealms extends ExpansionSet {
         cards.add(new SetCardInfo("Shambling Ghast", 119, Rarity.COMMON, mage.cards.s.ShamblingGhast.class));
         cards.add(new SetCardInfo("Shocking Grasp", 72, Rarity.COMMON, mage.cards.s.ShockingGrasp.class));
         cards.add(new SetCardInfo("Shortcut Seeker", 73, Rarity.COMMON, mage.cards.s.ShortcutSeeker.class));
+        cards.add(new SetCardInfo("Skullport Merchant", 120, Rarity.UNCOMMON, mage.cards.s.SkullportMerchant.class));
         cards.add(new SetCardInfo("Soulknife Spy", 75, Rarity.COMMON, mage.cards.s.SoulknifeSpy.class));
         cards.add(new SetCardInfo("Spike Pit Trap", 251, Rarity.COMMON, mage.cards.s.SpikePitTrap.class));
         cards.add(new SetCardInfo("Sudden Insight", 77, Rarity.UNCOMMON, mage.cards.s.SuddenInsight.class));


### PR DESCRIPTION
Issue #7808 

Don't merge this as is.  I need help with the syntax for the Predicate.  It's throwing an exception when it ETBs.

`Game exception occurred: java.lang.ClassCastException: mage.game.permanent.PermanentCard cannot be cast to mage.filter.predicate.ObjectSourcePlayer`