### PR TITLE
[BRO] Implemented Fade from History

### DIFF
--- a/Mage.Sets/src/mage/cards/f/FadeFromHistory.java
+++ b/Mage.Sets/src/mage/cards/f/FadeFromHistory.java
@@ -1,0 +1,70 @@
+package mage.cards.f;
+
+import java.util.HashSet;
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DestroyAllEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.game.permanent.token.BearToken;
+
+/**
+ *
+ * @author weirddan455
+ */
+public final class FadeFromHistory extends CardImpl {
+
+    public FadeFromHistory(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{G}{G}");
+
+        // Each player who controls an artifact or enchantment creates a 2/2 green Bear creature token. Then destroy all artifacts and enchantments.
+        this.getSpellAbility().addEffect(new FadeFromHistoryTokenEffect());
+        this.getSpellAbility().addEffect(new DestroyAllEffect(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_ENCHANTMENT)
+                .setText("Then destroy all artifacts and enchantments."));
+    }
+
+    private FadeFromHistory(final FadeFromHistory card) {
+        super(card);
+    }
+
+    @Override
+    public FadeFromHistory copy() {
+        return new FadeFromHistory(this);
+    }
+}
+
+class FadeFromHistoryTokenEffect extends OneShotEffect {
+
+    public FadeFromHistoryTokenEffect() {
+        super(Outcome.PutCreatureInPlay);
+        this.staticText = "Each player who controls an artifact or enchantment creates a 2/2 green Bear creature token.";
+    }
+
+    private FadeFromHistoryTokenEffect(final FadeFromHistoryTokenEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public FadeFromHistoryTokenEffect copy() {
+        return new FadeFromHistoryTokenEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        HashSet<UUID> playerIds = new HashSet<>();
+        for (Permanent permanent : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_ENCHANTMENT, source.getControllerId(), source, game)) {
+            playerIds.add(permanent.getControllerId());
+        }
+        for (UUID playerId : playerIds) {
+            new BearToken().putOntoBattlefield(1, game, source, playerId);
+        }
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/sets/TheBrothersWar.java
+++ b/Mage.Sets/src/mage/sets/TheBrothersWar.java
@@ -29,6 +29,7 @@ public final class TheBrothersWar extends ExpansionSet {
         cards.add(new SetCardInfo("Brushland", 259, Rarity.RARE, mage.cards.b.Brushland.class));
         cards.add(new SetCardInfo("Clay Revenant", 118, Rarity.COMMON, mage.cards.c.ClayRevenant.class));
         cards.add(new SetCardInfo("Drafna, Founder of Lat-Nam", 47, Rarity.RARE, mage.cards.d.DrafnaFounderOfLatNam.class));
+        cards.add(new SetCardInfo("Fade from History", 177, Rarity.RARE, mage.cards.f.FadeFromHistory.class));
         cards.add(new SetCardInfo("Feldon, Ronom Excavator", 135, Rarity.RARE, mage.cards.f.FeldonRonomExcavator.class));
         cards.add(new SetCardInfo("Forest", 286, Rarity.LAND, mage.cards.basiclands.Forest.class, FULL_ART_BFZ_VARIOUS));
         cards.add(new SetCardInfo("Giant Growth", 183, Rarity.COMMON, mage.cards.g.GiantGrowth.class));


### PR DESCRIPTION
I assume putting this into two separate effects eliminates the need to call `game.getState.processActions()` as discussed in #9692.  I tested with [[Mycosynth Lattice]] and it worked (bear gets created and then destroyed by the 2nd effect).