### PR TITLE
Updating standard (don't merge until 9/24)

### DIFF
--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Standard.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Standard.java
@@ -17,20 +17,7 @@ public class Standard extends Constructed {
 
         setCodes.addAll(makeLegalSets());
 
-        banned.add("Agent of Treachery");
-        banned.add("Cauldron Familiar");
-        banned.add("Escape to the Wilds");
-        banned.add("Field of the Dead");
-        banned.add("Fires of Invention");
-        banned.add("Growth Spiral");
-        banned.add("Lucky Clover");
-        banned.add("Oko, Thief of Crowns");
         banned.add("Omnath, Locus of Creation");
-        banned.add("Once Upon a Time");
-        banned.add("Teferi, Time Raveler");
-        banned.add("Uro, Titan of Nature's Wrath");
-        banned.add("Wilderness Reclamation");
-        banned.add("Veil of Summer");
     }
 
     private static boolean isFallSet(ExpansionSet set) {

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Standard.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Standard.java
@@ -43,8 +43,9 @@ public class Standard extends Constructed {
                 .filter(set -> !set.getReleaseDate().after(current.getTime()))
                 .filter(Standard::isFallSet)
                 .sorted(ExpansionSet.getComparator())
-                .collect(Collectors.toList())
-                .get(1)
+                .skip(1)
+                .findFirst()
+                .get()
                 .getReleaseDate();
         return Sets.getInstance()
                 .values()

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Standard.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Standard.java
@@ -23,8 +23,10 @@ public class Standard extends Constructed {
     private static boolean isFallSet(ExpansionSet set) {
         Calendar cal = Calendar.getInstance();
         cal.setTime(set.getReleaseDate());
-        // Fall sets are normally released during or after September
-        return set.getSetType() == SetType.EXPANSION && (cal.get(Calendar.MONTH) > 7);
+        // Fall sets are normally released during or after September and before November
+        return set.getSetType() == SetType.EXPANSION
+                && Calendar.SEPTEMBER <= cal.get(Calendar.MONTH)
+                && cal.get(Calendar.MONTH) < Calendar.NOVEMBER;
     }
 
     static List<String> makeLegalSets() {

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Standard.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Standard.java
@@ -5,7 +5,11 @@ import mage.cards.Sets;
 import mage.cards.decks.Constructed;
 import mage.constants.SetType;
 
-import java.util.*;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author BetaSteward_at_googlemail.com
@@ -30,37 +34,25 @@ public class Standard extends Constructed {
     }
 
     static List<String> makeLegalSets() {
-        List<String> codes = new ArrayList<>();
         GregorianCalendar current = new GregorianCalendar();
-        List<ExpansionSet> sets = new ArrayList(Sets.getInstance().values());
-        Collections.sort(sets, new Comparator<ExpansionSet>() {
-            @Override
-            public int compare(final ExpansionSet lhs, ExpansionSet rhs) {
-                return lhs.getReleaseDate().after(rhs.getReleaseDate()) ? -1 : 1;
-            }
-        });
-        int fallSetsAdded = 0;
-        Date earliestDate = null;
         // Get the second most recent fall set that's been released.
-        for (ExpansionSet set : sets) {
-            if (set.getReleaseDate().after(current.getTime())) {
-                continue;
-            }
-            if (isFallSet(set)) {
-                fallSetsAdded++;
-                if (fallSetsAdded == 2) {
-                    earliestDate = set.getReleaseDate();
-                    break;
-                }
-            }
-        }
-
-        for (ExpansionSet set : sets) {
-            boolean isDateCompatible = earliestDate != null && !set.getReleaseDate().before(earliestDate) /*!set.getReleaseDate().after(current.getTime())*/; // no after date restrict for early tests and beta
-            if (set.getSetType().isStandardLegal() && isDateCompatible) {
-                codes.add(set.getCode());
-            }
-        }
-        return codes;
+        Date earliestDate = Sets
+                .getInstance()
+                .values()
+                .stream()
+                .filter(set -> !set.getReleaseDate().after(current.getTime()))
+                .filter(Standard::isFallSet)
+                .sorted(ExpansionSet.getComparator())
+                .collect(Collectors.toList())
+                .get(1)
+                .getReleaseDate();
+        return Sets.getInstance()
+                .values()
+                .stream()
+                .filter(set -> set.getSetType().isStandardLegal())
+                .filter(set -> !set.getReleaseDate().before(earliestDate))
+//                .filter(set -> !set.getReleaseDate().after(current.getTime())) // no after date restrict for early tests and beta
+                .map(ExpansionSet::getCode)
+                .collect(Collectors.toList());
     }
 }

--- a/Mage/src/main/java/mage/cards/ExpansionSet.java
+++ b/Mage/src/main/java/mage/cards/ExpansionSet.java
@@ -87,6 +87,19 @@ public abstract class ExpansionSet implements Serializable {
         }
     }
 
+    private static enum ExpansionSetComparator implements Comparator<ExpansionSet> {
+        instance;
+
+        @Override
+        public int compare(ExpansionSet lhs, ExpansionSet rhs) {
+            return lhs.getReleaseDate().after(rhs.getReleaseDate()) ? -1 : 1;
+        }
+    }
+
+    public static ExpansionSetComparator getComparator() {
+        return ExpansionSetComparator.instance;
+    }
+
     protected final List<SetCardInfo> cards = new ArrayList<>();
 
     protected String name;


### PR DESCRIPTION
Simplifies the ban list and updates standard legality algorithm to handle upcoming post-fall sets like Innistrad: Crimson Vow and Brothers' War