### PR TITLE
[DMC] Implement Rohgahh, Kher Keep Overlord

### DIFF
--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardRendererUtils.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardRendererUtils.java
@@ -245,14 +245,12 @@ public final class CardRendererUtils {
         if (value != null) {
             int current = value.getValue();
             int origin = value.getModifiedBaseValue();
-            if (origin != 0) {
-                if (current < origin) {
-                    return textLight ? CARD_TEXT_COLOR_BAD_LIGHT : CARD_TEXT_COLOR_BAD_DARK;
-                } else if (current > origin) {
-                    return textLight ? CARD_TEXT_COLOR_GOOD_LIGHT : CARD_TEXT_COLOR_GOOD_DARK;
-                } else {
-                    return defaultColor;
-                }
+            if (current < origin) {
+                return textLight ? CARD_TEXT_COLOR_BAD_LIGHT : CARD_TEXT_COLOR_BAD_DARK;
+            } else if (current > origin) {
+                return textLight ? CARD_TEXT_COLOR_GOOD_LIGHT : CARD_TEXT_COLOR_GOOD_DARK;
+            } else {
+                return defaultColor;
             }
         }
 

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardRendererUtils.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardRendererUtils.java
@@ -243,11 +243,11 @@ public final class CardRendererUtils {
 
         // boost colorizing
         if (value != null) {
-            int current = value.getValue();
-            int origin = value.getModifiedBaseValue();
-            if (current < origin) {
+            int currentValue = value.getValue();
+            int baseValue = value.getModifiedBaseValue();
+            if (currentValue < baseValue) {
                 return textLight ? CARD_TEXT_COLOR_BAD_LIGHT : CARD_TEXT_COLOR_BAD_DARK;
-            } else if (current > origin) {
+            } else if (currentValue > baseValue) {
                 return textLight ? CARD_TEXT_COLOR_GOOD_LIGHT : CARD_TEXT_COLOR_GOOD_DARK;
             } else {
                 return defaultColor;

--- a/Mage.Sets/src/mage/cards/r/RohgahhKherKeepOverlord.java
+++ b/Mage.Sets/src/mage/cards/r/RohgahhKherKeepOverlord.java
@@ -1,0 +1,74 @@
+package mage.cards.r;
+
+import mage.MageInt;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.common.SpellCastControllerTriggeredAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.DoIfCostPaid;
+import mage.abilities.effects.common.continuous.BoostControlledEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.FilterSpell;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.DragonToken;
+import mage.game.permanent.token.KherKeepKoboldToken;
+
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public class RohgahhKherKeepOverlord extends CardImpl {
+
+    private static final FilterCreaturePermanent controlledKoboldsFilter = new FilterCreaturePermanent(SubType.KOBOLD, "Kobolds");
+    private static final FilterSpell koboldSpellFilter = new FilterSpell("a Kobold spell");
+    private static final FilterSpell dragonSpellFilter = new FilterSpell("a Dragon spell");
+
+    static {
+        koboldSpellFilter.add(SubType.KOBOLD.getPredicate());
+        dragonSpellFilter.add(SubType.DRAGON.getPredicate());
+    }
+
+    public RohgahhKherKeepOverlord(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{B}{R}");
+
+        addSuperType(SuperType.LEGENDARY);
+        this.subtype.add(SubType.KOBOLD);
+        this.subtype.add(SubType.WARRIOR);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(4);
+
+        // Other Kobolds you control get +2/+2.
+        this.addAbility(new SimpleStaticAbility(new BoostControlledEffect(
+                2, 2, Duration.WhileOnBattlefield, controlledKoboldsFilter, true
+        )));
+
+        // Whenever you cast a Kobold spell, you may pay {2}. If you do, create a 4/4 red Dragon creature token with flying.
+        this.addAbility(new SpellCastControllerTriggeredAbility(
+                new DoIfCostPaid(
+                        new CreateTokenEffect(new DragonToken()),
+                        new ManaCostsImpl<>("{2}")
+                ),
+                koboldSpellFilter,
+                false
+        ));
+
+        // Whenever you cast a Dragon spell, create a 0/1 red Kobold creature token named Kobolds of Kher Keep.
+        this.addAbility(new SpellCastControllerTriggeredAbility(
+                new CreateTokenEffect(new KherKeepKoboldToken()),
+                dragonSpellFilter,
+                false
+        ));
+    }
+
+    private RohgahhKherKeepOverlord(final RohgahhKherKeepOverlord card) {
+        super(card);
+    }
+
+    @Override
+    public RohgahhKherKeepOverlord copy() {
+        return new RohgahhKherKeepOverlord(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/DominariaUnitedCommander.java
+++ b/Mage.Sets/src/mage/sets/DominariaUnitedCommander.java
@@ -132,6 +132,8 @@ public final class DominariaUnitedCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Read the Bones", 117, Rarity.COMMON, mage.cards.r.ReadTheBones.class));
         cards.add(new SetCardInfo("Reliquary Tower", 227, Rarity.UNCOMMON, mage.cards.r.ReliquaryTower.class));
         cards.add(new SetCardInfo("Rienne, Angel of Rebirth", 166, Rarity.MYTHIC, mage.cards.r.RienneAngelOfRebirth.class));
+        cards.add(new SetCardInfo("Rohgahh, Kher Keep Overlord", 41, Rarity.RARE, mage.cards.r.RohgahhKherKeepOverlord.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Rohgahh, Kher Keep Overlord", 63, Rarity.RARE, mage.cards.r.RohgahhKherKeepOverlord.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Rocky Tar Pit", 228, Rarity.UNCOMMON, mage.cards.r.RockyTarPit.class));
         cards.add(new SetCardInfo("Rosnakht, Heir of Rohgahh", 25, Rarity.RARE, mage.cards.r.RosnakhtHeirOfRohgahh.class));
         cards.add(new SetCardInfo("Sandsteppe Citadel", 229, Rarity.UNCOMMON, mage.cards.s.SandsteppeCitadel.class));


### PR DESCRIPTION
Implements Rohgahh, Kher Keep Overlord. Card works as expected but for some reason Kobolds with a base power of 0 do not have the number change colour to green when buffed by Rohgahh. This is exclusive to 0 power Kobolds, and only affects their power - the toughness correctly displays as green. See below:
![image](https://user-images.githubusercontent.com/26198472/188517982-8ef139c7-1f0b-4b57-8408-98e750e3ac55.png)
Kobolds of Kher Keep and Rosnakht are both 0/1 Kobolds, so are 2/3s when buffed by Rohgahh. The power is, for whatever reason, still black. This is in contrast to Universal Automaton, a 1/1 Kobold, which correctly has its stats set to 3/3 and has both numbers green to indicate that they have been boosted. If Rohgahh is sacrificed, the Kobolds correctly have their stats return to 0/1.