### PR TITLE
Fixes net mana calculation for AddManaOfTwoDifferentColorsEffect

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/mana/AddManaOfTwoDifferentColorsEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/mana/AddManaOfTwoDifferentColorsEffect.java
@@ -4,6 +4,7 @@ package mage.abilities.effects.mana;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.choices.ManaChoice;
+import mage.constants.ManaType;
 import mage.game.Game;
 import mage.players.Player;
 
@@ -11,6 +12,32 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class AddManaOfTwoDifferentColorsEffect extends ManaEffect {
+
+    // Performing this calculation here since it never changes and should not be recalcualted each time.
+    private static final List<ManaType> colorsToCycle   = new ArrayList<>();
+    private static final List<Mana> netMana             = new ArrayList<>();
+    static {
+        // Add the colored mana in order to cycle through them
+        colorsToCycle.add(ManaType.WHITE);
+        colorsToCycle.add(ManaType.BLUE);
+        colorsToCycle.add(ManaType.BLACK);
+        colorsToCycle.add(ManaType.RED);
+        colorsToCycle.add(ManaType.GREEN);
+
+        // Create the possible combinations of two mana
+        for (ManaType manaType1 : colorsToCycle) {
+            for (ManaType manaType2 : colorsToCycle) {
+                // Mana types must be different
+                if (manaType1 == manaType2) {
+                    continue;
+                }
+
+                Mana manaCombo = new Mana(manaType1);
+                manaCombo.increase(manaType2);
+                netMana.add(manaCombo);
+            }
+        }
+    }
 
     public AddManaOfTwoDifferentColorsEffect() {
         super();
@@ -23,8 +50,6 @@ public class AddManaOfTwoDifferentColorsEffect extends ManaEffect {
 
     @Override
     public List<Mana> getNetMana(Game game, Ability source) {
-        List<Mana> netMana = new ArrayList<>();
-        netMana.add(Mana.AnyMana(2));
         return netMana;
     }
 


### PR DESCRIPTION
For #6702.

Previously the effect would return that it has 2 mana of any color as its net available mana. This is incorrect since the two mana cannot a share a color and so they aren't really both "any color".

This chances the effect to properly calculate and return all permutations of two different mana colors.

This will affect Component Pouch, Firemind Vessel, and Guild Globe.