### PR TITLE
Downgrade maven-surefire-plugin to 2.19.1 to run unit tests locally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
+                    <version>2.19.1</version>
                     <!--
                     for compatible with jacoco code coverage - argLine moved to properties section
                     <configuration>


### PR DESCRIPTION
I have no idea why this works, or if it would be a problem in any other way, but this fixes #10236 for me. @JayDi85 what do you think?