### PR TITLE
Added "available image set codes" functionality to emblems

### DIFF
--- a/Mage/src/main/java/mage/game/command/Emblem.java
+++ b/Mage/src/main/java/mage/game/command/Emblem.java
@@ -19,6 +19,7 @@ import mage.constants.SuperType;
 import mage.game.Game;
 import mage.game.events.ZoneChangeEvent;
 import mage.util.GameLog;
+import mage.util.RandomUtil;
 import mage.util.SubTypes;
 
 import java.util.ArrayList;
@@ -45,6 +46,9 @@ public class Emblem implements CommandObject {
     private Abilities<Ability> abilites = new AbilitiesImpl<>();
     private String expansionSetCodeForImage = "";
 
+    // list of set codes token images are available for
+    protected List<String> availableImageSetCodes = new ArrayList<>();
+
     public Emblem() {
         this.id = UUID.randomUUID();
     }
@@ -59,6 +63,7 @@ public class Emblem implements CommandObject {
         this.copyFrom = (emblem.copyFrom != null ? emblem.copyFrom : null);
         this.abilites = emblem.abilites.copy();
         this.expansionSetCodeForImage = emblem.expansionSetCodeForImage;
+        this.availableImageSetCodes = emblem.availableImageSetCodes;
     }
 
     @Override
@@ -79,6 +84,11 @@ public class Emblem implements CommandObject {
             }
             if (expansionSetCodeForImage.isEmpty()) {
                 expansionSetCodeForImage = ((Card) sourceObject).getExpansionSetCode();
+            }
+            if (!availableImageSetCodes.isEmpty()) {
+                if (expansionSetCodeForImage.equals("") || !availableImageSetCodes.contains(expansionSetCodeForImage)) {
+                        expansionSetCodeForImage = availableImageSetCodes.get(RandomUtil.nextInt(availableImageSetCodes.size()));
+                }
             }
         }
     }

--- a/Mage/src/main/java/mage/game/command/Emblem.java
+++ b/Mage/src/main/java/mage/game/command/Emblem.java
@@ -46,7 +46,7 @@ public class Emblem implements CommandObject {
     private Abilities<Ability> abilites = new AbilitiesImpl<>();
     private String expansionSetCodeForImage = "";
 
-    // list of set codes token images are available for
+    // list of set codes emblem images are available for
     protected List<String> availableImageSetCodes = new ArrayList<>();
 
     public Emblem() {

--- a/Mage/src/main/java/mage/game/command/emblems/DarettiScrapSavantEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/DarettiScrapSavantEmblem.java
@@ -17,6 +17,8 @@ import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
 import mage.target.targetpointer.FixedTarget;
 
+import java.util.Arrays;
+
 /**
  *
  * @author spjspj
@@ -26,6 +28,7 @@ public final class DarettiScrapSavantEmblem extends Emblem {
 
     public DarettiScrapSavantEmblem() {
         setName("Emblem Daretti");
+        availableImageSetCodes = Arrays.asList("C14", "C16", "CM2");
 
         this.getAbilities().add(new DarettiScrapSavantTriggeredAbility());
     }


### PR DESCRIPTION
If a card creates a token, xmage checks to see if the card's set code is inside of the token's available image set codes (manually written into the class of the token in question), as some sets have cards that create tokens but don't have the images for the tokens included in the set itself, thus allowing those cards to create a token using an image from another set which *does* have an image available for the token. This PR applies the same functionality to emblems. I've tested this with C21's "Daretti, Scrap Savant" (C21 doesn't have a new token image for Daretti), and can confirm the emblem successfully generates with an image from one of the sets in the available image set codes provided.