### PR TITLE
Fixed Card Ability of "Images Of The Past"

### DIFF
--- a/Mage.Sets/src/mage/cards/i/ImagesOfThePast.java
+++ b/Mage.Sets/src/mage/cards/i/ImagesOfThePast.java
@@ -1,20 +1,35 @@
 
 package mage.cards.i;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import mage.abilities.Ability;
+import mage.abilities.DelayedTriggeredAbility;
+import mage.abilities.TriggeredAbility;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.common.CardsLeaveGraveyardTriggeredAbility;
+import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
+import mage.abilities.common.delayed.AtTheEndOfTurnStepPostDelayedTriggeredAbility;
+import mage.abilities.common.delayed.ReflexiveTriggeredAbility;
+import mage.abilities.effects.CastCardFromGraveyardThenExileItEffect;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.*;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
+import mage.game.events.GameEvent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
+import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -26,8 +41,9 @@ public final class ImagesOfThePast extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{G}{W}");
 
         // Return up to two target creature cards from your graveyard to the battlefield, then exile those creatures.
-        this.getSpellAbility().addEffect(new ImagesOfThePastEffect());
+        this.getSpellAbility().addEffect(new ReturnFromGraveyardToBattlefieldTargetEffect());
         this.getSpellAbility().addTarget(new TargetCardInYourGraveyard(0, 2, StaticFilters.FILTER_CARD_CREATURES_YOUR_GRAVEYARD));
+        this.getSpellAbility().addEffect(new ExileTargetEffect());
 
     }
 
@@ -38,39 +54,5 @@ public final class ImagesOfThePast extends CardImpl {
     @Override
     public ImagesOfThePast copy() {
         return new ImagesOfThePast(this);
-    }
-}
-
-class ImagesOfThePastEffect extends OneShotEffect {
-
-    ImagesOfThePastEffect() {
-        super(Outcome.PutCreatureInPlay);
-        this.staticText = "Return up to two target creature cards from your graveyard to the battlefield, then exile those creatures";
-    }
-
-    ImagesOfThePastEffect(final ImagesOfThePastEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public ImagesOfThePastEffect copy() {
-        return new ImagesOfThePastEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player player = game.getPlayer(source.getControllerId());
-        if (player != null) {
-            List<UUID> targets = source.getTargets().get(0).getTargets();
-            for (UUID targetId : targets) {
-                Card card = game.getCard(targetId);
-                if (card != null) {
-                    player.moveCards(card, Zone.BATTLEFIELD, source, game);
-                    player.moveCards(card, Zone.EXILED, source, game);
-                }
-            }
-            return true;
-        }
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/i/ImagesOfThePast.java
+++ b/Mage.Sets/src/mage/cards/i/ImagesOfThePast.java
@@ -33,7 +33,7 @@ import mage.target.targetpointer.FixedTarget;
 
 /**
  *
- * @author Styxo
+ * @author Styxo, Merlingilb
  */
 public final class ImagesOfThePast extends CardImpl {
 


### PR DESCRIPTION
The Star Wars card "Images Of The Past" has the following ability:
"Return up to two target creature cards from your graveyard to the battlefield, then exile those creatures."

Before this fix, the target cards would be copied and one copy was put to exile and one stayed on the battlefield.

This problem is now fixed.