### PR TITLE
[ONE]Fix Orthodoxy Enforcer's boost condition

### DIFF
--- a/Mage.Sets/src/mage/cards/o/OrthodoxyEnforcer.java
+++ b/Mage.Sets/src/mage/cards/o/OrthodoxyEnforcer.java
@@ -11,6 +11,7 @@ import mage.abilities.keyword.VigilanceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.ComparisonType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.StaticFilters;
@@ -23,7 +24,7 @@ import java.util.UUID;
 public final class OrthodoxyEnforcer extends CardImpl {
 
     private static final Condition condition
-            = new PermanentsOnTheBattlefieldCondition(StaticFilters.FILTER_PERMANENT_ARTIFACT);
+            = new PermanentsOnTheBattlefieldCondition(StaticFilters.FILTER_PERMANENT_ARTIFACT, ComparisonType.MORE_THAN, 1);
 
     public OrthodoxyEnforcer(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{W}");


### PR DESCRIPTION
Orthodoxy Enforcer gets +2/+0 as long as you control **two or more artifacts**.