### PR TITLE
Removed unused JFX import for easier compilation in certain workspaces

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/znc/WhispersteelDaggerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/znc/WhispersteelDaggerTest.java
@@ -1,6 +1,5 @@
 package org.mage.test.cards.single.znc;
 
-import javafx.geometry.Pos;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Test;


### PR DESCRIPTION
This import isn't used, and JavaFX is a little bit annoying to include for some people's workspaces - and the rest of Mage.Test doesn't use JFX at all.