### PR TITLE
Specific token image bug fixes

### DIFF
--- a/Mage/src/main/java/mage/game/command/emblems/ChandraAwakenedInfernoEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/ChandraAwakenedInfernoEmblem.java
@@ -18,7 +18,7 @@ public final class ChandraAwakenedInfernoEmblem extends Emblem {
 
     public ChandraAwakenedInfernoEmblem() {
         setName("Emblem Chandra");
-        setExpansionSetCodeForImage("M19");
+        setExpansionSetCodeForImage("M20");
         this.getAbilities().add(new BeginningOfUpkeepTriggeredAbility(
                 Zone.COMMAND, new DamageControllerEffect(1, "this emblem"),
                 TargetController.YOU, false, true

--- a/Mage/src/main/java/mage/game/command/emblems/MuYanlingSkyDancerEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/MuYanlingSkyDancerEmblem.java
@@ -23,6 +23,7 @@ public final class MuYanlingSkyDancerEmblem extends Emblem {
     // "Islands you control have '{T}: Draw a card'."
     public MuYanlingSkyDancerEmblem() {
         this.setName("Emblem Yanling");
+        this.setExpansionSetCodeForImage("M20");
         this.getAbilities().add(new SimpleStaticAbility(
                 Zone.COMMAND,
                 new GainAbilityControlledEffect(new SimpleActivatedAbility(

--- a/Mage/src/main/java/mage/game/permanent/token/TheLocustGodInsectToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/TheLocustGodInsectToken.java
@@ -5,6 +5,7 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.HasteAbility;
 import mage.constants.CardType;
 import mage.constants.SubType;
+import mage.util.RandomUtil;
 
 import java.util.Arrays;
 
@@ -25,6 +26,15 @@ public final class TheLocustGodInsectToken extends TokenImpl {
         addAbility(HasteAbility.getInstance());
 
         availableImageSetCodes = Arrays.asList("HOU", "C20");
+    }
+
+    @Override
+    public void setExpansionSetCodeForImage(String code) {
+        super.setExpansionSetCodeForImage(code);
+
+        if (getOriginalExpansionSetCode() != null && getOriginalExpansionSetCode().equals("C20")) {
+            this.setTokenType(2);
+        }
     }
 
     public TheLocustGodInsectToken(final TheLocustGodInsectToken token) {


### PR DESCRIPTION
Fixes "Chandra, Awakened Inferno"'s emblem image, "Mu Yanling, Sky Dancer"'s emblem image, and fixes C20's Locust God insects image. Card viewer bug described in issue below already fixed by me in a previous PR.

Closes #6701