### PR TITLE
Fix Karumonix, the Rat King's second filter

### DIFF
--- a/Mage.Sets/src/mage/cards/k/KarumonixTheRatKing.java
+++ b/Mage.Sets/src/mage/cards/k/KarumonixTheRatKing.java
@@ -24,6 +24,7 @@ public final class KarumonixTheRatKing extends CardImpl {
 
     static {
         filter.add(SubType.RAT.getPredicate());
+        filter2.add(SubType.RAT.getPredicate());
     }
 
     public KarumonixTheRatKing(UUID ownerId, CardSetInfo setInfo) {


### PR DESCRIPTION
It currently has no criteria, and allows you to put any of the top 5 cards of your library into your hand whether or not they're rats.