### PR TITLE
Fixed #8173 and #8357

### DIFF
--- a/Mage.Sets/src/mage/sets/OathOfTheGatewatch.java
+++ b/Mage.Sets/src/mage/sets/OathOfTheGatewatch.java
@@ -28,7 +28,7 @@ public final class OathOfTheGatewatch extends ExpansionSet {
         this.blockName = "Battle for Zendikar";
         this.parentSet = BattleForZendikar.getInstance();
         this.hasBoosters = true;
-        this.hasBasicLands = true;
+        this.hasBasicLands = false;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
@@ -213,16 +213,26 @@ public final class OathOfTheGatewatch extends ExpansionSet {
         cards.add(new SetCardInfo("Wandering Fumarole", 182, Rarity.RARE, mage.cards.w.WanderingFumarole.class));
         cards.add(new SetCardInfo("Warden of Geometries", 11, Rarity.COMMON, mage.cards.w.WardenOfGeometries.class));
         cards.add(new SetCardInfo("Warping Wail", 12, Rarity.UNCOMMON, mage.cards.w.WarpingWail.class));
-        cards.add(new SetCardInfo("Wastes", "183a", Rarity.LAND, mage.cards.w.Wastes.class, NON_FULL_USE_VARIOUS));
-        cards.add(new SetCardInfo("Wastes", "184a", Rarity.LAND, mage.cards.w.Wastes.class, NON_FULL_USE_VARIOUS));
-        cards.add(new SetCardInfo("Wastes", 183, Rarity.LAND, mage.cards.w.Wastes.class, FULL_ART_BFZ_VARIOUS));
-        cards.add(new SetCardInfo("Wastes", 184, Rarity.LAND, mage.cards.w.Wastes.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Wastes", "183a", Rarity.COMMON, mage.cards.w.Wastes.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Wastes", "184a", Rarity.COMMON, mage.cards.w.Wastes.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Wastes", 183, Rarity.COMMON, mage.cards.w.Wastes.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Wastes", 184, Rarity.COMMON, mage.cards.w.Wastes.class, FULL_ART_BFZ_VARIOUS));
         cards.add(new SetCardInfo("Weapons Trainer", 160, Rarity.UNCOMMON, mage.cards.w.WeaponsTrainer.class));
         cards.add(new SetCardInfo("Witness the End", 82, Rarity.COMMON, mage.cards.w.WitnessTheEnd.class));
         cards.add(new SetCardInfo("World Breaker", 126, Rarity.MYTHIC, mage.cards.w.WorldBreaker.class));
         cards.add(new SetCardInfo("Zada's Commando", 120, Rarity.COMMON, mage.cards.z.ZadasCommando.class));
         cards.add(new SetCardInfo("Zendikar Resurgent", 147, Rarity.RARE, mage.cards.z.ZendikarResurgent.class));
         cards.add(new SetCardInfo("Zulaport Chainmage", 93, Rarity.COMMON, mage.cards.z.ZulaportChainmage.class));
+    }
+
+    @Override
+    public List<CardInfo> getCardsByRarity(Rarity rarity) {
+        List<CardInfo> cards = super.getCardsByRarity(rarity);
+        if (rarity == Rarity.COMMON) {
+            // only the full-art versions of Wastes are found in boosters
+            cards.removeIf(cardInfo -> cardInfo.getCardNumber().contains("a"));
+        }
+        return cards;
     }
 
     @Override

--- a/Mage.Sets/src/mage/sets/TimeSpiralRemastered.java
+++ b/Mage.Sets/src/mage/sets/TimeSpiralRemastered.java
@@ -30,7 +30,7 @@ public class TimeSpiralRemastered extends ExpansionSet {
     private TimeSpiralRemastered() {
         super("Time Spiral Remastered", "TSR", ExpansionSet.buildDate(2021, 3, 19), SetType.SUPPLEMENTAL);
         this.hasBoosters = true;
-        this.hasBasicLands = true;
+        this.hasBasicLands = false;
         this.maxCardNumberInBooster = 410;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -1756,22 +1756,27 @@ public class VerifyCardDataTest {
                 || checkName.equals("Forest")
                 || checkName.equals("Swamp")
                 || checkName.equals("Plains")
-                || checkName.equals("Mountain")
-                || checkName.equals("Wastes");
+                || checkName.equals("Mountain");
     }
 
     private void checkBasicLands(Card card, MtgJsonCard ref) {
 
         // basic lands must have Rarity.LAND and SuperType.BASIC
         // other cards can't have that stats
-        if (isBasicLandName(card.getName())) {
+        String name = card.getName();
+        if (isBasicLandName(name)) {
             // lands
-            if (card.getRarity() != Rarity.LAND && card.getRarity() != Rarity.SPECIAL) {
+            if (card.getRarity() != Rarity.LAND) {
                 fail(card, "rarity", "basic land must be Rarity.LAND");
             }
 
             if (!card.getSuperType().contains(SuperType.BASIC)) {
                 fail(card, "supertype", "basic land must be SuperType.BASIC");
+            }
+        } else if (name.equals("Wastes")) {
+            // Wastes are SuperType.BASIC but not necessarily Rarity.LAND
+            if (!card.getSuperType().contains(SuperType.BASIC)) {
+                fail(card, "supertype", "Wastes must be SuperType.BASIC");
             }
         } else {
             // non lands


### PR DESCRIPTION
Fixes #8173 (the OGW issue was the last remaining one to be fixed)
Fixes #8357

These fixes required changing `checkBasicLands` in `VerifyCardDataTest` so that it doesn't require Wastes to be `Rarity.LAND`. `Rarity.LAND` is used in various places in xmage that are all related to adding appropriate basic lands to decks. As far as I can tell, none of those places ever cared about or should care about Wastes.