### PR TITLE
[CLB] Implement Nalfeshnee

### DIFF
--- a/Mage.Sets/src/mage/cards/n/Nalfeshnee.java
+++ b/Mage.Sets/src/mage/cards/n/Nalfeshnee.java
@@ -62,7 +62,7 @@ class NalfeshneeEffect extends OneShotEffect {
 
     NalfeshneeEffect() {
         super(Outcome.Benefit);
-        staticText = "copy it, You may choose new targets for the copy. If it's a permanent spell, the copy gains haste and \"At the beginning of the end step, sacrifice this permanent.\"";
+        staticText = "copy it. You may choose new targets for the copy. If it's a permanent spell, the copy gains haste and \"At the beginning of the end step, sacrifice this permanent.\"";
     }
 
     private NalfeshneeEffect(final NalfeshneeEffect effect) {

--- a/Mage.Sets/src/mage/cards/n/Nalfeshnee.java
+++ b/Mage.Sets/src/mage/cards/n/Nalfeshnee.java
@@ -6,6 +6,7 @@ import mage.abilities.common.BeginningOfEndStepTriggeredAbility;
 import mage.abilities.common.SpellCastControllerTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.SacrificeSourceEffect;
+import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -39,6 +40,9 @@ public final class Nalfeshnee extends CardImpl {
         this.subtype.add(SubType.DEMON);
         this.power = new MageInt(4);
         this.toughness = new MageInt(6);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
 
         // Whenever you cast a spell from exile, copy it. You may choose new targets for the copy. If it’s a permanent spell, the copy gains haste and “At the beginning of the end step, sacrifice this permanent.”
         this.addAbility(new SpellCastControllerTriggeredAbility(new NalfeshneeEffect(), filter, false));

--- a/Mage.Sets/src/mage/cards/n/Nalfeshnee.java
+++ b/Mage.Sets/src/mage/cards/n/Nalfeshnee.java
@@ -1,0 +1,111 @@
+package mage.cards.n;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.BeginningOfEndStepTriggeredAbility;
+import mage.abilities.common.SpellCastControllerTriggeredAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.SacrificeSourceEffect;
+import mage.abilities.keyword.HasteAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.FilterSpell;
+import mage.filter.predicate.card.CastFromZonePredicate;
+import mage.filter.predicate.mageobject.MageObjectReferencePredicate;
+import mage.game.Game;
+import mage.game.stack.Spell;
+import mage.game.stack.StackObject;
+import mage.players.Player;
+import mage.util.functions.StackObjectCopyApplier;
+
+import java.util.UUID;
+
+/**
+ * @author Grath
+ */
+public final class Nalfeshnee extends CardImpl {
+
+    private static final FilterSpell filter = new FilterSpell("a spell from exile");
+
+    static {
+        filter.add(new CastFromZonePredicate(Zone.EXILED));
+    }
+
+    public Nalfeshnee(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{R}");
+
+        this.subtype.add(SubType.BEAST);
+        this.subtype.add(SubType.DEMON);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(6);
+
+        // Whenever you cast a spell from exile, copy it. You may choose new targets for the copy. If it’s a permanent spell, the copy gains haste and “At the beginning of the end step, sacrifice this permanent.”
+        this.addAbility(new SpellCastControllerTriggeredAbility(new NalfeshneeEffect(), filter, false));
+    }
+
+    private Nalfeshnee(final Nalfeshnee card) {
+        super(card);
+    }
+
+    @Override
+    public Nalfeshnee copy() {
+        return new Nalfeshnee(this);
+    }
+}
+
+class NalfeshneeEffect extends OneShotEffect {
+
+    NalfeshneeEffect() {
+        super(Outcome.Benefit);
+        staticText = "copy it, You may choose new targets for the copy. If it's a permanent spell, the copy gains haste and \"At the beginning of the end step, sacrifice this permanent.\"";
+    }
+
+    private NalfeshneeEffect(final NalfeshneeEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public NalfeshneeEffect copy() {
+        return new NalfeshneeEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        Spell spell = (Spell) getValue("spellCast");
+        if (controller == null || spell == null) {
+            return false;
+        }
+        // Create a token copy if it's a permanent, with haste and "must be sacrificed"
+        if (spell.isPermanent()) {
+            spell.createCopyOnStack(
+                    game, source, controller.getId(), true,
+                    1, NalfeshneeApplier.instance
+            );
+        }
+        // Non-permanent spells should not gain haste or "must be sacrificed".
+        else {
+            spell.createCopyOnStack(
+                    game, source, controller.getId(), true
+            );
+        }
+        return true;
+    }
+}
+
+enum NalfeshneeApplier implements StackObjectCopyApplier {
+    instance;
+
+    @Override
+    public void modifySpell(StackObject copiedSpell, Game game) {
+        Spell spell = (Spell) copiedSpell;
+        spell.addAbilityForCopy(HasteAbility.getInstance());
+        spell.addAbilityForCopy(new BeginningOfEndStepTriggeredAbility(new SacrificeSourceEffect(), TargetController.ANY, false));
+    }
+
+    @Override
+    public MageObjectReferencePredicate getNextNewTargetType() {
+        return null;
+    }
+}

--- a/Mage.Sets/src/mage/sets/CommanderLegendsBattleForBaldursGate.java
+++ b/Mage.Sets/src/mage/sets/CommanderLegendsBattleForBaldursGate.java
@@ -408,6 +408,7 @@ public final class CommanderLegendsBattleForBaldursGate extends ExpansionSet {
         cards.add(new SetCardInfo("Myrkul, Lord of Bones", 287, Rarity.RARE, mage.cards.m.MyrkulLordOfBones.class));
         cards.add(new SetCardInfo("Mystery Key", 85, Rarity.UNCOMMON, mage.cards.m.MysteryKey.class));
         cards.add(new SetCardInfo("Nalia de'Arnise", 649, Rarity.MYTHIC, mage.cards.n.NaliaDeArnise.class));
+        cards.add(new SetCardInfo("Nalfeshnee", 678, Rarity.RARE, mage.cards.n.Nalfeshnee.class));
         cards.add(new SetCardInfo("Natural Reclamation", 829, Rarity.COMMON, mage.cards.n.NaturalReclamation.class));
         cards.add(new SetCardInfo("Nature's Lore", 244, Rarity.COMMON, mage.cards.n.NaturesLore.class));
         cards.add(new SetCardInfo("Nautiloid Ship", 328, Rarity.MYTHIC, mage.cards.n.NautiloidShip.class));

--- a/Mage/src/main/java/mage/game/stack/Spell.java
+++ b/Mage/src/main/java/mage/game/stack/Spell.java
@@ -660,6 +660,11 @@ public class Spell extends StackObjectImpl implements Card {
         throw new UnsupportedOperationException("Not supported.");
     }
 
+    // To add abilities to permanent spell copies in a StackObjectCopyApplier
+    public void addAbilityForCopy(Ability ability) {
+        card.addAbility(ability);
+    }
+
     @Override
     public SpellAbility getSpellAbility() {
         return ability;

--- a/Mage/src/main/java/mage/game/stack/Spell.java
+++ b/Mage/src/main/java/mage/game/stack/Spell.java
@@ -660,7 +660,7 @@ public class Spell extends StackObjectImpl implements Card {
         throw new UnsupportedOperationException("Not supported.");
     }
 
-    // To add abilities to permanent spell copies in a StackObjectCopyApplier
+    // To add abilities to permanent spell copies in a StackObjectCopyApplier which will persist into the resulting token.
     public void addAbilityForCopy(Ability ability) {
         card.addAbility(ability);
     }


### PR DESCRIPTION
Adds function for adding an ability to a Spell (which adds the ability to the original Card) so that you can add abilities to, in particular, Permanent spell copies using a StackObjectCopyApplier which will persist into the resulting token. I made this a different function so that people have to knowingly use "addAbilityForCopy" to maintain the intended functionality in addAbility of "you shouldn't just arbitrarily add abilities to spells".