### PR TITLE
Implemented Optimistic getNetMana for Selvala, Explorer Returned

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SelvalaExplorerReturned.java
+++ b/Mage.Sets/src/mage/cards/s/SelvalaExplorerReturned.java
@@ -80,8 +80,12 @@ class SelvalaExplorerReturnedEffect extends ManaEffect {
         // but Selvala's ability can't be reversed.
         // Whatever mana that ability produced will be in your mana pool and each player will have drawn a card.
         // (2014-05-29)
-
         int maxPotentialGreenMana = 0;
+        List<Mana> netMana = new ArrayList<>();
+
+        if (game == null) {
+            return netMana;
+        }
 
         for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {
             Player player = game.getPlayer(playerId);
@@ -95,7 +99,6 @@ class SelvalaExplorerReturnedEffect extends ManaEffect {
             }
         }
 
-        List<Mana> netMana = new ArrayList<>();
         netMana.add(Mana.GreenMana(maxPotentialGreenMana));
 
         return netMana;

--- a/Mage.Sets/src/mage/cards/s/SelvalaExplorerReturned.java
+++ b/Mage.Sets/src/mage/cards/s/SelvalaExplorerReturned.java
@@ -1,6 +1,7 @@
 package mage.cards.s;
 
 import mage.MageInt;
+import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.costs.common.TapSourceCost;
@@ -10,8 +11,10 @@ import mage.abilities.effects.common.DrawCardAllEffect;
 import mage.abilities.effects.mana.ManaEffect;
 import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.abilities.mana.SimpleManaAbility;
+import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.cards.CardsImpl;
 import mage.constants.*;
 import mage.game.Game;
 import mage.players.Player;
@@ -34,7 +37,7 @@ public final class SelvalaExplorerReturned extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Parley - {T}: Each player reveals the top card of their library. For each nonland card revealed this way, add {G} and you gain 1 life. Then each player draws a card.
-        ActivatedManaAbilityImpl manaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, new SelvalaExplorerReturnedEffect(), new TapSourceCost(), false);
+        ActivatedManaAbilityImpl manaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, new SelvalaExplorerReturnedEffect(), new TapSourceCost());
         manaAbility.setUndoPossible(false);
         manaAbility.setAbilityWord(AbilityWord.PARLEY);
         Effect effect = new DrawCardAllEffect(1);
@@ -70,19 +73,48 @@ class SelvalaExplorerReturnedEffect extends ManaEffect {
 
     @Override
     public List<Mana> getNetMana(Game game, Ability source) {
-        return new ArrayList<>();
+        // If you activate Selvala's ability while casting a spell,
+        // and you discover you can't produce enough mana to pay that spell's costs, the spell is reversed.
+        // The spell returns to whatever zone you were casting it from.
+        // You may reverse other mana abilities you activated while casting the spell,
+        // but Selvala's ability can't be reversed.
+        // Whatever mana that ability produced will be in your mana pool and each player will have drawn a card.
+        // (2014-05-29)
+
+        int maxPotentialGreenMana = 0;
+
+        for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {
+            Player player = game.getPlayer(playerId);
+            if (player == null) {
+                continue;
+            }
+
+            // If the player's library is not empty, increase the max potential mana.
+            if (!(player.getLibrary().isEmptyDraw())) {
+                maxPotentialGreenMana++;
+            }
+        }
+
+        List<Mana> netMana = new ArrayList<>();
+        netMana.add(Mana.GreenMana(maxPotentialGreenMana));
+
+        return netMana;
     }
 
     @Override
     public Mana produceMana(Game game, Ability source) {
-        if (game != null) {
-            int parleyCount = ParleyCount.getInstance().calculate(game, source, this);
-            Player player = getPlayer(game, source);
-            if (player != null) {
-                player.gainLife(parleyCount, game, source);
-            }
-            return Mana.GreenMana(parleyCount);
+        if (game == null) {
+            return new Mana();
         }
-        return new Mana();
+
+        Player player = getPlayer(game, source);
+        if (player == null) {
+            return new Mana();
+        }
+
+        int parleyCount = ParleyCount.getInstance().calculate(game, source, this);
+        player.gainLife(parleyCount, game, source);
+
+        return Mana.GreenMana(parleyCount);
     }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/ParleyCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/ParleyCount.java
@@ -34,22 +34,30 @@ public class ParleyCount implements DynamicValue, MageSingleton {
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
         // Each player reveals the top card of their library. For each nonland card revealed this way
         int parleyValue = 0;
-        MageObject sourceObject = game.getObject(sourceAbility.getSourceId());
-        if (sourceObject != null) {
-            for (UUID playerId : game.getState().getPlayersInRange(sourceAbility.getControllerId(), game)) {
-                Player player = game.getPlayer(playerId);
-                if (player != null) {
-                    Card card = player.getLibrary().getFromTop(game);
-                    if (card != null) {
-                        if (!card.isLand(game)) {
-                            parleyValue++;
-                        }
-                        player.revealCards(sourceObject.getIdName() + " (" + player.getName() + ')', new CardsImpl(card), game);
-                    }
-                }
 
-            }
+        MageObject sourceObject = game.getObject(sourceAbility.getSourceId());
+        if (sourceObject == null) {
+            return parleyValue;
         }
+
+        for (UUID playerId : game.getState().getPlayersInRange(sourceAbility.getControllerId(), game)) {
+            Player player = game.getPlayer(playerId);
+            if (player == null) {
+                continue;
+            }
+
+            Card card = player.getLibrary().getFromTop(game);
+            if (card == null) {
+                continue;
+            }
+
+            if (!card.isLand(game)) {
+                parleyValue++;
+            }
+
+            player.revealCards(sourceObject.getIdName() + " (" + player.getName() + ')', new CardsImpl(card), game);
+        }
+
         return parleyValue;
     }
 


### PR DESCRIPTION
[[Selvala, Explorer Returned]] can produce up to one {G} per player in range. The current implementation has it returning noNetMana since it calculating the correct amount of mana that it would produce would involve leaking some degree of information.

This change re-implements the getNetMana to provide the max mana produceable in a way that does not leak information. It returns one green mana for each player in range which has a non-empty library. This may be higher than the actual mana producible since not all of those cards may be a non-land card.

I think this change brings it closer to the [Oracle](https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=559922) description:
> "If you activate Selvala's ability while casting a spell, and you discover you can't produce enough mana to pay that spell's costs, the spell is reversed. The spell returns to whatever zone you were casting it from. You may reverse other mana abilities you activated while casting the spell, but Selvala's ability can't be reversed. Whatever mana that ability produced will be in your mana pool and each player will have drawn a card."

Unfortunately this ability is reversible due to a known current limitation:
https://github.com/magefree/mage/blob/07d0e590a97c418e02532c90af07d879e60c7dc1/Mage/src/main/java/mage/abilities/mana/ActivatedManaAbilityImpl.java#L136-L138

For #6698.

- Added calculation of getNetMana based on wording of Oracle ruling.
- Flattened ParleyCount to make it more readable.