### PR TITLE
Share the spoils fix

### DIFF
--- a/Mage.Sets/src/mage/cards/s/ShareTheSpoils.java
+++ b/Mage.Sets/src/mage/cards/s/ShareTheSpoils.java
@@ -28,17 +28,14 @@ import java.util.UUID;
 public final class ShareTheSpoils extends CardImpl {
 
     public ShareTheSpoils(UUID ownderId, CardSetInfo setInfo) {
-        super(ownderId, setInfo, new CardType[] { CardType.ENCHANTMENT }, "{1}{R}");
+        super(ownderId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{R}");
 
         // When Share the Spoils enters the battlefield or an opponent loses the game,
-        // exile the top card of each player’s library.exile the top card of each
-        // player’s library.
+        // exile the top card of each player’s library.exile the top card of each player’s library.
         this.addAbility(new ShareTheSpoilsExileETBAndPlayerLossAbility());
 
-        // During each player’s turn, that player may play a land or cast a spell from
-        // among cards exiled with Share the Spoils,
-        // and they may spend mana as though it were mana of any color to cast that
-        // spell.
+        // During each player’s turn, that player may play a land or cast a spell from among cards exiled with Share the Spoils,
+        // and they may spend mana as though it were mana of any color to cast that spell.
         Ability castAbility = new SimpleStaticAbility(new ShareTheSpoilsPlayExiledCardEffect());
         castAbility.setIdentifier(MageIdentifier.ShareTheSpoilsWatcher);
         this.addAbility(castAbility, new ShareTheSpoilsWatcher());
@@ -58,7 +55,7 @@ public final class ShareTheSpoils extends CardImpl {
     }
 }
 
-// -- Exile from Everyone --//
+//-- Exile from Everyone --//
 class ShareTheSpoilsExileETBAndPlayerLossAbility extends TriggeredAbilityImpl {
 
     ShareTheSpoilsExileETBAndPlayerLossAbility() {
@@ -73,7 +70,7 @@ class ShareTheSpoilsExileETBAndPlayerLossAbility extends TriggeredAbilityImpl {
     public boolean checkEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD ||
                 event.getType() == GameEvent.EventType.LOST || // Player conceedes
-                event.getType() == GameEvent.EventType.LOSES; // Player loses by all other means
+                event.getType() == GameEvent.EventType.LOSES;  // Player loses by all other means
     }
 
     @Override
@@ -133,7 +130,8 @@ class ShareTheSpoilsExileCardFromEveryoneEffect extends OneShotEffect {
                     game,
                     true,
                     CardUtil.getExileZoneId(game, source),
-                    CardUtil.getSourceName(game, source));
+                    CardUtil.getSourceName(game, source)
+            );
 
             if (moved) {
                 ShareTheSpoilsSpendAnyManaEffect effect = new ShareTheSpoilsSpendAnyManaEffect();
@@ -150,7 +148,7 @@ class ShareTheSpoilsExileCardFromEveryoneEffect extends OneShotEffect {
     }
 }
 
-// -- Play a card Exiled by Share the Spoils --//
+//-- Play a card Exiled by Share the Spoils --//
 class ShareTheSpoilsPlayExiledCardEffect extends AsThoughEffectImpl {
 
     ShareTheSpoilsPlayExiledCardEffect() {
@@ -180,8 +178,7 @@ class ShareTheSpoilsPlayExiledCardEffect extends AsThoughEffectImpl {
         // TODO: This is a workaround for #8706, remove when that's fixed.
         int zoneChangeCounter = game.getState().getZoneChangeCounter(source.getSourceId());
         // Not a card exiled with this Share the Spoils
-        ExileZone exileZone = game.getExile()
-                .getExileZone(CardUtil.getExileZoneId(game, source.getSourceId(), zoneChangeCounter));
+        ExileZone exileZone = game.getExile().getExileZone(CardUtil.getExileZoneId(game, source.getSourceId(), zoneChangeCounter));
         if (exileZone == null) {
             return false;
         }
@@ -208,7 +205,7 @@ class ShareTheSpoilsPlayExiledCardEffect extends AsThoughEffectImpl {
     }
 }
 
-// -- Spend mana as any color --//
+//-- Spend mana as any color --//
 class ShareTheSpoilsSpendAnyManaEffect extends AsThoughEffectImpl implements AsThoughManaEffect {
 
     ShareTheSpoilsSpendAnyManaEffect() {
@@ -257,14 +254,12 @@ class ShareTheSpoilsSpendAnyManaEffect extends AsThoughEffectImpl implements AsT
     }
 
     @Override
-    public ManaType getAsThoughManaType(ManaType manaType, ManaPoolItem mana, UUID affectedControllerId, Ability source,
-            Game game) {
+    public ManaType getAsThoughManaType(ManaType manaType, ManaPoolItem mana, UUID affectedControllerId, Ability source, Game game) {
         return mana.getFirstAvailable();
     }
 }
 
-// -- Exile another card when a card is played that was exiled with Share the
-// Spoils --//
+//-- Exile another card when a card is played that was exiled with Share the Spoils  --//
 class ShareTheSpoilsExileCardWhenPlayACardAbility extends TriggeredAbilityImpl {
 
     private UUID triggeringPlayerID;
@@ -343,7 +338,8 @@ class ShareTheSpoilsExileSingleCardEffect extends OneShotEffect {
                 game,
                 true,
                 CardUtil.getExileZoneId(game, source),
-                CardUtil.getSourceName(game, source));
+                CardUtil.getSourceName(game, source)
+        );
 
         if (moved) {
             ShareTheSpoilsSpendAnyManaEffect effect = new ShareTheSpoilsSpendAnyManaEffect();


### PR DESCRIPTION
Fixes #9046

I couldn't write tests for this case, as I couldn't figure out how to let test players that don't control Share the Spoils play cards from the pool. They don't seem to be getting the abilities properly.
