### PR TITLE
Typo Fix: Frenzied Goblin rules text

### DIFF
--- a/Mage.Sets/src/mage/cards/f/FrenziedGoblin.java
+++ b/Mage.Sets/src/mage/cards/f/FrenziedGoblin.java
@@ -33,7 +33,7 @@ public final class FrenziedGoblin extends CardImpl {
 
         // Whenever Frenzied Goblin attacks, you may pay {R}. If you do, target creature can't block this turn.
         Ability ability = new AttacksTriggeredAbility(new DoIfCostPaid(new CantBlockTargetEffect(Duration.EndOfTurn), new ManaCostsImpl<>("{R}")),false,
-                "Whenever {this} attacks you, may pay {R}. If you do, target creature can't block this turn.");
+                "Whenever {this} attacks, you may pay {R}. If you do, target creature can't block this turn.");
         Target target = new TargetCreaturePermanent();
         ability.addTarget(target);
         this.addAbility(ability);


### PR DESCRIPTION
Very small typo fix.

"Whenever {this} attacks you, may pay {R}. If you do, target creature can't block this turn." -> "Whenever {this} attacks, you may pay {R}. If you do, target creature can't block this turn."