### PR TITLE
Remove slash breaking non-english releases

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
@@ -85,7 +85,7 @@ public enum ScryfallImageSource implements CardImageSource {
                     alternativeUrl = link + defaultCode + "?format=image";
                     // workaround to use cards without english images (some promos or special cards)
                     if (Objects.equals(baseUrl, alternativeUrl) && baseUrl.endsWith("/en?format=image")) {
-                        alternativeUrl = alternativeUrl.replace("/en?format=image", "/?format=image");
+                        alternativeUrl = alternativeUrl.replace("/en?format=image", "?format=image");
                     }
                 } else {
                     // image


### PR DESCRIPTION
The Scryfall `alternativeUrl` fallback special case for English seems to be failing for cards without an English print. I've noticed this fix for the NEO full-art lands - I have not thoroughly tested other cards where this may be the case.

URL examples for NEO full-art Swamp:
`baseUrl`: `https://api.scryfall.com/cards/neo/298/en?format=image` FAILS with a 404.
Old `alternativeUrl`: `https://api.scryfall.com/cards/neo/298/?format=image` FAILS with a 404.
New `alternativeUrl`: `https://api.scryfall.com/cards/neo/298?format=image` SUCCEEDS as expected.
