### PR TITLE
[WIP] Enforce .isUndoPossible == false

### DIFF
--- a/Mage/src/main/java/mage/abilities/mana/ActivatedManaAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/mana/ActivatedManaAbilityImpl.java
@@ -134,8 +134,8 @@ public abstract class ActivatedManaAbilityImpl extends ActivatedAbilityImpl impl
      * library)
      * <p>
      * TODO: it helps with single mana activate for mana pool, but will not work
-     * while activates on paying for casting (e.g. user can cheats to see next
-     * draw card)
+     *       while activates on paying for casting (e.g. user can cheats to see next
+     *       draw card)
      *
      * @return
      */

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -887,7 +887,7 @@ public abstract class GameImpl implements Game {
             return null;
         }
 
-        // If trying to
+        // Can't restore to before start of game
         if (bookmark == 0) {
             return null;
         }
@@ -916,8 +916,7 @@ public abstract class GameImpl implements Game {
     }
 
     @Override
-    public void removeBookmark(int bookmark
-    ) {
+    public void removeBookmark(int bookmark) {
         if (!simulation) {
             if (bookmark != 0) {
                 while (savedStates.size() > bookmark) {

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1256,9 +1256,11 @@ public abstract class PlayerImpl implements Player, Serializable {
             }
             game.removeBookmark(bookmark);
             resetStoredBookmark(game);
+            // TODO: Clear out list of queued up not-undoable mana abilities
             return true;
         }
         restoreState(bookmark, ability.getRule(), game);
+        // TODO: Get ordered list of not-undoable mana abilities along with targets, etc. and replay them in order
 
         return false;
     }
@@ -1360,6 +1362,7 @@ public abstract class PlayerImpl implements Player, Serializable {
                             setStoredBookmark(bookmark);
                         }
                     } else {
+                        // TODO: Add it to a list of abilities to playback
                         resetStoredBookmark(game);
                     }
                     return true;


### PR DESCRIPTION
I am still figuring out how the undo and restore system work, but my idea is the following. During mana payments:
1. Track of all mana abilities with `.isUndoPossible==false` that get activated. Store their ordered and all target and choice information.
2. If the spell cast is called allow the rollback to happen and then re-play all of the stored abilities in the same order and with the same targets.

Anyone have thoughts/input? I am especially looking for anywhere else in the code that something like this is being done, if there is a place, to re-use that code if possible.

Closes #2382.