### PR TITLE
Fix Twinning Staff to only happen when one or more copies would be made, and not zero.

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TwinningStaff.java
+++ b/Mage.Sets/src/mage/cards/t/TwinningStaff.java
@@ -82,7 +82,8 @@ class TwinningStaffEffect extends ReplacementEffectImpl {
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         return event.getPlayerId().equals(source.getControllerId())
-                && game.getSpellOrLKIStack(event.getTargetId()) != null;
+                && game.getSpellOrLKIStack(event.getTargetId()) != null
+                && event.getAmount() >= 1;
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/c20/TwinningStaffTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/c20/TwinningStaffTest.java
@@ -93,11 +93,13 @@ public class TwinningStaffTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, staff);
         addCard(Zone.HAND, playerA, "Lightning Bolt", 2);
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "LightningBolt", playerB);
+        castSpell(1, PhaseStep.UPKEEP, playerA, "Lightning Bolt", playerB);
         checkLife("before", 1, PhaseStep.PRECOMBAT_MAIN, playerB, 20 - 3);
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "LightningBolt", playerB);
-        setChoice(playerA, false); // change target for copy 1
-        checkLife("copy", 1, PhaseStep.END_COMBAT, playerB, 20 - 3 - 3 * 2);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
+        setStrictChooseMode(false);
+        checkLife("copy", 1, PhaseStep.END_COMBAT, playerB, 20 - 3 - 3 * 3);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/c20/TwinningStaffTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/c20/TwinningStaffTest.java
@@ -85,4 +85,19 @@ public class TwinningStaffTest extends CardTestPlayerBase {
         assertGraveyardCount(playerA, bear, 1);
         assertGraveyardCount(playerA, elite, 1);
     }
+
+    @Test
+    public void testThousandYearStormZeroCopies() {
+        addCard(Zone.BATTLEFIELD, playerA, "Badlands", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Thousand-Year Storm");
+        addCard(Zone.BATTLEFIELD, playerA, staff);
+        addCard(Zone.HAND, playerA, "Lightning Bolt", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "LightningBolt", playerB);
+        checkLife("before", 1, PhaseStep.PRECOMBAT_MAIN, playerB, 20 - 3);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "LightningBolt", playerB);
+        setChoice(playerA, false); // change target for copy 1
+        checkLife("copy", 1, PhaseStep.END_COMBAT, playerB, 20 - 3 - 3 * 2);
+    }
 }


### PR DESCRIPTION
Also adds a test for the case where I encountered the bug.