### PR TITLE
Prevent very long and very short usernames

### DIFF
--- a/Mage.Server/src/main/java/mage/server/Session.java
+++ b/Mage.Server/src/main/java/mage/server/Session.java
@@ -135,6 +135,12 @@ public class Session {
         if (userName.length() > config.getMaxUserNameLength()) {
             return "User name may not be longer than " + config.getMaxUserNameLength() + " characters";
         }
+        if (userName.length() <= 3) {
+            return "User name is too short (3 characters or fewer)";
+        }
+        if (userName.length() >= 500) {
+            return "User name is too long (500 characters or more)";
+        }
 
         Pattern invalidUserNamePattern = Pattern.compile(managerFactory.configSettings().getInvalidUserNamePattern(), Pattern.CASE_INSENSITIVE);
         Matcher m = invalidUserNamePattern.matcher(userName);
@@ -183,7 +189,12 @@ public class Session {
     }
 
     public String connectUser(String userName, String password) throws MageException {
-        String returnMessage = connectUserHandling(userName, password);
+        String returnMessage = validateUserName(userName);
+        if (returnMessage != null) {
+            sendErrorMessageToClient(returnMessage);
+            return returnMessage;
+        }
+        returnMessage = connectUserHandling(userName, password);
         if (returnMessage != null) {
             sendErrorMessageToClient(returnMessage);
         }

--- a/Mage.Server/src/main/java/mage/server/Session.java
+++ b/Mage.Server/src/main/java/mage/server/Session.java
@@ -119,15 +119,8 @@ public class Session {
             return null;
         }
     }
-
-    private String validateUserName(String userName) {
-        // return error message or null on good name
-
-        if (userName.equals("Admin")) {
-            // virtual user for admin console
-            return "User name Admin already in use";
-        }
-
+    
+    private String validateUserNameLength(String userName) {
         ConfigSettings config = managerFactory.configSettings();
         if (userName.length() < config.getMinUserNameLength()) {
             return "User name may not be shorter than " + config.getMinUserNameLength() + " characters";
@@ -140,6 +133,20 @@ public class Session {
         }
         if (userName.length() >= 500) {
             return "User name is too long (500 characters or more)";
+        }
+        return null;
+    }
+
+    private String validateUserName(String userName) {
+        // return error message or null on good name
+        if (userName.equals("Admin")) {
+            // virtual user for admin console
+            return "User name Admin already in use";
+        }
+        
+        String returnMessage = validateUserNameLength(userName);
+        if (returnMessage != null) {
+            return returnMessage;
         }
 
         Pattern invalidUserNamePattern = Pattern.compile(managerFactory.configSettings().getInvalidUserNamePattern(), Pattern.CASE_INSENSITIVE);
@@ -189,7 +196,7 @@ public class Session {
     }
 
     public String connectUser(String userName, String password) throws MageException {
-        String returnMessage = validateUserName(userName);
+        String returnMessage = validateUserNameLength(userName);
         if (returnMessage != null) {
             sendErrorMessageToClient(returnMessage);
             return returnMessage;


### PR DESCRIPTION
Currently a troll is killing the server with very long usernames.  This should validate each person's username up to being a maximum of 500 characters long (similar to the truncated message length).