### PR TITLE
Fix [INV] Pulse of Llanowar effect

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PulseOfLlanowar.java
+++ b/Mage.Sets/src/mage/cards/p/PulseOfLlanowar.java
@@ -67,7 +67,7 @@ class PulseOfLlanowarReplacementEffect extends ReplacementEffectImpl {
         Mana mana = manaEvent.getMana();
         new AddManaOfAnyColorEffect(mana.count()).apply(game, source);
         mana.setToMana(new Mana(0, 0, 0, 0, 0, 0, 0, 0));
-        return true;
+        return false;
     }
 
     @Override
@@ -78,6 +78,6 @@ class PulseOfLlanowarReplacementEffect extends ReplacementEffectImpl {
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         Permanent permanent = ((TappedForManaEvent) event).getPermanent();
-        return permanent != null && permanent.isLand(game) && permanent.isControlledBy(source.getControllerId());
+        return permanent != null && permanent.isLand(game) && permanent.isBasic() && permanent.isControlledBy(source.getControllerId());
     }
 }


### PR DESCRIPTION
1. For interaction with other abilities that care about tapping a land for mana, the replacement effect needs to not eat the event.
2. Only basic lands should be affected.