### PR TITLE
[WIP] Fix hybrid Phyrexian mana symbols not showing

### DIFF
--- a/Mage.Client/src/main/java/org/mage/card/arcane/ManaSymbols.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/ManaSymbols.java
@@ -78,7 +78,8 @@ public final class ManaSymbols {
             "S", "T", "Q",
             "U", "UB", "UR", "UP", "2U",
             "W", "WB", "WU", "WP", "2W",
-            "X", "C", "E"};
+            "X", "C", "E",
+            "BGP", "BRP", "GUP", "GWP", "RGP", "RWP", "UBP", "URP", "WBP", "WUP"};
 
     private static final JLabel labelRender = new JLabel(); // render mana text
 


### PR DESCRIPTION
Currently hybrid Phyrexian mana symbols such as the ones used in the costs of [Tamiyo, Compleated Sage](https://scryfall.com/card/neo/238/tamiyo-compleated-sage) and [Ajani, Sleeper Agent](https://scryfall.com/card/dmu/192/ajani-sleeper-agent), do not render on cards at all (see below):
Small card (what is seen in the player's hand)
![small-tamiyo](https://user-images.githubusercontent.com/26198472/221459783-30cfa41f-0da6-4032-8850-56d3223f80e7.PNG)
Mouse over display (i.e. what is seen when the player mouses over the card in their hand)
![mouseover-tamiyo](https://user-images.githubusercontent.com/26198472/221459902-8dff9d2f-6c51-4ba9-a24d-3cef2b0540b9.PNG)
Same symbols used when trying to pay for the card:
![pay-tamiyo](https://user-images.githubusercontent.com/26198472/221460800-5fe2ed57-0f06-4619-a36a-8ad51a96c80b.PNG)

I was able to resolve the issue with the mana symbols not showing while in hand by adding the hybrid Phyrexian mana symbols' names to the `symbols` string in ManaSymbols.java, so now it looks like this in hand:
![new-small-tamiyo](https://user-images.githubusercontent.com/26198472/221460493-7b0ee928-e436-4372-aabc-291cbf563ad1.PNG)
However, this did not resolve the issue with the mana symbols not showing correctly in the mouse over menu and I couldn't find the code that handles that (if there is any). Any ideas?