### PR TITLE
Fixed issue with birth of the imperium

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BirthOfTheImperium.java
+++ b/Mage.Sets/src/mage/cards/b/BirthOfTheImperium.java
@@ -82,11 +82,11 @@ enum BirthOfTheImperiumValue implements DynamicValue {
                 .map(Controllable::getControllerId)
                 .collect(Collectors.toMap(Function.identity(), x -> 1, Integer::sum));
         int yourCreatures = map.getOrDefault(sourceAbility.getControllerId(), 0);
-        return yourCreatures > 0 ? 2 * game
+        return yourCreatures > 0 ? (int) (2 * game
                 .getOpponents(sourceAbility.getControllerId())
                 .stream().mapToInt(uuid -> map.getOrDefault(uuid, 0))
                 .filter(x -> x < yourCreatures)
-                .count() : 0;
+                .count()) : 0;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/b/BirthOfTheImperium.java
+++ b/Mage.Sets/src/mage/cards/b/BirthOfTheImperium.java
@@ -86,7 +86,7 @@ enum BirthOfTheImperiumValue implements DynamicValue {
                 .getOpponents(sourceAbility.getControllerId())
                 .stream().mapToInt(uuid -> map.getOrDefault(uuid, 0))
                 .filter(x -> x < yourCreatures)
-                .sum() : 0;
+                .count() : 0;
     }
 
     @Override


### PR DESCRIPTION
The number of creatures was being counted, rather than the number of opponents.

Fixes #10252