### PR TITLE
New booster color validation algorithm, fixes #8177

### DIFF
--- a/Mage.Sets/src/mage/sets/AlaraReborn.java
+++ b/Mage.Sets/src/mage/sets/AlaraReborn.java
@@ -28,6 +28,7 @@ public final class AlaraReborn extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+        this.hasOnlyMulticolorCards = true;
         cards.add(new SetCardInfo("Anathemancer", 33, Rarity.UNCOMMON, mage.cards.a.Anathemancer.class));
         cards.add(new SetCardInfo("Architects of Will", 17, Rarity.COMMON, mage.cards.a.ArchitectsOfWill.class));
         cards.add(new SetCardInfo("Ardent Plea", 1, Rarity.UNCOMMON, mage.cards.a.ArdentPlea.class));

--- a/Mage.Sets/src/mage/sets/Judgment.java
+++ b/Mage.Sets/src/mage/sets/Judgment.java
@@ -28,6 +28,7 @@ public final class Judgment extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+        this.hasUnbalancedColors = true;
         cards.add(new SetCardInfo("Ancestor's Chosen", 1, Rarity.UNCOMMON, mage.cards.a.AncestorsChosen.class));
         cards.add(new SetCardInfo("Anger", 77, Rarity.UNCOMMON, mage.cards.a.Anger.class));
         cards.add(new SetCardInfo("Anurid Barkripper", 104, Rarity.COMMON, mage.cards.a.AnuridBarkripper.class));

--- a/Mage.Sets/src/mage/sets/Torment.java
+++ b/Mage.Sets/src/mage/sets/Torment.java
@@ -28,6 +28,7 @@ public final class Torment extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+        this.hasUnbalancedColors = true;
         cards.add(new SetCardInfo("Accelerate", 90, Rarity.COMMON, mage.cards.a.Accelerate.class));
         cards.add(new SetCardInfo("Acorn Harvest", 118, Rarity.COMMON, mage.cards.a.AcornHarvest.class));
         cards.add(new SetCardInfo("Ambassador Laquatus", 23, Rarity.RARE, mage.cards.a.AmbassadorLaquatus.class));


### PR DESCRIPTION
Fixes each of the issues listed in #8177:

- Multicolor cards are handled in a way that isn't biased in favor of boosters with two or more cards of the same guild/wedge/shard
- Devoid, emerge, and artifacts with colored activation costs (spellbombs etc.) are treated as cards of that color for the purpose of booster validation. This seems to match how sets with these cards/mechanics are actually designed--for example, the common emerge creatures in EMN replace common slots of the colors in their emerge costs, and MM2 replaces two white common slots and a blue common slot with artifacts that activate for those colors.
- Colorless cards are handled in a way that reduces the bias against them (it's not perfect; colorless commons are collectively underprinted by about 4% in the most colorless-heavy sets like Darksteel)
- Commons and uncommons are validated separately, mirroring the fact that in physical packs they have independent print runs
- The two intentionally color-unbalanced sets have special treatment
