### PR TITLE
BUGFIX: Myrkul Lord of Bones Ability

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MyrkulLordOfBones.java
+++ b/Mage.Sets/src/mage/cards/m/MyrkulLordOfBones.java
@@ -107,7 +107,7 @@ class MyrkulLordOfBonesEffect extends OneShotEffect {
         ).setPermanentModifier((token, g) -> {
             token.getCardType().clear();
             token.addCardType(CardType.ENCHANTMENT);
-            token.retainAllEnchantmentSubTypes(null);
+            token.retainAllEnchantmentSubTypes(g);
         }).apply(game, source);
     }
 }


### PR DESCRIPTION
Fixed a bug with Myrkul, Lord of Bones where creating an enchantment would crash the gameserver and require a rollback.

Providing a null game instance messes up the calls deeper in the code, so we must pass the game instance at this point. I think the null here was intended to represent removing all the other creature types, but that is already handled by Myrkul's class definition.

My first PR on here so please let me know if I've done something wrong or you need more information.