### PR TITLE
Fixed Incorrect Handling of Colourless mana for Mana.enough()

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/utils/ManaUtilTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/utils/ManaUtilTest.java
@@ -104,6 +104,7 @@ public class ManaUtilTest extends CardTestPlayerBase {
         testManaAvailEnough("{B}", 0, "{G}", false);
         testManaAvailEnough("{U}", 0, "{G}", false);
         testManaAvailEnough("{W}", 0, "{G}", false);
+        testManaAvailEnough("{W}", 0, "{C}", false);
 
         testManaAvailEnough("{R}", 1, "", true);
         testManaAvailEnough("{R}", 0, "{R}", true);
@@ -126,6 +127,13 @@ public class ManaUtilTest extends CardTestPlayerBase {
         testManaAvailEnough("{W}{W}", 0, "{G/W}{G/W}", true);
         testManaAvailEnough("{G}{G}", 0, "{G/W}{G/W}", true);
 
+        testManaAvailEnough("{C}", 1, "", false);
+        testManaAvailEnough("{C}", 0, "{C}", true);
+        testManaAvailEnough("{C}", 0, "{G}", false);
+        testManaAvailEnough("{C}", 0, "{R}", false);
+        testManaAvailEnough("{C}", 0, "{B}", false);
+        testManaAvailEnough("{C}", 0, "{W}", false);
+        testManaAvailEnough("{C}", 0, "{U}", false);
     }
 
     /**

--- a/Mage/src/main/java/mage/Mana.java
+++ b/Mage/src/main/java/mage/Mana.java
@@ -653,10 +653,17 @@ public class Mana implements Comparable<Mana>, Serializable, Copyable<Mana> {
      * @return if there is enough available mana to pay.
      */
     public boolean enough(final Mana cost) {
+        // Create a copy of the amount of mana available
         Mana compare = cost.copy();
+        // Subtract from the mana available the price of the spell (this) on a per color basis
         compare.subtract(this);
+        // A negative value for compare.X means that mana of type X for from the price could not be paid be mana
+        // of the same value from the available mana.
+        // Check each of the types, and see if there is enough mana of any color left to pay for the colors.
         if (compare.white < 0) {
             compare.any = CardUtil.overflowInc(compare.any, compare.white);
+            // A negatice value means that there was more colored mana required than there was mana of any color
+            // to pay for it. So, there is not enough mana to pay the cost.
             if (compare.any < 0) {
                 return false;
             }
@@ -691,11 +698,9 @@ public class Mana implements Comparable<Mana>, Serializable, Copyable<Mana> {
             compare.green = 0;
         }
         if (compare.colorless < 0) {
-            compare.any = CardUtil.overflowInc(compare.any, compare.colorless);
-            if (compare.any < 0) {
-                return false;
-            }
-            compare.colorless = 0;
+            // Colorless mana can only be paid by colorless mana.
+            // If there's a negative value, then there's nothing else that can be used to pay for it.
+            return false;
         }
         if (compare.generic < 0) {
             compare.generic = CardUtil.overflowInc(compare.generic, compare.white);


### PR DESCRIPTION
When calculating if a player had enough mana to cast a spell, Mana.enough() was incorrectly subtracting many of any color from the colourless mana cost, the same way that it did for color and generic mana costs. But this was incorrect as only colourless mana can pay for colourless mana costs.

Fixed the issue, added tests, and added some comments to Mana.enough() to describe how it works.

Closes #8153

