### PR TITLE
Fixed Yixlid Jailer interaction with cards moving to graveyard

### DIFF
--- a/Mage.Sets/src/mage/cards/y/YixlidJailer.java
+++ b/Mage.Sets/src/mage/cards/y/YixlidJailer.java
@@ -4,12 +4,15 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.common.ZoneChangeTriggeredAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
+import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.game.Game;
+import mage.game.events.GameEvent;
 import mage.players.Player;
 
 /**
@@ -28,6 +31,7 @@ public final class YixlidJailer extends CardImpl {
 
         // Cards in graveyards lose all abilities.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new YixlidJailerEffect()));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new YixlidJailerRulesEffect()));
     }
 
     private YixlidJailer(final YixlidJailer card) {
@@ -38,54 +42,85 @@ public final class YixlidJailer extends CardImpl {
     public YixlidJailer copy() {
         return new YixlidJailer(this);
     }
+}
 
-    static class YixlidJailerEffect extends ContinuousEffectImpl {
+class YixlidJailerEffect extends ContinuousEffectImpl {
 
-        YixlidJailerEffect() {
-            super(Duration.WhileOnBattlefield, Outcome.LoseAbility);
-            staticText = "Cards in graveyards lose all abilities.";
+    public YixlidJailerEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.LoseAbility);
+        staticText = "Cards in graveyards lose all abilities.";
 
-            this.dependencyTypes.add(DependencyType.AddingAbility); // Necrotic Ooze
-        }
+        this.dependencyTypes.add(DependencyType.AddingAbility); // Necrotic Ooze
+    }
 
-        YixlidJailerEffect(final YixlidJailerEffect effect) {
-            super(effect);
-        }
+    private YixlidJailerEffect(final YixlidJailerEffect effect) {
+        super(effect);
+    }
 
-        @Override
-        public YixlidJailerEffect copy() {
-            return new YixlidJailerEffect(this);
-        }
+    @Override
+    public YixlidJailerEffect copy() {
+        return new YixlidJailerEffect(this);
+    }
 
-        @Override
-        public boolean apply(Layer layer, SubLayer sublayer, Ability source, Game game) {
-            if (layer == Layer.AbilityAddingRemovingEffects_6) {
-                Player controller = game.getPlayer(source.getControllerId());
-                if (controller != null) {
-                    for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
-                        Player player = game.getPlayer(playerId);
-                        if (player != null) {
-                            for (Card card : player.getGraveyard().getCards(game)) {
-                                if (card != null) {
-                                    card.looseAllAbilities(game);
-                                }
+    @Override
+    public boolean apply(Layer layer, SubLayer sublayer, Ability source, Game game) {
+        if (layer == Layer.AbilityAddingRemovingEffects_6) {
+            Player controller = game.getPlayer(source.getControllerId());
+            if (controller != null) {
+                for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
+                    Player player = game.getPlayer(playerId);
+                    if (player != null) {
+                        for (Card card : player.getGraveyard().getCards(game)) {
+                            if (card != null) {
+                                card.looseAllAbilities(game);
                             }
                         }
                     }
-                    return true;
                 }
+                return true;
             }
-            return false;
         }
+        return false;
+    }
 
-        @Override
-        public boolean apply(Game game, Ability source) {
-            return false;
-        }
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return false;
+    }
 
-        @Override
-        public boolean hasLayer(Layer layer) {
-            return layer == Layer.AbilityAddingRemovingEffects_6;
+    @Override
+    public boolean hasLayer(Layer layer) {
+        return layer == Layer.AbilityAddingRemovingEffects_6;
+    }
+}
+
+class YixlidJailerRulesEffect extends ContinuousRuleModifyingEffectImpl {
+
+    public YixlidJailerRulesEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.Detriment, false, false);
+    }
+
+    private YixlidJailerRulesEffect(final YixlidJailerRulesEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public YixlidJailerRulesEffect copy() {
+        return new YixlidJailerRulesEffect(this);
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.ZONE_CHANGE;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        Object targetAbility = getValue("targetAbility");
+        if (targetAbility instanceof ZoneChangeTriggeredAbility) {
+            ZoneChangeTriggeredAbility zoneAbility = (ZoneChangeTriggeredAbility) targetAbility;
+            return zoneAbility.getFromZone() != Zone.BATTLEFIELD && zoneAbility.getToZone() == Zone.GRAVEYARD;
         }
+        return false;
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/fut/YixlidJailerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/fut/YixlidJailerTest.java
@@ -7,6 +7,11 @@ import org.mage.test.serverside.base.CardTestPlayerBase;
 
 public class YixlidJailerTest extends CardTestPlayerBase {
 
+    // Rulings on Yixlid Jailer
+    // 1. If an ability triggers when the object that has it is put into a graveyard from the battlefield, that ability triggers from the battlefield and isn’t affected by Yixlid Jailer. (2021-03-19)
+    // 2. If an ability triggers when the object that has it is put into a graveyard from anywhere other than the battlefield, such as Krosan Tusker or Narcomoeba, that ability triggers from the graveyard.
+    //    Yixlid Jailer stops those abilities from triggering at all. This includes abilities that trigger when a card is put into a graveyard “from anywhere,” even if that card was on the battlefield. (2021-03-19)
+
     @Test
     public void narcomoebaBaseCase() {
         skipInitShuffling();
@@ -47,6 +52,24 @@ public class YixlidJailerTest extends CardTestPlayerBase {
     }
 
     @Test
+    public void emrakulWrathBaseCase() {
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerA, "Emrakul, the Aeons Torn", 1);
+        addCard(Zone.HAND, playerA, "Wrath of God", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 4);
+        setStrictChooseMode(true);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Wrath of God");
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertAllCommandsUsed();
+        assertGraveyardCount(playerA, 0); // Emrakul should shuffle graveyard into library
+        assertPermanentCount(playerA, "Emrakul, the Aeons Torn", 0);
+    }
+
+    @Test
     public void narcomoebaWithJailer() {
         skipInitShuffling();
         addCard(Zone.LIBRARY, playerA, "Narcomoeba", 1);
@@ -84,5 +107,63 @@ public class YixlidJailerTest extends CardTestPlayerBase {
 
         assertAllCommandsUsed();
         assertGraveyardCount(playerA, "Emrakul, the Aeons Torn", 1);
+    }
+
+    @Test
+    public void emrakulWrathWithJailer() {
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerA, "Emrakul, the Aeons Torn", 1);
+        addCard(Zone.HAND, playerA, "Wrath of God", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 4);
+        addCard(Zone.BATTLEFIELD, playerB, "Yixlid Jailer", 1);
+        setStrictChooseMode(true);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Wrath of God");
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertAllCommandsUsed();
+        assertGraveyardCount(playerA, "Emrakul, the Aeons Torn", 1); // Emrakul should not trigger even if removed from the battlefield
+        assertPermanentCount(playerA, "Emrakul, the Aeons Torn", 0);
+    }
+
+    @Test
+    public void midnightReaperWithJailer() {
+        addCard(Zone.BATTLEFIELD, playerA, "Midnight Reaper", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Yixlid Jailer", 1);
+        addCard(Zone.HAND, playerA, "Lightning Bolt", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
+        setStrictChooseMode(true);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt");
+        addTarget(playerA, "Midnight Reaper");
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertAllCommandsUsed();
+        assertGraveyardCount(playerA, "Midnight Reaper", 1);
+        assertPermanentCount(playerB, "Yixlid Jailer", 1);
+        assertLife(playerA, 19); // Midnight Reaper should still trigger
+    }
+
+    @Test
+    public void midnightReaperWrathWithJailer() {
+        addCard(Zone.BATTLEFIELD, playerA, "Midnight Reaper", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Yixlid Jailer", 1);
+        addCard(Zone.HAND, playerA, "Wrath of God", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 4);
+        setStrictChooseMode(true);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Wrath of God");
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertAllCommandsUsed();
+        assertGraveyardCount(playerA, "Midnight Reaper", 1);
+        assertGraveyardCount(playerB, "Yixlid Jailer", 1);
+        assertLife(playerA, 19); // Midnight Reaper should still trigger
     }
 }

--- a/Mage/src/main/java/mage/abilities/common/ZoneChangeTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/ZoneChangeTriggeredAbility.java
@@ -2,7 +2,6 @@ package mage.abilities.common;
 
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
-import mage.cards.Card;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
@@ -58,17 +57,10 @@ public class ZoneChangeTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         if (event.getTargetId().equals(this.getSourceId())) {
-            // Workaround for cards in graveyards losing abilities (ex. Yixlid Jailer)
-            // https://github.com/magefree/mage/issues/8311
-            if (fromZone != Zone.BATTLEFIELD && toZone == Zone.GRAVEYARD) {
-                game.applyEffects();
-                Card card = game.getCard(this.getSourceId());
-                if (card == null || !card.hasAbility(this, game)) {
-                    return false;
-                }
-            }
             ZoneChangeEvent zEvent = (ZoneChangeEvent) event;
-            return (fromZone == null || zEvent.getFromZone() == fromZone) && (toZone == null || zEvent.getToZone() == toZone);
+            if ((fromZone == null || zEvent.getFromZone() == fromZone) && (toZone == null || zEvent.getToZone() == toZone)) {
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
Fixes #8311

This is maybe a janky workaround (needs "magic" game.applyEffects()) but it works in testing.  If anyone knows where in the code I should be looking at for a better fix, I'm all ears.