### PR TITLE
[WIP] Allows player to choose which asThough ability to use

### DIFF
--- a/Mage.Sets/src/mage/cards/r/RisenExecutioner.java
+++ b/Mage.Sets/src/mage/cards/r/RisenExecutioner.java
@@ -87,15 +87,13 @@ class RisenExecutionerCastEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
-        if (sourceId.equals(source.getSourceId())) {
-            Card card = game.getCard(source.getSourceId());
-            if (card != null
-                    && card.isOwnedBy(affectedControllerId)
-                    && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD) {
-                return true;
-            }
+        if (!sourceId.equals(source.getSourceId())) {
+            return false;
         }
-        return false;
+        Card card = game.getCard(source.getSourceId());
+        return card != null
+                && card.isOwnedBy(affectedControllerId)
+                && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD;
     }
 }
 
@@ -119,19 +117,22 @@ class RisenExecutionerCostIncreasingEffect extends CostModificationEffectImpl {
     @Override
     public boolean apply(Game game, Ability source, Ability abilityToModify) {
         Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null) {
-            CardUtil.increaseCost(abilityToModify, controller.getGraveyard().count(filter, source.getControllerId(), source, game));
+        if (controller == null) {
+            return false;
         }
+
+        CardUtil.increaseCost(abilityToModify, controller.getGraveyard().count(filter, source.getControllerId(), source, game));
         return true;
     }
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (abilityToModify.getSourceId().equals(source.getSourceId())) {
-            Spell spell = game.getStack().getSpell(abilityToModify.getSourceId());
-            return spell != null && spell.getFromZone() == Zone.GRAVEYARD;
+        if (!abilityToModify.getSourceId().equals(source.getSourceId())) {
+            return false;
         }
-        return false;
+
+        Spell spell = game.getStack().getSpell(abilityToModify.getSourceId());
+        return spell != null && spell.getFromZone() == Zone.GRAVEYARD;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/r/RisenExecutioner.java
+++ b/Mage.Sets/src/mage/cards/r/RisenExecutioner.java
@@ -1,11 +1,13 @@
 
 package mage.cards.r;
 
+import java.util.Objects;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.CantBlockAbility;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.AsThoughEffect;
 import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.common.continuous.BoostControlledEffect;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
@@ -47,7 +49,6 @@ public final class RisenExecutioner extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostControlledEffect(1, 1, Duration.WhileOnBattlefield, filter, true)));
 
         // You may cast Risen Executioner from your graveyard if you pay {1} more to cast it for each other creature card in your graveyard.
-        // TODO: cost increase does not happen if Risen Executioner is cast grom graveyard because of other effects
         Ability ability = new SimpleStaticAbility(Zone.ALL, new RisenExecutionerCastEffect());
         ability.addEffect(new RisenExecutionerCostIncreasingEffect());
         this.addAbility(ability);
@@ -127,7 +128,13 @@ class RisenExecutionerCostIncreasingEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (!abilityToModify.getSourceId().equals(source.getSourceId())) {
+        UUID cardId = abilityToModify.getSourceId();
+        if (!cardId.equals(source.getSourceId())) {
+            return false;
+        }
+
+        Object obj = game.getState().getValue("asThoughEffect used for " + cardId);
+        if (obj == null || !(obj instanceof RisenExecutionerCastEffect)) {
             return false;
         }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/other/MultipleAsThoughEffects.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/other/MultipleAsThoughEffects.java
@@ -25,7 +25,7 @@ public class MultipleAsThoughEffects extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Bolas's Citadel");
         // Random creature card to play with mana value of 3
         addCard(Zone.LIBRARY, playerA, "Abzan Beastmaster",3); // 1 for draw, 2 to play
-        addCard(Zone.LIBRARY, playerA, "Forest",4);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest",4);
 
         skipInitShuffling();
         setStrictChooseMode(true);
@@ -57,9 +57,9 @@ public class MultipleAsThoughEffects extends CardTestPlayerBase {
 
         setStrictChooseMode(true);
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Risen Executioner");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Risen Executioner"); // Should cost {2}{B}{B} since cast with Gisa
         setChoice(playerA, "Gisa");
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Risen Executioner");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Risen Executioner"); // Should cost {2}{B}{B} when cast with own ability since now only card
 
         execute();
         assertAllCommandsUsed();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/other/MultipleAsThoughEffects.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/other/MultipleAsThoughEffects.java
@@ -1,0 +1,68 @@
+package org.mage.test.cards.abilities.other;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Alex-Vasile
+ */
+public class MultipleAsThoughEffects extends CardTestPlayerBase {
+
+    /**
+     * Reported bug: https://github.com/magefree/mage/issues/8584
+     *
+     * If there are multiple effects which allow a player to cast a spell,
+     * they should be able to choose which one they whish to use.
+     */
+    @Test
+    public void multipleNonConsumable() {
+        // You may cast creature spells from the top of your library.
+        addCard(Zone.BATTLEFIELD, playerA, "Vivien, Monsters' Advocate");
+        // You may play lands and cast spells from the top of your library.
+        // If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.
+        addCard(Zone.BATTLEFIELD, playerA, "Bolas's Citadel");
+        // Random creature card to play with mana value of 3
+        addCard(Zone.LIBRARY, playerA, "Abzan Beastmaster",3); // 1 for draw, 2 to play
+        addCard(Zone.LIBRARY, playerA, "Forest",4);
+
+        skipInitShuffling();
+        setStrictChooseMode(true);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Abzan Beastmaster");
+        setChoice(playerA, "Vivien");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Abzan Beastmaster");
+        setChoice(playerA, "Bolas's");
+
+        execute();
+        assertAllCommandsUsed();
+        assertPermanentCount(playerA, "Abzan Beastmaster", 2);
+        assertLife(playerA, 20 - 3); // 3 from casting Abzan Beastmaster with Bolas Citadel
+    }
+
+    /**
+     * Reported bug: https://github.com/magefree/mage/issues/2087
+     *
+     * If there are multiple effects which allow a player to cast a spell,
+     * they should be able to choose which one they whish to use, even if one is single-use.
+     */
+    @Test
+    public void ConsumableAndNonConsumable() {
+        // You may cast Risen Executioner from your graveyard if you pay {1} more to cast it for each other creature card in your graveyard.
+        addCard(Zone.GRAVEYARD, playerA, "Risen Executioner", 2);
+        // During each of your turns, you may cast a Zombie creature spell from your graveyard.
+        addCard(Zone.BATTLEFIELD, playerA, "Gisa and Geralf");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp",8);  // Only enough mana to cast
+
+        setStrictChooseMode(true);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Risen Executioner");
+        setChoice(playerA, "Gisa");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Risen Executioner");
+
+        execute();
+        assertAllCommandsUsed();
+        assertPermanentCount(playerA, "Risen Executioner", 2);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
@@ -510,7 +510,6 @@ public class ContinuousEffects implements Serializable {
      * @return sourceId of the permitting effect if any exists otherwise returns null
      */
     public ApprovingObject asThough(UUID objectId, AsThoughEffectType type, Ability affectedAbility, UUID controllerId, Game game) {
-
         // usage check: effect must apply for specific ability only, not to full object (example: PLAY_FROM_NOT_OWN_HAND_ZONE)
         if (type.needAffectedAbility() && affectedAbility == null) {
             throw new IllegalArgumentException("ERROR, you can't call asThough check to whole object, call it with affected ability instead: " + type);
@@ -524,97 +523,106 @@ public class ContinuousEffects implements Serializable {
         }
 
         List<AsThoughEffect> asThoughEffectsList = getApplicableAsThoughEffects(type, game);
-        if (!asThoughEffectsList.isEmpty()) {
-            MageObject objectToCheck;
-            if (affectedAbility != null) {
-                objectToCheck = affectedAbility.getSourceObject(game);
-            } else {
-                objectToCheck = game.getCard(objectId);
-            }
-
-            UUID idToCheck;
-            if (!type.needPlayCardAbility() && objectToCheck instanceof SplitCardHalf) {
-                // each split side uses own characteristics to check for playing, all other cases must use main card
-                // rules:
-                // 708.4. In every zone except the stack, the characteristics of a split card are those of its two halves combined.
-                idToCheck = ((SplitCardHalf) objectToCheck).getMainCard().getId();
-            } else if (!type.needPlayCardAbility() && objectToCheck instanceof AdventureCardSpell) {
-                // adventure spell uses alternative characteristics for spell/stack, all other cases must use main card
-                idToCheck = ((AdventureCardSpell) objectToCheck).getMainCard().getId();
-            } else if (!type.needPlayCardAbility() && objectToCheck instanceof ModalDoubleFacesCardHalf) {
-                // each mdf side uses own characteristics to check for playing, all other cases must use main card
-                // rules:
-                // "If an effect allows you to play a land or cast a spell from among a group of cards,
-                // you may play or cast a modal double-faced card with any face that fits the criteria
-                // of that effect. For example, if Sejiri Shelter / Sejiri Glacier is in your graveyard
-                // and an effect allows you to play lands from your graveyard, you could play Sejiri Glacier.
-                // That effect doesn't allow you to cast Sejiri Shelter."
-                idToCheck = ((ModalDoubleFacesCardHalf) objectToCheck).getMainCard().getId();
-            } else {
-                idToCheck = objectId;
-            }
-
-            Set<ApprovingObject> possibleApprovingObjects = new HashSet<>();
-            for (AsThoughEffect effect : asThoughEffectsList) {
-                Set<Ability> abilities = asThoughEffectsMap.get(type).getAbility(effect.getId());
-                for (Ability ability : abilities) {
-                    if (affectedAbility == null) {
-                        // applies to full object (one effect can be used in multiple abilities)
-                        if (effect.applies(idToCheck, ability, controllerId, game)) {
-                            if (effect.isConsumable() && !game.inCheckPlayableState()) {
-                                possibleApprovingObjects.add(new ApprovingObject(ability, game));
-                            } else {
-                                return new ApprovingObject(ability, game);
-                            }
-                        }
-                    } else {
-                        // applies to one affected ability
-
-                        // filter play abilities (no need to check it in every effect's code)
-                        if (type.needPlayCardAbility() && !affectedAbility.getAbilityType().isPlayCardAbility()) {
-                            continue;
-                        }
-
-                        if (effect.applies(idToCheck, affectedAbility, ability, game, controllerId)) {
-                            if (effect.isConsumable() && !game.inCheckPlayableState()) {
-                                possibleApprovingObjects.add(new ApprovingObject(ability, game));
-                            } else {
-                                return new ApprovingObject(ability, game);
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (possibleApprovingObjects.size() == 1) {
-                return possibleApprovingObjects.iterator().next();
-            } else if (possibleApprovingObjects.size() > 1) {
-                // Select the ability that you use to permit the action                
-                Map<String, String> keyChoices = new HashMap<>();
-                for (ApprovingObject approvingObject : possibleApprovingObjects) {
-                    MageObject mageObject = game.getObject(approvingObject.getApprovingAbility().getSourceId());
-                    String choiceKey = approvingObject.getApprovingAbility().getId().toString();
-                    String choiceValue;
-                    if (mageObject == null) {
-                        choiceValue = approvingObject.getApprovingAbility().getRule();
-                    } else {
-                        choiceValue = mageObject.getIdName() + ": " + approvingObject.getApprovingAbility().getRule(mageObject.getName());
-                    }
-                    keyChoices.put(choiceKey, choiceValue);
-                }
-                Choice choicePermitting = new ChoiceImpl(true);
-                choicePermitting.setMessage("Choose the permitting object");
-                choicePermitting.setKeyChoices(keyChoices);
-                Player player = game.getPlayer(controllerId);
-                player.choose(Outcome.Detriment, choicePermitting, game);
-                for (ApprovingObject approvingObject : possibleApprovingObjects) {
-                    if (approvingObject.getApprovingAbility().getId().toString().equals(choicePermitting.getChoiceKey())) {
-                        return approvingObject;
-                    }
-                }
-            }
-
+        if (asThoughEffectsList.isEmpty()) {
+            return null;
         }
+        MageObject objectToCheck;
+        if (affectedAbility != null) {
+            objectToCheck = affectedAbility.getSourceObject(game);
+        } else {
+            objectToCheck = game.getCard(objectId);
+        }
+
+        UUID idToCheck;
+        if (!type.needPlayCardAbility() && objectToCheck instanceof SplitCardHalf) {
+            // each split side uses own characteristics to check for playing, all other cases must use main card
+            // rules:
+            // 708.4. In every zone except the stack, the characteristics of a split card are those of its two halves combined.
+            idToCheck = ((SplitCardHalf) objectToCheck).getMainCard().getId();
+        } else if (!type.needPlayCardAbility() && objectToCheck instanceof AdventureCardSpell) {
+            // adventure spell uses alternative characteristics for spell/stack, all other cases must use main card
+            idToCheck = ((AdventureCardSpell) objectToCheck).getMainCard().getId();
+        } else if (!type.needPlayCardAbility() && objectToCheck instanceof ModalDoubleFacesCardHalf) {
+            // each mdf side uses own characteristics to check for playing, all other cases must use main card
+            // rules:
+            // "If an effect allows you to play a land or cast a spell from among a group of cards,
+            // you may play or cast a modal double-faced card with any face that fits the criteria
+            // of that effect. For example, if Sejiri Shelter / Sejiri Glacier is in your graveyard
+            // and an effect allows you to play lands from your graveyard, you could play Sejiri Glacier.
+            // That effect doesn't allow you to cast Sejiri Shelter."
+            idToCheck = ((ModalDoubleFacesCardHalf) objectToCheck).getMainCard().getId();
+        } else {
+            idToCheck = objectId;
+        }
+
+        // Save the consumable and non-consumable objects seperately
+        Set<ApprovingObject> approvingObjects = new LinkedHashSet<>();  // Only the non-consumable effects go here
+        Set<ApprovingObject> consumableApprovingObjects = new HashSet<>();
+
+        for (AsThoughEffect effect : asThoughEffectsList) {
+            Set<Ability> abilities = asThoughEffectsMap.get(type).getAbility(effect.getId());
+            for (Ability ability : abilities) {
+                if (affectedAbility == null) { // applies to full object (one effect can be used in multiple abilities)
+                    if (!effect.applies(idToCheck, ability, controllerId, game)) {
+                        continue;
+                    }
+                } else { // applies to one affected ability
+                    // filter play abilities (no need to check it in every effect's code)
+                    if (type.needPlayCardAbility() && !affectedAbility.getAbilityType().isPlayCardAbility()
+                            || !effect.applies(idToCheck, affectedAbility, ability, game, controllerId)) {
+                        continue;
+                    }
+                }
+
+                if (effect.isConsumable() && !game.inCheckPlayableState()) {
+                    consumableApprovingObjects.add(new ApprovingObject(ability, game));
+                } else {
+                    approvingObjects.add(new ApprovingObject(ability, game));
+                }
+            }
+        }
+        // If only checking for playable, return the first available choice.
+        // The choice doesn't matter as long as something makes it playable.
+        if (game.inCheckPlayableState()) {
+            if (!approvingObjects.isEmpty()) {
+                return approvingObjects.iterator().next();
+            } else if (!consumableApprovingObjects.isEmpty()) {
+                return consumableApprovingObjects.iterator().next();
+            } else {
+                return null;
+            }
+        }
+
+        // Combine consumable and non-consumable together since the player must be able to choose from both
+        approvingObjects.addAll(consumableApprovingObjects);
+        if (approvingObjects.size() == 1) {
+            return approvingObjects.iterator().next();
+        }
+
+        // Select the ability that you use to permit the action
+        Map<String, String> keyChoices = new HashMap<>();
+        for (ApprovingObject approvingObject : approvingObjects) {
+            MageObject mageObject = game.getObject(approvingObject.getApprovingAbility().getSourceId());
+            String choiceKey = approvingObject.getApprovingAbility().getId().toString();
+            String choiceValue;
+            if (mageObject == null) {
+                choiceValue = approvingObject.getApprovingAbility().getRule();
+            } else {
+                choiceValue = mageObject.getIdName() + ": " + approvingObject.getApprovingAbility().getRule(mageObject.getName());
+            }
+            keyChoices.put(choiceKey, choiceValue);
+        }
+        Choice choicePermitting = new ChoiceImpl(true);
+        choicePermitting.setMessage("Choose the permitting object");
+        choicePermitting.setKeyChoices(keyChoices);
+        Player player = game.getPlayer(controllerId);
+        player.choose(Outcome.Detriment, choicePermitting, game);
+        for (ApprovingObject approvingObject : approvingObjects) {
+            if (approvingObject.getApprovingAbility().getId().toString().equals(choicePermitting.getChoiceKey())) {
+                return approvingObject;
+            }
+        }
+
         return null;
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
@@ -610,6 +610,7 @@ public class ContinuousEffects implements Serializable {
             // Apply it again before returning in order to add any alternative costs with setCastSourceIdWithAlternateMana
             // E.g. see Bolas's Citadel
             asThoughEffect.applies(idToCheck, affectedAbility, approvingObject.getApprovingAbility(), game, controllerId);
+            game.getState().setValue("asThoughEffect used for " + objectId, asThoughEffect);
             return approvingObject;
         }
 
@@ -644,6 +645,7 @@ public class ContinuousEffects implements Serializable {
                 // Apply it again before returning in order to add any alternative costs with setCastSourceIdWithAlternateMana
                 // E.g. see Bolas's Citadel
                 asThoughEffect.applies(idToCheck, affectedAbility, approvingObject.getApprovingAbility(), game, controllerId);
+                game.getState().setValue("asThoughEffect used for " + objectId, asThoughEffect);
                 return approvingObject;
             }
         }


### PR DESCRIPTION
Previously the player would be prompted for which permitting object to use only if all of the approving objects were consumable. Now, they are prompted whenever there is more than one object (consumable or not).
Also fixed Risen Executioner to only add its cost increase when its cast using its ability.

![Bolas and Vivian](https://user-images.githubusercontent.com/48962821/178861609-abb41f3f-64f8-46de-9f30-393244f85498.jpg)
![Gisa and Risen](https://user-images.githubusercontent.com/48962821/178861633-a9c568bc-8935-42eb-a230-f8d5f3106510.jpg)

Closes #2087.
Closes #8584.

TODO
- [ ] See which asThough's should give the player the option to choose, and which have rules for automatically picking them