### PR TITLE
Changed getTopCards to return cards in the order they're in the deck

### DIFF
--- a/Mage/src/main/java/mage/players/Library.java
+++ b/Mage/src/main/java/mage/players/Library.java
@@ -168,7 +168,7 @@ public class Library implements Serializable {
     }
 
     public Set<Card> getTopCards(Game game, int amount) {
-        Set<Card> cards = new HashSet<>();
+        Set<Card> cards = new LinkedHashSet<>();
         Iterator<UUID> it = library.iterator();
         int count = 0;
         while (it.hasNext() && count < amount) {


### PR DESCRIPTION
Changed from HashSet to LInkedHasSet so that the cards stored in `cards` are returned in the same order that they are in the library.

Fixes #4198.