### PR TITLE
[DMU] Karn's Sylex

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -83,6 +83,9 @@ public class ComputerPlayer extends PlayerImpl implements Player {
 
     private transient ManaCost currentUnpaidMana;
 
+    // For stopping infinite loops when trying to pay Phyrexian mana when the player can't spend life and no other sources are available
+    private transient boolean alreadyTryingToPayPhyrexian;
+
     public ComputerPlayer(String name, RangeOfInfluence range) {
         super(name, range);
         human = false;
@@ -1664,9 +1667,16 @@ public class ComputerPlayer extends PlayerImpl implements Player {
             }
         }
 
+        if (alreadyTryingToPayPhyrexian) {
+            return false;
+        }
+
         // pay phyrexian life costs
         if (cost.isPhyrexian()) {
-            return cost.pay(ability, game, ability, playerId, false, null) || approvingObject != null;
+            alreadyTryingToPayPhyrexian = true;
+            boolean paidPhyrexian = cost.pay(ability, game, ability, playerId, false, null) || approvingObject != null;
+            alreadyTryingToPayPhyrexian = false;
+            return paidPhyrexian;
         }
 
         // pay special mana like convoke cost (tap for pay)

--- a/Mage.Sets/src/mage/cards/a/AngelOfJubilation.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfJubilation.java
@@ -75,7 +75,7 @@ class AngelOfJubilationEffect extends ContinuousEffectImpl {
     public boolean apply(Game game, Ability source) {
         for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {
             Player player = game.getPlayer(playerId);
-            player.setCanPayLifeCost(false);
+            player.setPayLifeCostLevel(Player.PayLifeCostLevel.nonSpellnonActivatedAbilities);
             player.setCanPaySacrificeCostFilter(new FilterCreaturePermanent());
         }
         return true;

--- a/Mage.Sets/src/mage/cards/k/KarnsSylex.java
+++ b/Mage.Sets/src/mage/cards/k/KarnsSylex.java
@@ -1,0 +1,78 @@
+package mage.cards.k;
+
+import mage.abilities.Ability;
+import mage.abilities.common.ActivateAsSorceryActivatedAbility;
+import mage.abilities.common.EntersBattlefieldTappedAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.dynamicvalue.common.ManacostVariableValue;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DestroyAllEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.ComparisonType;
+import mage.constants.Outcome;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterNonlandPermanent;
+import mage.filter.predicate.mageobject.ManaValuePredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.targetadjustment.TargetAdjuster;
+
+import java.util.UUID;
+
+/**
+ * @author Alex-Vasile
+ */
+public class KarnsSylex extends CardImpl {
+    public KarnsSylex(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{}, "");
+
+        // Karn’s Sylex
+        this.addAbility(new EntersBattlefieldTappedAbility());
+
+        // Players can’t pay life to cast spells or to activate abilities that aren’t mana abilities.
+        // TODO: AngelOfJubilation
+
+        // {X}, {T}, Exile Karn’s Sylex: Destroy each nonland permanent with mana value X or less. Activate only as a sorcery.
+        this.addAbility(new ActivateAsSorceryActivatedAbility(new KarnsSylexDestroyEffect));
+    }
+
+    private KarnsSylex(final KarnsSylex card) {
+        super(card);
+    }
+
+    @Override
+    public KarnsSylex copy() {
+        return new KarnsSylex(this);
+    }
+}
+
+class KarnsSylexDestroyEffect extends OneShotEffect {
+
+    KarnsSylexDestroyEffect() {
+        super(Outcome.DestroyPermanent);
+        staticText = "Destroy each nonland permanent with mana value X or less.";
+    }
+
+    private KarnsSylexDestroyEffect(final KarnsSylexDestroyEffect effect) {
+        super(effect);
+    }
+
+    public KarnsSylexDestroyEffect copy() {
+        return new KarnsSylexDestroyEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        FilterNonlandPermanent filter = new FilterNonlandPermanent();
+        filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, source.getManaCostsToPay().getX() + 1));
+
+        boolean destroyed = false;
+        for (Permanent permanent : game.getState().getBattlefield().getActivePermanents(filter, source.getControllerId(), game)) {
+            destroyed |= permanent.destroy(source, game);
+        }
+        return destroyed;
+    }
+}

--- a/Mage.Sets/src/mage/cards/k/KarnsSylex.java
+++ b/Mage.Sets/src/mage/cards/k/KarnsSylex.java
@@ -1,25 +1,36 @@
 package mage.cards.k;
 
+import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.ActivateAsSorceryActivatedAbility;
 import mage.abilities.common.EntersBattlefieldTappedAbility;
 import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.common.ExileSourceCost;
+import mage.abilities.costs.common.PayLifeCost;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.costs.mana.VariableManaCost;
 import mage.abilities.dynamicvalue.common.ManacostVariableValue;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DestroyAllEffect;
+import mage.abilities.effects.common.cost.CostModificationEffectImpl;
+import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.ComparisonType;
-import mage.constants.Outcome;
+import mage.constants.*;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterNonlandPermanent;
 import mage.filter.predicate.mageobject.ManaValuePredicate;
 import mage.game.Game;
+import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetadjustment.TargetAdjuster;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -33,10 +44,13 @@ public class KarnsSylex extends CardImpl {
         this.addAbility(new EntersBattlefieldTappedAbility());
 
         // Players can’t pay life to cast spells or to activate abilities that aren’t mana abilities.
-        // TODO: AngelOfJubilation
+        this.addAbility(new SimpleStaticAbility(new KarnsSylexCantPayLifeEffect()));
 
         // {X}, {T}, Exile Karn’s Sylex: Destroy each nonland permanent with mana value X or less. Activate only as a sorcery.
-        this.addAbility(new ActivateAsSorceryActivatedAbility(new KarnsSylexDestroyEffect));
+        Ability ability = new ActivateAsSorceryActivatedAbility(new KarnsSylexDestroyEffect(), new ManaCostsImpl<>("{X}"));
+        ability.addCost(new TapSourceCost());
+        ability.addCost(new ExileSourceCost());
+        this.addAbility(ability);
     }
 
     private KarnsSylex(final KarnsSylex card) {
@@ -46,6 +60,45 @@ public class KarnsSylex extends CardImpl {
     @Override
     public KarnsSylex copy() {
         return new KarnsSylex(this);
+    }
+}
+
+class KarnsSylexCantPayLifeEffect extends ContinuousRuleModifyingEffectImpl {
+
+    KarnsSylexCantPayLifeEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.Detriment);
+        staticText = "players can’t pay life to cast spells or to activate abilities that aren’t mana abilities";
+    }
+
+    private KarnsSylexCantPayLifeEffect(final KarnsSylexCantPayLifeEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public KarnsSylexCantPayLifeEffect copy() {
+        return new KarnsSylexCantPayLifeEffect(this);
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        MageObject object = game.getObject(event.getSourceId());
+        if (event.getType() == GameEvent.EventType.CAST_SPELL) {
+            if (object == null) {
+                return false;
+            }
+//            return object != null && ((CardImpl) object).getManaCost().stream().anyMatch(manaCost -> manaCost.i)
+        } else if (event.getType() == GameEvent.EventType.ACTIVATE_ABILITY) {
+            Optional<Ability> abilityOptional = game.getAbility(event.getTargetId(), event.getSourceId());
+            if (!abilityOptional.isPresent()) {
+                return false;
+            }
+            Ability ability = abilityOptional.get();
+            boolean lifeCost = ability.getCosts().stream().anyMatch(cost -> cost instanceof PayLifeCost);
+            return lifeCost && !(ability instanceof ActivatedManaAbilityImpl);
+        } else {
+            return false;
+        }
+        return false;
     }
 }
 

--- a/Mage.Sets/src/mage/sets/DominariaUnited.java
+++ b/Mage.Sets/src/mage/sets/DominariaUnited.java
@@ -143,6 +143,7 @@ public final class DominariaUnited extends ExpansionSet {
         cards.add(new SetCardInfo("Joint Exploration", 56, Rarity.UNCOMMON, mage.cards.j.JointExploration.class));
         cards.add(new SetCardInfo("Juniper Order Rootweaver", 22, Rarity.COMMON, mage.cards.j.JuniperOrderRootweaver.class));
         cards.add(new SetCardInfo("Karn, Living Legacy", 1, Rarity.MYTHIC, mage.cards.k.KarnLivingLegacy.class));
+        cards.add(new SetCardInfo("Karn's Sylex", 234, Rarity.MYTHIC, mage.cards.k.KarnsSylex.class));
         cards.add(new SetCardInfo("Karplusan Forest", 250, Rarity.RARE, mage.cards.k.KarplusanForest.class));
         cards.add(new SetCardInfo("Keldon Flamesage", 135, Rarity.RARE, mage.cards.k.KeldonFlamesage.class));
         cards.add(new SetCardInfo("Keldon Strike Team", 136, Rarity.COMMON, mage.cards.k.KeldonStrikeTeam.class));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/AngelOfJubilationTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/AngelOfJubilationTest.java
@@ -229,7 +229,6 @@ public class AngelOfJubilationTest extends CardTestPlayerBase {
      * life (as Griselbrand’s activated ability does) or sacrifice a creature
      * (as Fling does), that spell or ability can’t be cast or activated.
      */
-    
     @Test
     public void testGriselbrandCantPay() {
         setStrictChooseMode(true);
@@ -244,6 +243,5 @@ public class AngelOfJubilationTest extends CardTestPlayerBase {
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
-
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/KarnsSylexTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/KarnsSylexTest.java
@@ -1,0 +1,76 @@
+package org.mage.test.cards.single.dmu;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * {@link mage.cards.k.KarnsSylex Karn's Sylex}
+ * Karn’s Sylex enters the battlefield tapped.
+ * Players can’t pay life to cast spells or to activate abilities that aren’t mana abilities.
+ * {X}, {T}, Exile Karn’s Sylex: Destroy each nonland permanent with mana value X or less. Activate only as a sorcery.
+ *
+ * @author Alex-Vasile
+ */
+public class KarnsSylexTest extends CardTestPlayerBase {
+    private static final String karnsSylex = "Karn's Sylex";
+
+    /**
+     * Test that it does not allow for Phyrexian mana to be paid with life.
+     */
+    @Test
+    public void blockPhyrexianMana() {
+        // {3}{B/P}
+        String tezzeretsGambit = "Tezzeret's Gambit";
+        addCard(Zone.HAND, playerA, tezzeretsGambit);
+        addCard(Zone.BATTLEFIELD, playerA, karnsSylex);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 3);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, tezzeretsGambit);
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+    }
+
+    /**
+     * Blocks things like Bolas's Citadel.
+     */
+    @Test
+    public void blockBolassCitadel() {
+        // You may play lands and cast spells from the top of your library.
+        // If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.
+        String bolassCitadel = "Bolas's Citadel";
+        addCard(Zone.BATTLEFIELD, playerA, bolassCitadel);
+        addCard(Zone.BATTLEFIELD, playerA, karnsSylex);
+        addCard(Zone.LIBRARY, playerA, "Lightning Bolt");
+
+        skipInitShuffling();
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+    }
+
+    /**
+     * Test that it works with mana abilities, e.g. Thran Portal.
+     */
+    @Test
+    public void allowsManaAbilities() {
+        addCard(Zone.HAND, playerA, "Thran Portal");
+        addCard(Zone.HAND, playerA, "Lightning Bolt");
+        addCard(Zone.BATTLEFIELD, playerA, karnsSylex);
+
+        playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Thran Portal");
+        setChoice(playerA, "Thran");
+        setChoice(playerA, "Mountain");
+
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertLife(playerA, 20 - 1);
+        assertLife(playerB, 20 - 3);
+        assertGraveyardCount(playerB, "Lightning Bolt", 1);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/KarnsSylexTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/KarnsSylexTest.java
@@ -31,6 +31,7 @@ public class KarnsSylexTest extends CardTestPlayerBase {
 
         setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
         execute();
+        assertLife(playerA, 20);
     }
 
     /**
@@ -50,6 +51,8 @@ public class KarnsSylexTest extends CardTestPlayerBase {
 
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
         execute();
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
     }
 
     /**
@@ -71,6 +74,6 @@ public class KarnsSylexTest extends CardTestPlayerBase {
         execute();
         assertLife(playerA, 20 - 1);
         assertLife(playerB, 20 - 3);
-        assertGraveyardCount(playerB, "Lightning Bolt", 1);
+        assertGraveyardCount(playerA, "Lightning Bolt", 1);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/KarnsSylexTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/KarnsSylexTest.java
@@ -2,6 +2,7 @@ package org.mage.test.cards.single.dmu;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -30,7 +31,16 @@ public class KarnsSylexTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, tezzeretsGambit);
 
         setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
-        execute();
+        try {
+            execute();
+
+            Assert.fail("must throw exception on execute");
+        } catch (Throwable e) {
+            if (!e.getMessage().contains("Can't find ability to activate command: Cast Tezzeret's Gambit")) {
+                Assert.fail("Should have thrown error about not being able to cast Tezzeret's Gambit, but got:\n" + e.getMessage());
+            }
+        }
+
         assertLife(playerA, 20);
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/KarnsSylexTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/KarnsSylexTest.java
@@ -28,18 +28,10 @@ public class KarnsSylexTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, karnsSylex);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 3);
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, tezzeretsGambit);
+        checkPlayableAbility("Can't pay life to cast", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast " + tezzeretsGambit, false);
 
         setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
-        try {
-            execute();
-
-            Assert.fail("must throw exception on execute");
-        } catch (Throwable e) {
-            if (!e.getMessage().contains("Can't find ability to activate command: Cast Tezzeret's Gambit")) {
-                Assert.fail("Should have thrown error about not being able to cast Tezzeret's Gambit, but got:\n" + e.getMessage());
-            }
-        }
+        execute();
 
         assertLife(playerA, 20);
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/KarnsSylexTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/KarnsSylexTest.java
@@ -47,12 +47,10 @@ public class KarnsSylexTest extends CardTestPlayerBase {
         addCard(Zone.LIBRARY, playerA, "Lightning Bolt");
 
         skipInitShuffling();
-        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
+        checkPlayableAbility("Can't pay life to cast", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Lightning Bolt", false);
 
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
         execute();
-        assertLife(playerA, 20);
-        assertLife(playerB, 20);
     }
 
     /**

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -3679,13 +3679,13 @@ public class TestPlayer implements Player {
     }
 
     @Override
-    public boolean getCanPayLifeCost() {
-        return computerPlayer.getCanPayLifeCost();
+    public PayLifeCostLevel getPayLifeCostLevel() {
+        return computerPlayer.getPayLifeCostLevel();
     }
 
     @Override
-    public void setCanPayLifeCost(boolean canPayLifeCost) {
-        computerPlayer.setCanPayLifeCost(canPayLifeCost);
+    public void setPayLifeCostLevel(PayLifeCostLevel payLifeCostLevel) {
+        computerPlayer.setPayLifeCostLevel(payLifeCostLevel);
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
+++ b/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
@@ -183,13 +183,12 @@ public class PlayerStub implements Player {
     }
 
     @Override
-    public void setCanPayLifeCost(boolean canPayLifeCost) {
-
+    public void setPayLifeCostLevel(PayLifeCostLevel playLifeCostLevel) {
     }
 
     @Override
-    public boolean getCanPayLifeCost() {
-        return false;
+    public PayLifeCostLevel getPayLifeCostLevel() {
+        return PayLifeCostLevel.none;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
@@ -8,12 +8,14 @@ import mage.abilities.costs.Costs;
 import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.Effects;
+import mage.abilities.mana.ManaAbility;
 import mage.abilities.mana.ManaOptions;
 import mage.cards.Card;
 import mage.constants.*;
 import mage.game.Game;
 import mage.game.command.CommandObject;
 import mage.game.permanent.Permanent;
+import mage.players.Player;
 import mage.util.CardUtil;
 
 import java.util.UUID;
@@ -204,7 +206,9 @@ public abstract class ActivatedAbilityImpl extends AbilityImpl implements Activa
 
     @Override
     public ManaOptions getMinimumCostToActivate(UUID playerId, Game game) {
-        return getManaCostsToPay().getOptions();
+        Player player = game.getPlayer(playerId);
+
+        return getManaCostsToPay().getOptions(player.canPayLifeCost(this));
     }
 
     protected boolean controlsAbility(UUID playerId, Game game) {

--- a/Mage/src/main/java/mage/abilities/costs/mana/ManaCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/mana/ManaCost.java
@@ -31,6 +31,21 @@ public interface ManaCost extends Cost {
 
     ManaOptions getOptions();
 
+    /**
+     * Return all options for paying the mana cost (this) while taking into accoutn if the player can pay life.
+     * Used to correctly highlight (or not) spells with Phyrexian mana depending on if the player can pay life costs.
+     * <p>
+     * E.g. Tezzeret's Gambit has a cost of {3}{U/P}.
+     * If `canPayLifeCost == true` the two options are {3}{U} and {3}. The second including a 2 life cost that is not
+     * captured by the ManaOptions object being returned.
+     * However, if `canPayLifeCost == false` than the return is only {3}{U} since the Phyrexian mana MUST be paid with
+     * a {U} and not with 2 life.
+     *
+     * @param canPayLifeCost if the player is able to pay life for the ability/effect that this cost is associated with
+     * @return
+     */
+    ManaOptions getOptions(boolean canPayLifeCost);
+
     boolean testPay(Mana testMana);
 
     Filter getSourceFilter();

--- a/Mage/src/main/java/mage/abilities/costs/mana/ManaCostImpl.java
+++ b/Mage/src/main/java/mage/abilities/costs/mana/ManaCostImpl.java
@@ -69,7 +69,18 @@ public abstract class ManaCostImpl extends CostImpl implements ManaCost {
 
     @Override
     public ManaOptions getOptions() {
-        return options;
+        return getOptions(true);
+    }
+
+    @Override
+    public ManaOptions getOptions(boolean canPayLifeCost) {
+        if (!canPayLifeCost && this.isPhyrexian()) {
+            ManaOptions optionsFiltered = new ManaOptions();
+            optionsFiltered.add(this.cost);
+            return optionsFiltered;
+        } else {
+            return options;
+        }
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/costs/mana/ManaCostsImpl.java
+++ b/Mage/src/main/java/mage/abilities/costs/mana/ManaCostsImpl.java
@@ -542,9 +542,14 @@ public class ManaCostsImpl<T extends ManaCost> extends ArrayList<T> implements M
 
     @Override
     public ManaOptions getOptions() {
+        return getOptions(true);
+    }
+
+    @Override
+    public ManaOptions getOptions(boolean canPayLifeCost) {
         ManaOptions options = new ManaOptions();
         for (ManaCost cost : this) {
-            options.addMana(cost.getOptions());
+            options.addMana(cost.getOptions(canPayLifeCost));
         }
         return options;
     }

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -48,6 +48,22 @@ import java.util.*;
 public interface Player extends MageItem, Copyable<Player> {
 
     /**
+     * Enum used to indicate what each player is allowed to spend life on.
+     * By default it is set to `allAbilities`, but can be changed by effects.
+     * E.g. Angel of Jubilation sets it to `nonSpellnonActivatedAbilities`,
+     *      and Karn's Sylex sets it to `onlyManaAbilities`.
+     *
+     *
+     * Default is PayLifeCostLevel.allAbilities.
+     */
+    enum PayLifeCostLevel {
+        allAbilities,
+        nonSpellnonActivatedAbilities,
+        onlyManaAbilities,
+        none
+    }
+
+    /**
      * Current player is real life player (human). Try to use in GUI and network engine only.
      * <p>
      * WARNING, you must use isComputer instead isHuman in card's code (for good Human/AI logic testing in unit tests)
@@ -147,12 +163,12 @@ public interface Player extends MageItem, Copyable<Player> {
     /**
      * Is the player allowed to pay life for casting spells or activate activated abilities
      *
-     * @param canPayLifeCost
+     * @param payLifeCostLevel
      */
 
-    void setCanPayLifeCost(boolean canPayLifeCost);
+    void setPayLifeCostLevel(PayLifeCostLevel payLifeCostLevel);
 
-    boolean getCanPayLifeCost();
+    PayLifeCostLevel getPayLifeCostLevel();
 
     /**
      * Can the player pay life to cast or activate the given ability


### PR DESCRIPTION
[[Karn's Sylex]]

Changes
- Implement Karn's Sylex
- Added an enum to track the different levels of what life is allowed to be paid for
- Changed finding of available abilities to consider if life is allowed to be paid. (e.g. Tezzerat's Gambit is no longer highlighted as playable if Karn's Sylex is on the battlefield and you don't have blue mana).


TODO
- [x] Fix stack overflow issue when Ai tries to pay for Phyrexian mana
- [x] Finish getting it working
- [x] Change castable calculations to take into account "can't pay life" effects when looking at Phyrexian mana (i.e. just treat it as simple colored mana). The issue appears to come from https://github.com/magefree/mage/blob/c77e63c49914d980b07b131866505b9630dc1d54/Mage/src/main/java/mage/players/PlayerImpl.java#L3524