### PR TITLE
[MOC] Implement Rashmi and Ragavan.

### DIFF
--- a/Mage.Sets/src/mage/cards/r/RashmiAndRagavan.java
+++ b/Mage.Sets/src/mage/cards/r/RashmiAndRagavan.java
@@ -1,0 +1,149 @@
+package mage.cards.r;
+
+import mage.ApprovingObject;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.SpellCastControllerTriggeredAbility;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.asthought.PlayFromNotOwnHandZoneTargetEffect;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.token.TreasureToken;
+import mage.game.stack.Spell;
+import mage.players.Player;
+import mage.target.common.TargetOpponent;
+import mage.watchers.common.SpellsCastWatcher;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ *
+ * @author emerald000
+ */
+public final class RashmiAndRagavan extends CardImpl {
+
+    public RashmiAndRagavan(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{G}{U}{R}");
+        addSuperType(SuperType.LEGENDARY);
+        this.subtype.add(SubType.ELF);
+        this.subtype.add(SubType.MONKEY);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(4);
+
+        // Whenever you cast your first spell during each of your turns,
+        // exile the top card of target opponent’s library and create a Treasure token.
+        // Then you may cast the exiled card without paying its mana cost if it’s a spell with mana value
+        // less than the number of artifacts you control.
+        // If you don’t cast it this way, you may cast it this turn.
+        Ability ability = new RashmiAndRagavanTriggeredAbility();
+        ability.addTarget(new TargetOpponent());
+        this.addAbility(ability, new SpellsCastWatcher());
+    }
+
+    private RashmiAndRagavan(final RashmiAndRagavan card) {
+        super(card);
+    }
+
+    @Override
+    public RashmiAndRagavan copy() {
+        return new RashmiAndRagavan(this);
+    }
+}
+
+class RashmiAndRagavanTriggeredAbility extends SpellCastControllerTriggeredAbility {
+
+    RashmiAndRagavanTriggeredAbility() {
+        super(new CreateTokenEffect(new TreasureToken()), false);
+        this.addEffect(new RashmiAndRagavanEffect());
+    }
+
+    RashmiAndRagavanTriggeredAbility(RashmiAndRagavanTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public RashmiAndRagavanTriggeredAbility copy() {
+        return new RashmiAndRagavanTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        if (super.checkTrigger(event, game) && game.isActivePlayer(event.getPlayerId())) {
+            SpellsCastWatcher watcher = game.getState().getWatcher(SpellsCastWatcher.class);
+            if (watcher != null) {
+                List<Spell> spells = watcher.getSpellsCastThisTurn(event.getPlayerId());
+                if (spells != null && spells.size() == 1) {
+                    Spell spell = game.getStack().getSpell(event.getTargetId());
+                    return spell != null;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String getRule() {
+        return "Whenever you cast your first spell during each of your turns, exile the top card of target "
+                + "opponent’s library and create a Treasure token. Then you may cast the exiled card without "
+                + "paying its mana cost if it’s a spell with mana value less than the number of artifacts you "
+                + "control. If you don’t cast it this way, you may cast it this turn.";
+    }
+}
+
+class RashmiAndRagavanEffect extends OneShotEffect {
+
+    RashmiAndRagavanEffect() {
+        super(Outcome.PlayForFree);
+        this.staticText = "exile the top card of target opponent’s library and create a Treasure token. "
+                + "Then you may cast the exiled card without paying its mana cost if it’s a spell with mana value "
+                + "less than the number of artifacts you control. If you don’t cast it this way, "
+                + "you may cast it this turn";
+    }
+
+    RashmiAndRagavanEffect(final RashmiAndRagavanEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public RashmiAndRagavanEffect copy() {
+        return new RashmiAndRagavanEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Boolean cardWasCast = false;
+        Player controller = game.getPlayer(source.getControllerId());
+        Player player = game.getPlayer(getTargetPointer().getFirst(game, source));
+        if (controller == null || player == null) {
+            return false;
+        }
+        Card card = player.getLibrary().getFromTop(game);
+        if (card == null || !player.moveCards(card, Zone.EXILED, source, game)) {
+            return false;
+        }
+        int artifactCount = new PermanentsOnBattlefieldCount(
+                StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT
+        ).calculate(game, source, this);
+        if (!card.isLand() && card.getManaValue() < artifactCount && controller.chooseUse(Outcome.PlayForFree, "Cast " + card.getName()
+                + " without paying its mana cost?", source, game)) {
+            game.getState().setValue("PlayFromNotOwnHandZone" + card.getId(), Boolean.TRUE);
+            cardWasCast = controller.cast(controller.chooseAbilityForCast(card, game, true),
+                    game, true, new ApprovingObject(source, game));
+            game.getState().setValue("PlayFromNotOwnHandZone" + card.getId(), null);
+        }
+        if (!cardWasCast) {
+            return PlayFromNotOwnHandZoneTargetEffect.exileAndPlayFromExile(
+                    game, source, card, TargetController.YOU, Duration.EndOfTurn, false, false, true
+            );
+        }
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/sets/MarchOfTheMachineCommander.java
+++ b/Mage.Sets/src/mage/sets/MarchOfTheMachineCommander.java
@@ -221,6 +221,7 @@ public final class MarchOfTheMachineCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Promise of Loyalty", 200, Rarity.RARE, mage.cards.p.PromiseOfLoyalty.class));
         cards.add(new SetCardInfo("Psychosis Crawler", 371, Rarity.RARE, mage.cards.p.PsychosisCrawler.class));
         cards.add(new SetCardInfo("Pull from Tomorrow", 230, Rarity.RARE, mage.cards.p.PullFromTomorrow.class));
+        cards.add(new SetCardInfo("Rashmi and Ragavan", 94, Rarity.MYTHIC, mage.cards.r.RashmiAndRagavan.class));
         cards.add(new SetCardInfo("Read the Bones", 267, Rarity.COMMON, mage.cards.r.ReadTheBones.class));
         cards.add(new SetCardInfo("Reality Shift", 231, Rarity.UNCOMMON, mage.cards.r.RealityShift.class));
         cards.add(new SetCardInfo("Replicating Ring", 372, Rarity.UNCOMMON, mage.cards.r.ReplicatingRing.class));


### PR DESCRIPTION
Used logic pulled from `PlayFromNotOwnHandZoneTargetEffect.exileAndPlayFromExile` to create the exile ID and name, plus being able to play it for the rest of turn if you chose not to (or couldn't) cast it for free, as using that directly was resulting in repeatedly exiling the card.