### PR TITLE
Fix AFR collator common print run ratios

### DIFF
--- a/Mage.Sets/src/mage/sets/AdventuresInTheForgottenRealms.java
+++ b/Mage.Sets/src/mage/sets/AdventuresInTheForgottenRealms.java
@@ -27,6 +27,7 @@ public final class AdventuresInTheForgottenRealms extends ExpansionSet {
         this.blockName = "Adventures in the Forgotten Realms";
         this.hasBoosters = true;
         this.hasBasicLands = true;
+        this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
@@ -457,7 +458,7 @@ class AdventuresInTheForgottenRealmsCollator implements BoosterCollator {
     }
 
     private static class AdventuresInTheForgottenRealmsStructure extends BoosterStructure {
-        private static final AdventuresInTheForgottenRealmsStructure C1 = new AdventuresInTheForgottenRealmsStructure(
+        private static final AdventuresInTheForgottenRealmsStructure ABBBBBBCCC = new AdventuresInTheForgottenRealmsStructure(
                 AdventuresInTheForgottenRealmsRun.commonA,
                 AdventuresInTheForgottenRealmsRun.commonB,
                 AdventuresInTheForgottenRealmsRun.commonB,
@@ -469,19 +470,7 @@ class AdventuresInTheForgottenRealmsCollator implements BoosterCollator {
                 AdventuresInTheForgottenRealmsRun.commonC,
                 AdventuresInTheForgottenRealmsRun.commonC
         );
-        private static final AdventuresInTheForgottenRealmsStructure C2 = new AdventuresInTheForgottenRealmsStructure(
-                AdventuresInTheForgottenRealmsRun.commonA,
-                AdventuresInTheForgottenRealmsRun.commonA,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonC,
-                AdventuresInTheForgottenRealmsRun.commonC,
-                AdventuresInTheForgottenRealmsRun.commonC
-        );
-        private static final AdventuresInTheForgottenRealmsStructure C3 = new AdventuresInTheForgottenRealmsStructure(
+        private static final AdventuresInTheForgottenRealmsStructure AABBBBBBCC = new AdventuresInTheForgottenRealmsStructure(
                 AdventuresInTheForgottenRealmsRun.commonA,
                 AdventuresInTheForgottenRealmsRun.commonA,
                 AdventuresInTheForgottenRealmsRun.commonB,
@@ -493,12 +482,12 @@ class AdventuresInTheForgottenRealmsCollator implements BoosterCollator {
                 AdventuresInTheForgottenRealmsRun.commonC,
                 AdventuresInTheForgottenRealmsRun.commonC
         );
-        private static final AdventuresInTheForgottenRealmsStructure U1 = new AdventuresInTheForgottenRealmsStructure(
+        private static final AdventuresInTheForgottenRealmsStructure AAA = new AdventuresInTheForgottenRealmsStructure(
                 AdventuresInTheForgottenRealmsRun.uncommonA,
                 AdventuresInTheForgottenRealmsRun.uncommonA,
                 AdventuresInTheForgottenRealmsRun.uncommonA
         );
-        private static final AdventuresInTheForgottenRealmsStructure U2 = new AdventuresInTheForgottenRealmsStructure(
+        private static final AdventuresInTheForgottenRealmsStructure BBB = new AdventuresInTheForgottenRealmsStructure(
                 AdventuresInTheForgottenRealmsRun.uncommonB,
                 AdventuresInTheForgottenRealmsRun.uncommonB,
                 AdventuresInTheForgottenRealmsRun.uncommonB
@@ -518,23 +507,28 @@ class AdventuresInTheForgottenRealmsCollator implements BoosterCollator {
         }
     }
 
+    // In order for equal numbers of each common to exist, the average booster must contain:
+    // 1.503 A commons (242 / 161)
+    // 6.012 B commons (968 / 161)
+    // 2.484 C commons (400 / 161)
+    // However, boosters with more than six B commons are not known to exist.
+    // This discrepancy is presumably related to foils--the above values are based on
+    // 10 commons per booster, but real boosters contain only 9.67 non-foil commons
     private final RarityConfiguration commonRuns = new RarityConfiguration(
-            false,
-            AdventuresInTheForgottenRealmsStructure.C1,
-            AdventuresInTheForgottenRealmsStructure.C2,
-            AdventuresInTheForgottenRealmsStructure.C3
+            AdventuresInTheForgottenRealmsStructure.ABBBBBBCCC,
+            AdventuresInTheForgottenRealmsStructure.AABBBBBBCC
     );
     private final RarityConfiguration uncommonRuns = new RarityConfiguration(
             false,
-            AdventuresInTheForgottenRealmsStructure.U1, AdventuresInTheForgottenRealmsStructure.U1,
-            AdventuresInTheForgottenRealmsStructure.U1, AdventuresInTheForgottenRealmsStructure.U1,
-            AdventuresInTheForgottenRealmsStructure.U1, AdventuresInTheForgottenRealmsStructure.U1,
-            AdventuresInTheForgottenRealmsStructure.U1, AdventuresInTheForgottenRealmsStructure.U1,
-            AdventuresInTheForgottenRealmsStructure.U1, AdventuresInTheForgottenRealmsStructure.U1,
-            AdventuresInTheForgottenRealmsStructure.U1,
-            AdventuresInTheForgottenRealmsStructure.U2, AdventuresInTheForgottenRealmsStructure.U2,
-            AdventuresInTheForgottenRealmsStructure.U2, AdventuresInTheForgottenRealmsStructure.U2,
-            AdventuresInTheForgottenRealmsStructure.U2
+            AdventuresInTheForgottenRealmsStructure.AAA, AdventuresInTheForgottenRealmsStructure.AAA,
+            AdventuresInTheForgottenRealmsStructure.AAA, AdventuresInTheForgottenRealmsStructure.AAA,
+            AdventuresInTheForgottenRealmsStructure.AAA, AdventuresInTheForgottenRealmsStructure.AAA,
+            AdventuresInTheForgottenRealmsStructure.AAA, AdventuresInTheForgottenRealmsStructure.AAA,
+            AdventuresInTheForgottenRealmsStructure.AAA, AdventuresInTheForgottenRealmsStructure.AAA,
+            AdventuresInTheForgottenRealmsStructure.AAA,
+            AdventuresInTheForgottenRealmsStructure.BBB, AdventuresInTheForgottenRealmsStructure.BBB,
+            AdventuresInTheForgottenRealmsStructure.BBB, AdventuresInTheForgottenRealmsStructure.BBB,
+            AdventuresInTheForgottenRealmsStructure.BBB
     );
     private final RarityConfiguration rareRuns = new RarityConfiguration(
             false,


### PR DESCRIPTION
@theelk801 This one was substantially trickier, which is why I'm creating this PR as a draft since I want your opinion on how to handle cases like it in the future.

First of all, the math discrepancy caused by excluding foils is worse for this set than it was for Kaldheim. According to https://www.lethe.xyz/mtg/collation/afr.html each booster has 5-6 B commons, but the average 10-common pack needs to contain slightly *more* than 6 B commons to make the numbers even.

Second, I got kind of lucky up until now in that the standard common run configuration for US-printed large sets from Shards through Kaldheim produces exact ratios with a nice small denominator of 22. For this set the numbers are... not so clean.

I've "solved" both problems here by simply rounding the average numbers of A, B and C commons per pack to 1.5, 6 and 2.5 respectively, which results in an error of a bit less than 1% too many C cards relative to the other two runs.

Two sets on my collation high priority list that have similar problems are OG Innistrad and Eldritch Moon. OG Innistrad has the first problem: it needs the average C1 pack to have 54/11 C1 commons (the usual 101-common numbers multiplied by 9/10) but according to Lethe all non-foil C1 packs have exactly five C1 commons. Eldritch Moon has the second problem: the booster type ratio needed to obtain perfectly evenly-distributed commons has a denominator of 560.
