### PR TITLE
[DON'T MERGE] Only allow Transmute ability at sorcery speed (fixes #8305)

### DIFF
--- a/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
@@ -206,7 +206,7 @@ public abstract class ActivatedAbilityImpl extends AbilityImpl implements Activa
         asInstant = approvingObject != null;
         asInstant |= (timing == TimingRule.INSTANT);
         Card card = game.getCard(getSourceId());
-        if (card != null) {
+        if (card != null && this instanceof SpellAbility) {
             asInstant |= card.isInstant(game);
             asInstant |= card.hasAbility(FlashAbility.getInstance(), game);
         }


### PR DESCRIPTION
Bug was happening when a sorcery speed ability is on an instant speed card.  I've tested that this fixes the bug with transmute but I'm not sure why we're looking at the Card object at all here.  Timings should be set per ability, I think.