### PR TITLE
Test method `addCard` can accept card class rather than string to find and add card

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/snc/UnlicensedHearseTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/snc/UnlicensedHearseTest.java
@@ -1,5 +1,8 @@
 package org.mage.test.cards.single.snc;
 
+import mage.cards.f.ForestBear;
+import mage.cards.g.GrizzlyBears;
+import mage.cards.u.UnlicensedHearse;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Before;
@@ -25,9 +28,9 @@ public class UnlicensedHearseTest extends CardTestPlayerBase {
      */
     @Before
     public void createHearseAndFillGraveyard() {
-        addCard(Zone.BATTLEFIELD, playerA, "Unlicensed Hearse");
-        addCard(Zone.GRAVEYARD, playerB, "Grizzly Bears");
-        addCard(Zone.GRAVEYARD, playerB, "Forest Bear");
+        addCard(Zone.BATTLEFIELD, playerA, UnlicensedHearse.class);
+        addCard(Zone.GRAVEYARD, playerB, GrizzlyBears.class);
+        addCard(Zone.GRAVEYARD, playerB, ForestBear.class);
     }
 
     /**

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestAPI.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestAPI.java
@@ -2,6 +2,7 @@ package org.mage.test.serverside.base;
 
 import java.util.List;
 import mage.abilities.Ability;
+import mage.cards.Card;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import mage.filter.Filter;
@@ -59,6 +60,8 @@ public interface CardTestAPI {
      * @param count Amount of cards to be added.
      */
     void addCard(Zone gameZone, TestPlayer player, String cardName, int count);
+
+    void addCard(Zone gameZone, TestPlayer player, Class<? extends Card> cardClass);
 
     /**
      * Add any amount of cards to specified zone of specified player.

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -671,6 +671,35 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     }
 
     /**
+     * Add a specified card for the specified player in the specified zone.
+     *
+     * @param gameZone {@link mage.constants.Zone} The game zone to which
+     *                                            the card will be added.
+     * @param player {@link Player} The player for whom the card will be added.
+     * @param cardClass {@link Card} The class of the card which will be added.
+     */
+    public void addCard(Zone gameZone, TestPlayer player, Class<? extends Card> cardClass) {
+        Optional<CardInfo> cardInfo = CardRepository.instance.findCardsByClass(
+                cardClass.getCanonicalName()).stream().findFirst();
+        if (!cardInfo.isPresent()) {
+            throw new RuntimeException(String.format(
+                    "Card Info not found for card %s.",
+                    cardClass.getCanonicalName()
+            ));
+        }
+        Card cardToAdd = cardInfo.get().getCard();
+
+        if (gameZone == Zone.BATTLEFIELD) {
+            cardToAdd = CardUtil.getDefaultCardSideForBattlefield(currentGame, cardToAdd);
+            PermanentCard permanentCard = new PermanentCard(cardToAdd, player.getId(), currentGame);
+            getBattlefieldCards(player).add(permanentCard);
+        } else {
+            List<Card> cards = getCardList(gameZone, player);
+            cards.add(cardToAdd);
+        }
+    }
+
+    /**
      * Add any amount of cards to specified zone of specified player.
      *
      * @param gameZone {@link mage.constants.Zone} to add cards to.


### PR DESCRIPTION
# What's Changed
This PR adds a new overloaded implementation of the test method [`addCard()`](https://github.com/magefree/mage/blob/master/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java#L687) in CardTestPlayerAPIImpl.java. This new `addCard()` method accepts a `Card` class rather than a `String` to determine which card is being added.

# Why This Change
Adding cards via passing the card's class is less error-prone than passing a string of the card name. If an invalid card class is being passed to the method (eg a class which doesn't extend `Card`), this error will be recognized at compile-time, before running the test. On the other hand, an invalid string being passed isn't recognized as an error until the test is ran.

Another small benefit of this change is that it provides an easy way to inspect the implementation of each card being added (just ⌘ + click on the card's class name). When adding cards via string, you need to search for the card's class name to see how it's implemented.

# How This Change was Tested
Used the new `addCard()` method in [UnlicensedHearseTest.java](https://github.com/magefree/mage/blob/master/Mage.Tests/src/test/java/org/mage/test/cards/single/snc/UnlicensedHearseTest.java) and confirmed that its test cases still run and pass the same as before.