### PR TITLE
Fix 6389

### DIFF
--- a/Mage/src/main/java/mage/abilities/keyword/JumpStartAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/JumpStartAbility.java
@@ -40,7 +40,7 @@ public class JumpStartAbility extends SpellAbility {
         this.newId();
         this.setCardName(card.getName() + " with jump-start");
         zone = Zone.GRAVEYARD;
-        spellAbilityType = SpellAbilityType.BASE_ALTERNATE;
+        spellAbilityType = SpellAbilityType.BASE_ADDITIONAL;
 
         Cost cost = new DiscardTargetCost(new TargetCardInHand());
         cost.setText("");

--- a/Mage/src/main/java/mage/abilities/keyword/RetraceAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/RetraceAbility.java
@@ -19,7 +19,7 @@ public class RetraceAbility extends SpellAbility {
         this.newId();
         this.setCardName(card.getName() + " with retrace");
         zone = Zone.GRAVEYARD;
-        spellAbilityType = SpellAbilityType.BASE_ALTERNATE;
+        spellAbilityType = SpellAbilityType.BASE_ADDITIONAL;
 
         Cost cost = new DiscardTargetCost(new TargetCardInHand(new FilterLandCard()));
         cost.setText("");

--- a/Mage/src/main/java/mage/constants/SpellAbilityType.java
+++ b/Mage/src/main/java/mage/constants/SpellAbilityType.java
@@ -6,6 +6,7 @@ package mage.constants;
 public enum SpellAbilityType {
     BASE("Basic SpellAbility"),
     BASE_ALTERNATE("Basic SpellAbility Alternate"), // used for Overload, Flashback to know they must be handled as Alternate casting costs
+    BASE_ADDITIONAL("Basic SpellAbility Additional"), // used for Retrace, Jump-Start to know they must be handled as Additional costs, not Alternate costs
     FACE_DOWN_CREATURE("Face down creature"), // used for Lands with Morph to cast as Face Down creature
     SPLIT("Split SpellAbility"),
     SPLIT_AFTERMATH("AftermathSplit SpellAbility"),

--- a/Mage/src/main/java/mage/game/command/Commander.java
+++ b/Mage/src/main/java/mage/game/command/Commander.java
@@ -43,6 +43,7 @@ public class Commander implements CommandObject {
                 switch (spellAbility.getSpellAbilityType()) {
                     case BASE:
                     case BASE_ALTERNATE:
+                    case BASE_ADDITIONAL:
                     case SPLIT:
                     case SPLIT_FUSED:
                     case SPLIT_LEFT:


### PR DESCRIPTION
Retrace and Jump-Start function similarly to Flashback in many ways (allowing you to pay a cost to cast a spell from a zone you couldn't normally do so from) but they follow the rules for additional costs rather than the rules for alternate costs. In particular, this means that (unlike Flashback) you can cast a spell via Retrace or Jump-Start while also playing another alternate cost (e.g. casting it for free via something like Fires of Invention)