### PR TITLE
[ONE] Implement Lukka, Bound to Ruin

### DIFF
--- a/Mage.Sets/src/mage/cards/l/LukkaBoundToRuin.java
+++ b/Mage.Sets/src/mage/cards/l/LukkaBoundToRuin.java
@@ -122,7 +122,7 @@ class LukkaBoundToRuinDamageEffect extends DamageMultiEffect {
                 "where X is the greatest power among creatures you controlled as you activated this ability.";
     }
 
-    private LukkaBoundToRuinDamageEffect(final mage.cards.l.LukkaBoundToRuinDamageEffect effect) {
+    private LukkaBoundToRuinDamageEffect(final LukkaBoundToRuinDamageEffect effect) {
         super(effect);
     }
 
@@ -131,8 +131,8 @@ class LukkaBoundToRuinDamageEffect extends DamageMultiEffect {
     }
 
     @Override
-    public mage.cards.l.LukkaBoundToRuinDamageEffect copy() {
-        return new mage.cards.l.LukkaBoundToRuinDamageEffect(this);
+    public LukkaBoundToRuinDamageEffect copy() {
+        return new LukkaBoundToRuinDamageEffect(this);
     }
 }
 

--- a/Mage.Sets/src/mage/cards/l/LukkaBoundToRuin.java
+++ b/Mage.Sets/src/mage/cards/l/LukkaBoundToRuin.java
@@ -1,0 +1,160 @@
+package mage.cards.l;
+
+import mage.ConditionalMana;
+import mage.MageObject;
+import mage.Mana;
+import mage.abilities.Ability;
+import mage.abilities.LoyaltyAbility;
+import mage.abilities.condition.Condition;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.GreatestPowerAmongControlledCreaturesValue;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.DamageMultiEffect;
+import mage.abilities.keyword.CompleatedAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.permanent.token.PhyrexianBeastToxicToken;
+import mage.players.Player;
+import mage.target.common.TargetCreatureOrPlaneswalkerAmount;
+import mage.target.targetadjustment.TargetAdjuster;
+
+import java.util.UUID;
+
+/**
+ * @author miesma
+ */
+public class LukkaBoundToRuin extends CardImpl {
+
+    public LukkaBoundToRuin(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.PLANESWALKER}, "{2}{R}{R/G/P}{G}");
+
+        this.addSuperType(SuperType.LEGENDARY);
+        this.subtype.add(SubType.LUKKA);
+        this.setStartingLoyalty(5);
+
+        // Compleated
+        this.addAbility(CompleatedAbility.getInstance());
+
+        // +1: Add {R}{G}. Spend this mana only to cast creature spells or activate abilities of creatures.
+        Ability ability = new LoyaltyAbility(new LukkaBoundToRuinManaEffect(),1);
+        this.addAbility(ability);
+
+        // −1: Create a 3/3 green Phyrexian Beast creature token with toxic 1.
+        ability = new LoyaltyAbility(new CreateTokenEffect(new PhyrexianBeastToxicToken()),-1);
+        this.addAbility(ability);
+
+        // −4: Lukka deals X damage divided as you choose among any number of target creatures and/or planeswalkers,
+        // where X is the greatest power among creatures you controlled as you activated this ability.
+        DynamicValue xValue = GreatestPowerAmongControlledCreaturesValue.instance;
+        ability = new LoyaltyAbility(new LukkaBoundToRuinDamageEffect(xValue), -4);
+        ability.setTargetAdjuster(LukkaBoundToRuinAdjuster.instance);
+        this.addAbility(ability);
+    }
+
+    private LukkaBoundToRuin(final LukkaBoundToRuin card) {
+        super(card);
+    }
+
+    @Override
+    public LukkaBoundToRuin copy() {
+        return new LukkaBoundToRuin(this);
+    }
+}
+
+class LukkaBoundToRuinManaEffect extends OneShotEffect {
+
+    LukkaBoundToRuinManaEffect() {
+        super(Outcome.Benefit);
+        staticText = "Add {R}{G}. Spend this mana only to cast creature spells or activate abilities of creatures.";
+    }
+
+    private LukkaBoundToRuinManaEffect(final LukkaBoundToRuinManaEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public LukkaBoundToRuinManaEffect copy() {
+        return new LukkaBoundToRuinManaEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getControllerId());
+        if (player == null) {
+            return false;
+        }
+        ConditionalMana mana = new LukkaBoundToRuinConditionalMana();
+        player.getManaPool().addMana(mana, game, source);
+        return true;
+    }
+}
+
+class LukkaBoundToRuinConditionalMana extends ConditionalMana {
+
+    // Add {R}{G}
+    private static Mana mana = new Mana(0,0,0,1,1,0,0,0);
+    public LukkaBoundToRuinConditionalMana() {
+        super(mana);
+        addCondition(LukkaBoundToRuinManaCondition.instance);
+    }
+}
+
+enum LukkaBoundToRuinManaCondition implements Condition {
+    instance;
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        MageObject object = game.getObject(source);
+        // Spend this mana only to cast creature spells or activate abilities of creatures.
+        return object != null && object.isCreature(game);
+    }
+}
+
+class LukkaBoundToRuinDamageEffect extends DamageMultiEffect {
+
+    LukkaBoundToRuinDamageEffect(DynamicValue xValue) {
+        super(xValue);
+        staticText = "Lukka deals X damage divided as you choose" +
+                " among any number of target creatures and/or planeswalkers," +
+                "where X is the greatest power among creatures you controlled as you activated this ability.";
+    }
+
+    private LukkaBoundToRuinDamageEffect(final mage.cards.l.LukkaBoundToRuinDamageEffect effect) {
+        super(effect);
+    }
+
+    public DynamicValue getDamage() {
+        return amount;
+    }
+
+    @Override
+    public mage.cards.l.LukkaBoundToRuinDamageEffect copy() {
+        return new mage.cards.l.LukkaBoundToRuinDamageEffect(this);
+    }
+}
+
+/**
+ * Gatherer Rulings:
+ * 04.02.2023
+ * You can't choose more targets than the greatest power among creatures you control as you activate the ability,
+ * and each chosen target must receive at least 1 damage.
+ */
+enum LukkaBoundToRuinAdjuster implements TargetAdjuster {
+    instance;
+
+    @Override
+    public void adjustTargets(Ability ability, Game game) {
+        // Maximum targets is equal to the damage - as each target need to be assigned at least 1 damage
+        ability.getTargets().clear();
+        LukkaBoundToRuinDamageEffect effect = (LukkaBoundToRuinDamageEffect) ability.getEffects().get(0);
+        int xValue = effect.getDamage().calculate(game,ability,effect);
+        TargetCreatureOrPlaneswalkerAmount targetCreatureOrPlaneswalkerAmount = new TargetCreatureOrPlaneswalkerAmount(xValue);
+        targetCreatureOrPlaneswalkerAmount.setMinNumberOfTargets(0);
+        targetCreatureOrPlaneswalkerAmount.setMaxNumberOfTargets(xValue);
+        ability.addTarget(targetCreatureOrPlaneswalkerAmount);
+    }
+}
+

--- a/Mage.Sets/src/mage/cards/l/LukkaBoundToRuin.java
+++ b/Mage.Sets/src/mage/cards/l/LukkaBoundToRuin.java
@@ -49,7 +49,11 @@ public class LukkaBoundToRuin extends CardImpl {
         // −4: Lukka deals X damage divided as you choose among any number of target creatures and/or planeswalkers,
         // where X is the greatest power among creatures you controlled as you activated this ability.
         DynamicValue xValue = GreatestPowerAmongControlledCreaturesValue.instance;
-        ability = new LoyaltyAbility(new LukkaBoundToRuinDamageEffect(xValue), -4);
+        DamageMultiEffect damageMultiEffect = new DamageMultiEffect(xValue);
+        damageMultiEffect.setText("Lukka deals X damage divided as you choose" +
+                " among any number of target creatures and/or planeswalkers," +
+                "where X is the greatest power among creatures you controlled as you activated this ability.");
+        ability = new LoyaltyAbility(damageMultiEffect, -4);
         ability.setTargetAdjuster(LukkaBoundToRuinAdjuster.instance);
         this.addAbility(ability);
     }
@@ -113,29 +117,6 @@ enum LukkaBoundToRuinManaCondition implements Condition {
     }
 }
 
-class LukkaBoundToRuinDamageEffect extends DamageMultiEffect {
-
-    LukkaBoundToRuinDamageEffect(DynamicValue xValue) {
-        super(xValue);
-        staticText = "Lukka deals X damage divided as you choose" +
-                " among any number of target creatures and/or planeswalkers," +
-                "where X is the greatest power among creatures you controlled as you activated this ability.";
-    }
-
-    private LukkaBoundToRuinDamageEffect(final LukkaBoundToRuinDamageEffect effect) {
-        super(effect);
-    }
-
-    public DynamicValue getDamage() {
-        return amount;
-    }
-
-    @Override
-    public LukkaBoundToRuinDamageEffect copy() {
-        return new LukkaBoundToRuinDamageEffect(this);
-    }
-}
-
 /**
  * Gatherer Rulings:
  * 04.02.2023
@@ -149,8 +130,7 @@ enum LukkaBoundToRuinAdjuster implements TargetAdjuster {
     public void adjustTargets(Ability ability, Game game) {
         // Maximum targets is equal to the damage - as each target need to be assigned at least 1 damage
         ability.getTargets().clear();
-        LukkaBoundToRuinDamageEffect effect = (LukkaBoundToRuinDamageEffect) ability.getEffects().get(0);
-        int xValue = effect.getDamage().calculate(game,ability,effect);
+        int xValue = GreatestPowerAmongControlledCreaturesValue.instance.calculate(game,ability,null);
         TargetCreatureOrPlaneswalkerAmount targetCreatureOrPlaneswalkerAmount = new TargetCreatureOrPlaneswalkerAmount(xValue);
         targetCreatureOrPlaneswalkerAmount.setMinNumberOfTargets(0);
         targetCreatureOrPlaneswalkerAmount.setMaxNumberOfTargets(xValue);

--- a/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOne.java
+++ b/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOne.java
@@ -131,6 +131,10 @@ public final class PhyrexiaAllWillBeOne extends ExpansionSet {
         cards.add(new SetCardInfo("Kuldotha Cackler", 139, Rarity.COMMON, mage.cards.k.KuldothaCackler.class));
         cards.add(new SetCardInfo("Lattice-Blade Mantis", 173, Rarity.COMMON, mage.cards.l.LatticeBladeMantis.class));
         cards.add(new SetCardInfo("Leonin Lightbringer", 20, Rarity.COMMON, mage.cards.l.LeoninLightbringer.class));
+        cards.add(new SetCardInfo("Lukka, Bound to Ruin", 207, Rarity.MYTHIC, mage.cards.l.LukkaBoundToRuin.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Lukka, Bound to Ruin", 328, Rarity.MYTHIC, mage.cards.l.LukkaBoundToRuin.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Lukka, Bound to Ruin", 342, Rarity.MYTHIC, mage.cards.l.LukkaBoundToRuin.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Lukka, Bound to Ruin", 363, Rarity.MYTHIC, mage.cards.l.LukkaBoundToRuin.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Magmatic Sprinter", 140, Rarity.UNCOMMON, mage.cards.m.MagmaticSprinter.class));
         cards.add(new SetCardInfo("Malcator's Watcher", 58, Rarity.COMMON, mage.cards.m.MalcatorsWatcher.class));
         cards.add(new SetCardInfo("Malcator, Purity Overseer", 208, Rarity.RARE, mage.cards.m.MalcatorPurityOverseer.class));


### PR DESCRIPTION
Implement Lukka, Bound to Ruin

As a comment:
The way the "deals ... damage divided as you choose among any number of ..." effects are selecting their targets in
two steps is kinda weird when testing behavior. Being able to select targets assign them 0 damage and those then
no longer being a target had me a little confused while testing Lukka.

Will probably never be relevant in regular play as you probably only choose targets you want to assign damage to anyway.