### PR TITLE
Fixed kicker costs not getting reset correctly (fixes #8495)

### DIFF
--- a/Mage/src/main/java/mage/abilities/condition/common/KickedCostCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/KickedCostCondition.java
@@ -1,5 +1,6 @@
 package mage.abilities.condition.common;
 
+import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.condition.Condition;
 import mage.abilities.keyword.KickerAbility;
@@ -21,9 +22,9 @@ public class KickedCostCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Card card = game.getCard(source.getSourceId());
-        if (card != null) {
-            for (Ability ability: card.getAbilities()) {
+        MageObject sourceObject = source.getSourceObject(game);
+        if (sourceObject instanceof Card) {
+            for (Ability ability : ((Card) sourceObject).getAbilities(game)) {
                 if (ability instanceof KickerAbility) {
                     return ((KickerAbility) ability).isKicked(game, source, kickerCostText);
                 }

--- a/Mage/src/main/java/mage/abilities/keyword/KickerAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/KickerAbility.java
@@ -115,18 +115,11 @@ public class KickerAbility extends StaticAbility implements OptionalAdditionalSo
         });
     }
 
-    public void resetKicker(Game game, Ability source) {
+    private void resetKicker() {
         for (OptionalAdditionalCost cost : kickerCosts) {
             cost.reset();
         }
-        String key = getActivationKey(source, "", game);
-        for (Iterator<String> iterator = activations.keySet().iterator(); iterator.hasNext(); ) {
-            String activationKey = iterator.next();
-            if (activationKey.startsWith(key)
-                    && activations.get(activationKey) > 0) {
-                activations.put(key, 0);
-            }
-        }
+        activations.clear();
     }
 
     private int getKickedCounterStrict(Game game, Ability source, String needKickerCost) {
@@ -241,7 +234,7 @@ public class KickerAbility extends StaticAbility implements OptionalAdditionalSo
         if (ability instanceof SpellAbility) {
             Player player = game.getPlayer(ability.getControllerId());
             if (player != null) {
-                this.resetKicker(game, ability);
+                this.resetKicker();
                 for (OptionalAdditionalCost kickerCost : kickerCosts) {
                     boolean again = true;
                     while (player.canRespond() && again) {


### PR DESCRIPTION
Fixes #8495

The kicker ability on Nightscape Battlemage will trigger if the player chooses "Yes" to pay the kicker cost then cancels and re-casts it without paying for kicker.

I've tested that this fixes it.  I'm not sure why we would need to retain anything in the activations hashmap when the spell is getting re-cast so simply clearing it out fixes the issue.  Let me know if there's some edge case where this might matter though.  None of the tests failed on my machine.