### PR TITLE
CI: added maven cache to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ dist: trusty
 language: java
 before_install:
   - echo "MAVEN_OPTS='-Xmx2g'" > ~/.mavenrc
+cache:
+  directories:
+    - $HOME/.m2

--- a/Mage.Sets/src/mage/cards/a/AetherInspector.java
+++ b/Mage.Sets/src/mage/cards/a/AetherInspector.java
@@ -1,4 +1,3 @@
-
 package mage.cards.a;
 
 import java.util.UUID;


### PR DESCRIPTION
Travis cache docs are [here](https://docs.travis-ci.com/user/caching).

Some information:
* cache resets every month or manually:
![shot_210917_222716](https://user-images.githubusercontent.com/8344157/133839180-7ab3ed1d-45d6-4b54-a1c8-3d7a9cc45653.png)
* cache contains maven repo (`.m2` folder), so it must speed up a build process (it downloads a cache instead each dependency library);
* cache contains xmage's modules too (project uses full build for all modules, so it must be ok).
