### PR TITLE
Fixing multiple triggers during combat

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BlazingSunsteel.java
+++ b/Mage.Sets/src/mage/cards/b/BlazingSunsteel.java
@@ -15,6 +15,9 @@ import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
+import mage.game.events.DamageEvent;
+import mage.game.events.DamagedEvent;
+import mage.game.events.DamagedPermanentBatchEvent;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -28,16 +31,16 @@ import java.util.UUID;
 public final class BlazingSunsteel extends CardImpl {
 
     public BlazingSunsteel(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{1}{R}");
+        super(ownerId, setInfo, new CardType[] { CardType.ARTIFACT }, "{1}{R}");
 
         this.subtype.add(SubType.EQUIPMENT);
 
         // Equipped creature gets +1/+0 for each opponent you have.
-        this.addAbility(new SimpleStaticAbility(new BoostEquippedEffect(
-                OpponentsCount.instance, StaticValue.get(0)
-        ).setText("equipped creature gets +1/+0 for each opponent you have")));
+        this.addAbility(new SimpleStaticAbility(new BoostEquippedEffect(OpponentsCount.instance, StaticValue.get(0))
+                .setText("equipped creature gets +1/+0 for each opponent you have")));
 
-        // Whenever equipped creature is dealt damage, it deals that much damage to any target.
+        // Whenever equipped creature is dealt damage, it deals that much damage to any
+        // target.
         this.addAbility(new BlazingSunsteelTriggeredAbility());
 
         // Equip {4}
@@ -72,20 +75,40 @@ class BlazingSunsteelTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.DAMAGED_PERMANENT;
+        return event.getType() == GameEvent.EventType.DAMAGED_PERMANENT_BATCH;
     }
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         Permanent equipment = game.getPermanent(this.getSourceId());
-        if (equipment == null
-                || equipment.getAttachedTo() == null
-                || !event.getTargetId().equals(equipment.getAttachedTo())) {
+        if (equipment == null) {
             return false;
         }
-        this.getEffects().setValue("equipped", game.getPermanent(equipment.getAttachedTo()));
-        this.getEffects().setValue("damage", event.getAmount());
-        return true;
+
+        UUID attachedCreature = equipment.getAttachedTo();
+        if (attachedCreature == null) {
+            return false;
+        }
+
+        int damage = 0;
+        DamagedPermanentBatchEvent dEvent = (DamagedPermanentBatchEvent) event;
+        for (DamagedEvent damagedEvent : dEvent.getEvents()) {
+            UUID targetID = damagedEvent.getTargetId();
+            if (targetID == null) {
+                continue;
+            }
+
+            if (targetID == attachedCreature) {
+                damage += damagedEvent.getAmount();
+            }
+        }
+
+        if (damage > 0) {
+            this.getEffects().setValue("equipped", attachedCreature);
+            this.getEffects().setValue("damage", damage);
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -111,11 +134,13 @@ class BlazingSunsteelEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Permanent creature = (Permanent) getValue("equipped");
-        Integer damage = (Integer) getValue("damage");
-        if (creature == null || damage == null || damage < 1) {
+        Permanent creature = game.getPermanentOrLKIBattlefield((UUID) getValue("equipped"));
+        int damage = (int)getValue("damage");
+
+        if (creature == null || damage < 1) {
             return false;
         }
+        
         Permanent permanent = game.getPermanent(source.getFirstTarget());
         if (permanent != null) {
             permanent.damage(damage, creature.getId(), source, game);

--- a/Mage.Sets/src/mage/cards/b/BlazingSunsteel.java
+++ b/Mage.Sets/src/mage/cards/b/BlazingSunsteel.java
@@ -15,7 +15,6 @@ import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
-import mage.game.events.DamageEvent;
 import mage.game.events.DamagedEvent;
 import mage.game.events.DamagedPermanentBatchEvent;
 import mage.game.events.GameEvent;
@@ -135,9 +134,9 @@ class BlazingSunsteelEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Permanent creature = game.getPermanentOrLKIBattlefield((UUID) getValue("equipped"));
-        int damage = (int)getValue("damage");
+        Integer damage = (Integer)getValue("damage");
 
-        if (creature == null || damage < 1) {
+        if (creature == null || damage == null  || damage < 1) {
             return false;
         }
         

--- a/Mage/src/main/java/mage/abilities/common/DealtDamageToSourceTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DealtDamageToSourceTriggeredAbility.java
@@ -1,12 +1,15 @@
 
 package mage.abilities.common;
 
+import java.util.UUID;
+
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
 import mage.constants.AbilityWord;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.DamagedEvent;
+import mage.game.events.DamagedPermanentBatchEvent;
 import mage.game.events.GameEvent;
 
 /**
@@ -47,30 +50,34 @@ public class DealtDamageToSourceTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.DAMAGED_PERMANENT || event.getType() == GameEvent.EventType.COMBAT_DAMAGE_STEP_POST;
+        return event.getType() == GameEvent.EventType.DAMAGED_PERMANENT_BATCH;
     }
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        if (event.getType() == GameEvent.EventType.DAMAGED_PERMANENT && event.getTargetId().equals(getSourceId())) {
-            if (useValue) {
-//              TODO: this ability should only trigger once for multiple creatures dealing combat damage.  
-//              If the damaged creature uses the amount (e.g. Boros Reckoner), this will still trigger separately instead of all at once
-                getEffects().setValue("damage", event.getAmount());
-                return true;
-            } else {
-                if (((DamagedEvent) event).isCombatDamage()) {
-                    if (!usedForCombatDamageStep) {
-                        usedForCombatDamageStep = true;
-                        return true;
-                    }
-                } else {
-                    return true;
-                }
+
+        if (event == null || game == null || this.getSourceId() == null) {
+            return false;
+        }
+
+        int damage = 0;
+        DamagedPermanentBatchEvent dEvent = (DamagedPermanentBatchEvent) event;
+        for (DamagedEvent damagedEvent : dEvent.getEvents()) {
+            UUID targetID = damagedEvent.getTargetId();
+            if (targetID == null) {
+                continue;
+            }
+
+            if (targetID == this.getSourceId()) {
+                damage += damagedEvent.getAmount();
             }
         }
-        if (event.getType() == GameEvent.EventType.COMBAT_DAMAGE_STEP_POST) {
-            usedForCombatDamageStep = false;
+
+        if (damage > 0) {
+            if (this.useValue) {
+                this.getEffects().setValue("damage", damage);
+            }
+            return true;
         }
         return false;
     }

--- a/Mage/src/main/java/mage/abilities/common/DealtDamageToSourceTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DealtDamageToSourceTriggeredAbility.java
@@ -18,7 +18,6 @@ import mage.game.events.GameEvent;
 public class DealtDamageToSourceTriggeredAbility extends TriggeredAbilityImpl {
 
     private final boolean useValue;
-    private boolean usedForCombatDamageStep;
 
     public DealtDamageToSourceTriggeredAbility(Effect effect, boolean optional) {
         this(effect, optional, false);
@@ -31,7 +30,6 @@ public class DealtDamageToSourceTriggeredAbility extends TriggeredAbilityImpl {
     public DealtDamageToSourceTriggeredAbility(Effect effect, boolean optional, boolean enrage, boolean useValue) {
         super(Zone.BATTLEFIELD, effect, optional);
         this.useValue = useValue;
-        this.usedForCombatDamageStep = false;
         if (enrage) {
             this.setAbilityWord(AbilityWord.ENRAGE);
         }
@@ -40,7 +38,6 @@ public class DealtDamageToSourceTriggeredAbility extends TriggeredAbilityImpl {
     public DealtDamageToSourceTriggeredAbility(final DealtDamageToSourceTriggeredAbility ability) {
         super(ability);
         this.useValue = ability.useValue;
-        this.usedForCombatDamageStep = ability.usedForCombatDamageStep;
     }
 
     @Override


### PR DESCRIPTION
References PR #8011

Updating logic to use `DAMAGED_PERMANENT_BATCH` to prevent multiple triggers during 1 instance of combat damage.