### PR TITLE
Fix #9905 by changing Silent Arbiter's blocking conditions to allow one block per player.

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SilentArbiter.java
+++ b/Mage.Sets/src/mage/cards/s/SilentArbiter.java
@@ -92,7 +92,16 @@ class SilentArbiterBlockRestrictionEffect extends RestrictionEffect {
     }
 
     @Override
-    public boolean canBlock(Permanent attacker, Permanent blocker, Ability source, Game game, boolean canUseChooseDialogs) {
-        return game.getCombat().getBlockers().isEmpty();
+    public boolean canBlock(Permanent attacker, Permanent newBlocker, Ability source, Game game, boolean canUseChooseDialogs) {
+        if (attacker == null) {
+            return true;
+        }
+        for (UUID creatureId : game.getCombat().getBlockers()) {
+            Permanent existingBlocker = game.getPermanent(creatureId);
+            if (game.getPlayer(existingBlocker.getControllerId()).hasOpponent(attacker.getControllerId(), game) && existingBlocker.isControlledBy(newBlocker.getControllerId())) {
+                return false;
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
As reported in #9905 per rule 802.4b, if you somehow have multiple creatures attacking (such as with Myriad in a multiplayer game) each player is allowed to make one block while Silent Arbiter is in play.