### PR TITLE
Fixed Wording on 2 cards and removed duplicate StaticFilter

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AngelsTomb.java
+++ b/Mage.Sets/src/mage/cards/a/AngelsTomb.java
@@ -34,7 +34,7 @@ public final class AngelsTomb extends CardImpl {
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD,
                 effect,
-                StaticFilters.FILTER_PERMANENT_CREATURE_A,
+                StaticFilters.FILTER_PERMANENT_A_CREATURE,
                 true)
         );
     }

--- a/Mage.Sets/src/mage/cards/a/AnsweredPrayers.java
+++ b/Mage.Sets/src/mage/cards/a/AnsweredPrayers.java
@@ -30,7 +30,7 @@ public final class AnsweredPrayers extends CardImpl {
 
         // Whenever a creature enters the battlefield under your control, you gain 1 life. If Answered Prayers isn't a creature, it becomes a 3/3 Angel creature with flying in addition to its other types until end of turn.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
-                new AnsweredPrayersEffect(), StaticFilters.FILTER_PERMANENT_CREATURE_A
+                new AnsweredPrayersEffect(), StaticFilters.FILTER_PERMANENT_A_CREATURE
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/c/CatharsCrusade.java
+++ b/Mage.Sets/src/mage/cards/c/CatharsCrusade.java
@@ -26,7 +26,7 @@ public final class CatharsCrusade extends CardImpl {
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD,
                 new AddCountersAllEffect(CounterType.P1P1.createInstance(), new FilterControlledCreaturePermanent()),
-                StaticFilters.FILTER_PERMANENT_CREATURE_A,
+                StaticFilters.FILTER_PERMANENT_A_CREATURE,
                 false)
         );
     }

--- a/Mage.Sets/src/mage/cards/d/DecoctionModule.java
+++ b/Mage.Sets/src/mage/cards/d/DecoctionModule.java
@@ -29,7 +29,7 @@ public final class DecoctionModule extends CardImpl {
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD,
                 new GetEnergyCountersControllerEffect(1),
-                StaticFilters.FILTER_PERMANENT_CREATURE_A,
+                StaticFilters.FILTER_PERMANENT_A_CREATURE,
                 false)
         );
 

--- a/Mage.Sets/src/mage/cards/d/DreamLeash.java
+++ b/Mage.Sets/src/mage/cards/d/DreamLeash.java
@@ -12,6 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetTappedPermanentAsYouCast;
 
@@ -28,7 +29,7 @@ public final class DreamLeash extends CardImpl {
         this.subtype.add(SubType.AURA);
 
         // Enchant permanent
-        TargetPermanent auraTarget = new TargetTappedPermanentAsYouCast();
+        TargetPermanent auraTarget = new TargetTappedPermanentAsYouCast(new FilterCreaturePermanent("tapped permanent"));
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.GainControl));
         Ability ability = new EnchantAbility(auraTarget.getTargetName());

--- a/Mage.Sets/src/mage/cards/d/DreamLeash.java
+++ b/Mage.Sets/src/mage/cards/d/DreamLeash.java
@@ -12,7 +12,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetTappedPermanentAsYouCast;
 
@@ -29,7 +28,8 @@ public final class DreamLeash extends CardImpl {
         this.subtype.add(SubType.AURA);
 
         // Enchant permanent
-        TargetPermanent auraTarget = new TargetTappedPermanentAsYouCast(new FilterCreaturePermanent("tapped permanent"));
+        TargetPermanent auraTarget = new TargetTappedPermanentAsYouCast();
+        auraTarget.withChooseHint("must be tapped");
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.GainControl));
         Ability ability = new EnchantAbility(auraTarget.getTargetName());

--- a/Mage.Sets/src/mage/cards/e/EnthrallingHold.java
+++ b/Mage.Sets/src/mage/cards/e/EnthrallingHold.java
@@ -12,7 +12,6 @@ import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetTappedPermanentAsYouCast;
 
@@ -30,7 +29,8 @@ public final class EnthrallingHold extends CardImpl {
         this.subtype.add(SubType.AURA);
 
         // Enchant creature
-        TargetPermanent auraTarget = new TargetTappedPermanentAsYouCast(new FilterCreaturePermanent("tapped creature"));
+        TargetPermanent auraTarget = new TargetTappedPermanentAsYouCast(StaticFilters.FILTER_PERMANENT_CREATURE);
+        auraTarget.withChooseHint("must be tapped");
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.GainControl));
         Ability ability = new EnchantAbility(auraTarget.getTargetName());

--- a/Mage.Sets/src/mage/cards/e/EnthrallingHold.java
+++ b/Mage.Sets/src/mage/cards/e/EnthrallingHold.java
@@ -12,6 +12,7 @@ import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetTappedPermanentAsYouCast;
 
@@ -29,7 +30,7 @@ public final class EnthrallingHold extends CardImpl {
         this.subtype.add(SubType.AURA);
 
         // Enchant creature
-        TargetPermanent auraTarget = new TargetTappedPermanentAsYouCast(StaticFilters.FILTER_PERMANENT_CREATURE);
+        TargetPermanent auraTarget = new TargetTappedPermanentAsYouCast(new FilterCreaturePermanent("tapped creature"));
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.GainControl));
         Ability ability = new EnchantAbility(auraTarget.getTargetName());

--- a/Mage.Sets/src/mage/cards/k/KaldraCompleat.java
+++ b/Mage.Sets/src/mage/cards/k/KaldraCompleat.java
@@ -65,7 +65,7 @@ public final class KaldraCompleat extends CardImpl {
                         true,
                         false,
                         true,
-                        StaticFilters.FILTER_PERMANENT_CREATURE_A
+                        StaticFilters.FILTER_PERMANENT_A_CREATURE
                 ),
                 AttachmentType.EQUIPMENT,
                 Duration.WhileOnBattlefield,

--- a/Mage.Sets/src/mage/cards/l/LeylineOfVitality.java
+++ b/Mage.Sets/src/mage/cards/l/LeylineOfVitality.java
@@ -33,7 +33,7 @@ public final class LeylineOfVitality extends CardImpl {
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD,
                 new GainLifeEffect(1),
-                StaticFilters.FILTER_PERMANENT_CREATURE_A,
+                StaticFilters.FILTER_PERMANENT_A_CREATURE,
                 true)
         );
     }

--- a/Mage.Sets/src/mage/cards/n/NurturingPresence.java
+++ b/Mage.Sets/src/mage/cards/n/NurturingPresence.java
@@ -41,7 +41,7 @@ public final class NurturingPresence extends CardImpl {
                 new EntersBattlefieldControlledTriggeredAbility(
                         new BoostSourceEffect(1, 1, Duration.EndOfTurn)
                                 .setText("this creature gets +1/+1 until end of turn"),
-                        StaticFilters.FILTER_PERMANENT_CREATURE_A
+                        StaticFilters.FILTER_PERMANENT_A_CREATURE
                 ), AttachmentType.AURA
         )));
 

--- a/Mage.Sets/src/mage/cards/s/SeasonOfGrowth.java
+++ b/Mage.Sets/src/mage/cards/s/SeasonOfGrowth.java
@@ -29,7 +29,7 @@ public final class SeasonOfGrowth extends CardImpl {
 
         // Whenever a creature enters the battlefield under your control, scry 1.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
-                new ScryEffect(1), StaticFilters.FILTER_PERMANENT_CREATURE_A
+                new ScryEffect(1), StaticFilters.FILTER_PERMANENT_A_CREATURE
         ));
 
         // Whenever you cast a spell that targets a creature you control, draw a card.

--- a/Mage.Sets/src/mage/cards/t/TrialOfAmbition.java
+++ b/Mage.Sets/src/mage/cards/t/TrialOfAmbition.java
@@ -31,7 +31,7 @@ public final class TrialOfAmbition extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{B}");
 
         // When Trial of Ambition enters the battlefield, target opponent sacrifices a creature.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new SacrificeEffect(StaticFilters.FILTER_PERMANENT_CREATURE_A, 1, "target opponent"));
+        Ability ability = new EntersBattlefieldTriggeredAbility(new SacrificeEffect(StaticFilters.FILTER_PERMANENT_A_CREATURE, 1, "target opponent"));
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/v/ValorInAkros.java
+++ b/Mage.Sets/src/mage/cards/v/ValorInAkros.java
@@ -24,7 +24,7 @@ public final class ValorInAkros extends CardImpl {
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD,
                 new BoostControlledEffect(1, 1, Duration.EndOfTurn),
-                StaticFilters.FILTER_PERMANENT_CREATURE_A,
+                StaticFilters.FILTER_PERMANENT_A_CREATURE,
                 false)
         );
     }

--- a/Mage/src/main/java/mage/abilities/common/BecomesBlockedAllTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/BecomesBlockedAllTriggeredAbility.java
@@ -19,7 +19,7 @@ public class BecomesBlockedAllTriggeredAbility extends TriggeredAbilityImpl {
     private final boolean setTargetPointer;
 
     public BecomesBlockedAllTriggeredAbility(Effect effect, boolean optional) {
-        this(effect, optional, StaticFilters.FILTER_PERMANENT_CREATURE_A, false);
+        this(effect, optional, StaticFilters.FILTER_PERMANENT_A_CREATURE, false);
     }
 
     public BecomesBlockedAllTriggeredAbility(Effect effect, boolean optional, FilterCreaturePermanent filter, boolean setTargetPointer) {

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -522,12 +522,6 @@ public final class StaticFilters {
         FILTER_PERMANENT_CREATURE.setLockedFilter(true);
     }
 
-    public static final FilterCreaturePermanent FILTER_PERMANENT_CREATURE_A = new FilterCreaturePermanent("a creature");
-
-    static {
-        FILTER_PERMANENT_CREATURE_A.setLockedFilter(true);
-    }
-
     public static final FilterPermanent FILTER_PERMANENT_CREATURE_OR_PLANESWALKER_A = new FilterPermanent("a creature or planeswalker");
 
     static {

--- a/Mage/src/main/java/mage/game/command/emblems/LukkaWaywardBonderEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/LukkaWaywardBonderEmblem.java
@@ -23,7 +23,7 @@ public final class LukkaWaywardBonderEmblem extends Emblem {
         this.setExpansionSetCodeForImage("STX");
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(
                 Zone.COMMAND, new LukkaWaywardBonderEmblemEffect(),
-                StaticFilters.FILTER_PERMANENT_CREATURE_A, false
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, false
         );
         ability.addTarget(new TargetAnyTarget());
         this.getAbilities().add(ability);


### PR DESCRIPTION
1. Fixed wording on creature selection for Enthralling Hold ("a creature" -> "a tapped creature")
2. Fixed wording on permanent selection for Dream Leash ("a permanent" -> "a tapped permanent")
3. Removed FILTER_PERMANENT_CREATURE_A since FILTER_PERMANENT_A_CREATURE already existed and they both did the exact same thing.