### PR TITLE
Improvements to constructed matches with limited decks

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.java
@@ -604,7 +604,7 @@ public class NewTableDialog extends MageDialog {
             options.getPlayerTypes().add(player.getPlayerType());
         }
         options.setDeckType((String) this.cbDeckType.getSelectedItem());
-        options.setLimited(false);
+        options.setLimited(options.getDeckType().startsWith("Limited"));
         options.setMatchTimeLimit((MatchTimeLimit) this.cbTimeLimit.getSelectedItem());
         options.setAttackOption((MultiplayerAttackOption) this.cbAttackOption.getSelectedItem());
         options.setSkillLevel((SkillLevel) this.cbSkillLevel.getSelectedItem());

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
@@ -1314,7 +1314,7 @@ public class NewTournamentDialog extends MageDialog {
             tOptions.getLimitedOptions().setDraftCubeName("");
             tOptions.getMatchOptions().setDeckType((String) this.cbDeckType.getSelectedItem());
             tOptions.getMatchOptions().setGameType(((GameTypeView) this.cbGameType.getSelectedItem()).getName());
-            tOptions.getMatchOptions().setLimited(false);
+            tOptions.getMatchOptions().setLimited(tOptions.getMatchOptions().getDeckType().startsWith("Limited"));
         }
 
         String serverAddress = SessionHandler.getSession().getServerHostname().orElse("");

--- a/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
+++ b/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
@@ -425,7 +425,7 @@ public class TablesPanel extends javax.swing.JPanel {
                 UUID tableId = (UUID) tableModel.getValueAt(modelRow, TablesTableModel.ACTION_COLUMN + 3);
                 UUID gameId = (UUID) tableModel.getValueAt(modelRow, TablesTableModel.ACTION_COLUMN + 2);
                 String action = (String) tableModel.getValueAt(modelRow, TablesTableModel.ACTION_COLUMN);
-                String deckType = (String) tableModel.getValueAt(modelRow, TablesTableModel.COLUMN_DECK_TYPE);
+                String gameType = (String) tableModel.getValueAt(modelRow, TablesTableModel.COLUMN_GAME_TYPE);
                 boolean isTournament = (Boolean) tableModel.getValueAt(modelRow, TablesTableModel.ACTION_COLUMN + 1);
                 String owner = (String) tableModel.getValueAt(modelRow, TablesTableModel.COLUMN_OWNER);
                 String pwdColumn = (String) tableModel.getValueAt(modelRow, TablesTableModel.COLUMN_PASSWORD);
@@ -454,14 +454,14 @@ public class TablesPanel extends javax.swing.JPanel {
                         }
                         if (isTournament) {
                             LOGGER.info("Joining tournament " + tableId);
-                            if (deckType.startsWith("Limited")) {
+                            if (!gameType.startsWith("Constructed")) {
                                 if (TablesTableModel.PASSWORD_VALUE_YES.equals(pwdColumn)) {
-                                    joinTableDialog.showDialog(roomId, tableId, true, deckType.startsWith("Limited"));
+                                    joinTableDialog.showDialog(roomId, tableId, true, !gameType.startsWith("Constructed"));
                                 } else {
                                     SessionHandler.joinTournamentTable(roomId, tableId, SessionHandler.getUserName(), PlayerType.HUMAN, 1, null, "");
                                 }
                             } else {
-                                joinTableDialog.showDialog(roomId, tableId, true, deckType.startsWith("Limited"));
+                                joinTableDialog.showDialog(roomId, tableId, true, !gameType.startsWith("Constructed"));
                             }
                         } else {
                             LOGGER.info("Joining table " + tableId);


### PR DESCRIPTION
Sometimes we do a draft type that's not supported on Xmage by drafting externally and importing the decks to play on Xmage. There are some issues with this though, and this PR aims to fix those.

Firstly, it is now possible to join a constructed tournament where the deck type is "Limited". Previously Xmage didn't allow selecting a deck when joining this kind of tournament. This is accomplished by looking at the game type instead of the deck type when determining whether the player must select a deck for the tournament.

Secondly, when hosting a constructed match/tournament where the deck type is "Limited", the sideboarding is now done limited-style, where you can add any number of basics to your deck during sideboarding. This way the participants don't need to add tons of basic lands to their sideboards before the match/tournament.