### PR TITLE
Fix Mistmeadow Witch behavior when flickering itself; also fixes #8504

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/MistmeadowWitchEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/MistmeadowWitchEffect.java
@@ -2,12 +2,13 @@ package mage.abilities.effects.common;
 
 import mage.abilities.Ability;
 import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
 import mage.constants.Outcome;
-import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
+import mage.target.targetpointer.FixedTarget;
 import mage.util.CardUtil;
 
 /**
@@ -32,7 +33,10 @@ public class MistmeadowWitchEffect extends OneShotEffect {
             return false;
         }
         player.moveCardsToExile(permanent, source, game, true, CardUtil.getExileZoneId(game, source), CardUtil.getSourceName(game, source));
-        game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(new ReturnFromExileEffect(Zone.BATTLEFIELD, "return the exiled card to the battlefield under its owner's control")), source);
+        Effect effect = new ReturnToBattlefieldUnderOwnerControlTargetEffect(false, false);
+        effect.setText("Return the exiled card to the battlefield under its owner's control");
+        effect.setTargetPointer(new FixedTarget(source.getFirstTarget(), game));
+        game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(effect), source);
         return true;
     }
 


### PR DESCRIPTION
Mistmeadow Witch had issues where when targeting itself with its own ability, it would not return to the battlefield and stay exiled. This fixes that (and #8504) by ensuring that the effect has a target.