### PR TITLE
[AFC] Implemented Death Tyrant

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DeathTyrant.java
+++ b/Mage.Sets/src/mage/cards/d/DeathTyrant.java
@@ -81,7 +81,7 @@ class DeathTyrantTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         ZoneChangeEvent zEvent = (ZoneChangeEvent) event;
         if (zEvent.isDiesEvent()) {
-            Permanent permanent = zEvent.getTarget();
+            Permanent permanent = game.getPermanentOrLKIBattlefield(zEvent.getTargetId());
             if (permanent != null && permanent.isCreature(game)) {
                 if (permanent.isControlledBy(controllerId) && permanent.isAttacking()) {
                     return true;

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/afc/DeathTyrantTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/afc/DeathTyrantTest.java
@@ -1,0 +1,45 @@
+package org.mage.test.cards.single.afc;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class DeathTyrantTest extends CardTestPlayerBase {
+
+    @Test
+    public void attackerDies() {
+        addCard(Zone.BATTLEFIELD, playerA, "Death Tyrant", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Grizzly Bears", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Hill Giant", 1);
+
+        attack(1, playerA, "Grizzly Bears");
+        block(1, playerB, "Hill Giant", "Grizzly Bears");
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertGraveyardCount(playerA, "Grizzly Bears", 1);
+        assertPermanentCount(playerA, "Zombie", 1);
+        assertPermanentCount(playerA, "Death Tyrant", 1);
+        assertPermanentCount(playerB, "Hill Giant", 1);
+    }
+
+    @Test
+    public void blockerDies() {
+        addCard(Zone.BATTLEFIELD, playerA, "Death Tyrant", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Hill Giant", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Grizzly Bears", 1);
+
+        attack(1, playerA, "Hill Giant");
+        block(1, playerB, "Grizzly Bears", "Hill Giant");
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertGraveyardCount(playerB, "Grizzly Bears", 1);
+        assertPermanentCount(playerA, "Zombie", 1);
+        assertPermanentCount(playerA, "Death Tyrant", 1);
+        assertPermanentCount(playerA, "Hill Giant", 1);
+    }
+}

--- a/Mage/src/main/java/mage/game/ZonesHandler.java
+++ b/Mage/src/main/java/mage/game/ZonesHandler.java
@@ -382,8 +382,8 @@ public final class ZonesHandler {
             } else if (event.getTarget() != null) {
                 card.setFaceDown(info.faceDown, game);
                 Permanent target = event.getTarget();
-                success = game.getPlayer(target.getControllerId()).removeFromBattlefield(target, source, game)
-                        && target.removeFromZone(game, fromZone, source);
+                success = target.removeFromZone(game, fromZone, source)
+                        && game.getPlayer(target.getControllerId()).removeFromBattlefield(target, source, game);
             } else {
                 card.setFaceDown(info.faceDown, game);
                 success = card.removeFromZone(game, fromZone, source);

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -1723,7 +1723,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
         Zone fromZone = game.getState().getZone(objectId);
         Player controller = game.getPlayer(controllerId);
         if (controller != null) {
-            ZoneChangeEvent event = new ZoneChangeEvent(this.copy(), source, controllerId, fromZone, toZone, appliedEffects);
+            ZoneChangeEvent event = new ZoneChangeEvent(this, source, controllerId, fromZone, toZone, appliedEffects);
             ZoneChangeInfo zoneChangeInfo;
             if (toZone == Zone.LIBRARY) {
                 zoneChangeInfo = new ZoneChangeInfo.Library(event, flag /* put on top */);


### PR DESCRIPTION
Just wanted to make sure the change I made to PermanentImpl is good.  I made it copy the Permanent object when it creates the ZoneChangeEvent to preserve attacking/blocking information.  Card was not working without this change.  None of the tests are failing and I thought this was the way it was supposed to work anyway.