### PR TITLE
Fix Theros Beyond Death collator common print run ratios

### DIFF
--- a/Mage.Sets/src/mage/sets/TherosBeyondDeath.java
+++ b/Mage.Sets/src/mage/sets/TherosBeyondDeath.java
@@ -415,7 +415,7 @@ class TherosBeyondDeathCollator implements BoosterCollator {
     }
 
     private static class TherosBeyondDeathStructure extends BoosterStructure {
-        private static final TherosBeyondDeathStructure C1 = new TherosBeyondDeathStructure(
+        private static final TherosBeyondDeathStructure AABBC1C1C1C1C1C1 = new TherosBeyondDeathStructure(
                 TherosBeyondDeathRun.commonA,
                 TherosBeyondDeathRun.commonA,
                 TherosBeyondDeathRun.commonB,
@@ -427,7 +427,7 @@ class TherosBeyondDeathCollator implements BoosterCollator {
                 TherosBeyondDeathRun.commonC1,
                 TherosBeyondDeathRun.commonC1
         );
-        private static final TherosBeyondDeathStructure C2 = new TherosBeyondDeathStructure(
+        private static final TherosBeyondDeathStructure AAABBC1C1C1C1C1 = new TherosBeyondDeathStructure(
                 TherosBeyondDeathRun.commonA,
                 TherosBeyondDeathRun.commonA,
                 TherosBeyondDeathRun.commonA,
@@ -439,7 +439,7 @@ class TherosBeyondDeathCollator implements BoosterCollator {
                 TherosBeyondDeathRun.commonC1,
                 TherosBeyondDeathRun.commonC1
         );
-        private static final TherosBeyondDeathStructure C3 = new TherosBeyondDeathStructure(
+        private static final TherosBeyondDeathStructure AAAABBC2C2C2C2 = new TherosBeyondDeathStructure(
                 TherosBeyondDeathRun.commonA,
                 TherosBeyondDeathRun.commonA,
                 TherosBeyondDeathRun.commonA,
@@ -451,7 +451,7 @@ class TherosBeyondDeathCollator implements BoosterCollator {
                 TherosBeyondDeathRun.commonC2,
                 TherosBeyondDeathRun.commonC2
         );
-        private static final TherosBeyondDeathStructure C4 = new TherosBeyondDeathStructure(
+        private static final TherosBeyondDeathStructure AAAABBBC2C2C2 = new TherosBeyondDeathStructure(
                 TherosBeyondDeathRun.commonA,
                 TherosBeyondDeathRun.commonA,
                 TherosBeyondDeathRun.commonA,
@@ -463,7 +463,7 @@ class TherosBeyondDeathCollator implements BoosterCollator {
                 TherosBeyondDeathRun.commonC2,
                 TherosBeyondDeathRun.commonC2
         );
-        private static final TherosBeyondDeathStructure C5 = new TherosBeyondDeathStructure(
+        private static final TherosBeyondDeathStructure AAAABBBBC2C2 = new TherosBeyondDeathStructure(
                 TherosBeyondDeathRun.commonA,
                 TherosBeyondDeathRun.commonA,
                 TherosBeyondDeathRun.commonA,
@@ -475,12 +475,12 @@ class TherosBeyondDeathCollator implements BoosterCollator {
                 TherosBeyondDeathRun.commonC2,
                 TherosBeyondDeathRun.commonC2
         );
-        private static final TherosBeyondDeathStructure U1 = new TherosBeyondDeathStructure(
+        private static final TherosBeyondDeathStructure ABB = new TherosBeyondDeathStructure(
                 TherosBeyondDeathRun.uncommonA,
                 TherosBeyondDeathRun.uncommonB,
                 TherosBeyondDeathRun.uncommonB
         );
-        private static final TherosBeyondDeathStructure U2 = new TherosBeyondDeathStructure(
+        private static final TherosBeyondDeathStructure AAB = new TherosBeyondDeathStructure(
                 TherosBeyondDeathRun.uncommonA,
                 TherosBeyondDeathRun.uncommonA,
                 TherosBeyondDeathRun.uncommonB
@@ -500,24 +500,41 @@ class TherosBeyondDeathCollator implements BoosterCollator {
         }
     }
 
+    // In order for equal numbers of each common to exist, the average booster must contain:
+    // 3.28 A commons (36 / 11)
+    // 2.18 B commons (24 / 11)
+    // 2.72 C1 commons (30 / 11, or 60 / 11 in each C1 booster)
+    // 1.81 C2 commons (20 / 11, or 40 / 11 in each C2 booster)
+    // (these numbers are the same for all sets with 101 commons and 10 common slots per booster)
     private final RarityConfiguration commonRuns = new RarityConfiguration(
             false,
-            TherosBeyondDeathStructure.C1,
-            TherosBeyondDeathStructure.C2,
-            TherosBeyondDeathStructure.C3,
-            TherosBeyondDeathStructure.C4,
-            TherosBeyondDeathStructure.C5,
-            TherosBeyondDeathStructure.C1,
-            TherosBeyondDeathStructure.C2,
-            TherosBeyondDeathStructure.C3,
-            TherosBeyondDeathStructure.C4,
-            TherosBeyondDeathStructure.C5,
-            TherosBeyondDeathStructure.C4,
-            TherosBeyondDeathStructure.C5
+            TherosBeyondDeathStructure.AABBC1C1C1C1C1C1,
+            TherosBeyondDeathStructure.AABBC1C1C1C1C1C1,
+            TherosBeyondDeathStructure.AABBC1C1C1C1C1C1,
+            TherosBeyondDeathStructure.AABBC1C1C1C1C1C1,
+            TherosBeyondDeathStructure.AABBC1C1C1C1C1C1,
+            TherosBeyondDeathStructure.AAABBC1C1C1C1C1,
+            TherosBeyondDeathStructure.AAABBC1C1C1C1C1,
+            TherosBeyondDeathStructure.AAABBC1C1C1C1C1,
+            TherosBeyondDeathStructure.AAABBC1C1C1C1C1,
+            TherosBeyondDeathStructure.AAABBC1C1C1C1C1,
+            TherosBeyondDeathStructure.AAABBC1C1C1C1C1,
+
+            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
+            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
+            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
+            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
+            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
+            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
+            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
+            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
+            TherosBeyondDeathStructure.AAAABBBC2C2C2,
+            TherosBeyondDeathStructure.AAAABBBC2C2C2,
+            TherosBeyondDeathStructure.AAAABBBBC2C2
     );
     private final RarityConfiguration uncommonRuns = new RarityConfiguration(
-            TherosBeyondDeathStructure.U1,
-            TherosBeyondDeathStructure.U2
+            TherosBeyondDeathStructure.ABB,
+            TherosBeyondDeathStructure.AAB
     );
     private final RarityConfiguration rareRuns = new RarityConfiguration(
             false,


### PR DESCRIPTION
This patch fixes the side-issue noted in #8179.

```
Theros Beyond Death - boosters opened: 1000. Found cards: 15000
C Forest: 200
C Swamp: 200
C Island: 200
C Mountain: 200
C Plains: 200
C Warbriar Blessing: 100
C Skola Grovedancer: 100
C Ilysian Caryatid: 100
C Transcendent Envoy: 100
C Arena Trickster: 100
C Mire's Grasp: 100
C Voracious Typhon: 100
C Final Flare: 100
C Scavenging Harpy: 100
C Towering-Wave Mystic: 100
C Starlit Mantle: 100
C Oread of Mountain's Blaze: 100
C Aspect of Lamprey: 100
C Daybreak Chimera: 100
C Elite Instructor: 100
C Moss Viper: 100
C Glory Bearers: 100
C Revoke Existence: 100
C Skophos Warleader: 100
C Chain to Memory: 99
C Sunmane Pegasus: 99
C Brine Giant: 99
C Leonin of the Lost Pride: 99
C Infuriate: 99
C Karametra's Blessing: 99
C Final Death: 99
C Aspect of Manticore: 99
C Unknown Shores: 99
C Iroas's Blessing: 99
C Plummet: 99
C Thirst for Meaning: 99
C Triumphant Surge: 99
C Nylea's Huntmaster: 99
C Omen of the Dead: 99
C Wrap in Flames: 99
C Naiad of Hidden Coves: 99
C Dreadful Apathy: 99
C Underworld Rage-Hound: 99
C Heliod's Pilgrim: 99
C Memory Drain: 99
C Nylea's Forerunner: 99
C Indomitable Will: 99
C Ichthyomorphosis: 99
C Relentless Pursuit: 99
C Gift of Strength: 99
C Discordant Piper: 99
C Sleep of the Dead: 99
C Wings of Hubris: 99
C Setessan Training: 99
C Return to Nature: 99
C Nyxborn Seaguard: 99
C Grim Physician: 99
C Satyr's Cunning: 99
C Nyxborn Courser: 99
C Pious Wayfarer: 99
C Witness of Tomorrows: 99
C Vexing Gull: 99
C Incendiary Oracle: 99
C Sentinel's Eyes: 99
C Mogis's Favor: 99
C Inspire Awe: 99
C Irreverent Revelers: 99
C Venomous Hierophant: 99
C Setessan Skirmisher: 99
C Hero of the Pride: 99
C Omen of the Hunt: 99
C Lampad of Death's Vigil: 99
C Triton Waverider: 99
C Stampede Rider: 99
C Omen of the Forge: 99
C Temple Thief: 99
C Captivating Unicorn: 99
C Hero of the Games: 99
C Omen of the Sea: 99
C Omen of the Sun: 99
C Portent of Betrayal: 99
C Nexus Wardens: 99
C Nyxborn Brute: 99
C Thrill of Possibility: 99
C Thaumaturge's Familiar: 99
C Blight-Breath Catoblepas: 99
C Underworld Charger: 99
C Fruit of Tizerus: 99
C Flicker of Fate: 99
C Altar of the Pantheon: 99
C Eidolon of Philosophy: 99
C Rumbling Sentry: 99
C Funeral Rites: 99
C Flummoxed Cyclops: 99
C Rage-Scarred Berserker: 99
C Soulreaper of Mogis: 99
C Traveler's Amulet: 99
C Hyrax Tower Scout: 99
C Riptide Turtle: 99
C Stern Dismissal: 99
C Loathsome Chimera: 99
C Nyxborn Marauder: 99
C Deny the Divine: 99
C Nyxborn Colossus: 99
C Pharika's Libation: 98
C Bronze Sword: 82
```
(Bronze Sword is the short-printed common, it is expected to appear exactly 5/6 as often as the rest)