### PR TITLE
Fixes to redirection effects that end prematurely

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CaptainsManeuver.java
+++ b/Mage.Sets/src/mage/cards/c/CaptainsManeuver.java
@@ -56,7 +56,7 @@ class CaptainsManeuverEffect extends RedirectionEffect {
     protected MageObjectReference redirectToObject;
 
     public CaptainsManeuverEffect() {
-        super(Duration.EndOfTurn, Integer.MAX_VALUE, UsageType.ONE_USAGE_ABSOLUTE);
+        super(Duration.EndOfTurn, Integer.MAX_VALUE, UsageType.ACCORDING_DURATION);
         staticText = "The next X damage that would be dealt to target creature, planeswalker, or player this turn is dealt to another target creature, planeswalker, or player instead.";
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarmsWay.java
+++ b/Mage.Sets/src/mage/cards/h/HarmsWay.java
@@ -46,7 +46,7 @@ class HarmsWayPreventDamageTargetEffect extends RedirectionEffect {
     private final TargetSource damageSource;
 
     public HarmsWayPreventDamageTargetEffect() {
-        super(Duration.EndOfTurn, 2, UsageType.ONE_USAGE_ABSOLUTE);
+        super(Duration.EndOfTurn, 2, UsageType.ACCORDING_DURATION);
         staticText = "The next 2 damage that a source of your choice would deal to you and/or permanents you control this turn is dealt to any target instead";
         this.damageSource = new TargetSource();
     }

--- a/Mage.Sets/src/mage/cards/h/HazduhrTheAbbot.java
+++ b/Mage.Sets/src/mage/cards/h/HazduhrTheAbbot.java
@@ -66,7 +66,7 @@ class HazduhrTheAbbotRedirectDamageEffect extends RedirectionEffect {
     private static FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent();
 
     public HazduhrTheAbbotRedirectDamageEffect(Duration duration) {
-        super(duration, 0, UsageType.ONE_USAGE_ABSOLUTE);
+        super(duration, 0, UsageType.ACCORDING_DURATION);
         this.staticText = "The next X damage that would be dealt this turn to target white creature you control is dealt to {this} instead";
     }
 

--- a/Mage.Sets/src/mage/cards/r/RaziaBorosArchangel.java
+++ b/Mage.Sets/src/mage/cards/r/RaziaBorosArchangel.java
@@ -81,7 +81,7 @@ class RaziaBorosArchangelEffect extends RedirectionEffect {
     protected MageObjectReference redirectToObject;
 
     public RaziaBorosArchangelEffect(Duration duration, int amount) {
-        super(duration, 3, UsageType.ONE_USAGE_ABSOLUTE);
+        super(duration, 3, UsageType.ACCORDING_DURATION);
         staticText = "The next " + amount + " damage that would be dealt to target creature you control this turn is dealt to another target creature instead";
     }
 

--- a/Mage.Sets/src/mage/cards/r/RaziaBorosArchangel.java
+++ b/Mage.Sets/src/mage/cards/r/RaziaBorosArchangel.java
@@ -81,7 +81,7 @@ class RaziaBorosArchangelEffect extends RedirectionEffect {
     protected MageObjectReference redirectToObject;
 
     public RaziaBorosArchangelEffect(Duration duration, int amount) {
-        super(duration, 3, UsageType.ACCORDING_DURATION);
+        super(duration, amount, UsageType.ACCORDING_DURATION);
         staticText = "The next " + amount + " damage that would be dealt to target creature you control this turn is dealt to another target creature instead";
     }
 

--- a/Mage.Sets/src/mage/cards/s/ShimianNightStalker.java
+++ b/Mage.Sets/src/mage/cards/s/ShimianNightStalker.java
@@ -62,7 +62,7 @@ class ShimianNightStalkerRedirectDamageEffect extends RedirectionEffect {
     private static FilterCreaturePermanent filter = new FilterCreaturePermanent();
 
     public ShimianNightStalkerRedirectDamageEffect() {
-        super(Duration.EndOfTurn, Integer.MAX_VALUE, UsageType.ONE_USAGE_ABSOLUTE);
+        super(Duration.EndOfTurn, Integer.MAX_VALUE, UsageType.ACCORDING_DURATION);
         this.staticText = "All damage that would be dealt to you this turn by target attacking creature is dealt to {this} instead";
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/RedirectionEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/RedirectionEffect.java
@@ -85,6 +85,12 @@ public abstract class RedirectionEffect extends ReplacementEffectImpl {
                 applyEffectsCounter = game.getState().getApplyEffectsCounter();
             }
         }
+        if (usageType == UsageType.ACCORDING_DURATION) {
+            amountToRedirect -= damageEvent.getAmount();
+            if (amountToRedirect <= 0) {
+                this.discard();
+            }
+        }
         Permanent permanent = game.getPermanent(redirectTarget.getFirstTarget());
         if (permanent != null) {
             permanent.damage(damageToRedirect, event.getSourceId(), source, game, damageEvent.isCombatDamage(), damageEvent.isPreventable(), event.getAppliedEffects());


### PR DESCRIPTION
This PR fixes the issues with five cards that are supposed to redirect a specified amount of damage, but their redirection effect ends prematurely when any amount of damage is dealt. These cards are Captain's Maneuver, Harm's Way, Hazduhr the Abbot, Razia Boros Archangel, and Shimian Night Stalker.

To accomplish fixing these cards I also fixed the ACCORDING_DURATION redirection type so that it works as intended, i.e. ends when the specified amount of damage has been redirected.

These cards now use the fixed ACCORDING_DURATION redirection type.