### PR TITLE
Fixes #10010 Ethereal Champion rules text

### DIFF
--- a/Mage.Sets/src/mage/cards/e/EtherealChampion.java
+++ b/Mage.Sets/src/mage/cards/e/EtherealChampion.java
@@ -29,7 +29,7 @@ public final class EtherealChampion extends CardImpl {
 
         // Pay 1 life: Prevent the next 1 damage that would be dealt to Ethereal Champion this turn.
         Effect effect = new PreventDamageToSourceEffect(Duration.EndOfTurn, 1);
-        effect.setText("Pay 1 life: Prevent the next 1 damage that would be dealt to {this} this turn");
+        effect.setText("Prevent the next 1 damage that would be dealt to {this} this turn");
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new PayLifeCost(1)));
     }
 


### PR DESCRIPTION
This PR concerns #10010
- fix extraneous "Pay 1 life: " in Ethereal Champion rules text