### PR TITLE
Refactor: Remove unused player param from additional constructor

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/GoadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/GoadTest.java
@@ -36,10 +36,10 @@ public class GoadTest extends CardTestMultiPlayerBase {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/damage/SatyrFiredancerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/damage/SatyrFiredancerTest.java
@@ -82,7 +82,7 @@ public class SatyrFiredancerTest extends CardTestPlayerBase {
 
     @Test
     public void testPriceOfProgressMultiplayer() throws GameException {
-        playerC = createPlayer(currentGame, playerC, "PlayerC");
+        playerC = createPlayer(currentGame, "PlayerC");
         addCard(Zone.BATTLEFIELD, playerA, "Satyr Firedancer", 1);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
         // Price of Progress deals damage to each player equal to twice the number of nonbasic lands that player controls.

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/other/NaturesWillTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/other/NaturesWillTest.java
@@ -17,9 +17,9 @@ public class NaturesWillTest extends CardTestPlayerBase {
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/other/StormTheVaultTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/other/StormTheVaultTest.java
@@ -17,9 +17,9 @@ public class StormTheVaultTest extends CardTestPlayerBase {
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/akh/RagsRichesTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/akh/RagsRichesTest.java
@@ -21,10 +21,10 @@ public class RagsRichesTest extends CardTestMultiPlayerBase {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.LEFT, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/c19/AeonEngineTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/c19/AeonEngineTest.java
@@ -9,9 +9,7 @@ import mage.game.FreeForAll;
 import mage.game.Game;
 import mage.game.GameException;
 import mage.game.mulligan.MulliganType;
-import mage.players.Player;
 import org.junit.Test;
-import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestMultiPlayerBase;
 
 /**
@@ -23,10 +21,10 @@ public class AeonEngineTest extends CardTestMultiPlayerBase {
     protected Game createNewGameAndPlayers() throws GameException {
         Game game = new FreeForAll(MultiplayerAttackOption.LEFT, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
     

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/eld/TorbranThaneOfRedFellTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/eld/TorbranThaneOfRedFellTest.java
@@ -76,7 +76,7 @@ public class TorbranThaneOfRedFellTest extends CardTestPlayerBase {
 
     @Test
     public void with3PlayersTest() throws GameException {
-        playerC = createPlayer(currentGame, playerC, "PlayerC");
+        playerC = createPlayer(currentGame, "PlayerC");
         setStrictChooseMode(true);
 
         // +1: Elementals you control get +2/+0 until end of turn.

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/hou/TormentOfHailfireTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/hou/TormentOfHailfireTest.java
@@ -25,10 +25,10 @@ public class TormentOfHailfireTest extends CardTestMultiPlayerBase {
         // Start Life = 2
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/m14/PyromancersGauntletTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/m14/PyromancersGauntletTest.java
@@ -79,7 +79,7 @@ public class PyromancersGauntletTest extends CardTestPlayerBase {
 
     @Test
     public void with3PlayersTest() throws GameException {
-        playerC = createPlayer(currentGame, playerC, "PlayerC");
+        playerC = createPlayer(currentGame, "PlayerC");
 
         setStrictChooseMode(true);
 

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/AngelOfSerenityTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/AngelOfSerenityTest.java
@@ -20,10 +20,10 @@ public class AngelOfSerenityTest extends CardTestMultiPlayerBase {
         // Start Life = 2
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 2);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/BlatantThieveryTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/BlatantThieveryTest.java
@@ -22,10 +22,10 @@ public class BlatantThieveryTest extends CardTestMultiPlayerBase {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/CreepingDreadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/CreepingDreadTest.java
@@ -27,10 +27,10 @@ public class CreepingDreadTest extends CardTestMultiPlayerBase {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/MultiplayerTriggerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/MultiplayerTriggerTest.java
@@ -19,10 +19,10 @@ public class MultiplayerTriggerTest extends CardTestMultiPlayerBase {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/MyriadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/MyriadTest.java
@@ -22,10 +22,10 @@ public class MyriadTest extends CardTestMultiPlayerBase {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerDiedStackTargetHandlingTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerDiedStackTargetHandlingTest.java
@@ -24,10 +24,10 @@ public class PlayerDiedStackTargetHandlingTest extends CardTestMultiPlayerBase {
         // Start Life = 2
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 3);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerLeftGameRange1Test.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerLeftGameRange1Test.java
@@ -26,10 +26,10 @@ public class PlayerLeftGameRange1Test extends CardTestMultiPlayerBase {
         // Start Life = 2
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 2);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerLeftGameRangeAllTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerLeftGameRangeAllTest.java
@@ -24,10 +24,10 @@ public class PlayerLeftGameRangeAllTest extends CardTestMultiPlayerBase {
         // Start Life = 2
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 2);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerWinsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerWinsTest.java
@@ -23,10 +23,10 @@ public class PlayerWinsTest extends CardTestMultiPlayerBase {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/PrivilegedPositionTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/PrivilegedPositionTest.java
@@ -24,10 +24,10 @@ public class PrivilegedPositionTest extends CardTestMultiPlayerBase {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/VindictiveLichTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/VindictiveLichTest.java
@@ -22,10 +22,10 @@ public class VindictiveLichTest extends CardTestMultiPlayerBase {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestCommander4Players.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestCommander4Players.java
@@ -19,10 +19,10 @@ public abstract class CardTestCommander4Players extends CardTestPlayerAPIImpl {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new CommanderFreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestMultiPlayerBase.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestMultiPlayerBase.java
@@ -23,10 +23,10 @@ public abstract class CardTestMultiPlayerBase extends CardTestPlayerAPIImpl {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.LEFT, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestMultiPlayerBaseWithRangeAll.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestMultiPlayerBaseWithRangeAll.java
@@ -19,10 +19,10 @@ public abstract class CardTestMultiPlayerBaseWithRangeAll extends CardTestPlayer
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(MultiplayerAttackOption.LEFT, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
         // Player order: A -> D -> C -> B
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
-        playerC = createPlayer(game, playerC, "PlayerC");
-        playerD = createPlayer(game, playerD, "PlayerD");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
+        playerC = createPlayer(game, "PlayerC");
+        playerD = createPlayer(game, "PlayerD");
         return game;
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestPlayerBaseAI.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestPlayerBaseAI.java
@@ -27,8 +27,8 @@ public abstract class CardTestPlayerBaseAI extends CardTestPlayerAPIImpl {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new TwoPlayerDuel(MultiplayerAttackOption.LEFT, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
 
-        playerA = createPlayer(game, playerA, "PlayerA");
-        playerB = createPlayer(game, playerB, "PlayerB");
+        playerA = createPlayer(game, "PlayerA");
+        playerB = createPlayer(game, "PlayerB");
         return game;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -252,7 +252,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
 
     abstract protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException;
 
-    protected TestPlayer createPlayer(Game game, TestPlayer player, String name) throws GameException {
+    protected TestPlayer createPlayer(Game game, String name) throws GameException {
         return createPlayer(game, name, "RB Aggro.dck");
     }
 


### PR DESCRIPTION
As titled, deleting unused `player` param from `Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java`'s `createPlayer` method.