### PR TITLE
[40K] Implement Inquisitor Eisenhorn

### DIFF
--- a/Mage.Sets/src/mage/cards/i/InquisitorEisenhorn.java
+++ b/Mage.Sets/src/mage/cards/i/InquisitorEisenhorn.java
@@ -86,12 +86,12 @@ class InquisitorEisenhornReplacementEffect extends ReplacementEffectImpl {
             return false;
         }
 
-        // reveal
-        controller.setTopCardRevealed(true);
-
         if (topCard.isInstantOrSorcery(game)) {
             new CherubaelToken().putOntoBattlefield(1, game, source);
         }
+
+        // reveal
+        controller.setTopCardRevealed(true);
 
         return false;
     }

--- a/Mage.Sets/src/mage/cards/i/InquisitorEisenhorn.java
+++ b/Mage.Sets/src/mage/cards/i/InquisitorEisenhorn.java
@@ -1,0 +1,145 @@
+package mage.cards.i;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.dynamicvalue.common.SavedDamageValue;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.keyword.InvestigateEffect;
+import mage.abilities.hint.HintUtils;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.game.permanent.token.CherubaelToken;
+import mage.players.Player;
+import mage.watchers.common.CardsAmountDrawnThisTurnWatcher;
+
+import java.awt.*;
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public final class InquisitorEisenhorn extends CardImpl {
+
+    public InquisitorEisenhorn(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}{B}");
+        this.addSuperType(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN, SubType.INQUISITOR);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(3);
+
+        // You may reveal the first card you draw each turn as you draw it. Whenever you reveal an instant or
+        // sorcery card this way, create Cherubael, a legendary 4/4 black Demon creature token with flying.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new InquisitorEisenhornReplacementEffect()), new CardsAmountDrawnThisTurnWatcher());
+
+        // Whenever Inquisitor Eisenhorn deals combat damage to a player, investigate that many times.
+        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
+                new InvestigateEffect(SavedDamageValue.MANY).setText("investigate that many times"),
+                false, true
+        ));
+    }
+
+    private InquisitorEisenhorn(final InquisitorEisenhorn card) {
+        super(card);
+    }
+
+    @Override
+    public InquisitorEisenhorn copy() {
+        return new InquisitorEisenhorn(this);
+    }
+}
+
+class InquisitorEisenhornReplacementEffect extends ReplacementEffectImpl {
+
+    public InquisitorEisenhornReplacementEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.Neutral);
+        this.staticText = "You may reveal the first card you draw each turn as you draw it. Whenever you reveal an instant or " +
+                "sorcery card this way, create Cherubael, a legendary 4/4 black Demon creature token with flying";
+    }
+
+    public InquisitorEisenhornReplacementEffect(final InquisitorEisenhornReplacementEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public InquisitorEisenhornReplacementEffect copy() {
+        return new InquisitorEisenhornReplacementEffect(this);
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        // reveal the top card and draw (return false to continue to default draw)
+        Permanent permanent = game.getPermanent(source.getSourceId());
+        Player controller = game.getPlayer(source.getControllerId());
+        if (permanent == null || controller == null) {
+            return false;
+        }
+
+        Card topCard = controller.getLibrary().getFromTop(game);
+        if (topCard == null) {
+            return false;
+        }
+
+        // reveal
+        controller.setTopCardRevealed(true);
+
+        if (topCard.isInstantOrSorcery(game)) {
+            new CherubaelToken().putOntoBattlefield(1, game, source);
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DRAW_CARD;
+    }
+
+    String getAppliedMark(Game game, Ability source) {
+        return source.getId() + "-applied-" + source.getControllerId() + "-" + game.getState().getTurnNum();
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (!event.getPlayerId().equals(source.getControllerId())) {
+            return false;
+        }
+
+        Permanent permanent = game.getPermanent(source.getSourceId());
+        Player controller = game.getPlayer(source.getControllerId());
+        if (permanent == null && controller == null) {
+            return false;
+        }
+
+        Card topCard = controller.getLibrary().getFromTop(game);
+        if (topCard == null) {
+            return false;
+        }
+
+        // only first drawn card
+        // if card cast on that turn or controller changed then needs history from watcher
+        CardsAmountDrawnThisTurnWatcher watcher = game.getState().getWatcher(CardsAmountDrawnThisTurnWatcher.class);
+        if (watcher != null && watcher.getAmountCardsDrawn(event.getPlayerId()) != 0) {
+            return false;
+        }
+
+        // one time use (if multiple cards drawn)
+        String mark = getAppliedMark(game, source);
+        if (game.getState().getValue(mark) != null) {
+            return false;
+        }
+        game.getState().setValue(mark, true);
+
+        // ask player to reveal top card
+        String mes = topCard.getName() + ", " + (topCard.isInstantOrSorcery(game)
+                ? HintUtils.prepareText("you will create Cherubael", Color.green)
+                : HintUtils.prepareText("you won't create Cherubael", Color.red));
+        return controller.chooseUse(Outcome.Benefit, "Reveal first drawn card (" + mes + ")?", source, game);
+    }
+}

--- a/Mage.Sets/src/mage/sets/Warhammer40000.java
+++ b/Mage.Sets/src/mage/sets/Warhammer40000.java
@@ -144,6 +144,7 @@ public final class Warhammer40000 extends ExpansionSet {
         cards.add(new SetCardInfo("Icon of Ancestry", 242, Rarity.RARE, mage.cards.i.IconOfAncestry.class));
         cards.add(new SetCardInfo("Illuminor Szeras", 37, Rarity.RARE, mage.cards.i.IlluminorSzeras.class));
         cards.add(new SetCardInfo("Imotekh the Stormlord", 5, Rarity.MYTHIC, mage.cards.i.ImotekhTheStormlord.class));
+        cards.add(new SetCardInfo("Inquisitor Eisenhorn", 127, Rarity.RARE, mage.cards.i.InquisitorEisenhorn.class));
         cards.add(new SetCardInfo("Inquisitor Greyfax", 3, Rarity.MYTHIC, mage.cards.i.InquisitorGreyfax.class));
         cards.add(new SetCardInfo("Inquisitorial Rosette", 159, Rarity.RARE, mage.cards.i.InquisitorialRosette.class));
         cards.add(new SetCardInfo("Inspiring Call", 217, Rarity.UNCOMMON, mage.cards.i.InspiringCall.class));

--- a/Mage/src/main/java/mage/game/permanent/token/CherubaelToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/CherubaelToken.java
@@ -6,6 +6,9 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 
+/**
+ * @author PurpleCrowbar
+ */
 public final class CherubaelToken extends TokenImpl {
 
     public CherubaelToken() {

--- a/Mage/src/main/java/mage/game/permanent/token/CherubaelToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/CherubaelToken.java
@@ -1,0 +1,29 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.abilities.keyword.FlyingAbility;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+
+public final class CherubaelToken extends TokenImpl {
+
+    public CherubaelToken() {
+        super("Cherubael", "Cherubael, a legendary 4/4 black Demon creature token with flying");
+        cardType.add(CardType.CREATURE);
+        addSuperType(SuperType.LEGENDARY);
+        subtype.add(SubType.DEMON);
+        color.setBlack(true);
+        power = new MageInt(4);
+        toughness = new MageInt(4);
+        this.addAbility(FlyingAbility.getInstance());
+    }
+
+    public CherubaelToken(final CherubaelToken token) {
+        super(token);
+    }
+
+    public CherubaelToken copy() {
+        return new CherubaelToken(this);
+    }
+}


### PR DESCRIPTION
Based on the implementation of God-Eternal Kefnet. Posting this as a draft because of an issue. In the current implementation, choosing to reveal the card that you're drawing does not reveal the card, but does create the demon token if it is a sorcery or instant. I've narrowed the issue down to the fact that after the top card in the library is revealed in the `replaceEvent`, the game does not update(?) before it creates the token and returns false to let the user draw the card for the turn. 

The reason this issue does not present itself with God-Eternal Kefnet is because that card prompts the user to decide if they want to copy the spell or not, and this prompt causes the game to update and thus the card becomes revealed. I know this because I tested Inquisitor Eisenhorn's implementation in the exact same way, but with an added dummy prompt in the if statement on line 92 of `InquisitorEisenhorn.java` in the same way that it is done with GEKefnet, and that caused the card to be revealed as expected. See below for the Kefnet code (note it prompting the user for a choice):
https://github.com/magefree/mage/blob/572104b8fcdb50b509c34b10e113cf39602374bb/Mage.Sets/src/mage/cards/g/GodEternalKefnet.java#L93-L94

I believe I saw another developer fix this type of issue in a card implementation a while ago by forcing the game to update(?) before the function ends, but can't find the commit. Anyone know what I'm thinking of?