### PR TITLE
[DMU] Implemented Tyrannical Pitlord

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TyrannicalPitlord.java
+++ b/Mage.Sets/src/mage/cards/t/TyrannicalPitlord.java
@@ -1,0 +1,155 @@
+package mage.cards.t;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.MageObjectReference;
+import mage.abilities.Ability;
+import mage.abilities.common.AsEntersBattlefieldAbility;
+import mage.abilities.common.LeavesBattlefieldTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.ContinuousEffectImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.ChooseCreatureEffect;
+import mage.constants.*;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.TrampleAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.util.CardUtil;
+
+/**
+ *
+ * @author weirddan455
+ */
+public final class TyrannicalPitlord extends CardImpl {
+
+    public TyrannicalPitlord(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{B}{B}");
+
+        this.subtype.add(SubType.DEMON);
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Trample
+        this.addAbility(TrampleAbility.getInstance());
+
+        // As Tyrannical Pitlord enters the battlefield, choose another creature you control.
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseCreatureEffect()));
+
+        // The chosen creature gets +3/+3 and has flying.
+        Ability ability = new SimpleStaticAbility(new TyrannicalPitlordBoostEffect());
+        ability.addEffect(new TyrannicalPitlordGainFlyingEffect());
+        this.addAbility(ability);
+
+        // When Tyrannical Pitlord leaves the battlefield, sacrifice the chosen creature.
+        this.addAbility(new LeavesBattlefieldTriggeredAbility(new TyrannicalPitlordSacrificeEffect(), false));
+    }
+
+    private TyrannicalPitlord(final TyrannicalPitlord card) {
+        super(card);
+    }
+
+    @Override
+    public TyrannicalPitlord copy() {
+        return new TyrannicalPitlord(this);
+    }
+}
+
+class TyrannicalPitlordBoostEffect extends ContinuousEffectImpl {
+
+    public TyrannicalPitlordBoostEffect() {
+        super(Duration.WhileOnBattlefield, Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, Outcome.BoostCreature);
+        this.staticText = "the chosen creature gets +3/+3";
+    }
+
+    private TyrannicalPitlordBoostEffect(final TyrannicalPitlordBoostEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public TyrannicalPitlordBoostEffect copy() {
+        return new TyrannicalPitlordBoostEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Object chosenCreature = game.getState().getValue(CardUtil.getCardZoneString("chosenCreature", source.getSourceId(), game));
+        if (!(chosenCreature instanceof MageObjectReference)) {
+            return false;
+        }
+        Permanent permanent = ((MageObjectReference) chosenCreature).getPermanent(game);
+        if (permanent == null) {
+            return false;
+        }
+        permanent.addPower(3);
+        permanent.addToughness(3);
+        return true;
+    }
+}
+
+class TyrannicalPitlordGainFlyingEffect extends ContinuousEffectImpl {
+
+    public TyrannicalPitlordGainFlyingEffect() {
+        super(Duration.WhileOnBattlefield, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
+        this.staticText = "and has flying";
+    }
+
+    private TyrannicalPitlordGainFlyingEffect(final TyrannicalPitlordGainFlyingEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public TyrannicalPitlordGainFlyingEffect copy() {
+        return new TyrannicalPitlordGainFlyingEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Object chosenCreature = game.getState().getValue(CardUtil.getCardZoneString("chosenCreature", source.getSourceId(), game));
+        if (!(chosenCreature instanceof MageObjectReference)) {
+            return false;
+        }
+        Permanent permanent = ((MageObjectReference) chosenCreature).getPermanent(game);
+        if (permanent == null) {
+            return false;
+        }
+        permanent.addAbility(FlyingAbility.getInstance(), source.getSourceId(), game);
+        return true;
+    }
+}
+
+class TyrannicalPitlordSacrificeEffect extends OneShotEffect {
+
+    public TyrannicalPitlordSacrificeEffect() {
+        super(Outcome.Sacrifice);
+        this.staticText = "sacrifice the chosen creature";
+    }
+
+    private TyrannicalPitlordSacrificeEffect(final TyrannicalPitlordSacrificeEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public TyrannicalPitlordSacrificeEffect copy() {
+        return new TyrannicalPitlordSacrificeEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Object chosenCreature = game.getState().getValue(CardUtil.getCardZoneString("chosenCreature", source.getSourceId(), game, true));
+        if (!(chosenCreature instanceof MageObjectReference)) {
+            return false;
+        }
+        Permanent permanent = ((MageObjectReference) chosenCreature).getPermanent(game);
+        if (permanent == null) {
+            return false;
+        }
+        permanent.sacrifice(source, game);
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/sets/DominariaUnited.java
+++ b/Mage.Sets/src/mage/sets/DominariaUnited.java
@@ -269,6 +269,7 @@ public final class DominariaUnited extends ExpansionSet {
         cards.add(new SetCardInfo("Tribute to Urborg", 113, Rarity.COMMON, mage.cards.t.TributeToUrborg.class));
         cards.add(new SetCardInfo("Tura Kennerud, Skyknight", 224, Rarity.UNCOMMON, mage.cards.t.TuraKennerudSkyknight.class));
         cards.add(new SetCardInfo("Twinferno", 149, Rarity.UNCOMMON, mage.cards.t.Twinferno.class));
+        cards.add(new SetCardInfo("Tyrannical Pitlord", 284, Rarity.RARE, mage.cards.t.TyrannicalPitlord.class));
         cards.add(new SetCardInfo("Urborg Lhurgoyf", 186, Rarity.RARE, mage.cards.u.UrborgLhurgoyf.class));
         cards.add(new SetCardInfo("Urborg Repossession", 114, Rarity.COMMON, mage.cards.u.UrborgRepossession.class));
         cards.add(new SetCardInfo("Urza Assembles the Titans", 37, Rarity.RARE, mage.cards.u.UrzaAssemblesTheTitans.class));

--- a/Mage/src/main/java/mage/abilities/effects/common/ChooseCreatureEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ChooseCreatureEffect.java
@@ -1,0 +1,75 @@
+package mage.abilities.effects.common;
+
+import mage.MageObjectReference;
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.constants.Outcome;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.util.CardUtil;
+
+/**
+ * To be used with AsEntersBattlefieldAbility (otherwise Zone Change Counter will be wrong)
+ *
+ * @author weirddan455
+ */
+public class ChooseCreatureEffect extends OneShotEffect {
+
+    private static final FilterPermanent defaultFilter
+            = new FilterControlledCreaturePermanent("another creature you control");
+
+    static {
+        defaultFilter.add(AnotherPredicate.instance);
+    }
+
+    private final FilterPermanent filter;
+
+    public ChooseCreatureEffect() {
+        this(defaultFilter);
+    }
+
+    public ChooseCreatureEffect(FilterPermanent filter) {
+        super(Outcome.Benefit);
+        this.filter = filter;
+        this.staticText = "choose " + filter.getMessage();
+    }
+
+    private ChooseCreatureEffect(final ChooseCreatureEffect effect) {
+        super(effect);
+        this.filter = effect.filter;
+    }
+
+    @Override
+    public ChooseCreatureEffect copy() {
+        return new ChooseCreatureEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null) {
+            return false;
+        }
+        Permanent sourcePermanent = game.getPermanentEntering(source.getSourceId());
+        if (sourcePermanent == null) {
+            return false;
+        }
+        TargetPermanent target = new TargetPermanent(1, 1, filter, true);
+        controller.chooseTarget(outcome, target, source, game);
+        Permanent chosenCreature = game.getPermanent(target.getFirstTarget());
+        if (chosenCreature == null) {
+            return false;
+        }
+        game.getState().setValue(
+                CardUtil.getObjectZoneString("chosenCreature", sourcePermanent.getId(), game, sourcePermanent.getZoneChangeCounter(game) + 1, false),
+                new MageObjectReference(chosenCreature, game)
+        );
+        sourcePermanent.addInfo("chosen creature", CardUtil.addToolTipMarkTags("Chosen Creature " + chosenCreature.getIdName()), game);
+        return true;
+    }
+}


### PR DESCRIPTION
I moved the ChooseCreatureEffect into a common class from Dauntless Bodyguard and improved it to also store the zone change counter information in the key string.

I wasn't sure if there is a good way to be able to use common effects with this like `BoostTargetEffect`.  Maybe some way to set the target pointer?  Let me know if you can think of a better way.