### PR TITLE
Refactor: Remove redundant boxing/unboxing to parse int primitives

### DIFF
--- a/Mage.Client/src/main/java/mage/client/MageFrame.java
+++ b/Mage.Client/src/main/java/mage/client/MageFrame.java
@@ -1317,7 +1317,7 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
                     i++;
                 }
                 if (arg.startsWith(PORT_ARG)) {
-                    startPort = Integer.valueOf(args[i + 1]);
+                    startPort = Integer.parseInt(args[i + 1]);
                     i++;
                 }
                 if (arg.startsWith(DEBUG_ARG)) {

--- a/Mage.Client/src/main/java/mage/client/cards/DragCardGrid.java
+++ b/Mage.Client/src/main/java/mage/client/cards/DragCardGrid.java
@@ -673,7 +673,7 @@ public class DragCardGrid extends JPanel implements DragCardSource, DragCardTarg
                     s.separateCreatures = Boolean.valueOf(m.group(2));
                 }
                 if (m.groupCount() > 2) {
-                    s.cardSize = Integer.valueOf(m.group(3));
+                    s.cardSize = Integer.parseInt(m.group(3));
                 } else {
                     s.cardSize = 50;
                 }

--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
@@ -3361,7 +3361,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
             String port = getCachedValue(KEY_PROXY_PORT, "");
             if (!host.isEmpty() && !port.isEmpty()) {
                 connection.setProxyHost(host);
-                connection.setProxyPort(Integer.valueOf(port));
+                connection.setProxyPort(Integer.parseInt(port));
                 String username = getCachedValue(KEY_PROXY_USERNAME, "");
                 connection.setProxyUsername(username);
                 if (getCachedValue(KEY_PROXY_REMEMBER, "false").equals("true")) {
@@ -3620,7 +3620,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
 
     public static int getSelectedAvatar() {
         try {
-            selectedAvatarId = Integer.valueOf(MageFrame.getPreferences().get(KEY_AVATAR, String.valueOf(DEFAULT_AVATAR_ID)));
+            selectedAvatarId = Integer.parseInt(MageFrame.getPreferences().get(KEY_AVATAR, String.valueOf(DEFAULT_AVATAR_ID)));
         } catch (NumberFormatException n) {
             selectedAvatarId = DEFAULT_AVATAR_ID;
         } finally {

--- a/Mage.Client/src/main/java/mage/client/dialog/RegisterUserDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/RegisterUserDialog.java
@@ -199,7 +199,7 @@ public class RegisterUserDialog extends MageDialog {
         }
         connection = new Connection();
         connection.setHost(this.txtServer.getText().trim());
-        connection.setPort(Integer.valueOf(this.txtPort.getText().trim()));
+        connection.setPort(Integer.parseInt(this.txtPort.getText().trim()));
         connection.setUsername(this.txtUserName.getText().trim());
         connection.setPassword(String.valueOf(this.txtPassword.getPassword()).trim());
         connection.setEmail(this.txtEmail.getText().trim());

--- a/Mage.Client/src/main/java/mage/client/dialog/ResetPasswordDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/ResetPasswordDialog.java
@@ -258,7 +258,7 @@ public class ResetPasswordDialog extends MageDialog {
 
         connection = new Connection();
         connection.setHost(this.txtServer.getText().trim());
-        connection.setPort(Integer.valueOf(this.txtPort.getText().trim()));
+        connection.setPort(Integer.parseInt(this.txtPort.getText().trim()));
         PreferencesDialog.setProxyInformation(connection);
         connection.setEmail(this.txtEmail.getText().trim());
 
@@ -286,7 +286,7 @@ public class ResetPasswordDialog extends MageDialog {
 
         connection = new Connection();
         connection.setHost(this.txtServer.getText().trim());
-        connection.setPort(Integer.valueOf(this.txtPort.getText().trim()));
+        connection.setPort(Integer.parseInt(this.txtPort.getText().trim()));
         PreferencesDialog.setProxyInformation(connection);
         connection.setEmail(this.txtEmail.getText().trim());
         connection.setAuthToken(this.txtAuthToken.getText().trim());

--- a/Mage.Server.Console/src/main/java/mage/server/console/ConnectDialog.java
+++ b/Mage.Server.Console/src/main/java/mage/server/console/ConnectDialog.java
@@ -341,7 +341,7 @@ public class ConnectDialog extends JDialog {
             JOptionPane.showMessageDialog(rootPane, "Please provide a port number");
             return;
         }
-        if (Integer.valueOf(txtPort.getText()) < 1 || Integer.valueOf(txtPort.getText()) > 65535) {
+        if (Integer.parseInt(txtPort.getText()) < 1 || Integer.parseInt(txtPort.getText()) > 65535) {
             JOptionPane.showMessageDialog(rootPane, "Invalid port number");
             txtPort.setText(ConsoleFrame.getPreferences().get("serverPort", Integer.toString(17171)));
             return;
@@ -350,13 +350,13 @@ public class ConnectDialog extends JDialog {
         setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
         connection = new Connection();
         connection.setHost(this.txtServer.getText());
-        connection.setPort(Integer.valueOf(this.txtPort.getText()));
+        connection.setPort(Integer.parseInt(this.txtPort.getText()));
         connection.setAdminPassword(new String(txtPassword.getPassword()));
         connection.setUsername("Admin");
         connection.setProxyType((ProxyType) this.cbProxyType.getSelectedItem());
         if (!this.cbProxyType.getSelectedItem().equals(ProxyType.NONE)) {
             connection.setProxyHost(this.txtProxyServer.getText());
-            connection.setProxyPort(Integer.valueOf(this.txtProxyPort.getText()));
+            connection.setProxyPort(Integer.parseInt(this.txtProxyPort.getText()));
             connection.setProxyUsername(this.txtProxyUserName.getText());
             connection.setProxyPassword(new String(this.txtPasswordField.getPassword()));
         }

--- a/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/SimulatedPlayer2.java
+++ b/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/SimulatedPlayer2.java
@@ -348,7 +348,7 @@ public class SimulatedPlayer2 extends ComputerPlayer {
         Collections.sort(list, new Comparator<Combat>() {
             @Override
             public int compare(Combat o1, Combat o2) {
-                return Integer.valueOf(o2.getGroups().size()).compareTo(Integer.valueOf(o1.getGroups().size()));
+                return Integer.valueOf(o2.getGroups().size()).compareTo(o1.getGroups().size());
             }
         });
         return list;

--- a/Mage.Server.Plugins/Mage.Player.AIMCTS/src/mage/player/ai/MCTSNode.java
+++ b/Mage.Server.Plugins/Mage.Player.AIMCTS/src/mage/player/ai/MCTSNode.java
@@ -508,7 +508,7 @@ public class MCTSNode {
         int count = 0;
         while(playablesIterator.hasNext()) {
             String next = playablesIterator.next();
-            int cacheTurn = Integer.valueOf(next.split(":", 2)[0].substring(1));
+            int cacheTurn = Integer.parseInt(next.split(":", 2)[0].substring(1));
             if (cacheTurn < turnNum) {
                 playablesIterator.remove();
                 count++;
@@ -518,7 +518,7 @@ public class MCTSNode {
         Set<String> attacksKeys = attacksCache.keySet();
         Iterator<String> attacksIterator = attacksKeys.iterator();
         while(attacksIterator.hasNext()) {
-            int cacheTurn = Integer.valueOf(attacksIterator.next().split(":", 2)[0].substring(1));
+            int cacheTurn = Integer.parseInt(attacksIterator.next().split(":", 2)[0].substring(1));
             if (cacheTurn < turnNum) {
                 attacksIterator.remove();
                 count++;
@@ -528,7 +528,7 @@ public class MCTSNode {
         Set<String> blocksKeys = blocksCache.keySet();
         Iterator<String> blocksIterator = blocksKeys.iterator();
         while(blocksIterator.hasNext()) {
-            int cacheTurn = Integer.valueOf(blocksIterator.next().split(":", 2)[0].substring(1));
+            int cacheTurn = Integer.parseInt(blocksIterator.next().split(":", 2)[0].substring(1));
             if (cacheTurn < turnNum) {
                 blocksIterator.remove();
                 count++;

--- a/Mage.Sets/src/mage/cards/e/ElementalResonance.java
+++ b/Mage.Sets/src/mage/cards/e/ElementalResonance.java
@@ -118,7 +118,7 @@ class ElementalResonanceEffect extends OneShotEffect {
         Integer generic = 0;
         for (String str : Arrays.asList(manaString.replaceAll("[^-?0-9]+", " ").trim().split(" "))) {
             if (!str.equals("")) {
-                generic += Integer.valueOf(str);
+                generic += Integer.parseInt(str);
             }
         }
         out.setColorless(generic);

--- a/Mage.Sets/src/mage/cards/f/FirstComeFirstServed.java
+++ b/Mage.Sets/src/mage/cards/f/FirstComeFirstServed.java
@@ -69,6 +69,6 @@ class FirstComeFirstServedPredicate implements Predicate<Permanent> {
         String str = input.getCardNumber();
         Matcher matcher = Pattern.compile("\\d+").matcher(str);
         matcher.find();
-        return Integer.valueOf(matcher.group());
+        return Integer.parseInt(matcher.group());
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -256,7 +256,7 @@ public class TestPlayer implements Player {
         int index = 0;
         if (indexedMatcher.matches()) {
             filteredName = indexedMatcher.group(1);
-            index = Integer.valueOf(indexedMatcher.group(2));
+            index = Integer.parseInt(indexedMatcher.group(2));
         }
         filter.add(new NamePredicate(filteredName, true)); // must find any cards even without names
         List<Permanent> allPermanents = game.getBattlefield().getAllActivePermanents(filter, controllerID, game);

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -1616,7 +1616,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
         int count = 0;
         if (indexedMatcher.matches()) {
             cardName = indexedMatcher.group(1);
-            index = Integer.valueOf(indexedMatcher.group(2));
+            index = Integer.parseInt(indexedMatcher.group(2));
         }
         for (Permanent permanent : currentGame.getBattlefield().getAllActivePermanents()) {
             if (permanent.getName().equals(cardName)) {

--- a/Mage/src/main/java/mage/abilities/costs/mana/ManaCostsImpl.java
+++ b/Mage/src/main/java/mage/abilities/costs/mana/ManaCostsImpl.java
@@ -458,7 +458,7 @@ public class ManaCostsImpl<T extends ManaCost> extends ArrayList<T> implements M
             }
             if (symbol.length() == 1 || isNumeric(symbol)) {
                 if (Character.isDigit(symbol.charAt(0))) {
-                    this.add(new GenericManaCost(Integer.valueOf(symbol)));
+                    this.add(new GenericManaCost(Integer.parseInt(symbol)));
                 } else if (symbol.equals("S")) {
                     this.add(new SnowManaCost());
                 } else if (symbol.equals("C")) {


### PR DESCRIPTION
Using `Integer.valueOf()` produces an `Integer`, while `Integer.parseInt()` produces a primitive `int`. This PR replaces instances of `Integer.valueOf()` with `Integer.parseInt()` in places where only a primitive `int` is expected, removing unnecessary and unperformant integer boxing/unboxings.