### PR TITLE
Fixed Card Ability of "Sith Manipulator"

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SithManipulator.java
+++ b/Mage.Sets/src/mage/cards/s/SithManipulator.java
@@ -8,8 +8,8 @@ import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.condition.InvertCondition;
 import mage.abilities.condition.common.HateCondition;
 import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
+import mage.abilities.effects.common.ReturnTargetToOwnersLibraryPermanentEffect;
 import mage.abilities.effects.common.ReturnToHandTargetEffect;
-import mage.abilities.effects.common.ReturnToLibraryPermanentEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -40,7 +40,7 @@ public final class SithManipulator extends CardImpl {
 
         // <i>Hate</i> &mdash; If opponent lost life from source other than combat damage this turn, put that card on top of its owner's library instead.
         ability = new ConditionalInterveningIfTriggeredAbility(
-                new EntersBattlefieldTriggeredAbility(new ReturnToLibraryPermanentEffect(true)),
+                new EntersBattlefieldTriggeredAbility(new ReturnTargetToOwnersLibraryPermanentEffect(true)),
                 HateCondition.instance,
                 "<i>Hate</i> &mdash; If opponent lost life from source other than combat damage this turn, put that card on top of its owner's library instead");
         ability.addTarget(new TargetCreaturePermanent());

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnTargetToOwnersLibraryPermanentEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnTargetToOwnersLibraryPermanentEffect.java
@@ -1,0 +1,48 @@
+
+package mage.abilities.effects.common;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.Card;
+import mage.constants.Outcome;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.players.Player;
+
+/**
+ *
+ * @author Merlingilb
+ */
+public class ReturnTargetToOwnersLibraryPermanentEffect extends OneShotEffect {
+
+    private final boolean toTop;
+
+    public ReturnTargetToOwnersLibraryPermanentEffect(boolean top) {
+        super(Outcome.Neutral);
+        staticText = "Put target card on "+ (top ? "top":"the bottom") + " of its owner's library";
+        this.toTop = top;
+    }
+
+    public ReturnTargetToOwnersLibraryPermanentEffect(final ReturnTargetToOwnersLibraryPermanentEffect effect) {
+        super(effect);
+        this.toTop = effect.toTop;
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Card card = game.getPermanent(source.getFirstTarget());
+        if (card != null) {
+            Player owner = game.getPlayer(card.getOwnerId());
+            if (owner != null) {
+                owner.moveCardToLibraryWithInfo(card, source, game, Zone.STACK, toTop, true);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public ReturnTargetToOwnersLibraryPermanentEffect copy() {
+        return new ReturnTargetToOwnersLibraryPermanentEffect(this);
+    }
+}


### PR DESCRIPTION
"Sith Manipulator" has the ability to send a creature an opponent controls to the top of their deck if the opponent lost life this turn.

Before this fix it did send itself to the players deck.
To achieve the above described ability I created a new effect to send a target card to its owners library.