### PR TITLE
[NCC] Lethal Scheme

### DIFF
--- a/Mage.Sets/src/mage/cards/l/LethalScheme.java
+++ b/Mage.Sets/src/mage/cards/l/LethalScheme.java
@@ -1,0 +1,176 @@
+package mage.cards.l;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import javafx.util.Pair;
+import mage.MageObjectReference;
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DestroyTargetEffect;
+import mage.abilities.effects.keyword.ConniveSourceEffect;
+import mage.abilities.keyword.ConvokeAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.choices.Choice;
+import mage.choices.ChoiceImpl;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.WatcherScope;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.game.stack.Spell;
+import mage.players.Player;
+import mage.target.common.TargetCreatureOrPlaneswalker;
+import mage.watchers.Watcher;
+
+/**
+ *
+ * @author Susucre
+ */
+public final class LethalScheme extends CardImpl {
+
+    public LethalScheme(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{B}{B}");
+
+        // Convoke
+        this.addAbility(new ConvokeAbility());
+
+        // Destroy target creature or planeswalker.
+        this.getSpellAbility().addEffect(new DestroyTargetEffect());
+        this.getSpellAbility().addTarget(new TargetCreatureOrPlaneswalker());
+        // Each creature that convoked Lethal Scheme connives.
+        this.getSpellAbility().addWatcher(new LethalSchemeWatcher());
+        this.getSpellAbility().addEffect(new LethalSchemeEffect());
+    }
+
+    private LethalScheme(final LethalScheme card) {
+        super(card);
+    }
+
+    @Override
+    public LethalScheme copy() {
+        return new LethalScheme(this);
+    }
+}
+
+// Based loosely on "Venerated Loxodon" and "Change of Plans"
+class LethalSchemeEffect extends OneShotEffect {
+
+    public LethalSchemeEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "Each creature that convoked Lethal Scheme connives.";
+    }
+
+    public LethalSchemeEffect(final LethalSchemeEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public LethalSchemeEffect copy() {
+        return new LethalSchemeEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        LethalSchemeWatcher watcher = game.getState().getWatcher(LethalSchemeWatcher.class);
+        if (watcher != null) {
+            MageObjectReference mor = new MageObjectReference(source.getSourceId(), game);
+            Set<MageObjectReference> creatures = watcher.getConvokingCreatures(mor);
+            if (creatures != null) {
+                Set<Pair<UUID,Permanent>> playerPermanentsPairs =
+                    creatures
+                        .stream()
+                        .map(creatureMOR -> creatureMOR.getPermanentOrLKIBattlefield(game))
+                        .filter(Objects::nonNull)
+                        .map(permanent -> new Pair<>(permanent.getControllerId(),permanent))
+                        .collect(Collectors.toSet());
+
+                Map<Player, Set<Permanent>> permanentsPerPlayer = new HashMap<>();
+
+                playerPermanentsPairs.forEach(pair -> {
+                    Player player = game.getPlayer(pair.getKey());
+                    if(!permanentsPerPlayer.containsKey(player)){
+                        permanentsPerPlayer.put(player, new HashSet<>());
+                    }
+                    permanentsPerPlayer.get(player).add(pair.getValue());
+                });
+
+                if (playerPermanentsPairs.isEmpty()) {
+                    return false;
+                }
+
+                for (Player player : game
+                    .getState()
+                    .getPlayersInRange(source.getControllerId(), game)
+                    .stream()
+                    .map(game::getPlayer)
+                    .filter(Objects::nonNull)
+                    .filter(player -> permanentsPerPlayer.containsKey(player))
+                    .collect(Collectors.toList())) {
+
+                    Set<Permanent> permanents = permanentsPerPlayer.get(player);
+
+                    while (permanents.size() > 0) {
+                        Choice choiceForThisLoop = new ChoiceImpl(true);
+                        choiceForThisLoop.setMessage("Choose next connive to resolve.");
+
+                        permanents.stream()
+                                .forEach(permanent -> choiceForThisLoop.getChoices().add(permanent.getIdName()));
+
+                        player.choose(Outcome.Neutral, choiceForThisLoop, game);
+
+                        String choice = choiceForThisLoop.getChoice();
+                        Permanent choicePermanent = permanents.stream().filter(permanent -> permanent.getIdName().equals(choice)).findFirst().get();
+
+                        ConniveSourceEffect.connive(choicePermanent, 1, source, game);
+                        permanents.remove(choicePermanent);
+                    }
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}
+
+// Based on "Venerated Loxodon"
+class LethalSchemeWatcher extends Watcher {
+
+    private final Map<MageObjectReference, Set<MageObjectReference>> convokingCreatures = new HashMap<>();
+
+    public LethalSchemeWatcher() {
+        super(WatcherScope.GAME);
+    }
+
+    @Override
+    public void watch(GameEvent event, Game game) {
+        if (event.getType() == GameEvent.EventType.CONVOKED) {
+            Spell spell = game.getSpell(event.getSourceId());
+            Permanent tappedCreature = game.getPermanentOrLKIBattlefield(event.getTargetId());
+            if (spell != null && tappedCreature != null) {
+                MageObjectReference convokedSpell = new MageObjectReference(spell.getSourceId(), game);
+                Set<MageObjectReference> creatures;
+                if (convokingCreatures.containsKey(convokedSpell)) {
+                    creatures = convokingCreatures.get(convokedSpell);
+                } else {
+                    creatures = new HashSet<>();
+                    convokingCreatures.put(convokedSpell, creatures);
+                }
+                creatures.add(new MageObjectReference(tappedCreature, game));
+            }
+        }
+    }
+
+    public Set<MageObjectReference> getConvokingCreatures(MageObjectReference mor) {
+        return convokingCreatures.get(mor);
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        convokingCreatures.clear();
+    }
+
+}

--- a/Mage.Sets/src/mage/sets/NewCapennaCommander.java
+++ b/Mage.Sets/src/mage/sets/NewCapennaCommander.java
@@ -177,6 +177,8 @@ public final class NewCapennaCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Kodama's Reach", 298, Rarity.COMMON, mage.cards.k.KodamasReach.class));
         cards.add(new SetCardInfo("Kresh the Bloodbraided", 345, Rarity.MYTHIC, mage.cards.k.KreshTheBloodbraided.class));
         cards.add(new SetCardInfo("Leafkin Druid", 299, Rarity.COMMON, mage.cards.l.LeafkinDruid.class));
+        cards.add(new SetCardInfo("Lethal Scheme", 36, Rarity.RARE, mage.cards.l.LethalScheme.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Lethal Scheme", 137, Rarity.RARE, mage.cards.l.LethalScheme.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Life Insurance", 74, Rarity.RARE, mage.cards.l.LifeInsurance.class));
         cards.add(new SetCardInfo("Life of the Party", 48, Rarity.RARE, mage.cards.l.LifeOfTheParty.class));
         cards.add(new SetCardInfo("Life's Legacy", 300, Rarity.RARE, mage.cards.l.LifesLegacy.class));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ncc/LethalSchemeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ncc/LethalSchemeTest.java
@@ -1,0 +1,496 @@
+package org.mage.test.cards.single.ncc;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.game.permanent.Permanent;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author Susucre
+ */
+public class LethalSchemeTest extends CardTestPlayerBase {
+
+    /*
+     * Lethal Scheme {2}{B}{B}
+     * Instant
+     *
+     * Convoke
+     * Destroy target creature or planeswalker. Each creature that convoked Lethal Scheme connives.
+     */
+    private String scheme = "Lethal Scheme";
+
+    private String vanguard = "Elite Vanguard"; // vanilla 2/1
+    private String bear = "Grizzly Bears"; // vanilla 2/2
+    private String ogre = "Gray Ogre"; // vanilla 2/2
+    private String mino = "Felhide Minotaur"; // vanilla 2/3
+
+    private String blade = "Doom Blade"; // instant {1}{B} destroy target non-black creature.
+    /*
+     * Act of Aggression {3}{R/P}{R/P}
+     * Instant
+     *
+     * Gain control of target creature an opponent controls until end of turn.
+     * Untap that creature. It gains haste until end of turn.
+     */
+    private String aggression = "Act of Aggression";
+
+    private String swamp = "Swamp";
+    private String island = "Island";
+    private String mountain = "Mountain";
+
+    @Test
+    public void LethalSchemeNoConvoke() {
+        addCard(Zone.HAND, playerA, scheme, 1);
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 4);
+        addCard(Zone.BATTLEFIELD, playerB, vanguard, 1);
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {B}", 4);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, scheme, vanguard);
+        setChoice(playerA, "Black"); // pay 1
+        setChoice(playerA, "Black"); // pay 2
+        setChoice(playerA, "Black"); // pay 3
+        setChoice(playerA, "Black"); // pay 4
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerB, 0);
+        assertGraveyardCount(playerA, 1);
+    }
+
+    @Test
+    public void LethalSchemeConvokeOneConniveLandFromHand() {
+        addCard(Zone.HAND, playerA, scheme, 1);
+        addCard(Zone.HAND, playerA, mountain,1);
+        removeAllCardsFromLibrary(playerA);
+        addCard(Zone.LIBRARY, playerA, island,1);
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 4);
+        addCard(Zone.BATTLEFIELD, playerA, bear, 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, vanguard, 1);
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+        Permanent pBear = getPermanent(bear, playerA);
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        setStrictChooseMode(true);
+
+        activateManaAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{T}: Add {B}", 4);
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, scheme, vanguard);
+        setChoice(playerA, "Black"); // pay 1
+        setChoice(playerA, "Black"); // pay 2
+        setChoice(playerA, "Black"); // pay 3
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, bear); // pay 4 as convoke
+
+        // Choose to discard the Island for the "Grizzly Bears" connive choice.
+        setChoice(playerA, pBear.getIdName());
+        setChoice(playerA, island);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerB, 0);
+        assertHandCount(playerA, 1);
+
+        assertGraveyardCount(playerA, 2);
+        assertGraveyardCount(playerA, island, 1);
+        assertHandCount(playerA, island, 0);
+        assertGraveyardCount(playerA, mountain, 0);
+        assertHandCount(playerA, mountain, 1);
+
+        assertPowerToughness(playerA, bear, 2, 2);
+    }
+
+    @Test
+    public void LethalSchemeConvokeOneConniveLandFromLib() {
+        addCard(Zone.HAND, playerA, scheme, 1);
+        addCard(Zone.HAND, playerA, mountain,1);
+        removeAllCardsFromLibrary(playerA);
+        addCard(Zone.LIBRARY, playerA, island);
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 4);
+        addCard(Zone.BATTLEFIELD, playerA, bear, 1, true);
+
+        addCard(Zone.BATTLEFIELD, playerB, vanguard, 1);
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+        Permanent pBear = getPermanent("Grizzly Bears", playerA);
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        setStrictChooseMode(true);
+
+        activateManaAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{T}: Add {B}", 4);
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, scheme, vanguard);
+        setChoice(playerA, "Black"); // pay 1
+        setChoice(playerA, "Black"); // pay 2
+        setChoice(playerA, "Black"); // pay 3
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, bear); // pay 4 as convoke
+
+        // Choose to discard the Mountain for the "Grizzly Bears" connive choice.
+        setChoice(playerA, pBear.getIdName());
+        setChoice(playerA, mountain);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerB, 0);
+
+        assertHandCount(playerA, 1);
+        assertGraveyardCount(playerA, 2);
+        assertGraveyardCount(playerA, island, 0);
+        assertHandCount(playerA, island, 1);
+        assertGraveyardCount(playerA, mountain, 1);
+        assertHandCount(playerA, mountain, 0);
+        assertPowerToughness(playerA, bear, 2, 2);
+    }
+
+
+    @Test
+    public void LethalSchemeConvokeOneConniveNonLandFromHand() {
+        addCard(Zone.HAND, playerA, scheme, 1);
+        addCard(Zone.HAND, playerA, ogre,1);
+        removeAllCardsFromLibrary(playerA);
+        addCard(Zone.LIBRARY, playerA, mino,1);
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 4);
+        addCard(Zone.BATTLEFIELD, playerA, bear, 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, vanguard, 1); // unfortunate target.
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+        Permanent pBear = getPermanent(bear, playerA);
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        setStrictChooseMode(true);
+
+        activateManaAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{T}: Add {B}", 4);
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, scheme, vanguard);
+        setChoice(playerA, "Black"); // pay 1
+        setChoice(playerA, "Black"); // pay 2
+        setChoice(playerA, "Black"); // pay 3
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, bear); // pay 4 as convoke
+
+        // Choose to discard the "Gray Ogre" for the "Grizzly Bears" connive choice.
+        setChoice(playerA, pBear.getIdName());
+        setChoice(playerA, ogre);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerB, 0);
+
+        assertHandCount(playerA, 1);
+        assertGraveyardCount(playerA, 2);
+        assertGraveyardCount(playerA, ogre, 1);
+        assertHandCount(playerA, ogre, 0);
+        assertGraveyardCount(playerA, mino, 0);
+        assertHandCount(playerA, mino, 1);
+        assertPowerToughness(playerA,bear, 3, 3);
+    }
+
+    @Test
+    public void LethalSchemeConvokeOneConniveNonLandFromLib() {
+        addCard(Zone.HAND, playerA, scheme, 1);
+        addCard(Zone.HAND, playerA, ogre,1);
+        removeAllCardsFromLibrary(playerA);
+        addCard(Zone.LIBRARY, playerA, mino,1);
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 4);
+        addCard(Zone.BATTLEFIELD, playerA, bear, 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, vanguard, 1);
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+        Permanent pBear = getPermanent(bear, playerA);
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        setStrictChooseMode(true);
+
+        activateManaAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{T}: Add {B}", 4);
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, scheme, vanguard);
+        setChoice(playerA, "Black"); // pay 1
+        setChoice(playerA, "Black"); // pay 2
+        setChoice(playerA, "Black"); // pay 3
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, bear); // pay 4 as convoke
+
+        // Choose to discard the "Felhide Minotaur" for the "Grizzly Bears" connive choice.
+        setChoice(playerA, pBear.getIdName());
+        setChoice(playerA, mino);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerB, 0);
+
+        assertHandCount(playerA, 1);
+        assertGraveyardCount(playerA, 2);
+        assertGraveyardCount(playerA, ogre, 0);
+        assertHandCount(playerA, ogre, 1);
+        assertGraveyardCount(playerA, mino, 1);
+        assertHandCount(playerA, mino, 0);
+        assertPowerToughness(playerA, bear, 3, 3);
+    }
+
+    @Test
+    public void LethalSchemeConvokeTwoConniveMixed() {
+        addCard(Zone.HAND, playerA, scheme, 1);
+        addCard(Zone.HAND, playerA, ogre,1);
+        removeAllCardsFromLibrary(playerA);
+        addCard(Zone.LIBRARY, playerA, blade,1);
+        addCard(Zone.LIBRARY, playerA, island,1);
+
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 4);
+        addCard(Zone.BATTLEFIELD, playerA, bear, 1);
+        addCard(Zone.BATTLEFIELD, playerA, mino, 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, vanguard, 1); // unfortunate target.
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+        Permanent pBear = getPermanent(bear, playerA);
+        Permanent pMino = getPermanent(mino, playerA);
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        setStrictChooseMode(true);
+
+        activateManaAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{T}: Add {B}", 4);
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, scheme, vanguard);
+        setChoice(playerA, "Black"); // pay 1
+        setChoice(playerA, "Black"); // pay 2
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, bear); // pay 3 as convoke
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, mino); // pay 4 as convoke
+
+        // Choose to discard the "Gray Ogre" for the "Grizzly Bears" connive choice.
+        setChoice(playerA, pBear.getIdName());
+        setChoice(playerA, ogre);
+        // Choose to discard the "Island" for the "Felhide Minotaur" connive choice.
+        setChoice(playerA, pMino.getIdName());
+        setChoice(playerA, island);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerB, 0);
+
+        assertHandCount(playerA, 1);
+        assertGraveyardCount(playerA, 3);
+        assertGraveyardCount(playerA, ogre, 1);
+        assertHandCount(playerA, ogre, 0);
+        assertGraveyardCount(playerA, blade, 0);
+        assertHandCount(playerA, blade, 1);
+        assertGraveyardCount(playerA, island, 1);
+        assertHandCount(playerA, island, 0);
+
+        assertPowerToughness(playerA, bear, 3, 3);
+        assertPowerToughness(playerA, mino, 2, 3);
+    }
+
+    @Test
+    public void LethalSchemeConvokeTwoConniveMixedOtherOrder() {
+        addCard(Zone.HAND, playerA, scheme, 1);
+        addCard(Zone.HAND, playerA, ogre,1);
+        removeAllCardsFromLibrary(playerA);
+        addCard(Zone.LIBRARY, playerA, blade,1);
+        addCard(Zone.LIBRARY, playerA, island,1);
+
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 4);
+        addCard(Zone.BATTLEFIELD, playerA, bear, 1);
+        addCard(Zone.BATTLEFIELD, playerA, mino, 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, vanguard, 1);
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+        Permanent pBear = getPermanent(bear, playerA);
+        Permanent pMino = getPermanent(mino, playerA);
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        setStrictChooseMode(true);
+
+        activateManaAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{T}: Add {B}", 4);
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, scheme, vanguard);
+        setChoice(playerA, "Black"); // pay 1
+        setChoice(playerA, "Black"); // pay 2
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, bear); // pay 3 as convoke
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, mino); // pay 4 as convoke
+
+        // Choose to discard the "Gray Ogre" for the "Felhide Minotaur" connive choice.
+        setChoice(playerA, pMino.getIdName());
+        setChoice(playerA, ogre);
+        // Choose to discard the "Island" for the "Grizzly Bears" connive choice.
+        setChoice(playerA, pBear.getIdName());
+        setChoice(playerA, island);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertPermanentCount(playerB, 0);
+
+        assertHandCount(playerA, 1);
+        assertGraveyardCount(playerA, 3);
+        assertGraveyardCount(playerA, ogre, 1);
+        assertHandCount(playerA, ogre, 0);
+        assertGraveyardCount(playerA, blade, 0);
+        assertHandCount(playerA, blade, 1);
+        assertGraveyardCount(playerA, island, 1);
+        assertHandCount(playerA, island, 0);
+
+        assertPowerToughness(playerA, bear, 2, 2);
+        assertPowerToughness(playerA, mino, 3, 4);
+    }
+
+    /**
+     * This test's purpose is to check the behavior if the control
+     * of one of the convoking creature change between the cast
+     * and the resolve of "Lethal Scheme".
+     *
+     * It is assumed that the correct behavior is for each player
+     * in APNAP order, to connive for each of their controlled
+     * creatures.
+     */
+    @Test
+    public void LethalSchemeConvokeTwoWithControlChange() {
+        addCard(Zone.HAND, playerA, scheme, 1);
+        addCard(Zone.HAND, playerA, island, 1);
+        addCard(Zone.HAND, playerB, aggression, 1);
+        addCard(Zone.HAND, playerB, island, 1);
+
+        removeAllCardsFromLibrary(playerA);
+        removeAllCardsFromLibrary(playerB);
+        addCard(Zone.LIBRARY, playerA, blade,1);
+        addCard(Zone.LIBRARY, playerB, island,1);
+
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 4);
+        addCard(Zone.BATTLEFIELD, playerA, bear, 1);
+        addCard(Zone.BATTLEFIELD, playerA, mino, 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, mountain, 5);
+        addCard(Zone.BATTLEFIELD, playerB, vanguard, 1);
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+        Permanent pBear = getPermanent(bear);
+        Permanent pMino = getPermanent(mino, playerA);
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        setStrictChooseMode(true);
+
+        activateManaAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{T}: Add {B}", 4);
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, scheme, vanguard);
+        setChoice(playerA, "Black"); // pay 1
+        setChoice(playerA, "Black"); // pay 2
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, bear); // pay 3 as convoke
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, mino); // pay 4 as convoke
+
+        // player B takes control of the "Grizzly Bears" in response
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerB, aggression, bear, scheme, StackClause.WHILE_ON_STACK);
+        setChoice(playerB, false); // not paying phyrexian mana
+        setChoice(playerB, false); // not paying phyrexian mana
+
+        // Player A choose to discard the "Doom Blade" for the "Felhide Minotaur" connive choice.
+        setChoice(playerA, pMino.getIdName());
+        setChoice(playerA, blade);
+        // Player B choose to discard the "Island" for the "Grizzly Bears" connive choice.
+        setChoice(playerB, pBear.getIdName());
+        setChoice(playerB, island);
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertGraveyardCount(playerA, 2); // Lethal Scheme + Doom Blade
+        assertGraveyardCount(playerB, 3); // Act of Aggression + Elite Vanguard + Island
+
+        assertGraveyardCount(playerA, blade, 1);
+        assertGraveyardCount(playerB, island, 1);
+
+        assertPowerToughness(playerB, bear, 2, 2);
+        assertPowerToughness(playerA, mino, 3, 4);
+    }
+
+
+    /**
+     * This test's purpose is to check the behavior a convoking creature
+     * leaves the battlefield before "Lethal Scheme"'s resolution.
+     *
+     * The player last controlling the creature should still be able to connive.
+     */
+    @Test
+    public void LethalSchemeConvokeOneThatGetsKilled() {
+        addCard(Zone.HAND, playerA, scheme, 1);
+        addCard(Zone.HAND, playerA, island, 1);
+        addCard(Zone.HAND, playerB, blade, 1);
+
+        removeAllCardsFromLibrary(playerA);
+        removeAllCardsFromLibrary(playerB);
+        addCard(Zone.LIBRARY, playerA, ogre,1);
+
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 4);
+        addCard(Zone.BATTLEFIELD, playerA, bear, 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, swamp, 2);
+        addCard(Zone.BATTLEFIELD, playerB, vanguard, 1);
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+        Permanent pBear = getPermanent(bear, playerA);
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        setStrictChooseMode(true);
+
+        activateManaAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{T}: Add {B}", 4);
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, scheme, vanguard);
+        setChoice(playerA, "Black"); // pay 1
+        setChoice(playerA, "Black"); // pay 2
+        setChoice(playerA, "Black"); // pay 3
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, bear); // pay 4 as convoke
+
+        // player B destroys the "Grizzly Bears" in response
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerB, blade, bear, scheme, StackClause.WHILE_ON_STACK);
+
+        // Player A choose to discard the "Gray Ogre" for the "Grizzly Bears" connive choice.
+        setChoice(playerA, pBear.getIdName());
+        setChoice(playerA, ogre);
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+        assertAllCommandsUsed();
+
+        assertGraveyardCount(playerA, 3); // Grizzly Bears + Lethal Scheme + Gray Ogre
+
+        assertGraveyardCount(playerA, ogre, 1);
+        assertGraveyardCount(playerA, bear, 1);
+    }
+}


### PR DESCRIPTION
Implementation of [[Lethal Scheme]] from New Capenna Commander.

Resolving multiple connive in the effect "Each creature that convoked Lethal Scheme connives." has multiple tricky subtillty, hopefully properly handled in this branch. The current [[Change of Plans]] implementation is not correct on those points.

1. Conniving multiple creatures is resolved as a series of choices for which permanent does connive, then the conniving for that permanent, and multiple players may be involved (e.g. if one of the convoking creature did change controller between cast and resolution):
> 701.47d If multiple permanents are instructed to connive at the same time, the first player in APNAP order who controls one or more of those permanents chooses one of them and it connives. Then if any permanents remain on the battlefield which have been instructed to connive and have not done so, this process is repeated.

2. Conniving creatures that have left the battlefield at resolve time still connive for their LKI controller.
> 701.47c If a permanent changes zones before an effect causes it to connive, its last known information is used to determine which object connived and who controlled it.