### PR TITLE
Fix for Sram's Expertise

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SramsExpertise.java
+++ b/Mage.Sets/src/mage/cards/s/SramsExpertise.java
@@ -6,7 +6,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.ComparisonType;
-import mage.filter.FilterCard;
 import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.mageobject.ManaValuePredicate;
 import mage.game.permanent.token.ServoToken;
@@ -18,7 +17,7 @@ import java.util.UUID;
  */
 public final class SramsExpertise extends CardImpl {
 
-    private static final FilterCard filter = new FilterNonlandCard("a spell with mana value 3 or less");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("a spell with mana value 3 or less");
 
     static {
         filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 4));

--- a/Mage.Sets/src/mage/cards/s/SramsExpertise.java
+++ b/Mage.Sets/src/mage/cards/s/SramsExpertise.java
@@ -7,6 +7,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.ComparisonType;
 import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.mageobject.ManaValuePredicate;
 import mage.game.permanent.token.ServoToken;
 
@@ -17,7 +18,7 @@ import java.util.UUID;
  */
 public final class SramsExpertise extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("a spell with mana value 3 or less");
+    private static final FilterCard filter = new FilterNonlandCard("a spell with mana value 3 or less");
 
     static {
         filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 4));


### PR DESCRIPTION
[[Sram's Expertise]] lets you cast a card from your hand for free when it's cast.

The current implementation limited you to casting a card, but it let you *select* a land. After you selected the land, nothing happened. This changes the filter so that only non-land cards can be picked.