### PR TITLE
Fixes Mind maggots giving 1 counter instead of 2 (Untested)

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MindMaggots.java
+++ b/Mage.Sets/src/mage/cards/m/MindMaggots.java
@@ -72,7 +72,7 @@ class MindMaggotsEffect extends OneShotEffect {
         }
         TargetCard target = new TargetDiscard(0, Integer.MAX_VALUE, StaticFilters.FILTER_CARD_CREATURE, controller.getId());
         controller.choose(outcome, controller.getHand(), target, game);
-        int counters = controller.discard(new CardsImpl(target.getTargets()), false, source, game).size();
+        int counters = (controller.discard(new CardsImpl(target.getTargets()), false, source, game).size())*2;//it was only adding 1 counter per discarded creature
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent == null || counters < 1) {
             return true;


### PR DESCRIPTION
the code was only counting the amount of discarded creature cards, it was not multiplying them by two