### PR TITLE
Change ManaTest to use JUnit 5 instead of JUnit 4 ( issue #9738 )

### DIFF
--- a/Mage/src/test/java/mage/ManaTest.java
+++ b/Mage/src/test/java/mage/ManaTest.java
@@ -2,22 +2,22 @@ package mage;
 
 import mage.abilities.SpellAbility;
 import mage.abilities.costs.mana.ManaCost;
-import mage.abilities.costs.mana.ManaCostImpl;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.constants.ColoredManaSymbol;
 import mage.constants.ManaType;
 import mage.filter.FilterMana;
 import mage.util.CardUtil;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Custom unit tests for {@link Mana}.
@@ -26,18 +26,16 @@ import static org.junit.Assert.*;
  */
 public class ManaTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
     public void shouldNotAllowNullCopyConstructor() {
-        // given
-        expectedException.expect(NullPointerException.class);
-        expectedException.expectMessage("The passed in mana can not be null");
-
         // when
-        Mana nullMana = null;
-        new Mana(nullMana);
+        NullPointerException expectedException = assertThrows(NullPointerException.class, () -> {
+            Mana nullMana = null;
+            new Mana(nullMana);
+        });
+
+        // then
+        assertEquals("The passed in mana can not be null", expectedException.getMessage());
     }
 
     @Test
@@ -139,19 +137,18 @@ public class ManaTest {
 
     @Test
     public void shouldNotCreateManaFromNullColoredManaSymbol() {
-        // given
-        ColoredManaSymbol nullSymbol = null;
-
-        expectedException.expect(NullPointerException.class);
-        expectedException.expectMessage("The passed in ColoredManaSymbol can not be null");
-
         // when
-        new Mana(nullSymbol);
+        NullPointerException exception = assertThrows(NullPointerException.class, () -> {
+            ColoredManaSymbol nullSymbol = null;
+            new Mana(nullSymbol);
+        });
+
+        // then
+        assertEquals("The passed in ColoredManaSymbol can not be null", exception.getMessage());
     }
 
     @Test
     public void shouldCreateManaFromIntegers() {
-
         // when
         Mana mana = new Mana(4, 3, 5, 1, 2, 6, 7, 8);
 
@@ -168,8 +165,6 @@ public class ManaTest {
 
     @Test
     public void shouldNotAllowNegativeIntegers() {
-        // given
-
         // when
         Mana mana = new Mana(4, 3, 5, -1, 2, 6, 7, 0);
 
@@ -179,7 +174,6 @@ public class ManaTest {
 
     @Test
     public void shouldCreateRedMana() {
-
         // when
         Mana mana = Mana.RedMana(1);
 
@@ -189,7 +183,6 @@ public class ManaTest {
 
     @Test
     public void shouldCreateGreenMana() {
-
         // when
         Mana mana = Mana.GreenMana(1);
 
@@ -199,7 +192,6 @@ public class ManaTest {
 
     @Test
     public void shouldCreateBlueMana() {
-
         // when
         Mana mana = Mana.BlueMana(1);
 
@@ -209,7 +201,6 @@ public class ManaTest {
 
     @Test
     public void shouldCreateWhiteMana() {
-
         // when
         Mana mana = Mana.WhiteMana(1);
 
@@ -219,7 +210,6 @@ public class ManaTest {
 
     @Test
     public void shouldCreateBlackMana() {
-
         // when
         Mana mana = Mana.BlackMana(1);
 
@@ -229,7 +219,6 @@ public class ManaTest {
 
     @Test
     public void shouldCreateGenericMana() {
-
         // when
         Mana mana = Mana.GenericMana(1);
 
@@ -239,7 +228,6 @@ public class ManaTest {
 
     @Test
     public void shouldCreateColorlessMana() {
-
         // when
         Mana mana = Mana.ColorlessMana(1);
 
@@ -249,19 +237,15 @@ public class ManaTest {
 
     @Test
     public void shouldNotAllowNegativeRedMana() {
-        // given
-
         // when
         Mana mana = Mana.RedMana(-1);
 
-        //then
+        // then
         assertEquals(0, mana.getRed());
     }
 
     @Test
     public void shouldNotAllowNegativeGreenMana() {
-        // given
-
         // when
         Mana mana = Mana.GreenMana(-1);
 
@@ -271,8 +255,6 @@ public class ManaTest {
 
     @Test
     public void shouldNotAllowNegativeBlueMana() {
-        // given
-
         // when
         Mana mana = Mana.BlueMana(-1);
 
@@ -282,8 +264,6 @@ public class ManaTest {
 
     @Test
     public void shouldNotAllowNegativeWhiteMana() {
-        // given
-
         // when
         Mana mana = Mana.WhiteMana(-1);
 
@@ -293,23 +273,19 @@ public class ManaTest {
 
     @Test
     public void shouldNotAllowNegativeBlackMana() {
-        // given
-
         // when
         Mana mana = Mana.BlackMana(-1);
 
-        //then
+        // then
         assertEquals(0, mana.getBlack());
     }
 
     @Test
     public void shouldNotAllowNegativeColorlessMana() {
-        // given
-
         // when
         Mana mana = Mana.GenericMana(-1);
 
-        //then
+        // then
         assertEquals(0, mana.getGeneric());
     }
 
@@ -463,8 +439,6 @@ public class ManaTest {
     @Test
     public void shouldThrowExceptionOnUnavailableColorless() {
         // given
-        expectedException.expect(ArithmeticException.class);
-        expectedException.expectMessage("Not enough mana to pay colorless");
         Mana available = new Mana();
         available.setRed(4);
 
@@ -473,7 +447,12 @@ public class ManaTest {
         cost.setGeneric(2);
 
         // when
-        available.subtractCost(cost);
+        ArithmeticException exception = assertThrows(ArithmeticException.class, () -> {
+            available.subtractCost(cost);
+        });
+
+        // then
+        assertEquals("Not enough mana to pay colorless", exception.getMessage());
     }
 
     @Test
@@ -819,8 +798,8 @@ public class ManaTest {
         // 1. A color of WUBURG is not more valuable than any other
         for (Mana coloredMana1 : coloredManas) {
             for (Mana coloredMana2 : coloredManas) {
-                assertNull(coloredMana1 + " and " + coloredMana2 + " should not be comparable.", Mana.getMoreValuableMana(coloredMana1, coloredMana2));
-                assertNull(coloredMana1 + " and " + coloredMana2 + " should not be comparable.", Mana.getMoreValuableMana(coloredMana2, coloredMana1));
+              assertNull(Mana.getMoreValuableMana(coloredMana1, coloredMana2), String.format("%s and %s should not be comparable.", coloredMana1, coloredMana2));
+              assertNull(Mana.getMoreValuableMana(coloredMana2, coloredMana1), String.format("%s and %s should not be comparable.", coloredMana1, coloredMana2));
             }
         }
 
@@ -900,10 +879,9 @@ public class ManaTest {
      */
     private void testManaNeeded(Mana available, Mana cost, Mana neededExpected) {
         Mana neededActual = cost.needed(available);
-        Assert.assertTrue(
-                "The mana needed to pay " + cost + " given " + available
-                        + " should have been " + neededExpected + " but was calculate to be " + neededActual,
-                neededActual.equalManaValue(neededExpected)
+        assertTrue(
+            neededActual.equalManaValue(neededExpected),
+            String.format("The mana needed to pay %s given %s should have been %s but was calculated to be %s", cost, available, neededExpected, neededActual)
         );
     }
 
@@ -921,9 +899,15 @@ public class ManaTest {
         Mana manaAvailable = costAvailable.getMana();
         manaAvailable.setAny(availablyAny);
         if (expected) {
-            Assert.assertTrue("The available Mana " + costAvailable.getText() + " should be enough to pay the costs " + unpaid.getText(), unpaid.getMana().enough(manaAvailable));
+            assertTrue(
+                unpaid.getMana().enough(manaAvailable),
+                String.format("The available Mana %s should be enough to pay the costs %s", costAvailable.getText(), unpaid.getText())
+            );
         } else {
-            Assert.assertFalse("The available Mana " + costAvailable.getText() + " shouldn't be enough to pay the costs " + unpaid.getText(), unpaid.getMana().enough(manaAvailable));
+            assertFalse(
+                unpaid.getMana().enough(manaAvailable),
+                String.format("The available Mana %s shouldn't be enough to pay the costs %s", costAvailable.getText(), unpaid.getText())
+            );
         }
     }
 
@@ -937,11 +921,10 @@ public class ManaTest {
     private void assertManaReduction(String manaCostsToPay, String manaToReduce, String restMana) {
         SpellAbility spellAbility = new SpellAbility(new ManaCostsImpl<>(manaCostsToPay), "Test");
         CardUtil.adjustCost(spellAbility, new ManaCostsImpl<>(manaToReduce), true);
-        Assert.assertEquals(
-                "The mana cost to pay " + manaCostsToPay + " reduced by " + manaToReduce +
-                        " should left " + restMana + " but the rest was " + spellAbility.getManaCostsToPay(),
-                spellAbility.getManaCostsToPay().getText(),
-                restMana
+        assertEquals(
+            spellAbility.getManaCostsToPay().getText(),
+            restMana,
+            String.format("The mana cost to pay %s reduced by %s should have left %s but the rest was %s", manaCostsToPay,manaToReduce, restMana, spellAbility.getManaCostsToPay() )
         );
     }
 


### PR DESCRIPTION
This is an example change for upgrading a test from JUnit 4 to JUnit 5.
By doing this we are reducing the reliance on the legacy API and can use better matchers and test lifecycles/wrappers.

I have tested that the change works by temporarily inserting an `assertFalse(true)` call which failed the test. The tests are being picked up and run.