### PR TITLE
[WIP] [CLB] Implement Jon Irenicus, Shattered One

### DIFF
--- a/Mage.Sets/src/mage/cards/j/JonIrenicusShatteredOne.java
+++ b/Mage.Sets/src/mage/cards/j/JonIrenicusShatteredOne.java
@@ -1,0 +1,104 @@
+package mage.cards.j;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.AttacksAllTriggeredAbility;
+import mage.abilities.common.BeginningOfEndStepTriggeredAbility;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.combat.GoadTargetEffect;
+import mage.abilities.effects.common.continuous.GainControlTargetEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.counters.CounterType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.common.TargetControlledCreaturePermanent;
+import mage.target.common.TargetOpponent;
+import mage.target.targetpointer.FixedTarget;
+
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public final class JonIrenicusShatteredOne extends CardImpl {
+
+    private static final FilterCreaturePermanent filter
+            = new FilterCreaturePermanent("creature you own but don't control");
+
+    static {
+        filter.add(TargetController.YOU.getOwnerPredicate());
+        filter.add(TargetController.NOT_YOU.getControllerPredicate());
+    }
+
+    public JonIrenicusShatteredOne(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{U}{B}");
+
+        addSuperType(SuperType.LEGENDARY);
+        this.subtype.add(SubType.ELF);
+        this.subtype.add(SubType.WIZARD);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(3);
+
+        // At the beginning of your end step, target opponent gains control of up to one target creature you control. Put two +1/+1 counters on it and tap it.
+        // It's goaded for the rest of the game and it gains “This creature can't be sacrificed.”
+        Ability ability = new BeginningOfEndStepTriggeredAbility(new JonIrenicusShatteredOneEffect(), TargetController.YOU, false);
+        ability.addTarget(new TargetOpponent());
+        ability.addTarget(new TargetControlledCreaturePermanent(0, 1));
+        this.addAbility(ability);
+
+        // Whenever a creature you own but don't control attacks, you draw a card.
+        this.addAbility(new AttacksAllTriggeredAbility(new DrawCardSourceControllerEffect(1), false, filter, SetTargetPointer.NONE, false));
+    }
+
+    private JonIrenicusShatteredOne(final JonIrenicusShatteredOne card) {super(card);}
+
+    @Override
+    public JonIrenicusShatteredOne copy() {return new JonIrenicusShatteredOne(this);}
+}
+
+
+class JonIrenicusShatteredOneEffect extends OneShotEffect {
+
+    public JonIrenicusShatteredOneEffect() {
+        super(Outcome.Detriment);
+        this.staticText = "target opponent gains control of up to one target creature you control. Put two +1/+1 counters on it and tap it. " +
+                "It's goaded for the rest of the game and it gains “This creature can't be sacrificed.\"";
+    }
+
+    public JonIrenicusShatteredOneEffect(final JonIrenicusShatteredOneEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public JonIrenicusShatteredOneEffect copy() {
+        return new JonIrenicusShatteredOneEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        UUID opponentID = source.getTargets().get(0).getFirstTarget();
+        Player opponent = game.getPlayer(opponentID);
+        Permanent creature = game.getPermanent(source.getTargets().get(1).getFirstTarget());
+        if (creature == null || opponent == null) {
+            return false;
+        }
+        ContinuousEffect effect = new GainControlTargetEffect(Duration.EndOfGame, opponentID);
+        effect.setTargetPointer(new FixedTarget(creature, game));
+        game.addEffect(effect, source);
+        creature.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
+        creature.tap(source, game);
+        game.addEffect(new GoadTargetEffect()
+                .setDuration(Duration.EndOfGame)
+                .setTargetPointer(new FixedTarget(creature, game)),
+                source
+        );
+        // TODO: Grant creature "This creature can't be sacrificed" ability here.
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/sets/CommanderLegendsBattleForBaldursGate.java
+++ b/Mage.Sets/src/mage/sets/CommanderLegendsBattleForBaldursGate.java
@@ -322,6 +322,9 @@ public final class CommanderLegendsBattleForBaldursGate extends ExpansionSet {
         cards.add(new SetCardInfo("Javelin of Lightning", 185, Rarity.COMMON, mage.cards.j.JavelinOfLightning.class));
         cards.add(new SetCardInfo("Jazal Goldmane", 697, Rarity.MYTHIC, mage.cards.j.JazalGoldmane.class));
         cards.add(new SetCardInfo("Jeska's Will", 799, Rarity.RARE, mage.cards.j.JeskasWill.class));
+        cards.add(new SetCardInfo("Jon Irenicus, Shattered One", 278, Rarity.RARE, mage.cards.j.JonIrenicusShatteredOne.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Jon Irenicus, Shattered One", 425, Rarity.RARE, mage.cards.j.JonIrenicusShatteredOne.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Jon Irenicus, Shattered One", 536, Rarity.RARE, mage.cards.j.JonIrenicusShatteredOne.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Journey to the Lost City", 681, Rarity.RARE, mage.cards.j.JourneyToTheLostCity.class));
         cards.add(new SetCardInfo("Juvenile Mist Dragon", 79, Rarity.UNCOMMON, mage.cards.j.JuvenileMistDragon.class));
         cards.add(new SetCardInfo("Karlach, Fury of Avernus", 186, Rarity.MYTHIC, mage.cards.k.KarlachFuryOfAvernus.class));


### PR DESCRIPTION
It occurred to me that I should probably have this up to avoid any horizontal development of the same code.

This implements Jon Irenicus, Shattered One, *omitting the part of the first ability where the creature is granted "This creature can't be sacrificed"*. That feature of the card can only be implemented once #9375 is resolved and sacrifice effects have been refactored to accommodate this ability.