### PR TITLE
Fix searching for split card halves returning full card in incorrect instances.

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/utils/CardRepositoryTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/utils/CardRepositoryTest.java
@@ -140,23 +140,23 @@ public class CardRepositoryTest {
         // Consecrate   // Consume
         // {1}{W/B}     // {2}{W}{B}
         List<CardInfo> fullCard1 = CardRepository.instance.findCards("Consecrate", 1, false);
-        assert fullCard1.get(0).isSplitCard();
-        assert fullCard1.get(0).getName().equals("Consecrate // Consume");
+        Assert.assertTrue(fullCard1.get(0).isSplitCard());
+        Assert.assertEquals("Consecrate // Consume", fullCard1.get(0).getName());
         List<CardInfo> fullCard2 = CardRepository.instance.findCards("Consume", 1, false);
-        assert fullCard2.get(0).isSplitCard();
-        assert fullCard2.get(0).getName().equals("Consecrate // Consume");
+        Assert.assertTrue(fullCard2.get(0).isSplitCard());
+        Assert.assertEquals("Consecrate // Consume", fullCard2.get(0).getName());
 
         List<CardInfo> splitHalfCardLeft  = CardRepository.instance.findCards("Consecrate", 1, true);
-        assert splitHalfCardLeft.get(0).isSplitCardHalf();
-        assert splitHalfCardLeft.get(0).getName().equals("Consecrate");
+        Assert.assertTrue(splitHalfCardLeft.get(0).isSplitCardHalf());
+        Assert.assertEquals("Consecrate", splitHalfCardLeft.get(0).getName());
         List<CardInfo> splitHalfCardRight = CardRepository.instance.findCards("Consume", 1, true);
-        assert splitHalfCardRight.get(0).isSplitCardHalf();
-        assert splitHalfCardRight.get(0).getName().equals("Consume");
+        Assert.assertTrue(splitHalfCardRight.get(0).isSplitCardHalf());
+        Assert.assertEquals("Consume", splitHalfCardRight.get(0).getName());
     }
 
     /**
      * Checks if the card with name cardName can be found when searched for
-     * using the case sensitive approach.
+     * using the case-sensitive approach.
      *
      * @param cardName The name of the card to search by.
      */

--- a/Mage.Tests/src/test/java/org/mage/test/utils/CardRepositoryTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/utils/CardRepositoryTest.java
@@ -129,6 +129,32 @@ public class CardRepositoryTest {
     }
 
     /**
+     * Reported bug: https://github.com/magefree/mage/issues/9533
+     *
+     * Each half of a split card displays the combined information of both halves in the deck editor.
+     *
+     * `findCards`'s `returnSplitCardHalf` parameter should handle this issue
+     */
+    @Test
+    public void splitCardInfoIsntDoubled() {
+        // Consecrate   // Consume
+        // {1}{W/B}     // {2}{W}{B}
+        List<CardInfo> fullCard1 = CardRepository.instance.findCards("Consecrate", 1, false);
+        assert fullCard1.get(0).isSplitCard();
+        assert fullCard1.get(0).getName().equals("Consecrate // Consume");
+        List<CardInfo> fullCard2 = CardRepository.instance.findCards("Consume", 1, false);
+        assert fullCard2.get(0).isSplitCard();
+        assert fullCard2.get(0).getName().equals("Consecrate // Consume");
+
+        List<CardInfo> splitHalfCardLeft  = CardRepository.instance.findCards("Consecrate", 1, true);
+        assert splitHalfCardLeft.get(0).isSplitCardHalf();
+        assert splitHalfCardLeft.get(0).getName().equals("Consecrate");
+        List<CardInfo> splitHalfCardRight = CardRepository.instance.findCards("Consume", 1, true);
+        assert splitHalfCardRight.get(0).isSplitCardHalf();
+        assert splitHalfCardRight.get(0).getName().equals("Consume");
+    }
+
+    /**
      * Checks if the card with name cardName can be found when searched for
      * using the case sensitive approach.
      *

--- a/Mage/src/main/java/mage/cards/mock/MockSplitCard.java
+++ b/Mage/src/main/java/mage/cards/mock/MockSplitCard.java
@@ -49,13 +49,13 @@ public class MockSplitCard extends SplitCard {
             this.addAbility(textAbilityFromString(ruleText));
         }
 
-        CardInfo leftHalf = CardRepository.instance.findCardWPreferredSet(getLeftHalfName(card), card.getSetCode());
+        CardInfo leftHalf = CardRepository.instance.findCardWPreferredSet(getLeftHalfName(card), card.getSetCode(), true);
         if (leftHalf != null) {
             this.leftHalfCard = new MockSplitCardHalf(leftHalf);
             ((SplitCardHalf) this.leftHalfCard).setParentCard(this);
         }
 
-        CardInfo rightHalf = CardRepository.instance.findCardWPreferredSet(getRightHalfName(card), card.getSetCode());
+        CardInfo rightHalf = CardRepository.instance.findCardWPreferredSet(getRightHalfName(card), card.getSetCode(), true);
         if (rightHalf != null) {
             this.rightHalfCard = new MockSplitCardHalf(rightHalf);
             ((SplitCardHalf) this.rightHalfCard).setParentCard(this);

--- a/Mage/src/main/java/mage/cards/repository/CardRepository.java
+++ b/Mage/src/main/java/mage/cards/repository/CardRepository.java
@@ -389,14 +389,17 @@ public enum CardRepository {
      * Function to find a card by name from a specific set.
      * Used for building cubes, packs, and for ensuring that dual faces and split cards have sides/halves from the same set.
      *
-     * @param name      name of the card, or side of the card, to find
-     * @param expansion the set name from which to find the card
+     * @param name                  name of the card, or side of the card, to find
+     * @param expansion             the set name from which to find the card
+     * @param returnSplitCardHalf   whether to return a half of a split card or the corresponding full card.
+     *                              Want this `false` when user is searching by either names in a split card so that
+     *                              the full card can be found by either name.
      * @return
      */
-    public CardInfo findCardWPreferredSet(String name, String expansion) {
+    public CardInfo findCardWPreferredSet(String name, String expansion, boolean returnSplitCardHalf) {
         List<CardInfo> cards;
 
-        cards = findCards(name);
+        cards = findCards(name, 0, returnSplitCardHalf);
 
         if (!cards.isEmpty()) {
             for (CardInfo cardinfo : cards) {
@@ -406,6 +409,10 @@ public enum CardRepository {
             }
         }
         return findPreferredCoreExpansionCard(name);
+    }
+
+    public CardInfo findCardWPreferredSet(String name, String expansion) {
+        return findCardWPreferredSet(name, expansion, false);
     }
 
     public List<CardInfo> findCards(String name) {
@@ -424,12 +431,16 @@ public enum CardRepository {
      *      ALL the others MUST be queried for by the first half of their full name (i.e. "A" from "A // B")
      *      when querying by "name".
      *
-     * @param name              the name of the card to search for
-     * @param limitByMaxAmount  return max amount of different cards (if 0 then return card from all sets)
-     * @return                  A list of the reprints of the card if it was found (up to limitByMaxAmount number), or
-     *                          an empty list if the card was not found.
+     * @param name                  the name of the card to search for
+     * @param limitByMaxAmount      return max amount of different cards (if 0 then return card from all sets)
+     * @param returnSplitCardHalf   whether to return a half of a split card or the corresponding full card.
+     *                              Want this `false` when user is searching by either names in a split card so that
+     *                              the full card can be found by either name.
+     *                              Want this `true` when the client is searching for info on both halves to display it.
+     * @return                      a list of the reprints of the card if it was found (up to limitByMaxAmount number),
+     *                              or an empty list if the card was not found.
      */
-    public List<CardInfo> findCards(String name, long limitByMaxAmount) {
+    public List<CardInfo> findCards(String name, long limitByMaxAmount, boolean returnSplitCardHalf) {
         List<CardInfo> results;
         QueryBuilder<CardInfo, Object> queryBuilder = cardDao.queryBuilder();
         if (limitByMaxAmount > 0) {
@@ -467,8 +478,8 @@ public enum CardRepository {
                     // Check that a full card was found and not a SplitCardHalf
                     // Can be caused by searching for "Fire" instead of "Fire // Ice"
                     CardInfo firstCardInfo = results.get(0);
-                    if (firstCardInfo.isSplitCardHalf()) {
-                        // Find the main card by it's setCode and CardNumber
+                    if (firstCardInfo.isSplitCardHalf() && !returnSplitCardHalf) {
+                        // Find the main card by its setCode and CardNumber
                         queryBuilder.where()
                                 .eq("setCode", new SelectArg(firstCardInfo.setCode)).and()
                                 .eq("cardNumber", new SelectArg(firstCardInfo.cardNumber));
@@ -496,6 +507,10 @@ public enum CardRepository {
         }
 
         return Collections.emptyList();
+    }
+
+    public List<CardInfo> findCards(String name, long limitByMaxAmount) {
+        return findCards(name, limitByMaxAmount, false);
     }
 
     public List<CardInfo> findCardsByClass(String canonicalClassName) {


### PR DESCRIPTION
So the issue was that the changed code *always* returned the full split card (`Consecrate // Consume`) when searching for one of the half card names (`Consecrate` or `Consume`). This was intended behaviour when *the user* was searching for a card. But this was incorrect when the client performed internal searches for building the MockCard info.

Closes #9533.