### PR TITLE
Update Premodern.java

### DIFF
--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Premodern.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Premodern.java
@@ -59,7 +59,6 @@ public class Premodern extends Constructed {
         banned.add("Mind Twist");
         banned.add("Mystical Tutor");
         banned.add("Necropotence");
-        banned.add("Show and Tell");
         banned.add("Strip Mine");
         banned.add("Tendrils of Agony");
         banned.add("Time Spiral");


### PR DESCRIPTION
Banlist update October 2022 as published on [premodernmagic](https://premodernmagic.com/blog/ban-list-update-2022/).

- Show&Tell removed from Banlist