### PR TITLE
Random pack selector dialog has more space & is resizeable

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/RandomPacksSelectorDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/RandomPacksSelectorDialog.form
@@ -9,9 +9,9 @@
       <Value id="APPLICATION_EXCLUDE"/>
     </Property>
     <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[600, 450]"/>
+      <Dimension value="[875, 475]"/>
     </Property>
-    <Property name="resizable" type="boolean" value="false"/>
+    <Property name="resizable" type="boolean" value="true"/>
   </Properties>
   <SyntheticProperties>
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
@@ -71,8 +71,8 @@
     <Container class="java.awt.Panel" name="pnlPacks">
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridLayout">
-        <Property name="columns" type="int" value="13"/>
-        <Property name="rows" type="int" value="12"/>
+        <Property name="columns" type="int" value="14"/>
+        <Property name="rows" type="int" value="14"/>
       </Layout>
     </Container>
     <Container class="javax.swing.JPanel" name="pnlSelect">

--- a/Mage.Client/src/main/java/mage/client/dialog/RandomPacksSelectorDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/RandomPacksSelectorDialog.java
@@ -116,15 +116,15 @@ public class RandomPacksSelectorDialog extends javax.swing.JDialog {
         setTitle("Random Booster Draft Packs Selector");
         setModal(true);
         setModalExclusionType(java.awt.Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
-        setPreferredSize(new java.awt.Dimension(600, 450));
-        setResizable(false);
+        setPreferredSize(new java.awt.Dimension(875, 475));
+        setResizable(true);
         addWindowListener(new java.awt.event.WindowAdapter() {
             public void windowClosing(java.awt.event.WindowEvent evt) {
                 formWindowClosing(evt);
             }
         });
 
-        pnlPacks.setLayout(new java.awt.GridLayout(12, 13));
+        pnlPacks.setLayout(new java.awt.GridLayout(14, 14));
 
         pnlSelect.setLayout(new javax.swing.BoxLayout(pnlSelect, javax.swing.BoxLayout.LINE_AXIS));
 


### PR DESCRIPTION
Currently the random pack selector dialog is unusable due to having no space to show all the sets and the apply-button:
![currentdialog](https://user-images.githubusercontent.com/13901691/165648302-011d4cff-f6d4-42fd-93ac-dbeaa443a7fe.png)

This commit adds more space to the dialog so it will fit the sets for a long time again. And the dialog is also now resizeable as a precaution against getting overly cramped in the future.
![newdialog](https://user-images.githubusercontent.com/13901691/165648449-e31b75d4-0076-4965-a027-d5658619cc08.png)

A beta release would be appreciated in addition to merging this, due to the random pack selector being essential for themed chaos drafts that don't use all the sets.