### PR TITLE
Fix Path of Peril

### DIFF
--- a/Mage.Server/src/test/data/config_error.xml
+++ b/Mage.Server/src/test/data/config_error.xml
@@ -87,6 +87,7 @@
         <draftCube name="Sam Black's No Search Cube" jar="mage-tournament-booster-draft.jar" className="mage.tournament.cubes.SamBlacksCube"/>
         <draftCube name="Timothee Simonot's Twisted Color Pie Cube" jar="mage-tournament-booster-draft.jar" className="mage.tournament.cubes.TimotheeSimonotsTwistedColorPieCube"/>
         <draftCube name="MTGA Cube 2020 April" jar="mage-tournament-booster-draft.jar" className="mage.tournament.cubes.MTGACube2020April"/>
+        <draftCube name="MTGO Khans Expanded Cube" jar="mage-tournament-booster-draft.jar" className="mage.tournament.cubes.KhansExpandedCube"/>
         <draftCube name="MTGO Cube March 2014" jar="mage-tournament-booster-draft.jar" className="mage.tournament.cubes.MTGOMarchCube2014"/>
         <draftCube name="MTGO Legacy Cube" jar="mage-tournament-booster-draft.jar" className="mage.tournament.cubes.LegacyCube"/>
         <draftCube name="MTGO Legacy Cube 2015 March" jar="mage-tournament-booster-draft.jar" className="mage.tournament.cubes.LegacyCubeMarch2015"/>

--- a/Mage.Sets/src/mage/cards/p/PathOfPeril.java
+++ b/Mage.Sets/src/mage/cards/p/PathOfPeril.java
@@ -22,7 +22,7 @@ public final class PathOfPeril extends CardImpl {
             = new FilterCreaturePermanent("creatures [with mana value 2 or less]");
 
     static {
-        filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 2));
+        filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 3));
     }
 
     public PathOfPeril(UUID ownerId, CardSetInfo setInfo) {


### PR DESCRIPTION
[[Path of Peril]] said "less than 2", which only kills 1 drops. I changed it to "less than 3", so it also kills 2 drops. 