### PR TITLE
Refactored FirstTargetPointer, SecondTargetPointer, and ThirdTargetPointer to use a common implementation

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AcquireTarget.java
+++ b/Mage.Sets/src/mage/cards/a/AcquireTarget.java
@@ -32,7 +32,7 @@ public final class AcquireTarget extends CardImpl {
 
         // Put a bounty counter on up to one target creature an opponent controls.
         effect = new AddCountersTargetEffect(CounterType.BOUNTY.createInstance());
-        effect.setTargetPointer(SecondTargetPointer.getInstance());
+        effect.setTargetPointer(new SecondTargetPointer());
         effect.setText("Put a bounty counter on up to one target creature an opponent controls.");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetOpponentsCreaturePermanent(0, 1));

--- a/Mage.Sets/src/mage/cards/a/AgonyWarp.java
+++ b/Mage.Sets/src/mage/cards/a/AgonyWarp.java
@@ -25,7 +25,7 @@ public final class AgonyWarp extends CardImpl {
         // Target creature gets -0/-3 until end of turn.
         this.getSpellAbility().addTarget(new TargetCreaturePermanent().withChooseHint("-0/-3"));
         this.getSpellAbility().addEffect(new BoostTargetEffect(0, -3, Duration.EndOfTurn)
-                .setTargetPointer(SecondTargetPointer.getInstance())
+                .setTargetPointer(new SecondTargetPointer())
                 .concatBy("<br>"));
     }
 

--- a/Mage.Sets/src/mage/cards/a/AzoriusPloy.java
+++ b/Mage.Sets/src/mage/cards/a/AzoriusPloy.java
@@ -34,7 +34,7 @@ public final class AzoriusPloy extends CardImpl {
         // Prevent all combat damage that would be dealt to target creature this turn.
         Effect effect2 = new PreventDamageToTargetEffect(Duration.EndOfTurn, true);
         effect2.setText("<br><br>Prevent all combat damage that would be dealt to target creature this turn.");
-        effect2.setTargetPointer(SecondTargetPointer.getInstance());
+        effect2.setTargetPointer(new SecondTargetPointer());
         this.getSpellAbility().addEffect(effect2);
         target = new TargetCreaturePermanent(new FilterCreaturePermanent("second creature (can be the same as the first)"));
         this.getSpellAbility().addTarget(target);

--- a/Mage.Sets/src/mage/cards/c/CrawlFromTheCellar.java
+++ b/Mage.Sets/src/mage/cards/c/CrawlFromTheCellar.java
@@ -33,7 +33,7 @@ public final class CrawlFromTheCellar extends CardImpl {
         this.getSpellAbility().addEffect(new ReturnFromGraveyardToHandTargetEffect());
         this.getSpellAbility().addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD));
 
-        this.getSpellAbility().addEffect(new AddCountersTargetEffect(CounterType.P1P1.createInstance()).setTargetPointer(SecondTargetPointer.getInstance()));
+        this.getSpellAbility().addEffect(new AddCountersTargetEffect(CounterType.P1P1.createInstance()).setTargetPointer(new SecondTargetPointer()));
         this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent(0, 1, filter, false));
 
         // Flashback {3}{B}

--- a/Mage.Sets/src/mage/cards/m/MartialGlory.java
+++ b/Mage.Sets/src/mage/cards/m/MartialGlory.java
@@ -25,7 +25,7 @@ public final class MartialGlory extends CardImpl {
         // Target creature gets +0/+3 until end of turn.
         this.getSpellAbility().addTarget(new TargetCreaturePermanent().withChooseHint("+0/+3"));
         this.getSpellAbility().addEffect(new BoostTargetEffect(0, 3, Duration.EndOfTurn)
-                .setTargetPointer(SecondTargetPointer.getInstance())
+                .setTargetPointer(new SecondTargetPointer())
                 .concatBy("<br>"));
     }
 

--- a/Mage.Sets/src/mage/cards/r/RallyManeuver.java
+++ b/Mage.Sets/src/mage/cards/r/RallyManeuver.java
@@ -44,11 +44,11 @@ public final class RallyManeuver extends CardImpl {
         this.getSpellAbility().addTarget(target.withChooseHint("+0/+2 and lifelink"));
         this.getSpellAbility().addEffect(new BoostTargetEffect(0, 2)
                 .setText("Up to one other target creature gets +0/+2")
-                .setTargetPointer(SecondTargetPointer.getInstance())
+                .setTargetPointer(new SecondTargetPointer())
         );
         this.getSpellAbility().addEffect(
                 new GainAbilityTargetEffect(LifelinkAbility.getInstance(), Duration.EndOfTurn, "and gains lifelink until end of turn")
-                .setTargetPointer(SecondTargetPointer.getInstance())
+                .setTargetPointer(new SecondTargetPointer())
         );
     }
 

--- a/Mage.Sets/src/mage/cards/r/Repurpose.java
+++ b/Mage.Sets/src/mage/cards/r/Repurpose.java
@@ -28,7 +28,7 @@ public final class Repurpose extends CardImpl {
 
         // Return up to one target creature card from graveyard to your hand.
         Effect effect = new ReturnFromGraveyardToHandTargetEffect();
-        effect.setTargetPointer(SecondTargetPointer.getInstance());
+        effect.setTargetPointer(new SecondTargetPointer());
         effect.setText("Return up to one target creature card from graveyard to your hand.");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetCardInYourGraveyard(0, 1, StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD));

--- a/Mage/src/main/java/mage/abilities/effects/EffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/EffectImpl.java
@@ -21,7 +21,7 @@ public abstract class EffectImpl implements Effect {
     protected EffectType effectType;
 
     // read related docs about static and dynamic targets in ContinuousEffectImpl.affectedObjectsSet
-    protected TargetPointer targetPointer = FirstTargetPointer.getInstance();
+    protected TargetPointer targetPointer = new FirstTargetPointer();
 
     protected String staticText = "";
     protected Map<String, Object> values;

--- a/Mage/src/main/java/mage/target/targetpointer/FirstTargetPointer.java
+++ b/Mage/src/main/java/mage/target/targetpointer/FirstTargetPointer.java
@@ -1,131 +1,17 @@
 package mage.target.targetpointer;
 
-import mage.MageObject;
-import mage.abilities.Ability;
-import mage.cards.Card;
-import mage.constants.Zone;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.target.Targets;
-
-import java.util.*;
-
-public class FirstTargetPointer extends TargetPointerImpl {
-
-    private Map<UUID, Integer> zoneChangeCounter = new HashMap<>();
-
-    public static FirstTargetPointer getInstance() {
-        return new FirstTargetPointer();
-    }
+public class FirstTargetPointer extends NthTargetPointer {
 
     public FirstTargetPointer() {
-        super();
+        super(1);
     }
 
-    public FirstTargetPointer(final FirstTargetPointer targetPointer) {
-        super(targetPointer);
-
-        this.zoneChangeCounter = new HashMap<>();
-        for (Map.Entry<UUID, Integer> entry : targetPointer.zoneChangeCounter.entrySet()) {
-            this.zoneChangeCounter.put(entry.getKey(), entry.getValue());
-        }
-    }
-
-    @Override
-    public void init(Game game, Ability source) {
-        if (!source.getTargets().isEmpty()) {
-            for (UUID target : source.getTargets().get(0).getTargets()) {
-                Card card = game.getCard(target);
-                if (card != null) {
-                    this.zoneChangeCounter.put(target, card.getZoneChangeCounter(game));
-                }
-            }
-        }
-    }
-
-    @Override
-    public List<UUID> getTargets(Game game, Ability source) {
-        List<UUID> target = new ArrayList<>();
-        if (!source.getTargets().isEmpty()) {
-            for (UUID targetId : source.getTargets().get(0).getTargets()) {
-                Card card = game.getCard(targetId);
-                if (card != null && zoneChangeCounter.containsKey(targetId)
-                        && card.getZoneChangeCounter(game) != zoneChangeCounter.get(targetId)) {
-                    // but no longer if new permanent is already on the battlefield
-                    Permanent permanent = game.getPermanentOrLKIBattlefield(targetId);
-                    if (permanent == null || permanent.getZoneChangeCounter(game) != zoneChangeCounter.get(targetId)) {
-                        continue;
-                    }
-                }
-                target.add(targetId);
-            }
-        }
-        return target;
-    }
-
-    @Override
-    public UUID getFirst(Game game, Ability source) {
-        UUID targetId = source.getFirstTarget();
-        if (zoneChangeCounter.containsKey(targetId)) {
-            Card card = game.getCard(targetId);
-            if (card != null && zoneChangeCounter.containsKey(targetId)
-                    && card.getZoneChangeCounter(game) != zoneChangeCounter.get(targetId)) {
-                // because if dies trigger has to trigger as permanent has already moved zone, we have to check if target was on the battlefield immed. before
-                // but no longer if new permanent is already on the battlefield
-                Permanent permanent = game.getPermanentOrLKIBattlefield(targetId);
-                if (permanent == null || permanent.getZoneChangeCounter(game) != zoneChangeCounter.get(targetId)) {
-                    return null;
-                }
-            }
-        }
-        return targetId;
+    public FirstTargetPointer(final FirstTargetPointer firstTargetPointer) {
+        super(firstTargetPointer);
     }
 
     @Override
     public FirstTargetPointer copy() {
         return new FirstTargetPointer(this);
-    }
-
-    @Override
-    public FixedTarget getFixedTarget(Game game, Ability source) {
-        this.init(game, source);
-        UUID firstId = getFirst(game, source);
-        if (firstId != null) {
-            return new FixedTarget(firstId, game.getState().getZoneChangeCounter(firstId));
-        }
-        return null;
-
-    }
-
-    @Override
-    public Permanent getFirstTargetPermanentOrLKI(Game game, Ability source) {
-        UUID targetId = source.getFirstTarget();
-        Permanent permanent;
-        if (zoneChangeCounter.containsKey(targetId)) {
-            permanent = game.getPermanent(targetId);
-            if (permanent != null && permanent.getZoneChangeCounter(game) == zoneChangeCounter.get(targetId)) {
-                return permanent;
-            }
-            MageObject mageObject = game.getLastKnownInformation(targetId, Zone.BATTLEFIELD, zoneChangeCounter.get(targetId));
-            if (mageObject instanceof Permanent) {
-                return (Permanent) mageObject;
-            }
-        } else {
-            permanent = game.getPermanent(targetId);
-            if (permanent == null) {
-                permanent = (Permanent) game.getLastKnownInformation(targetId, Zone.BATTLEFIELD);
-            }
-        }
-        return permanent;
-    }
-
-    @Override
-    public String describeTargets(Targets targets, String defaultDescription) {
-        return targets.isEmpty() ? defaultDescription : targets.get(0).getDescription();
-    }
-
-    @Override
-    public boolean isPlural(Targets targets) {
-        return !targets.isEmpty() && targets.get(0).getMaxNumberOfTargets() > 1;
     }
 }

--- a/Mage/src/main/java/mage/target/targetpointer/NthTargetPointer.java
+++ b/Mage/src/main/java/mage/target/targetpointer/NthTargetPointer.java
@@ -1,0 +1,161 @@
+package mage.target.targetpointer;
+
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.cards.Card;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.target.Targets;
+
+import java.util.*;
+
+/**
+ * Class to create the Nth target pointer classes (FirstTargetPointer, SecondTargetPointer, etc._
+ */
+public abstract class NthTargetPointer extends TargetPointerImpl {
+
+    private static final Map<UUID, Integer> emptyZoneChangeCounter = Collections.unmodifiableMap(new HashMap<>(0));
+    private static final List<UUID> emptyTargets = Collections.unmodifiableList(new ArrayList<>(0));
+
+    private Map<UUID, Integer> zoneChangeCounter;
+    private int targetNumber;
+
+    public NthTargetPointer(int targetNumber) {
+        super();
+        this.targetNumber = targetNumber;
+    }
+
+    public NthTargetPointer(final  NthTargetPointer nthTargetPointer) {
+        super(nthTargetPointer);
+        this.targetNumber = nthTargetPointer.targetNumber;
+
+        if (nthTargetPointer.zoneChangeCounter != null) {
+            this.zoneChangeCounter = new HashMap<>(nthTargetPointer.zoneChangeCounter.size());
+            for (Map.Entry<UUID, Integer> entry : nthTargetPointer.zoneChangeCounter.entrySet()) {
+                addToZoneChangeCounter(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    @Override
+    public void init(Game game, Ability source) {
+        if (source.getTargets().size() < targetNumber) {
+            return;
+        }
+
+        for (UUID target : source.getTargets().get(targetIndex()).getTargets()) {
+            Card card = game.getCard(target);
+            if (card != null) {
+                addToZoneChangeCounter(target, card.getZoneChangeCounter(game));
+            }
+        }
+    }
+
+    @Override
+    public List<UUID> getTargets(Game game, Ability source) {
+        if (source.getTargets().size() < targetNumber) {
+            return emptyTargets;
+        }
+
+        List<UUID> targetIds = source.getTargets().get(targetIndex()).getTargets();
+        List<UUID> finalTargetIds = new ArrayList<>(targetIds.size());
+
+        for (UUID targetId : targetIds) {
+            Card card = game.getCard(targetId);
+            if (card != null
+                    && getZoneChangeCounter().containsKey(targetId)
+            && card.getZoneChangeCounter(game) != getZoneChangeCounter().get(targetId)) {
+                Permanent permanent = game.getPermanentOrLKIBattlefield(targetId);
+                if (permanent == null || permanent.getZoneChangeCounter(game) != getZoneChangeCounter().get(targetId)) {
+                    continue;
+                }
+            }
+
+            finalTargetIds.add(targetId);
+        }
+        return finalTargetIds;
+    }
+
+    @Override
+    public UUID getFirst(Game game, Ability source) {
+        if (source.getTargets().size() < targetNumber) {
+            return null;
+        }
+
+        UUID targetId = source.getTargets().get(targetIndex()).getFirstTarget();
+        if (getZoneChangeCounter().containsKey(targetId)) {
+            Card card = game.getCard(targetId);
+            if (card != null && getZoneChangeCounter().containsKey(targetId)
+                    && card.getZoneChangeCounter(game) != getZoneChangeCounter().get(targetId)) {
+                return null;
+            }
+        }
+        return targetId;
+
+    }
+
+    @Override
+    public FixedTarget getFixedTarget(Game game, Ability source) {
+        this.init(game, source);
+        UUID firstId = getFirst(game, source);
+        if (firstId != null) {
+            return new FixedTarget(firstId, game.getState().getZoneChangeCounter(firstId));
+        }
+
+        return null;
+    }
+
+    @Override
+    public Permanent getFirstTargetPermanentOrLKI(Game game, Ability source) {
+        if (source.getTargets().size() < targetNumber) {
+            return null;
+        }
+
+        Permanent permanent;
+        UUID targetId = source.getTargets().get(targetIndex()).getFirstTarget();
+
+        if (getZoneChangeCounter().containsKey(targetId)) {
+            permanent = game.getPermanent(targetId);
+            if (permanent != null && permanent.getZoneChangeCounter(game) == getZoneChangeCounter().get(targetId)) {
+                return permanent;
+            }
+            MageObject mageObject = game.getLastKnownInformation(targetId, Zone.BATTLEFIELD, getZoneChangeCounter().get(targetId));
+            if (mageObject instanceof Permanent) {
+                return (Permanent) mageObject;
+            }
+
+        } else {
+            permanent = game.getPermanent(targetId);
+            if (permanent == null) {
+                permanent = (Permanent) game.getLastKnownInformation(targetId, Zone.BATTLEFIELD);
+            }
+        }
+        return permanent;
+    }
+
+    @Override
+    public String describeTargets(Targets targets, String defaultDescription) {
+        return targets.size() < targetNumber ? defaultDescription : targets.get(targetIndex()).getDescription();
+    }
+
+    @Override
+    public boolean isPlural(Targets targets) {
+        return targets.size() > targetIndex() && targets.get(targetIndex()).getMaxNumberOfTargets() > 1;
+    }
+
+    private int targetIndex() {
+        return targetNumber - 1;
+    }
+
+    private Map<UUID, Integer> getZoneChangeCounter() {
+        return zoneChangeCounter != null ? zoneChangeCounter : emptyZoneChangeCounter;
+    }
+
+    private void addToZoneChangeCounter(UUID key, Integer value) {
+        if (zoneChangeCounter == null) {
+            zoneChangeCounter = new HashMap<>();
+        }
+        getZoneChangeCounter().put(key, value);
+    }
+}

--- a/Mage/src/main/java/mage/target/targetpointer/SecondTargetPointer.java
+++ b/Mage/src/main/java/mage/target/targetpointer/SecondTargetPointer.java
@@ -1,128 +1,17 @@
 package mage.target.targetpointer;
 
-import mage.MageObject;
-import mage.abilities.Ability;
-import mage.cards.Card;
-import mage.constants.Zone;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.target.Targets;
-
-import java.util.*;
-
-public class SecondTargetPointer extends TargetPointerImpl {
-
-    private Map<UUID, Integer> zoneChangeCounter = new HashMap<>();
-
-    public static SecondTargetPointer getInstance() {
-        return new SecondTargetPointer();
-    }
+public class SecondTargetPointer extends NthTargetPointer {
 
     public SecondTargetPointer() {
-        super();
+        super(2);
     }
 
-    public SecondTargetPointer(final SecondTargetPointer targetPointer) {
-        super(targetPointer);
-
-        this.zoneChangeCounter = new HashMap<>();
-        for (Map.Entry<UUID, Integer> entry : targetPointer.zoneChangeCounter.entrySet()) {
-            this.zoneChangeCounter.put(entry.getKey(), entry.getValue());
-        }
-    }
-
-    @Override
-    public void init(Game game, Ability source) {
-        if (source.getTargets().size() > 1) {
-            for (UUID target : source.getTargets().get(1).getTargets()) {
-                Card card = game.getCard(target);
-                if (card != null) {
-                    this.zoneChangeCounter.put(target, card.getZoneChangeCounter(game));
-                }
-            }
-        }
-    }
-
-    @Override
-    public List<UUID> getTargets(Game game, Ability source) {
-        List<UUID> target = new ArrayList<>();
-        if (source.getTargets().size() > 1) {
-            for (UUID targetId : source.getTargets().get(1).getTargets()) {
-                Card card = game.getCard(targetId);
-                if (card != null && zoneChangeCounter.containsKey(targetId)
-                        && card.getZoneChangeCounter(game) != zoneChangeCounter.get(targetId)) {
-                    continue;
-                }
-                target.add(targetId);
-            }
-        }
-        return target;
-    }
-
-    @Override
-    public UUID getFirst(Game game, Ability source) {
-        if (source.getTargets().size() > 1) {
-            UUID targetId = source.getTargets().get(1).getFirstTarget();
-            if (zoneChangeCounter.containsKey(targetId)) {
-                Card card = game.getCard(targetId);
-                if (card != null && zoneChangeCounter.containsKey(targetId)
-                        && card.getZoneChangeCounter(game) != zoneChangeCounter.get(targetId)) {
-                    return null;
-                }
-            }
-            return targetId;
-        }
-        return null;
+    public SecondTargetPointer(final SecondTargetPointer secondTargetPointer) {
+        super(secondTargetPointer);
     }
 
     @Override
     public SecondTargetPointer copy() {
         return new SecondTargetPointer(this);
-    }
-
-    @Override
-    public FixedTarget getFixedTarget(Game game, Ability source) {
-        this.init(game, source);
-        UUID firstId = getFirst(game, source);
-        if (firstId != null) {
-            return new FixedTarget(firstId, game.getState().getZoneChangeCounter(firstId));
-        }
-        return null;
-    }
-
-    @Override
-    public Permanent getFirstTargetPermanentOrLKI(Game game, Ability source) {
-        if (source.getTargets().size() > 1) {
-            Permanent permanent;
-            UUID targetId = source.getTargets().get(1).getFirstTarget();
-            if (zoneChangeCounter.containsKey(targetId)) {
-                permanent = game.getPermanent(targetId);
-                if (permanent != null && permanent.getZoneChangeCounter(game) == zoneChangeCounter.get(targetId)) {
-                    return permanent;
-                }
-                MageObject mageObject = game.getLastKnownInformation(targetId, Zone.BATTLEFIELD, zoneChangeCounter.get(targetId));
-                if (mageObject instanceof Permanent) {
-                    return (Permanent) mageObject;
-                }
-
-            } else {
-                permanent = game.getPermanent(targetId);
-                if (permanent == null) {
-                    permanent = (Permanent) game.getLastKnownInformation(targetId, Zone.BATTLEFIELD);
-                }
-            }
-            return permanent;
-        }
-        return null;
-    }
-
-    @Override
-    public String describeTargets(Targets targets, String defaultDescription) {
-        return targets.size() < 2 ? defaultDescription : targets.get(1).getDescription();
-    }
-
-    @Override
-    public boolean isPlural(Targets targets) {
-        return targets.size() > 1 && targets.get(1).getMaxNumberOfTargets() > 1;
     }
 }

--- a/Mage/src/main/java/mage/target/targetpointer/ThirdTargetPointer.java
+++ b/Mage/src/main/java/mage/target/targetpointer/ThirdTargetPointer.java
@@ -1,132 +1,17 @@
 package mage.target.targetpointer;
 
-import mage.MageObject;
-import mage.abilities.Ability;
-import mage.cards.Card;
-import mage.constants.Zone;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.target.Targets;
-
-import java.util.*;
-
-/**
- * @author LevelX2
- */
-public class ThirdTargetPointer extends TargetPointerImpl {
-
-    private Map<UUID, Integer> zoneChangeCounter = new HashMap<>();
-
-    public static ThirdTargetPointer getInstance() {
-        return new ThirdTargetPointer();
-    }
+public class ThirdTargetPointer extends NthTargetPointer {
 
     public ThirdTargetPointer() {
-        super();
+        super(3);
     }
 
-    public ThirdTargetPointer(final ThirdTargetPointer targetPointer) {
-        super(targetPointer);
-
-        this.zoneChangeCounter = new HashMap<>();
-        for (Map.Entry<UUID, Integer> entry : targetPointer.zoneChangeCounter.entrySet()) {
-            this.zoneChangeCounter.put(entry.getKey(), entry.getValue());
-        }
-    }
-
-    @Override
-    public void init(Game game, Ability source) {
-        if (source.getTargets().size() > 2) {
-            for (UUID target : source.getTargets().get(2).getTargets()) {
-                Card card = game.getCard(target);
-                if (card != null) {
-                    this.zoneChangeCounter.put(target, card.getZoneChangeCounter(game));
-                }
-            }
-        }
-    }
-
-    @Override
-    public List<UUID> getTargets(Game game, Ability source) {
-        List<UUID> target = new ArrayList<>();
-        if (source.getTargets().size() > 2) {
-            for (UUID targetId : source.getTargets().get(2).getTargets()) {
-                Card card = game.getCard(targetId);
-                if (card != null && zoneChangeCounter.containsKey(targetId)
-                        && card.getZoneChangeCounter(game) != zoneChangeCounter.get(targetId)) {
-                    continue;
-                }
-                target.add(targetId);
-            }
-        }
-        return target;
-    }
-
-    @Override
-    public UUID getFirst(Game game, Ability source) {
-        if (source.getTargets().size() > 2) {
-            UUID targetId = source.getTargets().get(2).getFirstTarget();
-            if (zoneChangeCounter.containsKey(targetId)) {
-                Card card = game.getCard(targetId);
-                if (card != null && zoneChangeCounter.containsKey(targetId)
-                        && card.getZoneChangeCounter(game) != zoneChangeCounter.get(targetId)) {
-                    return null;
-                }
-            }
-            return targetId;
-        }
-        return null;
+    public ThirdTargetPointer(final ThirdTargetPointer thirdTargetPointer) {
+        super(thirdTargetPointer);
     }
 
     @Override
     public ThirdTargetPointer copy() {
         return new ThirdTargetPointer(this);
-    }
-
-    @Override
-    public FixedTarget getFixedTarget(Game game, Ability source) {
-        this.init(game, source);
-        UUID firstId = getFirst(game, source);
-        if (firstId != null) {
-            return new FixedTarget(firstId, game.getState().getZoneChangeCounter(firstId));
-        }
-        return null;
-
-    }
-
-    @Override
-    public Permanent getFirstTargetPermanentOrLKI(Game game, Ability source) {
-        if (source.getTargets().size() > 2) {
-            Permanent permanent;
-            UUID targetId = source.getTargets().get(2).getFirstTarget();
-            if (zoneChangeCounter.containsKey(targetId)) {
-                permanent = game.getPermanent(targetId);
-                if (permanent != null && permanent.getZoneChangeCounter(game) == zoneChangeCounter.get(targetId)) {
-                    return permanent;
-                }
-                MageObject mageObject = game.getLastKnownInformation(targetId, Zone.BATTLEFIELD, zoneChangeCounter.get(targetId));
-                if (mageObject instanceof Permanent) {
-                    return (Permanent) mageObject;
-                }
-
-            } else {
-                permanent = game.getPermanent(targetId);
-                if (permanent == null) {
-                    permanent = (Permanent) game.getLastKnownInformation(targetId, Zone.BATTLEFIELD);
-                }
-            }
-            return permanent;
-        }
-        return null;
-    }
-
-    @Override
-    public String describeTargets(Targets targets, String defaultDescription) {
-        return targets.size() < 3 ? defaultDescription : targets.get(2).getDescription();
-    }
-
-    @Override
-    public boolean isPlural(Targets targets) {
-        return targets.size() > 2 && targets.get(2).getMaxNumberOfTargets() > 1;
     }
 }


### PR DESCRIPTION
FirstTargetPointer, SecondTargetPointer, and ThirdTargetPointer currently have the exact same implementation.

There are two differences:
1. The use of a different number to index into the targets
2. The three implementations get out of sync. E.g. https://github.com/magefree/mage/commit/faa2b0a0bf0712040db8e14b4c1af8a2c6b9ed62 added a fix to `FirstTargetPointer`, but `SecondTargetPointer` and `ThirdTargetPointer` did not get fix.

Changes
1. Added a `NthTargetPointer` to act as the main class for all three.
2. Lazily instantiate `zoneChangeCounter` (using an unmodifiable map as the default value)
3. Removed `getInstance()` "constructor" since it was misleading given that it creates a new instance of the targetPointer object, rather than a static instance.