### PR TITLE
Refactor: Delete Unused `useWhiteDefault()` Test Method

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestAPIImpl.java
@@ -52,23 +52,6 @@ public abstract class CardTestAPIImpl extends MageTestBase implements CardTestAP
     }
 
     /**
-     * Default game initialization params for white player (that plays with Plains)
-     */
-    public void useWhiteDefault() {
-        // *** ComputerA ***
-        addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);
-        addCard(Zone.HAND, playerA, "Plains", 5);
-        removeAllCardsFromLibrary(playerA);
-        addCard(Zone.LIBRARY, playerA, "Plains", 10);
-
-        // *** ComputerB ***
-        addCard(Zone.BATTLEFIELD, playerB, "Plains", 2);
-        addCard(Zone.HAND, playerB, "Plains", 2);
-        removeAllCardsFromLibrary(playerB);
-        addCard(Zone.LIBRARY, playerB, "Plains", 10);
-    }
-
-    /**
      * Removes all cards from player's library from the game.
      * Usually this should be used once before initialization to form the library in certain order.
      *

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestAPIImpl.java
@@ -1,10 +1,10 @@
 package org.mage.test.serverside.base.impl;
 
-import mage.constants.PhaseStep;
 import mage.abilities.Ability;
 import mage.cards.Card;
 import mage.cards.repository.CardInfo;
 import mage.cards.repository.CardRepository;
+import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import mage.filter.Filter;
 import mage.game.permanent.Permanent;
@@ -186,9 +186,9 @@ public abstract class CardTestAPIImpl extends MageTestBase implements CardTestAP
     @Override
     public void setLife(TestPlayer player, int life) {
         if (player.equals(playerA)) {
-            commandsA.put(Zone.OUTSIDE, "life:" + String.valueOf(life));
+            commandsA.put(Zone.OUTSIDE, "life:" + life);
         } else if (player.equals(playerB)) {
-            commandsB.put(Zone.OUTSIDE, "life:" + String.valueOf(life));
+            commandsB.put(Zone.OUTSIDE, "life:" + life);
         }
     }
 
@@ -392,25 +392,25 @@ public abstract class CardTestAPIImpl extends MageTestBase implements CardTestAP
     }
 
     public void playLand(Player player, String cardName) {
-        player.addAction("play:"+cardName);
+        player.addAction("play:" + cardName);
     }
 
     public void castSpell(Player player, String cardName) {
-        player.addAction("cast:"+cardName);
+        player.addAction("cast:" + cardName);
     }
 
     public void addFixedTarget(Player player, String cardName, Player target) {
-        player.addAction("cast:"+cardName + ";name=" + target.getName());
+        player.addAction("cast:" + cardName + ";name=" + target.getName());
     }
 
     public void addFixedTarget(Player player, String cardName, String targetName) {
-        player.addAction("cast:"+cardName + ";name=" + targetName);
+        player.addAction("cast:" + cardName + ";name=" + targetName);
     }
 
     public void useAbility(Player player, String cardName) {
     }
 
     public void attack(Player player, String cardName) {
-        player.addAction("attack:"+cardName);
+        player.addAction("attack:" + cardName);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -52,23 +52,32 @@ import static org.junit.Assert.assertTrue;
  */
 public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implements CardTestAPI {
 
+    // DEBUG only, enable it to fast startup tests without database create (delete \db\ folder to force db recreate)
+    private static final boolean FAST_SCAN_WITHOUT_DATABASE_CREATE = false;
+
+    private static final boolean SHOW_EXECUTE_TIME_PER_TEST = false;
+
     public static final String ALIAS_PREFIX = "@"; // don't change -- it uses in user's tests
     public static final String CHECK_PARAM_DELIMETER = "#";
     public static final String CHECK_PREFIX = "check:"; // prefix for all check commands
     public static final String SHOW_PREFIX = "show:"; // prefix for all show commands
     public static final String AI_PREFIX = "ai:"; // prefix for all ai commands
     public static final String RUN_PREFIX = "run:"; // prefix for all run commands
+
     // prefix for activate commands
     // can be called with alias, example: @card_ref ability text
     public static final String ACTIVATE_ABILITY = "activate:";
     public static final String ACTIVATE_PLAY = "activate:Play ";
     public static final String ACTIVATE_CAST = "activate:Cast ";
     public static final String ACTIVATE_MANA = "manaActivate:";
+
     // commands for AI
     public static final String AI_COMMAND_PLAY_PRIORITY = "play priority";
     public static final String AI_COMMAND_PLAY_STEP = "play step";
+
     // commands for run
     public static final String RUN_COMMAND_CODE = "code";
+
     // TODO: add target player param to commands
     public static final String CHECK_COMMAND_PT = "PT";
     public static final String CHECK_COMMAND_DAMAGE = "DAMAGE";
@@ -93,6 +102,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     public static final String CHECK_COMMAND_PLAYER_IN_GAME = "PLAYER_IN_GAME";
     public static final String CHECK_COMMAND_STACK_SIZE = "STACK_SIZE";
     public static final String CHECK_COMMAND_STACK_OBJECT = "STACK_OBJECT";
+
     // TODO: add target player param to commands
     public static final String SHOW_COMMAND_LIBRARY = "LIBRARY";
     public static final String SHOW_COMMAND_HAND = "HAND";
@@ -104,11 +114,9 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     public static final String SHOW_COMMAND_AVAILABLE_MANA = "AVAILABLE_MANA";
     public static final String SHOW_COMMAND_ALIASES = "ALIASES";
     public static final String SHOW_COMMAND_STACK = "STACK";
+
     // TODO: add target player param to commands
     public static final String ALIAS_COMMAND_ADD = "ADD";
-    // DEBUG only, enable it to fast startup tests without database create (delete \db\ folder to force db recreate)
-    private static final boolean FAST_SCAN_WITHOUT_DATABASE_CREATE = false;
-    private static final boolean SHOW_EXECUTE_TIME_PER_TEST = false;
 
     static {
         // aliases can be used in check commands, so all prefixes and delimeters must be unique

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -176,24 +176,6 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     }
 
     /**
-     * Default game initialization params for white player (that plays with
-     * Plains)
-     */
-    public void useWhiteDefault() {
-        // *** ComputerA ***
-        addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);
-        addCard(Zone.HAND, playerA, "Plains", 5);
-        removeAllCardsFromLibrary(playerA);
-        addCard(Zone.LIBRARY, playerA, "Plains", 10);
-
-        // *** ComputerB ***
-        addCard(Zone.BATTLEFIELD, playerB, "Plains", 2);
-        addCard(Zone.HAND, playerB, "Plains", 2);
-        removeAllCardsFromLibrary(playerB);
-        addCard(Zone.LIBRARY, playerB, "Plains", 10);
-    }
-
-    /**
      * @throws GameException
      * @throws FileNotFoundException
      */


### PR DESCRIPTION
As titled, removing `useWhiteDefault()` test method from `CardTestAPIImpl.java` and `CardTestPlayerAPIImpl.java` since it has no usages.