### PR TITLE
Cleanup instanceof checks for MDFC and the rest

### DIFF
--- a/Mage/src/main/java/mage/cards/AdventureCard.java
+++ b/Mage/src/main/java/mage/cards/AdventureCard.java
@@ -10,6 +10,7 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.ZoneChangeEvent;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -46,6 +47,11 @@ public abstract class AdventureCard extends CardImpl {
     public void assignNewId() {
         super.assignNewId();
         spellCard.assignNewId();
+    }
+
+    @Override
+    public List<SubCard> getSubCards() {
+        return Arrays.asList(spellCard);
     }
 
     @Override

--- a/Mage/src/main/java/mage/cards/Card.java
+++ b/Mage/src/main/java/mage/cards/Card.java
@@ -18,6 +18,7 @@ import mage.game.permanent.Permanent;
 import mage.util.ManaUtil;
 import mage.watchers.common.CommanderPlaysCountWatcher;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -215,4 +216,8 @@ public interface Card extends MageObject {
      * @return
      */
     boolean hasSubTypeForDeckbuilding(SubType subType);
+
+    default List<SubCard> getSubCards() {
+        return new ArrayList<>();
+    }
 }

--- a/Mage/src/main/java/mage/cards/ModalDoubleFacesCard.java
+++ b/Mage/src/main/java/mage/cards/ModalDoubleFacesCard.java
@@ -15,9 +15,7 @@ import mage.game.events.ZoneChangeEvent;
 import mage.util.CardUtil;
 import mage.util.SubTypes;
 
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * @author JayDi85
@@ -44,6 +42,11 @@ public abstract class ModalDoubleFacesCard extends CardImpl implements CardWithH
         ((ModalDoubleFacesCardHalf) leftHalfCard).setParentCard(this);
         this.rightHalfCard = card.rightHalfCard.copy();
         ((ModalDoubleFacesCardHalf) rightHalfCard).setParentCard(this);
+    }
+
+    @Override
+    public List<SubCard> getSubCards() {
+        return (List<SubCard>) Arrays.asList((SubCard) leftHalfCard, (SubCard) rightHalfCard);
     }
 
     public ModalDoubleFacesCardHalf getLeftHalfCard() {

--- a/Mage/src/main/java/mage/cards/SplitCard.java
+++ b/Mage/src/main/java/mage/cards/SplitCard.java
@@ -12,6 +12,7 @@ import mage.game.Game;
 import mage.game.events.ZoneChangeEvent;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -48,6 +49,11 @@ public abstract class SplitCard extends CardImpl implements CardWithHalves {
         leftHalfCard.setParentCard(this);
         this.rightHalfCard = rightHalfCard;
         rightHalfCard.setParentCard(this);
+    }
+
+    @Override
+    public List<SubCard> getSubCards() {
+        return (List<SubCard>) Arrays.asList((SubCard) leftHalfCard, (SubCard) rightHalfCard);
     }
 
     public SplitCardHalf getLeftHalfCard() {

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -317,28 +317,9 @@ public abstract class GameImpl implements Game {
             addCardToState(card);
 
             // parts
-            if (card instanceof SplitCard) {
-                // left
-                Card leftCard = ((SplitCard) card).getLeftHalfCard();
-                leftCard.setOwnerId(ownerId);
-                addCardToState(leftCard);
-                // right
-                Card rightCard = ((SplitCard) card).getRightHalfCard();
-                rightCard.setOwnerId(ownerId);
-                addCardToState(rightCard);
-            } else if (card instanceof ModalDoubleFacesCard) {
-                // left
-                Card leftCard = ((ModalDoubleFacesCard) card).getLeftHalfCard();
-                leftCard.setOwnerId(ownerId);
-                addCardToState(leftCard);
-                // right
-                Card rightCard = ((ModalDoubleFacesCard) card).getRightHalfCard();
-                rightCard.setOwnerId(ownerId);
-                addCardToState(rightCard);
-            } else if (card instanceof AdventureCard) {
-                Card spellCard = ((AdventureCard) card).getSpellCard();
-                spellCard.setOwnerId(ownerId);
-                addCardToState(spellCard);
+            for (SubCard subCard: card.getSubCards()) {
+                subCard.setOwnerId(ownerId);
+                addCardToState(subCard);
             }
         }
     }


### PR DESCRIPTION
My attempt at starting to collapse many of the `instanceof` checks that are needed (and often missed) in order to handle MDFC, split, etc. properly in the game.