### PR TITLE
Fix message on targetAmount dialogs

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -832,6 +832,10 @@ public class HumanPlayer extends PlayerImpl {
             return true;
         }
 
+        if (source == null) {
+            return false;
+        }
+
         UUID abilityControllerId = playerId;
         if (target.getAbilityController() != null) {
             abilityControllerId = target.getAbilityController();
@@ -876,8 +880,7 @@ public class HumanPlayer extends PlayerImpl {
             prepareForResponse(game);
             if (!isExecutingMacro()) {
                 // target amount uses for damage only, if you see another use case then message must be changed here and on getMultiAmount call
-                String message = String.format("Select targets to distribute %d damage (selected %d)", amountTotal, target.getTargets().size());
-                game.fireSelectTargetEvent(playerId, new MessageToClient(message, getRelatedObjectName(source, game)), possibleTargets, required, options);
+                game.fireSelectTargetEvent(playerId, new MessageToClient(target.getMessage(), getRelatedObjectName(source, game)), possibleTargets, required, options);
             }
             waitForResponse(game);
 
@@ -923,8 +926,9 @@ public class HumanPlayer extends PlayerImpl {
             }
         }
 
+        MultiAmountType multiAmountType = source.toString().contains("counters") ? MultiAmountType.P1P1 : MultiAmountType.DAMAGE;
         // ask and assign new amount
-        List<Integer> targetValues = getMultiAmount(outcome, targetNames, 1, amountTotal, MultiAmountType.DAMAGE, game);
+        List<Integer> targetValues = getMultiAmount(outcome, targetNames, 1, amountTotal, multiAmountType, game);
         for (int i = 0; i < targetValues.size(); i++) {
             int newAmount = targetValues.get(i);
             UUID targetId = targets.get(i);

--- a/Mage/src/main/java/mage/constants/MultiAmountType.java
+++ b/Mage/src/main/java/mage/constants/MultiAmountType.java
@@ -12,7 +12,8 @@ import java.util.stream.IntStream;
 public enum MultiAmountType {
 
     MANA("Add mana", "Distribute mana among colors"),
-    DAMAGE("Assign damage", "Assign damage among targets");
+    DAMAGE("Assign damage", "Assign damage among targets"),
+    P1P1("Add +1/+1 counters", "Distribute +1/+1 counters among creatures");
 
     private final String title;
     private final String header;


### PR DESCRIPTION
Now correctly describes the targeting reason and what is being distributed (+1/+1 counters) for effects such as Lathiel, the Bounteous Dawn.

Closes #8069.