### PR TITLE
Minsc & Boo -2 Ability target

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MinscBooTimelessHeroes.java
+++ b/Mage.Sets/src/mage/cards/m/MinscBooTimelessHeroes.java
@@ -28,6 +28,7 @@ import mage.game.permanent.Permanent;
 import mage.game.permanent.token.BooToken;
 import mage.players.Player;
 import mage.target.TargetPermanent;
+import mage.target.common.TargetAnyTarget;
 import mage.target.common.TargetControlledCreaturePermanent;
 
 import java.util.UUID;
@@ -125,6 +126,7 @@ class MinscBooTimelessHeroesEffect extends OneShotEffect {
         if (permanent.hasSubtype(SubType.HAMSTER, game)) {
             ability.addEffect(new DrawCardSourceControllerEffect(power));
         }
+        ability.addTarget(new TargetAnyTarget());
         game.fireReflexiveTriggeredAbility(ability, source);
         return true;
     }


### PR DESCRIPTION
Changed the -2 ability on Minsc and Boo by adding a target to the reflexive trigger.
fixes #8976