### PR TITLE
Shower of sparks fix

### DIFF
--- a/Mage.Sets/src/mage/cards/s/ShowerOfSparks.java
+++ b/Mage.Sets/src/mage/cards/s/ShowerOfSparks.java
@@ -23,13 +23,13 @@ public final class ShowerOfSparks extends CardImpl {
         // Shower of Sparks deals 1 damage to target creature and 1 damage to target player.
         this.getSpellAbility().addEffect(new DamageTargetEffect(1)); 
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
-
+        this.getSpellAbility().addEffect(new DamagePlayersEffect(1, TargetController.ANY));
         //** doing it the way below this causes the ability to trigger twice making it do 2 damage to player and 2 damage to target creature                                    
         //Effect effect = new DamageTargetEffect(1);
         //effect.setTargetPointer(new SecondTargetPointer()); 
         //effect.setText("and 1 damage to target player");
         //this.getSpellAbility().addEffect(effect); **//
-        this.getSpellAbility().addTarget(new TargetPlayerOrPlaneswalker());
+        //this.getSpellAbility().addTarget(new TargetPlayerOrPlaneswalker());
         //setText("deals 1 damage to target creature and 1 damage to target player") (not sure where to put this)
     }
 

--- a/Mage.Sets/src/mage/cards/s/ShowerOfSparks.java
+++ b/Mage.Sets/src/mage/cards/s/ShowerOfSparks.java
@@ -1,15 +1,12 @@
-
 package mage.cards.s;
 
 import java.util.UUID;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.target.common.TargetCreaturePermanent;
 import mage.target.common.TargetPlayerOrPlaneswalker;
-import mage.target.targetpointer.SecondTargetPointer;
 
 /**
  *
@@ -21,11 +18,9 @@ public final class ShowerOfSparks extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{R}");
         
         // Shower of sparks deals 1 damage to target creature and 1 damage to target player.
-        this.getSpellAbility().addEffect(new DamageTargetEffect(1, true, "to target creature and 1 damage to target player or planeswalker")); //code modified from punish the enemy
-        target = new TargetCreaturePermanent();
-        this.getSpellAbility().addTarget(target);
-        Target target = new TargetPlayerOrPlaneswalker();
-        this.getSpellAbility().addTarget(target);
+        this.getSpellAbility().addEffect(new DamageTargetEffect(1, true, "target creature and 1 damage to target player or planeswalker"));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent());
+        this.getSpellAbility().addTarget(new TargetPlayerOrPlaneswalker());
     }
 
     private ShowerOfSparks(final ShowerOfSparks card) {

--- a/Mage.Sets/src/mage/cards/s/ShowerOfSparks.java
+++ b/Mage.Sets/src/mage/cards/s/ShowerOfSparks.java
@@ -21,14 +21,16 @@ public final class ShowerOfSparks extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{R}");
 
         // Shower of Sparks deals 1 damage to target creature and 1 damage to target player.
-        this.getSpellAbility().addEffect(new DamageTargetEffect(1));
+        this.getSpellAbility().addEffect(new DamageTargetEffect(1).setText("deals 1 damage to target creature and 1 damage to target player");
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
 
-        Effect effect = new DamageTargetEffect(1);
-        effect.setTargetPointer(new SecondTargetPointer());
-        effect.setText("and 1 damage to target player");
-        this.getSpellAbility().addEffect(effect);
+        //** doing it the way below this causes the ability to trigger twice making it do 2 damage to player and 2 damage to target creature                                    
+        //Effect effect = new DamageTargetEffect(1);
+        //effect.setTargetPointer(new SecondTargetPointer()); 
+        //effect.setText("and 1 damage to target player");
+        //this.getSpellAbility().addEffect(effect); **//
         this.getSpellAbility().addTarget(new TargetPlayerOrPlaneswalker());
+        
     }
 
     private ShowerOfSparks(final ShowerOfSparks card) {

--- a/Mage.Sets/src/mage/cards/s/ShowerOfSparks.java
+++ b/Mage.Sets/src/mage/cards/s/ShowerOfSparks.java
@@ -21,7 +21,7 @@ public final class ShowerOfSparks extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{R}");
 
         // Shower of Sparks deals 1 damage to target creature and 1 damage to target player.
-        this.getSpellAbility().addEffect(new DamageTargetEffect(1).setText("deals 1 damage to target creature and 1 damage to target player");
+        this.getSpellAbility().addEffect(new DamageTargetEffect(1)); 
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
 
         //** doing it the way below this causes the ability to trigger twice making it do 2 damage to player and 2 damage to target creature                                    
@@ -30,7 +30,7 @@ public final class ShowerOfSparks extends CardImpl {
         //effect.setText("and 1 damage to target player");
         //this.getSpellAbility().addEffect(effect); **//
         this.getSpellAbility().addTarget(new TargetPlayerOrPlaneswalker());
-        
+        //setText("deals 1 damage to target creature and 1 damage to target player") (not sure where to put this)
     }
 
     private ShowerOfSparks(final ShowerOfSparks card) {

--- a/Mage.Sets/src/mage/cards/s/ShowerOfSparks.java
+++ b/Mage.Sets/src/mage/cards/s/ShowerOfSparks.java
@@ -19,18 +19,13 @@ public final class ShowerOfSparks extends CardImpl {
 
     public ShowerOfSparks(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{R}");
-
-        // Shower of Sparks deals 1 damage to target creature and 1 damage to target player.
-        this.getSpellAbility().addEffect(new DamageTargetEffect(1)); 
-        this.getSpellAbility().addTarget(new TargetCreaturePermanent());
-        this.getSpellAbility().addEffect(new DamagePlayersEffect(1, TargetController.ANY));
-        //** doing it the way below this causes the ability to trigger twice making it do 2 damage to player and 2 damage to target creature                                    
-        //Effect effect = new DamageTargetEffect(1);
-        //effect.setTargetPointer(new SecondTargetPointer()); 
-        //effect.setText("and 1 damage to target player");
-        //this.getSpellAbility().addEffect(effect); **//
-        //this.getSpellAbility().addTarget(new TargetPlayerOrPlaneswalker());
-        //setText("deals 1 damage to target creature and 1 damage to target player") (not sure where to put this)
+        
+        // Shower of sparks deals 1 damage to target creature and 1 damage to target player.
+        this.getSpellAbility().addEffect(new DamageTargetEffect(1, true, "to target creature and 1 damage to target player or planeswalker")); //code modified from punish the enemy
+        target = new TargetCreaturePermanent();
+        this.getSpellAbility().addTarget(target);
+        Target target = new TargetPlayerOrPlaneswalker();
+        this.getSpellAbility().addTarget(target);
     }
 
     private ShowerOfSparks(final ShowerOfSparks card) {


### PR DESCRIPTION
It was using multipile instances of the damage 1 effect so it was twice as effective as it should have been