### PR TITLE
Fix #8484 and fix #9541

### DIFF
--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -947,22 +947,12 @@ public abstract class AbilityImpl implements Ability {
 
     @Override
     public boolean canChooseTarget(Game game, UUID playerId) {
-        if (this instanceof SpellAbility) {
-            if (SpellAbilityType.SPLIT_FUSED.equals(((SpellAbility) this).getSpellAbilityType())) {
-                Card card = game.getCard(getSourceId());
-                if (card != null) {
-                    return canChooseTargetAbility(((SplitCard) card).getLeftHalfCard().getSpellAbility(), game, playerId)
-                            && canChooseTargetAbility(((SplitCard) card).getRightHalfCard().getSpellAbility(), game, playerId);
-                }
-                return false;
-            }
-        }
-        return canChooseTargetAbility(this, game, playerId);
+        return canChooseTargetAbility(this, getModes(), game, playerId);
     }
 
-    private static boolean canChooseTargetAbility(Ability ability, Game game, UUID controllerId) {
+    protected static boolean canChooseTargetAbility(Ability ability, Modes modes, Game game, UUID controllerId) {
         int found = 0;
-        for (Mode mode : ability.getModes().values()) {
+        for (Mode mode : modes.values()) {
             boolean validTargets = true;
             for (Target target : mode.getTargets()) {
                 UUID abilityControllerId = controllerId;
@@ -977,10 +967,10 @@ public abstract class AbilityImpl implements Ability {
 
             if (validTargets) {
                 found++;
-                if (ability.getModes().isEachModeMoreThanOnce()) {
+                if (modes.isEachModeMoreThanOnce()) {
                     return true;
                 }
-                if (found >= ability.getModes().getMinModes()) {
+                if (found >= modes.getMinModes()) {
                     return true;
                 }
             }

--- a/Mage/src/main/java/mage/abilities/SpellAbility.java
+++ b/Mage/src/main/java/mage/abilities/SpellAbility.java
@@ -55,6 +55,24 @@ public class SpellAbility extends ActivatedAbilityImpl {
         this.cardName = ability.cardName;
     }
 
+    @Override
+    public boolean canChooseTarget(Game game, UUID playerId) {
+        if (SpellAbilityType.SPLIT_FUSED.equals(getSpellAbilityType())) {
+            Card card = game.getCard(getSourceId());
+            if (card == null) {
+                return false;
+            }
+            SpellAbility left = ((SplitCard) card).getLeftHalfCard().getSpellAbility();
+            SpellAbility right = ((SplitCard) card).getRightHalfCard().getSpellAbility();
+            return canChooseTargetAbility(left, left.getModes(), game, playerId) && canChooseTargetAbility(right, right.getModes(), game, playerId);
+        }
+        return super.canChooseTarget(game, playerId);
+    }
+
+    public boolean canSpliceOnto(Ability abilityToModify, Game game) {
+        return canChooseTargetAbility(abilityToModify, getModes(), game, abilityToModify.getControllerId());
+    }
+
     /*
      * 7/5/19 - jgray1206 - Moved null != game.getContinuesEffects()... into this method instead of having it in
      *                      canActivate. There are abilities that directly use this method that should know when spells

--- a/Mage/src/main/java/mage/abilities/keyword/SpliceAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SpliceAbility.java
@@ -1,7 +1,6 @@
 package mage.abilities.keyword;
 
 import java.util.Iterator;
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -188,23 +187,13 @@ class SpliceCardEffectImpl extends ContinuousEffectImpl implements SpliceCardEff
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        MageObject object = game.getObject(abilityToModify.getSourceId());
-        if (object != null && filter.match(object, game)) {
-            return spliceSpellCanBeActivated(source, game);
+        if (!filter.match(game.getObject(abilityToModify.getSourceId()), game)) {
+            return false;
         }
-        return false;
-    }
-
-    private boolean spliceSpellCanBeActivated(Ability source, Game game) {
-        // check if spell can be activated (protection problem not solved because effect will be used from the base spell?)
         Card card = game.getCard(source.getSourceId());
-        if (card != null) {
-            if (card.getManaCost().isEmpty()) { // e.g. Evermind
-                return card.getSpellAbility().spellCanBeActivatedRegularlyNow(source.getControllerId(), game);
-            } else {
-                return card.getSpellAbility().canActivate(source.getControllerId(), game).canActivate();
-            }
+        if (card == null) {
+            return false;
         }
-        return false;
+        return card.getSpellAbility().canSpliceOnto(abilityToModify, game);
     }
 }


### PR DESCRIPTION
#8484
#9541

This PR isn't very large, but it touches some pretty fundamental classes so I want to run it by someone.

`SpliceAbility` was using `SpellAbility.canActivate` to determine whether a card could be spliced, which was checking a whole bunch of irrelevant things:

- Timing restrictions. Splicing cannot happen at sorcery speed by definition, because the spell being spliced onto is already on the stack (in fact it isn't even instant speed, because you reveal the card(s) to splice *in the middle of announcing the spell*). This was the cause of 8484.
- Rules-modifying effects. Splicing is not casting, and being allowed to splice a card is not in any way conditional on being allowed to cast it as a spell (it's not like Suspend that way).
- (Non-mana) costs. `canActivate` checks the *casting* cost, which is completely different from the splice cost. This didn't affect anything (there are no cards with splice that have non-mana additional *casting* costs) but it was still wrong.

The one actually relevant thing that was being checked was the presence of legal targets, and even that was wrong because it was using the characteristics of the `SpellAbility`'s source object, rather than the characteristics of the spell being spliced onto. In other words, 9541. Fixing this required a small refactor: the static method `AbilityImpl.canChooseTargetAbility` now takes as two separate arguments the `Ability` to be passed to `Target.canChoose` and the set of `Modes` to check.

I also changed the `if (this instanceof SpellAbility)` block inside `AbilityImpl.canChooseTarget` to a proper method override, and removed a redundant null check from `SpliceAbility` (`FilterImpl.match` can handle a null object just fine).