### PR TITLE
Implement [ONS] Circle of Solace

### DIFF
--- a/Mage.Sets/src/mage/cards/c/ChameleonSpirit.java
+++ b/Mage.Sets/src/mage/cards/c/ChameleonSpirit.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.ObjectColor;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
@@ -33,7 +33,7 @@ public final class ChameleonSpirit extends CardImpl {
         this.toughness = new MageInt(0);
 
         // As Chameleon Spirit enters the battlefield, choose a color.
-        this.addAbility(new EntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral)));
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral)));
 
         // Chameleon Spirit's power and toughness are each equal to the number 
         // of permanents of the chosen color your opponents control.

--- a/Mage.Sets/src/mage/cards/c/CircleOfSolace.java
+++ b/Mage.Sets/src/mage/cards/c/CircleOfSolace.java
@@ -57,9 +57,11 @@ class CircleOfSolaceEffect extends PreventionEffectImpl {
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (!this.used && super.applies(event, source, game)) {
             if (event.getTargetId().equals(source.getControllerId()) && event.getAmount() > 0) {
-                SubType subType = ChooseCreatureTypeEffect.getChosenCreatureType(source.getSourceId(), game);
                 Permanent perm = game.getPermanent(event.getSourceId());
-                return perm.getCardType().contains(CardType.CREATURE) && perm.getSubtype().contains(subType);
+                if (perm != null) {
+                    SubType subType = ChooseCreatureTypeEffect.getChosenCreatureType(source.getSourceId(), game);
+                    return perm.getCardType().contains(CardType.CREATURE) && perm.getSubtype().contains(subType);
+                }
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/c/CircleOfSolace.java
+++ b/Mage.Sets/src/mage/cards/c/CircleOfSolace.java
@@ -15,9 +15,9 @@ import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 
 /**
- *
  * @author xenohedron
  */
+
 public final class CircleOfSolace extends CardImpl {
 
     public CircleOfSolace(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/c/CircleOfSolace.java
+++ b/Mage.Sets/src/mage/cards/c/CircleOfSolace.java
@@ -1,0 +1,77 @@
+package mage.cards.c;
+
+import java.util.UUID;
+import mage.abilities.Ability;
+import mage.abilities.common.AsEntersBattlefieldAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.PreventionEffectImpl;
+import mage.abilities.effects.common.ChooseCreatureTypeEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+
+/**
+ *
+ * @author xenohedron
+ */
+public final class CircleOfSolace extends CardImpl {
+
+    public CircleOfSolace(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{3}{W}");
+
+        // As Circle of Solace enters the battlefield, choose a creature type.
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseCreatureTypeEffect(Outcome.Neutral)));
+        // {1}{W}: The next time a creature of the chosen type would deal damage to you this turn, prevent that damage.
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new CircleOfSolaceEffect(), new ManaCostsImpl<>("{1}{W}")));
+    }
+
+    private CircleOfSolace(final CircleOfSolace card) {
+        super(card);
+    }
+
+    @Override
+    public CircleOfSolace copy() {
+        return new CircleOfSolace(this);
+    }
+}
+
+class CircleOfSolaceEffect extends PreventionEffectImpl {
+
+    public CircleOfSolaceEffect() {
+        super(Duration.EndOfTurn, Integer.MAX_VALUE, false);
+        this.staticText = "The next time a creature of the chosen type would deal damage to you this turn, prevent that damage.";
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        preventDamageAction(event, source, game);
+        this.used = true;
+        return false;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (!this.used && super.applies(event, source, game)) {
+            if (event.getTargetId().equals(source.getControllerId())) {
+                SubType subType = ChooseCreatureTypeEffect.getChosenCreatureType(source.getSourceId(), game);
+                Permanent perm = game.getPermanent(event.getSourceId());
+                return perm.getCardType().contains(CardType.CREATURE) && perm.getSubtype().contains(subType);
+            }
+        }
+        return false;
+    }
+
+    public CircleOfSolaceEffect(CircleOfSolaceEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public CircleOfSolaceEffect copy() {
+        return new CircleOfSolaceEffect(this);
+    }
+
+}

--- a/Mage.Sets/src/mage/cards/c/CircleOfSolace.java
+++ b/Mage.Sets/src/mage/cards/c/CircleOfSolace.java
@@ -56,7 +56,7 @@ class CircleOfSolaceEffect extends PreventionEffectImpl {
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (!this.used && super.applies(event, source, game)) {
-            if (event.getTargetId().equals(source.getControllerId())) {
+            if (event.getTargetId().equals(source.getControllerId()) && event.getAmount() > 0) {
                 SubType subType = ChooseCreatureTypeEffect.getChosenCreatureType(source.getSourceId(), game);
                 Permanent perm = game.getPermanent(event.getSourceId());
                 return perm.getCardType().contains(CardType.CREATURE) && perm.getSubtype().contains(subType);

--- a/Mage.Sets/src/mage/cards/p/PrismaticCircle.java
+++ b/Mage.Sets/src/mage/cards/p/PrismaticCircle.java
@@ -4,7 +4,7 @@ package mage.cards.p;
 import java.util.UUID;
 import mage.ObjectColor;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.ChooseColorEffect;
@@ -33,7 +33,7 @@ public final class PrismaticCircle extends CardImpl {
         this.addAbility(new CumulativeUpkeepAbility(new ManaCostsImpl<>("{1}")));
 
         // As Prismatic Circle enters the battlefield, choose a color.
-        this.addAbility(new EntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral)));
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral)));
 
         // {1}: The next time a source of your choice of the chosen color would deal damage to you this turn, prevent that damage.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new PrismaticCircleEffect(), new ManaCostsImpl<>("{1}")));

--- a/Mage.Sets/src/mage/cards/q/QuirionElves.java
+++ b/Mage.Sets/src/mage/cards/q/QuirionElves.java
@@ -3,7 +3,7 @@ package mage.cards.q;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.effects.common.ChooseColorEffect;
 import mage.abilities.effects.mana.AddManaChosenColorEffect;
@@ -30,7 +30,7 @@ public final class QuirionElves extends CardImpl {
         this.toughness = new MageInt(1);
 
         // As Quirion Elves enters the battlefield, choose a color.
-        this.addAbility(new EntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral)));
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral)));
 
         // {tap}: Add {G}.
         this.addAbility(new GreenManaAbility());

--- a/Mage.Sets/src/mage/cards/r/RiptideReplicator.java
+++ b/Mage.Sets/src/mage/cards/r/RiptideReplicator.java
@@ -2,6 +2,7 @@ package mage.cards.r;
 
 import mage.ObjectColor;
 import mage.abilities.Ability;
+import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -33,7 +34,7 @@ public final class RiptideReplicator extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{X}{4}");
 
         // As Riptide Replicator enters the battlefield, choose a color and a creature type.
-        Ability ability = new EntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral));
+        Ability ability = new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral));
         Effect effect = new ChooseCreatureTypeEffect(Outcome.Neutral);
         effect.setText("and a creature type");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/s/SolGrail.java
+++ b/Mage.Sets/src/mage/cards/s/SolGrail.java
@@ -2,7 +2,7 @@
 package mage.cards.s;
 
 import java.util.UUID;
-import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.effects.common.ChooseColorEffect;
 import mage.abilities.effects.mana.AddManaChosenColorEffect;
@@ -23,7 +23,7 @@ public final class SolGrail extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
 
         // As Sol Grail enters the battlefield, choose a color.
-        this.addAbility(new EntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral)));
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral)));
 
         // {T}: Add one mana of the chosen color.
         this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, new AddManaChosenColorEffect(), new TapSourceCost()));

--- a/Mage.Sets/src/mage/cards/s/StoryCircle.java
+++ b/Mage.Sets/src/mage/cards/s/StoryCircle.java
@@ -4,7 +4,7 @@ package mage.cards.s;
 import java.util.UUID;
 import mage.ObjectColor;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.ChooseColorEffect;
@@ -22,15 +22,15 @@ import mage.game.Game;
 /**
  *
  * @author LoneFox
-
  */
+
 public final class StoryCircle extends CardImpl {
 
     public StoryCircle(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{W}{W}");
 
         // As Story Circle enters the battlefield, choose a color.
-        this.addAbility(new EntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral)));
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral)));
         // {W}: The next time a source of your choice of the chosen color would deal damage to you this turn, prevent that damage.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new StoryCircleEffect(), new ManaCostsImpl<>("{W}")));
     }

--- a/Mage.Sets/src/mage/cards/t/TeferisMoat.java
+++ b/Mage.Sets/src/mage/cards/t/TeferisMoat.java
@@ -2,7 +2,7 @@ package mage.cards.t;
 
 import mage.ObjectColor;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.RestrictionEffect;
 import mage.abilities.effects.common.ChooseColorEffect;
@@ -28,7 +28,7 @@ public final class TeferisMoat extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{W}{U}");
 
         // As Teferi's Moat enters the battlefield, choose a color.
-        this.addAbility(new EntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral)));
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral)));
         // Creatures of the chosen color without flying can't attack you.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new TeferisMoatRestrictionEffect()));
     }

--- a/Mage.Sets/src/mage/cards/v/VolrathsLaboratory.java
+++ b/Mage.Sets/src/mage/cards/v/VolrathsLaboratory.java
@@ -2,7 +2,7 @@ package mage.cards.v;
 
 import mage.ObjectColor;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
@@ -30,7 +30,7 @@ public final class VolrathsLaboratory extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{5}");
 
         // As Volrath's Laboratory enters the battlefield, choose a color and a creature type.
-        Ability ability = new EntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral));
+        Ability ability = new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral));
         Effect effect = new ChooseCreatureTypeEffect(Outcome.Neutral);
         effect.setText("and a creature type");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/sets/Onslaught.java
+++ b/Mage.Sets/src/mage/sets/Onslaught.java
@@ -78,6 +78,7 @@ public final class Onslaught extends ExpansionSet {
         cards.add(new SetCardInfo("Chain of Vapor", 73, Rarity.UNCOMMON, mage.cards.c.ChainOfVapor.class));
         cards.add(new SetCardInfo("Charging Slateback", 194, Rarity.COMMON, mage.cards.c.ChargingSlateback.class));
         cards.add(new SetCardInfo("Choking Tethers", 74, Rarity.COMMON, mage.cards.c.ChokingTethers.class));
+        cards.add(new SetCardInfo("Circle of Solace", 13, Rarity.RARE, mage.cards.c.CircleOfSolace.class));
         cards.add(new SetCardInfo("Clone", 75, Rarity.RARE, mage.cards.c.Clone.class));
         cards.add(new SetCardInfo("Commando Raid", 195, Rarity.UNCOMMON, mage.cards.c.CommandoRaid.class));
         cards.add(new SetCardInfo("Complicate", 76, Rarity.UNCOMMON, mage.cards.c.Complicate.class));


### PR DESCRIPTION
Set implementation tracker is #4900. Started with logic from Story Circle, but the ability doesn't involve choosing a source, so rewrote the inner class appropriately as a direct extension of PreventionEffectImpl. Also updated several similar cards to use "AsEntersBattlefieldAbility" rather than "EntersBattlefieldAbility" to correct their text.