### PR TITLE
Fix Maven build no longer running any junit4 tests

### DIFF
--- a/Mage.Client/pom.xml
+++ b/Mage.Client/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>truevfs-profile-base</artifactId>
         </dependency>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.unbescape</groupId>
             <artifactId>unbescape</artifactId>
         </dependency>

--- a/Mage.Common/pom.xml
+++ b/Mage.Common/pom.xml
@@ -56,6 +56,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>

--- a/Mage.Server.Console/pom.xml
+++ b/Mage.Server.Console/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>swingx</artifactId>
             <version>1.6.1</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Mage.Server/pom.xml
+++ b/Mage.Server/pom.xml
@@ -266,6 +266,10 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.unbescape</groupId>
             <artifactId>unbescape</artifactId>
         </dependency>

--- a/Mage.Sets/pom.xml
+++ b/Mage.Sets/pom.xml
@@ -21,6 +21,10 @@
             <artifactId>mage</artifactId>
             <version>${mage-version}</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Mage.Tests/pom.xml
+++ b/Mage.Tests/pom.xml
@@ -48,6 +48,10 @@
         </dependency>
 
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>mage-game-freeforall</artifactId>
             <version>${project.version}</version>

--- a/Mage.Verify/pom.xml
+++ b/Mage.Verify/pom.xml
@@ -35,6 +35,10 @@
             <version>${mage-version}</version>
         </dependency>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>[2.9.9.1,)</version>

--- a/Mage/pom.xml
+++ b/Mage/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>4.0.0-rc-2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -182,20 +182,6 @@
         </dependency>
 
         <dependency>
-            <!-- junit 4 tests -->
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <!-- junit 5 tests -->
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.8.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <!-- write asserts in unit tests like a real language -->
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
@@ -237,6 +223,20 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.12.0</version>
+            </dependency>
+            <dependency>
+                <!-- junit 4 tests -->
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <!-- junit 5 tests -->
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>5.8.1</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This reverts the `junit` and `org.junit.jupiter` changes in 58ab020065ecb43b3102e7b2ca76cf679c9711c6 because the changes were causing all junit4-based tests (which is the great majority of tests in the project) not to run any more as part of the Maven build process.