### PR TITLE
Feature improvement: automatic deck submissions now add lands sensibly

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.java
@@ -1,6 +1,5 @@
 package mage.client.dialog;
 
-import mage.Mana;
 import mage.cards.Card;
 import mage.cards.FrameStyle;
 import mage.cards.decks.Deck;
@@ -10,6 +9,7 @@ import mage.client.constants.Constants.DeckEditorMode;
 import mage.client.util.gui.FastSearchUtil;
 import mage.constants.Rarity;
 import mage.util.RandomUtil;
+import mage.util.DeckBuildUtils;
 import org.apache.log4j.Logger;
 import org.mage.card.arcane.ManaSymbols;
 
@@ -17,7 +17,6 @@ import javax.swing.*;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 import java.util.List;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -471,57 +470,13 @@ public class AddLandDialog extends MageDialog {
     }//GEN-LAST:event_btnSetFastSearchActionPerformed
 
     private void autoAddLands() {
-        int red = 0;
-        int green = 0;
-        int black = 0;
-        int blue = 0;
-        int white = 0;
-        Set<Card> cards = deck.getCards();
-        int land_number = ((Number) spnDeckSize.getValue()).intValue() - cards.size();
-        if (land_number < 0) {
-            land_number = 0;
-        }
-        for (Card cd : cards) {
-            for (String s : cd.getManaCostSymbols()) {
-                if (s.contains("W")) white++;
-                if (s.contains("U")) blue++;
-                if (s.contains("B")) black++;
-                if (s.contains("R")) red++;
-                if (s.contains("G")) green++;
-            }
-        }
-        int total = red + green + black + blue + white;
-
-        int redcards = 0;
-        int greencards = 0;
-        int blackcards = 0;
-        int bluecards = 0;
-        int whitecards = 0;
-        if (total > 0) {
-            redcards = Math.round(land_number * ((float) red / (float) total));
-            total -= red;
-            land_number -= redcards;
-
-            greencards = Math.round(land_number * ((float) green / (float) total));
-            total -= green;
-            land_number -= greencards;
-
-            blackcards = Math.round(land_number * ((float) black / (float) total));
-            total -= black;
-            land_number -= blackcards;
-
-            bluecards = Math.round(land_number * ((float) blue / (float) total));
-            total -= blue;
-            land_number -= bluecards;
-
-            whitecards = land_number;
-        }
-
-        spnMountain.setValue(redcards);
-        spnForest.setValue(greencards);
-        spnSwamp.setValue(blackcards);
-        spnIsland.setValue(bluecards);
-        spnPlains.setValue(whitecards);
+        int deckSize = ((Number) spnDeckSize.getValue()).intValue();
+        int[] lands = DeckBuildUtils.landCountSuggestion(deckSize, deck.getCards());
+        spnPlains.setValue(lands[0]);
+        spnIsland.setValue(lands[1]);
+        spnSwamp.setValue(lands[2]);
+        spnMountain.setValue(lands[3]);
+        spnForest.setValue(lands[4]);
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/Mage.Server/src/main/java/mage/server/tournament/TournamentController.java
+++ b/Mage.Server/src/main/java/mage/server/tournament/TournamentController.java
@@ -2,6 +2,8 @@ package mage.server.tournament;
 
 import mage.MageException;
 import mage.cards.decks.Deck;
+import mage.cards.decks.DeckValidator;
+import mage.cards.decks.DeckValidatorFactory;
 import mage.constants.TableState;
 import mage.constants.TournamentPlayerState;
 import mage.game.GameException;
@@ -333,7 +335,9 @@ public class TournamentController {
         if (userPlayerMap.containsKey(userId)) {
             TournamentPlayer tournamentPlayer = tournament.getPlayer(userPlayerMap.get(userId));
             if (tournamentPlayer.getDeck() != null) {
-                tournament.autoSubmit(userPlayerMap.get(userId), tournamentPlayer.generateDeck());
+                DeckValidator deckValidator = DeckValidatorFactory.instance.createDeckValidator(tournament.getOptions().getMatchOptions().getDeckType());
+                int deckMinSize = deckValidator != null ? deckValidator.getDeckMinSize() : 40;
+                tournament.autoSubmit(userPlayerMap.get(userId), tournamentPlayer.generateDeck(deckMinSize));
             } else {
                 StringBuilder sb = new StringBuilder();
                 managerFactory.userManager().getUser(userId).ifPresent(user

--- a/Mage/src/main/java/mage/game/tournament/TournamentPlayer.java
+++ b/Mage/src/main/java/mage/game/tournament/TournamentPlayer.java
@@ -6,8 +6,8 @@ import mage.game.result.ResultProtos.TourneyPlayerProto;
 import mage.game.result.ResultProtos.TourneyQuitStatus;
 import mage.players.Player;
 import mage.players.PlayerType;
+import mage.util.DeckBuildUtils;
 import mage.util.TournamentUtil;
-
 import java.util.Set;
 
 /**
@@ -91,7 +91,7 @@ public class TournamentPlayer {
     public boolean updateDeck(Deck deck) {
         // Check if the cards included in the deck are the same as in the original deck
         boolean validDeck = (getDeck().getDeckCompleteHashCode() == deck.getDeckCompleteHashCode());
-        if (validDeck == false) {
+        if (!validDeck) {
             // Clear the deck so the player cheating looses the game
             deck.getCards().clear();
             deck.getSideboard().clear();
@@ -101,25 +101,22 @@ public class TournamentPlayer {
     }
 
     public Deck generateDeck() {
-        // user passed to submit deck in time
-        // all all cards to deck
-        deck.getCards().addAll(deck.getSideboard());
-        deck.getSideboard().clear();
-        // add lands to deck
-        int landsPerType = 7;
-        if (deck.getCards().size() >= 90) {
-            landsPerType = 14;
+        /*
+        If user fails to submit deck on time, submit deck as is if meets minimum size,
+        else add basic lands per suggested land counts
+         */
+        int minDeckSize = 40;
+        if (deck.getCards().size() < minDeckSize) {
+            int[] lands = DeckBuildUtils.landCountSuggestion(minDeckSize, deck.getCards());
+            Set<String> landSets = TournamentUtil.getLandSetCodeForDeckSets(deck.getExpansionSetCodes());
+            deck.getCards().addAll(TournamentUtil.getLands("Plains", lands[0], landSets));
+            deck.getCards().addAll(TournamentUtil.getLands("Island", lands[1], landSets));
+            deck.getCards().addAll(TournamentUtil.getLands("Swamp", lands[2], landSets));
+            deck.getCards().addAll(TournamentUtil.getLands("Mountain", lands[3], landSets));
+            deck.getCards().addAll(TournamentUtil.getLands("Forest", lands[4], landSets));
         }
-        Set<String> landSets = TournamentUtil.getLandSetCodeForDeckSets(deck.getExpansionSetCodes());
-        deck.getCards().addAll(TournamentUtil.getLands("Mountain", landsPerType, landSets));
-        deck.getCards().addAll(TournamentUtil.getLands("Plains", landsPerType, landSets));
-        deck.getCards().addAll(TournamentUtil.getLands("Swamp", landsPerType, landSets));
-        deck.getCards().addAll(TournamentUtil.getLands("Forest", landsPerType, landSets));
-        deck.getCards().addAll(TournamentUtil.getLands("Island", landsPerType, landSets));
-
         this.doneConstructing = true;
         this.setState(TournamentPlayerState.WAITING);
-
         return deck;
     }
 

--- a/Mage/src/main/java/mage/game/tournament/TournamentPlayer.java
+++ b/Mage/src/main/java/mage/game/tournament/TournamentPlayer.java
@@ -100,12 +100,11 @@ public class TournamentPlayer {
         return validDeck;
     }
 
-    public Deck generateDeck() {
+    public Deck generateDeck(int minDeckSize) {
         /*
         If user fails to submit deck on time, submit deck as is if meets minimum size,
         else add basic lands per suggested land counts
          */
-        int minDeckSize = 40;
         if (deck.getCards().size() < minDeckSize) {
             int[] lands = DeckBuildUtils.landCountSuggestion(minDeckSize, deck.getCards());
             Set<String> landSets = TournamentUtil.getLandSetCodeForDeckSets(deck.getExpansionSetCodes());

--- a/Mage/src/main/java/mage/util/DeckBuildUtils.java
+++ b/Mage/src/main/java/mage/util/DeckBuildUtils.java
@@ -1,0 +1,53 @@
+package mage.util;
+
+import mage.cards.Card;
+
+import java.util.Set;
+
+public class DeckBuildUtils {
+
+    public static int[] landCountSuggestion(int deckSize, Set<Card> deckList) {
+        /*
+        Returns the number of basic lands suggested to complete a deck
+         */
+        int plains = 0, islands = 0, swamps = 0, mountains = 0, forests = 0;
+        int landsNeeded = deckSize - deckList.size();
+        if (landsNeeded > 0) {
+            int white = 0, blue = 0, black = 0, red = 0, green = 0;
+            for (Card cd : deckList) {
+                for (String s : cd.getManaCostSymbols()) {
+                    if (s.contains("W")) white++;
+                    if (s.contains("U")) blue++;
+                    if (s.contains("B")) black++;
+                    if (s.contains("R")) red++;
+                    if (s.contains("G")) green++;
+                }
+            }
+            int total = white + blue + black + red + green;
+            if (total > 0) {
+                plains = Math.round(landsNeeded * ((float) white / (float) total));
+                total -= white;
+                landsNeeded -= plains;
+
+                islands = Math.round(landsNeeded * ((float) blue / (float) total));
+                total -= blue;
+                landsNeeded -= islands;
+
+                swamps = Math.round(landsNeeded * ((float) black / (float) total));
+                total -= black;
+                landsNeeded -= swamps;
+
+                mountains = Math.round(landsNeeded * ((float) red / (float) total));
+                landsNeeded -= mountains;
+
+                forests = landsNeeded;
+            }
+        }
+        return new int[] {plains, islands, swamps, mountains, forests};
+    }
+
+    // Hide constructor - not to be instantiated
+    private DeckBuildUtils() {
+    }
+
+}

--- a/Mage/src/main/java/mage/util/DeckBuildUtils.java
+++ b/Mage/src/main/java/mage/util/DeckBuildUtils.java
@@ -9,11 +9,14 @@ public final class DeckBuildUtils {
     public static int[] landCountSuggestion(int deckSize, Set<Card> deckList) {
         /*
         Returns the number of basic lands suggested to complete a deck
+        as an array of five ints: plains, islands, swamps, mountains, forests
+        Total number of lands always sufficient to reach deckSize
          */
         int plains = 0, islands = 0, swamps = 0, mountains = 0, forests = 0;
         int landsNeeded = deckSize - deckList.size();
         if (landsNeeded > 0) {
             int white = 0, blue = 0, black = 0, red = 0, green = 0;
+            // Rudimentary algorithm that simply counts number of cards with each mana symbol
             for (Card cd : deckList) {
                 for (String s : cd.getManaCostSymbols()) {
                     if (s.contains("W")) white++;

--- a/Mage/src/main/java/mage/util/DeckBuildUtils.java
+++ b/Mage/src/main/java/mage/util/DeckBuildUtils.java
@@ -4,7 +4,7 @@ import mage.cards.Card;
 
 import java.util.Set;
 
-public class DeckBuildUtils {
+public final class DeckBuildUtils {
 
     public static int[] landCountSuggestion(int deckSize, Set<Card> deckList) {
         /*
@@ -24,24 +24,27 @@ public class DeckBuildUtils {
                 }
             }
             int total = white + blue + black + red + green;
-            if (total > 0) {
-                plains = Math.round(landsNeeded * ((float) white / (float) total));
-                total -= white;
-                landsNeeded -= plains;
-
-                islands = Math.round(landsNeeded * ((float) blue / (float) total));
-                total -= blue;
-                landsNeeded -= islands;
-
-                swamps = Math.round(landsNeeded * ((float) black / (float) total));
-                total -= black;
-                landsNeeded -= swamps;
-
-                mountains = Math.round(landsNeeded * ((float) red / (float) total));
-                landsNeeded -= mountains;
-
-                forests = landsNeeded;
+            // If no colored mana symbols, distribute evenly
+            if (total == 0) {
+                total = 5; white = 1; blue = 1; black = 1; red = 1;
             }
+
+            plains = Math.round(landsNeeded * ((float) white / (float) total));
+            total -= white;
+            landsNeeded -= plains;
+
+            islands = Math.round(landsNeeded * ((float) blue / (float) total));
+            total -= blue;
+            landsNeeded -= islands;
+
+            swamps = Math.round(landsNeeded * ((float) black / (float) total));
+            total -= black;
+            landsNeeded -= swamps;
+
+            mountains = Math.round(landsNeeded * ((float) red / (float) total));
+            landsNeeded -= mountains;
+
+            forests = landsNeeded;
         }
         return new int[] {plains, islands, swamps, mountains, forests};
     }


### PR DESCRIPTION
Previously, if a player in a limited tournament timed out during deckbuilding, a deck was automatically entered consisting of their entire pool plus seven of each basic land type. This is unreasonably punishing especially if the deck was already fully built or just missing lands. This update changes the functionality of the auto-submitted deck to submit the deck as-is if it is at least 40 cards, and otherwise automatically add lands to get up to 40 cards.

To use common logic with the auto lands feature in the add lands dialog, I moved that logic to a separate utils class. Since it is now necessary to always fill to deck size, I added a way to handle the edge case of no colored cards. The existing logic is quite rudimentary but making it smarter would be a separate scope for a future improvement; for now I am just leveraging existing functionality.

I tested the build and confirmed that the add lands dialog still works, and that timing out uses the new logic when auto-submitting a deck.