### PR TITLE
Implement [JUD] Infectious Rage

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AuraGraft.java
+++ b/Mage.Sets/src/mage/cards/a/AuraGraft.java
@@ -12,17 +12,16 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.filter.Filter;
 import mage.filter.FilterPermanent;
 import mage.filter.predicate.ObjectSourcePlayer;
 import mage.filter.predicate.ObjectSourcePlayerPredicate;
 import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.predicate.permanent.PermanentCanBeAttachedToPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.TargetPermanent;
-import mage.util.TargetAddress;
 
 /**
  * @author duncant
@@ -63,27 +62,6 @@ class AttachedToPermanentPredicate implements ObjectSourcePlayerPredicate<Perman
     public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
         Permanent attached = input.getObject();
         return attached != null && game.getPermanent(attached.getAttachedTo()) != null;
-    }
-}
-
-class PermanentCanBeAttachedToPredicate implements ObjectSourcePlayerPredicate<Permanent> {
-
-    protected Permanent aura;
-
-    public PermanentCanBeAttachedToPredicate(Permanent aura) {
-        super();
-        this.aura = aura;
-    }
-
-    @Override
-    public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
-        Permanent potentialAttachment = input.getObject();
-        for (TargetAddress addr : TargetAddress.walk(aura)) {
-            Target target = addr.getTarget(aura);
-            Filter filter = target.getFilter();
-            return filter.match(potentialAttachment, game);
-        }
-        return false;
     }
 }
 

--- a/Mage.Sets/src/mage/cards/i/InfectiousRage.java
+++ b/Mage.Sets/src/mage/cards/i/InfectiousRage.java
@@ -86,16 +86,26 @@ class InfectiousRageReattachEffect extends OneShotEffect {
         }
 
         FilterPermanent filter = new FilterPermanent();
-        filter.add(new PermanentCanBeAttachedToPredicate(auraPermanent));
+        filter.add(new PermanentCanBeAttachedToPredicate(auraPermanent)); // Doesn't exclude creatures with protection abilities
         List<Permanent> permanents = game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game);
 
         if (!permanents.isEmpty()) {
             Permanent creature = permanents.get(RandomUtil.nextInt(permanents.size()));
             if (creature != null) {
+                StringBuilder message = new StringBuilder(creature.getLogName());
+                message.append(" was randomly chosen from among: ");
+                for (Permanent p : permanents) {
+                    message.append(p.getLogName());
+                    message.append(", ");
+                }
+                game.informPlayers(message.substring(0, message.length() - 2));
                 game.getState().setValue("attachTo:" + auraCard.getId(), creature);
                 controller.moveCards(auraCard, Zone.BATTLEFIELD, source, game);
                 return creature.addAttachment(auraCard.getId(), source, game);
             }
+        }
+        else {
+            game.informPlayers("No valid creatures for " + auraPermanent.getLogName() + "to enchant.");
         }
 
         return false;

--- a/Mage.Sets/src/mage/cards/i/InfectiousRage.java
+++ b/Mage.Sets/src/mage/cards/i/InfectiousRage.java
@@ -1,0 +1,104 @@
+package mage.cards.i;
+
+import mage.abilities.Ability;
+import mage.abilities.common.DiesAttachedTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
+import mage.abilities.keyword.EnchantAbility;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.permanent.PermanentCanBeAttachedToPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetCreaturePermanent;
+import mage.util.RandomUtil;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * @author xenohedron
+ */
+
+public final class InfectiousRage extends CardImpl {
+
+    public InfectiousRage(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{R}");
+        this.subtype.add(SubType.AURA);
+
+        // Enchant creature
+        TargetPermanent auraTarget = new TargetCreaturePermanent();
+        this.getSpellAbility().addTarget(auraTarget);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.BoostCreature));
+        Ability ability = new EnchantAbility(auraTarget);
+        this.addAbility(ability);
+
+        // Enchanted creature gets +2/-1.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(2, -1)));
+        
+        // When enchanted creature dies, choose a creature at random Infectious Rage can enchant.
+        // Return Infectious Rage to the battlefield attached to that creature.
+        this.addAbility(new DiesAttachedTriggeredAbility(new InfectiousRageReattachEffect(), "enchanted creature"));
+        
+    }
+
+    private InfectiousRage(final InfectiousRage card) {
+        super(card);
+    }
+
+    @Override
+    public InfectiousRage copy() {
+        return new InfectiousRage(this);
+    }
+}
+
+class InfectiousRageReattachEffect extends OneShotEffect {
+
+    public InfectiousRageReattachEffect() {
+        super(Outcome.PutCardInPlay);
+        this.staticText = "choose a creature at random {this} can enchant. Return {this} to the battlefield attached to that creature.";
+    }
+
+    public InfectiousRageReattachEffect(final InfectiousRageReattachEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public InfectiousRageReattachEffect copy() {
+        return new InfectiousRageReattachEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+
+        Card aura = game.getCard(source.getSourceId());
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null || aura == null) {
+            return false;
+        }
+
+        FilterPermanent filter = new FilterPermanent();
+        filter.add(new PermanentCanBeAttachedToPredicate((Permanent) aura));
+        List<Permanent> permanents = game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game);
+
+        if (!permanents.isEmpty()) {
+            Permanent creature = permanents.get(RandomUtil.nextInt(permanents.size()));
+            if (creature != null) {
+                game.getState().setValue("attachTo:" + aura.getId(), creature);
+                controller.moveCards(aura, Zone.BATTLEFIELD, source, game);
+                return creature.addAttachment(aura.getId(), source, game);
+            }
+        }
+
+        return false;
+
+    }
+
+}

--- a/Mage.Sets/src/mage/cards/i/InfectiousRage.java
+++ b/Mage.Sets/src/mage/cards/i/InfectiousRage.java
@@ -86,7 +86,8 @@ class InfectiousRageReattachEffect extends OneShotEffect {
         }
 
         FilterPermanent filter = new FilterPermanent();
-        filter.add(new PermanentCanBeAttachedToPredicate(auraPermanent)); // Doesn't exclude creatures with protection abilities
+        filter.add(CardType.CREATURE.getPredicate());
+        filter.add(new PermanentCanBeAttachedToPredicate(auraPermanent)); // Doesn't yet exclude creatures with protection abilities
         List<Permanent> permanents = game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game);
 
         if (!permanents.isEmpty()) {

--- a/Mage.Sets/src/mage/cards/i/InfectiousRage.java
+++ b/Mage.Sets/src/mage/cards/i/InfectiousRage.java
@@ -80,7 +80,7 @@ class InfectiousRageReattachEffect extends OneShotEffect {
 
         Player controller = game.getPlayer(source.getControllerId());
         Card auraCard = game.getCard(source.getSourceId());
-        Permanent auraPermanent = (Permanent) game.getLastKnownInformation(source.getSourceId(), Zone.BATTLEFIELD);
+        Permanent auraPermanent = source.getSourcePermanentOrLKI(game);
         if (controller == null || auraCard == null || auraPermanent == null) {
             return false;
         }
@@ -91,15 +91,8 @@ class InfectiousRageReattachEffect extends OneShotEffect {
         List<Permanent> permanents = game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game);
 
         if (!permanents.isEmpty()) {
-            Permanent creature = permanents.get(RandomUtil.nextInt(permanents.size()));
+            Permanent creature = RandomUtil.randomFromCollection(permanents);
             if (creature != null) {
-                StringBuilder message = new StringBuilder(creature.getLogName());
-                message.append(" was randomly chosen from among: ");
-                for (Permanent p : permanents) {
-                    message.append(p.getLogName());
-                    message.append(", ");
-                }
-                game.informPlayers(message.substring(0, message.length() - 2));
                 game.getState().setValue("attachTo:" + auraCard.getId(), creature);
                 controller.moveCards(auraCard, Zone.BATTLEFIELD, source, game);
                 return creature.addAttachment(auraCard.getId(), source, game);

--- a/Mage.Sets/src/mage/cards/i/InfectiousRage.java
+++ b/Mage.Sets/src/mage/cards/i/InfectiousRage.java
@@ -78,22 +78,23 @@ class InfectiousRageReattachEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
 
-        Card aura = game.getCard(source.getSourceId());
         Player controller = game.getPlayer(source.getControllerId());
-        if (controller == null || aura == null) {
+        Card auraCard = game.getCard(source.getSourceId());
+        Permanent auraPermanent = (Permanent) game.getLastKnownInformation(source.getSourceId(), Zone.BATTLEFIELD);
+        if (controller == null || auraCard == null || auraPermanent == null) {
             return false;
         }
 
         FilterPermanent filter = new FilterPermanent();
-        filter.add(new PermanentCanBeAttachedToPredicate((Permanent) aura));
+        filter.add(new PermanentCanBeAttachedToPredicate(auraPermanent));
         List<Permanent> permanents = game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game);
 
         if (!permanents.isEmpty()) {
             Permanent creature = permanents.get(RandomUtil.nextInt(permanents.size()));
             if (creature != null) {
-                game.getState().setValue("attachTo:" + aura.getId(), creature);
-                controller.moveCards(aura, Zone.BATTLEFIELD, source, game);
-                return creature.addAttachment(aura.getId(), source, game);
+                game.getState().setValue("attachTo:" + auraCard.getId(), creature);
+                controller.moveCards(auraCard, Zone.BATTLEFIELD, source, game);
+                return creature.addAttachment(auraCard.getId(), source, game);
             }
         }
 

--- a/Mage.Sets/src/mage/cards/i/InfectiousRage.java
+++ b/Mage.Sets/src/mage/cards/i/InfectiousRage.java
@@ -84,6 +84,9 @@ class InfectiousRageReattachEffect extends OneShotEffect {
         if (controller == null || auraCard == null || auraPermanent == null) {
             return false;
         }
+        if (source.getSourceObjectZoneChangeCounter() != auraCard.getZoneChangeCounter(game)) {
+            return false;
+        }
 
         FilterPermanent filter = new FilterPermanent();
         filter.add(CardType.CREATURE.getPredicate());

--- a/Mage.Sets/src/mage/sets/Judgment.java
+++ b/Mage.Sets/src/mage/sets/Judgment.java
@@ -93,6 +93,7 @@ public final class Judgment extends ExpansionSet {
         cards.add(new SetCardInfo("Hapless Researcher", 42, Rarity.COMMON, mage.cards.h.HaplessResearcher.class));
         cards.add(new SetCardInfo("Harvester Druid", 120, Rarity.COMMON, mage.cards.h.HarvesterDruid.class));
         cards.add(new SetCardInfo("Hunting Grounds", 138, Rarity.RARE, mage.cards.h.HuntingGrounds.class));
+        cards.add(new SetCardInfo("Infectious Rage", 92, Rarity.UNCOMMON, mage.cards.i.InfectiousRage.class));
         cards.add(new SetCardInfo("Ironshell Beetle", 121, Rarity.COMMON, mage.cards.i.IronshellBeetle.class));
         cards.add(new SetCardInfo("Jeska, Warrior Adept", 93, Rarity.RARE, mage.cards.j.JeskaWarriorAdept.class));
         cards.add(new SetCardInfo("Keep Watch", 43, Rarity.COMMON, mage.cards.k.KeepWatch.class));

--- a/Mage/src/main/java/mage/filter/predicate/permanent/PermanentCanBeAttachedToPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/PermanentCanBeAttachedToPredicate.java
@@ -23,6 +23,7 @@ public class PermanentCanBeAttachedToPredicate implements ObjectSourcePlayerPred
 
     @Override
     public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
+        // TODO: Is it possible to add functionality to exclude objects the aura can't enchant (e.g. protection from)?
         Permanent potentialAttachment = input.getObject();
         for (TargetAddress addr : TargetAddress.walk(aura)) {
             Target target = addr.getTarget(aura);

--- a/Mage/src/main/java/mage/filter/predicate/permanent/PermanentCanBeAttachedToPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/PermanentCanBeAttachedToPredicate.java
@@ -1,0 +1,34 @@
+package mage.filter.predicate.permanent;
+
+import mage.filter.Filter;
+import mage.filter.predicate.ObjectSourcePlayer;
+import mage.filter.predicate.ObjectSourcePlayerPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.target.Target;
+import mage.util.TargetAddress;
+
+/**
+ * @author duncant
+ */
+
+public class PermanentCanBeAttachedToPredicate implements ObjectSourcePlayerPredicate<Permanent> {
+
+    protected Permanent aura;
+
+    public PermanentCanBeAttachedToPredicate(Permanent aura) {
+        super();
+        this.aura = aura;
+    }
+
+    @Override
+    public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
+        Permanent potentialAttachment = input.getObject();
+        for (TargetAddress addr : TargetAddress.walk(aura)) {
+            Target target = addr.getTarget(aura);
+            Filter filter = target.getFilter();
+            return filter.match(potentialAttachment, game);
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Not quite a perfect implementation, as the ability doesn't target and it is not yet possible to accurately filter permanents that could legally be enchanted, see #9583 for reference. Moved the predicate inner class from Aura Graft to its own class and used it here, eventually logic can be added to cover the rare edge cases (protection from red, protection from enchantments, can't be enchanted). Set implementation tracker is #4897.