### PR TITLE
Fixed indestructible condition being inverted

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MyrkulLordOfBones.java
+++ b/Mage.Sets/src/mage/cards/m/MyrkulLordOfBones.java
@@ -70,7 +70,7 @@ enum MyrkulLordOfBonesCondition implements Condition {
     public boolean apply(Game game, Ability source) {
         return Optional.ofNullable(game.getPlayer(source.getControllerId()))
                 .map(Player::getLife)
-                .map(x -> 2 * x >= game.getStartingLife())
+                .map(x -> (2 * x) <= game.getStartingLife())
                 .orElse(false);
     }
 }


### PR DESCRIPTION
Give Myrkul indesctructible when controller's life total is LESS than or equal to half the starting life total (rather than the other way around)