### PR TITLE
normalizeCardName replaces ★ and ///

### DIFF
--- a/Mage/src/main/java/mage/cards/decks/CardNameUtil.java
+++ b/Mage/src/main/java/mage/cards/decks/CardNameUtil.java
@@ -9,6 +9,7 @@ public class CardNameUtil {
     public static String normalizeCardName(String name) {
         return name
             .replace("&amp;", "//")
+            .replace("///", "//")
             .replace("Ã†", "Ae")
             .replace("Ã¶", "A")
             .replace("ö", "o")
@@ -19,7 +20,8 @@ public class CardNameUtil {
             .replace("à", "a")
             .replace("é", "e")
             .replace("ú", "u")
-            .replace("†", "+");
+            .replace("†", "+")
+            .replace("★", "*");
     }
 
 }


### PR DESCRIPTION
```normalizeCardName``` now turns ★ to * which is used in XMage. Also turns the /// used in Amonkhet Remastered aftermath cardnames to // which is used in XMage.