### PR TITLE
Make BoosterCollator not share state between tables on a server

### DIFF
--- a/Mage.Sets/src/mage/sets/AdventuresInTheForgottenRealms.java
+++ b/Mage.Sets/src/mage/sets/AdventuresInTheForgottenRealms.java
@@ -23,7 +23,7 @@ public final class AdventuresInTheForgottenRealms extends ExpansionSet {
     }
 
     private AdventuresInTheForgottenRealms() {
-        super("Adventures in the Forgotten Realms", "AFR", ExpansionSet.buildDate(2021, 7, 23), SetType.EXPANSION, new AdventuresInTheForgottenRealmsCollator());
+        super("Adventures in the Forgotten Realms", "AFR", ExpansionSet.buildDate(2021, 7, 23), SetType.EXPANSION);
         this.blockName = "Adventures in the Forgotten Realms";
         this.hasBoosters = true;
         this.hasBasicLands = true;
@@ -436,76 +436,41 @@ public final class AdventuresInTheForgottenRealms extends ExpansionSet {
         cards.add(new SetCardInfo("Zariel, Archduke of Avernus", 285, Rarity.MYTHIC, mage.cards.z.ZarielArchdukeOfAvernus.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Zombie Ogre", 129, Rarity.COMMON, mage.cards.z.ZombieOgre.class));
     }
+
+    @Override
+    public BoosterCollator createCollator() {
+        return new AdventuresInTheForgottenRealmsCollator();
+    }
 }
 
 // Booster collation info from https://www.lethe.xyz/mtg/collation/afr.html
 // Using USA collation for common/uncommon, rare collation inferred from other information
 class AdventuresInTheForgottenRealmsCollator implements BoosterCollator {
 
-    private static class AdventuresInTheForgottenRealmsRun extends CardRun {
-        private static final AdventuresInTheForgottenRealmsRun commonA = new AdventuresInTheForgottenRealmsRun(true, "144", "30", "122", "85", "153", "250", "164", "199", "133", "38", "141", "251", "101", "74", "245", "153", "122", "85", "30", "318", "250", "133", "199", "38", "153", "245", "74", "101", "251", "141", "30", "85", "164", "122", "144", "101", "251", "133", "199", "164", "250", "85", "141", "38", "74", "144", "30", "245", "122", "164", "38", "133", "250", "153", "248", "144", "101", "245", "74", "199", "141", "251", "30", "250", "122", "153", "85", "38", "164", "199", "133", "245", "101", "251", "141", "74", "153", "85", "133", "250", "318", "122", "164", "30", "199", "101", "251", "38", "85", "122", "245", "164", "74", "30", "141", "199", "101", "153", "38", "144", "250", "133", "245", "74", "164", "85", "122", "251", "141", "250", "144", "30", "153", "38", "133", "199", "74", "251", "141", "245", "101");
-        private static final AdventuresInTheForgottenRealmsRun commonB = new AdventuresInTheForgottenRealmsRun(true, "115", "182", "37", "47", "134", "119", "204", "16", "70", "146", "103", "189", "31", "51", "139", "102", "177", "14", "72", "158", "128", "205", "10", "46", "168", "108", "203", "43", "75", "150", "110", "178", "19", "52", "142", "123", "174", "40", "83", "140", "94", "213", "34", "73", "130", "109", "206", "9", "71", "162", "97", "183", "1", "65", "148", "118", "187", "11", "84", "159", "115", "204", "37", "51", "146", "119", "182", "31", "47", "134", "102", "177", "16", "70", "139", "103", "189", "14", "46", "168", "108", "205", "10", "72", "158", "128", "178", "19", "75", "150", "123", "203", "43", "52", "140", "110", "174", "40", "73", "142", "97", "206", "9", "83", "130", "118", "183", "34", "71", "162", "94", "213", "1", "65", "159", "109", "187", "11", "84", "148", "248");
-        private static final AdventuresInTheForgottenRealmsRun commonC = new AdventuresInTheForgottenRealmsRun(true, "55", "311", "24", "208", "106", "69", "165", "179", "129", "249", "50", "42", "198", "353", "35", "113", "185", "2", "309", "195", "312", "5", "45", "334", "152", "89", "24", "173", "306", "106", "179", "165", "69", "129", "198", "256", "50", "249", "35", "113", "326", "42", "45", "195", "93", "299", "66", "208", "24", "89", "152", "324", "55", "5", "165", "69", "106", "179", "50", "314", "185", "2", "129", "349", "198", "42", "66", "256", "35", "329", "45", "5", "152", "89", "55", "208", "93", "310", "165", "173", "24", "249", "331", "42", "50", "106", "256", "35", "325", "129", "2", "185", "113", "66", "195", "93", "45", "301", "152", "173");
-        private static final AdventuresInTheForgottenRealmsRun uncommonA = new AdventuresInTheForgottenRealmsRun(true, "76", "234", "92", "67", "175", "132", "96", "79", "154", "98", "188", "21", "125", "215", "61", "13", "120", "44", "136", "99", "244", "214", "135", "6", "81", "114", "170", "59", "116", "200", "68", "22", "240", "111", "58", "26", "210", "145", "25", "77", "242", "131", "33", "180", "163", "12", "117", "57", "32", "137", "212", "107", "36", "169", "191", "234", "76", "92", "132", "67", "96", "175", "79", "98", "21", "188", "125", "154", "44", "13", "120", "215", "61", "244", "136", "214", "99", "81", "135", "6", "59", "114", "170", "200", "22", "68", "116", "240", "26", "58", "111", "25", "131", "210", "33", "145", "77", "12", "163", "242", "180", "137", "107", "57", "32", "212", "117", "169", "191", "36");
-        private static final AdventuresInTheForgottenRealmsRun uncommonB = new AdventuresInTheForgottenRealmsRun(true, "247", "332", "49", "224", "300", "41", "219", "357", "160", "223", "225", "54", "90", "7", "346", "218", "95", "231", "186", "149", "327", "221", "161", "194", "348", "49", "224", "201", "343", "41", "219", "260", "305", "223", "160", "3", "342", "95", "218", "7", "236", "291", "247", "149", "186", "345", "192", "339", "161", "194", "288", "219", "201", "289", "224", "226", "160", "340", "95", "3", "336", "54", "260", "225", "231", "7", "90", "149", "236", "295", "321", "192", "49", "341", "247", "194", "221", "226", "260", "54", "223", "41", "201", "337", "218", "302", "3", "95", "294", "225", "192", "236", "90", "319", "231", "186", "226", "328", "161", "221");
-        private static final AdventuresInTheForgottenRealmsRun rareA = new AdventuresInTheForgottenRealmsRun(false, "87", "53", "100", "181", "143", "17", "20", "151", "62", "112", "227", "64", "197", "4", "91", "241", "207", "235", "239", "172", "216", "88", "217", "253", "176", "8", "138", "254", "56", "220", "255", "243", "222", "15", "104", "184", "105", "60", "18", "257", "246", "258", "147", "190", "259", "193", "23", "155", "63", "156", "228", "27", "196", "157", "229", "28", "29", "202", "230", "232", "233", "121", "78", "39", "48", "252", "261", "237", "80", "209", "238", "124", "211", "126", "127", "166", "82", "167", "86", "171", "216", "88", "217", "253", "176", "8", "138", "254", "56", "220", "255", "243", "222", "15", "104", "184", "105", "60", "18", "257", "246", "258", "147", "190", "259", "193", "23", "155", "63", "156", "228", "27", "196", "157", "229", "28", "29", "202", "230", "232", "233", "121", "78", "39", "48", "252", "261", "237", "80", "209", "238", "124", "211", "126", "127", "166", "82", "167", "86", "171");
-        private static final AdventuresInTheForgottenRealmsRun rareB = new AdventuresInTheForgottenRealmsRun(false, "87", "53", "292", "286", "143", "282", "287", "293", "290", "284", "344", "283", "296", "4", "91", "241", "333", "298", "239", "285", "297", "88", "217", "350", "176", "8", "317", "351", "307", "338", "352", "243", "222", "15", "104", "184", "313", "60", "18", "354", "246", "355", "147", "190", "356", "193", "23", "155", "308", "320", "228", "303", "330", "157", "229", "304", "29", "202", "230", "232", "233", "121", "78", "39", "48", "397", "358", "237", "80", "335", "347", "396", "211", "315", "316", "166", "82", "322", "86", "323", "297", "88", "217", "350", "176", "8", "317", "351", "307", "338", "352", "243", "222", "15", "104", "184", "313", "60", "18", "354", "246", "355", "147", "190", "356", "193", "23", "155", "308", "320", "228", "303", "330", "157", "229", "304", "29", "202", "230", "232", "233", "121", "78", "39", "48", "397", "358", "237", "80", "335", "347", "396", "211", "315", "316", "166", "82", "322", "86", "323");
-        private static final AdventuresInTheForgottenRealmsRun land = new AdventuresInTheForgottenRealmsRun(false, "262", "263", "264", "265", "266", "267", "268", "269", "270", "271", "272", "273", "274", "275", "276", "277", "278", "279", "280", "281");
+    private final CardRun commonA = new CardRun(true, "144", "30", "122", "85", "153", "250", "164", "199", "133", "38", "141", "251", "101", "74", "245", "153", "122", "85", "30", "318", "250", "133", "199", "38", "153", "245", "74", "101", "251", "141", "30", "85", "164", "122", "144", "101", "251", "133", "199", "164", "250", "85", "141", "38", "74", "144", "30", "245", "122", "164", "38", "133", "250", "153", "248", "144", "101", "245", "74", "199", "141", "251", "30", "250", "122", "153", "85", "38", "164", "199", "133", "245", "101", "251", "141", "74", "153", "85", "133", "250", "318", "122", "164", "30", "199", "101", "251", "38", "85", "122", "245", "164", "74", "30", "141", "199", "101", "153", "38", "144", "250", "133", "245", "74", "164", "85", "122", "251", "141", "250", "144", "30", "153", "38", "133", "199", "74", "251", "141", "245", "101");
+    private final CardRun commonB = new CardRun(true, "115", "182", "37", "47", "134", "119", "204", "16", "70", "146", "103", "189", "31", "51", "139", "102", "177", "14", "72", "158", "128", "205", "10", "46", "168", "108", "203", "43", "75", "150", "110", "178", "19", "52", "142", "123", "174", "40", "83", "140", "94", "213", "34", "73", "130", "109", "206", "9", "71", "162", "97", "183", "1", "65", "148", "118", "187", "11", "84", "159", "115", "204", "37", "51", "146", "119", "182", "31", "47", "134", "102", "177", "16", "70", "139", "103", "189", "14", "46", "168", "108", "205", "10", "72", "158", "128", "178", "19", "75", "150", "123", "203", "43", "52", "140", "110", "174", "40", "73", "142", "97", "206", "9", "83", "130", "118", "183", "34", "71", "162", "94", "213", "1", "65", "159", "109", "187", "11", "84", "148", "248");
+    private final CardRun commonC = new CardRun(true, "55", "311", "24", "208", "106", "69", "165", "179", "129", "249", "50", "42", "198", "353", "35", "113", "185", "2", "309", "195", "312", "5", "45", "334", "152", "89", "24", "173", "306", "106", "179", "165", "69", "129", "198", "256", "50", "249", "35", "113", "326", "42", "45", "195", "93", "299", "66", "208", "24", "89", "152", "324", "55", "5", "165", "69", "106", "179", "50", "314", "185", "2", "129", "349", "198", "42", "66", "256", "35", "329", "45", "5", "152", "89", "55", "208", "93", "310", "165", "173", "24", "249", "331", "42", "50", "106", "256", "35", "325", "129", "2", "185", "113", "66", "195", "93", "45", "301", "152", "173");
+    private final CardRun uncommonA = new CardRun(true, "76", "234", "92", "67", "175", "132", "96", "79", "154", "98", "188", "21", "125", "215", "61", "13", "120", "44", "136", "99", "244", "214", "135", "6", "81", "114", "170", "59", "116", "200", "68", "22", "240", "111", "58", "26", "210", "145", "25", "77", "242", "131", "33", "180", "163", "12", "117", "57", "32", "137", "212", "107", "36", "169", "191", "234", "76", "92", "132", "67", "96", "175", "79", "98", "21", "188", "125", "154", "44", "13", "120", "215", "61", "244", "136", "214", "99", "81", "135", "6", "59", "114", "170", "200", "22", "68", "116", "240", "26", "58", "111", "25", "131", "210", "33", "145", "77", "12", "163", "242", "180", "137", "107", "57", "32", "212", "117", "169", "191", "36");
+    private final CardRun uncommonB = new CardRun(true, "247", "332", "49", "224", "300", "41", "219", "357", "160", "223", "225", "54", "90", "7", "346", "218", "95", "231", "186", "149", "327", "221", "161", "194", "348", "49", "224", "201", "343", "41", "219", "260", "305", "223", "160", "3", "342", "95", "218", "7", "236", "291", "247", "149", "186", "345", "192", "339", "161", "194", "288", "219", "201", "289", "224", "226", "160", "340", "95", "3", "336", "54", "260", "225", "231", "7", "90", "149", "236", "295", "321", "192", "49", "341", "247", "194", "221", "226", "260", "54", "223", "41", "201", "337", "218", "302", "3", "95", "294", "225", "192", "236", "90", "319", "231", "186", "226", "328", "161", "221");
+    private final CardRun rareA = new CardRun(false, "87", "53", "100", "181", "143", "17", "20", "151", "62", "112", "227", "64", "197", "4", "91", "241", "207", "235", "239", "172", "216", "88", "217", "253", "176", "8", "138", "254", "56", "220", "255", "243", "222", "15", "104", "184", "105", "60", "18", "257", "246", "258", "147", "190", "259", "193", "23", "155", "63", "156", "228", "27", "196", "157", "229", "28", "29", "202", "230", "232", "233", "121", "78", "39", "48", "252", "261", "237", "80", "209", "238", "124", "211", "126", "127", "166", "82", "167", "86", "171", "216", "88", "217", "253", "176", "8", "138", "254", "56", "220", "255", "243", "222", "15", "104", "184", "105", "60", "18", "257", "246", "258", "147", "190", "259", "193", "23", "155", "63", "156", "228", "27", "196", "157", "229", "28", "29", "202", "230", "232", "233", "121", "78", "39", "48", "252", "261", "237", "80", "209", "238", "124", "211", "126", "127", "166", "82", "167", "86", "171");
+    private final CardRun rareB = new CardRun(false, "87", "53", "292", "286", "143", "282", "287", "293", "290", "284", "344", "283", "296", "4", "91", "241", "333", "298", "239", "285", "297", "88", "217", "350", "176", "8", "317", "351", "307", "338", "352", "243", "222", "15", "104", "184", "313", "60", "18", "354", "246", "355", "147", "190", "356", "193", "23", "155", "308", "320", "228", "303", "330", "157", "229", "304", "29", "202", "230", "232", "233", "121", "78", "39", "48", "397", "358", "237", "80", "335", "347", "396", "211", "315", "316", "166", "82", "322", "86", "323", "297", "88", "217", "350", "176", "8", "317", "351", "307", "338", "352", "243", "222", "15", "104", "184", "313", "60", "18", "354", "246", "355", "147", "190", "356", "193", "23", "155", "308", "320", "228", "303", "330", "157", "229", "304", "29", "202", "230", "232", "233", "121", "78", "39", "48", "397", "358", "237", "80", "335", "347", "396", "211", "315", "316", "166", "82", "322", "86", "323");
+    private final CardRun land = new CardRun(false, "262", "263", "264", "265", "266", "267", "268", "269", "270", "271", "272", "273", "274", "275", "276", "277", "278", "279", "280", "281");
 
-        private AdventuresInTheForgottenRealmsRun(boolean keepOrder, String... numbers) {
-            super(keepOrder, numbers);
-        }
-    }
-
-    private static class AdventuresInTheForgottenRealmsStructure extends BoosterStructure {
-        private static final AdventuresInTheForgottenRealmsStructure ABBBBBBCCC = new AdventuresInTheForgottenRealmsStructure(
-                AdventuresInTheForgottenRealmsRun.commonA,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonC,
-                AdventuresInTheForgottenRealmsRun.commonC,
-                AdventuresInTheForgottenRealmsRun.commonC
-        );
-        private static final AdventuresInTheForgottenRealmsStructure AABBBBBBCC = new AdventuresInTheForgottenRealmsStructure(
-                AdventuresInTheForgottenRealmsRun.commonA,
-                AdventuresInTheForgottenRealmsRun.commonA,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonB,
-                AdventuresInTheForgottenRealmsRun.commonC,
-                AdventuresInTheForgottenRealmsRun.commonC
-        );
-        private static final AdventuresInTheForgottenRealmsStructure AAA = new AdventuresInTheForgottenRealmsStructure(
-                AdventuresInTheForgottenRealmsRun.uncommonA,
-                AdventuresInTheForgottenRealmsRun.uncommonA,
-                AdventuresInTheForgottenRealmsRun.uncommonA
-        );
-        private static final AdventuresInTheForgottenRealmsStructure BBB = new AdventuresInTheForgottenRealmsStructure(
-                AdventuresInTheForgottenRealmsRun.uncommonB,
-                AdventuresInTheForgottenRealmsRun.uncommonB,
-                AdventuresInTheForgottenRealmsRun.uncommonB
-        );
-        private static final AdventuresInTheForgottenRealmsStructure R1 = new AdventuresInTheForgottenRealmsStructure(
-                AdventuresInTheForgottenRealmsRun.rareA
-        );
-        private static final AdventuresInTheForgottenRealmsStructure R2 = new AdventuresInTheForgottenRealmsStructure(
-                AdventuresInTheForgottenRealmsRun.rareB
-        );
-        private static final AdventuresInTheForgottenRealmsStructure L1 = new AdventuresInTheForgottenRealmsStructure(
-                AdventuresInTheForgottenRealmsRun.land
-        );
-
-        private AdventuresInTheForgottenRealmsStructure(CardRun... runs) {
-            super(runs);
-        }
-    }
+    private final BoosterStructure ABBBBBBCCC = new BoosterStructure(
+            commonA,
+            commonB, commonB, commonB, commonB, commonB, commonB,
+            commonC, commonC, commonC
+    );
+    private final BoosterStructure AABBBBBBCC = new BoosterStructure(
+            commonA, commonA,
+            commonB, commonB, commonB, commonB, commonB, commonB,
+            commonC, commonC
+    );
+    private final BoosterStructure AAA = new BoosterStructure(uncommonA, uncommonA, uncommonA);
+    private final BoosterStructure BBB = new BoosterStructure(uncommonB, uncommonB, uncommonB);
+    private final BoosterStructure R1 = new BoosterStructure(rareA);
+    private final BoosterStructure R2 = new BoosterStructure(rareB);
+    private final BoosterStructure L1 = new BoosterStructure(land);
 
     // In order for equal numbers of each common to exist, the average booster must contain:
     // 1.503 A commons (242 / 161)
@@ -514,41 +479,13 @@ class AdventuresInTheForgottenRealmsCollator implements BoosterCollator {
     // However, boosters with more than six B commons are not known to exist.
     // This discrepancy is presumably related to foils--the above values are based on
     // 10 commons per booster, but real boosters contain only 9.67 non-foil commons
-    private final RarityConfiguration commonRuns = new RarityConfiguration(
-            AdventuresInTheForgottenRealmsStructure.ABBBBBBCCC,
-            AdventuresInTheForgottenRealmsStructure.AABBBBBBCC
-    );
+    private final RarityConfiguration commonRuns = new RarityConfiguration(ABBBBBBCCC, AABBBBBBCC);
     private final RarityConfiguration uncommonRuns = new RarityConfiguration(
-            false,
-            AdventuresInTheForgottenRealmsStructure.AAA, AdventuresInTheForgottenRealmsStructure.AAA,
-            AdventuresInTheForgottenRealmsStructure.AAA, AdventuresInTheForgottenRealmsStructure.AAA,
-            AdventuresInTheForgottenRealmsStructure.AAA, AdventuresInTheForgottenRealmsStructure.AAA,
-            AdventuresInTheForgottenRealmsStructure.AAA, AdventuresInTheForgottenRealmsStructure.AAA,
-            AdventuresInTheForgottenRealmsStructure.AAA, AdventuresInTheForgottenRealmsStructure.AAA,
-            AdventuresInTheForgottenRealmsStructure.AAA,
-            AdventuresInTheForgottenRealmsStructure.BBB, AdventuresInTheForgottenRealmsStructure.BBB,
-            AdventuresInTheForgottenRealmsStructure.BBB, AdventuresInTheForgottenRealmsStructure.BBB,
-            AdventuresInTheForgottenRealmsStructure.BBB
+            AAA, AAA, AAA, AAA, AAA, AAA, AAA, AAA, AAA, AAA, AAA,
+            BBB, BBB, BBB, BBB, BBB
     );
-    private final RarityConfiguration rareRuns = new RarityConfiguration(
-            false,
-            AdventuresInTheForgottenRealmsStructure.R1,
-            AdventuresInTheForgottenRealmsStructure.R1,
-            AdventuresInTheForgottenRealmsStructure.R1,
-            AdventuresInTheForgottenRealmsStructure.R2
-    );
-    private final RarityConfiguration landRuns = new RarityConfiguration(
-            AdventuresInTheForgottenRealmsStructure.L1
-    );
-
-
-    @Override
-    public void shuffle() {
-        commonRuns.shuffle();
-        uncommonRuns.shuffle();
-        rareRuns.shuffle();
-        landRuns.shuffle();
-    }
+    private final RarityConfiguration rareRuns = new RarityConfiguration(R1, R1, R1, R2);
+    private final RarityConfiguration landRuns = new RarityConfiguration(L1);
 
     @Override
     public List<String> makeBooster() {

--- a/Mage.Sets/src/mage/sets/DoubleMasters.java
+++ b/Mage.Sets/src/mage/sets/DoubleMasters.java
@@ -23,7 +23,7 @@ public final class DoubleMasters extends ExpansionSet {
     }
 
     private DoubleMasters() {
-        super("Double Masters", "2XM", ExpansionSet.buildDate(2020, 8, 7), SetType.SUPPLEMENTAL, new DoubleMastersCollator());
+        super("Double Masters", "2XM", ExpansionSet.buildDate(2020, 8, 7), SetType.SUPPLEMENTAL);
         this.blockName = "Reprint";
         this.hasBasicLands = true;
         this.hasBoosters = true;
@@ -418,6 +418,11 @@ public final class DoubleMasters extends ExpansionSet {
         cards.add(new SetCardInfo("Wurmcoil Engine", 368, Rarity.MYTHIC, mage.cards.w.WurmcoilEngine.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Yavimaya's Embrace", 229, Rarity.UNCOMMON, mage.cards.y.YavimayasEmbrace.class));
     }
+
+    @Override
+    public BoosterCollator createCollator() {
+        return new DoubleMastersCollator();
+    }
 }
 
 // Booster collation info from https://www.lethe.xyz/mtg/collation/2xm.html
@@ -428,351 +433,222 @@ public final class DoubleMasters extends ExpansionSet {
 // TODO: write a test, not sure how right now
 class DoubleMastersCollator implements BoosterCollator {
 
-    private static class DoubleMastersRun extends CardRun {
-        private static final DoubleMastersRun commonA = new DoubleMastersRun(true, "160", "108", "146", "79", "247", "165", "114", "111", "163", "29", "143", "105", "162", "135", "154", "78", "144", "151", "140", "84", "187", "304", "87", "133", "173", "95", "126", "28", "176", "90", "137", "165", "83", "159", "116", "168", "92", "121", "154", "79", "150", "181", "247", "146", "111", "160", "143", "96", "114", "108", "151", "78", "135", "95", "162", "144", "87", "140", "105", "163", "304", "84", "126", "173", "111", "133", "29", "187", "83", "137", "176", "90", "159", "150", "96", "247", "146", "165", "92", "116", "28", "160", "108", "121", "79", "168", "144", "162", "87", "163", "114", "84", "154", "304", "105", "135", "173", "95", "126", "29", "151", "83", "140", "181", "133", "78", "143", "187", "28", "150", "96", "159", "176", "90", "137", "168", "116", "92", "181", "121");
-        private static final DoubleMastersRun commonB = new DoubleMastersRun(true, "250", "70", "259", "305", "45", "80", "261", "60", "288", "331", "294", "63", "255", "263", "46", "230", "262", "50", "257", "256", "44", "283", "237", "74", "157", "277", "59", "330", "280", "52", "254", "329", "250", "69", "239", "331", "45", "287", "288", "42", "115", "273", "40", "305", "269", "63", "294", "257", "50", "80", "230", "60", "256", "259", "46", "261", "283", "44", "237", "330", "70", "263", "255", "52", "262", "254", "40", "157", "287", "115", "69", "277", "273", "59", "329", "280", "74", "250", "257", "60", "331", "261", "45", "239", "269", "42", "288", "305", "63", "80", "283", "50", "294", "259", "70", "263", "237", "44", "255", "262", "46", "230", "157", "59", "256", "330", "52", "254", "277", "74", "280", "329", "69", "287", "115", "42", "239", "269", "40", "273");
-        private static final DoubleMastersRun commonC = new DoubleMastersRun(true, "18", "35", "4", "17", "2", "30", "12", "27", "3", "13", "33", "30", "18", "12", "35", "27", "4", "3", "17", "13", "2", "33", "12", "4", "13", "18", "27", "17", "33", "30", "35", "3", "2", "18", "35", "4", "17", "2", "30", "12", "27", "3", "13", "33", "30", "18", "12", "35", "27", "4", "3", "17", "13", "2", "33", "12", "4", "13", "18", "27", "17", "33", "30", "35", "3", "2", "18", "35", "4", "17", "2", "30", "12", "27", "3", "13", "33", "30", "18", "12", "35", "27", "4", "3", "17", "13", "2", "33", "12", "4", "13", "18", "27", "17", "33", "30", "35", "3", "2", "18", "35", "4", "17", "2", "30", "12", "27", "3", "13", "33", "30", "18", "12", "35", "27", "4", "3", "17", "13", "2", "33");
-        private static final DoubleMastersRun uncommonA = new DoubleMastersRun(true, "315", "244", "73", "274", "208", "147", "202", "169", "290", "102", "65", "285", "220", "67", "186", "246", "112", "222", "22", "301", "86", "62", "228", "161", "101", "302", "54", "184", "220", "307", "73", "93", "15", "119", "202", "291", "169", "323", "102", "244", "201", "172", "312", "290", "37", "208", "246", "6", "65", "307", "86", "186", "67", "222", "141", "15", "315", "22", "274", "161", "37", "101", "285", "228", "184", "112", "147", "302", "172", "54", "220", "141", "301", "6", "93", "119", "169", "323", "291", "312", "201", "62", "244", "184", "102", "15", "222", "37", "290", "112", "147", "65", "285", "101", "315", "67", "202", "186", "274", "208", "323", "73", "307", "228", "86", "161", "119", "246", "312", "6", "22", "172", "301", "62", "302", "141", "93", "291", "54", "201");
-        private static final DoubleMastersRun uncommonB = new DoubleMastersRun(true, "217", "23", "49", "245", "91", "194", "148", "71", "16", "125", "238", "198", "180", "36", "278", "99", "224", "38", "232", "123", "68", "258", "229", "310", "120", "242", "188", "25", "66", "267", "138", "178", "281", "199", "89", "194", "241", "23", "49", "91", "245", "166", "134", "238", "217", "148", "36", "265", "16", "125", "198", "232", "71", "100", "267", "229", "180", "68", "278", "123", "25", "99", "241", "38", "120", "258", "199", "188", "224", "281", "310", "49", "23", "66", "138", "178", "245", "217", "166", "134", "242", "89", "36", "265", "148", "100", "242", "198", "180", "25", "238", "16", "194", "38", "91", "71", "125", "278", "229", "310", "68", "232", "123", "178", "99", "258", "188", "120", "267", "199", "89", "224", "241", "66", "134", "166", "281", "138", "100", "265");
-        private static final DoubleMastersRun rareA = new DoubleMastersRun(false, "76", "231", "153", "77", "117", "118", "10", "43", "313", "158", "48", "85", "124", "252", "14", "167", "316", "318", "196", "127", "320", "130", "321", "97", "175", "271", "210", "272", "282", "26", "139", "103", "64", "325", "104", "179", "289", "32", "293", "326", "299", "327", "72", "109", "223", "225", "226", "75", "332", "113", "76", "231", "153", "77", "117", "118", "10", "43", "313", "158", "48", "85", "124", "252", "14", "167", "316", "318", "196", "127", "320", "130", "321", "97", "175", "271", "210", "272", "282", "26", "139", "103", "64", "325", "104", "179", "289", "32", "293", "326", "299", "327", "72", "109", "223", "225", "226", "75", "332", "113", "190", "8", "192", "240", "81", "314", "248", "164", "253", "51", "131", "204", "205", "20", "206", "136", "275", "214", "218", "303");
-        private static final DoubleMastersRun rareB = new DoubleMastersRun(false, "122", "82", "317", "55", "264", "174", "324", "24", "284", "215", "328");
-        private static final DoubleMastersRun rareC = new DoubleMastersRun(false, "189", "7", "311", "155", "236", "193", "11", "47", "249", "195", "128", "170", "260", "132", "203", "21", "268", "98", "57", "322", "209", "177", "279", "61", "212", "219", "292", "34", "183", "110", "149", "227", "306");
-        private static final DoubleMastersRun rareD = new DoubleMastersRun(false, "309", "191", "233", "9", "156", "243", "88", "251", "319", "53", "129", "200", "171", "19", "266", "207", "58", "211", "276", "213", "142", "286", "106", "31", "221", "182", "39");
-        private static final DoubleMastersRun rareE = new DoubleMastersRun(false, "5", "41", "152", "234", "235", "197", "94", "56", "1", "270", "107", "145", "295", "296", "297", "298", "300", "216", "185", "308");
-        private static final DoubleMastersRun foilUncommonA = new DoubleMastersRun(false, "6", "119", "312", "244", "161", "246", "315", "86", "93", "15", "169", "201", "54", "172", "202", "208", "22", "274", "323", "101", "102", "62", "141", "65", "285", "67", "220", "290", "291", "147", "222", "301", "302", "73", "184", "37", "112", "186", "228", "307");
-        private static final DoubleMastersRun foilUncommonB = new DoubleMastersRun(false, "310", "232", "120", "238", "241", "242", "245", "194", "123", "89", "91", "166", "49", "16", "125", "198", "199", "258", "265", "134", "267", "99", "23", "278", "100", "25", "281", "138", "178", "66", "217", "68", "180", "71", "36", "148", "224", "38", "188", "229");
-        private static final DoubleMastersRun foilRareA = new DoubleMastersRun(false, "309", "231", "76", "189", "7", "153", "191", "233", "77", "9", "117", "311", "118", "155", "10", "236", "43", "193", "313", "156", "158", "243", "11", "122", "47", "82", "48", "85", "88", "124", "249", "251", "252", "14", "167", "195", "316", "317", "318", "196", "319", "127", "128", "53", "320", "170", "129", "260", "200", "171", "130", "321", "55", "132", "264", "203", "19", "266", "21", "174", "268", "207", "97", "98", "175", "57", "58", "271", "322", "209", "210", "211", "272", "276", "324", "177", "279", "24", "61", "282", "212", "26", "139", "284", "103", "64", "213", "142", "325", "104", "215", "286", "179", "219", "106", "289", "31", "32", "292", "293", "326", "221", "299", "34", "182", "327", "72", "109", "183", "223", "110", "149", "328", "225", "226", "227", "306", "75", "332", "113", "39");
-        private static final DoubleMastersRun foilRareB = new DoubleMastersRun(false, "5", "41", "190", "8", "152", "234", "235", "192", "240", "81", "314", "248", "164", "253", "51", "197", "94", "131", "56", "204", "1", "205", "20", "206", "270", "136", "275", "214", "218", "107", "145", "295", "296", "297", "298", "300", "216", "303", "185", "308");
+    private final CardRun commonA = new CardRun(true, "160", "108", "146", "79", "247", "165", "114", "111", "163", "29", "143", "105", "162", "135", "154", "78", "144", "151", "140", "84", "187", "304", "87", "133", "173", "95", "126", "28", "176", "90", "137", "165", "83", "159", "116", "168", "92", "121", "154", "79", "150", "181", "247", "146", "111", "160", "143", "96", "114", "108", "151", "78", "135", "95", "162", "144", "87", "140", "105", "163", "304", "84", "126", "173", "111", "133", "29", "187", "83", "137", "176", "90", "159", "150", "96", "247", "146", "165", "92", "116", "28", "160", "108", "121", "79", "168", "144", "162", "87", "163", "114", "84", "154", "304", "105", "135", "173", "95", "126", "29", "151", "83", "140", "181", "133", "78", "143", "187", "28", "150", "96", "159", "176", "90", "137", "168", "116", "92", "181", "121");
+    private final CardRun commonB = new CardRun(true, "250", "70", "259", "305", "45", "80", "261", "60", "288", "331", "294", "63", "255", "263", "46", "230", "262", "50", "257", "256", "44", "283", "237", "74", "157", "277", "59", "330", "280", "52", "254", "329", "250", "69", "239", "331", "45", "287", "288", "42", "115", "273", "40", "305", "269", "63", "294", "257", "50", "80", "230", "60", "256", "259", "46", "261", "283", "44", "237", "330", "70", "263", "255", "52", "262", "254", "40", "157", "287", "115", "69", "277", "273", "59", "329", "280", "74", "250", "257", "60", "331", "261", "45", "239", "269", "42", "288", "305", "63", "80", "283", "50", "294", "259", "70", "263", "237", "44", "255", "262", "46", "230", "157", "59", "256", "330", "52", "254", "277", "74", "280", "329", "69", "287", "115", "42", "239", "269", "40", "273");
+    private final CardRun commonC = new CardRun(true, "18", "35", "4", "17", "2", "30", "12", "27", "3", "13", "33", "30", "18", "12", "35", "27", "4", "3", "17", "13", "2", "33", "12", "4", "13", "18", "27", "17", "33", "30", "35", "3", "2", "18", "35", "4", "17", "2", "30", "12", "27", "3", "13", "33", "30", "18", "12", "35", "27", "4", "3", "17", "13", "2", "33", "12", "4", "13", "18", "27", "17", "33", "30", "35", "3", "2", "18", "35", "4", "17", "2", "30", "12", "27", "3", "13", "33", "30", "18", "12", "35", "27", "4", "3", "17", "13", "2", "33", "12", "4", "13", "18", "27", "17", "33", "30", "35", "3", "2", "18", "35", "4", "17", "2", "30", "12", "27", "3", "13", "33", "30", "18", "12", "35", "27", "4", "3", "17", "13", "2", "33");
+    private final CardRun uncommonA = new CardRun(true, "315", "244", "73", "274", "208", "147", "202", "169", "290", "102", "65", "285", "220", "67", "186", "246", "112", "222", "22", "301", "86", "62", "228", "161", "101", "302", "54", "184", "220", "307", "73", "93", "15", "119", "202", "291", "169", "323", "102", "244", "201", "172", "312", "290", "37", "208", "246", "6", "65", "307", "86", "186", "67", "222", "141", "15", "315", "22", "274", "161", "37", "101", "285", "228", "184", "112", "147", "302", "172", "54", "220", "141", "301", "6", "93", "119", "169", "323", "291", "312", "201", "62", "244", "184", "102", "15", "222", "37", "290", "112", "147", "65", "285", "101", "315", "67", "202", "186", "274", "208", "323", "73", "307", "228", "86", "161", "119", "246", "312", "6", "22", "172", "301", "62", "302", "141", "93", "291", "54", "201");
+    private final CardRun uncommonB = new CardRun(true, "217", "23", "49", "245", "91", "194", "148", "71", "16", "125", "238", "198", "180", "36", "278", "99", "224", "38", "232", "123", "68", "258", "229", "310", "120", "242", "188", "25", "66", "267", "138", "178", "281", "199", "89", "194", "241", "23", "49", "91", "245", "166", "134", "238", "217", "148", "36", "265", "16", "125", "198", "232", "71", "100", "267", "229", "180", "68", "278", "123", "25", "99", "241", "38", "120", "258", "199", "188", "224", "281", "310", "49", "23", "66", "138", "178", "245", "217", "166", "134", "242", "89", "36", "265", "148", "100", "242", "198", "180", "25", "238", "16", "194", "38", "91", "71", "125", "278", "229", "310", "68", "232", "123", "178", "99", "258", "188", "120", "267", "199", "89", "224", "241", "66", "134", "166", "281", "138", "100", "265");
+    private final CardRun rareA = new CardRun(false, "76", "231", "153", "77", "117", "118", "10", "43", "313", "158", "48", "85", "124", "252", "14", "167", "316", "318", "196", "127", "320", "130", "321", "97", "175", "271", "210", "272", "282", "26", "139", "103", "64", "325", "104", "179", "289", "32", "293", "326", "299", "327", "72", "109", "223", "225", "226", "75", "332", "113", "76", "231", "153", "77", "117", "118", "10", "43", "313", "158", "48", "85", "124", "252", "14", "167", "316", "318", "196", "127", "320", "130", "321", "97", "175", "271", "210", "272", "282", "26", "139", "103", "64", "325", "104", "179", "289", "32", "293", "326", "299", "327", "72", "109", "223", "225", "226", "75", "332", "113", "190", "8", "192", "240", "81", "314", "248", "164", "253", "51", "131", "204", "205", "20", "206", "136", "275", "214", "218", "303");
+    private final CardRun rareB = new CardRun(false, "122", "82", "317", "55", "264", "174", "324", "24", "284", "215", "328");
+    private final CardRun rareC = new CardRun(false, "189", "7", "311", "155", "236", "193", "11", "47", "249", "195", "128", "170", "260", "132", "203", "21", "268", "98", "57", "322", "209", "177", "279", "61", "212", "219", "292", "34", "183", "110", "149", "227", "306");
+    private final CardRun rareD = new CardRun(false, "309", "191", "233", "9", "156", "243", "88", "251", "319", "53", "129", "200", "171", "19", "266", "207", "58", "211", "276", "213", "142", "286", "106", "31", "221", "182", "39");
+    private final CardRun rareE = new CardRun(false, "5", "41", "152", "234", "235", "197", "94", "56", "1", "270", "107", "145", "295", "296", "297", "298", "300", "216", "185", "308");
+    private final CardRun foilUncommonA = new CardRun(false, "6", "119", "312", "244", "161", "246", "315", "86", "93", "15", "169", "201", "54", "172", "202", "208", "22", "274", "323", "101", "102", "62", "141", "65", "285", "67", "220", "290", "291", "147", "222", "301", "302", "73", "184", "37", "112", "186", "228", "307");
+    private final CardRun foilUncommonB = new CardRun(false, "310", "232", "120", "238", "241", "242", "245", "194", "123", "89", "91", "166", "49", "16", "125", "198", "199", "258", "265", "134", "267", "99", "23", "278", "100", "25", "281", "138", "178", "66", "217", "68", "180", "71", "36", "148", "224", "38", "188", "229");
+    private final CardRun foilRareA = new CardRun(false, "309", "231", "76", "189", "7", "153", "191", "233", "77", "9", "117", "311", "118", "155", "10", "236", "43", "193", "313", "156", "158", "243", "11", "122", "47", "82", "48", "85", "88", "124", "249", "251", "252", "14", "167", "195", "316", "317", "318", "196", "319", "127", "128", "53", "320", "170", "129", "260", "200", "171", "130", "321", "55", "132", "264", "203", "19", "266", "21", "174", "268", "207", "97", "98", "175", "57", "58", "271", "322", "209", "210", "211", "272", "276", "324", "177", "279", "24", "61", "282", "212", "26", "139", "284", "103", "64", "213", "142", "325", "104", "215", "286", "179", "219", "106", "289", "31", "32", "292", "293", "326", "221", "299", "34", "182", "327", "72", "109", "183", "223", "110", "149", "328", "225", "226", "227", "306", "75", "332", "113", "39");
+    private final CardRun foilRareB = new CardRun(false, "5", "41", "190", "8", "152", "234", "235", "192", "240", "81", "314", "248", "164", "253", "51", "197", "94", "131", "56", "204", "1", "205", "20", "206", "270", "136", "275", "214", "218", "107", "145", "295", "296", "297", "298", "300", "216", "303", "185", "308");
 
-        private DoubleMastersRun(boolean keepOrder, String... numbers) {
-            super(keepOrder, numbers);
-        }
-    }
+    private final BoosterStructure C1 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB, commonC
+    );
+    private final BoosterStructure C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB,
+            commonC
+    );
+    private final BoosterStructure C3 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB
+    );
+    private final BoosterStructure U1 = new BoosterStructure(uncommonA, uncommonB, uncommonB);
+    private final BoosterStructure U2 = new BoosterStructure(uncommonA, uncommonA, uncommonB);
+    private final BoosterStructure R1 = new BoosterStructure(rareA, rareC);
+    private final BoosterStructure R2 = new BoosterStructure(rareA, rareD);
+    private final BoosterStructure R3 = new BoosterStructure(rareA, rareE);
+    private final BoosterStructure R4 = new BoosterStructure(rareB, rareC);
+    private final BoosterStructure R5 = new BoosterStructure(rareB, rareD);
+    private final BoosterStructure R6 = new BoosterStructure(rareB, rareE);
 
-    private static class DoubleMastersStructure extends BoosterStructure {
-        private static final DoubleMastersStructure C1 = new DoubleMastersStructure(
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.commonC
-        );
-        private static final DoubleMastersStructure C2 = new DoubleMastersStructure(
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.commonC
-        );
-        private static final DoubleMastersStructure C3 = new DoubleMastersStructure(
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.commonB
-        );
-        private static final DoubleMastersStructure U1 = new DoubleMastersStructure(
-                DoubleMastersRun.uncommonA,
-                DoubleMastersRun.uncommonB,
-                DoubleMastersRun.uncommonB
-        );
-        private static final DoubleMastersStructure U2 = new DoubleMastersStructure(
-                DoubleMastersRun.uncommonA,
-                DoubleMastersRun.uncommonA,
-                DoubleMastersRun.uncommonB
-        );
-        private static final DoubleMastersStructure R1 = new DoubleMastersStructure(
-                DoubleMastersRun.rareA,
-                DoubleMastersRun.rareC
-        );
-        private static final DoubleMastersStructure R2 = new DoubleMastersStructure(
-                DoubleMastersRun.rareA,
-                DoubleMastersRun.rareD
-        );
-        private static final DoubleMastersStructure R3 = new DoubleMastersStructure(
-                DoubleMastersRun.rareA,
-                DoubleMastersRun.rareE
-        );
-        private static final DoubleMastersStructure R4 = new DoubleMastersStructure(
-                DoubleMastersRun.rareB,
-                DoubleMastersRun.rareC
-        );
-        private static final DoubleMastersStructure R5 = new DoubleMastersStructure(
-                DoubleMastersRun.rareB,
-                DoubleMastersRun.rareD
-        );
-        private static final DoubleMastersStructure R6 = new DoubleMastersStructure(
-                DoubleMastersRun.rareB,
-                DoubleMastersRun.rareE
-        );
-        private static final DoubleMastersStructure F01 = new DoubleMastersStructure(
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonB
-        );
-        private static final DoubleMastersStructure F02 = new DoubleMastersStructure(
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.commonC
-        );
-        private static final DoubleMastersStructure F03 = new DoubleMastersStructure(
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.foilUncommonA
-        );
-        private static final DoubleMastersStructure F04 = new DoubleMastersStructure(
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.foilUncommonB
-        );
-        private static final DoubleMastersStructure F05 = new DoubleMastersStructure(
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.foilRareA
-        );
-        private static final DoubleMastersStructure F06 = new DoubleMastersStructure(
-                DoubleMastersRun.commonA,
-                DoubleMastersRun.foilRareB
-        );
-        private static final DoubleMastersStructure F07 = new DoubleMastersStructure(
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.commonC
-        );
-        private static final DoubleMastersStructure F08 = new DoubleMastersStructure(
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.foilUncommonA
-        );
-        private static final DoubleMastersStructure F09 = new DoubleMastersStructure(
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.foilUncommonB
-        );
-        private static final DoubleMastersStructure F10 = new DoubleMastersStructure(
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.foilRareA
-        );
-        private static final DoubleMastersStructure F11 = new DoubleMastersStructure(
-                DoubleMastersRun.commonB,
-                DoubleMastersRun.foilRareB
-        );
-        private static final DoubleMastersStructure F12 = new DoubleMastersStructure(
-                DoubleMastersRun.commonC,
-                DoubleMastersRun.foilUncommonA
-        );
-        private static final DoubleMastersStructure F13 = new DoubleMastersStructure(
-                DoubleMastersRun.commonC,
-                DoubleMastersRun.foilUncommonB
-        );
-        private static final DoubleMastersStructure F14 = new DoubleMastersStructure(
-                DoubleMastersRun.commonC,
-                DoubleMastersRun.foilRareA
-        );
-        private static final DoubleMastersStructure F15 = new DoubleMastersStructure(
-                DoubleMastersRun.commonC,
-                DoubleMastersRun.foilRareB
-        );
-        private static final DoubleMastersStructure F16 = new DoubleMastersStructure(
-                DoubleMastersRun.foilUncommonA,
-                DoubleMastersRun.foilUncommonB
-        );
-        private static final DoubleMastersStructure F17 = new DoubleMastersStructure(
-                DoubleMastersRun.foilUncommonA,
-                DoubleMastersRun.foilRareA
-        );
-        private static final DoubleMastersStructure F18 = new DoubleMastersStructure(
-                DoubleMastersRun.foilUncommonA,
-                DoubleMastersRun.foilRareB
-        );
-        private static final DoubleMastersStructure F19 = new DoubleMastersStructure(
-                DoubleMastersRun.foilUncommonB,
-                DoubleMastersRun.foilRareA
-        );
-        private static final DoubleMastersStructure F20 = new DoubleMastersStructure(
-                DoubleMastersRun.foilUncommonB,
-                DoubleMastersRun.foilRareB
-        );
-        private static final DoubleMastersStructure F21 = new DoubleMastersStructure(
-                DoubleMastersRun.foilRareA,
-                DoubleMastersRun.foilRareB
-        );
-
-
-        private DoubleMastersStructure(CardRun... runs) {
-            super(runs);
-        }
-    }
+    private final BoosterStructure F01 = new BoosterStructure(commonA, commonB);
+    private final BoosterStructure F02 = new BoosterStructure(commonA, commonC);
+    private final BoosterStructure F03 = new BoosterStructure(commonA, foilUncommonA);
+    private final BoosterStructure F04 = new BoosterStructure(commonA, foilUncommonB);
+    private final BoosterStructure F05 = new BoosterStructure(commonA, foilRareA);
+    private final BoosterStructure F06 = new BoosterStructure(commonA, foilRareB);
+    private final BoosterStructure F07 = new BoosterStructure(commonB, commonC);
+    private final BoosterStructure F08 = new BoosterStructure(commonB, foilUncommonA);
+    private final BoosterStructure F09 = new BoosterStructure(commonB, foilUncommonB);
+    private final BoosterStructure F10 = new BoosterStructure(commonB, foilRareA);
+    private final BoosterStructure F11 = new BoosterStructure(commonB, foilRareB);
+    private final BoosterStructure F12 = new BoosterStructure(commonC, foilUncommonA);
+    private final BoosterStructure F13 = new BoosterStructure(commonC, foilUncommonB);
+    private final BoosterStructure F14 = new BoosterStructure(commonC, foilRareA);
+    private final BoosterStructure F15 = new BoosterStructure(commonC, foilRareB);
+    private final BoosterStructure F16 = new BoosterStructure(foilUncommonA, foilUncommonB);
+    private final BoosterStructure F17 = new BoosterStructure(foilUncommonA, foilRareA);
+    private final BoosterStructure F18 = new BoosterStructure(foilUncommonA, foilRareB);
+    private final BoosterStructure F19 = new BoosterStructure(foilUncommonB, foilRareA);
+    private final BoosterStructure F20 = new BoosterStructure(foilUncommonB, foilRareB);
+    private final BoosterStructure F21 = new BoosterStructure(foilRareA, foilRareB);
 
     private final RarityConfiguration commonRuns = new RarityConfiguration(
-            false,
-            DoubleMastersStructure.C1, DoubleMastersStructure.C2, DoubleMastersStructure.C1, DoubleMastersStructure.C2,
-            DoubleMastersStructure.C1, DoubleMastersStructure.C2, DoubleMastersStructure.C1, DoubleMastersStructure.C2,
-            DoubleMastersStructure.C1, DoubleMastersStructure.C2, DoubleMastersStructure.C1, DoubleMastersStructure.C2,
-            DoubleMastersStructure.C1, DoubleMastersStructure.C2, DoubleMastersStructure.C1, DoubleMastersStructure.C2,
-            DoubleMastersStructure.C1, DoubleMastersStructure.C2, DoubleMastersStructure.C1, DoubleMastersStructure.C2,
-            DoubleMastersStructure.C1, DoubleMastersStructure.C2, DoubleMastersStructure.C1, DoubleMastersStructure.C2,
-            DoubleMastersStructure.C1, DoubleMastersStructure.C2, DoubleMastersStructure.C1, DoubleMastersStructure.C2,
-            DoubleMastersStructure.C1, DoubleMastersStructure.C2, DoubleMastersStructure.C1, DoubleMastersStructure.C2,
-            DoubleMastersStructure.C1, DoubleMastersStructure.C2, DoubleMastersStructure.C1, DoubleMastersStructure.C2,
-            DoubleMastersStructure.C1, DoubleMastersStructure.C2, DoubleMastersStructure.C1, DoubleMastersStructure.C2,
-            DoubleMastersStructure.C1, DoubleMastersStructure.C2, DoubleMastersStructure.C1, DoubleMastersStructure.C2,
-            DoubleMastersStructure.C3, DoubleMastersStructure.C3, DoubleMastersStructure.C3
+            C1, C2, C1, C2,
+            C1, C2, C1, C2,
+            C1, C2, C1, C2,
+            C1, C2, C1, C2,
+            C1, C2, C1, C2,
+            C1, C2, C1, C2,
+            C1, C2, C1, C2,
+            C1, C2, C1, C2,
+            C1, C2, C1, C2,
+            C1, C2, C1, C2,
+            C1, C2, C1, C2,
+            C3, C3, C3
     );
     private final RarityConfiguration uncommonRuns = new RarityConfiguration(
-            DoubleMastersStructure.U1, DoubleMastersStructure.U2
+            U1, U2
     );
     private final RarityConfiguration rareRuns = new RarityConfiguration(
-            false,
-            DoubleMastersStructure.R1, DoubleMastersStructure.R2, DoubleMastersStructure.R3,
-            DoubleMastersStructure.R4, DoubleMastersStructure.R5, DoubleMastersStructure.R6
+            R1, R2, R3,
+            R4, R5, R6
     );
     private final RarityConfiguration foilRuns = new RarityConfiguration(
-            false,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
-            DoubleMastersStructure.F01, DoubleMastersStructure.F01, DoubleMastersStructure.F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
+            F01, F01, F01,
 
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
-            DoubleMastersStructure.F02, DoubleMastersStructure.F02, DoubleMastersStructure.F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
+            F02, F02, F02,
 
-            DoubleMastersStructure.F03, DoubleMastersStructure.F03, DoubleMastersStructure.F03,
-            DoubleMastersStructure.F03, DoubleMastersStructure.F03, DoubleMastersStructure.F03,
-            DoubleMastersStructure.F03, DoubleMastersStructure.F03, DoubleMastersStructure.F03,
-            DoubleMastersStructure.F03, DoubleMastersStructure.F03, DoubleMastersStructure.F03,
-            DoubleMastersStructure.F03, DoubleMastersStructure.F03, DoubleMastersStructure.F03,
-            DoubleMastersStructure.F03,
+            F03, F03, F03,
+            F03, F03, F03,
+            F03, F03, F03,
+            F03, F03, F03,
+            F03, F03, F03,
+            F03,
 
-            DoubleMastersStructure.F04, DoubleMastersStructure.F04, DoubleMastersStructure.F04,
-            DoubleMastersStructure.F04, DoubleMastersStructure.F04, DoubleMastersStructure.F04,
-            DoubleMastersStructure.F04, DoubleMastersStructure.F04, DoubleMastersStructure.F04,
-            DoubleMastersStructure.F04, DoubleMastersStructure.F04, DoubleMastersStructure.F04,
-            DoubleMastersStructure.F04, DoubleMastersStructure.F04, DoubleMastersStructure.F04,
-            DoubleMastersStructure.F04,
+            F04, F04, F04,
+            F04, F04, F04,
+            F04, F04, F04,
+            F04, F04, F04,
+            F04, F04, F04,
+            F04,
 
-            DoubleMastersStructure.F05, DoubleMastersStructure.F05, DoubleMastersStructure.F05,
-            DoubleMastersStructure.F05, DoubleMastersStructure.F05, DoubleMastersStructure.F05,
-            DoubleMastersStructure.F05, DoubleMastersStructure.F05,
+            F05, F05, F05,
+            F05, F05, F05,
+            F05, F05,
 
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
-            DoubleMastersStructure.F07, DoubleMastersStructure.F07, DoubleMastersStructure.F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
+            F07, F07, F07,
 
-            DoubleMastersStructure.F08, DoubleMastersStructure.F08, DoubleMastersStructure.F08,
-            DoubleMastersStructure.F08, DoubleMastersStructure.F08, DoubleMastersStructure.F08,
-            DoubleMastersStructure.F08, DoubleMastersStructure.F08, DoubleMastersStructure.F08,
-            DoubleMastersStructure.F08, DoubleMastersStructure.F08, DoubleMastersStructure.F08,
-            DoubleMastersStructure.F08, DoubleMastersStructure.F08, DoubleMastersStructure.F08,
-            DoubleMastersStructure.F08,
+            F08, F08, F08,
+            F08, F08, F08,
+            F08, F08, F08,
+            F08, F08, F08,
+            F08, F08, F08,
+            F08,
 
-            DoubleMastersStructure.F09, DoubleMastersStructure.F09, DoubleMastersStructure.F09,
-            DoubleMastersStructure.F09, DoubleMastersStructure.F09, DoubleMastersStructure.F09,
-            DoubleMastersStructure.F09, DoubleMastersStructure.F09, DoubleMastersStructure.F09,
-            DoubleMastersStructure.F09, DoubleMastersStructure.F09, DoubleMastersStructure.F09,
-            DoubleMastersStructure.F09, DoubleMastersStructure.F09, DoubleMastersStructure.F09,
-            DoubleMastersStructure.F09,
+            F09, F09, F09,
+            F09, F09, F09,
+            F09, F09, F09,
+            F09, F09, F09,
+            F09, F09, F09,
+            F09,
 
-            DoubleMastersStructure.F10, DoubleMastersStructure.F10, DoubleMastersStructure.F10,
-            DoubleMastersStructure.F10, DoubleMastersStructure.F10, DoubleMastersStructure.F10,
-            DoubleMastersStructure.F10, DoubleMastersStructure.F10,
+            F10, F10, F10,
+            F10, F10, F10,
+            F10, F10,
 
-            DoubleMastersStructure.F12, DoubleMastersStructure.F12, DoubleMastersStructure.F12,
-            DoubleMastersStructure.F12, DoubleMastersStructure.F12, DoubleMastersStructure.F12,
-            DoubleMastersStructure.F12, DoubleMastersStructure.F12, DoubleMastersStructure.F12,
-            DoubleMastersStructure.F12, DoubleMastersStructure.F12, DoubleMastersStructure.F12,
-            DoubleMastersStructure.F12, DoubleMastersStructure.F12, DoubleMastersStructure.F12,
-            DoubleMastersStructure.F12,
+            F12, F12, F12,
+            F12, F12, F12,
+            F12, F12, F12,
+            F12, F12, F12,
+            F12, F12, F12,
+            F12,
 
-            DoubleMastersStructure.F13, DoubleMastersStructure.F13, DoubleMastersStructure.F13,
-            DoubleMastersStructure.F13, DoubleMastersStructure.F13, DoubleMastersStructure.F13,
-            DoubleMastersStructure.F13, DoubleMastersStructure.F13, DoubleMastersStructure.F13,
-            DoubleMastersStructure.F13, DoubleMastersStructure.F13, DoubleMastersStructure.F13,
-            DoubleMastersStructure.F13, DoubleMastersStructure.F13, DoubleMastersStructure.F13,
-            DoubleMastersStructure.F13,
+            F13, F13, F13,
+            F13, F13, F13,
+            F13, F13, F13,
+            F13, F13, F13,
+            F13, F13, F13,
+            F13,
 
-            DoubleMastersStructure.F14, DoubleMastersStructure.F14, DoubleMastersStructure.F14,
-            DoubleMastersStructure.F14, DoubleMastersStructure.F14, DoubleMastersStructure.F14,
-            DoubleMastersStructure.F14, DoubleMastersStructure.F14,
+            F14, F14, F14,
+            F14, F14, F14,
+            F14, F14,
 
-            DoubleMastersStructure.F16, DoubleMastersStructure.F16, DoubleMastersStructure.F16,
-            DoubleMastersStructure.F16, DoubleMastersStructure.F16, DoubleMastersStructure.F16,
-            DoubleMastersStructure.F16, DoubleMastersStructure.F16, DoubleMastersStructure.F16,
-            DoubleMastersStructure.F16, DoubleMastersStructure.F16, DoubleMastersStructure.F16,
-            DoubleMastersStructure.F16, DoubleMastersStructure.F16, DoubleMastersStructure.F16,
-            DoubleMastersStructure.F16,
+            F16, F16, F16,
+            F16, F16, F16,
+            F16, F16, F16,
+            F16, F16, F16,
+            F16, F16, F16,
+            F16,
 
-            DoubleMastersStructure.F17, DoubleMastersStructure.F17, DoubleMastersStructure.F17,
-            DoubleMastersStructure.F17, DoubleMastersStructure.F17, DoubleMastersStructure.F17,
-            DoubleMastersStructure.F17, DoubleMastersStructure.F17,
+            F17, F17, F17,
+            F17, F17, F17,
+            F17, F17,
 
-            DoubleMastersStructure.F19, DoubleMastersStructure.F19, DoubleMastersStructure.F19,
-            DoubleMastersStructure.F19, DoubleMastersStructure.F19, DoubleMastersStructure.F19,
-            DoubleMastersStructure.F19, DoubleMastersStructure.F19,
+            F19, F19, F19,
+            F19, F19, F19,
+            F19, F19,
 
-            DoubleMastersStructure.F06, DoubleMastersStructure.F11, DoubleMastersStructure.F15,
-            DoubleMastersStructure.F18, DoubleMastersStructure.F20, DoubleMastersStructure.F21
+            F06, F11, F15,
+            F18, F20, F21
     );
-
-    @Override
-    public void shuffle() {
-        commonRuns.shuffle();
-        uncommonRuns.shuffle();
-        rareRuns.shuffle();
-        foilRuns.shuffle();
-    }
 
     @Override
     public List<String> makeBooster() {

--- a/Mage.Sets/src/mage/sets/Kaldheim.java
+++ b/Mage.Sets/src/mage/sets/Kaldheim.java
@@ -30,7 +30,7 @@ public final class Kaldheim extends ExpansionSet {
     private final List<CardInfo> savedSpecialLand = new ArrayList<>();
 
     private Kaldheim() {
-        super("Kaldheim", "KHM", ExpansionSet.buildDate(2021, 2, 5), SetType.EXPANSION, new KaldheimCollator());
+        super("Kaldheim", "KHM", ExpansionSet.buildDate(2021, 2, 5), SetType.EXPANSION);
         this.blockName = "Kaldheim";
         this.hasBasicLands = true;
         this.hasBoosters = true;
@@ -492,101 +492,52 @@ public final class Kaldheim extends ExpansionSet {
         }
         return new ArrayList<>(savedSpecialLand);
     }
+
+    @Override
+    public BoosterCollator createCollator() {
+        return new KaldheimCollator();
+    }
 }
 
 // Booster collation info from https://www.lethe.xyz/mtg/collation/khm.html
 // Using USA collation for common/uncommon and JP for rare/mythic
 class KaldheimCollator implements BoosterCollator {
 
-    private static class KaldheimRun extends CardRun {
-        private static final KaldheimRun commonA = new KaldheimRun(true,  "34","77","136","13","78","149","3","47","127","14","67","140","19","54","124","38","49","147","39","55","157","1","53","141","37","66","126","10","71","155","4","65","121","13","77","136","34","78","127","3","47","149","14","54","124","38","67","140","19","55","147","39","49","157","37","53","141","10","65","155","1","71","121","4","66","126");
-        private static final KaldheimRun commonB = new KaldheimRun(true,  "102","176","87","183","93","184","104","178","117","174","111","171","96","194","84","176","119","180","83","164","89","172","87","175","102","183","104","178","93","174","117","184","111","171","84","194","119","164","96","180","89","176","83","172","102","175","87","178","104","174","93","183","117","171","119","184","84","164","111","194","89","180","96","172","83","175");
-        private static final KaldheimRun commonC1 = new KaldheimRun(true,  "187","152","242","46","173","23","101","246","48","190","32","151","99","68","267","31","91","192","143","57","100","243","105","16","134","42","196","238","187","46","23","242","152","173","48","32","246","190","151","101","31","68","99","267","91","134","105","57","16","192","100","143","243","196","42");
-        private static final KaldheimRun commonC2 = new KaldheimRun(true,  "11","193","95","158","17","239","44","159","129","7","118","85","138","74","165","11","129","193","150","72","5","95","159","74","158","17","85","239","118","138","44","7","238","193","150","165","5","72","158","95","11","44","159","239","129","17","85","74","7","118","5","150","165","138","72");
-        private static final KaldheimRun uncommonA = new KaldheimRun(true,  "215","236","212","208","195","224","332","6","232","18","106","268","209","162","8","76","122","88","182","206","202","62","110","132","200","325","271","211","144","103","215","236","258","56","163","113","28","226","2","58","263","148","232","162","224","208","195","323","268","18","106","6","233","8","76","122","209","88","182","206","202","62","110","132","321","220","271","211","144","258","2","28","263","113","226","103","236","163","56","215","148","58","329","195","6","232","233","18","212","162","268","106","208","103","322","76","122","88","182","206","202","62","110","132","200","220","271","211","144","8","58","28","258","113","56","148","2","263","226","163");
-        private static final KaldheimRun uncommonB = new KaldheimRun(true,  "30","166","75","201","265","222","45","135","256","191","231","235","36","250","316","128","25","247","264","35","97","186","223","59","60","130","216","80","244","259","217","133","64","245","108","189","331","137","116","253","30","166","75","201","265","327","45","128","256","247","235","36","191","25","170","250","135","231","186","35","60","324","97","130","59","264","244","80","328","259","133","217","64","245","108","189","230","137","116","253","30","166","75","201","265","222","45","256","191","235","170","135","36","128","25","247","250","231","35","223","60","130","97","264","216","186","59","244","80","259","217","133","304","245","108","189","230","137","116","253");
-        private static final KaldheimRun rareA = new KaldheimRun(false,  "9","12","20","21","24","26","27","29","43","50","51","52","61","63","69","73","79","82","86","90","92","107","109","112","115","120","123","125","131","142","146","153","156","161","167","169","177","179","181","185","188","197","203","204","205","207","210","213","214","219","227","228","229","234","237","240","241","251","252","254","255","260","272","275","9","12","20","21","24","26","27","29","43","50","51","52","61","63","69","73","79","82","86","90","92","107","109","112","115","120","123","125","131","142","146","153","156","161","167","169","177","179","181","185","188","197","203","204","205","207","210","213","214","219","227","228","229","234","237","240","241","251","252","254","255","260","272","275","15","22","33","40","41","70","81","94","98","114","139","145","154","160","168","198","199","218","221","225");
-        private static final KaldheimRun rareB = new KaldheimRun(false,  "9","12","20","300","24","26","27","301","43","303","51","52","61","63","69","73","79","82","86","90","306","107","109","307","309","310","311","125","131","312","146","153","156","161","167","315","177","317","318","185","188","319","203","204","205","207","210","213","214","219","227","330","229","234","237","240","241","290","291","292","255","293","272","275","9","12","20","300","24","26","27","301","43","303","51","52","61","63","69","73","79","82","86","90","306","107","109","307","309","310","311","125","131","312","146","153","156","161","167","315","177","317","318","185","188","319","203","204","205","207","210","213","214","219","227","330","229","234","237","240","241","290","291","292","255","293","272","275","299","22","294","302","295","305","81","94","296","308","139","297","313","298","314","287","320","288","326","289");
-        private static final KaldheimRun land = new KaldheimRun(true,  "270","282","248","277","276","280","278","266","270","283","282","285","274","277","281","279","262","284","282","248","283","276","269","276","280","285","281","249","257","284","277","249","281","284","283","266","257","281","269","280","261","276","277","283","249","278","285","248","276","285","279","261","269","257","249","248","283","270","285","277","282","284","270","278","248","279","269","281","274","280","279","257","281","284","277","257","274","273","279","276","262","266","284","281","273","282","278","262","280","279","274","262","282","283","278","262","279","261","285","273","266","283","261","280","284","266","278","270","285","282","280","276","277","273","278","269","273","249","261","274");
+    private final CardRun commonA = new CardRun(true,  "34","77","136","13","78","149","3","47","127","14","67","140","19","54","124","38","49","147","39","55","157","1","53","141","37","66","126","10","71","155","4","65","121","13","77","136","34","78","127","3","47","149","14","54","124","38","67","140","19","55","147","39","49","157","37","53","141","10","65","155","1","71","121","4","66","126");
+    private final CardRun commonB = new CardRun(true,  "102","176","87","183","93","184","104","178","117","174","111","171","96","194","84","176","119","180","83","164","89","172","87","175","102","183","104","178","93","174","117","184","111","171","84","194","119","164","96","180","89","176","83","172","102","175","87","178","104","174","93","183","117","171","119","184","84","164","111","194","89","180","96","172","83","175");
+    private final CardRun commonC1 = new CardRun(true,  "187","152","242","46","173","23","101","246","48","190","32","151","99","68","267","31","91","192","143","57","100","243","105","16","134","42","196","238","187","46","23","242","152","173","48","32","246","190","151","101","31","68","99","267","91","134","105","57","16","192","100","143","243","196","42");
+    private final CardRun commonC2 = new CardRun(true,  "11","193","95","158","17","239","44","159","129","7","118","85","138","74","165","11","129","193","150","72","5","95","159","74","158","17","85","239","118","138","44","7","238","193","150","165","5","72","158","95","11","44","159","239","129","17","85","74","7","118","5","150","165","138","72");
+    private final CardRun uncommonA = new CardRun(true,  "215","236","212","208","195","224","332","6","232","18","106","268","209","162","8","76","122","88","182","206","202","62","110","132","200","325","271","211","144","103","215","236","258","56","163","113","28","226","2","58","263","148","232","162","224","208","195","323","268","18","106","6","233","8","76","122","209","88","182","206","202","62","110","132","321","220","271","211","144","258","2","28","263","113","226","103","236","163","56","215","148","58","329","195","6","232","233","18","212","162","268","106","208","103","322","76","122","88","182","206","202","62","110","132","200","220","271","211","144","8","58","28","258","113","56","148","2","263","226","163");
+    private final CardRun uncommonB = new CardRun(true,  "30","166","75","201","265","222","45","135","256","191","231","235","36","250","316","128","25","247","264","35","97","186","223","59","60","130","216","80","244","259","217","133","64","245","108","189","331","137","116","253","30","166","75","201","265","327","45","128","256","247","235","36","191","25","170","250","135","231","186","35","60","324","97","130","59","264","244","80","328","259","133","217","64","245","108","189","230","137","116","253","30","166","75","201","265","222","45","256","191","235","170","135","36","128","25","247","250","231","35","223","60","130","97","264","216","186","59","244","80","259","217","133","304","245","108","189","230","137","116","253");
+    private final CardRun rareA = new CardRun(false,  "9","12","20","21","24","26","27","29","43","50","51","52","61","63","69","73","79","82","86","90","92","107","109","112","115","120","123","125","131","142","146","153","156","161","167","169","177","179","181","185","188","197","203","204","205","207","210","213","214","219","227","228","229","234","237","240","241","251","252","254","255","260","272","275","9","12","20","21","24","26","27","29","43","50","51","52","61","63","69","73","79","82","86","90","92","107","109","112","115","120","123","125","131","142","146","153","156","161","167","169","177","179","181","185","188","197","203","204","205","207","210","213","214","219","227","228","229","234","237","240","241","251","252","254","255","260","272","275","15","22","33","40","41","70","81","94","98","114","139","145","154","160","168","198","199","218","221","225");
+    private final CardRun rareB = new CardRun(false,  "9","12","20","300","24","26","27","301","43","303","51","52","61","63","69","73","79","82","86","90","306","107","109","307","309","310","311","125","131","312","146","153","156","161","167","315","177","317","318","185","188","319","203","204","205","207","210","213","214","219","227","330","229","234","237","240","241","290","291","292","255","293","272","275","9","12","20","300","24","26","27","301","43","303","51","52","61","63","69","73","79","82","86","90","306","107","109","307","309","310","311","125","131","312","146","153","156","161","167","315","177","317","318","185","188","319","203","204","205","207","210","213","214","219","227","330","229","234","237","240","241","290","291","292","255","293","272","275","299","22","294","302","295","305","81","94","296","308","139","297","313","298","314","287","320","288","326","289");
+    private final CardRun land = new CardRun(true,  "270","282","248","277","276","280","278","266","270","283","282","285","274","277","281","279","262","284","282","248","283","276","269","276","280","285","281","249","257","284","277","249","281","284","283","266","257","281","269","280","261","276","277","283","249","278","285","248","276","285","279","261","269","257","249","248","283","270","285","277","282","284","270","278","248","279","269","281","274","280","279","257","281","284","277","257","274","273","279","276","262","266","284","281","273","282","278","262","280","279","274","262","282","283","278","262","279","261","285","273","266","283","261","280","284","266","278","270","285","282","280","276","277","273","278","269","273","249","261","274");
 
-        private KaldheimRun(boolean keepOrder, String... numbers) {
-            super(keepOrder, numbers);
-        }
-    }
-
-    private static class KaldheimStructure extends BoosterStructure {
-        private static final KaldheimStructure AABBC1C1C1C1C1C1 = new KaldheimStructure(
-                KaldheimRun.commonA,
-                KaldheimRun.commonA,
-                KaldheimRun.commonB,
-                KaldheimRun.commonB,
-                KaldheimRun.commonC1,
-                KaldheimRun.commonC1,
-                KaldheimRun.commonC1,
-                KaldheimRun.commonC1,
-                KaldheimRun.commonC1,
-                KaldheimRun.commonC1
-        );
-        private static final KaldheimStructure AAABBC1C1C1C1C1 = new KaldheimStructure(
-                KaldheimRun.commonA,
-                KaldheimRun.commonA,
-                KaldheimRun.commonA,
-                KaldheimRun.commonB,
-                KaldheimRun.commonB,
-                KaldheimRun.commonC1,
-                KaldheimRun.commonC1,
-                KaldheimRun.commonC1,
-                KaldheimRun.commonC1,
-                KaldheimRun.commonC1
-        );
-        private static final KaldheimStructure AAAABBBC2C2C2 = new KaldheimStructure(
-                KaldheimRun.commonA,
-                KaldheimRun.commonA,
-                KaldheimRun.commonA,
-                KaldheimRun.commonA,
-                KaldheimRun.commonB,
-                KaldheimRun.commonB,
-                KaldheimRun.commonB,
-                KaldheimRun.commonC2,
-                KaldheimRun.commonC2,
-                KaldheimRun.commonC2
-        );
-        private static final KaldheimStructure AAAABBC2C2C2C2 = new KaldheimStructure(
-                KaldheimRun.commonA,
-                KaldheimRun.commonA,
-                KaldheimRun.commonA,
-                KaldheimRun.commonA,
-                KaldheimRun.commonB,
-                KaldheimRun.commonB,
-                KaldheimRun.commonC2,
-                KaldheimRun.commonC2,
-                KaldheimRun.commonC2,
-                KaldheimRun.commonC2
-        );
-        private static final KaldheimStructure AAA = new KaldheimStructure(
-                KaldheimRun.uncommonA,
-                KaldheimRun.uncommonA,
-                KaldheimRun.uncommonA
-        );
-        private static final KaldheimStructure BBB = new KaldheimStructure(
-                KaldheimRun.uncommonB,
-                KaldheimRun.uncommonB,
-                KaldheimRun.uncommonB
-        );
-        private static final KaldheimStructure R1 = new KaldheimStructure(
-                KaldheimRun.rareA
-        );
-        private static final KaldheimStructure R2 = new KaldheimStructure(
-                KaldheimRun.rareB
-        );
-        private static final KaldheimStructure L1 = new KaldheimStructure(
-                KaldheimRun.land
-        );
-
-        private KaldheimStructure(CardRun... runs) {
-            super(runs);
-        }
-    }
+    private final BoosterStructure AABBC1C1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA,
+            commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABBC1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAAABBBC2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBC2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAA = new BoosterStructure(uncommonA, uncommonA, uncommonA);
+    private final BoosterStructure BBB = new BoosterStructure(uncommonB, uncommonB, uncommonB);
+    private final BoosterStructure R1 = new BoosterStructure(rareA);
+    private final BoosterStructure R2 = new BoosterStructure(rareB);
+    private final BoosterStructure L1 = new BoosterStructure(land);
 
     // In order for equal numbers of each common to exist, the average booster must contain:
     // 3.27 A commons (36 / 11)
@@ -596,53 +547,33 @@ class KaldheimCollator implements BoosterCollator {
     // These numbers are the same for all sets with 101 commons in A/B/C1/C2 print runs
     // and with 10 common slots per booster
     private final RarityConfiguration commonRuns = new RarityConfiguration(
-            false,
-            KaldheimStructure.AABBC1C1C1C1C1C1,
-            KaldheimStructure.AABBC1C1C1C1C1C1,
-            KaldheimStructure.AABBC1C1C1C1C1C1,
-            KaldheimStructure.AABBC1C1C1C1C1C1,
-            KaldheimStructure.AABBC1C1C1C1C1C1,
-            KaldheimStructure.AAABBC1C1C1C1C1,
-            KaldheimStructure.AAABBC1C1C1C1C1,
-            KaldheimStructure.AAABBC1C1C1C1C1,
-            KaldheimStructure.AAABBC1C1C1C1C1,
-            KaldheimStructure.AAABBC1C1C1C1C1,
-            KaldheimStructure.AAABBC1C1C1C1C1,
+            AABBC1C1C1C1C1C1,
+            AABBC1C1C1C1C1C1,
+            AABBC1C1C1C1C1C1,
+            AABBC1C1C1C1C1C1,
+            AABBC1C1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
 
-            KaldheimStructure.AAAABBC2C2C2C2,
-            KaldheimStructure.AAAABBC2C2C2C2,
-            KaldheimStructure.AAAABBC2C2C2C2,
-            KaldheimStructure.AAAABBC2C2C2C2,
-            KaldheimStructure.AAAABBC2C2C2C2,
-            KaldheimStructure.AAAABBC2C2C2C2,
-            KaldheimStructure.AAAABBC2C2C2C2,
-            KaldheimStructure.AAAABBBC2C2C2,
-            KaldheimStructure.AAAABBBC2C2C2,
-            KaldheimStructure.AAAABBBC2C2C2,
-            KaldheimStructure.AAAABBBC2C2C2
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2
     );
-    private final RarityConfiguration uncommonRuns = new RarityConfiguration(
-            KaldheimStructure.AAA,
-            KaldheimStructure.BBB
-    );
-    private final RarityConfiguration rareRuns = new RarityConfiguration(
-            false,
-            KaldheimStructure.R1,
-            KaldheimStructure.R1,
-            KaldheimStructure.R2
-    );
-    private final RarityConfiguration landRuns = new RarityConfiguration(
-            KaldheimStructure.L1
-    );
-
-
-    @Override
-    public void shuffle() {
-        commonRuns.shuffle();
-        uncommonRuns.shuffle();
-        rareRuns.shuffle();
-        landRuns.shuffle();
-    }
+    private final RarityConfiguration uncommonRuns = new RarityConfiguration(AAA, BBB);
+    private final RarityConfiguration rareRuns = new RarityConfiguration(R1, R1, R2);
+    private final RarityConfiguration landRuns = new RarityConfiguration(L1);
 
     @Override
     public List<String> makeBooster() {

--- a/Mage.Sets/src/mage/sets/ModernHorizons2.java
+++ b/Mage.Sets/src/mage/sets/ModernHorizons2.java
@@ -26,7 +26,7 @@ public final class ModernHorizons2 extends ExpansionSet {
     }
 
     private ModernHorizons2() {
-        super("Modern Horizons 2", "MH2", ExpansionSet.buildDate(2021, 6, 11), SetType.SUPPLEMENTAL_MODERN_LEGAL, new ModernHorizons2Collator());
+        super("Modern Horizons 2", "MH2", ExpansionSet.buildDate(2021, 6, 11), SetType.SUPPLEMENTAL_MODERN_LEGAL);
         this.blockName = "Modern Horizons 2";
         this.hasBasicLands = true;
         this.hasBoosters = true;
@@ -559,6 +559,11 @@ public final class ModernHorizons2 extends ExpansionSet {
         cards.removeIf(cardInfo -> cardInfo.getCardNumberAsInt() >= 262);
         return cards;
     }
+
+    @Override
+    public BoosterCollator createCollator() {
+        return new ModernHorizons2Collator();
+    }
 }
 
 // Booster collation info from https://www.lethe.xyz/mtg/collation/mh2.html
@@ -566,111 +571,48 @@ public final class ModernHorizons2 extends ExpansionSet {
 // TODO: add reprint variants (waiting on more info for this)
 class ModernHorizons2Collator implements BoosterCollator {
 
-    private static class ModernHorizons2Run extends CardRun {
-        private static final ModernHorizons2Run commonA = new ModernHorizons2Run(true, "62", "134", "38", "156", "136", "168", "43", "170", "145", "65", "154", "112", "49", "169", "131", "51", "155", "144", "46", "181", "114", "40", "173", "111", "57", "159", "140", "54", "149", "139", "62", "161", "136", "38", "168", "134", "63", "146", "156", "65", "145", "170", "43", "131", "169", "51", "114", "154", "49", "112", "155", "46", "140", "181", "40", "144", "173", "63", "139", "159", "57", "111", "161", "54", "146", "149");
-        private static final ModernHorizons2Run commonB = new ModernHorizons2Run(true, "15", "395", "8", "95", "21", "89", "381", "88", "36", "86", "4", "109", "20", "91", "17", "107", "18", "78", "33", "99", "329", "76", "15", "95", "8", "101", "21", "88", "6", "86", "4", "343", "36", "109", "17", "91", "18", "78", "330", "107", "15", "99", "19", "399", "33", "76", "8", "88", "382", "86", "6", "101", "4", "348", "36", "91", "17", "89", "18", "107", "20", "78", "19", "99", "33", "101");
-        private static final ModernHorizons2Run commonC1 = new ModernHorizons2Run(true, "3", "246", "24", "253", "190", "103", "226", "187", "239", "252", "230", "255", "11", "213", "249", "83", "256", "104", "194", "13", "82", "24", "257", "193", "245", "3", "196", "235", "246", "188", "222", "190", "253", "187", "252", "230", "226", "255", "11", "239", "103", "249", "194", "104", "13", "82", "213", "256", "196", "245", "83", "193", "257", "188", "235");
-        private static final ModernHorizons2Run commonC2 = new ModernHorizons2Run(true, "424", "163", "349", "167", "37", "152", "430", "200", "354", "135", "247", "258", "55", "217", "127", "351", "163", "122", "215", "152", "66", "356", "42", "408", "200", "147", "232", "37", "406", "247", "55", "258", "217", "128", "335", "167", "215", "411", "66", "413", "122", "135", "421", "147", "232", "389", "127", "339", "258", "247", "217", "222", "392", "128", "42");
-        private static final ModernHorizons2Run uncommonA = new ModernHorizons2Run(true, "5", "429", "172", "125", "110", "369", "2", "228", "165", "123", "28", "185", "64", "150", "98", "14", "164", "376", "94", "237", "191", "143", "251", "108", "360", "221", "113", "179", "85", "124", "241", "16", "79", "56", "195", "77", "220", "2", "110", "174", "50", "5", "203", "404", "229", "172", "125", "28", "228", "150", "361", "123", "98", "64", "165", "143", "94", "14", "164", "191", "237", "251", "212", "221", "403", "124", "179", "16", "85", "184", "113", "241", "79", "56", "364", "77", "174", "220", "50", "2", "110", "150", "28", "115", "229", "5", "350", "203", "172", "428", "64", "98", "123", "165", "185", "94", "14", "143", "212", "164", "221", "362", "251", "108", "124", "237", "358", "16", "113", "184", "220", "85", "195", "174", "79", "241", "56", "77", "115", "50");
-        private static final ModernHorizons2Run uncommonB = new ModernHorizons2Run(true, "74", "373", "141", "60", "183", "31", "70", "233", "10", "130", "211", "72", "180", "133", "41", "160", "346", "25", "121", "48", "210", "90", "177", "201", "34", "73", "9", "434", "119", "105", "1", "426", "53", "84", "175", "45", "141", "327", "60", "142", "209", "74", "61", "158", "233", "72", "133", "180", "10", "130", "375", "160", "31", "90", "48", "183", "210", "70", "384", "100", "41", "121", "201", "9", "73", "240", "177", "34", "45", "84", "415", "61", "119", "1", "53", "347", "223", "141", "60", "209", "142", "7", "158", "74", "133", "180", "31", "394", "211", "10", "233", "130", "183", "70", "100", "48", "160", "90", "25", "374", "121", "41", "177", "9", "240", "73", "201", "34", "175", "45", "223", "84", "338", "1", "119", "105", "61", "158", "142", "7");
-        private static final ModernHorizons2Run rareA = new ModernHorizons2Run(false, "12", "12", "22", "22", "23", "23", "26", "26", "27", "27", "29", "29", "30", "32", "35", "35", "39", "39", "44", "44", "47", "47", "52", "58", "58", "59", "59", "67", "68", "68", "69", "71", "71", "75", "80", "80", "81", "81", "87", "92", "92", "93", "93", "96", "96", "97", "97", "102", "106", "106", "116", "116", "117", "117", "118", "118", "120", "120", "126", "129", "129", "132", "132", "137", "137", "138", "148", "148", "151", "153", "153", "157", "162", "162", "166", "166", "171", "171", "176", "176", "178", "182", "182", "186", "186", "189", "189", "192", "197", "198", "198", "199", "202", "204", "204", "205", "205", "206", "206", "207", "207", "208", "208", "214", "214", "216", "216", "218", "218", "219", "219", "224", "224", "225", "225", "227", "231", "231", "234", "236", "236", "238", "242", "242", "243", "243", "244", "244", "248", "248", "250", "250", "254", "254", "259", "259", "260", "260", "261", "261");
-        private static final ModernHorizons2Run rareB = new ModernHorizons2Run(false, "328", "328", "331", "331", "332", "332", "333", "334", "334", "336", "336", "337", "340", "340", "341", "341", "342", "344", "344", "345", "345", "352", "352", "353", "353", "355", "355", "357", "357", "359", "359", "363", "365", "366", "366", "367", "368", "370", "370", "371", "371", "372", "372", "377", "377", "378", "378", "379", "380", "380", "383", "383", "385", "385", "386", "386", "388", "388", "390", "390", "391", "391", "393", "396", "396", "397", "397", "398", "398", "400", "400", "401", "401", "402", "405", "405", "407", "407", "409", "409", "410", "412", "412", "414", "414", "417", "417", "418", "418", "420", "422", "422", "425", "425", "427", "427", "431", "432", "432", "433", "435", "435", "436", "436", "437", "437", "438", "438", "439", "439", "440", "440", "441", "441");
-        private static final ModernHorizons2Run rareC = new ModernHorizons2Run(false, "304", "305", "306", "307", "309", "310", "311", "312", "313", "315", "316", "317", "318", "323", "324");
-        private static final ModernHorizons2Run reprint = new ModernHorizons2Run(false, "262", "264", "266", "267", "268", "269", "272", "274", "276", "278", "280", "282", "284", "285", "288", "296", "297", "299", "300", "302", "262", "264", "266", "267", "268", "269", "272", "274", "276", "278", "280", "282", "284", "285", "288", "296", "297", "299", "300", "302", "262", "264", "266", "267", "268", "269", "272", "274", "276", "278", "280", "282", "284", "285", "288", "296", "297", "299", "300", "302", "262", "264", "266", "267", "268", "269", "272", "274", "276", "278", "280", "282", "284", "285", "288", "296", "297", "299", "300", "302", "263", "265", "270", "271", "273", "275", "277", "279", "283", "286", "289", "290", "292", "293", "294", "295", "298", "303", "263", "265", "270", "271", "273", "275", "277", "279", "283", "286", "289", "290", "292", "293", "294", "295", "298", "303", "281", "287", "291", "301");
+    private final CardRun commonA = new CardRun(true, "62", "134", "38", "156", "136", "168", "43", "170", "145", "65", "154", "112", "49", "169", "131", "51", "155", "144", "46", "181", "114", "40", "173", "111", "57", "159", "140", "54", "149", "139", "62", "161", "136", "38", "168", "134", "63", "146", "156", "65", "145", "170", "43", "131", "169", "51", "114", "154", "49", "112", "155", "46", "140", "181", "40", "144", "173", "63", "139", "159", "57", "111", "161", "54", "146", "149");
+    private final CardRun commonB = new CardRun(true, "15", "395", "8", "95", "21", "89", "381", "88", "36", "86", "4", "109", "20", "91", "17", "107", "18", "78", "33", "99", "329", "76", "15", "95", "8", "101", "21", "88", "6", "86", "4", "343", "36", "109", "17", "91", "18", "78", "330", "107", "15", "99", "19", "399", "33", "76", "8", "88", "382", "86", "6", "101", "4", "348", "36", "91", "17", "89", "18", "107", "20", "78", "19", "99", "33", "101");
+    private final CardRun commonC1 = new CardRun(true, "3", "246", "24", "253", "190", "103", "226", "187", "239", "252", "230", "255", "11", "213", "249", "83", "256", "104", "194", "13", "82", "24", "257", "193", "245", "3", "196", "235", "246", "188", "222", "190", "253", "187", "252", "230", "226", "255", "11", "239", "103", "249", "194", "104", "13", "82", "213", "256", "196", "245", "83", "193", "257", "188", "235");
+    private final CardRun commonC2 = new CardRun(true, "424", "163", "349", "167", "37", "152", "430", "200", "354", "135", "247", "258", "55", "217", "127", "351", "163", "122", "215", "152", "66", "356", "42", "408", "200", "147", "232", "37", "406", "247", "55", "258", "217", "128", "335", "167", "215", "411", "66", "413", "122", "135", "421", "147", "232", "389", "127", "339", "258", "247", "217", "222", "392", "128", "42");
+    private final CardRun uncommonA = new CardRun(true, "5", "429", "172", "125", "110", "369", "2", "228", "165", "123", "28", "185", "64", "150", "98", "14", "164", "376", "94", "237", "191", "143", "251", "108", "360", "221", "113", "179", "85", "124", "241", "16", "79", "56", "195", "77", "220", "2", "110", "174", "50", "5", "203", "404", "229", "172", "125", "28", "228", "150", "361", "123", "98", "64", "165", "143", "94", "14", "164", "191", "237", "251", "212", "221", "403", "124", "179", "16", "85", "184", "113", "241", "79", "56", "364", "77", "174", "220", "50", "2", "110", "150", "28", "115", "229", "5", "350", "203", "172", "428", "64", "98", "123", "165", "185", "94", "14", "143", "212", "164", "221", "362", "251", "108", "124", "237", "358", "16", "113", "184", "220", "85", "195", "174", "79", "241", "56", "77", "115", "50");
+    private final CardRun uncommonB = new CardRun(true, "74", "373", "141", "60", "183", "31", "70", "233", "10", "130", "211", "72", "180", "133", "41", "160", "346", "25", "121", "48", "210", "90", "177", "201", "34", "73", "9", "434", "119", "105", "1", "426", "53", "84", "175", "45", "141", "327", "60", "142", "209", "74", "61", "158", "233", "72", "133", "180", "10", "130", "375", "160", "31", "90", "48", "183", "210", "70", "384", "100", "41", "121", "201", "9", "73", "240", "177", "34", "45", "84", "415", "61", "119", "1", "53", "347", "223", "141", "60", "209", "142", "7", "158", "74", "133", "180", "31", "394", "211", "10", "233", "130", "183", "70", "100", "48", "160", "90", "25", "374", "121", "41", "177", "9", "240", "73", "201", "34", "175", "45", "223", "84", "338", "1", "119", "105", "61", "158", "142", "7");
+    private final CardRun rareA = new CardRun(false, "12", "12", "22", "22", "23", "23", "26", "26", "27", "27", "29", "29", "30", "32", "35", "35", "39", "39", "44", "44", "47", "47", "52", "58", "58", "59", "59", "67", "68", "68", "69", "71", "71", "75", "80", "80", "81", "81", "87", "92", "92", "93", "93", "96", "96", "97", "97", "102", "106", "106", "116", "116", "117", "117", "118", "118", "120", "120", "126", "129", "129", "132", "132", "137", "137", "138", "148", "148", "151", "153", "153", "157", "162", "162", "166", "166", "171", "171", "176", "176", "178", "182", "182", "186", "186", "189", "189", "192", "197", "198", "198", "199", "202", "204", "204", "205", "205", "206", "206", "207", "207", "208", "208", "214", "214", "216", "216", "218", "218", "219", "219", "224", "224", "225", "225", "227", "231", "231", "234", "236", "236", "238", "242", "242", "243", "243", "244", "244", "248", "248", "250", "250", "254", "254", "259", "259", "260", "260", "261", "261");
+    private final CardRun rareB = new CardRun(false, "328", "328", "331", "331", "332", "332", "333", "334", "334", "336", "336", "337", "340", "340", "341", "341", "342", "344", "344", "345", "345", "352", "352", "353", "353", "355", "355", "357", "357", "359", "359", "363", "365", "366", "366", "367", "368", "370", "370", "371", "371", "372", "372", "377", "377", "378", "378", "379", "380", "380", "383", "383", "385", "385", "386", "386", "388", "388", "390", "390", "391", "391", "393", "396", "396", "397", "397", "398", "398", "400", "400", "401", "401", "402", "405", "405", "407", "407", "409", "409", "410", "412", "412", "414", "414", "417", "417", "418", "418", "420", "422", "422", "425", "425", "427", "427", "431", "432", "432", "433", "435", "435", "436", "436", "437", "437", "438", "438", "439", "439", "440", "440", "441", "441");
+    private final CardRun rareC = new CardRun(false, "304", "305", "306", "307", "309", "310", "311", "312", "313", "315", "316", "317", "318", "323", "324");
+    private final CardRun reprint = new CardRun(false, "262", "264", "266", "267", "268", "269", "272", "274", "276", "278", "280", "282", "284", "285", "288", "296", "297", "299", "300", "302", "262", "264", "266", "267", "268", "269", "272", "274", "276", "278", "280", "282", "284", "285", "288", "296", "297", "299", "300", "302", "262", "264", "266", "267", "268", "269", "272", "274", "276", "278", "280", "282", "284", "285", "288", "296", "297", "299", "300", "302", "262", "264", "266", "267", "268", "269", "272", "274", "276", "278", "280", "282", "284", "285", "288", "296", "297", "299", "300", "302", "263", "265", "270", "271", "273", "275", "277", "279", "283", "286", "289", "290", "292", "293", "294", "295", "298", "303", "263", "265", "270", "271", "273", "275", "277", "279", "283", "286", "289", "290", "292", "293", "294", "295", "298", "303", "281", "287", "291", "301");
 
-        private ModernHorizons2Run(boolean keepOrder, String... numbers) {
-            super(keepOrder, numbers);
-        }
-    }
-
-    private static class ModernHorizons2Structure extends BoosterStructure {
-        private static final ModernHorizons2Structure AAABC1C1C1C1C1C1 = new ModernHorizons2Structure(
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonB,
-                ModernHorizons2Run.commonC1,
-                ModernHorizons2Run.commonC1,
-                ModernHorizons2Run.commonC1,
-                ModernHorizons2Run.commonC1,
-                ModernHorizons2Run.commonC1,
-                ModernHorizons2Run.commonC1
-        );
-        private static final ModernHorizons2Structure AAABBC1C1C1C1C1 = new ModernHorizons2Structure(
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonB,
-                ModernHorizons2Run.commonB,
-                ModernHorizons2Run.commonC1,
-                ModernHorizons2Run.commonC1,
-                ModernHorizons2Run.commonC1,
-                ModernHorizons2Run.commonC1,
-                ModernHorizons2Run.commonC1
-        );
-        private static final ModernHorizons2Structure AAABBBC2C2C2C2 = new ModernHorizons2Structure(
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonB,
-                ModernHorizons2Run.commonB,
-                ModernHorizons2Run.commonB,
-                ModernHorizons2Run.commonC2,
-                ModernHorizons2Run.commonC2,
-                ModernHorizons2Run.commonC2,
-                ModernHorizons2Run.commonC2
-        );
-        private static final ModernHorizons2Structure AAAABBC2C2C2C2 = new ModernHorizons2Structure(
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonB,
-                ModernHorizons2Run.commonB,
-                ModernHorizons2Run.commonC2,
-                ModernHorizons2Run.commonC2,
-                ModernHorizons2Run.commonC2,
-                ModernHorizons2Run.commonC2
-        );
-        private static final ModernHorizons2Structure AAAABBBC2C2C2 = new ModernHorizons2Structure(
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonA,
-                ModernHorizons2Run.commonB,
-                ModernHorizons2Run.commonB,
-                ModernHorizons2Run.commonB,
-                ModernHorizons2Run.commonC2,
-                ModernHorizons2Run.commonC2,
-                ModernHorizons2Run.commonC2
-        );
-        private static final ModernHorizons2Structure AAA = new ModernHorizons2Structure(
-                ModernHorizons2Run.uncommonA,
-                ModernHorizons2Run.uncommonA,
-                ModernHorizons2Run.uncommonA
-        );
-        private static final ModernHorizons2Structure BBB = new ModernHorizons2Structure(
-                ModernHorizons2Run.uncommonB,
-                ModernHorizons2Run.uncommonB,
-                ModernHorizons2Run.uncommonB
-        );
-        private static final ModernHorizons2Structure R1 = new ModernHorizons2Structure(
-                ModernHorizons2Run.rareA
-        );
-        private static final ModernHorizons2Structure R2 = new ModernHorizons2Structure(
-                ModernHorizons2Run.rareB
-        );
-        private static final ModernHorizons2Structure R3 = new ModernHorizons2Structure(
-                ModernHorizons2Run.rareC
-        );
-        private static final ModernHorizons2Structure RP1 = new ModernHorizons2Structure(
-                ModernHorizons2Run.reprint
-        );
-
-        private ModernHorizons2Structure(CardRun... runs) {
-            super(runs);
-        }
-    }
+    private final BoosterStructure AAABC1C1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1,commonC1
+    );
+    private final BoosterStructure AAABBC1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABBBC2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBC2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBBC2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAA = new BoosterStructure(uncommonA, uncommonA, uncommonA);
+    private final BoosterStructure BBB = new BoosterStructure(uncommonB, uncommonB, uncommonB);
+    private final BoosterStructure R1 = new BoosterStructure(rareA);
+    private final BoosterStructure R2 = new BoosterStructure(rareB);
+    private final BoosterStructure R3 = new BoosterStructure(rareC);
+    private final BoosterStructure RP1 = new BoosterStructure(reprint);
 
     // In order for equal numbers of each common to exist, the average booster must contain:
     // 3.27 A commons (36 / 11)
@@ -680,82 +622,67 @@ class ModernHorizons2Collator implements BoosterCollator {
     // These numbers are the same for all sets with 101 commons in A/B/C1/C2 print runs
     // and with 10 common slots per booster
     private final RarityConfiguration commonRuns = new RarityConfiguration(
-            false,
-            ModernHorizons2Structure.AAABC1C1C1C1C1C1,
-            ModernHorizons2Structure.AAABC1C1C1C1C1C1,
-            ModernHorizons2Structure.AAABC1C1C1C1C1C1,
-            ModernHorizons2Structure.AAABC1C1C1C1C1C1,
-            ModernHorizons2Structure.AAABC1C1C1C1C1C1,
-            ModernHorizons2Structure.AAABBC1C1C1C1C1,
-            ModernHorizons2Structure.AAABBC1C1C1C1C1,
-            ModernHorizons2Structure.AAABBC1C1C1C1C1,
-            ModernHorizons2Structure.AAABBC1C1C1C1C1,
-            ModernHorizons2Structure.AAABBC1C1C1C1C1,
-            ModernHorizons2Structure.AAABBC1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
 
-            ModernHorizons2Structure.AAABBBC2C2C2C2,
-            ModernHorizons2Structure.AAABBBC2C2C2C2,
-            ModernHorizons2Structure.AAABBBC2C2C2C2,
-            ModernHorizons2Structure.AAABBBC2C2C2C2,
-            ModernHorizons2Structure.AAABBBC2C2C2C2,
-            ModernHorizons2Structure.AAAABBC2C2C2C2,
-            ModernHorizons2Structure.AAAABBC2C2C2C2,
-            ModernHorizons2Structure.AAAABBBC2C2C2,
-            ModernHorizons2Structure.AAAABBBC2C2C2,
-            ModernHorizons2Structure.AAAABBBC2C2C2,
-            ModernHorizons2Structure.AAAABBBC2C2C2
+            AAABBBC2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2
     );
-    private final RarityConfiguration uncommonRuns = new RarityConfiguration(
-            ModernHorizons2Structure.AAA,
-            ModernHorizons2Structure.BBB
-    );
+    private final RarityConfiguration uncommonRuns = new RarityConfiguration(AAA, BBB);
     private final RarityConfiguration rareRuns = new RarityConfiguration(
-            false,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1, ModernHorizons2Structure.R1, ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R1,
-            ModernHorizons2Structure.R2, ModernHorizons2Structure.R2,
-            ModernHorizons2Structure.R3
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1, R1, R1,
+            R1,
+            R2, R2,
+            R3
     );
-    private final RarityConfiguration reprintRuns = new RarityConfiguration(
-            ModernHorizons2Structure.RP1
-    );
-
-    @Override
-    public void shuffle() {
-        commonRuns.shuffle();
-        uncommonRuns.shuffle();
-        rareRuns.shuffle();
-        reprintRuns.shuffle();
-    }
+    private final RarityConfiguration reprintRuns = new RarityConfiguration(RP1);
 
     @Override
     public List<String> makeBooster() {

--- a/Mage.Sets/src/mage/sets/RiseOfTheEldrazi.java
+++ b/Mage.Sets/src/mage/sets/RiseOfTheEldrazi.java
@@ -25,7 +25,7 @@ public final class RiseOfTheEldrazi extends ExpansionSet {
     }
 
     private RiseOfTheEldrazi() {
-        super("Rise of the Eldrazi", "ROE", ExpansionSet.buildDate(2010, 3, 17), SetType.EXPANSION, new RiseOfTheEldraziCollator());
+        super("Rise of the Eldrazi", "ROE", ExpansionSet.buildDate(2010, 3, 17), SetType.EXPANSION);
         this.blockName = "Zendikar";
         this.parentSet = Zendikar.getInstance();
         this.hasBoosters = true;
@@ -283,135 +283,66 @@ public final class RiseOfTheEldrazi extends ExpansionSet {
         cards.add(new SetCardInfo("Zof Shade", 132, Rarity.COMMON, mage.cards.z.ZofShade.class));
         cards.add(new SetCardInfo("Zulaport Enforcer", 133, Rarity.COMMON, mage.cards.z.ZulaportEnforcer.class));
     }
+
+    @Override
+    public BoosterCollator createCollator() {
+        return new RiseOfTheEldraziCollator();
+    }
 }
 
 // Booster collation info from https://www.lethe.xyz/mtg/collation/roe.html
 // Using USA collation
 class RiseOfTheEldraziCollator implements BoosterCollator {
-    private static class RiseOfTheEldraziRun extends CardRun {
-        private static final RiseOfTheEldraziRun commonA = new RiseOfTheEldraziRun(true, "153", "16", "186", "60", "228", "148", "111", "145", "29", "213", "72", "110", "138", "36", "174", "133", "88", "222", "56", "138", "42", "203", "142", "121", "223", "88", "213", "43", "97", "56", "145", "222", "111", "187", "29", "149", "60", "16", "148", "74", "186", "130", "41", "133", "166", "223", "65", "36", "203", "149", "110", "142", "41", "65", "228", "187", "97", "72", "153", "42", "130", "174", "43", "166", "74", "121");
-        private static final RiseOfTheEldraziRun commonB = new RiseOfTheEldraziRun(true, "144", "30", "196", "83", "98", "22", "195", "135", "59", "106", "209", "30", "147", "83", "118", "195", "106", "201", "22", "144", "76", "123", "154", "44", "199", "95", "59", "76", "209", "144", "44", "19", "123", "54", "98", "201", "135", "76", "199", "106", "147", "22", "59", "196", "19", "135", "118", "30", "201", "54", "147", "95", "44", "196", "118", "154", "83", "199", "98", "19", "54", "209", "95", "154", "195", "123");
-        private static final RiseOfTheEldraziRun commonC1 = new RiseOfTheEldraziRun(true, "132", "50", "85", "207", "136", "116", "175", "26", "5", "85", "99", "155", "78", "207", "15", "150", "108", "86", "27", "210", "164", "5", "202", "99", "79", "23", "182", "136", "114", "155", "175", "78", "23", "132", "182", "15", "164", "114", "68", "210", "171", "193", "50", "86", "150", "27", "68", "202", "108", "26", "79", "171", "116", "193", "5");
-        private static final RiseOfTheEldraziRun commonC2 = new RiseOfTheEldraziRun(true, "87", "173", "73", "102", "34", "161", "208", "18", "200", "93", "105", "34", "159", "87", "24", "102", "208", "93", "18", "161", "13", "67", "46", "159", "208", "73", "200", "34", "67", "161", "126", "18", "105", "13", "194", "73", "24", "173", "102", "200", "13", "87", "194", "24", "159", "126", "67", "46", "93", "173", "194", "105", "126", "13", "46");
-        private static final RiseOfTheEldraziRun uncommonA = new RiseOfTheEldraziRun(true, "168", "8", "189", "63", "28", "127", "190", "168", "10", "40", "162", "226", "119", "204", "77", "8", "53", "103", "216", "163", "63", "48", "9", "204", "122", "28", "221", "146", "61", "189", "143", "122", "53", "226", "2", "71", "178", "143", "103", "77", "48", "216", "61", "178", "2", "127", "146", "37", "221", "71", "179", "162", "94", "9", "66", "40", "119", "179", "220", "163", "10", "190", "37", "94", "66", "220");
-        private static final RiseOfTheEldraziRun uncommonB = new RiseOfTheEldraziRun(true, "137", "80", "224", "49", "115", "217", "205", "137", "92", "45", "185", "115", "70", "49", "134", "217", "104", "181", "20", "81", "180", "170", "92", "14", "128", "157", "109", "181", "35", "58", "167", "104", "157", "224", "180", "35", "81", "131", "80", "170", "128", "188", "45", "167", "109", "20", "185", "58", "134", "205", "14", "70", "131", "188");
-        private static final RiseOfTheEldraziRun rareA = new RiseOfTheEldraziRun(true, "158", "47", "198", "12", "129", "7", "52", "191", "215", "64", "160", "113", "219", "39", "84", "3", "218", "31", "125", "212", "158", "184", "25", "112", "75", "156", "84", "11", "225", "31", "211", "219", "107", "172", "25", "191", "227", "62", "214", "3", "160", "7", "57", "52", "107", "156", "125", "184", "6", "225", "64", "47", "211", "215", "152", "39", "198", "129", "11", "112", "62", "172", "21", "218", "227", "57");
-        private static final RiseOfTheEldraziRun rareB = new RiseOfTheEldraziRun(true, "38", "176", "91", "139", "140", "183", "117", "51", "90", "169", "124", "177", "100", "55", "38", "141", "197", "89", "206", "117", "151", "17", "1", "82", "96", "140", "69", "183", "100", "169", "192", "197", "165", "90", "17", "91", "101", "139", "4", "124", "32", "176", "141", "69", "177", "82", "33", "151", "96", "206", "101", "89", "165", "32", "120");
-        private static final RiseOfTheEldraziRun land = new RiseOfTheEldraziRun(false, "229", "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248");
-        private RiseOfTheEldraziRun(boolean keepOrder, String... numbers) {
-            super(keepOrder, numbers);
-        }
-    }
+    private final CardRun commonA = new CardRun(true, "153", "16", "186", "60", "228", "148", "111", "145", "29", "213", "72", "110", "138", "36", "174", "133", "88", "222", "56", "138", "42", "203", "142", "121", "223", "88", "213", "43", "97", "56", "145", "222", "111", "187", "29", "149", "60", "16", "148", "74", "186", "130", "41", "133", "166", "223", "65", "36", "203", "149", "110", "142", "41", "65", "228", "187", "97", "72", "153", "42", "130", "174", "43", "166", "74", "121");
+    private final CardRun commonB = new CardRun(true, "144", "30", "196", "83", "98", "22", "195", "135", "59", "106", "209", "30", "147", "83", "118", "195", "106", "201", "22", "144", "76", "123", "154", "44", "199", "95", "59", "76", "209", "144", "44", "19", "123", "54", "98", "201", "135", "76", "199", "106", "147", "22", "59", "196", "19", "135", "118", "30", "201", "54", "147", "95", "44", "196", "118", "154", "83", "199", "98", "19", "54", "209", "95", "154", "195", "123");
+    private final CardRun commonC1 = new CardRun(true, "132", "50", "85", "207", "136", "116", "175", "26", "5", "85", "99", "155", "78", "207", "15", "150", "108", "86", "27", "210", "164", "5", "202", "99", "79", "23", "182", "136", "114", "155", "175", "78", "23", "132", "182", "15", "164", "114", "68", "210", "171", "193", "50", "86", "150", "27", "68", "202", "108", "26", "79", "171", "116", "193", "5");
+    private final CardRun commonC2 = new CardRun(true, "87", "173", "73", "102", "34", "161", "208", "18", "200", "93", "105", "34", "159", "87", "24", "102", "208", "93", "18", "161", "13", "67", "46", "159", "208", "73", "200", "34", "67", "161", "126", "18", "105", "13", "194", "73", "24", "173", "102", "200", "13", "87", "194", "24", "159", "126", "67", "46", "93", "173", "194", "105", "126", "13", "46");
+    private final CardRun uncommonA = new CardRun(true, "168", "8", "189", "63", "28", "127", "190", "168", "10", "40", "162", "226", "119", "204", "77", "8", "53", "103", "216", "163", "63", "48", "9", "204", "122", "28", "221", "146", "61", "189", "143", "122", "53", "226", "2", "71", "178", "143", "103", "77", "48", "216", "61", "178", "2", "127", "146", "37", "221", "71", "179", "162", "94", "9", "66", "40", "119", "179", "220", "163", "10", "190", "37", "94", "66", "220");
+    private final CardRun uncommonB = new CardRun(true, "137", "80", "224", "49", "115", "217", "205", "137", "92", "45", "185", "115", "70", "49", "134", "217", "104", "181", "20", "81", "180", "170", "92", "14", "128", "157", "109", "181", "35", "58", "167", "104", "157", "224", "180", "35", "81", "131", "80", "170", "128", "188", "45", "167", "109", "20", "185", "58", "134", "205", "14", "70", "131", "188");
+    private final CardRun rareA = new CardRun(true, "158", "47", "198", "12", "129", "7", "52", "191", "215", "64", "160", "113", "219", "39", "84", "3", "218", "31", "125", "212", "158", "184", "25", "112", "75", "156", "84", "11", "225", "31", "211", "219", "107", "172", "25", "191", "227", "62", "214", "3", "160", "7", "57", "52", "107", "156", "125", "184", "6", "225", "64", "47", "211", "215", "152", "39", "198", "129", "11", "112", "62", "172", "21", "218", "227", "57");
+    private final CardRun rareB = new CardRun(true, "38", "176", "91", "139", "140", "183", "117", "51", "90", "169", "124", "177", "100", "55", "38", "141", "197", "89", "206", "117", "151", "17", "1", "82", "96", "140", "69", "183", "100", "169", "192", "197", "165", "90", "17", "91", "101", "139", "4", "124", "32", "176", "141", "69", "177", "82", "33", "151", "96", "206", "101", "89", "165", "32", "120");
+    private final CardRun land = new CardRun(false, "229", "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248");
 
-    private static class RiseOfTheEldraziStructure extends BoosterStructure {
-        private static final RiseOfTheEldraziStructure AAABC1C1C1C1C1C1 = new RiseOfTheEldraziStructure(
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonC1,
-                RiseOfTheEldraziRun.commonC1,
-                RiseOfTheEldraziRun.commonC1,
-                RiseOfTheEldraziRun.commonC1,
-                RiseOfTheEldraziRun.commonC1,
-                RiseOfTheEldraziRun.commonC1
-        );
-        private static final RiseOfTheEldraziStructure AAABBC1C1C1C1C1 = new RiseOfTheEldraziStructure(
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonC1,
-                RiseOfTheEldraziRun.commonC1,
-                RiseOfTheEldraziRun.commonC1,
-                RiseOfTheEldraziRun.commonC1,
-                RiseOfTheEldraziRun.commonC1
-        );
-        private static final RiseOfTheEldraziStructure AAABC2C2C2C2C2C2 = new RiseOfTheEldraziStructure(
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2
-        );
-        private static final RiseOfTheEldraziStructure AAABBC2C2C2C2C2 = new RiseOfTheEldraziStructure(
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2
-        );
-        private static final RiseOfTheEldraziStructure AAABBBC2C2C2C2 = new RiseOfTheEldraziStructure(
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2
-        );
-        private static final RiseOfTheEldraziStructure AAAABBBC2C2C2 = new RiseOfTheEldraziStructure(
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2
-        );
-        private static final RiseOfTheEldraziStructure AAAABBBBC2C2 = new RiseOfTheEldraziStructure(
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonA,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonB,
-                RiseOfTheEldraziRun.commonC2,
-                RiseOfTheEldraziRun.commonC2
-        );
-        private static final RiseOfTheEldraziStructure AAB = new RiseOfTheEldraziStructure(
-                RiseOfTheEldraziRun.uncommonA,
-                RiseOfTheEldraziRun.uncommonA,
-                RiseOfTheEldraziRun.uncommonB
-        );
-        private static final RiseOfTheEldraziStructure ABB = new RiseOfTheEldraziStructure(
-                RiseOfTheEldraziRun.uncommonA,
-                RiseOfTheEldraziRun.uncommonB,
-                RiseOfTheEldraziRun.uncommonB
-        );
-        private static final RiseOfTheEldraziStructure R1 = new RiseOfTheEldraziStructure(
-                RiseOfTheEldraziRun.rareA
-        );
-        private static final RiseOfTheEldraziStructure R2 = new RiseOfTheEldraziStructure(
-                RiseOfTheEldraziRun.rareB
-        );
-        private static final RiseOfTheEldraziStructure L1 = new RiseOfTheEldraziStructure(
-                RiseOfTheEldraziRun.land
-        );
-
-        private RiseOfTheEldraziStructure(CardRun... runs) {
-            super(runs);
-        }
-    }
+    private final BoosterStructure AAABC1C1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABBC1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABC2C2C2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB,
+            commonC2, commonC2, commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAABBC2C2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAABBBC2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBBC2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBBBC2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB,
+            commonC2, commonC2
+    );
+    private final BoosterStructure AAB = new BoosterStructure(uncommonA, uncommonA, uncommonB);
+    private final BoosterStructure ABB = new BoosterStructure(uncommonA, uncommonB, uncommonB);
+    private final BoosterStructure R1 = new BoosterStructure(rareA);
+    private final BoosterStructure R2 = new BoosterStructure(rareB);
+    private final BoosterStructure L1 = new BoosterStructure(land);
 
     // In order for equal numbers of each common to exist, the average booster must contain:
     // 3.27 A commons (36 / 11)
@@ -421,83 +352,43 @@ class RiseOfTheEldraziCollator implements BoosterCollator {
     // These numbers are the same as all sets with 101 commons in A/B/C1/C2 print runs
     // The only difference is ROE has two overprinted commons instead of one short-printed
     private final RarityConfiguration commonRuns = new RarityConfiguration(
-            false,
-            RiseOfTheEldraziStructure.AAABC1C1C1C1C1C1,
-            RiseOfTheEldraziStructure.AAABC1C1C1C1C1C1,
-            RiseOfTheEldraziStructure.AAABC1C1C1C1C1C1,
-            RiseOfTheEldraziStructure.AAABC1C1C1C1C1C1,
-            RiseOfTheEldraziStructure.AAABC1C1C1C1C1C1,
-            RiseOfTheEldraziStructure.AAABBC1C1C1C1C1,
-            RiseOfTheEldraziStructure.AAABBC1C1C1C1C1,
-            RiseOfTheEldraziStructure.AAABBC1C1C1C1C1,
-            RiseOfTheEldraziStructure.AAABBC1C1C1C1C1,
-            RiseOfTheEldraziStructure.AAABBC1C1C1C1C1,
-            RiseOfTheEldraziStructure.AAABBC1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
 
-            RiseOfTheEldraziStructure.AAABC2C2C2C2C2C2,
-            RiseOfTheEldraziStructure.AAABBC2C2C2C2C2,
-            RiseOfTheEldraziStructure.AAABBBC2C2C2C2,
-            RiseOfTheEldraziStructure.AAABBBC2C2C2C2,
-            RiseOfTheEldraziStructure.AAABBBC2C2C2C2,
-            RiseOfTheEldraziStructure.AAAABBBC2C2C2,
-            RiseOfTheEldraziStructure.AAAABBBC2C2C2,
-            RiseOfTheEldraziStructure.AAAABBBC2C2C2,
-            RiseOfTheEldraziStructure.AAAABBBC2C2C2,
-            RiseOfTheEldraziStructure.AAAABBBC2C2C2,
-            RiseOfTheEldraziStructure.AAAABBBBC2C2
+            AAABC2C2C2C2C2C2,
+            AAABBC2C2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBBC2C2
     );
     // In order for equal numbers of each uncommon to exist, the average booster must contain:
     // 1.65 A uncommons (33 / 20)
     // 1.35 B uncommons (27 / 20)
     // These numbers are the same for all sets with 60 uncommons in asymmetrical A/B print runs
     private final RarityConfiguration uncommonRuns = new RarityConfiguration(
-            false,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.AAB,
-            RiseOfTheEldraziStructure.ABB,
-            RiseOfTheEldraziStructure.ABB,
-            RiseOfTheEldraziStructure.ABB,
-            RiseOfTheEldraziStructure.ABB,
-            RiseOfTheEldraziStructure.ABB,
-            RiseOfTheEldraziStructure.ABB,
-            RiseOfTheEldraziStructure.ABB
+            AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB,
+            ABB, ABB, ABB, ABB, ABB, ABB, ABB
     );
     private final RarityConfiguration rareRuns = new RarityConfiguration(
-            false,
-            RiseOfTheEldraziStructure.R1,
-            RiseOfTheEldraziStructure.R1,
-            RiseOfTheEldraziStructure.R1,
-            RiseOfTheEldraziStructure.R1,
-            RiseOfTheEldraziStructure.R1,
-            RiseOfTheEldraziStructure.R1,
-            RiseOfTheEldraziStructure.R2,
-            RiseOfTheEldraziStructure.R2,
-            RiseOfTheEldraziStructure.R2,
-            RiseOfTheEldraziStructure.R2,
-            RiseOfTheEldraziStructure.R2
+            R1, R1, R1, R1, R1, R1,
+            R2, R2, R2, R2, R2
     );
-    private final RarityConfiguration landRuns = new RarityConfiguration(
-            RiseOfTheEldraziStructure.L1
-    );
-
-    @Override
-    public void shuffle() {
-        commonRuns.shuffle();
-        uncommonRuns.shuffle();
-        rareRuns.shuffle();
-        landRuns.shuffle();
-    }
+    private final RarityConfiguration landRuns = new RarityConfiguration(L1);
 
     @Override
     public List<String> makeBooster() {

--- a/Mage.Sets/src/mage/sets/StrixhavenSchoolOfMages.java
+++ b/Mage.Sets/src/mage/sets/StrixhavenSchoolOfMages.java
@@ -29,7 +29,7 @@ public final class StrixhavenSchoolOfMages extends ExpansionSet {
     }
 
     private StrixhavenSchoolOfMages() {
-        super("Strixhaven: School of Mages", "STX", ExpansionSet.buildDate(2021, 4, 23), SetType.EXPANSION, new StrixhavenSchoolOfMagesCollator());
+        super("Strixhaven: School of Mages", "STX", ExpansionSet.buildDate(2021, 4, 23), SetType.EXPANSION);
         this.blockName = "Strixhaven: School of Mages";
         this.hasBoosters = true;
         this.hasBasicLands = true;
@@ -479,157 +479,85 @@ public final class StrixhavenSchoolOfMages extends ExpansionSet {
                 .stream()
                 .forEach(cardInfo -> inBoosterMap.put("STA_" + cardInfo.getCardNumber(), cardInfo));
     }
+
+    @Override
+    public BoosterCollator createCollator() {
+        return new StrixhavenSchoolOfMagesCollator();
+    }
 }
 
 // Booster collation info from https://www.lethe.xyz/mtg/collation/stx.html
 // Using Belgian collation plus other info inferred from various sources
 class StrixhavenSchoolOfMagesCollator implements BoosterCollator {
 
-    private static class StrixhavenSchoolOfMagesRun extends CardRun {
-        private static final StrixhavenSchoolOfMagesRun commonA = new StrixhavenSchoolOfMagesRun(true, "249", "206", "182", "226", "237", "255", "210", "209", "239", "226", "251", "185", "219", "243", "206", "164", "215", "238", "256", "184", "239", "208", "254", "237", "185", "223", "251", "206", "166", "182", "164", "238", "204", "233", "184", "210", "182", "252", "243", "254", "208", "194", "255", "243", "249", "201", "204", "194", "235", "239", "166", "251", "223", "252", "237", "208", "233", "241", "219", "255", "201", "194", "164", "252", "170", "223", "241", "215", "166", "249", "237", "238", "184", "210", "243", "209", "235", "252", "204", "210", "185", "233", "249", "256", "239", "235", "209", "170", "201", "226", "241", "215", "206", "256", "208", "254", "185", "251", "226", "170", "184", "256", "235", "233", "209", "238", "254", "219", "201", "241", "182", "164", "194", "223", "170", "204", "166", "219", "215", "255");
-        private static final StrixhavenSchoolOfMagesRun commonB = new StrixhavenSchoolOfMagesRun(true, "79", "9", "111", "136", "52", "85", "12", "118", "131", "40", "90", "34", "117", "141", "60", "69", "30", "93", "140", "36", "74", "16", "97", "143", "40", "87", "11", "99", "121", "39", "75", "30", "106", "122", "38", "79", "22", "97", "131", "51", "90", "23", "112", "145", "50", "87", "18", "103", "124", "43", "68", "34", "102", "142", "49", "77", "16", "93", "140", "52", "73", "32", "116", "144", "60", "63", "22", "109", "124", "55", "69", "9", "106", "143", "39", "73", "23", "116", "142", "61", "84", "8", "99", "122", "43", "74", "32", "117", "145", "36", "75", "19", "112", "141", "61", "77", "8", "109", "144", "50", "84", "18", "118", "137", "55", "68", "12", "111", "121", "38", "63", "19", "103", "136", "51", "85", "11", "102", "137", "49");
-        private static final StrixhavenSchoolOfMagesRun commonC = new StrixhavenSchoolOfMagesRun(false, "263", "268", "270", "271", "273", "275");
-        private static final StrixhavenSchoolOfMagesRun uncommonA = new StrixhavenSchoolOfMagesRun(true, "257", "65", "56", "132", "92", "125", "72", "62", "104", "89", "123", "54", "10", "135", "114", "53", "105", "188", "45", "115", "47", "70", "100", "129", "88", "260", "46", "76", "257", "110", "65", "13", "139", "78", "92", "26", "72", "15", "56", "89", "134", "28", "70", "91", "132", "105", "31", "123", "88", "104", "135", "54", "115", "25", "76", "13", "62", "125", "35", "188", "65", "260", "10", "114", "129", "47", "100", "15", "257", "53", "26", "110", "139", "28", "134", "56", "35", "45", "91", "72", "10", "31", "132", "54", "89", "15", "78", "46", "123", "25", "92", "135", "104", "70", "125", "105", "260", "62", "188", "129", "114", "88", "13", "53", "26", "115", "47", "76", "28", "139", "100", "35", "91", "45", "78", "134", "31", "46", "25", "110");
-        private static final StrixhavenSchoolOfMagesRun uncommonB = new StrixhavenSchoolOfMagesRun(true, "229", "218", "216", "222", "212", "198", "71", "177", "202", "138", "258", "162", "81", "175", "213", "224", "220", "176", "227", "107", "247", "186", "169", "216", "261", "197", "242", "126", "262", "198", "24", "225", "207", "229", "190", "202", "81", "178", "200", "193", "41", "162", "71", "171", "59", "212", "218", "222", "227", "138", "231", "220", "258", "175", "169", "186", "107", "193", "250", "197", "176", "171", "126", "261", "247", "227", "213", "177", "262", "207", "190", "224", "225", "24", "216", "200", "242", "71", "178", "41", "212", "59", "198", "81", "231", "220", "229", "218", "202", "169", "175", "222", "193", "197", "250", "213", "186", "126", "177", "190", "258", "138", "162", "107", "261", "224", "200", "176", "178", "24", "247", "262", "207", "171", "225", "59", "231", "242", "41", "250");
-        private static final StrixhavenSchoolOfMagesRun rareA = new StrixhavenSchoolOfMagesRun(false, "6", "14", "17", "20", "27", "29", "33", "37", "42", "44", "48", "58", "64", "66", "80", "82", "86", "94", "96", "98", "101", "113", "119", "127", "130", "133", "146", "147", "150", "152", "154", "155", "157", "158", "159", "160", "161", "165", "172", "173", "174", "179", "180", "181", "199", "205", "214", "217", "221", "228", "232", "234", "244", "246", "248", "253", "259", "264", "265", "266", "267", "269", "272", "274", "6", "14", "17", "20", "27", "29", "33", "37", "42", "44", "48", "58", "64", "66", "80", "82", "86", "94", "96", "98", "101", "113", "119", "127", "130", "133", "146", "147", "150", "152", "154", "155", "157", "158", "159", "160", "161", "165", "172", "173", "174", "179", "180", "181", "199", "205", "214", "217", "221", "228", "232", "234", "244", "246", "248", "253", "259", "264", "265", "266", "267", "269", "272", "274", "21", "83", "95", "128", "148", "149", "151", "153", "156", "163", "167", "168", "189", "191", "192", "196", "203", "230", "240", "245");
-        private static final StrixhavenSchoolOfMagesRun commonLesson = new StrixhavenSchoolOfMagesRun(true, "4", "187", "183", "195", "211", "3", "1", "236", "2", "187", "195", "4", "183", "211", "1", "2", "236", "3", "183", "187", "4", "195", "2", "211", "3", "1", "236", "187", "183", "195", "4", "1", "211", "3", "2", "236", "187", "4", "183", "195", "3", "1", "2", "211", "236", "187", "195", "4", "183", "2", "1", "211", "3", "187", "183", "4", "236", "195", "1", "3", "211", "236", "2", "187", "4", "195", "183", "3", "211", "1", "2", "236", "187", "4", "195", "183", "211", "3", "1", "2", "236", "183", "195", "4", "187", "1", "211", "3", "2", "236", "187", "4", "195", "183", "2", "211", "3", "1", "187", "236", "4", "183", "195", "211", "1", "236", "3", "2", "195", "187", "183", "4", "2", "236", "3", "211", "1");
-        private static final StrixhavenSchoolOfMagesRun rareLesson = new StrixhavenSchoolOfMagesRun(false, "5", "7", "57", "67", "108", "120", "7", "57", "67", "108", "120");
-        private static final StrixhavenSchoolOfMagesRun uncommonArchive = new StrixhavenSchoolOfMagesRun(true, "18", "29", "19", "41", "4", "57", "46", "23", "35", "3", "20", "49", "37", "30", "41", "24", "9", "44", "4", "29", "3", "46", "35", "18", "57", "41", "9", "19", "24", "44", "51", "30", "23", "37", "18", "49", "20", "29", "4", "19", "35", "46", "51", "23", "30", "18", "57", "3", "37", "49", "41", "24", "9", "44", "20", "4", "23", "37", "30", "3", "35", "46", "57", "29", "9", "29", "49", "19", "51", "44", "4", "24", "41", "18", "46", "3", "20", "57", "19", "35", "44", "23", "24", "9", "51", "30", "49", "37", "20", "51");
-        private static final StrixhavenSchoolOfMagesRun rareArchive = new StrixhavenSchoolOfMagesRun(false, "5", "6", "7", "8", "10", "13", "14", "15", "16", "21", "26", "28", "31", "32", "34", "38", "39", "42", "45", "47", "48", "52", "53", "56", "58", "59", "60", "61", "62", "63", "5", "6", "7", "8", "10", "13", "14", "15", "16", "21", "26", "28", "31", "32", "34", "38", "39", "42", "45", "47", "48", "52", "53", "56", "58", "59", "60", "61", "62", "63", "1", "2", "11", "12", "17", "22", "25", "27", "33", "36", "40", "43", "50", "54", "55");
+    private final CardRun commonA = new CardRun(true, "249", "206", "182", "226", "237", "255", "210", "209", "239", "226", "251", "185", "219", "243", "206", "164", "215", "238", "256", "184", "239", "208", "254", "237", "185", "223", "251", "206", "166", "182", "164", "238", "204", "233", "184", "210", "182", "252", "243", "254", "208", "194", "255", "243", "249", "201", "204", "194", "235", "239", "166", "251", "223", "252", "237", "208", "233", "241", "219", "255", "201", "194", "164", "252", "170", "223", "241", "215", "166", "249", "237", "238", "184", "210", "243", "209", "235", "252", "204", "210", "185", "233", "249", "256", "239", "235", "209", "170", "201", "226", "241", "215", "206", "256", "208", "254", "185", "251", "226", "170", "184", "256", "235", "233", "209", "238", "254", "219", "201", "241", "182", "164", "194", "223", "170", "204", "166", "219", "215", "255");
+    private final CardRun commonB = new CardRun(true, "79", "9", "111", "136", "52", "85", "12", "118", "131", "40", "90", "34", "117", "141", "60", "69", "30", "93", "140", "36", "74", "16", "97", "143", "40", "87", "11", "99", "121", "39", "75", "30", "106", "122", "38", "79", "22", "97", "131", "51", "90", "23", "112", "145", "50", "87", "18", "103", "124", "43", "68", "34", "102", "142", "49", "77", "16", "93", "140", "52", "73", "32", "116", "144", "60", "63", "22", "109", "124", "55", "69", "9", "106", "143", "39", "73", "23", "116", "142", "61", "84", "8", "99", "122", "43", "74", "32", "117", "145", "36", "75", "19", "112", "141", "61", "77", "8", "109", "144", "50", "84", "18", "118", "137", "55", "68", "12", "111", "121", "38", "63", "19", "103", "136", "51", "85", "11", "102", "137", "49");
+    private final CardRun commonC = new CardRun(false, "263", "268", "270", "271", "273", "275");
+    private final CardRun uncommonA = new CardRun(true, "257", "65", "56", "132", "92", "125", "72", "62", "104", "89", "123", "54", "10", "135", "114", "53", "105", "188", "45", "115", "47", "70", "100", "129", "88", "260", "46", "76", "257", "110", "65", "13", "139", "78", "92", "26", "72", "15", "56", "89", "134", "28", "70", "91", "132", "105", "31", "123", "88", "104", "135", "54", "115", "25", "76", "13", "62", "125", "35", "188", "65", "260", "10", "114", "129", "47", "100", "15", "257", "53", "26", "110", "139", "28", "134", "56", "35", "45", "91", "72", "10", "31", "132", "54", "89", "15", "78", "46", "123", "25", "92", "135", "104", "70", "125", "105", "260", "62", "188", "129", "114", "88", "13", "53", "26", "115", "47", "76", "28", "139", "100", "35", "91", "45", "78", "134", "31", "46", "25", "110");
+    private final CardRun uncommonB = new CardRun(true, "229", "218", "216", "222", "212", "198", "71", "177", "202", "138", "258", "162", "81", "175", "213", "224", "220", "176", "227", "107", "247", "186", "169", "216", "261", "197", "242", "126", "262", "198", "24", "225", "207", "229", "190", "202", "81", "178", "200", "193", "41", "162", "71", "171", "59", "212", "218", "222", "227", "138", "231", "220", "258", "175", "169", "186", "107", "193", "250", "197", "176", "171", "126", "261", "247", "227", "213", "177", "262", "207", "190", "224", "225", "24", "216", "200", "242", "71", "178", "41", "212", "59", "198", "81", "231", "220", "229", "218", "202", "169", "175", "222", "193", "197", "250", "213", "186", "126", "177", "190", "258", "138", "162", "107", "261", "224", "200", "176", "178", "24", "247", "262", "207", "171", "225", "59", "231", "242", "41", "250");
+    private final CardRun rareA = new CardRun(false, "6", "14", "17", "20", "27", "29", "33", "37", "42", "44", "48", "58", "64", "66", "80", "82", "86", "94", "96", "98", "101", "113", "119", "127", "130", "133", "146", "147", "150", "152", "154", "155", "157", "158", "159", "160", "161", "165", "172", "173", "174", "179", "180", "181", "199", "205", "214", "217", "221", "228", "232", "234", "244", "246", "248", "253", "259", "264", "265", "266", "267", "269", "272", "274", "6", "14", "17", "20", "27", "29", "33", "37", "42", "44", "48", "58", "64", "66", "80", "82", "86", "94", "96", "98", "101", "113", "119", "127", "130", "133", "146", "147", "150", "152", "154", "155", "157", "158", "159", "160", "161", "165", "172", "173", "174", "179", "180", "181", "199", "205", "214", "217", "221", "228", "232", "234", "244", "246", "248", "253", "259", "264", "265", "266", "267", "269", "272", "274", "21", "83", "95", "128", "148", "149", "151", "153", "156", "163", "167", "168", "189", "191", "192", "196", "203", "230", "240", "245");
+    private final CardRun commonLesson = new CardRun(true, "4", "187", "183", "195", "211", "3", "1", "236", "2", "187", "195", "4", "183", "211", "1", "2", "236", "3", "183", "187", "4", "195", "2", "211", "3", "1", "236", "187", "183", "195", "4", "1", "211", "3", "2", "236", "187", "4", "183", "195", "3", "1", "2", "211", "236", "187", "195", "4", "183", "2", "1", "211", "3", "187", "183", "4", "236", "195", "1", "3", "211", "236", "2", "187", "4", "195", "183", "3", "211", "1", "2", "236", "187", "4", "195", "183", "211", "3", "1", "2", "236", "183", "195", "4", "187", "1", "211", "3", "2", "236", "187", "4", "195", "183", "2", "211", "3", "1", "187", "236", "4", "183", "195", "211", "1", "236", "3", "2", "195", "187", "183", "4", "2", "236", "3", "211", "1");
+    private final CardRun rareLesson = new CardRun(false, "5", "7", "57", "67", "108", "120", "7", "57", "67", "108", "120");
+    private final CardRun uncommonArchive = new CardRun(true, "18", "29", "19", "41", "4", "57", "46", "23", "35", "3", "20", "49", "37", "30", "41", "24", "9", "44", "4", "29", "3", "46", "35", "18", "57", "41", "9", "19", "24", "44", "51", "30", "23", "37", "18", "49", "20", "29", "4", "19", "35", "46", "51", "23", "30", "18", "57", "3", "37", "49", "41", "24", "9", "44", "20", "4", "23", "37", "30", "3", "35", "46", "57", "29", "9", "29", "49", "19", "51", "44", "4", "24", "41", "18", "46", "3", "20", "57", "19", "35", "44", "23", "24", "9", "51", "30", "49", "37", "20", "51");
+    private final CardRun rareArchive = new CardRun(false, "5", "6", "7", "8", "10", "13", "14", "15", "16", "21", "26", "28", "31", "32", "34", "38", "39", "42", "45", "47", "48", "52", "53", "56", "58", "59", "60", "61", "62", "63", "5", "6", "7", "8", "10", "13", "14", "15", "16", "21", "26", "28", "31", "32", "34", "38", "39", "42", "45", "47", "48", "52", "53", "56", "58", "59", "60", "61", "62", "63", "1", "2", "11", "12", "17", "22", "25", "27", "33", "36", "40", "43", "50", "54", "55");
 
-        private StrixhavenSchoolOfMagesRun(boolean keepOrder, String... numbers) {
-            super(keepOrder, numbers);
-        }
-    }
-
-    private static class StrixhavenSchoolOfMagesStructure extends BoosterStructure {
-        private static final StrixhavenSchoolOfMagesStructure AABBBBBBC = new StrixhavenSchoolOfMagesStructure(
-                StrixhavenSchoolOfMagesRun.commonA,
-                StrixhavenSchoolOfMagesRun.commonA,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonC
-        );
-        private static final StrixhavenSchoolOfMagesStructure AAABBBBBC = new StrixhavenSchoolOfMagesStructure(
-                StrixhavenSchoolOfMagesRun.commonA,
-                StrixhavenSchoolOfMagesRun.commonA,
-                StrixhavenSchoolOfMagesRun.commonA,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonC
-        );
-        private static final StrixhavenSchoolOfMagesStructure AAABBBBBB = new StrixhavenSchoolOfMagesStructure(
-                StrixhavenSchoolOfMagesRun.commonA,
-                StrixhavenSchoolOfMagesRun.commonA,
-                StrixhavenSchoolOfMagesRun.commonA,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB,
-                StrixhavenSchoolOfMagesRun.commonB
-        );
-        private static final StrixhavenSchoolOfMagesStructure ABB = new StrixhavenSchoolOfMagesStructure(
-                StrixhavenSchoolOfMagesRun.uncommonA,
-                StrixhavenSchoolOfMagesRun.uncommonB,
-                StrixhavenSchoolOfMagesRun.uncommonB
-        );
-        private static final StrixhavenSchoolOfMagesStructure AAB = new StrixhavenSchoolOfMagesStructure(
-                StrixhavenSchoolOfMagesRun.uncommonA,
-                StrixhavenSchoolOfMagesRun.uncommonA,
-                StrixhavenSchoolOfMagesRun.uncommonB
-        );
-        private static final StrixhavenSchoolOfMagesStructure R1 = new StrixhavenSchoolOfMagesStructure(
-                StrixhavenSchoolOfMagesRun.rareA
-        );
-        private static final StrixhavenSchoolOfMagesStructure L1 = new StrixhavenSchoolOfMagesStructure(
-                StrixhavenSchoolOfMagesRun.commonLesson
-        );
-        private static final StrixhavenSchoolOfMagesStructure L2 = new StrixhavenSchoolOfMagesStructure(
-                StrixhavenSchoolOfMagesRun.rareLesson
-        );
-        private static final StrixhavenSchoolOfMagesStructure A1 = new StrixhavenSchoolOfMagesStructure(
-                StrixhavenSchoolOfMagesRun.uncommonArchive
-        );
-        private static final StrixhavenSchoolOfMagesStructure A2 = new StrixhavenSchoolOfMagesStructure(
-                StrixhavenSchoolOfMagesRun.rareArchive
-        );
-
-        private StrixhavenSchoolOfMagesStructure(CardRun... runs) {
-            super(runs);
-        }
-    }
+    private final BoosterStructure AABBBBBBC = new BoosterStructure(
+            commonA, commonA,
+            commonB, commonB, commonB, commonB, commonB, commonB,
+            commonC
+    );
+    private final BoosterStructure AAABBBBBC = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB, commonB,
+            commonC
+    );
+    private final BoosterStructure AAABBBBBB = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB, commonB, commonB
+    );
+    private final BoosterStructure AAB = new BoosterStructure(uncommonA, uncommonA, uncommonB);
+    private final BoosterStructure ABB = new BoosterStructure(uncommonA, uncommonB, uncommonB);
+    private final BoosterStructure R1 = new BoosterStructure(rareA);
+    private final BoosterStructure L1 = new BoosterStructure(commonLesson);
+    private final BoosterStructure L2 = new BoosterStructure(rareLesson);
+    private final BoosterStructure A1 = new BoosterStructure(uncommonArchive);
+    private final BoosterStructure A2 = new BoosterStructure(rareArchive);
 
     // In order for equal numbers of each common to exist, the average booster must contain:
     // 2.81 A commons (45 / 16)
     // 5.63 B commons (90 / 16)
     // 0.56 C commons ( 9 / 16)
     private final RarityConfiguration commonRuns = new RarityConfiguration(
-            false,
-            StrixhavenSchoolOfMagesStructure.AABBBBBBC,
-            StrixhavenSchoolOfMagesStructure.AABBBBBBC,
-            StrixhavenSchoolOfMagesStructure.AABBBBBBC,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBC,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBC,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBC,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBC,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBC,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBC,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBB,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBB,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBB,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBB,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBB,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBB,
-            StrixhavenSchoolOfMagesStructure.AAABBBBBB
+            AABBBBBBC,
+            AABBBBBBC,
+            AABBBBBBC,
+            AAABBBBBC,
+            AAABBBBBC,
+            AAABBBBBC,
+            AAABBBBBC,
+            AAABBBBBC,
+            AAABBBBBC,
+            AAABBBBBB,
+            AAABBBBBB,
+            AAABBBBBB,
+            AAABBBBBB,
+            AAABBBBBB,
+            AAABBBBBB,
+            AAABBBBBB
     );
-    private final RarityConfiguration uncommonRuns = new RarityConfiguration(
-            StrixhavenSchoolOfMagesStructure.ABB,
-            StrixhavenSchoolOfMagesStructure.AAB
-    );
-    private final RarityConfiguration rareRuns = new RarityConfiguration(
-            StrixhavenSchoolOfMagesStructure.R1
-    );
+    private final RarityConfiguration uncommonRuns = new RarityConfiguration(AAB, ABB);
+    private final RarityConfiguration rareRuns = new RarityConfiguration(R1);
 
     // The ratio of common to rare/mythic Lesson cards hasn't been officially disclosed
     // rare/mythic Lessons were observed in 37 out of 468 packs, which is very close to 2/25
     private final RarityConfiguration lessonRuns = new RarityConfiguration(
-            false,
-            StrixhavenSchoolOfMagesStructure.L1, StrixhavenSchoolOfMagesStructure.L1,
-            StrixhavenSchoolOfMagesStructure.L1, StrixhavenSchoolOfMagesStructure.L1,
-            StrixhavenSchoolOfMagesStructure.L1, StrixhavenSchoolOfMagesStructure.L1,
-            StrixhavenSchoolOfMagesStructure.L1, StrixhavenSchoolOfMagesStructure.L1,
-            StrixhavenSchoolOfMagesStructure.L1, StrixhavenSchoolOfMagesStructure.L1,
-            StrixhavenSchoolOfMagesStructure.L1, StrixhavenSchoolOfMagesStructure.L1,
-            StrixhavenSchoolOfMagesStructure.L1, StrixhavenSchoolOfMagesStructure.L1,
-            StrixhavenSchoolOfMagesStructure.L1, StrixhavenSchoolOfMagesStructure.L1,
-            StrixhavenSchoolOfMagesStructure.L1, StrixhavenSchoolOfMagesStructure.L1,
-            StrixhavenSchoolOfMagesStructure.L1, StrixhavenSchoolOfMagesStructure.L1,
-            StrixhavenSchoolOfMagesStructure.L1, StrixhavenSchoolOfMagesStructure.L1,
-            StrixhavenSchoolOfMagesStructure.L1,
-            StrixhavenSchoolOfMagesStructure.L2, StrixhavenSchoolOfMagesStructure.L2
+            L1, L1, L1, L1, L1,
+            L1, L1, L1, L1, L1,
+            L1, L1, L1, L1, L1,
+            L1, L1, L1, L1, L1,
+            L1, L1, L1, L2, L2
     );
-    private final RarityConfiguration archiveRuns = new RarityConfiguration(
-            false,
-            StrixhavenSchoolOfMagesStructure.A1, StrixhavenSchoolOfMagesStructure.A1,
-            StrixhavenSchoolOfMagesStructure.A2
-    );
-
-    @Override
-    public void shuffle() {
-        commonRuns.shuffle();
-        uncommonRuns.shuffle();
-        rareRuns.shuffle();
-        lessonRuns.shuffle();
-        archiveRuns.shuffle();
-    }
+    private final RarityConfiguration archiveRuns = new RarityConfiguration(A1, A1, A2);
 
     @Override
     public List<String> makeBooster() {

--- a/Mage.Sets/src/mage/sets/TherosBeyondDeath.java
+++ b/Mage.Sets/src/mage/sets/TherosBeyondDeath.java
@@ -23,7 +23,7 @@ public final class TherosBeyondDeath extends ExpansionSet {
     }
 
     private TherosBeyondDeath() {
-        super("Theros Beyond Death", "THB", ExpansionSet.buildDate(2020, 1, 24), SetType.EXPANSION, new TherosBeyondDeathCollator());
+        super("Theros Beyond Death", "THB", ExpansionSet.buildDate(2020, 1, 24), SetType.EXPANSION);
         this.blockName = "Theros Beyond Death";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
@@ -392,113 +392,56 @@ public final class TherosBeyondDeath extends ExpansionSet {
         cards.add(new SetCardInfo("Wolfwillow Haven", 357, Rarity.UNCOMMON, mage.cards.w.WolfwillowHaven.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Wrap in Flames", 164, Rarity.COMMON, mage.cards.w.WrapInFlames.class));
     }
+
+    @Override
+    public BoosterCollator createCollator() {
+        return new TherosBeyondDeathCollator();
+    }
 }
 
 // Booster collation info from https://www.lethe.xyz/mtg/collation/thb.html
 // Using USA collation for common/uncommon, rare collation inferred from other sets
 class TherosBeyondDeathCollator implements BoosterCollator {
+    private final CardRun commonA = new CardRun(true, "155", "29", "79", "127", "38", "57", "159", "41", "66", "140", "30", "78", "163", "28", "56", "137", "25", "68", "144", "20", "67", "146", "26", "49", "134", "40", "61", "159", "29", "51", "164", "17", "57", "149", "38", "66", "127", "30", "47", "144", "36", "79", "155", "41", "67", "137", "28", "78", "140", "25", "56", "163", "20", "49", "146", "40", "68", "134", "17", "51", "149", "26", "47", "164", "36", "61");
+    private final CardRun commonB = new CardRun(true, "186", "85", "191", "116", "201", "103", "202", "115", "184", "120", "194", "110", "192", "88", "177", "113", "171", "86", "195", "109", "179", "114", "202", "85", "201", "103", "184", "116", "186", "115", "192", "110", "191", "114", "177", "120", "194", "88", "171", "113", "179", "86", "195", "109", "201", "85", "184", "116", "202", "110", "186", "103", "191", "115", "192", "114", "179", "113", "194", "109", "195", "86", "177", "88", "171", "120");
+    private final CardRun commonC1 = new CardRun(true, "203", "154", "106", "77", "10", "174", "58", "16", "141", "238", "122", "46", "173", "152", "22", "240", "100", "74", "200", "142", "97", "11", "48", "203", "241", "154", "106", "35", "82", "174", "77", "10", "240", "141", "100", "58", "238", "122", "232", "152", "22", "46", "111", "173", "241", "16", "74", "97", "48", "11", "200", "142", "111", "82", "35");
+    private final CardRun commonC2 = new CardRun(true, "44", "96", "197", "145", "232", "34", "126", "204", "249", "54", "135", "231", "187", "175", "44", "143", "95", "96", "197", "135", "107", "6", "32", "204", "126", "34", "54", "249", "145", "231", "187", "96", "6", "143", "44", "107", "34", "175", "135", "249", "95", "197", "54", "204", "126", "32", "6", "175", "95", "231", "145", "107", "187", "32", "143");
+    private final CardRun uncommonA = new CardRun(true, "223", "65", "153", "8", "112", "227", "99", "167", "33", "138", "4", "189", "228", "45", "59", "180", "105", "1", "136", "196", "206", "139", "83", "89", "233", "31", "131", "91", "219", "193", "27", "133", "64", "199", "213", "264", "42", "153", "205", "8", "136", "4", "189", "33", "223", "2", "138", "112", "27", "233", "260", "180", "31", "59", "99", "131", "105", "267", "81", "139", "228", "167", "133", "219", "65", "1", "83", "125", "206", "193", "42", "91", "227", "89", "199", "153", "8", "81", "213", "64", "112", "223", "4", "136", "205", "105", "139", "99", "65", "2", "180", "228", "59", "1", "233", "45", "189", "227", "33", "196", "83", "138", "206", "42", "219", "167", "131", "31", "89", "193", "91", "125", "213", "199", "81", "27", "2", "64", "133", "205");
+    private final CardRun uncommonB = new CardRun(true, "226", "101", "128", "183", "21", "234", "87", "50", "242", "176", "239", "132", "9", "216", "62", "119", "172", "160", "104", "69", "168", "225", "130", "237", "63", "15", "102", "166", "5", "129", "121", "53", "239", "70", "182", "128", "21", "234", "92", "69", "101", "160", "23", "230", "75", "130", "104", "172", "50", "7", "162", "87", "183", "226", "62", "216", "258", "132", "176", "237", "263", "15", "242", "63", "5", "225", "168", "129", "121", "53", "230", "21", "70", "102", "166", "128", "92", "234", "23", "183", "160", "104", "75", "226", "162", "7", "239", "182", "9", "132", "101", "69", "172", "216", "242", "50", "176", "87", "225", "62", "15", "168", "119", "237", "130", "5", "70", "102", "166", "63", "23", "129", "121", "53", "182", "7", "162", "230", "92", "75");
+    private final CardRun rareA = new CardRun(false, "207", "84", "165", "3", "43", "209", "210", "212", "214", "169", "90", "12", "13", "215", "94", "217", "98", "218", "19", "24", "222", "243", "178", "55", "181", "108", "188", "235", "148", "60", "151", "198", "236", "37", "156", "157", "39", "158", "244", "245", "246", "247", "248", "72", "73", "124", "170", "76", "117", "118", "161", "80", "123", "207", "84", "165", "3", "43", "209", "210", "212", "214", "169", "90", "12", "13", "215", "94", "217", "98", "218", "19", "24", "222", "243", "178", "55", "181", "108", "188", "235", "148", "60", "151", "198", "236", "37", "156", "157", "39", "158", "244", "245", "246", "247", "248", "72", "73", "124", "170", "76", "117", "118", "161", "80", "123", "14", "18", "52", "71", "93", "147", "150", "185", "190", "208", "211", "220", "221", "224", "229");
+    private final CardRun rareB = new CardRun(false, "207", "84", "165", "3", "43", "209", "210", "212", "214", "169", "90", "12", "13", "215", "94", "217", "98", "218", "19", "24", "222", "243", "178", "55", "181", "108", "188", "235", "148", "60", "151", "198", "236", "37", "156", "157", "39", "158", "244", "245", "246", "247", "248", "72", "73", "124", "170", "76", "117", "118", "161", "80", "123", "207", "84", "165", "3", "43", "209", "210", "212", "214", "169", "90", "12", "13", "215", "94", "217", "98", "218", "19", "24", "222", "243", "178", "55", "181", "108", "188", "235", "148", "60", "151", "198", "236", "37", "156", "157", "39", "158", "244", "245", "246", "247", "248", "72", "73", "124", "170", "76", "117", "118", "161", "80", "123", "255", "259", "52", "261", "262", "147", "265", "266", "190", "256", "257", "268", "221", "224", "229");
+    private final CardRun land = new CardRun(false, "250", "251", "252", "253", "254");
 
-    private static class TherosBeyondDeathRun extends CardRun {
-        private static final TherosBeyondDeathRun commonA = new TherosBeyondDeathRun(true, "155", "29", "79", "127", "38", "57", "159", "41", "66", "140", "30", "78", "163", "28", "56", "137", "25", "68", "144", "20", "67", "146", "26", "49", "134", "40", "61", "159", "29", "51", "164", "17", "57", "149", "38", "66", "127", "30", "47", "144", "36", "79", "155", "41", "67", "137", "28", "78", "140", "25", "56", "163", "20", "49", "146", "40", "68", "134", "17", "51", "149", "26", "47", "164", "36", "61");
-        private static final TherosBeyondDeathRun commonB = new TherosBeyondDeathRun(true, "186", "85", "191", "116", "201", "103", "202", "115", "184", "120", "194", "110", "192", "88", "177", "113", "171", "86", "195", "109", "179", "114", "202", "85", "201", "103", "184", "116", "186", "115", "192", "110", "191", "114", "177", "120", "194", "88", "171", "113", "179", "86", "195", "109", "201", "85", "184", "116", "202", "110", "186", "103", "191", "115", "192", "114", "179", "113", "194", "109", "195", "86", "177", "88", "171", "120");
-        private static final TherosBeyondDeathRun commonC1 = new TherosBeyondDeathRun(true, "203", "154", "106", "77", "10", "174", "58", "16", "141", "238", "122", "46", "173", "152", "22", "240", "100", "74", "200", "142", "97", "11", "48", "203", "241", "154", "106", "35", "82", "174", "77", "10", "240", "141", "100", "58", "238", "122", "232", "152", "22", "46", "111", "173", "241", "16", "74", "97", "48", "11", "200", "142", "111", "82", "35");
-        private static final TherosBeyondDeathRun commonC2 = new TherosBeyondDeathRun(true, "44", "96", "197", "145", "232", "34", "126", "204", "249", "54", "135", "231", "187", "175", "44", "143", "95", "96", "197", "135", "107", "6", "32", "204", "126", "34", "54", "249", "145", "231", "187", "96", "6", "143", "44", "107", "34", "175", "135", "249", "95", "197", "54", "204", "126", "32", "6", "175", "95", "231", "145", "107", "187", "32", "143");
-        private static final TherosBeyondDeathRun uncommonA = new TherosBeyondDeathRun(true, "223", "65", "153", "8", "112", "227", "99", "167", "33", "138", "4", "189", "228", "45", "59", "180", "105", "1", "136", "196", "206", "139", "83", "89", "233", "31", "131", "91", "219", "193", "27", "133", "64", "199", "213", "264", "42", "153", "205", "8", "136", "4", "189", "33", "223", "2", "138", "112", "27", "233", "260", "180", "31", "59", "99", "131", "105", "267", "81", "139", "228", "167", "133", "219", "65", "1", "83", "125", "206", "193", "42", "91", "227", "89", "199", "153", "8", "81", "213", "64", "112", "223", "4", "136", "205", "105", "139", "99", "65", "2", "180", "228", "59", "1", "233", "45", "189", "227", "33", "196", "83", "138", "206", "42", "219", "167", "131", "31", "89", "193", "91", "125", "213", "199", "81", "27", "2", "64", "133", "205");
-        private static final TherosBeyondDeathRun uncommonB = new TherosBeyondDeathRun(true, "226", "101", "128", "183", "21", "234", "87", "50", "242", "176", "239", "132", "9", "216", "62", "119", "172", "160", "104", "69", "168", "225", "130", "237", "63", "15", "102", "166", "5", "129", "121", "53", "239", "70", "182", "128", "21", "234", "92", "69", "101", "160", "23", "230", "75", "130", "104", "172", "50", "7", "162", "87", "183", "226", "62", "216", "258", "132", "176", "237", "263", "15", "242", "63", "5", "225", "168", "129", "121", "53", "230", "21", "70", "102", "166", "128", "92", "234", "23", "183", "160", "104", "75", "226", "162", "7", "239", "182", "9", "132", "101", "69", "172", "216", "242", "50", "176", "87", "225", "62", "15", "168", "119", "237", "130", "5", "70", "102", "166", "63", "23", "129", "121", "53", "182", "7", "162", "230", "92", "75");
-        private static final TherosBeyondDeathRun rareA = new TherosBeyondDeathRun(false, "207", "84", "165", "3", "43", "209", "210", "212", "214", "169", "90", "12", "13", "215", "94", "217", "98", "218", "19", "24", "222", "243", "178", "55", "181", "108", "188", "235", "148", "60", "151", "198", "236", "37", "156", "157", "39", "158", "244", "245", "246", "247", "248", "72", "73", "124", "170", "76", "117", "118", "161", "80", "123", "207", "84", "165", "3", "43", "209", "210", "212", "214", "169", "90", "12", "13", "215", "94", "217", "98", "218", "19", "24", "222", "243", "178", "55", "181", "108", "188", "235", "148", "60", "151", "198", "236", "37", "156", "157", "39", "158", "244", "245", "246", "247", "248", "72", "73", "124", "170", "76", "117", "118", "161", "80", "123", "14", "18", "52", "71", "93", "147", "150", "185", "190", "208", "211", "220", "221", "224", "229");
-        private static final TherosBeyondDeathRun rareB = new TherosBeyondDeathRun(false, "207", "84", "165", "3", "43", "209", "210", "212", "214", "169", "90", "12", "13", "215", "94", "217", "98", "218", "19", "24", "222", "243", "178", "55", "181", "108", "188", "235", "148", "60", "151", "198", "236", "37", "156", "157", "39", "158", "244", "245", "246", "247", "248", "72", "73", "124", "170", "76", "117", "118", "161", "80", "123", "207", "84", "165", "3", "43", "209", "210", "212", "214", "169", "90", "12", "13", "215", "94", "217", "98", "218", "19", "24", "222", "243", "178", "55", "181", "108", "188", "235", "148", "60", "151", "198", "236", "37", "156", "157", "39", "158", "244", "245", "246", "247", "248", "72", "73", "124", "170", "76", "117", "118", "161", "80", "123", "255", "259", "52", "261", "262", "147", "265", "266", "190", "256", "257", "268", "221", "224", "229");
-        private static final TherosBeyondDeathRun land = new TherosBeyondDeathRun(false, "250", "251", "252", "253", "254");
-
-        private TherosBeyondDeathRun(boolean keepOrder, String... numbers) {
-            super(keepOrder, numbers);
-        }
-    }
-
-    private static class TherosBeyondDeathStructure extends BoosterStructure {
-        private static final TherosBeyondDeathStructure AABBC1C1C1C1C1C1 = new TherosBeyondDeathStructure(
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonC1,
-                TherosBeyondDeathRun.commonC1,
-                TherosBeyondDeathRun.commonC1,
-                TherosBeyondDeathRun.commonC1,
-                TherosBeyondDeathRun.commonC1,
-                TherosBeyondDeathRun.commonC1
-        );
-        private static final TherosBeyondDeathStructure AAABBC1C1C1C1C1 = new TherosBeyondDeathStructure(
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonC1,
-                TherosBeyondDeathRun.commonC1,
-                TherosBeyondDeathRun.commonC1,
-                TherosBeyondDeathRun.commonC1,
-                TherosBeyondDeathRun.commonC1
-        );
-        private static final TherosBeyondDeathStructure AAAABBC2C2C2C2 = new TherosBeyondDeathStructure(
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonC2,
-                TherosBeyondDeathRun.commonC2,
-                TherosBeyondDeathRun.commonC2,
-                TherosBeyondDeathRun.commonC2
-        );
-        private static final TherosBeyondDeathStructure AAAABBBC2C2C2 = new TherosBeyondDeathStructure(
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonC2,
-                TherosBeyondDeathRun.commonC2,
-                TherosBeyondDeathRun.commonC2
-        );
-        private static final TherosBeyondDeathStructure AAAABBBBC2C2 = new TherosBeyondDeathStructure(
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonA,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonB,
-                TherosBeyondDeathRun.commonC2,
-                TherosBeyondDeathRun.commonC2
-        );
-        private static final TherosBeyondDeathStructure ABB = new TherosBeyondDeathStructure(
-                TherosBeyondDeathRun.uncommonA,
-                TherosBeyondDeathRun.uncommonB,
-                TherosBeyondDeathRun.uncommonB
-        );
-        private static final TherosBeyondDeathStructure AAB = new TherosBeyondDeathStructure(
-                TherosBeyondDeathRun.uncommonA,
-                TherosBeyondDeathRun.uncommonA,
-                TherosBeyondDeathRun.uncommonB
-        );
-        private static final TherosBeyondDeathStructure R1 = new TherosBeyondDeathStructure(
-                TherosBeyondDeathRun.rareA
-        );
-        private static final TherosBeyondDeathStructure R2 = new TherosBeyondDeathStructure(
-                TherosBeyondDeathRun.rareB
-        );
-        private static final TherosBeyondDeathStructure L1 = new TherosBeyondDeathStructure(
-                TherosBeyondDeathRun.land
-        );
-
-        private TherosBeyondDeathStructure(CardRun... runs) {
-            super(runs);
-        }
-    }
+    private final BoosterStructure AABBC1C1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA,
+            commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABBC1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAAABBC2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBBC2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBBBC2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB,
+            commonC2, commonC2
+    );
+    private final BoosterStructure AAB = new BoosterStructure(uncommonA, uncommonA, uncommonB);
+    private final BoosterStructure ABB = new BoosterStructure(uncommonA, uncommonB, uncommonB);
+    private final BoosterStructure R1 = new BoosterStructure(rareA);
+    private final BoosterStructure R2 = new BoosterStructure(rareB);
+    private final BoosterStructure L1 = new BoosterStructure(land);
 
     // In order for equal numbers of each common to exist, the average booster must contain:
     // 3.27 A commons (36 / 11)
@@ -508,53 +451,33 @@ class TherosBeyondDeathCollator implements BoosterCollator {
     // These numbers are the same for all sets with 101 commons in A/B/C1/C2 print runs
     // and with 10 common slots per booster
     private final RarityConfiguration commonRuns = new RarityConfiguration(
-            false,
-            TherosBeyondDeathStructure.AABBC1C1C1C1C1C1,
-            TherosBeyondDeathStructure.AABBC1C1C1C1C1C1,
-            TherosBeyondDeathStructure.AABBC1C1C1C1C1C1,
-            TherosBeyondDeathStructure.AABBC1C1C1C1C1C1,
-            TherosBeyondDeathStructure.AABBC1C1C1C1C1C1,
-            TherosBeyondDeathStructure.AAABBC1C1C1C1C1,
-            TherosBeyondDeathStructure.AAABBC1C1C1C1C1,
-            TherosBeyondDeathStructure.AAABBC1C1C1C1C1,
-            TherosBeyondDeathStructure.AAABBC1C1C1C1C1,
-            TherosBeyondDeathStructure.AAABBC1C1C1C1C1,
-            TherosBeyondDeathStructure.AAABBC1C1C1C1C1,
+            AABBC1C1C1C1C1C1,
+            AABBC1C1C1C1C1C1,
+            AABBC1C1C1C1C1C1,
+            AABBC1C1C1C1C1C1,
+            AABBC1C1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
 
-            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
-            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
-            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
-            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
-            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
-            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
-            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
-            TherosBeyondDeathStructure.AAAABBC2C2C2C2,
-            TherosBeyondDeathStructure.AAAABBBC2C2C2,
-            TherosBeyondDeathStructure.AAAABBBC2C2C2,
-            TherosBeyondDeathStructure.AAAABBBBC2C2
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBC2C2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBBC2C2
     );
-    private final RarityConfiguration uncommonRuns = new RarityConfiguration(
-            TherosBeyondDeathStructure.ABB,
-            TherosBeyondDeathStructure.AAB
-    );
-    private final RarityConfiguration rareRuns = new RarityConfiguration(
-            false,
-            TherosBeyondDeathStructure.R1,
-            TherosBeyondDeathStructure.R1,
-            TherosBeyondDeathStructure.R2
-    );
-    private final RarityConfiguration landRuns = new RarityConfiguration(
-            TherosBeyondDeathStructure.L1
-    );
-
-
-    @Override
-    public void shuffle() {
-        commonRuns.shuffle();
-        uncommonRuns.shuffle();
-        rareRuns.shuffle();
-        landRuns.shuffle();
-    }
+    private final RarityConfiguration uncommonRuns = new RarityConfiguration(AAB, ABB);
+    private final RarityConfiguration rareRuns = new RarityConfiguration(R1, R1, R2);
+    private final RarityConfiguration landRuns = new RarityConfiguration(L1);
 
     @Override
     public List<String> makeBooster() {

--- a/Mage.Sets/src/mage/sets/TimeSpiralRemastered.java
+++ b/Mage.Sets/src/mage/sets/TimeSpiralRemastered.java
@@ -28,7 +28,7 @@ public class TimeSpiralRemastered extends ExpansionSet {
     private final List<CardInfo> savedSpecialBonus = new ArrayList<>();
 
     private TimeSpiralRemastered() {
-        super("Time Spiral Remastered", "TSR", ExpansionSet.buildDate(2021, 3, 19), SetType.SUPPLEMENTAL, new TimeSpiralRemasteredCollator());
+        super("Time Spiral Remastered", "TSR", ExpansionSet.buildDate(2021, 3, 19), SetType.SUPPLEMENTAL);
         this.hasBoosters = true;
         this.hasBasicLands = true;
         this.maxCardNumberInBooster = 410;
@@ -461,121 +461,60 @@ public class TimeSpiralRemastered extends ExpansionSet {
 
         return new ArrayList<>(savedSpecialBonus);
     }
+
+    @Override
+    public BoosterCollator createCollator() {
+        return new TimeSpiralRemasteredCollator();
+    }
 }
 
 // Booster collation info from https://www.lethe.xyz/mtg/collation/tsr.html
 // Using USA collation for common/uncommon, rare and bonus sheet are standard
 class TimeSpiralRemasteredCollator implements BoosterCollator {
 
-    private static class TimeSpiralRemasteredRun extends CardRun {
-        private static final TimeSpiralRemasteredRun commonA = new TimeSpiralRemasteredRun(true, "176", "65", "177", "94", "192", "70", "86", "191", "84", "168", "80", "69", "173", "73", "154", "87", "197", "92", "166", "67", "183", "78", "171", "81", "155", "95", "190", "70", "191", "58", "168", "63", "162", "89", "157", "65", "173", "69", "159", "73", "176", "94", "192", "86", "197", "84", "166", "67", "177", "92", "171", "80", "162", "81", "155", "78", "154", "87", "157", "95", "190", "58", "159", "63", "183", "89");
-        private static final TimeSpiralRemasteredRun commonB = new TimeSpiralRemasteredRun(true, "110", "245", "135", "241", "104", "226", "233", "108", "236", "107", "207", "229", "101", "201", "116", "199", "123", "246", "130", "240", "109", "245", "103", "202", "118", "221", "117", "230", "105", "212", "148", "243", "134", "237", "135", "226", "110", "236", "108", "233", "107", "241", "101", "229", "116", "201", "118", "199", "104", "246", "109", "240", "130", "207", "103", "202", "117", "221", "105", "230", "134", "243", "148", "212", "123", "237");
-        private static final TimeSpiralRemasteredRun commonC1 = new TimeSpiralRemasteredRun(true, "44", "223", "20", "140", "53", "21", "181", "17", "184", "2", "205", "151", "42", "119", "74", "1", "161", "272", "10", "228", "12", "68", "6", "285", "7", "48", "53", "20", "133", "44", "223", "21", "140", "151", "2", "184", "17", "74", "42", "181", "228", "1", "10", "119", "12", "68", "285", "48", "272", "6", "205", "161", "7", "133", "185");
-        private static final TimeSpiralRemasteredRun commonC2 = new TimeSpiralRemasteredRun(true, "25", "147", "31", "64", "269", "47", "206", "43", "178", "132", "263", "18", "200", "59", "26", "145", "9", "66", "50", "14", "147", "28", "232", "49", "122", "71", "22", "25", "165", "132", "31", "206", "43", "47", "269", "64", "18", "178", "200", "26", "263", "59", "9", "145", "14", "66", "50", "165", "28", "122", "232", "22", "49", "71", "185");
-        private static final TimeSpiralRemasteredRun uncommonA = new TimeSpiralRemasteredRun(true, "217", "283", "196", "242", "126", "194", "13", "222", "248", "40", "128", "195", "204", "5", "189", "113", "56", "249", "218", "180", "149", "276", "16", "258", "224", "79", "163", "142", "19", "61", "273", "153", "85", "30", "111", "170", "57", "231", "24", "99", "143", "279", "100", "174", "213", "55", "131", "46", "244", "126", "196", "82", "219", "102", "188", "208", "33", "120", "60", "186", "217", "283", "169", "124", "242", "194", "61", "218", "16", "153", "142", "258", "13", "224", "249", "113", "189", "79", "248", "204", "19", "149", "163", "5", "276", "222", "195", "40", "56", "180", "128", "273", "85", "30", "111", "170", "231", "57", "24", "143", "99", "279", "174", "213", "100", "131", "46", "244", "124", "55", "208", "188", "120", "60", "186", "33", "219", "169", "102", "82");
-        private static final TimeSpiralRemasteredRun uncommonB = new TimeSpiralRemasteredRun(true, "38", "152", "141", "29", "72", "225", "11", "158", "88", "271", "23", "76", "247", "160", "139", "250", "216", "288", "264", "45", "93", "252", "137", "275", "214", "39", "54", "129", "193", "227", "35", "112", "83", "282", "38", "164", "254", "115", "90", "37", "211", "152", "72", "141", "29", "247", "250", "158", "88", "11", "271", "225", "76", "139", "23", "160", "216", "288", "93", "45", "252", "137", "275", "214", "54", "264", "39", "227", "129", "193", "35", "282", "83", "112", "37", "254", "211", "38", "115", "90", "164", "29", "72", "152", "141", "225", "11", "88", "271", "158", "247", "23", "139", "76", "250", "160", "288", "252", "216", "93", "45", "137", "264", "214", "54", "275", "227", "129", "39", "193", "112", "35", "282", "83", "254", "211", "115", "37", "164", "90");
-        private static final TimeSpiralRemasteredRun rare = new TimeSpiralRemasteredRun(false, "3", "4", "8", "27", "32", "34", "41", "51", "62", "75", "77", "96", "97", "98", "114", "125", "127", "136", "138", "144", "146", "156", "167", "172", "175", "179", "182", "187", "203", "209", "215", "220", "234", "238", "239", "251", "253", "255", "256", "257", "259", "260", "265", "266", "268", "270", "274", "277", "278", "281", "284", "286", "287", "3", "4", "8", "27", "32", "34", "41", "51", "62", "75", "77", "96", "97", "98", "114", "125", "127", "136", "138", "144", "146", "156", "167", "172", "175", "179", "182", "187", "203", "209", "215", "220", "234", "238", "239", "251", "253", "255", "256", "257", "259", "260", "265", "266", "268", "270", "274", "277", "278", "281", "284", "286", "287", "15", "36", "52", "91", "106", "121", "150", "198", "210", "235", "261", "262", "267", "280", "289");
-        private static final TimeSpiralRemasteredRun special = new TimeSpiralRemasteredRun(false, "290", "291", "292", "293", "294", "295", "296", "297", "298", "299", "300", "301", "302", "303", "304", "305", "306", "307", "308", "309", "310", "311", "312", "313", "314", "315", "316", "317", "318", "319", "320", "321", "322", "323", "324", "325", "326", "327", "328", "329", "330", "331", "332", "333", "334", "335", "336", "337", "338", "339", "340", "341", "342", "343", "344", "345", "346", "347", "348", "349", "350", "351", "352", "353", "354", "355", "356", "357", "358", "359", "360", "361", "362", "363", "364", "365", "366", "367", "368", "369", "370", "371", "372", "373", "374", "375", "376", "377", "378", "379", "380", "381", "382", "383", "384", "385", "386", "387", "388", "389", "390", "391", "392", "393", "394", "395", "396", "397", "398", "399", "400", "401", "402", "403", "404", "405", "406", "407", "408", "409", "410");
+    private final CardRun commonA = new CardRun(true, "176", "65", "177", "94", "192", "70", "86", "191", "84", "168", "80", "69", "173", "73", "154", "87", "197", "92", "166", "67", "183", "78", "171", "81", "155", "95", "190", "70", "191", "58", "168", "63", "162", "89", "157", "65", "173", "69", "159", "73", "176", "94", "192", "86", "197", "84", "166", "67", "177", "92", "171", "80", "162", "81", "155", "78", "154", "87", "157", "95", "190", "58", "159", "63", "183", "89");
+    private final CardRun commonB = new CardRun(true, "110", "245", "135", "241", "104", "226", "233", "108", "236", "107", "207", "229", "101", "201", "116", "199", "123", "246", "130", "240", "109", "245", "103", "202", "118", "221", "117", "230", "105", "212", "148", "243", "134", "237", "135", "226", "110", "236", "108", "233", "107", "241", "101", "229", "116", "201", "118", "199", "104", "246", "109", "240", "130", "207", "103", "202", "117", "221", "105", "230", "134", "243", "148", "212", "123", "237");
+    private final CardRun commonC1 = new CardRun(true, "44", "223", "20", "140", "53", "21", "181", "17", "184", "2", "205", "151", "42", "119", "74", "1", "161", "272", "10", "228", "12", "68", "6", "285", "7", "48", "53", "20", "133", "44", "223", "21", "140", "151", "2", "184", "17", "74", "42", "181", "228", "1", "10", "119", "12", "68", "285", "48", "272", "6", "205", "161", "7", "133", "185");
+    private final CardRun commonC2 = new CardRun(true, "25", "147", "31", "64", "269", "47", "206", "43", "178", "132", "263", "18", "200", "59", "26", "145", "9", "66", "50", "14", "147", "28", "232", "49", "122", "71", "22", "25", "165", "132", "31", "206", "43", "47", "269", "64", "18", "178", "200", "26", "263", "59", "9", "145", "14", "66", "50", "165", "28", "122", "232", "22", "49", "71", "185");
+    private final CardRun uncommonA = new CardRun(true, "217", "283", "196", "242", "126", "194", "13", "222", "248", "40", "128", "195", "204", "5", "189", "113", "56", "249", "218", "180", "149", "276", "16", "258", "224", "79", "163", "142", "19", "61", "273", "153", "85", "30", "111", "170", "57", "231", "24", "99", "143", "279", "100", "174", "213", "55", "131", "46", "244", "126", "196", "82", "219", "102", "188", "208", "33", "120", "60", "186", "217", "283", "169", "124", "242", "194", "61", "218", "16", "153", "142", "258", "13", "224", "249", "113", "189", "79", "248", "204", "19", "149", "163", "5", "276", "222", "195", "40", "56", "180", "128", "273", "85", "30", "111", "170", "231", "57", "24", "143", "99", "279", "174", "213", "100", "131", "46", "244", "124", "55", "208", "188", "120", "60", "186", "33", "219", "169", "102", "82");
+    private final CardRun uncommonB = new CardRun(true, "38", "152", "141", "29", "72", "225", "11", "158", "88", "271", "23", "76", "247", "160", "139", "250", "216", "288", "264", "45", "93", "252", "137", "275", "214", "39", "54", "129", "193", "227", "35", "112", "83", "282", "38", "164", "254", "115", "90", "37", "211", "152", "72", "141", "29", "247", "250", "158", "88", "11", "271", "225", "76", "139", "23", "160", "216", "288", "93", "45", "252", "137", "275", "214", "54", "264", "39", "227", "129", "193", "35", "282", "83", "112", "37", "254", "211", "38", "115", "90", "164", "29", "72", "152", "141", "225", "11", "88", "271", "158", "247", "23", "139", "76", "250", "160", "288", "252", "216", "93", "45", "137", "264", "214", "54", "275", "227", "129", "39", "193", "112", "35", "282", "83", "254", "211", "115", "37", "164", "90");
+    private final CardRun rare = new CardRun(false, "3", "4", "8", "27", "32", "34", "41", "51", "62", "75", "77", "96", "97", "98", "114", "125", "127", "136", "138", "144", "146", "156", "167", "172", "175", "179", "182", "187", "203", "209", "215", "220", "234", "238", "239", "251", "253", "255", "256", "257", "259", "260", "265", "266", "268", "270", "274", "277", "278", "281", "284", "286", "287", "3", "4", "8", "27", "32", "34", "41", "51", "62", "75", "77", "96", "97", "98", "114", "125", "127", "136", "138", "144", "146", "156", "167", "172", "175", "179", "182", "187", "203", "209", "215", "220", "234", "238", "239", "251", "253", "255", "256", "257", "259", "260", "265", "266", "268", "270", "274", "277", "278", "281", "284", "286", "287", "15", "36", "52", "91", "106", "121", "150", "198", "210", "235", "261", "262", "267", "280", "289");
+    private final CardRun special = new CardRun(false, "290", "291", "292", "293", "294", "295", "296", "297", "298", "299", "300", "301", "302", "303", "304", "305", "306", "307", "308", "309", "310", "311", "312", "313", "314", "315", "316", "317", "318", "319", "320", "321", "322", "323", "324", "325", "326", "327", "328", "329", "330", "331", "332", "333", "334", "335", "336", "337", "338", "339", "340", "341", "342", "343", "344", "345", "346", "347", "348", "349", "350", "351", "352", "353", "354", "355", "356", "357", "358", "359", "360", "361", "362", "363", "364", "365", "366", "367", "368", "369", "370", "371", "372", "373", "374", "375", "376", "377", "378", "379", "380", "381", "382", "383", "384", "385", "386", "387", "388", "389", "390", "391", "392", "393", "394", "395", "396", "397", "398", "399", "400", "401", "402", "403", "404", "405", "406", "407", "408", "409", "410");
 
-        private TimeSpiralRemasteredRun(boolean keepOrder, String... numbers) {
-            super(keepOrder, numbers);
-        }
-    }
-
-    private static class TimeSpiralRemasteredStructure extends BoosterStructure {
-        private static final TimeSpiralRemasteredStructure AAABBBC1C1C1C1 = new TimeSpiralRemasteredStructure(
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonC1,
-                TimeSpiralRemasteredRun.commonC1,
-                TimeSpiralRemasteredRun.commonC1,
-                TimeSpiralRemasteredRun.commonC1
-        );
-        private static final TimeSpiralRemasteredStructure AAABBC1C1C1C1C1 = new TimeSpiralRemasteredStructure(
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonC1,
-                TimeSpiralRemasteredRun.commonC1,
-                TimeSpiralRemasteredRun.commonC1,
-                TimeSpiralRemasteredRun.commonC1,
-                TimeSpiralRemasteredRun.commonC1
-        );
-        private static final TimeSpiralRemasteredStructure AABBBC1C1C1C1C1 = new TimeSpiralRemasteredStructure(
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonC1,
-                TimeSpiralRemasteredRun.commonC1,
-                TimeSpiralRemasteredRun.commonC1,
-                TimeSpiralRemasteredRun.commonC1,
-                TimeSpiralRemasteredRun.commonC1
-        );
-        private static final TimeSpiralRemasteredStructure AAABBBC2C2C2C2 = new TimeSpiralRemasteredStructure(
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonC2,
-                TimeSpiralRemasteredRun.commonC2,
-                TimeSpiralRemasteredRun.commonC2,
-                TimeSpiralRemasteredRun.commonC2
-        );
-        private static final TimeSpiralRemasteredStructure AAABBC2C2C2C2C2 = new TimeSpiralRemasteredStructure(
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonC2,
-                TimeSpiralRemasteredRun.commonC2,
-                TimeSpiralRemasteredRun.commonC2,
-                TimeSpiralRemasteredRun.commonC2,
-                TimeSpiralRemasteredRun.commonC2
-        );
-        private static final TimeSpiralRemasteredStructure AABBBC2C2C2C2C2 = new TimeSpiralRemasteredStructure(
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonA,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonB,
-                TimeSpiralRemasteredRun.commonC2,
-                TimeSpiralRemasteredRun.commonC2,
-                TimeSpiralRemasteredRun.commonC2,
-                TimeSpiralRemasteredRun.commonC2,
-                TimeSpiralRemasteredRun.commonC2
-        );
-        private static final TimeSpiralRemasteredStructure AAA = new TimeSpiralRemasteredStructure(
-                TimeSpiralRemasteredRun.uncommonA,
-                TimeSpiralRemasteredRun.uncommonA,
-                TimeSpiralRemasteredRun.uncommonA
-        );
-        private static final TimeSpiralRemasteredStructure BBB = new TimeSpiralRemasteredStructure(
-                TimeSpiralRemasteredRun.uncommonB,
-                TimeSpiralRemasteredRun.uncommonB,
-                TimeSpiralRemasteredRun.uncommonB
-        );
-        private static final TimeSpiralRemasteredStructure R1 = new TimeSpiralRemasteredStructure(
-                TimeSpiralRemasteredRun.rare
-        );
-        private static final TimeSpiralRemasteredStructure S1 = new TimeSpiralRemasteredStructure(
-                TimeSpiralRemasteredRun.special
-        );
-
-        private TimeSpiralRemasteredStructure(CardRun... runs) {
-            super(runs);
-        }
-    }
+    private final BoosterStructure AAABBBC1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABBC1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AABBBC1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA,
+            commonB, commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABBBC2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAABBC2C2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AABBBC2C2C2C2C2 = new BoosterStructure(
+            commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAA = new BoosterStructure(uncommonA, uncommonA, uncommonA);
+    private final BoosterStructure BBB = new BoosterStructure(uncommonB, uncommonB, uncommonB);
+    private final BoosterStructure R1 = new BoosterStructure(rare);
+    private final BoosterStructure S1 = new BoosterStructure(special);
 
     // In order for equal numbers of each common to exist, the average booster must contain:
     // 2.73 A commons (30 / 11)
@@ -583,53 +522,33 @@ class TimeSpiralRemasteredCollator implements BoosterCollator {
     // 2.27 C1 commons (25 / 11, or 50 / 11 in each C1 booster)
     // 2.27 C2 commons (25 / 11, or 50 / 11 in each C2 booster)
     private final RarityConfiguration commonRuns = new RarityConfiguration(
-            false,
-            TimeSpiralRemasteredStructure.AAABBBC1C1C1C1,
-            TimeSpiralRemasteredStructure.AAABBBC1C1C1C1,
-            TimeSpiralRemasteredStructure.AAABBBC1C1C1C1,
-            TimeSpiralRemasteredStructure.AAABBBC1C1C1C1,
-            TimeSpiralRemasteredStructure.AAABBBC1C1C1C1,
-            TimeSpiralRemasteredStructure.AAABBC1C1C1C1C1,
-            TimeSpiralRemasteredStructure.AAABBC1C1C1C1C1,
-            TimeSpiralRemasteredStructure.AAABBC1C1C1C1C1,
-            TimeSpiralRemasteredStructure.AABBBC1C1C1C1C1,
-            TimeSpiralRemasteredStructure.AABBBC1C1C1C1C1,
-            TimeSpiralRemasteredStructure.AABBBC1C1C1C1C1,
+            AAABBBC1C1C1C1,
+            AAABBBC1C1C1C1,
+            AAABBBC1C1C1C1,
+            AAABBBC1C1C1C1,
+            AAABBBC1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AABBBC1C1C1C1C1,
+            AABBBC1C1C1C1C1,
+            AABBBC1C1C1C1C1,
 
-            TimeSpiralRemasteredStructure.AAABBBC2C2C2C2,
-            TimeSpiralRemasteredStructure.AAABBBC2C2C2C2,
-            TimeSpiralRemasteredStructure.AAABBBC2C2C2C2,
-            TimeSpiralRemasteredStructure.AAABBBC2C2C2C2,
-            TimeSpiralRemasteredStructure.AAABBBC2C2C2C2,
-            TimeSpiralRemasteredStructure.AAABBC2C2C2C2C2,
-            TimeSpiralRemasteredStructure.AAABBC2C2C2C2C2,
-            TimeSpiralRemasteredStructure.AAABBC2C2C2C2C2,
-            TimeSpiralRemasteredStructure.AABBBC2C2C2C2C2,
-            TimeSpiralRemasteredStructure.AABBBC2C2C2C2C2,
-            TimeSpiralRemasteredStructure.AABBBC2C2C2C2C2
+            AAABBBC2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAABBC2C2C2C2C2,
+            AAABBC2C2C2C2C2,
+            AAABBC2C2C2C2C2,
+            AABBBC2C2C2C2C2,
+            AABBBC2C2C2C2C2,
+            AABBBC2C2C2C2C2
     );
-    private final RarityConfiguration uncommonRuns = new RarityConfiguration(
-            false,
-            TimeSpiralRemasteredStructure.AAA,
-            TimeSpiralRemasteredStructure.AAA,
-            TimeSpiralRemasteredStructure.AAA,
-            TimeSpiralRemasteredStructure.BBB,
-            TimeSpiralRemasteredStructure.BBB
-    );
-    private final RarityConfiguration rareRuns = new RarityConfiguration(
-            TimeSpiralRemasteredStructure.R1
-    );
-    private final RarityConfiguration specialRuns = new RarityConfiguration(
-            TimeSpiralRemasteredStructure.S1
-    );
-
-    @Override
-    public void shuffle() {
-        commonRuns.shuffle();
-        uncommonRuns.shuffle();
-        rareRuns.shuffle();
-        specialRuns.shuffle();
-    }
+    private final RarityConfiguration uncommonRuns = new RarityConfiguration(AAA, AAA, AAA, BBB, BBB);
+    private final RarityConfiguration rareRuns = new RarityConfiguration(R1);
+    private final RarityConfiguration specialRuns = new RarityConfiguration(S1);
 
     @Override
     public List<String> makeBooster() {

--- a/Mage/src/main/java/mage/collation/BoosterCollator.java
+++ b/Mage/src/main/java/mage/collation/BoosterCollator.java
@@ -6,8 +6,5 @@ import java.util.List;
  * @author TheElk801
  */
 public interface BoosterCollator {
-
-    public void shuffle();
-
     public List<String> makeBooster();
 }

--- a/Mage/src/main/java/mage/collation/BoosterStructure.java
+++ b/Mage/src/main/java/mage/collation/BoosterStructure.java
@@ -12,11 +12,11 @@ import java.util.List;
  *
  * @author TheElk801
  */
-public abstract class BoosterStructure {
+public class BoosterStructure {
 
     private final List<CardRun> slots;
 
-    protected BoosterStructure(CardRun... runs) {
+    public BoosterStructure(CardRun... runs) {
         this.slots = Arrays.asList(runs);
     }
 
@@ -26,11 +26,5 @@ public abstract class BoosterStructure {
             cards.add(run.getNext());
         }
         return cards;
-    }
-
-    public void shuffle() {
-        for (CardRun run : this.slots) {
-            run.shuffle();
-        }
     }
 }

--- a/Mage/src/main/java/mage/collation/CardRun.java
+++ b/Mage/src/main/java/mage/collation/CardRun.java
@@ -3,7 +3,7 @@ package mage.collation;
 /**
  * @author TheElk801
  */
-public abstract class CardRun extends Rotater<String> {
+public class CardRun extends Rotater<String> {
 
     public CardRun(boolean keepOrder, String... numbers) {
         super(keepOrder, numbers);

--- a/Mage/src/main/java/mage/collation/RarityConfiguration.java
+++ b/Mage/src/main/java/mage/collation/RarityConfiguration.java
@@ -13,15 +13,8 @@ public class RarityConfiguration extends Rotater<BoosterStructure> {
         super(item1, item2);
     }
 
-    public RarityConfiguration(boolean keepOrder, BoosterStructure... items) {
-        super(keepOrder, items);
-    }
-
-    @Override
-    public void shuffle() {
-        for (BoosterStructure structure : this.items) {
-            structure.shuffle();
-        }
-        super.shuffle();
+    public RarityConfiguration(BoosterStructure... items) {
+        // change to false if we ever decide to generate sequential boosters
+        super(true, items);
     }
 }

--- a/Mage/src/main/java/mage/collation/Rotater.java
+++ b/Mage/src/main/java/mage/collation/Rotater.java
@@ -2,6 +2,7 @@ package mage.collation;
 
 import mage.util.RandomUtil;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -13,9 +14,8 @@ import java.util.List;
  */
 public class Rotater<T> {
 
-    protected final List<T> items;
-    private final boolean keepOrder;
-    private int position = 0;
+    private final List<T> items;
+    private int position;
 
     public Rotater(T item) {
         this(true, item);
@@ -26,8 +26,15 @@ public class Rotater<T> {
     }
 
     public Rotater(boolean keepOrder, T... items) {
-        this.items = Arrays.asList(items);
-        this.keepOrder = keepOrder;
+        if (keepOrder) {
+            this.items = Arrays.asList(items);
+            this.position = RandomUtil.nextInt(this.items.size());
+        } else {
+            this.items = new ArrayList<T>();
+            Collections.addAll(this.items, items);
+            Collections.shuffle(this.items, RandomUtil.getRandom());
+            this.position = 0;
+        }
     }
 
     public int iterate() {
@@ -39,12 +46,5 @@ public class Rotater<T> {
 
     public T getNext() {
         return items.get(iterate());
-    }
-
-    public void shuffle() {
-        position = RandomUtil.nextInt(items.size());
-        if (!keepOrder) {
-            Collections.shuffle(items, RandomUtil.getRandom());
-        }
     }
 }


### PR DESCRIPTION
Fixes #8179 as well as the issues discovered by myself and @JayDi85 in the conversation over #8300

* `ExpansionSet` subclasses now Instantiate their `BoosterCollator` via the new method `createCollator` (currently called each time a booster is created) instead of having a persistent instance as a field of the class
* Changed all static fields of BoosterCollator subclasses to non-static so that the above actually does what we want
* Removed superfluous per-set subclasses of `CardRun` and `BoosterStructure` after discussion with @theelk801
* `Rotater` objects (the base class of `CardRun` and `RarityConfiguration`) now randomize/shuffle themselves on construction instead of having a `shuffle` method that you need to call before using them