### PR TITLE
Implement [JUD] Wormfang Crab

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WormfangCrab.java
+++ b/Mage.Sets/src/mage/cards/w/WormfangCrab.java
@@ -97,8 +97,8 @@ class WormfangCrabExileEffect extends OneShotEffect {
         if (!opponent.choose(outcome, target, source, game)) {
             return false;
         }
-        Card cardToMove = game.getCard(target.getFirstTarget());
-        UUID exileId = CardUtil.getExileZoneId(game, source.getSourceId(), source.getSourceObjectZoneChangeCounter());
+        Card cardToMove = game.getPermanent(target.getFirstTarget());
+        UUID exileId = CardUtil.getExileZoneId(game, source);
         return cardToMove != null && opponent.moveCardsToExile(cardToMove, source, game, true, exileId, sourceObject.getIdName());
     }
 

--- a/Mage.Sets/src/mage/cards/w/WormfangCrab.java
+++ b/Mage.Sets/src/mage/cards/w/WormfangCrab.java
@@ -1,0 +1,105 @@
+package mage.cards.w;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.common.LeavesBattlefieldTriggeredAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.ReturnFromExileForSourceEffect;
+import mage.abilities.keyword.CantBeBlockedSourceAbility;
+import mage.cards.Card;
+import mage.constants.SubType;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.predicate.permanent.ControllerIdPredicate;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetOpponent;
+import mage.util.CardUtil;
+
+/**
+ * @author xenohedron
+ */
+
+public final class WormfangCrab extends CardImpl {
+
+    public WormfangCrab(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{U}");
+        
+        this.subtype.add(SubType.NIGHTMARE);
+        this.subtype.add(SubType.CRAB);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(6);
+
+        // Wormfang Crab is unblockable.
+        this.addAbility(new CantBeBlockedSourceAbility());
+
+        // When Wormfang Crab enters the battlefield, an opponent chooses a permanent you control other than Wormfang Crab and exiles it.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new WormfangCrabExileEffect(), false));
+
+        // When Wormfang Crab leaves the battlefield, return the exiled card to the battlefield under its owner's control.
+        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.BATTLEFIELD), false));
+    }
+
+    private WormfangCrab(final WormfangCrab card) {
+        super(card);
+    }
+
+    @Override
+    public WormfangCrab copy() {
+        return new WormfangCrab(this);
+    }
+}
+
+class WormfangCrabExileEffect extends OneShotEffect {
+
+    public WormfangCrabExileEffect() {
+        super(Outcome.Exile);
+        this.staticText = "an opponent chooses a permanent you control other than {this} and exiles it";
+    }
+
+    public WormfangCrabExileEffect(final WormfangCrabExileEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public WormfangCrabExileEffect copy() {
+        return new WormfangCrabExileEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        MageObject sourceObject = source.getSourceObject(game);
+        if (controller == null || sourceObject == null) {
+            return false;
+        }
+        TargetOpponent targetOpponent = new TargetOpponent(true);
+        controller.choose(outcome, targetOpponent, source, game);
+        Player opponent = game.getPlayer(targetOpponent.getFirstTarget());
+        if (opponent == null) {
+            return false;
+        }
+        game.informPlayers(sourceObject.getLogName() + ": "
+                + controller.getLogName() + " has selected " + opponent.getLogName() + " to choose a permanent to exile");
+        FilterPermanent filter = new FilterPermanent();
+        filter.add(AnotherPredicate.instance);
+        filter.add(new ControllerIdPredicate(controller.getId()));
+        TargetPermanent target = new TargetPermanent(filter);
+        target.setNotTarget(true);
+        target.setTargetName("a permanent that player controls");
+        if (!opponent.choose(outcome, target, source, game)) {
+            return false;
+        }
+        Card cardToMove = game.getCard(target.getFirstTarget());
+        UUID exileId = CardUtil.getExileZoneId(game, source.getSourceId(), source.getSourceObjectZoneChangeCounter());
+        return cardToMove != null && opponent.moveCardsToExile(cardToMove, source, game, true, exileId, sourceObject.getIdName());
+    }
+
+}

--- a/Mage.Sets/src/mage/cards/w/WormfangCrab.java
+++ b/Mage.Sets/src/mage/cards/w/WormfangCrab.java
@@ -2,7 +2,6 @@ package mage.cards.w;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.LeavesBattlefieldTriggeredAbility;
@@ -76,8 +75,7 @@ class WormfangCrabExileEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
-        MageObject sourceObject = source.getSourceObject(game);
-        if (controller == null || sourceObject == null) {
+        if (controller == null) {
             return false;
         }
         TargetOpponent targetOpponent = new TargetOpponent(true);
@@ -86,8 +84,7 @@ class WormfangCrabExileEffect extends OneShotEffect {
         if (opponent == null) {
             return false;
         }
-        game.informPlayers(sourceObject.getLogName() + ": "
-                + controller.getLogName() + " has selected " + opponent.getLogName() + " to choose a permanent to exile");
+        game.informPlayers(controller.getLogName() + " has selected " + opponent.getLogName() + " to choose a permanent to exile" + CardUtil.getSourceLogName(game, source));
         FilterPermanent filter = new FilterPermanent();
         filter.add(AnotherPredicate.instance);
         filter.add(new ControllerIdPredicate(controller.getId()));
@@ -99,7 +96,7 @@ class WormfangCrabExileEffect extends OneShotEffect {
         }
         Card cardToMove = game.getPermanent(target.getFirstTarget());
         UUID exileId = CardUtil.getExileZoneId(game, source);
-        return cardToMove != null && opponent.moveCardsToExile(cardToMove, source, game, true, exileId, sourceObject.getIdName());
+        return cardToMove != null && opponent.moveCardsToExile(cardToMove, source, game, true, exileId, CardUtil.getSourceName(game, source));
     }
 
 }

--- a/Mage.Sets/src/mage/sets/Judgment.java
+++ b/Mage.Sets/src/mage/sets/Judgment.java
@@ -163,6 +163,7 @@ public final class Judgment extends ExpansionSet {
         cards.add(new SetCardInfo("Wonder", 54, Rarity.UNCOMMON, mage.cards.w.Wonder.class));
         cards.add(new SetCardInfo("Worldgorger Dragon", 103, Rarity.RARE, mage.cards.w.WorldgorgerDragon.class));
         cards.add(new SetCardInfo("Wormfang Behemoth", 55, Rarity.RARE, mage.cards.w.WormfangBehemoth.class));
+        cards.add(new SetCardInfo("Wormfang Crab", 56, Rarity.UNCOMMON, mage.cards.w.WormfangCrab.class));
         cards.add(new SetCardInfo("Wormfang Drake", 57, Rarity.COMMON, mage.cards.w.WormfangDrake.class));
         cards.add(new SetCardInfo("Wormfang Manta", 58, Rarity.RARE, mage.cards.w.WormfangManta.class));
         cards.add(new SetCardInfo("Wormfang Newt", 59, Rarity.COMMON, mage.cards.w.WormfangNewt.class));


### PR DESCRIPTION
This implementation is bugged such that while the permanent is exiled, a phantom of it still exists on the battlefield that can be interacted with. I cannot figure out how `moveCardsToExile()` would cause that behavior. Maybe someone else can figure out what the issue is.
[[Wormfang Crab]]