### PR TITLE
Refactor: Remove unused `sourceID` param from `contains` method

### DIFF
--- a/Mage.Sets/src/mage/cards/a/ArcticFoxes.java
+++ b/Mage.Sets/src/mage/cards/a/ArcticFoxes.java
@@ -68,6 +68,6 @@ enum ArcticFoxesCondition implements Condition {
         if (defenderId == null) {
             return false;
         }
-        return game.getBattlefield().contains(filter, source.getSourceId(), defenderId, source, game, 1);
+        return game.getBattlefield().contains(filter, defenderId, source, game, 1);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CityInABottle.java
+++ b/Mage.Sets/src/mage/cards/c/CityInABottle.java
@@ -158,7 +158,7 @@ class CityInABottleStateTriggeredAbility extends StateTriggeredAbility {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        return game.getBattlefield().contains(filter, this.getSourceId(), this.getControllerId(), this, game, 1);
+        return game.getBattlefield().contains(filter, this.getControllerId(), this, game, 1);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/c/CullingScales.java
+++ b/Mage.Sets/src/mage/cards/c/CullingScales.java
@@ -58,7 +58,7 @@ class HasLowestCMCAmongstNonlandPermanentsPredicate implements ObjectSourcePlaye
     public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
         FilterPermanent filter = new FilterNonlandPermanent();
         filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, input.getObject().getManaValue()));
-        return !game.getBattlefield().contains(filter, input.getSourceId(), input.getPlayerId(), input.getSource(), game, 1);
+        return !game.getBattlefield().contains(filter, input.getPlayerId(), input.getSource(), game, 1);
     }
 
 }

--- a/Mage.Sets/src/mage/cards/h/HeraldOfLeshrac.java
+++ b/Mage.Sets/src/mage/cards/h/HeraldOfLeshrac.java
@@ -101,7 +101,7 @@ class HeraldOfLeshracCumulativeCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return game.getBattlefield().contains(filter, source.getSourceId(), controllerId, source, game, 1);
+        return game.getBattlefield().contains(filter, controllerId, source, game, 1);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/s/Seasinger.java
+++ b/Mage.Sets/src/mage/cards/s/Seasinger.java
@@ -81,6 +81,6 @@ enum SeasingerPredicate implements ObjectSourcePlayerPredicate<Permanent> {
 
     @Override
     public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
-        return game.getBattlefield().contains(filter, input.getSourceId(), input.getObject().getControllerId(), input.getSource(), game, 1);
+        return game.getBattlefield().contains(filter, input.getObject().getControllerId(), input.getSource(), game, 1);
     }
 }

--- a/Mage.Sets/src/mage/cards/w/WeddingRing.java
+++ b/Mage.Sets/src/mage/cards/w/WeddingRing.java
@@ -124,7 +124,7 @@ class WeddingRingTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         if (!game.isActivePlayer(event.getPlayerId())
                 || !game.getOpponents(getControllerId()).contains(event.getPlayerId())
-                || !game.getBattlefield().contains(filter, getSourceId(), event.getPlayerId(), this, game, 1)) {
+                || !game.getBattlefield().contains(filter, event.getPlayerId(), this, game, 1)) {
             return false;
         }
         this.getEffects().clear();

--- a/Mage/src/main/java/mage/abilities/keyword/LandwalkAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/LandwalkAbility.java
@@ -64,7 +64,7 @@ class LandwalkEffect extends RestrictionEffect {
 
     @Override
     public boolean canBeBlocked(Permanent attacker, Permanent blocker, Ability source, Game game, boolean canUseChooseDialogs) {
-        if (game.getBattlefield().contains(filter, source.getSourceId(), blocker.getControllerId(), source, game, 1)
+        if (game.getBattlefield().contains(filter, blocker.getControllerId(), source, game, 1)
                 && null == game.getContinuousEffects().asThough(blocker.getId(), AsThoughEffectType.BLOCK_LANDWALK, null, blocker.getControllerId(), game)) {
             switch (filter.getMessage()) {
                 case "plains":

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -2583,7 +2583,7 @@ public abstract class GameImpl implements Game {
                 filterLegendName.add(SuperType.LEGENDARY.getPredicate());
                 filterLegendName.add(new NamePredicate(legend.getName()));
                 filterLegendName.add(new ControllerIdPredicate(legend.getControllerId()));
-                if (getBattlefield().contains(filterLegendName, null, legend.getControllerId(), null, this, 2)) {
+                if (getBattlefield().contains(filterLegendName, legend.getControllerId(), null, this, 2)) {
                     if (!replaceEvent(GameEvent.getEvent(GameEvent.EventType.DESTROY_PERMANENT_BY_LEGENDARY_RULE, legend.getId(), legend.getControllerId()))) {
                         Player controller = this.getPlayer(legend.getControllerId());
                         if (controller != null) {

--- a/Mage/src/main/java/mage/game/permanent/Battlefield.java
+++ b/Mage/src/main/java/mage/game/permanent/Battlefield.java
@@ -120,7 +120,7 @@ public class Battlefield implements Serializable {
     }
 
     public boolean contains(FilterPermanent filter, Ability source, Game game, int num) {
-        return contains(filter, source.getSourceId(), source.getControllerId(), source, game, num);
+        return contains(filter, source.getControllerId(), source, game, num);
     }
 
     /**
@@ -129,14 +129,13 @@ public class Battlefield implements Serializable {
      * matches the supplied filter.
      *
      * @param filter
-     * @param sourceId       can be null for default SBA checks like legendary rule
      * @param sourcePlayerId
      * @param source
      * @param game
      * @param num
      * @return boolean
      */
-    public boolean contains(FilterPermanent filter, UUID sourceId, UUID sourcePlayerId, Ability source, Game game, int num) {
+    public boolean contains(FilterPermanent filter, UUID sourcePlayerId, Ability source, Game game, int num) {
         if (game.getRangeOfInfluence() == RangeOfInfluence.ALL) {
             return field.values().stream()
                     .filter(permanent -> filter.match(permanent, sourcePlayerId, source, game)


### PR DESCRIPTION
As titled, cleaning up `sourceId` param in `Battlefield`'s `contains` method since this parameter wasn't used by the method.