### PR TITLE
[WIP] Refactor AsThoughEffect to split .applies into two functions

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AetherWeb.java
+++ b/Mage.Sets/src/mage/cards/a/AetherWeb.java
@@ -69,11 +69,6 @@ class AetherWebEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public AetherWebEffect copy() {
         return new AetherWebEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -127,11 +127,6 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public AminatousAuguryCastFromExileEffect copy() {
         return new AminatousAuguryCastFromExileEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -134,9 +134,26 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         Player player = game.getPlayer(affectedControllerId);
-        if (player == null) { return false; }
+        if (player == null) {
+            return false;
+        }
 
-        if (!affectedControllerId.equals(source.getControllerId())) { return false; }
+        if (!affectedControllerId.equals(source.getControllerId())) {
+            return false;
+        }
+
+        if (objectId == null || !objectId.equals(getTargetPointer().getFirst(game, source))) {
+            return false;
+        }
+
+        if (game.getState().getZone(objectId) != Zone.EXILED) {
+            return false;
+        }
+
+        Card card = game.getCard(objectId);
+        if (card == null) {
+            return false;
+        }
 
         EnumSet<CardType> usedCardTypes;
         if (game.getState().getValue(source.getSourceId().toString() + "cardTypes") == null) {
@@ -145,14 +162,6 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
         } else {
             usedCardTypes = (EnumSet<CardType>) game.getState().getValue(source.getSourceId().toString() + "cardTypes");
         }
-
-        if (objectId == null || !objectId.equals(getTargetPointer().getFirst(game, source))) { return false; }
-
-        if (game.getState().getZone(objectId) != Zone.EXILED) { return false; }
-
-        Card card = game.getCard(objectId);
-        if (card == null) { return false; }
-
         // Figure out which of the current card's types have not been cast before
         EnumSet<CardType> unusedCardTypes = EnumSet.noneOf(CardType.class);
         for (CardType cardT : card.getCardType(game)) {
@@ -162,7 +171,31 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
         }
 
         // The current card has only card types that have been cast before, so it can't be cast
-        if (unusedCardTypes.isEmpty()) { return false; }
+        if (unusedCardTypes.isEmpty()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Player player = game.getPlayer(affectedControllerId);
+        Card card = game.getCard(objectId);
+
+        EnumSet<CardType> usedCardTypes;
+        if (game.getState().getValue(source.getSourceId().toString() + "cardTypes") == null) {
+            // The effect has not been applied fully yet, so there are no previously cast times
+            usedCardTypes = EnumSet.noneOf(CardType.class);
+        } else {
+            usedCardTypes = (EnumSet<CardType>) game.getState().getValue(source.getSourceId().toString() + "cardTypes");
+        }
+        EnumSet<CardType> unusedCardTypes = EnumSet.noneOf(CardType.class);
+        for (CardType cardT : card.getCardType(game)) {
+            if (!usedCardTypes.contains(cardT)) {
+                unusedCardTypes.add(cardT);
+            }
+        }
 
         // some actions may not be done while the game only checks if a card can be cast
         if (!game.inCheckPlayableState()) {

--- a/Mage.Sets/src/mage/cards/a/ArvinoxTheMindFlail.java
+++ b/Mage.Sets/src/mage/cards/a/ArvinoxTheMindFlail.java
@@ -127,11 +127,6 @@ class ArvinoxTheMindFlailCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ArvinoxTheMindFlailCastFromExileEffect copy() {
         return new ArvinoxTheMindFlailCastFromExileEffect(this);
     }
@@ -170,11 +165,6 @@ class ArvinoxTheMindFlailSpendAnyManaEffect extends AsThoughEffectImpl implement
 
     private ArvinoxTheMindFlailSpendAnyManaEffect(final ArvinoxTheMindFlailSpendAnyManaEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override
@@ -219,11 +209,6 @@ class ArvinoxTheMindFlailLookEffect extends AsThoughEffectImpl {
     private ArvinoxTheMindFlailLookEffect(final ArvinoxTheMindFlailLookEffect effect) {
         super(effect);
         this.authorizedPlayerId = effect.authorizedPlayerId;
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/a/AutumnWillow.java
+++ b/Mage.Sets/src/mage/cards/a/AutumnWillow.java
@@ -59,11 +59,6 @@ class AutumnWillowEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public AutumnWillowEffect copy() {
         return new AutumnWillowEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/b/BaneAlleyBroker.java
+++ b/Mage.Sets/src/mage/cards/b/BaneAlleyBroker.java
@@ -178,11 +178,6 @@ class BaneAlleyBrokerLookAtCardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public BaneAlleyBrokerLookAtCardEffect copy() {
         return new BaneAlleyBrokerLookAtCardEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/b/BolassCitadel.java
+++ b/Mage.Sets/src/mage/cards/b/BolassCitadel.java
@@ -107,6 +107,14 @@ class BolassCitadelPlayTheTopCardEffect extends AsThoughEffectImpl {
             return false;
         }
 
+        return true;
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Card cardToCheck = game.getCard(objectId);
+        Player player = game.getPlayer(cardToCheck.getOwnerId());
+
         // allows to play/cast with alternative life cost
         if (!cardToCheck.isLand(game)) {
             PayLifeCost lifeCost = new PayLifeCost(cardToCheck.getSpellAbility().getManaCosts().manaValue());

--- a/Mage.Sets/src/mage/cards/b/BolassCitadel.java
+++ b/Mage.Sets/src/mage/cards/b/BolassCitadel.java
@@ -78,11 +78,6 @@ class BolassCitadelPlayTheTopCardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public BolassCitadelPlayTheTopCardEffect copy() {
         return new BolassCitadelPlayTheTopCardEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/b/BosiumStrip.java
+++ b/Mage.Sets/src/mage/cards/b/BosiumStrip.java
@@ -68,20 +68,22 @@ class BosiumStripCastFromGraveyardEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (!(source instanceof FlashbackAbility)
-                && affectedControllerId.equals(source.getControllerId())) {
-            Player player = game.getPlayer(affectedControllerId);
-            Card card = game.getCard(objectId);
-            if (card != null
-                    && player != null
-                    && card.equals(player.getGraveyard().getTopCard(game))
-                    && StaticFilters.FILTER_CARD_INSTANT_OR_SORCERY.match(card, game)
-                    && game.getState().getZone(objectId) == Zone.GRAVEYARD) {
-                game.getState().setValue("BosiumStrip", card);
-                return true;
-            }
-        }
-        return false;
+        Player player = game.getPlayer(affectedControllerId);
+        Card card = game.getCard(objectId);
+
+        return !(source instanceof FlashbackAbility)
+                && affectedControllerId.equals(source.getControllerId())
+                && card != null
+                && player != null
+                && card.equals(player.getGraveyard().getTopCard(game))
+                && StaticFilters.FILTER_CARD_INSTANT_OR_SORCERY.match(card, game)
+                && game.getState().getZone(objectId) == Zone.GRAVEYARD;
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        game.getState().setValue("BosiumStrip", game.getCard(objectId));
+        return true;
     }
 }
 

--- a/Mage.Sets/src/mage/cards/b/BosiumStrip.java
+++ b/Mage.Sets/src/mage/cards/b/BosiumStrip.java
@@ -62,11 +62,6 @@ class BosiumStripCastFromGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public BosiumStripCastFromGraveyardEffect copy() {
         return new BosiumStripCastFromGraveyardEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/c/CelestialDawn.java
+++ b/Mage.Sets/src/mage/cards/c/CelestialDawn.java
@@ -188,11 +188,6 @@ class CelestialDawnSpendAnyManaEffect extends AsThoughEffectImpl implements AsTh
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CelestialDawnSpendAnyManaEffect copy() {
         return new CelestialDawnSpendAnyManaEffect(this);
     }
@@ -220,11 +215,6 @@ class CelestialDawnSpendColorlessManaEffect extends AsThoughEffectImpl implement
 
     public CelestialDawnSpendColorlessManaEffect(final CelestialDawnSpendColorlessManaEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/c/CemeteryIlluminator.java
+++ b/Mage.Sets/src/mage/cards/c/CemeteryIlluminator.java
@@ -118,11 +118,6 @@ class CemeteryIlluminatorPlayTopEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         // Same checks as in PlayTheTopCardEffect
         // Once per turn clause checked by Watcher same as Lurrus of the Dream Den

--- a/Mage.Sets/src/mage/cards/c/ChainerNightmareAdept.java
+++ b/Mage.Sets/src/mage/cards/c/ChainerNightmareAdept.java
@@ -73,11 +73,6 @@ class ChainerNightmareAdeptContinuousEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ChainerNightmareAdeptContinuousEffect copy() {
         return new ChainerNightmareAdeptContinuousEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/c/ChandraAcolyteOfFlame.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraAcolyteOfFlame.java
@@ -166,11 +166,6 @@ class ChandraAcolyteOfFlameCastFromGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ChandraAcolyteOfFlameCastFromGraveyardEffect copy() {
         return new ChandraAcolyteOfFlameCastFromGraveyardEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/c/ChaosLord.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosLord.java
@@ -144,11 +144,6 @@ class ChaosLordEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ChaosLordEffect copy() {
         return new ChaosLordEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/c/ChromaticOrrery.java
+++ b/Mage.Sets/src/mage/cards/c/ChromaticOrrery.java
@@ -73,11 +73,6 @@ class ChromaticOrreryEffect extends AsThoughEffectImpl implements AsThoughManaEf
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ManaType getAsThoughManaType(ManaType manaType, ManaPoolItem mana, UUID affectedControllerId, Ability source, Game game) {
         return mana.getFirstAvailable();
     }

--- a/Mage.Sets/src/mage/cards/c/ColfenorsPlans.java
+++ b/Mage.Sets/src/mage/cards/c/ColfenorsPlans.java
@@ -105,11 +105,6 @@ class ColfenorsPlansPlayCardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ColfenorsPlansPlayCardEffect copy() {
         return new ColfenorsPlansPlayCardEffect(this);
     }
@@ -133,11 +128,6 @@ class ColfenorsPlansLookAtCardEffect extends AsThoughEffectImpl {
 
     public ColfenorsPlansLookAtCardEffect(final ColfenorsPlansLookAtCardEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/c/ColfenorsPlans.java
+++ b/Mage.Sets/src/mage/cards/c/ColfenorsPlans.java
@@ -137,19 +137,16 @@ class ColfenorsPlansLookAtCardEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (affectedControllerId.equals(source.getControllerId())) {
-            Card card = game.getCard(objectId);
-            if (card != null) {
-                MageObject sourceObject = game.getObject(source);
-                if (sourceObject == null) {
-                    return false;
-                }
-                UUID exileId = CardUtil.getCardExileZoneId(game, source);
-                ExileZone exile = game.getExile().getExileZone(exileId);
-                return exile != null && exile.contains(objectId);
-            }
-        }
-        return false;
+        Card card = game.getCard(objectId);
+        MageObject sourceObject = game.getObject(source);
+        UUID exileId = CardUtil.getCardExileZoneId(game, source);
+        ExileZone exile = game.getExile().getExileZone(exileId);
+
+        return affectedControllerId.equals(source.getControllerId())
+                && card != null
+                && sourceObject != null
+                && exile != null
+                && exile.contains(objectId);
     }
 
 }

--- a/Mage.Sets/src/mage/cards/c/CommuneWithLava.java
+++ b/Mage.Sets/src/mage/cards/c/CommuneWithLava.java
@@ -110,11 +110,6 @@ class CommuneWithLavaMayPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         return source.isControlledBy(affectedControllerId)
                 && getTargetPointer().getTargets(game, source).contains(sourceId);

--- a/Mage.Sets/src/mage/cards/c/CosimaGodOfTheVoyage.java
+++ b/Mage.Sets/src/mage/cards/c/CosimaGodOfTheVoyage.java
@@ -287,11 +287,6 @@ class TheOmenkeelPlayFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public TheOmenkeelPlayFromExileEffect copy() {
         return new TheOmenkeelPlayFromExileEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/c/CosmosCharger.java
+++ b/Mage.Sets/src/mage/cards/c/CosmosCharger.java
@@ -95,11 +95,6 @@ class CosmosChargerAllowForetellAnytime extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CosmosChargerAllowForetellAnytime copy() {
         return new CosmosChargerAllowForetellAnytime(this);
     }

--- a/Mage.Sets/src/mage/cards/c/Crevasse.java
+++ b/Mage.Sets/src/mage/cards/c/Crevasse.java
@@ -44,13 +44,8 @@ class CrevasseEffect extends AsThoughEffectImpl {
         staticText = "Creatures with mountainwalk can be blocked as though they didn't have mountainwalk";
     }
 
-    public CrevasseEffect(final CrevasseEffect effect) {
+    private CrevasseEffect(final CrevasseEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/c/CunningAbduction.java
+++ b/Mage.Sets/src/mage/cards/c/CunningAbduction.java
@@ -111,11 +111,6 @@ class CunningAbductionSpendAnyManaEffect extends AsThoughEffectImpl implements A
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CunningAbductionSpendAnyManaEffect copy() {
         return new CunningAbductionSpendAnyManaEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/d/DeadMansChest.java
+++ b/Mage.Sets/src/mage/cards/d/DeadMansChest.java
@@ -117,11 +117,6 @@ class DeadMansChestCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public DeadMansChestCastFromExileEffect copy() {
         return new DeadMansChestCastFromExileEffect(this);
     }
@@ -149,11 +144,6 @@ class DeadMansChestSpendManaEffect extends AsThoughEffectImpl implements AsThoug
 
     public DeadMansChestSpendManaEffect(final DeadMansChestSpendManaEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/d/Deadfall.java
+++ b/Mage.Sets/src/mage/cards/d/Deadfall.java
@@ -49,11 +49,6 @@ class DeadfallEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public DeadfallEffect copy() {
         return new DeadfallEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/d/Demilich.java
+++ b/Mage.Sets/src/mage/cards/d/Demilich.java
@@ -148,16 +148,20 @@ class DemilichPlayEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (source.getSourceId().equals(objectId) && source.isControlledBy(affectedControllerId)
-                && game.getState().getZone(objectId) == Zone.GRAVEYARD) {
-            Player controller = game.getPlayer(affectedControllerId);
-            if (controller != null) {
-                Costs<Cost> costs = new CostsImpl<>();
-                costs.add(new ExileFromGraveCost(new TargetCardInYourGraveyard(4, StaticFilters.FILTER_CARD_INSTANT_OR_SORCERY_FROM_YOUR_GRAVEYARD)));
-                controller.setCastSourceIdWithAlternateMana(objectId, new ManaCostsImpl<>("{U}{U}{U}{U}"), costs);
-                return true;
-            }
-        }
-        return false;
+        Player controller = game.getPlayer(affectedControllerId);
+        return controller != null
+                && source.getSourceId().equals(objectId)
+                && source.isControlledBy(affectedControllerId)
+                && game.getState().getZone(objectId) == Zone.GRAVEYARD;
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Player controller = game.getPlayer(affectedControllerId);
+
+        Costs<Cost> costs = new CostsImpl<>();
+        costs.add(new ExileFromGraveCost(new TargetCardInYourGraveyard(4, StaticFilters.FILTER_CARD_INSTANT_OR_SORCERY_FROM_YOUR_GRAVEYARD)));
+        controller.setCastSourceIdWithAlternateMana(objectId, new ManaCostsImpl<>("{U}{U}{U}{U}"), costs);
+        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/d/Demilich.java
+++ b/Mage.Sets/src/mage/cards/d/Demilich.java
@@ -147,11 +147,6 @@ class DemilichPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         if (source.getSourceId().equals(objectId) && source.isControlledBy(affectedControllerId)
                 && game.getState().getZone(objectId) == Zone.GRAVEYARD) {

--- a/Mage.Sets/src/mage/cards/d/DemonicEmbrace.java
+++ b/Mage.Sets/src/mage/cards/d/DemonicEmbrace.java
@@ -80,11 +80,6 @@ class DemonicEmbracePlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public DemonicEmbracePlayEffect copy() {
         return new DemonicEmbracePlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/d/DemonicEmbrace.java
+++ b/Mage.Sets/src/mage/cards/d/DemonicEmbrace.java
@@ -86,18 +86,21 @@ class DemonicEmbracePlayEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
-        if (sourceId.equals(source.getSourceId()) && source.isControlledBy(affectedControllerId)) {
-            if (game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD) {
-                Player player = game.getPlayer(affectedControllerId);
-                if (player != null) {
-                    Costs<Cost> costs = new CostsImpl<>();
-                    costs.add(new PayLifeCost(3));
-                    costs.add(new DiscardCardCost());
-                    player.setCastSourceIdWithAlternateMana(sourceId, new ManaCostsImpl<>("{1}{B}{B}"), costs);
-                    return true;
-                }
-            }
-        }
-        return false;
+        Player player = game.getPlayer(affectedControllerId);
+        return player != null
+                && sourceId.equals(source.getSourceId())
+                && source.isControlledBy(affectedControllerId)
+                && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD;
+    }
+
+    @Override
+    public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        Player player = game.getPlayer(affectedControllerId);
+
+        Costs<Cost> costs = new CostsImpl<>();
+        costs.add(new PayLifeCost(3));
+        costs.add(new DiscardCardCost());
+        player.setCastSourceIdWithAlternateMana(sourceId, new ManaCostsImpl<>("{1}{B}{B}"), costs);
+        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DetectionTower.java
+++ b/Mage.Sets/src/mage/cards/d/DetectionTower.java
@@ -62,11 +62,6 @@ class DetectionTowerEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public DetectionTowerEffect copy() {
         return new DetectionTowerEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/d/DragonHunter.java
+++ b/Mage.Sets/src/mage/cards/d/DragonHunter.java
@@ -55,11 +55,6 @@ class CanBlockDragonsAsThoughtIthadReachEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CanBlockDragonsAsThoughtIthadReachEffect copy() {
         return new CanBlockDragonsAsThoughtIthadReachEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/d/DraugrNecromancer.java
+++ b/Mage.Sets/src/mage/cards/d/DraugrNecromancer.java
@@ -110,11 +110,6 @@ class DraugrNecromancerCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public DraugrNecromancerCastFromExileEffect copy() {
         return new DraugrNecromancerCastFromExileEffect(this);
     }
@@ -144,11 +139,6 @@ class DraugrNecromancerSpendAnyManaEffect extends AsThoughEffectImpl implements 
 
     private DraugrNecromancerSpendAnyManaEffect(final DraugrNecromancerSpendAnyManaEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/e/EbondeathDracolich.java
+++ b/Mage.Sets/src/mage/cards/e/EbondeathDracolich.java
@@ -75,11 +75,6 @@ class EbondeathDracolichEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         if (sourceId.equals(source.getSourceId()) && source.isControlledBy(affectedControllerId)) {
             Card card = game.getCard(source.getSourceId());

--- a/Mage.Sets/src/mage/cards/e/EliteSpellbinder.java
+++ b/Mage.Sets/src/mage/cards/e/EliteSpellbinder.java
@@ -108,11 +108,6 @@ class EliteSpellbinderCastEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public EliteSpellbinderCastEffect copy() {
         return new EliteSpellbinderCastEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/e/ElkinBottle.java
+++ b/Mage.Sets/src/mage/cards/e/ElkinBottle.java
@@ -106,11 +106,6 @@ class ElkinBottleCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         return source.isControlledBy(affectedControllerId)
                 && sourceId.equals(getTargetPointer().getFirst(game, source));

--- a/Mage.Sets/src/mage/cards/e/EmryLurkerOfTheLoch.java
+++ b/Mage.Sets/src/mage/cards/e/EmryLurkerOfTheLoch.java
@@ -72,11 +72,6 @@ class EmryLurkerOfTheLochPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public EmryLurkerOfTheLochPlayEffect copy() {
         return new EmryLurkerOfTheLochPlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/e/EscapeToTheWilds.java
+++ b/Mage.Sets/src/mage/cards/e/EscapeToTheWilds.java
@@ -108,11 +108,6 @@ class EscapeToTheWildsMayPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         UUID objectIdToCast = CardUtil.getMainCardId(game, sourceId);
         return source.isControlledBy(affectedControllerId)

--- a/Mage.Sets/src/mage/cards/e/EternalScourge.java
+++ b/Mage.Sets/src/mage/cards/e/EternalScourge.java
@@ -58,11 +58,6 @@ class EternalScourgePlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public EternalScourgePlayEffect copy() {
         return new EternalScourgePlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/e/EvelynTheCovetous.java
+++ b/Mage.Sets/src/mage/cards/e/EvelynTheCovetous.java
@@ -123,11 +123,6 @@ class EvelynTheCovetousCastEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         if (!source.isControlledBy(affectedControllerId) || EvelynTheCovetousWatcher.checkUsed(source, game)) {
             return false;
@@ -148,11 +143,6 @@ class EvelynTheCovetousManaEffect extends AsThoughEffectImpl implements AsThough
 
     private EvelynTheCovetousManaEffect(final EvelynTheCovetousManaEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/f/FalcoSparaPactweaver.java
+++ b/Mage.Sets/src/mage/cards/f/FalcoSparaPactweaver.java
@@ -82,11 +82,6 @@ class FalcoSparaPactweaverEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public FalcoSparaPactweaverEffect copy() {
         return new FalcoSparaPactweaverEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/f/FalcoSparaPactweaver.java
+++ b/Mage.Sets/src/mage/cards/f/FalcoSparaPactweaver.java
@@ -99,11 +99,15 @@ class FalcoSparaPactweaverEffect extends AsThoughEffectImpl {
             return false;
         }
         Card topCard = player.getLibrary().getFromTop(game);
-        if (topCard == null
-                || !topCard.getId().equals(cardToCheck.getMainCard().getId())
-                || cardToCheck.isLand(game)) {
-            return false;
-        }
+        return topCard != null
+                && topCard.getId().equals(cardToCheck.getMainCard().getId())
+                && !cardToCheck.isLand(game);
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Card cardToCheck = game.getCard(objectId);
+        Player player = game.getPlayer(cardToCheck.getOwnerId());
 
         Costs<Cost> newCosts = new CostsImpl<>();
         newCosts.add(new RemoveCounterCost(new TargetControlledCreaturePermanent(1, 1, new FilterControlledCreaturePermanent(), true)));

--- a/Mage.Sets/src/mage/cards/f/FireGiantsFury.java
+++ b/Mage.Sets/src/mage/cards/f/FireGiantsFury.java
@@ -206,11 +206,6 @@ class FireGiantsFuryMayPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         UUID objectIdToCast = CardUtil.getMainCardId(game, sourceId);
         return source.isControlledBy(affectedControllerId)

--- a/Mage.Sets/src/mage/cards/f/FlamesOfRemembrance.java
+++ b/Mage.Sets/src/mage/cards/f/FlamesOfRemembrance.java
@@ -105,11 +105,6 @@ class FlamesOfRemembranceMayPlayExiledEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         return source.isControlledBy(affectedControllerId) && this.getTargetPointer().getTargets(game, source).contains(objectId);
     }

--- a/Mage.Sets/src/mage/cards/f/Flameskull.java
+++ b/Mage.Sets/src/mage/cards/f/Flameskull.java
@@ -107,11 +107,6 @@ class FlameskullPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         UUID objectIdToCast = CardUtil.getMainCardId(game, sourceId);
         return source.isControlledBy(affectedControllerId)

--- a/Mage.Sets/src/mage/cards/f/FrenziedSaddlebrute.java
+++ b/Mage.Sets/src/mage/cards/f/FrenziedSaddlebrute.java
@@ -54,11 +54,6 @@ class FrenziedSaddlebruteEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public FrenziedSaddlebruteEffect copy() {
         return new FrenziedSaddlebruteEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/f/FuriousRise.java
+++ b/Mage.Sets/src/mage/cards/f/FuriousRise.java
@@ -110,11 +110,6 @@ class FuriousRisePlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public FuriousRisePlayEffect copy() {
         return new FuriousRisePlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/g/GalvanicRelay.java
+++ b/Mage.Sets/src/mage/cards/g/GalvanicRelay.java
@@ -111,11 +111,6 @@ class GalvanicRelayMayPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         UUID mainCardId = CardUtil.getMainCardId(game, sourceId);
         return source.isControlledBy(affectedControllerId)

--- a/Mage.Sets/src/mage/cards/g/GisaAndGeralf.java
+++ b/Mage.Sets/src/mage/cards/g/GisaAndGeralf.java
@@ -66,11 +66,6 @@ class GisaAndGeralfCastFromGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public GisaAndGeralfCastFromGraveyardEffect copy() {
         return new GisaAndGeralfCastFromGraveyardEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/g/GlaringSpotlight.java
+++ b/Mage.Sets/src/mage/cards/g/GlaringSpotlight.java
@@ -70,11 +70,6 @@ class GlaringSpotlightEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public GlaringSpotlightEffect copy() {
         return new GlaringSpotlightEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/g/GlimpseTheCosmos.java
+++ b/Mage.Sets/src/mage/cards/g/GlimpseTheCosmos.java
@@ -70,11 +70,6 @@ class GlimpseTheCosmosPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public GlimpseTheCosmosPlayEffect copy() {
         return new GlimpseTheCosmosPlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/g/GlimpseTheCosmos.java
+++ b/Mage.Sets/src/mage/cards/g/GlimpseTheCosmos.java
@@ -76,17 +76,18 @@ class GlimpseTheCosmosPlayEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
-        if (sourceId.equals(source.getSourceId())
-                && source.isControlledBy(affectedControllerId)) {
-            if (game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD) {
-                Player controller = game.getPlayer(affectedControllerId);
-                if (controller != null) {
-                    controller.setCastSourceIdWithAlternateMana(sourceId, new ManaCostsImpl<>("{U}"), null);
-                    return true;
-                }
-            }
-        }
-        return false;
+        Player controller = game.getPlayer(affectedControllerId);
+        return sourceId.equals(source.getSourceId())
+                && source.isControlledBy(affectedControllerId)
+                && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD
+                && controller != null;
+    }
+
+    @Override
+    public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        Player controller = game.getPlayer(affectedControllerId);
+        controller.setCastSourceIdWithAlternateMana(sourceId, new ManaCostsImpl<>("{U}"), null);
+        return true;
     }
 }
 

--- a/Mage.Sets/src/mage/cards/g/GontiLordOfLuxury.java
+++ b/Mage.Sets/src/mage/cards/g/GontiLordOfLuxury.java
@@ -136,11 +136,6 @@ class GontiLordOfLuxuryCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public GontiLordOfLuxuryCastFromExileEffect copy() {
         return new GontiLordOfLuxuryCastFromExileEffect(this);
     }
@@ -177,11 +172,6 @@ class GontiLordOfLuxurySpendAnyManaEffect extends AsThoughEffectImpl implements 
 
     private GontiLordOfLuxurySpendAnyManaEffect(final GontiLordOfLuxurySpendAnyManaEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override
@@ -226,11 +216,6 @@ class GontiLordOfLuxuryLookEffect extends AsThoughEffectImpl {
     private GontiLordOfLuxuryLookEffect(final GontiLordOfLuxuryLookEffect effect) {
         super(effect);
         this.authorizedPlayerId = effect.authorizedPlayerId;
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/g/GostaDirk.java
+++ b/Mage.Sets/src/mage/cards/g/GostaDirk.java
@@ -55,11 +55,6 @@ class GostaDirkEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public GostaDirkEffect copy() {
         return new GostaDirkEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/g/Gravecrawler.java
+++ b/Mage.Sets/src/mage/cards/g/Gravecrawler.java
@@ -63,11 +63,6 @@ class GravecrawlerPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public GravecrawlerPlayEffect copy() {
         return new GravecrawlerPlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/g/GreatWall.java
+++ b/Mage.Sets/src/mage/cards/g/GreatWall.java
@@ -49,11 +49,6 @@ class GreatWallEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public GreatWallEffect copy() {
         return new GreatWallEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/g/GrimoireThief.java
+++ b/Mage.Sets/src/mage/cards/g/GrimoireThief.java
@@ -134,31 +134,32 @@ class GrimoireThiefLookEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (affectedControllerId.equals(source.getControllerId())
-                && game.getState().getZone(objectId) == Zone.EXILED) {
-            Player controller = game.getPlayer(source.getControllerId());
-            MageObject sourceObject = source.getSourceObject(game);
-            if (controller != null
-                    && sourceObject != null) {
-                Card card = game.getCard(objectId);
-                if (card != null
-                        && card.isFaceDown(game)) {
-                    Set<UUID> exileZones = (Set<UUID>) game.getState().
-                            getValue(GrimoireThief.VALUE_PREFIX + source.getSourceId().toString());
-                    if (exileZones != null) {
-                        for (ExileZone exileZone : game.getExile().getExileZones()) {
-                            if (exileZone.contains(objectId)) {
-                                if (!exileZones.contains(exileZone.getId())) {
-                                    return false;
-                                }
-                            }
-                        }
-                        return true;
-                    }
-                }
+        Player controller = game.getPlayer(source.getControllerId());
+        MageObject sourceObject = source.getSourceObject(game);
+        if (controller == null
+                || sourceObject == null
+                || !affectedControllerId.equals(source.getControllerId())
+                || game.getState().getZone(objectId) != Zone.EXILED) {
+            return false;
+        }
+
+        Card card = game.getCard(objectId);
+        if (card == null || !card.isFaceDown(game)) {
+            return false;
+        }
+
+        Set<UUID> exileZones = (Set<UUID>) game.getState().
+                getValue(GrimoireThief.VALUE_PREFIX + source.getSourceId().toString());
+        if (exileZones == null) {
+            return false;
+        }
+
+        for (ExileZone exileZone : game.getExile().getExileZones()) {
+            if (exileZone.contains(objectId) && !exileZones.contains(exileZone.getId())) {
+                return false;
             }
         }
-        return false;
+        return true;
     }
 }
 

--- a/Mage.Sets/src/mage/cards/g/GrimoireThief.java
+++ b/Mage.Sets/src/mage/cards/g/GrimoireThief.java
@@ -128,11 +128,6 @@ class GrimoireThiefLookEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public GrimoireThiefLookEffect copy() {
         return new GrimoireThiefLookEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/g/GrinningTotem.java
+++ b/Mage.Sets/src/mage/cards/g/GrinningTotem.java
@@ -122,11 +122,6 @@ class GrinningTotemMayPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         return source.isControlledBy(affectedControllerId)
                 && sourceId.equals(getTargetPointer().getFirst(game, source));

--- a/Mage.Sets/src/mage/cards/g/GrolnokTheOmnivore.java
+++ b/Mage.Sets/src/mage/cards/g/GrolnokTheOmnivore.java
@@ -136,11 +136,6 @@ class GrolnokTheOmnivorePlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         if (affectedControllerId.equals(source.getControllerId())) {
             Card card = game.getCard(objectId);

--- a/Mage.Sets/src/mage/cards/g/GrolnokTheOmnivore.java
+++ b/Mage.Sets/src/mage/cards/g/GrolnokTheOmnivore.java
@@ -137,14 +137,15 @@ class GrolnokTheOmnivorePlayEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (affectedControllerId.equals(source.getControllerId())) {
-            Card card = game.getCard(objectId);
-            if (card != null) {
-                Card mainCard = card.getMainCard();
-                return game.getState().getZone(mainCard.getId()).equals(Zone.EXILED) && mainCard.isOwnedBy(source.getControllerId())
-                        && mainCard.getCounters(game).containsKey(CounterType.CROAK);
-            }
+        Card card = game.getCard(objectId);
+
+        if (!affectedControllerId.equals(source.getControllerId()) || card == null) {
+            return false;
         }
-        return false;
+
+        Card mainCard = card.getMainCard();
+        return game.getState().getZone(mainCard.getId()).equals(Zone.EXILED)
+                && mainCard.isOwnedBy(source.getControllerId())
+                && mainCard.getCounters(game).containsKey(CounterType.CROAK);
     }
 }

--- a/Mage.Sets/src/mage/cards/g/GusthasScepter.java
+++ b/Mage.Sets/src/mage/cards/g/GusthasScepter.java
@@ -142,11 +142,6 @@ class GusthasScepterLookAtCardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public GusthasScepterLookAtCardEffect copy() {
         return new GusthasScepterLookAtCardEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/h/HaakonStromgaldScourge.java
+++ b/Mage.Sets/src/mage/cards/h/HaakonStromgaldScourge.java
@@ -142,16 +142,15 @@ class HaakonPlayKnightsFromGraveyardEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {       
-        if (affectedControllerId.equals(source.getControllerId())) {
-            Card knightToCast = game.getCard(objectId);
-            if (knightToCast != null
-                    && knightToCast.hasSubtype(SubType.KNIGHT, game)
-                    && knightToCast.isOwnedBy(source.getControllerId())
-                    && game.getState().getZone(objectId) == Zone.GRAVEYARD) {
-                return true;
-            }
+        if (!affectedControllerId.equals(source.getControllerId())) {
+            return false;
         }
-        return false;
+
+        Card knightToCast = game.getCard(objectId);
+        return knightToCast != null
+                && knightToCast.hasSubtype(SubType.KNIGHT, game)
+                && knightToCast.isOwnedBy(source.getControllerId())
+                && game.getState().getZone(objectId) == Zone.GRAVEYARD;
     }
 }
 

--- a/Mage.Sets/src/mage/cards/h/HaakonStromgaldScourge.java
+++ b/Mage.Sets/src/mage/cards/h/HaakonStromgaldScourge.java
@@ -68,11 +68,6 @@ class HaakonStromgaldScourgePlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public HaakonStromgaldScourgePlayEffect copy() {
         return new HaakonStromgaldScourgePlayEffect(this);
     }
@@ -138,11 +133,6 @@ class HaakonPlayKnightsFromGraveyardEffect extends AsThoughEffectImpl {
 
     public HaakonPlayKnightsFromGraveyardEffect(final HaakonPlayKnightsFromGraveyardEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/h/HaldanAvidArcanist.java
+++ b/Mage.Sets/src/mage/cards/h/HaldanAvidArcanist.java
@@ -63,11 +63,6 @@ class HaldanAvidArcanistCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public HaldanAvidArcanistCastFromExileEffect copy() {
         return new HaldanAvidArcanistCastFromExileEffect(this);
     }
@@ -93,11 +88,6 @@ class HaldanAvidArcanistSpendAnyManaEffect extends AsThoughEffectImpl implements
 
     private HaldanAvidArcanistSpendAnyManaEffect(final HaldanAvidArcanistSpendAnyManaEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/h/HaukensInsight.java
+++ b/Mage.Sets/src/mage/cards/h/HaukensInsight.java
@@ -117,11 +117,6 @@ class HaukensInsightLookEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         UUID cardId = getTargetPointer().getFirst(game, source);
         if (cardId == null) {
@@ -146,11 +141,6 @@ class HaukensInsightPlayEffect extends AsThoughEffectImpl {
     @Override
     public HaukensInsightPlayEffect copy() {
         return new HaukensInsightPlayEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/h/HaukensInsight.java
+++ b/Mage.Sets/src/mage/cards/h/HaukensInsight.java
@@ -145,20 +145,28 @@ class HaukensInsightPlayEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (affectedControllerId.equals(source.getControllerId()) && game.isActivePlayer(source.getControllerId())) {
-            Player controller = game.getPlayer(source.getControllerId());
-            HaukensInsightWatcher watcher = game.getState().getWatcher(HaukensInsightWatcher.class);
-            Permanent sourceObject = game.getPermanent(source.getSourceId());
-            if (controller != null && watcher != null && sourceObject != null && !watcher.isAbilityUsed(new MageObjectReference(sourceObject, game))) {
-                UUID exileId = CardUtil.getExileZoneId(game, source.getSourceId(), game.getState().getZoneChangeCounter(source.getSourceId()));
-                ExileZone exileZone = game.getExile().getExileZone(exileId);
-                if (exileZone != null && exileZone.contains(CardUtil.getMainCardId(game, objectId))) {
-                    allowCardToPlayWithoutMana(objectId, source, affectedControllerId, game);
-                    return true;
-                }
-            }
+        Player controller = game.getPlayer(source.getControllerId());
+        HaukensInsightWatcher watcher = game.getState().getWatcher(HaukensInsightWatcher.class);
+        Permanent sourceObject = game.getPermanent(source.getSourceId());
+
+        if (!affectedControllerId.equals(source.getControllerId())
+                || !game.isActivePlayer(source.getControllerId())
+                || controller == null
+                || sourceObject == null
+                || watcher == null
+                || watcher.isAbilityUsed(new MageObjectReference(sourceObject, game))) {
+            return false;
         }
-        return false;
+
+        UUID exileId = CardUtil.getExileZoneId(game, source.getSourceId(), game.getState().getZoneChangeCounter(source.getSourceId()));
+        ExileZone exileZone = game.getExile().getExileZone(exileId);
+        return exileZone != null && exileZone.contains(CardUtil.getMainCardId(game, objectId));
+
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        return allowCardToPlayWithoutMana(objectId, source, affectedControllerId, game);
     }
 }
 

--- a/Mage.Sets/src/mage/cards/h/HavengulLich.java
+++ b/Mage.Sets/src/mage/cards/h/HavengulLich.java
@@ -76,11 +76,6 @@ class HavengulLichPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public HavengulLichPlayEffect copy() {
         return new HavengulLichPlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/h/HedonistsTrove.java
+++ b/Mage.Sets/src/mage/cards/h/HedonistsTrove.java
@@ -95,11 +95,6 @@ class HedonistsTrovePlayLandEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public HedonistsTrovePlayLandEffect copy() {
         return new HedonistsTrovePlayLandEffect(this);
     }
@@ -130,11 +125,6 @@ class HedonistsTroveCastNonlandCardsEffect extends AsThoughEffectImpl {
 
     private HedonistsTroveCastNonlandCardsEffect(final HedonistsTroveCastNonlandCardsEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/h/HogaakArisenNecropolis.java
+++ b/Mage.Sets/src/mage/cards/h/HogaakArisenNecropolis.java
@@ -79,11 +79,6 @@ class HogaakArisenNecropolisEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public HogaakArisenNecropolisEffect copy() {
         return new HogaakArisenNecropolisEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/i/IceCauldron.java
+++ b/Mage.Sets/src/mage/cards/i/IceCauldron.java
@@ -126,11 +126,6 @@ class IceCauldronCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public IceCauldronCastFromExileEffect copy() {
         return new IceCauldronCastFromExileEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/i/IdolOfEndurance.java
+++ b/Mage.Sets/src/mage/cards/i/IdolOfEndurance.java
@@ -183,14 +183,20 @@ class IdolOfEnduranceCastFromExileEffect extends AsThoughEffectImpl {
         if (!IdolOfEnduranceWatcher.checkPermission(affectedControllerId, source, game)) {
             return false;
         }
+
         ExileZone exileZone = game.getExile().getExileZone(CardUtil.getExileZoneId(game, source));
         if (exileZone == null || !exileZone.contains(sourceId)) {
             return false;
         }
+
         Card card = game.getCard(sourceId);
-        if (card == null || !card.isCreature(game) || card.isLand(game)) {
-            return false;
-        }
+        return card != null
+                && card.isCreature(game)
+                && card.isLand(game);
+    }
+
+    @Override
+    public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         return allowCardToPlayWithoutMana(sourceId, source, affectedControllerId, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/i/IdolOfEndurance.java
+++ b/Mage.Sets/src/mage/cards/i/IdolOfEndurance.java
@@ -168,11 +168,6 @@ class IdolOfEnduranceCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public IdolOfEnduranceCastFromExileEffect copy() {
         return new IdolOfEnduranceCastFromExileEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/i/IdolOfEndurance.java
+++ b/Mage.Sets/src/mage/cards/i/IdolOfEndurance.java
@@ -192,7 +192,7 @@ class IdolOfEnduranceCastFromExileEffect extends AsThoughEffectImpl {
         Card card = game.getCard(sourceId);
         return card != null
                 && card.isCreature(game)
-                && card.isLand(game);
+                && !card.isLand(game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/i/IndomitableMight.java
+++ b/Mage.Sets/src/mage/cards/i/IndomitableMight.java
@@ -84,11 +84,6 @@ class IndomitableMightEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public IndomitableMightEffect copy() {
         return new IndomitableMightEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/i/IndomitableMight.java
+++ b/Mage.Sets/src/mage/cards/i/IndomitableMight.java
@@ -78,8 +78,16 @@ class IndomitableMightEffect extends AsThoughEffectImpl {
             return false;
         }
         Player controller = game.getPlayer(permanent.getControllerId());
-        return controller != null
-                && controller.chooseUse(Outcome.Damage, "Have " + permanent.getLogName()
+        return controller != null;
+    }
+
+    @Override
+    public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        Permanent sourcePermanent = source.getSourcePermanentOrLKI(game);
+        Permanent permanent = game.getPermanent(sourcePermanent.getAttachedTo());
+        Player controller = game.getPlayer(permanent.getControllerId());
+
+        return controller.chooseUse(Outcome.Damage, "Have " + permanent.getLogName()
                 + " assign damage as though it weren't blocked?", source, game);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IndomitableMight.java
+++ b/Mage.Sets/src/mage/cards/i/IndomitableMight.java
@@ -83,6 +83,11 @@ class IndomitableMightEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        // Assume the option that will let the player
+        if (game.inCheckPlayableState()) {
+            return true;
+        }
+
         Permanent sourcePermanent = source.getSourcePermanentOrLKI(game);
         Permanent permanent = game.getPermanent(sourcePermanent.getAttachedTo());
         Player controller = game.getPlayer(permanent.getControllerId());

--- a/Mage.Sets/src/mage/cards/i/InstillEnergy.java
+++ b/Mage.Sets/src/mage/cards/i/InstillEnergy.java
@@ -68,11 +68,6 @@ class CanAttackAsThoughItHadHasteEnchantedEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CanAttackAsThoughItHadHasteEnchantedEffect copy() {
         return new CanAttackAsThoughItHadHasteEnchantedEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/i/IntetTheDreamer.java
+++ b/Mage.Sets/src/mage/cards/i/IntetTheDreamer.java
@@ -110,11 +110,6 @@ class IntetTheDreamerAsThoughEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public IntetTheDreamerAsThoughEffect copy() {
         return new IntetTheDreamerAsThoughEffect(this);
     }
@@ -167,11 +162,6 @@ class IntetTheDreamerLookEffect extends AsThoughEffectImpl {
 
     public IntetTheDreamerLookEffect(final IntetTheDreamerLookEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/j/JacobHaukenInspector.java
+++ b/Mage.Sets/src/mage/cards/j/JacobHaukenInspector.java
@@ -120,11 +120,6 @@ class JacobHaukenInspectorLookEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         UUID cardId = getTargetPointer().getFirst(game, source);
         if (cardId == null) {

--- a/Mage.Sets/src/mage/cards/j/JestersScepter.java
+++ b/Mage.Sets/src/mage/cards/j/JestersScepter.java
@@ -111,11 +111,6 @@ class JestersScepterLookAtCardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public JestersScepterLookAtCardEffect copy() {
         return new JestersScepterLookAtCardEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/j/JornGodOfWinter.java
+++ b/Mage.Sets/src/mage/cards/j/JornGodOfWinter.java
@@ -125,11 +125,6 @@ class KaldringTheRimestaffGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         return objectId.equals(this.getTargetPointer().getFirst(game, source)) && affectedControllerId.equals(source.getControllerId());
     }

--- a/Mage.Sets/src/mage/cards/k/KaradorGhostChieftain.java
+++ b/Mage.Sets/src/mage/cards/k/KaradorGhostChieftain.java
@@ -107,11 +107,6 @@ class KaradorGhostChieftainCastFromGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public KaradorGhostChieftainCastFromGraveyardEffect copy() {
         return new KaradorGhostChieftainCastFromGraveyardEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/k/KaradorGhostChieftain.java
+++ b/Mage.Sets/src/mage/cards/k/KaradorGhostChieftain.java
@@ -113,23 +113,20 @@ class KaradorGhostChieftainCastFromGraveyardEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (source.isControlledBy(affectedControllerId)
-                && Zone.GRAVEYARD.equals(game.getState().getZone(objectId))) {
-            Card objectCard = game.getCard(objectId);
-            Permanent sourceObject = game.getPermanent(source.getSourceId()); // needs to be onto the battlefield
-            if (objectCard != null
-                    && sourceObject != null
-                    && objectCard.isOwnedBy(source.getControllerId())
-                    && objectCard.isCreature(game)
-                    && objectCard.getSpellAbility() != null
-                    && objectCard.getSpellAbility().spellCanBeActivatedRegularlyNow(affectedControllerId, game)) {
-                KaradorGhostChieftainWatcher watcher
-                        = game.getState().getWatcher(KaradorGhostChieftainWatcher.class);
-                return watcher != null
-                        && !watcher.isAbilityUsed(new MageObjectReference(sourceObject, game));
-            }
-        }
-        return false;
+        Card objectCard = game.getCard(objectId);
+        Permanent sourceObject = game.getPermanent(source.getSourceId()); // needs to be onto the battlefield
+        KaradorGhostChieftainWatcher watcher = game.getState().getWatcher(KaradorGhostChieftainWatcher.class);
+
+        return source.isControlledBy(affectedControllerId)
+                && Zone.GRAVEYARD.equals(game.getState().getZone(objectId))
+                && objectCard != null
+                && sourceObject != null
+                && objectCard.isOwnedBy(source.getControllerId())
+                && objectCard.isCreature(game)
+                && objectCard.getSpellAbility() != null
+                && objectCard.getSpellAbility().spellCanBeActivatedRegularlyNow(affectedControllerId, game)
+                && watcher != null
+                && !watcher.isAbilityUsed(new MageObjectReference(sourceObject, game));
     }
 }
 

--- a/Mage.Sets/src/mage/cards/k/KayaBaneOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/k/KayaBaneOfTheDead.java
@@ -58,11 +58,6 @@ class KayaBaneOfTheDeadEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public KayaBaneOfTheDeadEffect copy() {
         return new KayaBaneOfTheDeadEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/k/KessDissidentMage.java
+++ b/Mage.Sets/src/mage/cards/k/KessDissidentMage.java
@@ -69,11 +69,6 @@ class KessDissidentMageCastFromGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public KessDissidentMageCastFromGraveyardEffect copy() {
         return new KessDissidentMageCastFromGraveyardEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/k/KethisTheHiddenHand.java
+++ b/Mage.Sets/src/mage/cards/k/KethisTheHiddenHand.java
@@ -135,11 +135,6 @@ class KethisTheHiddenHandGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public KethisTheHiddenHandGraveyardEffect copy() {
         return new KethisTheHiddenHandGraveyardEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/k/KheruMindEater.java
+++ b/Mage.Sets/src/mage/cards/k/KheruMindEater.java
@@ -115,11 +115,13 @@ class KheruMindEaterEffect extends AsThoughEffectImpl {
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         Card card = game.getCard(objectId);
-        if (affectedControllerId.equals(source.getControllerId()) && card != null && game.getState().getZone(card.getId()) == Zone.EXILED) {
-            ExileZone zone = game.getExile().getExileZone(CardUtil.getCardExileZoneId(game, source));
-            return zone != null && zone.contains(card.getId());
-        }
-        return false;
+        ExileZone zone = game.getExile().getExileZone(CardUtil.getCardExileZoneId(game, source));
+
+        return affectedControllerId.equals(source.getControllerId())
+                && card != null
+                && game.getState().getZone(card.getId()) == Zone.EXILED
+                && zone != null
+                && zone.contains(card.getId());
     }
 }
 
@@ -141,19 +143,15 @@ class KheruMindEaterLookAtCardEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (affectedControllerId.equals(source.getControllerId())) {
-            Card card = game.getCard(objectId);
-            if (card != null) {
-                MageObject sourceObject = game.getObject(source);
-                if (sourceObject == null) {
-                    return false;
-                }
-                UUID exileId = CardUtil.getCardExileZoneId(game, source);
-                ExileZone exile = game.getExile().getExileZone(exileId);
-                return exile != null && exile.contains(objectId);
-            }
-        }
-        return false;
-    }
+        Card card = game.getCard(objectId);
+        MageObject sourceObject = game.getObject(source);
+        UUID exileId = CardUtil.getCardExileZoneId(game, source);
+        ExileZone exile = game.getExile().getExileZone(exileId);
 
+        return affectedControllerId.equals(source.getControllerId())
+                && card != null
+                && sourceObject != null
+                && exile != null
+                && exile.contains(objectId);
+    }
 }

--- a/Mage.Sets/src/mage/cards/k/KheruMindEater.java
+++ b/Mage.Sets/src/mage/cards/k/KheruMindEater.java
@@ -108,11 +108,6 @@ class KheruMindEaterEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public KheruMindEaterEffect copy() {
         return new KheruMindEaterEffect(this);
     }
@@ -137,11 +132,6 @@ class KheruMindEaterLookAtCardEffect extends AsThoughEffectImpl {
 
     public KheruMindEaterLookAtCardEffect(final KheruMindEaterLookAtCardEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/k/KnacksawClique.java
+++ b/Mage.Sets/src/mage/cards/k/KnacksawClique.java
@@ -110,11 +110,6 @@ class KnacksawCliqueCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public KnacksawCliqueCastFromExileEffect copy() {
         return new KnacksawCliqueCastFromExileEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/l/LilianaUntouchedByDeath.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaUntouchedByDeath.java
@@ -104,11 +104,6 @@ class LilianaUntouchedByDeathGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public LilianaUntouchedByDeathGraveyardEffect copy() {
         return new LilianaUntouchedByDeathGraveyardEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/l/LordMagnus.java
+++ b/Mage.Sets/src/mage/cards/l/LordMagnus.java
@@ -58,11 +58,6 @@ class LordMagnusFirstEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public LordMagnusFirstEffect copy() {
         return new LordMagnusFirstEffect(this);
     }
@@ -82,11 +77,6 @@ class LordMagnusSecondEffect extends AsThoughEffectImpl {
 
     public LordMagnusSecondEffect(final LordMagnusSecondEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/l/LukkaCoppercoatOutcast.java
+++ b/Mage.Sets/src/mage/cards/l/LukkaCoppercoatOutcast.java
@@ -110,11 +110,6 @@ class LukkaCoppercoatOutcastCastEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         return game.getBattlefield().countAll(filter, affectedControllerId, game) > 0
                 && source.isControlledBy(affectedControllerId)

--- a/Mage.Sets/src/mage/cards/m/MaestrosAscendancy.java
+++ b/Mage.Sets/src/mage/cards/m/MaestrosAscendancy.java
@@ -59,11 +59,6 @@ class MaestrosAscendancyCastEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public MaestrosAscendancyCastEffect copy() {
         return new MaestrosAscendancyCastEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/m/MaestrosAscendancy.java
+++ b/Mage.Sets/src/mage/cards/m/MaestrosAscendancy.java
@@ -65,20 +65,24 @@ class MaestrosAscendancyCastEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (!source.isControlledBy(affectedControllerId)
-                || !game.isActivePlayer(affectedControllerId)) {
-            return false;
-        }
         Card card = game.getCard(objectId);
         Player player = game.getPlayer(affectedControllerId);
-        if (card == null
-                || player == null
-                || !card.isOwnedBy(affectedControllerId)
-                || !card.isInstantOrSorcery(game)
-                || !game.getState().getZone(objectId).match(Zone.GRAVEYARD)
-                || !MaestrosAscendancyWatcher.checkPlayer(source, game)) {
-            return false;
-        }
+
+        return source.isControlledBy(affectedControllerId)
+                && game.isActivePlayer(affectedControllerId)
+                && card != null
+                && player != null
+                && card.isOwnedBy(affectedControllerId)
+                && card.isInstantOrSorcery(game)
+                && game.getState().getZone(objectId).match(Zone.GRAVEYARD)
+                && MaestrosAscendancyWatcher.checkPlayer(source, game);
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Card card = game.getCard(objectId);
+        Player player = game.getPlayer(affectedControllerId);
+
         Costs<Cost> newCosts = new CostsImpl<>();
         newCosts.addAll(card.getSpellAbility().getCosts());
         newCosts.add(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));

--- a/Mage.Sets/src/mage/cards/m/MagmaticChanneler.java
+++ b/Mage.Sets/src/mage/cards/m/MagmaticChanneler.java
@@ -127,11 +127,6 @@ class MagmaticChannelerCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public MagmaticChannelerCastFromExileEffect copy() {
         return new MagmaticChannelerCastFromExileEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/m/ManascapeRefractor.java
+++ b/Mage.Sets/src/mage/cards/m/ManascapeRefractor.java
@@ -114,11 +114,6 @@ class ManascapeRefractorSpendAnyManaEffect extends AsThoughEffectImpl implements
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ManascapeRefractorSpendAnyManaEffect copy() {
         return new ManascapeRefractorSpendAnyManaEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/m/MarangRiverProwler.java
+++ b/Mage.Sets/src/mage/cards/m/MarangRiverProwler.java
@@ -75,11 +75,6 @@ class MarangRiverProwlerCastEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public MarangRiverProwlerCastEffect copy() {
         return new MarangRiverProwlerCastEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/m/MasakoTheHumorless.java
+++ b/Mage.Sets/src/mage/cards/m/MasakoTheHumorless.java
@@ -56,11 +56,6 @@ class BlockTappedEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public BlockTappedEffect copy() {
         return new BlockTappedEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/m/Mindleecher.java
+++ b/Mage.Sets/src/mage/cards/m/Mindleecher.java
@@ -114,11 +114,6 @@ class MindleecherCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public MindleecherCastFromExileEffect copy() {
         return new MindleecherCastFromExileEffect(this);
     }
@@ -149,11 +144,6 @@ class MindleecherLookEffect extends AsThoughEffectImpl {
     private MindleecherLookEffect(final MindleecherLookEffect effect) {
         super(effect);
         this.authorizedPlayerId = effect.authorizedPlayerId;
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/m/MisthollowGriffin.java
+++ b/Mage.Sets/src/mage/cards/m/MisthollowGriffin.java
@@ -59,11 +59,6 @@ class MisthollowGriffinPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public MisthollowGriffinPlayEffect copy() {
         return new MisthollowGriffinPlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/m/MonkClass.java
+++ b/Mage.Sets/src/mage/cards/m/MonkClass.java
@@ -149,9 +149,4 @@ class MonkClassCastEffect extends AsThoughEffectImpl {
     public MonkClassCastEffect copy() {
         return new MonkClassCastEffect(this);
     }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
 }

--- a/Mage.Sets/src/mage/cards/m/MonkClass.java
+++ b/Mage.Sets/src/mage/cards/m/MonkClass.java
@@ -141,8 +141,8 @@ class MonkClassCastEffect extends AsThoughEffectImpl {
         }
         Card card = game.getCard(sourceId);
         SpellsCastWatcher watcher = game.getState().getWatcher(SpellsCastWatcher.class);
-        return card != null && watcher != null && !card.isLand(game)
-                && watcher.getSpellsCastThisTurn(affectedControllerId).size() > 0;
+        return card != null && !card.isLand(game)
+                && watcher != null && !watcher.getSpellsCastThisTurn(affectedControllerId).isEmpty();
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/m/MuldrothaTheGravetide.java
+++ b/Mage.Sets/src/mage/cards/m/MuldrothaTheGravetide.java
@@ -25,6 +25,7 @@ import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.constants.WatcherScope;
 import mage.constants.Zone;
+import mage.game.Controllable;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
@@ -140,54 +141,63 @@ class MuldrothaTheGravetideWatcher extends Watcher {
     }
 
     private void addPermanentTypes(GameEvent event, Card mageObject, Game game) {
-        if (mageObject != null 
-                && event.getAdditionalReference() != null 
-                && MageIdentifier.MuldrothaTheGravetideWatcher.equals(event.getAdditionalReference().getApprovingAbility().getIdentifier())) {
-            UUID playerId = null;
-            if (mageObject instanceof Spell) {
-                playerId = ((Spell) mageObject).getControllerId();
-            } else if (mageObject instanceof Permanent) {
-                playerId = ((Permanent) mageObject).getControllerId();
+        if (mageObject == null
+                || event.getAdditionalReference() == null
+                || !MageIdentifier.MuldrothaTheGravetideWatcher.equals(event.getAdditionalReference().getApprovingAbility().getIdentifier())) {
+            return;
+        }
+
+        // TODO: double check logic here
+        UUID playerId;
+        if (mageObject instanceof Spell || mageObject instanceof Permanent) {
+            playerId = ((Controllable) mageObject).getControllerId();
+            if (playerId == null) {
+                return;
             }
-            if (playerId != null) {
-                Set<CardType> permanentTypes = sourcePlayedPermanentTypes.get(event.getAdditionalReference().getApprovingMageObjectReference());
-                if (permanentTypes == null) {
-                    permanentTypes = EnumSet.noneOf(CardType.class);
-                    sourcePlayedPermanentTypes.put(event.getAdditionalReference().getApprovingMageObjectReference(), permanentTypes);
+        } else {
+            return;
+        }
+
+        Set<CardType> permanentTypes = sourcePlayedPermanentTypes.get(event.getAdditionalReference().getApprovingMageObjectReference());
+        if (permanentTypes == null) {
+            permanentTypes = EnumSet.noneOf(CardType.class);
+            sourcePlayedPermanentTypes.put(event.getAdditionalReference().getApprovingMageObjectReference(), permanentTypes);
+        }
+
+        Set<CardType> typesNotCast = EnumSet.noneOf(CardType.class);
+        for (CardType cardType : mageObject.getCardType(game)) {
+            if (cardType.isPermanentType() && !permanentTypes.contains(cardType)) {
+                typesNotCast.add(cardType);
+            }
+        }
+
+        if (typesNotCast.size() <= 1) {
+            permanentTypes.addAll(typesNotCast);
+            return;
+        } else {
+            Player player = game.getPlayer(playerId);
+            if (player == null) {
+                return;
+            }
+
+            Choice typeChoice = new ChoiceImpl(true);
+            typeChoice.setMessage("Choose permanent type you consume for casting from graveyard.");
+            typesNotCast.forEach(cardType ->  typeChoice.getChoices().add(cardType.toString()));
+            if (!player.choose(Outcome.Detriment, typeChoice, game)) {
+                return;
+            }
+
+            String typeName = typeChoice.getChoice();
+            CardType chosenType = null;
+            for (CardType cardType : CardType.values()) {
+                if (cardType.toString().equals(typeName)) {
+                    chosenType = cardType;
+                    break;
                 }
-                Set<CardType> typesNotCast = EnumSet.noneOf(CardType.class);
-                for (CardType cardType : mageObject.getCardType(game)) {
-                    if (cardType.isPermanentType()) {
-                        if (!permanentTypes.contains(cardType)) {
-                            typesNotCast.add(cardType);
-                        }
-                    }
-                }
-                if (typesNotCast.size() <= 1) {
-                    permanentTypes.addAll(typesNotCast);
-                } else {
-                    Player player = game.getPlayer(playerId);
-                    if (player != null) {
-                        Choice typeChoice = new ChoiceImpl(true);
-                        typeChoice.setMessage("Choose permanent type you consume for casting from graveyard.");
-                        for (CardType cardType : typesNotCast) {
-                            typeChoice.getChoices().add(cardType.toString());
-                        }
-                        if (player.choose(Outcome.Detriment, typeChoice, game)) {
-                            String typeName = typeChoice.getChoice();
-                            CardType chosenType = null;
-                            for (CardType cardType : CardType.values()) {
-                                if (cardType.toString().equals(typeName)) {
-                                    chosenType = cardType;
-                                    break;
-                                }
-                            }
-                            if (chosenType != null) {
-                                permanentTypes.add(chosenType);
-                            }
-                        }
-                    }
-                }
+            }
+
+            if (chosenType != null) {
+                permanentTypes.add(chosenType);
             }
         }
     }

--- a/Mage.Sets/src/mage/cards/m/MuldrothaTheGravetide.java
+++ b/Mage.Sets/src/mage/cards/m/MuldrothaTheGravetide.java
@@ -76,11 +76,6 @@ class MuldrothaTheGravetideCastFromGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public MuldrothaTheGravetideCastFromGraveyardEffect copy() {
         return new MuldrothaTheGravetideCastFromGraveyardEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/m/MuseVessel.java
+++ b/Mage.Sets/src/mage/cards/m/MuseVessel.java
@@ -112,11 +112,6 @@ class MuseVesselMayPlayExiledEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         return affectedControllerId.equals(source.getControllerId())
                 && getTargetPointer().getTargets(game, source).contains(objectId);

--- a/Mage.Sets/src/mage/cards/m/MycosynthLattice.java
+++ b/Mage.Sets/src/mage/cards/m/MycosynthLattice.java
@@ -178,11 +178,6 @@ class ManaCanBeSpentAsAnyColorEffect extends AsThoughEffectImpl implements AsTho
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         return game.getState().getPlayersInRange(source.getControllerId(), game).contains(affectedControllerId);
     }

--- a/Mage.Sets/src/mage/cards/n/NarsetEnlightenedMaster.java
+++ b/Mage.Sets/src/mage/cards/n/NarsetEnlightenedMaster.java
@@ -109,13 +109,15 @@ class NarsetEnlightenedMasterCastFromExileEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (objectId.equals(getTargetPointer().getFirst(game, source))
-                && affectedControllerId.equals(source.getControllerId())) {
-            Player player = game.getPlayer(affectedControllerId);
-            if (player != null) {
-                return allowCardToPlayWithoutMana(objectId, source, affectedControllerId, game);
-            }
-        }
-        return false;
+        Player player = game.getPlayer(affectedControllerId);
+
+        return objectId.equals(getTargetPointer().getFirst(game, source))
+                && affectedControllerId.equals(source.getControllerId())
+                && player != null;
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        return allowCardToPlayWithoutMana(objectId, source, affectedControllerId, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/n/NarsetEnlightenedMaster.java
+++ b/Mage.Sets/src/mage/cards/n/NarsetEnlightenedMaster.java
@@ -103,11 +103,6 @@ class NarsetEnlightenedMasterCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public NarsetEnlightenedMasterCastFromExileEffect copy() {
         return new NarsetEnlightenedMasterCastFromExileEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/n/NashiMoonSagesScion.java
+++ b/Mage.Sets/src/mage/cards/n/NashiMoonSagesScion.java
@@ -180,21 +180,29 @@ class NashiMoonSagesScionPlayEffect extends CanPlayCardControllerEffect {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (!super.applies(objectId, source, affectedControllerId, game)
-                || !NashiMoonSagesScionWatcher.checkCard(game, source, mor)) {
-            return false;
-        }
+        Player controller = game.getPlayer(source.getControllerId());
         Card cardToCheck = mor.getCard(game);
+
+        return controller != null
+                && cardToCheck != null
+                && NashiMoonSagesScionWatcher.checkCard(game, source, mor)
+                && super.applies(objectId, source, affectedControllerId, game);
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Player controller = game.getPlayer(source.getControllerId());
+        Card cardToCheck = mor.getCard(game);
+
         if (cardToCheck.isLand(game)) {
             return true;
+        } else {
+            PayLifeCost lifeCost = new PayLifeCost(cardToCheck.getSpellAbility().getManaCosts().manaValue());
+            Costs<Cost> newCosts = new CostsImpl<>();
+            newCosts.add(lifeCost);
+            newCosts.addAll(cardToCheck.getSpellAbility().getCosts());
+            controller.setCastSourceIdWithAlternateMana(cardToCheck.getId(), null, newCosts);
+            return true;
         }
-        // allows to play/cast with alternative life cost
-        Player controller = game.getPlayer(source.getControllerId());
-        PayLifeCost lifeCost = new PayLifeCost(cardToCheck.getSpellAbility().getManaCosts().manaValue());
-        Costs<Cost> newCosts = new CostsImpl<>();
-        newCosts.add(lifeCost);
-        newCosts.addAll(cardToCheck.getSpellAbility().getCosts());
-        controller.setCastSourceIdWithAlternateMana(cardToCheck.getId(), null, newCosts);
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/n/NightveilSpecter.java
+++ b/Mage.Sets/src/mage/cards/n/NightveilSpecter.java
@@ -108,11 +108,6 @@ class NightveilSpecterEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public NightveilSpecterEffect copy() {
         return new NightveilSpecterEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/n/NivixAerieOfTheFiremind.java
+++ b/Mage.Sets/src/mage/cards/n/NivixAerieOfTheFiremind.java
@@ -101,11 +101,6 @@ class NivixAerieOfTheFiremindCanCastEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public NivixAerieOfTheFiremindCanCastEffect copy() {
         return new NivixAerieOfTheFiremindCanCastEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/o/OathOfNissa.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfNissa.java
@@ -69,11 +69,6 @@ class OathOfNissaSpendAnyManaEffect extends AsThoughEffectImpl implements AsThou
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public OathOfNissaSpendAnyManaEffect copy() {
         return new OathOfNissaSpendAnyManaEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/o/OathswornVampire.java
+++ b/Mage.Sets/src/mage/cards/o/OathswornVampire.java
@@ -59,11 +59,6 @@ class OathswornVampirePlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public OathswornVampirePlayEffect copy() {
         return new OathswornVampirePlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/o/OrnateKanzashi.java
+++ b/Mage.Sets/src/mage/cards/o/OrnateKanzashi.java
@@ -102,11 +102,6 @@ class OrnateKanzashiCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public OrnateKanzashiCastFromExileEffect copy() {
         return new OrnateKanzashiCastFromExileEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/o/Outmaneuver.java
+++ b/Mage.Sets/src/mage/cards/o/Outmaneuver.java
@@ -74,11 +74,6 @@ class OutmaneuverEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public OutmaneuverEffect copy() {
         return new OutmaneuverEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/p/PlaneswalkersMischief.java
+++ b/Mage.Sets/src/mage/cards/p/PlaneswalkersMischief.java
@@ -111,16 +111,18 @@ class PlaneswalkersMischiefCastFromExileEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (targetPointer.getTargets(game, source).contains(objectId)
-                && game.getState().getZone(objectId) == Zone.EXILED) {
-            Player player = game.getPlayer(source.getControllerId());
-            Card card = game.getCard(objectId);
-            if (player != null
-                    && card != null) {
-                return allowCardToPlayWithoutMana(objectId, source, affectedControllerId, game);
-            }
-        }
-        return false;
+        Player player = game.getPlayer(source.getControllerId());
+        Card card = game.getCard(objectId);
+
+        return player != null
+                && card != null
+                && targetPointer.getTargets(game, source).contains(objectId)
+                && game.getState().getZone(objectId) == Zone.EXILED;
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        return allowCardToPlayWithoutMana(objectId, source, affectedControllerId, game);
     }
 }
 

--- a/Mage.Sets/src/mage/cards/p/PlaneswalkersMischief.java
+++ b/Mage.Sets/src/mage/cards/p/PlaneswalkersMischief.java
@@ -105,11 +105,6 @@ class PlaneswalkersMischiefCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public PlaneswalkersMischiefCastFromExileEffect copy() {
         return new PlaneswalkersMischiefCastFromExileEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/p/PraetorsGrasp.java
+++ b/Mage.Sets/src/mage/cards/p/PraetorsGrasp.java
@@ -109,11 +109,6 @@ class PraetorsGraspPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public PraetorsGraspPlayEffect copy() {
         return new PraetorsGraspPlayEffect(this);
     }
@@ -153,11 +148,6 @@ class PraetorsGraspRevealEffect extends AsThoughEffectImpl {
     public PraetorsGraspRevealEffect(final PraetorsGraspRevealEffect effect) {
         super(effect);
         this.cardId = effect.cardId;
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/p/PraetorsGrasp.java
+++ b/Mage.Sets/src/mage/cards/p/PraetorsGrasp.java
@@ -115,24 +115,22 @@ class PraetorsGraspPlayEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (objectId.equals(cardId)
-                && affectedControllerId.equals(source.getControllerId())) {
-            Player controller = game.getPlayer(source.getControllerId());
-            UUID exileId = CardUtil.getExileZoneId(cardId.toString() + game.getState().getZoneChangeCounter(cardId), game);
-            if (exileId != null
-                    && controller != null) {
-                ExileZone exileZone = game.getExile().getExileZone(exileId);
-                if (exileZone != null
-                        && exileZone.contains(cardId)) {
-                    return true;
-                } else {
-                    discard();
-                }
-            }
+        Player controller = game.getPlayer(source.getControllerId());
+        if (!objectId.equals(cardId)
+                || !affectedControllerId.equals(source.getControllerId())
+                || controller == null) {
+            return false;
         }
-        return false;
-    }
 
+        UUID exileId = CardUtil.getExileZoneId(cardId.toString() + game.getState().getZoneChangeCounter(cardId), game);
+        ExileZone exileZone = game.getExile().getExileZone(exileId);
+        if (exileZone != null && exileZone.contains(cardId)) {
+            return true;
+        } else {
+            discard();
+            return false;
+        }
+    }
 }
 
 class PraetorsGraspRevealEffect extends AsThoughEffectImpl {
@@ -157,28 +155,25 @@ class PraetorsGraspRevealEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (objectId.equals(cardId)
-                && affectedControllerId.equals(source.getControllerId())) {
-            MageObject sourceObject = source.getSourceObject(game);
-            UUID exileId = CardUtil.getExileZoneId(cardId.toString() + game.getState().getZoneChangeCounter(cardId), game);
-            if (exileId != null
-                    && sourceObject != null) {
-                ExileZone exileZone = game.getExile().getExileZone(exileId);
-                if (exileZone != null
-                        && exileZone.contains(cardId)) {
-                    Player controller = game.getPlayer(source.getControllerId());
-                    Card card = game.getCard(cardId);
-                    if (controller != null
-                            && card != null
-                            && game.getState().getZone(cardId) == Zone.EXILED) {
-                        return true;
-                    }
-                } else {
-                    discard();
-                }
-            }
+        MageObject sourceObject = source.getSourceObject(game);
+        if (!objectId.equals(cardId)
+                || !affectedControllerId.equals(source.getControllerId())
+                || sourceObject == null) {
+            return false;
         }
-        return false;
+
+        UUID exileId = CardUtil.getExileZoneId(cardId.toString() + game.getState().getZoneChangeCounter(cardId), game);
+        ExileZone exileZone = game.getExile().getExileZone(exileId);
+
+        if (exileZone == null || !exileZone.contains(cardId)) {
+            discard();
+            return false;
+        }
+        Player controller = game.getPlayer(source.getControllerId());
+        Card card = game.getCard(cardId);
+        return controller != null
+                && card != null
+                && game.getState().getZone(cardId) == Zone.EXILED;
     }
 
 }

--- a/Mage.Sets/src/mage/cards/p/PredatorsHour.java
+++ b/Mage.Sets/src/mage/cards/p/PredatorsHour.java
@@ -139,9 +139,6 @@ class PredatorsHourPlayFromExileEffect extends AsThoughEffectImpl {
     private PredatorsHourPlayFromExileEffect(final PredatorsHourPlayFromExileEffect effect) { super(effect); }
 
     @Override
-    public boolean apply(Game game, Ability source) { return true; }
-
-    @Override
     public PredatorsHourPlayFromExileEffect copy() { return new PredatorsHourPlayFromExileEffect(this); }
 
     @Override
@@ -174,9 +171,6 @@ class PredatorsHourSpendAnyManaEffect extends AsThoughEffectImpl implements AsTh
     }
 
     private PredatorsHourSpendAnyManaEffect(final PredatorsHourSpendAnyManaEffect effect) { super(effect); }
-
-    @Override
-    public boolean apply(Game game, Ability source) { return true; }
 
     @Override
     public PredatorsHourSpendAnyManaEffect copy() { return new PredatorsHourSpendAnyManaEffect(this); }
@@ -220,9 +214,6 @@ class PredatorsHourLookEffect extends AsThoughEffectImpl {
         super(effect);
         this.authorizedPlayerId = effect.authorizedPlayerId;
     }
-
-    @Override
-    public boolean apply(Game game, Ability source) { return true; }
 
     @Override
     public PredatorsHourLookEffect copy() { return new PredatorsHourLookEffect(this); }

--- a/Mage.Sets/src/mage/cards/p/PredatorsHour.java
+++ b/Mage.Sets/src/mage/cards/p/PredatorsHour.java
@@ -150,7 +150,9 @@ class PredatorsHourPlayFromExileEffect extends AsThoughEffectImpl {
             return false;
         }
         Card theCard = game.getCard(objectId);
-        if (theCard == null ) { return false; }
+        if (theCard == null ) {
+            return false;
+        }
 
         // for split cards
         objectId = theCard.getMainCard().getId();
@@ -223,7 +225,9 @@ class PredatorsHourLookEffect extends AsThoughEffectImpl {
         UUID cardId = getTargetPointer().getFirst(game, source);
 
         // card is no longer in the origin zone, effect can be discarded
-        if (cardId == null) { this.discard(); }
+        if (cardId == null) {
+            this.discard();
+        }
 
         return affectedControllerId.equals(authorizedPlayerId) && objectId.equals(cardId);
     }

--- a/Mage.Sets/src/mage/cards/p/PredatoryFocus.java
+++ b/Mage.Sets/src/mage/cards/p/PredatoryFocus.java
@@ -46,6 +46,7 @@ class PredatoryFocusEffect extends AsThoughEffectImpl {
 
     public PredatoryFocusEffect(PredatoryFocusEffect effect) {
         super(effect);
+        this.choseUse = effect.choseUse;
     }
 
     @Override
@@ -62,11 +63,6 @@ class PredatoryFocusEffect extends AsThoughEffectImpl {
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         return choseUse && affectedControllerId.equals(source.getControllerId());
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/p/PrimordialMist.java
+++ b/Mage.Sets/src/mage/cards/p/PrimordialMist.java
@@ -129,11 +129,6 @@ class PrimordialMistCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public PrimordialMistCastFromExileEffect copy() {
         return new PrimordialMistCastFromExileEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/p/PropheticFlamespeaker.java
+++ b/Mage.Sets/src/mage/cards/p/PropheticFlamespeaker.java
@@ -102,11 +102,6 @@ class PropheticFlamespeakerCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public PropheticFlamespeakerCastFromExileEffect copy() {
         return new PropheticFlamespeakerCastFromExileEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/p/PsychicIntrusion.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicIntrusion.java
@@ -133,11 +133,6 @@ class PsychicIntrusionCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public PsychicIntrusionCastFromExileEffect copy() {
         return new PsychicIntrusionCastFromExileEffect(this);
     }
@@ -166,11 +161,6 @@ class PsychicIntrusionSpendAnyManaEffect extends AsThoughEffectImpl implements A
 
     public PsychicIntrusionSpendAnyManaEffect(final PsychicIntrusionSpendAnyManaEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/q/Quagmire.java
+++ b/Mage.Sets/src/mage/cards/q/Quagmire.java
@@ -49,11 +49,6 @@ class QuagmireEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public QuagmireEffect copy() {
         return new QuagmireEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/q/Quicken.java
+++ b/Mage.Sets/src/mage/cards/q/Quicken.java
@@ -73,11 +73,6 @@ class QuickenAsThoughEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public QuickenAsThoughEffect copy() {
         return new QuickenAsThoughEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/q/QuicksilverElemental.java
+++ b/Mage.Sets/src/mage/cards/q/QuicksilverElemental.java
@@ -97,11 +97,6 @@ class QuickSilverElementalBlueManaEffect extends AsThoughEffectImpl implements A
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public QuickSilverElementalBlueManaEffect copy() {
         return new QuickSilverElementalBlueManaEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/r/RaffinesGuidance.java
+++ b/Mage.Sets/src/mage/cards/r/RaffinesGuidance.java
@@ -66,17 +66,21 @@ class RafinnesGuidancePlayEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
-        if (sourceId.equals(source.getSourceId()) && source.isControlledBy(affectedControllerId)) {
-            if (game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD) {
-                Player player = game.getPlayer(affectedControllerId);
-                if (player != null) {
-                    Costs<Cost> costs = new CostsImpl<>();
-                    player.setCastSourceIdWithAlternateMana(sourceId, new ManaCostsImpl<>("{2}{W}"), costs);
-                    return true;
-                }
-            }
-        }
-        return false;
+        Player player = game.getPlayer(affectedControllerId);
+
+        return player != null
+                && sourceId.equals(source.getSourceId())
+                && source.isControlledBy(affectedControllerId)
+                && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD;
+    }
+
+    @Override
+    public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        Player player = game.getPlayer(affectedControllerId);
+
+        Costs<Cost> costs = new CostsImpl<>();
+        player.setCastSourceIdWithAlternateMana(sourceId, new ManaCostsImpl<>("{2}{W}"), costs);
+        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/r/RaffinesGuidance.java
+++ b/Mage.Sets/src/mage/cards/r/RaffinesGuidance.java
@@ -80,11 +80,6 @@ class RafinnesGuidancePlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public RafinnesGuidancePlayEffect copy() {
         return new RafinnesGuidancePlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/r/RideTheAvalanche.java
+++ b/Mage.Sets/src/mage/cards/r/RideTheAvalanche.java
@@ -61,11 +61,6 @@ class RideTheAvalancheAsThoughEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public RideTheAvalancheAsThoughEffect copy() {
         return new RideTheAvalancheAsThoughEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/r/RisenExecutioner.java
+++ b/Mage.Sets/src/mage/cards/r/RisenExecutioner.java
@@ -76,11 +76,6 @@ class RisenExecutionerCastEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public RisenExecutionerCastEffect copy() {
         return new RisenExecutionerCastEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/r/RisenExecutioner.java
+++ b/Mage.Sets/src/mage/cards/r/RisenExecutioner.java
@@ -82,15 +82,13 @@ class RisenExecutionerCastEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
-        if (sourceId.equals(source.getSourceId())) {
-            Card card = game.getCard(source.getSourceId());
-            if (card != null
-                    && card.isOwnedBy(affectedControllerId)
-                    && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD) {
-                return true;
-            }
+        if (!sourceId.equals(source.getSourceId())) {
+            return false;
         }
-        return false;
+        Card card = game.getCard(source.getSourceId());
+        return card != null
+                && card.isOwnedBy(affectedControllerId)
+                && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD;
     }
 }
 

--- a/Mage.Sets/src/mage/cards/r/RogueClass.java
+++ b/Mage.Sets/src/mage/cards/r/RogueClass.java
@@ -131,11 +131,6 @@ class RogueClassLookEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public RogueClassLookEffect copy() {
         return new RogueClassLookEffect(this);
     }
@@ -162,11 +157,6 @@ class RogueClassPlayEffect extends AsThoughEffectImpl {
 
     private RogueClassPlayEffect(final RogueClassPlayEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override
@@ -206,11 +196,6 @@ class RogueClassManaEffect extends AsThoughEffectImpl implements AsThoughManaEff
 
     private RogueClassManaEffect(final RogueClassManaEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/r/RonaDiscipleOfGix.java
+++ b/Mage.Sets/src/mage/cards/r/RonaDiscipleOfGix.java
@@ -86,11 +86,6 @@ class RonaDiscipleOfGixPlayNonLandEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public RonaDiscipleOfGixPlayNonLandEffect copy() {
         return new RonaDiscipleOfGixPlayNonLandEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/r/RonaDiscipleOfGix.java
+++ b/Mage.Sets/src/mage/cards/r/RonaDiscipleOfGix.java
@@ -92,18 +92,19 @@ class RonaDiscipleOfGixPlayNonLandEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (affectedControllerId.equals(source.getControllerId())) {
-            Card card = game.getCard(objectId);
-            MageObject sourceObject = game.getObject(source);
-            if (card != null && !card.isLand(game) && sourceObject != null) {
-                UUID exileId = CardUtil.getExileZoneId(game, source.getSourceId(), sourceObject.getZoneChangeCounter(game));
-                if (exileId != null) {
-                    ExileZone exileZone = game.getState().getExile().getExileZone(exileId);
-                    return exileZone != null && exileZone.contains(objectId);
-                }
-            }
+        Card card = game.getCard(objectId);
+        MageObject sourceObject = game.getObject(source);
+
+        if (!affectedControllerId.equals(source.getControllerId())
+                || card == null
+                || card.isLand(game)
+                || sourceObject == null) {
+            return false;
         }
-        return false;
+
+        UUID exileId = CardUtil.getExileZoneId(game, source.getSourceId(), sourceObject.getZoneChangeCounter(game));
+        ExileZone exileZone = game.getState().getExile().getExileZone(exileId);
+        return exileZone != null && exileZone.contains(objectId);
     }
 }
 

--- a/Mage.Sets/src/mage/cards/r/RonaSheoldredsFaithful.java
+++ b/Mage.Sets/src/mage/cards/r/RonaSheoldredsFaithful.java
@@ -74,15 +74,18 @@ class RonaSheoldredsFaithfulEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (!source.getSourceId().equals(objectId)
-                || !source.isControlledBy(affectedControllerId)
-                || game.getState().getZone(objectId) != Zone.GRAVEYARD) {
-            return false;
-        }
         Player controller = game.getPlayer(affectedControllerId);
-        if (controller == null) {
-            return false;
-        }
+
+        return controller != null
+                && source.getSourceId().equals(objectId)
+                && source.isControlledBy(affectedControllerId)
+                && game.getState().getZone(objectId) == Zone.GRAVEYARD;
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Player controller = game.getPlayer(affectedControllerId);
+
         Costs<Cost> costs = new CostsImpl<>();
         costs.add(new DiscardTargetCost(new TargetCardInHand(2, StaticFilters.FILTER_CARD_CARDS)));
         controller.setCastSourceIdWithAlternateMana(objectId, new ManaCostsImpl<>("{1}{U}{B}{B}"), costs);

--- a/Mage.Sets/src/mage/cards/r/RonaSheoldredsFaithful.java
+++ b/Mage.Sets/src/mage/cards/r/RonaSheoldredsFaithful.java
@@ -73,11 +73,6 @@ class RonaSheoldredsFaithfulEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         if (!source.getSourceId().equals(objectId)
                 || !source.isControlledBy(affectedControllerId)

--- a/Mage.Sets/src/mage/cards/r/RootingMoloch.java
+++ b/Mage.Sets/src/mage/cards/r/RootingMoloch.java
@@ -124,11 +124,6 @@ class RootingMolochMayPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         return source.isControlledBy(affectedControllerId)
                 && getTargetPointer().getTargets(game, source).contains(sourceId);

--- a/Mage.Sets/src/mage/cards/r/RuxaPatientProfessor.java
+++ b/Mage.Sets/src/mage/cards/r/RuxaPatientProfessor.java
@@ -95,11 +95,6 @@ class RuxaPatientProfessorEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public RuxaPatientProfessorEffect copy() {
         return new RuxaPatientProfessorEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/r/RuxaPatientProfessor.java
+++ b/Mage.Sets/src/mage/cards/r/RuxaPatientProfessor.java
@@ -94,6 +94,11 @@ class RuxaPatientProfessorEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        // Don't ask for player input when in checkPlayable state
+        if (game.inCheckPlayableState()) {
+            return true;
+        }
+
         Player controller = game.getPlayer(source.getControllerId());
         Permanent permanent = game.getPermanent(sourceId);
 

--- a/Mage.Sets/src/mage/cards/r/RuxaPatientProfessor.java
+++ b/Mage.Sets/src/mage/cards/r/RuxaPatientProfessor.java
@@ -89,8 +89,15 @@ class RuxaPatientProfessorEffect extends AsThoughEffectImpl {
         return controller != null
                 && permanent != null
                 && permanent.isControlledBy(controller.getId())
-                && NoAbilityPredicate.instance.apply(permanent, game)
-                && controller.chooseUse(Outcome.Damage, "Have " + permanent.getLogName()
+                && NoAbilityPredicate.instance.apply(permanent, game);
+    }
+
+    @Override
+    public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        Player controller = game.getPlayer(source.getControllerId());
+        Permanent permanent = game.getPermanent(sourceId);
+
+        return controller.chooseUse(Outcome.Damage, "Have " + permanent.getLogName()
                 + " assign damage as though it weren't blocked?", source, game);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SavageSummoning.java
+++ b/Mage.Sets/src/mage/cards/s/SavageSummoning.java
@@ -89,21 +89,23 @@ class SavageSummoningAsThoughEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (watcher.isSavageSummoningSpellActive()) {
-            MageObject mageObject = game.getBaseObject(objectId);
-            if (mageObject instanceof Commander) {
-                Commander commander = (Commander) mageObject;
-                if (commander.isCreature(game) && commander.isControlledBy(source.getControllerId())) {
-                    return true;
-                }
-            } else if (mageObject instanceof Card) {
-                Card card = (Card) mageObject;
-                if (card.isCreature(game) && card.isOwnedBy(source.getControllerId())) {
-                    return true;
-                }
-            }
+        if (!watcher.isSavageSummoningSpellActive()) {
+            return false;
         }
-        return false;
+        MageObject mageObject = game.getBaseObject(objectId);
+        if (mageObject == null || !mageObject.isCreature(game)){
+            return false;
+        }
+
+        if (mageObject instanceof Commander) {
+            Commander commander = (Commander) mageObject;
+            return commander.isControlledBy(source.getControllerId());
+        } else if (mageObject instanceof Card) {
+            Card card = (Card) mageObject;
+            return card.isOwnedBy(source.getControllerId());
+        } else {
+            return false;
+        }
     }
 
 }

--- a/Mage.Sets/src/mage/cards/s/SavageSummoning.java
+++ b/Mage.Sets/src/mage/cards/s/SavageSummoning.java
@@ -83,11 +83,6 @@ class SavageSummoningAsThoughEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SavageSummoningAsThoughEffect copy() {
         return new SavageSummoningAsThoughEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SchemingFence.java
+++ b/Mage.Sets/src/mage/cards/s/SchemingFence.java
@@ -208,11 +208,6 @@ class SchemingFenceManaEffect extends AsThoughEffectImpl implements AsThoughMana
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SchemingFenceManaEffect copy() {
         return new SchemingFenceManaEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/ScourgeOfNelToth.java
+++ b/Mage.Sets/src/mage/cards/s/ScourgeOfNelToth.java
@@ -65,11 +65,6 @@ class ScourgeOfNelTothPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ScourgeOfNelTothPlayEffect copy() {
         return new ScourgeOfNelTothPlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/ScourgeOfNelToth.java
+++ b/Mage.Sets/src/mage/cards/s/ScourgeOfNelToth.java
@@ -71,19 +71,22 @@ class ScourgeOfNelTothPlayEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
-        if (sourceId.equals(source.getSourceId()) && source.isControlledBy(affectedControllerId)) {
-            if (game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD) {
-                Player player = game.getPlayer(affectedControllerId);
-                if (player != null) {
-                    // can sometimes be cast with base mana cost from grave????
-                    Costs<Cost> costs = new CostsImpl<>();
-                    costs.add(new SacrificeTargetCost(new TargetControlledCreaturePermanent(2)));
-                    player.setCastSourceIdWithAlternateMana(sourceId, new ManaCostsImpl<>("{B}{B}"), costs);
-                    return true;
-                }
-            }
-        }
-        return false;
+        Player player = game.getPlayer(affectedControllerId);
+
+        return player != null
+                && sourceId.equals(source.getSourceId())
+                && source.isControlledBy(affectedControllerId)
+                && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD;
+    }
+
+    @Override
+    public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        Player player = game.getPlayer(affectedControllerId);
+
+        Costs<Cost> costs = new CostsImpl<>();
+        costs.add(new SacrificeTargetCost(new TargetControlledCreaturePermanent(2)));
+        player.setCastSourceIdWithAlternateMana(sourceId, new ManaCostsImpl<>("{B}{B}"), costs);
+        return true;
     }
 
 }

--- a/Mage.Sets/src/mage/cards/s/ScoutsWarning.java
+++ b/Mage.Sets/src/mage/cards/s/ScoutsWarning.java
@@ -74,11 +74,6 @@ class ScoutsWarningAsThoughEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ScoutsWarningAsThoughEffect copy() {
         return new ScoutsWarningAsThoughEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/ScoutsWarning.java
+++ b/Mage.Sets/src/mage/cards/s/ScoutsWarning.java
@@ -80,13 +80,13 @@ class ScoutsWarningAsThoughEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
-        if (watcher.isScoutsWarningSpellActive(source.getSourceId(), zoneChangeCounter)) {
-            Card card = game.getCard(sourceId);
-            if (card != null && card.isCreature(game) && source.isControlledBy(affectedControllerId)) {
-                return true;
-            }
+        if (!watcher.isScoutsWarningSpellActive(source.getSourceId(), zoneChangeCounter)) {
+            return false;
         }
-        return false;
+        Card card = game.getCard(sourceId);
+        return card != null
+                && card.isCreature(game)
+                && source.isControlledBy(affectedControllerId);
     }
 
 }

--- a/Mage.Sets/src/mage/cards/s/SenTriplets.java
+++ b/Mage.Sets/src/mage/cards/s/SenTriplets.java
@@ -137,11 +137,6 @@ class SenTripletsPlayFromOpponentsHandEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SenTripletsPlayFromOpponentsHandEffect copy() {
         return new SenTripletsPlayFromOpponentsHandEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SerpentsSoulJar.java
+++ b/Mage.Sets/src/mage/cards/s/SerpentsSoulJar.java
@@ -102,11 +102,6 @@ class SerpentsSoulJarCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SerpentsSoulJarCastFromExileEffect copy() {
         return new SerpentsSoulJarCastFromExileEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/ShareTheSpoils.java
+++ b/Mage.Sets/src/mage/cards/s/ShareTheSpoils.java
@@ -198,11 +198,6 @@ class ShareTheSpoilsPlayExiledCardEffect extends AsThoughEffectImpl {
     public ShareTheSpoilsPlayExiledCardEffect copy() {
         return new ShareTheSpoilsPlayExiledCardEffect(this);
     }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
 }
 
 //-- Spend mana as any color --//
@@ -214,11 +209,6 @@ class ShareTheSpoilsSpendAnyManaEffect extends AsThoughEffectImpl implements AsT
 
     private ShareTheSpoilsSpendAnyManaEffect(final ShareTheSpoilsSpendAnyManaEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/s/SharedFate.java
+++ b/Mage.Sets/src/mage/cards/s/SharedFate.java
@@ -105,11 +105,6 @@ class SharedFatePlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SharedFatePlayEffect copy() {
         return new SharedFatePlayEffect(this);
     }
@@ -135,11 +130,6 @@ class SharedFateLookEffect extends AsThoughEffectImpl {
 
     public SharedFateLookEffect(final SharedFateLookEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/s/ShowdownOfTheSkalds.java
+++ b/Mage.Sets/src/mage/cards/s/ShowdownOfTheSkalds.java
@@ -128,11 +128,6 @@ class ShowdownOfTheSkaldsMayPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         UUID objectIdToCast = CardUtil.getMainCardId(game, sourceId);
         return source.isControlledBy(affectedControllerId)

--- a/Mage.Sets/src/mage/cards/s/SiegeBehemoth.java
+++ b/Mage.Sets/src/mage/cards/s/SiegeBehemoth.java
@@ -60,15 +60,23 @@ class SiegeBehemothEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        Player controller = game.getPlayer(source.getControllerId());
         Permanent sourcePermanent = source.getSourcePermanentIfItStillExists(game);
-        if (sourcePermanent != null && sourcePermanent.isAttacking()){
-            Player controller = game.getPlayer(source.getControllerId());
-            Permanent otherCreature = game.getPermanent(sourceId);
-            if (controller != null && otherCreature != null && otherCreature.isControlledBy(controller.getId())){
-                return controller.chooseUse(Outcome.Damage, "Have " + otherCreature.getLogName() + " assign damage as though it weren't blocked?", source, game);
-            }
-        }
-        return false;
+        Permanent otherCreature = game.getPermanent(sourceId);
+
+        return controller != null
+                && sourcePermanent != null
+                && otherCreature != null
+                && sourcePermanent.isAttacking()
+                && otherCreature.isControlledBy(controller.getId());
+    }
+
+    @Override
+    public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        Player controller = game.getPlayer(source.getControllerId());
+        Permanent otherCreature = game.getPermanent(sourceId);
+
+        return controller.chooseUse(Outcome.Damage, "Have " + otherCreature.getLogName() + " assign damage as though it weren't blocked?", source, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/s/SiegeBehemoth.java
+++ b/Mage.Sets/src/mage/cards/s/SiegeBehemoth.java
@@ -73,6 +73,11 @@ class SiegeBehemothEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        // Don't ask for player input when in checkPlayable state
+        if (game.inCheckPlayableState()) {
+            return true;
+        }
+
         Player controller = game.getPlayer(source.getControllerId());
         Permanent otherCreature = game.getPermanent(sourceId);
 

--- a/Mage.Sets/src/mage/cards/s/SiegeBehemoth.java
+++ b/Mage.Sets/src/mage/cards/s/SiegeBehemoth.java
@@ -72,11 +72,6 @@ class SiegeBehemothEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SiegeBehemothEffect copy() {
         return new SiegeBehemothEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SilasRennSeekerAdept.java
+++ b/Mage.Sets/src/mage/cards/s/SilasRennSeekerAdept.java
@@ -65,11 +65,6 @@ class SilasRennSeekerAdeptPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SilasRennSeekerAdeptPlayEffect copy() {
         return new SilasRennSeekerAdeptPlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SiphonInsight.java
+++ b/Mage.Sets/src/mage/cards/s/SiphonInsight.java
@@ -130,11 +130,6 @@ class SiphonInsightCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SiphonInsightCastFromExileEffect copy() {
         return new SiphonInsightCastFromExileEffect(this);
     }
@@ -171,11 +166,6 @@ class SiphonInsightSpendAnyManaEffect extends AsThoughEffectImpl implements AsTh
 
     private SiphonInsightSpendAnyManaEffect(final SiphonInsightSpendAnyManaEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override
@@ -220,11 +210,6 @@ class SiphonInsightLookEffect extends AsThoughEffectImpl {
     private SiphonInsightLookEffect(final SiphonInsightLookEffect effect) {
         super(effect);
         this.authorizedPlayerId = effect.authorizedPlayerId;
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/s/SkaabRuinator.java
+++ b/Mage.Sets/src/mage/cards/s/SkaabRuinator.java
@@ -67,11 +67,6 @@ class SkaabRuinatorPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SkaabRuinatorPlayEffect copy() {
         return new SkaabRuinatorPlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SkyclaveShade.java
+++ b/Mage.Sets/src/mage/cards/s/SkyclaveShade.java
@@ -84,11 +84,6 @@ class SkyclaveShadeEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SkyclaveShadeEffect copy() {
         return new SkyclaveShadeEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SoulfireEruption.java
+++ b/Mage.Sets/src/mage/cards/s/SoulfireEruption.java
@@ -109,11 +109,6 @@ class SoulfireEruptionCastEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SoulfireEruptionCastEffect copy() {
         return new SoulfireEruptionCastEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SparkOfCreativity.java
+++ b/Mage.Sets/src/mage/cards/s/SparkOfCreativity.java
@@ -103,11 +103,6 @@ class SparkOfCreativityPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SparkOfCreativityPlayEffect copy() {
         return new SparkOfCreativityPlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SqueeDubiousMonarch.java
+++ b/Mage.Sets/src/mage/cards/s/SqueeDubiousMonarch.java
@@ -84,11 +84,6 @@ class SqueeDubiousMonarchEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         if (!source.getSourceId().equals(objectId)
                 || !source.isControlledBy(affectedControllerId)

--- a/Mage.Sets/src/mage/cards/s/SqueeDubiousMonarch.java
+++ b/Mage.Sets/src/mage/cards/s/SqueeDubiousMonarch.java
@@ -85,15 +85,18 @@ class SqueeDubiousMonarchEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (!source.getSourceId().equals(objectId)
-                || !source.isControlledBy(affectedControllerId)
-                || game.getState().getZone(objectId) != Zone.GRAVEYARD) {
-            return false;
-        }
         Player controller = game.getPlayer(affectedControllerId);
-        if (controller == null) {
-            return false;
-        }
+
+        return controller != null
+                && source.getSourceId().equals(objectId)
+                && source.isControlledBy(affectedControllerId)
+                && game.getState().getZone(objectId) == Zone.GRAVEYARD;
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Player controller = game.getPlayer(affectedControllerId);
+
         Costs<Cost> costs = new CostsImpl<>();
         costs.add(new ExileFromGraveCost(new TargetCardInYourGraveyard(4, filter)));
         controller.setCastSourceIdWithAlternateMana(objectId, new ManaCostsImpl<>("{3}{R}"), costs);

--- a/Mage.Sets/src/mage/cards/s/SqueeTheImmortal.java
+++ b/Mage.Sets/src/mage/cards/s/SqueeTheImmortal.java
@@ -58,11 +58,6 @@ class SqueePlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SqueePlayEffect copy() {
         return new SqueePlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/StaffOfTheAges.java
+++ b/Mage.Sets/src/mage/cards/s/StaffOfTheAges.java
@@ -49,11 +49,6 @@ class StaffOfTheAgesEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public StaffOfTheAgesEffect copy() {
         return new StaffOfTheAgesEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/StreetSavvy.java
+++ b/Mage.Sets/src/mage/cards/s/StreetSavvy.java
@@ -63,11 +63,6 @@ class StreetSavvyEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public StreetSavvyEffect copy() {
         return new StreetSavvyEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SunglassesOfUrza.java
+++ b/Mage.Sets/src/mage/cards/s/SunglassesOfUrza.java
@@ -42,11 +42,6 @@ class SunglassesOfUrzaManaAsThoughtEffect extends AsThoughEffectImpl implements 
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         return source.isControlledBy(affectedControllerId);
     }

--- a/Mage.Sets/src/mage/cards/t/TectonicGiant.java
+++ b/Mage.Sets/src/mage/cards/t/TectonicGiant.java
@@ -166,11 +166,6 @@ class TectonicGiantMayPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         return source.isControlledBy(affectedControllerId)
                 && getTargetPointer().getTargets(game, source).contains(sourceId);

--- a/Mage.Sets/src/mage/cards/t/TeferiMasterOfTime.java
+++ b/Mage.Sets/src/mage/cards/t/TeferiMasterOfTime.java
@@ -67,11 +67,6 @@ class TeferiMasterOfTimeActivationEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public TeferiMasterOfTimeActivationEffect copy() {
         return new TeferiMasterOfTimeActivationEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/t/TemporalAperture.java
+++ b/Mage.Sets/src/mage/cards/t/TemporalAperture.java
@@ -102,11 +102,6 @@ class TemporalApertureTopCardCastEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public TemporalApertureTopCardCastEffect copy() {
         return new TemporalApertureTopCardCastEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/t/TemporalAperture.java
+++ b/Mage.Sets/src/mage/cards/t/TemporalAperture.java
@@ -108,21 +108,20 @@ class TemporalApertureTopCardCastEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (affectedControllerId.equals(source.getControllerId())) {
-            Card objectCard = game.getCard(objectId);
-            if (objectCard != null) {
-                Player controller = game.getPlayer(affectedControllerId);
-                if (controller != null
-                        && game.getState().getZone(objectId) == Zone.LIBRARY) {
-                    if (controller.getLibrary().getFromTop(game).equals(card)) {
-                        if (objectCard == card && (objectCard.getSpellAbility() != null || objectCard.isLand(game))) { // only if castable or land
-                            allowCardToPlayWithoutMana(objectId, source, affectedControllerId, game);
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-        return false;
+        Card objectCard = game.getCard(objectId);
+        Player controller = game.getPlayer(affectedControllerId);
+
+        return controller != null
+                && objectCard != null
+                && affectedControllerId.equals(source.getControllerId())
+                && game.getState().getZone(objectId) == Zone.LIBRARY
+                && controller.getLibrary().getFromTop(game).equals(card)
+                && objectCard == card
+                && (objectCard.getSpellAbility() != null || objectCard.isLand(game));
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        return allowCardToPlayWithoutMana(objectId, source, affectedControllerId, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TenaciousUnderdog.java
+++ b/Mage.Sets/src/mage/cards/t/TenaciousUnderdog.java
@@ -57,11 +57,6 @@ class TenaciousUnderdogEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public TenaciousUnderdogEffect copy() {
         return new TenaciousUnderdogEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/t/TheWanderingEmperor.java
+++ b/Mage.Sets/src/mage/cards/t/TheWanderingEmperor.java
@@ -92,11 +92,6 @@ class TheWanderingEmperorEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public TheWanderingEmperorEffect copy() {
         return new TheWanderingEmperorEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/t/TheaterOfHorrors.java
+++ b/Mage.Sets/src/mage/cards/t/TheaterOfHorrors.java
@@ -104,11 +104,6 @@ class TheaterOfHorrorsCastEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public TheaterOfHorrorsCastEffect copy() {
         return new TheaterOfHorrorsCastEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/t/TheaterOfHorrors.java
+++ b/Mage.Sets/src/mage/cards/t/TheaterOfHorrors.java
@@ -114,17 +114,16 @@ class TheaterOfHorrorsCastEffect extends AsThoughEffectImpl {
         if (theCard == null) {
             return false;
         }
+
         objectId = theCard.getMainCard().getId(); // for split cards and mdfc
         PlayerLostLifeWatcher watcher = game.getState().getWatcher(PlayerLostLifeWatcher.class);
-        if (watcher != null
+        ExileZone zone = game.getExile().getExileZone(CardUtil.getCardExileZoneId(game, source));
+        return watcher != null
                 && game.isActivePlayer(source.getControllerId())
                 && watcher.getAllOppLifeLost(source.getControllerId(), game) > 0
                 && affectedControllerId.equals(source.getControllerId())
-                && game.getState().getZone(objectId) == Zone.EXILED) {
-            ExileZone zone = game.getExile().getExileZone(CardUtil.getCardExileZoneId(game, source));
-            return zone != null
-                    && zone.contains(objectId);
-        }
-        return false;
+                && game.getState().getZone(objectId) == Zone.EXILED
+                && zone != null
+                && zone.contains(objectId);
     }
 }

--- a/Mage.Sets/src/mage/cards/t/ThickSkinnedGoblin.java
+++ b/Mage.Sets/src/mage/cards/t/ThickSkinnedGoblin.java
@@ -65,11 +65,6 @@ class ThickSkinnedGoblinCostModificationEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ThickSkinnedGoblinCostModificationEffect copy() {
         return new ThickSkinnedGoblinCostModificationEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/t/ThiefOfSanity.java
+++ b/Mage.Sets/src/mage/cards/t/ThiefOfSanity.java
@@ -136,11 +136,6 @@ class ThiefOfSanityCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ThiefOfSanityCastFromExileEffect copy() {
         return new ThiefOfSanityCastFromExileEffect(this);
     }
@@ -184,11 +179,6 @@ class ThiefOfSanitySpendAnyManaEffect extends AsThoughEffectImpl implements AsTh
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ThiefOfSanitySpendAnyManaEffect copy() {
         return new ThiefOfSanitySpendAnyManaEffect(this);
     }
@@ -226,11 +216,6 @@ class ThiefOfSanityLookEffect extends AsThoughEffectImpl {
     private ThiefOfSanityLookEffect(final ThiefOfSanityLookEffect effect) {
         super(effect);
         this.authorizedPlayerId = effect.authorizedPlayerId;
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/t/ThousandYearElixir.java
+++ b/Mage.Sets/src/mage/cards/t/ThousandYearElixir.java
@@ -62,11 +62,6 @@ class ThousandYearElixirEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ThousandYearElixirEffect copy() {
         return new ThousandYearElixirEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/t/ThreeWishes.java
+++ b/Mage.Sets/src/mage/cards/t/ThreeWishes.java
@@ -131,11 +131,6 @@ class ThreeWishesLookAtCardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ThreeWishesLookAtCardEffect copy() {
         return new ThreeWishesLookAtCardEffect(this);
     }
@@ -168,11 +163,6 @@ class ThreeWishesPlayFromExileEffect extends AsThoughEffectImpl {
 
     ThreeWishesPlayFromExileEffect(final ThreeWishesPlayFromExileEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/u/UbaMask.java
+++ b/Mage.Sets/src/mage/cards/u/UbaMask.java
@@ -100,11 +100,6 @@ class UbaMaskPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public UbaMaskPlayEffect copy() {
         return new UbaMaskPlayEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/u/UginTheIneffable.java
+++ b/Mage.Sets/src/mage/cards/u/UginTheIneffable.java
@@ -206,11 +206,6 @@ class UginTheIneffableLookAtFaceDownEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public UginTheIneffableLookAtFaceDownEffect copy() {
         return new UginTheIneffableLookAtFaceDownEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/u/Undertow.java
+++ b/Mage.Sets/src/mage/cards/u/Undertow.java
@@ -49,11 +49,6 @@ class UndertowEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public UndertowEffect copy() {
         return new UndertowEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/u/UnluckyWitness.java
+++ b/Mage.Sets/src/mage/cards/u/UnluckyWitness.java
@@ -99,11 +99,6 @@ class UnluckyWitnessPlayEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         UUID objectIdToCast = CardUtil.getMainCardId(game, sourceId);
         return source.isControlledBy(affectedControllerId)

--- a/Mage.Sets/src/mage/cards/u/UrDrago.java
+++ b/Mage.Sets/src/mage/cards/u/UrDrago.java
@@ -54,11 +54,6 @@ class UrDragoEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public UrDragoEffect copy() {
         return new UrDragoEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/v/VancesBlastingCannons.java
+++ b/Mage.Sets/src/mage/cards/v/VancesBlastingCannons.java
@@ -106,11 +106,6 @@ class CastFromNonHandZoneTargetEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CastFromNonHandZoneTargetEffect copy() {
         return new CastFromNonHandZoneTargetEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/v/VancesBlastingCannons.java
+++ b/Mage.Sets/src/mage/cards/v/VancesBlastingCannons.java
@@ -112,14 +112,11 @@ class CastFromNonHandZoneTargetEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (getTargetPointer().getTargets(game, source).contains(objectId)
-                && source.isControlledBy(affectedControllerId)) {
-            Card card = game.getCard(objectId);
-            if (card != null) {
-                return true;
-            }
-        }
-        return false;
+        Card card = game.getCard(objectId);
+
+        return getTargetPointer().getTargets(game, source).contains(objectId)
+                && source.isControlledBy(affectedControllerId)
+                && card != null;
     }
 }
 

--- a/Mage.Sets/src/mage/cards/v/VivienChampionOfTheWilds.java
+++ b/Mage.Sets/src/mage/cards/v/VivienChampionOfTheWilds.java
@@ -148,11 +148,6 @@ class VivienChampionOfTheWildsLookEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public VivienChampionOfTheWildsLookEffect copy() {
         return new VivienChampionOfTheWildsLookEffect(this);
     }
@@ -180,11 +175,6 @@ class VivienChampionOfTheWildsCastFromExileEffect extends AsThoughEffectImpl {
     private VivienChampionOfTheWildsCastFromExileEffect(final VivienChampionOfTheWildsCastFromExileEffect effect) {
         super(effect);
         this.authorizedPlayerId = effect.authorizedPlayerId;
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/v/VizierOfTheMenagerie.java
+++ b/Mage.Sets/src/mage/cards/v/VizierOfTheMenagerie.java
@@ -66,11 +66,6 @@ class VizierOfTheMenagerieManaEffect extends AsThoughEffectImpl implements AsTho
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public VizierOfTheMenagerieManaEffect copy() {
         return new VizierOfTheMenagerieManaEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/w/WarmongersChariot.java
+++ b/Mage.Sets/src/mage/cards/w/WarmongersChariot.java
@@ -63,14 +63,17 @@ class WarmongersChariotEffect extends AsThoughEffectImpl {
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         Permanent equipment = game.getPermanent(source.getSourceId());
-        if (equipment != null && equipment.getAttachedTo() != null) {
-            Permanent creature = game.getPermanent(equipment.getAttachedTo());
-            if (creature != null && creature.getId().equals(sourceId)
-                    && creature.getAbilities().containsKey(DefenderAbility.getInstance().getId())) {
-                return true;
-            }
+        if (equipment == null) {
+            return false;
         }
-        return false;
+
+        Permanent creature = game.getPermanent(equipment.getAttachedTo());
+        if (creature == null) {
+            return false;
+        }
+
+        return creature.getId().equals(sourceId)
+                && creature.getAbilities().containsKey(DefenderAbility.getInstance().getId());
     }
 
 }

--- a/Mage.Sets/src/mage/cards/w/WarmongersChariot.java
+++ b/Mage.Sets/src/mage/cards/w/WarmongersChariot.java
@@ -56,11 +56,6 @@ class WarmongersChariotEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public WarmongersChariotEffect copy() {
         return new WarmongersChariotEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/w/WhispersteelDagger.java
+++ b/Mage.Sets/src/mage/cards/w/WhispersteelDagger.java
@@ -71,11 +71,6 @@ class WhispersteelDaggerCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public WhispersteelDaggerCastFromExileEffect copy() {
         return new WhispersteelDaggerCastFromExileEffect(this);
     }
@@ -119,11 +114,6 @@ class WhispersteelDaggerSpendAnyManaEffect extends AsThoughEffectImpl implements
 
     private WhispersteelDaggerSpendAnyManaEffect(final WhispersteelDaggerSpendAnyManaEffect effect) {
         super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/w/Wish.java
+++ b/Mage.Sets/src/mage/cards/w/Wish.java
@@ -90,11 +90,6 @@ class WishPlayFromSideboardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         if (source.getControllerId().equals(affectedControllerId)) {
             Player controller = game.getPlayer(source.getControllerId());

--- a/Mage.Sets/src/mage/cards/w/WordOfCommand.java
+++ b/Mage.Sets/src/mage/cards/w/WordOfCommand.java
@@ -232,11 +232,6 @@ class WordOfCommandTestFlashEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID affectedSpellId, Ability source, UUID affectedControllerId, Game game) {
         return true;
     }

--- a/Mage.Sets/src/mage/cards/w/WorldheartPhoenix.java
+++ b/Mage.Sets/src/mage/cards/w/WorldheartPhoenix.java
@@ -69,11 +69,6 @@ public final class WorldheartPhoenix extends CardImpl {
         }
 
         @Override
-        public boolean apply(Game game, Ability source) {
-            return true;
-        }
-
-        @Override
         public WorldheartPhoenixPlayEffect copy() {
             return new WorldheartPhoenixPlayEffect(this);
         }

--- a/Mage.Sets/src/mage/cards/w/WorldheartPhoenix.java
+++ b/Mage.Sets/src/mage/cards/w/WorldheartPhoenix.java
@@ -75,17 +75,20 @@ public final class WorldheartPhoenix extends CardImpl {
 
         @Override
         public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
-            if (sourceId.equals(source.getSourceId()) && source.isControlledBy(affectedControllerId)) {
-                if (game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD) {
-                    Player player = game.getPlayer(affectedControllerId);
-                    if (player != null) {
-                        // can sometimes be cast with base mana cost from grave????
-                        player.setCastSourceIdWithAlternateMana(sourceId, new ManaCostsImpl<>("{W}{U}{B}{R}{G}"), null);
-                        return true;
-                    }
-                }
-            }
-            return false;
+            Player player = game.getPlayer(affectedControllerId);
+            return player != null
+                    && sourceId.equals(source.getSourceId())
+                    && source.isControlledBy(affectedControllerId)
+                    && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD;
+
+        }
+
+        @Override
+        public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+            Player player = game.getPlayer(affectedControllerId);
+            player.setCastSourceIdWithAlternateMana(sourceId, new ManaCostsImpl<>("{W}{U}{B}{R}{G}"), null);
+
+            return true;
         }
 
     }

--- a/Mage.Sets/src/mage/cards/x/XanatharGuildKingpin.java
+++ b/Mage.Sets/src/mage/cards/x/XanatharGuildKingpin.java
@@ -147,11 +147,6 @@ class SpendManaAsAnyColorToCastTopOfLibraryTargetEffect extends AsThoughEffectIm
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SpendManaAsAnyColorToCastTopOfLibraryTargetEffect copy() {
         return new SpendManaAsAnyColorToCastTopOfLibraryTargetEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/x/XandersPact.java
+++ b/Mage.Sets/src/mage/cards/x/XandersPact.java
@@ -113,10 +113,14 @@ class XandersPactCastEffect extends CanPlayCardControllerEffect {
             return false;
         }
         Card cardToCheck = game.getCard(objectId);
-        if (cardToCheck.isLand(game)) {
-            return false;
-        }
+        return cardToCheck != null && !cardToCheck.isLand(game);
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        Card cardToCheck = game.getCard(objectId);
         Player controller = game.getPlayer(source.getControllerId());
+
         Costs<Cost> newCosts = new CostsImpl<>();
         newCosts.add(new PayLifeCost(cardToCheck.getManaValue()));
         newCosts.addAll(cardToCheck.getSpellAbility().getCosts());

--- a/Mage/src/main/java/mage/abilities/common/CastFromGraveyardOnceStaticAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/CastFromGraveyardOnceStaticAbility.java
@@ -62,11 +62,6 @@ class CastFromGraveyardOnceEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         if (source.isControlledBy(affectedControllerId)
                 && Zone.GRAVEYARD.equals(game.getState().getZone(objectId))

--- a/Mage/src/main/java/mage/abilities/decorator/ConditionalAsThoughEffect.java
+++ b/Mage/src/main/java/mage/abilities/decorator/ConditionalAsThoughEffect.java
@@ -67,28 +67,62 @@ public class ConditionalAsThoughEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
-        conditionState = condition.apply(game, source);
-        if (conditionState) {
-            effect.setTargetPointer(this.targetPointer);
-            return effect.applies(sourceId, affectedAbility, source, game, playerId);
+        boolean conditionStateTmp = condition.apply(game, source);
+        if (conditionStateTmp) {
+            AsThoughEffect effectCopy = effect.copy();
+            effectCopy.setTargetPointer(this.targetPointer);
+            return effectCopy.applies(sourceId, affectedAbility, source, game, playerId);
         } else if (otherwiseEffect != null) {
-            otherwiseEffect.setTargetPointer(this.targetPointer);
-            return otherwiseEffect.applies(sourceId, affectedAbility, source, game, playerId);
+            AsThoughEffect otherwiseEffectCopy = otherwiseEffect.copy();
+            otherwiseEffectCopy.setTargetPointer(this.targetPointer);
+            return otherwiseEffectCopy.applies(sourceId, affectedAbility, source, game, playerId);
+        } else {
+            return false;
         }
-        return false;
     }
 
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        boolean conditionStateTmp = condition.apply(game, source);
+        if (conditionStateTmp) {
+            AsThoughEffect effectCopy = effect.copy();
+            effectCopy.setTargetPointer(this.targetPointer);
+            return effectCopy.applies(sourceId, source, affectedControllerId, game);
+        } else if (otherwiseEffect != null) {
+            AsThoughEffect otherwiseEffectCopy = otherwiseEffect.copy();
+            otherwiseEffectCopy.setTargetPointer(this.targetPointer);
+            return otherwiseEffectCopy.applies(sourceId, source, affectedControllerId, game);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean apply(UUID sourceId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
         conditionState = condition.apply(game, source);
         if (conditionState) {
             effect.setTargetPointer(this.targetPointer);
-            return effect.applies(sourceId, source, affectedControllerId, game);
+            return effect.apply(sourceId, affectedAbility, source, game, playerId);
         } else if (otherwiseEffect != null) {
             otherwiseEffect.setTargetPointer(this.targetPointer);
-            return otherwiseEffect.applies(sourceId, source, affectedControllerId, game);
+            return otherwiseEffect.apply(sourceId, affectedAbility, source, game, playerId);
+        } else {
+            return false;
         }
-        return false;
+    }
+
+    @Override
+    public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        conditionState = condition.apply(game, source);
+        if (conditionState) {
+            effect.setTargetPointer(this.targetPointer);
+            return effect.apply(sourceId, source, affectedControllerId, game);
+        } else if (otherwiseEffect != null) {
+            otherwiseEffect.setTargetPointer(this.targetPointer);
+            return otherwiseEffect.apply(sourceId, source, affectedControllerId, game);
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/decorator/ConditionalAsThoughEffect.java
+++ b/Mage/src/main/java/mage/abilities/decorator/ConditionalAsThoughEffect.java
@@ -68,6 +68,7 @@ public class ConditionalAsThoughEffect extends AsThoughEffectImpl {
     @Override
     public boolean applies(UUID sourceId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
         boolean conditionStateTmp = condition.apply(game, source);
+        // TODO: I don't think this works properly. If I copy the effect, then the calls to discard() won't work
         if (conditionStateTmp) {
             AsThoughEffect effectCopy = effect.copy();
             effectCopy.setTargetPointer(this.targetPointer);

--- a/Mage/src/main/java/mage/abilities/decorator/ConditionalAsThoughEffect.java
+++ b/Mage/src/main/java/mage/abilities/decorator/ConditionalAsThoughEffect.java
@@ -7,8 +7,11 @@ import mage.abilities.Ability;
 import mage.abilities.condition.Condition;
 import mage.abilities.effects.AsThoughEffect;
 import mage.abilities.effects.AsThoughEffectImpl;
+import mage.abilities.effects.Effect;
 import mage.constants.Duration;
 import mage.game.Game;
+import mage.target.targetpointer.FirstTargetPointer;
+import mage.target.targetpointer.TargetPointer;
 
 /**
  * @author LevelX2
@@ -67,63 +70,58 @@ public class ConditionalAsThoughEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
-        boolean conditionStateTmp = condition.apply(game, source);
-        // TODO: I don't think this works properly. If I copy the effect, then the calls to discard() won't work
-        if (conditionStateTmp) {
-            AsThoughEffect effectCopy = effect.copy();
-            effectCopy.setTargetPointer(this.targetPointer);
-            return effectCopy.applies(sourceId, affectedAbility, source, game, playerId);
-        } else if (otherwiseEffect != null) {
-            AsThoughEffect otherwiseEffectCopy = otherwiseEffect.copy();
-            otherwiseEffectCopy.setTargetPointer(this.targetPointer);
-            return otherwiseEffectCopy.applies(sourceId, affectedAbility, source, game, playerId);
-        } else {
+        AsThoughEffect effectOrOtherwiseEffect = condition.apply(game, source) ? effect : otherwiseEffect;
+        if (effectOrOtherwiseEffect == null) {
             return false;
         }
+
+        // Function can't have side-effects, so reset target pointer after checking.
+        TargetPointer originalTargetPoint = effectOrOtherwiseEffect.getTargetPointer();
+
+        effectOrOtherwiseEffect.setTargetPointer(this.targetPointer);
+        boolean appliesTrue = effectOrOtherwiseEffect.applies(sourceId, affectedAbility, source, game, playerId);
+        effectOrOtherwiseEffect.setTargetPointer(originalTargetPoint);
+
+        return appliesTrue;
     }
 
     @Override
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
-        boolean conditionStateTmp = condition.apply(game, source);
-        if (conditionStateTmp) {
-            AsThoughEffect effectCopy = effect.copy();
-            effectCopy.setTargetPointer(this.targetPointer);
-            return effectCopy.applies(sourceId, source, affectedControllerId, game);
-        } else if (otherwiseEffect != null) {
-            AsThoughEffect otherwiseEffectCopy = otherwiseEffect.copy();
-            otherwiseEffectCopy.setTargetPointer(this.targetPointer);
-            return otherwiseEffectCopy.applies(sourceId, source, affectedControllerId, game);
-        } else {
+        AsThoughEffect effectOrOtherwiseEffect = condition.apply(game, source) ? effect : otherwiseEffect;
+        if (effectOrOtherwiseEffect == null) {
             return false;
         }
+
+        // Function can't have side-effects, so reset target pointer after checking.
+        TargetPointer originalTargetPoint = effectOrOtherwiseEffect.getTargetPointer();
+
+        effectOrOtherwiseEffect.setTargetPointer(this.targetPointer);
+        boolean appliesTrue = effectOrOtherwiseEffect.applies(sourceId, source, affectedControllerId, game);
+        effectOrOtherwiseEffect.setTargetPointer(originalTargetPoint);
+
+        return appliesTrue;
     }
 
     @Override
     public boolean apply(UUID sourceId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
-        conditionState = condition.apply(game, source);
-        if (conditionState) {
-            effect.setTargetPointer(this.targetPointer);
-            return effect.apply(sourceId, affectedAbility, source, game, playerId);
-        } else if (otherwiseEffect != null) {
-            otherwiseEffect.setTargetPointer(this.targetPointer);
-            return otherwiseEffect.apply(sourceId, affectedAbility, source, game, playerId);
-        } else {
-            return false;
-        }
+        // If we get to this function then .applies has already returned true, so we know that either
+        // effect or otherwiseEffect will be call, no need for the else-if and else like above, the third option
+        // will never happen since it will return false from .applies.
+        AsThoughEffect effectOrOtherwiseEffect = condition.apply(game, source) ? effect : otherwiseEffect;
+        effectOrOtherwiseEffect.setTargetPointer(this.targetPointer);
+
+        return effectOrOtherwiseEffect.apply(sourceId, affectedAbility, source, game, playerId);
     }
 
     @Override
     public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
-        conditionState = condition.apply(game, source);
-        if (conditionState) {
-            effect.setTargetPointer(this.targetPointer);
-            return effect.apply(sourceId, source, affectedControllerId, game);
-        } else if (otherwiseEffect != null) {
-            otherwiseEffect.setTargetPointer(this.targetPointer);
-            return otherwiseEffect.apply(sourceId, source, affectedControllerId, game);
-        } else {
-            return false;
-        }
+        // If we get to this function then .applies has already returned true, so we know that either
+        // effect or otherwiseEffect will be call, no need for the else-if and else like above, the third option
+        // will never happen since it will return false from .applies.
+        AsThoughEffect effectOrOtherwiseEffect = condition.apply(game, source) ? effect : otherwiseEffect;
+        effectOrOtherwiseEffect.setTargetPointer(this.targetPointer);
+
+        return effectOrOtherwiseEffect.apply(sourceId, source, affectedControllerId, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/AsThoughEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/AsThoughEffect.java
@@ -46,6 +46,10 @@ public interface AsThoughEffect extends ContinuousEffect {
     boolean applies(UUID sourceId, Ability affectedAbility, Ability source, Game game, UUID playerId);
 
     /**
+     * TODO Need refactoring
+     *      - SpendManaAsAnyColorToCastTopOfLibraryTargetEffect
+     */
+    /**
      * WARNING: DO NOT CHANGE STATE IN THIS FUNCTION. (other than discard the effect)
      * If your implementation requires that the state of the game be changed, any information stored, or the player asked
      * a question, you must do all of that in the `.apply()` functions from this class.

--- a/Mage/src/main/java/mage/abilities/effects/AsThoughEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/AsThoughEffect.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 public interface AsThoughEffect extends ContinuousEffect {
 
     // TODO: sourceId appears to have been renamed to objectId
+    // TODO: Change order of game and playerId to match other function
     /**
      * WARNING: DO NOT CHANGE STATE IN THIS FUNCTION. (other than discard the effect)
      * If your implementation requires that the state of the game be changed, any information stored, or the player asked
@@ -66,6 +67,7 @@ public interface AsThoughEffect extends ContinuousEffect {
      */
     boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game);
 
+    // TODO: Change order of game and playerId to match other function
     /**
      * Called after {@link AsThoughEffect#applies(UUID, Ability, Ability, Game, UUID)} has been called and returned true.
      * Put any code that requires changing of state, storing of information, or asking the player for input in this method.

--- a/Mage/src/main/java/mage/abilities/effects/AsThoughEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/AsThoughEffect.java
@@ -7,35 +7,86 @@ import mage.game.Game;
 import java.util.UUID;
 
 /**
- * @author BetaSteward_at_googlemail.com
+ * This class functions in two steps:
+ * 1. Check if the effect `applies` to a given situation using the two `.applies()` method.
+ * 2. If the effect applies (because `.applies()` return true) then the corresponding `.apply()` method
+ *    will be called to make any of the required changes to the state.
+ * <p>
+ * The `.applies()` method MUST NOT change the state of the game as they are called multiple times in the course of
+ * figuring out which cards and abilities are playable.
+ * <p>
+ * For example. Bolas's Citadel allows you to play lands and cast spells from the top of your library.
+ * Its `.applies()` method must only check if the the specified card can be played.
+ * The changing of casting cost (mana to life) MUST be handled by the `.apply()` method.
+ *
+ * @author BetaSteward_at_googlemail.com, Alex-Vasile
  */
 public interface AsThoughEffect extends ContinuousEffect {
 
+    // TODO: sourceId appears to have been renamed to objectId
     /**
-     * Apply to ONE affected ability from the object (sourceId)
+     * WARNING: DO NOT CHANGE STATE IN THIS FUNCTION. (other than discard the effect)
+     * If your implementation requires that the state of the game be changed, any information stored, or the player asked
+     * a question, you must do all of that in the `.apply()` functions from this class.
+     * For the purpose of the `.applies()` methods, assume that the player will pick whichever answer allows for the
+     * greatest number of abilities to be used.
+     * <p>
+     * Check if the asThoughEffect applies for the SINGLE specified ability from the object (sourceId).
      * <p>
      * Warning, if you don't need ability to check then ignore it (by default it calls full object check)
      * Warning, if you use conditional effect then you must override both applies methods to support different types
      *
-     * @param sourceId
-     * @param affectedAbility ability to check (example: check if spell ability can be cast from non hand)
-     * @param source
-     * @param game
-     * @param playerId        player to check
-     * @return
+     * @param sourceId          object to check
+     * @param affectedAbility   ability from object to check (example: check if spell ability can be cast from non hand)
+     * @param source            ability that created this effect
+     * @param game              game to check in
+     * @param playerId          player to check
+     * @return                  boolean indicating if the effect can apply (i.e. applies) for affectedAbility from sourceId.
      */
     boolean applies(UUID sourceId, Ability affectedAbility, Ability source, Game game, UUID playerId);
 
     /**
+     * WARNING: DO NOT CHANGE STATE IN THIS FUNCTION. (other than discard the effect)
+     * If your implementation requires that the state of the game be changed, any information stored, or the player asked
+     * a question, you must do all of that in the `.apply()` functions from this class.
+     * For the purpose of the `.applies()` methods, assume that the player will pick whichever answer allows for the
+     * greatest number of abilities to be used.
+     * <p>
      * Apply to ANY ability from the object (sourceId)
      *
-     * @param sourceId             object to check
-     * @param source
-     * @param affectedControllerId player to check (example: you can activate opponent's card or ability)
-     * @param game
-     * @return
+     * @param sourceId              object to check
+     * @param source                TODO
+     * @param affectedControllerId  player to check (example: you can activate opponent's card or ability)
+     * @param game                  game to check in
+     * @return                      boolean indicating if the effect can apply (i.e. applies) for sourceId.
      */
     boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game);
+
+    /**
+     * Called after {@link AsThoughEffect#applies(UUID, Ability, Ability, Game, UUID)} has been called and returned true.
+     * Put any code that requires changing of state, storing of information, or asking the player for input in this method.
+     *
+     * @param sourceId          object whose ability to check
+     * @param affectedAbility   ability to check
+     * @param source            TODO
+     * @param game              game to apply the effect in
+     * @param playerId          player to check
+     * @return                  boolean indicating if the effect WAS APPLIED to affectedAbility from sourceId.
+     */
+    boolean apply(UUID sourceId, Ability affectedAbility, Ability source, Game game, UUID playerId);
+
+    /**
+     * Called after {@link AsThoughEffect#applies(UUID, Ability, UUID, Game)} has been called and returned true.
+     * Put any code that requires changing of state, storing of information, or asking the player for input in this method.
+     *
+     *
+     * @param sourceId              Object to check
+     * @param source                TODO
+     * @param affectedControllerId  player to check if the effect applies to them
+     * @param game                  game to apply the effect in
+     * @return                      boolean indicating if the effect WAS APPLIED to sourceId.
+     */
+    boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game);
 
     AsThoughEffectType getAsThoughEffectType();
 

--- a/Mage/src/main/java/mage/abilities/effects/AsThoughEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/AsThoughEffectImpl.java
@@ -52,6 +52,19 @@ public abstract class AsThoughEffectImpl extends ContinuousEffectImpl implements
     }
 
     @Override
+    public boolean apply(UUID sourceId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
+        // Default implementation will simply check the whole card, just like `.applies()`.
+        return apply(sourceId, source, playerId, game);
+    }
+
+    @Override
+    public boolean apply(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        // Overriding and returning true since most effects will not need to change state.
+        // This will cut down on the boilerplate code.
+        return true;
+    }
+
+    @Override
     public AsThoughEffectType getAsThoughEffectType() {
         return type;
     }

--- a/Mage/src/main/java/mage/abilities/effects/AsThoughEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/AsThoughEffectImpl.java
@@ -45,6 +45,12 @@ public abstract class AsThoughEffectImpl extends ContinuousEffectImpl implements
         return applies(objectId, source, playerId, game);
     }
 
+    // TODO: Is the override in ConditionalAsThoughEffect needed?
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return true;
+    }
+
     @Override
     public AsThoughEffectType getAsThoughEffectType() {
         return type;

--- a/Mage/src/main/java/mage/abilities/effects/CastCardFromGraveyardThenExileItEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/CastCardFromGraveyardThenExileItEffect.java
@@ -56,11 +56,6 @@ class CastCardFromGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CastCardFromGraveyardEffect copy() {
         return new CastCardFromGraveyardEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/CanBlockAsThoughtItHadShadowEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CanBlockAsThoughtItHadShadowEffect.java
@@ -21,11 +21,6 @@ public class CanBlockAsThoughtItHadShadowEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CanBlockAsThoughtItHadShadowEffect copy() {
         return new CanBlockAsThoughtItHadShadowEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/ExileAdventureSpellEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ExileAdventureSpellEffect.java
@@ -81,11 +81,6 @@ class AdventureCastFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public AdventureCastFromExileEffect copy() {
         return new AdventureCastFromExileEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/asthought/CanPlayCardControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/asthought/CanPlayCardControllerEffect.java
@@ -47,11 +47,6 @@ public class CanPlayCardControllerEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CanPlayCardControllerEffect copy() {
         return new CanPlayCardControllerEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/asthought/PlayFromNotOwnHandZoneAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/asthought/PlayFromNotOwnHandZoneAllEffect.java
@@ -40,11 +40,6 @@ public class PlayFromNotOwnHandZoneAllEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public PlayFromNotOwnHandZoneAllEffect copy() {
         return new PlayFromNotOwnHandZoneAllEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/asthought/PlayFromNotOwnHandZoneTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/asthought/PlayFromNotOwnHandZoneTargetEffect.java
@@ -130,9 +130,14 @@ public class PlayFromNotOwnHandZoneTargetEffect extends AsThoughEffectImpl {
             return false;
         }
 
+        return true;
+    }
+
+    @Override
+    public boolean apply(UUID objectId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
         // OK, allow to play
         if (withoutMana) {
-            allowCardToPlayWithoutMana(objectId, source, playerId, game);
+            return allowCardToPlayWithoutMana(objectId, source, playerId, game);
         }
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/asthought/PlayFromNotOwnHandZoneTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/asthought/PlayFromNotOwnHandZoneTargetEffect.java
@@ -66,11 +66,6 @@ public class PlayFromNotOwnHandZoneTargetEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public PlayFromNotOwnHandZoneTargetEffect copy() {
         return new PlayFromNotOwnHandZoneTargetEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/asthought/YouMaySpendManaAsAnyColorToCastTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/asthought/YouMaySpendManaAsAnyColorToCastTargetEffect.java
@@ -42,11 +42,6 @@ public class YouMaySpendManaAsAnyColorToCastTargetEffect extends AsThoughEffectI
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public YouMaySpendManaAsAnyColorToCastTargetEffect copy() {
         return new YouMaySpendManaAsAnyColorToCastTargetEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/combat/CanAttackAsThoughItDidntHaveDefenderAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/combat/CanAttackAsThoughItDidntHaveDefenderAllEffect.java
@@ -35,11 +35,6 @@ public class CanAttackAsThoughItDidntHaveDefenderAllEffect extends AsThoughEffec
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         Permanent permanent = game.getPermanent(objectId);
         return filter.match(permanent, source.getControllerId(), source, game);

--- a/Mage/src/main/java/mage/abilities/effects/common/combat/CanAttackAsThoughItDidntHaveDefenderSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/combat/CanAttackAsThoughItDidntHaveDefenderSourceEffect.java
@@ -31,11 +31,6 @@ public class CanAttackAsThoughItDidntHaveDefenderSourceEffect extends AsThoughEf
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CanAttackAsThoughItDidntHaveDefenderSourceEffect copy() {
         return new CanAttackAsThoughItDidntHaveDefenderSourceEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/combat/CanAttackAsThoughItDidntHaveDefenderTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/combat/CanAttackAsThoughItDidntHaveDefenderTargetEffect.java
@@ -26,11 +26,6 @@ public class CanAttackAsThoughItDidntHaveDefenderTargetEffect extends AsThoughEf
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CanAttackAsThoughItDidntHaveDefenderTargetEffect copy() {
         return new CanAttackAsThoughItDidntHaveDefenderTargetEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/ActivateAbilitiesAnyTimeYouCouldCastInstantEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/ActivateAbilitiesAnyTimeYouCouldCastInstantEffect.java
@@ -28,11 +28,6 @@ public class ActivateAbilitiesAnyTimeYouCouldCastInstantEffect extends AsThoughE
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ActivateAbilitiesAnyTimeYouCouldCastInstantEffect copy() {
         return new ActivateAbilitiesAnyTimeYouCouldCastInstantEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/CastAsThoughItHadFlashAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/CastAsThoughItHadFlashAllEffect.java
@@ -40,11 +40,6 @@ public class CastAsThoughItHadFlashAllEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CastAsThoughItHadFlashAllEffect copy() {
         return new CastAsThoughItHadFlashAllEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/CastAsThoughItHadFlashSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/CastAsThoughItHadFlashSourceEffect.java
@@ -26,11 +26,6 @@ public class CastAsThoughItHadFlashSourceEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CastAsThoughItHadFlashSourceEffect copy() {
         return new CastAsThoughItHadFlashSourceEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/PlayTheTopCardEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/PlayTheTopCardEffect.java
@@ -76,11 +76,6 @@ public class PlayTheTopCardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public PlayTheTopCardEffect copy() {
         return new PlayTheTopCardEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/ruleModifying/PlayLandsFromGraveyardControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ruleModifying/PlayLandsFromGraveyardControllerEffect.java
@@ -36,12 +36,6 @@ public class PlayLandsFromGraveyardControllerEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-
-    @Override
     public PlayLandsFromGraveyardControllerEffect copy() {
         return new PlayLandsFromGraveyardControllerEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/keyword/AftermathAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/AftermathAbility.java
@@ -63,11 +63,6 @@ class AftermathCastFromGraveyard extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public AftermathCastFromGraveyard copy() {
         return new AftermathCastFromGraveyard(this);
     }

--- a/Mage/src/main/java/mage/abilities/keyword/ForetellAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ForetellAbility.java
@@ -161,11 +161,6 @@ public class ForetellAbility extends SpecialAction {
         }
 
         @Override
-        public boolean apply(Game game, Ability source) {
-            return true;
-        }
-
-        @Override
         public ForetellLookAtCardEffect copy() {
             return new ForetellLookAtCardEffect(this);
         }

--- a/Mage/src/main/java/mage/abilities/keyword/HideawayAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/HideawayAbility.java
@@ -121,11 +121,6 @@ class HideawayLookAtFaceDownCardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public HideawayLookAtFaceDownCardEffect copy() {
         return new HideawayLookAtFaceDownCardEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/keyword/OfferingAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/OfferingAbility.java
@@ -182,6 +182,11 @@ class OfferingAsThoughEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean apply(UUID sourceId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
+        // Don't ask for player input when in checkPlayable state
+        if (game.inCheckPlayableState()) {
+            return true;
+        }
+
         Card spellToCast = game.getCard(source.getSourceId());
         Card card = game.getCard(sourceId);
         Player player = game.getPlayer(source.getControllerId());

--- a/Mage/src/main/java/mage/abilities/keyword/OfferingAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/OfferingAbility.java
@@ -131,11 +131,6 @@ class OfferingAsThoughEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public OfferingAsThoughEffect copy() {
         return new OfferingAsThoughEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/keyword/OfferingAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/OfferingAbility.java
@@ -142,61 +142,76 @@ class OfferingAsThoughEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID sourceId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
-        if (sourceId.equals(source.getSourceId())) {
-            Card card = game.getCard(sourceId);
-            if (card == null || !card.isOwnedBy(source.getControllerId())) {
+        if (!sourceId.equals(source.getSourceId())) {
+            return false;
+        }
+
+        Card card = game.getCard(sourceId);
+        Player player = game.getPlayer(source.getControllerId());
+        if (card == null || player == null || !card.isOwnedBy(source.getControllerId())) {
+            return false;
+        }
+        // because can activate is always called twice, result from first call will be used
+        Object object = game.getState().getValue("offering_" + card.getId());
+        if (object != null && object.equals(true)) {
+            Object alreadyConfirmed = game.getState().getValue("offering_ok_" + card.getId());
+            game.getState().setValue("offering_" + card.getId(), null);
+            game.getState().setValue("offering_ok_" + card.getId(), null);
+            return alreadyConfirmed != null;
+        } else {
+            // first call -> remove previous Ids
+            game.getState().setValue("offering_Id_" + card.getId(), null);
+        }
+
+        if (game.getBattlefield().count(((OfferingAbility) source).getFilter(), source.getControllerId(), source, game) == 0) {
+            return false;
+        }
+
+        if (game.inCheckPlayableState()) {
+            return true;
+        }
+
+        Card spellToCast = game.getCard(source.getSourceId());
+        if (spellToCast == null) {
+            return false;
+        }
+
+        // Assume the player chooses to use the ability
+        return true;
+    }
+
+    @Override
+    public boolean apply(UUID sourceId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
+        Card spellToCast = game.getCard(source.getSourceId());
+        Card card = game.getCard(sourceId);
+        Player player = game.getPlayer(source.getControllerId());
+        FilterControlledCreaturePermanent filter = ((OfferingAbility) source).getFilter();
+
+        if (!player.chooseUse(Outcome.Benefit, "Offer a " + filter.getMessage() + " to cast " + spellToCast.getName() + '?', source, game)) {
+            game.getState().setValue("offering_" + card.getId(), true);
+            return false;
+        } else {
+            Target target = new TargetControlledCreaturePermanent(1, 1, filter, true);
+            player.chooseTarget(Outcome.Sacrifice, target, source, game);
+            if (!target.isChosen()) {
                 return false;
             }
-            // because can activate is always called twice, result from first call will be used
-            Object object = game.getState().getValue("offering_" + card.getId());
-            if (object != null && object.equals(true)) {
-                Object alreadyConfirmed = game.getState().getValue("offering_ok_" + card.getId());
-                game.getState().setValue("offering_" + card.getId(), null);
-                game.getState().setValue("offering_ok_" + card.getId(), null);
-                return alreadyConfirmed != null;
-            } else {
-                // first call -> remove previous Ids
-                game.getState().setValue("offering_Id_" + card.getId(), null);
+            game.getState().setValue("offering_" + card.getId(), true);
+            Permanent offer = game.getPermanent(target.getFirstTarget());
+            if (offer == null) {
+                return false;
             }
-
-            if (game.getBattlefield().count(((OfferingAbility) source).getFilter(), source.getControllerId(), source, game) > 0) {
-
-                if (game.inCheckPlayableState()) {
-                    return true;
-                }
-                FilterControlledCreaturePermanent filter = ((OfferingAbility) source).getFilter();
-                Card spellToCast = game.getCard(source.getSourceId());
-                if (spellToCast == null) {
-                    return false;
-                }
-                Player player = game.getPlayer(source.getControllerId());
-                if (player != null
-                        && player.chooseUse(Outcome.Benefit, "Offer a " + filter.getMessage() + " to cast " + spellToCast.getName() + '?', source, game)) {
-                    Target target = new TargetControlledCreaturePermanent(1, 1, filter, true);
-                    player.chooseTarget(Outcome.Sacrifice, target, source, game);
-                    if (!target.isChosen()) {
-                        return false;
-                    }
-                    game.getState().setValue("offering_" + card.getId(), true);
-                    Permanent offer = game.getPermanent(target.getFirstTarget());
-                    if (offer != null) {
-                        UUID activationId = UUID.randomUUID();
-                        OfferingCostReductionEffect effect = new OfferingCostReductionEffect(activationId);
-                        effect.setTargetPointer(new FixedTarget(offer, game));
-                        game.addEffect(effect, source);
-                        game.getState().setValue("offering_ok_" + card.getId(), true);
-                        game.getState().setValue("offering_Id_" + card.getId(), activationId);
-                        game.informPlayers(player.getLogName() + " announces to offer "
-                                + offer.getLogName() + " to cast "
-                                + GameLog.getColoredObjectName(spellToCast));// No id name to prevent to offer hand card knowledge after cancel casting
-                        return true;
-                    }
-                } else {
-                    game.getState().setValue("offering_" + card.getId(), true);
-                }
-            }
+            UUID activationId = UUID.randomUUID();
+            OfferingCostReductionEffect effect = new OfferingCostReductionEffect(activationId);
+            effect.setTargetPointer(new FixedTarget(offer, game));
+            game.addEffect(effect, source);
+            game.getState().setValue("offering_ok_" + card.getId(), true);
+            game.getState().setValue("offering_Id_" + card.getId(), activationId);
+            game.informPlayers(player.getLogName() + " announces to offer "
+                    + offer.getLogName() + " to cast "
+                    + GameLog.getColoredObjectName(spellToCast));// No id name to prevent to offer hand card knowledge after cancel casting
+            return true;
         }
-        return false;
     }
 }
 

--- a/Mage/src/main/java/mage/abilities/keyword/RepairAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/RepairAbility.java
@@ -68,11 +68,6 @@ class RepairCastFromGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public RepairCastFromGraveyardEffect copy() {
         return new RepairCastFromGraveyardEffect(this);
     }

--- a/Mage/src/main/java/mage/game/command/emblems/JayaBallardEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/JayaBallardEmblem.java
@@ -47,11 +47,6 @@ class JayaBallardCastFromGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public JayaBallardCastFromGraveyardEffect copy() {
         return new JayaBallardCastFromGraveyardEffect(this);
     }

--- a/Mage/src/main/java/mage/game/command/emblems/TibaltCosmicImpostorEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/TibaltCosmicImpostorEmblem.java
@@ -41,11 +41,6 @@ class TibaltCosmicImpostorPlayFromExileEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public TibaltCosmicImpostorPlayFromExileEffect copy() {
         return new TibaltCosmicImpostorPlayFromExileEffect(this);
     }


### PR DESCRIPTION
See related issue for explanation of why it's needed.

The idea is is that `AsThoughEffect` `.applies()` method (both version) is split into two functions `.applies` and `.apply` (both taking the same parameters. The `.applies()` checks if the AsThoughEffect *applies* to the situation. 

The important thing is that `.applies` does **not** (for the most part, see TODOs at the bottom) make changes to the state or ask the user for anything. All of that must be handled by the `.apply()` method.  the `.apply()` method is called if and only if `.applies()` returns `true`.

This does **not** address any of the problems that #9268 is trying to address. After this is merged, that PR will be rebased off of this one and re-written with the new functions in mind. Because of that `asThough()` and `asThoughMana()` look a little funny. They do not take advantage of the changes yet, that will be done in #9268 afterwards.

Changes:
- `AsThoughEffectImpl` now implements a default `.apply(Game, Ability)`. All of the Overrides were simply returning `true`.
- Split the functionality found in `.applies()` over into 2 functions.
- Simplified several highly nested AsThoughEffects that I ran across.

TODOs:
- [ ] The rest of the TODOs
- [ ] Figure out how to deal with `.discard()` in `.applies()` and with `IntetTheDreamerLookEffect`.
	- I left these calls in there since they require the information available only inside .applies. There is no way to know if the effects left in there must be applied once the `.applies()` method returns. Importantly, they cannot be placed in `.apply()` since the changes in question would always be accompanied by a `.applies()` returning `false` (so `.apply()` would not be called)
- [ ] Should I merge this and #9268 and fix those issues in here as well?

TODO after this is merged:
- [ ] change parameter name and ordering of .applies to be consistent (no functional changes but will add a lot of noise to this PR)

Closes #9521.