### PR TITLE
Improve randomness of collated booster generation

### DIFF
--- a/Mage/src/main/java/mage/cards/ExpansionSet.java
+++ b/Mage/src/main/java/mage/cards/ExpansionSet.java
@@ -297,22 +297,25 @@ public abstract class ExpansionSet implements Serializable {
         if (boosterCollator == null) {
             return;
         }
-        // don't open a new box if the old one hasn't been used yet
-        if (boosterBox.size() >= boosterBoxSize) {
-            return;
-        }
-        boosterCollator.shuffle();
-        boosterBox.clear();
-        for (int i = 0; i < boosterBoxSize; i++) {
-            boosterBox.add(createBoosterUsingCollator());
+        synchronized (boosterBox) {
+            // don't open a new box if haven't taken any boosters from the old one
+            if (boosterBox.size() < boosterBoxSize) {
+                boosterCollator.shuffle();
+                boosterBox.clear();
+                for (int i = 0; i < boosterBoxSize; i++) {
+                    boosterBox.add(createBoosterUsingCollator());
+                }
+            }
         }
     }
 
     private List<Card> createBoosterFromBox() {
-        if (boosterBox.isEmpty()) {
-            openBoosterBox();
+        synchronized (boosterBox) {
+            if (boosterBox.isEmpty()) {
+                openBoosterBox();
+            }
+            return boosterBox.remove(RandomUtil.nextInt(boosterBox.size()));
         }
-        return boosterBox.remove(RandomUtil.nextInt(boosterBox.size()));
     }
 
     protected void generateBoosterMap() {

--- a/Mage/src/main/java/mage/game/draft/DraftImpl.java
+++ b/Mage/src/main/java/mage/game/draft/DraftImpl.java
@@ -193,11 +193,15 @@ public abstract class DraftImpl implements Draft {
 
     protected void openBooster() {
         if (boosterNum <= numberBoosters) {
-            for (DraftPlayer player : players.values()) {
-                if (draftCube != null) {
+            if (draftCube != null) {
+                for (DraftPlayer player : players.values()) {
                     player.setBooster(draftCube.createBooster());
-                } else {
-                    player.setBooster(sets.get(boosterNum - 1).createBooster());
+                }
+            } else {
+                ExpansionSet set = sets.get(boosterNum - 1);
+                set.openBoosterBox();
+                for (DraftPlayer player : players.values()) {
+                    player.setBooster(set.createBooster());
                 }
             }
         }

--- a/Mage/src/main/java/mage/game/draft/DraftImpl.java
+++ b/Mage/src/main/java/mage/game/draft/DraftImpl.java
@@ -199,6 +199,9 @@ public abstract class DraftImpl implements Draft {
                 }
             } else {
                 ExpansionSet set = sets.get(boosterNum - 1);
+                // each round gets a fresh box so rounds aren't negatively correlated
+                // (seeing duplicate cards go around the table in P1 shouldn't leak
+                //  information that those cards won't be opened in P2 and P3)
                 set.openBoosterBox();
                 for (DraftPlayer player : players.values()) {
                     player.setBooster(set.createBooster());

--- a/Mage/src/main/java/mage/game/draft/RandomBoosterDraft.java
+++ b/Mage/src/main/java/mage/game/draft/RandomBoosterDraft.java
@@ -42,10 +42,7 @@ public class RandomBoosterDraft extends BoosterDraft {
         return theBooster;
     }
 
-    private void resetBoosters() {
-        for (ExpansionSet set : allSets) {
-            set.openBoosterBox();
-        }
+    private void resetBoosters(){
         useBoosters = new ArrayList<>(allSets);
         Collections.shuffle(useBoosters);
     }

--- a/Mage/src/main/java/mage/game/draft/RandomBoosterDraft.java
+++ b/Mage/src/main/java/mage/game/draft/RandomBoosterDraft.java
@@ -42,7 +42,10 @@ public class RandomBoosterDraft extends BoosterDraft {
         return theBooster;
     }
 
-    private void resetBoosters(){
+    private void resetBoosters() {
+        for (ExpansionSet set : allSets) {
+            set.openBoosterBox();
+        }
         useBoosters = new ArrayList<>(allSets);
         Collections.shuffle(useBoosters);
     }

--- a/Mage/src/main/java/mage/game/draft/RichManBoosterDraft.java
+++ b/Mage/src/main/java/mage/game/draft/RichManBoosterDraft.java
@@ -25,9 +25,6 @@ public class RichManBoosterDraft extends DraftImpl {
 
     @Override
     public void start() {
-        for (ExpansionSet set : sets) {
-            set.openBoosterBox();
-        }
         cardNum = 1;
         boosterNum = 1;
         while (!isAbort() && cardNum <= 36) {

--- a/Mage/src/main/java/mage/game/draft/RichManBoosterDraft.java
+++ b/Mage/src/main/java/mage/game/draft/RichManBoosterDraft.java
@@ -25,6 +25,9 @@ public class RichManBoosterDraft extends DraftImpl {
 
     @Override
     public void start() {
+        for (ExpansionSet set : sets) {
+            set.openBoosterBox();
+        }
         cardNum = 1;
         boosterNum = 1;
         while (!isAbort() && cardNum <= 36) {
@@ -62,6 +65,15 @@ public class RichManBoosterDraft extends DraftImpl {
     }
 
     @Override
+    protected void openBooster() {
+        if (boosterNum <= numberBoosters) {
+            for (DraftPlayer player : players.values()) {
+                player.setBooster(sets.get(boosterNum - 1).createBooster());
+            }
+        }
+    }
+
+    @Override
     protected boolean pickCards() {
         for (DraftPlayer player : players.values()) {
             if (cardNum > 36) {
@@ -90,4 +102,4 @@ public class RichManBoosterDraft extends DraftImpl {
         int time = (int) Math.ceil(customProfiTimes[cardNum - 1] * timing.getCustomTimeoutFactor());
         playerQueryEventSource.pickCard(playerId, "Pick card", player.getBooster(), time);
     }
-} 
+}

--- a/Mage/src/main/java/mage/game/tournament/TournamentImpl.java
+++ b/Mage/src/main/java/mage/game/tournament/TournamentImpl.java
@@ -414,6 +414,10 @@ public abstract class TournamentImpl implements Tournament {
                     player.getDeck().getCards().addAll(JumpstartPoolGenerator.generatePool(options.getLimitedOptions().jumpstartPacks));
                 }
             } else {
+                // each player gets their own fresh box so pools aren't negatively correlated
+                for (ExpansionSet set : sets) {
+                    set.openBoosterBox();
+                }
                 for (ExpansionSet set : sets) {
                     player.getDeck().getSideboard().addAll(set.createBooster());
                 }

--- a/Mage/src/main/java/mage/game/tournament/TournamentImpl.java
+++ b/Mage/src/main/java/mage/game/tournament/TournamentImpl.java
@@ -415,6 +415,8 @@ public abstract class TournamentImpl implements Tournament {
                 }
             } else {
                 // each player gets their own fresh box so pools aren't negatively correlated
+                // (seeing duplicate cards in your pool shouldn't leak information
+                //  that your opponents don't have those cards)
                 for (ExpansionSet set : sets) {
                     set.openBoosterBox();
                 }


### PR DESCRIPTION
Fixes #8179

@theelk801 This PR implements exactly what I suggested in my last comment in the issue thread. The behaviour I decided on for each tournament type are as follows:

For sealed, each player gets packs from their own personal box(es). If the sealed format is six packs of one set then they get six packs from one box; if the format is two packs each of sets X, Y and Z then they get two packs from a new box of X, two packs from a new box of Y and two packs from a new box of Z. This ensures that players' sealed pools aren't correlated with each other--it's not good if having four copies of common C or two copies of uncommon U in your pool means that you know that your opponents can't have the same card.

For normal booster draft, a new box is opened for each round of the draft. This allows for a small chance of opening unusual numbers of the same card--i.e. it'll still be possible to get all Seven Dwarves once Eldraine gets its `BoosterCollator`, though it's somewhat less likely than with 24 completely random boosters.

For Rich Man draft, one new box per set is opened at the start of the draft, since the entire conceit of the format is that you're drafting one card out of each pack in a box.

For random draft I'm afraid I might not fully understand how the format is implemented in the first place, because I have no idea why #8224 is a bug. I open new boxes in `resetBoosters` because that looked like a reasonable place to do it, and it appeared to work fine when I tested it with various combinations of collated and non-collated sets.