### PR TITLE
Fix Alloy Golem color set duration

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AlloyGolem.java
+++ b/Mage.Sets/src/mage/cards/a/AlloyGolem.java
@@ -3,19 +3,23 @@ package mage.cards.a;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAbility;
-import mage.abilities.effects.common.continuous.BecomesColorSourceEffect;
+import mage.abilities.Ability;
+import mage.abilities.common.AsEntersBattlefieldAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.ChooseColorEffect;
+import mage.abilities.effects.common.continuous.SetChosenColorEffect;
+import mage.abilities.effects.common.enterAttribute.EnterAttributeSetChosenColorEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
+import mage.constants.Outcome;
 import mage.constants.SubType;
+import mage.constants.Zone;
 
 /**
- *
- * @author LoneFox
-
+ * @author LoneFox, xenohedron
  */
+
 public final class AlloyGolem extends CardImpl {
 
     public AlloyGolem(UUID ownerId, CardSetInfo setInfo) {
@@ -26,8 +30,10 @@ public final class AlloyGolem extends CardImpl {
 
         // As Alloy Golem enters the battlefield, choose a color.
         // Alloy Golem is the chosen color.
-        this.addAbility(new EntersBattlefieldAbility(new BecomesColorSourceEffect(Duration.WhileOnBattlefield),
-            null, "As {this} enters the battlefield, choose a color.\n{this} is the chosen color.", ""));
+        Ability ability = new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral));
+        ability.addEffect(new EnterAttributeSetChosenColorEffect());
+        this.addAbility(ability);
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetChosenColorEffect()));
     }
 
     private AlloyGolem(final AlloyGolem card) {

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/SetChosenColorEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/SetChosenColorEffect.java
@@ -1,0 +1,44 @@
+package mage.abilities.effects.common.continuous;
+
+import mage.ObjectColor;
+import mage.abilities.Ability;
+import mage.abilities.effects.ContinuousEffectImpl;
+import mage.constants.Duration;
+import mage.constants.Layer;
+import mage.constants.Outcome;
+import mage.constants.SubLayer;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+/**
+ * @author xenohedron
+ */
+
+public class SetChosenColorEffect extends ContinuousEffectImpl {
+
+    public SetChosenColorEffect() {
+        super(Duration.WhileOnBattlefield, Layer.ColorChangingEffects_5, SubLayer.NA, Outcome.Neutral);
+        staticText = "{this} is the chosen color.";
+    }
+
+    public SetChosenColorEffect(final SetChosenColorEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public SetChosenColorEffect copy() {
+        return new SetChosenColorEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanent(source.getSourceId());
+        ObjectColor color = (ObjectColor) game.getState().getValue(source.getSourceId() + "_color") ;
+        if (permanent != null && color != null) {
+            permanent.getColor().setColor(color);
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/enterAttribute/EnterAttributeSetChosenColorEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/enterAttribute/EnterAttributeSetChosenColorEffect.java
@@ -1,0 +1,44 @@
+package mage.abilities.effects.common.enterAttribute;
+
+import mage.ObjectColor;
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.constants.Outcome;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+/**
+ * IMPORTANT: This only sets the chosen color while the source permanent is entering the battlefield.
+ * You should also use @link{mage.abilities.effects.common.continuous.SetChosenColorEffect} so that the color persists.
+ *
+ * @author xenohedron
+ */
+
+public class EnterAttributeSetChosenColorEffect extends OneShotEffect {
+
+
+    public EnterAttributeSetChosenColorEffect() {
+        super(Outcome.Neutral);
+    }
+
+    public EnterAttributeSetChosenColorEffect(final EnterAttributeSetChosenColorEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public EnterAttributeSetChosenColorEffect copy() {
+        return new EnterAttributeSetChosenColorEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanentEntering(source.getSourceId());
+        ObjectColor color = (ObjectColor) game.getState().getValue(source.getSourceId() + "_color") ;
+        if (permanent != null && color != null) {
+            permanent.getColor().setColor(color);
+            return true;
+        }
+        return false;
+    }
+
+}


### PR DESCRIPTION
Resolves #10180 by using the logic from (Adaptive Automaton / Metallic Mimic / Thran Portal) adapted to color instead of subtype, so that the ability applies in the correct layer.