### PR TITLE
[NEO] Implemented Historian's Wisdom

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HistoriansWisdom.java
+++ b/Mage.Sets/src/mage/cards/h/HistoriansWisdom.java
@@ -1,0 +1,93 @@
+package mage.cards.h;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.Condition;
+import mage.abilities.condition.common.AttachedToMatchesFilterCondition;
+import mage.abilities.decorator.ConditionalContinuousEffect;
+import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
+import mage.constants.ComparisonType;
+import mage.constants.SubType;
+import mage.abilities.effects.common.AttachEffect;
+import mage.constants.Outcome;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.mageobject.PowerPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.target.TargetPermanent;
+import mage.abilities.keyword.EnchantAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+
+/**
+ *
+ * @author weirddan455
+ */
+public final class HistoriansWisdom extends CardImpl {
+
+    private static final Condition creatureCondition = new AttachedToMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_CREATURE);
+
+    public HistoriansWisdom(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{G}");
+
+        this.subtype.add(SubType.AURA);
+
+        // Enchant artifact or creature
+        TargetPermanent auraTarget = new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE);
+        this.getSpellAbility().addTarget(auraTarget);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.BoostCreature));
+        this.addAbility(new EnchantAbility(auraTarget.getTargetName()));
+
+        // When Historian's Wisdom enters the battlefield, if enchanted permanent is a creature with the greatest power among creatures on the battlefield, draw a card.
+        this.addAbility(new ConditionalInterveningIfTriggeredAbility(
+                new EntersBattlefieldTriggeredAbility(new DrawCardSourceControllerEffect(1)),
+                HistoriansWisdomCondition.instance,
+                "When {this} enters the battlefield, if enchanted permanent is a creature with the greatest power among creatures on the battlefield, draw a card."
+        ));
+
+        // As long as enchanted permanent is a creature, it gets +2/+1.
+        this.addAbility(new SimpleStaticAbility(new ConditionalContinuousEffect(
+                new BoostEnchantedEffect(2, 1),
+                creatureCondition,
+                "As long as enchanted permanent is a creature, it gets +2/+1"
+        )));
+    }
+
+    private HistoriansWisdom(final HistoriansWisdom card) {
+        super(card);
+    }
+
+    @Override
+    public HistoriansWisdom copy() {
+        return new HistoriansWisdom(this);
+    }
+}
+
+enum HistoriansWisdomCondition implements Condition {
+    instance;
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent enchantment = source.getSourcePermanentIfItStillExists(game);
+        if (enchantment == null) {
+            return false;
+        }
+        Permanent creature = game.getPermanent(enchantment.getAttachedTo());
+        if (creature == null) {
+            return false;
+        }
+        if (!creature.isCreature(game)) {
+            return false;
+        }
+        FilterCreaturePermanent filter = new FilterCreaturePermanent();
+        filter.add(new PowerPredicate(ComparisonType.MORE_THAN, creature.getPower().getValue()));
+        return game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source.getSourceId(), game).size() == 0;
+    }
+}

--- a/Mage.Sets/src/mage/cards/h/HistoriansWisdom.java
+++ b/Mage.Sets/src/mage/cards/h/HistoriansWisdom.java
@@ -75,6 +75,7 @@ enum HistoriansWisdomCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
+        game.applyEffects(); // Make sure +2/+1 buff gets applied first
         Permanent enchantment = source.getSourcePermanentIfItStillExists(game);
         if (enchantment == null) {
             return false;

--- a/Mage.Sets/src/mage/cards/h/HistoriansWisdom.java
+++ b/Mage.Sets/src/mage/cards/h/HistoriansWisdom.java
@@ -89,6 +89,6 @@ enum HistoriansWisdomCondition implements Condition {
         }
         FilterCreaturePermanent filter = new FilterCreaturePermanent();
         filter.add(new PowerPredicate(ComparisonType.MORE_THAN, creature.getPower().getValue()));
-        return game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source.getSourceId(), game).size() == 0;
+        return game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source.getSourceId(), game).isEmpty();
     }
 }

--- a/Mage.Sets/src/mage/sets/KamigawaNeonDynasty.java
+++ b/Mage.Sets/src/mage/sets/KamigawaNeonDynasty.java
@@ -86,6 +86,7 @@ public final class KamigawaNeonDynasty extends ExpansionSet {
         cards.add(new SetCardInfo("Heir of the Ancient Fang", 191, Rarity.COMMON, mage.cards.h.HeirOfTheAncientFang.class));
         cards.add(new SetCardInfo("Hidetsugu, Devouring Chaos", 99, Rarity.RARE, mage.cards.h.HidetsuguDevouringChaos.class));
         cards.add(new SetCardInfo("High-Speed Hoverbike", 247, Rarity.UNCOMMON, mage.cards.h.HighSpeedHoverbike.class));
+        cards.add(new SetCardInfo("Historian's Wisdom", 192, Rarity.UNCOMMON, mage.cards.h.HistoriansWisdom.class));
         cards.add(new SetCardInfo("Hotshot Mechanic", 16, Rarity.UNCOMMON, mage.cards.h.HotshotMechanic.class));
         cards.add(new SetCardInfo("Imperial Moth", 4, Rarity.COMMON, mage.cards.i.ImperialMoth.class));
         cards.add(new SetCardInfo("Imperial Recovery Unit", 18, Rarity.UNCOMMON, mage.cards.i.ImperialRecoveryUnit.class));


### PR DESCRIPTION
I think there's a bug in this.  It's not taking its own buff into account when calculating the largest creature power.

Ex. 2/2 and 3/3 on the battlefield.  Put this enchantment on the 2/2 so grows into a 4/3 but the 2nd ability doesn't trigger to draw a card.

Or maybe that's right and I'm misunderstanding the rules?