### PR TITLE
Stop permanents getting counters when phased out

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersSourceEffect.java
@@ -104,9 +104,10 @@ public class AddCountersSourceEffect extends OneShotEffect {
             if (permanent == null && source.getAbilityType() == AbilityType.STATIC) {
                 permanent = game.getPermanentEntering(source.getSourceId());
             }
-            if (permanent == null || !permanent.isPhasedIn()) {
+            if (permanent == null) {
                 return false;
             }
+
             if ((source.getSourceObjectZoneChangeCounter() == 0 // from static ability
                     || source.getSourceObjectZoneChangeCounter() == permanent.getZoneChangeCounter(game))) { // prevent to add counters to later source objects
                 Counter newCounter = counter.copy();

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersSourceEffect.java
@@ -69,12 +69,12 @@ public class AddCountersSourceEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        if (controller == null) {
+        if (counter == null) {
             return false;
         }
 
-        if (counter == null) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null) {
             return false;
         }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersSourceEffect.java
@@ -70,61 +70,66 @@ public class AddCountersSourceEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null) {
-            if (putOnCard) {
-                Card card = game.getCard(source.getSourceId());
-                if (card != null) {
-                    if (counter != null) {
-                        Counter newCounter = counter.copy();
-                        int countersToAdd = amount.calculate(game, source, this);
-                        if (countersToAdd > 0 && newCounter.getCount() == 1) {
-                            countersToAdd--;
-                        }
-                        newCounter.add(countersToAdd);
-                        List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects");
-                        card.addCounters(newCounter, source.getControllerId(), source, game, appliedEffects);
-                        if (informPlayers && !game.isSimulation()) {
-                            Player player = game.getPlayer(source.getControllerId());
-                            if (player != null) {
-                                game.informPlayers(player.getLogName() + " puts " + newCounter.getCount() + ' ' + newCounter.getName().toLowerCase(Locale.ENGLISH) + " counter on " + card.getLogName());
-                            }
-                        }
+        if (controller == null) {
+            return false;
+        }
+
+        if (counter == null) {
+            return false;
+        }
+
+        if (putOnCard) {
+            Card card = game.getCard(source.getSourceId());
+            if (card == null) {
+                return false;
+            }
+
+            Counter newCounter = counter.copy();
+            int countersToAdd = amount.calculate(game, source, this);
+            if (countersToAdd > 0 && newCounter.getCount() == 1) {
+                countersToAdd--;
+            }
+            newCounter.add(countersToAdd);
+            List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects");
+            card.addCounters(newCounter, source.getControllerId(), source, game, appliedEffects);
+            if (informPlayers && !game.isSimulation()) {
+                Player player = game.getPlayer(source.getControllerId());
+                if (player != null) {
+                    game.informPlayers(player.getLogName() + " puts " + newCounter.getCount() + ' ' + newCounter.getName().toLowerCase(Locale.ENGLISH) + " counter on " + card.getLogName());
+                }
+            }
+            return true;
+        } else {
+            Permanent permanent = game.getPermanent(source.getSourceId());
+            if (permanent == null && source.getAbilityType() == AbilityType.STATIC) {
+                permanent = game.getPermanentEntering(source.getSourceId());
+            }
+            if (permanent == null || !permanent.isPhasedIn()) {
+                return false;
+            }
+            if ((source.getSourceObjectZoneChangeCounter() == 0 // from static ability
+                    || source.getSourceObjectZoneChangeCounter() == permanent.getZoneChangeCounter(game))) { // prevent to add counters to later source objects
+                Counter newCounter = counter.copy();
+                int countersToAdd = amount.calculate(game, source, this);
+                if (amount instanceof StaticValue || countersToAdd > 0) {
+                    if (countersToAdd > 0 && newCounter.getCount() == 1) {
+                        countersToAdd--;
                     }
-                    return true;
-                }
-            } else {
-                Permanent permanent = game.getPermanent(source.getSourceId());
-                if (permanent == null && source.getAbilityType() == AbilityType.STATIC) {
-                    permanent = game.getPermanentEntering(source.getSourceId());
-                }
-                if (permanent != null
-                        && (source.getSourceObjectZoneChangeCounter() == 0 // from static ability
-                        || source.getSourceObjectZoneChangeCounter() == permanent.getZoneChangeCounter(game))) { // prevent to add counters to later source objects
-                    if (counter != null) {
-                        Counter newCounter = counter.copy();
-                        int countersToAdd = amount.calculate(game, source, this);
-                        if (amount instanceof StaticValue || countersToAdd > 0) {
-                            if (countersToAdd > 0 && newCounter.getCount() == 1) {
-                                countersToAdd--;
-                            }
-                            newCounter.add(countersToAdd);
-                            int before = permanent.getCounters(game).getCount(newCounter.getName());
-                            List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects");
-                            permanent.addCounters(newCounter, source.getControllerId(), source, game, appliedEffects); // if used from a replacement effect, the basic event determines if an effect was already applied to an event
-                            if (informPlayers && !game.isSimulation()) {
-                                int amountAdded = permanent.getCounters(game).getCount(newCounter.getName()) - before;
-                                Player player = game.getPlayer(source.getControllerId());
-                                if (player != null) {
-                                    game.informPlayers(player.getLogName() + " puts " + amountAdded + ' ' + newCounter.getName().toLowerCase(Locale.ENGLISH) + " counter on " + permanent.getLogName());
-                                }
-                            }
+                    newCounter.add(countersToAdd);
+                    int before = permanent.getCounters(game).getCount(newCounter.getName());
+                    List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects");
+                    permanent.addCounters(newCounter, source.getControllerId(), source, game, appliedEffects); // if used from a replacement effect, the basic event determines if an effect was already applied to an event
+                    if (informPlayers && !game.isSimulation()) {
+                        int amountAdded = permanent.getCounters(game).getCount(newCounter.getName()) - before;
+                        Player player = game.getPlayer(source.getControllerId());
+                        if (player != null) {
+                            game.informPlayers(player.getLogName() + " puts " + amountAdded + ' ' + newCounter.getName().toLowerCase(Locale.ENGLISH) + " counter on " + permanent.getLogName());
                         }
                     }
                 }
             }
-            return true;
         }
-        return false;
+        return true;
     }
 
     private void setText() {

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -699,6 +699,12 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
     }
 
     public boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, List<UUID> appliedEffects, boolean isEffect, int maxCounters) {
+        if (this instanceof Permanent) {
+            if (!((Permanent) this).isPhasedIn()) {
+                return false;
+            }
+        }
+
         boolean returnCode = true;
         GameEvent addingAllEvent = GameEvent.getEvent(GameEvent.EventType.ADD_COUNTERS, objectId, source, playerAddingCounters, counter.getName(), counter.getCount());
         addingAllEvent.setAppliedEffects(appliedEffects);


### PR DESCRIPTION
`AddCountersSourceEffect ` did not check if the permanent was phased in before adding counters to it.

**It may not be the only effect that has this issue.**

Changes
- Fix `AddCountersSourceEffect`'s `apply`
- Flatted `AddCountersSourceEffect`'s `apply`

Closes #9187