### PR TITLE
[ONE] Implement Bladehold War-Whip

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BladeholdWarWhip.java
+++ b/Mage.Sets/src/mage/cards/b/BladeholdWarWhip.java
@@ -19,7 +19,7 @@ import mage.constants.Outcome;
 
 /**
  *
- * @author anonymous
+ * @author @stwalsh4118
  */
 public final class BladeholdWarWhip extends CardImpl {
 

--- a/Mage.Sets/src/mage/cards/b/BladeholdWarWhip.java
+++ b/Mage.Sets/src/mage/cards/b/BladeholdWarWhip.java
@@ -1,0 +1,56 @@
+package mage.cards.b;
+
+import java.util.UUID;
+import mage.constants.SubType;
+import mage.constants.Zone;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
+import mage.abilities.effects.common.cost.AbilitiesCostReductionControllerEffect;
+import mage.abilities.keyword.DoubleStrikeAbility;
+import mage.abilities.keyword.EquipAbility;
+import mage.abilities.keyword.ForMirrodinAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.AttachmentType;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+
+/**
+ *
+ * @author anonymous
+ */
+public final class BladeholdWarWhip extends CardImpl {
+
+    public BladeholdWarWhip(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{1}{R}{W}");
+        
+        this.subtype.add(SubType.EQUIPMENT);
+
+        // For Mirrodin!
+        this.addAbility(new ForMirrodinAbility());
+
+        // Equip abilities you activate of other Equipment cost {1} less to activate.
+        Ability ability = new SimpleStaticAbility(
+            new AbilitiesCostReductionControllerEffect(
+                    EquipAbility.class, "Equip", 1, true
+            ).setText("Equip abilities you activate of other Equipment cost {1} less to activate."));
+        this.addAbility(ability);
+
+        // Equipped creature has double strike.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(DoubleStrikeAbility.getInstance(), AttachmentType.EQUIPMENT)));
+
+        // Equip {3}{R}{W}
+        this.addAbility(new EquipAbility(Outcome.BoostCreature, new ManaCostsImpl<>("{3}{R}{W}")));
+    }
+
+    private BladeholdWarWhip(final BladeholdWarWhip card) {
+        super(card);
+    }
+
+    @Override
+    public BladeholdWarWhip copy() {
+        return new BladeholdWarWhip(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/b/BladeholdWarWhip.java
+++ b/Mage.Sets/src/mage/cards/b/BladeholdWarWhip.java
@@ -42,7 +42,7 @@ public final class BladeholdWarWhip extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(DoubleStrikeAbility.getInstance(), AttachmentType.EQUIPMENT)));
 
         // Equip {3}{R}{W}
-        this.addAbility(new EquipAbility(Outcome.BoostCreature, new ManaCostsImpl<>("{3}{R}{W}")));
+        this.addAbility(new EquipAbility(Outcome.BoostCreature, new ManaCostsImpl<>("{3}{R}{W}"), false));
     }
 
     private BladeholdWarWhip(final BladeholdWarWhip card) {

--- a/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOne.java
+++ b/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOne.java
@@ -43,6 +43,7 @@ public final class PhyrexiaAllWillBeOne extends ExpansionSet {
         cards.add(new SetCardInfo("Black Sun's Twilight", 84, Rarity.RARE, mage.cards.b.BlackSunsTwilight.class));
         cards.add(new SetCardInfo("Blackcleave Cliffs", 248, Rarity.RARE, mage.cards.b.BlackcleaveCliffs.class));
         cards.add(new SetCardInfo("Bladed Ambassador", 5, Rarity.UNCOMMON, mage.cards.b.BladedAmbassador.class));
+        cards.add(new SetCardInfo("Bladehold War-Whip", 197, Rarity.UNCOMMON, mage.cards.b.BladeholdWarWhip.class));
         cards.add(new SetCardInfo("Blazing Crescendo", 123, Rarity.COMMON, mage.cards.b.BlazingCrescendo.class));
         cards.add(new SetCardInfo("Blightbelly Rat", 85, Rarity.COMMON, mage.cards.b.BlightbellyRat.class));
         cards.add(new SetCardInfo("Bloated Contaminator", 159, Rarity.RARE, mage.cards.b.BloatedContaminator.class));

--- a/Mage/src/main/java/mage/abilities/effects/common/cost/AbilitiesCostReductionControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/cost/AbilitiesCostReductionControllerEffect.java
@@ -15,22 +15,29 @@ public class AbilitiesCostReductionControllerEffect extends CostModificationEffe
 
     private final Class<? extends ActivatedAbility> activatedAbility;
     private final int amount;
+    private final boolean excludeSource;
 
     public AbilitiesCostReductionControllerEffect(Class<? extends ActivatedAbility> activatedAbility, String activatedAbilityName) {
         this(activatedAbility, activatedAbilityName, 1);
     }
 
     public AbilitiesCostReductionControllerEffect(Class<? extends ActivatedAbility> activatedAbility, String activatedAbilityName, int amount) {
+        this(activatedAbility, activatedAbilityName, 1, false);
+    }
+
+    public AbilitiesCostReductionControllerEffect(Class<? extends ActivatedAbility> activatedAbility, String activatedAbilityName, int amount, boolean excludeSource) {
         super(Duration.WhileOnBattlefield, Outcome.Benefit, CostModificationType.REDUCE_COST);
         this.activatedAbility = activatedAbility;
         staticText = activatedAbilityName + " costs you pay cost {" + amount + "} less";
         this.amount = amount;
+        this.excludeSource = excludeSource;
     }
 
     public AbilitiesCostReductionControllerEffect(AbilitiesCostReductionControllerEffect effect) {
         super(effect);
         this.activatedAbility = effect.activatedAbility;
         this.amount = effect.amount;
+        this.excludeSource = effect.excludeSource;
     }
 
     @Override
@@ -40,6 +47,11 @@ public class AbilitiesCostReductionControllerEffect extends CostModificationEffe
 
     @Override
     public boolean apply(Game game, Ability source, Ability abilityToModify) {
+
+        if (excludeSource && abilityToModify.getSourceId().equals(source.getSourceId())) {
+            return false;
+        }
+        
         CardUtil.reduceCost(abilityToModify, amount);
         return true;
     }


### PR DESCRIPTION
This PR implements Bladehold War-Whip

- Included is a modification to the AbilitiesCostReductionControllerEffect class which excludeSource to constructor which defaults to false which lets you choose to exclude the source from its effect (like Bladehold War-Whip requires)