### PR TITLE
[SNC] Fix Sizzling Soloist and Venom Connoisseur triggering error

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SizzlingSoloist.java
+++ b/Mage.Sets/src/mage/cards/s/SizzlingSoloist.java
@@ -12,6 +12,7 @@ import mage.constants.*;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetOpponentsCreaturePermanent;
+import mage.watchers.common.AbilityResolvedWatcher;
 
 import java.util.UUID;
 
@@ -34,7 +35,7 @@ public final class SizzlingSoloist extends CardImpl {
                 Outcome.Benefit, 2, new SizzlingSoloistEffect()
         ));
         ability.addTarget(new TargetOpponentsCreaturePermanent());
-        this.addAbility(ability);
+        this.addAbility(ability, new AbilityResolvedWatcher());
     }
 
     private SizzlingSoloist(final SizzlingSoloist card) {

--- a/Mage.Sets/src/mage/cards/v/VenomConnoisseur.java
+++ b/Mage.Sets/src/mage/cards/v/VenomConnoisseur.java
@@ -14,6 +14,7 @@ import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.StaticFilters;
+import mage.watchers.common.AbilityResolvedWatcher;
 
 import java.util.UUID;
 
@@ -41,7 +42,7 @@ public final class VenomConnoisseur extends CardImpl {
                         StaticFilters.FILTER_CONTROLLED_CREATURE
                 ).setText("all creatures you control gain deathtouch until end of turn")
         ));
-        this.addAbility(ability);
+        this.addAbility(ability, new AbilityResolvedWatcher());
     }
 
     private VenomConnoisseur(final VenomConnoisseur card) {


### PR DESCRIPTION
[[Sizzling Soloist]] and [[Venom Connoisseur]] were missing ```AbilityResolvedWatcher``` which caused the game to rollback whenever they triggered.

Fixes https://github.com/magefree/mage/issues/9862 and https://github.com/magefree/mage/issues/9861