### PR TITLE
Adjust canLookAtNextTopLibraryCard function

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
@@ -431,7 +431,7 @@ public abstract class ContinuousEffectImpl extends EffectImpl implements Continu
             StackObject stackObject = game.getStack().getFirst();
             return !(stackObject instanceof Spell)
                     || !Zone.LIBRARY.equals(((Spell) stackObject).getFromZone())
-                    || ((Spell) stackObject).getCurrentActivatingManaAbilitiesStep() == ActivationManaAbilityStep.AFTER; // mana payment finished
+                    || stackObject.getStackAbility().getManaCostsToPay().isPaid(); // mana payment finished
         }
         return true;
     }


### PR DESCRIPTION
While implementing [Xanathar, Guild Kingpin](https://github.com/magefree/mage/pull/8045) I recognized that the `canLookAtNextTopLibraryCard` function does not work as expected.

Right now the function uses `getCurrentActivatingManaAbilitiesStep.AFTER` to check if the mana has already been paid.
But I don't think that this field is actually inteded to do that here. The `ActivationManaAbilityStep` will only be set to `AFTER` for convoke, delve or improvise cards if I understood that correctly 🤔 
![manastep](https://user-images.githubusercontent.com/72562197/127776032-56aff019-4c07-4f8e-b61c-2accf69de16c.PNG)

Because of this, abilities that let the player look at and cast cards from the top of libraries is not working as expected.
As the ruling in the function says the player should be able to lookt at the next card after the costs for the current have been paid.
![ruling](https://user-images.githubusercontent.com/72562197/127776446-ff025024-929b-476e-a22a-455f32fc57d8.PNG)
But right now the next card will only be revealed after the current spell has resolved or when another spell/ability has been put on the stack.

This behaviour can be seen for many different cards with this effect (e.g. [Experimental Frenzy](https://scryfall.com/card/grn/99/experimental-frenzy), [Precognition Field](https://scryfall.com/card/dom/61/precognition-field)).

[Elsha of the Infinite](https://scryfall.com/card/c19/40/elsha-of-the-infinite#) is a special case here.
For this card it actually works as it should because after the costs for the spell has been paid the prowess trigger goes onto the stack which makes the effect actually behave as it should behave :D

The change from this PR makes the `canLookAtNextTopLibraryCard` function behave as described in the ruling above. 