### PR TITLE
Fix multiple issues with CSP, BFZ and OGW booster generation

### DIFF
--- a/Mage.Sets/src/mage/sets/BattleForZendikar.java
+++ b/Mage.Sets/src/mage/sets/BattleForZendikar.java
@@ -36,6 +36,10 @@ public final class BattleForZendikar extends ExpansionSet {
         this.numBoosterSpecial = 0;
         this.ratioBoosterSpecialLand = 144;
 
+        // validateColors does not work well with Devoid
+        // it makes all Devoid cards too rare and the non-Devoid blue and black cards too common
+        this.validateBoosterColors = false;
+
         cards.add(new SetCardInfo("Adverse Conditions", 54, Rarity.UNCOMMON, mage.cards.a.AdverseConditions.class));
         cards.add(new SetCardInfo("Akoum Firebird", 138, Rarity.MYTHIC, mage.cards.a.AkoumFirebird.class));
         cards.add(new SetCardInfo("Akoum Hellkite", 139, Rarity.RARE, mage.cards.a.AkoumHellkite.class));

--- a/Mage.Sets/src/mage/sets/Coldsnap.java
+++ b/Mage.Sets/src/mage/sets/Coldsnap.java
@@ -20,7 +20,6 @@ public final class Coldsnap extends ExpansionSet {
         super("Coldsnap", "CSP", ExpansionSet.buildDate(2006, 6, 21), SetType.EXPANSION);
         this.blockName = "Ice Age";
         this.hasBoosters = true;
-        this.numBoosterLands = 1;
         this.numBoosterCommon = 11;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
@@ -147,11 +146,11 @@ public final class Coldsnap extends ExpansionSet {
         cards.add(new SetCardInfo("Sheltering Ancient", 121, Rarity.UNCOMMON, mage.cards.s.ShelteringAncient.class));
         cards.add(new SetCardInfo("Simian Brawler", 122, Rarity.COMMON, mage.cards.s.SimianBrawler.class));
         cards.add(new SetCardInfo("Skred", 97, Rarity.COMMON, mage.cards.s.Skred.class));
-        cards.add(new SetCardInfo("Snow-Covered Forest", 155, Rarity.LAND, mage.cards.s.SnowCoveredForest.class));
-        cards.add(new SetCardInfo("Snow-Covered Island", 152, Rarity.LAND, mage.cards.s.SnowCoveredIsland.class));
-        cards.add(new SetCardInfo("Snow-Covered Mountain", 154, Rarity.LAND, mage.cards.s.SnowCoveredMountain.class));
-        cards.add(new SetCardInfo("Snow-Covered Plains", 151, Rarity.LAND, mage.cards.s.SnowCoveredPlains.class));
-        cards.add(new SetCardInfo("Snow-Covered Swamp", 153, Rarity.LAND, mage.cards.s.SnowCoveredSwamp.class));
+        cards.add(new SetCardInfo("Snow-Covered Forest", 155, Rarity.COMMON, mage.cards.s.SnowCoveredForest.class));
+        cards.add(new SetCardInfo("Snow-Covered Island", 152, Rarity.COMMON, mage.cards.s.SnowCoveredIsland.class));
+        cards.add(new SetCardInfo("Snow-Covered Mountain", 154, Rarity.COMMON, mage.cards.s.SnowCoveredMountain.class));
+        cards.add(new SetCardInfo("Snow-Covered Plains", 151, Rarity.COMMON, mage.cards.s.SnowCoveredPlains.class));
+        cards.add(new SetCardInfo("Snow-Covered Swamp", 153, Rarity.COMMON, mage.cards.s.SnowCoveredSwamp.class));
         cards.add(new SetCardInfo("Soul Spike", 70, Rarity.RARE, mage.cards.s.SoulSpike.class));
         cards.add(new SetCardInfo("Sound the Call", 123, Rarity.COMMON, mage.cards.s.SoundTheCall.class));
         cards.add(new SetCardInfo("Squall Drifter", 17, Rarity.COMMON, mage.cards.s.SquallDrifter.class));

--- a/Mage.Sets/src/mage/sets/OathOfTheGatewatch.java
+++ b/Mage.Sets/src/mage/sets/OathOfTheGatewatch.java
@@ -28,13 +28,22 @@ public final class OathOfTheGatewatch extends ExpansionSet {
         this.blockName = "Battle for Zendikar";
         this.parentSet = BattleForZendikar.getInstance();
         this.hasBoosters = true;
-        this.hasBasicLands = true;
+        this.hasBasicLands = false;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
         this.ratioBoosterSpecialLand = 48;
+
+        // FIXME: non-full-art Wastes do not appear in boosters, only in preconstructed decks
+        // this kludge excludes the wrong art variants (184 and 184+ rather than 183+ and 184+)
+        // but at least it gets the frequency of Wastes relative to other commons right
+        this.maxCardNumberInBooster = 183;
+
+        // validateColors does not work well with Devoid
+        // it makes all Devoid cards too rare and the few non-Devoid black cards too common
+        this.validateBoosterColors = false;
 
         cards.add(new SetCardInfo("Abstruse Interference", 40, Rarity.COMMON, mage.cards.a.AbstruseInterference.class));
         cards.add(new SetCardInfo("Affa Protector", 14, Rarity.COMMON, mage.cards.a.AffaProtector.class));
@@ -213,10 +222,10 @@ public final class OathOfTheGatewatch extends ExpansionSet {
         cards.add(new SetCardInfo("Wandering Fumarole", 182, Rarity.RARE, mage.cards.w.WanderingFumarole.class));
         cards.add(new SetCardInfo("Warden of Geometries", 11, Rarity.COMMON, mage.cards.w.WardenOfGeometries.class));
         cards.add(new SetCardInfo("Warping Wail", 12, Rarity.UNCOMMON, mage.cards.w.WarpingWail.class));
-        cards.add(new SetCardInfo("Wastes", "183a", Rarity.LAND, mage.cards.w.Wastes.class, NON_FULL_USE_VARIOUS));
-        cards.add(new SetCardInfo("Wastes", "184a", Rarity.LAND, mage.cards.w.Wastes.class, NON_FULL_USE_VARIOUS));
-        cards.add(new SetCardInfo("Wastes", 183, Rarity.LAND, mage.cards.w.Wastes.class, FULL_ART_BFZ_VARIOUS));
-        cards.add(new SetCardInfo("Wastes", 184, Rarity.LAND, mage.cards.w.Wastes.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Wastes", "183a", Rarity.COMMON, mage.cards.w.Wastes.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Wastes", "184a", Rarity.COMMON, mage.cards.w.Wastes.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Wastes", 183, Rarity.COMMON, mage.cards.w.Wastes.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Wastes", 184, Rarity.COMMON, mage.cards.w.Wastes.class, FULL_ART_BFZ_VARIOUS));
         cards.add(new SetCardInfo("Weapons Trainer", 160, Rarity.UNCOMMON, mage.cards.w.WeaponsTrainer.class));
         cards.add(new SetCardInfo("Witness the End", 82, Rarity.COMMON, mage.cards.w.WitnessTheEnd.class));
         cards.add(new SetCardInfo("World Breaker", 126, Rarity.MYTHIC, mage.cards.w.WorldBreaker.class));

--- a/Mage.Sets/src/mage/sets/TimeSpiralRemastered.java
+++ b/Mage.Sets/src/mage/sets/TimeSpiralRemastered.java
@@ -30,7 +30,7 @@ public class TimeSpiralRemastered extends ExpansionSet {
     private TimeSpiralRemastered() {
         super("Time Spiral Remastered", "TSR", ExpansionSet.buildDate(2021, 3, 19), SetType.SUPPLEMENTAL, new TimeSpiralRemasteredCollator());
         this.hasBoosters = true;
-        this.hasBasicLands = true;
+        this.hasBasicLands = false;
         this.maxCardNumberInBooster = 410;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;

--- a/Mage.Tests/src/test/java/org/mage/test/sets/BoosterGenerationTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/sets/BoosterGenerationTest.java
@@ -249,14 +249,6 @@ public class BoosterGenerationTest extends MageTestBase {
     }
 
     @Test
-    public void testColdSnap_BoosterMustHaveOneSnowLand() {
-        for (int i = 0; i < 10; i++) {
-            List<Card> booster = Coldsnap.getInstance().createBooster();
-            assertTrue("coldsnap's booster must contain 1 snow covered land", booster.stream().anyMatch(card -> card.isBasic() && card.getName().startsWith("Snow-Covered ")));
-        }
-    }
-
-    @Test
     public void testModernHorizons_BoosterMustHaveOneSnowLand() {
         for (int i = 0; i < 10; i++) {
             List<Card> booster = ModernHorizons.getInstance().createBooster();

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -1747,20 +1747,18 @@ public class VerifyCardDataTest {
                 || checkName.equals("Forest")
                 || checkName.equals("Swamp")
                 || checkName.equals("Plains")
-                || checkName.equals("Mountain")
-                || checkName.equals("Wastes");
+                || checkName.equals("Mountain");
     }
 
     private void checkBasicLands(Card card, MtgJsonCard ref) {
 
-        // basic lands must have Rarity.LAND and SuperType.BASIC
-        // other cards can't have that stats
-        if (isBasicLandName(card.getName())) {
+        // basic lands must have SuperType.BASIC
+        // other cards can't have Rarity.LAND or SuperType.BASIC
+        // basic lands are usually Rarity.LAND, but in a few sets they are
+        // COMMON (pre-4ED core sets, Coldsnap)
+        String name = card.getName();
+        if (isBasicLandName(name)) {
             // lands
-            if (card.getRarity() != Rarity.LAND && card.getRarity() != Rarity.SPECIAL) {
-                fail(card, "rarity", "basic land must be Rarity.LAND");
-            }
-
             if (!card.getSuperType().contains(SuperType.BASIC)) {
                 fail(card, "supertype", "basic land must be SuperType.BASIC");
             }
@@ -1770,8 +1768,11 @@ public class VerifyCardDataTest {
                 fail(card, "rarity", "only basic land can be Rarity.LAND");
             }
 
-            if (card.getSuperType().contains(SuperType.BASIC)) {
-                fail(card, "supertype", "only basic land can be SuperType.BASIC");
+            // OGW boosters contain Wastes, but also contain basics from BFZ
+            // In order to handle this, Wastes must not satisfy hasBasicLands
+            // i.e. we must special case them here
+            if (card.getSuperType().contains(SuperType.BASIC) && !name.equals("Wastes")) {
+                fail(card, "supertype", "only basic land or Wastes can be SuperType.BASIC");
             }
         }
     }


### PR DESCRIPTION
This patch fixes one issue specific to OGW booster generation and another that affects both BFZ and OGW.

OGW boosters had Wastes in 100% of boosters in the basic land slot, which is incorrect. Wastes in OGW are normal commons; the basic land slot in boosters contains one of the five normal basic lands. There are four art versions of Wastes in the set, two full-art and two non-full-art, of which only the full-art versions should appear in boosters. I couldn't find a way to implement this as the CardCriteria class does not seem to be able to distinguish between e.g. "183" and "183a". So I used maxCardNumberInBooster = 183 as a dirty hack to at least get the ratio of Wastes to other commons right (Wastes should be twice as common as each other individual common, not four times)

The other issue which affects both BFZ and OGW is the interaction between validateColors and devoid. Basically, it makes the non-devoid cards in colors that have many devoid cards (mainly black) appear much too often in packs--you can easily verify this using the test_CollectBoosterStats unit test. So I set validateBoosterColors to false for both sets. It might be a good idea to set validateBoosterColors to false in other sets that have a large number of colorless cards (e.g. Mirrodin sets) since it does skew these boosters towards having too many colored cards and too few artifacts, though at least in those sets it doesn't cause color balance problems like it does with BFZ and OGW.