### PR TITLE
Fix Unlicensed Hearse

### DIFF
--- a/Mage.Sets/src/mage/cards/u/UnlicensedHearse.java
+++ b/Mage.Sets/src/mage/cards/u/UnlicensedHearse.java
@@ -19,81 +19,80 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
+import mage.game.ExileZone;
 import mage.game.Game;
 import mage.target.common.TargetCardInASingleGraveyard;
 import mage.util.CardUtil;
 
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 
 /**
  * @author TheElk801
  */
-public final class UnlicensedHearse extends CardImpl {
+enum UnlicensedHearseValue implements DynamicValue {
+  instance;
 
-    private static final Hint hint = new ValueHint("Cards exiled", UnlicensedHearseValue.instance);
-
-    public UnlicensedHearse(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
-
-        this.subtype.add(SubType.VEHICLE);
-        this.power = new MageInt(0);
-        this.toughness = new MageInt(0);
-
-        // {T}: Exile up to two target cards from a single graveyard.
-        Ability ability = new SimpleActivatedAbility(new ExileTargetForSourceEffect(), new TapSourceCost());
-        ability.addTarget(new TargetCardInASingleGraveyard(
-                0, 2, StaticFilters.FILTER_CARD_CARDS
-        ));
-        this.addAbility(ability);
-
-        // Unlicensed Hearse's power and toughness are each equal to the number of cards exiled with it.
-        this.addAbility(new SimpleStaticAbility(
-                Zone.ALL,
-                new SetPowerToughnessSourceEffect(
-                        UnlicensedHearseValue.instance, Duration.Custom
-                )
-        ).addHint(hint));
-
-        // Crew 2
-        this.addAbility(new CrewAbility(2));
+  @Override
+  public int calculate(Game game, Ability sourceAbility, Effect effect) {
+    ExileZone cardsExiledWithUnlicensedHearse =
+        game.getExile()
+            .getExileZone(
+                CardUtil.getExileZoneId(
+                    game,
+                    sourceAbility.getSourceId(),
+                    game.getState().getZoneChangeCounter(sourceAbility.getSourceId())));
+    if (cardsExiledWithUnlicensedHearse == null) {
+      return 0;
     }
 
-    private UnlicensedHearse(final UnlicensedHearse card) {
-        super(card);
-    }
+    return cardsExiledWithUnlicensedHearse.size();
+  }
 
-    @Override
-    public UnlicensedHearse copy() {
-        return new UnlicensedHearse(this);
-    }
+  @Override
+  public UnlicensedHearseValue copy() {
+    return this;
+  }
+
+  @Override
+  public String getMessage() {
+    return "cards exiled with it";
+  }
 }
 
-enum UnlicensedHearseValue implements DynamicValue {
-    instance;
+public final class UnlicensedHearse extends CardImpl {
 
-    @Override
-    public int calculate(Game game, Ability sourceAbility, Effect effect) {
-        return Optional.of(game
-                .getExile()
-                .getExileZone(CardUtil.getExileZoneId(
-                        game, sourceAbility.getSourceId(),
-                        game.getState().getZoneChangeCounter(sourceAbility.getSourceId())
-                )))
-                .filter(Objects::nonNull)
-                .map(HashSet::size)
-                .orElse(0);
-    }
+  private static final Hint hint = new ValueHint("Cards exiled", UnlicensedHearseValue.instance);
 
-    @Override
-    public UnlicensedHearseValue copy() {
-        return this;
-    }
+  public UnlicensedHearse(UUID ownerId, CardSetInfo setInfo) {
+    super(ownerId, setInfo, new CardType[] {CardType.ARTIFACT}, "{2}");
 
-    @Override
-    public String getMessage() {
-        return "cards exiled with it";
-    }
+    this.subtype.add(SubType.VEHICLE);
+    this.power = new MageInt(0);
+    this.toughness = new MageInt(0);
+
+    // {T}: Exile up to two target cards from a single graveyard.
+    Ability ability =
+        new SimpleActivatedAbility(new ExileTargetForSourceEffect(), new TapSourceCost());
+    ability.addTarget(new TargetCardInASingleGraveyard(0, 2, StaticFilters.FILTER_CARD_CARDS));
+    this.addAbility(ability);
+
+    // Unlicensed Hearse's power and toughness are each equal to the number of cards exiled with it.
+    this.addAbility(
+        new SimpleStaticAbility(
+                Zone.ALL,
+                new SetPowerToughnessSourceEffect(UnlicensedHearseValue.instance, Duration.Custom))
+            .addHint(hint));
+
+    // Crew 2
+    this.addAbility(new CrewAbility(2));
+  }
+
+  private UnlicensedHearse(final UnlicensedHearse card) {
+    super(card);
+  }
+
+  @Override
+  public UnlicensedHearse copy() {
+    return new UnlicensedHearse(this);
+  }
 }


### PR DESCRIPTION
# Purpose
When casting [Unlicensed Hearse](https://scryfall.com/card/snc/246/unlicensed-hearse), a null pointer exception is thrown and the action is rolled back. Here is the stack for the NPE this throws:
```
Game exception occurred: java.lang.NullPointerException
Server version: 1.4.50-V2 (build: runtime)
java.util.Objects.requireNonNull(Objects.java:203)
java.util.Optional.<init>(Optional.java:96)
java.util.Optional.of(Optional.java:108)
mage.cards.u.UnlicensedHearseValue.calculate(UnlicensedHearse.java:79)
mage.abilities.effects.common.continuous.SetPowerToughnessSourceEffect.apply(SetPowerToughnessSourceEffect.java:73)
mage.abilities.effects.ContinuousEffectImpl.apply(ContinuousEffectImpl.java:115)
mage.abilities.effects.ContinuousEffects.apply(ContinuousEffects.java:1140)
mage.game.GameState.applyEffects(GameState.java:660)
mage.game.GameImpl.applyEffects(GameImpl.java:1775)
mage.game.GameImpl.playPriority(GameImpl.java:1556)
mage.game.turn.Step.priority(Step.java:61)
mage.game.turn.Phase.playStep(Phase.java:184)
mage.game.turn.Phase.play(Phase.java:89)
mage.game.turn.Turn.play(Turn.java:132)
mage.game.GameImpl.playTurn(GameImpl.java:1070)
mage.game.GameImpl.play(GameImpl.java:980)
mage.game.GameImpl.start(GameImpl.java:956)
mage.server.game.GameWorker.call(GameWorker.java:34)
java.util.concurrent.FutureTask.run(FutureTask.java:266)
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
java.lang.Thread.run(Thread.java:750)
```

# Code Changes
This PR does the following:
- Fix Unlicensed Hearse by updating its `calculate` method to return `0` whenever it hasn't exiled any cards, rather than throwing an NPE
- Reformat UnlicensedHearse.java to match [Google's Java Style Guide](https://google.github.io/styleguide/javaguide.html)

# Test Plan
- Locally run server in test mode
- Locally run client, connect to server, begin match against bot
- Add the following test commands to `Mage.Server\config\init.txt`:
```
[bears in yard]
graveyard:Computer 2:Grizzly Bears:4

[1 Hearst]
battlefield:DeepCrimson:Unlicensed Hearse:1
```
- Click the smiley button and execute both of the aforementioned commands:
|Before|After|
| ----------- | ----------- |
|Putting an Unlicensed Hearse into play throws the NPE listed above|Unlicensed Hearse enters the battlefield as a 0/0 vehicle without issue. Exiling cards from graveyards with its activated ability increases its power and toughness as expected.|