### PR TITLE
[WIP] Add test for exiling from graveyard

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/activated/ExileFromGraveyardTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/activated/ExileFromGraveyardTest.java
@@ -1,0 +1,77 @@
+package org.mage.test.cards.abilities.activated;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author DeepCrimson
+ */
+public class ExileFromGraveyardTest extends CardTestPlayerBase {
+
+    /**
+     * Unlicensed Hearse - It can only exile cards from one graveyard per activation
+     */
+    @Test
+    public void testCannotExileFromTwoGraveyardsWithUnlicensedHearse() {
+        addCard(Zone.BATTLEFIELD, playerA, "Unlicensed Hearse");
+        addCard(Zone.GRAVEYARD, playerA, "Grizzly Bears");
+        addCard(Zone.GRAVEYARD, playerB, "Salt Flats");
+        setStrictChooseMode(true);
+        execute();
+
+//      Each graveyard has 1 card. Unlicensed Hearse hasn't exiled any cards, so it's a 0/0.
+        assertGraveyardCount(playerB, 1);
+        assertGraveyardCount(playerA, 1);
+        assertPowerToughness(playerA, "Unlicensed Hearse", 0, 0);
+
+        activateAbility(
+                1,
+                PhaseStep.PRECOMBAT_MAIN,
+                playerA,
+                "{T}: Exile up to two target cards from a single graveyard.",
+                new String[]{"Salt Flats", "Grizzly Bears"}
+        );
+//        try {
+        execute();
+        assertAllCommandsUsed();
+
+//            Assert.fail("must throw exception on execute");
+//        } catch (Throwable e) {
+//            if (!e.getMessage().contains("Player PlayerA must have 0 actions but found 1")) {
+//                Assert.fail("Expected error about PlayerA actions, but got:\n" + e.getMessage());
+//            }
+//        }
+
+
+        // Activation failed since tried to exile from two graveyards. Nothing has changed
+        // since earlier.
+        assertGraveyardCount(playerB, 1);
+        assertGraveyardCount(playerA, 1);
+        assertPowerToughness(playerA, "Unlicensed Hearse", 0, 0);
+    }
+
+    @Test
+    public void testExileFromOneGraveyardWithUnlicensedHearse() {
+        addCard(Zone.BATTLEFIELD, playerA, "Unlicensed Hearse");
+        addCard(Zone.GRAVEYARD, playerB, "Grizzly Bears");
+        addCard(Zone.GRAVEYARD, playerB, "Grizzly Bears");
+        setStrictChooseMode(true);
+        execute();
+
+        assertGraveyardCount(playerB, 2);
+        assertPowerToughness(playerA, "Unlicensed Hearse", 0, 0);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA,
+                "{T}: Exile up to two target cards from a single graveyard.",
+                new String[]{"Grizzly Bears", "Grizzly Bears"}
+        );
+
+        execute();
+        assertAllCommandsUsed();
+
+        assertGraveyardCount(playerB, 0);
+        assertPowerToughness(playerA, "Unlicensed Hearse", 2, 2);
+    }
+}

--- a/Mage/src/main/java/mage/target/TargetImpl.java
+++ b/Mage/src/main/java/mage/target/TargetImpl.java
@@ -13,6 +13,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.util.CardUtil;
 import mage.util.RandomUtil;
+import org.apache.log4j.Logger;
 
 import java.util.*;
 
@@ -20,6 +21,8 @@ import java.util.*;
  * @author BetaSteward_at_googlemail.com
  */
 public abstract class TargetImpl implements Target {
+
+    private static final Logger LOGGER = Logger.getLogger(TargetImpl.class);
 
     protected final Map<UUID, Integer> targets = new LinkedHashMap<>();
     protected final Map<UUID, Integer> zoneChangeCounters = new HashMap<>();
@@ -482,6 +485,8 @@ public abstract class TargetImpl implements Target {
 
     @Override
     public UUID getFirstTarget() {
+        LOGGER.warn("invoking TargetImpl->getFirstTarget()");
+        LOGGER.warn("targets: " + targets);
         if (!targets.isEmpty()) {
             return targets.keySet().iterator().next();
         }

--- a/Mage/src/main/java/mage/target/common/TargetCardInASingleGraveyard.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInASingleGraveyard.java
@@ -9,6 +9,7 @@ import mage.game.Game;
 import mage.game.events.TargetEvent;
 import mage.players.Player;
 import mage.target.TargetCard;
+import org.apache.log4j.Logger;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -18,6 +19,8 @@ import java.util.stream.Collectors;
  */
 
 public class TargetCardInASingleGraveyard extends TargetCard {
+
+    private static final Logger LOGGER = Logger.getLogger(TargetCardInASingleGraveyard.class);
 
     public TargetCardInASingleGraveyard(int minNumTargets, int maxNumTargets, FilterCard filter) {
         // workaround to add extra message to final ability text
@@ -30,12 +33,16 @@ public class TargetCardInASingleGraveyard extends TargetCard {
 
     @Override
     public boolean canTarget(UUID id, Ability source, Game game) {
+        LOGGER.warn("invoking TargetCardInASingleGraveyard->canTarget()");
+        LOGGER.warn("passed in id: " + id);
         UUID firstTarget = this.getFirstTarget();
+        LOGGER.warn("firstTarget: " + firstTarget);
 
         // If a card is already targeted, ensure that this new target has the same owner as currently chosen target
         if (firstTarget != null) {
             Card card = game.getCard(firstTarget);
             Card targetCard = game.getCard(id);
+            LOGGER.warn("are first target and current ID in the same graveyard: " + card.isOwnedBy(targetCard.getOwnerId()));
             if (card == null || targetCard == null || !card.isOwnedBy(targetCard.getOwnerId())) {
                 return false;
             }


### PR DESCRIPTION
Test confirms that [[Unlicensed Hearse]] can only exile from one graveyard per activation. Will add test for [[Night Soil]] bug [8771](https://github.com/magefree/mage/issues/8771) next.