### PR TITLE
fix: Cleave Ability

### DIFF
--- a/Mage/src/main/java/mage/abilities/keyword/CleaveAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/CleaveAbility.java
@@ -16,7 +16,7 @@ public class CleaveAbility extends SpellAbility {
         super(new ManaCostsImpl<>(manaString), card.getName() + " with cleave");
         this.spellAbilityType = SpellAbilityType.BASE_ALTERNATE;
         this.addEffect(effect);
-        this.setRuleAtTheTop(true);
+        setRuleAtTheTop(true);
         this.timing = (card.isSorcery(null) ? TimingRule.SORCERY : TimingRule.INSTANT);
     }
 


### PR DESCRIPTION
Fix: Cleave Ability is not being shown at the top of rules text #8437
https://github.com/magefree/mage/issues/8437

Removed "this" reference to resolve issue.