### PR TITLE
Draft pick timer tweak (to make sure it's at least 1 second)

### DIFF
--- a/Mage/src/main/java/mage/game/draft/DraftImpl.java
+++ b/Mage/src/main/java/mage/game/draft/DraftImpl.java
@@ -310,7 +310,12 @@ public abstract class DraftImpl implements Draft {
     public void firePickCardEvent(UUID playerId) {
         DraftPlayer player = players.get(playerId);
         int cardNum = Math.min(15, this.cardNum);
-        int time = timing.getPickTimeout(cardNum) - boosterLoadingCounter * BOOSTER_LOADING_INTERVAL;
+        int time = timing.getPickTimeout(cardNum);
+        // if the pack is re-sent to a player because they haven't been able to successfully load it, the pick time is reduced appropriately because of the elapsed time
+        // the time is always at least 1 second unless it's set to 0, i.e. unlimited time
+        if (time > 0) {
+            time = Math.max(1, time - boosterLoadingCounter * BOOSTER_LOADING_INTERVAL);
+        }
         playerQueryEventSource.pickCard(playerId, "Pick card", player.getBooster(), time);
     }
 


### PR DESCRIPTION
In https://github.com/magefree/mage/pull/9435 I added a system where a draft pack gets re-sent to a player until their client has successfully confirmed to have loaded it.

That PR also had a part where the pick timer is reduced every time the pack is re-sent, because of the time that has elapsed between sending the pack.

This PR makes sure that the pick timer doesn't go below 1 second when it's reduced, unless the timer has been deliberately set to 0, i.e. unlimited time.