### PR TITLE
Change from jboss to java serialization (fixes #8609)

### DIFF
--- a/Mage.Common/src/main/java/mage/remote/Connection.java
+++ b/Mage.Common/src/main/java/mage/remote/Connection.java
@@ -40,7 +40,7 @@ public class Connection {
 //    private boolean confirmEmptyManaPool;
 //    private String flagName;
 //    private UserSkipPrioritySteps userSkipPrioritySteps;
-    private static final String serialization = "?serializationtype=jboss";
+    private static final String serialization = "?serializationtype=java";
     private static final String transport = "bisocket";
     private static final String threadpool = "onewayThreadPool=mage.remote.CustomThreadPool";
 

--- a/Mage.Common/src/test/java/mage/remote/ConnectionTest.java
+++ b/Mage.Common/src/test/java/mage/remote/ConnectionTest.java
@@ -72,7 +72,7 @@ public class ConnectionTest {
         void serialisation() {
             final String query = make(testeeBuilder).getQuery();
 
-            assertThat(query).contains("serializationtype=jboss");
+            assertThat(query).contains("serializationtype=java");
         }
 
         @Test


### PR DESCRIPTION
Discussed in #8609 

A change in OpenJDK 8u312 appears to be incompatible with JBoss serialization.  Specifically this commit: https://github.com/openjdk/jdk8u/commit/b9cde8b454e31538fe34abcd621fb55a23267e03

After I looked a little more into what that commit actually does, it looks like it deals with de-serialization specifically.

Documentation for JBoss Remoting regarding this change:  https://docs.jboss.org/jbossremoting/2.5.4.SP4/guide/html/ch08.html

> Currently there are only two different types of serialization implementations; 'java' and 'jboss'. The 'java' type uses org.jboss.remoting.serialization.impl.java.JavaSerializationManager as the SerializationManager implementation and is backed by standard Java serialization provide by the JVM, which is the default. The 'jboss' type uses org.jboss.remoting.serialization.impl.jboss.JBossSerializationManager as the SerializationManager implementation and is backed by JBoss Serialization.

The JBoss serialization project appears to be unmaintained so I doubt it will ever get a fix (version we're using was last updated in 2010...)  I've tested that this works on both the older OpenJDK release as well as the new one.