### PR TITLE
Fix #9329 by removing explicit lockedIn parameter

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AbhorrentOverlord.java
+++ b/Mage.Sets/src/mage/cards/a/AbhorrentOverlord.java
@@ -35,7 +35,7 @@ public final class AbhorrentOverlord extends CardImpl {
 
         // When Abhorrent Overlord enters the battlefield, create a number of 1/1 black Harpy creature tokens with flying equal to your devotion to black.
         Effect effect = new CreateTokenEffect(new HarpyToken(), DevotionCount.B);
-        effect.setText("create a number of 1/1 black Harpy creature tokens with flying equal to your devotion to black. <i>(Each {B} in the mana costs of permanents you control counts toward your devotion to black.)</i>");
+        effect.setText("create a number of 1/1 black Harpy creature tokens with flying equal to your devotion to black. " + DevotionCount.B.getReminder());
         this.addAbility(new EntersBattlefieldTriggeredAbility(effect).addHint(DevotionCount.B.getHint()));
 
         // At the beginning of your upkeep, sacrifice a creature.

--- a/Mage.Sets/src/mage/cards/a/AcceleratedMutation.java
+++ b/Mage.Sets/src/mage/cards/a/AcceleratedMutation.java
@@ -1,4 +1,3 @@
-
 package mage.cards.a;
 
 import java.util.UUID;
@@ -17,12 +16,13 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class AcceleratedMutation extends CardImpl {
 
+    private static final DynamicValue xValue = new HighestManaValueCount();
+
     public AcceleratedMutation(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{G}{G}");
 
         // Target creature gets +X/+X until end of turn, where X is the highest converted mana cost among permanents you control.
-        DynamicValue amount = new HighestManaValueCount();
-        this.getSpellAbility().addEffect(new BoostTargetEffect(amount, amount, Duration.EndOfTurn, true));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/a/AllSeeingArbiter.java
+++ b/Mage.Sets/src/mage/cards/a/AllSeeingArbiter.java
@@ -43,7 +43,7 @@ public final class AllSeeingArbiter extends CardImpl {
 
         // Whenever you discard a card, target creature an opponent controls gets -X/-0 until your next turn, where X is the number of different mana values among cards in your graveyard.
         Ability ability = new DiscardCardControllerTriggeredAbility(new BoostTargetEffect(
-                AllSeeingArbiterValue.instance, StaticValue.get(0), Duration.UntilYourNextTurn, true
+                AllSeeingArbiterValue.instance, StaticValue.get(0), Duration.UntilYourNextTurn
         ), false);
         ability.addTarget(new TargetOpponentsCreaturePermanent());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/a/AllSeeingArbiter.java
+++ b/Mage.Sets/src/mage/cards/a/AllSeeingArbiter.java
@@ -92,4 +92,9 @@ enum AllSeeingArbiterValue implements DynamicValue {
     public String getMessage() {
         return "the number of different mana values among cards in your graveyard";
     }
+
+    @Override
+    public int getSign() {
+        return -1;
+    }
 }

--- a/Mage.Sets/src/mage/cards/a/AlliedAssault.java
+++ b/Mage.Sets/src/mage/cards/a/AlliedAssault.java
@@ -21,7 +21,7 @@ public final class AlliedAssault extends CardImpl {
 
         // Up to two target creatures each get +X/+X until end of turn, where X is the number of creatures in your party.
         this.getSpellAbility().addEffect(new BoostTargetEffect(
-                PartyCount.instance, PartyCount.instance, Duration.EndOfTurn, true
+                PartyCount.instance, PartyCount.instance, Duration.EndOfTurn
         ).setText("up to two target creatures each get +X/+X until end of turn, " +
                 "where X is the number of creatures in your party. " + PartyCount.getReminder()
         ));

--- a/Mage.Sets/src/mage/cards/a/AltarOfTheGoyf.java
+++ b/Mage.Sets/src/mage/cards/a/AltarOfTheGoyf.java
@@ -34,7 +34,7 @@ public final class AltarOfTheGoyf extends CardImpl {
         this.addAbility(new AttacksAloneControlledTriggeredAbility(new BoostTargetEffect(
                 CardTypesInGraveyardCount.ALL,
                 CardTypesInGraveyardCount.ALL,
-                Duration.EndOfTurn, true
+                Duration.EndOfTurn
         ).setText("it gets +X/+X until end of turn, where X is " +
                 "the number of card types among cards in all graveyards."), true, false).addHint(CardTypesInGraveyardHint.ALL));
 

--- a/Mage.Sets/src/mage/cards/a/AltarOfTheGoyf.java
+++ b/Mage.Sets/src/mage/cards/a/AltarOfTheGoyf.java
@@ -30,13 +30,10 @@ public final class AltarOfTheGoyf extends CardImpl {
 
         this.subtype.add(SubType.LHURGOYF);
 
-        // Whenever a creature you control attacks alone, it gets +X/+X until end of turn, where X is the number of card types among cards in all graveyard.
-        this.addAbility(new AttacksAloneControlledTriggeredAbility(new BoostTargetEffect(
-                CardTypesInGraveyardCount.ALL,
-                CardTypesInGraveyardCount.ALL,
-                Duration.EndOfTurn
-        ).setText("it gets +X/+X until end of turn, where X is " +
-                "the number of card types among cards in all graveyards."), true, false).addHint(CardTypesInGraveyardHint.ALL));
+        // Whenever a creature you control attacks alone, it gets +X/+X until end of turn, where X is the number of card types among cards in all graveyards.
+        this.addAbility(new AttacksAloneControlledTriggeredAbility(
+                new BoostTargetEffect(CardTypesInGraveyardCount.ALL, CardTypesInGraveyardCount.ALL, Duration.EndOfTurn),
+                true, false).addHint(CardTypesInGraveyardHint.ALL));
 
         // Lhurgoyf creatures you control have trample.
         this.addAbility(new SimpleStaticAbility(new GainAbilityControlledEffect(

--- a/Mage.Sets/src/mage/cards/a/AngelicExaltation.java
+++ b/Mage.Sets/src/mage/cards/a/AngelicExaltation.java
@@ -23,7 +23,7 @@ public final class AngelicExaltation extends CardImpl {
         this.addAbility(new AttacksAloneControlledTriggeredAbility(new BoostTargetEffect(
                 CreaturesYouControlCount.instance,
                 CreaturesYouControlCount.instance,
-                Duration.EndOfTurn, true
+                Duration.EndOfTurn
         ).setText("it gets +X/+X until end of turn, where X is the number of creatures you control"), true, false).addHint(CreaturesYouControlHint.instance));
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelicExaltation.java
+++ b/Mage.Sets/src/mage/cards/a/AngelicExaltation.java
@@ -20,11 +20,9 @@ public final class AngelicExaltation extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{W}");
 
         // Whenever a creature you control attacks alone, it gets +X/+X until end of turn, where X is the number of creatures you control.
-        this.addAbility(new AttacksAloneControlledTriggeredAbility(new BoostTargetEffect(
-                CreaturesYouControlCount.instance,
-                CreaturesYouControlCount.instance,
-                Duration.EndOfTurn
-        ).setText("it gets +X/+X until end of turn, where X is the number of creatures you control"), true, false).addHint(CreaturesYouControlHint.instance));
+        this.addAbility(new AttacksAloneControlledTriggeredAbility(
+                new BoostTargetEffect(CreaturesYouControlCount.instance, CreaturesYouControlCount.instance, Duration.EndOfTurn),
+                true, false).addHint(CreaturesYouControlHint.instance));
     }
 
     private AngelicExaltation(final AngelicExaltation card) {

--- a/Mage.Sets/src/mage/cards/a/AppealAuthority.java
+++ b/Mage.Sets/src/mage/cards/a/AppealAuthority.java
@@ -32,7 +32,7 @@ public final class AppealAuthority extends SplitCard {
         // Until end of turn, target creature gains trample and gets +X/+X, where X is the number of creatures you control.
         getLeftHalfCard().getSpellAbility().addEffect(new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn)
                 .setText("Until end of turn, target creature gains trample"));
-        getLeftHalfCard().getSpellAbility().addEffect(new BoostTargetEffect(CreaturesYouControlCount.instance, CreaturesYouControlCount.instance, Duration.EndOfTurn, true)
+        getLeftHalfCard().getSpellAbility().addEffect(new BoostTargetEffect(CreaturesYouControlCount.instance, CreaturesYouControlCount.instance, Duration.EndOfTurn)
                 .setText("and gets +X/+X, where X is the number of creatures you control"));
         getLeftHalfCard().getSpellAbility().addTarget(new TargetCreaturePermanent());
         getLeftHalfCard().getSpellAbility().addHint(CreaturesYouControlHint.instance);

--- a/Mage.Sets/src/mage/cards/a/ArmixFiligreeThrasher.java
+++ b/Mage.Sets/src/mage/cards/a/ArmixFiligreeThrasher.java
@@ -51,7 +51,7 @@ public final class ArmixFiligreeThrasher extends CardImpl {
 
         // Whenever Armix, Filigree Thrasher attacks, you may discard a card. When you do, target creature defending player controls gets -X/-X until end of turn, where X is the number of artifacts you control plus the number of artifact cards in your graveyard.
         ReflexiveTriggeredAbility ability = new ReflexiveTriggeredAbility(
-                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true), false,
+                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn), false,
                 "target creature defending player controls gets -X/-X until end of turn, " +
                 "where X is the number of artifacts you control plus the number of artifact cards in your graveyard"
         );

--- a/Mage.Sets/src/mage/cards/a/AsariCaptain.java
+++ b/Mage.Sets/src/mage/cards/a/AsariCaptain.java
@@ -40,8 +40,7 @@ public final class AsariCaptain extends CardImpl {
 
         // Whenever a Samurai or Warrior you control attacks alone, it gets +1/+0 until end of turn for each Samurai or Warrior you control.
         this.addAbility(new AttacksAloneControlledTriggeredAbility(
-                new BoostTargetEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, true)
-                        .setText("it gets +1/+0 until end of turn for each Samurai or Warrior you control"),
+                new BoostTargetEffect(xValue, StaticValue.get(0), Duration.EndOfTurn),
                 StaticFilters.FILTER_CONTROLLED_SAMURAI_OR_WARRIOR, true, false
         ).addHint(hint));
     }

--- a/Mage.Sets/src/mage/cards/a/AspectOfHydra.java
+++ b/Mage.Sets/src/mage/cards/a/AspectOfHydra.java
@@ -1,6 +1,7 @@
 package mage.cards.a;
 
 import mage.abilities.dynamicvalue.common.DevotionCount;
+import mage.abilities.effects.common.InfoEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -20,6 +21,7 @@ public final class AspectOfHydra extends CardImpl {
 
         // Target creature gets +X/+X until end of turn, where X is your devotion to green.
         this.getSpellAbility().addEffect(new BoostTargetEffect(DevotionCount.G, DevotionCount.G, Duration.EndOfTurn));
+        this.getSpellAbility().addEffect(new InfoEffect(DevotionCount.G.getReminder()));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addHint(DevotionCount.G.getHint());
     }

--- a/Mage.Sets/src/mage/cards/a/AspectOfHydra.java
+++ b/Mage.Sets/src/mage/cards/a/AspectOfHydra.java
@@ -1,7 +1,6 @@
 package mage.cards.a;
 
 import mage.abilities.dynamicvalue.common.DevotionCount;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -20,9 +19,7 @@ public final class AspectOfHydra extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{G}");
 
         // Target creature gets +X/+X until end of turn, where X is your devotion to green.
-        Effect effect = new BoostTargetEffect(DevotionCount.G, DevotionCount.G, Duration.EndOfTurn, true);
-        effect.setText("Target creature gets +X/+X until end of turn, where X is your devotion to green");
-        this.getSpellAbility().addEffect(effect);
+        this.getSpellAbility().addEffect(new BoostTargetEffect(DevotionCount.G, DevotionCount.G, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addHint(DevotionCount.G.getHint());
     }

--- a/Mage.Sets/src/mage/cards/a/AuriokBladewarden.java
+++ b/Mage.Sets/src/mage/cards/a/AuriokBladewarden.java
@@ -31,7 +31,7 @@ public final class AuriokBladewarden extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {tap}: Target creature gets +X/+X until end of turn, where X is Auriok Bladewarden's power.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(new SourcePermanentPowerCount(), new SourcePermanentPowerCount(), Duration.EndOfTurn, true), new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(new BoostTargetEffect(new SourcePermanentPowerCount(), new SourcePermanentPowerCount(), Duration.EndOfTurn), new TapSourceCost());
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BarrelDownSokenzan.java
+++ b/Mage.Sets/src/mage/cards/b/BarrelDownSokenzan.java
@@ -1,4 +1,3 @@
-
 package mage.cards.b;
 
 import java.util.UUID;
@@ -19,14 +18,17 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class BarrelDownSokenzan extends CardImpl {
 
+    private static final DynamicValue xValue = new MultipliedValue(SweepNumber.MOUNTAIN, 2);
+
     public BarrelDownSokenzan(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{R}");
         this.subtype.add(SubType.ARCANE);
 
         // Sweep - Return any number of Mountains you control to their owner's hand. Barrel Down Sokenzan deals damage to target creature equal to twice the number of Mountains returned this way.
         this.getSpellAbility().addEffect(new SweepEffect(SubType.MOUNTAIN));
-        DynamicValue sweepValue = new MultipliedValue(new SweepNumber("Mountain"), 2);
-        this.getSpellAbility().addEffect(new DamageTargetEffect(sweepValue));
+        this.getSpellAbility().addEffect(new DamageTargetEffect(xValue)
+                .setText("{this} deals damage to target creature equal to twice the number of Mountains returned this way")
+        );
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/b/BasiliskGate.java
+++ b/Mage.Sets/src/mage/cards/b/BasiliskGate.java
@@ -39,12 +39,14 @@ public final class BasiliskGate extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
 
         // {2}, {T}: Target creature gets +X/+X until end of turn, where X is the number of Gates you control. Activate only as a sorcery.
-        Ability ability = new ActivateAsSorceryActivatedAbility(new BoostTargetEffect(
-                xValue, xValue, Duration.EndOfTurn, true
-        ), new GenericManaCost(2));
+        Ability ability = new ActivateAsSorceryActivatedAbility(
+                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn),
+                new GenericManaCost(2)
+        );
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetCreaturePermanent());
-        this.addAbility(ability.addHint(hint));
+        ability.addHint(hint);
+        this.addAbility(ability);
     }
 
     private BasiliskGate(final BasiliskGate card) {

--- a/Mage.Sets/src/mage/cards/b/BattleAtTheBridge.java
+++ b/Mage.Sets/src/mage/cards/b/BattleAtTheBridge.java
@@ -20,6 +20,8 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class BattleAtTheBridge extends CardImpl {
 
+    private static final DynamicValue xValue = new SignInversionDynamicValue(ManacostVariableValue.REGULAR);
+
     public BattleAtTheBridge(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{X}{B}");
 
@@ -27,8 +29,8 @@ public final class BattleAtTheBridge extends CardImpl {
         addAbility(new ImproviseAbility());
 
         // Target creature gets -X/-X until end of turn. You gain X life.
-        DynamicValue x = new SignInversionDynamicValue(ManacostVariableValue.REGULAR);
-        this.getSpellAbility().addEffect(new BoostTargetEffect(x, x, Duration.EndOfTurn, true));
+        
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addEffect(new GainLifeEffect(ManacostVariableValue.REGULAR));
     }

--- a/Mage.Sets/src/mage/cards/b/Berserk.java
+++ b/Mage.Sets/src/mage/cards/b/Berserk.java
@@ -42,7 +42,7 @@ public final class Berserk extends CardImpl {
         Effect effect = new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("Target creature gains trample");
         this.getSpellAbility().addEffect(effect);
-        effect = new BoostTargetEffect(TargetPermanentPowerCount.instance, StaticValue.get(0), Duration.EndOfTurn, true);
+        effect = new BoostTargetEffect(TargetPermanentPowerCount.instance, StaticValue.get(0), Duration.EndOfTurn);
         effect.setText("and gets +X/+0 until end of turn, where X is its power");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addEffect(new BerserkDestroyEffect());

--- a/Mage.Sets/src/mage/cards/b/BishopOfBinding.java
+++ b/Mage.Sets/src/mage/cards/b/BishopOfBinding.java
@@ -1,4 +1,3 @@
-
 package mage.cards.b;
 
 import java.util.UUID;
@@ -34,11 +33,11 @@ import mage.util.CardUtil;
  */
 public final class BishopOfBinding extends CardImpl {
 
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.VAMPIRE, "Vampire");
+
     public BishopOfBinding(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{W}");
-
-        this.subtype.add(SubType.VAMPIRE);
-        this.subtype.add(SubType.CLERIC);
+        this.subtype.add(SubType.VAMPIRE, SubType.CLERIC);
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
 
@@ -49,10 +48,8 @@ public final class BishopOfBinding extends CardImpl {
         this.addAbility(ability);
 
         // Whenever Bishop of Binding attacks, target Vampire gets +X/+X until end of turn, where X is the power of the exiled card.
-        DynamicValue xVale = new BishopOfBindingExiledCardsPowerCount();
-        ability = new AttacksTriggeredAbility(new BoostTargetEffect(xVale, xVale, Duration.EndOfTurn, true)
-                .setText("target Vampire gets +X/+X until end of turn, where X is the power of the exiled card"), false);
-        ability.addTarget(new TargetCreaturePermanent(new FilterCreaturePermanent(SubType.VAMPIRE, "Vampire")));
+        ability = new AttacksTriggeredAbility(new BoostTargetEffect(BishopOfBindingValue.instance, BishopOfBindingValue.instance, Duration.EndOfTurn));
+        ability.addTarget(new TargetCreaturePermanent(filter));
         this.addAbility(ability);
     }
 
@@ -69,7 +66,7 @@ public final class BishopOfBinding extends CardImpl {
 class BishopOfBindingExileEffect extends OneShotEffect {
 
     public BishopOfBindingExileEffect() {
-        super(Outcome.Benefit);
+        super(Outcome.Exile);
         this.staticText = "exile target creature an opponent controls until {this} leaves the battlefield";
     }
 
@@ -94,7 +91,8 @@ class BishopOfBindingExileEffect extends OneShotEffect {
     }
 }
 
-class BishopOfBindingExiledCardsPowerCount implements DynamicValue {
+enum BishopOfBindingValue implements DynamicValue {
+    instance;
 
     @Override
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
@@ -109,13 +107,17 @@ class BishopOfBindingExiledCardsPowerCount implements DynamicValue {
     }
 
     @Override
-    public BishopOfBindingExiledCardsPowerCount copy() {
-        return new BishopOfBindingExiledCardsPowerCount();
+    public BishopOfBindingValue copy() {
+        return instance;
+    }
+
+    @Override
+    public String toString() {
+        return "X";
     }
 
     @Override
     public String getMessage() {
-        return "power of the exiled card";
+        return "the power of the exiled card";
     }
-
 }

--- a/Mage.Sets/src/mage/cards/b/BloodthirstyOgre.java
+++ b/Mage.Sets/src/mage/cards/b/BloodthirstyOgre.java
@@ -1,4 +1,3 @@
-
 package mage.cards.b;
 
 import java.util.UUID;
@@ -29,11 +28,8 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class BloodthirstyOgre extends CardImpl {
 
-    private static final FilterControlledPermanent filter = new FilterControlledPermanent("you control a Demon");
-    
-    static {
-        filter.add(SubType.DEMON.getPredicate());
-    }
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent(SubType.DEMON, "you control a Demon");
+    private static final DynamicValue xValue = new SignInversionDynamicValue(new CountersSourceCount(CounterType.DEVOTION));
 
     public BloodthirstyOgre(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
@@ -46,9 +42,10 @@ public final class BloodthirstyOgre extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.DEVOTION.createInstance()),new TapSourceCost()));
 
         // {T}: Target creature gets -X/-X until end of turn, where X is the number of devotion counters on Bloodthirsty Ogre. Activate this ability only if you control a Demon.
-        DynamicValue devotionCounters = new SignInversionDynamicValue(new CountersSourceCount(CounterType.DEVOTION));
+
         Ability ability = new ActivateIfConditionActivatedAbility(Zone.BATTLEFIELD,
-                new BoostTargetEffect(devotionCounters,devotionCounters, Duration.EndOfTurn, true),
+                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn)
+                        .setText("target creature gets -X/-X until end of turn, where X is the number of devotion counters on {this}"),
                 new TapSourceCost(),
                 new PermanentsOnTheBattlefieldCondition(filter));
         ability.addTarget(new TargetCreaturePermanent());
@@ -63,5 +60,4 @@ public final class BloodthirstyOgre extends CardImpl {
     public BloodthirstyOgre copy() {
         return new BloodthirstyOgre(this);
     }
-
 }

--- a/Mage.Sets/src/mage/cards/c/CallForBlood.java
+++ b/Mage.Sets/src/mage/cards/c/CallForBlood.java
@@ -30,9 +30,8 @@ public final class CallForBlood extends CardImpl {
         // As an additional cost to cast this spell, sacrifice a creature.
         this.getSpellAbility().addCost(new SacrificeTargetCost(new TargetControlledCreaturePermanent(FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
         // Target creature gets -X/-X until end of turn, where X is the sacrificed creature's power.
-        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
-
     }
 
     private CallForBlood(final CallForBlood card) {

--- a/Mage.Sets/src/mage/cards/c/CanopyCrawler.java
+++ b/Mage.Sets/src/mage/cards/c/CanopyCrawler.java
@@ -1,4 +1,3 @@
-
 package mage.cards.c;
 
 import java.util.UUID;
@@ -6,6 +5,7 @@ import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.CountersSourceCount;
 import mage.abilities.effects.common.AmplifyEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
@@ -25,6 +25,8 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class CanopyCrawler extends CardImpl {
 
+    private static final DynamicValue xValue = new CountersSourceCount(CounterType.P1P1);
+
     public CanopyCrawler(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{G}");
         this.subtype.add(SubType.BEAST);
@@ -33,9 +35,9 @@ public final class CanopyCrawler extends CardImpl {
 
         // Amplify 1
         this.addAbility(new AmplifyAbility(AmplifyEffect.AmplifyFactor.Amplify1));
+
         // {tap}: Target creature gets +1/+1 until end of turn for each +1/+1 counter on Canopy Crawler.
-        CountersSourceCount count = new CountersSourceCount(CounterType.P1P1);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(count, count, Duration.EndOfTurn, true), new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn), new TapSourceCost());
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/c/CapitalOffense.java
+++ b/Mage.Sets/src/mage/cards/c/CapitalOffense.java
@@ -28,7 +28,7 @@ public final class CapitalOffense extends CardImpl {
 
         // target creature gets -x/-x until end of turn, where x is the number of times a capital letter appears in its rules text. (ignore reminder text and flavor text.)
         this.getSpellAbility().addEffect(new BoostTargetEffect(
-                capitaloffensecount.instance, capitaloffensecount.instance, Duration.EndOfTurn, true
+                capitaloffensecount.instance, capitaloffensecount.instance, Duration.EndOfTurn
         ).setText("target creature gets -x/-x until end of turn, where x is the number of times " +
                 "a capital letter appears in its rules text. <i>(ignore reminder text and flavor text.)</i>"
         ));

--- a/Mage.Sets/src/mage/cards/c/ChargeAcrossTheAraba.java
+++ b/Mage.Sets/src/mage/cards/c/ChargeAcrossTheAraba.java
@@ -1,8 +1,6 @@
-
 package mage.cards.c;
 
 import java.util.UUID;
-import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.SweepNumber;
 import mage.abilities.effects.common.continuous.BoostControlledEffect;
 import mage.abilities.effects.keyword.SweepEffect;
@@ -24,9 +22,7 @@ public final class ChargeAcrossTheAraba extends CardImpl {
 
         // Sweep - Return any number of Plains you control to their owner's hand. Creatures you control get +1/+1 until end of turn for each Plains returned this way.
         this.getSpellAbility().addEffect(new SweepEffect(SubType.PLAINS));
-        DynamicValue sweepValue = new SweepNumber("Plains");
-        this.getSpellAbility().addEffect(new BoostControlledEffect(sweepValue, sweepValue, Duration.EndOfTurn, null, false, true));
-
+        this.getSpellAbility().addEffect(new BoostControlledEffect(SweepNumber.PLAINS, SweepNumber.PLAINS, Duration.EndOfTurn, null, false, true));
     }
 
     private ChargeAcrossTheAraba(final ChargeAcrossTheAraba card) {

--- a/Mage.Sets/src/mage/cards/c/ChorusOfMight.java
+++ b/Mage.Sets/src/mage/cards/c/ChorusOfMight.java
@@ -1,14 +1,14 @@
 package mage.cards.c;
 
-import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
+import mage.abilities.dynamicvalue.common.CreaturesYouControlCount;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
+import mage.abilities.hint.common.CreaturesYouControlHint;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
@@ -21,12 +21,15 @@ public final class ChorusOfMight extends CardImpl {
     public ChorusOfMight(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{G}");
 
-
         // Until end of turn, target creature gets +1/+1 for each creature you control and gains trample.
-        PermanentsOnBattlefieldCount value = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURE);
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
-        this.getSpellAbility().addEffect(new BoostTargetEffect(value, value, Duration.EndOfTurn, true));
-        this.getSpellAbility().addEffect(new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(CreaturesYouControlCount.instance, CreaturesYouControlCount.instance, Duration.EndOfTurn)
+                .setText("until end of turn, target creature gets +1/+1 for each creature you control")
+        );
+        this.getSpellAbility().addEffect(new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn)
+                .setText("and gains trample")
+        );
+        this.getSpellAbility().addHint(CreaturesYouControlHint.instance);
     }
 
     private ChorusOfMight(final ChorusOfMight card) {
@@ -38,4 +41,3 @@ public final class ChorusOfMight extends CardImpl {
         return new ChorusOfMight(this);
     }
 }
-

--- a/Mage.Sets/src/mage/cards/c/ConfrontTheUnknown.java
+++ b/Mage.Sets/src/mage/cards/c/ConfrontTheUnknown.java
@@ -1,7 +1,7 @@
-
 package mage.cards.c;
 
 import java.util.UUID;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
@@ -20,11 +20,7 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class ConfrontTheUnknown extends CardImpl {
 
-    private static final FilterControlledPermanent filter = new FilterControlledPermanent("each Clue you control");
-
-    static {
-        filter.add(SubType.CLUE.getPredicate());
-    }
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.CLUE, "Clue you control"));
 
     public ConfrontTheUnknown(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{G}");
@@ -33,7 +29,7 @@ public final class ConfrontTheUnknown extends CardImpl {
         Effect effect = new InvestigateEffect();
         effect.setText("Investigate");
         getSpellAbility().addEffect(effect);
-        effect = new BoostTargetEffect(new PermanentsOnBattlefieldCount(filter), new PermanentsOnBattlefieldCount(filter), Duration.EndOfTurn, true);
+        effect = new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn);
         effect.setText(", then target creature gets +1/+1 until end of turn for each Clue you control. <i>(To investigate, "
                 + "create a colorless Clue artifact token with \"{2}, Sacrifice this artifact: Draw a card.\")</i>");
         getSpellAbility().addEffect(effect);

--- a/Mage.Sets/src/mage/cards/d/DarkSalvation.java
+++ b/Mage.Sets/src/mage/cards/d/DarkSalvation.java
@@ -40,7 +40,7 @@ public final class DarkSalvation extends CardImpl {
                 Duration.EndOfTurn
         );
         effect.setTargetPointer(new SecondTargetPointer());
-        effect.concatBy(", then");
+        effect.setText(", then up to one target creature gets -1/-1 until end of turn for each Zombie that player controls");
         this.getSpellAbility().addEffect(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkSalvation.java
+++ b/Mage.Sets/src/mage/cards/d/DarkSalvation.java
@@ -84,4 +84,9 @@ enum ZombiesControlledByTargetPlayerCount implements DynamicValue {
     public String getMessage() {
         return "Zombie that player controls";
     }
+
+    @Override
+    public int getSign() {
+        return -1;
+    }
 }

--- a/Mage.Sets/src/mage/cards/d/DarkSalvation.java
+++ b/Mage.Sets/src/mage/cards/d/DarkSalvation.java
@@ -1,4 +1,3 @@
-
 package mage.cards.d;
 
 import java.util.UUID;
@@ -13,8 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.FilterPermanent;
 import mage.game.Game;
 import mage.game.permanent.token.ZombieToken;
 import mage.players.Player;
@@ -33,15 +31,16 @@ public final class DarkSalvation extends CardImpl {
 
         // Target player creates X 2/2 black Zombie creature tokens, then up to one target creature gets -1/-1 until end of turn for each Zombie that player controls.
         this.getSpellAbility().addTarget(new TargetPlayer());
-        Effect effect = new CreateTokenTargetEffect(new ZombieToken(), ManacostVariableValue.REGULAR);
-        effect.setText("Target player creates X 2/2 black Zombie creature tokens");
-        this.getSpellAbility().addEffect(effect);
-        DynamicValue value = new ZombiesControlledByTargetPlayerCount();
+        this.getSpellAbility().addEffect(new CreateTokenTargetEffect(new ZombieToken(), ManacostVariableValue.REGULAR));
 
-        this.getSpellAbility().addTarget(new TargetCreaturePermanent(0, 1, StaticFilters.FILTER_PERMANENT_CREATURE, false));
-        effect = new BoostTargetEffect(value, value, Duration.EndOfTurn, true);
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(0, 1));
+        Effect effect = new BoostTargetEffect(
+                ZombiesControlledByTargetPlayerCount.instance,
+                ZombiesControlledByTargetPlayerCount.instance,
+                Duration.EndOfTurn
+        );
         effect.setTargetPointer(new SecondTargetPointer());
-        effect.setText(", then up to one target creature gets -1/-1 until end of turn for each Zombie that player controls");
+        effect.concatBy(", then");
         this.getSpellAbility().addEffect(effect);
     }
 
@@ -55,18 +54,10 @@ public final class DarkSalvation extends CardImpl {
     }
 }
 
-class ZombiesControlledByTargetPlayerCount implements DynamicValue {
+enum ZombiesControlledByTargetPlayerCount implements DynamicValue {
+    instance;
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Zombies");
-
-    static {
-        filter.add(SubType.ZOMBIE.getPredicate());
-    }
-
-    @Override
-    public ZombiesControlledByTargetPlayerCount copy() {
-        return new ZombiesControlledByTargetPlayerCount();
-    }
+    private static final FilterPermanent filter = new FilterPermanent(SubType.ZOMBIE, "Zombie");
 
     @Override
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
@@ -80,7 +71,17 @@ class ZombiesControlledByTargetPlayerCount implements DynamicValue {
     }
 
     @Override
+    public ZombiesControlledByTargetPlayerCount copy() {
+        return instance;
+    }
+
+    @Override
+    public String toString() {
+        return "-1";
+    }
+
+    @Override
     public String getMessage() {
-        return filter.getMessage() + " that player controls";
+        return "Zombie that player controls";
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DeathWind.java
+++ b/Mage.Sets/src/mage/cards/d/DeathWind.java
@@ -1,4 +1,3 @@
-
 package mage.cards.d;
 
 import java.util.UUID;
@@ -17,13 +16,13 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class DeathWind extends CardImpl {
 
+    private static final DynamicValue xValue = new SignInversionDynamicValue(ManacostVariableValue.REGULAR);
+
     public DeathWind(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{X}{B}");
 
-
         // Target creature gets -X/-X until end of turn.
-        DynamicValue x = new SignInversionDynamicValue(ManacostVariableValue.REGULAR);
-        this.getSpellAbility().addEffect(new BoostTargetEffect(x, x, Duration.EndOfTurn, true));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/d/Defile.java
+++ b/Mage.Sets/src/mage/cards/d/Defile.java
@@ -3,6 +3,8 @@ package mage.cards.d;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -19,22 +21,17 @@ import java.util.UUID;
  */
 public final class Defile extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterControlledPermanent();
-
-    static {
-        filter.add(SubType.SWAMP.getPredicate());
-    }
-
+    private static final FilterPermanent filter = new FilterControlledPermanent(SubType.SWAMP, "Swamp you control");
     private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(filter, -1);
+    private static final Hint hint = new ValueHint("Swamps you control", new PermanentsOnBattlefieldCount(filter));
 
     public Defile(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{B}");
 
         // Target creature gets -1/-1 until end of turn for each Swamp you control.
-        this.getSpellAbility().addEffect(new BoostTargetEffect(
-                xValue, xValue, Duration.EndOfTurn, true
-        ).setText("Target creature gets -1/-1 until end of turn for each Swamp you control."));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
+        this.getSpellAbility().addHint(hint);
     }
 
     private Defile(final Defile card) {

--- a/Mage.Sets/src/mage/cards/d/DownhillCharge.java
+++ b/Mage.Sets/src/mage/cards/d/DownhillCharge.java
@@ -1,9 +1,9 @@
-
 package mage.cards.d;
 
 import java.util.UUID;
 import mage.abilities.costs.AlternativeCostSourceAbility;
 import mage.abilities.costs.common.SacrificeTargetCost;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.Effect;
@@ -23,21 +23,19 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class DownhillCharge extends CardImpl {
 
-     private static final FilterControlledPermanent filter = new FilterControlledPermanent("a Mountain");
-
-     static {
-        filter.add(SubType.MOUNTAIN.getPredicate());
-    }
+     private static final FilterControlledPermanent filter = new FilterControlledPermanent(SubType.MOUNTAIN, "a Mountain");
+     private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(
+            new FilterControlledPermanent(SubType.MOUNTAIN, "Mountains you control"), null
+    );
 
     public DownhillCharge(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{2}{R}");
 
         // You may sacrifice a Mountain rather than pay Downhill Charge's mana cost.
         this.addAbility(new AlternativeCostSourceAbility(new SacrificeTargetCost(new TargetControlledPermanent(filter))));
+
         // Target creature gets +X/+0 until end of turn, where X is the number of Mountains you control.
-        Effect effect = new BoostTargetEffect(new PermanentsOnBattlefieldCount(filter), StaticValue.get(0), Duration.EndOfTurn, true);
-        effect.setText("Target creature gets +X/+0 until end of turn, where X is the number of Mountains you control.");
-        this.getSpellAbility().addEffect(effect);
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, StaticValue.get(0), Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/d/DragDown.java
+++ b/Mage.Sets/src/mage/cards/d/DragDown.java
@@ -1,8 +1,8 @@
 package mage.cards.d;
 
 import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.dynamicvalue.MultipliedValue;
 import mage.abilities.dynamicvalue.common.DomainValue;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.abilities.hint.common.DomainHint;
 import mage.cards.CardImpl;
@@ -19,14 +19,13 @@ import java.util.UUID;
  */
 public final class DragDown extends CardImpl {
 
-    private static final DynamicValue xValue = new MultipliedValue(DomainValue.REGULAR, -1);
+    private static final DynamicValue xValue = new SignInversionDynamicValue(DomainValue.REGULAR);
 
     public DragDown(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{B}");
 
         // Domain - Target creature gets -1/-1 until end of turn for each basic land type among lands you control.
-        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true)
-                .setText("target creature gets -1/-1 until end of turn for each basic land type among lands you control"));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addHint(DomainHint.instance);
         this.getSpellAbility().setAbilityWord(AbilityWord.DOMAIN);

--- a/Mage.Sets/src/mage/cards/d/DranasSilencer.java
+++ b/Mage.Sets/src/mage/cards/d/DranasSilencer.java
@@ -26,15 +26,13 @@ public final class DranasSilencer extends CardImpl {
 
     public DranasSilencer(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{B}");
-
-        this.subtype.add(SubType.VAMPIRE);
-        this.subtype.add(SubType.ROGUE);
+        this.subtype.add(SubType.VAMPIRE, SubType.ROGUE);
         this.power = new MageInt(3);
         this.toughness = new MageInt(2);
 
         // When Drana's Silencer enters the battlefield, target creature an opponent controls gets -X/-X until end of turn, where X is the number of creatures in your party.
         Ability ability = new EntersBattlefieldTriggeredAbility(new BoostTargetEffect(
-                xValue, xValue, Duration.EndOfTurn, true
+                xValue, xValue, Duration.EndOfTurn
         ).setText("target creature an opponent controls gets -X/-X until end of turn, " +
                 "where X is the number of creatures in your party. " + PartyCount.getReminder()));
         ability.addTarget(new TargetOpponentsCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/e/EiganjoExemplar.java
+++ b/Mage.Sets/src/mage/cards/e/EiganjoExemplar.java
@@ -26,7 +26,7 @@ public final class EiganjoExemplar extends CardImpl {
 
         // Whenever a Samurai or Warrior you control attacks alone, it gets +1/+1 until end of turn.
         this.addAbility(new AttacksAloneControlledTriggeredAbility(
-                new BoostTargetEffect(1, 1).setText("it gets +1/+1 until end of turn"),
+                new BoostTargetEffect(1, 1),
                 StaticFilters.FILTER_CONTROLLED_SAMURAI_OR_WARRIOR, true, false
         ));
     }

--- a/Mage.Sets/src/mage/cards/e/ElderOfLaurels.java
+++ b/Mage.Sets/src/mage/cards/e/ElderOfLaurels.java
@@ -11,7 +11,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
@@ -30,8 +29,8 @@ public final class ElderOfLaurels extends CardImpl {
         this.toughness = new MageInt(3);
 
         // {3}{G}: Target creature gets +X/+X until end of turn, where X is the number of creatures you control.
-        SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new BoostTargetEffect(CreaturesYouControlCount.instance, CreaturesYouControlCount.instance, Duration.EndOfTurn, true),
+        SimpleActivatedAbility ability = new SimpleActivatedAbility(
+                new BoostTargetEffect(CreaturesYouControlCount.instance, CreaturesYouControlCount.instance, Duration.EndOfTurn),
                 new ManaCostsImpl<>("{3}{G}"));
         ability.addTarget(new TargetCreaturePermanent());
         ability.addHint(CreaturesYouControlHint.instance);

--- a/Mage.Sets/src/mage/cards/e/EssencePulse.java
+++ b/Mage.Sets/src/mage/cards/e/EssencePulse.java
@@ -1,24 +1,24 @@
 package mage.cards.e;
 
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.ControllerGotLifeCount;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.effects.common.GainLifeEffect;
 import mage.abilities.effects.common.continuous.BoostAllEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
+import mage.watchers.common.PlayerGainedLifeWatcher;
 
 import java.util.UUID;
-import mage.abilities.dynamicvalue.LockedInDynamicValue;
-import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 
 /**
  * @author TheElk801
  */
 public final class EssencePulse extends CardImpl {
 
-    // rule 608.2h
-    private static final LockedInDynamicValue xValue = new LockedInDynamicValue(new SignInversionDynamicValue(ControllerGotLifeCount.instance));
+    private static final DynamicValue xValue = new SignInversionDynamicValue(ControllerGotLifeCount.instance);
 
     public EssencePulse(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{B}");
@@ -28,6 +28,7 @@ public final class EssencePulse extends CardImpl {
         this.getSpellAbility().addEffect(new BoostAllEffect(
                 xValue, xValue, Duration.EndOfTurn
         ).setText("Each creature gets -X/-X until end of turn, where X is the amount of life you gained this turn"));
+        this.getSpellAbility().addWatcher(new PlayerGainedLifeWatcher());
         this.getSpellAbility().addHint(ControllerGotLifeCount.getHint());
     }
 

--- a/Mage.Sets/src/mage/cards/f/FatalFrenzy.java
+++ b/Mage.Sets/src/mage/cards/f/FatalFrenzy.java
@@ -35,7 +35,7 @@ public final class FatalFrenzy extends CardImpl {
         this.getSpellAbility().addEffect(new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn)
                 .setText("Until end of turn, target creature you control gains trample")
         );
-        this.getSpellAbility().addEffect(new BoostTargetEffect(TargetPermanentPowerCount.instance, StaticValue.get(0), Duration.EndOfTurn, true)
+        this.getSpellAbility().addEffect(new BoostTargetEffect(TargetPermanentPowerCount.instance, StaticValue.get(0), Duration.EndOfTurn)
                 .setText("and gets +X/+0, where X is its power")
         );
         this.getSpellAbility().addEffect(new FatalFrenzyEffect());

--- a/Mage.Sets/src/mage/cards/f/FearOfDeath.java
+++ b/Mage.Sets/src/mage/cards/f/FearOfDeath.java
@@ -5,28 +5,31 @@ import java.util.UUID;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.CardsInControllerGraveyardCount;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.dynamicvalue.common.StaticValue;
-import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.effects.common.MillCardsControllerEffect;
 import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
-import mage.constants.SubType;
-import mage.game.Game;
-import mage.players.Player;
-import mage.target.common.TargetCreaturePermanent;
-import mage.abilities.Ability;
-import mage.abilities.effects.common.AttachEffect;
-import mage.constants.Outcome;
-import mage.target.TargetPermanent;
 import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.filter.StaticFilters;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetCreaturePermanent;
 
 /**
  *
- * @author weirddan455
+ * @author awjackson
  */
 public final class FearOfDeath extends CardImpl {
+
+    private static final DynamicValue xValue = new SignInversionDynamicValue(
+            new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CARDS, null)
+    );
 
     public FearOfDeath(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{U}");
@@ -37,14 +40,13 @@ public final class FearOfDeath extends CardImpl {
         TargetPermanent auraTarget = new TargetCreaturePermanent();
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.UnboostCreature));
-        Ability ability = new EnchantAbility(auraTarget.getTargetName());
-        this.addAbility(ability);
+        this.addAbility(new EnchantAbility(auraTarget.getTargetName()));
 
         // When Fear of Death enters the battlefield, mill two cards.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new MillCardsControllerEffect(2)));
 
         // Enchanted creature gets -X/-0, where X is the number of cards in your graveyard.
-        this.addAbility(new SimpleStaticAbility(new BoostEnchantedEffect(FearOfDeathValue.instance, StaticValue.get(0))));
+        this.addAbility(new SimpleStaticAbility(new BoostEnchantedEffect(xValue, StaticValue.get(0))));
     }
 
     private FearOfDeath(final FearOfDeath card) {
@@ -54,33 +56,5 @@ public final class FearOfDeath extends CardImpl {
     @Override
     public FearOfDeath copy() {
         return new FearOfDeath(this);
-    }
-}
-
-enum FearOfDeathValue implements DynamicValue {
-    instance;
-
-    @Override
-    public int calculate(Game game, Ability sourceAbility, Effect effect) {
-        Player controller = game.getPlayer(sourceAbility.getControllerId());
-        if (controller == null) {
-            return 0;
-        }
-        return -controller.getGraveyard().size();
-    }
-
-    @Override
-    public FearOfDeathValue copy() {
-        return instance;
-    }
-
-    @Override
-    public String toString() {
-        return "-X";
-    }
-
-    @Override
-    public String getMessage() {
-        return "the number of cards in your graveyard";
     }
 }

--- a/Mage.Sets/src/mage/cards/f/FeedingFrenzy.java
+++ b/Mage.Sets/src/mage/cards/f/FeedingFrenzy.java
@@ -1,10 +1,9 @@
-
 package mage.cards.f;
 
 import java.util.UUID;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
-import mage.abilities.effects.Effect;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -20,20 +19,15 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class FeedingFrenzy extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent();
-
-    static {
-        filter.add(SubType.ZOMBIE.getPredicate());
-    }
+    private static final DynamicValue xValue = new SignInversionDynamicValue(
+            new PermanentsOnBattlefieldCount(new FilterPermanent(SubType.ZOMBIE, "Zombies on the battlefield"), null)
+    );
 
     public FeedingFrenzy(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{2}{B}");
 
         // Target creature gets -X/-X until end of turn, where X is the number of Zombies on the battlefield.
-        DynamicValue x = new PermanentsOnBattlefieldCount(filter, -1);
-        Effect effect = new BoostTargetEffect(x, x, Duration.EndOfTurn, true);
-        effect.setText("Target creature gets -X/-X until end of turn, where X is the number of Zombies on the battlefield");
-        this.getSpellAbility().addEffect(effect);
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/f/FestiveFuneral.java
+++ b/Mage.Sets/src/mage/cards/f/FestiveFuneral.java
@@ -2,7 +2,10 @@ package mage.cards.f;
 
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.CardsInControllerGraveyardCount;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -17,16 +20,17 @@ import java.util.UUID;
  */
 public final class FestiveFuneral extends CardImpl {
 
-    private static final DynamicValue xValue = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD, -1);
+    private static final DynamicValue cardsInGraveyard = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CARDS, null);
+    private static final DynamicValue xValue = new SignInversionDynamicValue(cardsInGraveyard);
+    private static final Hint hint = new ValueHint("Cards in your graveyard", cardsInGraveyard);
 
     public FestiveFuneral(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{4}{B}");
 
         // Target creature gets -X/-X until end of turn, where X is the number of cards in your graveyard.
-        this.getSpellAbility().addEffect(new BoostTargetEffect(
-                xValue, xValue, Duration.EndOfTurn, true
-        ).setText("target creature gets -X/-X until end of turn, where X is the number of cards in your graveyard"));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
+        this.getSpellAbility().addHint(hint);
     }
 
     private FestiveFuneral(final FestiveFuneral card) {

--- a/Mage.Sets/src/mage/cards/f/FortifyingDraught.java
+++ b/Mage.Sets/src/mage/cards/f/FortifyingDraught.java
@@ -25,8 +25,7 @@ public final class FortifyingDraught extends CardImpl {
         this.getSpellAbility().addEffect(new BoostTargetEffect(
                 ControllerGotLifeCount.instance,
                 ControllerGotLifeCount.instance,
-                Duration.EndOfTurn, true
-        ).setText("Target creature gets +X/+X until end of turn, where X is the amount of life you gained this turn."));
+                Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addWatcher(new PlayerGainedLifeWatcher());
         this.getSpellAbility().addHint(ControllerGotLifeCount.getHint());

--- a/Mage.Sets/src/mage/cards/g/GhoulsFeast.java
+++ b/Mage.Sets/src/mage/cards/g/GhoulsFeast.java
@@ -10,7 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.filter.common.FilterCreatureCard;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -19,12 +19,13 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class GhoulsFeast extends CardImpl {
 
+    private static final DynamicValue xValue = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURES, null);
+
     public GhoulsFeast(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{B}");
 
         // Target creature gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.
-        DynamicValue xValue = new CardsInControllerGraveyardCount(new FilterCreatureCard("creature card"));
-        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, true));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, StaticValue.get(0), Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrayMerchantOfAsphodel.java
+++ b/Mage.Sets/src/mage/cards/g/GrayMerchantOfAsphodel.java
@@ -50,8 +50,7 @@ class GrayMerchantOfAsphodelEffect extends OneShotEffect {
         super(Outcome.GainLife);
         this.staticText = "each opponent loses X life, where X is your devotion to black. "
                 + "You gain life equal to the life lost this way. "
-                + "<i>(Each {B} in the mana costs of permanents you control "
-                + "counts towards your devotion to black.)</i>";
+                + DevotionCount.B.getReminder();
     }
 
     private GrayMerchantOfAsphodelEffect(final GrayMerchantOfAsphodelEffect effect) {

--- a/Mage.Sets/src/mage/cards/g/GreatDefender.java
+++ b/Mage.Sets/src/mage/cards/g/GreatDefender.java
@@ -22,7 +22,7 @@ public final class GreatDefender extends CardImpl {
 
         // Target creature gets +0/+X until end of turn, where X is its converted mana cost.
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
-        this.getSpellAbility().addEffect(new BoostTargetEffect(StaticValue.get(0), TargetManaValue.instance, Duration.EndOfTurn, true)
+        this.getSpellAbility().addEffect(new BoostTargetEffect(StaticValue.get(0), TargetManaValue.instance, Duration.EndOfTurn)
                 .setText("Target creature gets +0/+X until end of turn, where X is its mana value.")
         );
     }

--- a/Mage.Sets/src/mage/cards/g/GrowthCycle.java
+++ b/Mage.Sets/src/mage/cards/g/GrowthCycle.java
@@ -1,35 +1,37 @@
 package mage.cards.g;
 
-import mage.abilities.Ability;
 import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.effects.Effect;
+import mage.abilities.dynamicvalue.common.CardsInControllerGraveyardCount;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.game.Game;
-import mage.players.Player;
+import mage.filter.FilterCard;
+import mage.filter.predicate.mageobject.NamePredicate;
 import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
 
 /**
- * @author TheElk801
+ * @author awjackson
  */
 public final class GrowthCycle extends CardImpl {
+
+    private static final FilterCard filter = new FilterCard("card named Growth Cycle");
+    static {
+        filter.add(new NamePredicate("Growth Cycle"));
+    }
+    private static final DynamicValue xValue = new CardsInControllerGraveyardCount(filter, 2);
+    private static final String rule = "it gets an additional +2/+2 until end of turn for each " + xValue.getMessage();
 
     public GrowthCycle(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{G}");
 
-        // Target creature gets +3/+3 until end of turn. It gets an additional +2/+2 until end of turn for each card named Growth Cycle in your graveyard.
-        this.getSpellAbility().addEffect(new BoostTargetEffect(
-                        GrowthCycleValue.instance, GrowthCycleValue.instance,
-                        Duration.EndOfTurn, true
-                ).setText("Target creature gets +3/+3 until end of turn. " +
-                        "It gets an additional +2/+2 until end of turn " +
-                        "for each card named Growth Cycle in your graveyard.")
-        );
+        // Target creature gets +3/+3 until end of turn.
+        this.getSpellAbility().addEffect(new BoostTargetEffect(3, 3, Duration.EndOfTurn));
+        // It gets an additional +2/+2 until end of turn for each card named Growth Cycle in your graveyard.
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn).setText(rule));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
@@ -40,33 +42,5 @@ public final class GrowthCycle extends CardImpl {
     @Override
     public GrowthCycle copy() {
         return new GrowthCycle(this);
-    }
-}
-
-enum GrowthCycleValue implements DynamicValue {
-    instance;
-
-    @Override
-    public int calculate(Game game, Ability sourceAbility, Effect effect) {
-        Player player = game.getPlayer(sourceAbility.getControllerId());
-        if (player == null) {
-            return 3;
-        }
-        return 3 + player
-                .getGraveyard()
-                .getCards(game)
-                .stream()
-                .mapToInt(card -> "Growth Cycle".equals(card.getName()) ? 2 : 0)
-                .sum();
-    }
-
-    @Override
-    public GrowthCycleValue copy() {
-        return instance;
-    }
-
-    @Override
-    public String getMessage() {
-        return "";
     }
 }

--- a/Mage.Sets/src/mage/cards/g/GruulBeastmaster.java
+++ b/Mage.Sets/src/mage/cards/g/GruulBeastmaster.java
@@ -36,9 +36,7 @@ public final class GruulBeastmaster extends CardImpl {
 
     public GruulBeastmaster(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{G}");
-
-        this.subtype.add(SubType.HUMAN);
-        this.subtype.add(SubType.SHAMAN);
+        this.subtype.add(SubType.HUMAN, SubType.SHAMAN);
         this.power = new MageInt(2);
         this.toughness = new MageInt(2);
 
@@ -47,8 +45,7 @@ public final class GruulBeastmaster extends CardImpl {
 
         // Whenever Gruul Beastmaster attacks, another target creature you control gets +X/+0 until end of turn, where X is Gruul Beastmaster's power.
         Ability ability = new AttacksTriggeredAbility(new BoostTargetEffect(
-                xValue, StaticValue.get(0), Duration.EndOfTurn, true
-        ), false);
+                xValue, StaticValue.get(0), Duration.EndOfTurn), false);
         ability.addTarget(new TargetPermanent(filter));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/h/HardyOutlander.java
+++ b/Mage.Sets/src/mage/cards/h/HardyOutlander.java
@@ -33,7 +33,7 @@ public final class HardyOutlander extends CardImpl {
 
         // Commander creatures you own have "Whenever this creature attacks a player, if no opponent has more life than that player, another target creature you control gets +X/+X until end of turn, where X is this creature's power."
         Ability ability = new AttacksOpponentWithMostLifeTriggeredAbility(new BoostTargetEffect(
-                xValue, xValue, Duration.EndOfTurn, true
+                xValue, xValue, Duration.EndOfTurn
         ).setText("another target creature you control gets +X/+X until end of turn, where X is this creature's power"), false);
         ability.addTarget(new TargetPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE));
         this.addAbility(new SimpleStaticAbility(new GainAbilityAllEffect(

--- a/Mage.Sets/src/mage/cards/h/HuatliRadiantChampion.java
+++ b/Mage.Sets/src/mage/cards/h/HuatliRadiantChampion.java
@@ -37,7 +37,7 @@ public final class HuatliRadiantChampion extends CardImpl {
 
         // -1: Target creature gets +X/+X until end of turn, where X is the number of creatures you control.
         PermanentsOnBattlefieldCount amount = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_PERMANENT_CREATURE_CONTROLLED);
-        LoyaltyAbility ability2 = new LoyaltyAbility(new BoostTargetEffect(amount, amount, Duration.EndOfTurn, true)
+        LoyaltyAbility ability2 = new LoyaltyAbility(new BoostTargetEffect(amount, amount, Duration.EndOfTurn)
                 .setText("Target creature gets +X/+X until end of turn, where X is the number of creatures you control"), -1);
         ability2.addTarget(new TargetCreaturePermanent());
         ability2.addHint(CreaturesYouControlHint.instance);

--- a/Mage.Sets/src/mage/cards/h/HungerOfTheNim.java
+++ b/Mage.Sets/src/mage/cards/h/HungerOfTheNim.java
@@ -2,7 +2,6 @@ package mage.cards.h;
 
 import mage.abilities.dynamicvalue.common.ArtifactYouControlCount;
 import mage.abilities.dynamicvalue.common.StaticValue;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.abilities.hint.common.ArtifactYouControlHint;
 import mage.cards.CardImpl;
@@ -22,8 +21,7 @@ public final class HungerOfTheNim extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{B}");
 
         // Target creature gets +1/+0 until end of turn for each artifact you control.
-        Effect effect = new BoostTargetEffect(ArtifactYouControlCount.instance, StaticValue.get(0), Duration.EndOfTurn, true);
-        getSpellAbility().addEffect(effect);
+        getSpellAbility().addEffect(new BoostTargetEffect(ArtifactYouControlCount.instance, StaticValue.get(0), Duration.EndOfTurn));
         getSpellAbility().addTarget(new TargetCreaturePermanent());
         getSpellAbility().addHint(ArtifactYouControlHint.instance);
     }

--- a/Mage.Sets/src/mage/cards/i/IchorExplosion.java
+++ b/Mage.Sets/src/mage/cards/i/IchorExplosion.java
@@ -1,39 +1,34 @@
-
 package mage.cards.i;
 
 import java.util.UUID;
-import mage.abilities.Ability;
-import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.effects.Effect;
+import mage.abilities.dynamicvalue.common.SacrificeCostCreaturesPower;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.effects.common.continuous.BoostAllEffect;
-import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.Zone;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.target.common.TargetControlledPermanent;
 
 /**
  *
- * @author Loki
+ * @author awjackson
  */
 public final class IchorExplosion extends CardImpl {
+
+    private static final DynamicValue xValue = new SignInversionDynamicValue(SacrificeCostCreaturesPower.instance, false);
 
     public IchorExplosion(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{5}{B}{B}");
 
         // As an additional cost to cast Ichor Explosion, sacrifice a creature.
         this.getSpellAbility().addCost(new SacrificeTargetCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
-        // All creatures get -X/-X until end of turn, where X is the sacrificed creature's power.
-        DynamicValue xValue = new IchorExplosionDynamicValue();
-        this.getSpellAbility().addEffect(new BoostAllEffect(xValue, xValue, Duration.EndOfTurn, StaticFilters.FILTER_PERMANENT_ALL_CREATURES, false, null));
 
+        // All creatures get -X/-X until end of turn, where X is the sacrificed creature's power.
+        this.getSpellAbility().addEffect(new BoostAllEffect(xValue, xValue, Duration.EndOfTurn));
     }
 
     private IchorExplosion(final IchorExplosion card) {
@@ -43,37 +38,5 @@ public final class IchorExplosion extends CardImpl {
     @Override
     public IchorExplosion copy() {
         return new IchorExplosion(this);
-    }
-}
-
-class IchorExplosionDynamicValue implements DynamicValue {
-
-    @Override
-    public int calculate(Game game, Ability sourceAbility, Effect effect) {
-        Card sourceCard = game.getCard(sourceAbility.getSourceId());
-        if (sourceCard != null) {
-            for (Cost cost : sourceAbility.getCosts()) {
-                if (cost instanceof SacrificeTargetCost) {
-                    Permanent p = (Permanent) game.getLastKnownInformation(((SacrificeTargetCost) cost).getPermanents().get(0).getId(), Zone.BATTLEFIELD);
-                    return -1 * p.getPower().getValue();
-                }
-            }
-        }
-        return 0;
-    }
-
-    @Override
-    public DynamicValue copy() {
-        return this;
-    }
-
-    @Override
-    public String getMessage() {
-        return "the sacrificed creature's power";
-    }
-
-    @Override
-    public String toString() {
-        return "-X";
     }
 }

--- a/Mage.Sets/src/mage/cards/i/InnerCalmOuterStrength.java
+++ b/Mage.Sets/src/mage/cards/i/InnerCalmOuterStrength.java
@@ -1,4 +1,3 @@
-
 package mage.cards.i;
 
 import mage.abilities.dynamicvalue.DynamicValue;
@@ -26,7 +25,7 @@ public final class InnerCalmOuterStrength extends CardImpl {
 
         // Target creature gets +X/+X until end of turn, where X is the number of cards in your hand.
         DynamicValue xValue= CardsInControllerHandCount.instance;
-        Effect effect = new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true);
+        Effect effect = new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn);
         effect.setText("Target creature gets +X/+X until end of turn, where X is the number of cards in your hand");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/i/Irradiate.java
+++ b/Mage.Sets/src/mage/cards/i/Irradiate.java
@@ -1,5 +1,6 @@
 package mage.cards.i;
 
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.abilities.hint.common.ArtifactYouControlHint;
@@ -17,12 +18,13 @@ import java.util.UUID;
  */
 public final class Irradiate extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledArtifactPermanent(), -1);
+
     public Irradiate(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{B}");
 
         // Target creature gets -1/-1 until end of turn for each artifact you control.
-        PermanentsOnBattlefieldCount count = new PermanentsOnBattlefieldCount(new FilterControlledArtifactPermanent(), -1);
-        this.getSpellAbility().addEffect(new BoostTargetEffect(count, count, Duration.EndOfTurn, true));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addHint(ArtifactYouControlHint.instance);
     }

--- a/Mage.Sets/src/mage/cards/j/JiangYanggu.java
+++ b/Mage.Sets/src/mage/cards/j/JiangYanggu.java
@@ -49,12 +49,12 @@ public final class JiangYanggu extends CardImpl {
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
 
-        // -1: If you don't control a creature named Mowu, creature a legendary 3/3 green Hound creature token named Mowu.
+        // -1: If you don't control a creature named Mowu, create Mowu, a legendary 3/3 green Dog creature token.
         this.addAbility(new LoyaltyAbility(new ConditionalOneShotEffect(
                 new CreateTokenEffect(new MowuToken()),
                 new InvertCondition(new PermanentsOnTheBattlefieldCondition(filter)),
                 "If you don't control a creature named Mowu, "
-                + "creature Mowu, a legendary 3/3 green Dog creature token."
+                + "create Mowu, a legendary 3/3 green Dog creature token."
         ), -1));
 
         // -5: Until end of turn, target creature gains trample and gets +X/+X, where X is the number of lands you control.
@@ -65,7 +65,7 @@ public final class JiangYanggu extends CardImpl {
                 "Until end of turn, target creature gains trample"
         ), -5);
         ability.addEffect(
-                new BoostTargetEffect(controlledLands, controlledLands, Duration.EndOfTurn, true)
+                new BoostTargetEffect(controlledLands, controlledLands, Duration.EndOfTurn)
                         .setText("and gets +X/+X, where X is the number of lands you control")
         );
         ability.addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/j/JunkyoBell.java
+++ b/Mage.Sets/src/mage/cards/j/JunkyoBell.java
@@ -33,7 +33,7 @@ public final class JunkyoBell extends CardImpl {
         // At the beginning of your upkeep, you may have target creature you control get +X/+X until end of turn,
         // where X is the number of creatures you control. If you do, sacrifice that creature at the beginning of the next end step.
         Ability ability = new BeginningOfUpkeepTriggeredAbility(
-                new BoostTargetEffect(CreaturesYouControlCount.instance, CreaturesYouControlCount.instance, Duration.EndOfTurn, true),
+                new BoostTargetEffect(CreaturesYouControlCount.instance, CreaturesYouControlCount.instance, Duration.EndOfTurn),
                 TargetController.YOU,
                 true);
         ability.addTarget(new TargetControlledCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/k/KabiraOutrider.java
+++ b/Mage.Sets/src/mage/cards/k/KabiraOutrider.java
@@ -30,8 +30,7 @@ public final class KabiraOutrider extends CardImpl {
 
         // When Kabria Outrider enters the battlefield, target creature gets +1/+1 until end of turn for each creature in your party.
         Ability ability = new EntersBattlefieldTriggeredAbility(new BoostTargetEffect(
-                PartyCount.instance, PartyCount.instance, Duration.EndOfTurn, true
-        ));
+                PartyCount.instance, PartyCount.instance, Duration.EndOfTurn));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability.addHint(PartyCountHint.instance));
     }

--- a/Mage.Sets/src/mage/cards/k/KarametrasAcolyte.java
+++ b/Mage.Sets/src/mage/cards/k/KarametrasAcolyte.java
@@ -26,8 +26,7 @@ public final class KarametrasAcolyte extends CardImpl {
 
         // {T}: Add an amount of {G} equal to your devotion to green.
         this.addAbility(new DynamicManaAbility(
-                Mana.GreenMana(1), DevotionCount.G, "Add an amount of {G} equal to your devotion to green. " +
-                "(Each {G} in the mana costs of permanents you control counts towards your devotion to green.)"
+                Mana.GreenMana(1), DevotionCount.G, "Add an amount of {G} equal to your devotion to green. " + DevotionCount.G.getReminder()
         ).addHint(DevotionCount.G.getHint()));
     }
 

--- a/Mage.Sets/src/mage/cards/k/KingHaraldsRevenge.java
+++ b/Mage.Sets/src/mage/cards/k/KingHaraldsRevenge.java
@@ -1,7 +1,6 @@
 package mage.cards.k;
 
-import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
+import mage.abilities.dynamicvalue.common.CreaturesYouControlCount;
 import mage.abilities.effects.common.combat.MustBeBlockedByAtLeastOneTargetEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
@@ -10,7 +9,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
@@ -20,15 +18,12 @@ import java.util.UUID;
  */
 public final class KingHaraldsRevenge extends CardImpl {
 
-    private static final DynamicValue xValue
-            = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURE);
-
     public KingHaraldsRevenge(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{G}");
 
         // Until end of turn, target creature gets +1/+1 for each creature you control and gains trample. It must be blocked this turn if able.
         this.getSpellAbility().addEffect(new BoostTargetEffect(
-                xValue, xValue, Duration.EndOfTurn, true
+                CreaturesYouControlCount.instance, CreaturesYouControlCount.instance, Duration.EndOfTurn
         ).setText("until end of turn, target creature gets +1/+1 for each creature you control"));
         this.getSpellAbility().addEffect(new GainAbilityTargetEffect(
                 TrampleAbility.getInstance(), Duration.EndOfTurn

--- a/Mage.Sets/src/mage/cards/k/KryShield.java
+++ b/Mage.Sets/src/mage/cards/k/KryShield.java
@@ -31,7 +31,7 @@ public final class KryShield extends CardImpl {
         Effect effect = new PreventDamageByTargetEffect(Duration.EndOfTurn);
         effect.setText("Prevent all damage that would be dealt this turn by target creature you control");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new GenericManaCost(2));
-        ability.addEffect(new BoostTargetEffect(StaticValue.get(0), TargetManaValue.instance, Duration.EndOfTurn, true)
+        ability.addEffect(new BoostTargetEffect(StaticValue.get(0), TargetManaValue.instance, Duration.EndOfTurn)
                 .setText("That creature gets +0/+X until end of turn, where X is its mana value"));
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetControlledCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/l/LilianaUntouchedByDeath.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaUntouchedByDeath.java
@@ -4,6 +4,7 @@ import mage.abilities.Ability;
 import mage.abilities.LoyaltyAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.LoseLifeOpponentsEffect;
@@ -12,7 +13,7 @@ import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetCreaturePermanent;
@@ -24,8 +25,9 @@ import java.util.UUID;
  */
 public final class LilianaUntouchedByDeath extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter
-            = new FilterControlledCreaturePermanent(SubType.ZOMBIE, "Zombies you control");
+    private static final DynamicValue xValue = new SignInversionDynamicValue(
+            new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ZOMBIE, "Zombies you control"), null)
+    );
 
     public LilianaUntouchedByDeath(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.PLANESWALKER}, "{2}{B}{B}");
@@ -38,12 +40,7 @@ public final class LilianaUntouchedByDeath extends CardImpl {
         this.addAbility(new LoyaltyAbility(new LilianaUntouchedByDeathEffect(), 1));
 
         // -2: Target creature gets -X/-X until end of turn, where X is the number of Zombies you control.
-        DynamicValue xValue = new PermanentsOnBattlefieldCount(filter, -1);
-        Ability ability = new LoyaltyAbility(
-                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true)
-                        .setText("target creature gets -X/-X until end of turn, "
-                                + "where X is the number of Zombies you control"), -2
-        );
+        Ability ability = new LoyaltyAbility(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn), -2);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/l/LilianaWakerOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaWakerOfTheDead.java
@@ -4,9 +4,11 @@ import mage.abilities.Ability;
 import mage.abilities.LoyaltyAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.CardsInControllerGraveyardCount;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.GetEmblemEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
+import mage.abilities.hint.Hint;
 import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -31,8 +33,9 @@ import java.util.UUID;
  */
 public final class LilianaWakerOfTheDead extends CardImpl {
 
-    private static final DynamicValue xValue = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD, -1);
-    private static final DynamicValue xValue_hint = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD);
+    private static final DynamicValue cardsInGraveyard = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CARDS, null);
+    private static final DynamicValue xValue = new SignInversionDynamicValue(cardsInGraveyard);
+    private static final Hint hint = new ValueHint("Cards in your graveyard", cardsInGraveyard);
 
     public LilianaWakerOfTheDead(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.PLANESWALKER}, "{2}{B}{B}");
@@ -45,10 +48,8 @@ public final class LilianaWakerOfTheDead extends CardImpl {
         this.addAbility(new LoyaltyAbility(new LilianaWakerOfTheDeadDiscardEffect(), 1));
 
         // −3: Target creature gets -X/-X until end of turn, where X is the number of cards in your graveyard.
-        Ability ability = new LoyaltyAbility(new BoostTargetEffect(
-                xValue, xValue, Duration.EndOfTurn, true
-        ).setText("target creature gets -X/-X until end of turn, where X is the number of cards in your graveyard"), -3)
-        .addHint(new ValueHint("Cards in your graveyard", xValue_hint));
+        Ability ability = new LoyaltyAbility(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn), -3);
+        ability.addHint(hint);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/l/LivaanCultistOfTiamat.java
+++ b/Mage.Sets/src/mage/cards/l/LivaanCultistOfTiamat.java
@@ -38,7 +38,7 @@ public final class LivaanCultistOfTiamat extends CardImpl {
 
         // Whenever you cast a noncreature spell, target creature gets +X/+0 until end of turn, where X is that spell's mana value.
         Ability ability = new SpellCastControllerTriggeredAbility(new BoostTargetEffect(
-                LivaanCultistOfTiamatValue.instance, StaticValue.get(0), Duration.EndOfTurn, true
+                LivaanCultistOfTiamatValue.instance, StaticValue.get(0), Duration.EndOfTurn
         ), StaticFilters.FILTER_SPELL_A_NON_CREATURE, false);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/l/LysAlanaScarblade.java
+++ b/Mage.Sets/src/mage/cards/l/LysAlanaScarblade.java
@@ -1,4 +1,3 @@
-
 package mage.cards.l;
 
 import java.util.UUID;
@@ -7,6 +6,7 @@ import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.DiscardCardCost;
 import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.effects.Effect;
@@ -16,7 +16,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.filter.common.FilterControlledPermanent;
 import mage.target.common.TargetCreaturePermanent;
@@ -27,27 +26,26 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class LysAlanaScarblade extends CardImpl {
 
-    private static final FilterControlledPermanent filter1 = new FilterControlledPermanent();
-    private static final FilterCard filter2 = new FilterCard("an Elf card");
+    private static final FilterCard filter = new FilterCard("an Elf card");
 
     static {
-        filter1.add(SubType.ELF.getPredicate());
-        filter2.add(SubType.ELF.getPredicate());
+        filter.add(SubType.ELF.getPredicate());
     }
+
+    private static final DynamicValue xValue = new SignInversionDynamicValue(
+            new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ELF, "Elves you control"), null)
+    );
 
     public LysAlanaScarblade(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{B}");
-        this.subtype.add(SubType.ELF);
-        this.subtype.add(SubType.ASSASSIN);
+        this.subtype.add(SubType.ELF, SubType.ASSASSIN);
+
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
 
         // {tap}, Discard an Elf card: Target creature gets -X/-X until end of turn, where X is the number of Elves you control.
-        SignInversionDynamicValue count = new SignInversionDynamicValue(new PermanentsOnBattlefieldCount(filter1));
-        Effect effect = new BoostTargetEffect(count, count, Duration.EndOfTurn, true);
-        effect.setText("target creature gets -X/-X until end of turn, where X is the number of Elves you control");
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new TapSourceCost());
-        ability.addCost(new DiscardCardCost(filter2));
+        Ability ability = new SimpleActivatedAbility(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn), new TapSourceCost());
+        ability.addCost(new DiscardCardCost(filter));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/m/MagmaSliver.java
+++ b/Mage.Sets/src/mage/cards/m/MagmaSliver.java
@@ -40,7 +40,7 @@ public final class MagmaSliver extends CardImpl {
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new BoostTargetEffect(new PermanentsOnBattlefieldCount(
                         StaticFilters.FILTER_PERMANENT_ALL_SLIVERS),
-                        StaticValue.get(0), Duration.EndOfTurn, true),
+                        StaticValue.get(0), Duration.EndOfTurn),
                 new TapSourceCost());
         Target target = new TargetCreaturePermanent(
                 new FilterCreaturePermanent(SubType.SLIVER, "Sliver creature"));

--- a/Mage.Sets/src/mage/cards/m/MartyrOfSpores.java
+++ b/Mage.Sets/src/mage/cards/m/MartyrOfSpores.java
@@ -1,4 +1,3 @@
-
 package mage.cards.m;
 
 import java.util.UUID;
@@ -28,7 +27,7 @@ import mage.target.common.TargetCreaturePermanent;
  * @author emerald000
  */
 public final class MartyrOfSpores extends CardImpl {
-    
+
     private static final FilterCard filter = new FilterCard("X green cards from your hand");
     static {
         filter.add(new ColorPredicate(ObjectColor.GREEN));
@@ -36,16 +35,16 @@ public final class MartyrOfSpores extends CardImpl {
 
     public MartyrOfSpores(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{G}");
-        this.subtype.add(SubType.HUMAN);
-        this.subtype.add(SubType.SHAMAN);
+        this.subtype.add(SubType.HUMAN, SubType.SHAMAN);
 
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
 
         // {1}, Reveal X green cards from your hand, Sacrifice Martyr of Spores: Target creature gets +X/+X until end of turn.
-        Effect effect = new BoostTargetEffect(RevealTargetFromHandCostCount.instance, RevealTargetFromHandCostCount.instance, Duration.EndOfTurn, true);
-        effect.setText("Target creature gets +X/+X until end of turn.");
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new GenericManaCost(1));
+        Ability ability = new SimpleActivatedAbility(
+                new BoostTargetEffect(RevealTargetFromHandCostCount.instance, RevealTargetFromHandCostCount.instance, Duration.EndOfTurn),
+                new GenericManaCost(1)
+        );
         ability.addCost(new RevealTargetFromHandCost(new TargetCardInHand(0, Integer.MAX_VALUE, filter)));
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/m/MasterOfWaves.java
+++ b/Mage.Sets/src/mage/cards/m/MasterOfWaves.java
@@ -46,7 +46,7 @@ public final class MasterOfWaves extends CardImpl {
         // When Master of Waves enters the battlefield, create a number of 1/0 blue Elemental creature tokens equal to your devotion to blue.
         // <i>(Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)</i>
         Effect effect = new CreateTokenEffect(new MasterOfWavesElementalToken(), DevotionCount.U);
-        effect.setText("create a number of 1/0 blue Elemental creature tokens equal to your devotion to blue. <i>(Each {U} in the mana costs of permanents you control counts toward your devotion to blue.)</i>");
+        effect.setText("create a number of 1/0 blue Elemental creature tokens equal to your devotion to blue. " + DevotionCount.U.getReminder());
         this.addAbility(new EntersBattlefieldTriggeredAbility(effect).addHint(DevotionCount.U.getHint()));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MichikosReignOfTruth.java
+++ b/Mage.Sets/src/mage/cards/m/MichikosReignOfTruth.java
@@ -38,7 +38,7 @@ public final class MichikosReignOfTruth extends CardImpl {
         // I, II — Target creature gets +1/+1 until end of turn for each artifact and/or enchantment you control.
         sagaAbility.addChapterEffect(
                 this, SagaChapter.CHAPTER_I, SagaChapter.CHAPTER_II,
-                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true)
+                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn)
                         .setText("target creature gets +1/+1 until end of turn " +
                                 "for each artifact and/or enchantment you control"),
                 new TargetCreaturePermanent()

--- a/Mage.Sets/src/mage/cards/m/MightOfAlara.java
+++ b/Mage.Sets/src/mage/cards/m/MightOfAlara.java
@@ -17,14 +17,11 @@ import java.util.UUID;
  */
 public final class MightOfAlara extends CardImpl {
 
-
     public MightOfAlara(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{G}");
 
         // Domain - Target creature gets +1/+1 until end of turn for each basic land type among lands you control.
-        this.getSpellAbility().addEffect(new BoostTargetEffect(
-                DomainValue.REGULAR, DomainValue.REGULAR, Duration.EndOfTurn, true
-        ));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(DomainValue.REGULAR, DomainValue.REGULAR, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addHint(DomainHint.instance);
         this.getSpellAbility().setAbilityWord(AbilityWord.DOMAIN);

--- a/Mage.Sets/src/mage/cards/m/MightOfTheMasses.java
+++ b/Mage.Sets/src/mage/cards/m/MightOfTheMasses.java
@@ -1,5 +1,6 @@
 package mage.cards.m;
 
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
@@ -16,13 +17,14 @@ import java.util.UUID;
  */
 public final class MightOfTheMasses extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURE);
+
     public MightOfTheMasses(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{G}");
 
         // Target creature gets +1/+1 until end of turn for each creature you control.
-        PermanentsOnBattlefieldCount value = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURE);
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
-        this.getSpellAbility().addEffect(new BoostTargetEffect(value, value, Duration.EndOfTurn, true));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
     }
 
     private MightOfTheMasses(final MightOfTheMasses card) {

--- a/Mage.Sets/src/mage/cards/m/MightOfTheNephilim.java
+++ b/Mage.Sets/src/mage/cards/m/MightOfTheNephilim.java
@@ -24,9 +24,9 @@ public final class MightOfTheNephilim extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{1}{G}");
 
         // Target creature gets +2/+2 until end of turn for each of its colors.
-        DynamicValue boostValue = MightOfTheNephilimValue.instance;
-        Effect effect = new BoostTargetEffect(boostValue, boostValue, Duration.EndOfTurn, true);
-        this.getSpellAbility().addEffect(effect);
+        this.getSpellAbility().addEffect(new BoostTargetEffect(
+                MightOfTheNephilimValue.instance, MightOfTheNephilimValue.instance, Duration.EndOfTurn
+        ));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/m/MobMentality.java
+++ b/Mage.Sets/src/mage/cards/m/MobMentality.java
@@ -59,7 +59,7 @@ public final class MobMentality extends CardImpl {
 
 class MobMentalityTriggeredAbility extends TriggeredAbilityImpl {
     MobMentalityTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new BoostTargetEffect(new AttackingCreatureCount(), StaticValue.get(0), Duration.EndOfTurn, true));
+        super(Zone.BATTLEFIELD, new BoostTargetEffect(new AttackingCreatureCount(), StaticValue.get(0), Duration.EndOfTurn));
     }
 
     private MobMentalityTriggeredAbility(final MobMentalityTriggeredAbility ability) {

--- a/Mage.Sets/src/mage/cards/m/MoodmarkPainter.java
+++ b/Mage.Sets/src/mage/cards/m/MoodmarkPainter.java
@@ -25,11 +25,12 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class MoodmarkPainter extends CardImpl {
 
+    private static final DynamicValue xValue = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURES, null);
+
     public MoodmarkPainter(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{B}{B}");
 
-        this.subtype.add(SubType.HUMAN);
-        this.subtype.add(SubType.SHAMAN);
+        this.subtype.add(SubType.HUMAN, SubType.SHAMAN);
         this.power = new MageInt(2);
         this.toughness = new MageInt(3);
 
@@ -42,10 +43,9 @@ public final class MoodmarkPainter extends CardImpl {
                 false);
         // target creature gains menace and gets +X/+0 until end of turn,
         // where X is the number of creature cards in your graveyard.
-        DynamicValue xValue = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURE);
         ability.addEffect(new BoostTargetEffect(
                 xValue, StaticValue.get(0),
-                Duration.EndOfTurn, true
+                Duration.EndOfTurn
         ).setText("and gets +X/+0 until end of turn, "
                 + "where X is the number of creature cards in your graveyard. " +
                 "<i>(It can't be blocked except by two or more creatures.)</i>")); // Must be here to match Oracle text

--- a/Mage.Sets/src/mage/cards/m/MuscleBurst.java
+++ b/Mage.Sets/src/mage/cards/m/MuscleBurst.java
@@ -45,7 +45,7 @@ public final class MuscleBurst extends CardImpl {
 
         // Target creature gets +X/+X until end of turn, where X is 3 plus the number of cards named Muscle Burst in all graveyards.
         this.getSpellAbility().addEffect(new BoostTargetEffect(
-                xValue, xValue, Duration.EndOfTurn, true
+                xValue, xValue, Duration.EndOfTurn
         ).setText("Target creature gets +X/+X until end of turn, where X is 3 plus the number of cards named Muscle Burst in all graveyards."));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }

--- a/Mage.Sets/src/mage/cards/n/NecroticWound.java
+++ b/Mage.Sets/src/mage/cards/n/NecroticWound.java
@@ -3,6 +3,7 @@ package mage.cards.n;
 import java.util.UUID;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.CardsInControllerGraveyardCount;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.effects.common.ExileTargetIfDiesEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
@@ -19,19 +20,14 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class NecroticWound extends CardImpl {
 
+    private static final DynamicValue xValue = new SignInversionDynamicValue(new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURES, null));
+
     public NecroticWound(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{B}");
 
-        // Undergrowth — Target creature gets -X/-X until end of turn, where X is the number of creature cards in your graveyard. If that creature would die this turn, exile it instead.
-        DynamicValue xValue = new CardsInControllerGraveyardCount(
-                StaticFilters.FILTER_CARD_CREATURE, -1
-        );
-        this.getSpellAbility().addEffect(
-                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true)
-                        .setText("Target creature gets -X/-X until end of turn, "
-                                + "where X is the number "
-                                + "of creature cards in your graveyard.")
-        );
+        // Undergrowth — Target creature gets -X/-X until end of turn, where X is the number of creature cards in your graveyard.
+        // If that creature would die this turn, exile it instead.
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addEffect(new ExileTargetIfDiesEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().setAbilityWord(AbilityWord.UNDERGROWTH);

--- a/Mage.Sets/src/mage/cards/n/NightmaresThirst.java
+++ b/Mage.Sets/src/mage/cards/n/NightmaresThirst.java
@@ -1,8 +1,8 @@
 package mage.cards.n;
 
 import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.dynamicvalue.MultipliedValue;
 import mage.abilities.dynamicvalue.common.ControllerGotLifeCount;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.effects.common.GainLifeEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
@@ -19,16 +19,14 @@ import java.util.UUID;
  */
 public final class NightmaresThirst extends CardImpl {
 
-    private static final DynamicValue xValue = new MultipliedValue(ControllerGotLifeCount.instance, -1);
+    private static final DynamicValue xValue = new SignInversionDynamicValue(ControllerGotLifeCount.instance);
 
     public NightmaresThirst(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{B}");
 
         // You gain 1 life. Target creature gets -X/-X until end of turn, where X is the amount of life you gained this turn.
         this.getSpellAbility().addEffect(new GainLifeEffect(1));
-        this.getSpellAbility().addEffect(new BoostTargetEffect(
-                xValue, xValue, Duration.EndOfTurn, true
-        ).setText("Target creature gets -X/-X until end of turn, where X is the amount of life you gained this turn."));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addWatcher(new PlayerGainedLifeWatcher());
         this.getSpellAbility().addHint(ControllerGotLifeCount.getHint());

--- a/Mage.Sets/src/mage/cards/n/NightmarishEnd.java
+++ b/Mage.Sets/src/mage/cards/n/NightmarishEnd.java
@@ -1,4 +1,3 @@
-
 package mage.cards.n;
 
 import java.util.UUID;
@@ -19,13 +18,13 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class NightmarishEnd extends CardImpl {
 
+    private static final DynamicValue xValue = new SignInversionDynamicValue(CardsInControllerHandCount.instance);
+
     public NightmarishEnd(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{2}{B}");
 
-
         // Target creature gets -X/-X until end of turn, where X is the number of cards in your hand.
-        DynamicValue xValue = new SignInversionDynamicValue(CardsInControllerHandCount.instance);
-        Effect effect = new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true);
+        Effect effect = new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn);
         effect.setText("Target creature gets -X/-X until end of turn, where X is the number of cards in your hand");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/n/NourishingShoal.java
+++ b/Mage.Sets/src/mage/cards/n/NourishingShoal.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 public final class NourishingShoal extends CardImpl {
 
     private static final FilterOwnedCard filter
-            = new FilterOwnedCard("a red card with mana value X from your hand");
+            = new FilterOwnedCard("a green card with mana value X from your hand");
 
     static {
         filter.add(new ColorPredicate(ObjectColor.GREEN));

--- a/Mage.Sets/src/mage/cards/n/NyleasHuntmaster.java
+++ b/Mage.Sets/src/mage/cards/n/NyleasHuntmaster.java
@@ -5,6 +5,7 @@ import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.dynamicvalue.common.DevotionCount;
 import mage.abilities.dynamicvalue.common.StaticValue;
+import mage.abilities.effects.common.InfoEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -22,17 +23,20 @@ public final class NyleasHuntmaster extends CardImpl {
 
     public NyleasHuntmaster(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{G}");
-
-        this.subtype.add(SubType.CENTAUR);
-        this.subtype.add(SubType.SHAMAN);
+        this.subtype.add(SubType.CENTAUR, SubType.SHAMAN);
         this.power = new MageInt(4);
         this.toughness = new MageInt(3);
 
-        // When Nylea's Huntmaster enters the battlefield, target creature you control gets +X/+0 until end of turn, where X is your devotion to green.
+        // When Nylea's Huntmaster enters the battlefield,
+        // target creature you control gets +X/+0 until end of turn,
+        // where X is your devotion to green.
         Ability ability = new EntersBattlefieldTriggeredAbility(new BoostTargetEffect(
                 DevotionCount.G, StaticValue.get(0), Duration.EndOfTurn
         ));
+        ability.addEffect(new InfoEffect(DevotionCount.G.getReminder()));
         ability.addTarget(new TargetControlledCreaturePermanent());
+        ability.addHint(DevotionCount.G.getHint());
+
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OboroEnvoy.java
+++ b/Mage.Sets/src/mage/cards/o/OboroEnvoy.java
@@ -1,4 +1,3 @@
-
 package mage.cards.o;
 
 import java.util.UUID;
@@ -7,6 +6,7 @@ import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.ReturnToHandChosenControlledPermanentCost;
 import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.CardsInControllerHandCount;
 import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.dynamicvalue.common.StaticValue;
@@ -18,8 +18,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.Zone;
-import mage.filter.common.FilterControlledLandPermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetControlledPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -29,20 +28,23 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class OboroEnvoy extends CardImpl {
 
+    private static final DynamicValue xValue = new SignInversionDynamicValue(CardsInControllerHandCount.instance);
+
     public OboroEnvoy(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{U}");
-        this.subtype.add(SubType.MOONFOLK);
-        this.subtype.add(SubType.WIZARD);
+        this.subtype.add(SubType.MOONFOLK, SubType.WIZARD);
+
         this.power = new MageInt(1);
         this.toughness = new MageInt(3);
 
         // Flying
         this.addAbility(FlyingAbility.getInstance());
+
         // {2}, Return a land you control to its owner's hand: Target creature gets -X/-0 until end of turn, where X is the number of cards in your hand.
-        Effect effect = new BoostTargetEffect(new SignInversionDynamicValue(CardsInControllerHandCount.instance), StaticValue.get(-0), Duration.EndOfTurn, true);
+        Effect effect = new BoostTargetEffect(xValue, StaticValue.get(0), Duration.EndOfTurn);
         effect.setText("Target creature gets -X/-0 until end of turn, where X is the number of cards in your hand");
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new GenericManaCost(2));
-        ability.addCost(new ReturnToHandChosenControlledPermanentCost(new TargetControlledPermanent(new FilterControlledLandPermanent("a land"))));
+        Ability ability = new SimpleActivatedAbility(effect, new GenericManaCost(2));
+        ability.addCost(new ReturnToHandChosenControlledPermanentCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/o/OnwardVictory.java
+++ b/Mage.Sets/src/mage/cards/o/OnwardVictory.java
@@ -24,7 +24,7 @@ public final class OnwardVictory extends SplitCard {
         // Onward
         // Target creature gets +X/+0 until end of turn where X is its power.
         getLeftHalfCard().getSpellAbility().addTarget(new TargetCreaturePermanent());
-        getLeftHalfCard().getSpellAbility().addEffect(new BoostTargetEffect(TargetPermanentPowerCount.instance, StaticValue.get(0), Duration.EndOfTurn, true));
+        getLeftHalfCard().getSpellAbility().addEffect(new BoostTargetEffect(TargetPermanentPowerCount.instance, StaticValue.get(0), Duration.EndOfTurn));
 
         // to
         // Victory

--- a/Mage.Sets/src/mage/cards/p/PacksDisdain.java
+++ b/Mage.Sets/src/mage/cards/p/PacksDisdain.java
@@ -14,7 +14,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetCreaturePermanent;
@@ -67,10 +67,9 @@ class PacksDisdainEffect extends OneShotEffect {
         Choice typeChoice = new ChoiceCreatureType(game.getObject(source));
         if (player != null
                 && player.choose(Outcome.UnboostCreature, typeChoice, game)) {
-            FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent();
-            filter.add(SubType.byDescription(typeChoice.getChoice()).getPredicate());
+            FilterControlledPermanent filter = new FilterControlledPermanent(SubType.byDescription(typeChoice.getChoice()));
             DynamicValue negativePermanentsCount = new PermanentsOnBattlefieldCount(filter, -1);
-            ContinuousEffect effect = new BoostTargetEffect(negativePermanentsCount, negativePermanentsCount, Duration.EndOfTurn, true);
+            ContinuousEffect effect = new BoostTargetEffect(negativePermanentsCount, negativePermanentsCount, Duration.EndOfTurn);
             effect.setTargetPointer(new FixedTarget(source.getFirstTarget(), game));
             game.addEffect(effect, source);
             return true;

--- a/Mage.Sets/src/mage/cards/p/PaladinClass.java
+++ b/Mage.Sets/src/mage/cards/p/PaladinClass.java
@@ -65,7 +65,7 @@ public final class PaladinClass extends CardImpl {
 
         // Whenever you attack, until end of turn, target attacking creature gets +1/+1 for each other attacking creature and gains double strike.
         Ability ability = new AttacksWithCreaturesTriggeredAbility(
-                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true)
+                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn)
                         .setText("until end of turn, target attacking creature " +
                                 "gets +1/+1 for each other attacking creature"),
                 1

--- a/Mage.Sets/src/mage/cards/p/PlanarDespair.java
+++ b/Mage.Sets/src/mage/cards/p/PlanarDespair.java
@@ -1,14 +1,14 @@
 package mage.cards.p;
 
 import java.util.UUID;
-import mage.abilities.dynamicvalue.LockedInDynamicValue;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.DomainValue;
 import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.BoostAllEffect;
 import mage.abilities.hint.common.DomainHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.constants.AbilityWord;
 import mage.constants.CardType;
 import mage.constants.Duration;
 
@@ -19,17 +19,15 @@ import mage.constants.Duration;
  */
 public final class PlanarDespair extends CardImpl {
 
-    // rule 608.2h
-    private static final LockedInDynamicValue dv = new LockedInDynamicValue(new SignInversionDynamicValue(DomainValue.REGULAR));
+    private static final DynamicValue xValue = new SignInversionDynamicValue(DomainValue.REGULAR);
 
     public PlanarDespair(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{B}{B}");
 
         // Domain - All creatures get -1/-1 until end of turn for each basic land type among lands you control.
-        Effect effect = new BoostAllEffect(dv, dv, Duration.EndOfTurn);
-        effect.setText("<i>Domain</i> &mdash; All creatures get -1/-1 until end of turn for each basic land type among lands you control.");
-        this.getSpellAbility().addEffect(effect);
+        this.getSpellAbility().addEffect(new BoostAllEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addHint(DomainHint.instance);
+        this.getSpellAbility().setAbilityWord(AbilityWord.DOMAIN);
     }
 
     private PlanarDespair(final PlanarDespair card) {

--- a/Mage.Sets/src/mage/cards/p/PlowThroughReito.java
+++ b/Mage.Sets/src/mage/cards/p/PlowThroughReito.java
@@ -1,8 +1,6 @@
-
 package mage.cards.p;
 
 import java.util.UUID;
-import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.SweepNumber;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.abilities.effects.keyword.SweepEffect;
@@ -25,8 +23,7 @@ public final class PlowThroughReito extends CardImpl {
 
         // Sweep - Return any number of Plains you control to their owner's hand. Target creature gets +1/+1 until end of turn for each Plains returned this way.
         this.getSpellAbility().addEffect(new SweepEffect(SubType.PLAINS));
-        DynamicValue sweepValue = new SweepNumber("Plains");
-        this.getSpellAbility().addEffect(new BoostTargetEffect(sweepValue, sweepValue, Duration.EndOfTurn, true));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(SweepNumber.PLAINS, SweepNumber.PLAINS, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/p/PriestOfTheHauntedEdge.java
+++ b/Mage.Sets/src/mage/cards/p/PriestOfTheHauntedEdge.java
@@ -6,8 +6,8 @@ import mage.abilities.common.ActivateAsSorceryActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.dynamicvalue.MultipliedValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -29,22 +29,22 @@ public final class PriestOfTheHauntedEdge extends CardImpl {
         filter.add(SuperType.SNOW.getPredicate());
     }
 
-    private static final DynamicValue xValue = new MultipliedValue(new PermanentsOnBattlefieldCount(filter), -1);
+    private static final DynamicValue xValue = new SignInversionDynamicValue(new PermanentsOnBattlefieldCount(filter, null));
 
     public PriestOfTheHauntedEdge(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{B}");
 
         this.addSuperType(SuperType.SNOW);
-        this.subtype.add(SubType.ZOMBIE);
-        this.subtype.add(SubType.CLERIC);
+        this.subtype.add(SubType.ZOMBIE, SubType.CLERIC);
         this.power = new MageInt(0);
         this.toughness = new MageInt(4);
 
-        // {T}, Sacrifice Priest of the Haunted Edge: Target creature gets -X/-X until end of turn, where X is the number of snow lands you control. Activate this ability only any time you could cast a sorcery.
+        // {T}, Sacrifice Priest of the Haunted Edge: Target creature gets -X/-X until end of turn,
+        // where X is the number of snow lands you control. Activate only as a sorcery.
         Ability ability = new ActivateAsSorceryActivatedAbility(
-                Zone.BATTLEFIELD, new BoostTargetEffect(
-                xValue, xValue, Duration.EndOfTurn, true
-        ).setText("target creature gets -X/-X until end of turn, where X is the number of snow lands you control"), new TapSourceCost());
+                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn),
+                new TapSourceCost()
+        );
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/r/RaffinesSilencer.java
+++ b/Mage.Sets/src/mage/cards/r/RaffinesSilencer.java
@@ -37,7 +37,7 @@ public final class RaffinesSilencer extends CardImpl {
 
         // When Raffine's Silencer dies, target creature an opponent controls gets -X/-X until end of turn, where X is Raffine's Silencer's power.
         Ability ability = new DiesSourceTriggeredAbility(
-                new BoostTargetEffect(RaffinesSilencerValue.instance, RaffinesSilencerValue.instance, Duration.EndOfTurn, true),
+                new BoostTargetEffect(RaffinesSilencerValue.instance, RaffinesSilencerValue.instance, Duration.EndOfTurn),
                 false
         );
         ability.addTarget(new TargetOpponentsCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/r/RaffinesSilencer.java
+++ b/Mage.Sets/src/mage/cards/r/RaffinesSilencer.java
@@ -80,4 +80,9 @@ enum RaffinesSilencerValue implements DynamicValue {
     public String getMessage() {
         return "{this}'s power";
     }
+
+    @Override
+    public int getSign() {
+        return -1;
+    }
 }

--- a/Mage.Sets/src/mage/cards/r/ResilientKhenra.java
+++ b/Mage.Sets/src/mage/cards/r/ResilientKhenra.java
@@ -1,4 +1,3 @@
-
 package mage.cards.r;
 
 import java.util.UUID;
@@ -26,14 +25,13 @@ public final class ResilientKhenra extends CardImpl {
     public ResilientKhenra(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{G}");
 
-        this.subtype.add(SubType.JACKAL);
-        this.subtype.add(SubType.WIZARD);
+        this.subtype.add(SubType.JACKAL, SubType.WIZARD);
         this.power = new MageInt(2);
         this.toughness = new MageInt(2);
 
         // When Resilient Khenra enters the battlefield, you may have target creature get +X/+X until end of turn, where X is Resilient Khenra's power.
-        DynamicValue xValue = new SourcePermanentPowerCount();
-        Ability ability = new EntersBattlefieldTriggeredAbility(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true), true);
+        DynamicValue xValue = new SourcePermanentPowerCount(false);
+        Ability ability = new EntersBattlefieldTriggeredAbility(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn), true);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/r/RetributionOfTheAncients.java
+++ b/Mage.Sets/src/mage/cards/r/RetributionOfTheAncients.java
@@ -3,7 +3,7 @@ package mage.cards.r;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.RemoveVariableCountersTargetCost;
-import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.costs.mana.ColoredManaCost;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.GetXValue;
 import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
@@ -11,8 +11,8 @@ import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.ColoredManaSymbol;
 import mage.constants.Duration;
-import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
@@ -24,13 +24,14 @@ import java.util.UUID;
  */
 public final class RetributionOfTheAncients extends CardImpl {
 
+    private static final DynamicValue xValue = new SignInversionDynamicValue(GetXValue.instance);
+
     public RetributionOfTheAncients(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{B}");
 
         // {B}, Remove X +1/+1 counters from among creatures you control: Target creature gets -X/-X until end of turn.
-        DynamicValue xValue = new SignInversionDynamicValue(GetXValue.instance);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true), new ManaCostsImpl<>("{B}"));
-        ability.addCost(new RemoveVariableCountersTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURES, CounterType.P1P1, "X", 0));
+        Ability ability = new SimpleActivatedAbility(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn), new ColoredManaCost(ColoredManaSymbol.B));
+        ability.addCost(new RemoveVariableCountersTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURES, CounterType.P1P1));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }
@@ -44,4 +45,3 @@ public final class RetributionOfTheAncients extends CardImpl {
         return new RetributionOfTheAncients(this);
     }
 }
-

--- a/Mage.Sets/src/mage/cards/r/Rubblehulk.java
+++ b/Mage.Sets/src/mage/cards/r/Rubblehulk.java
@@ -36,7 +36,7 @@ public final class Rubblehulk extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetPowerToughnessSourceEffect(controlledLands, Duration.EndOfGame)));
 
         // Bloodrush - 1{R}{G}, Discard Rubblehulk: Target attacking creature gets +X/+X until end of turn, where X is the number of lands you control.
-        this.addAbility(new BloodrushAbility("{1}{R}{G}", new BoostTargetEffect(controlledLands, controlledLands, Duration.EndOfTurn, true)));
+        this.addAbility(new BloodrushAbility("{1}{R}{G}", new BoostTargetEffect(controlledLands, controlledLands, Duration.EndOfTurn)));
     }
 
     private Rubblehulk(final Rubblehulk card) {

--- a/Mage.Sets/src/mage/cards/r/RushOfBlood.java
+++ b/Mage.Sets/src/mage/cards/r/RushOfBlood.java
@@ -1,4 +1,3 @@
-
 package mage.cards.r;
 
 import java.util.UUID;
@@ -20,9 +19,8 @@ public final class RushOfBlood extends CardImpl {
     public RushOfBlood(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{2}{R}");
 
-
         // Target creature gets +X/+0 until end of turn, where X is its power.
-        this.getSpellAbility().addEffect(new BoostTargetEffect(TargetPermanentPowerCount.instance, StaticValue.get(0), Duration.EndOfTurn, true));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(TargetPermanentPowerCount.instance, StaticValue.get(0), Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/s/SickeningShoal.java
+++ b/Mage.Sets/src/mage/cards/s/SickeningShoal.java
@@ -42,7 +42,7 @@ public final class SickeningShoal extends CardImpl {
         )));
 
         // Target creature gets -X/-X until end of turn.
-        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/s/SilvergillDouser.java
+++ b/Mage.Sets/src/mage/cards/s/SilvergillDouser.java
@@ -1,4 +1,3 @@
-
 package mage.cards.s;
 
 import java.util.UUID;
@@ -8,6 +7,7 @@ import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
@@ -15,14 +15,13 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.Predicates;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
  *
- * @author Styxo
+ * @author awjackson
  */
 public final class SilvergillDouser extends CardImpl {
 
@@ -32,16 +31,17 @@ public final class SilvergillDouser extends CardImpl {
         filter.add(Predicates.or(SubType.MERFOLK.getPredicate(), SubType.FAERIE.getPredicate()));
     }
 
+    private static final DynamicValue xValue = new SignInversionDynamicValue(new PermanentsOnBattlefieldCount(filter, null));
+
     public SilvergillDouser(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{U}");
-        this.subtype.add(SubType.MERFOLK);
-        this.subtype.add(SubType.WIZARD);
+        this.subtype.add(SubType.MERFOLK, SubType.WIZARD);
+
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
 
         // {tap}: Target creature gets -X/-0 until end of turn, where X is the number of Merfolk and/or Faeries you control.
-        DynamicValue number = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(filter), -1);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(number, StaticValue.get(0), Duration.EndOfTurn, true), new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(new BoostTargetEffect(xValue, StaticValue.get(0), Duration.EndOfTurn), new TapSourceCost());
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SinkIntoTakenuma.java
+++ b/Mage.Sets/src/mage/cards/s/SinkIntoTakenuma.java
@@ -1,8 +1,6 @@
-
 package mage.cards.s;
 
 import java.util.UUID;
-import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.SweepNumber;
 import mage.abilities.effects.common.discard.DiscardTargetEffect;
 import mage.abilities.effects.keyword.SweepEffect;
@@ -24,8 +22,7 @@ public final class SinkIntoTakenuma extends CardImpl {
 
         // Sweep - Return any number of Swamps you control to their owner's hand. Target player discards a card for each Swamp returned this way.
         this.getSpellAbility().addEffect(new SweepEffect(SubType.SWAMP));
-        DynamicValue sweepValue = new SweepNumber("Swamp");
-        this.getSpellAbility().addEffect(new DiscardTargetEffect(sweepValue));
+        this.getSpellAbility().addEffect(new DiscardTargetEffect(SweepNumber.SWAMP));
         this.getSpellAbility().addTarget(new TargetPlayer());
     }
 

--- a/Mage.Sets/src/mage/cards/s/Skyreaping.java
+++ b/Mage.Sets/src/mage/cards/s/Skyreaping.java
@@ -28,7 +28,7 @@ public final class Skyreaping extends CardImpl {
 
         // Skyreaping deals damage to each creature with flying equal to your devotion to green.
         Effect effect = new DamageAllEffect(DevotionCount.G, filter);
-        effect.setText("{this} deals damage to each creature with flying equal to your devotion to green <i>(Each {G} in the mana costs of permanents you control counts toward your devotion to green.)</i>");
+        effect.setText("{this} deals damage to each creature with flying equal to your devotion to green. " + DevotionCount.G.getReminder());
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addHint(DevotionCount.G.getHint());
     }

--- a/Mage.Sets/src/mage/cards/s/Soulshriek.java
+++ b/Mage.Sets/src/mage/cards/s/Soulshriek.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import mage.abilities.Ability;
 import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.CardsInControllerGraveyardCount;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.Effect;
@@ -27,15 +28,14 @@ import mage.target.targetpointer.FixedTarget;
  */
 public class Soulshriek extends CardImpl {
 
+    private static final DynamicValue xValue = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURES, null);
+
     public Soulshriek(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{B}");
 
         // Target creature you control gets +X/+0 until end of turn, where X is the number 
         // of creature cards in your graveyard. Sacrifice that creature at the beginning of the next end step.
-        CardsInControllerGraveyardCount count = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURES_YOUR_GRAVEYARD);
-        Effect effect = new BoostTargetEffect(count, StaticValue.get(0), Duration.EndOfTurn, true);
-        effect.setText("Target creature you control gets +X/+0 until end of turn, where X is the number of creature cards in your graveyard.");
-        this.getSpellAbility().addEffect(effect);
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, StaticValue.get(0), Duration.EndOfTurn));
         this.getSpellAbility().addEffect(new SoulshriekEffect());
         this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent());
     }

--- a/Mage.Sets/src/mage/cards/s/SpinedSliver.java
+++ b/Mage.Sets/src/mage/cards/s/SpinedSliver.java
@@ -11,7 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.combat.CombatGroup;
 
@@ -22,6 +22,8 @@ import java.util.UUID;
  */
 public final class SpinedSliver extends CardImpl {
 
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.SLIVER, "a Sliver");
+
     public SpinedSliver(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{R}{G}");
         this.subtype.add(SubType.SLIVER);
@@ -31,10 +33,10 @@ public final class SpinedSliver extends CardImpl {
 
         // Whenever a Sliver becomes blocked, that Sliver gets +1/+1 until end of turn for each creature blocking it.
         this.addAbility(new BecomesBlockedAllTriggeredAbility(
-                new BoostTargetEffect(BlockersCount.instance, BlockersCount.instance, Duration.EndOfTurn, true)
+                new BoostTargetEffect(BlockersCount.instance, BlockersCount.instance, Duration.EndOfTurn)
                         .setText("that Sliver gets +1/+1 until end of turn for each creature blocking it"),
-                false, StaticFilters.FILTER_PERMANENT_ALL_SLIVERS, true
-        ).setTriggerPhrase("Whenever a Sliver becomes blocked, "));
+                false, filter, true
+        ));
     }
 
     private SpinedSliver(final SpinedSliver card) {
@@ -68,11 +70,11 @@ enum BlockersCount implements DynamicValue {
 
     @Override
     public String getMessage() {
-        return "each creature blocking it";
+        return "creature blocking it";
     }
 
     @Override
     public String toString() {
-        return "X";
+        return "1";
     }
 }

--- a/Mage.Sets/src/mage/cards/s/StrengthFromTheFallen.java
+++ b/Mage.Sets/src/mage/cards/s/StrengthFromTheFallen.java
@@ -1,4 +1,3 @@
-
 package mage.cards.s;
 
 import java.util.UUID;
@@ -11,7 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.filter.common.FilterCreatureCard;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,16 +19,16 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class StrengthFromTheFallen extends CardImpl {
 
+    private static final DynamicValue xValue = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURES, null);
+
     public StrengthFromTheFallen(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{G}");
 
-
-        // Constellation - Whenever Strength from the Fallen or another entchantment enters the battlefield under your control, target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.
-        DynamicValue xValue = new CardsInControllerGraveyardCount(new FilterCreatureCard("creature cards"));
-        Ability ability = new ConstellationAbility(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true));
+        // Constellation - Whenever Strength from the Fallen or another entchantment enters the battlefield under your control,
+        // target creature gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.
+        Ability ability = new ConstellationAbility(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
-
     }
 
     private StrengthFromTheFallen(final StrengthFromTheFallen card) {

--- a/Mage.Sets/src/mage/cards/s/StrengthInNumbers.java
+++ b/Mage.Sets/src/mage/cards/s/StrengthInNumbers.java
@@ -28,7 +28,7 @@ public final class StrengthInNumbers extends CardImpl {
                 TrampleAbility.getInstance(), Duration.EndOfTurn
         ).setText("Until end of turn, target creature gains trample"));
         this.getSpellAbility().addEffect(new BoostTargetEffect(
-                xValue, xValue, Duration.EndOfTurn, true
+                xValue, xValue, Duration.EndOfTurn
         ).setText("and gets +X/+X, where X is the number of attacking creatures"));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }

--- a/Mage.Sets/src/mage/cards/s/StrengthOfCedars.java
+++ b/Mage.Sets/src/mage/cards/s/StrengthOfCedars.java
@@ -1,5 +1,3 @@
-
-
 package mage.cards.s;
 
 import java.util.UUID;
@@ -11,7 +9,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.filter.common.FilterControlledLandPermanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -20,16 +18,14 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class StrengthOfCedars extends CardImpl {
 
-    private static final FilterControlledLandPermanent filter = new FilterControlledLandPermanent("lands you control");
-
-    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(filter, null);
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_PERMANENT_LANDS, null);
 
     public StrengthOfCedars (UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{4}{G}");
         this.subtype.add(SubType.ARCANE);
 
         // Target creature gets +X/+X until end of turn, where X is the number of lands you control.
-        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/s/Subdue.java
+++ b/Mage.Sets/src/mage/cards/s/Subdue.java
@@ -1,4 +1,3 @@
-
 package mage.cards.s;
 
 import java.util.UUID;
@@ -24,7 +23,7 @@ public final class Subdue extends CardImpl {
         // Prevent all combat damage that would be dealt by target creature this turn. That creature gets +0/+X until end of turn, where X is its converted mana cost.
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addEffect(new PreventDamageByTargetEffect(Duration.EndOfTurn, true));
-        this.getSpellAbility().addEffect(new BoostTargetEffect(StaticValue.get(0), TargetManaValue.instance, Duration.EndOfTurn, true)
+        this.getSpellAbility().addEffect(new BoostTargetEffect(StaticValue.get(0), TargetManaValue.instance, Duration.EndOfTurn)
                 .setText("That creature gets +0/+X until end of turn, where X is its mana value"));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SurgeOfStrength.java
+++ b/Mage.Sets/src/mage/cards/s/SurgeOfStrength.java
@@ -1,4 +1,3 @@
-
 package mage.cards.s;
 
 import java.util.UUID;
@@ -41,7 +40,7 @@ public final class SurgeOfStrength extends CardImpl {
         Effect effect = new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("Target creature gains trample");
         this.getSpellAbility().addEffect(effect);
-        effect = new BoostTargetEffect(TargetManaValue.instance, StaticValue.get(0), Duration.EndOfTurn, true);
+        effect = new BoostTargetEffect(TargetManaValue.instance, StaticValue.get(0), Duration.EndOfTurn);
         effect.setText("and gets +X/+0 until end of turn, where X is that creature's mana value");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/s/SyrFarenTheHengehammer.java
+++ b/Mage.Sets/src/mage/cards/s/SyrFarenTheHengehammer.java
@@ -36,14 +36,14 @@ public final class SyrFarenTheHengehammer extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{G}{G}");
 
         this.addSuperType(SuperType.LEGENDARY);
-        this.subtype.add(SubType.HUMAN);
-        this.subtype.add(SubType.KNIGHT);
+        this.subtype.add(SubType.HUMAN, SubType.KNIGHT);
+
         this.power = new MageInt(2);
         this.toughness = new MageInt(2);
 
         // Whenever Syr Faren, the Hengehammer attacks, another target attacking creature gets +X/+X until end of turn, where X is Syr Faren's power.
         Ability ability = new AttacksTriggeredAbility(
-                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true), false
+                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn), false
         );
         ability.addTarget(new TargetPermanent(filter));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/t/TezzeretTheSchemer.java
+++ b/Mage.Sets/src/mage/cards/t/TezzeretTheSchemer.java
@@ -1,4 +1,3 @@
-
 package mage.cards.t;
 
 import java.util.UUID;
@@ -7,7 +6,6 @@ import mage.abilities.LoyaltyAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.GetEmblemEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
@@ -26,6 +24,9 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class TezzeretTheSchemer extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledArtifactPermanent("artifacts you control"), null);
+    private static final DynamicValue xValue2 = new SignInversionDynamicValue(xValue);
+
     public TezzeretTheSchemer(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.PLANESWALKER}, "{2}{U}{B}");
         this.addSuperType(SuperType.LEGENDARY);
@@ -38,10 +39,7 @@ public final class TezzeretTheSchemer extends CardImpl {
         this.addAbility(new LoyaltyAbility(new CreateTokenEffect(new EtheriumCellToken()), 1));
 
         // -2: Target creature gets +X/-X until end of turn, where X is the number of artifacts you control.
-        DynamicValue count = new PermanentsOnBattlefieldCount(new FilterControlledArtifactPermanent("artifacts you control"));
-        Effect effect = new BoostTargetEffect(count, new SignInversionDynamicValue(count), Duration.EndOfTurn, true);
-        effect.setText("Target creature gets +X/-X until end of turn, where X is the number of artifacts you control");
-        Ability ability = new LoyaltyAbility(effect, -2);
+        Ability ability = new LoyaltyAbility(new BoostTargetEffect(xValue, xValue2, Duration.EndOfTurn), -2);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
 
@@ -58,4 +56,3 @@ public final class TezzeretTheSchemer extends CardImpl {
         return new TezzeretTheSchemer(this);
     }
 }
-

--- a/Mage.Sets/src/mage/cards/t/TheTriumphOfAnax.java
+++ b/Mage.Sets/src/mage/cards/t/TheTriumphOfAnax.java
@@ -46,7 +46,7 @@ public final class TheTriumphOfAnax extends CardImpl {
                         TrampleAbility.getInstance(), Duration.EndOfTurn,
                         "Until end of turn, target creature gains trample"
                 ), new BoostTargetEffect(
-                        xValue, StaticValue.get(0), Duration.EndOfTurn, true
+                        xValue, StaticValue.get(0), Duration.EndOfTurn
                 ).setText("and gets +X/+0, where X is the number of lore counters on {this}")),
                 new TargetCreaturePermanent()
         );

--- a/Mage.Sets/src/mage/cards/t/ThornmantleStriker.java
+++ b/Mage.Sets/src/mage/cards/t/ThornmantleStriker.java
@@ -33,15 +33,15 @@ import mage.target.common.TargetOpponentsCreaturePermanent;
 public final class ThornmantleStriker extends CardImpl {
 
     private static final PermanentsOnBattlefieldCount elfCount
-            = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ELF));
+            = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ELF, "Elves you control"), null);
     private static final SignInversionDynamicValue negativeElfCount
             = new SignInversionDynamicValue(elfCount);
 
     public ThornmantleStriker(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{B}");
 
-        this.subtype.add(SubType.ELF);
-        this.subtype.add(SubType.ROGUE);
+        this.subtype.add(SubType.ELF, SubType.ROGUE);
+
         this.power = new MageInt(4);
         this.toughness = new MageInt(3);
 
@@ -51,8 +51,7 @@ public final class ThornmantleStriker extends CardImpl {
         ability.addTarget(new TargetPermanent());
 
         // • Target creature an opponent controls gets -X/-X until end of turn, where X is the number of Elves you control.
-        Mode mode = new Mode(new BoostTargetEffect(negativeElfCount, negativeElfCount, Duration.EndOfTurn, true
-        ).setText("Target creature an opponent controls gets -X/-X until end of turn, where X is the number of Elves you control"));
+        Mode mode = new Mode(new BoostTargetEffect(negativeElfCount, negativeElfCount, Duration.EndOfTurn));
         mode.addTarget(new TargetOpponentsCreaturePermanent());
 
         ability.addMode(mode);

--- a/Mage.Sets/src/mage/cards/t/TimberwatchElf.java
+++ b/Mage.Sets/src/mage/cards/t/TimberwatchElf.java
@@ -1,20 +1,18 @@
-
 package mage.cards.t;
 
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.FilterPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -23,11 +21,9 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class TimberwatchElf extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Elves");
-
-    static {
-        filter.add(SubType.ELF.getPredicate());
-    }
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(
+            new FilterPermanent(SubType.ELF, "Elves on the battlefield"), null
+    );
 
     public TimberwatchElf(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{G}");
@@ -36,13 +32,8 @@ public final class TimberwatchElf extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(2);
 
-
         // {tap}: Target creature gets +X/+X until end of turn, where X is the number of Elves on the battlefield.
-        PermanentsOnBattlefieldCount amount = new PermanentsOnBattlefieldCount(filter);
-        Effect effect = new BoostTargetEffect(amount, amount, Duration.EndOfTurn, true);
-        effect.setText("Target creature gets +X/+X until end of turn, where X is the number of Elves on the battlefield");
-        SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                effect, new TapSourceCost());
+        SimpleActivatedAbility ability = new SimpleActivatedAbility(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn), new TapSourceCost());
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/v/VigorsporeWurm.java
+++ b/Mage.Sets/src/mage/cards/v/VigorsporeWurm.java
@@ -23,6 +23,8 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class VigorsporeWurm extends CardImpl {
 
+    private static final DynamicValue xValue = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURES, null);
+
     public VigorsporeWurm(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{G}");
 
@@ -31,9 +33,7 @@ public final class VigorsporeWurm extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Undergrowth — When Vigorspore Wurm enters the battlefield, target creature gains vigilance and gets +X/+X until end of turn, where X is the number of creature cards in your graveyard.
-        DynamicValue xValue = new CardsInControllerGraveyardCount(
-                StaticFilters.FILTER_CARD_CREATURE
-        );
+        
         Ability ability = new EntersBattlefieldTriggeredAbility(
                 new GainAbilityTargetEffect(
                         VigilanceAbility.getInstance(),
@@ -41,7 +41,7 @@ public final class VigorsporeWurm extends CardImpl {
                 ).setText("target creature gains vigilance"),
                 false);
         ability.addEffect(new BoostTargetEffect(
-                xValue, xValue, Duration.EndOfTurn, true
+                xValue, xValue, Duration.EndOfTurn
         ).setText("and gets +X/+X until end of turn, "
                 + "where X is the number of creature cards in your graveyard."));
         ability.addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/v/ViridianLorebearers.java
+++ b/Mage.Sets/src/mage/cards/v/ViridianLorebearers.java
@@ -1,4 +1,3 @@
-
 package mage.cards.v;
 
 import java.util.UUID;
@@ -7,8 +6,8 @@ import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -32,18 +31,17 @@ public final class ViridianLorebearers extends CardImpl {
         filter.add(TargetController.OPPONENT.getControllerPredicate());
     }
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(filter, null);
+
     public ViridianLorebearers(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{G}");
-        this.subtype.add(SubType.ELF);
-        this.subtype.add(SubType.SHAMAN);
+        this.subtype.add(SubType.ELF, SubType.SHAMAN);
 
         this.power = new MageInt(3);
         this.toughness = new MageInt(3);
 
         // {3}{G}, {tap}: Target creature gets +X/+X until end of turn, where X is the number of artifacts your opponents control.
-        Effect effect = new BoostTargetEffect(new PermanentsOnBattlefieldCount(filter), new PermanentsOnBattlefieldCount(filter), Duration.EndOfTurn, true);
-        effect.setText("Target creature gets +X/+X until end of turn, where X is the number of artifacts your opponents control");
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{3}{G}"));
+        Ability ability = new SimpleActivatedAbility(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn), new ManaCostsImpl<>("{3}{G}"));
         ability.addTarget(new TargetCreaturePermanent());
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/v/VishKalBloodArbiter.java
+++ b/Mage.Sets/src/mage/cards/v/VishKalBloodArbiter.java
@@ -102,4 +102,9 @@ enum VishKalBloodArbiterDynamicValue implements DynamicValue {
     public String getMessage() {
         return "+1/+1 counter removed this way";
     }
+
+    @Override
+    public int getSign() {
+        return -1;
+    }
 }

--- a/Mage.Sets/src/mage/cards/v/VishKalBloodArbiter.java
+++ b/Mage.Sets/src/mage/cards/v/VishKalBloodArbiter.java
@@ -59,8 +59,7 @@ public final class VishKalBloodArbiter extends CardImpl {
         Ability ability = new SimpleActivatedAbility(new BoostTargetEffect(
                 VishKalBloodArbiterDynamicValue.instance,
                 VishKalBloodArbiterDynamicValue.instance,
-                Duration.EndOfTurn, true
-        ).setText("target creature gets -1/-1 until end of turn for each +1/+1 counter removed this way"), new RemoveAllCountersSourceCost(CounterType.P1P1));
+                Duration.EndOfTurn), new RemoveAllCountersSourceCost(CounterType.P1P1));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }
@@ -96,11 +95,11 @@ enum VishKalBloodArbiterDynamicValue implements DynamicValue {
 
     @Override
     public String toString() {
-        return "1";
+        return "-1";
     }
 
     @Override
     public String getMessage() {
-        return "the number of +1/+1 counters removed this way";
+        return "+1/+1 counter removed this way";
     }
 }

--- a/Mage.Sets/src/mage/cards/w/WarpedPhysique.java
+++ b/Mage.Sets/src/mage/cards/w/WarpedPhysique.java
@@ -1,5 +1,3 @@
-
-
 package mage.cards.w;
 
 import java.util.UUID;
@@ -18,16 +16,15 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 
-
 public final class WarpedPhysique extends CardImpl {
+
+    private static final DynamicValue xValue = new SignInversionDynamicValue(CardsInControllerHandCount.instance);
 
     public WarpedPhysique(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{U}{B}");
 
-
         // Target creature gets +X/-X until end of turn, where X is the number of cards in your hand.
-        DynamicValue xValue =  CardsInControllerHandCount.instance;
-        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, new SignInversionDynamicValue(xValue), Duration.EndOfTurn, true));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(CardsInControllerHandCount.instance, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/w/WineOfBloodAndIron.java
+++ b/Mage.Sets/src/mage/cards/w/WineOfBloodAndIron.java
@@ -29,7 +29,7 @@ public final class WineOfBloodAndIron extends CardImpl {
 
         // {4}: Target creature gets +X/+0 until end of turn, where X is its power. Sacrifice Wine of Blood and Iron at the beginning of the next end step.
         SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new BoostTargetEffect(TargetPermanentPowerCount.instance, StaticValue.get(0), Duration.EndOfTurn, true),
+                new BoostTargetEffect(TargetPermanentPowerCount.instance, StaticValue.get(0), Duration.EndOfTurn),
                 new GenericManaCost(4));
         Effect effect = new CreateDelayedTriggeredAbilityEffect(
                 new AtTheBeginOfNextEndStepDelayedTriggeredAbility(new SacrificeSourceEffect()), false);

--- a/Mage.Sets/src/mage/cards/w/WirewoodPride.java
+++ b/Mage.Sets/src/mage/cards/w/WirewoodPride.java
@@ -1,7 +1,6 @@
 package mage.cards.w;
 
 import java.util.UUID;
-
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
@@ -18,15 +17,15 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class WirewoodPride extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent(SubType.ELF, "Elves");
-    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(filter);
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(
+            new FilterPermanent(SubType.ELF, "Elves on the battlefield"), null
+    );
 
     public WirewoodPride(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{G}");
 
         // Target creature gets +X/+X until end of turn, where X is the number of Elves on the battlefield.
-        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn, true)
-                .setText("Target creature gets +X/+X until end of turn, where X is the number of Elves on the battlefield"));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage/src/main/java/mage/abilities/common/AttacksAloneControlledTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/AttacksAloneControlledTriggeredAbility.java
@@ -9,6 +9,7 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  * @author TheElk801
@@ -69,6 +70,6 @@ public class AttacksAloneControlledTriggeredAbility extends TriggeredAbilityImpl
 
     @Override
     public String getTriggerPhrase() {
-        return "Whenever " + filter.getMessage() + " attacks alone, ";
+        return "Whenever " + CardUtil.addArticle(filter.getMessage()) + " attacks alone, ";
     }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/DynamicValue.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/DynamicValue.java
@@ -18,4 +18,12 @@ public interface DynamicValue extends Serializable, Copyable<DynamicValue> {
     DynamicValue copy();
 
     String getMessage();
+
+    /**
+     *
+     * @return A positive value if the result of calculate() is usually positive, and a negative value if it is usually negative.
+     */
+    default int getSign() {
+        return 1;
+    }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/IntPlusDynamicValue.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/IntPlusDynamicValue.java
@@ -45,4 +45,9 @@ public class IntPlusDynamicValue implements DynamicValue {
     public String getMessage() {
         return value.getMessage();
     }
+
+    @Override
+    public int getSign() {
+        return value.getSign();
+    }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/LimitedDynamicValue.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/LimitedDynamicValue.java
@@ -48,4 +48,9 @@ public class LimitedDynamicValue implements DynamicValue {
     public String getMessage() {
         return value.getMessage();
     }
+
+    @Override
+    public int getSign() {
+        return value.getSign();
+    }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/MultipliedValue.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/MultipliedValue.java
@@ -49,4 +49,9 @@ public class MultipliedValue implements DynamicValue {
     public String getMessage() {
         return value.getMessage();
     }
+
+    @Override
+    public int getSign() {
+        return multiplier * value.getSign();
+    }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/AuraAttachedCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/AuraAttachedCount.java
@@ -1,4 +1,3 @@
-
 package mage.abilities.dynamicvalue.common;
 
 import java.util.List;
@@ -16,18 +15,18 @@ import mage.game.permanent.Permanent;
  */
 public class AuraAttachedCount implements DynamicValue {
 
-    private Integer amount;
+    private final int multiplier;
 
     public AuraAttachedCount() {
         this(1);
     }
 
-    public AuraAttachedCount(Integer amount) {
-        this.amount = amount;
+    public AuraAttachedCount(int multiplier) {
+        this.multiplier = multiplier;
     }
 
     public AuraAttachedCount(final AuraAttachedCount dynamicValue) {
-        this.amount = dynamicValue.amount;
+        this.multiplier = dynamicValue.multiplier;
     }
 
     @Override
@@ -44,7 +43,7 @@ public class AuraAttachedCount implements DynamicValue {
             }
 
         }
-        return amount * count;
+        return multiplier * count;
     }
 
     @Override
@@ -54,14 +53,16 @@ public class AuraAttachedCount implements DynamicValue {
 
     @Override
     public String toString() {
-        if (amount != null) {
-            return amount.toString();
-        }
-        return "";
+        return Integer.toString(multiplier);
     }
 
     @Override
     public String getMessage() {
         return "Aura attached to it";
+    }
+
+    @Override
+    public int getSign() {
+        return multiplier;
     }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/CardTypesInGraveyardCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/CardTypesInGraveyardCount.java
@@ -23,7 +23,7 @@ public enum CardTypesInGraveyardCount implements DynamicValue {
     private final String message;
 
     CardTypesInGraveyardCount(String message) {
-        this.message = message;
+        this.message = "the number of card types among cards in " + message;
     }
 
     @Override
@@ -44,12 +44,12 @@ public enum CardTypesInGraveyardCount implements DynamicValue {
 
     @Override
     public String toString() {
-        return "1";
+        return "X";
     }
 
     @Override
     public String getMessage() {
-        return "the number of card types in " + message;
+        return message;
     }
 
     private final Stream<Card> getStream(Game game, Ability ability) {

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/CardsInControllerGraveyardCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/CardsInControllerGraveyardCount.java
@@ -8,13 +8,15 @@ import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
  * @author North
  */
 public class CardsInControllerGraveyardCount implements DynamicValue {
 
     private final FilterCard filter;
-    private final Integer amount;
+    private final Integer multiplier;
 
     public CardsInControllerGraveyardCount() {
         this(StaticFilters.FILTER_CARD, 1);
@@ -24,25 +26,28 @@ public class CardsInControllerGraveyardCount implements DynamicValue {
         this(filter, 1);
     }
 
-    public CardsInControllerGraveyardCount(FilterCard filter, Integer amount) {
+    public CardsInControllerGraveyardCount(FilterCard filter, Integer multiplier) {
         this.filter = filter;
-        this.amount = amount;
+        this.multiplier = multiplier;
     }
 
     public CardsInControllerGraveyardCount(final CardsInControllerGraveyardCount dynamicValue) {
         this.filter = dynamicValue.filter;
-        this.amount = dynamicValue.amount;
+        this.multiplier = dynamicValue.multiplier;
     }
 
     @Override
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
-        Player player = game.getPlayer(sourceAbility.getControllerId());
-        if (player != null) {
-            return amount * player.getGraveyard().count(
-                    filter, sourceAbility.getControllerId(), sourceAbility, game
-            );
+        UUID playerId = sourceAbility.getControllerId();
+        Player player = game.getPlayer(playerId);
+        if (player == null) {
+            return 0;
         }
-        return 0;
+        int value = player.getGraveyard().count(filter, playerId, sourceAbility, game);
+        if (multiplier != null) {
+            value *= multiplier;
+        }
+        return value;
     }
 
     @Override
@@ -52,11 +57,11 @@ public class CardsInControllerGraveyardCount implements DynamicValue {
 
     @Override
     public String toString() {
-        return amount.toString();
+        return multiplier == null ? "X" : multiplier.toString();
     }
 
     @Override
     public String getMessage() {
-        return filter.getMessage() + " in your graveyard";
+        return (multiplier == null ? "the number of " : "") + filter.getMessage() + " in your graveyard";
     }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/CardsInControllerGraveyardCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/CardsInControllerGraveyardCount.java
@@ -64,4 +64,9 @@ public class CardsInControllerGraveyardCount implements DynamicValue {
     public String getMessage() {
         return (multiplier == null ? "the number of " : "") + filter.getMessage() + " in your graveyard";
     }
+
+    @Override
+    public int getSign() {
+        return multiplier == null ? 1 : multiplier;
+    }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/ControllerGotLifeCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/ControllerGotLifeCount.java
@@ -45,7 +45,7 @@ public enum ControllerGotLifeCount implements DynamicValue {
 
     @Override
     public String getMessage() {
-        return "the amount of life you've gained this turn";
+        return "the amount of life you gained this turn";
     }
 
     public static Hint getHint() {

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/DevotionCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/DevotionCount.java
@@ -41,11 +41,26 @@ public enum DevotionCount implements DynamicValue {
     GU(ColoredManaSymbol.G, ColoredManaSymbol.U);
 
     private final ArrayList<ColoredManaSymbol> devotionColors = new ArrayList<>();
+    private final String message;
+    private final String reminder;
     private final Hint hint;
 
     DevotionCount(ColoredManaSymbol... devotionColor) {
         this.devotionColors.addAll(Arrays.asList(devotionColor));
-        this.hint = new ValueHint(this.getMessage().replace("your d", "D"), this);
+        this.message = "your devotion to "
+                + String.join(" and ", devotionColors.stream()
+                        .map(ColoredManaSymbol::getColorName)
+                        .collect(Collectors.toList()));
+
+        this.reminder = "<i>(Each "
+                + String.join(" and ", devotionColors.stream()
+                        .map(s -> "{" + s + "}")
+                        .collect(Collectors.toList()))
+                + " in the mana costs of permanents you control counts toward "
+                + this.message
+                + ".)</i>";
+
+        this.hint = new ValueHint(this.message.replace("your d", "D"), this);
     }
 
     @Override
@@ -84,12 +99,11 @@ public enum DevotionCount implements DynamicValue {
 
     @Override
     public String getMessage() {
-        return "your devotion to " + String.join(
-                " and ",
-                devotionColors.stream()
-                        .map(ColoredManaSymbol::getColorName)
-                        .collect(Collectors.toList())
-        );
+        return message;
+    }
+
+    public String getReminder() {
+        return reminder;
     }
 
     public Hint getHint() {

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/DomainValue.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/DomainValue.java
@@ -61,10 +61,6 @@ public enum DomainValue implements DynamicValue {
         return "1";
     }
 
-    public int getAmount() {
-        return 1;
-    }
-
     @Override
     public String getMessage() {
         return "basic land type among lands " + (this == TARGET ? "they control" : "you control");

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/EquipmentAttachedCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/EquipmentAttachedCount.java
@@ -1,4 +1,3 @@
-
 package mage.abilities.dynamicvalue.common;
 
 import mage.abilities.Ability;
@@ -17,18 +16,18 @@ import java.util.UUID;
  */
 public class EquipmentAttachedCount implements DynamicValue {
 
-    private Integer amount;
+    private final int multiplier;
 
     public EquipmentAttachedCount() {
         this(1);
     }
 
-    public EquipmentAttachedCount(Integer amount) {
-        this.amount = amount;
+    public EquipmentAttachedCount(int multiplier) {
+        this.multiplier = multiplier;
     }
 
     public EquipmentAttachedCount(final EquipmentAttachedCount dynamicValue) {
-        this.amount = dynamicValue.amount;
+        this.multiplier = dynamicValue.multiplier;
     }
 
     @Override
@@ -44,7 +43,7 @@ public class EquipmentAttachedCount implements DynamicValue {
                 }
             }
         }
-        return amount * count;
+        return multiplier * count;
     }
 
     @Override
@@ -54,14 +53,16 @@ public class EquipmentAttachedCount implements DynamicValue {
 
     @Override
     public String toString() {
-        if (amount != null) {
-            return amount.toString();
-        }
-        return "";
+        return Integer.toString(multiplier);
     }
 
     @Override
     public String getMessage() {
         return "Equipment attached to it";
+    }
+
+    @Override
+    public int getSign() {
+        return multiplier;
     }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/HalfValue.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/HalfValue.java
@@ -48,6 +48,11 @@ public class HalfValue implements DynamicValue {
     }
 
     @Override
+    public int getSign() {
+        return value.getSign();
+    }
+
+    @Override
     public String toString() {
         return "half ";
     }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/HighestManaValueCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/HighestManaValueCount.java
@@ -51,7 +51,7 @@ public class HighestManaValueCount implements DynamicValue {
 
     @Override
     public String getMessage() {
-        return "the highest mana value among permanents you control";
+        return "the highest mana value among " + filter.getMessage() + " you control";
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/PermanentsOnBattlefieldCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/PermanentsOnBattlefieldCount.java
@@ -1,4 +1,3 @@
-
 package mage.abilities.dynamicvalue.common;
 
 import mage.abilities.Ability;
@@ -13,8 +12,8 @@ import mage.game.Game;
  */
 public class PermanentsOnBattlefieldCount implements DynamicValue {
 
-    private FilterPermanent filter;
-    private Integer multiplier;
+    private final FilterPermanent filter;
+    private final Integer multiplier;
 
     public PermanentsOnBattlefieldCount() {
         this(new FilterPermanent(), 1);
@@ -55,14 +54,16 @@ public class PermanentsOnBattlefieldCount implements DynamicValue {
 
     @Override
     public String toString() {
-        if (multiplier != null) {
-            return multiplier.toString();
-        }
-        return "X";
+        return multiplier == null ? "X" : multiplier.toString();
     }
 
     @Override
     public String getMessage() {
         return multiplier == null ? "the number of " + filter.getMessage() : filter.getMessage();
+    }
+
+    @Override
+    public int getSign() {
+        return multiplier == null ? 1 : multiplier;
     }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/PermanentsTargetOpponentControlsCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/PermanentsTargetOpponentControlsCount.java
@@ -1,4 +1,3 @@
-
 package mage.abilities.dynamicvalue.common;
 
 import java.util.UUID;
@@ -14,8 +13,8 @@ import mage.game.Game;
  */
 public class PermanentsTargetOpponentControlsCount implements DynamicValue {
 
-    private FilterPermanent filter;
-    private Integer multiplier;
+    private final FilterPermanent filter;
+    private final Integer multiplier;
 
     public PermanentsTargetOpponentControlsCount() {
         this(new FilterPermanent(), 1);
@@ -43,24 +42,28 @@ public class PermanentsTargetOpponentControlsCount implements DynamicValue {
     @Override
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
         UUID targetOpponentId = effect.getTargetPointer().getFirst(game, sourceAbility);
-        if (targetOpponentId != null) {
-            int value = game.getBattlefield().countAll(filter, targetOpponentId, game);
-            return multiplier * value;
-        } else {
+        if (targetOpponentId == null) {
             return 0;
         }
+        int value = game.getBattlefield().countAll(filter, targetOpponentId, game);
+        if (multiplier != null) {
+            value *= multiplier;
+        }
+        return value;
     }
 
     @Override
     public String toString() {
-        if (multiplier != null) {
-            return multiplier.toString();
-        }
-        return "X";
+        return multiplier == null ? "X" : multiplier.toString();
     }
 
     @Override
     public String getMessage() {
-        return filter.getMessage() + " target opponent controls";
+        return (multiplier == null ? "the number of " : "") + filter.getMessage() + " target opponent controls";
+    }
+
+    @Override
+    public int getSign() {
+        return multiplier == null ? 1 : multiplier;
     }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/RevealTargetFromHandCostCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/RevealTargetFromHandCostCount.java
@@ -25,12 +25,12 @@ public enum RevealTargetFromHandCostCount implements DynamicValue {
 
     @Override
     public String getMessage() {
-        return "number of revealed cards";
+        return "";
     }
 
     @Override
     public RevealTargetFromHandCostCount copy() {
-        return RevealTargetFromHandCostCount.instance;
+        return instance;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/SignInversionDynamicValue.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/SignInversionDynamicValue.java
@@ -48,4 +48,9 @@ public class SignInversionDynamicValue implements DynamicValue {
     public String getMessage() {
         return value.getMessage();
     }
+
+    @Override
+    public int getSign() {
+        return -1 * value.getSign();
+    }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/StaticValue.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/StaticValue.java
@@ -45,6 +45,11 @@ public class StaticValue implements DynamicValue {
         return "";
     }
 
+    @Override
+    public int getSign() {
+        return value;
+    }
+
     public int getValue() {
         return value;
     }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/SweepNumber.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/SweepNumber.java
@@ -10,12 +10,17 @@ import mage.game.Game;
  *
  * @author LevelX2
  */
-public class SweepNumber implements DynamicValue {
+public enum SweepNumber implements DynamicValue {
+    // FOREST("Forest");
+    // ISLAND("Island");
+    PLAINS("Plains"),
+    MOUNTAIN("Mountain"),
+    SWAMP("Swamp");
 
-    private final String sweepSubtype;
+    private final String message;
 
-    public SweepNumber(String sweepSubtype) {
-        this.sweepSubtype = sweepSubtype;
+    SweepNumber(String landType) {
+        this.message = landType + " returned this way";
     }
 
     @Override
@@ -27,16 +32,16 @@ public class SweepNumber implements DynamicValue {
 
     @Override
     public SweepNumber copy() {
-        return new SweepNumber(sweepSubtype);
+        return this;
     }
 
     @Override
     public String toString() {
-        return "X";
+        return "1";
     }
 
     @Override
     public String getMessage() {
-        return "the number of " + sweepSubtype + (sweepSubtype.endsWith("s") ? "" : "s") + " returned this way";
+        return message;
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
@@ -293,17 +293,6 @@ public abstract class ContinuousEffectImpl extends EffectImpl implements Continu
         return sublayer;
     }
 
-    protected static boolean isCanKill(DynamicValue toughness) {
-        if (toughness instanceof StaticValue) {
-            return toughness.calculate(null, null, null) < 0;
-        }
-        if (toughness instanceof SignInversionDynamicValue) {
-            // count this class as used for "-{something_positive}"
-            return true;
-        }
-        return false;
-    }
-
     @Override
     public List<MageObjectReference> getAffectedObjects() {
         return affectedObjectList;

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
@@ -301,9 +301,6 @@ public abstract class ContinuousEffectImpl extends EffectImpl implements Continu
             // count this class as used for "-{something_positive}"
             return true;
         }
-        if (toughness instanceof DomainValue) {
-            return ((DomainValue) toughness).getAmount() < 0;
-        }
         return false;
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostAllEffect.java
@@ -49,7 +49,7 @@ public class BoostAllEffect extends ContinuousEffectImpl {
     }
 
     public BoostAllEffect(DynamicValue power, DynamicValue toughness, Duration duration, FilterCreaturePermanent filter, boolean excludeSource, String rule) {
-        super(duration, Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, isCanKill(toughness) ? Outcome.UnboostCreature : Outcome.BoostCreature);
+        super(duration, Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, CardUtil.getBoostOutcome(power, toughness));
         this.power = power;
         this.toughness = toughness;
         this.filter = filter;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostEnchantedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostEnchantedEffect.java
@@ -37,7 +37,7 @@ public class BoostEnchantedEffect extends ContinuousEffectImpl {
     }
 
     public BoostEnchantedEffect(DynamicValue power, DynamicValue toughness, Duration duration) {
-        super(duration, Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, isCanKill(toughness) ? Outcome.UnboostCreature : Outcome.BoostCreature);
+        super(duration, Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, CardUtil.getBoostOutcome(power, toughness));
         this.power = power;
         this.toughness = toughness;
         this.staticText = "enchanted creature gets " + CardUtil.getBoostText(power, toughness, duration);

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostTargetEffect.java
@@ -24,39 +24,30 @@ public class BoostTargetEffect extends ContinuousEffectImpl {
 
     private DynamicValue power;
     private DynamicValue toughness;
-    private final boolean lockedIn;
 
     public BoostTargetEffect(int power, int toughness) {
         this(power, toughness, Duration.EndOfTurn);
     }
 
     public BoostTargetEffect(int power, int toughness, Duration duration) {
-        this(StaticValue.get(power), StaticValue.get(toughness), duration, false);
-    }
-
-    public BoostTargetEffect(DynamicValue power, DynamicValue toughness, Duration duration) {
-        this(power, toughness, duration, false);
+        this(StaticValue.get(power), StaticValue.get(toughness), duration);
     }
 
     /**
      * @param power
      * @param toughness
      * @param duration
-     * @param lockedIn  if true, power and toughness will be calculated only
-     *                  once, when the ability resolves
      */
-    public BoostTargetEffect(DynamicValue power, DynamicValue toughness, Duration duration, boolean lockedIn) {
+    public BoostTargetEffect(DynamicValue power, DynamicValue toughness, Duration duration) {
         super(duration, Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, isCanKill(toughness) ? Outcome.UnboostCreature : Outcome.BoostCreature);
         this.power = power;
         this.toughness = toughness;
-        this.lockedIn = lockedIn;
     }
 
     public BoostTargetEffect(final BoostTargetEffect effect) {
         super(effect);
         this.power = effect.power.copy();
         this.toughness = effect.toughness.copy();
-        this.lockedIn = effect.lockedIn;
     }
 
     @Override
@@ -67,7 +58,7 @@ public class BoostTargetEffect extends ContinuousEffectImpl {
     @Override
     public void init(Ability source, Game game) {
         super.init(source, game);
-        if (lockedIn) {
+        if (affectedObjectsSet) {
             power = StaticValue.get(power.calculate(game, source, this));
             toughness = StaticValue.get(toughness.calculate(game, source, this));
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostTargetEffect.java
@@ -39,7 +39,7 @@ public class BoostTargetEffect extends ContinuousEffectImpl {
      * @param duration
      */
     public BoostTargetEffect(DynamicValue power, DynamicValue toughness, Duration duration) {
-        super(duration, Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, isCanKill(toughness) ? Outcome.UnboostCreature : Outcome.BoostCreature);
+        super(duration, Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, CardUtil.getBoostOutcome(power, toughness));
         this.power = power;
         this.toughness = toughness;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostTargetEffect.java
@@ -83,24 +83,25 @@ public class BoostTargetEffect extends ContinuousEffectImpl {
         if (staticText != null && !staticText.isEmpty()) {
             return staticText;
         }
-        if (mode == null || mode.getTargets().isEmpty()) {
-            return "no target";
-        }
-        Target target = mode.getTargets().get(0);
         StringBuilder sb = new StringBuilder();
-        if (target.getMaxNumberOfTargets() > 1) {
-            if (target.getNumberOfTargets() < target.getMaxNumberOfTargets()) {
-                sb.append("up to ");
-            }
-            sb.append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(" target ").append(target.getTargetName()).append(" get ");
+        if (mode == null || mode.getTargets().isEmpty()) {
+            sb.append("it gets ");
         } else {
-            if (target.getNumberOfTargets() < target.getMaxNumberOfTargets()) {
-                sb.append("up to ").append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(' ');
+            Target target = mode.getTargets().get(0);
+            if (target.getMaxNumberOfTargets() > 1) {
+                if (target.getNumberOfTargets() < target.getMaxNumberOfTargets()) {
+                    sb.append("up to ");
+                }
+                sb.append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(" target ").append(target.getTargetName()).append(" get ");
+            } else {
+                if (target.getNumberOfTargets() < target.getMaxNumberOfTargets()) {
+                    sb.append("up to ").append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(' ');
+                }
+                if (!target.getTargetName().toLowerCase(Locale.ENGLISH).startsWith("another")) {
+                    sb.append("target ");
+                }
+                sb.append(target.getTargetName()).append(" gets ");
             }
-            if (!target.getTargetName().toLowerCase(Locale.ENGLISH).startsWith("another")) {
-                sb.append("target ");
-            }
-            sb.append(target.getTargetName()).append(" gets ");
         }
         sb.append(CardUtil.getBoostText(power, toughness, duration));
         return sb.toString();

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -675,7 +675,7 @@ public final class StaticFilters {
         FILTER_PERMANENT_ALL_SLIVERS.setLockedFilter(true);
     }
 
-    public static final FilterControlledPermanent FILTER_CONTROLLED_SAMURAI_OR_WARRIOR = new FilterControlledPermanent("a Samurai or Warrior you control");
+    public static final FilterControlledPermanent FILTER_CONTROLLED_SAMURAI_OR_WARRIOR = new FilterControlledPermanent("Samurai or Warrior you control");
 
     static {
         FILTER_CONTROLLED_SAMURAI_OR_WARRIOR.add(Predicates.or(

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -901,6 +901,16 @@ public final class CardUtil {
         return sb.toString();
     }
 
+    public static Outcome getBoostOutcome(DynamicValue power, DynamicValue toughness) {
+        if (toughness.getSign() < 0) {
+            return Outcome.Removal;
+        }
+        if (power.getSign() < 0) {
+            return Outcome.UnboostCreature;
+        }
+        return Outcome.BoostCreature;
+    }
+
     public static boolean isSpliceAbility(Ability ability, Game game) {
         if (ability instanceof SpellAbility) {
             return ((SpellAbility) ability).getSpellAbilityType() == SpellAbilityType.SPLICE;


### PR DESCRIPTION
This PR fixes #9329 by removing the explicit `lockedIn` parameter from `BoostTargetEffect`. Instead of being specified explicitly, the locked-in-ness is now inferred from the type of ability. It's exactly the same change that was made to `BoostAllEffect` in ecbfc4edc46ea77a836ad52d68d248662763f537. The PR also contains some improvements to various `DynamicValue` classes that I noticed while updating all the cards. Because of the rather large number of files touched, I've opened a PR rather than shoving it directly into master.

Ideally, the same change should eventually be made to all of the Boost(foo)Effect classes.