### PR TITLE
[DMC] Implement Hazezon, Shaper of Sand

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HazezonShaperOfSand.java
+++ b/Mage.Sets/src/mage/cards/h/HazezonShaperOfSand.java
@@ -1,0 +1,65 @@
+package mage.cards.h;
+
+import mage.MageInt;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.ruleModifying.PlayLandsFromGraveyardControllerEffect;
+import mage.abilities.keyword.LandwalkAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.constants.Zone;
+import mage.filter.common.FilterControlledLandPermanent;
+import mage.filter.common.FilterLandCard;
+import mage.game.permanent.token.HazezonTamarSandWarriorToken;
+
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public final class HazezonShaperOfSand extends CardImpl {
+
+    private static final FilterControlledLandPermanent filter = new FilterControlledLandPermanent("Desert");
+    private static final FilterLandCard filter2 = new FilterLandCard("Desert lands");
+    private static final FilterControlledLandPermanent filter3 = new FilterControlledLandPermanent("a Desert");
+
+    static {
+        filter.add(SubType.DESERT.getPredicate());
+        filter2.add(SubType.DESERT.getPredicate());
+        filter3.add(SubType.DESERT.getPredicate());
+    }
+
+    public HazezonShaperOfSand(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{R}{G}{W}");
+        addSuperType(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.WARRIOR);
+
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(3);
+
+        // Desertwalk
+        this.addAbility(new LandwalkAbility(filter));
+
+        // You may play Desert lands from your graveyard.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PlayLandsFromGraveyardControllerEffect(filter2)));
+
+        // Whenever a Desert enters the battlefield under your control create two 1/1 red, green, and white Sand Warrior creature tokens.
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new CreateTokenEffect(
+                new HazezonTamarSandWarriorToken(), 2), filter3
+        ));
+    }
+
+    private HazezonShaperOfSand(final HazezonShaperOfSand card) {
+        super(card);
+    }
+
+    @Override
+    public HazezonShaperOfSand copy() {
+        return new HazezonShaperOfSand(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/DominariaUnitedCommander.java
+++ b/Mage.Sets/src/mage/sets/DominariaUnitedCommander.java
@@ -83,6 +83,8 @@ public final class DominariaUnitedCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Glint-Eye Nephilim", 152, Rarity.RARE, mage.cards.g.GlintEyeNephilim.class));
         cards.add(new SetCardInfo("Grasslands", 214, Rarity.UNCOMMON, mage.cards.g.Grasslands.class));
         cards.add(new SetCardInfo("Growth Spiral", 153, Rarity.COMMON, mage.cards.g.GrowthSpiral.class));
+        cards.add(new SetCardInfo("Hazezon, Shaper of Sand", 32, Rarity.RARE, mage.cards.h.HazezonShaperOfSand.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Hazezon, Shaper of Sand", 54, Rarity.RARE, mage.cards.h.HazezonShaperOfSand.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Hazoret's Monument", 183, Rarity.UNCOMMON, mage.cards.h.HazoretsMonument.class));
         cards.add(new SetCardInfo("Hedron Archive", 184, Rarity.UNCOMMON, mage.cards.h.HedronArchive.class));
         cards.add(new SetCardInfo("Hero of Precinct One", 101, Rarity.RARE, mage.cards.h.HeroOfPrecinctOne.class));


### PR DESCRIPTION
`filter` and `filter3` are identical in all but `name`. This is because reusing `filter` for Hazezon's third ability resulted in the constructed string "**Whenever Desert** enters the battlefield under your control.." instead of "Whenever **a** Desert enters the battlefield under your control..". I tried writing `filter.setMessage("a Desert");` right before adding the third abililty, but this caused the card's Desertwalk ability to predictably display as "A Desertwalk". The card's abilities work fine, but I feel like there's a better way to handle the filter names not matching up.