### PR TITLE
[DMU] Implemented Garna, Bloodfist of Keld

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GarnaBloodfistOfKeld.java
+++ b/Mage.Sets/src/mage/cards/g/GarnaBloodfistOfKeld.java
@@ -1,0 +1,81 @@
+package mage.cards.g;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DiesCreatureTriggeredAbility;
+import mage.abilities.condition.Condition;
+import mage.abilities.decorator.ConditionalOneShotEffect;
+import mage.abilities.effects.Effects;
+import mage.abilities.effects.common.DamagePlayersEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.TargetController;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+/**
+ *
+ * @author weirddan455
+ */
+public final class GarnaBloodfistOfKeld extends CardImpl {
+
+    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("another creature you control");
+
+    static {
+        filter.add(AnotherPredicate.instance);
+    }
+
+    public GarnaBloodfistOfKeld(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{B}{R}{R}");
+
+        this.addSuperType(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.BERSERKER);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(3);
+
+        // Whenever another creature you control dies, draw a card if it was attacking. Otherwise, Garna, Bloodfist of Keld deals 1 damage to each opponent.
+        this.addAbility(new DiesCreatureTriggeredAbility(
+                new ConditionalOneShotEffect(
+                        new DrawCardSourceControllerEffect(1),
+                        new DamagePlayersEffect(1, TargetController.OPPONENT),
+                        GarnaBloodfistOfKeldCondition.instance,
+                        "draw a card if it was attacking. Otherwise, {this} deals 1 damage to each opponent"
+                ),
+                false,
+                filter
+        ));
+    }
+
+    private GarnaBloodfistOfKeld(final GarnaBloodfistOfKeld card) {
+        super(card);
+    }
+
+    @Override
+    public GarnaBloodfistOfKeld copy() {
+        return new GarnaBloodfistOfKeld(this);
+    }
+}
+
+enum GarnaBloodfistOfKeldCondition implements Condition {
+    instance;
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Effects effects = source.getEffects();
+        if (!effects.isEmpty()) {
+            Object value = effects.get(0).getValue("creatureDied");
+            if (value instanceof Permanent) {
+                return ((Permanent) value).isAttacking();
+            }
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/DominariaUnited.java
+++ b/Mage.Sets/src/mage/sets/DominariaUnited.java
@@ -111,6 +111,7 @@ public final class DominariaUnited extends ExpansionSet {
         cards.add(new SetCardInfo("Frostfist Strider", 51, Rarity.UNCOMMON, mage.cards.f.FrostfistStrider.class));
         cards.add(new SetCardInfo("Furious Bellow", 126, Rarity.COMMON, mage.cards.f.FuriousBellow.class));
         cards.add(new SetCardInfo("Gaea's Might", 164, Rarity.COMMON, mage.cards.g.GaeasMight.class));
+        cards.add(new SetCardInfo("Garna, Bloodfist of Keld", 200, Rarity.UNCOMMON, mage.cards.g.GarnaBloodfistOfKeld.class));
         cards.add(new SetCardInfo("Geothermal Bog", 247, Rarity.COMMON, mage.cards.g.GeothermalBog.class));
         cards.add(new SetCardInfo("Ghitu Amplifier", 127, Rarity.COMMON, mage.cards.g.GhituAmplifier.class));
         cards.add(new SetCardInfo("Gibbering Barricade", 95, Rarity.COMMON, mage.cards.g.GibberingBarricade.class));


### PR DESCRIPTION
Some history:  Triggers that care about attacking creatures dying were not being handled properly.  I put in a PR #7495 and then @jeffwadsworth made some improvements on top of that and it ended up in commit 43dbaf405b9bae3cc54772345db10d5c1aa79eec

I went back and looked at it and I think this is a much simpler way of handling it.  Rather than having that whole class that tries to keep track of what creatures are attacking, you can just make a copy of the Permanent and store that in the ZoneChangeEvent.

This copy is made after replacement effects are handled (which may need access to the original Permanent) and before `player.removeFromBattlefield` is called (which removes the creature from combat and sets `attacking` to false.  As this is a zone change event, the original permanent won't exist by the time triggers are looking at it (it will have already changed zones) so I don't see a situation where a trigger would need to modify the original.

This way we retain the full state of the permanent as it was before it dies and allows the regular AttackingPredicate to work.  Tests have already been written for Kardur and Kithkin Mourncaller and everything is passing.