### PR TITLE
Remove dead image scaling library

### DIFF
--- a/Mage.Client/pom.xml
+++ b/Mage.Client/pom.xml
@@ -64,13 +64,6 @@
         </dependency>
 
         <dependency>
-            <!-- image scaling for card images -->
-            <!-- TODO: library is dead, must be replaced -->
-            <groupId>com.mortennobel</groupId>
-            <artifactId>java-image-scaling</artifactId>
-            <version>0.8.6</version>
-        </dependency>
-        <dependency>
             <!-- graphic lib to draw GUI with effects -->
             <!-- TODO: library is dead, must be replaced -->
             <groupId>org.swinglabs</groupId>

--- a/Mage.Client/src/main/java/mage/client/util/TransformedImageCache.java
+++ b/Mage.Client/src/main/java/mage/client/util/TransformedImageCache.java
@@ -3,8 +3,6 @@ package mage.client.util;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 
-import com.mortennobel.imagescaling.ResampleOp;
-
 /**
  *
  * @author user
@@ -95,9 +93,12 @@ public final class TransformedImageCache {
     }
 
     private static BufferedImage resizeImage(BufferedImage original, int width, int height) {
-        ResampleOp resampleOp = new ResampleOp(width, height);
-        BufferedImage image = resampleOp.filter(original, null);
-        return image;
+        Image scaled = original.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+        BufferedImage output = new BufferedImage(width, height, original.getType());
+        Graphics2D graphics = output.createGraphics();
+        graphics.drawImage(scaled, 0, 0, null);
+        graphics.dispose();
+        return output;
     }
 
     public static BufferedImage getResizedImage(BufferedImage image, int width, int height) {


### PR DESCRIPTION
I saw this TODO in the pom file that this image scaling library is no longer being maintained.  The library was only being used in this one place and it's a pretty easy replacement with built-in Java methods.  Image quality looks about the same form what I can tell when Image.SCALE_SMOOTH is used.