### PR TITLE
Fix Dark Ascension packs not having DFCs and Shadows wrong common:uncommon DFC ratio

### DIFF
--- a/Mage.Sets/src/mage/sets/DarkAscension.java
+++ b/Mage.Sets/src/mage/sets/DarkAscension.java
@@ -26,6 +26,7 @@ public final class DarkAscension extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+        this.numBoosterDoubleFaced = 1;
         this.parentSet = Innistrad.getInstance();
         this.hasBasicLands = false;
         cards.add(new SetCardInfo("Afflicted Deserter", 81, Rarity.UNCOMMON, mage.cards.a.AfflictedDeserter.class));

--- a/Mage.Sets/src/mage/sets/ShadowsOverInnistrad.java
+++ b/Mage.Sets/src/mage/sets/ShadowsOverInnistrad.java
@@ -379,15 +379,16 @@ public final class ShadowsOverInnistrad extends ExpansionSet {
 
     /* add double faced card for SOI booster
      * add only common or uncommon
+       80/120 packs contain one of 20 uncommon DFCs and 40/120 packs contain one of 4 common DFCs
      */
     @Override
     public void addDoubleFace(List<Card> booster) {
         for (int i = 0; i < numBoosterDoubleFaced; i++) {
             List<CardInfo> doubleFacedCards;
             if (RandomUtil.nextInt(15) < 10) {
-                doubleFacedCards = getDoubleFacedCardsByRarity(Rarity.COMMON);
-            } else {
                 doubleFacedCards = getDoubleFacedCardsByRarity(Rarity.UNCOMMON);
+            } else {
+                doubleFacedCards = getDoubleFacedCardsByRarity(Rarity.COMMON);
             }
             addToBooster(booster, doubleFacedCards);
         }


### PR DESCRIPTION
Eldritch Moon should be using the same special pack logic as Shadows over Innistrad (every pack has a common/uncommon DFC and 1/8 of packs additionally have a rare or mythic one) but I don't know enough Java to implement it short of simply copying and pasting the code from ShadowsOverInnistrad.java