### PR TITLE
Button focus adjustments for yes/no dialogs

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/UserRequestDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/UserRequestDialog.java
@@ -58,16 +58,19 @@ public class UserRequestDialog extends MageDialog {
         this.lblText.setText(text);
         if (userRequestMessage.getButton1Text() != null) {
             this.btn1.setText(userRequestMessage.getButton1Text());
+            this.btn1.setFocusable(false);
         } else {
             this.btn1.setVisible(false);
         }
         if (userRequestMessage.getButton2Text() != null) {
             this.btn2.setText(userRequestMessage.getButton2Text());
+            this.btn2.setFocusable(false);
         } else {
             this.btn2.setVisible(false);
         }
         if (userRequestMessage.getButton3Text() != null) {
             this.btn3.setText(userRequestMessage.getButton3Text());
+            this.btn3.setFocusable(false);
         } else {
             this.btn3.setVisible(false);
         }

--- a/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
+++ b/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
@@ -526,6 +526,7 @@
          draftLeftPane.setVerifyInputWhenFocusTarget(false);
 
          btnQuitTournament.setText("Quit Tournament");
+         btnQuitTournament.setFocusable(false);
          btnQuitTournament.addActionListener(evt -> btnQuitTournamentActionPerformed(evt));
 
          lblPack1.setText("Pack 1:");

--- a/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
+++ b/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
@@ -826,8 +826,8 @@
 
      private void btnQuitTournamentActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnQuitTournamentActionPerformed
          UserRequestMessage message = new UserRequestMessage("Confirm quit tournament", "Are you sure you want to quit the draft tournament?");
-         message.setButton1("Yes", PlayerAction.CLIENT_QUIT_DRAFT_TOURNAMENT);
-         message.setButton2("No", null);
+         message.setButton1("No", null);
+         message.setButton2("Yes", PlayerAction.CLIENT_QUIT_DRAFT_TOURNAMENT);
          message.setTournamentId(draftId);
          MageFrame.getInstance().showUserRequestDialog(message);
      }//GEN-LAST:event_btnQuitTournamentActionPerformed

--- a/Mage.Client/src/main/java/mage/client/tournament/TournamentPanel.java
+++ b/Mage.Client/src/main/java/mage/client/tournament/TournamentPanel.java
@@ -490,8 +490,8 @@ public class TournamentPanel extends javax.swing.JPanel {
 
     private void btnQuitTournamentActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnQuitTournamentActionPerformed
         UserRequestMessage message = new UserRequestMessage("Confirm quit tournament", "Are you sure you want to quit the tournament?");
-        message.setButton1("Yes", PlayerAction.CLIENT_QUIT_TOURNAMENT);
-        message.setButton2("No", null);
+        message.setButton1("No", null);
+        message.setButton2("Yes", PlayerAction.CLIENT_QUIT_TOURNAMENT);
         message.setTournamentId(tournamentId);
         MageFrame.getInstance().showUserRequestDialog(message);
     }//GEN-LAST:event_btnQuitTournamentActionPerformed


### PR DESCRIPTION
This PR removes the focusability of the UserRequestDialog buttons, which means they can't be pressed with spacebar anymore. This gets rid of a UI annoyance: When you're typing into chat and someone requests a rollback from you, the request is no longer instantly denied when you type a spacebar. (This comes up often because people are often typing into chat when sorting out rollback situations.)

This PR also removes the focus from the quit button in DraftPanel, so pressing spacebar during draft no longer brings up the quit draft menu.

Lastly, I reverted the yes/no button switch for the DraftPanel and TournamentPanel quit menus that I did in July, because this PR fixes the same issue (possibility to accidentally quit a draft by pressing spacebar twice) in a better way. 