### PR TITLE
[40K] Implement Out of the Tombs

### DIFF
--- a/Mage.Sets/src/mage/cards/o/OutOfTheTombs.java
+++ b/Mage.Sets/src/mage/cards/o/OutOfTheTombs.java
@@ -1,0 +1,110 @@
+package mage.cards.o;
+
+import mage.abilities.Ability;
+import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.dynamicvalue.common.CountersSourceCount;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.common.MillCardsControllerEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.counters.CounterType;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.players.Player;
+import mage.target.common.TargetCardInYourGraveyard;
+
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public final class OutOfTheTombs extends CardImpl {
+
+    public OutOfTheTombs(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{B}");
+
+        // At the beginning of your upkeep, put two eon counters on Out of the Tombs, then mill cards equal to the number of eon counters on it.
+        Ability ability = new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.EON.createInstance(2)), TargetController.YOU, false);
+        ability.addEffect(new MillCardsControllerEffect(new CountersSourceCount(CounterType.EON)).concatBy(", then").setText("mill cards equal to the number of eon counters on it"));
+        this.addAbility(ability);
+
+        // If you would draw a card while your library has no cards in it, instead return a creature card from your graveyard to the battlefield. If you can’t, you lose the game.
+        this.addAbility(new SimpleStaticAbility(new OutOfTheTombsReplacementEffect()));
+    }
+
+    private OutOfTheTombs(final OutOfTheTombs card) {
+        super(card);
+    }
+
+    @Override
+    public OutOfTheTombs copy() {
+        return new OutOfTheTombs(this);
+    }
+}
+
+class OutOfTheTombsReplacementEffect extends ReplacementEffectImpl {
+
+    public OutOfTheTombsReplacementEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.Benefit);
+        staticText = "If you would draw a card while your library has no cards in it, instead return a creature card " +
+                "from your graveyard to the battlefield. If you can’t, you lose the game.";
+    }
+
+    public OutOfTheTombsReplacementEffect(final OutOfTheTombsReplacementEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public OutOfTheTombsReplacementEffect copy() {
+        return new OutOfTheTombsReplacementEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return true;
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        Player player = game.getPlayer(event.getPlayerId());
+        if (player == null) {
+            return false;
+        }
+        boolean cardReturned = false;
+        TargetCardInYourGraveyard target = new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD);
+        target.setNotTarget(true);
+        if (target.canChoose(player.getId(), source, game)) {
+            if (target.choose(Outcome.PutCreatureInPlay, player.getId(), source.getSourceId(), source, game)) {
+                Card card = game.getCard(target.getFirstTarget());
+                if (card != null) {
+                    player.moveCards(card, Zone.BATTLEFIELD, source, game);
+                    cardReturned = true;
+                }
+            }
+        }
+        if (!cardReturned) {
+            game.informPlayers(player.getLogName() + " can't return a card from graveyard to hand.");
+            player.lost(game);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DRAW_CARD;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (event.getPlayerId().equals(source.getControllerId())) {
+            Player player = game.getPlayer(event.getPlayerId());
+            return player != null && !player.hasLost() && !player.getLibrary().hasCards();
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/o/OutOfTheTombs.java
+++ b/Mage.Sets/src/mage/cards/o/OutOfTheTombs.java
@@ -52,7 +52,7 @@ class OutOfTheTombsReplacementEffect extends ReplacementEffectImpl {
     public OutOfTheTombsReplacementEffect() {
         super(Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "If you would draw a card while your library has no cards in it, instead return a creature card " +
-                "from your graveyard to the battlefield. If you can’t, you lose the game.";
+                "from your graveyard to the battlefield. If you can't, you lose the game.";
     }
 
     public OutOfTheTombsReplacementEffect(final OutOfTheTombsReplacementEffect effect) {

--- a/Mage.Sets/src/mage/cards/t/TamiyoTheMoonSage.java
+++ b/Mage.Sets/src/mage/cards/t/TamiyoTheMoonSage.java
@@ -82,7 +82,7 @@ class TappedCreaturesControlledByTargetCount implements DynamicValue {
 
     @Override
     public String toString() {
-        return "a";
+        return "1";
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/u/UrborgLhurgoyf.java
+++ b/Mage.Sets/src/mage/cards/u/UrborgLhurgoyf.java
@@ -1,7 +1,7 @@
 package mage.cards.u;
 
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.IntPlusDynamicValue;
 import mage.abilities.dynamicvalue.DynamicValue;
@@ -40,11 +40,7 @@ public final class UrborgLhurgoyf extends CardImpl {
         this.addAbility(kickerAbility);
 
         // As Urborg Lhurgoyf enters the battlefield, mill three cards for each time it was kicked.
-        this.addAbility(new EntersBattlefieldAbility(
-                new MillCardsControllerEffect(millValue), null,
-                "As {this} enters the battlefield, " +
-                        "mill three cards for each time it was kicked.", ""
-        ));
+        this.addAbility(new AsEntersBattlefieldAbility(new MillCardsControllerEffect(millValue)));
 
         // Urborg Lhurgoyf's power is equal to the number of creature cards in your graveyard and its toughness is equal to that number plus 1.
         this.addAbility(new SimpleStaticAbility(

--- a/Mage.Sets/src/mage/sets/Warhammer40000.java
+++ b/Mage.Sets/src/mage/sets/Warhammer40000.java
@@ -174,6 +174,7 @@ public final class Warhammer40000 extends ExpansionSet {
         cards.add(new SetCardInfo("Nurgle's Rot", 45, Rarity.UNCOMMON, mage.cards.n.NurglesRot.class));
         cards.add(new SetCardInfo("Old One Eye", 96, Rarity.RARE, mage.cards.o.OldOneEye.class));
         cards.add(new SetCardInfo("Opal Palace", 286, Rarity.COMMON, mage.cards.o.OpalPalace.class));
+        cards.add(new SetCardInfo("Out of the Tombs", 46, Rarity.RARE, mage.cards.o.OutOfTheTombs.class));
         cards.add(new SetCardInfo("Overgrowth", 219, Rarity.COMMON, mage.cards.o.Overgrowth.class));
         cards.add(new SetCardInfo("Past in Flames", 206, Rarity.MYTHIC, mage.cards.p.PastInFlames.class));
         cards.add(new SetCardInfo("Path of Ancestry", 287, Rarity.COMMON, mage.cards.p.PathOfAncestry.class));

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/MultikickerCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/MultikickerCount.java
@@ -26,7 +26,7 @@ public enum MultikickerCount implements DynamicValue {
 
     @Override
     public String toString() {
-        return "a";
+        return "1";
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/common/DrawCardSourceControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DrawCardSourceControllerEffect.java
@@ -17,7 +17,6 @@ import mage.util.CardUtil;
 public class DrawCardSourceControllerEffect extends OneShotEffect {
 
     protected DynamicValue amount;
-    protected String whoDrawCard = "";
 
     public DrawCardSourceControllerEffect(int amount) {
         this(amount, "");
@@ -34,13 +33,12 @@ public class DrawCardSourceControllerEffect extends OneShotEffect {
     public DrawCardSourceControllerEffect(DynamicValue amount, String whoDrawCard) {
         super(Outcome.DrawCard);
         this.amount = amount.copy();
-        this.whoDrawCard = whoDrawCard;
+        createStaticText(whoDrawCard);
     }
 
     public DrawCardSourceControllerEffect(final DrawCardSourceControllerEffect effect) {
         super(effect);
         this.amount = effect.amount.copy();
-        this.whoDrawCard = effect.whoDrawCard;
     }
 
     @Override
@@ -59,28 +57,17 @@ public class DrawCardSourceControllerEffect extends OneShotEffect {
         return false;
     }
 
-    @Override
-    public String getText(Mode mode) {
-        if (staticText != null && !staticText.isEmpty()) {
-            return staticText;
-        }
-        StringBuilder sb = new StringBuilder();
-        boolean oneCard = (amount instanceof StaticValue
-                && amount.calculate(null, null, this) == 1)
-                || amount instanceof PermanentsOnBattlefieldCount
-                || amount.toString().equals("1")
-                || amount.toString().equals("a");
-        sb.append(whoDrawCard.isEmpty() ? "" : whoDrawCard
-                + " ").append("draw ").append(oneCard ? "a"
-                : CardUtil.numberToText(amount.toString())).append(" card");
-        if (!oneCard) {
-            sb.append('s');
-        }
+    private void createStaticText(String whoDrawCard) {
+        StringBuilder sb = new StringBuilder(whoDrawCard);
+        sb.append(whoDrawCard.isEmpty() ? "draw " : " draw ");
+        String value = amount.toString();
+        sb.append(CardUtil.numberToText(value, "a"));
+        sb.append(value.equals("1") ? " card" : " cards");
         String message = amount.getMessage();
         if (!message.isEmpty()) {
-            sb.append(" for each ");
+            sb.append(value.equals("X") ? ", where X is " : " for each ");
+            sb.append(message);
         }
-        sb.append(message);
-        return sb.toString();
+        staticText = sb.toString();
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/MillCardsControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/MillCardsControllerEffect.java
@@ -25,6 +25,7 @@ public class MillCardsControllerEffect extends OneShotEffect {
     public MillCardsControllerEffect(DynamicValue numberCards) {
         super(Outcome.Discard);
         this.numberCards = numberCards;
+        setText();
     }
 
     public MillCardsControllerEffect(final MillCardsControllerEffect effect) {
@@ -45,12 +46,16 @@ public class MillCardsControllerEffect extends OneShotEffect {
         ).isEmpty();
     }
 
-    @Override
-    public String getText(Mode mode) {
-        if (numberCards instanceof StaticValue) {
-            return "mill " + (((StaticValue) numberCards).getValue() > 1 ?
-                    CardUtil.numberToText(numberCards.toString()) + " cards" : "a card");
+    private void setText() {
+        StringBuilder sb = new StringBuilder("mill ");
+        String value = numberCards.toString();
+        sb.append(CardUtil.numberToText(value, "a"));
+        sb.append(value.equals("1") ? " card" : " cards");
+        String message = numberCards.getMessage();
+        if (!message.isEmpty()) {
+            sb.append(value.equals("X") ? ", where X is " : " for each ");
+            sb.append(message);
         }
-        return "mill X cards, where X is " + numberCards.getMessage();
+        staticText = sb.toString();
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardControllerEffect.java
@@ -55,19 +55,17 @@ public class DiscardControllerEffect extends OneShotEffect {
 
     private void setText() {
         StringBuilder sb = new StringBuilder("discard ");
-        if (amount.toString().equals("1") || amount.toString().equals("a")) {
-            sb.append("a card");
-        } else {
-            sb.append(CardUtil.numberToText(amount.toString())).append(" cards");
-        }
+        String value = amount.toString();
+        sb.append(CardUtil.numberToText(value, "a"));
+        sb.append(value.equals("1") ? " card" : " cards");
         if (randomDiscard) {
             sb.append(" at random");
         }
         String message = amount.getMessage();
         if (!message.isEmpty()) {
-            sb.append(" for each ");
+            sb.append(value.equals("X") ? ", where X is " : " for each ");
+            sb.append(message);
         }
-        sb.append(message);
         staticText = sb.toString();
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardTargetEffect.java
@@ -74,26 +74,19 @@ public class DiscardTargetEffect extends OneShotEffect {
         if (staticText != null && !staticText.isEmpty()) {
             return staticText;
         }
-        StringBuilder sb = new StringBuilder();
-        if (mode.getTargets().isEmpty()) {
-            sb.append("that player");
-        } else {
-            sb.append("target ").append(mode.getTargets().get(0).getTargetName());
-        }
+        StringBuilder sb = new StringBuilder(getTargetPointer().describeTargets(mode.getTargets(), "that player"));
         sb.append(" discards ");
-        if (amount.toString().equals("1") || amount.toString().equals("a")) {
-            sb.append("a card");
-        } else {
-            sb.append(CardUtil.numberToText(amount.toString())).append(" cards");
-        }
+        String value = amount.toString();
+        sb.append(CardUtil.numberToText(value, "a"));
+        sb.append(value.equals("1") ? " card" : " cards");
         if (randomDiscard) {
             sb.append(" at random");
         }
         String message = amount.getMessage();
         if (!message.isEmpty()) {
-            sb.append(" for each ");
+            sb.append(value.equals("X") ? ", where X is " : " for each ");
+            sb.append(message);
         }
-        sb.append(message);
         return sb.toString();
     }
 }

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -546,8 +546,7 @@ public final class CardUtil {
     }
 
     public static boolean checkNumeric(String s) {
-        return s.chars().allMatch(Character::isDigit);
-
+        return !s.isEmpty() && s.chars().allMatch(Character::isDigit);
     }
 
     /**


### PR DESCRIPTION
Card functions as expected, but I'm making this a draft because I can't seem to figure out how to solve this text issue. On line 33 I write:
`ability.addEffect(new MillCardsControllerEffect(new CountersSourceCount(CounterType.EON)).concatBy(", then").setText("mill cards equal to the number of eon counters on it"));`
But the card in-game reads as below:
![image](https://user-images.githubusercontent.com/26198472/194730183-611ac45f-70c8-4fb2-bdb2-8bf658113992.png)
Specifically, the `.setText("mill cards equal to the number of eon counters on it"));` is ignored. Anyone have any idea as to why / how to get the desired effect?