### PR TITLE
Fix targetability of [ONE] Thrun, Breaker of Silence

### DIFF
--- a/Mage.Sets/src/mage/cards/t/ThrunBreakerOfSilence.java
+++ b/Mage.Sets/src/mage/cards/t/ThrunBreakerOfSilence.java
@@ -2,23 +2,28 @@ package mage.cards.t;
 
 import java.util.UUID;
 import mage.MageInt;
+import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.condition.common.MyTurnCondition;
 import mage.abilities.decorator.ConditionalContinuousEffect;
+import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.common.CantBeCounteredSourceEffect;
-import mage.abilities.effects.common.CantBeTargetedSourceEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
 import mage.abilities.hint.common.MyTurnHint;
 import mage.abilities.keyword.IndestructibleAbility;
+import mage.cards.Card;
 import mage.constants.*;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.game.stack.StackObject;
 
 /**
  *
- * @author # -*- AhmadYProjects-*-
+ * @author # -*- AhmadYProjects-*- , xenohedron
  */
 public final class ThrunBreakerOfSilence extends CardImpl {
 
@@ -39,7 +44,7 @@ public final class ThrunBreakerOfSilence extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Thrun, Breaker of Silence can't be the target of nongreen spells your opponents control or abilities from nongreen sources your opponents control.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new CantBeTargetedSourceEffect(StaticFilters.FILTER_SPELL_OR_ABILITY_OPPONENTS_NON_GREEN,Duration.WhileOnBattlefield)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new ThrunBreakerOfSilenceEffect()));
         // As long as it's your turn, Thrun has indestructible.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD,
                 new ConditionalContinuousEffect(new GainAbilitySourceEffect(IndestructibleAbility.getInstance(), Duration.WhileOnBattlefield),
@@ -55,5 +60,53 @@ public final class ThrunBreakerOfSilence extends CardImpl {
     @Override
     public ThrunBreakerOfSilence copy() {
         return new ThrunBreakerOfSilence(this);
+    }
+}
+
+class ThrunBreakerOfSilenceEffect extends ContinuousRuleModifyingEffectImpl {
+
+    public ThrunBreakerOfSilenceEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.BoostCreature);
+        staticText = "{this} can't be the target of nongreen spells your opponents control or abilities from nongreen sources your opponents control";
+    }
+
+    public ThrunBreakerOfSilenceEffect(final mage.cards.t.ThrunBreakerOfSilenceEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public mage.cards.t.ThrunBreakerOfSilenceEffect copy() {
+        return new mage.cards.t.ThrunBreakerOfSilenceEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return true;
+    }
+
+    @Override
+    public String getInfoMessage(Ability source, GameEvent event, Game game) {
+        Permanent sourcePermanent = game.getPermanent(source.getSourceId());
+        if (sourcePermanent != null) {
+            return sourcePermanent.getLogName() + " can't be the target of nongreen spells you control or abilities from nongreen sources you control";
+        }
+        return null;
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.TARGET;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        Card targetCard = game.getCard(event.getTargetId());
+        StackObject stackObject = game.getStack().getStackObject(event.getSourceId());
+        if (targetCard != null && stackObject != null && targetCard.getId().equals(source.getSourceId())) {
+            if (!stackObject.getColor(game).isGreen()) {
+                return (!stackObject.isControlledBy(source.getControllerId()));
+            }
+        }
+        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/t/ThrunBreakerOfSilence.java
+++ b/Mage.Sets/src/mage/cards/t/ThrunBreakerOfSilence.java
@@ -103,7 +103,12 @@ class ThrunBreakerOfSilenceEffect extends ContinuousRuleModifyingEffectImpl {
         Card targetCard = game.getCard(event.getTargetId());
         StackObject stackObject = game.getStack().getStackObject(event.getSourceId());
         if (targetCard != null && stackObject != null && targetCard.getId().equals(source.getSourceId())) {
-            if (!stackObject.getColor(game).isGreen()) {
+            if (stackObject instanceof Ability) {
+                if (!((Ability) stackObject).getSourceObject(game).getColor(game).isGreen()) {
+                    return (!stackObject.isControlledBy(source.getControllerId()));
+                }
+            }
+            else if (!stackObject.getColor(game).isGreen()) {
                 return (!stackObject.isControlledBy(source.getControllerId()));
             }
         }

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -761,15 +761,6 @@ public final class StaticFilters {
         FILTER_SPELL_OR_ABILITY_OPPONENTS.setLockedFilter(true);
     }
 
-    public static final FilterStackObject FILTER_SPELL_OR_ABILITY_OPPONENTS_NON_GREEN = new FilterStackObject("a nongreen spell or ability an opponent controls");
-
-    static {
-        FILTER_SPELL_OR_ABILITY_OPPONENTS_NON_GREEN.add(Predicates.not(new ColorPredicate(ObjectColor.GREEN)));
-        FILTER_SPELL_OR_ABILITY_OPPONENTS_NON_GREEN.add(TargetController.OPPONENT.getControllerPredicate());
-        FILTER_SPELL_OR_ABILITY_OPPONENTS_NON_GREEN.setLockedFilter(true);
-
-    }
-
     public static final FilterStackObject FILTER_SPELL_OR_ABILITY = new FilterStackObject();
 
     static {


### PR DESCRIPTION
Resolves #10135.

Seems like the ControllerPredicate of the filter wasn't applying (couldn't trace exactly why). No other cards with o:"can't be the target" and o:"opponent" use that technique. So instead I reimplemented using a custom inner class similar to Shanna, Sisay's Legacy and Fiendslayer Paladin.

Tested alongside Giant Growth, Ulvenwald Tracker, Scour From Existence, Staff of Nin and confirmed the following:

- Thrun can be the target of green spells from either player
- Thrun can be the target of abilities from green sources from either player
- Thrun can be the target of its controller's colorless spells
- Thrun can be the target of abilities from its controller's colorless sources
- Thrun cannot be the target of opponent's colorless spells
- Thrun cannot be the target of abilities from opponent's colorless sources.