### PR TITLE
Refactor PutCards to address issue #9643

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/LookLibraryAndPickControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/LookLibraryAndPickControllerEffect.java
@@ -144,8 +144,8 @@ public class LookLibraryAndPickControllerEffect extends LookLibraryControllerEff
     }
 
     protected boolean actionWithPickedCards(Game game, Ability source, Player player, Cards pickedCards, Cards otherCards) {
-        boolean result = moveCards(game, source, player, pickedCards, putPickedCards);
-        result |= moveCards(game, source, player, otherCards, putLookedCards);
+        boolean result = putPickedCards.moveCards(player, pickedCards, source, game);
+        result |= putLookedCards.moveCards(player, otherCards, source, game);
         return result;
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/LookLibraryControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/LookLibraryControllerEffect.java
@@ -82,22 +82,7 @@ public class LookLibraryControllerEffect extends OneShotEffect {
     }
 
     protected boolean actionWithLookedCards(Game game, Ability source, Player player, Cards cards) {
-        return moveCards(game, source, player, cards, putLookedCards);
-    }
-
-    protected static boolean moveCards(Game game, Ability source, Player player, Cards cards, PutCards putCards) {
-        switch (putCards) {
-            case TOP_ANY:
-                return player.putCardsOnTopOfLibrary(cards, game, source, true);
-            case BOTTOM_ANY:
-                return player.putCardsOnBottomOfLibrary(cards, game, source, true);
-            case BOTTOM_RANDOM:
-                return player.putCardsOnBottomOfLibrary(cards, game, source, false);
-            case BATTLEFIELD_TAPPED:
-                return player.moveCards(cards.getCards(game), Zone.BATTLEFIELD, source, game, true, false, false, null);
-            default:
-                return player.moveCards(cards, putCards.getZone(), source, game);
-        }
+        return putLookedCards.moveCards(player, cards, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/constants/PutCards.java
+++ b/Mage/src/main/java/mage/constants/PutCards.java
@@ -1,5 +1,12 @@
 package mage.constants;
 
+import mage.abilities.Ability;
+import mage.cards.Card;
+import mage.cards.Cards;
+import mage.cards.CardsImpl;
+import mage.game.Game;
+import mage.players.Player;
+
 /**
  *
  * @author awjackson
@@ -45,5 +52,46 @@ public enum PutCards {
     public String getMessage(boolean owner, boolean withOrder) {
         String message = owner ? messageOwner : messageYour;
         return withOrder ? message + order : message;
+    }
+
+    public boolean moveCard(Player player, Card card, Ability source, Game game, String description) {
+        switch (this) {
+            case TOP_OR_BOTTOM:
+                if (player.chooseUse(Outcome.Neutral,
+                        "Put the " + description + " on the top or bottom of its owner's library?",
+                        null, "Top", "Bottom", source, game
+                )) {
+                    return player.putCardsOnTopOfLibrary(new CardsImpl(card), game, source, true);
+                } else {
+                    return player.putCardsOnBottomOfLibrary(new CardsImpl(card), game, source, true);
+                }
+            case TOP_ANY:
+                return player.putCardsOnTopOfLibrary(new CardsImpl(card), game, source, true);
+            case BOTTOM_ANY:
+                return player.putCardsOnBottomOfLibrary(new CardsImpl(card), game, source, true);
+            case BOTTOM_RANDOM:
+                return player.putCardsOnBottomOfLibrary(new CardsImpl(card), game, source, false);
+            case BATTLEFIELD_TAPPED:
+                return player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
+            default:
+                return player.moveCards(card, zone, source, game);
+        }
+    }
+
+    public boolean moveCards(Player player, Cards cards, Ability source, Game game) {
+        switch (this) {
+            case TOP_OR_BOTTOM:
+                throw new UnsupportedOperationException("PutCards.TOP_OR_BOTTOM does not support moving multiple cards");
+            case TOP_ANY:
+                return player.putCardsOnTopOfLibrary(cards, game, source, true);
+            case BOTTOM_ANY:
+                return player.putCardsOnBottomOfLibrary(cards, game, source, true);
+            case BOTTOM_RANDOM:
+                return player.putCardsOnBottomOfLibrary(cards, game, source, false);
+            case BATTLEFIELD_TAPPED:
+                return player.moveCards(cards.getCards(game), Zone.BATTLEFIELD, source, game, true, false, false, null);
+            default:
+                return player.moveCards(cards, zone, source, game);
+        }
     }
 }

--- a/Mage/src/main/java/mage/constants/PutCards.java
+++ b/Mage/src/main/java/mage/constants/PutCards.java
@@ -73,9 +73,13 @@ public enum PutCards {
                 return player.putCardsOnBottomOfLibrary(new CardsImpl(card), game, source, false);
             case BATTLEFIELD_TAPPED:
                 return player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
+            case BATTLEFIELD:
+            case EXILED:
+            case HAND:
+            case GRAVEYARD:
+                return player.moveCards(card, this.zone, source, game);
             default:
-                // HAND, GRAVEYARD, BATTLEFIELD, EXILED don't need unique method call
-                return player.moveCards(card, zone, source, game);
+                throw new UnsupportedOperationException("Missing case for " + this.name() + "in PutCards.moveCard");
         }
     }
 
@@ -91,9 +95,13 @@ public enum PutCards {
                 return player.putCardsOnBottomOfLibrary(cards, game, source, false);
             case BATTLEFIELD_TAPPED:
                 return player.moveCards(cards.getCards(game), Zone.BATTLEFIELD, source, game, true, false, false, null);
+            case BATTLEFIELD:
+            case EXILED:
+            case HAND:
+            case GRAVEYARD:
+                return player.moveCards(cards, this.zone, source, game);
             default:
-                // HAND, GRAVEYARD, BATTLEFIELD, EXILED don't need unique method call
-                return player.moveCards(cards, zone, source, game);
+                throw new UnsupportedOperationException("Missing case for " + this.name() + "in PutCards.moveCards");
         }
     }
 }

--- a/Mage/src/main/java/mage/constants/PutCards.java
+++ b/Mage/src/main/java/mage/constants/PutCards.java
@@ -74,6 +74,7 @@ public enum PutCards {
             case BATTLEFIELD_TAPPED:
                 return player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
             default:
+                // HAND, GRAVEYARD, BATTLEFIELD, EXILED don't need unique method call
                 return player.moveCards(card, zone, source, game);
         }
     }
@@ -91,6 +92,7 @@ public enum PutCards {
             case BATTLEFIELD_TAPPED:
                 return player.moveCards(cards.getCards(game), Zone.BATTLEFIELD, source, game, true, false, false, null);
             default:
+                // HAND, GRAVEYARD, BATTLEFIELD, EXILED don't need unique method call
                 return player.moveCards(cards, zone, source, game);
         }
     }

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -65,7 +65,8 @@ public class GameEvent implements Serializable {
         //player events
         /* ZONE_CHANGE
          targetId    id of the zone changing object
-         sourceId    sourceId of the ability with the object moving effect (WARNING, can be null if it move of fizzled spells)
+         sourceId    sourceId of the ability with the object moving effect
+                     WARNING: can be null if moved by game rules (e.g. draw in draw step, discard in cleanup step, fizzled spell)
          playerId    controller of the moved object
          amount      not used for this event
          flag        not used for this event

--- a/Mage/src/main/java/mage/game/stack/Spell.java
+++ b/Mage/src/main/java/mage/game/stack/Spell.java
@@ -417,7 +417,7 @@ public class Spell extends StackObjectImpl implements Card {
     }
 
     @Override
-    public void counter(Ability source, Game game, PutCards zone) {
+    public void counter(Ability source, Game game, PutCards putCard) {
         // source can be null for fizzled spells, don't use that code in your ZONE_CHANGE watchers/triggers:
         // event.getSourceId().equals
         // TODO: fizzled spells are no longer considered "countered" as of current rules; may need refactor
@@ -429,30 +429,7 @@ public class Spell extends StackObjectImpl implements Card {
         }
         Player player = game.getPlayer(source == null ? getControllerId() : source.getControllerId());
         if (player != null) {
-            switch (zone) {
-                case TOP_OR_BOTTOM:
-                    if (player.chooseUse(Outcome.Detriment,
-                            "Put the countered spell on the top or bottom of its owner's library?",
-                            null, "Top", "Bottom", source, game
-                    )) {
-                        player.putCardsOnTopOfLibrary(new CardsImpl(card), game, source, false);
-                    } else {
-                        player.putCardsOnBottomOfLibrary(new CardsImpl(card), game, source, false);
-                    }
-                    break;
-                case TOP_ANY:
-                    player.putCardsOnTopOfLibrary(new CardsImpl(card), game, source, false);
-                    break;
-                case BOTTOM_ANY:
-                case BOTTOM_RANDOM:
-                    player.putCardsOnBottomOfLibrary(new CardsImpl(card), game, source, false);
-                    break;
-                case BATTLEFIELD_TAPPED:
-                    player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
-                    break;
-                default:
-                    player.moveCards(card, zone.getZone(), source, game);
-            }
+            putCard.moveCard(player, card, source, game, "countered spell");
         }
     }
 

--- a/Mage/src/main/java/mage/game/stack/SpellStack.java
+++ b/Mage/src/main/java/mage/game/stack/SpellStack.java
@@ -62,7 +62,7 @@ public class SpellStack extends ArrayDeque<StackObject> {
         return counter(objectId, source, game, PutCards.GRAVEYARD);
     }
 
-    public boolean counter(UUID objectId, Ability source, Game game, PutCards zone) {
+    public boolean counter(UUID objectId, Ability source, Game game, PutCards putCard) {
         StackObject stackObject = getStackObject(objectId);
         MageObject sourceObject = game.getObject(source);
         if (stackObject != null && sourceObject != null) {
@@ -82,7 +82,7 @@ public class SpellStack extends ArrayDeque<StackObject> {
                 if (!(stackObject instanceof Spell)) { // spells are removed from stack by the card movement
                     this.remove(stackObject, game);
                 }
-                stackObject.counter(source, game, zone);
+                stackObject.counter(source, game, putCard);
                 if (!game.isSimulation()) {
                     game.informPlayers(counteredObjectName + " is countered by " + sourceObject.getLogName());
                 }

--- a/Mage/src/main/java/mage/game/stack/StackAbility.java
+++ b/Mage/src/main/java/mage/game/stack/StackAbility.java
@@ -109,7 +109,7 @@ public class StackAbility extends StackObjectImpl implements Ability {
     }
 
     @Override
-    public void counter(Ability source, Game game, PutCards zone) {
+    public void counter(Ability source, Game game, PutCards putCard) {
         //20100716 - 603.8
         if (ability instanceof StateTriggeredAbility) {
             ((StateTriggeredAbility) ability).counter(game);

--- a/Mage/src/main/java/mage/game/stack/StackObject.java
+++ b/Mage/src/main/java/mage/game/stack/StackObject.java
@@ -24,7 +24,7 @@ public interface StackObject extends MageObject, Controllable {
      */
     void counter(Ability source, Game game);
 
-    void counter(Ability source, Game game, PutCards zone);
+    void counter(Ability source, Game game, PutCards putCard);
 
     Ability getStackAbility();
 


### PR DESCRIPTION
I moved the card-moving logic into the `PutCards` enum itself. There are separate methods for single card (`Card` class) and multiple (`Cards` class) in order to avoid round-trip conversions between `Card` and `Cards` and `Set<Card>`, and in order to error on unsupported usage (I can't imagine a card template that would need TOP_OR_BOTTOM with multiple cards or how that should work).

Re naming of the enum members--I think TOP and BOTTOM are unambiguous without needing the word LIBRARY. It's just wasted horizontal space. The library is the only zone that even has a meaningful "top" and "bottom" (the rules of Magic don't support putting cards on the bottom of a graveyard, and graveyard order mattering has been "deprecated" since the late 1990s)