### PR TITLE
Fix the UI pitfall of double spacebar press quitting a draft

### DIFF
--- a/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
+++ b/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
@@ -821,8 +821,8 @@
 
      private void btnQuitTournamentActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnQuitTournamentActionPerformed
          UserRequestMessage message = new UserRequestMessage("Confirm quit tournament", "Are you sure you want to quit the draft tournament?");
-         message.setButton1("No", null);
-         message.setButton2("Yes", PlayerAction.CLIENT_QUIT_DRAFT_TOURNAMENT);
+         message.setButton1("Yes", PlayerAction.CLIENT_QUIT_DRAFT_TOURNAMENT);
+         message.setButton2("No", null);
          message.setTournamentId(draftId);
          MageFrame.getInstance().showUserRequestDialog(message);
      }//GEN-LAST:event_btnQuitTournamentActionPerformed

--- a/Mage.Client/src/main/java/mage/client/tournament/TournamentPanel.java
+++ b/Mage.Client/src/main/java/mage/client/tournament/TournamentPanel.java
@@ -490,8 +490,8 @@ public class TournamentPanel extends javax.swing.JPanel {
 
     private void btnQuitTournamentActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnQuitTournamentActionPerformed
         UserRequestMessage message = new UserRequestMessage("Confirm quit tournament", "Are you sure you want to quit the tournament?");
-        message.setButton1("No", null);
-        message.setButton2("Yes", PlayerAction.CLIENT_QUIT_TOURNAMENT);
+        message.setButton1("Yes", PlayerAction.CLIENT_QUIT_TOURNAMENT);
+        message.setButton2("No", null);
         message.setTournamentId(tournamentId);
         MageFrame.getInstance().showUserRequestDialog(message);
     }//GEN-LAST:event_btnQuitTournamentActionPerformed


### PR DESCRIPTION
It's possible to quit a draft tournament by pressing spacebar twice. This does not happen during the first pick of a draft, but during any other pick after that, the quit-button in the top left is active in such a way that pressing spacebar brings up an "Are you sure you want to quit the draft tournament?" dialog. This dialog has the yes-button active by default so if you press spacebar again, you are considered to have quit the tournament.

This commit fixes the behavior by making the no-button active by default in the quit dialog.

Fixes https://github.com/magefree/mage/issues/8417