### PR TITLE
[ONE] Implement Vraska, Betrayal's Sting

### DIFF
--- a/Mage.Sets/src/mage/cards/v/VraskaBetrayalsSting.java
+++ b/Mage.Sets/src/mage/cards/v/VraskaBetrayalsSting.java
@@ -1,0 +1,98 @@
+package mage.cards.v;
+
+import mage.abilities.Ability;
+import mage.abilities.LoyaltyAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.LoseLifeSourceControllerEffect;
+import mage.abilities.effects.common.continuous.BecomesCreatureTargetEffect;
+import mage.abilities.effects.common.counter.ProliferateEffect;
+import mage.abilities.keyword.CompleatedAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.game.permanent.token.TreasureToken;
+import mage.players.Player;
+import mage.target.TargetPlayer;
+import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public final class VraskaBetrayalsSting extends CardImpl {
+
+    public VraskaBetrayalsSting(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.PLANESWALKER}, "{4}{B}{B/P}");
+
+        this.addSuperType(SuperType.LEGENDARY);
+        this.subtype.add(SubType.VRASKA);
+        this.setStartingLoyalty(6);
+
+        // Compleated
+        this.addAbility(CompleatedAbility.getInstance());
+
+        // 0: You draw a card and you lose 1 life. Proliferate.
+        Ability ability = new LoyaltyAbility(new DrawCardSourceControllerEffect(1).setText("You draw a card"), 0);
+        ability.addEffect(new LoseLifeSourceControllerEffect(1).concatBy("and"));
+        ability.addEffect(new ProliferateEffect());
+        this.addAbility(ability);
+
+        // −2: Target creature becomes a Treasure artifact with "{T}, Sacrifice this artifact:
+        // Add one mana of any color" and loses all other card types and abilities.
+        ability = new LoyaltyAbility(new BecomesCreatureTargetEffect(
+                new TreasureToken(), true, false, Duration.WhileOnBattlefield, false, false, true)
+                .setText("Target creature becomes a Treasure artifact with \"{T}, Sacrifice this artifact: " +
+                        "Add one mana of any color\" and loses all other card types and abilities"), -2
+        );
+        ability.addTarget(new TargetCreaturePermanent());
+        this.addAbility(ability);
+
+        // −9: If target player has fewer than nine poison counters, they get a number of poison counters equal to the difference.
+        ability = new LoyaltyAbility(new VraskaBetrayalsStingEffect(), -9);
+        ability.addTarget(new TargetPlayer());
+        this.addAbility(ability);
+    }
+
+    private VraskaBetrayalsSting(final VraskaBetrayalsSting card) {
+        super(card);
+    }
+
+    @Override
+    public VraskaBetrayalsSting copy() {
+        return new VraskaBetrayalsSting(this);
+    }
+}
+
+class VraskaBetrayalsStingEffect extends OneShotEffect {
+
+    VraskaBetrayalsStingEffect() {
+        super(Outcome.Benefit);
+        staticText = "If target player has fewer than nine poison counters, they get a number of poison counters equal to the difference";
+    }
+
+    private VraskaBetrayalsStingEffect(final VraskaBetrayalsStingEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public VraskaBetrayalsStingEffect copy() {
+        return new VraskaBetrayalsStingEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player targetPlayer = game.getPlayer(source.getFirstTarget());
+        if (targetPlayer == null) {
+            return false;
+        }
+        int totalPoison = targetPlayer.getCounters().getCount(CounterType.POISON);
+        if (totalPoison < 9) {
+            targetPlayer.addCounters(CounterType.POISON.createInstance(9 - totalPoison), source.getControllerId(), source, game);
+        }
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOne.java
+++ b/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOne.java
@@ -228,6 +228,10 @@ public final class PhyrexiaAllWillBeOne extends ExpansionSet {
         cards.add(new SetCardInfo("Voidwing Hybrid", 221, Rarity.UNCOMMON, mage.cards.v.VoidwingHybrid.class));
         cards.add(new SetCardInfo("Volt Charge", 155, Rarity.COMMON, mage.cards.v.VoltCharge.class));
         cards.add(new SetCardInfo("Vraan, Executioner Thane", 114, Rarity.RARE, mage.cards.v.VraanExecutionerThane.class));
+        cards.add(new SetCardInfo("Vraska, Betrayal's Sting", 115, Rarity.MYTHIC, mage.cards.v.VraskaBetrayalsSting.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Vraska, Betrayal's Sting", 361, Rarity.MYTHIC, mage.cards.v.VraskaBetrayalsSting.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Vraska, Betrayal's Sting", 326, Rarity.MYTHIC, mage.cards.v.VraskaBetrayalsSting.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Vraska, Betrayal's Sting", 337, Rarity.MYTHIC, mage.cards.v.VraskaBetrayalsSting.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Vraska's Fall", 116, Rarity.COMMON, mage.cards.v.VraskasFall.class));
         cards.add(new SetCardInfo("Vulshok Splitter", 156, Rarity.COMMON, mage.cards.v.VulshokSplitter.class));
         cards.add(new SetCardInfo("Watchful Blisterzoa", 78, Rarity.UNCOMMON, mage.cards.w.WatchfulBlisterzoa.class));

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java
@@ -23,6 +23,7 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
     protected boolean loseName;
     protected boolean keepAbilities;
     protected boolean removeSubtypes = false;
+    protected boolean loseOtherCardTypes;
 
     public BecomesCreatureTargetEffect(Token token, boolean loseAllAbilities, boolean stillALand, Duration duration) {
         this(token, loseAllAbilities, stillALand, duration, false);
@@ -32,23 +33,29 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
         this(token, loseAllAbilities, stillALand, duration, loseName, false);
     }
 
+    public BecomesCreatureTargetEffect(Token token, boolean loseAllAbilities, boolean stillALand, Duration duration, boolean loseName, boolean keepAbilities) {
+        this(token, loseAllAbilities, stillALand, duration, loseName, keepAbilities, false);
+    }
+
     /**
      * @param token
      * @param loseAllAbilities loses all subtypes, colors and abilities
      * @param stillALand add rule text, "it's still a land"
-     * @param loseName permanent lose name and get's it from token
-     * @param keepAbilities lose types/colors, but keep abilities (example:
+     * @param loseName permanent loses name and gets it from token
+     * @param keepAbilities lose subtypes/colors, but keep abilities (example:
      * Scale Up)
      * @param duration
+     * @param loseOtherCardTypes permanent loses other (original) card types, exclusively obtains card types of token
      */
     public BecomesCreatureTargetEffect(Token token, boolean loseAllAbilities, boolean stillALand, Duration duration, boolean loseName,
-            boolean keepAbilities) {
+            boolean keepAbilities, boolean loseOtherCardTypes) {
         super(duration, Outcome.BecomeCreature);
         this.token = token;
         this.loseAllAbilities = loseAllAbilities;
         this.addStillALandText = stillALand;
         this.loseName = loseName;
         this.keepAbilities = keepAbilities;
+        this.loseOtherCardTypes = loseOtherCardTypes;
         this.dependencyTypes.add(DependencyType.BecomeCreature);
     }
 
@@ -59,6 +66,7 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
         this.addStillALandText = effect.addStillALandText;
         this.loseName = effect.loseName;
         this.keepAbilities = effect.keepAbilities;
+        this.loseOtherCardTypes = effect.loseOtherCardTypes;
         this.dependencyTypes.add(DependencyType.BecomeCreature);
     }
 
@@ -83,11 +91,14 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
                     break;
 
                 case TypeChangingEffects_4:
-                    for (CardType t : token.getCardType(game)) {
-                        permanent.addCardType(game, t);
+                    if (loseOtherCardTypes) {
+                        permanent.removeAllCardTypes(game);
                     }
                     if (loseAllAbilities || removeSubtypes) {
-                        permanent.removeAllCreatureTypes(game);
+                        permanent.removeAllSubTypes(game);
+                    }
+                    for (CardType t : token.getCardType(game)) {
+                        permanent.addCardType(game, t);
                     }
                     permanent.copySubTypesFrom(game, token);
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java
@@ -94,7 +94,7 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
                     if (loseOtherCardTypes) {
                         permanent.removeAllCardTypes(game);
                     }
-                    if (loseAllAbilities || removeSubtypes) {
+                    if (loseAllAbilities || keepAbilities || removeSubtypes) {
                         permanent.removeAllSubTypes(game);
                     }
                     for (CardType t : token.getCardType(game)) {


### PR DESCRIPTION
Also includes additions and fixes to `BecomesCreatureTargetEffect.java`.

- **Addition**: [BecomesCreatureTargetEffect.java](https://github.com/magefree/mage/blob/07a142c9e8ef39784d1259635187e2a4c8417a16/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java) now allows for the removal of card types as opposed to just subtypes (necessary for Vraska as in her -2 it states that the creature "loses all other card types"). This was also something that the similar [BecomesCreatureAttachedEffect.java](https://github.com/magefree/mage/blob/07a142c9e8ef39784d1259635187e2a4c8417a16/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureAttachedEffect.java) could already do.
- **Fix**: A true `keepAbilities` boolean not clearing subtypes, despite it being described as doing such in the class description
- **Fix**: Grammar errors / obscure wording