### PR TITLE
Fix #9357

### DIFF
--- a/Mage.Sets/src/mage/cards/e/EmrakulTheAeonsTorn.java
+++ b/Mage.Sets/src/mage/cards/e/EmrakulTheAeonsTorn.java
@@ -16,7 +16,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.filter.FilterStackObject;
+import mage.filter.FilterSpell;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.ColorlessPredicate;
 
@@ -25,7 +25,7 @@ import mage.filter.predicate.mageobject.ColorlessPredicate;
  */
 public final class EmrakulTheAeonsTorn extends CardImpl {
 
-    private static final FilterStackObject filter = new FilterStackObject("spells that are one or more colors");
+    private static final FilterSpell filter = new FilterSpell("spells that are one or more colors");
 
     static {
         filter.add(Predicates.not(ColorlessPredicate.instance));

--- a/Mage/src/main/java/mage/abilities/keyword/ProtectionAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ProtectionAbility.java
@@ -95,23 +95,12 @@ public class ProtectionAbility extends StaticAbility {
         }
 
         if (filter instanceof FilterSpell) {
-            if (source instanceof Spell) {
+            // Problem here is that for the check if a player can play a Spell, the source
+            // object is still a card and not a spell yet.
+            if (source instanceof Spell || game.inCheckPlayableState() && source.isInstantOrSorcery(game)) {
                 return !filter.match(source, game);
             }
-            // Problem here is that for the check if a player can play a Spell, the source
-            // object is still a card and not a spell yet. So return only if the source object can't be a spell
-            // otherwise the following FilterObject check will be applied
-            if (source instanceof StackObject
-                    || !source.isInstantOrSorcery(game)) {
-                return true;
-            }
-        }
-
-        // Emrakul, the Aeons Torn
-        if (filter instanceof FilterStackObject) {
-            if (filter.match(source, game)) {
-                return !source.isInstantOrSorcery(game);
-            }
+            return true;
         }
 
         if (filter instanceof FilterObject) {


### PR DESCRIPTION
This PR fixes #9357.

Emrakul's "protection from spells" ability has been the subject of numerous bugs and regressions (#9357 itself was a regression caused by an incorrect fix for #7033, and that in turn was caused by an incorrect fix for #6946) and really needs a comprehensive set of tests:

- Emrakul should not be targettable by instant or sorcery spells (this test already exists in `ProtectionTest`)
- Emrakul should not be targettable by Aura spells
- If and when mutate is successfully implemented, Emrakul should not be targettable by spells cast for their mutate cost
- Emrakul *should* be targettable by activated and triggered abilities of instant and sorcery cards (e.g. Choking Tethers, but also Forecast cards like Piercing Rays)
- Emrakul *should* be targettable by activated and triggered abilities of Aura cards (e.g. Gryff's Boon, Inferno Fist)
- Emrakul *should* be targettable by activated and triggered abilities of all other cards (e.g. Banishing Light)

I've done each of these tests "by hand" before opening this PR, but they all need to be added to `ProtectionTest` which currently only tests the simplest case.

Also, this PR adds an explicit `game.inCheckPlayableState` test for the case of potential spells before casting, but this check is still problematic:

- If you have an instant or sorcery card with a targetted Forecast ability (e.g. Piercing Rays) and Emrakul is the only potential target on the battlefield, the Forecast card will not be highlighted or selectable. However, if another, non-protected potential target also exists, then you will correctly be able to activate the Forecast ability targetting Emrakul.
- Conversely, if you have an Aura card and Emrakul is the only potential target on the battlefield, the Aura card will incorrectly be highlighted (but you won't actually be able to cast it).

I don't know how to fix this without substantial changes to the process of scanning for playable abilities. The problem is that during the check-playable scan, the "source" passed to `ProtectionAbility.canTarget` is simply the Card object in whatever zone it's in, and there's no way to tell whether the proposed use of the card is casting it as a spell or activating one of its abilities.