### PR TITLE
Removed game.preventDamage method (fixes #8280)

### DIFF
--- a/Mage/src/main/java/mage/game/Game.java
+++ b/Mage/src/main/java/mage/game/Game.java
@@ -316,30 +316,16 @@ public interface Game extends MageItem, Serializable, Copyable<Game> {
     boolean replaceEvent(GameEvent event, Ability targetAbility);
 
     /**
-     * Creates and fires an damage prevention event
+     * Creates and fires a damage prevention event
      *
      * @param damageEvent     damage event that will be replaced (instanceof
      *                        check will be done)
      * @param source          ability that's the source of the prevention effect
      * @param game
      * @param amountToPrevent max preventable amount
-     * @return true prevention was successfull / false prevention was replaced
+     * @return true prevention was successful / false prevention was replaced
      */
     PreventionEffectData preventDamage(GameEvent damageEvent, Ability source, Game game, int amountToPrevent);
-
-    /**
-     * Creates and fires an damage prevention event
-     *
-     * @param event            damage event that will be replaced (instanceof
-     *                         check will be done)
-     * @param source           ability that's the source of the prevention
-     *                         effect
-     * @param game
-     * @param preventAllDamage true if there is no limit to the damage that can
-     *                         be prevented
-     * @return true prevention was successfull / false prevention was replaced
-     */
-    PreventionEffectData preventDamage(GameEvent event, Ability source, Game game, boolean preventAllDamage);
 
     void start(UUID choosingPlayerId);
 

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -3068,11 +3068,6 @@ public abstract class GameImpl implements Game {
     }
 
     @Override
-    public PreventionEffectData preventDamage(GameEvent event, Ability source, Game game, boolean preventAllDamage) {
-        return preventDamage(event, source, game, Integer.MAX_VALUE);
-    }
-
-    @Override
     public PreventionEffectData preventDamage(GameEvent event, Ability source, Game game, int amountToPrevent) {
         PreventionEffectData result = new PreventionEffectData(amountToPrevent);
         if (!event.getFlag()) { // damage is not preventable


### PR DESCRIPTION
This method seems to be unused and does not respect the "preventAllDamage" argument.  I've removed it and tested that there are no build or test failures.  Just wanted to put in this PR to make sure there are no objections.  I've not gotten any comments in bug #8280