### PR TITLE
Add Captain's Maneuver

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CaptainsManeuver.java
+++ b/Mage.Sets/src/mage/cards/c/CaptainsManeuver.java
@@ -60,8 +60,9 @@ class CaptainsManeuverEffect extends RedirectionEffect {
         staticText = "The next X damage that would be dealt to target creature, planeswalker, or player this turn is dealt to another target creature, planeswalker, or player instead.";
     }
 
-    public CaptainsManeuverEffect(final CaptainsManeuverEffect effect) {
+    private CaptainsManeuverEffect(final CaptainsManeuverEffect effect) {
         super(effect);
+        this.redirectToObject = effect.redirectToObject;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/c/CaptainsManeuver.java
+++ b/Mage.Sets/src/mage/cards/c/CaptainsManeuver.java
@@ -1,0 +1,91 @@
+
+package mage.cards.c;
+
+import java.util.UUID;
+import mage.MageObjectReference;
+import mage.abilities.Ability;
+import mage.abilities.dynamicvalue.common.ManacostVariableValue;
+import mage.abilities.effects.RedirectionEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.filter.common.FilterCreaturePlayerOrPlaneswalker;
+import mage.filter.predicate.other.AnotherTargetPredicate;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.target.common.TargetAnyTarget;
+
+/**
+ *
+ * @author sprangg
+ */
+public final class CaptainsManeuver extends CardImpl {
+
+    public CaptainsManeuver(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{X}{R}{W}");
+
+        //The next X damage that would be dealt to target creature, planeswalker, or player this turn is dealt to another target creature, planeswalker, or player instead.
+        this.getSpellAbility().addEffect(new CaptainsManeuverEffect());
+
+        FilterCreaturePlayerOrPlaneswalker filter = new FilterCreaturePlayerOrPlaneswalker("creature, planeswalker or player (damage is redirected from)");        
+        TargetAnyTarget target = new TargetAnyTarget(filter);
+        target.setTargetTag(1);
+        this.getSpellAbility().addTarget(target);
+ 
+        FilterCreaturePlayerOrPlaneswalker filter2 = new FilterCreaturePlayerOrPlaneswalker("another creature, planeswalker or player (damage is redirected to)");     
+        filter2.getPlayerFilter().add(new AnotherTargetPredicate(2));
+        filter2.getPermanentFilter().add(new AnotherTargetPredicate(2));
+        TargetAnyTarget target2 = new TargetAnyTarget(filter2);
+        target2.setTargetTag(2);
+        this.getSpellAbility().addTarget(target2);
+    }
+
+    private CaptainsManeuver(final CaptainsManeuver card) {
+        super(card);
+    }
+
+    @Override
+    public CaptainsManeuver copy() {
+        return new CaptainsManeuver(this);
+    }
+}
+
+class CaptainsManeuverEffect extends RedirectionEffect {
+
+    protected MageObjectReference redirectToObject;
+
+    public CaptainsManeuverEffect() {
+        super(Duration.EndOfTurn, Integer.MAX_VALUE, UsageType.ONE_USAGE_ABSOLUTE);
+        staticText = "The next X damage that would be dealt to target creature, planeswalker, or player this turn is dealt to another target creature, planeswalker, or player instead.";
+    }
+
+    public CaptainsManeuverEffect(final CaptainsManeuverEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public CaptainsManeuverEffect copy() {
+        return new CaptainsManeuverEffect(this);
+    }
+
+    @Override
+    public void init(Ability source, Game game) {
+        super.init(source, game);
+        amountToRedirect = ManacostVariableValue.REGULAR.calculate(game, source, this);
+        redirectToObject = new MageObjectReference(source.getTargets().get(1).getFirstTarget(), game);
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (event.getTargetId().equals(getTargetPointer().getFirst(game, source))) {
+            if (game.getPlayer(redirectToObject.getSourceId()) != null || game.getControllerId(redirectToObject.getSourceId()) != null) {
+                if (redirectToObject.equals(new MageObjectReference(source.getTargets().get(1).getFirstTarget(), game))) {
+                    redirectTarget = source.getTargets().get(1);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/Apocalypse.java
+++ b/Mage.Sets/src/mage/sets/Apocalypse.java
@@ -146,6 +146,7 @@ public final class Apocalypse extends ExpansionSet {
         cards.add(new SetCardInfo("Suffocating Blast", 124, Rarity.RARE, mage.cards.s.SuffocatingBlast.class));
         cards.add(new SetCardInfo("Sylvan Messenger", 87, Rarity.UNCOMMON, mage.cards.s.SylvanMessenger.class));
         cards.add(new SetCardInfo("Symbiotic Deployment", 88, Rarity.RARE, mage.cards.s.SymbioticDeployment.class));
+        cards.add(new SetCardInfo("Tahngarth's Glare", 70, Rarity.COMMON, mage.cards.t.TahngarthsGlare.class));
         cards.add(new SetCardInfo("Temporal Spring", 125, Rarity.COMMON, mage.cards.t.TemporalSpring.class));
         cards.add(new SetCardInfo("Tidal Courier", 31, Rarity.UNCOMMON, mage.cards.t.TidalCourier.class));
         cards.add(new SetCardInfo("Tranquil Path", 89, Rarity.COMMON, mage.cards.t.TranquilPath.class));
@@ -161,5 +162,6 @@ public final class Apocalypse extends ExpansionSet {
         cards.add(new SetCardInfo("Wild Research", 72, Rarity.RARE, mage.cards.w.WildResearch.class));
         cards.add(new SetCardInfo("Yavimaya Coast", 143, Rarity.RARE, mage.cards.y.YavimayaCoast.class));
         cards.add(new SetCardInfo("Yavimaya's Embrace", 127, Rarity.RARE, mage.cards.y.YavimayasEmbrace.class));
+        cards.add(new SetCardInfo("Zombie Boa", 54, Rarity.COMMON, mage.cards.z.ZombieBoa.class));
     }
 }

--- a/Mage.Sets/src/mage/sets/Apocalypse.java
+++ b/Mage.Sets/src/mage/sets/Apocalypse.java
@@ -35,6 +35,7 @@ public final class Apocalypse extends ExpansionSet {
         cards.add(new SetCardInfo("Bloodfire Kavu", 58, Rarity.UNCOMMON, mage.cards.b.BloodfireKavu.class));
         cards.add(new SetCardInfo("Bog Gnarr", 76, Rarity.COMMON, mage.cards.b.BogGnarr.class));
         cards.add(new SetCardInfo("Brass Herald", 133, Rarity.UNCOMMON, mage.cards.b.BrassHerald.class));
+        cards.add(new SetCardInfo("Captain's Maneuver", 92, Rarity.UNCOMMON, mage.cards.c.CaptainsManeuver.class));
         cards.add(new SetCardInfo("Caves of Koilos", 140, Rarity.RARE, mage.cards.c.CavesOfKoilos.class));
         cards.add(new SetCardInfo("Ceta Disciple", 19, Rarity.COMMON, mage.cards.c.CetaDisciple.class));
         cards.add(new SetCardInfo("Ceta Sanctuary", 20, Rarity.UNCOMMON, mage.cards.c.CetaSanctuary.class));
@@ -145,7 +146,6 @@ public final class Apocalypse extends ExpansionSet {
         cards.add(new SetCardInfo("Suffocating Blast", 124, Rarity.RARE, mage.cards.s.SuffocatingBlast.class));
         cards.add(new SetCardInfo("Sylvan Messenger", 87, Rarity.UNCOMMON, mage.cards.s.SylvanMessenger.class));
         cards.add(new SetCardInfo("Symbiotic Deployment", 88, Rarity.RARE, mage.cards.s.SymbioticDeployment.class));
-        cards.add(new SetCardInfo("Tahngarth's Glare", 70, Rarity.COMMON, mage.cards.t.TahngarthsGlare.class));
         cards.add(new SetCardInfo("Temporal Spring", 125, Rarity.COMMON, mage.cards.t.TemporalSpring.class));
         cards.add(new SetCardInfo("Tidal Courier", 31, Rarity.UNCOMMON, mage.cards.t.TidalCourier.class));
         cards.add(new SetCardInfo("Tranquil Path", 89, Rarity.COMMON, mage.cards.t.TranquilPath.class));
@@ -161,6 +161,5 @@ public final class Apocalypse extends ExpansionSet {
         cards.add(new SetCardInfo("Wild Research", 72, Rarity.RARE, mage.cards.w.WildResearch.class));
         cards.add(new SetCardInfo("Yavimaya Coast", 143, Rarity.RARE, mage.cards.y.YavimayaCoast.class));
         cards.add(new SetCardInfo("Yavimaya's Embrace", 127, Rarity.RARE, mage.cards.y.YavimayasEmbrace.class));
-        cards.add(new SetCardInfo("Zombie Boa", 54, Rarity.COMMON, mage.cards.z.ZombieBoa.class));
     }
 }

--- a/Mage.Sets/src/mage/sets/Planechase.java
+++ b/Mage.Sets/src/mage/sets/Planechase.java
@@ -48,6 +48,7 @@ public final class Planechase extends ExpansionSet {
         cards.add(new SetCardInfo("Bull Cerodon", 84, Rarity.UNCOMMON, mage.cards.b.BullCerodon.class));
         cards.add(new SetCardInfo("Cabal Coffers", 132, Rarity.UNCOMMON, mage.cards.c.CabalCoffers.class));
         cards.add(new SetCardInfo("Cadaverous Knight", 20, Rarity.COMMON, mage.cards.c.CadaverousKnight.class));
+        cards.add(new SetCardInfo("Captain's Maneuver", 85, Rarity.UNCOMMON, mage.cards.c.CaptainsManeuver.class));
         cards.add(new SetCardInfo("Cerodon Yearling", 86, Rarity.COMMON, mage.cards.c.CerodonYearling.class));
         cards.add(new SetCardInfo("Cinder Elemental", 51, Rarity.UNCOMMON, mage.cards.c.CinderElemental.class));
         cards.add(new SetCardInfo("Cone of Flame", 52, Rarity.UNCOMMON, mage.cards.c.ConeOfFlame.class));


### PR DESCRIPTION
This commit adds the card Captain's Maneuver to Apocalypse and Planechase. Used [Carom](https://github.com/magefree/mage/blob/master/Mage.Sets/src/mage/cards/c/Carom.java) as the main reference on how to implement this. Tested with all permutations redirecting to/from a creature, a planeswalker, and a player.