### PR TITLE
(WIP) Add API for chaining commands on same turn & step

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/akh/ApproachOfTheSecondSunTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/akh/ApproachOfTheSecondSunTest.java
@@ -14,8 +14,13 @@ public class ApproachOfTheSecondSunTest extends CardTestPlayerBase {
         removeAllCardsFromLibrary(playerA);
         addCard(Zone.HAND, playerA, "Approach of the Second Sun", 2);
         addCard(Zone.BATTLEFIELD, playerA, "Plains", 14);
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Approach of the Second Sun");
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Approach of the Second Sun");
+
+        // Example of how to use API:
+        // Note the readability and "built-in" comment about when the commands happen
+        // And automatic grouping of commands that happen during same phase
+        onTurn(1).onStep(PhaseStep.PRECOMBAT_MAIN)
+                .castSpell(playerA, "Approach of the Second Sun")
+                .castSpell(playerA, "Approach of the Second Sun");
 
         setStopAt(1, PhaseStep.END_TURN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -2159,6 +2159,82 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
         return GameSessionPlayer.prepareGameView(currentGame, player.getId(), null);
     }
 
+    public OnTurn onTurn(int turnNum) {
+        return new OnTurn(turnNum);
+    }
+
+    public class OnTurn {
+
+        final int turnNum;
+
+        public OnTurn(int turnNum) {
+            this.turnNum = turnNum;
+        }
+
+        public int getTurnNum() {
+            return turnNum;
+        }
+
+        public OnTurn attack(TestPlayer player, String attacker) {
+            CardTestPlayerAPIImpl.this.attack(turnNum, player, attacker);
+            return this;
+        }
+
+        public OnTurn attack(TestPlayer player, String attacker, TestPlayer defendingPlayer) {
+            CardTestPlayerAPIImpl.this.attack(turnNum, player, attacker, defendingPlayer);
+            return this;
+        }
+
+        public OnTurn attack(TestPlayer player, String attacker, String planeswalker) {
+            CardTestPlayerAPIImpl.this.attack(turnNum, player, attacker, planeswalker);
+            return this;
+        }
+
+        public OnTurn attackSkip(TestPlayer player) {
+            CardTestPlayerAPIImpl.this.attackSkip(turnNum, player);
+            return this;
+        }
+
+        public OnTurn block(TestPlayer player, String blocker, String attacker) {
+            CardTestPlayerAPIImpl.this.block(turnNum, player, blocker, attacker);
+            return this;
+        }
+
+        public OnTurn blockSkip(TestPlayer player) {
+            CardTestPlayerAPIImpl.this.blockSkip(turnNum, player);
+            return this;
+        }
+
+        public OnStep onStep(PhaseStep step) {
+            return new OnStep(this, step);
+        }
+
+    }
+
+    public class OnStep {
+        final OnTurn onTurn;
+        final PhaseStep step;
+
+        public OnStep(int turnNum, PhaseStep step) {
+            this.onTurn = new OnTurn(turnNum);
+            this.step = step;
+        }
+
+        private OnStep(OnTurn onTurn, PhaseStep step) {
+            this.onTurn = onTurn;
+            this.step = step;
+        }
+
+        public OnTurn then() {
+            return onTurn;
+        }
+
+        public OnStep castSpell(TestPlayer player, String cardName) {
+            CardTestPlayerAPIImpl.this.castSpell(onTurn.getTurnNum(), step, player, cardName);
+            return this;
+        }
+    }
+
     protected enum ExpectedType {
         TURN_NUMBER,
         RESULT,


### PR DESCRIPTION
When working on tests, I found tests with multiple actions on same step were cumbersome to write. Therefore I though of a way to chain commands like so:

```
        onTurn(1).onStep(PhaseStep.PRECOMBAT_MAIN)
                .castSpell(playerA, "Approach of the Second Sun")
                .castSpell(playerA, "Approach of the Second Sun");
```

This reduces repetitive/redundant typing of turn number and step over and over. It also serves like an "implicit comment" as the beginning of each block tells you which turn and step you are on.

Thoughts?