### PR TITLE
[40k] Implement Squad (WIP don't merge)

### DIFF
--- a/Mage.Sets/src/mage/sets/Warhammer40000.java
+++ b/Mage.Sets/src/mage/sets/Warhammer40000.java
@@ -12,8 +12,6 @@ import java.util.List;
  */
 public final class Warhammer40000 extends ExpansionSet {
 
-    private static final List<String> unfinished = Arrays.asList("Arco-Flagellant", "Sicarian Infiltrator", "Space Marine Devastator", "Ultramarines Honour Guard", "Vanguard Suppressor", "Zephyrim");
-
     private static final Warhammer40000 instance = new Warhammer40000();
 
     public static Warhammer40000 getInstance() {
@@ -300,7 +298,5 @@ public final class Warhammer40000 extends ExpansionSet {
         cards.add(new SetCardInfo("Worn Powerstone", 263, Rarity.UNCOMMON, mage.cards.w.WornPowerstone.class));
         cards.add(new SetCardInfo("Zephyrim", 20, Rarity.RARE, mage.cards.z.Zephyrim.class));
         cards.add(new SetCardInfo("Zoanthrope", 149, Rarity.RARE, mage.cards.z.Zoanthrope.class));
-
-        cards.removeIf(setCardInfo -> unfinished.contains(setCardInfo.getName())); // remove when mechanic is implemented
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SquadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SquadTest.java
@@ -1,0 +1,361 @@
+package org.mage.test.cards.abilities.keywords;
+
+import java.util.UUID;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.game.GameState;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class SquadTest extends CardTestPlayerBase {
+
+    /**
+     * Rulling at 2022-11-15
+     * 702.157. Squad
+     * 702.157a Squad is a keyword that represents two linked abilities.
+     * The first is a static ability that functions while the creature
+     * spell with squad is on the stack. The second is a triggered ability
+     * that functions when the creature with squad enters the battlefield.
+     * “Squad [cost]” means “As an additional cost to cast this spell,
+     * youmay pay [cost] any number of times” and “When this creature
+     * enters the battlefield, if its squad cost was paid, create a token
+     * that’s a copy of it for each time its squad cost was paid.” Paying
+     * a spell’s squad cost follows the rules for paying additional costs
+     * in rules 601.2b and 601.2f–h.
+     * 702.157b If a spell has multiple instances of squad, each is paid separately.
+     * If a permanent has multiple instances of squad, each triggers based
+     * on the payments made for that squad ability as it was cast, not based
+     * on payments for any other instance of squad.
+     */
+
+    /**
+     * Arco-Flagellant
+     * {2}{B} 3/1
+     * Creature — Human
+     *
+     * Squad {2} (As an additional cost to cast this spell, you may pay {2} any number of times. When this creature enters the battlefield, create that many tokens that are copies of it.)
+     * Arco-Flagellant can’t block.
+     * Endurant — Pay 3 life: Arco-Flagellant gains indestructible until end of turn.
+     */
+    private static String flagellant = "Arco-Flagellant";
+
+    private static String swamp = "Swamp";
+
+    @Test
+    public void test_Squad_DontUse_Manual() {
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 5);
+        addCard(Zone.HAND, playerA, flagellant);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
+        setChoice(playerA, false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, flagellant, 1);
+    }
+
+    @Test
+    //@Ignore
+    // TODO: enable test after replicate ability will be supported by AI
+    public void test_Squad_DontUse_AI() {
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 5 - 1); // haven't all mana
+        addCard(Zone.HAND, playerA, flagellant);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
+        //setChoice(playerA, false); - AI must choose
+
+        //setStrictChooseMode(true); - AI must choose
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, flagellant, 1);
+    }
+
+    @Test
+    public void test_Squad_UseOnce() {
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 5);
+        addCard(Zone.HAND, playerA, flagellant);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
+        setChoice(playerA, true);
+        setChoice(playerA, false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, flagellant, 2);
+    }
+
+    @Test
+    public void test_Squad_UseTwice() {
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 7);
+        addCard(Zone.HAND, playerA, flagellant);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
+        setChoice(playerA, true);
+        setChoice(playerA, true);
+        setChoice(playerA, false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, flagellant, 3);
+    }
+
+    @Test
+    public void test_ZCC_ReturnedFromGraveyardMustNotRememberSquad() {
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 9); // 3 + 2 + 4
+        addCard(Zone.HAND, playerA, flagellant, 1);
+        // Return target creature card from your graveyard to the battlefield.
+        addCard(Zone.HAND, playerA, "Zombify", 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, swamp, 1);
+        // Target creature gets -2/-2 until end of turn.
+        addCard(Zone.HAND, playerB, "Disfigure", 1);
+
+        // casting with squad
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
+        setChoice(playerA, true);  // use squad once.
+        setChoice(playerA, false);
+
+        // poor flagellant dies an horrible death
+        castSpell(1, PhaseStep.BEGIN_COMBAT, playerB, "Disfigure", flagellant);
+
+        // return the flagellant from graveyard
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Zombify", flagellant);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerB, "Disfigure", 1);
+        assertGraveyardCount(playerA, "Zombify", 1);
+        assertPermanentCount(playerA, flagellant, 2); // The first token of squad + the zombified original
+    }
+
+    @Test
+    public void test_ZCC_ReturnedToHandPermanentMustNotRememberSquad() {
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 8); // 3 + 2 + 3
+        addCard(Zone.HAND, playerA, flagellant, 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+        // Return target permanent to its owner's hand.
+        addCard(Zone.HAND, playerB, "Boomerang", 1);
+
+        // first cast paying for squad
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {B}", 5);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
+        setChoice(playerA, true);  // use squad once.
+        setChoice(playerA, false);
+
+        // return to hand
+        castSpell(1, PhaseStep.BEGIN_COMBAT, playerB, "Boomerang", flagellant);
+
+        // second cast not paying for squad
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, flagellant);
+        setChoice(playerA, false);  // no squad
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerB, "Boomerang", 1);
+        assertPermanentCount(playerA, flagellant, 2); // The first token of squad + the recasted original
+    }
+
+    @Test
+    public void test_ZCC_BlinkMustNotRememberSquad() {
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 5); // 3 + 2
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 1);
+        addCard(Zone.HAND, playerA, flagellant + "@flaggy", 1);
+        // Exile target creature you control, then return it to the battlefield under its owner’s control.
+        // Rebound
+        addCard(Zone.HAND, playerA, "Ephemerate", 1);
+
+        // first cast paying for squad
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {B}", 5);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
+        setChoice(playerA, true);  // use squad once.
+        setChoice(playerA, false);
+
+        // casting Ephemerate
+        castSpell(1, PhaseStep.BEGIN_COMBAT, playerA, "Ephemerate", "@flaggy");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, flagellant, 2); // The first token of squad + the blinked back original
+    }
+
+    // The squad status is a copiable value of the spell, and should be carried over on copy.
+    @Test
+    public void test_CopyingSpellMustKeepSquadStatus() {
+
+        addCard(Zone.HAND, playerA, flagellant, 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5); // 3 + 2
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 1);
+
+        // Copy target creature spell you control, except it isn’t legendary if the spell is legendary.
+        addCard(Zone.HAND, playerA, "Double Major", 1);
+
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {B}", 5);
+        // cast and pay once for squad, then copy it (squad status must be copied)
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
+        setChoice(playerA, true); // pay squad once
+        setChoice(playerA, false);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Double Major", flagellant, flagellant, StackClause.WHILE_ON_STACK);
+        checkStackSize("before copy", 1, PhaseStep.PRECOMBAT_MAIN, playerA, 2); // flagellant + double major
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, true);
+        checkStackSize("after copy", 1, PhaseStep.PRECOMBAT_MAIN, playerA, 2); // spell + copy
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, flagellant, 4); // One original + its squad buddy + the copy + the copy's squad buddy
+    }
+
+    // Copying the trigger remembers the squad status.
+    @Test
+    public void test_CopyingETBTriggerMustKeepSquadStatus() {
+
+        addCard(Zone.HAND, playerA, flagellant + "@flaggy", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 7); // 3 + 2 + 2
+
+        /**
+         * Lithoform Engine
+         * {4}
+         * Legendary Artifact
+         * {2}, {T}: Copy target activated or triggered ability you control. You may choose new targets for the copy. <------- using this one.
+         * {3}, {T}: Copy target instant or sorcery spell you control. You may choose new targets for the copy.
+         * {4}, {T}: Copy target permanent spell you control. (The copy becomes a token.)
+         */
+        addCard(Zone.BATTLEFIELD, playerA, "Lithoform Engine", 1);
+
+        // cast and pay once for squad, then copy it (squad status must be copied)
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
+        setChoice(playerA, true); // pay squad once
+        setChoice(playerA, false);
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, true);
+        // flagellant does resolve, its squad trigger goes in the stack.
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA,
+                "{2}, {T}: Copy target activated or triggered ability you control.");
+
+        //setStrictChooseMode(true); // Could not make it work for explicitly target the trigger with Lithoform Engine
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, flagellant, 3); // One original + its squad buddy + the squad buddy from the copied trigger
+    }
+
+    @Test
+    public void test_PanharmoniconDoubleSquadETBStatus() {
+
+        addCard(Zone.HAND, playerA, flagellant, 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5); // 3 + 2
+
+        // If an artifact or creature entering the battlefield causes a triggered ability
+        // of a permanent you control to trigger, that ability triggers an additional time.
+        addCard(Zone.BATTLEFIELD, playerA, "Panharmonicon", 1);
+
+        // cast and pay once for squad, then copy it (squad status must be copied)
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
+        setChoice(playerA, true); // pay squad once
+        setChoice(playerA, false);
+
+        //setStrictChooseMode(true); // There is a double trigger to put in the stack, not sure how to order them.
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, flagellant, 3); // One original + its squad buddy + the squad buddy from the additional trigger
+    }
+
+    @Test
+    public void test_CloneMustNotCopySquad() {
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 8); // 3 + 2 + 3
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 1);
+        addCard(Zone.HAND, playerA, flagellant + "@flaggy", 1);
+        // You may have Clone enter the battlefield as a copy of any creature on the battlefield.
+        addCard(Zone.HAND, playerA, "Clone", 1);
+
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {B}", 5);
+
+        // cast paying for squad
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
+        setChoice(playerA, true);  // use squad once.
+        setChoice(playerA, false);
+
+        // cloning the flagellant
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Clone");
+        setChoice(playerA, true);  // yes to the 'may copy'
+        setChoice(playerA, "@flaggy");  // cloning the flagellant.
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, flagellant, 3); // The first token of squad + the recasted original + the clone
+    }
+
+    @Test
+    public void test_CopyMustNotCopySquad() {
+        addCard(Zone.BATTLEFIELD, playerA, swamp, 8); // 3 + 2
+        addCard(Zone.HAND, playerA, flagellant + "@flaggy", 1);
+
+        //{T}: Create a token that’s a copy of target nonlegendary creature you control,
+        //     except it has haste. Sacrifice it at the beginning of the next end step.
+        addCard(Zone.BATTLEFIELD, playerA, "Kiki-Jiki, Mirror Breaker", 1);
+
+        // casting with a squad buddy
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
+        setChoice(playerA, true);  // use squad once.
+        setChoice(playerA, false);
+
+        // copying the flagellant with kiki-jiki
+        activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{T}: Create a token", flagellant);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, flagellant, 3); // The first token of squad + the recasted original + the copy
+    }
+
+    @Test
+    public void test_Squad_FreeCast() {
+        skipInitShuffling();
+
+        addCard(Zone.LIBRARY, playerA, flagellant, 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 4);
+        //
+        // Whenever Etali, Primal Storm attacks, exile the top card of each player's library,
+        // then you may cast any number of nonland cards exiled this way without paying their mana costs.
+        addCard(Zone.BATTLEFIELD, playerA, "Etali, Primal Storm", 1);
+
+        checkPlayableAbility("before", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Arco-Flagellant", false);
+
+        // attack and prepare free cast, pay squad
+        attack(1, playerA, "Etali, Primal Storm", playerB);
+        setChoice(playerA, true); // cast for free
+        setChoice(playerA, true); // pay squad once.
+        setChoice(playerA, true); // pay squad twice.
+        setChoice(playerA, false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, flagellant, 3); // card + 2 buddies
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SquadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SquadTest.java
@@ -1,9 +1,7 @@
 package org.mage.test.cards.abilities.keywords;
 
-import java.util.UUID;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import mage.game.GameState;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -12,7 +10,7 @@ import org.mage.test.serverside.base.CardTestPlayerBase;
  */
 public class SquadTest extends CardTestPlayerBase {
 
-    /**
+    /*
      * Rulling at 2022-11-15
      * 702.157. Squad
      * 702.157a Squad is a keyword that represents two linked abilities.
@@ -40,9 +38,9 @@ public class SquadTest extends CardTestPlayerBase {
      * Arco-Flagellant can’t block.
      * Endurant — Pay 3 life: Arco-Flagellant gains indestructible until end of turn.
      */
-    private static String flagellant = "Arco-Flagellant";
+    private final static String flagellant = "Arco-Flagellant";
 
-    private static String swamp = "Swamp";
+    private final static String swamp = "Swamp";
 
     @Test
     public void test_Squad_DontUse_Manual() {
@@ -125,8 +123,9 @@ public class SquadTest extends CardTestPlayerBase {
         setChoice(playerA, true);  // use squad once.
         setChoice(playerA, false);
 
-        // poor flagellant dies an horrible death
-        castSpell(1, PhaseStep.BEGIN_COMBAT, playerB, "Disfigure", flagellant);
+        // poor flagellant dies a horrible death
+        addTarget(playerB, flagellant + "[no copy]");
+        castSpell(1, PhaseStep.BEGIN_COMBAT, playerB, "Disfigure");
 
         // return the flagellant from graveyard
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Zombify", flagellant);
@@ -156,7 +155,8 @@ public class SquadTest extends CardTestPlayerBase {
         setChoice(playerA, false);
 
         // return to hand
-        castSpell(1, PhaseStep.BEGIN_COMBAT, playerB, "Boomerang", flagellant);
+        addTarget(playerB, flagellant+"[no copy]");
+        castSpell(1, PhaseStep.BEGIN_COMBAT, playerB, "Boomerang");
 
         // second cast not paying for squad
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, flagellant);
@@ -174,7 +174,7 @@ public class SquadTest extends CardTestPlayerBase {
     public void test_ZCC_BlinkMustNotRememberSquad() {
         addCard(Zone.BATTLEFIELD, playerA, swamp, 5); // 3 + 2
         addCard(Zone.BATTLEFIELD, playerA, "Plains", 1);
-        addCard(Zone.HAND, playerA, flagellant + "@flaggy", 1);
+        addCard(Zone.HAND, playerA, flagellant, 1);
         // Exile target creature you control, then return it to the battlefield under its owner’s control.
         // Rebound
         addCard(Zone.HAND, playerA, "Ephemerate", 1);
@@ -186,7 +186,8 @@ public class SquadTest extends CardTestPlayerBase {
         setChoice(playerA, false);
 
         // casting Ephemerate
-        castSpell(1, PhaseStep.BEGIN_COMBAT, playerA, "Ephemerate", "@flaggy");
+        addTarget(playerA, flagellant+"[no copy]");
+        castSpell(1, PhaseStep.BEGIN_COMBAT, playerA, "Ephemerate");
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
@@ -218,7 +219,7 @@ public class SquadTest extends CardTestPlayerBase {
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, true);
         checkStackSize("after copy", 1, PhaseStep.PRECOMBAT_MAIN, playerA, 2); // spell + copy
 
-        setStrictChooseMode(true);
+        //setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 
@@ -229,10 +230,10 @@ public class SquadTest extends CardTestPlayerBase {
     @Test
     public void test_CopyingETBTriggerMustKeepSquadStatus() {
 
-        addCard(Zone.HAND, playerA, flagellant + "@flaggy", 1);
+        addCard(Zone.HAND, playerA, flagellant, 1);
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 7); // 3 + 2 + 2
 
-        /**
+        /*
          * Lithoform Engine
          * {4}
          * Legendary Artifact
@@ -248,12 +249,11 @@ public class SquadTest extends CardTestPlayerBase {
         setChoice(playerA, false);
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, true);
         // flagellant does resolve, its squad trigger goes in the stack.
-
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA,
                 "{2}, {T}: Copy target activated or triggered ability you control.");
 
         //setStrictChooseMode(true); // Could not make it work for explicitly target the trigger with Lithoform Engine
-        setStopAt(1, PhaseStep.END_TURN);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
         execute();
 
         assertPermanentCount(playerA, flagellant, 3); // One original + its squad buddy + the squad buddy from the copied trigger
@@ -299,13 +299,13 @@ public class SquadTest extends CardTestPlayerBase {
         // cloning the flagellant
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Clone");
         setChoice(playerA, true);  // yes to the 'may copy'
-        setChoice(playerA, "@flaggy");  // cloning the flagellant.
+        setChoice(playerA, "@flaggy");  // cloning the original flagellant.
 
-        setStrictChooseMode(true);
+        //setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 
-        assertPermanentCount(playerA, flagellant, 3); // The first token of squad + the recasted original + the clone
+        assertPermanentCount(playerA, flagellant, 3); // The original + its token + the clone
     }
 
     @Test
@@ -322,14 +322,14 @@ public class SquadTest extends CardTestPlayerBase {
         setChoice(playerA, true);  // use squad once.
         setChoice(playerA, false);
 
-        // copying the flagellant with kiki-jiki
-        activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{T}: Create a token", flagellant);
+        // copying the original flagellant with kiki-jiki
+        activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{T}: Create a token", "@flaggy");
 
         setStrictChooseMode(true);
-        setStopAt(1, PhaseStep.END_TURN);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
         execute();
 
-        assertPermanentCount(playerA, flagellant, 3); // The first token of squad + the recasted original + the copy
+        assertPermanentCount(playerA, flagellant, 3); // The original + the first token of squad + the copy token
     }
 
     @Test

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SquadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SquadTest.java
@@ -43,7 +43,7 @@ public class SquadTest extends CardTestPlayerBase {
     private final static String swamp = "Swamp";
 
     @Test
-    public void test_Squad_DontUse_Manual() {
+    public void test_Squad_NotUsed_Manual() {
         addCard(Zone.BATTLEFIELD, playerA, swamp, 5);
         addCard(Zone.HAND, playerA, flagellant);
 
@@ -60,7 +60,7 @@ public class SquadTest extends CardTestPlayerBase {
     @Test
     //@Ignore
     // TODO: enable test after replicate ability will be supported by AI
-    public void test_Squad_DontUse_AI() {
+    public void test_Squad_NotUsed_AI() {
         addCard(Zone.BATTLEFIELD, playerA, swamp, 5 - 1); // haven't all mana
         addCard(Zone.HAND, playerA, flagellant);
 

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/SquadDynamicValue.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/SquadDynamicValue.java
@@ -1,0 +1,49 @@
+
+package mage.abilities.dynamicvalue.common;
+
+import mage.abilities.Ability;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.effects.Effect;
+import mage.abilities.hint.ValueHint;
+import mage.abilities.keyword.KickerAbility;
+import mage.abilities.keyword.SquadAbility;
+import mage.constants.AbilityType;
+import mage.game.Game;
+import mage.watchers.common.CardsDrawnThisTurnWatcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Susucre
+ */
+public enum SquadDynamicValue implements DynamicValue {
+    instance;
+
+    private static final ValueHint hint = new ValueHint("Time(s) squad was paid", instance);
+
+    @Override
+    public int calculate(Game game, Ability source, Effect effect) {
+        return SquadAbility.getSourceObjectSquadCount(game, source);
+    }
+
+    @Override
+    public SquadDynamicValue copy() {
+        return instance;
+    }
+
+    @Override
+    public String toString() {
+        return "1";
+    }
+
+    @Override
+    public String getMessage() {
+
+        return "time(s) squad was paid";
+    }
+
+    public static ValueHint getHint() {
+        return hint;
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/CreateTokenCopySourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/CreateTokenCopySourceEffect.java
@@ -1,6 +1,8 @@
 package mage.abilities.effects;
 
 import mage.abilities.Ability;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
 import mage.constants.Outcome;
 import mage.game.Game;
@@ -12,7 +14,7 @@ import mage.target.targetpointer.FixedTarget;
  */
 public class CreateTokenCopySourceEffect extends OneShotEffect {
 
-    private final int number;
+    private final DynamicValue amount;
     private final boolean tapped;
 
     public CreateTokenCopySourceEffect() {
@@ -20,19 +22,23 @@ public class CreateTokenCopySourceEffect extends OneShotEffect {
     }
 
     public CreateTokenCopySourceEffect(int copies) {
-        this(copies, false);
+        this(StaticValue.get(copies), false);
     }
 
-    public CreateTokenCopySourceEffect(int copies, boolean tapped) {
+    public CreateTokenCopySourceEffect(int copies, boolean tapped) { this(StaticValue.get(copies), tapped); }
+
+    public CreateTokenCopySourceEffect(DynamicValue amount) { this(amount, false); }
+
+    public CreateTokenCopySourceEffect(DynamicValue amount, boolean tapped) {
         super(Outcome.PutCreatureInPlay);
-        this.number = copies;
+        this.amount = amount.copy();
         this.tapped = tapped;
         staticText = "create a " + (tapped ? "tapped " : "") + "token that's a copy of {this}";
     }
 
     public CreateTokenCopySourceEffect(final CreateTokenCopySourceEffect effect) {
         super(effect);
-        this.number = effect.number;
+        this.amount = effect.amount.copy();
         this.tapped = effect.tapped;
     }
 
@@ -42,8 +48,9 @@ public class CreateTokenCopySourceEffect extends OneShotEffect {
         if (permanent == null) {
             return false;
         }
+        int value = amount.calculate(game, source, this);
         CreateTokenCopyTargetEffect effect = new CreateTokenCopyTargetEffect(
-                source.getControllerId(), null, false, number, tapped, false
+                source.getControllerId(), null, false, value, tapped, false
         );
         effect.setTargetPointer(new FixedTarget(source.getSourceId(), game));
         return effect.apply(game, source);

--- a/Mage/src/main/java/mage/abilities/keyword/SquadAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SquadAbility.java
@@ -1,14 +1,66 @@
 package mage.abilities.keyword;
 
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.SpellAbility;
 import mage.abilities.StaticAbility;
-import mage.abilities.costs.Cost;
+import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.costs.*;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.constants.Zone;
+import mage.abilities.costs.mana.ManaCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.MultikickerCount;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.CreateTokenCopySourceEffect;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
+import mage.cards.Card;
+import mage.constants.*;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.predicate.permanent.TokenPredicate;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.players.Player;
+import mage.watchers.common.CastFromHandWatcher;
+
+import java.util.Iterator;
 
 /**
- * @author TheElk801
+ * Rulling at 2022-11-15
+ * 702.157. Squad
+ * 702.157a Squad is a keyword that represents two linked abilities.
+ * The first is a static ability that functions while the creature
+ * spell with squad is on the stack. The second is a triggered ability
+ * that functions when the creature with squad enters the battlefield.
+ * “Squad [cost]” means “As an additional cost to cast this spell,
+ * youmay pay [cost] any number of times” and “When this creature
+ * enters the battlefield, if its squad cost was paid, create a token
+ * that’s a copy of it for each time its squad cost was paid.” Paying
+ * a spell’s squad cost follows the rules for paying additional costs
+ * in rules 601.2b and 601.2f–h.
+ * 702.157b If a spell has multiple instances of squad, each is paid separately.
+ * If a permanent has multiple instances of squad, each triggers based
+ * on the payments made for that squad ability as it was cast, not based
+ * on payments for any other instance of squad.
+ *
+ * @author TheElk801, Susucre
  */
-public class SquadAbility extends StaticAbility {
+public class SquadAbility extends StaticAbility implements OptionalAdditionalSourceCosts  {
+
+    protected static final String SQUAD_KEYWORD = "Squad";
+    protected static final String SQUAD_REMINDER = "You may pay an additional "
+            + "{cost} as you cast this spell.\n"
+            + "When this creature enters the battlefield, "
+            + "if its squad cost was paid, create a token "
+            + "that's a copy of it for each time its squad cost was paid.";
+
+    protected OptionalAdditionalCost squadCost;
+
+    protected SquadTriggeredAbility linkedTrigger;
+
+    protected int activations;
 
     public SquadAbility() {
         this(new GenericManaCost(2));
@@ -16,20 +68,145 @@ public class SquadAbility extends StaticAbility {
 
     public SquadAbility(Cost cost) {
         super(Zone.STACK, null);
-        // TODO: implement this
+        this.squadCost = new OptionalAdditionalCostImpl(SQUAD_KEYWORD, SQUAD_REMINDER, cost);
+        this.squadCost.setCostType(VariableCostType.ADDITIONAL);
+        this.squadCost.setRepeatable(true);
+
+        setRuleAtTheTop(true);
+        this.activations = 0;
+
+        this.linkedTrigger = new SquadTriggeredAbility(this);
+        this.addSubAbility(this.linkedTrigger);
     }
 
     private SquadAbility(final SquadAbility ability) {
         super(ability);
+        this.squadCost = ability.squadCost;
+        this.activations = ability.activations;
+
+        this.linkedTrigger = new SquadTriggeredAbility(this);
+        this.addSubAbility(this.linkedTrigger);
     }
 
     @Override
-    public SquadAbility copy() {
-        return new SquadAbility(this);
-    }
+    public SquadAbility copy() { return new SquadAbility(this); }
 
     @Override
     public String getRule() {
-        return "Squad";
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.squadCost.getText(false));
+        sb.append(this.squadCost.getReminderText());
+        return sb.toString();
+    }
+
+    @Override
+    public String getCastMessageSuffix() {
+        if (this.squadCost.isActivated()) {
+            return this.squadCost.getCastSuffixMessage(0);
+        }
+        return "";
+    }
+
+    @Override
+    public void addOptionalAdditionalCosts(Ability ability, Game game) {
+        if (!(ability instanceof SpellAbility)) {
+            return;
+        }
+        Player player = game.getPlayer(ability.getControllerId());
+        if (player == null) {
+            return;
+        }
+
+        squadCost.reset();
+        this.activations = 0;
+        boolean again = true;
+        while (player.canRespond() && again) {
+            String times = (this.activations + 1) + (this.activations == 0 ? " time " : " times ");
+            // TODO: add AI support to find max number of possible activations (from available mana)
+            //  canPay checks only single mana available, not total mana usage
+            if (squadCost.canPay(ability, this, ability.getControllerId(), game)
+                    && player.chooseUse(/*Outcome.Benefit*/Outcome.AIDontUseIt,
+                    "Pay " + times + squadCost.getText(false) + " ?", ability, game)) {
+                this.activations += 1;
+                game.fireEvent(GameEvent.getEvent(GameEvent.EventType.SQUAD_PAID,
+                                                    ability.getSourceId(),
+                                                    ability,
+                                                    ability.getControllerId()));
+                ability.getCosts().add(squadCost.copy());
+            } else {
+                again = false;
+            }
+        }
+    }
+
+    protected enum SquadPaidCount implements DynamicValue {
+        instance;
+
+        @Override
+        public int calculate(Game game, Ability sourceAbility, Effect effect) {
+            return SquadAbility.getSourceObjectSquadCount(game, sourceAbility);
+        }
+
+        @Override
+        public SquadPaidCount copy() {
+            return SquadPaidCount.instance;
+        }
+
+        @Override
+        public String toString() {
+            return "1";
+        }
+
+        @Override
+        public String getMessage() {
+            return "time its squad cost was paid.";
+        }
+    }
+
+    /**
+     * Find source object's squad status. Can be used in any places, e.g. in ETB effects
+     */
+    protected static int getSourceObjectSquadCount(Game game, Ability abilityToCheck) {
+        if(abilityToCheck == null) return 0;
+
+        MageObject sourceObject = abilityToCheck.getSourceObject(game);
+        int count = 0;
+        if (sourceObject instanceof Card) {
+            for (Ability ability : ((Card) sourceObject).getAbilities(game)) {
+                if (ability instanceof SquadAbility) {
+                    count += ((SquadAbility) ability).activations;
+                }
+            }
+        }
+        return count;
+    }
+
+    // The linked triggered ability for Squad.
+    protected class SquadTriggeredAbility extends EntersBattlefieldTriggeredAbility {
+
+        protected SquadAbility staticAbility;
+
+        public SquadTriggeredAbility(SquadAbility staticAbility){
+            super(new CreateTokenCopySourceEffect(SquadPaidCount.instance));
+            this.staticAbility = staticAbility;
+        }
+
+        public SquadTriggeredAbility(final SquadTriggeredAbility ability) {
+            super(ability);
+        }
+
+        @Override
+        public String getRule() { return "When this creature enters the battlefield, "
+            + "if its squad cost was paid, create a token "
+            + "that's a copy of it for each time its squad cost was paid."; }
+
+        @Override
+        public SquadTriggeredAbility copy() { return new SquadTriggeredAbility(this); }
+
+        @Override
+        public boolean checkTrigger(GameEvent event, Game game){
+            if(!super.checkTrigger(event, game)) return false;
+            return SquadAbility.getSourceObjectSquadCount(game, this.staticAbility) > 0;
+        }
     }
 }

--- a/Mage/src/main/java/mage/abilities/keyword/SquadAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SquadAbility.java
@@ -69,7 +69,7 @@ public class SquadAbility extends StaticAbility implements OptionalAdditionalSou
 
     private SquadAbility(final SquadAbility ability) {
         super(ability);
-        this.squadCost = ability.squadCost;
+        this.squadCost = ability.squadCost.copy();
 
         setRuleAtTheTop(true);
         this.activations.putAll(ability.activations);
@@ -103,7 +103,7 @@ public class SquadAbility extends StaticAbility implements OptionalAdditionalSou
             --zcc;
         }
 
-        return zcc + ""; // + "-" + source.getSourceId() ???
+        return zcc + "|" + source.getSourceId();
     }
 
     private void activateSquad(int count, Ability source, Game game) {

--- a/Mage/src/main/java/mage/abilities/keyword/SquadAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SquadAbility.java
@@ -4,28 +4,21 @@ import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
 import mage.abilities.StaticAbility;
-import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.dynamicvalue.common.SquadDynamicValue;
 import mage.abilities.costs.*;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.costs.mana.ManaCost;
-import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.dynamicvalue.common.MultikickerCount;
-import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.CreateTokenCopySourceEffect;
-import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
 import mage.cards.Card;
 import mage.constants.*;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.permanent.TokenPredicate;
 import mage.game.Game;
 import mage.game.events.GameEvent;
+import mage.game.permanent.PermanentCard;
 import mage.players.Player;
-import mage.watchers.common.CastFromHandWatcher;
+import mage.util.CardUtil;
 
-import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Rulling at 2022-11-15
@@ -49,6 +42,8 @@ import java.util.Iterator;
  */
 public class SquadAbility extends StaticAbility implements OptionalAdditionalSourceCosts  {
 
+    protected Map<String, Integer> activations = new ConcurrentHashMap<>(); // zoneChangeCounter, activations
+
     protected static final String SQUAD_KEYWORD = "Squad";
     protected static final String SQUAD_REMINDER = "You may pay an additional "
             + "{cost} as you cast this spell.\n"
@@ -57,10 +52,6 @@ public class SquadAbility extends StaticAbility implements OptionalAdditionalSou
             + "that's a copy of it for each time its squad cost was paid.";
 
     protected OptionalAdditionalCost squadCost;
-
-    protected SquadTriggeredAbility linkedTrigger;
-
-    protected int activations;
 
     public SquadAbility() {
         this(new GenericManaCost(2));
@@ -73,19 +64,69 @@ public class SquadAbility extends StaticAbility implements OptionalAdditionalSou
         this.squadCost.setRepeatable(true);
 
         setRuleAtTheTop(true);
-        this.activations = 0;
-
-        this.linkedTrigger = new SquadTriggeredAbility(this);
-        this.addSubAbility(this.linkedTrigger);
+        this.addSubAbility(new SquadTriggeredAbility());
     }
 
     private SquadAbility(final SquadAbility ability) {
         super(ability);
         this.squadCost = ability.squadCost;
-        this.activations = ability.activations;
 
-        this.linkedTrigger = new SquadTriggeredAbility(this);
-        this.addSubAbility(this.linkedTrigger);
+        setRuleAtTheTop(true);
+        this.activations.putAll(ability.activations);
+    }
+
+    private void resetSquad() {
+        squadCost.reset();
+        activations.clear();
+    }
+
+    /**
+     * Return activation zcc key for searching spell's
+     * settings in source object
+     */
+    public static String getActivationKey(Ability source, Game game) {
+        // Squad activates in STACK zone so all zcc must be from "stack moment"
+        // Use cases:
+        // * copied spell have same zcc as source spell (see Spell.copySpell and zcc sync);
+        // * creature/token from resolved spell have +1 zcc after moved to battlefield (example: check kicker status in ETB triggers/effects);
+
+        // find object info from the source ability (it can be a permanent or a spell on stack, on the moment of trigger/resolve)
+        MageObject sourceObject = source.getSourceObject(game);
+        Zone sourceObjectZone = game.getState().getZone(sourceObject.getId());
+        int zcc = CardUtil.getActualSourceObjectZoneChangeCounter(game, source);
+
+        // find "stack moment" zcc:
+        // * permanent cards enters from STACK to BATTLEFIELD (+1 zcc)
+        // * permanent tokens enters from OUTSIDE to BATTLEFIELD (+1 zcc, see prepare code in TokenImpl.putOntoBattlefieldHelper)
+        // * spells and copied spells resolves on STACK (zcc not changes)
+        if (sourceObjectZone != Zone.STACK) {
+            --zcc;
+        }
+
+        return zcc + ""; // + "-" + source.getSourceId() ???
+    }
+
+    private void activateSquad(int count, Ability source, Game game) {
+        int amount = count;
+        String key = getActivationKey(source, game);
+        if (activations.containsKey(key)) {
+            amount += activations.get(key);
+        }
+        activations.put(key, amount);
+    }
+
+    private int getSquadCounter(Game game, Ability source) {
+        String key = getActivationKey(source, game);
+
+        int totalActivations = 0;
+        if(source.getSourceId().equals(this.getSourceId())) {
+            for (String activationKey : activations.keySet()) {
+                if (activationKey.startsWith(key) && activations.get(activationKey) > 0) {
+                    totalActivations += activations.get(activationKey);
+                }
+            }
+        }
+        return totalActivations;
     }
 
     @Override
@@ -94,15 +135,15 @@ public class SquadAbility extends StaticAbility implements OptionalAdditionalSou
     @Override
     public String getRule() {
         StringBuilder sb = new StringBuilder();
-        sb.append(this.squadCost.getText(false));
-        sb.append(this.squadCost.getReminderText());
+        sb.append(squadCost.getText(false));
+        sb.append(squadCost.getReminderText());
         return sb.toString();
     }
 
     @Override
     public String getCastMessageSuffix() {
-        if (this.squadCost.isActivated()) {
-            return this.squadCost.getCastSuffixMessage(0);
+        if (squadCost.isActivated()) {
+            return squadCost.getCastSuffixMessage(0);
         }
         return "";
     }
@@ -117,78 +158,45 @@ public class SquadAbility extends StaticAbility implements OptionalAdditionalSou
             return;
         }
 
-        squadCost.reset();
-        this.activations = 0;
+        this.resetSquad();
+        int count = 0;
         boolean again = true;
         while (player.canRespond() && again) {
-            String times = (this.activations + 1) + (this.activations == 0 ? " time " : " times ");
+            String times = (count + 1) + (count == 0 ? " time " : " times ");
             // TODO: add AI support to find max number of possible activations (from available mana)
             //  canPay checks only single mana available, not total mana usage
             if (squadCost.canPay(ability, this, ability.getControllerId(), game)
                     && player.chooseUse(/*Outcome.Benefit*/Outcome.AIDontUseIt,
                     "Pay " + times + squadCost.getText(false) + " ?", ability, game)) {
-                this.activations += 1;
-                game.fireEvent(GameEvent.getEvent(GameEvent.EventType.SQUAD_PAID,
-                                                    ability.getSourceId(),
-                                                    ability,
-                                                    ability.getControllerId()));
                 ability.getCosts().add(squadCost.copy());
+                count += 1;
             } else {
                 again = false;
             }
         }
-    }
-
-    protected enum SquadPaidCount implements DynamicValue {
-        instance;
-
-        @Override
-        public int calculate(Game game, Ability sourceAbility, Effect effect) {
-            return SquadAbility.getSourceObjectSquadCount(game, sourceAbility);
-        }
-
-        @Override
-        public SquadPaidCount copy() {
-            return SquadPaidCount.instance;
-        }
-
-        @Override
-        public String toString() {
-            return "1";
-        }
-
-        @Override
-        public String getMessage() {
-            return "time its squad cost was paid.";
-        }
+        if(count > 0) this.activateSquad(count, ability, game);
     }
 
     /**
-     * Find source object's squad status. Can be used in any places, e.g. in ETB effects
+     * Find source object's kicked stats. Can be used in any places, e.g. in the linked ETB effects
      */
-    protected static int getSourceObjectSquadCount(Game game, Ability abilityToCheck) {
-        if(abilityToCheck == null) return 0;
-
+    public static int getSourceObjectSquadCount(Game game, Ability abilityToCheck) {
         MageObject sourceObject = abilityToCheck.getSourceObject(game);
         int count = 0;
         if (sourceObject instanceof Card) {
             for (Ability ability : ((Card) sourceObject).getAbilities(game)) {
                 if (ability instanceof SquadAbility) {
-                    count += ((SquadAbility) ability).activations;
+                    count += ((SquadAbility) ability).getSquadCounter(game, abilityToCheck);
                 }
             }
         }
         return count;
     }
-
     // The linked triggered ability for Squad.
     protected class SquadTriggeredAbility extends EntersBattlefieldTriggeredAbility {
 
-        protected SquadAbility staticAbility;
-
-        public SquadTriggeredAbility(SquadAbility staticAbility){
-            super(new CreateTokenCopySourceEffect(SquadPaidCount.instance));
-            this.staticAbility = staticAbility;
+        public SquadTriggeredAbility(){
+            super(new CreateTokenCopySourceEffect(SquadDynamicValue.instance));
         }
 
         public SquadTriggeredAbility(final SquadTriggeredAbility ability) {
@@ -206,7 +214,7 @@ public class SquadAbility extends StaticAbility implements OptionalAdditionalSou
         @Override
         public boolean checkTrigger(GameEvent event, Game game){
             if(!super.checkTrigger(event, game)) return false;
-            return SquadAbility.getSourceObjectSquadCount(game, this.staticAbility) > 0;
+            return SquadDynamicValue.instance.calculate(game, this, null) > 0;
         }
     }
 }

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -85,6 +85,7 @@ public class GameEvent implements Serializable {
          */
         MADNESS_CARD_EXILED,
         INVESTIGATED,
+        SQUAD_PAID,
         KICKED,
         /* CONVOKED
          targetId    id of the creature that was taped to convoke the sourceId

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -85,7 +85,6 @@ public class GameEvent implements Serializable {
          */
         MADNESS_CARD_EXILED,
         INVESTIGATED,
-        SQUAD_PAID,
         KICKED,
         /* CONVOKED
          targetId    id of the creature that was taped to convoke the sourceId


### PR DESCRIPTION
Hello,
Here is my attempt to implement the squad mechanic from the 40k set. For instance [[Arco-Flagellant]].

I am currently stuck on resolving some complex interactions with copying a spell cast with squad (that should copy the squad count), and cloning a permanent with squad on the battlefield (that should not add any squad). I have very little clue how to fix those situations, zcc/instance/setSubAbilities are what I suspect to not behave like I expected.

3 tests are wrong in the current WIP, the rest is working:
- test_CopyingETBTriggerMustKeepSquadStatus : Sometimes the [[Lithoform Engine]] seems to not be activated at the right moment. Not sure how to fix that, I did not succeed to set an explicit trigger target for the ability.
- test_CloneMustNotCopySquad: cloning a squad permanent should never produce more tokens, but as of now the clone comes with 2 additional tokens. Adding a source id in SquadAbility.getActivationKey seems to help with this one, but it feels incorrect. I used good old [[Clone]] for that one.
- test_CopyingSpellMustKeepSquadStatus: there is an additional token produced. I suspect addSubAbility to not work like I was expecting. The copy was made with [[Double Major]], which should be straightforward for that kind of effect.

Any help would be hugely appreciated.