### PR TITLE
Improvements to limited with Freeform Unlimited Commander

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.java
@@ -603,7 +603,6 @@ public class NewTableDialog extends MageDialog {
             options.getPlayerTypes().add(player.getPlayerType());
         }
         options.setDeckType((String) this.cbDeckType.getSelectedItem());
-        options.setLimited(options.getDeckType().startsWith("Limited"));
         options.setMatchTimeLimit((MatchTimeLimit) this.cbTimeLimit.getSelectedItem());
         options.setAttackOption((MultiplayerAttackOption) this.cbAttackOption.getSelectedItem());
         options.setSkillLevel((SkillLevel) this.cbSkillLevel.getSelectedItem());
@@ -621,6 +620,10 @@ public class NewTableDialog extends MageDialog {
         options.setMullgianType((MulliganType) this.cbMulligan.getSelectedItem());
         String serverAddress = SessionHandler.getSession().getServerHostname().orElse("");
         options.setBannedUsers(IgnoreList.getIgnoredUsers(serverAddress));
+        options.setLimited(options.getDeckType().startsWith("Limited"));
+        if (options.getDeckType().startsWith("Variant Magic - Freeform Unlimited Commander")) {
+            options.setLimited(true); // limited-style sideboarding with unlimited basics enabled for Freeform Unlimited Commander
+        }
 
         return options;
     }

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
@@ -1315,6 +1315,9 @@ public class NewTournamentDialog extends MageDialog {
             tOptions.getMatchOptions().setDeckType((String) this.cbDeckType.getSelectedItem());
             tOptions.getMatchOptions().setGameType(((GameTypeView) this.cbGameType.getSelectedItem()).getName());
             tOptions.getMatchOptions().setLimited(tOptions.getMatchOptions().getDeckType().startsWith("Limited"));
+            if (tOptions.getMatchOptions().getDeckType().startsWith("Variant Magic - Freeform Unlimited Commander")) {
+                tOptions.getMatchOptions().setLimited(true); // limited-style sideboarding with unlimited basics enabled for Freeform Unlimited Commander
+            }
         }
 
         String serverAddress = SessionHandler.getSession().getServerHostname().orElse("");

--- a/Mage.Server.Plugins/Mage.Game.FreeformUnlimitedCommander/src/mage/game/FreeformUnlimitedCommander.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeformUnlimitedCommander/src/mage/game/FreeformUnlimitedCommander.java
@@ -22,7 +22,7 @@ public class FreeformUnlimitedCommander extends GameCommanderImpl {
 
     @Override
     protected void init(UUID choosingPlayerId) {
-        if (numPlayers > 2) {
+        if (state.getPlayerList().size() > 2) {
             startingPlayerSkipsDraw = false;
         }
         super.init(choosingPlayerId); 

--- a/Mage.Server.Plugins/Mage.Game.FreeformUnlimitedCommander/src/mage/game/FreeformUnlimitedCommander.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeformUnlimitedCommander/src/mage/game/FreeformUnlimitedCommander.java
@@ -1,19 +1,49 @@
+
 package mage.game;
 
+import java.util.UUID;
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.RangeOfInfluence;
+import mage.game.match.MatchType;
 import mage.game.mulligan.Mulligan;
 
-public class FreeformUnlimitedCommander extends FreeformCommanderFreeForAll {
+public class FreeformUnlimitedCommander extends GameCommanderImpl {
 
-    protected int numPlayers;
+    private int numPlayers;
 
     public FreeformUnlimitedCommander(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife);
+        super(attackOption, range, mulligan, startLife, 60);
     }
 
     public FreeformUnlimitedCommander(final FreeformUnlimitedCommander game) {
         super(game);
         this.numPlayers = game.numPlayers;
+    }
+
+    @Override
+    protected void init(UUID choosingPlayerId) {
+        if (numPlayers > 2) {
+            startingPlayerSkipsDraw = false;
+        }
+        super.init(choosingPlayerId); 
+    }
+
+    @Override
+    public MatchType getGameType() {
+        return new FreeformUnlimitedCommanderType();
+    }
+
+    @Override
+    public int getNumPlayers() {
+        return numPlayers;
+    }
+
+    public void setNumPlayers(int numPlayers) {
+        this.numPlayers = numPlayers;
+    }
+
+    @Override
+    public FreeformUnlimitedCommander copy() {
+        return new FreeformUnlimitedCommander(this);
     }
 }

--- a/Mage.Server.Plugins/Mage.Game.FreeformUnlimitedCommander/src/mage/game/FreeformUnlimitedCommanderMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeformUnlimitedCommander/src/mage/game/FreeformUnlimitedCommanderMatch.java
@@ -1,10 +1,23 @@
 package mage.game;
 
+import mage.game.match.MatchImpl;
 import mage.game.match.MatchOptions;
+import mage.game.mulligan.Mulligan;
 
-public class FreeformUnlimitedCommanderMatch extends FreeformCommanderFreeForAllMatch {
+public class FreeformUnlimitedCommanderMatch extends MatchImpl {
 
     public FreeformUnlimitedCommanderMatch(MatchOptions options) {
         super(options);
     }
+
+    @Override
+    public void startGame() throws GameException {
+        int startLife = 40;
+        Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
+        FreeformUnlimitedCommander game = new FreeformUnlimitedCommander(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        game.setStartMessage(this.createGameStartMessage());
+        initGame(game);
+        games.add(game);
+    }
+
 }

--- a/Mage.Server.Plugins/Mage.Game.FreeformUnlimitedCommander/src/mage/game/FreeformUnlimitedCommanderType.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeformUnlimitedCommander/src/mage/game/FreeformUnlimitedCommanderType.java
@@ -1,6 +1,8 @@
 package mage.game;
 
-public class FreeformUnlimitedCommanderType extends FreeformCommanderFreeForAllType {
+import mage.game.match.MatchType;
+
+public class FreeformUnlimitedCommanderType extends MatchType {
 
     public FreeformUnlimitedCommanderType() {
         this.name = "Freeform Unlimited Commander";
@@ -10,7 +12,7 @@ public class FreeformUnlimitedCommanderType extends FreeformCommanderFreeForAllT
         this.playersPerTeam = 0;
         this.useAttackOption = true;
         this.useRange = true;
-        this.sideboardingAllowed = false;
+        this.sideboardingAllowed = true;
     }
 
     protected FreeformUnlimitedCommanderType(final FreeformUnlimitedCommanderType matchType) {

--- a/Mage.Tests/src/test/java/org/mage/test/game/FreeformUnlimitedCommander/FreeformUnlimitedCommanderTypeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/game/FreeformUnlimitedCommander/FreeformUnlimitedCommanderTypeTest.java
@@ -90,11 +90,11 @@ public class FreeformUnlimitedCommanderTypeTest extends MageTestPlayerBase {
     }
 
     @Test
-    public void test_isSideboardingAllowed_returnsFalse() {
+    public void test_isSideboardingAllowed_returnsTrue() {
         // Arrange
         MatchType gametype = new FreeformUnlimitedCommanderType();
 
         // Assert
-        Assert.assertFalse(gametype.isSideboardingAllowed());
+        Assert.assertTrue(gametype.isSideboardingAllowed());
     }
 }


### PR DESCRIPTION
Freeform Unlimited Commander is the best way to play commander limited on XMage. This PR improves it with additional support:
- In a two-player match of Freeform Unlimited Commander, the starting player doesn't draw a card on their first turn.
- Sideboarding is allowed in matches of Freeform Unlimited Commander and players can add unlimited basic lands when sideboarding.

This PR also removes Freeform Unlimited Commander's dependency on the Freeform Commander Free-For-All game type, to better accommodate the changes mentioned above.