### PR TITLE
[don't merge] Fix TappingAtTheWindow

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TappingAtTheWindow.java
+++ b/Mage.Sets/src/mage/cards/t/TappingAtTheWindow.java
@@ -1,18 +1,13 @@
 package mage.cards.t;
 
-import mage.abilities.Ability;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.dynamicvalue.common.StaticValue;
+import mage.abilities.effects.common.LookLibraryAndPickControllerEffect;
 import mage.abilities.keyword.FlashbackAbility;
 import mage.cards.*;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.players.Player;
-import mage.target.TargetCard;
-import mage.target.common.TargetCardInLibrary;
 
 import java.util.UUID;
 
@@ -25,7 +20,18 @@ public final class TappingAtTheWindow extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{G}");
 
         // Look at the top three cards of your library. You may reveal a creature card from among them and put it into your hand. Put the rest into your graveyard.
-        this.getSpellAbility().addEffect(new TappingAtTheWindowEffect());
+        this.getSpellAbility().addEffect(new LookLibraryAndPickControllerEffect(
+                StaticValue.get(3),
+                false,
+                StaticValue.get(1),
+                StaticFilters.FILTER_CARD_CREATURE_A,
+                Zone.GRAVEYARD,
+                false,
+                true,
+                false,
+                Zone.HAND,
+                true
+        ));
 
         // Flashback {2}{G}
         this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{2}{G}")));
@@ -38,44 +44,5 @@ public final class TappingAtTheWindow extends CardImpl {
     @Override
     public TappingAtTheWindow copy() {
         return new TappingAtTheWindow(this);
-    }
-}
-
-class TappingAtTheWindowEffect extends OneShotEffect {
-
-    TappingAtTheWindowEffect() {
-        super(Outcome.Benefit);
-        staticText = "look at the top three cards of your library. You may reveal a creature card " +
-                "from among them and put it into your hand. Put the rest into your graveyard";
-    }
-
-    private TappingAtTheWindowEffect(final TappingAtTheWindowEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public TappingAtTheWindowEffect copy() {
-        return new TappingAtTheWindowEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player player = game.getPlayer(source.getControllerId());
-        if (player == null) {
-            return false;
-        }
-        Cards cards = new CardsImpl(player.getLibrary().getTopCards(game, 3));
-        TargetCard target = new TargetCardInLibrary(
-                0, 1, StaticFilters.FILTER_CARD_CREATURE
-        );
-        player.choose(outcome, cards, target, game);
-        Card card = game.getCard(target.getFirstTarget());
-        if (card != null) {
-            player.revealCards(source, new CardsImpl(card), game);
-            player.moveCards(card, Zone.HAND, source, game);
-        }
-        cards.retainZone(Zone.LIBRARY, game);
-        player.moveCards(card, Zone.GRAVEYARD, source, game);
-        return true;
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/LookLibraryAndPickControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/LookLibraryAndPickControllerEffect.java
@@ -328,8 +328,8 @@ public class LookLibraryAndPickControllerEffect extends LookLibraryControllerEff
             sb.append(targetPickedCards.toString().toLowerCase(Locale.ENGLISH));
 
             if (targetZoneLookedCards == Zone.LIBRARY) {
-                sb.append(revealPickedCards?". Put ":" and ");
-                sb.append(cardCount-pickCount==1?"the other ":"the rest ");
+                sb.append(revealPickedCards ? ". Put " : " and ");
+                sb.append(cardCount-pickCount == 1 ? "the other " : "the rest ");
                 if (putOnTop) {
                     sb.append("back on top");
                 } else {
@@ -346,12 +346,12 @@ public class LookLibraryAndPickControllerEffect extends LookLibraryControllerEff
                     sb.append(" order");
                 }
             } else if (targetZoneLookedCards == Zone.GRAVEYARD) {
-                sb.append(" and the");
+                sb.append(revealPickedCards ? ". Put" : " and");
                 if (numberOfCards instanceof StaticValue && numberToPick instanceof StaticValue
                         && ((StaticValue) numberToPick).getValue() + 1 == ((StaticValue) numberOfCards).getValue()) {
-                    sb.append(" other");
+                    sb.append(" the other");
                 } else {
-                    sb.append(" rest");
+                    sb.append(" the rest");
                 }
                 sb.append(" into your graveyard");
             }


### PR DESCRIPTION
Someone mentioned that Tapping at the window moved all cards in to the graveyard instead of putting the chosen creature in your hand. Fixed it by removing the custom implementation and based the effect on Sultai Soothsayer.

There is currently no linked issue logged for this. Is it preferred to create one?