### PR TITLE
Implement booster collation for ALA, ZEN and SOM

### DIFF
--- a/Mage.Sets/src/mage/sets/RiseOfTheEldrazi.java
+++ b/Mage.Sets/src/mage/sets/RiseOfTheEldrazi.java
@@ -1,4 +1,3 @@
-
 package mage.sets;
 
 import mage.cards.ExpansionSet;
@@ -328,6 +327,11 @@ class RiseOfTheEldraziCollator implements BoosterCollator {
             commonB, commonB, commonB,
             commonC2, commonC2, commonC2, commonC2
     );
+    private final BoosterStructure AAABBBBC2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB,
+            commonC2, commonC2, commonC2
+    );
     private final BoosterStructure AAAABBBC2C2C2 = new BoosterStructure(
             commonA, commonA, commonA, commonA,
             commonB, commonB, commonB,
@@ -366,9 +370,9 @@ class RiseOfTheEldraziCollator implements BoosterCollator {
 
             AAABC2C2C2C2C2C2,
             AAABBC2C2C2C2C2,
+            AAABBC2C2C2C2C2,
             AAABBBC2C2C2C2,
-            AAABBBC2C2C2C2,
-            AAABBBC2C2C2C2,
+            AAABBBBC2C2C2,
             AAAABBBC2C2C2,
             AAAABBBC2C2C2,
             AAAABBBC2C2C2,

--- a/Mage.Sets/src/mage/sets/ScarsOfMirrodin.java
+++ b/Mage.Sets/src/mage/sets/ScarsOfMirrodin.java
@@ -1,9 +1,15 @@
-
 package mage.sets;
 
 import mage.cards.ExpansionSet;
+import mage.collation.BoosterCollator;
+import mage.collation.BoosterStructure;
+import mage.collation.CardRun;
+import mage.collation.RarityConfiguration;
 import mage.constants.Rarity;
 import mage.constants.SetType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
@@ -277,4 +283,124 @@ public final class ScarsOfMirrodin extends ExpansionSet {
         cards.add(new SetCardInfo("Wurmcoil Engine", 223, Rarity.MYTHIC, mage.cards.w.WurmcoilEngine.class));
     }
 
+    @Override
+    public BoosterCollator createCollator() {
+        return new ScarsOfMirrodinCollator();
+    }
+}
+
+// Booster collation info from https://www.lethe.xyz/mtg/collation/som.html
+// Using USA collation
+class ScarsOfMirrodinCollator implements BoosterCollator {
+    private final CardRun commonA = new CardRun(true, "70", "8", "189", "38", "106", "166", "65", "23", "221", "112", "138", "75", "84", "168", "13", "29", "157", "68", "117", "156", "89", "210", "70", "44", "200", "10", "170", "63", "130", "4", "168", "38", "157", "88", "8", "204", "65", "29", "221", "106", "23", "200", "130", "166", "75", "36", "189", "89", "13", "204", "4", "138", "68", "44", "202", "84", "112", "210", "63", "10", "156", "36", "88", "202", "117", "170");
+    private final CardRun commonB = new CardRun(true, "114", "58", "207", "109", "18", "146", "107", "37", "142", "114", "147", "41", "2", "192", "107", "52", "146", "125", "18", "209", "129", "178", "58", "91", "192", "55", "52", "207", "125", "2", "186", "91", "142", "129", "37", "209", "109", "103", "178", "41", "18", "207", "58", "186", "103", "129", "146", "41", "91", "178", "55", "37", "147", "125", "186", "114", "52", "209", "55", "103", "192", "109", "107", "147", "2", "142");
+    private final CardRun commonC1 = new CardRun(true, "116", "54", "184", "97", "15", "160", "113", "51", "203", "54", "153", "82", "21", "155", "120", "45", "187", "60", "97", "153", "46", "15", "133", "45", "165", "227", "92", "184", "31", "7", "60", "116", "187", "227", "96", "219", "51", "21", "191", "120", "77", "165", "82", "219", "133", "92", "203", "46", "77", "155", "113", "7", "96", "31", "191");
+    private final CardRun commonC2 = new CardRun(true, "197", "56", "27", "102", "136", "19", "140", "20", "76", "49", "131", "222", "158", "56", "136", "80", "20", "131", "140", "100", "158", "160", "80", "49", "20", "134", "222", "27", "218", "42", "100", "76", "197", "140", "102", "131", "42", "80", "218", "19", "197", "158", "134", "42", "56", "100", "19", "222", "136", "27", "49", "102", "134", "76", "218");
+    private final CardRun uncommonA = new CardRun(true, "78", "108", "171", "90", "47", "185", "101", "132", "217", "3", "214", "71", "167", "127", "53", "159", "85", "161", "71", "216", "26", "149", "62", "164", "124", "47", "161", "61", "81", "3", "185", "26", "143", "62", "50", "213", "90", "216", "124", "214", "30", "167", "17", "139", "61", "1", "171", "85", "30", "217", "81", "108", "139", "1", "149", "78", "127", "159", "101", "53", "213", "17", "132", "164", "50", "143");
+    private final CardRun uncommonB = new CardRun(true, "59", "151", "115", "9", "211", "40", "144", "59", "198", "83", "174", "128", "48", "199", "5", "9", "152", "148", "67", "99", "151", "34", "16", "211", "174", "87", "115", "198", "40", "74", "181", "215", "83", "111", "190", "34", "162", "16", "144", "67", "152", "111", "181", "87", "148", "5", "74", "199", "128", "190", "99", "215", "48", "162");
+    private final CardRun rareA = new CardRun(true, "180", "95", "119", "201", "177", "66", "122", "14", "205", "226", "220", "43", "223", "95", "121", "69", "212", "22", "183", "229", "173", "28", "73", "194", "33", "98", "205", "25", "179", "224", "182", "122", "93", "201", "22", "180", "43", "64", "188", "229", "212", "119", "145", "28", "69", "194", "14", "135", "163", "93", "183", "224", "220", "25", "39", "188", "66", "182", "121", "98", "145", "73", "11", "226", "163", "33");
+    private final CardRun rareB = new CardRun(true, "154", "104", "225", "193", "24", "172", "118", "105", "175", "72", "169", "228", "141", "208", "35", "150", "86", "126", "118", "12", "195", "176", "72", "32", "137", "105", "123", "150", "24", "196", "225", "141", "57", "154", "206", "6", "228", "104", "110", "137", "126", "175", "35", "169", "94", "195", "172", "57", "12", "86", "206", "79", "110", "196", "32");
+    private final CardRun land = new CardRun(false, "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248", "249");
+
+    private final BoosterStructure AAABC1C1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABBC1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABC2C2C2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB,
+            commonC2, commonC2, commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAABBC2C2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAABBBC2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAABBBBC2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB,
+            commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBBC2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBBBC2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB,
+            commonC2, commonC2
+    );
+    private final BoosterStructure AAB = new BoosterStructure(uncommonA, uncommonA, uncommonB);
+    private final BoosterStructure ABB = new BoosterStructure(uncommonA, uncommonB, uncommonB);
+    private final BoosterStructure R1 = new BoosterStructure(rareA);
+    private final BoosterStructure R2 = new BoosterStructure(rareB);
+    private final BoosterStructure L1 = new BoosterStructure(land);
+
+    // In order for equal numbers of each common to exist, the average booster must contain:
+    // 3.27 A commons (36 / 11)
+    // 2.18 B commons (24 / 11)
+    // 2.73 C1 commons (30 / 11, or 60 / 11 in each C1 booster)
+    // 1.82 C2 commons (20 / 11, or 40 / 11 in each C2 booster)
+    // These numbers are the same for all sets with 101 commons in A/B/C1/C2 print runs
+    // and with 10 common slots per booster
+    private final RarityConfiguration commonRuns = new RarityConfiguration(
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+
+            AAABC2C2C2C2C2C2,
+            AAABBC2C2C2C2C2,
+            AAABBC2C2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAABBBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBBC2C2
+    );
+    // In order for equal numbers of each uncommon to exist, the average booster must contain:
+    // 1.65 A uncommons (33 / 20)
+    // 1.35 B uncommons (27 / 20)
+    // These numbers are the same for all sets with 60 uncommons in asymmetrical A/B print runs
+    private final RarityConfiguration uncommonRuns = new RarityConfiguration(
+            AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB,
+            ABB, ABB, ABB, ABB, ABB, ABB, ABB
+    );
+    private final RarityConfiguration rareRuns = new RarityConfiguration(
+            R1, R1, R1, R1, R1, R1,
+            R2, R2, R2, R2, R2
+    );
+    private final RarityConfiguration landRuns = new RarityConfiguration(L1);
+
+    @Override
+    public List<String> makeBooster() {
+        List<String> booster = new ArrayList<>();
+        booster.addAll(commonRuns.getNext().makeRun());
+        booster.addAll(uncommonRuns.getNext().makeRun());
+        booster.addAll(rareRuns.getNext().makeRun());
+        booster.addAll(landRuns.getNext().makeRun());
+        return booster;
+    }
 }

--- a/Mage.Sets/src/mage/sets/ShardsOfAlara.java
+++ b/Mage.Sets/src/mage/sets/ShardsOfAlara.java
@@ -1,9 +1,15 @@
-
 package mage.sets;
 
 import mage.cards.ExpansionSet;
+import mage.collation.BoosterCollator;
+import mage.collation.BoosterStructure;
+import mage.collation.CardRun;
+import mage.collation.RarityConfiguration;
 import mage.constants.Rarity;
 import mage.constants.SetType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
@@ -278,4 +284,114 @@ public final class ShardsOfAlara extends ExpansionSet {
         cards.add(new SetCardInfo("Yoked Plowbeast", 31, Rarity.COMMON, mage.cards.y.YokedPlowbeast.class));
     }
 
+    @Override
+    public BoosterCollator createCollator() {
+        return new ShardsOfAlaraCollator();
+    }
+}
+
+// Booster collation info from https://www.lethe.xyz/mtg/collation/ala.html
+// Using USA collation
+class ShardsOfAlaraCollator implements BoosterCollator {
+    private final CardRun commonA = new CardRun(true, "134", "116", "42", "18", "71", "195", "126", "118", "32", "11", "92", "128", "116", "37", "31", "65", "165", "126", "110", "46", "22", "74", "127", "115", "62", "30", "67", "165", "147", "104", "59", "18", "92", "144", "118", "42", "1", "73", "195", "128", "111", "59", "11", "65", "134", "104", "62", "22", "71", "176", "144", "115", "46", "30", "73", "127", "110", "32", "31", "74", "176", "147", "111", "37", "1", "67");
+    private final CardRun commonB = new CardRun(true, "189", "130", "93", "28", "198", "47", "136", "203", "88", "12", "169", "102", "130", "26", "93", "153", "61", "86", "203", "47", "28", "139", "207", "130", "97", "88", "198", "26", "61", "203", "36", "24", "86", "189", "136", "93", "12", "153", "102", "87", "207", "36", "28", "88", "169", "139", "97", "24", "189", "61", "136", "153", "47", "26", "87", "198", "139", "102", "24", "169", "36", "86", "207", "12", "97", "87");
+    private final CardRun commonC1 = new CardRun(true, "221", "13", "149", "90", "213", "108", "8", "133", "34", "156", "107", "4", "90", "221", "214", "66", "125", "57", "8", "121", "218", "54", "149", "15", "83", "227", "33", "186", "94", "141", "4", "66", "215", "34", "107", "227", "81", "213", "133", "13", "54", "108", "156", "141", "214", "83", "94", "15", "125", "33", "215", "121", "186", "81", "57");
+    private final CardRun commonC2 = new CardRun(true, "223", "75", "162", "120", "132", "52", "216", "208", "225", "218", "173", "120", "152", "75", "52", "20", "162", "225", "77", "132", "212", "158", "105", "224", "162", "35", "77", "223", "216", "132", "208", "75", "158", "52", "224", "212", "152", "105", "208", "35", "216", "20", "223", "173", "152", "224", "77", "120", "35", "158", "20", "225", "212", "173", "105");
+    private final CardRun uncommonA = new CardRun(true, "161", "129", "43", "184", "228", "171", "5", "226", "205", "114", "202", "76", "142", "155", "43", "197", "27", "222", "168", "106", "188", "85", "142", "180", "40", "209", "229", "5", "220", "168", "161", "112", "80", "184", "145", "155", "44", "27", "228", "157", "175", "106", "76", "205", "222", "129", "197", "40", "19", "209", "220", "157", "114", "175", "85", "145", "188", "229", "44", "180", "19", "171", "112", "226", "202", "80");
+    private final CardRun uncommonB = new CardRun(true, "82", "124", "23", "181", "29", "137", "98", "68", "174", "39", "123", "99", "78", "167", "53", "117", "2", "181", "200", "39", "113", "124", "68", "177", "41", "201", "3", "99", "151", "58", "123", "117", "72", "200", "53", "2", "137", "82", "167", "113", "201", "29", "72", "190", "41", "78", "23", "151", "174", "98", "177", "3", "58", "190");
+    private final CardRun rareA = new CardRun(true, "55", "100", "183", "89", "159", "148", "6", "219", "70", "192", "95", "48", "187", "49", "183", "140", "21", "217", "70", "204", "100", "164", "95", "49", "148", "187", "25", "211", "163", "89", "160", "150", "109", "17", "48", "199", "25", "138", "163", "64", "206", "91", "103", "219", "45", "199", "6", "140", "159", "55", "164", "64", "109", "217", "17", "160", "138", "103", "206", "45", "204", "211", "21", "91", "150", "192");
+    private final CardRun rareB = new CardRun(true, "69", "196", "10", "84", "122", "194", "51", "16", "210", "131", "96", "56", "154", "146", "122", "7", "191", "14", "50", "170", "84", "135", "119", "193", "38", "79", "10", "182", "131", "51", "185", "63", "101", "143", "178", "14", "56", "119", "9", "135", "69", "172", "38", "96", "146", "179", "7", "50", "63", "166", "101", "16", "60", "79", "143");
+    private final CardRun land = new CardRun(false, "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248", "249");
+
+    private final BoosterStructure AAABC1C1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABBC1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABBC2C2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAABBBC2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBBC2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBBBC2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB,
+            commonC2, commonC2
+    );
+    private final BoosterStructure AAB = new BoosterStructure(uncommonA, uncommonA, uncommonB);
+    private final BoosterStructure ABB = new BoosterStructure(uncommonA, uncommonB, uncommonB);
+    private final BoosterStructure R1 = new BoosterStructure(rareA);
+    private final BoosterStructure R2 = new BoosterStructure(rareB);
+    private final BoosterStructure L1 = new BoosterStructure(land);
+
+    // In order for equal numbers of each common to exist, the average booster must contain:
+    // 3.27 A commons (36 / 11)
+    // 2.18 B commons (24 / 11)
+    // 2.73 C1 commons (30 / 11, or 60 / 11 in each C1 booster)
+    // 1.82 C2 commons (20 / 11, or 40 / 11 in each C2 booster)
+    // These numbers are the same for all sets with 101 commons in A/B/C1/C2 print runs
+    // and with 10 common slots per booster
+    private final RarityConfiguration commonRuns = new RarityConfiguration(
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+
+            AAABBC2C2C2C2C2,
+            AAABBC2C2C2C2C2,
+            AAABBC2C2C2C2C2,
+            AAABBC2C2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBBC2C2,
+            AAAABBBBC2C2
+    );
+    // In order for equal numbers of each uncommon to exist, the average booster must contain:
+    // 1.65 A uncommons (33 / 20)
+    // 1.35 B uncommons (27 / 20)
+    // These numbers are the same for all sets with 60 uncommons in asymmetrical A/B print runs
+    private final RarityConfiguration uncommonRuns = new RarityConfiguration(
+            AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB,
+            ABB, ABB, ABB, ABB, ABB, ABB, ABB
+    );
+    private final RarityConfiguration rareRuns = new RarityConfiguration(
+            R1, R1, R1, R1, R1, R1,
+            R2, R2, R2, R2, R2
+    );
+    private final RarityConfiguration landRuns = new RarityConfiguration(L1);
+
+    @Override
+    public List<String> makeBooster() {
+        List<String> booster = new ArrayList<>();
+        booster.addAll(commonRuns.getNext().makeRun());
+        booster.addAll(uncommonRuns.getNext().makeRun());
+        booster.addAll(rareRuns.getNext().makeRun());
+        booster.addAll(landRuns.getNext().makeRun());
+        return booster;
+    }
 }

--- a/Mage.Sets/src/mage/sets/Zendikar.java
+++ b/Mage.Sets/src/mage/sets/Zendikar.java
@@ -3,8 +3,15 @@ package mage.sets;
 import mage.ObjectColor;
 import mage.cards.CardGraphicInfo;
 import mage.cards.ExpansionSet;
+import mage.collation.BoosterCollator;
+import mage.collation.BoosterStructure;
+import mage.collation.CardRun;
+import mage.collation.RarityConfiguration;
 import mage.constants.Rarity;
 import mage.constants.SetType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author BetaSteward_at_googlemail.com
@@ -298,4 +305,124 @@ public final class Zendikar extends ExpansionSet {
         cards.add(new SetCardInfo("Zendikar Farguide", 194, Rarity.COMMON, mage.cards.z.ZendikarFarguide.class));
     }
 
+    @Override
+    public BoosterCollator createCollator() {
+        return new ZendikarCollator();
+    }
+}
+
+// Booster collation info from https://www.lethe.xyz/mtg/collation/zen.html
+// Using USA collation
+class ZendikarCollator implements BoosterCollator {
+    private final CardRun commonA = new CardRun(true, "87", "189", "58", "118", "7", "222", "163", "66", "14", "132", "195", "106", "192", "77", "118", "23", "222", "189", "48", "3", "145", "202", "98", "192", "60", "226", "216", "94", "169", "78", "7", "119", "195", "90", "181", "60", "132", "216", "87", "169", "77", "23", "226", "207", "94", "181", "78", "148", "14", "90", "193", "58", "31", "145", "207", "98", "163", "48", "148", "3", "106", "193", "66", "31", "119", "202");
+    private final CardRun commonB = new CardRun(true, "113", "173", "141", "97", "225", "22", "165", "150", "49", "113", "206", "20", "173", "152", "97", "75", "18", "188", "151", "225", "85", "201", "36", "165", "152", "115", "49", "20", "188", "141", "76", "97", "206", "22", "174", "152", "85", "49", "36", "173", "151", "75", "113", "201", "188", "22", "150", "115", "225", "20", "174", "141", "85", "76", "206", "18", "165", "151", "115", "75", "36", "174", "150", "201", "76", "18");
+    private final CardRun commonC1 = new CardRun(true, "155", "194", "28", "73", "167", "112", "35", "65", "138", "158", "91", "121", "44", "29", "166", "103", "37", "72", "112", "138", "167", "104", "136", "194", "35", "44", "84", "149", "158", "21", "183", "73", "117", "136", "179", "28", "67", "103", "29", "72", "204", "155", "183", "104", "149", "166", "37", "65", "91", "21", "67", "84", "121", "179", "117");
+    private final CardRun commonC2 = new CardRun(true, "147", "70", "171", "93", "5", "128", "227", "27", "86", "43", "50", "129", "30", "171", "80", "27", "128", "70", "93", "147", "227", "5", "50", "26", "186", "125", "51", "86", "171", "27", "43", "129", "5", "147", "50", "227", "86", "26", "43", "80", "186", "128", "51", "30", "125", "70", "26", "93", "186", "129", "51", "80", "125", "204", "30");
+    private final CardRun uncommonA = new CardRun(true, "32", "55", "114", "139", "185", "2", "52", "108", "127", "156", "197", "17", "40", "89", "124", "190", "38", "56", "116", "137", "160", "209", "17", "55", "108", "139", "156", "38", "46", "114", "127", "185", "209", "16", "71", "116", "133", "157", "32", "56", "89", "137", "180", "205", "16", "52", "95", "142", "160", "34", "46", "101", "133", "180", "197", "2", "40", "95", "124", "157", "34", "71", "101", "142", "190", "205");
+    private final CardRun uncommonB = new CardRun(true, "130", "33", "102", "64", "214", "198", "153", "176", "59", "109", "215", "19", "102", "47", "177", "210", "146", "164", "198", "33", "74", "217", "105", "130", "208", "24", "47", "215", "144", "177", "88", "19", "214", "59", "153", "161", "4", "224", "109", "208", "144", "164", "64", "210", "88", "146", "24", "176", "217", "4", "74", "161", "105", "224");
+    private final CardRun rareA = new CardRun(true, "191", "140", "45", "82", "123", "229", "187", "100", "41", "9", "218", "120", "172", "25", "92", "42", "213", "6", "187", "83", "122", "218", "53", "1", "100", "8", "45", "229", "159", "126", "96", "219", "200", "54", "9", "143", "172", "223", "170", "82", "122", "68", "6", "220", "41", "8", "143", "159", "99", "219", "1", "68", "123", "92", "213", "12", "191", "126", "83", "42", "220", "168", "54", "96", "25", "223");
+    private final CardRun rareB = new CardRun(true, "175", "211", "135", "162", "134", "61", "10", "107", "69", "203", "175", "212", "39", "154", "196", "62", "79", "184", "11", "211", "57", "228", "81", "131", "162", "62", "13", "182", "79", "212", "135", "63", "11", "81", "196", "221", "178", "134", "203", "61", "110", "15", "199", "10", "182", "221", "184", "131", "69", "228", "110", "39", "63", "111", "15");
+    private final CardRun land = new CardRun(false, "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248", "249");
+
+    private final BoosterStructure AAABC1C1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABBC1C1C1C1C1 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1
+    );
+    private final BoosterStructure AAABC2C2C2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB,
+            commonC2, commonC2, commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAABBC2C2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAABBBC2C2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAABBBBC2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB,
+            commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBBC2C2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2, commonC2
+    );
+    private final BoosterStructure AAAABBBBC2C2 = new BoosterStructure(
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB,
+            commonC2, commonC2
+    );
+    private final BoosterStructure AAB = new BoosterStructure(uncommonA, uncommonA, uncommonB);
+    private final BoosterStructure ABB = new BoosterStructure(uncommonA, uncommonB, uncommonB);
+    private final BoosterStructure R1 = new BoosterStructure(rareA);
+    private final BoosterStructure R2 = new BoosterStructure(rareB);
+    private final BoosterStructure L1 = new BoosterStructure(land);
+
+    // In order for equal numbers of each common to exist, the average booster must contain:
+    // 3.27 A commons (36 / 11)
+    // 2.18 B commons (24 / 11)
+    // 2.73 C1 commons (30 / 11, or 60 / 11 in each C1 booster)
+    // 1.82 C2 commons (20 / 11, or 40 / 11 in each C2 booster)
+    // These numbers are the same for all sets with 101 commons in A/B/C1/C2 print runs
+    // and with 10 common slots per booster
+    private final RarityConfiguration commonRuns = new RarityConfiguration(
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABC1C1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+            AAABBC1C1C1C1C1,
+
+            AAABC2C2C2C2C2C2,
+            AAABBC2C2C2C2C2,
+            AAABBC2C2C2C2C2,
+            AAABBBC2C2C2C2,
+            AAABBBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBC2C2C2,
+            AAAABBBBC2C2
+    );
+    // In order for equal numbers of each uncommon to exist, the average booster must contain:
+    // 1.65 A uncommons (33 / 20)
+    // 1.35 B uncommons (27 / 20)
+    // These numbers are the same for all sets with 60 uncommons in asymmetrical A/B print runs
+    private final RarityConfiguration uncommonRuns = new RarityConfiguration(
+            AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB,
+            ABB, ABB, ABB, ABB, ABB, ABB, ABB
+    );
+    private final RarityConfiguration rareRuns = new RarityConfiguration(
+            R1, R1, R1, R1, R1, R1,
+            R2, R2, R2, R2, R2
+    );
+    private final RarityConfiguration landRuns = new RarityConfiguration(L1);
+
+    @Override
+    public List<String> makeBooster() {
+        List<String> booster = new ArrayList<>();
+        booster.addAll(commonRuns.getNext().makeRun());
+        booster.addAll(uncommonRuns.getNext().makeRun());
+        booster.addAll(rareRuns.getNext().makeRun());
+        booster.addAll(landRuns.getNext().makeRun());
+        return booster;
+    }
 }


### PR DESCRIPTION
Also fixed a minor error in ROE (AAABBBBC2C2C2 *can* be fitted in; it was actually Shards of Alara where it couldn't)