### PR TITLE
Fixed Fabled Passage to have correct interaction with Amulet of Vigor

### DIFF
--- a/Mage.Sets/src/mage/cards/f/FabledPassage.java
+++ b/Mage.Sets/src/mage/cards/f/FabledPassage.java
@@ -4,6 +4,7 @@ import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
@@ -15,7 +16,10 @@ import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
+import mage.target.TargetCard;
 import mage.target.common.TargetCardInLibrary;
+import mage.target.targetpointer.FirstTargetPointer;
+import mage.target.targetpointer.FixedTarget;
 
 import java.util.UUID;
 
@@ -27,9 +31,11 @@ public final class FabledPassage extends CardImpl {
     public FabledPassage(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.LAND}, "");
 
-        // {T}, Sacrifice Fabled Passage: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library. Then if you control four or more lands, untap that land.
-        Ability ability = new SimpleActivatedAbility(new FabledPassageEffect(), new TapSourceCost());
+        // {T}, Sacrifice Fabled Passage: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.
+        // Then if you control four or more lands, untap that land.
+        Ability ability = new SimpleActivatedAbility(new FabledPassageSearchForLandEffect(), new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
+        ability.addEffect(new FabledPassageUntapLandEffect());
         this.addAbility(ability);
     }
 
@@ -43,21 +49,20 @@ public final class FabledPassage extends CardImpl {
     }
 }
 
-class FabledPassageEffect extends OneShotEffect {
+class FabledPassageSearchForLandEffect extends OneShotEffect {
 
-    FabledPassageEffect() {
-        super(Outcome.Benefit);
-        staticText = "Search your library for a basic land card, put it onto the battlefield tapped, " +
-                "then shuffle. Then if you control four or more lands, untap that land.";
+    FabledPassageSearchForLandEffect() {
+        super(Outcome.PutCardInPlay);
+        staticText = "Search your library for a basic land card, put it onto the battlefield tapped, then shuffle ";
     }
 
-    private FabledPassageEffect(final FabledPassageEffect effect) {
+    private FabledPassageSearchForLandEffect(final FabledPassageSearchForLandEffect effect) {
         super(effect);
     }
 
     @Override
-    public FabledPassageEffect copy() {
-        return new FabledPassageEffect(this);
+    public FabledPassageSearchForLandEffect copy() {
+        return new FabledPassageSearchForLandEffect(this);
     }
 
     @Override
@@ -78,13 +83,50 @@ class FabledPassageEffect extends OneShotEffect {
         if (!player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null)) {
             return false;
         }
+        for (Effect effect : source.getEffects()) {
+            if (effect instanceof FabledPassageUntapLandEffect) {
+                effect.setTargetPointer(new FixedTarget(card, game));
+                return true;
+            }
+        }
+
+        return true;
+    }
+}
+
+// Need to be split across two effects so that other cards (e.g. Amulet of Vigor)
+// see the land enterring tapped (before this part of the effect untaps it).
+class FabledPassageUntapLandEffect extends OneShotEffect {
+
+    FabledPassageUntapLandEffect() {
+        super(Outcome.Untap);
+        staticText = "Then if you control four or more lands, untap that land.";
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Card targetLandCard = game.getCard(getTargetPointer().getFirst(game, source));
+        if (targetLandCard == null) {
+            return false;
+        }
+
         if (game.getBattlefield().countAll(StaticFilters.FILTER_LAND, source.getControllerId(), game) < 4) {
             return true;
         }
-        Permanent permanent = game.getPermanent(card.getId());
-        if (permanent == null) {
+
+        Permanent land = game.getPermanent(targetLandCard.getId());
+        if (land == null) {
             return false;
         }
-        return permanent.untap(game);
+        return land.untap(game);
+    }
+
+    private FabledPassageUntapLandEffect(final FabledPassageUntapLandEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public FabledPassageUntapLandEffect copy() {
+        return new FabledPassageUntapLandEffect(this);
     }
 }


### PR DESCRIPTION
Before this fix when [[Fabled Passage]] put the land tapped onto the battlefield and the untapped it would appear as if it entered untapped. Thus effects such as those from [[Amulet of Vigor]] would not trigger for it.

By splitting the resolution over two effects, the land is seen as entering tapped and Amulet of Vigor's ability gets placed on the stack.

The combo for this is:
1. Play land with Fabled Passage
2. While Amulet of Vigor's ability is on the stack, tap the land and float the mana
3. Amulet's ability un-taps the land and it can be tapped a second time.

For #6075.