### PR TITLE
Fixed issue with Elspeth Resplendent -3

### DIFF
--- a/Mage.Sets/src/mage/cards/e/ElspethResplendent.java
+++ b/Mage.Sets/src/mage/cards/e/ElspethResplendent.java
@@ -144,8 +144,9 @@ class ElspethResplendentLookEffect extends OneShotEffect {
                 permanent.addCounters(CounterType.SHIELD.createInstance(), source, game);
             }
         }
+        cards.remove(card);
         cards.retainZone(Zone.LIBRARY, game);
-        player.putCardsOnBottomOfLibrary(card, game, source, false);
+        player.putCardsOnBottomOfLibrary(cards, game, source, false);
         return true;
     }
 }


### PR DESCRIPTION
Previously was putting all 7 cards looked at onto the bottom of library regardless of whether or not a card was chosen to go to the battlefield (did not ungroup the card from the group of 7 before putting back in library); now chosen card goes to battlefield with shield counter. 
fixes #8981