### PR TITLE
Update jackson-databind dependency

### DIFF
--- a/Mage.Verify/pom.xml
+++ b/Mage.Verify/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>[2.9.9.1,)</version>
+            <version>2.13.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This is an attempt to fix the build errors.  The version string looked strange to me so I just changed it to the latest version.  I was not able to reproduce the build error on my machine even after deleting my ~/.m2 folder so we'll see if this PR builds successfully.