### PR TITLE
Fix: Pyre-Sledge Arsonist, Public Enemy, Reckoner Shakedown, Kami's Flare

### DIFF
--- a/Mage.Sets/src/mage/cards/k/KamisFlare.java
+++ b/Mage.Sets/src/mage/cards/k/KamisFlare.java
@@ -48,6 +48,7 @@ class KamisFlareEffect extends OneShotEffect {
 
     static {
         filter.add(ModifiedPredicate.instance);
+        filter.add(CardType.CREATURE.getPredicate());
     }
 
     private static final Hint hint = new ConditionHint(

--- a/Mage.Sets/src/mage/cards/p/PublicEnemy.java
+++ b/Mage.Sets/src/mage/cards/p/PublicEnemy.java
@@ -75,6 +75,14 @@ class PublicEnemyEffect extends RequirementEffect {
 
     @Override
     public boolean applies(Permanent permanent, Ability source, Game game) {
+        Permanent enchantment = game.getPermanent(source.getSourceId());
+        Permanent enchantedCreature = game.getPermanent(enchantment.getAttachedTo());
+        if (enchantment == null || enchantedCreature == null) {
+            return false;
+        }
+        if (permanent.isControlledBy(enchantedCreature.getControllerId())) {
+            return false;
+        }
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/p/PyreSledgeArsonist.java
+++ b/Mage.Sets/src/mage/cards/p/PyreSledgeArsonist.java
@@ -48,7 +48,7 @@ public final class PyreSledgeArsonist extends CardImpl {
         );
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetAnyTarget());
-        this.addAbility(ability.addHint(hint));
+        this.addAbility(ability.addHint(hint), new PyreSledgeArsonistWatcher());
     }
 
     private PyreSledgeArsonist(final PyreSledgeArsonist card) {

--- a/Mage.Sets/src/mage/cards/r/ReckonerShakedown.java
+++ b/Mage.Sets/src/mage/cards/r/ReckonerShakedown.java
@@ -93,7 +93,7 @@ class ReckonerShakedownEffect extends OneShotEffect {
         }
         TargetPermanent targetPermanent = new TargetPermanent(filter);
         targetPermanent.setNotTarget(true);
-        player.choose(Outcome.BoostCreature, targetPermanent, source, game);
+        controller.choose(Outcome.BoostCreature, targetPermanent, source, game);
         Permanent permanent = game.getPermanent(targetPermanent.getFirstTarget());
         if (permanent != null) {
             permanent.addCounters(CounterType.P1P1.createInstance(2), source, game);


### PR DESCRIPTION
- Pyre-Sledge Arsonist was missing the watcher.
- Public Enemy no longer forces the enchanted creature's controller to attack.
- Reckoner Shakedown no longer gives counters to the opponent if you don't pick a card to discard.
- Kami's Flare checks for modified creatures, not modified permanents.

Fixes https://github.com/magefree/mage/issues/9863, https://github.com/magefree/mage/issues/9433, https://github.com/magefree/mage/issues/9871, https://github.com/magefree/mage/issues/9870