### PR TITLE
Fix basics being overrated in draft

### DIFF
--- a/Mage/src/main/java/mage/game/draft/RateCard.java
+++ b/Mage/src/main/java/mage/game/draft/RateCard.java
@@ -80,6 +80,15 @@ public final class RateCard {
         if (card == null) {
             return 0;
         }
+        
+        String name = card.getName();
+        if (name.equals("Plains")
+                || name.equals("Island")
+                || name.equals("Swamp")
+                || name.equals("Mountain")
+                || name.equals("Forest")) {
+            return 1;
+        }
 
         if (useCache && allowedColors == null && rated.containsKey(card.getName())) {
             int rate = rated.get(card.getName());

--- a/Mage/src/main/java/mage/game/draft/RateCard.java
+++ b/Mage/src/main/java/mage/game/draft/RateCard.java
@@ -38,10 +38,14 @@ public final class RateCard {
      * Ratings are in [1,10] range, so setting it high will make new cards appear more often.
      * nowadays, cards that are more rare are more powerful, lets trust that and play the shiny cards.
      */
+    private static final int DEFAULT_BASIC_LAND_RATING = 1;
     private static final int DEFAULT_NOT_RATED_CARD_RATING = 40;
     private static final int DEFAULT_NOT_RATED_UNCOMMON_RATING = 60;
     private static final int DEFAULT_NOT_RATED_RARE_RATING = 75;
     private static final int DEFAULT_NOT_RATED_MYTHIC_RATING = 90;
+    
+    // Cards that aren't in the deck's colors get a penalty to their rating
+    private static final int OFF_COLOR_PENALTY = -100;
 
     private static String RATINGS_DIR = "/ratings/";
     private static String RATINGS_SET_LIST = RATINGS_DIR + "setsWithRatings.csv";
@@ -79,15 +83,6 @@ public final class RateCard {
     public static int rateCard(Card card, List<ColoredManaSymbol> allowedColors, boolean useCache) {
         if (card == null) {
             return 0;
-        }
-        
-        String name = card.getName();
-        if (name.equals("Plains")
-                || name.equals("Island")
-                || name.equals("Swamp")
-                || name.equals("Mountain")
-                || name.equals("Forest")) {
-            return 1;
         }
 
         if (useCache && allowedColors == null && rated.containsKey(card.getName())) {
@@ -213,7 +208,11 @@ public final class RateCard {
                     newRating = DEFAULT_NOT_RATED_MYTHIC_RATING;
                     break;
                 default:
-                    newRating = DEFAULT_NOT_RATED_CARD_RATING;
+                    if (isBasicLand(card)) {
+                        newRating = DEFAULT_BASIC_LAND_RATING;
+                    } else {
+                        newRating = DEFAULT_NOT_RATED_CARD_RATING;
+                    }
                     break;
             }
         } else {
@@ -336,6 +335,12 @@ public final class RateCard {
             }
             return 2 * (converted - colorPenalty + 1);
         }
+        
+        // Basic lands have no value so they're always treated as off-color
+        if (isBasicLand(card)) {
+            return OFF_COLOR_PENALTY;
+        }
+        
         final Map<String, Integer> singleCount = new HashMap<>();
         int maxSingleCount = 0;
         for (String symbol : card.getManaCostSymbols()) {
@@ -348,7 +353,7 @@ public final class RateCard {
                     }
                 }
                 if (count == 0) {
-                    return -100;
+                    return OFF_COLOR_PENALTY;
                 }
                 Integer typeCount = singleCount.get(symbol);
                 if (typeCount == null) {
@@ -416,5 +421,24 @@ public final class RateCard {
             }
         }
         return symbols.size();
+    }
+    
+    /**
+     * Return true if the card is one of the basic land types that can be added to the deck for free.
+     *
+     * @param card
+     * @return
+     */
+     public static boolean isBasicLand(Card card) {
+        String name = card.getName();
+        if (name.equals("Plains")
+                || name.equals("Island")
+                || name.equals("Swamp")
+                || name.equals("Mountain")
+                || name.equals("Forest")) {
+            return true;
+        } else {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Currently the basic lands that you can add into your deck for free (plains, island, swamp, mountain, forest) have overrated draft ratings. They're literally worthless picks, but they're rated higher than some commons.

This commit sets their rating to 1, so the bots don't pick them over real cards anymore.