### PR TITLE
fix (paragonOfModernity): use pre-converted mana

### DIFF
--- a/Mage.Sets/src/mage/cards/p/ParagonOfModernity.java
+++ b/Mage.Sets/src/mage/cards/p/ParagonOfModernity.java
@@ -60,6 +60,6 @@ enum ParagonOfModernityCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        return source.getManaCosts().getUsedManaToPay().getDifferentColors() == 3;
+        return source.getManaCostsToPay().getUsedManaToPay().getDifferentColors() == 3;
     }
 }


### PR DESCRIPTION
#8895
When using `getManaCost()`, the mana is already converted to generic mana and cannot retroactively get the colored mana. 

Current fix inspired by [[Soul Burn]].
