### PR TITLE
Replaced several created filters inside card classes with pre-built static filters and simplified 3 cards

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AbzanBattlePriest.java
+++ b/Mage.Sets/src/mage/cards/a/AbzanBattlePriest.java
@@ -10,8 +10,7 @@ import mage.abilities.keyword.OutlastAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -19,14 +18,6 @@ import java.util.UUID;
  * @author LevelX2
  */
 public final class AbzanBattlePriest extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterPermanent();
-
-    static {
-        filter.add(CardType.CREATURE.getPredicate());
-        filter.add(TargetController.YOU.getControllerPredicate());
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public AbzanBattlePriest(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{W}");
@@ -44,7 +35,8 @@ public final class AbzanBattlePriest extends CardImpl {
                 Zone.BATTLEFIELD,
                 new GainAbilityAllEffect(
                         LifelinkAbility.getInstance(), Duration.WhileOnBattlefield,
-                        filter, "Each creature you control with a +1/+1 counter on it has lifelink"
+                        StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1,
+                        "Each creature you control with a +1/+1 counter on it has lifelink"
                 )
         ));
     }

--- a/Mage.Sets/src/mage/cards/a/AbzanFalconer.java
+++ b/Mage.Sets/src/mage/cards/a/AbzanFalconer.java
@@ -11,21 +11,13 @@ import mage.abilities.keyword.OutlastAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author emerald000
  */
 public final class AbzanFalconer extends CardImpl {
-    
-    private static final FilterPermanent filter = new FilterPermanent();
-    static {
-        filter.add(CardType.CREATURE.getPredicate());
-        filter.add(TargetController.YOU.getControllerPredicate());
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public AbzanFalconer(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{W}");
@@ -39,7 +31,11 @@ public final class AbzanFalconer extends CardImpl {
         this.addAbility(new OutlastAbility(new ColoredManaCost(ColoredManaSymbol.W)));
         
         // Each creature you control with a +1/+1 counter on it has flying.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(FlyingAbility.getInstance(), Duration.WhileOnBattlefield, filter, "Each creature you control with a +1/+1 counter on it has flying")));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(
+                FlyingAbility.getInstance(),
+                Duration.WhileOnBattlefield,
+                StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)
+        ));
     }
 
     private AbzanFalconer(final AbzanFalconer card) {

--- a/Mage.Sets/src/mage/cards/a/ActOfAggression.java
+++ b/Mage.Sets/src/mage/cards/a/ActOfAggression.java
@@ -10,8 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,15 +19,9 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class ActOfAggression extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public ActOfAggression(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{R/P}{R/P}");
-        this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.getSpellAbility().addEffect(new GainControlTargetEffect(Duration.EndOfTurn));
         this.getSpellAbility().addEffect(new UntapTargetEffect().setText("Untap that creature"));
         this.getSpellAbility().addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn).setText("It gains haste until end of turn."));

--- a/Mage.Sets/src/mage/cards/a/AhnCropChampion.java
+++ b/Mage.Sets/src/mage/cards/a/AhnCropChampion.java
@@ -10,7 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -26,7 +26,7 @@ public final class AhnCropChampion extends CardImpl {
         this.toughness = new MageInt(4);
 
         // You may exert Ahn-Crop Champion as it attacks. When you do, untap all other creatures you control.
-        addAbility(new ExertAbility(new BecomesExertSourceTriggeredAbility(new UntapAllControllerEffect(new FilterControlledCreaturePermanent("creatures you control"), null, false))));
+        addAbility(new ExertAbility(new BecomesExertSourceTriggeredAbility(new UntapAllControllerEffect(StaticFilters.FILTER_CONTROLLED_CREATURES, null, false))));
     }
 
     private AhnCropChampion(final AhnCropChampion card) {

--- a/Mage.Sets/src/mage/cards/a/AinokBondKin.java
+++ b/Mage.Sets/src/mage/cards/a/AinokBondKin.java
@@ -11,24 +11,13 @@ import mage.abilities.keyword.OutlastAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author LevelX2
  */
 public final class AinokBondKin extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterPermanent();
-
-    static {
-        filter.add(CardType.CREATURE.getPredicate());
-        filter.add(TargetController.YOU.getControllerPredicate());
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
-    static final String rule = "Each creature you control with a +1/+1 counter on it has first strike";
 
     public AinokBondKin(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{W}");
@@ -42,8 +31,10 @@ public final class AinokBondKin extends CardImpl {
         this.addAbility(new OutlastAbility(new ManaCostsImpl("{1}{W}")));
 
         // Each creature you control with a +1/+1 counter on it has first strike.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(FirstStrikeAbility.getInstance(), Duration.WhileOnBattlefield, filter, rule)));
-
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(
+                FirstStrikeAbility.getInstance(),
+                Duration.WhileOnBattlefield,
+                StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)));
     }
 
     private AinokBondKin(final AinokBondKin card) {

--- a/Mage.Sets/src/mage/cards/a/AkromasBlessing.java
+++ b/Mage.Sets/src/mage/cards/a/AkromasBlessing.java
@@ -9,7 +9,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 
 /**
@@ -23,7 +23,7 @@ public final class AkromasBlessing extends CardImpl {
 
 
         // Choose a color. Creatures you control gain protection from the chosen color until end of turn.
-        this.getSpellAbility().addEffect(new GainProtectionFromColorAllEffect(Duration.EndOfTurn, new FilterControlledCreaturePermanent("Creatures you control")));
+        this.getSpellAbility().addEffect(new GainProtectionFromColorAllEffect(Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES));
         // Cycling {W}
         this.addAbility(new CyclingAbility(new ManaCostsImpl("{W}")));
     }

--- a/Mage.Sets/src/mage/cards/a/AlluringSiren.java
+++ b/Mage.Sets/src/mage/cards/a/AlluringSiren.java
@@ -11,7 +11,7 @@ import mage.abilities.effects.common.combat.AttacksIfAbleTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,12 +20,6 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class AlluringSiren extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public AlluringSiren(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{U}");
 
@@ -33,7 +27,7 @@ public final class AlluringSiren extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AttacksIfAbleTargetEffect(Duration.EndOfTurn), new TapSourceCost());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AltacBloodseeker.java
+++ b/Mage.Sets/src/mage/cards/a/AltacBloodseeker.java
@@ -15,20 +15,13 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author Quercitron
  */
 public final class AltacBloodseeker extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-    
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
     
     public AltacBloodseeker(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{R}");
@@ -41,7 +34,7 @@ public final class AltacBloodseeker extends CardImpl {
         // Whenever a creature an opponent controls dies, Altac Bloodseeker gets +2/+0 and gains first strike and haste until end of turn.
         Effect effect = new BoostSourceEffect(2, 0, Duration.EndOfTurn);
         effect.setText("{this} gets +2/+0");
-        Ability ability = new DiesCreatureTriggeredAbility(effect, false, filter);
+        Ability ability = new DiesCreatureTriggeredAbility(effect, false, StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         
         effect = new GainAbilitySourceEffect(FirstStrikeAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("and gains first strike");

--- a/Mage.Sets/src/mage/cards/a/AngelOfDeliverance.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfDeliverance.java
@@ -15,9 +15,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.target.common.TargetCreaturePermanent;
@@ -26,12 +25,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author fireshoes
  */
 public final class AngelOfDeliverance extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public AngelOfDeliverance(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{6}{W}{W}");
@@ -49,7 +42,7 @@ public final class AngelOfDeliverance extends CardImpl {
                 DeliriumCondition.instance,
                 "<i>Delirium</i> &mdash; Whenever {this} deals damage, if there are four or more card types among cards in your graveyard, exile target creature an opponent controls"
         );
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         ability.addHint(CardTypesInGraveyardHint.YOU);
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/a/AngelicRenewal.java
+++ b/Mage.Sets/src/mage/cards/a/AngelicRenewal.java
@@ -7,7 +7,7 @@ import mage.abilities.effects.common.ReturnToBattlefieldUnderOwnerControlTargetE
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -22,7 +22,7 @@ public final class AngelicRenewal extends CardImpl {
         // Whenever a creature is put into your graveyard from the battlefield, you may sacrifice Angelic Renewal. If you do, return that card to the battlefield.
         this.addAbility(new PutIntoGraveFromBattlefieldAllTriggeredAbility(new DoIfCostPaid(
                 new ReturnToBattlefieldUnderOwnerControlTargetEffect(false, false), new SacrificeSourceCost()), false,
-                new FilterCreaturePermanent("a creature"), true, true));
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, true, true));
     }
 
     private AngelicRenewal(final AngelicRenewal card) {

--- a/Mage.Sets/src/mage/cards/a/AquastrandSpider.java
+++ b/Mage.Sets/src/mage/cards/a/AquastrandSpider.java
@@ -15,8 +15,7 @@ import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -24,14 +23,7 @@ import mage.target.common.TargetCreaturePermanent;
  * @author JotaPeRL
  */
 public final class AquastrandSpider extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter
-            = new FilterCreaturePermanent("creature with a +1/+1 counter on it");
 
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-    
     public AquastrandSpider(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{G}");
         this.subtype.add(SubType.SPIDER);
@@ -46,7 +38,7 @@ public final class AquastrandSpider extends CardImpl {
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new GainAbilityTargetEffect(ReachAbility.getInstance(),
                         Duration.EndOfTurn), new ManaCostsImpl("{G}"));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_CREATURE_P1P1));
         this.addAbility(ability.addCustomOutcome(Outcome.Benefit));        
     }
     

--- a/Mage.Sets/src/mage/cards/a/ArcusAcolyte.java
+++ b/Mage.Sets/src/mage/cards/a/ArcusAcolyte.java
@@ -12,10 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -23,13 +20,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class ArcusAcolyte extends CardImpl {
-
-    private static final FilterPermanent filter
-            = new FilterControlledCreaturePermanent("creature you control without a +1/+1 counter on it");
-
-    static {
-        filter.add(Predicates.not(CounterType.P1P1.getPredicate()));
-    }
 
     public ArcusAcolyte(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{G}{W}");
@@ -52,7 +42,7 @@ public final class ArcusAcolyte extends CardImpl {
         // Each other creature you control without a +1/+1 counter on it has outlast {G/W}.
         this.addAbility(new SimpleStaticAbility(new GainAbilityAllEffect(
                 new OutlastAbility(new ManaCostsImpl<>("{G/W}")),
-                Duration.WhileOnBattlefield, filter, true
+                Duration.WhileOnBattlefield, StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1, true
         ).setText("each other creature you control without a +1/+1 counter on it has outlast {G/W}")));
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArcusAcolyte.java
+++ b/Mage.Sets/src/mage/cards/a/ArcusAcolyte.java
@@ -12,7 +12,10 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.filter.StaticFilters;
+import mage.counters.CounterType;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.predicate.Predicates;
 
 import java.util.UUID;
 
@@ -20,6 +23,13 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class ArcusAcolyte extends CardImpl {
+
+    private static final FilterPermanent filter
+            = new FilterControlledCreaturePermanent("creature you control without a +1/+1 counter on it");
+
+    static {
+        filter.add(Predicates.not(CounterType.P1P1.getPredicate()));
+    }
 
     public ArcusAcolyte(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{G}{W}");
@@ -42,7 +52,7 @@ public final class ArcusAcolyte extends CardImpl {
         // Each other creature you control without a +1/+1 counter on it has outlast {G/W}.
         this.addAbility(new SimpleStaticAbility(new GainAbilityAllEffect(
                 new OutlastAbility(new ManaCostsImpl<>("{G/W}")),
-                Duration.WhileOnBattlefield, StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1, true
+                Duration.WhileOnBattlefield, filter, true
         ).setText("each other creature you control without a +1/+1 counter on it has outlast {G/W}")));
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArenaAthlete.java
+++ b/Mage.Sets/src/mage/cards/a/ArenaAthlete.java
@@ -11,8 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,12 +19,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author Plopman
  */
 public final class ArenaAthlete extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
     
     public ArenaAthlete(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{R}");
@@ -36,7 +29,7 @@ public final class ArenaAthlete extends CardImpl {
 
         // <i>Heroic</i>  Whenever you cast a spell that targets Arena Athlete, target creature an opponent controls can't block this turn.
         Ability ability = new HeroicAbility(new CantBlockTargetEffect(Duration.EndOfTurn));
-        TargetCreaturePermanent target = new TargetCreaturePermanent(filter);
+        TargetCreaturePermanent target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/a/ArmorcraftJudge.java
+++ b/Mage.Sets/src/mage/cards/a/ArmorcraftJudge.java
@@ -10,20 +10,13 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author LevelX2
  */
 public final class ArmorcraftJudge extends CardImpl {
-
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public ArmorcraftJudge(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{G}");
@@ -33,7 +26,9 @@ public final class ArmorcraftJudge extends CardImpl {
         this.toughness = new MageInt(3);
 
         // When Armorcraft Judge enters the battlefield, draw a card for each creature you control with a +1/+1 counter on it.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new DrawCardSourceControllerEffect(new PermanentsOnBattlefieldCount(filter))));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new DrawCardSourceControllerEffect(
+                new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1))
+        ));
     }
 
     private ArmorcraftJudge(final ArmorcraftJudge card) {

--- a/Mage.Sets/src/mage/cards/a/AvatarOfTheResolute.java
+++ b/Mage.Sets/src/mage/cards/a/AvatarOfTheResolute.java
@@ -14,21 +14,13 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author jeffwadsworth
  */
 public final class AvatarOfTheResolute extends CardImpl {
-    
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("other creature you control with a +1/+1 counter on it");
-    
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-        filter.add(AnotherPredicate.instance);
-    }
 
     public AvatarOfTheResolute(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{G}{G}");
@@ -43,9 +35,11 @@ public final class AvatarOfTheResolute extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
         
         // Avatar of the Resolute enters the battlefield with a +1/+1 counter on it for each other creature you control with a +1/+1 counter on it.
-        DynamicValue numberCounters = new PermanentsOnBattlefieldCount(filter);
-        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), numberCounters, true),
-                "with a +1/+1 counter on it for each other creature you control with a +1/+1 counter on it"));
+        DynamicValue numberCounters = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_OTHER_CONTROLLED_CREATURE_P1P1);
+        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
+                CounterType.P1P1.createInstance(0), numberCounters, true),
+                "with a +1/+1 counter on it for each other creature you control with a +1/+1 counter on it")
+        );
         
     }
 

--- a/Mage.Sets/src/mage/cards/a/AzoriusArrester.java
+++ b/Mage.Sets/src/mage/cards/a/AzoriusArrester.java
@@ -10,8 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -19,12 +18,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class AzoriusArrester extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
- 
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
     
     public AzoriusArrester(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{W}");
@@ -36,7 +29,7 @@ public final class AzoriusArrester extends CardImpl {
 
         // When Azorius Arrester enters the battlefield, detain target creature an opponent controls.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DetainTargetEffect(), false);
-        TargetCreaturePermanent target = new TargetCreaturePermanent(filter);
+        TargetCreaturePermanent target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BanisherPriest.java
+++ b/Mage.Sets/src/mage/cards/b/BanisherPriest.java
@@ -14,8 +14,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
@@ -27,12 +26,6 @@ import mage.util.CardUtil;
  */
 public final class BanisherPriest extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public BanisherPriest(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{W}{W}");
         this.subtype.add(SubType.HUMAN, SubType.CLERIC);
@@ -42,7 +35,7 @@ public final class BanisherPriest extends CardImpl {
 
         // When Banisher Priest enters the battlefield, exile target creature an opponent controls until Banisher Priest leaves the battlefield.
         Ability ability = new EntersBattlefieldTriggeredAbility(new BanisherPriestExileEffect());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         ability.addEffect(new CreateDelayedTriggeredAbilityEffect(new OnLeaveReturnExiledToBattlefieldAbility()));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BattlefrontKrushok.java
+++ b/Mage.Sets/src/mage/cards/b/BattlefrontKrushok.java
@@ -11,6 +11,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
 
 import java.util.UUID;
@@ -20,12 +21,6 @@ import java.util.UUID;
  * @author LevelX2
  */
 public final class BattlefrontKrushok extends CardImpl {
-
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public BattlefrontKrushok(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{G}");
@@ -37,7 +32,9 @@ public final class BattlefrontKrushok extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new CantBeBlockedByMoreThanOneSourceEffect()));
 
         // Each creature you control with a +1/+1 counter on it can't be blocked by more than one creature.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new CantBeBlockedByMoreThanOneAllEffect(filter)));
+        this.addAbility(new SimpleStaticAbility(
+                Zone.BATTLEFIELD,
+                new CantBeBlockedByMoreThanOneAllEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1)));
     }
 
     private BattlefrontKrushok(final BattlefrontKrushok card) {

--- a/Mage.Sets/src/mage/cards/b/Betrayal.java
+++ b/Mage.Sets/src/mage/cards/b/Betrayal.java
@@ -10,8 +10,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -22,18 +21,12 @@ import java.util.UUID;
  */
 public final class Betrayal extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public Betrayal(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{U}");
         this.subtype.add(SubType.AURA);
 
         // Enchant creature an opponent controls
-        TargetPermanent auraTarget = new TargetCreaturePermanent(filter);
+        TargetPermanent auraTarget = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.Detriment));
         Ability ability = new EnchantAbility(auraTarget.getTargetName());

--- a/Mage.Sets/src/mage/cards/b/BishopOfBinding.java
+++ b/Mage.Sets/src/mage/cards/b/BishopOfBinding.java
@@ -20,7 +20,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.constants.TargetController;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.ExileZone;
 import mage.game.Game;
@@ -34,12 +34,6 @@ import mage.util.CardUtil;
  */
 public final class BishopOfBinding extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public BishopOfBinding(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{W}");
 
@@ -50,7 +44,7 @@ public final class BishopOfBinding extends CardImpl {
 
         // When Bishop of Binding enters the battlefield, exile target creature an opponent controls until Bishop of Binding leaves the battlefield.
         Ability ability = new EntersBattlefieldTriggeredAbility(new BishopOfBindingExileEffect());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         ability.addEffect(new CreateDelayedTriggeredAbilityEffect(new OnLeaveReturnExiledToBattlefieldAbility()));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/b/BlastingStation.java
+++ b/Mage.Sets/src/mage/cards/b/BlastingStation.java
@@ -14,7 +14,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Zone;
 import static mage.filter.StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.common.TargetAnyTarget;
 
@@ -32,8 +32,9 @@ public final class BlastingStation extends CardImpl {
         ability.addCost(new SacrificeTargetCost(new TargetControlledCreaturePermanent(FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
+
         // Whenever a creature enters the battlefield, you may untap Blasting Station.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new UntapSourceEffect(), new FilterCreaturePermanent("a creature"), true));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new UntapSourceEffect(), StaticFilters.FILTER_PERMANENT_A_CREATURE, true));
 
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlessedReincarnation.java
+++ b/Mage.Sets/src/mage/cards/b/BlessedReincarnation.java
@@ -8,9 +8,8 @@ import mage.abilities.keyword.ReboundAbility;
 import mage.cards.*;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Library;
@@ -23,12 +22,6 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class BlessedReincarnation extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public BlessedReincarnation(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{U}");
 
@@ -36,7 +29,7 @@ public final class BlessedReincarnation extends CardImpl {
         // That player reveals cards from the top of their library until a creature card is revealed.
         // The player puts that card onto the battlefield, then shuffles the rest into their library.
         this.getSpellAbility().addEffect(new BlessedReincarnationEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
 
         // Rebound
         this.addAbility(new ReboundAbility());

--- a/Mage.Sets/src/mage/cards/b/BlessedSanctuary.java
+++ b/Mage.Sets/src/mage/cards/b/BlessedSanctuary.java
@@ -9,7 +9,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.predicate.permanent.TokenPredicate;
 import mage.game.permanent.token.UnicornToken;
@@ -18,7 +18,6 @@ import java.util.UUID;
 
 public class BlessedSanctuary extends CardImpl {
 
-    private static final FilterPermanent filterYourCreatures = new FilterControlledCreaturePermanent("creatures you control");
     private static final FilterControlledCreaturePermanent filterNontoken = new FilterControlledCreaturePermanent("a nontoken creature");
 
     static {
@@ -30,7 +29,7 @@ public class BlessedSanctuary extends CardImpl {
 
         //Prevent all noncombat damage that would be dealt to you and creatures you control.
         this.addAbility(new SimpleStaticAbility(new PreventAllNonCombatDamageToAllEffect(
-                Duration.WhileOnBattlefield, filterYourCreatures, true)));
+                Duration.WhileOnBattlefield, StaticFilters.FILTER_CONTROLLED_CREATURES, true)));
 
         //Whenever a nontoken creature enters the battlefield under your control, create a 2/2 white Unicorn creature token.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,

--- a/Mage.Sets/src/mage/cards/b/BloodcrazedHoplite.java
+++ b/Mage.Sets/src/mage/cards/b/BloodcrazedHoplite.java
@@ -12,13 +12,11 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -26,12 +24,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class BloodcrazedHoplite extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public BloodcrazedHoplite(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{B}");
@@ -44,7 +36,7 @@ public final class BloodcrazedHoplite extends CardImpl {
         this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), false)));
         // Whenever a +1/+1 counter is put on Bloodcrazed Hoplite, remove a +1/+1 counter from target creature an opponent controls.
         Ability ability = new BloodcrazedHopliteTriggeredAbility();
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BramblewoodParagon.java
+++ b/Mage.Sets/src/mage/cards/b/BramblewoodParagon.java
@@ -12,7 +12,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
@@ -23,12 +23,6 @@ import mage.game.permanent.Permanent;
  * @author emerald000
  */
 public final class BramblewoodParagon extends CardImpl {
-
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("Each creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public BramblewoodParagon(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{G}");
@@ -45,7 +39,9 @@ public final class BramblewoodParagon extends CardImpl {
                 new GainAbilityAllEffect(
                         TrampleAbility.getInstance(),
                         Duration.WhileOnBattlefield,
-                        filter)));
+                        StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)
+                )
+        );
 
     }
 

--- a/Mage.Sets/src/mage/cards/c/CaptivatingCrew.java
+++ b/Mage.Sets/src/mage/cards/c/CaptivatingCrew.java
@@ -16,9 +16,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -26,12 +25,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author TheElk801
  */
 public final class CaptivatingCrew extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public CaptivatingCrew(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{R}");
@@ -49,7 +42,7 @@ public final class CaptivatingCrew extends CardImpl {
         effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("It gains haste until end of turn");
         ability.addEffect(effect);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CarnivalOfSouls.java
+++ b/Mage.Sets/src/mage/cards/c/CarnivalOfSouls.java
@@ -13,7 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -23,11 +23,10 @@ public final class CarnivalOfSouls extends CardImpl {
 
     public CarnivalOfSouls(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{B}");
-        
 
         // Whenever a creature enters the battlefield, you lose 1 life and add {B}.
         Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new LoseLifeSourceControllerEffect(1),
-                new FilterCreaturePermanent("a creature"), false, SetTargetPointer.PERMANENT, null, false);
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT, null, false);
         Effect effect = new AddManaToManaPoolSourceControllerEffect(Mana.BlackMana(1));
         effect.setText("and add {B}.");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/c/CemeteryPuca.java
+++ b/Mage.Sets/src/mage/cards/c/CemeteryPuca.java
@@ -15,6 +15,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -35,8 +36,11 @@ public final class CemeteryPuca extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever a creature dies, you may pay {1}. If you do, Cemetery Puca becomes a copy of that creature, except it has this ability.
-        this.addAbility(new DiesCreatureTriggeredAbility(new DoIfCostPaid(new CemeteryPucaEffect(), new ManaCostsImpl("{1}")), false, new FilterCreaturePermanent("a creature"), true));
-
+        this.addAbility(new DiesCreatureTriggeredAbility(
+                new DoIfCostPaid(new CemeteryPucaEffect(), new ManaCostsImpl("{1}")),
+                false,
+                StaticFilters.FILTER_PERMANENT_A_CREATURE,
+                true));
     }
 
     private CemeteryPuca(final CemeteryPuca card) {
@@ -72,7 +76,7 @@ class CemeteryPucaEffect extends OneShotEffect {
             Permanent copyFromCreature = getTargetPointer().getFirstTargetPermanentOrLKI(game, source);
             if (copyFromCreature != null) {
                 game.copyPermanent(Duration.WhileOnBattlefield, copyFromCreature, copyToCreature.getId(), source, new EmptyCopyApplier());
-                ContinuousEffect effect = new GainAbilityTargetEffect(new DiesCreatureTriggeredAbility(new DoIfCostPaid(new CemeteryPucaEffect(), new ManaCostsImpl("{1}")), false, new FilterCreaturePermanent("a creature"), true), Duration.WhileOnBattlefield);
+                ContinuousEffect effect = new GainAbilityTargetEffect(new DiesCreatureTriggeredAbility(new DoIfCostPaid(new CemeteryPucaEffect(), new ManaCostsImpl("{1}")), false, StaticFilters.FILTER_PERMANENT_A_CREATURE, true), Duration.WhileOnBattlefield);
                 effect.setTargetPointer(new FixedTarget(copyToCreature.getId(), game));
                 game.addEffect(effect, source);
                 return true;

--- a/Mage.Sets/src/mage/cards/c/CennsTactician.java
+++ b/Mage.Sets/src/mage/cards/c/CennsTactician.java
@@ -14,7 +14,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -25,10 +25,8 @@ import mage.target.common.TargetCreaturePermanent;
 public final class CennsTactician extends CardImpl {
     
     private static final FilterCreaturePermanent filterSoldier = new FilterCreaturePermanent("Soldier creature");
-    private static final FilterControlledCreaturePermanent filterCounter = new FilterControlledCreaturePermanent("Each creature you control with a +1/+1 counter on it");
     static {
         filterSoldier.add(SubType.SOLDIER.getPredicate());
-        filterCounter.add(CounterType.P1P1.getPredicate());
     }
 
     public CennsTactician(UUID ownerId, CardSetInfo setInfo) {
@@ -45,7 +43,14 @@ public final class CennsTactician extends CardImpl {
         this.addAbility(ability);
         
         // Each creature you control with a +1/+1 counter on it can block an additional creature each combat.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new CanBlockAdditionalCreatureAllEffect(1, filterCounter, Duration.WhileOnBattlefield)));
+        this.addAbility(new SimpleStaticAbility(
+                Zone.BATTLEFIELD,
+                new CanBlockAdditionalCreatureAllEffect(
+                        1,
+                        StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1,
+                        Duration.WhileOnBattlefield)
+                )
+        );
     }
 
     private CennsTactician(final CennsTactician card) {

--- a/Mage.Sets/src/mage/cards/c/ChainedToTheRocks.java
+++ b/Mage.Sets/src/mage/cards/c/ChainedToTheRocks.java
@@ -15,9 +15,8 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.constants.TargetController;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledLandPermanent;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
@@ -62,11 +61,9 @@ import mage.util.CardUtil;
 public final class ChainedToTheRocks extends CardImpl {
 
     private static final FilterControlledLandPermanent filter = new FilterControlledLandPermanent("Mountain you control");
-    private static final FilterCreaturePermanent filterTarget = new FilterCreaturePermanent("creature an opponent controls");
 
     static {
         filter.add(SubType.MOUNTAIN.getPredicate());
-        filterTarget.add(TargetController.OPPONENT.getControllerPredicate());
     }
 
     public ChainedToTheRocks(UUID ownerId, CardSetInfo setInfo) {
@@ -82,7 +79,7 @@ public final class ChainedToTheRocks extends CardImpl {
 
         // When Chained to the Rocks enters the battlefield, exile target creature an opponent controls until Chained to the Rocks leaves the battlefield. (That creature returns under its owner's control.)
         ability = new EntersBattlefieldTriggeredAbility(new ChainedToTheRocksEffect());
-        ability.addTarget(new TargetCreaturePermanent(filterTarget));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         ability.addEffect(new CreateDelayedTriggeredAbilityEffect(new OnLeaveReturnExiledToBattlefieldAbility()));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/c/ChromeshellCrab.java
+++ b/Mage.Sets/src/mage/cards/c/ChromeshellCrab.java
@@ -14,8 +14,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -26,12 +25,6 @@ import mage.target.common.TargetCreaturePermanent;
 public final class ChromeshellCrab extends CardImpl {
     
     private static final String rule = "you may exchange control of target creature you control and target creature an opponent controls";
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public ChromeshellCrab(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{U}");
@@ -48,7 +41,7 @@ public final class ChromeshellCrab extends CardImpl {
         effect.setText("exchange control of target creature you control and target creature an opponent controls");
         Ability ability = new TurnedFaceUpSourceTriggeredAbility(effect, false, true);
         ability.addTarget(new TargetControlledCreaturePermanent());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChroniclerOfHeroes.java
+++ b/Mage.Sets/src/mage/cards/c/ChroniclerOfHeroes.java
@@ -11,9 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
 
@@ -49,12 +47,6 @@ public final class ChroniclerOfHeroes extends CardImpl {
 
 class ChroniclerOfHeroesEffect extends OneShotEffect {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with a +1/+1 counter on it");
-    static {
-        filter.add(TargetController.YOU.getControllerPredicate());
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
     public ChroniclerOfHeroesEffect() {
         super(Outcome.DrawCard);
         this.staticText = "draw a card if you control a creature with a +1/+1 counter on it";
@@ -73,7 +65,7 @@ class ChroniclerOfHeroesEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            if (new PermanentsOnTheBattlefieldCondition(filter).apply(game, source)) {
+            if (new PermanentsOnTheBattlefieldCondition(StaticFilters.FILTER_A_CREATURE_P1P1).apply(game, source)) {
                 controller.drawCards(1, source, game);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/c/CloseQuarters.java
+++ b/Mage.Sets/src/mage/cards/c/CloseQuarters.java
@@ -9,6 +9,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.TargetController;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.target.common.TargetAnyTarget;
 
@@ -17,7 +18,7 @@ import mage.target.common.TargetAnyTarget;
  * @author fireshoes
  */
 public final class CloseQuarters extends CardImpl {
-    
+
     static final private FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature you control");
 
     static {

--- a/Mage.Sets/src/mage/cards/c/CloseQuarters.java
+++ b/Mage.Sets/src/mage/cards/c/CloseQuarters.java
@@ -9,7 +9,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.TargetController;
-import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.target.common.TargetAnyTarget;
 

--- a/Mage.Sets/src/mage/cards/c/ConqueringManticore.java
+++ b/Mage.Sets/src/mage/cards/c/ConqueringManticore.java
@@ -15,8 +15,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -24,12 +23,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author North
  */
 public final class ConqueringManticore extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public ConqueringManticore(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{R}{R}");
@@ -43,7 +36,7 @@ public final class ConqueringManticore extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(new GainControlTargetEffect(Duration.EndOfTurn), false);
         ability.addEffect(new UntapTargetEffect().setText("Untap that creature"));
         ability.addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn).setText("It gains haste until end of turn."));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConstrictingSliver.java
+++ b/Mage.Sets/src/mage/cards/c/ConstrictingSliver.java
@@ -14,7 +14,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
@@ -26,12 +25,6 @@ import mage.util.CardUtil;
  */
 public final class ConstrictingSliver extends CardImpl {
 
-    private static final FilterCreaturePermanent filterTarget = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filterTarget.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public ConstrictingSliver(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{W}");
         this.subtype.add(SubType.SLIVER);
@@ -42,7 +35,7 @@ public final class ConstrictingSliver extends CardImpl {
         // Sliver creatures you control have "When this creature enters the battlefield, you may exile target creature an opponent controls
         // until this creature leaves the battlefield."
         Ability ability = new EntersBattlefieldTriggeredAbility(new ConstrictingSliverExileEffect(), true);
-        ability.addTarget(new TargetCreaturePermanent(filterTarget));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         ability.addEffect(new CreateDelayedTriggeredAbilityEffect(new OnLeaveReturnExiledToBattlefieldAbility()));
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD,
                 new GainAbilityControlledEffect(ability,

--- a/Mage.Sets/src/mage/cards/c/ContestedCliffs.java
+++ b/Mage.Sets/src/mage/cards/c/ContestedCliffs.java
@@ -15,6 +15,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.TargetController;
 import mage.constants.Zone;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
@@ -26,11 +27,9 @@ import mage.target.common.TargetCreaturePermanent;
 public final class ContestedCliffs extends CardImpl {
 
     private static final FilterCreaturePermanent filter1 = new FilterCreaturePermanent("Beast creature you control");
-    private static final FilterCreaturePermanent filter2 = new FilterCreaturePermanent("creature an opponent controls");
     static {
         filter1.add(TargetController.YOU.getControllerPredicate());
         filter1.add(SubType.BEAST.getPredicate());
-        filter2.add(TargetController.OPPONENT.getControllerPredicate());
     }
 
     public ContestedCliffs(UUID ownerId, CardSetInfo setInfo) {
@@ -38,16 +37,16 @@ public final class ContestedCliffs extends CardImpl {
 
         // {tap}: Add {C}.
         this.addAbility(new ColorlessManaAbility());
+
         // {R}{G}, {tap}: Choose target Beast creature you control and target creature an opponent controls. Those creatures fight each other.
         Effect effect = new FightTargetsEffect();
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl("{R}{G}"));
         ability.addCost(new TapSourceCost());
         Target target1 = new TargetCreaturePermanent(filter1);
         ability.addTarget(target1);
-        Target target2 = new TargetCreaturePermanent(filter2);
+        Target target2 = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target2);
         this.addAbility(ability);
-        
     }
 
     private ContestedCliffs(final ContestedCliffs card) {

--- a/Mage.Sets/src/mage/cards/c/CrownedCeratok.java
+++ b/Mage.Sets/src/mage/cards/c/CrownedCeratok.java
@@ -11,22 +11,14 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author LevelX2
  */
 public final class CrownedCeratok extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Each creature you control with a +1/+1 counter on it");
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-        filter.add(TargetController.YOU.getControllerPredicate());
-    }
 
     public CrownedCeratok(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{G}");
@@ -39,8 +31,14 @@ public final class CrownedCeratok extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Each creature you control with a +1/+1 counter on it has trample.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(TrampleAbility.getInstance(), Duration.WhileOnBattlefield, filter)));
-
+        this.addAbility(new SimpleStaticAbility(
+                Zone.BATTLEFIELD,
+                new GainAbilityAllEffect(
+                        TrampleAbility.getInstance(),
+                        Duration.WhileOnBattlefield,
+                        StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)
+                )
+        );
     }
 
     private CrownedCeratok(final CrownedCeratok card) {

--- a/Mage.Sets/src/mage/cards/c/CrypticCommand.java
+++ b/Mage.Sets/src/mage/cards/c/CrypticCommand.java
@@ -12,8 +12,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -68,12 +67,6 @@ public final class CrypticCommand extends CardImpl {
 
 class CrypticCommandEffect extends OneShotEffect {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public CrypticCommandEffect() {
         super(Outcome.Tap);
         staticText = "Tap all creatures your opponents control";
@@ -89,7 +82,7 @@ class CrypticCommandEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        for (Permanent creature : game.getBattlefield().getActivePermanents(filter, player.getId(), source.getSourceId(), game)) {
+        for (Permanent creature : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE, player.getId(), source.getSourceId(), game)) {
             creature.tap(source, game);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/c/CytoplastManipulator.java
+++ b/Mage.Sets/src/mage/cards/c/CytoplastManipulator.java
@@ -17,8 +17,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -26,11 +25,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author JotaPeRL
  */
 public final class CytoplastManipulator extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with a +1/+1 counter on it");
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }    
 
     public CytoplastManipulator(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{U}{U}");
@@ -50,7 +44,7 @@ public final class CytoplastManipulator extends CardImpl {
                 "gain control of target creature with a +1/+1 counter on it for as long as {this} remains on the battlefield");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl("{U}"));
         ability.addCost(new TapSourceCost());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_CREATURE_P1P1));
         this.addAbility(ability);
         
     }

--- a/Mage.Sets/src/mage/cards/c/CytoplastRootKin.java
+++ b/Mage.Sets/src/mage/cards/c/CytoplastRootKin.java
@@ -17,8 +17,7 @@ import mage.constants.SubType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetControlledCreaturePermanent;
@@ -28,12 +27,6 @@ import mage.target.common.TargetControlledCreaturePermanent;
  * @author emerald000
  */
 public final class CytoplastRootKin extends CardImpl {
-    
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("other creature you control that has a +1/+1 counter on it");
-    static {
-        filter.add(AnotherPredicate.instance);
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public CytoplastRootKin(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{G}{G}");
@@ -45,8 +38,8 @@ public final class CytoplastRootKin extends CardImpl {
         // Graft 4
         this.addAbility(new GraftAbility(this, 4));
         
-        // When Cytoplast Root-Kin enters the battlefield, put a +1/+1 counter on each other creature you control that has a +1/+1 counter on it.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new AddCountersAllEffect(CounterType.P1P1.createInstance(), filter)));
+        // When Cytoplast Root-Kin enters the battlefield, put a +1/+1 counter on each other creature you control with a +1/+1 counter on it.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new AddCountersAllEffect(CounterType.P1P1.createInstance(), StaticFilters.FILTER_OTHER_CONTROLLED_CREATURE_P1P1)));
         
         // {2}: Move a +1/+1 counter from target creature you control onto Cytoplast Root-Kin.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new CytoplastRootKinEffect(), new GenericManaCost(2));

--- a/Mage.Sets/src/mage/cards/c/CytospawnShambler.java
+++ b/Mage.Sets/src/mage/cards/c/CytospawnShambler.java
@@ -15,8 +15,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -24,11 +23,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author JotaPeRL
  */
 public final class CytospawnShambler extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with a +1/+1 counter on it");
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }       
 
     public CytospawnShambler(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{6}{G}");
@@ -42,7 +36,7 @@ public final class CytospawnShambler extends CardImpl {
         
         // {G}: Target creature with a +1/+1 counter on it gains trample until end of turn.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn), new ManaCostsImpl("{G}"));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_CREATURE_P1P1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkProphecy.java
+++ b/Mage.Sets/src/mage/cards/d/DarkProphecy.java
@@ -9,6 +9,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.TargetController;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 
 import java.util.UUID;
@@ -18,18 +19,12 @@ import java.util.UUID;
  */
 public final class DarkProphecy extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature you control");
-
-    static {
-        filter.add(TargetController.YOU.getControllerPredicate());
-    }
-
     public DarkProphecy(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{B}{B}{B}");
 
         // Whenever a creature you control dies, you draw a card and you lose 1 life.
         Effect effect = new DrawCardSourceControllerEffect(1, "you");
-        Ability ability = new DiesCreatureTriggeredAbility(effect, false, filter);
+        Ability ability = new DiesCreatureTriggeredAbility(effect, false, StaticFilters.FILTER_CONTROLLED_A_CREATURE);
         effect = new LoseLifeSourceControllerEffect(1);
         ability.addEffect(effect.concatBy("and"));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/d/DauntlessEscort.java
+++ b/Mage.Sets/src/mage/cards/d/DauntlessEscort.java
@@ -14,8 +14,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -34,8 +33,7 @@ public final class DauntlessEscort extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Sacrifice Dauntless Escort: Creatures you control are indestructible this turn.
-        FilterPermanent filter = new FilterControlledCreaturePermanent("Creatures you control");
-        Effect effect = new GainAbilityAllEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn, filter, false);
+        Effect effect = new GainAbilityAllEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES, false);
         effect.setText("Creatures you control are indestructible this turn");
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new SacrificeSourceCost()));
     }

--- a/Mage.Sets/src/mage/cards/d/DeadMansChest.java
+++ b/Mage.Sets/src/mage/cards/d/DeadMansChest.java
@@ -14,7 +14,7 @@ import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.ManaPoolItem;
@@ -31,19 +31,13 @@ import java.util.UUID;
  */
 public final class DeadMansChest extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public DeadMansChest(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{B}");
 
         this.subtype.add(SubType.AURA);
 
         // Enchant creature an opponent controls
-        TargetPermanent auraTarget = new TargetPermanent(filter);
+        TargetPermanent auraTarget = new TargetPermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.Benefit));
         Ability ability = new EnchantAbility(auraTarget.getTargetName());

--- a/Mage.Sets/src/mage/cards/d/DeepwaterHypnotist.java
+++ b/Mage.Sets/src/mage/cards/d/DeepwaterHypnotist.java
@@ -11,8 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,13 +19,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class DeepwaterHypnotist extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-    
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-    
             
     public DeepwaterHypnotist(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{U}");
@@ -38,7 +30,7 @@ public final class DeepwaterHypnotist extends CardImpl {
 
         // <i>Inspired</i> &mdash; Whenever Deepwater Hypnotist becomes untapped, target creature an opponent controls gets -3/-0 until end of turn.
         Ability ability = new InspiredAbility(new BoostTargetEffect(-3,0,Duration.EndOfTurn));
-        ability.addTarget(new TargetCreaturePermanent(filter));        
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);        
     }
 

--- a/Mage.Sets/src/mage/cards/d/DemonicAppetite.java
+++ b/Mage.Sets/src/mage/cards/d/DemonicAppetite.java
@@ -7,13 +7,12 @@ import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.effects.common.SacrificeControllerEffect;
-import mage.abilities.effects.common.SacrificeTargetEffect;
 import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
 import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetControlledCreaturePermanent;
 
@@ -38,7 +37,7 @@ public final class DemonicAppetite extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(3, 3, Duration.WhileOnBattlefield)));
 
         // At the beginning of your upkeep, sacrifice a creature.
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new SacrificeControllerEffect(new FilterCreaturePermanent("a creature"), 1, ""),
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new SacrificeControllerEffect(StaticFilters.FILTER_PERMANENT_A_CREATURE, 1, ""),
                 TargetController.YOU, false));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DictateOfErebos.java
+++ b/Mage.Sets/src/mage/cards/d/DictateOfErebos.java
@@ -9,6 +9,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.TargetController;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.common.FilterCreaturePermanent;
 
@@ -18,19 +19,13 @@ import mage.filter.common.FilterCreaturePermanent;
  */
 public final class DictateOfErebos extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature you control");
-
-    static {
-        filter.add(TargetController.YOU.getControllerPredicate());
-    }
-
     public DictateOfErebos(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{B}{B}");
 
         // Flash
         this.addAbility(FlashAbility.getInstance());
         // Whenever a creature you control dies, each opponent sacrifices a creature.
-        this.addAbility(new DiesCreatureTriggeredAbility(new SacrificeOpponentsEffect(new FilterControlledCreaturePermanent("creature")), false, filter));
+        this.addAbility(new DiesCreatureTriggeredAbility(new SacrificeOpponentsEffect(new FilterControlledCreaturePermanent("creature")), false, StaticFilters.FILTER_CONTROLLED_A_CREATURE));
     }
 
     private DictateOfErebos(final DictateOfErebos card) {

--- a/Mage.Sets/src/mage/cards/d/Displace.java
+++ b/Mage.Sets/src/mage/cards/d/Displace.java
@@ -6,7 +6,7 @@ import mage.abilities.effects.common.ReturnToBattlefieldUnderOwnerControlTargetE
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetControlledCreaturePermanent;
 
 import java.util.UUID;
@@ -20,7 +20,7 @@ public final class Displace extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{U}");
 
         // Exile up to two target creatures you control, then return those cards to the battlefield under their owner's control.
-        this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent(0, 2, new FilterControlledCreaturePermanent("creatures you control"), false));
+        this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent(0, 2, StaticFilters.FILTER_CONTROLLED_CREATURES, false));
         this.getSpellAbility().addEffect(new ExileTargetForSourceEffect());
         this.getSpellAbility().addEffect(new ReturnToBattlefieldUnderOwnerControlTargetEffect(false, false)
                 .withReturnNames("those cards", "their owner's").concatBy(", then"));

--- a/Mage.Sets/src/mage/cards/d/DongZhouTheTyrant.java
+++ b/Mage.Sets/src/mage/cards/d/DongZhouTheTyrant.java
@@ -7,7 +7,7 @@ import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -20,12 +20,6 @@ import java.util.UUID;
  */
 public final class DongZhouTheTyrant extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public DongZhouTheTyrant(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{R}");
         addSuperType(SuperType.LEGENDARY);
@@ -36,7 +30,7 @@ public final class DongZhouTheTyrant extends CardImpl {
 
         // When Dong Zhou, the Tyrant enters the battlefield, target creature an opponent controls deals damage equal to its power to that player.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DongZhouTheTyrantEffect(), false);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DuelingCoach.java
+++ b/Mage.Sets/src/mage/cards/d/DuelingCoach.java
@@ -13,8 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
@@ -23,13 +22,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class DuelingCoach extends CardImpl {
-
-    private static final FilterPermanent filter
-            = new FilterControlledCreaturePermanent("creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public DuelingCoach(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{W}");
@@ -48,7 +40,10 @@ public final class DuelingCoach extends CardImpl {
 
         // {4}{W}, {T}: Put a +1/+1 counter on each creature you control with a +1/+1 counter on it.
         ability = new SimpleActivatedAbility(
-                new AddCountersAllEffect(CounterType.P1P1.createInstance(), filter), new ManaCostsImpl("{4}{W}")
+                new AddCountersAllEffect(
+                        CounterType.P1P1.createInstance(),
+                        StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1),
+                new ManaCostsImpl("{4}{W}")
         );
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/d/DungeonGeists.java
+++ b/Mage.Sets/src/mage/cards/d/DungeonGeists.java
@@ -12,7 +12,7 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
@@ -27,12 +27,6 @@ import mage.watchers.Watcher;
  */
 public final class DungeonGeists extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public DungeonGeists(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{U}{U}");
         this.subtype.add(SubType.SPIRIT);
@@ -45,7 +39,7 @@ public final class DungeonGeists extends CardImpl {
         // When Dungeon Geists enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Dungeon Geists.
         Ability ability = new EntersBattlefieldTriggeredAbility(new TapTargetEffect(), false);
         ability.addEffect(new DungeonGeistsEffect());
-        Target target = new TargetCreaturePermanent(filter);
+        Target target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         this.addAbility(ability, new DungeonGeistsWatcher());
         // watcher needed to send normal events to Dungeon Geists ReplacementEffect

--- a/Mage.Sets/src/mage/cards/d/DuskshellCrawler.java
+++ b/Mage.Sets/src/mage/cards/d/DuskshellCrawler.java
@@ -5,7 +5,7 @@ import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
 import mage.abilities.effects.common.counter.AddCountersTargetEffect;
 import mage.abilities.keyword.TrampleAbility;
 import mage.constants.Duration;
@@ -14,7 +14,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -22,12 +22,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author weirddan455
  */
 public final class DuskshellCrawler extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent();
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public DuskshellCrawler(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{G}");
@@ -43,9 +37,12 @@ public final class DuskshellCrawler extends CardImpl {
 
         // Each creature you control with a +1/+1 counter on it has trample.
         this.addAbility(new SimpleStaticAbility(
-                new GainAbilityControlledEffect(TrampleAbility.getInstance(), Duration.WhileOnBattlefield, filter)
-                .setText("Each creature you control with a +1/+1 counter on it has trample")
-        ));
+                new GainAbilityAllEffect(
+                        TrampleAbility.getInstance(),
+                        Duration.WhileOnBattlefield,
+                        StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)
+                )
+        );
     }
 
     private DuskshellCrawler(final DuskshellCrawler card) {

--- a/Mage.Sets/src/mage/cards/e/EliteScaleguard.java
+++ b/Mage.Sets/src/mage/cards/e/EliteScaleguard.java
@@ -12,8 +12,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
@@ -26,12 +25,6 @@ import mage.target.targetpointer.FirstTargetPointer;
  */
 public final class EliteScaleguard extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
     public EliteScaleguard(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{W}");
         this.subtype.add(SubType.HUMAN);
@@ -43,7 +36,11 @@ public final class EliteScaleguard extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new BolsterEffect(2)));
 
         // Whenever a creature you control with a +1/+1 counter on it attacks, tap target creature defending player controls.
-        Ability ability = new AttacksCreatureYouControlTriggeredAbility(new TapTargetEffect(), false, filter, true);
+        Ability ability = new AttacksCreatureYouControlTriggeredAbility(
+                new TapTargetEffect(),
+                false,
+                StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1,
+                true);
         ability.addTarget(new TargetCreaturePermanent(new FilterCreaturePermanent("creature defending player controls")));
         ability.setTargetAdjuster(EliteScaleguardTargetAdjuster.instance);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/e/EnduringRenewal.java
+++ b/Mage.Sets/src/mage/cards/e/EnduringRenewal.java
@@ -8,8 +8,7 @@ import mage.abilities.effects.common.ReturnFromGraveyardToHandTargetEffect;
 import mage.abilities.effects.common.continuous.PlayWithHandRevealedEffect;
 import mage.cards.*;
 import mage.constants.*;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.players.Player;
@@ -20,8 +19,6 @@ import java.util.UUID;
  * @author anonymous
  */
 public final class EnduringRenewal extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterCreaturePermanent("a creature");
 
     public EnduringRenewal(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{W}{W}");
@@ -35,7 +32,7 @@ public final class EnduringRenewal extends CardImpl {
         // Whenever a creature is put into your graveyard from the battlefield, return it to your hand.
         this.addAbility(new PutIntoGraveFromBattlefieldAllTriggeredAbility(
                 new ReturnFromGraveyardToHandTargetEffect().setText("return it to your hand"),
-                false, filter, true, true
+                false, StaticFilters.FILTER_PERMANENT_A_CREATURE, true, true
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/e/EpharasEnlightenment.java
+++ b/Mage.Sets/src/mage/cards/e/EpharasEnlightenment.java
@@ -20,7 +20,7 @@ import mage.constants.SubType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -47,8 +47,8 @@ public final class EpharasEnlightenment extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(FlyingAbility.getInstance(), AttachmentType.AURA)));
         // Whenever a creature enters the battlefield under your control, you may return Ephara's Enlightenment to its owner's hand.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, 
-                new ReturnToHandSourceEffect(true), 
-                new FilterCreaturePermanent("a creature"),
+                new ReturnToHandSourceEffect(true),
+                StaticFilters.FILTER_PERMANENT_A_CREATURE,
                 true));
         
     }

--- a/Mage.Sets/src/mage/cards/e/EternalThirst.java
+++ b/Mage.Sets/src/mage/cards/e/EternalThirst.java
@@ -15,7 +15,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -24,16 +24,10 @@ import mage.target.common.TargetCreaturePermanent;
  * @author emerald000
  */
 public final class EternalThirst extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature an opponent controls");
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public EternalThirst(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{B}");
         this.subtype.add(SubType.AURA);
-
 
         // Enchant creature
         TargetPermanent auraTarget = new TargetCreaturePermanent();
@@ -47,12 +41,10 @@ public final class EternalThirst extends CardImpl {
         effect.setText("Enchanted creature has lifelink");
         ability = new SimpleStaticAbility(Zone.BATTLEFIELD, effect);
         // and "Whenever a creature an opponent controls dies, put a +1/+1 counter on this creature."
-        effect = new GainAbilityAttachedEffect(new DiesCreatureTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false, filter), AttachmentType.AURA);
+        effect = new GainAbilityAttachedEffect(new DiesCreatureTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false, StaticFilters.FILTER_OPPONENTS_PERMANENT_A_CREATURE), AttachmentType.AURA);
         ability.addEffect(effect);
         effect.setText("and \"Whenever a creature an opponent controls dies, put a +1/+1 counter on this creature.\"");
         this.addAbility(ability);
-
-
     }
 
     private EternalThirst(final EternalThirst card) {

--- a/Mage.Sets/src/mage/cards/e/EvolutionaryEscalation.java
+++ b/Mage.Sets/src/mage/cards/e/EvolutionaryEscalation.java
@@ -12,7 +12,7 @@ import mage.constants.Outcome;
 import mage.constants.TargetController;
 import mage.counters.Counter;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.Target;
@@ -24,11 +24,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author spjspj
  */
 public final class EvolutionaryEscalation extends CardImpl {
-    private static final FilterCreaturePermanent filterOpponentCreature = new FilterCreaturePermanent("creature an opponent controls");
-    
-    static {
-        filterOpponentCreature.add(TargetController.OPPONENT.getControllerPredicate());
-    }    
 
     public EvolutionaryEscalation(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{G}");
@@ -37,7 +32,7 @@ public final class EvolutionaryEscalation extends CardImpl {
         EvolutionaryEscalationEffect effect = new EvolutionaryEscalationEffect();
         Ability ability = new BeginningOfUpkeepTriggeredAbility(effect, TargetController.YOU, false);
         ability.addTarget(new TargetControlledCreaturePermanent());
-        ability.addTarget(new TargetCreaturePermanent(filterOpponentCreature));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExavaRakdosBloodWitch.java
+++ b/Mage.Sets/src/mage/cards/e/ExavaRakdosBloodWitch.java
@@ -11,23 +11,13 @@ import mage.abilities.keyword.UnleashAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author LevelX2
  */
 public final class ExavaRakdosBloodWitch extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterPermanent();
-    static {
-        filter.add(CardType.CREATURE.getPredicate());
-        filter.add(TargetController.YOU.getControllerPredicate());
-        filter.add(CounterType.P1P1.getPredicate());
-        filter.add(AnotherPredicate.instance);
-    }
 
     static final String rule = "Each other creature you control with a +1/+1 counter on it has haste";
     public ExavaRakdosBloodWitch(UUID ownerId, CardSetInfo setInfo) {
@@ -46,7 +36,11 @@ public final class ExavaRakdosBloodWitch extends CardImpl {
         // Unleash
         this.addAbility(new UnleashAbility());
         // Each other creature you control with a +1/+1 counter on it has haste.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(HasteAbility.getInstance(), Duration.WhileOnBattlefield, filter, rule)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(
+                HasteAbility.getInstance(),
+                Duration.WhileOnBattlefield,
+                StaticFilters.FILTER_OTHER_CONTROLLED_CREATURE_P1P1,
+                rule)));
 
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExperimentKraj.java
+++ b/Mage.Sets/src/mage/cards/e/ExperimentKraj.java
@@ -14,8 +14,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
@@ -56,12 +55,6 @@ public final class ExperimentKraj extends CardImpl {
 
 class ExperimentKrajEffect extends ContinuousEffectImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent();
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-        filter.add(AnotherPredicate.instance);
-    }
-
     public ExperimentKrajEffect() {
         super(Duration.WhileOnBattlefield, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
         staticText = "{this} has all activated abilities of each other creature with a +1/+1 counter on it";
@@ -75,7 +68,7 @@ class ExperimentKrajEffect extends ContinuousEffectImpl {
     public boolean apply(Game game, Ability source) {
         Permanent perm = game.getPermanent(source.getSourceId());
         if (perm != null) {
-            for (Permanent creature :game.getState().getBattlefield().getActivePermanents(filter, source.getControllerId(), source.getSourceId(), game)){
+            for (Permanent creature :game.getState().getBattlefield().getActivePermanents(StaticFilters.FILTER_CREATURE_P1P1, source.getControllerId(), source.getSourceId(), game)){
                 for (Ability ability: creature.getAbilities()) {
                     if (ability instanceof ActivatedAbility) {
                         perm.addAbility(ability, source.getSourceId(), game);

--- a/Mage.Sets/src/mage/cards/e/ExperimentKraj.java
+++ b/Mage.Sets/src/mage/cards/e/ExperimentKraj.java
@@ -15,6 +15,8 @@ import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
@@ -55,6 +57,13 @@ public final class ExperimentKraj extends CardImpl {
 
 class ExperimentKrajEffect extends ContinuousEffectImpl {
 
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent();
+
+    static {
+        filter.add(CounterType.P1P1.getPredicate());
+        filter.add(AnotherPredicate.instance);
+    }
+
     public ExperimentKrajEffect() {
         super(Duration.WhileOnBattlefield, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
         staticText = "{this} has all activated abilities of each other creature with a +1/+1 counter on it";
@@ -68,7 +77,7 @@ class ExperimentKrajEffect extends ContinuousEffectImpl {
     public boolean apply(Game game, Ability source) {
         Permanent perm = game.getPermanent(source.getSourceId());
         if (perm != null) {
-            for (Permanent creature :game.getState().getBattlefield().getActivePermanents(StaticFilters.FILTER_CREATURE_P1P1, source.getControllerId(), source.getSourceId(), game)){
+            for (Permanent creature :game.getState().getBattlefield().getActivePermanents(filter, source.getControllerId(), source.getSourceId(), game)){
                 for (Ability ability: creature.getAbilities()) {
                     if (ability instanceof ActivatedAbility) {
                         perm.addAbility(ability, source.getSourceId(), game);

--- a/Mage.Sets/src/mage/cards/e/EyeblightAssassin.java
+++ b/Mage.Sets/src/mage/cards/e/EyeblightAssassin.java
@@ -11,8 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,12 +19,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author fireshoes
  */
 public final class EyeblightAssassin extends CardImpl {
-    
-    private static final FilterCreaturePermanent filterOpponentCreature = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filterOpponentCreature.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public EyeblightAssassin(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
@@ -36,7 +29,7 @@ public final class EyeblightAssassin extends CardImpl {
 
         // When Eyeblight Assassin enters the battlefield, target creature an opponent controls gets -1/-1 until end of turn.
         Ability ability = new EntersBattlefieldTriggeredAbility(new BoostTargetEffect(-1,-1, Duration.EndOfTurn));
-        ability.addTarget(new TargetCreaturePermanent(filterOpponentCreature));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FairgroundsWarden.java
+++ b/Mage.Sets/src/mage/cards/f/FairgroundsWarden.java
@@ -14,8 +14,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
@@ -27,12 +26,6 @@ import mage.util.CardUtil;
  */
 public final class FairgroundsWarden extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public FairgroundsWarden(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{W}");
         this.subtype.add(SubType.DWARF);
@@ -42,7 +35,7 @@ public final class FairgroundsWarden extends CardImpl {
 
         // When Fairgrounds Warden enters the battlefield, exile target creature an opponent controls until Fairgrounds Warden leaves the battlefield.
         Ability ability = new EntersBattlefieldTriggeredAbility(new FairsgroundsWardenExileEffect());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         ability.addEffect(new CreateDelayedTriggeredAbilityEffect(new OnLeaveReturnExiledToBattlefieldAbility()));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/f/FaithUnbroken.java
+++ b/Mage.Sets/src/mage/cards/f/FaithUnbroken.java
@@ -15,7 +15,7 @@ import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
@@ -28,12 +28,6 @@ import mage.util.CardUtil;
  * @author LevelX2
  */
 public final class FaithUnbroken extends CardImpl {
-
-    private static final FilterCreaturePermanent filterTarget = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filterTarget.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public FaithUnbroken(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{3}{W}");
@@ -48,7 +42,7 @@ public final class FaithUnbroken extends CardImpl {
 
         // When Faith Unbroken enters the battlefield, exile target creature an opponent controls until Faith Unbroken leaves the battlefield.
         ability = new EntersBattlefieldTriggeredAbility(new FaithUnbrokenEffect());
-        ability.addTarget(new TargetCreaturePermanent(filterTarget));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         ability.addEffect(new CreateDelayedTriggeredAbilityEffect(new OnLeaveReturnExiledToBattlefieldAbility()));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/f/FesteringNewt.java
+++ b/Mage.Sets/src/mage/cards/f/FesteringNewt.java
@@ -15,7 +15,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.NamePredicate;
 import mage.target.common.TargetCreaturePermanent;
@@ -26,12 +26,12 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class FesteringNewt extends CardImpl {
 
-    private static final FilterCreaturePermanent filterCreature = new FilterCreaturePermanent("creature an opponent controls");
     private static final FilterCreaturePermanent filterBogbrewWitch = new FilterCreaturePermanent();
+
     static {
-        filterCreature.add(TargetController.OPPONENT.getControllerPredicate());
         filterBogbrewWitch.add(new NamePredicate("Bogbrew Witch"));
     }
+
     public FesteringNewt(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{B}");
         this.subtype.add(SubType.SALAMANDER);
@@ -46,7 +46,7 @@ public final class FesteringNewt extends CardImpl {
                 new LockedInCondition(new PermanentsOnTheBattlefieldCondition(filterBogbrewWitch)),
                 "target creature an opponent controls gets -1/-1 until end of turn. That creature gets -4/-4 instead if you control a creature named Bogbrew Witch");
         Ability ability = new DiesSourceTriggeredAbility(effect);
-        ability.addTarget(new TargetCreaturePermanent(filterCreature));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FiresOfYavimaya.java
+++ b/Mage.Sets/src/mage/cards/f/FiresOfYavimaya.java
@@ -13,9 +13,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -24,17 +23,11 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class FiresOfYavimaya extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("Creatures you control");
-
-    static {
-        filter.add(TargetController.YOU.getControllerPredicate());
-    }
-
     public FiresOfYavimaya(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{R}{G}");
 
 
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(HasteAbility.getInstance(), Duration.WhileOnBattlefield, filter, false)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(HasteAbility.getInstance(), Duration.WhileOnBattlefield, StaticFilters.FILTER_CONTROLLED_CREATURES, false)));
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(2, 2, Duration.EndOfTurn), new SacrificeSourceCost());
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/f/FlailingDrake.java
+++ b/Mage.Sets/src/mage/cards/f/FlailingDrake.java
@@ -13,7 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -32,7 +32,7 @@ public final class FlailingDrake extends CardImpl {
         // Whenever Flailing Drake blocks or becomes blocked by a creature, that creature gets +1/+1 until end of turn.
         Effect effect = new BoostTargetEffect(+1, +1, Duration.EndOfTurn);
         effect.setText("that creature gets +1/+1 until end of turn");
-        Ability ability = new BlocksOrBecomesBlockedSourceTriggeredAbility(effect, new FilterCreaturePermanent("a creature"), false, null, true);
+        Ability ability = new BlocksOrBecomesBlockedSourceTriggeredAbility(effect, StaticFilters.FILTER_PERMANENT_A_CREATURE, false, null, true);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Fogwalker.java
+++ b/Mage.Sets/src/mage/cards/f/Fogwalker.java
@@ -10,8 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -19,12 +18,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class Fogwalker extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public Fogwalker(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{U}");
@@ -36,7 +29,7 @@ public final class Fogwalker extends CardImpl {
         this.addAbility(new SkulkAbility());
         // When Fogwalker enters the battlefield, target creature an opponent controls doesn't untap during it controler's next untap step.
         EntersBattlefieldTriggeredAbility ability = new EntersBattlefieldTriggeredAbility(new DontUntapInControllersNextUntapStepTargetEffect());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FoundryHornet.java
+++ b/Mage.Sets/src/mage/cards/f/FoundryHornet.java
@@ -14,24 +14,13 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
-import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author LevelX2
  */
 public final class FoundryHornet extends CardImpl {
-
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("a creature with a +1/+1 counter on it");
-    private static final FilterCreaturePermanent filterOpponent = new FilterCreaturePermanent();
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-        filterOpponent.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     private static final String rule = "When {this} enters the battlefield, if you control a creature with a +1/+1 counter on it, creatures your opponents control get -1/-1 until end of turn.";
 
@@ -46,8 +35,8 @@ public final class FoundryHornet extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // When Foundry Hornet enters the battlefield, if you control a creature with a +1/+1 counter on it, creatures your opponents control get -1/-1 until end of turn.
-        TriggeredAbility ability = new EntersBattlefieldTriggeredAbility(new BoostAllEffect(-1, -1, Duration.EndOfTurn, filterOpponent, false), false);
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new PermanentsOnTheBattlefieldCondition(filter), rule));
+        TriggeredAbility ability = new EntersBattlefieldTriggeredAbility(new BoostAllEffect(-1, -1, Duration.EndOfTurn, StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE, false), false);
+        this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new PermanentsOnTheBattlefieldCondition(StaticFilters.FILTER_A_CREATURE_P1P1), rule));
     }
 
     private FoundryHornet(final FoundryHornet card) {

--- a/Mage.Sets/src/mage/cards/g/GOTOJAIL.java
+++ b/Mage.Sets/src/mage/cards/g/GOTOJAIL.java
@@ -14,9 +14,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
@@ -32,18 +31,12 @@ import java.util.UUID;
  */
 public final class GOTOJAIL extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public GOTOJAIL(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{W}");
 
         // When GO TO JAIL enters the battlefield, exile target creature an opponent controls until GO TO JAIL leaves the battlefield.
         Ability ability = new EntersBattlefieldTriggeredAbility(new GoToJailExileEffect());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         ability.addEffect(new CreateDelayedTriggeredAbilityEffect(new OnLeaveReturnExiledToBattlefieldAbility()));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/g/GideonsAvenger.java
+++ b/Mage.Sets/src/mage/cards/g/GideonsAvenger.java
@@ -9,21 +9,14 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author Loki
  */
 public final class GideonsAvenger extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public GideonsAvenger(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{W}{W}");
@@ -34,7 +27,7 @@ public final class GideonsAvenger extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever a creature an opponent controls becomes tapped, put a +1/+1 counter on Gideon's Avenger.
-        this.addAbility(new BecomesTappedTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false, filter));
+        this.addAbility(new BecomesTappedTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false, StaticFilters.FILTER_OPPONENTS_PERMANENT_A_CREATURE));
     }
 
     private GideonsAvenger(final GideonsAvenger card) {

--- a/Mage.Sets/src/mage/cards/g/GildedDrake.java
+++ b/Mage.Sets/src/mage/cards/g/GildedDrake.java
@@ -15,8 +15,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -27,12 +26,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class GildedDrake extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public GildedDrake(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{U}");
@@ -47,7 +40,7 @@ public final class GildedDrake extends CardImpl {
         // This ability can't be countered except by spells and abilities.
         Ability ability = new EntersBattlefieldTriggeredAbility(new GildedDrakeEffect());
         ability.setCanFizzle(false);
-        ability.addTarget(new TargetCreaturePermanent(0, 1, filter, false));
+        ability.addTarget(new TargetCreaturePermanent(0, 1, StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE, false));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlaringAegis.java
+++ b/Mage.Sets/src/mage/cards/g/GlaringAegis.java
@@ -12,7 +12,7 @@ import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -21,12 +21,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author fireshoes
  */
 public final class GlaringAegis extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-    
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public GlaringAegis(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{W}");
@@ -41,7 +35,7 @@ public final class GlaringAegis extends CardImpl {
         
         // When Glaring Aegis enters the battlefield, tap target creature an opponent controls.
         Ability ability2 = new EntersBattlefieldTriggeredAbility(new TapTargetEffect());
-        ability2.addTarget(new TargetCreaturePermanent(filter));
+        ability2.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability2);
         
         // Enchanted creature gets +1/+3.

--- a/Mage.Sets/src/mage/cards/g/Glory.java
+++ b/Mage.Sets/src/mage/cards/g/Glory.java
@@ -14,7 +14,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -31,7 +31,7 @@ public final class Glory extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // {2}{W}: Choose a color. Creatures you control gain protection from the chosen color until end of turn. Activate this ability only if Glory is in your graveyard.
-        Effect effect = new GainProtectionFromColorAllEffect(Duration.EndOfTurn, new FilterControlledCreaturePermanent("Creatures you control"));
+        Effect effect = new GainProtectionFromColorAllEffect(Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES);
         effect.setText("Choose a color. Creatures you control gain protection from the chosen color until end of turn. Activate only if {this} is in your graveyard.");
         this.addAbility(new SimpleActivatedAbility(Zone.GRAVEYARD, effect, new ManaCostsImpl("{2}{W}")));
     }

--- a/Mage.Sets/src/mage/cards/g/GnarlidColony.java
+++ b/Mage.Sets/src/mage/cards/g/GnarlidColony.java
@@ -14,8 +14,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -23,12 +22,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class GnarlidColony extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterControlledCreaturePermanent();
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public GnarlidColony(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{G}");
@@ -48,9 +41,10 @@ public final class GnarlidColony extends CardImpl {
 
         // Each creature you control with a +1/+1 counter on it has trample.
         this.addAbility(new SimpleStaticAbility(new GainAbilityAllEffect(
-                TrampleAbility.getInstance(), Duration.WhileOnBattlefield, filter,
-                "Each creature you control with a +1/+1 counter on it has trample"
-        )));
+                TrampleAbility.getInstance(),
+                Duration.WhileOnBattlefield,
+                StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1))
+        );
     }
 
     private GnarlidColony(final GnarlidColony card) {

--- a/Mage.Sets/src/mage/cards/g/GriffinCanyon.java
+++ b/Mage.Sets/src/mage/cards/g/GriffinCanyon.java
@@ -12,7 +12,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
@@ -47,8 +47,6 @@ public final class GriffinCanyon extends CardImpl {
 }
 
 class GriffinCanyonEffect extends OneShotEffect {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature");
 
     public GriffinCanyonEffect() {
         super(Outcome.Benefit);
@@ -69,7 +67,7 @@ class GriffinCanyonEffect extends OneShotEffect {
         Permanent targetCreature = game.getPermanent(source.getFirstTarget());
         if (targetCreature != null) {
             targetCreature.untap(game);
-            if (filter.match(targetCreature, game)) {
+            if (StaticFilters.FILTER_PERMANENT_A_CREATURE.match(targetCreature, game)) {
                 game.addEffect(new BoostTargetEffect(1, 1, Duration.EndOfTurn), source);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/g/GrimContest.java
+++ b/Mage.Sets/src/mage/cards/g/GrimContest.java
@@ -8,8 +8,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -22,19 +21,13 @@ import mage.target.common.TargetControlledCreaturePermanent;
  */
 public final class GrimContest extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public GrimContest(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{1}{B}{G}");
 
         // Choose target creature you control and target creature an opponent controls. Each of those creatures deals damage equal to its toughness to the other.
         this.getSpellAbility().addEffect(new GrimContestEffect());
         this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent());
-        this.getSpellAbility().addTarget(new TargetPermanent(filter));
+        this.getSpellAbility().addTarget(new TargetPermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
     }
 
     private GrimContest(final GrimContest card) {

--- a/Mage.Sets/src/mage/cards/g/GrowingRanks.java
+++ b/Mage.Sets/src/mage/cards/g/GrowingRanks.java
@@ -8,18 +8,11 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
 
 /**
  * @author LevelX2
  */
 public final class GrowingRanks extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public GrowingRanks(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{2}{G/W}{G/W}");

--- a/Mage.Sets/src/mage/cards/g/GuardianOfTazeem.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianOfTazeem.java
@@ -14,7 +14,7 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
@@ -27,12 +27,6 @@ import mage.target.targetpointer.FixedTarget;
  */
 public final class GuardianOfTazeem extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public GuardianOfTazeem(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{U}{U}");
         this.subtype.add(SubType.SPHINX);
@@ -44,7 +38,7 @@ public final class GuardianOfTazeem extends CardImpl {
 
         // <i>Landfall</i> &mdash; Whenever a land enters the battlefield under you control, tap target creature an opponent controls. If that land is an Island, that creature doesn't untap during its controller's next untap step.
         Ability ability = new GuardianOfTazeemTriggeredAbility();
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HaazdaSnareSquad.java
+++ b/Mage.Sets/src/mage/cards/h/HaazdaSnareSquad.java
@@ -12,8 +12,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -27,11 +26,6 @@ import java.util.UUID;
 
 public final class HaazdaSnareSquad extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public HaazdaSnareSquad (UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{W}");
         this.subtype.add(SubType.HUMAN);
@@ -43,7 +37,7 @@ public final class HaazdaSnareSquad extends CardImpl {
         // Whenever Haazda Snare Squad attacks you may pay {W}. If you do, tap target creature an opponent controls.
         Ability ability = new AttacksTriggeredAbility(new DoIfCostPaid(new TapTargetEffect(), new ManaCostsImpl("{W}")),false,
                 "Whenever {this} attacks, you may pay {W}. If you do, tap target creature an opponent controls.");
-        Target target = new TargetCreaturePermanent(filter);
+        Target target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/h/HagraConstrictor.java
+++ b/Mage.Sets/src/mage/cards/h/HagraConstrictor.java
@@ -12,8 +12,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -21,12 +20,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class HagraConstrictor extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterControlledCreaturePermanent();
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public HagraConstrictor(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{B}");
@@ -43,7 +36,9 @@ public final class HagraConstrictor extends CardImpl {
 
         // Each creature you control with a +1/+1 counter on it has menace.
         this.addAbility(new SimpleStaticAbility(new GainAbilityAllEffect(
-                new MenaceAbility(), Duration.WhileOnBattlefield, filter,
+                new MenaceAbility(),
+                Duration.WhileOnBattlefield,
+                StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1,
                 "Each creature you control with a +1/+1 counter on it has menace. " +
                         "<i>(A creature with menace can't be blocked except by two or more creatures.)</i>"
         )));

--- a/Mage.Sets/src/mage/cards/h/HamzaGuardianOfArashin.java
+++ b/Mage.Sets/src/mage/cards/h/HamzaGuardianOfArashin.java
@@ -14,9 +14,7 @@ import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.util.CardUtil;
 
@@ -27,14 +25,7 @@ import java.util.UUID;
  */
 public final class HamzaGuardianOfArashin extends CardImpl {
 
-    private static final FilterPermanent filter
-            = new FilterControlledCreaturePermanent("creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
-    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(filter);
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1);
     private static final Hint hint = new ValueHint("Creatures you control with +1/+1 counter on them", xValue);
 
     public HamzaGuardianOfArashin(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/h/HeavyInfantry.java
+++ b/Mage.Sets/src/mage/cards/h/HeavyInfantry.java
@@ -10,8 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -19,12 +18,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class HeavyInfantry extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-    
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
     
     public HeavyInfantry(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{W}");
@@ -35,7 +28,7 @@ public final class HeavyInfantry extends CardImpl {
 
         // When Heavy Infantry enters the battlefield, tap target creature an opponent controls.
         Ability ability = new EntersBattlefieldTriggeredAbility(new TapTargetEffect());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);        
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeliodsEmissary.java
+++ b/Mage.Sets/src/mage/cards/h/HeliodsEmissary.java
@@ -16,9 +16,8 @@ import mage.constants.AttachmentType;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -27,11 +26,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class HeliodsEmissary extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public HeliodsEmissary(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT,CardType.CREATURE},"{3}{W}");
@@ -44,11 +38,11 @@ public final class HeliodsEmissary extends CardImpl {
         this.addAbility(new BestowAbility(this, "{6}{W}"));
         // Whenever Heliod's Emissary or enchanted creature attacks, tap target creature an opponent controls.
         Ability ability = new AttacksTriggeredAbility(new TapTargetEffect(), false);
-        Target target = new TargetCreaturePermanent(filter);
+        Target target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         this.addAbility(ability);
         ability = new AttacksAttachedTriggeredAbility(new TapTargetEffect(), AttachmentType.AURA, false);
-        target = new TargetCreaturePermanent(filter);
+        target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         this.addAbility(ability);
         // Enchanted creature gets +3/+3.

--- a/Mage.Sets/src/mage/cards/h/HeliumSquirter.java
+++ b/Mage.Sets/src/mage/cards/h/HeliumSquirter.java
@@ -15,8 +15,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -24,11 +23,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author JotaPeRL
  */
 public final class HeliumSquirter extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with a +1/+1 counter on it");
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }     
 
     public HeliumSquirter(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{U}");
@@ -42,7 +36,7 @@ public final class HeliumSquirter extends CardImpl {
         
         // {1}: Target creature with a +1/+1 counter on it gains flying until end of turn.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilityTargetEffect(FlyingAbility.getInstance(), Duration.EndOfTurn), new GenericManaCost(1));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_CREATURE_P1P1));
         this.addAbility(ability);        
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeroOfGomaFada.java
+++ b/Mage.Sets/src/mage/cards/h/HeroOfGomaFada.java
@@ -12,7 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -31,7 +31,7 @@ public final class HeroOfGomaFada extends CardImpl {
         // <i>Rally</i> &mdash; Whenever Hero of Goma Fada or another Ally enters the battlefield under your control, creatures you control gain indestructible until end of turn.
         Ability ability = new AllyEntersBattlefieldTriggeredAbility(
                 new GainAbilityAllEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn,
-                        new FilterControlledCreaturePermanent("creatures you control")), false);
+                        StaticFilters.FILTER_CONTROLLED_CREATURES), false);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HighSentinelsOfArashin.java
+++ b/Mage.Sets/src/mage/cards/h/HighSentinelsOfArashin.java
@@ -19,8 +19,7 @@ import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -28,12 +27,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author emerald000
  */
 public final class HighSentinelsOfArashin extends CardImpl {
-    
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("other creature you control with a +1/+1 counter on it");
-    static {
-        filter.add(AnotherPredicate.instance);
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public HighSentinelsOfArashin(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{W}");
@@ -47,7 +40,7 @@ public final class HighSentinelsOfArashin extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         
         // High Sentinels of Arashin gets +1/+1 for each other creature you control with a +1/+1 counter on it.
-        DynamicValue count = new PermanentsOnBattlefieldCount(filter);
+        DynamicValue count = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_OTHER_CONTROLLED_CREATURE_P1P1);
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostSourceEffect(count, count, Duration.WhileOnBattlefield)));
         
         // {3}{W}: Put a +1/+1 counter on target creature.

--- a/Mage.Sets/src/mage/cards/i/IcefallRegent.java
+++ b/Mage.Sets/src/mage/cards/i/IcefallRegent.java
@@ -12,7 +12,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterCard;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
@@ -28,12 +28,6 @@ import java.util.UUID;
  */
 public final class IcefallRegent extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public IcefallRegent(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{U}{U}");
         this.subtype.add(SubType.DRAGON);
@@ -43,10 +37,11 @@ public final class IcefallRegent extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
 
-        // When Icefall Regent enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's untap step for as long as you control Icefall Regent.
+        // When Icefall Regent enters the battlefield, tap target creature an opponent controls.
+        // That creature doesn't untap during its controller's untap step for as long as you control Icefall Regent.
         Ability ability = new EntersBattlefieldTriggeredAbility(new TapTargetEffect(), false);
         ability.addEffect(new IcefallRegentEffect());
-        Target target = new TargetCreaturePermanent(filter);
+        Target target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         this.addAbility(ability, new IcefallRegentWatcher());
 

--- a/Mage.Sets/src/mage/cards/i/IllusionistsStratagem.java
+++ b/Mage.Sets/src/mage/cards/i/IllusionistsStratagem.java
@@ -6,7 +6,7 @@ import mage.abilities.effects.common.ReturnToBattlefieldUnderYourControlTargetEf
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetControlledCreaturePermanent;
 
 import java.util.UUID;
@@ -24,7 +24,7 @@ public final class IllusionistsStratagem extends CardImpl {
         this.getSpellAbility().addEffect(new ReturnToBattlefieldUnderYourControlTargetEffect(false)
                 .withReturnNames("those cards", "their owner's").concatBy(", then"));
         this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent(0, 2,
-                new FilterControlledCreaturePermanent("creatures you control"), false));
+                StaticFilters.FILTER_CONTROLLED_CREATURES, false));
 
         // Draw a card.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1));

--- a/Mage.Sets/src/mage/cards/i/ImpactTremors.java
+++ b/Mage.Sets/src/mage/cards/i/ImpactTremors.java
@@ -11,7 +11,7 @@ import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -25,7 +25,7 @@ public final class ImpactTremors extends CardImpl {
         // Whenever a creature enters the battlefield under your control, Impact Tremors deals 1 damage to each opponent.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
                 new DamagePlayersEffect(Outcome.Damage, StaticValue.get(1), TargetController.OPPONENT),
-                new FilterCreaturePermanent("a creature"),
+                StaticFilters.FILTER_PERMANENT_A_CREATURE,
                 false));
     }
 

--- a/Mage.Sets/src/mage/cards/i/InTheWebOfWar.java
+++ b/Mage.Sets/src/mage/cards/i/InTheWebOfWar.java
@@ -14,6 +14,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 
 /**
@@ -22,16 +23,13 @@ import mage.filter.common.FilterCreaturePermanent;
  */
 public final class InTheWebOfWar extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature");
-
     public InTheWebOfWar(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{3}{R}{R}");
-
 
         // Whenever a creature enters the battlefield under your control, it gets +2/+0 and gains haste until end of turn.
         Effect effect = new BoostTargetEffect(2,0, Duration.EndOfTurn);
         effect.setText("it gets +2/+0");
-        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filter, false, SetTargetPointer.PERMANENT, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT, null);
         effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("and gains haste until end of turn");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/i/InactionInjunction.java
+++ b/Mage.Sets/src/mage/cards/i/InactionInjunction.java
@@ -7,8 +7,7 @@ import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
  
 /**
@@ -17,26 +16,17 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class InactionInjunction extends CardImpl {
  
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
- 
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
- 
     public InactionInjunction(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{1}{U}");
- 
-
  
         // Detain target creature an opponent controls.
         // (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)
         this.getSpellAbility().addEffect(new DetainTargetEffect());
-        TargetCreaturePermanent target = new TargetCreaturePermanent(filter);
+        TargetCreaturePermanent target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         this.getSpellAbility().addTarget(target);
         
         // Draw a card.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1));
- 
     }
  
     private InactionInjunction(final InactionInjunction card) {

--- a/Mage.Sets/src/mage/cards/i/InspiringCall.java
+++ b/Mage.Sets/src/mage/cards/i/InspiringCall.java
@@ -11,8 +11,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -20,19 +19,18 @@ import mage.filter.common.FilterControlledCreaturePermanent;
  */
 public final class InspiringCall extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
     public InspiringCall(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{2}{G}");
 
-        // Draw a card for each creature you control with a +1/+1 counter on it. Those creatures gain indestructible until end of turn. <i>(Damage and effects that say "destroy" don't destroy them.)
-        this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(new PermanentsOnBattlefieldCount(filter)));
-        Effect effect = new GainAbilityControlledEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn, filter);
-        effect.setText("Those creatures gain indestructible until end of turn. <i>(Damage and effects that say \"destroy\" don't destroy them.)</i>");
+        // Draw a card for each creature you control with a +1/+1 counter on it.
+        // Those creatures gain indestructible until end of turn.
+        // <i>(Damage and effects that say "destroy" don't destroy them.)
+        this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(
+                new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1)));
+        Effect effect = new GainAbilityControlledEffect(
+                IndestructibleAbility.getInstance(), Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1);
+        effect.setText("Those creatures gain indestructible until end of turn. " +
+                "<i>(Damage and effects that say \"destroy\" don't destroy them.)</i>");
         this.getSpellAbility().addEffect(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IntruderAlarm.java
+++ b/Mage.Sets/src/mage/cards/i/IntruderAlarm.java
@@ -13,7 +13,7 @@ import mage.constants.Duration;
 import mage.constants.TargetController;
 import mage.constants.Zone;
 import static mage.filter.StaticFilters.FILTER_PERMANENT_CREATURES;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -27,7 +27,7 @@ public final class IntruderAlarm extends CardImpl {
         // Creatures don't untap during their controllers' untap steps.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new DontUntapInControllersUntapStepAllEffect(Duration.WhileOnBattlefield, TargetController.ANY, FILTER_PERMANENT_CREATURES)));
         // Whenever a creature enters the battlefield, untap all creatures.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(new UntapAllEffect(FILTER_PERMANENT_CREATURES), new FilterCreaturePermanent("a creature")));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(new UntapAllEffect(FILTER_PERMANENT_CREATURES), StaticFilters.FILTER_PERMANENT_A_CREATURE));
     }
 
     private IntruderAlarm(final IntruderAlarm card) {

--- a/Mage.Sets/src/mage/cards/i/IsperiasSkywatch.java
+++ b/Mage.Sets/src/mage/cards/i/IsperiasSkywatch.java
@@ -11,8 +11,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,12 +19,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class IsperiasSkywatch extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
- 
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
     
     public IsperiasSkywatch(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{5}{U}");
@@ -41,7 +34,7 @@ public final class IsperiasSkywatch extends CardImpl {
         // When Isperia's Skywatch enters the battlefield, detain target creature an opponent controls.
         // (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)
         Ability ability = new EntersBattlefieldTriggeredAbility(new DetainTargetEffect());
-        TargetCreaturePermanent target = new TargetCreaturePermanent(filter);
+        TargetCreaturePermanent target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/i/IvorytuskFortress.java
+++ b/Mage.Sets/src/mage/cards/i/IvorytuskFortress.java
@@ -10,20 +10,13 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author LevelX2
  */
 public final class IvorytuskFortress extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("each creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public IvorytuskFortress(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{W}{B}{G}");
@@ -33,7 +26,8 @@ public final class IvorytuskFortress extends CardImpl {
         this.toughness = new MageInt(7);
 
         // Untap each creature you control with a +1/+1 counter on it during each other player's untap step.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new UntapAllDuringEachOtherPlayersUntapStepEffect(filter)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD,
+                new UntapAllDuringEachOtherPlayersUntapStepEffect(StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)));
     }
 
     private IvorytuskFortress(final IvorytuskFortress card) {

--- a/Mage.Sets/src/mage/cards/j/JiangYangguWildcrafter.java
+++ b/Mage.Sets/src/mage/cards/j/JiangYangguWildcrafter.java
@@ -14,8 +14,7 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
@@ -24,13 +23,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class JiangYangguWildcrafter extends CardImpl {
-
-    private static final FilterPermanent filter
-            = new FilterControlledCreaturePermanent("Each creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public JiangYangguWildcrafter(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.PLANESWALKER}, "{2}{G}");
@@ -41,7 +33,7 @@ public final class JiangYangguWildcrafter extends CardImpl {
 
         // Each creature you control with a +1/+1 counter on it has "{T}: Add one mana of any color."
         this.addAbility(new SimpleStaticAbility(new GainAbilityControlledEffect(
-                new AnyColorManaAbility(), Duration.WhileOnBattlefield, filter
+                new AnyColorManaAbility(), Duration.WhileOnBattlefield, StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1
         )));
 
         // -1: Put a +1/+1 counter on target creature.

--- a/Mage.Sets/src/mage/cards/k/KalonianHydra.java
+++ b/Mage.Sets/src/mage/cards/k/KalonianHydra.java
@@ -17,6 +17,7 @@ import mage.constants.SubType;
 import mage.constants.Outcome;
 import mage.constants.TargetController;
 import mage.counters.CounterType;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -56,12 +57,6 @@ public final class KalonianHydra extends CardImpl {
 
 class KalonianHydraEffect extends OneShotEffect {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent();
-    static {
-        filter.add(TargetController.YOU.getControllerPredicate());
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
     public KalonianHydraEffect() {
         super(Outcome.BoostCreature);
         this.staticText = "double the number of +1/+1 counters on each creature you control";
@@ -78,7 +73,7 @@ class KalonianHydraEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        List<Permanent> permanents = game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source.getSourceId(), game);
+        List<Permanent> permanents = game.getBattlefield().getActivePermanents(StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1, source.getControllerId(), source.getSourceId(), game);
         for (Permanent permanent : permanents) {
             int existingCounters = permanent.getCounters(game).getCount(CounterType.P1P1);
             if (existingCounters > 0) {

--- a/Mage.Sets/src/mage/cards/k/KeeperOfKeys.java
+++ b/Mage.Sets/src/mage/cards/k/KeeperOfKeys.java
@@ -16,7 +16,7 @@ import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -38,7 +38,7 @@ public final class KeeperOfKeys extends CardImpl {
 
         // At the beginning of your upkeep, if you're the monarch, creatures you control can't be blocked this turn.
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD,
-                new CantBeBlockedAllEffect(new FilterControlledCreaturePermanent("creatures you control"), Duration.EndOfTurn),
+                new CantBeBlockedAllEffect(StaticFilters.FILTER_CONTROLLED_CREATURES, Duration.EndOfTurn),
                 TargetController.YOU, false), MonarchIsSourceControllerCondition.instance,
                 "At the beginning of your upkeep, if you're the monarch, creatures you control can't be blocked this turn."));
     }

--- a/Mage.Sets/src/mage/cards/k/KefnetsMonument.java
+++ b/Mage.Sets/src/mage/cards/k/KefnetsMonument.java
@@ -12,11 +12,10 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SuperType;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.filter.FilterSpell;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.ColorPredicate;
 import mage.target.common.TargetCreaturePermanent;
@@ -29,18 +28,11 @@ public final class KefnetsMonument extends CardImpl {
 
     private static final FilterCard filter = new FilterCard("Blue creature spells");
     private static final FilterSpell filter2 = new FilterSpell("a creature spell");
-    private static final FilterCreaturePermanent filter3 = new FilterCreaturePermanent("creature an opponent controls");
 
     static {
         filter.add(Predicates.and(new ColorPredicate(ObjectColor.BLUE), CardType.CREATURE.getPredicate()));
-    }
-    static {
         filter2.add(CardType.CREATURE.getPredicate());
     }
-    static {
-        filter3.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
 
     public KefnetsMonument(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
@@ -52,7 +44,7 @@ public final class KefnetsMonument extends CardImpl {
 
         // Whenever you cast a creature spell, target creature an opponent controls doesn't untap during its controller's next untap step.
         Ability ability = new SpellCastControllerTriggeredAbility(new DontUntapInControllersNextUntapStepTargetEffect(), filter2, false);
-        ability.addTarget(new TargetCreaturePermanent(filter3));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KolaghanForerunners.java
+++ b/Mage.Sets/src/mage/cards/k/KolaghanForerunners.java
@@ -14,7 +14,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -34,7 +34,7 @@ public final class KolaghanForerunners extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Kolaghan Forerunners' power is equal to the number of creatures you control.
-        Effect effect = new SetPowerSourceEffect(new PermanentsOnBattlefieldCount(new FilterControlledCreaturePermanent("creatures you control")), Duration.EndOfGame);
+        Effect effect = new SetPowerSourceEffect(new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURES), Duration.EndOfGame);
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect).addHint(CreaturesYouControlHint.instance));
 
         // Dash {2}{R} <i.(You may cast this spell for its dash cost. If you do it gains haste and it's returned to its owner's hand at the beginning of the next end step.)</i>

--- a/Mage.Sets/src/mage/cards/k/KorEntanglers.java
+++ b/Mage.Sets/src/mage/cards/k/KorEntanglers.java
@@ -10,8 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -19,12 +18,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class KorEntanglers extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public KorEntanglers(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{W}");
@@ -36,7 +29,7 @@ public final class KorEntanglers extends CardImpl {
 
         // <i>Rally</i> &mdash; Whenever Kor Entanglers or another Ally enters the battlefield under your control, tap target creature an opponent controls.
         Ability ability = new AllyEntersBattlefieldTriggeredAbility(new TapTargetEffect(), false);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/k/KorHookmaster.java
+++ b/Mage.Sets/src/mage/cards/k/KorHookmaster.java
@@ -10,8 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -19,12 +18,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author North
  */
 public final class KorHookmaster extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public KorHookmaster(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{W}");
@@ -38,7 +31,7 @@ public final class KorHookmaster extends CardImpl {
         // That creature doesn't untap during its controller's next untap step.
         EntersBattlefieldTriggeredAbility ability = new EntersBattlefieldTriggeredAbility(new TapTargetEffect());
         ability.addEffect(new DontUntapInControllersNextUntapStepTargetEffect());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LaidToRest.java
+++ b/Mage.Sets/src/mage/cards/l/LaidToRest.java
@@ -7,9 +7,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.counters.CounterType;
 import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledPermanent;
 
 import java.util.UUID;
@@ -21,12 +20,6 @@ public final class LaidToRest extends CardImpl {
 
     private static final FilterPermanent filter
             = new FilterControlledPermanent(SubType.HUMAN, "a Human you control");
-    private static final FilterPermanent filter2
-            = new FilterControlledCreaturePermanent("a creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public LaidToRest(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{G}");
@@ -37,7 +30,7 @@ public final class LaidToRest extends CardImpl {
         ));
 
         // Whenever a creature you control with a +1/+1 counter on it dies, you gain 2 life.
-        this.addAbility(new DiesCreatureTriggeredAbility(new GainLifeEffect(2), false, filter2));
+        this.addAbility(new DiesCreatureTriggeredAbility(new GainLifeEffect(2), false, StaticFilters.FILTER_A_CONTROLLED_CREATURE_P1P1));
     }
 
     private LaidToRest(final LaidToRest card) {

--- a/Mage.Sets/src/mage/cards/l/LavacoreElemental.java
+++ b/Mage.Sets/src/mage/cards/l/LavacoreElemental.java
@@ -16,7 +16,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SetTargetPointer;
 import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -42,7 +42,7 @@ public final class LavacoreElemental extends CardImpl {
         effect.setText("put a time counter on {this}");
         this.addAbility(new DealsDamageToAPlayerAllTriggeredAbility(
                 effect,
-                new FilterControlledCreaturePermanent("a creature you control"), false, SetTargetPointer.PERMANENT, true
+                StaticFilters.FILTER_CONTROLLED_A_CREATURE, false, SetTargetPointer.PERMANENT, true
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/l/LifecraftersGift.java
+++ b/Mage.Sets/src/mage/cards/l/LifecraftersGift.java
@@ -2,19 +2,13 @@
 package mage.cards.l;
 
 import java.util.UUID;
-import mage.MageObject;
-import mage.abilities.Ability;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.counter.AddCountersAllEffect;
 import mage.abilities.effects.common.counter.AddCountersTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -26,10 +20,14 @@ public final class LifecraftersGift extends CardImpl {
     public LifecraftersGift(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{G}");
 
-        // Put a +1/+1 counter on target creature, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it.
+        // Put a +1/+1 counter on target creature,
         getSpellAbility().addEffect(new AddCountersTargetEffect(CounterType.P1P1.createInstance(1)));
         getSpellAbility().addTarget(new TargetCreaturePermanent());
-        getSpellAbility().addEffect(new LifecraftersGiftEffect());
+
+        // then put a +1/+1 counter on each creature you control with a +1/+1 counter on it.
+        getSpellAbility().addEffect(new AddCountersAllEffect(
+                CounterType.P1P1.createInstance(), StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1
+        ).concatBy(", then"));
     }
 
     private LifecraftersGift(final LifecraftersGift card) {
@@ -39,41 +37,5 @@ public final class LifecraftersGift extends CardImpl {
     @Override
     public LifecraftersGift copy() {
         return new LifecraftersGift(this);
-    }
-}
-
-class LifecraftersGiftEffect extends OneShotEffect {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent();
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
-    public LifecraftersGiftEffect() {
-        super(Outcome.Benefit);
-        this.staticText = ", then put a +1/+1 counter on each creature you control with a +1/+1 counter on it";
-    }
-
-    public LifecraftersGiftEffect(final LifecraftersGiftEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public LifecraftersGiftEffect copy() {
-        return new LifecraftersGiftEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        MageObject sourceObject = source.getSourceObject(game);
-        if (controller != null && sourceObject != null) {
-            for(Permanent permanent: game.getState().getBattlefield().getAllActivePermanents(filter , controller.getId(), game)) {
-                permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
-                game.informPlayers(sourceObject.getName() + ": Put a +1/+1 counter on " + permanent.getLogName());
-            }
-        }
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/l/Lifegift.java
+++ b/Mage.Sets/src/mage/cards/l/Lifegift.java
@@ -8,7 +8,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Zone;
-import mage.filter.common.FilterLandPermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -21,7 +21,7 @@ public final class Lifegift extends CardImpl {
 
 
         // Whenever a land enters the battlefield, you may gain 1 life.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new GainLifeEffect(1), new FilterLandPermanent("a land"), true));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new GainLifeEffect(1), StaticFilters.FILTER_LAND_A, true));
     }
 
     private Lifegift(final Lifegift card) {

--- a/Mage.Sets/src/mage/cards/l/LimDulTheNecromancer.java
+++ b/Mage.Sets/src/mage/cards/l/LimDulTheNecromancer.java
@@ -15,6 +15,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -29,11 +30,9 @@ import java.util.UUID;
  */
 public final class LimDulTheNecromancer extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature an opponent controls");
     private static final FilterPermanent filter2 = new FilterPermanent("Zombie");
 
     static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
         filter2.add(SubType.ZOMBIE.getPredicate());
     }
 
@@ -46,7 +45,7 @@ public final class LimDulTheNecromancer extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Whenever a creature an opponent controls dies, you may pay {1}{B}. If you do, return that card to the battlefield under your control. If it's a creature, it's a Zombie in addition to its other creature types.
-        this.addAbility(new DiesCreatureTriggeredAbility(new DoIfCostPaid(new LimDulTheNecromancerEffect(), new ManaCostsImpl("{1}{B}")), false, filter, true));
+        this.addAbility(new DiesCreatureTriggeredAbility(new DoIfCostPaid(new LimDulTheNecromancerEffect(), new ManaCostsImpl("{1}{B}")), false, StaticFilters.FILTER_OPPONENTS_PERMANENT_A_CREATURE, true));
 
         // {1}{B}: Regenerate target Zombie.
         Ability ability2 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateTargetEffect(), new ManaCostsImpl("{1}{B}"));

--- a/Mage.Sets/src/mage/cards/l/LoathsomeCatoblepas.java
+++ b/Mage.Sets/src/mage/cards/l/LoathsomeCatoblepas.java
@@ -14,9 +14,8 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -25,11 +24,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class LoathsomeCatoblepas extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public LoathsomeCatoblepas(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{5}{B}");
@@ -42,7 +36,7 @@ public final class LoathsomeCatoblepas extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new MustBeBlockedByAtLeastOneSourceEffect(), new ManaCostsImpl("{2}{G}")));
         // When Loathsome Catoblepas dies, target creature an opponent controls gets -3/-3 until end of turn.
         Ability ability = new DiesSourceTriggeredAbility(new BoostTargetEffect(-3,-3, Duration.EndOfTurn), false);
-        Target target = new TargetCreaturePermanent(filter);
+        Target target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/l/LongshotSquad.java
+++ b/Mage.Sets/src/mage/cards/l/LongshotSquad.java
@@ -13,24 +13,14 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author LevelX2
  */
 public final class LongshotSquad extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterPermanent();
-
-    static {
-        filter.add(CardType.CREATURE.getPredicate());
-        filter.add(TargetController.YOU.getControllerPredicate());
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public LongshotSquad(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{G}");
@@ -43,9 +33,14 @@ public final class LongshotSquad extends CardImpl {
         // Outlast 1G
         this.addAbility(new OutlastAbility(new ManaCostsImpl("{1}{G}")));
         // Each creature you control with a +1/+1 counter on it has reach.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(ReachAbility.getInstance(), Duration.WhileOnBattlefield, filter, 
-                "Each creature you control with a +1/+1 counter on it has reach")));
-
+        this.addAbility(new SimpleStaticAbility(
+                Zone.BATTLEFIELD,
+                new GainAbilityAllEffect(
+                        ReachAbility.getInstance(),
+                        Duration.WhileOnBattlefield,
+                        StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)
+                )
+        );
     }
 
     private LongshotSquad(final LongshotSquad card) {

--- a/Mage.Sets/src/mage/cards/l/LurkingChupacabra.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingChupacabra.java
@@ -11,8 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,12 +19,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author TheElk801
  */
 public final class LurkingChupacabra extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public LurkingChupacabra(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{B}");
@@ -37,7 +30,7 @@ public final class LurkingChupacabra extends CardImpl {
 
         // Whenever a creature you control explores, target creature an opponent controls gets -2/-2 until end of turn
         Ability ability = new CreatureExploresTriggeredAbility(new BoostTargetEffect(-2, -2, Duration.EndOfTurn));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MalakirCullblade.java
+++ b/Mage.Sets/src/mage/cards/m/MalakirCullblade.java
@@ -9,21 +9,14 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author fireshoes
  */
 public final class MalakirCullblade extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature an opponent controls");
-    
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public MalakirCullblade(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{B}");
@@ -33,7 +26,7 @@ public final class MalakirCullblade extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Whenever a creature an opponent controls dies, put a +1/+1 counter on Malakir Cullblade.
-        this.addAbility(new DiesCreatureTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false, filter));
+        this.addAbility(new DiesCreatureTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false, StaticFilters.FILTER_OPPONENTS_PERMANENT_A_CREATURE));
     }
 
     private MalakirCullblade(final MalakirCullblade card) {

--- a/Mage.Sets/src/mage/cards/m/ManaEchoes.java
+++ b/Mage.Sets/src/mage/cards/m/ManaEchoes.java
@@ -13,7 +13,6 @@ import mage.constants.Outcome;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -29,7 +28,7 @@ public final class ManaEchoes extends CardImpl {
 
         // Whenever a creature enters the battlefield, you may add X mana of {C}, where X is the number of creatures you control that share a creature type with it.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                new ManaEchoesEffect(), new FilterCreaturePermanent("a creature"), true, SetTargetPointer.PERMANENT, ""));
+                new ManaEchoesEffect(), StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT, ""));
     }
 
     private ManaEchoes(final ManaEchoes card) {

--- a/Mage.Sets/src/mage/cards/m/MartialLaw.java
+++ b/Mage.Sets/src/mage/cards/m/MartialLaw.java
@@ -9,19 +9,13 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
  * @author LevelX2
  */
 public final class MartialLaw extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
- 
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public MartialLaw(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{2}{W}{W}");
@@ -30,7 +24,7 @@ public final class MartialLaw extends CardImpl {
         // At the beginning of your upkeep, detain target creature an opponent controls. 
         // (Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)
         Ability ability = new BeginningOfUpkeepTriggeredAbility(new DetainTargetEffect(), TargetController.YOU, false);
-        TargetCreaturePermanent target = new TargetCreaturePermanent(filter);
+        TargetCreaturePermanent target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/m/MathasFiendSeeker.java
+++ b/Mage.Sets/src/mage/cards/m/MathasFiendSeeker.java
@@ -21,7 +21,7 @@ import mage.constants.Outcome;
 import mage.constants.SuperType;
 import mage.constants.TargetController;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -34,11 +34,6 @@ import mage.target.common.TargetCreaturePermanent;
 public final class MathasFiendSeeker extends CardImpl {
 
     private static final String rule = "For as long as that creature has a bounty counter on it, it has \"When this creature dies, each opponent draws a card and gains 2 life.\"";
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public MathasFiendSeeker(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{R}{W}{B}");
@@ -53,7 +48,7 @@ public final class MathasFiendSeeker extends CardImpl {
 
         // At the beginning of your end step, put a bounty counter on target creature an opponent controls. For as long as that creature has a bounty counter on it, it has "When this creature dies, each opponent draws a card and gains 2 life."
         Ability ability = new BeginningOfYourEndStepTriggeredAbility(new AddCountersTargetEffect(CounterType.BOUNTY.createInstance()), false);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         Ability ability2 = new DiesSourceTriggeredAbility(new DrawCardAllEffect(1, TargetController.OPPONENT));
         ability2.addEffect(new OpponentsGainLifeEffect());
         Effect effect = new MathasFiendSeekerGainAbilityEffect(ability2, Duration.Custom, rule);

--- a/Mage.Sets/src/mage/cards/m/MerEkNightblade.java
+++ b/Mage.Sets/src/mage/cards/m/MerEkNightblade.java
@@ -13,23 +13,14 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author emerald000
  */
 public final class MerEkNightblade extends CardImpl {
-    
-    private static final FilterPermanent filter = new FilterPermanent();
-    static {
-        filter.add(CardType.CREATURE.getPredicate());
-        filter.add(TargetController.YOU.getControllerPredicate());
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public MerEkNightblade(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{B}");
@@ -43,7 +34,14 @@ public final class MerEkNightblade extends CardImpl {
         this.addAbility(new OutlastAbility(new ManaCostsImpl<>("{B}")));
         
         // Each creature you control with a +1/+1 counter on it has deathtouch.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(DeathtouchAbility.getInstance(), Duration.WhileOnBattlefield, filter, "Each creature you control with a +1/+1 counter on it has deathtouch")));
+        this.addAbility(new SimpleStaticAbility(
+                Zone.BATTLEFIELD,
+                new GainAbilityAllEffect(
+                        DeathtouchAbility.getInstance(),
+                        Duration.WhileOnBattlefield,
+                        StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)
+                )
+        );
     }
 
     private MerEkNightblade(final MerEkNightblade card) {

--- a/Mage.Sets/src/mage/cards/m/MightMakesRight.java
+++ b/Mage.Sets/src/mage/cards/m/MightMakesRight.java
@@ -17,6 +17,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.TargetController;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -30,12 +31,6 @@ public final class MightMakesRight extends CardImpl {
     private static final String ruleText = "At the beginning of combat on your turn, if you control each creature on the battlefield with the greatest power, "
             + "gain control of target creature an opponent controls until end of turn. Untap that creature. It gains haste until end of turn.";
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public MightMakesRight(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{5}{R}");
 
@@ -45,7 +40,7 @@ public final class MightMakesRight extends CardImpl {
         TriggeredAbility gainControlAbility = new BeginningOfCombatTriggeredAbility(new GainControlTargetEffect(Duration.EndOfTurn), TargetController.YOU, false);
         gainControlAbility.addEffect(new UntapTargetEffect());
         gainControlAbility.addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn));
-        gainControlAbility.addTarget(new TargetCreaturePermanent(filter));
+        gainControlAbility.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         Ability conditionalAbility = new ConditionalInterveningIfTriggeredAbility(gainControlAbility, ControlsEachCreatureWithGreatestPowerCondition.instance, ruleText);
         this.addAbility(conditionalAbility);
     }

--- a/Mage.Sets/src/mage/cards/m/MightOfTheWild.java
+++ b/Mage.Sets/src/mage/cards/m/MightOfTheWild.java
@@ -13,7 +13,7 @@ import mage.constants.CardType;
 import mage.constants.ComparisonType;
 import mage.constants.Duration;
 import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.PowerPredicate;
@@ -47,7 +47,7 @@ public final class MightOfTheWild extends CardImpl {
 
         // Creatures you control gain indestructible this turn.
         mode = new Mode();
-        mode.addEffect(new GainAbilityControlledEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn, new FilterControlledCreaturePermanent("creatures you control")));
+        mode.addEffect(new GainAbilityControlledEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.getSpellAbility().addMode(mode);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MonkeyCage.java
+++ b/Mage.Sets/src/mage/cards/m/MonkeyCage.java
@@ -13,7 +13,7 @@ import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.game.permanent.token.ApeToken;
@@ -29,7 +29,7 @@ public final class MonkeyCage extends CardImpl {
 
         // When a creature enters the battlefield, sacrifice Monkey Cage and create X 2/2 green Ape creature tokens, where X is that creature's converted mana cost.
         Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new SacrificeSourceEffect(),
-                new FilterCreaturePermanent("a creature"), false, SetTargetPointer.PERMANENT, "");
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT, "");
         ability.addEffect(new MonkeyCageEffect());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/m/MuYanling.java
+++ b/Mage.Sets/src/mage/cards/m/MuYanling.java
@@ -15,8 +15,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -59,12 +58,6 @@ public final class MuYanling extends CardImpl {
 
 class MuYanlingEffect extends OneShotEffect {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public MuYanlingEffect() {
         super(Outcome.Tap);
         staticText = "tap all creatures your opponents control. You take an extra turn after this one.";
@@ -80,7 +73,7 @@ class MuYanlingEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        for (Permanent creature : game.getBattlefield().getActivePermanents(filter, player.getId(), source.getSourceId(), game)) {
+        for (Permanent creature : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE, player.getId(), source.getSourceId(), game)) {
             creature.tap(source, game);
         }
         return new AddExtraTurnControllerEffect().apply(game, source);

--- a/Mage.Sets/src/mage/cards/m/MutantsPrey.java
+++ b/Mage.Sets/src/mage/cards/m/MutantsPrey.java
@@ -7,35 +7,22 @@ import mage.abilities.effects.common.FightTargetsEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
+import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
- *
  * @author LevelX2
  */
-
-
 public final class MutantsPrey extends CardImpl {
-
-    private static final FilterCreaturePermanent filter1 = new FilterCreaturePermanent("creature you control with a +1/+1 counter on it");
-    private static final FilterCreaturePermanent filter2 = new FilterCreaturePermanent("creature an opponent controls");
-    static {
-        filter1.add(TargetController.YOU.getControllerPredicate());
-        filter1.add(CounterType.P1P1.getPredicate());
-        filter2.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public MutantsPrey(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{G}");
 
-
         // Target creature you control with a +1/+1 counter on it fights target creature an opponent controls.
         this.getSpellAbility().addEffect(new FightTargetsEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter1));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter2));
+        this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent(StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
     }
 
     private MutantsPrey(final MutantsPrey card) {

--- a/Mage.Sets/src/mage/cards/m/Mutiny.java
+++ b/Mage.Sets/src/mage/cards/m/Mutiny.java
@@ -7,7 +7,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.permanent.ControllerIdPredicate;
@@ -24,18 +24,12 @@ import java.util.UUID;
  */
 public final class Mutiny extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public Mutiny(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{R}");
 
         // Target creature an opponent controls deals damage equal to its power to another target creature that player controls.
         this.getSpellAbility().addEffect(new MutinyEffect());
-        this.getSpellAbility().addTarget(new MutinyFirstTarget(filter));
+        this.getSpellAbility().addTarget(new MutinyFirstTarget(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(new FilterCreaturePermanent("another target creature that player controls")));
 
     }

--- a/Mage.Sets/src/mage/cards/n/NeedletoothRaptor.java
+++ b/Mage.Sets/src/mage/cards/n/NeedletoothRaptor.java
@@ -10,8 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -19,12 +18,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author L_J
  */
 public final class NeedletoothRaptor extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public NeedletoothRaptor(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{R}");
@@ -34,7 +27,7 @@ public final class NeedletoothRaptor extends CardImpl {
 
         // <i>Enrage</i> &mdash; Whenever Needletooth Raptor is dealt damage, it deals 5 damage to target creature an opponent controls.
         Ability ability = new DealtDamageToSourceTriggeredAbility(new DamageTargetEffect(5).setText("it deals 5 damage to target creature an opponent controls"), false, true);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NerfHerder.java
+++ b/Mage.Sets/src/mage/cards/n/NerfHerder.java
@@ -14,20 +14,13 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author Styxo
  */
 public final class NerfHerder extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Each creature with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public NerfHerder(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{G}");
@@ -39,8 +32,11 @@ public final class NerfHerder extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new AbilitiesCostReductionControllerEffect(MonstrosityAbility.class, "Monstrosity")));
 
         // Each creature you control with a +1/+1 counter on it has trample.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityControlledEffect(TrampleAbility.getInstance(), Duration.WhileOnBattlefield, filter)));
-
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityControlledEffect(
+                TrampleAbility.getInstance(),
+                Duration.WhileOnBattlefield,
+                StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1))
+        );
     }
 
     private NerfHerder(final NerfHerder card) {

--- a/Mage.Sets/src/mage/cards/n/NiblisOfFrost.java
+++ b/Mage.Sets/src/mage/cards/n/NiblisOfFrost.java
@@ -11,9 +11,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
@@ -22,11 +20,6 @@ import java.util.UUID;
  * @author fireshoes
  */
 public final class NiblisOfFrost extends CardImpl {
-    private static final FilterCreaturePermanent filterCreature = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filterCreature.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public NiblisOfFrost(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}{U}");
@@ -42,7 +35,7 @@ public final class NiblisOfFrost extends CardImpl {
 
         // Whenever you cast an instant or sorcery spell, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.
         Ability ability = new SpellCastControllerTriggeredAbility(new TapTargetEffect(), StaticFilters.FILTER_SPELL_AN_INSTANT_OR_SORCERY, false);
-        ability.addTarget(new TargetCreaturePermanent(filterCreature));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         ability.addEffect(new DontUntapInControllersNextUntapStepTargetEffect("That creature"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/n/NissasJudgment.java
+++ b/Mage.Sets/src/mage/cards/n/NissasJudgment.java
@@ -10,9 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -25,12 +23,6 @@ import mage.target.targetpointer.SecondTargetPointer;
  */
 public final class NissasJudgment extends CardImpl {
 
-    private static final FilterCreaturePermanent FILTER = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        FILTER.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public NissasJudgment(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{G}");
 
@@ -41,7 +33,7 @@ public final class NissasJudgment extends CardImpl {
         // Choose up to one target creature an opponent controls. Each creature you control with a +1/+1 counter on it deals damage equal to its power to that creature.
         effect = new NissasJudgmentEffect();
         effect.setTargetPointer(new SecondTargetPointer()); // First target is used by Support
-        getSpellAbility().addTarget(new TargetCreaturePermanent(0, 1, FILTER, false));
+        getSpellAbility().addTarget(new TargetCreaturePermanent(0, 1, StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE, false));
         getSpellAbility().addEffect(effect);
     }
 
@@ -56,14 +48,6 @@ public final class NissasJudgment extends CardImpl {
 }
 
 class NissasJudgmentEffect extends OneShotEffect {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-    private static final FilterCreaturePermanent filterWithCounter = new FilterCreaturePermanent();
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-        filterWithCounter.add(CounterType.P1P1.getPredicate());
-    }
 
     public NissasJudgmentEffect() {
         super(Outcome.Damage);
@@ -85,7 +69,7 @@ class NissasJudgmentEffect extends OneShotEffect {
         if (controller != null) {
             Permanent targetCreature = game.getPermanent(getTargetPointer().getFirst(game, source));
             if (targetCreature != null) {
-                for (Permanent permanent : game.getBattlefield().getAllActivePermanents(filterWithCounter, controller.getId(), game)) {
+                for (Permanent permanent : game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1, controller.getId(), game)) {
                     if (permanent.getPower().getValue() > 0) {
                         targetCreature.damage(permanent.getPower().getValue(), permanent.getId(), source, game, false, true);
                     }

--- a/Mage.Sets/src/mage/cards/n/NovijenSages.java
+++ b/Mage.Sets/src/mage/cards/n/NovijenSages.java
@@ -24,7 +24,8 @@ import mage.target.TargetPermanent;
  */
 public final class NovijenSages extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creatures you control with a +1/+1 counter on it");
+    // Creatures you control with +1/+1 counters, name is what it is to make rules come out
+    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("among creatures you control");
 
     static {
         filter.add(CounterType.P1P1.getPredicate());

--- a/Mage.Sets/src/mage/cards/o/OathOfChandra.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfChandra.java
@@ -16,7 +16,7 @@ import mage.abilities.effects.common.DamageTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
@@ -29,12 +29,6 @@ import mage.watchers.Watcher;
  */
 public final class OathOfChandra extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public OathOfChandra(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{R}");
         addSuperType(SuperType.LEGENDARY);
@@ -43,8 +37,9 @@ public final class OathOfChandra extends CardImpl {
         Effect effect = new DamageTargetEffect(3);
         effect.setText("it deals 3 damage to target creature an opponent controls");
         Ability ability = new EntersBattlefieldTriggeredAbility(effect, false);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
+
         // At the beginning of each end step, if a planeswalker entered the battlefield under your control this turn, Oath of Chandra deals 2 damage to each opponent.
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(new BeginningOfEndStepTriggeredAbility(
                 new DamagePlayersEffect(Outcome.Damage, StaticValue.get(2), TargetController.OPPONENT),

--- a/Mage.Sets/src/mage/cards/o/OllenbockEscort.java
+++ b/Mage.Sets/src/mage/cards/o/OllenbockEscort.java
@@ -13,9 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -24,13 +22,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class OllenbockEscort extends CardImpl {
-
-    private static final FilterPermanent filter
-            = new FilterControlledCreaturePermanent("creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public OllenbockEscort(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{W}");
@@ -50,7 +41,7 @@ public final class OllenbockEscort extends CardImpl {
         ability.addEffect(new GainAbilityTargetEffect(
                 IndestructibleAbility.getInstance(), Duration.EndOfTurn
         ).setText("and indestructible until end of turn"));
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OminousSphinx.java
+++ b/Mage.Sets/src/mage/cards/o/OminousSphinx.java
@@ -11,8 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,12 +19,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author spjspj
  */
 public final class OminousSphinx extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public OminousSphinx(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{U}{U}");
@@ -39,7 +32,7 @@ public final class OminousSphinx extends CardImpl {
 
         // Whenever you cycle or discard a card,target creature an opponent controls gets -2/-0 until end of turn.
         CycleOrDiscardControllerTriggeredAbility ability = new CycleOrDiscardControllerTriggeredAbility(new BoostTargetEffect(-2, -0, Duration.EndOfTurn));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OozeFlux.java
+++ b/Mage.Sets/src/mage/cards/o/OozeFlux.java
@@ -14,7 +14,7 @@ import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.token.OozeToken;
 import mage.game.permanent.token.Token;
@@ -30,7 +30,7 @@ public final class OozeFlux extends CardImpl {
 
         // {1}{G}, Remove one or more +1/+1 counters from among creatures you control: Create an X/X green Ooze creature token, where X is the number of +1/+1 counters removed this way.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new OozeFluxCreateTokenEffect(new OozeToken()),new ManaCostsImpl("{1}{G}"));
-        ability.addCost(new RemoveVariableCountersTargetCost(new FilterControlledCreaturePermanent("creatures you control"), CounterType.P1P1, "one or more", 1));
+        ability.addCost(new RemoveVariableCountersTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURES, CounterType.P1P1, "one or more", 1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrcSureshot.java
+++ b/Mage.Sets/src/mage/cards/o/OrcSureshot.java
@@ -11,10 +11,9 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.constants.Zone;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -25,11 +24,9 @@ import mage.target.common.TargetCreaturePermanent;
 public final class OrcSureshot extends CardImpl {
 
     private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("another creature under your control");
-    private static final FilterCreaturePermanent filterOpponentCreature = new FilterCreaturePermanent("creature an opponent controls");
 
     static {
         filter.add(AnotherPredicate.instance);
-        filterOpponentCreature.add(TargetController.OPPONENT.getControllerPredicate());
     }
 
     public OrcSureshot(UUID ownerId, CardSetInfo setInfo) {
@@ -41,9 +38,8 @@ public final class OrcSureshot extends CardImpl {
 
         // Whenever another creature enters the battlefield under your control, target creature an opponent controls gets -1/-1 until end of turn.
         Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new BoostTargetEffect(-1,-1, Duration.EndOfTurn),filter,false);
-        ability.addTarget(new TargetCreaturePermanent(filterOpponentCreature));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
-        
     }
 
     private OrcSureshot(final OrcSureshot card) {

--- a/Mage.Sets/src/mage/cards/p/PalaceJailer.java
+++ b/Mage.Sets/src/mage/cards/p/PalaceJailer.java
@@ -18,9 +18,8 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.ExileZone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
@@ -33,12 +32,6 @@ import mage.util.CardUtil;
  * @author LevelX2
  */
 public final class PalaceJailer extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public PalaceJailer(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{W}{W}");
@@ -53,7 +46,7 @@ public final class PalaceJailer extends CardImpl {
 
         // When Palace Jailer enters the battlefield, exile target creature an opponent controls until an opponent becomes the monarch. (That creature returns under its owner's control.)
         Ability ability = new EntersBattlefieldTriggeredAbility(new PalaceJailerExileEffect());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         ability.addEffect(new CreateDelayedTriggeredAbilityEffect(new OnOpponentBecomesMonarchReturnExiledToBattlefieldAbility()));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/p/PalliationAccord.java
+++ b/Mage.Sets/src/mage/cards/p/PalliationAccord.java
@@ -11,10 +11,9 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -22,17 +21,11 @@ import mage.filter.common.FilterCreaturePermanent;
  */
 public final class PalliationAccord extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public PalliationAccord(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{W}{U}");
 
         // Whenever a creature an opponent controls becomes tapped, put a shield counter on Palliation Accord.
-        this.addAbility(new BecomesTappedTriggeredAbility(new AddCountersSourceEffect(CounterType.SHIELD.createInstance()), false, filter));
+        this.addAbility(new BecomesTappedTriggeredAbility(new AddCountersSourceEffect(CounterType.SHIELD.createInstance()), false, StaticFilters.FILTER_OPPONENTS_PERMANENT_A_CREATURE));
 
         // Remove a shield counter from Palliation Accord: Prevent the next 1 damage that would be dealt to you this turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD,

--- a/Mage.Sets/src/mage/cards/p/PatronOfTheValiant.java
+++ b/Mage.Sets/src/mage/cards/p/PatronOfTheValiant.java
@@ -3,21 +3,15 @@ package mage.cards.p;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.MageObject;
-import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.counter.AddCountersAllEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Outcome;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -33,9 +27,12 @@ public final class PatronOfTheValiant extends CardImpl {
 
         // Flying
         this.addAbility(FlyingAbility.getInstance());
-        
+
         // When Patron of the Valiant enters the battlefield, put a +1/+1 counter on each creature you control with a +1/+1 counter on it.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new PatronOfTheValiantEffect()));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new AddCountersAllEffect(
+                CounterType.P1P1.createInstance(),
+                StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1
+        )));
     }
 
     private PatronOfTheValiant(final PatronOfTheValiant card) {
@@ -45,41 +42,5 @@ public final class PatronOfTheValiant extends CardImpl {
     @Override
     public PatronOfTheValiant copy() {
         return new PatronOfTheValiant(this);
-    }
-}
-
-class PatronOfTheValiantEffect extends OneShotEffect {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent();
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
-    public PatronOfTheValiantEffect() {
-        super(Outcome.Benefit);
-        this.staticText = "put a +1/+1 counter on each creature you control with a +1/+1 counter on it.";
-    }
-
-    public PatronOfTheValiantEffect(final PatronOfTheValiantEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public PatronOfTheValiantEffect copy() {
-        return new PatronOfTheValiantEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        MageObject sourceObject = source.getSourceObject(game);
-        if (controller != null && sourceObject != null) {
-            for(Permanent permanent: game.getState().getBattlefield().getAllActivePermanents(filter , controller.getId(), game)) {
-                permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
-                game.informPlayers(sourceObject.getName() + ": Put a +1/+1 counter on " + permanent.getLogName());
-            }
-        }
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PatronOfTheVein.java
+++ b/Mage.Sets/src/mage/cards/p/PatronOfTheVein.java
@@ -17,11 +17,10 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.counters.CounterType;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
@@ -36,12 +35,6 @@ import mage.target.targetpointer.FixedTarget;
  */
 public final class PatronOfTheVein extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public PatronOfTheVein(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{B}{B}");
 
@@ -55,7 +48,7 @@ public final class PatronOfTheVein extends CardImpl {
 
         // When Patron of the Vein enters the battlefield, destroy target creature an opponent controls.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DestroyTargetEffect(), false);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
 
         // Whenever a creature an opponent controls dies, exile it and put a +1/+1 counter on each Vampire you control.

--- a/Mage.Sets/src/mage/cards/p/Petradon.java
+++ b/Mage.Sets/src/mage/cards/p/Petradon.java
@@ -15,7 +15,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.common.FilterLandPermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetLandPermanent;
 
 import java.util.UUID;
@@ -34,7 +34,7 @@ public final class Petradon extends CardImpl {
 
         // When Petradon enters the battlefield, exile two target lands.
         Ability ability = new EntersBattlefieldTriggeredAbility(new ExileTargetForSourceEffect(), false);
-        ability.addTarget(new TargetLandPermanent(2, 2, new FilterLandPermanent("lands"), false));
+        ability.addTarget(new TargetLandPermanent(2, 2, StaticFilters.FILTER_LANDS, false));
         this.addAbility(ability);
 
         // When Petradon leaves the battlefield, return the exiled cards to the battlefield under their owners' control.

--- a/Mage.Sets/src/mage/cards/p/PietyCharm.java
+++ b/Mage.Sets/src/mage/cards/p/PietyCharm.java
@@ -13,7 +13,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.permanent.AttachedToPredicate;
 import mage.target.TargetPermanent;
@@ -47,7 +47,7 @@ public final class PietyCharm extends CardImpl {
         this.getSpellAbility().addMode(mode);
         // or creatures you control gain vigilance until end of turn.
         mode = new Mode();
-        mode.addEffect(new GainAbilityAllEffect(VigilanceAbility.getInstance(), Duration.EndOfTurn, new FilterControlledCreaturePermanent("creatures you control")));
+        mode.addEffect(new GainAbilityAllEffect(VigilanceAbility.getInstance(), Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.getSpellAbility().addMode(mode);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlaxcasterFrogling.java
+++ b/Mage.Sets/src/mage/cards/p/PlaxcasterFrogling.java
@@ -15,8 +15,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -24,11 +23,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author JotaPeRL
  */
 public final class PlaxcasterFrogling extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature with a +1/+1 counter on it");
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }       
 
     public PlaxcasterFrogling(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{G}{U}");
@@ -42,7 +36,7 @@ public final class PlaxcasterFrogling extends CardImpl {
         
         // {2}: Target creature with a +1/+1 counter on it gains shroud until end of turn.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilityTargetEffect(ShroudAbility.getInstance(), Duration.EndOfTurn), new GenericManaCost(2));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_CREATURE_P1P1));
         this.addAbility(ability);        
     }
 

--- a/Mage.Sets/src/mage/cards/p/Portcullis.java
+++ b/Mage.Sets/src/mage/cards/p/Portcullis.java
@@ -13,10 +13,10 @@ import mage.abilities.effects.common.ReturnToBattlefieldUnderOwnerControlTargetE
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.events.ZoneChangeEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -30,8 +30,6 @@ import java.util.UUID;
  */
 public final class Portcullis extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature");
-
     public Portcullis(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{4}");
 
@@ -40,7 +38,7 @@ public final class Portcullis extends CardImpl {
         String rule = "Whenever a creature enters the battlefield, if there are two or more other creatures on the battlefield, exile that creature.";
         String rule2 = " Return that card to the battlefield under its owner's control when {this} leaves the battlefield.";
         TriggeredAbility ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new PortcullisExileEffect(),
-                filter, false, SetTargetPointer.PERMANENT, rule);
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT, rule);
         MoreThanXCreaturesOnBFCondition condition = new MoreThanXCreaturesOnBFCondition(2);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, condition, rule + rule2));
 

--- a/Mage.Sets/src/mage/cards/p/Pridemalkin.java
+++ b/Mage.Sets/src/mage/cards/p/Pridemalkin.java
@@ -13,8 +13,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetControlledCreaturePermanent;
 
 import java.util.UUID;
@@ -23,13 +22,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class Pridemalkin extends CardImpl {
-
-    private static final FilterPermanent filter
-            = new FilterControlledCreaturePermanent("each creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public Pridemalkin(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}");
@@ -45,7 +37,7 @@ public final class Pridemalkin extends CardImpl {
 
         // Each creature you control with a +1/+1 counter on it has trample.
         this.addAbility(new SimpleStaticAbility(new GainAbilityAllEffect(
-                TrampleAbility.getInstance(), Duration.WhileOnBattlefield, filter
+                TrampleAbility.getInstance(), Duration.WhileOnBattlefield, StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1
         )));
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimevalBounty.java
+++ b/Mage.Sets/src/mage/cards/p/PrimevalBounty.java
@@ -46,7 +46,7 @@ public final class PrimevalBounty extends CardImpl {
 
         // Whenever a land enters the battlefield under your control, you gain 3 life.
         effect = new GainLifeEffect(3);
-        ability = new EntersBattlefieldControlledTriggeredAbility(effect, new FilterLandPermanent("a land"));
+        ability = new EntersBattlefieldControlledTriggeredAbility(effect, StaticFilters.FILTER_LAND_A);
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/p/PromiseOfBunrei.java
+++ b/Mage.Sets/src/mage/cards/p/PromiseOfBunrei.java
@@ -8,8 +8,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.game.permanent.token.SpiritToken;
@@ -22,18 +21,12 @@ import java.util.UUID;
  */
 public final class PromiseOfBunrei extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature you control");
-
-    static {
-        filter.add(TargetController.YOU.getControllerPredicate());
-    }
-
     public PromiseOfBunrei(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{W}");
 
         // When a creature you control dies, sacrifice Promise of Bunrei. If you do, create four 1/1 colorless Spirit creature tokens.
         this.addAbility(new DiesCreatureTriggeredAbility(
-                new PromiseOfBunreiEffect(), false, filter
+                new PromiseOfBunreiEffect(), false, StaticFilters.FILTER_CONTROLLED_A_CREATURE
         ).setTriggerPhrase("When a creature you control dies, "));
     }
 

--- a/Mage.Sets/src/mage/cards/p/PublicExecution.java
+++ b/Mage.Sets/src/mage/cards/p/PublicExecution.java
@@ -8,6 +8,7 @@ import mage.abilities.effects.common.continuous.BoostAllEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.permanent.ControllerIdPredicate;
@@ -23,18 +24,12 @@ import java.util.UUID;
  */
 public final class PublicExecution extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public PublicExecution(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{5}{B}");
 
         // Destroy target creature an opponent controls. Each other creature that player controls gets -2/-0 until end of turn.
         this.getSpellAbility().addEffect(new DestroyTargetEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.getSpellAbility().addEffect(new PublicExecutionEffect());
     }
 

--- a/Mage.Sets/src/mage/cards/q/QuestForRenewal.java
+++ b/Mage.Sets/src/mage/cards/q/QuestForRenewal.java
@@ -13,6 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
 
 /**
@@ -26,7 +27,7 @@ public final class QuestForRenewal extends CardImpl {
 
         // Whenever a creature you control becomes tapped, you may put a quest counter on Quest for Renewal.
         this.addAbility(new BecomesTappedTriggeredAbility(new AddCountersSourceEffect(CounterType.QUEST.createInstance()),
-                true, new FilterControlledCreaturePermanent("a creature you control")));
+                true, StaticFilters.FILTER_CONTROLLED_A_CREATURE));
 
         // As long as there are four or more quest counters on Quest for Renewal, untap all creatures you control during each other player's untap step.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new ConditionalContinuousEffect(

--- a/Mage.Sets/src/mage/cards/q/QuietContemplation.java
+++ b/Mage.Sets/src/mage/cards/q/QuietContemplation.java
@@ -12,9 +12,8 @@ import mage.abilities.effects.common.TapTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.filter.FilterSpell;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.predicate.Predicates;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -24,12 +23,10 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class QuietContemplation extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
     private static final FilterSpell filterNonCreature = new FilterSpell("a noncreature spell");
 
     static {
         filterNonCreature.add(Predicates.not(CardType.CREATURE.getPredicate()));
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
     }
        
     public QuietContemplation(UUID ownerId, CardSetInfo setInfo) {
@@ -42,7 +39,7 @@ public final class QuietContemplation extends CardImpl {
         effect.setText("and it doesn't untap during its controller's next untap step");
         doIfCostPaid.addEffect(effect);
         Ability ability = new SpellCastControllerTriggeredAbility(doIfCostPaid, filterNonCreature, false);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);        
     }
 

--- a/Mage.Sets/src/mage/cards/r/RageForger.java
+++ b/Mage.Sets/src/mage/cards/r/RageForger.java
@@ -15,7 +15,7 @@ import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.TargetController;
 import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.Game;
@@ -30,13 +30,11 @@ import mage.target.common.TargetPlayerOrPlaneswalker;
 public final class RageForger extends CardImpl {
 
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("other Shaman creature you control");
-    private static final FilterControlledCreaturePermanent filterAttack = new FilterControlledCreaturePermanent("creature you control with a +1/+1 counter on it");
 
     static {
         filter.add(SubType.SHAMAN.getPredicate());
         filter.add(TargetController.YOU.getControllerPredicate());
         filter.add(AnotherPredicate.instance);
-        filterAttack.add(CounterType.P1P1.getPredicate());
     }
 
     public RageForger(UUID ownerId, CardSetInfo setInfo) {
@@ -49,11 +47,11 @@ public final class RageForger extends CardImpl {
 
         // When Rage Forger enters the battlefield, put a +1/+1 counter on each other Shaman creature you control.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new AddCountersAllEffect(CounterType.P1P1.createInstance(), filter), false));
+
         // Whenever a creature you control with a +1/+1 counter on it attacks, you may have that creature deal 1 damage to target player.
-        Ability ability = new AttacksCreatureYouControlTriggeredAbility(new RageForgerDamageEffect(), true, filterAttack, true);
+        Ability ability = new AttacksCreatureYouControlTriggeredAbility(new RageForgerDamageEffect(), true, StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1, true);
         ability.addTarget(new TargetPlayerOrPlaneswalker());
         this.addAbility(ability);
-
     }
 
     private RageForger(final RageForger card) {

--- a/Mage.Sets/src/mage/cards/r/RavenousChupacabra.java
+++ b/Mage.Sets/src/mage/cards/r/RavenousChupacabra.java
@@ -10,8 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -19,12 +18,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author L_J
  */
 public final class RavenousChupacabra extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public RavenousChupacabra(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}{B}");
@@ -35,7 +28,7 @@ public final class RavenousChupacabra extends CardImpl {
 
         // When Ravenous Chupacabra enters the battlefield, destroy target creature an opponent controls.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DestroyTargetEffect());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RayOfCommand.java
+++ b/Mage.Sets/src/mage/cards/r/RayOfCommand.java
@@ -13,11 +13,9 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -25,24 +23,16 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class RayOfCommand extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }    
     
     public RayOfCommand(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{3}{U}");
-
 
         // Untap target creature an opponent controls and gain control of it until end of turn. That creature gains haste until end of turn. When you lose control of the creature, tap it.
         this.getSpellAbility().addEffect(new UntapTargetEffect());
         this.getSpellAbility().addEffect(new GainControlTargetEffect(Duration.EndOfTurn));
         this.getSpellAbility().addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn));
         this.getSpellAbility().addEffect(new CreateDelayedTriggeredAbilityEffect(new RayOfCommandDelayedTriggeredAbility(), true));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter));
-        
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
     }
 
     private RayOfCommand(final RayOfCommand card) {

--- a/Mage.Sets/src/mage/cards/r/RenegadeKrasis.java
+++ b/Mage.Sets/src/mage/cards/r/RenegadeKrasis.java
@@ -12,8 +12,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 
@@ -47,15 +46,8 @@ public final class RenegadeKrasis extends CardImpl {
 
 class RenegadeKrasisTriggeredAbility extends TriggeredAbilityImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent();
-
-    static {
-        filter.add(AnotherPredicate.instance);
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
     public RenegadeKrasisTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new AddCountersAllEffect(CounterType.P1P1.createInstance(1), filter), false);
+        super(Zone.BATTLEFIELD, new AddCountersAllEffect(CounterType.P1P1.createInstance(1), StaticFilters.FILTER_OTHER_CONTROLLED_CREATURE_P1P1), false);
     }
 
     public RenegadeKrasisTriggeredAbility(final RenegadeKrasisTriggeredAbility ability) {

--- a/Mage.Sets/src/mage/cards/r/ResoluteBlademaster.java
+++ b/Mage.Sets/src/mage/cards/r/ResoluteBlademaster.java
@@ -12,7 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -32,7 +32,7 @@ public final class ResoluteBlademaster extends CardImpl {
         // you control gain double strike until end of turn.
         Ability ability = new AllyEntersBattlefieldTriggeredAbility(
                 new GainAbilityAllEffect(DoubleStrikeAbility.getInstance(), Duration.EndOfTurn,
-                        new FilterControlledCreaturePermanent("creatures you control")), false);
+                        StaticFilters.FILTER_CONTROLLED_CREATURES), false);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Resuscitate.java
+++ b/Mage.Sets/src/mage/cards/r/Resuscitate.java
@@ -11,7 +11,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -19,15 +19,13 @@ import mage.filter.common.FilterControlledCreaturePermanent;
  */
 public final class Resuscitate extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creatures you control");
-
     public Resuscitate(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{G}");
 
         // Until end of turn, creatures you control gain "{1}: Regenerate this creature."
         Ability ability = new SimpleActivatedAbility(new RegenerateSourceEffect().setText("Regenerate this creature"), new GenericManaCost(1));
         this.getSpellAbility().addEffect(
-                new GainAbilityAllEffect(ability, Duration.EndOfTurn, filter,
+                new GainAbilityAllEffect(ability, Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES,
                         "Until end of turn, creatures you control gain \"{1}: Regenerate this creature.\""
                 )
         );

--- a/Mage.Sets/src/mage/cards/r/RetributionOfTheAncients.java
+++ b/Mage.Sets/src/mage/cards/r/RetributionOfTheAncients.java
@@ -14,6 +14,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.counters.CounterType;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -36,7 +37,7 @@ public final class RetributionOfTheAncients extends CardImpl {
         // {B}, Remove X +1/+1 counters from among creatures you control: Target creature gets -X/-X until end of turn.
         DynamicValue xValue = new SignInversionDynamicValue(GetXValue.instance);
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true), new ManaCostsImpl("{B}"));
-        ability.addCost(new RemoveVariableCountersTargetCost(filter, CounterType.P1P1, "X", 0));
+        ability.addCost(new RemoveVariableCountersTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURES, CounterType.P1P1, "X", 0));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/r/RetributionOfTheAncients.java
+++ b/Mage.Sets/src/mage/cards/r/RetributionOfTheAncients.java
@@ -15,7 +15,6 @@ import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
@@ -24,12 +23,6 @@ import java.util.UUID;
  * @author LevelX2
  */
 public final class RetributionOfTheAncients extends CardImpl {
-
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creatures you control");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public RetributionOfTheAncients(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{B}");

--- a/Mage.Sets/src/mage/cards/r/RevelInRiches.java
+++ b/Mage.Sets/src/mage/cards/r/RevelInRiches.java
@@ -14,7 +14,7 @@ import mage.constants.ComparisonType;
 import mage.constants.SubType;
 import mage.constants.TargetController;
 import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.permanent.token.TreasureToken;
 
 import java.util.UUID;
@@ -24,11 +24,9 @@ import java.util.UUID;
  */
 public final class RevelInRiches extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature an opponent controls");
     private static final FilterPermanent filter2 = new FilterPermanent("Treasures");
 
     static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
         filter2.add(SubType.TREASURE.getPredicate());
     }
 
@@ -36,7 +34,7 @@ public final class RevelInRiches extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{4}{B}");
 
         // Whenever a creature an opponent controls dies, create a colorless Treasure artifact token with "{T}, Sacrifice this artifact: Add one mana of any color."
-        this.addAbility(new DiesCreatureTriggeredAbility(new CreateTokenEffect(new TreasureToken()), false, filter));
+        this.addAbility(new DiesCreatureTriggeredAbility(new CreateTokenEffect(new TreasureToken()), false, StaticFilters.FILTER_OPPONENTS_PERMANENT_A_CREATURE));
         // At the beginning of your upkeep, if you control ten or more Treasures, you win the game.
         TriggeredAbility ability = new BeginningOfUpkeepTriggeredAbility(new WinGameSourceControllerEffect(), TargetController.YOU, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/s/SapphireCharm.java
+++ b/Mage.Sets/src/mage/cards/s/SapphireCharm.java
@@ -14,8 +14,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.TargetPlayer;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -24,12 +23,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author fireshoes
  */
 public final class SapphireCharm extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public SapphireCharm(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{U}");
@@ -50,7 +43,7 @@ public final class SapphireCharm extends CardImpl {
         // or target creature an opponent controls phases out.
         mode = new Mode();
         mode.addEffect(new PhaseOutTargetEffect());
-        mode.addTarget(new TargetCreaturePermanent(filter));
+        mode.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.getSpellAbility().addMode(mode);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SapphireDrake.java
+++ b/Mage.Sets/src/mage/cards/s/SapphireDrake.java
@@ -9,24 +9,13 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author jeffwadsworth
  */
 public final class SapphireDrake extends CardImpl {
-    
-    private static final FilterPermanent filter = new FilterPermanent();
-    
-    static {
-        filter.add(CardType.CREATURE.getPredicate());
-        filter.add(TargetController.YOU.getControllerPredicate());
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-    
-    static final String rule = "Each creature you control with a +1/+1 counter on it has flying";
 
     public SapphireDrake(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{5}{U}");
@@ -39,7 +28,13 @@ public final class SapphireDrake extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         
         // Each creature you control with a +1/+1 counter on it has flying.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(FlyingAbility.getInstance(), Duration.WhileOnBattlefield, filter, rule)));
+        this.addAbility(new SimpleStaticAbility(
+                Zone.BATTLEFIELD,
+                new GainAbilityAllEffect(FlyingAbility.getInstance(),
+                        Duration.WhileOnBattlefield,
+                        StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)
+                )
+        );
     }
 
     private SapphireDrake(final SapphireDrake card) {

--- a/Mage.Sets/src/mage/cards/s/SaskiaTheUnyielding.java
+++ b/Mage.Sets/src/mage/cards/s/SaskiaTheUnyielding.java
@@ -11,6 +11,7 @@ import mage.abilities.keyword.VigilanceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.game.Game;
 import mage.players.Player;
@@ -40,7 +41,7 @@ public final class SaskiaTheUnyielding extends CardImpl {
         // Whenever a creature you control deals combat damage to a player, it deals that much damage to the chosen player.
         this.addAbility(new DealsDamageToAPlayerAllTriggeredAbility(
                 new SaskiaTheUnyieldingEffect(),
-                new FilterControlledCreaturePermanent("a creature you control"), false, SetTargetPointer.NONE, true
+                StaticFilters.FILTER_CONTROLLED_A_CREATURE, false, SetTargetPointer.NONE, true
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/s/ScabClanGiant.java
+++ b/Mage.Sets/src/mage/cards/s/ScabClanGiant.java
@@ -9,8 +9,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -20,12 +19,6 @@ import java.util.UUID;
  * @author LevelX2
  */
 public final class ScabClanGiant extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public ScabClanGiant(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{R}{G}");
@@ -38,7 +31,7 @@ public final class ScabClanGiant extends CardImpl {
         // When Scab-Clan Giant enters the battlefield, it fights target creature an opponent controls chosen at random.
         Ability ability = new EntersBattlefieldTriggeredAbility(new FightTargetSourceEffect()
                 .setText("it fights target creature an opponent controls chosen at random"));
-        Target target = new TargetCreaturePermanent(filter);
+        Target target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         target.setRandom(true);
         ability.addTarget(target);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/ScaleBlessing.java
+++ b/Mage.Sets/src/mage/cards/s/ScaleBlessing.java
@@ -2,20 +2,13 @@
 package mage.cards.s;
 
 import java.util.UUID;
-import mage.MageObject;
-import mage.abilities.Ability;
-import mage.abilities.effects.Effect;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.counter.AddCountersAllEffect;
 import mage.abilities.effects.keyword.BolsterEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -26,12 +19,15 @@ public final class ScaleBlessing extends CardImpl {
     public ScaleBlessing(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{W}");
 
-        // Bolster 1, then put a +1/+1 counter on each creature you control with a +1/+1 counter on it. <i.(To bolster 1, choose a creature with the least toughness among creatures you control and put +1/+1 counter on it.)</i>
-        Effect effect = new BolsterEffect(1);
-        effect.setText("Bolster 1");
-        this.getSpellAbility().addEffect(effect);
-        this.getSpellAbility().addEffect(new ScaleBlessingEffect());
+        // Bolster 1,
+        this.getSpellAbility().addEffect(new BolsterEffect(1).setText("Bolster 1, "));
 
+        // then put a +1/+1 counter on each creature you control with a +1/+1 counter on it. <i.(To bolster 1, choose a creature with the least toughness among creatures you control and put +1/+1 counter on it.)</i>
+        this.getSpellAbility().addEffect(new AddCountersAllEffect(
+                CounterType.P1P1.createInstance(), StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1
+        ).setText("then put a +1/+1 counter on each creature you control with a +1/+1 counter on it. " +
+                "<i>(To bolster 1, choose a creature with the least toughness among creatures you control " +
+                "and put a +1/+1 counter on it.)</i>"));
     }
 
     private ScaleBlessing(final ScaleBlessing card) {
@@ -41,41 +37,5 @@ public final class ScaleBlessing extends CardImpl {
     @Override
     public ScaleBlessing copy() {
         return new ScaleBlessing(this);
-    }
-}
-
-class ScaleBlessingEffect extends OneShotEffect {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent();
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
-    public ScaleBlessingEffect() {
-        super(Outcome.Benefit);
-        this.staticText = ", then put a +1/+1 counter on each creature you control with a +1/+1 counter on it. <i>(To bolster 1, choose a creature with the least toughness among creatures you control and put +1/+1 counter on it.)</i>";
-    }
-
-    public ScaleBlessingEffect(final ScaleBlessingEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public ScaleBlessingEffect copy() {
-        return new ScaleBlessingEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        MageObject sourceObject = source.getSourceObject(game);
-        if (controller != null && sourceObject != null) {
-            for (Permanent permanent : game.getState().getBattlefield().getAllActivePermanents(filter, controller.getId(), game)) {
-                permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
-                game.informPlayers(sourceObject.getName() + ": Put a +1/+1 counter on " + permanent.getLogName());
-            }
-        }
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/s/ScionOfTheWild.java
+++ b/Mage.Sets/src/mage/cards/s/ScionOfTheWild.java
@@ -12,14 +12,12 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  * @author anonymous
  */
 public final class ScionOfTheWild extends CardImpl {
-
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creatures you control");
 
     public ScionOfTheWild(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{G}{G}");
@@ -27,7 +25,7 @@ public final class ScionOfTheWild extends CardImpl {
 
         this.power = new MageInt(0);
         this.toughness = new MageInt(0);
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetPowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetPowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURES), Duration.EndOfGame)));
     }
 
     private ScionOfTheWild(final ScionOfTheWild card) {

--- a/Mage.Sets/src/mage/cards/s/SelflessSpirit.java
+++ b/Mage.Sets/src/mage/cards/s/SelflessSpirit.java
@@ -14,7 +14,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -34,7 +34,7 @@ public final class SelflessSpirit extends CardImpl {
 
         // Sacrifice Selfless Spirit: Creatures you control gain indestructible until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn,
-                        new FilterControlledCreaturePermanent("creatures you control")), new SacrificeSourceCost()));
+                StaticFilters.FILTER_CONTROLLED_CREATURES), new SacrificeSourceCost()));
     }
 
     private SelflessSpirit(final SelflessSpirit card) {

--- a/Mage.Sets/src/mage/cards/s/ShaileDeanOfRadiance.java
+++ b/Mage.Sets/src/mage/cards/s/ShaileDeanOfRadiance.java
@@ -17,6 +17,7 @@ import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.counters.CounterType;
 import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicate;
@@ -35,13 +36,11 @@ public final class ShaileDeanOfRadiance extends ModalDoubleFacesCard {
 
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
     private static final FilterPermanent shaileFilter = new FilterControlledCreaturePermanent("creature that entered the battlefield under your control this turn");
-    private static final FilterPermanent embroseFilter = new FilterControlledCreaturePermanent("a creature you control with a +1/+1 counter on it");
 
     static {
         filter.add(AnotherPredicate.instance);
         shaileFilter.add(EnteredThisTurnPredicate.instance);
         shaileFilter.add((Predicate<Permanent>) (input, game) -> !input.checkControlChanged(game));
-        embroseFilter.add(CounterType.P1P1.getPredicate());
     }
 
     public ShaileDeanOfRadiance(UUID ownerId, CardSetInfo setInfo) {
@@ -77,7 +76,7 @@ public final class ShaileDeanOfRadiance extends ModalDoubleFacesCard {
         this.getRightHalfCard().addAbility(ability);
 
         // Whenever a creature you control with a +1/+1 counter on it dies, draw a card.
-        this.getRightHalfCard().addAbility(new DiesCreatureTriggeredAbility(new DrawCardSourceControllerEffect(1), false, embroseFilter));
+        this.getRightHalfCard().addAbility(new DiesCreatureTriggeredAbility(new DrawCardSourceControllerEffect(1), false, StaticFilters.FILTER_A_CONTROLLED_CREATURE_P1P1));
     }
 
     private ShaileDeanOfRadiance(final ShaileDeanOfRadiance card) {

--- a/Mage.Sets/src/mage/cards/s/ShamanOfTheGreatHunt.java
+++ b/Mage.Sets/src/mage/cards/s/ShamanOfTheGreatHunt.java
@@ -22,6 +22,7 @@ import mage.constants.ComparisonType;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
 import mage.counters.CounterType;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.predicate.mageobject.PowerPredicate;
 
@@ -52,7 +53,7 @@ public final class ShamanOfTheGreatHunt extends CardImpl {
         effect.setText("put a +1/+1 counter on that creature");
         this.addAbility(new DealsDamageToAPlayerAllTriggeredAbility(
                 effect,
-                new FilterControlledCreaturePermanent("a creature you control"), false, SetTargetPointer.PERMANENT, true
+                StaticFilters.FILTER_CONTROLLED_A_CREATURE, false, SetTargetPointer.PERMANENT, true
         ));
         
         // <i>Ferocious</i> &mdash; {2}{G/U}{G/U}: Draw a card for each creature you control with power 4 or greater.

--- a/Mage.Sets/src/mage/cards/s/ShamblingGoblin.java
+++ b/Mage.Sets/src/mage/cards/s/ShamblingGoblin.java
@@ -11,8 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,12 +19,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class ShamblingGoblin extends CardImpl {
-
-    private static final FilterCreaturePermanent filterOpponentCreature = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filterOpponentCreature.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public ShamblingGoblin(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{B}");
@@ -36,7 +29,7 @@ public final class ShamblingGoblin extends CardImpl {
 
         // When Shambling Goblin dies, target creature an opponent controls gets -1/-1 until end of turn.
         Ability ability = new DiesSourceTriggeredAbility(new BoostTargetEffect(-1,-1, Duration.EndOfTurn));
-        ability.addTarget(new TargetCreaturePermanent(filterOpponentCreature));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/s/ShannaSisaysLegacy.java
+++ b/Mage.Sets/src/mage/cards/s/ShannaSisaysLegacy.java
@@ -18,7 +18,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
@@ -29,8 +29,6 @@ import mage.game.stack.StackObject;
  * @author TheElk801
  */
 public final class ShannaSisaysLegacy extends CardImpl {
-
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creatures you control");
 
     public ShannaSisaysLegacy(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{G}{W}");
@@ -45,7 +43,7 @@ public final class ShannaSisaysLegacy extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new ShannaSisaysLegacyEffect()));
 
         // Shanna gets +1/+1 for each creature you control.
-        DynamicValue value = new PermanentsOnBattlefieldCount(filter);
+        DynamicValue value = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURES);
         this.addAbility(new SimpleStaticAbility(
                 Zone.BATTLEFIELD,
                 new BoostSourceEffect(value, value, Duration.WhileOnBattlefield)

--- a/Mage.Sets/src/mage/cards/s/ShieldedByFaith.java
+++ b/Mage.Sets/src/mage/cards/s/ShieldedByFaith.java
@@ -18,7 +18,7 @@ import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -48,7 +48,7 @@ public final class ShieldedByFaith extends CardImpl {
         // Whenever a creature enters the battlefield, you may attach Shielded by Faith to that creature.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Benefit, "attach {this} to that creature"),
-                new FilterCreaturePermanent("a creature"), true, SetTargetPointer.PERMANENT, null, false));
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT, null, false));
     }
 
     private ShieldedByFaith(final ShieldedByFaith card) {

--- a/Mage.Sets/src/mage/cards/s/Showstopper.java
+++ b/Mage.Sets/src/mage/cards/s/Showstopper.java
@@ -11,7 +11,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -23,8 +22,6 @@ import mage.target.common.TargetCreaturePermanent;
 
 public final class Showstopper extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creatures you control");
-
     public Showstopper (UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{1}{B}{R}");
 
@@ -32,7 +29,7 @@ public final class Showstopper extends CardImpl {
         TriggeredAbility ability = new DiesSourceTriggeredAbility(new DamageTargetEffect(2, "it"), false);
         Target target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
-        Effect effect = new GainAbilityControlledEffect(ability, Duration.EndOfTurn, filter);
+        Effect effect = new GainAbilityControlledEffect(ability, Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES);
         effect.setText("Until end of turn, creatures you control gain \"When this creature dies, it deals 2 damage to target creature an opponent controls.\"");
         this.getSpellAbility().addEffect(effect);
     }

--- a/Mage.Sets/src/mage/cards/s/Showstopper.java
+++ b/Mage.Sets/src/mage/cards/s/Showstopper.java
@@ -10,9 +10,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -25,22 +24,17 @@ import mage.target.common.TargetCreaturePermanent;
 public final class Showstopper extends CardImpl {
 
     private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creatures you control");
-    private static final FilterCreaturePermanent filter2 = new FilterCreaturePermanent("creature an opponent controls");
-    static {
-        filter2.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public Showstopper (UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{1}{B}{R}");
 
         // Until end of turn, creatures you control gain "When this creature dies, it deals 2 damage to target creature an opponent controls."
         TriggeredAbility ability = new DiesSourceTriggeredAbility(new DamageTargetEffect(2, "it"), false);
-        Target target = new TargetCreaturePermanent(filter2);
+        Target target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         Effect effect = new GainAbilityControlledEffect(ability, Duration.EndOfTurn, filter);
         effect.setText("Until end of turn, creatures you control gain \"When this creature dies, it deals 2 damage to target creature an opponent controls.\"");
         this.getSpellAbility().addEffect(effect);
-
     }
 
     public Showstopper (final Showstopper card) {

--- a/Mage.Sets/src/mage/cards/s/ShrikeHarpy.java
+++ b/Mage.Sets/src/mage/cards/s/ShrikeHarpy.java
@@ -14,7 +14,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetOpponent;
 
 /**
@@ -32,10 +32,12 @@ public final class ShrikeHarpy extends CardImpl {
 
         // Flying
         this.addAbility(FlyingAbility.getInstance());
+
         // Tribute 2</i>
         this.addAbility(new TributeAbility(2));
+
         // When Shrike Harpy enters the battlefield, if tribute wasn't paid, target opponent sacrifices a creature.
-        TriggeredAbility ability = new EntersBattlefieldTriggeredAbility(new SacrificeEffect(new FilterCreaturePermanent("a creature"), 1, "target opponent"), false);
+        TriggeredAbility ability = new EntersBattlefieldTriggeredAbility(new SacrificeEffect(StaticFilters.FILTER_PERMANENT_A_CREATURE, 1, "target opponent"), false);
         ability.addTarget(new TargetOpponent());
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, TributeNotPaidCondition.instance,
                 "When {this} enters the battlefield, if its tribute wasn't paid, target opponent sacrifices a creature."));

--- a/Mage.Sets/src/mage/cards/s/SigardasSummons.java
+++ b/Mage.Sets/src/mage/cards/s/SigardasSummons.java
@@ -7,9 +7,7 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 
@@ -39,12 +37,6 @@ public final class SigardasSummons extends CardImpl {
 
 class SigardasSummonsEffect extends ContinuousEffectImpl {
 
-    private static final FilterPermanent filter = new FilterControlledCreaturePermanent();
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
     SigardasSummonsEffect() {
         super(Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "creatures you control with +1/+1 counters on them have base power and toughness 4/4, " +
@@ -63,7 +55,7 @@ class SigardasSummonsEffect extends ContinuousEffectImpl {
     @Override
     public boolean apply(Layer layer, SubLayer sublayer, Ability source, Game game) {
         for (Permanent permanent : game.getBattlefield().getActivePermanents(
-                filter, source.getControllerId(), source.getSourceId(), game
+                StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1, source.getControllerId(), source.getSourceId(), game
         )) {
             switch (layer) {
                 case TypeChangingEffects_4:

--- a/Mage.Sets/src/mage/cards/s/SigardianPaladin.java
+++ b/Mage.Sets/src/mage/cards/s/SigardianPaladin.java
@@ -20,8 +20,7 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.WatcherScope;
 import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
@@ -36,13 +35,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class SigardianPaladin extends CardImpl {
-
-    private static final FilterPermanent filter
-            = new FilterControlledCreaturePermanent("creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public SigardianPaladin(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}{W}");
@@ -74,7 +66,7 @@ public final class SigardianPaladin extends CardImpl {
         ability.addEffect(new GainAbilityTargetEffect(
                 LifelinkAbility.getInstance()
         ).setText("and lifelink until end of turn"));
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SimicBasilisk.java
+++ b/Mage.Sets/src/mage/cards/s/SimicBasilisk.java
@@ -19,8 +19,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -28,11 +27,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author JotaPeRL
  */
 public final class SimicBasilisk extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with a +1/+1 counter on it");
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }     
 
     public SimicBasilisk(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{G}{G}");
@@ -49,7 +43,7 @@ public final class SimicBasilisk extends CardImpl {
                 new AtTheEndOfCombatDelayedTriggeredAbility(new DestroyTargetEffect()), true);
         effect.setText("destroy that creature at end of combat");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilityTargetEffect(new DealsDamageToACreatureTriggeredAbility(effect, true, false, true), Duration.EndOfTurn), new ManaCostsImpl("{1}{G}"));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_A_CREATURE_P1P1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SkatewingSpy.java
+++ b/Mage.Sets/src/mage/cards/s/SkatewingSpy.java
@@ -11,9 +11,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -21,12 +19,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class SkatewingSpy extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterControlledCreaturePermanent();
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public SkatewingSpy(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{U}");
@@ -46,10 +38,9 @@ public final class SkatewingSpy extends CardImpl {
                 new GainAbilityAllEffect(
                         FlyingAbility.getInstance(),
                         Duration.WhileOnBattlefield,
-                        filter, "Each creature you control " +
-                        "with a +1/+1 counter on it has flying"
+                        StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)
                 )
-        ));
+        );
     }
 
     private SkatewingSpy(final SkatewingSpy card) {

--- a/Mage.Sets/src/mage/cards/s/Skulduggery.java
+++ b/Mage.Sets/src/mage/cards/s/Skulduggery.java
@@ -11,8 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetControlledCreaturePermanent;
@@ -25,19 +24,13 @@ import mage.target.targetpointer.FixedTarget;
  */
 public final class Skulduggery extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public Skulduggery(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{B}");
 
         // Until end of turn, target creature you control gets +1/+1 and target creature an opponent controls gets -1/-1.
         this.getSpellAbility().addEffect(new SkulduggeryEffect());
         this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
     }
 
     private Skulduggery(final Skulduggery card) {

--- a/Mage.Sets/src/mage/cards/s/SkyclaveShadowcat.java
+++ b/Mage.Sets/src/mage/cards/s/SkyclaveShadowcat.java
@@ -13,9 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.target.common.TargetControlledPermanent;
 
 import java.util.UUID;
@@ -24,13 +22,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class SkyclaveShadowcat extends CardImpl {
-
-    private static final FilterPermanent filter
-            = new FilterControlledCreaturePermanent("a creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public SkyclaveShadowcat(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{B}");
@@ -50,7 +41,10 @@ public final class SkyclaveShadowcat extends CardImpl {
         this.addAbility(ability);
 
         // Whenever a creature you control with a +1/+1 counter on it dies, draw a card.
-        this.addAbility(new DiesCreatureTriggeredAbility(new DrawCardSourceControllerEffect(1), false, filter));
+        this.addAbility(new DiesCreatureTriggeredAbility(
+                new DrawCardSourceControllerEffect(1),
+                false,
+                StaticFilters.FILTER_A_CONTROLLED_CREATURE_P1P1));
     }
 
     private SkyclaveShadowcat(final SkyclaveShadowcat card) {

--- a/Mage.Sets/src/mage/cards/s/SkylineCascade.java
+++ b/Mage.Sets/src/mage/cards/s/SkylineCascade.java
@@ -10,8 +10,7 @@ import mage.abilities.mana.BlueManaAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -19,12 +18,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author fireshoes
  */
 public final class SkylineCascade extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public SkylineCascade(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.LAND},"");
@@ -34,7 +27,7 @@ public final class SkylineCascade extends CardImpl {
 
         // When Skyline Cascade enters the battlefield, target creature an opponent controls doesn't untap during its controller's next untap step.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DontUntapInControllersNextUntapStepTargetEffect(), false);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
 
         // {T}: Add {U}.

--- a/Mage.Sets/src/mage/cards/s/SmeltWardGatekeepers.java
+++ b/Mage.Sets/src/mage/cards/s/SmeltWardGatekeepers.java
@@ -14,8 +14,8 @@ import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledPermanent;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -29,11 +29,9 @@ import java.util.UUID;
 public final class SmeltWardGatekeepers extends CardImpl {
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent();
-    private static final FilterCreaturePermanent targetFilter = new FilterCreaturePermanent("creature an opponent controls");
 
     static {
         filter.add(SubType.GATE.getPredicate());
-        targetFilter.add(TargetController.OPPONENT.getControllerPredicate());
     }
 
     private static final Condition gatesCondition = new PermanentsOnTheBattlefieldCondition(filter, ComparisonType.MORE_THAN, 1);
@@ -53,7 +51,7 @@ public final class SmeltWardGatekeepers extends CardImpl {
                 "When {this} enters the battlefield, if you control two or more Gates, gain control of target creature an opponent controls until end of turn. Untap that creature. That creature gains haste until end of turn.");
         ability.addEffect(new UntapTargetEffect());
         ability.addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn));
-        Target target = new TargetCreaturePermanent(targetFilter);
+        Target target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         ability.addHint(new ConditionHint(gatesCondition, "You control two or more Gates"));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/SoulbladeCorrupter.java
+++ b/Mage.Sets/src/mage/cards/s/SoulbladeCorrupter.java
@@ -13,8 +13,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SetTargetPointer;
 import mage.constants.SubType;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
@@ -57,17 +56,11 @@ public final class SoulbladeCorrupter extends CardImpl {
 
 class SoulbladeCorrupterTriggeredAbility extends AttacksAllTriggeredAbility {
 
-    private static final FilterCreaturePermanent filter2 = new FilterCreaturePermanent("creature with a +1/+1 counter on it");
-
-    static {
-        filter2.add(CounterType.P1P1.getPredicate());
-    }
-
     SoulbladeCorrupterTriggeredAbility() {
         super(new GainAbilityTargetEffect(
                 DeathtouchAbility.getInstance(),
                 Duration.EndOfTurn
-        ).setText("that creature gains deathtouch until end of turn"), false, filter2, SetTargetPointer.PERMANENT, false);
+        ).setText("that creature gains deathtouch until end of turn"), false, StaticFilters.FILTER_CREATURE_P1P1, SetTargetPointer.PERMANENT, false);
     }
 
     SoulbladeCorrupterTriggeredAbility(final SoulbladeCorrupterTriggeredAbility effect) {

--- a/Mage.Sets/src/mage/cards/s/SoulswornSpirit.java
+++ b/Mage.Sets/src/mage/cards/s/SoulswornSpirit.java
@@ -11,8 +11,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,12 +19,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class SoulswornSpirit extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
- 
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
     
     public SoulswornSpirit(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{U}");
@@ -40,7 +33,7 @@ public final class SoulswornSpirit extends CardImpl {
         // When Soulsworn Spirit enters the battlefield, detain target creature an opponent controls. 
         //(Until your next turn, that creature can't attack or block and its activated abilities can't be activated.)
         Ability ability = new EntersBattlefieldTriggeredAbility(new DetainTargetEffect());
-        TargetCreaturePermanent target = new TargetCreaturePermanent(filter);
+        TargetCreaturePermanent target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SpellbaneCentaur.java
+++ b/Mage.Sets/src/mage/cards/s/SpellbaneCentaur.java
@@ -14,7 +14,7 @@ import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.FilterObject;
 import mage.filter.FilterStackObject;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.predicate.mageobject.ColorPredicate;
 
 /**
@@ -37,7 +37,7 @@ public final class SpellbaneCentaur extends CardImpl {
 
         // Creatures you control can't be the targets of blue spells or abilities from blue sources.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD,
-                new CantBeTargetedAllEffect(new FilterControlledCreaturePermanent("Creatures you control"),
+                new CantBeTargetedAllEffect(StaticFilters.FILTER_CONTROLLED_CREATURES,
                         filter, Duration.WhileOnBattlefield)));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpinedFluke.java
+++ b/Mage.Sets/src/mage/cards/s/SpinedFluke.java
@@ -14,7 +14,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.ColoredManaSymbol;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -31,7 +31,8 @@ public final class SpinedFluke extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Spined Fluke enters the battlefield, sacrifice a creature.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SacrificeControllerEffect(new FilterCreaturePermanent("a creature"), 1, "")));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SacrificeControllerEffect(StaticFilters.FILTER_PERMANENT_A_CREATURE, 1, "")));
+
         // {B}: Regenerate Spined Fluke.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new ColoredManaCost(ColoredManaSymbol.B)));
     }

--- a/Mage.Sets/src/mage/cards/s/SporebackTroll.java
+++ b/Mage.Sets/src/mage/cards/s/SporebackTroll.java
@@ -13,8 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -22,11 +21,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author fireshoes
  */
 public final class SporebackTroll extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with a +1/+1 counter on it");
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public SporebackTroll(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{G}");
@@ -40,7 +34,7 @@ public final class SporebackTroll extends CardImpl {
         
         // {1}{G}: Regenerate target creature with a +1/+1 counter on it.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateTargetEffect(), new ManaCostsImpl("{1}{G}"));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_A_CREATURE_P1P1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SteppeGlider.java
+++ b/Mage.Sets/src/mage/cards/s/SteppeGlider.java
@@ -16,8 +16,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -25,12 +24,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author fireshoes
  */
 public final class SteppeGlider extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public SteppeGlider(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{W}");
@@ -51,7 +44,7 @@ public final class SteppeGlider extends CardImpl {
         effect = new GainAbilityTargetEffect(VigilanceAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("and vigilance until end of turn");
         ability.addEffect(effect);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_A_CREATURE_P1P1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/Stingscourger.java
+++ b/Mage.Sets/src/mage/cards/s/Stingscourger.java
@@ -11,8 +11,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,12 +19,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author jonubuu
  */
 public final class Stingscourger extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public Stingscourger(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{R}");
@@ -39,7 +32,7 @@ public final class Stingscourger extends CardImpl {
         this.addAbility(new EchoAbility("{3}{R}"));
         // When Stingscourger enters the battlefield, return target creature an opponent controls to its owner's hand.
         Ability ability = new EntersBattlefieldTriggeredAbility(new ReturnToHandTargetEffect());
-        TargetCreaturePermanent target = new TargetCreaturePermanent(filter);
+        TargetCreaturePermanent target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/StitchedMangler.java
+++ b/Mage.Sets/src/mage/cards/s/StitchedMangler.java
@@ -12,8 +12,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -21,12 +20,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class StitchedMangler extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public StitchedMangler(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{U}");
@@ -43,7 +36,7 @@ public final class StitchedMangler extends CardImpl {
         Effect effect = new DontUntapInControllersNextUntapStepTargetEffect();
         effect.setText("That creature doesn't untap during its controller's next untap step");
         ability.addEffect(effect);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/StormfrontRiders.java
+++ b/Mage.Sets/src/mage/cards/s/StormfrontRiders.java
@@ -14,7 +14,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.permanent.token.SoldierToken;
 
@@ -41,7 +41,7 @@ public final class StormfrontRiders extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // When Stormfront Riders enters the battlefield, return two creatures you control to their owner's hand.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new ReturnToHandChosenControlledPermanentEffect(new FilterControlledCreaturePermanent("creatures you control"), 2)));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new ReturnToHandChosenControlledPermanentEffect(StaticFilters.FILTER_CONTROLLED_CREATURES, 2)));
         // Whenever Stormfront Riders or another creature is returned to your hand from the battlefield, create a 1/1 white Soldier creature token.
         this.addAbility(new ZoneChangeAllTriggeredAbility(Zone.BATTLEFIELD, Zone.BATTLEFIELD, Zone.HAND, new CreateTokenEffect(new SoldierToken()),
                 filter, "Whenever {this} or another creature is returned to your hand from the battlefield, ", false));

--- a/Mage.Sets/src/mage/cards/s/SunbringersTouch.java
+++ b/Mage.Sets/src/mage/cards/s/SunbringersTouch.java
@@ -11,29 +11,25 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author fireshoes
  */
 public final class SunbringersTouch extends CardImpl {
-    
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("Each creature you control with a +1/+1 counter on it");
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public SunbringersTouch(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{G}{G}");
 
         // Bolster X, where X is the number of cards in your hand. 
-        this.getSpellAbility().addEffect(new BolsterEffect(CardsInControllerHandCount.instance));
+        this.getSpellAbility().addEffect(new BolsterEffect(CardsInControllerHandCount.instance).setText("Bolster X, where X is the number of cards in your hand."));
         
         // Each creature you control with a +1/+1 counter on it gains trample until end of turn.
-        Effect effect = new GainAbilityControlledEffect(TrampleAbility.getInstance(), Duration.EndOfTurn, filter);
-        effect.setText("Each creature you control with a +1/+1 counter on it gains trample until end of turn");
+        Effect effect = new GainAbilityControlledEffect(
+                TrampleAbility.getInstance(), Duration.EndOfTurn, StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1);
+        effect.setText("Each creature you control with a +1/+1 counter on it gains trample until end of turn. " +
+                "<i>(To bolster X, choose a creature with the least toughness among creatures you control and put X +1/+1 counters on it.)</i>");
         this.getSpellAbility().addEffect(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SwarmShambler.java
+++ b/Mage.Sets/src/mage/cards/s/SwarmShambler.java
@@ -15,9 +15,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
@@ -68,12 +66,6 @@ public final class SwarmShambler extends CardImpl {
 
 class SwarmShamblerTriggeredAbility extends TriggeredAbilityImpl {
 
-    private static final FilterPermanent filter = new FilterControlledCreaturePermanent();
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
     SwarmShamblerTriggeredAbility() {
         super(Zone.BATTLEFIELD, new CreateTokenEffect(new InsectToken()), false);
     }
@@ -98,7 +90,7 @@ class SwarmShamblerTriggeredAbility extends TriggeredAbilityImpl {
         Permanent permanent = game.getPermanent(event.getTargetId());
         return sourceObject != null
                 && permanent != null
-                && filter.match(permanent, getSourceId(), getControllerId(), game)
+                && StaticFilters.FILTER_CONTROLLED_CREATURE_P1P1.match(permanent, getSourceId(), getControllerId(), game)
                 && StaticFilters.FILTER_SPELL_OR_ABILITY_OPPONENTS.match(sourceObject, getSourceId(), getControllerId(), game);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Tanglewalker.java
+++ b/Mage.Sets/src/mage/cards/t/Tanglewalker.java
@@ -15,7 +15,7 @@ import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterLandPermanent;
 
 /**
@@ -39,7 +39,7 @@ public final class Tanglewalker extends CardImpl {
 
         // Each creature you control can't be blocked as long as defending player controls an artifact land.
         Effect effect = new ConditionalRestrictionEffect(
-                new CantBeBlockedAllEffect(new FilterControlledCreaturePermanent("Creatures you control"), Duration.WhileOnBattlefield),
+                new CantBeBlockedAllEffect(StaticFilters.FILTER_CONTROLLED_CREATURES, Duration.WhileOnBattlefield),
                 new DefendingPlayerControlsCondition(filter));
         effect.setText("Each creature you control can't be blocked as long as defending player controls an artifact land");
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, effect));

--- a/Mage.Sets/src/mage/cards/t/TemperedVeteran.java
+++ b/Mage.Sets/src/mage/cards/t/TemperedVeteran.java
@@ -11,8 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -22,13 +21,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class TemperedVeteran extends CardImpl {
-
-    private static final FilterPermanent filter
-            = new FilterCreaturePermanent("creature with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public TemperedVeteran(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{W}");
@@ -43,7 +35,7 @@ public final class TemperedVeteran extends CardImpl {
                 new AddCountersTargetEffect(CounterType.P1P1.createInstance()), new ManaCostsImpl("{W}")
         );
         ability.addCost(new TapSourceCost());
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_CREATURE_P1P1));
         this.addAbility(ability);
 
         // {4}{W}{W}, {T}: Put a +1/+1 counter on target creature.

--- a/Mage.Sets/src/mage/cards/t/TerritorialHammerskull.java
+++ b/Mage.Sets/src/mage/cards/t/TerritorialHammerskull.java
@@ -10,8 +10,7 @@ import mage.constants.SubType;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -19,12 +18,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author TheElk801
  */
 public final class TerritorialHammerskull extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public TerritorialHammerskull(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{W}");
@@ -35,7 +28,7 @@ public final class TerritorialHammerskull extends CardImpl {
 
         // Whenever Territorial Hammerskull attacks, tap target creature an opponent controls.
         Ability ability = new AttacksTriggeredAbility(new TapTargetEffect(), false);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TimeToFeed.java
+++ b/Mage.Sets/src/mage/cards/t/TimeToFeed.java
@@ -15,12 +15,10 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.events.ZoneChangeEvent;
 import mage.game.permanent.Permanent;
 import mage.target.Target;
@@ -40,11 +38,6 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class TimeToFeed extends CardImpl {
 
-    private static final FilterCreaturePermanent filter1 = new FilterCreaturePermanent("creature an opponent controls");
-    static {
-        filter1.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public TimeToFeed(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{G}");
 
@@ -57,7 +50,7 @@ public final class TimeToFeed extends CardImpl {
                 "<i>(Each deals damage equal to its power to the other.)</i>");
         this.getSpellAbility().addEffect(effect);
 
-        Target target = new TargetCreaturePermanent(filter1);
+        Target target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         this.getSpellAbility().addTarget(target);
         this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent());
         

--- a/Mage.Sets/src/mage/cards/t/TitanicBrawl.java
+++ b/Mage.Sets/src/mage/cards/t/TitanicBrawl.java
@@ -9,10 +9,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -23,14 +20,7 @@ import java.util.UUID;
  */
 public final class TitanicBrawl extends CardImpl {
 
-    private static final FilterPermanent filter
-            = new FilterControlledCreaturePermanent("a creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
-    private static final Condition condition = new SourceTargetsPermanentCondition(filter);
+    private static final Condition condition = new SourceTargetsPermanentCondition(StaticFilters.FILTER_A_CONTROLLED_CREATURE_P1P1);
 
     public TitanicBrawl(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{G}");

--- a/Mage.Sets/src/mage/cards/t/ToothCollector.java
+++ b/Mage.Sets/src/mage/cards/t/ToothCollector.java
@@ -15,8 +15,8 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.constants.Zone;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
@@ -29,12 +29,6 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class ToothCollector extends CardImpl {
 
-    private static final FilterCreaturePermanent FILTER = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        FILTER.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public ToothCollector(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{B}");
         this.subtype.add(SubType.HUMAN);
@@ -44,7 +38,7 @@ public final class ToothCollector extends CardImpl {
 
         // When Tooth Collector enters the battlefield, target creature an opponent controls gets -1/-1 until end of turn.
         Ability ability = new EntersBattlefieldTriggeredAbility(new BoostTargetEffect(-1, -1, Duration.EndOfTurn));
-        ability.addTarget(new TargetCreaturePermanent(FILTER));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
 
         // {<i>Delirium</i> &mdash; At the beginning of each opponent's upkeep, if there are four or more card types among cards in your graveyard,

--- a/Mage.Sets/src/mage/cards/t/Topplegeist.java
+++ b/Mage.Sets/src/mage/cards/t/Topplegeist.java
@@ -15,8 +15,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.constants.Zone;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
@@ -29,12 +29,6 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class Topplegeist extends CardImpl {
 
-    private static final FilterCreaturePermanent FILTER = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        FILTER.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public Topplegeist(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{W}");
         this.subtype.add(SubType.SPIRIT);
@@ -46,7 +40,7 @@ public final class Topplegeist extends CardImpl {
 
         // When Topplegeist enters the battlefield, tap target creature an opponent controls.
         Ability ability = new EntersBattlefieldTriggeredAbility(new TapTargetEffect());
-        ability.addTarget(new TargetCreaturePermanent(FILTER));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
 
         // <i>Delirium</i> &mdash; At the beginning of each opponent's upkeep, if there are four or more card types among cards in your graveyard,

--- a/Mage.Sets/src/mage/cards/t/ToshiroUmezawa.java
+++ b/Mage.Sets/src/mage/cards/t/ToshiroUmezawa.java
@@ -13,10 +13,9 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterCard;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.events.ZoneChangeEvent;
 import mage.game.stack.Spell;
 import mage.game.stack.StackObject;
@@ -28,13 +27,9 @@ import mage.target.common.TargetCardInYourGraveyard;
  * @author LevelX2
  */
 public final class ToshiroUmezawa extends CardImpl {
-
-    private static final FilterCreaturePermanent filter
-            = new FilterCreaturePermanent("a creature an opponent controls");
     private static final FilterCard filterInstant = new FilterCard("instant card from your graveyard");
 
     static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
         filterInstant.add(CardType.INSTANT.getPredicate());
     }
 
@@ -52,7 +47,7 @@ public final class ToshiroUmezawa extends CardImpl {
         // Whenever a creature an opponent controls dies, you may cast target 
         // instant card from your graveyard. If that card would be put into a 
         // graveyard this turn, exile it instead.
-        Ability ability = new DiesCreatureTriggeredAbility(new ToshiroUmezawaEffect(), true, filter);
+        Ability ability = new DiesCreatureTriggeredAbility(new ToshiroUmezawaEffect(), true, StaticFilters.FILTER_OPPONENTS_PERMANENT_A_CREATURE);
         ability.addTarget(new TargetCardInYourGraveyard(1, 1, filterInstant));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/t/TriangleOfWar.java
+++ b/Mage.Sets/src/mage/cards/t/TriangleOfWar.java
@@ -10,9 +10,8 @@ import mage.abilities.effects.common.FightTargetsEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -21,12 +20,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author fireshoes
  */
 public final class TriangleOfWar extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public TriangleOfWar(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
@@ -37,7 +30,7 @@ public final class TriangleOfWar extends CardImpl {
             new ManaCostsImpl("{2}"));
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetControlledCreaturePermanent());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrollbredGuardian.java
+++ b/Mage.Sets/src/mage/cards/t/TrollbredGuardian.java
@@ -11,9 +11,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -21,12 +19,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class TrollbredGuardian extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterControlledCreaturePermanent();
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
 
     public TrollbredGuardian(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{G}");
@@ -46,10 +38,9 @@ public final class TrollbredGuardian extends CardImpl {
                 new GainAbilityAllEffect(
                         TrampleAbility.getInstance(),
                         Duration.WhileOnBattlefield,
-                        filter, "Each creature you control " +
-                        "with a +1/+1 counter on it has trample"
+                        StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)
                 )
-        ));
+        );
     }
 
     private TrollbredGuardian(final TrollbredGuardian card) {

--- a/Mage.Sets/src/mage/cards/t/TuskguardCaptain.java
+++ b/Mage.Sets/src/mage/cards/t/TuskguardCaptain.java
@@ -13,26 +13,14 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
  * @author LevelX2
  */
 public final class TuskguardCaptain extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterPermanent();
-
-    static {
-        filter.add(CardType.CREATURE.getPredicate());
-        filter.add(TargetController.YOU.getControllerPredicate());
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
-    static final String rule = "Each creature you control with a +1/+1 counter on it has trample";
 
     public TuskguardCaptain(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{G}");
@@ -45,9 +33,14 @@ public final class TuskguardCaptain extends CardImpl {
         // Outlast G
         this.addAbility(new OutlastAbility(new ManaCostsImpl("{G}")));
         // Each creature you control with a +1/+1 counter on it has trample.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(TrampleAbility.getInstance(), Duration.WhileOnBattlefield, filter, rule)));
-
-
+        this.addAbility(new SimpleStaticAbility(
+                Zone.BATTLEFIELD,
+                new GainAbilityAllEffect(
+                        TrampleAbility.getInstance(),
+                        Duration.WhileOnBattlefield,
+                        StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)
+                )
+        );
     }
 
     private TuskguardCaptain(final TuskguardCaptain card) {

--- a/Mage.Sets/src/mage/cards/u/UbulSarGatekeepers.java
+++ b/Mage.Sets/src/mage/cards/u/UbulSarGatekeepers.java
@@ -11,8 +11,8 @@ import mage.abilities.hint.ConditionHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledPermanent;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -24,11 +24,9 @@ import java.util.UUID;
 public final class UbulSarGatekeepers extends CardImpl {
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent();
-    private static final FilterCreaturePermanent targetFilter = new FilterCreaturePermanent("creature an opponent controls");
 
     static {
         filter.add(SubType.GATE.getPredicate());
-        targetFilter.add(TargetController.OPPONENT.getControllerPredicate());
     }
 
     private static final Condition gatesCondition = new PermanentsOnTheBattlefieldCondition(filter, ComparisonType.MORE_THAN, 1);
@@ -46,7 +44,7 @@ public final class UbulSarGatekeepers extends CardImpl {
                 new EntersBattlefieldTriggeredAbility(new BoostTargetEffect(-2, -2, Duration.EndOfTurn)),
                 gatesCondition,
                 "Whenever {this} enters the battlefield, if you control two or more Gates, target creature an opponent controls gets -2/-2 until end of turn.");
-        Target target = new TargetCreaturePermanent(targetFilter);
+        Target target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         ability.addTarget(target);
         ability.addHint(new ConditionHint(gatesCondition, "You control two or more Gates"));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/u/UnityOfPurpose.java
+++ b/Mage.Sets/src/mage/cards/u/UnityOfPurpose.java
@@ -7,8 +7,7 @@ import mage.abilities.effects.keyword.SupportEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -16,20 +15,15 @@ import mage.filter.common.FilterCreaturePermanent;
  */
 public final class UnityOfPurpose extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("each creature you control with a +1/+1 counter on it");
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }
-
     public UnityOfPurpose(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{3}{U}");
 
         // Support 2.
-        getSpellAbility().addEffect(new SupportEffect(this, 2, false));
+        this.getSpellAbility().addEffect(new SupportEffect(this, 2, false));
 
         // Untap each creature you control with a +1/+1 counter on it.
-        this.getSpellAbility().addEffect(new UntapAllControllerEffect(filter, "Untap each creature you control with a +1/+1 counter on it"));
+        this.getSpellAbility().addEffect(new UntapAllControllerEffect(
+                StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1, "Untap each creature you control with a +1/+1 counter on it"));
     }
 
     private UnityOfPurpose(final UnityOfPurpose card) {

--- a/Mage.Sets/src/mage/cards/u/UnnaturalAggression.java
+++ b/Mage.Sets/src/mage/cards/u/UnnaturalAggression.java
@@ -9,8 +9,7 @@ import mage.abilities.keyword.DevoidAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.common.TargetCreaturePermanent;
 import mage.target.targetpointer.SecondTargetPointer;
@@ -21,12 +20,6 @@ import mage.target.targetpointer.SecondTargetPointer;
  */
 public final class UnnaturalAggression extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public UnnaturalAggression(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{G}");
 
@@ -36,7 +29,7 @@ public final class UnnaturalAggression extends CardImpl {
         // Target creature you control fights target creature an opponent controls.
         this.getSpellAbility().addEffect(new FightTargetsEffect(false));
         this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         // If the creature an opponent controls would die this turn, exile it instead.
         Effect effect = new ExileTargetIfDiesEffect();
         effect.setText("If the creature an opponent controls would die this turn, exile it instead");

--- a/Mage.Sets/src/mage/cards/v/VeneratedTeacher.java
+++ b/Mage.Sets/src/mage/cards/v/VeneratedTeacher.java
@@ -14,7 +14,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Outcome;
 import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 
@@ -48,8 +48,6 @@ public final class VeneratedTeacher extends CardImpl {
 
 class VeneratedTeacherEffect extends OneShotEffect {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creatures you control");
-
     public VeneratedTeacherEffect() {
         super(Outcome.BoostCreature);
         staticText = "put two level counters on each creature you control with level up";
@@ -61,7 +59,7 @@ class VeneratedTeacherEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        List<Permanent> permanents = game.getBattlefield().getAllActivePermanents(filter, source.getControllerId(), game);
+        List<Permanent> permanents = game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_CONTROLLED_CREATURES, source.getControllerId(), game);
         if (!permanents.isEmpty()) {
             for (Permanent permanent : permanents) {
                 for (Ability ability : permanent.getAbilities()) {

--- a/Mage.Sets/src/mage/cards/v/VigeanGraftmage.java
+++ b/Mage.Sets/src/mage/cards/v/VigeanGraftmage.java
@@ -13,8 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -22,11 +21,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author JotaPeRL
  */
 public final class VigeanGraftmage extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with a +1/+1 counter on it");
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-    }    
 
     public VigeanGraftmage(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{U}");
@@ -41,7 +35,7 @@ public final class VigeanGraftmage extends CardImpl {
         
         // {1}{U}: Untap target creature with a +1/+1 counter on it.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new UntapTargetEffect(), new ManaCostsImpl("{1}{U}"));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_CREATURE_P1P1));
         this.addAbility(ability);        
     }
 

--- a/Mage.Sets/src/mage/cards/v/VizierOfTheTrue.java
+++ b/Mage.Sets/src/mage/cards/v/VizierOfTheTrue.java
@@ -10,12 +10,10 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -51,15 +49,9 @@ public final class VizierOfTheTrue extends CardImpl {
 
 class VizierOfTheTrueAbility extends TriggeredAbilityImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public VizierOfTheTrueAbility() {
         super(Zone.BATTLEFIELD, new TapTargetEffect());
-        addTarget(new TargetCreaturePermanent(filter));
+        addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
     }
 
     public VizierOfTheTrueAbility(final VizierOfTheTrueAbility ability) {

--- a/Mage.Sets/src/mage/cards/w/WarsToll.java
+++ b/Mage.Sets/src/mage/cards/w/WarsToll.java
@@ -9,7 +9,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.common.FilterLandPermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -21,12 +20,9 @@ import java.util.UUID;
  * @author jeffwadsworth
  */
 public final class WarsToll extends CardImpl {
-
-    private static final FilterCreaturePermanent filterOpponentCreature = new FilterCreaturePermanent("creature an opponent controls");
     private static final FilterLandPermanent filterOpponentLand = new FilterLandPermanent("an opponent taps a land");
 
     static {
-        filterOpponentCreature.add(TargetController.OPPONENT.getControllerPredicate());
         filterOpponentLand.add(TargetController.OPPONENT.getControllerPredicate());
     }
 

--- a/Mage.Sets/src/mage/cards/w/WashOut.java
+++ b/Mage.Sets/src/mage/cards/w/WashOut.java
@@ -12,10 +12,8 @@ import mage.cards.CardSetInfo;
 import mage.choices.ChoiceColor;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.ColorPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -27,18 +25,11 @@ import mage.players.Player;
  */
 public final class WashOut extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public WashOut(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{U}");
 
         // Return all permanents of the color of your choice to their owners' hands.
         this.getSpellAbility().addEffect(new WashOutEffect());
-
     }
 
     private WashOut(final WashOut card) {

--- a/Mage.Sets/src/mage/cards/w/WatertrapWeaver.java
+++ b/Mage.Sets/src/mage/cards/w/WatertrapWeaver.java
@@ -10,8 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -19,12 +18,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author TheElk801
  */
 public final class WatertrapWeaver extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public WatertrapWeaver(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}");
@@ -37,7 +30,7 @@ public final class WatertrapWeaver extends CardImpl {
         // When Watertrap Weaver enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.
         EntersBattlefieldTriggeredAbility ability = new EntersBattlefieldTriggeredAbility(new TapTargetEffect());
         ability.addEffect(new DontUntapInControllersNextUntapStepTargetEffect("that creature"));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WavecrashTriton.java
+++ b/Mage.Sets/src/mage/cards/w/WavecrashTriton.java
@@ -11,8 +11,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,11 +19,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class WavecrashTriton extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-    static{
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public WavecrashTriton(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{U}");
@@ -36,7 +30,7 @@ public final class WavecrashTriton extends CardImpl {
 
         // Heroic - Whenever you cast a spell that targets Wavecrash Triton, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.
         Ability ability = new HeroicAbility(new TapTargetEffect());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         ability.addEffect(new DontUntapInControllersNextUntapStepTargetEffect("That creature"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/w/WeaverOfLightning.java
+++ b/Mage.Sets/src/mage/cards/w/WeaverOfLightning.java
@@ -11,8 +11,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterInstantOrSorcerySpell;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -21,12 +20,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class WeaverOfLightning extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public WeaverOfLightning(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{R}");
@@ -39,7 +32,7 @@ public final class WeaverOfLightning extends CardImpl {
         this.addAbility(ReachAbility.getInstance());
         // Whenever you cast an instant or sorcery spell, Weaver of Lightning deals 1 damage to target creature an opponent controls.
         Ability ability = new SpellCastControllerTriggeredAbility(new DamageTargetEffect(1), new FilterInstantOrSorcerySpell(), false);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WitchHunter.java
+++ b/Mage.Sets/src/mage/cards/w/WitchHunter.java
@@ -13,9 +13,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 import mage.target.common.TargetPlayerOrPlaneswalker;
 
@@ -24,12 +23,6 @@ import mage.target.common.TargetPlayerOrPlaneswalker;
  * @author fireshoes
  */
 public final class WitchHunter extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature an opponent controls");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public WitchHunter(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{W}{W}");
@@ -46,7 +39,7 @@ public final class WitchHunter extends CardImpl {
         // {1}{W}{W}, {tap}: Return target creature an opponent controls to its owner's hand.
         Ability returnAbility = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ReturnToHandTargetEffect(), new ManaCostsImpl("{1}{W}{W}"));
         returnAbility.addCost(new TapSourceCost());
-        TargetCreaturePermanent target = new TargetCreaturePermanent(filter);
+        TargetCreaturePermanent target = new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
         returnAbility.addTarget(target);
         this.addAbility(returnAbility);
     }

--- a/Mage.Sets/src/mage/cards/w/WitherscaleWurm.java
+++ b/Mage.Sets/src/mage/cards/w/WitherscaleWurm.java
@@ -16,7 +16,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -34,7 +34,7 @@ public final class WitherscaleWurm extends CardImpl {
         // Whenever Witherscale Wurm blocks or becomes blocked by a creature, that creature gains wither until end of turn.
         Effect effect = new GainAbilityTargetEffect(WitherAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("that creature gains wither until end of turn");
-        Ability ability = new BlocksOrBecomesBlockedSourceTriggeredAbility(effect, new FilterCreaturePermanent("a creature"), false, null, true);
+        Ability ability = new BlocksOrBecomesBlockedSourceTriggeredAbility(effect, StaticFilters.FILTER_PERMANENT_A_CREATURE, false, null, true);
         this.addAbility(ability);
 
         // Whenever Witherscale Wurm deals damage to an opponent, remove all -1/-1 counters from it.

--- a/Mage.Sets/src/mage/cards/z/ZeganaUtopianSpeaker.java
+++ b/Mage.Sets/src/mage/cards/z/ZeganaUtopianSpeaker.java
@@ -12,10 +12,7 @@ import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -23,15 +20,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class ZeganaUtopianSpeaker extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterControlledCreaturePermanent();
-    private static final FilterPermanent filter2 = new FilterControlledCreaturePermanent();
-
-    static {
-        filter.add(CounterType.P1P1.getPredicate());
-        filter.add(AnotherPredicate.instance);
-        filter2.add(CounterType.P1P1.getPredicate());
-    }
 
     public ZeganaUtopianSpeaker(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}{U}");
@@ -46,11 +34,12 @@ public final class ZeganaUtopianSpeaker extends CardImpl {
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(
                 new EntersBattlefieldTriggeredAbility(
                         new DrawCardSourceControllerEffect(1), false
-                ), new PermanentsOnTheBattlefieldCondition(filter),
+                ), new PermanentsOnTheBattlefieldCondition(StaticFilters.FILTER_OTHER_CONTROLLED_CREATURE_P1P1),
                 "When {this} enters the battlefield, " +
                         "if you control another creature " +
                         "with a +1/+1 counter on it, draw a card."
-        ));
+                )
+        );
 
         // {4}{G}{U}: Adapt 4.
         this.addAbility(new AdaptAbility(4, "{4}{G}{U}"));
@@ -60,9 +49,9 @@ public final class ZeganaUtopianSpeaker extends CardImpl {
                 Zone.BATTLEFIELD,
                 new GainAbilityAllEffect(
                         TrampleAbility.getInstance(), Duration.WhileOnBattlefield,
-                        filter2, "Each creature you control with a +1/+1 counter on it has trample"
+                        StaticFilters.FILTER_EACH_CONTROLLED_CREATURE_P1P1)
                 )
-        ));
+        );
     }
 
     private ZeganaUtopianSpeaker(final ZeganaUtopianSpeaker card) {

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -5,6 +5,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.constants.TargetController;
+import mage.counters.CounterType;
 import mage.filter.common.*;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.AnotherPredicate;
@@ -747,6 +748,49 @@ public final class StaticFilters {
     static {
         FILTER_CREATURE_TOKEN.add(TokenPredicate.TRUE);
         FILTER_CREATURE_TOKEN.setLockedFilter(true);
+    }
+
+    public static final FilterControlledCreaturePermanent FILTER_A_CONTROLLED_CREATURE_P1P1 = new FilterControlledCreaturePermanent("a creature you control with a +1/+1 counter on it");
+
+    static {
+        FILTER_A_CONTROLLED_CREATURE_P1P1.add(CounterType.P1P1.getPredicate());
+        FILTER_A_CONTROLLED_CREATURE_P1P1.setLockedFilter(true);
+    }
+
+    public static final FilterControlledCreaturePermanent FILTER_CONTROLLED_CREATURE_P1P1 = new FilterControlledCreaturePermanent("creature you control with a +1/+1 counter on it");
+
+    static {
+        FILTER_CONTROLLED_CREATURE_P1P1.add(CounterType.P1P1.getPredicate());
+        FILTER_CONTROLLED_CREATURE_P1P1.setLockedFilter(true);
+    }
+
+    public static final FilterControlledCreaturePermanent FILTER_EACH_CONTROLLED_CREATURE_P1P1 = new FilterControlledCreaturePermanent("each creature you control with a +1/+1 counter on it");
+
+    static {
+        FILTER_EACH_CONTROLLED_CREATURE_P1P1.add(CounterType.P1P1.getPredicate());
+        FILTER_EACH_CONTROLLED_CREATURE_P1P1.setLockedFilter(true);
+    }
+
+    public static final FilterControlledCreaturePermanent FILTER_OTHER_CONTROLLED_CREATURE_P1P1 = new FilterControlledCreaturePermanent("other creature you control with a +1/+1 counter on it");
+
+    static {
+        FILTER_OTHER_CONTROLLED_CREATURE_P1P1.add(CounterType.P1P1.getPredicate());
+        FILTER_OTHER_CONTROLLED_CREATURE_P1P1.add(AnotherPredicate.instance);
+        FILTER_OTHER_CONTROLLED_CREATURE_P1P1.setLockedFilter(true);
+    }
+
+    public static final FilterCreaturePermanent FILTER_A_CREATURE_P1P1 = new FilterCreaturePermanent("a creature with a +1/+1 counter on it");
+
+    static {
+        FILTER_A_CREATURE_P1P1.add(CounterType.P1P1.getPredicate());
+        FILTER_A_CREATURE_P1P1.setLockedFilter(true);
+    }
+
+    public static final FilterCreaturePermanent FILTER_CREATURE_P1P1 = new FilterCreaturePermanent("creature with a +1/+1 counter on it");
+
+    static {
+        FILTER_CREATURE_P1P1.add(CounterType.P1P1.getPredicate());
+        FILTER_CREATURE_P1P1.setLockedFilter(true);
     }
 
     public static final FilterCreaturePermanent FILTER_CREATURE_TOKENS = new FilterCreaturePermanent("creature tokens");

--- a/Mage/src/main/java/mage/game/command/emblems/LilianaDefiantNecromancerEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/LilianaDefiantNecromancerEmblem.java
@@ -11,7 +11,7 @@ import mage.cards.Card;
 import mage.constants.Outcome;
 import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.command.Emblem;
 import mage.target.targetpointer.FixedTarget;
@@ -23,11 +23,9 @@ import mage.target.targetpointer.FixedTarget;
 public final class LilianaDefiantNecromancerEmblem extends Emblem {
     // You get an emblem with "Whenever a creature you control dies, return it to the battlefield under your control at the beginning of the next end step."
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature");
-
     public LilianaDefiantNecromancerEmblem() {
         this.setName("Emblem Liliana");
-        Ability ability = new DiesCreatureTriggeredAbility(Zone.COMMAND, new LilianaDefiantNecromancerEmblemEffect(), false, filter, true);
+        Ability ability = new DiesCreatureTriggeredAbility(Zone.COMMAND, new LilianaDefiantNecromancerEmblemEffect(), false, StaticFilters.FILTER_PERMANENT_A_CREATURE, true);
         this.getAbilities().add(ability);
     }
 }

--- a/Mage/src/main/java/mage/game/command/planes/FeedingGroundsPlane.java
+++ b/Mage/src/main/java/mage/game/command/planes/FeedingGroundsPlane.java
@@ -20,7 +20,7 @@ import mage.cards.Card;
 import mage.constants.*;
 import mage.counters.CounterType;
 import mage.filter.FilterCard;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.ColorPredicate;
 import mage.game.Game;
@@ -36,7 +36,6 @@ import mage.watchers.common.PlanarRollWatcher;
  */
 public class FeedingGroundsPlane extends Plane {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature");
     private static final String rule = "put X +1/+1 counters on target creature, where X is that creature's mana value";
 
     public FeedingGroundsPlane() {
@@ -49,7 +48,7 @@ public class FeedingGroundsPlane extends Plane {
 
         // Active player can roll the planar die: Whenever you roll {CHAOS}, target red or green creature gets X +1/+1 counters
         Effect chaosEffect = new AddCountersTargetEffect(CounterType.P1P1.createInstance(), TargetManaValue.instance);
-        Target chaosTarget = new TargetCreaturePermanent(1, 1, filter, false);
+        Target chaosTarget = new TargetCreaturePermanent(1, 1, StaticFilters.FILTER_PERMANENT_A_CREATURE, false);
 
         List<Effect> chaosEffects = new ArrayList<>();
         chaosEffects.add(chaosEffect);

--- a/Mage/src/main/java/mage/game/permanent/token/OviyaPashiriSageLifecrafterToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/OviyaPashiriSageLifecrafterToken.java
@@ -3,7 +3,6 @@ package mage.game.permanent.token;
 import mage.MageInt;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.filter.common.FilterControlledCreaturePermanent;
 
 import java.util.Arrays;
 
@@ -11,8 +10,6 @@ import java.util.Arrays;
  * @author spjspj
  */
 public final class OviyaPashiriSageLifecrafterToken extends TokenImpl {
-
-    static final FilterControlledCreaturePermanent filterCreature = new FilterControlledCreaturePermanent("creatures you control");
 
     public OviyaPashiriSageLifecrafterToken() {
         this(1);


### PR DESCRIPTION
- Created static filters for creatures with +1/+1 counters
- Simplified Lifecrafter's Gift, Patron of the Valiant, and Scale Blessing based on similar cards (stumbled across them during +1/+1 changes)
- FILTER_OPPONENTS_PERMANENT_CREATURE, FILTER_OPPONENTS_PERMANENT_A_CREATURE, FILTER_PERMANENT_A_CREATURE, FILTER_CONTROLLED_A_CREATURE, FILTER_CONTROLLED_CREATURES
