### PR TITLE
[CLB] Implement Noble Heritage (plus refactor Guardian Archon from C21)

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GuardianArchon.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianArchon.java
@@ -1,7 +1,6 @@
 package mage.cards.g;
 
 import mage.MageInt;
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -12,18 +11,15 @@ import mage.abilities.effects.common.continuous.GainAbilityControllerEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.ProtectionAbility;
-import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.filter.FilterCard;
+import mage.filter.FilterPlayer;
+import mage.filter.predicate.other.PlayerIdPredicate;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.game.stack.Spell;
-import mage.game.stack.StackObject;
 import mage.players.Player;
 import mage.target.common.TargetControlledPermanent;
 
@@ -86,56 +82,14 @@ class GuardianArchonEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
+        FilterPlayer filter = new FilterPlayer(player.getName());
+        filter.add(new PlayerIdPredicate(player.getId()));
         game.addEffect(new GainAbilityTargetEffect(
-                new GuardianArchonProtectionAbility(player.getId()), Duration.EndOfTurn
+                new ProtectionAbility(filter), Duration.EndOfTurn
         ), source);
         game.addEffect(new GainAbilityControllerEffect(
-                new GuardianArchonProtectionAbility(player.getId()), Duration.EndOfTurn
+                new ProtectionAbility(filter), Duration.EndOfTurn
         ), source);
-        return true;
-    }
-}
-
-class GuardianArchonProtectionAbility extends ProtectionAbility {
-
-    private final UUID playerId;
-
-    public GuardianArchonProtectionAbility(UUID playerId) {
-        super(new FilterCard());
-        this.playerId = playerId;
-    }
-
-    public GuardianArchonProtectionAbility(final GuardianArchonProtectionAbility ability) {
-        super(ability);
-        this.playerId = ability.playerId;
-    }
-
-    @Override
-    public GuardianArchonProtectionAbility copy() {
-        return new GuardianArchonProtectionAbility(this);
-    }
-
-    @Override
-    public String getRule() {
-        return "{this} has protection from the chosen player.";
-    }
-
-    @Override
-    public boolean canTarget(MageObject source, Game game) {
-        if (playerId != null && source != null) {
-            if (source instanceof Permanent) {
-                return !((Permanent) source).isControlledBy(playerId);
-            }
-            if (source instanceof Spell) {
-                return !((Spell) source).isControlledBy(playerId);
-            }
-            if (source instanceof StackObject) {
-                return !((StackObject) source).isControlledBy(playerId);
-            }
-            if (source instanceof Card) { // e.g. for Vengeful Pharaoh
-                return !((Card) source).isOwnedBy(playerId);
-            }
-        }
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/n/NobleHeritage.java
+++ b/Mage.Sets/src/mage/cards/n/NobleHeritage.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * @author TheElk801
+ * @author Grath
  */
 public final class NobleHeritage extends CardImpl {
 

--- a/Mage.Sets/src/mage/cards/n/NobleHeritage.java
+++ b/Mage.Sets/src/mage/cards/n/NobleHeritage.java
@@ -1,6 +1,5 @@
 package mage.cards.n;
 
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.SimpleStaticAbility;
@@ -9,19 +8,17 @@ import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
 import mage.abilities.effects.common.continuous.GainAbilityControllerEffect;
 import mage.abilities.keyword.ProtectionAbility;
-import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
-import mage.filter.FilterCard;
+import mage.filter.FilterPlayer;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.predicate.other.PlayerIdPredicate;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
-import mage.game.stack.Spell;
-import mage.game.stack.StackObject;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetControlledCreaturePermanent;
@@ -149,57 +146,15 @@ class NobleHeritageEffect extends OneShotEffect {
             }
             for (UUID playerId : players) {
                 if (!Objects.equals(playerId, source.getControllerId())) {
+                    FilterPlayer filter = new FilterPlayer();
+                    filter.add(new PlayerIdPredicate(playerId));
                     game.addEffect(new GainAbilityControllerEffect(
-                            new NobleHeritageProtectionAbility(playerId), Duration.UntilYourNextTurn
+                            new ProtectionAbility(filter), Duration.UntilYourNextTurn
                     ), source);
                 }
             }
             return true;
         }
         return false;
-    }
-}
-
-class NobleHeritageProtectionAbility extends ProtectionAbility {
-
-    private final UUID playerId;
-
-    public NobleHeritageProtectionAbility(UUID playerId) {
-        super(new FilterCard());
-        this.playerId = playerId;
-    }
-
-    public NobleHeritageProtectionAbility(final NobleHeritageProtectionAbility ability) {
-        super(ability);
-        this.playerId = ability.playerId;
-    }
-
-    @Override
-    public NobleHeritageProtectionAbility copy() {
-        return new NobleHeritageProtectionAbility(this);
-    }
-
-    @Override
-    public String getRule() {
-        return "{this} has protection from the chosen player.";
-    }
-
-    @Override
-    public boolean canTarget(MageObject source, Game game) {
-        if (playerId != null && source != null) {
-            if (source instanceof Permanent) {
-                return !((Permanent) source).isControlledBy(playerId);
-            }
-            if (source instanceof Spell) {
-                return !((Spell) source).isControlledBy(playerId);
-            }
-            if (source instanceof StackObject) {
-                return !((StackObject) source).isControlledBy(playerId);
-            }
-            if (source instanceof Card) { // e.g. for Vengeful Pharaoh
-                return !((Card) source).isOwnedBy(playerId);
-            }
-        }
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/n/NobleHeritage.java
+++ b/Mage.Sets/src/mage/cards/n/NobleHeritage.java
@@ -1,0 +1,205 @@
+package mage.cards.n;
+
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
+import mage.abilities.effects.common.continuous.GainAbilityControllerEffect;
+import mage.abilities.keyword.ProtectionAbility;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.counters.CounterType;
+import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.game.stack.Spell;
+import mage.game.stack.StackObject;
+import mage.players.Player;
+import mage.target.Target;
+import mage.target.common.TargetControlledCreaturePermanent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * @author TheElk801
+ */
+public final class NobleHeritage extends CardImpl {
+
+    public NobleHeritage(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{W}");
+
+        this.addSuperType(SuperType.LEGENDARY);
+        this.subtype.add(SubType.BACKGROUND);
+
+        // Commander creatures you own have “When this creature enters the battlefield and at the beginning of your upkeep, each player may put two +1/+1 counters on a creature they control. For each opponent who does, you gain protection from that player until your next turn.” (You can’t be targeted, dealt damage, or enchanted by anything controlled by that player.)
+        this.addAbility(new SimpleStaticAbility(new GainAbilityAllEffect(new NobleHeritageTriggeredAbility(), Duration.WhileOnBattlefield,
+                StaticFilters.FILTER_CREATURES_OWNED_COMMANDER
+        )));
+    }
+
+    private NobleHeritage(final NobleHeritage card) {
+        super(card);
+    }
+
+    @Override
+    public NobleHeritage copy() {
+        return new NobleHeritage(this);
+    }
+}
+
+class NobleHeritageTriggeredAbility extends TriggeredAbilityImpl {
+
+    public NobleHeritageTriggeredAbility() {
+        super(Zone.BATTLEFIELD, null, false);
+    }
+
+    public NobleHeritageTriggeredAbility(final NobleHeritageTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public NobleHeritageTriggeredAbility copy() {
+        return new NobleHeritageTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD || event.getType() == GameEvent.EventType.UPKEEP_STEP_PRE;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        this.getEffects().clear();
+        boolean result;
+        if (event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD) {
+            result = event.getTargetId().equals(this.getSourceId());
+        } else {
+            result = event.getPlayerId().equals(this.getControllerId());
+        }
+        if (result) {
+            Permanent enchantment = game.getPermanentOrLKIBattlefield(getSourceId());
+            if (enchantment != null) {
+                Effect effect = new NobleHeritageEffect();
+                this.getEffects().add(effect);
+            } else {
+                result = false;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public String getRule() {
+        return "When {this} enters the battlefield or at the beginning of your upkeep, each player may put two +1/+1 counters on a creature they control. For each opponent who does, you gain protection from that player until your next turn.";
+    }
+}
+
+class NobleHeritageEffect extends OneShotEffect {
+
+    public NobleHeritageEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "each player may put two +1/+1 counters on a creature they control. "
+                + "If a player does, creatures that player controls can't attack you or planeswalkers you control until your next turn";
+    }
+
+    public NobleHeritageEffect(final NobleHeritageEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public NobleHeritageEffect copy() {
+        return new NobleHeritageEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            List<UUID> players = new ArrayList<>();
+            List<UUID> creatures = new ArrayList<>();
+            for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
+                Player player = game.getPlayer(playerId);
+                if (player != null) {
+                    if (player.chooseUse(outcome, "Put two +1/+1 counters on a creature you control?", source, game)) {
+                        Target target = new TargetControlledCreaturePermanent(new FilterControlledCreaturePermanent("a creature you control (to add two +1/+1 counters on it)"));
+                        if (player.choose(outcome, target, source, game)) {
+                            creatures.add(target.getFirstTarget());
+                            players.add(player.getId());
+                        }
+
+                    }
+                }
+            }
+            for (UUID creatureId : creatures) {
+                Permanent creature = game.getPermanent(creatureId);
+                if (creature != null) {
+                    creature.addCounters(CounterType.P1P1.createInstance(2), creature.getControllerId(), source, game);
+                }
+            }
+            for (UUID playerId : players) {
+                if (!Objects.equals(playerId, source.getControllerId())) {
+                    game.addEffect(new GainAbilityControllerEffect(
+                            new NobleHeritageProtectionAbility(playerId), Duration.UntilYourNextTurn
+                    ), source);
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}
+
+class NobleHeritageProtectionAbility extends ProtectionAbility {
+
+    private final UUID playerId;
+
+    public NobleHeritageProtectionAbility(UUID playerId) {
+        super(new FilterCard());
+        this.playerId = playerId;
+    }
+
+    public NobleHeritageProtectionAbility(final NobleHeritageProtectionAbility ability) {
+        super(ability);
+        this.playerId = ability.playerId;
+    }
+
+    @Override
+    public NobleHeritageProtectionAbility copy() {
+        return new NobleHeritageProtectionAbility(this);
+    }
+
+    @Override
+    public String getRule() {
+        return "{this} has protection from the chosen player.";
+    }
+
+    @Override
+    public boolean canTarget(MageObject source, Game game) {
+        if (playerId != null && source != null) {
+            if (source instanceof Permanent) {
+                return !((Permanent) source).isControlledBy(playerId);
+            }
+            if (source instanceof Spell) {
+                return !((Spell) source).isControlledBy(playerId);
+            }
+            if (source instanceof StackObject) {
+                return !((StackObject) source).isControlledBy(playerId);
+            }
+            if (source instanceof Card) { // e.g. for Vengeful Pharaoh
+                return !((Card) source).isOwnedBy(playerId);
+            }
+        }
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/n/NobleHeritage.java
+++ b/Mage.Sets/src/mage/cards/n/NobleHeritage.java
@@ -98,7 +98,7 @@ class NobleHeritageTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public String getRule() {
-        return "When {this} enters the battlefield or at the beginning of your upkeep, each player may put two +1/+1 counters on a creature they control. For each opponent who does, you gain protection from that player until your next turn.";
+        return "When this creature enters the battlefield and at the beginning of your upkeep, each player may put two +1/+1 counters on a creature they control. For each opponent who does, you gain protection from that player until your next turn.";
     }
 }
 

--- a/Mage.Sets/src/mage/sets/CommanderLegendsBattleForBaldursGate.java
+++ b/Mage.Sets/src/mage/sets/CommanderLegendsBattleForBaldursGate.java
@@ -424,6 +424,7 @@ public final class CommanderLegendsBattleForBaldursGate extends ExpansionSet {
         cards.add(new SetCardInfo("Nimblewright Schematic", 330, Rarity.COMMON, mage.cards.n.NimblewrightSchematic.class));
         cards.add(new SetCardInfo("Nine-Fingers Keene", 289, Rarity.RARE, mage.cards.n.NineFingersKeene.class));
         cards.add(new SetCardInfo("Niv-Mizzet, Parun", 851, Rarity.RARE, mage.cards.n.NivMizzetParun.class));
+        cards.add(new SetCardInfo("Noble Heritage", 35, Rarity.RARE, mage.cards.n.NobleHeritage.class));
         cards.add(new SetCardInfo("Noble's Purse", 331, Rarity.UNCOMMON, mage.cards.n.NoblesPurse.class));
         cards.add(new SetCardInfo("Nothic", 138, Rarity.UNCOMMON, mage.cards.n.Nothic.class));
         cards.add(new SetCardInfo("Oceanus Dragon", 87, Rarity.COMMON, mage.cards.o.OceanusDragon.class));


### PR DESCRIPTION
Apologies for the large amount of custom code in Noble Heritage.
- Effect: This is rare enough that I believe it is worthwhile to just leave as a custom effect.
- Triggered ability: "When ~ enters the battlefield and/or at the beginning of your upkeep" is becoming more common and may be worth refactoring to a codified form of Triggered Ability, but I don't feel confident doing that in this pull request.
- Protection From Player: I realized from TheElk's implementation of Eon Frolicker that a custom Protection Ability wasn't necessary, so I did this the correct way and also fixed Guardian Archon which I had originally copied a custom 'Protection From Player' from.