### PR TITLE
[BRO] Remove land, 10 common packs

### DIFF
--- a/Mage.Sets/src/mage/sets/TheBrothersWar.java
+++ b/Mage.Sets/src/mage/sets/TheBrothersWar.java
@@ -27,7 +27,7 @@ public final class TheBrothersWar extends ExpansionSet {
         this.blockName = "The Brothers' War";
         this.hasBoosters = true;
         this.numBoosterLands = 0;
-        this.numBoosterCommon = 10; //someone can make it so 1/4 of the time a common is replaced by a basic land in the future if they want to
+        this.numBoosterCommon = 10; // TODO: someone can make it so 1/4 of the time a common is replaced by a basic land in the future if they want to
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.numBoosterSpecial = 1;

--- a/Mage.Sets/src/mage/sets/TheBrothersWar.java
+++ b/Mage.Sets/src/mage/sets/TheBrothersWar.java
@@ -26,8 +26,8 @@ public final class TheBrothersWar extends ExpansionSet {
         super("The Brothers' War", "BRO", ExpansionSet.buildDate(2022, 11, 18), SetType.EXPANSION);
         this.blockName = "The Brothers' War";
         this.hasBoosters = true;
-        this.numBoosterLands = 1;
-        this.numBoosterCommon = 9;
+        this.numBoosterLands = 0;
+        this.numBoosterCommon = 10; //someone can make it so 1/4 of the time a common is replaced by a basic land in the future if they want to
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.numBoosterSpecial = 1;


### PR DESCRIPTION
Real draft boosters of Brothers war have a 1/4 chance of basic lands appearing; so having 10 commons in every draft booster rather than 9 and a land means that the draft experience is closer to that of the paper draft experience.

Closes #9805 