### PR TITLE
Fixes to handling of snow basics

### DIFF
--- a/Mage.Client/src/main/java/mage/client/deck/generator/DeckGenerator.java
+++ b/Mage.Client/src/main/java/mage/client/deck/generator/DeckGenerator.java
@@ -291,7 +291,7 @@ public final class DeckGenerator {
 
         for (ColoredManaSymbol c : ColoredManaSymbol.values()) {
             String landName = DeckGeneratorPool.getBasicLandName(c.toString());
-            criteria.rarities(Rarity.LAND).name(landName);
+            criteria.rarities(Rarity.LAND).nameExact(landName);
             List<CardInfo> cards = CardRepository.instance.findCards(criteria);
             if (cards.isEmpty()) { // Workaround to get basic lands if lands are not available for the given sets
                 criteria.setCodes("M15");

--- a/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.java
@@ -31,6 +31,8 @@ public class AddLandDialog extends MageDialog {
     private static final Logger logger = Logger.getLogger(MageDialog.class);
 
     private Deck deck;
+    
+    private DeckEditorMode mode;
 
     private static final int DEFAULT_SEALED_DECK_CARD_NUMBER = 40;
 
@@ -41,6 +43,7 @@ public class AddLandDialog extends MageDialog {
 
     public void showDialog(Deck deck, DeckEditorMode mode) {
         this.deck = deck;
+        this.mode = mode;
         SortedSet<String> landSetNames = new TreeSet<>();
         String defaultSetName = null;
         if (mode != DeckEditorMode.FREE_BUILDING) {
@@ -73,10 +76,6 @@ public class AddLandDialog extends MageDialog {
         // if still no set with lands found, add list of all available
         List<ExpansionInfo> basicLandSets = ExpansionRepository.instance.getSetsWithBasicLandsByReleaseDate();
         for (ExpansionInfo expansionInfo : basicLandSets) {
-            // snow lands only in free mode
-            if (mode != DeckEditorMode.FREE_BUILDING && CardRepository.haveSnowLands(expansionInfo.getCode())) {
-                continue;
-            }
             landSetNames.add(expansionInfo.getName());
         }
         if (landSetNames.isEmpty()) {
@@ -150,7 +149,12 @@ public class AddLandDialog extends MageDialog {
         } else {
             criteria.ignoreSetsWithSnowLands();
         }
-        criteria.rarities(Rarity.LAND).name(landName);
+        if (mode != DeckEditorMode.FREE_BUILDING) {
+            criteria.nameExact(landName);
+        } else {
+            criteria.name(landName); // snow basics only in free mode
+        }
+        criteria.rarities(Rarity.LAND);        
         List<CardInfo> cards = CardRepository.instance.findCards(criteria);
         if (cards.isEmpty()) {
             logger.error("No basic lands found in Set: " + landSetName);

--- a/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.java
@@ -76,6 +76,10 @@ public class AddLandDialog extends MageDialog {
         // if still no set with lands found, add list of all available
         List<ExpansionInfo> basicLandSets = ExpansionRepository.instance.getSetsWithBasicLandsByReleaseDate();
         for (ExpansionInfo expansionInfo : basicLandSets) {
+            // snow lands only in free mode
+            if (mode != DeckEditorMode.FREE_BUILDING && CardRepository.haveSnowLands(expansionInfo.getCode())) {
+                continue;
+            }
             landSetNames.add(expansionInfo.getName());
         }
         if (landSetNames.isEmpty()) {

--- a/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.java
@@ -142,10 +142,11 @@ public class AddLandDialog extends MageDialog {
 
     private void addLands(String landName, int number, boolean useFullArt) {
         String landSetName = (String) cbLandSet.getSelectedItem();
-        ExpansionInfo expansionInfo = ExpansionRepository.instance.getSetByName(landSetName);
+        ExpansionInfo expansionInfo = null;
 
         CardCriteria criteria = new CardCriteria();
         if (!landSetName.equals("<Random lands>")) {
+            expansionInfo = ExpansionRepository.instance.getSetByName(landSetName);
             if (expansionInfo == null) {
                 throw new IllegalArgumentException("Code of Set " + landSetName + " not found");
             }

--- a/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.java
@@ -142,10 +142,10 @@ public class AddLandDialog extends MageDialog {
 
     private void addLands(String landName, int number, boolean useFullArt) {
         String landSetName = (String) cbLandSet.getSelectedItem();
+        ExpansionInfo expansionInfo = ExpansionRepository.instance.getSetByName(landSetName);
 
         CardCriteria criteria = new CardCriteria();
         if (!landSetName.equals("<Random lands>")) {
-            ExpansionInfo expansionInfo = ExpansionRepository.instance.getSetByName(landSetName);
             if (expansionInfo == null) {
                 throw new IllegalArgumentException("Code of Set " + landSetName + " not found");
             }
@@ -153,10 +153,10 @@ public class AddLandDialog extends MageDialog {
         } else {
             criteria.ignoreSetsWithSnowLands();
         }
-        if (mode != DeckEditorMode.FREE_BUILDING) {
-            criteria.nameExact(landName);
+        if (mode == DeckEditorMode.FREE_BUILDING && expansionInfo != null && CardRepository.haveSnowLands(expansionInfo.getCode())) {
+            criteria.name(landName); // snow basics added only if in free mode and the chosen set has exclusively snow basics
         } else {
-            criteria.name(landName); // snow basics only in free mode
+            criteria.nameExact(landName);
         }
         criteria.rarities(Rarity.LAND);        
         List<CardInfo> cards = CardRepository.instance.findCards(criteria);

--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -2212,7 +2212,7 @@ public class ComputerPlayer extends PlayerImpl implements Player {
         if (!landSets.isEmpty()) {
             criteria.setCodes(landSets.toArray(new String[landSets.size()]));
         }
-        criteria.rarities(Rarity.LAND).name(landName);
+        criteria.rarities(Rarity.LAND).nameExact(landName);
         List<CardInfo> cards = CardRepository.instance.findCards(criteria);
 
         if (cards.isEmpty()) {

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -870,19 +870,23 @@ public class VerifyCardDataTest {
             // TODO: add test to check num cards (hasBasicLands and numLand > 0)
         }
 
-        // CHECK: wrong snow land info
+        // CHECK: wrong snow land info - set needs to have exclusively snow basics to qualify
         for (ExpansionSet set : sets) {
             boolean needSnow = CardRepository.haveSnowLands(set.getCode());
             boolean haveSnow = false;
+            boolean haveNonSnow = false;
             for (ExpansionSet.SetCardInfo card : set.getSetCardInfo()) {
                 if (card.getName().startsWith("Snow-Covered ")) {
                     haveSnow = true;
+                }
+                if (isNonSnowBasicLandName(card.getName())) {
+                    haveNonSnow = true;
                     break;
                 }
             }
-            if (needSnow != haveSnow) {
+            if (needSnow != haveSnow && !haveNonSnow) {
                 errorsList.add("Error: found incorrect snow land info in set " + set.getCode() + ": "
-                        + (haveSnow ? "set has snow cards" : "set doesn't have snow card")
+                        + ((haveSnow && !haveNonSnow) ? "set has exclusively snow basics" : "set doesn't have exclusively snow basics")
                         + ", but xmage thinks that it " + (needSnow ? "does" : "doesn't"));
             }
         }
@@ -1819,6 +1823,14 @@ public class VerifyCardDataTest {
                 || checkName.equals("Swamp")
                 || checkName.equals("Plains")
                 || checkName.equals("Mountain");
+    }
+    
+    private boolean isNonSnowBasicLandName(String name) {
+        return name.equals("Island")
+                || name.equals("Forest")
+                || name.equals("Swamp")
+                || name.equals("Plains")
+                || name.equals("Mountain");
     }
 
     private void checkBasicLands(Card card, MtgJsonCard ref) {

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -884,7 +884,7 @@ public class VerifyCardDataTest {
                     break;
                 }
             }
-            if (needSnow != haveSnow && !haveNonSnow) {
+            if (needSnow != (haveSnow && !haveNonSnow)) {
                 errorsList.add("Error: found incorrect snow land info in set " + set.getCode() + ": "
                         + ((haveSnow && !haveNonSnow) ? "set has exclusively snow basics" : "set doesn't have exclusively snow basics")
                         + ", but xmage thinks that it " + (needSnow ? "does" : "doesn't"));

--- a/Mage/src/main/java/mage/cards/repository/CardCriteria.java
+++ b/Mage/src/main/java/mage/cards/repository/CardCriteria.java
@@ -246,7 +246,7 @@ public class CardCriteria {
             where.ne("setCode", ignoreSetCode);
         }
         if (!ignoreSetCodes.isEmpty()) {
-            where.or(ignoreSetCodes.size());
+            where.and(ignoreSetCodes.size());
             clausesCount++;
         }
 

--- a/Mage/src/main/java/mage/cards/repository/CardRepository.java
+++ b/Mage/src/main/java/mage/cards/repository/CardRepository.java
@@ -37,13 +37,11 @@ public enum CardRepository {
     private Dao<CardInfo, Object> cardDao;
     private Set<String> classNames;
 
+    // sets with exclusively snow basics
     public static final Set<String> snowLandSetCodes = new HashSet<>(Arrays.asList(
             "CSP",
             "MH1",
-            "SLD",
-            "ME2",
-            "ICE",
-            "KHM"
+            "ME2"
     ));
 
     CardRepository() {

--- a/Mage/src/main/java/mage/util/TournamentUtil.java
+++ b/Mage/src/main/java/mage/util/TournamentUtil.java
@@ -68,7 +68,7 @@ public final class TournamentUtil {
         } else {
             criteria.ignoreSetsWithSnowLands();
         }
-        criteria.rarities(Rarity.LAND).name(landName);
+        criteria.rarities(Rarity.LAND).nameExact(landName);
         List<CardInfo> lands = CardRepository.instance.findCards(criteria);
         List<Card> cards = new ArrayList<>();
         if (!lands.isEmpty()) {


### PR DESCRIPTION
CardCriteria: Fix ignoreSetCodes so that it works (or -> and). This is called in multiple places of the code to filter out sets with snow basics in them.

AddLandDialog: Make it possible to add non-snow basic lands from sets that have snow basics in them, outside free deckbuilding mode (for example in a draft tournament). In free deckbuilding mode it's already possible.