### PR TITLE
Refactor to clean up base P/T setting and fix text generation

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AbominableTreefolk.java
+++ b/Mage.Sets/src/mage/cards/a/AbominableTreefolk.java
@@ -45,7 +45,7 @@ public final class AbominableTreefolk extends CardImpl {
 
         // Abominable Treefolk's power and toughness are each equal to the number of snow permanents you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)
         ));
 
         // When Abominable Treefolk enters the battlefield, tap target creature an opponent controls. That creature doesn't untap during its controller's next untap step.

--- a/Mage.Sets/src/mage/cards/a/AbominationOfLlanowar.java
+++ b/Mage.Sets/src/mage/cards/a/AbominationOfLlanowar.java
@@ -54,7 +54,7 @@ public final class AbominationOfLlanowar extends CardImpl {
 
         // Abomination of Llanowar's power and toughness are each equal to the number of Elves you control plus the number of Elf cards in your graveyard.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/a/AdamaroFirstToDesire.java
+++ b/Mage.Sets/src/mage/cards/a/AdamaroFirstToDesire.java
@@ -29,7 +29,7 @@ public final class AdamaroFirstToDesire extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Adamaro, First to Desire's power and toughness are each equal to the number of cards in the hand of the opponent with the most cards in hand.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new MostCardsInOpponentsHandCount(), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new MostCardsInOpponentsHandCount())));
     }
 
     private AdamaroFirstToDesire(final AdamaroFirstToDesire card) {

--- a/Mage.Sets/src/mage/cards/a/AdelineResplendentCathar.java
+++ b/Mage.Sets/src/mage/cards/a/AdelineResplendentCathar.java
@@ -36,7 +36,7 @@ public final class AdelineResplendentCathar extends CardImpl {
 
         // Adeline, Resplendent Cathar's power is equal to the number of creatures you control.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(
-                CreaturesYouControlCount.instance, Duration.EndOfGame)).addHint(CreaturesYouControlHint.instance)
+                CreaturesYouControlCount.instance)).addHint(CreaturesYouControlHint.instance)
         );
 
         // Whenever you attack, for each opponent, create a 1/1 white Human creature token that's tapped and attacking that player or a planeswalker they control.

--- a/Mage.Sets/src/mage/cards/a/AeonChronicler.java
+++ b/Mage.Sets/src/mage/cards/a/AeonChronicler.java
@@ -14,7 +14,6 @@ import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
@@ -35,7 +34,7 @@ public final class AeonChronicler extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Aeon Chronicler's power and toughness are each equal to the number of cards in your hand.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance)));
         
         // Suspend X-{X}{3}{U}. X can't be 0.
         this.addAbility(new SuspendAbility(Integer.MAX_VALUE, new ManaCostsImpl<>("{3}{U}"), this, true));

--- a/Mage.Sets/src/mage/cards/a/AetherwingGoldenScaleFlagship.java
+++ b/Mage.Sets/src/mage/cards/a/AetherwingGoldenScaleFlagship.java
@@ -34,7 +34,7 @@ public final class AetherwingGoldenScaleFlagship extends CardImpl {
         // Aetherwing, Golden-Scale Flagship's power is equal to the number of artifacts you control.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBasePowerSourceEffect(ArtifactYouControlCount.instance, Duration.Custom)
+                new SetBasePowerSourceEffect(ArtifactYouControlCount.instance)
                         .setText("{this}'s power is equal to the number of artifacts you control")
         ));
 

--- a/Mage.Sets/src/mage/cards/a/AllosaurusRider.java
+++ b/Mage.Sets/src/mage/cards/a/AllosaurusRider.java
@@ -14,7 +14,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
@@ -47,7 +46,7 @@ public final class AllosaurusRider extends CardImpl {
 
         // Allosaurus Rider's power and toughness are each equal to 1 plus the number of lands you control.
         DynamicValue onePlusControlledLands = new IntPlusDynamicValue(1, new PermanentsOnBattlefieldCount(new FilterControlledLandPermanent("lands you control")));
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(onePlusControlledLands, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(onePlusControlledLands)));
 
     }
 

--- a/Mage.Sets/src/mage/cards/a/AltarGolem.java
+++ b/Mage.Sets/src/mage/cards/a/AltarGolem.java
@@ -15,7 +15,6 @@ import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledCreaturePermanent;
@@ -48,7 +47,7 @@ public final class AltarGolem extends CardImpl {
 
         // Altar Golem's power and toughness are each equal to the number of creatures on the battlefield.
         DynamicValue amount = new PermanentsOnBattlefieldCount(new FilterCreaturePermanent("creatures on the battlefield"));
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(amount, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(amount)));
 
         // Altar Golem doesn't untap during your untap step.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new DontUntapInControllersUntapStepSourceEffect()));

--- a/Mage.Sets/src/mage/cards/a/Amplifire.java
+++ b/Mage.Sets/src/mage/cards/a/Amplifire.java
@@ -84,8 +84,7 @@ class AmplifireEffect extends OneShotEffect {
                     2*lastCard.getPower().getValue(),
                     2*lastCard.getToughness().getValue(),
                     Duration.UntilYourNextTurn,
-                    SubLayer.SetPT_7b,
-                    true
+                    SubLayer.SetPT_7b
             );
             game.addEffect(setBasePowerToughnessSourceEffect, source);
         }

--- a/Mage.Sets/src/mage/cards/a/AnaxHardenedInTheForge.java
+++ b/Mage.Sets/src/mage/cards/a/AnaxHardenedInTheForge.java
@@ -42,7 +42,7 @@ public final class AnaxHardenedInTheForge extends CardImpl {
         // Anax's power is equal to your devotion to red.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBasePowerSourceEffect(DevotionCount.R, Duration.EndOfGame)
+                new SetBasePowerSourceEffect(DevotionCount.R)
                         .setText("{this}'s power is equal to your devotion to red")
         ).addHint(DevotionCount.R.getHint()));
 

--- a/Mage.Sets/src/mage/cards/a/AncientOoze.java
+++ b/Mage.Sets/src/mage/cards/a/AncientOoze.java
@@ -10,7 +10,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledCreaturePermanent;
@@ -32,7 +31,7 @@ public final class AncientOoze extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Ancient Ooze's power and toughness are each equal to the total converted mana cost of other creatures you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new AncientOozePowerToughnessValue(), Duration.EndOfGame)
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new AncientOozePowerToughnessValue())
                 .setText("{this}'s power and toughness are each equal to the total mana value of other creatures you control.")
         ));
     }

--- a/Mage.Sets/src/mage/cards/a/AngelicEnforcer.java
+++ b/Mage.Sets/src/mage/cards/a/AngelicEnforcer.java
@@ -12,7 +12,6 @@ import mage.abilities.keyword.HexproofAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -40,7 +39,7 @@ public final class AngelicEnforcer extends CardImpl {
 
         // Angelic Enforcer's power and toughness are each equal to your life total.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(
-                ControllerLifeCount.instance, Duration.EndOfGame
+                ControllerLifeCount.instance
         ).setText("{this}'s power and toughness are each equal to your life total")));
 
         // Whenever Angelic Enforcer attacks, double your life total.

--- a/Mage.Sets/src/mage/cards/a/ApocalypseDemon.java
+++ b/Mage.Sets/src/mage/cards/a/ApocalypseDemon.java
@@ -29,7 +29,7 @@ public final class ApocalypseDemon extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Apocalypse Demon's power and toughness are each equal to the number of cards in your graveyard.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CardsInControllerGraveyardCount(), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CardsInControllerGraveyardCount())));
 
         // At the beginning of your upkeep, tap Apocalypse Demon unless you sacrifice another creature.
         TapSourceUnlessPaysEffect tapEffect = new TapSourceUnlessPaysEffect(new SacrificeTargetCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE)));

--- a/Mage.Sets/src/mage/cards/a/AquamorphEntity.java
+++ b/Mage.Sets/src/mage/cards/a/AquamorphEntity.java
@@ -124,7 +124,7 @@ class AquamorphEntityReplacementEffect extends ReplacementEffectImpl {
                 toughness = 5;
                 break;
         }
-        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield), source);
+        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.CharacteristicDefining_7a), source);
         return false;
     }
 

--- a/Mage.Sets/src/mage/cards/a/AquamorphEntity.java
+++ b/Mage.Sets/src/mage/cards/a/AquamorphEntity.java
@@ -87,9 +87,7 @@ class AquamorphEntityReplacementEffect extends ReplacementEffectImpl {
             }
         }
         if (event.getType() == GameEvent.EventType.TURNFACEUP) {
-            if (event.getTargetId().equals(source.getSourceId())) {
-                return true;
-            }
+            return event.getTargetId().equals(source.getSourceId());
         }
         return false;
     }
@@ -126,7 +124,7 @@ class AquamorphEntityReplacementEffect extends ReplacementEffectImpl {
                 toughness = 5;
                 break;
         }
-        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, true), source);
+        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield), source);
         return false;
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArchpriestOfIona.java
+++ b/Mage.Sets/src/mage/cards/a/ArchpriestOfIona.java
@@ -36,7 +36,7 @@ public final class ArchpriestOfIona extends CardImpl {
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
                 new SetBasePowerSourceEffect(
-                        PartyCount.instance, Duration.EndOfGame
+                        PartyCount.instance
                 ).setText("{this}'s power is equal to the number of creatures in your party. " + PartyCount.getReminder())
         ).addHint(PartyCountHint.instance));
 

--- a/Mage.Sets/src/mage/cards/a/ArniBrokenbrow.java
+++ b/Mage.Sets/src/mage/cards/a/ArniBrokenbrow.java
@@ -88,7 +88,7 @@ class ArniBrokenbrowEffect extends OneShotEffect {
         if (controller.chooseUse(outcome, "Change base power of " + mageObject.getLogName() + " to "
                 + power + " until end of turn?", source, game
         )) {
-            game.addEffect(new SetBasePowerToughnessSourceEffect(StaticValue.get(power), null, Duration.EndOfTurn, SubLayer.SetPT_7b, true), source);
+            game.addEffect(new SetBasePowerToughnessSourceEffect(StaticValue.get(power), null, Duration.EndOfTurn, SubLayer.SetPT_7b), source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/a/AscendantSpirit.java
+++ b/Mage.Sets/src/mage/cards/a/AscendantSpirit.java
@@ -40,8 +40,7 @@ public final class AscendantSpirit extends CardImpl {
                 2,
                 3,
                 Duration.WhileOnBattlefield,
-                SubLayer.SetPT_7b,
-                true
+                SubLayer.SetPT_7b
         ).setText("with base power and toughness 2/3"));
         this.addAbility(ability);
 
@@ -94,7 +93,7 @@ class AscendantSpiritWarriorEffect extends OneShotEffect {
                 Duration.Custom, SubType.SPIRIT, SubType.WARRIOR, SubType.ANGEL
         ), source);
         game.addEffect(new SetBasePowerToughnessSourceEffect(
-                4, 4, Duration.Custom, SubLayer.SetPT_7b, true
+                4, 4, Duration.Custom, SubLayer.SetPT_7b
         ), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/a/AshayaSoulOfTheWild.java
+++ b/Mage.Sets/src/mage/cards/a/AshayaSoulOfTheWild.java
@@ -33,7 +33,7 @@ public final class AshayaSoulOfTheWild extends CardImpl {
 
         // Ashaya, Soul of the Wild’s power and toughness are each equal to the number of lands you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerToughnessSourceEffect(LandsYouControlCount.instance, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerToughnessSourceEffect(LandsYouControlCount.instance)
         ));
 
         // Nontoken creatures you control are Forest lands in addition to their other types. (They’re still affected by summoning sickness.)

--- a/Mage.Sets/src/mage/cards/a/AvenTrailblazer.java
+++ b/Mage.Sets/src/mage/cards/a/AvenTrailblazer.java
@@ -30,7 +30,7 @@ public final class AvenTrailblazer extends CardImpl {
 
         // Domain - Aven Trailblazer's toughness is equal to the number of basic land types among lands you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBaseToughnessSourceEffect(DomainValue.REGULAR, Duration.EndOfGame)
+                Zone.ALL, new SetBaseToughnessSourceEffect(DomainValue.REGULAR)
                 .setText("{this}'s toughness is equal to the number of basic land types among lands you control")
         ).addHint(DomainHint.instance).setAbilityWord(AbilityWord.DOMAIN));
     }

--- a/Mage.Sets/src/mage/cards/a/AwakenedAmalgam.java
+++ b/Mage.Sets/src/mage/cards/a/AwakenedAmalgam.java
@@ -51,9 +51,6 @@ class AwakenedAmalgamLandNamesCount implements DynamicValue {
     public AwakenedAmalgamLandNamesCount() {
     }
 
-    public AwakenedAmalgamLandNamesCount(AwakenedAmalgamLandNamesCount dynamicValue) {
-    }
-
     @Override
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
         Set<String> landNames = new HashSet<>();
@@ -67,7 +64,7 @@ class AwakenedAmalgamLandNamesCount implements DynamicValue {
 
     @Override
     public AwakenedAmalgamLandNamesCount copy() {
-        return new AwakenedAmalgamLandNamesCount(this);
+        return this;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/a/AwakenedAmalgam.java
+++ b/Mage.Sets/src/mage/cards/a/AwakenedAmalgam.java
@@ -13,7 +13,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
@@ -34,7 +33,7 @@ public final class AwakenedAmalgam extends CardImpl {
 
         // Awakened Amalgam's power and toughness are each equal to the number of differently named lands you control.
         DynamicValue value = (new AwakenedAmalgamLandNamesCount());
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(value, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(value)));
     }
 
     private AwakenedAmalgam(final AwakenedAmalgam card) {

--- a/Mage.Sets/src/mage/cards/a/AysenCrusader.java
+++ b/Mage.Sets/src/mage/cards/a/AysenCrusader.java
@@ -12,7 +12,6 @@ import mage.constants.SubType;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreaturePermanent;
@@ -44,7 +43,7 @@ public final class AysenCrusader extends CardImpl {
 
         // Aysen Crusader's power and toughness are each equal to 2 plus the number of Soldiers and Warriors you control.
         DynamicValue value = new IntPlusDynamicValue(2, new PermanentsOnBattlefieldCount(filter));
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(value, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(value)));
     }
 
     private AysenCrusader(final AysenCrusader card) {

--- a/Mage.Sets/src/mage/cards/b/BattleSquadron.java
+++ b/Mage.Sets/src/mage/cards/b/BattleSquadron.java
@@ -9,7 +9,6 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -30,7 +29,7 @@ public final class BattleSquadron extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Battle Squadron's power and toughness are each equal to the number of creatures you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance, Duration.EndOfGame))
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance))
                 .addHint(CreaturesYouControlHint.instance));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BattlegateMimic.java
+++ b/Mage.Sets/src/mage/cards/b/BattlegateMimic.java
@@ -41,7 +41,7 @@ public final class BattlegateMimic extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Whenever you cast a spell that's both red and white, Battlegate Mimic has base power and toughness 4/2 and gains first strike until end of turn.
-        SetBasePowerToughnessSourceEffect baseToughnessSourceEffect = new SetBasePowerToughnessSourceEffect(4, 2, Duration.EndOfTurn, SubLayer.SetPT_7b, true);
+        SetBasePowerToughnessSourceEffect baseToughnessSourceEffect = new SetBasePowerToughnessSourceEffect(4, 2, Duration.EndOfTurn, SubLayer.SetPT_7b);
         Ability ability = new SpellCastControllerTriggeredAbility(baseToughnessSourceEffect, filter, false, rule);
         ability.addEffect(new GainAbilitySourceEffect(FirstStrikeAbility.getInstance(), Duration.EndOfTurn, false, true));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/b/BeanstalkGiant.java
+++ b/Mage.Sets/src/mage/cards/b/BeanstalkGiant.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.AdventureCard;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
@@ -33,7 +32,7 @@ public final class BeanstalkGiant extends AdventureCard {
         this.toughness = new MageInt(0);
 
         // Beanstalk Giant's power and toughness are each equal to the number of lands you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)));
 
         // Fertile Footsteps
         // Search your library for a basic land card, put it onto the battlefield, then shuffle your library.

--- a/Mage.Sets/src/mage/cards/b/BeastOfBurden.java
+++ b/Mage.Sets/src/mage/cards/b/BeastOfBurden.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreaturePermanent;
@@ -28,7 +27,7 @@ public final class BeastOfBurden extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Beast of Burden's power and toughness are each equal to the number of creatures on the battlefield.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(new FilterCreaturePermanent("creatures on the battlefield")), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(new FilterCreaturePermanent("creatures on the battlefield")))));
         
     }
 

--- a/Mage.Sets/src/mage/cards/b/BellBorcaSpectralSergeant.java
+++ b/Mage.Sets/src/mage/cards/b/BellBorcaSpectralSergeant.java
@@ -47,7 +47,7 @@ public final class BellBorcaSpectralSergeant extends CardImpl {
 
         // Bell Borca, Spectral Sergeant's power is equal to the greatest number noted for it this turn.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(
-                BellBorcaSpectralSergeantValue.instance, Duration.EndOfGame
+                BellBorcaSpectralSergeantValue.instance
         ).setText("{this}'s power is equal to the greatest number noted for it this turn")));
 
         // At the beginning of your upkeep, exile the top card of your library. You may play that card this turn.

--- a/Mage.Sets/src/mage/cards/b/BenalishCommander.java
+++ b/Mage.Sets/src/mage/cards/b/BenalishCommander.java
@@ -13,7 +13,6 @@ import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
@@ -42,7 +41,7 @@ public final class BenalishCommander extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Benalish Commander's power and toughness are each equal to the number of Soldiers you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
 
         // Suspend X-{X}{W}{W}. X can't be 0.
         this.addAbility(new SuspendAbility(Integer.MAX_VALUE, new ManaCostsImpl<>("{W}{W}"), this, true));

--- a/Mage.Sets/src/mage/cards/b/BloodswornKnight.java
+++ b/Mage.Sets/src/mage/cards/b/BloodswornKnight.java
@@ -42,7 +42,7 @@ public final class BloodswornKnight extends CardImpl {
         this.nightCard = true;
 
         // Bloodsworn Knight's power and toughness are each equal to the number of creature cards in your graveyard.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)));
 
         // {1}{B}, Discard a card: Bloodsworn Knight gains indestructible until end of turn. Tap it.
         Ability ability = new SimpleActivatedAbility(

--- a/Mage.Sets/src/mage/cards/b/BodyOfKnowledge.java
+++ b/Mage.Sets/src/mage/cards/b/BodyOfKnowledge.java
@@ -33,7 +33,7 @@ public final class BodyOfKnowledge extends CardImpl {
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
                 new SetBasePowerToughnessSourceEffect(
-                        CardsInControllerHandCount.instance, Duration.EndOfGame
+                        CardsInControllerHandCount.instance
                 )
         ));
 

--- a/Mage.Sets/src/mage/cards/b/BoneyardMycodrax.java
+++ b/Mage.Sets/src/mage/cards/b/BoneyardMycodrax.java
@@ -10,7 +10,6 @@ import mage.abilities.keyword.ScavengeAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
@@ -40,7 +39,7 @@ public final class BoneyardMycodrax extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Boneyard Mycodrax's power and toughness are each equal to the number of other creature cards in your graveyard.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)));
 
         // Scavenge {4}{B}
         this.addAbility(new ScavengeAbility(new ManaCostsImpl<>("{4}{B}")));

--- a/Mage.Sets/src/mage/cards/b/BoneyardWurm.java
+++ b/Mage.Sets/src/mage/cards/b/BoneyardWurm.java
@@ -8,7 +8,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
@@ -24,7 +23,7 @@ public final class BoneyardWurm extends CardImpl {
 
         // Boneyard Wurm's power and toughness are each equal to the number of creature cards in your graveyard.
         DynamicValue value = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURE);
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(value, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(value)));
     }
 
     private BoneyardWurm(final BoneyardWurm card) {

--- a/Mage.Sets/src/mage/cards/b/BramblefortFink.java
+++ b/Mage.Sets/src/mage/cards/b/BramblefortFink.java
@@ -34,7 +34,7 @@ public final class BramblefortFink extends CardImpl {
         this.addAbility(new ActivateIfConditionActivatedAbility(
                 Zone.BATTLEFIELD,
                 new SetBasePowerToughnessSourceEffect(
-                        10, 10, Duration.EndOfTurn, SubLayer.SetPT_7b, true
+                        10, 10, Duration.EndOfTurn, SubLayer.SetPT_7b
                 ).setText("{this} has base power and toughness 10/10 until end of turn"),
                 new GenericManaCost(8),
                 condition));

--- a/Mage.Sets/src/mage/cards/b/BrokersInitiate.java
+++ b/Mage.Sets/src/mage/cards/b/BrokersInitiate.java
@@ -28,7 +28,7 @@ public final class BrokersInitiate extends CardImpl {
 
         // {4}{G/U}: Brokers Initiate has base power and toughness 5/5 until end of turn.
         this.addAbility(new SimpleActivatedAbility(
-                new SetBasePowerToughnessSourceEffect(5, 5, Duration.EndOfTurn, SubLayer.SetPT_7b, true),
+                new SetBasePowerToughnessSourceEffect(5, 5, Duration.EndOfTurn, SubLayer.SetPT_7b),
                 new ManaCostsImpl<>("{4}{G/U}")
         ));
     }

--- a/Mage.Sets/src/mage/cards/b/BronzeGuardian.java
+++ b/Mage.Sets/src/mage/cards/b/BronzeGuardian.java
@@ -45,7 +45,7 @@ public final class BronzeGuardian extends CardImpl {
 
         // Bronze Guardian's power is equal to the number of artifacts you control.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(
-                ArtifactYouControlCount.instance, Duration.EndOfGame
+                ArtifactYouControlCount.instance
         )));
     }
 

--- a/Mage.Sets/src/mage/cards/b/Broodstar.java
+++ b/Mage.Sets/src/mage/cards/b/Broodstar.java
@@ -11,7 +11,6 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -38,7 +37,7 @@ public final class Broodstar extends CardImpl {
         this.addAbility(new AffinityForArtifactsAbility());
         this.addAbility(FlyingAbility.getInstance());
         // Broodstar's power and toughness are each equal to the number of artifacts you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private Broodstar(final Broodstar card) {

--- a/Mage.Sets/src/mage/cards/c/CallapheBelovedOfTheSea.java
+++ b/Mage.Sets/src/mage/cards/c/CallapheBelovedOfTheSea.java
@@ -41,7 +41,7 @@ public final class CallapheBelovedOfTheSea extends CardImpl {
 
         // Callaphe's power is equal to your to devotion to blue.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerSourceEffect(DevotionCount.U, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerSourceEffect(DevotionCount.U)
                 .setText("{this}'s power is equal to your devotion to blue")
         ).addHint(DevotionCount.U.getHint()));
 

--- a/Mage.Sets/src/mage/cards/c/CallerOfTheHunt.java
+++ b/Mage.Sets/src/mage/cards/c/CallerOfTheHunt.java
@@ -115,7 +115,7 @@ enum CallerOfTheHuntAdjuster implements CostAdjuster {
         FilterCreaturePermanent filter = new FilterCreaturePermanent("chosen creature type");
         filter.add(typeChoice.getPredicate());
         ContinuousEffect effectPowerToughness = new SetBasePowerToughnessSourceEffect(
-                new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame);
+                new PermanentsOnBattlefieldCount(filter));
         effectPowerToughness.setText("");
         SimpleStaticAbility setPT = new SimpleStaticAbility(Zone.ALL, effectPowerToughness);
         GainAbilityTargetEffect gainAbility = new GainAbilityTargetEffect(setPT, Duration.EndOfGame);

--- a/Mage.Sets/src/mage/cards/c/Cantivore.java
+++ b/Mage.Sets/src/mage/cards/c/Cantivore.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 
@@ -40,7 +39,7 @@ public final class Cantivore extends CardImpl {
         this.addAbility(VigilanceAbility.getInstance());
         // Cantivore's power and toughness are each equal to the number of enchantment cards in all graveyards.
         DynamicValue value = (new CardsInAllGraveyardsCount(filter));
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(value , Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(value)));
     }
 
     private Cantivore(final Cantivore card) {

--- a/Mage.Sets/src/mage/cards/c/CephalopodSentry.java
+++ b/Mage.Sets/src/mage/cards/c/CephalopodSentry.java
@@ -8,7 +8,6 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -32,7 +31,7 @@ public final class CephalopodSentry extends CardImpl {
 
         // Cephalopod Sentry's power is equal to the number of artifacts you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerSourceEffect(ArtifactYouControlCount.instance, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerSourceEffect(ArtifactYouControlCount.instance)
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChameleonSpirit.java
+++ b/Mage.Sets/src/mage/cards/c/ChameleonSpirit.java
@@ -40,8 +40,8 @@ public final class ChameleonSpirit extends CardImpl {
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
                 new SetBasePowerToughnessSourceEffect(
-                        PermanentsOfTheChosenColorOpponentsControlCount.instance,
-                        Duration.EndOfGame)));
+                        PermanentsOfTheChosenColorOpponentsControlCount.instance
+                )));
     }
 
     private ChameleonSpirit(final ChameleonSpirit card) {

--- a/Mage.Sets/src/mage/cards/c/ChimericMass.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericMass.java
@@ -37,7 +37,7 @@ public final class ChimericMass extends CardImpl {
                 new CreatureToken(0, 0, "Construct artifact creature with \"This creature's power and toughness are each equal to the number of charge counters on it.\"")
                         .withType(CardType.ARTIFACT)
                         .withSubType(SubType.CONSTRUCT)
-                        .withAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new CountersSourceCount(CounterType.CHARGE), Duration.WhileOnBattlefield))),
+                        .withAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new CountersSourceCount(CounterType.CHARGE)))),
                 "", Duration.EndOfTurn, false, true), new GenericManaCost(1)));
     }
 

--- a/Mage.Sets/src/mage/cards/c/Cognivore.java
+++ b/Mage.Sets/src/mage/cards/c/Cognivore.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 
@@ -38,7 +37,7 @@ public final class Cognivore extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // Cognivore's power and toughness are each equal to the number of instant cards in all graveyards.
         DynamicValue value = (new CardsInAllGraveyardsCount(filter));
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(value, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(value)));
     }
 
     private Cognivore(final Cognivore card) {

--- a/Mage.Sets/src/mage/cards/c/CoilingWoodworm.java
+++ b/Mage.Sets/src/mage/cards/c/CoilingWoodworm.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
@@ -34,7 +33,7 @@ public final class CoilingWoodworm extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Coiling Woodworm's power is equal to the number of Forests on the battlefield.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(count, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(count)));
     }
 
     private CoilingWoodworm(final CoilingWoodworm card) {

--- a/Mage.Sets/src/mage/cards/c/ConsumingAberration.java
+++ b/Mage.Sets/src/mage/cards/c/ConsumingAberration.java
@@ -93,10 +93,6 @@ class CardsInOpponentsGraveyardsCount implements DynamicValue {
         super();
     }
 
-    public CardsInOpponentsGraveyardsCount(DynamicValue count) {
-        super();
-    }
-
     @Override
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
         int amount = 0;
@@ -111,7 +107,7 @@ class CardsInOpponentsGraveyardsCount implements DynamicValue {
 
     @Override
     public DynamicValue copy() {
-        return new CardsInOpponentsGraveyardsCount(this);
+        return this;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/c/ConsumingAberration.java
+++ b/Mage.Sets/src/mage/cards/c/ConsumingAberration.java
@@ -12,7 +12,6 @@ import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
 import mage.cards.*;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
@@ -34,7 +33,7 @@ public final class ConsumingAberration extends CardImpl {
         this.toughness = new MageInt(0);
 
         //Consuming Aberration's power and toughness are each equal to the number of cards in your opponents' graveyards.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CardsInOpponentsGraveyardsCount(), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CardsInOpponentsGraveyardsCount())));
         //Whenever you cast a spell, each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard.
         this.addAbility(new SpellCastControllerTriggeredAbility(new ConsumingAberrationEffect(), false));
     }

--- a/Mage.Sets/src/mage/cards/c/ConsumingBlob.java
+++ b/Mage.Sets/src/mage/cards/c/ConsumingBlob.java
@@ -1,23 +1,17 @@
 package mage.cards.c;
 
 import mage.MageInt;
-import mage.MageObject;
-import mage.abilities.Ability;
 import mage.abilities.common.BeginningOfEndStepTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.AdditiveDynamicValue;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.CardTypesInGraveyardCount;
 import mage.abilities.dynamicvalue.common.StaticValue;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
-import mage.abilities.hint.common.CardTypesInGraveyardHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.StaticFilters;
-import mage.game.Game;
 import mage.game.permanent.token.ConsumingBlobOozeToken;
 
 import java.util.UUID;
@@ -40,7 +34,7 @@ public final class ConsumingBlob extends CardImpl {
         // Consuming Blob's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBasePowerToughnessSourceEffect(powerValue, toughnessValue, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a, false)
+                new SetBasePowerToughnessSourceEffect(powerValue, toughnessValue, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a)
                         .setText("{this}'s power is equal to the number of creature cards in all graveyards and its toughness is equal to that number plus 1")
         ));
 

--- a/Mage.Sets/src/mage/cards/c/CracklingDrake.java
+++ b/Mage.Sets/src/mage/cards/c/CracklingDrake.java
@@ -12,7 +12,6 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -41,7 +40,7 @@ public final class CracklingDrake extends CardImpl {
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
                 new SetBasePowerSourceEffect(
-                        InstantSorceryExileGraveyardCount.instance, Duration.EndOfGame
+                        InstantSorceryExileGraveyardCount.instance
                 ).setText("{this}'s power is equal to the total number "
                         + "of instant and sorcery cards you own "
                         + "in exile and in your graveyard.")

--- a/Mage.Sets/src/mage/cards/c/CraterElemental.java
+++ b/Mage.Sets/src/mage/cards/c/CraterElemental.java
@@ -41,7 +41,7 @@ public final class CraterElemental extends CardImpl {
         // <i>Formidable</i> &mdash; {2}{R}: Crater Elemental has base power 8 until end of turn. Activate this ability only if creatures you control have total power 8 or greater.
         ability = new ActivateIfConditionActivatedAbility(
                 Zone.BATTLEFIELD,
-                new SetBasePowerToughnessSourceEffect(StaticValue.get(8), null, Duration.EndOfTurn, SubLayer.SetPT_7b,true)
+                new SetBasePowerToughnessSourceEffect(StaticValue.get(8), null, Duration.EndOfTurn, SubLayer.SetPT_7b)
                         .setText("{this} has base power 8 until end of turn"),
                 new ManaCostsImpl<>("{2}{R}"),
                 FormidableCondition.instance

--- a/Mage.Sets/src/mage/cards/c/CrowdOfCinders.java
+++ b/Mage.Sets/src/mage/cards/c/CrowdOfCinders.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.mageobject.ColorPredicate;
@@ -38,7 +37,7 @@ public final class CrowdOfCinders extends CardImpl {
 
         this.addAbility(FearAbility.getInstance());
         // Crowd of Cinders's power and toughness are each equal to the number of black permanents you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private CrowdOfCinders(final CrowdOfCinders card) {

--- a/Mage.Sets/src/mage/cards/c/CrusaderOfOdric.java
+++ b/Mage.Sets/src/mage/cards/c/CrusaderOfOdric.java
@@ -8,7 +8,6 @@ import mage.abilities.hint.common.CreaturesYouControlHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -28,7 +27,7 @@ public final class CrusaderOfOdric extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Crusader of Odric's power and toughness are each equal to the number of creatures you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance, Duration.EndOfGame))
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance))
                 .addHint(CreaturesYouControlHint.instance));
     }
 

--- a/Mage.Sets/src/mage/cards/c/CultivatorColossus.java
+++ b/Mage.Sets/src/mage/cards/c/CultivatorColossus.java
@@ -38,7 +38,7 @@ public final class CultivatorColossus extends CardImpl {
 
         // Cultivator Colossus's power and toughness are each equal to the number of lands you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerToughnessSourceEffect(LandsYouControlCount.instance, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerToughnessSourceEffect(LandsYouControlCount.instance)
         ));
 
         // When Cultivator Colossus enters the battlefield, you may put a land card from your hand onto the battlefield tapped. If you do, draw a card and repeat this process.

--- a/Mage.Sets/src/mage/cards/d/DakkonBlackblade.java
+++ b/Mage.Sets/src/mage/cards/d/DakkonBlackblade.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.SuperType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledLandPermanent;
@@ -35,7 +34,7 @@ public final class DakkonBlackblade extends CardImpl {
 
         // Dakkon Blackblade's power and toughness are each equal to the number of lands you control.
         DynamicValue controlledLands = new PermanentsOnBattlefieldCount(filter);
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(controlledLands, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(controlledLands)));
     }
 
     private DakkonBlackblade(final DakkonBlackblade card) {

--- a/Mage.Sets/src/mage/cards/d/DakmorSorceress.java
+++ b/Mage.Sets/src/mage/cards/d/DakmorSorceress.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -34,7 +33,7 @@ public final class DakmorSorceress extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Dakmor Sorceress's power is equal to the number of Swamps you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private DakmorSorceress(final DakmorSorceress card) {

--- a/Mage.Sets/src/mage/cards/d/DarksteelJuggernaut.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelJuggernaut.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledArtifactPermanent;
 
@@ -34,7 +33,7 @@ public final class DarksteelJuggernaut extends CardImpl {
         // Darksteel Juggernaut's power and toughness are each equal to the number of artifacts you control.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(new FilterControlledArtifactPermanent("artifacts you control")), Duration.EndOfGame)
+                new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(new FilterControlledArtifactPermanent("artifacts you control")))
         ));
 
         // Darksteel Juggernaut attacks each turn if able.

--- a/Mage.Sets/src/mage/cards/d/DauntlessDourbark.java
+++ b/Mage.Sets/src/mage/cards/d/DauntlessDourbark.java
@@ -51,7 +51,7 @@ public final class DauntlessDourbark extends CardImpl {
 
         // Dauntless Dourbark's power and toughness are each equal to the number of Forests you control plus the number of Treefolk you control.
         DynamicValue amount = new PermanentsOnBattlefieldCount(filter);
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(amount, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(amount)));
         
         // Dauntless Dourbark has trample as long as you control another Treefolk.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new ConditionalContinuousEffect(new GainAbilitySourceEffect(TrampleAbility.getInstance(), Duration.WhileOnBattlefield), new PermanentsOnTheBattlefieldCondition(filter2), rule)));

--- a/Mage.Sets/src/mage/cards/d/DauthiWarlord.java
+++ b/Mage.Sets/src/mage/cards/d/DauthiWarlord.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterCreaturePermanent;
@@ -41,7 +40,7 @@ public final class DauthiWarlord extends CardImpl {
         this.addAbility(ShadowAbility.getInstance());
         
         // Dauthi Warlord's power is equal to the number of creatures with shadow on the battlefield.
-        Effect effect = new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame);
+        Effect effect = new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter));
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DaxosBlessedByTheSun.java
+++ b/Mage.Sets/src/mage/cards/d/DaxosBlessedByTheSun.java
@@ -32,7 +32,7 @@ public final class DaxosBlessedByTheSun extends CardImpl {
         // Daxos's toughness is equal to your devotion to white.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBaseToughnessSourceEffect(DevotionCount.W, Duration.EndOfGame)
+                new SetBaseToughnessSourceEffect(DevotionCount.W)
                         .setText("{this}'s toughness is equal to your devotion to white")
         ).addHint(DevotionCount.W.getHint()));
 

--- a/Mage.Sets/src/mage/cards/d/Detritivore.java
+++ b/Mage.Sets/src/mage/cards/d/Detritivore.java
@@ -16,7 +16,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.SuperType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
@@ -41,7 +40,7 @@ public final class Detritivore extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Detritivore's power and toughness are each equal to the number of nonbasic land cards in your opponents' graveyards.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new NonBasicLandsInOpponentsGraveyards(), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new NonBasicLandsInOpponentsGraveyards())));
 
         // Suspend X-{X}{3}{R}. X can't be 0.
         this.addAbility(new SuspendAbility(Integer.MAX_VALUE, new ManaCostsImpl<>("{3}{R}"), this, true));

--- a/Mage.Sets/src/mage/cards/d/DodgyJalopy.java
+++ b/Mage.Sets/src/mage/cards/d/DodgyJalopy.java
@@ -14,7 +14,6 @@ import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
@@ -39,7 +38,7 @@ public final class DodgyJalopy extends CardImpl {
 
         // Dodgy Jalopy's power is equal to the highest mana value among creatures you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerSourceEffect(DodgyJalopyValue.instance, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerSourceEffect(DodgyJalopyValue.instance)
         ));
 
         // Crew 3

--- a/Mage.Sets/src/mage/cards/d/DoubtlessOne.java
+++ b/Mage.Sets/src/mage/cards/d/DoubtlessOne.java
@@ -10,7 +10,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
@@ -35,7 +34,7 @@ public final class DoubtlessOne extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Doubtless One's power and toughness are each equal to the number of Clerics on the battlefield.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
         
         // Whenever Doubtless One deals damage, you gain that much life.
         this.addAbility(new DealsDamageGainLifeSourceTriggeredAbility());

--- a/Mage.Sets/src/mage/cards/d/Dracoplasm.java
+++ b/Mage.Sets/src/mage/cards/d/Dracoplasm.java
@@ -117,7 +117,7 @@ class DracoplasmEffect extends ReplacementEffectImpl {
                 toughness = CardUtil.overflowInc(toughness, targetCreature.getToughness().getValue());
             }
         }
-        ContinuousEffect effect = new SetBasePowerToughnessSourceEffect(power, toughness, Duration.Custom, SubLayer.SetPT_7b, false);
+        ContinuousEffect effect = new SetBasePowerToughnessSourceEffect(power, toughness, Duration.Custom, SubLayer.SetPT_7b);
         game.addEffect(effect, source);
         return false;
     }

--- a/Mage.Sets/src/mage/cards/d/Dracoplasm.java
+++ b/Mage.Sets/src/mage/cards/d/Dracoplasm.java
@@ -117,7 +117,7 @@ class DracoplasmEffect extends ReplacementEffectImpl {
                 toughness = CardUtil.overflowInc(toughness, targetCreature.getToughness().getValue());
             }
         }
-        ContinuousEffect effect = new SetBasePowerToughnessSourceEffect(power, toughness, Duration.Custom, SubLayer.SetPT_7b);
+        ContinuousEffect effect = new SetBasePowerToughnessSourceEffect(power, toughness, Duration.Custom, SubLayer.SetPT_7b, false);
         game.addEffect(effect, source);
         return false;
     }

--- a/Mage.Sets/src/mage/cards/d/DriftOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/d/DriftOfTheDead.java
@@ -11,7 +11,6 @@ import mage.abilities.keyword.DefenderAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SuperType;
 import mage.constants.TargetController;
 import mage.constants.Zone;
@@ -42,7 +41,7 @@ public final class DriftOfTheDead extends CardImpl {
         this.addAbility(DefenderAbility.getInstance());
 
         // Drift of the Dead's power and toughness are each equal to the number of snow lands you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private DriftOfTheDead(final DriftOfTheDead card) {

--- a/Mage.Sets/src/mage/cards/d/DroveOfElves.java
+++ b/Mage.Sets/src/mage/cards/d/DroveOfElves.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.mageobject.ColorPredicate;
@@ -38,7 +37,7 @@ public final class DroveOfElves extends CardImpl {
 
         this.addAbility(HexproofAbility.getInstance());
         // Drove of Elves's power and toughness are each equal to the number of green permanents you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private DroveOfElves(final DroveOfElves card) {

--- a/Mage.Sets/src/mage/cards/d/DruidClass.java
+++ b/Mage.Sets/src/mage/cards/d/DruidClass.java
@@ -80,7 +80,7 @@ class DruidClassToken extends TokenImpl {
 
         this.addAbility(HasteAbility.getInstance());
         this.addAbility(new SimpleStaticAbility(new SetBasePowerToughnessSourceEffect(
-                LandsYouControlCount.instance, Duration.EndOfGame
+                LandsYouControlCount.instance
         ).setText("this creature's power and toughness are each equal to the number of lands you control")));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DruidClass.java
+++ b/Mage.Sets/src/mage/cards/d/DruidClass.java
@@ -18,7 +18,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.SubLayer;
 import mage.constants.SubType;
 import mage.filter.StaticFilters;
 import mage.game.permanent.token.TokenImpl;
@@ -81,7 +80,7 @@ class DruidClassToken extends TokenImpl {
 
         this.addAbility(HasteAbility.getInstance());
         this.addAbility(new SimpleStaticAbility(new SetBasePowerToughnessSourceEffect(
-                LandsYouControlCount.instance, Duration.EndOfGame, SubLayer.SetPT_7b
+                LandsYouControlCount.instance, Duration.EndOfGame
         ).setText("this creature's power and toughness are each equal to the number of lands you control")));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DruidClass.java
+++ b/Mage.Sets/src/mage/cards/d/DruidClass.java
@@ -16,9 +16,7 @@ import mage.abilities.keyword.ClassReminderAbility;
 import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.SubType;
+import mage.constants.*;
 import mage.filter.StaticFilters;
 import mage.game.permanent.token.TokenImpl;
 import mage.target.TargetPermanent;
@@ -80,7 +78,7 @@ class DruidClassToken extends TokenImpl {
 
         this.addAbility(HasteAbility.getInstance());
         this.addAbility(new SimpleStaticAbility(new SetBasePowerToughnessSourceEffect(
-                LandsYouControlCount.instance
+                LandsYouControlCount.instance, LandsYouControlCount.instance, Duration.EndOfGame, SubLayer.SetPT_7b, false
         ).setText("this creature's power and toughness are each equal to the number of lands you control")));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DruidClass.java
+++ b/Mage.Sets/src/mage/cards/d/DruidClass.java
@@ -78,7 +78,7 @@ class DruidClassToken extends TokenImpl {
 
         this.addAbility(HasteAbility.getInstance());
         this.addAbility(new SimpleStaticAbility(new SetBasePowerToughnessSourceEffect(
-                LandsYouControlCount.instance, LandsYouControlCount.instance, Duration.EndOfGame, SubLayer.SetPT_7b, false
+                LandsYouControlCount.instance, LandsYouControlCount.instance, Duration.EndOfGame, SubLayer.SetPT_7b
         ).setText("this creature's power and toughness are each equal to the number of lands you control")));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DungroveElder.java
+++ b/Mage.Sets/src/mage/cards/d/DungroveElder.java
@@ -11,7 +11,6 @@ import mage.abilities.keyword.HexproofAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -39,7 +38,7 @@ public final class DungroveElder extends CardImpl {
             this.addAbility(HexproofAbility.getInstance());
 
             // Dungrove Elder's power and toughness are each equal to the number of Forests you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands))));
     }
 
     public DungroveElder (final DungroveElder card) {

--- a/Mage.Sets/src/mage/cards/e/ElvishHouseParty.java
+++ b/Mage.Sets/src/mage/cards/e/ElvishHouseParty.java
@@ -12,7 +12,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
@@ -33,7 +32,7 @@ public final class ElvishHouseParty extends CardImpl {
         // Elvish House Party's power and toughness are each equal to the current hour,
         // using the twelve-hour system.
         this.addAbility(new SimpleStaticAbility(Zone.ALL,
-                new SetBasePowerToughnessSourceEffect(new CurrentHourCount(), Duration.WhileOnBattlefield)));
+                new SetBasePowerToughnessSourceEffect(new CurrentHourCount())));
     }
 
     private ElvishHouseParty(final ElvishHouseParty card) {

--- a/Mage.Sets/src/mage/cards/e/ElvishImpersonators.java
+++ b/Mage.Sets/src/mage/cards/e/ElvishImpersonators.java
@@ -65,7 +65,7 @@ class ElvishImpersonatorsEffect extends OneShotEffect {
         List<Integer> results = controller.rollDice(outcome, source, game, 6, 2, 0);
         int firstRoll = results.get(0);
         int secondRoll = results.get(1);
-        game.addEffect(new SetBasePowerToughnessSourceEffect(firstRoll, secondRoll, Duration.WhileOnBattlefield, SubLayer.SetPT_7b, true), source);
+        game.addEffect(new SetBasePowerToughnessSourceEffect(firstRoll, secondRoll, Duration.WhileOnBattlefield, SubLayer.SetPT_7b), source);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/e/EnigmaDrake.java
+++ b/Mage.Sets/src/mage/cards/e/EnigmaDrake.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterInstantOrSorceryCard;
 
@@ -33,7 +32,7 @@ public final class EnigmaDrake extends CardImpl {
 
         // Enigma Drakes's power is equal to the number of instant and sorcery cards in your graveyard.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(
-                new CardsInControllerGraveyardCount(new FilterInstantOrSorceryCard("instant and sorcery cards")), Duration.EndOfGame)));
+                new CardsInControllerGraveyardCount(new FilterInstantOrSorceryCard("instant and sorcery cards")))));
     }
 
     private EnigmaDrake(final EnigmaDrake card) {

--- a/Mage.Sets/src/mage/cards/e/EntropicSpecter.java
+++ b/Mage.Sets/src/mage/cards/e/EntropicSpecter.java
@@ -41,8 +41,8 @@ public final class EntropicSpecter extends CardImpl {
 
         // Entropic Specter's power and toughness are each equal to the number of cards in the chosen player's hand.
         this.addAbility(new SimpleStaticAbility(Zone.ALL,
-                // back to the graveyard or if the chosen player left the gane it's again a 0/0
-                new SetBasePowerToughnessSourceEffect(CardsInTargetPlayerHandCount.instance, Duration.WhileOnBattlefield, SubLayer.CharacteristicDefining_7a)));
+                // back to the graveyard or if the chosen player left the game it's again a 0/0
+                new SetBasePowerToughnessSourceEffect(CardsInTargetPlayerHandCount.instance, Duration.WhileOnBattlefield)));
 
         // Whenever Entropic Specter deals damage to a player, that player discards a card.
         this.addAbility(new DealsDamageToAPlayerTriggeredAbility(new DiscardTargetEffect(1, false), false, true));

--- a/Mage.Sets/src/mage/cards/e/EntropicSpecter.java
+++ b/Mage.Sets/src/mage/cards/e/EntropicSpecter.java
@@ -42,7 +42,7 @@ public final class EntropicSpecter extends CardImpl {
         // Entropic Specter's power and toughness are each equal to the number of cards in the chosen player's hand.
         this.addAbility(new SimpleStaticAbility(Zone.ALL,
                 // back to the graveyard or if the chosen player left the game it's again a 0/0
-                new SetBasePowerToughnessSourceEffect(CardsInTargetPlayerHandCount.instance, Duration.WhileOnBattlefield)));
+                new SetBasePowerToughnessSourceEffect(CardsInTargetPlayerHandCount.instance)));
 
         // Whenever Entropic Specter deals damage to a player, that player discards a card.
         this.addAbility(new DealsDamageToAPlayerTriggeredAbility(new DiscardTargetEffect(1, false), false, true));

--- a/Mage.Sets/src/mage/cards/e/EntropicSpecter.java
+++ b/Mage.Sets/src/mage/cards/e/EntropicSpecter.java
@@ -42,7 +42,8 @@ public final class EntropicSpecter extends CardImpl {
         // Entropic Specter's power and toughness are each equal to the number of cards in the chosen player's hand.
         this.addAbility(new SimpleStaticAbility(Zone.ALL,
                 // back to the graveyard or if the chosen player left the game it's again a 0/0
-                new SetBasePowerToughnessSourceEffect(CardsInTargetPlayerHandCount.instance)));
+                new SetBasePowerToughnessSourceEffect(CardsInTargetPlayerHandCount.instance, CardsInTargetPlayerHandCount.instance,
+                        Duration.WhileOnBattlefield, SubLayer.SetPT_7b, false)));
 
         // Whenever Entropic Specter deals damage to a player, that player discards a card.
         this.addAbility(new DealsDamageToAPlayerTriggeredAbility(new DiscardTargetEffect(1, false), false, true));

--- a/Mage.Sets/src/mage/cards/e/EntropicSpecter.java
+++ b/Mage.Sets/src/mage/cards/e/EntropicSpecter.java
@@ -43,7 +43,8 @@ public final class EntropicSpecter extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.ALL,
                 // back to the graveyard or if the chosen player left the game it's again a 0/0
                 new SetBasePowerToughnessSourceEffect(CardsInTargetPlayerHandCount.instance, CardsInTargetPlayerHandCount.instance,
-                        Duration.WhileOnBattlefield, SubLayer.SetPT_7b, false)));
+                        Duration.WhileOnBattlefield, SubLayer.SetPT_7b)
+                        .setText("{this}'s power and toughness are each equal to the number of cards in the chosen player's hand")));
 
         // Whenever Entropic Specter deals damage to a player, that player discards a card.
         this.addAbility(new DealsDamageToAPlayerTriggeredAbility(new DiscardTargetEffect(1, false), false, true));

--- a/Mage.Sets/src/mage/cards/e/EvolvedSleeper.java
+++ b/Mage.Sets/src/mage/cards/e/EvolvedSleeper.java
@@ -34,7 +34,7 @@ public final class EvolvedSleeper extends CardImpl {
                 Duration.Custom, SubType.HUMAN, SubType.CLERIC
         ).setText("{this} becomes a Human Cleric"), new ManaCostsImpl<>("{B}"));
         ability.addEffect(new SetBasePowerToughnessSourceEffect(
-                2, 2, Duration.Custom, SubLayer.SetPT_7b, true
+                2, 2, Duration.Custom, SubLayer.SetPT_7b
         ).setText("with base power and toughness 2/2"));
         this.addAbility(ability);
 
@@ -87,7 +87,7 @@ class EvolvedSleeperClericEffect extends OneShotEffect {
                 Duration.Custom, SubType.PHYREXIAN, SubType.HUMAN, SubType.CLERIC
         ), source);
         game.addEffect(new SetBasePowerToughnessSourceEffect(
-                3, 3, Duration.Custom, SubLayer.SetPT_7b, true
+                3, 3, Duration.Custom, SubLayer.SetPT_7b
         ), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/e/EvraHalcyonWitness.java
+++ b/Mage.Sets/src/mage/cards/e/EvraHalcyonWitness.java
@@ -88,7 +88,7 @@ class EvraHalcyonWitnessEffect extends OneShotEffect {
                 //      For example, say Evra is enchanted with Dub (which makes it 6/6) and your life total is 7.
                 //      After the exchange, Evra would be a 9/6 creature (its power became 7, which was then modified by Dub) and your life total would be 6.
                 //      (2018-04-27)
-                game.addEffect(new SetBasePowerToughnessSourceEffect(StaticValue.get(life), null, Duration.Custom, SubLayer.SetPT_7b, true), source);
+                game.addEffect(new SetBasePowerToughnessSourceEffect(StaticValue.get(life), null, Duration.Custom, SubLayer.SetPT_7b), source);
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/f/FaerieSwarm.java
+++ b/Mage.Sets/src/mage/cards/f/FaerieSwarm.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.mageobject.ColorPredicate;
@@ -38,7 +37,7 @@ public final class FaerieSwarm extends CardImpl {
 
         this.addAbility(FlyingAbility.getInstance());
         // Faerie Swarm's power and toughness are each equal to the number of blue permanents you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private FaerieSwarm(final FaerieSwarm card) {

--- a/Mage.Sets/src/mage/cards/f/FigureOfDestiny.java
+++ b/Mage.Sets/src/mage/cards/f/FigureOfDestiny.java
@@ -35,7 +35,7 @@ public final class FigureOfDestiny extends CardImpl {
                 Duration.Custom, SubType.KITHKIN, SubType.SPIRIT
         ).setText("{this} becomes a Kithkin Spirit"), new ManaCostsImpl<>("{R/W}"));
         ability.addEffect(new SetBasePowerToughnessSourceEffect(
-                2, 2, Duration.Custom, SubLayer.SetPT_7b, true
+                2, 2, Duration.Custom, SubLayer.SetPT_7b
         ).setText("with base power and toughness 2/2"));
         this.addAbility(ability);
 
@@ -86,7 +86,7 @@ class FigureOfDestinySpiritEffect extends OneShotEffect {
                 Duration.Custom, SubType.KITHKIN, SubType.SPIRIT, SubType.WARRIOR
         ), source);
         game.addEffect(new SetBasePowerToughnessSourceEffect(
-                4, 4, Duration.Custom, SubLayer.SetPT_7b, true
+                4, 4, Duration.Custom, SubLayer.SetPT_7b
         ), source);
         return true;
     }
@@ -119,7 +119,7 @@ class FigureOfDestinyWarriorEffect extends OneShotEffect {
                 Duration.Custom, SubType.KITHKIN, SubType.SPIRIT, SubType.WARRIOR, SubType.AVATAR
         ), source);
         game.addEffect(new SetBasePowerToughnessSourceEffect(
-                8, 8, Duration.Custom, SubLayer.SetPT_7b, true
+                8, 8, Duration.Custom, SubLayer.SetPT_7b
         ), source);
         game.addEffect(new GainAbilitySourceEffect(
                 FlyingAbility.getInstance(), Duration.Custom

--- a/Mage.Sets/src/mage/cards/f/FiligreeAttendant.java
+++ b/Mage.Sets/src/mage/cards/f/FiligreeAttendant.java
@@ -28,7 +28,7 @@ public final class FiligreeAttendant extends CardImpl {
 
         // Filigree Attendant's power is equal to the number of artifacts you control.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(
-                ArtifactYouControlCount.instance, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a
+                ArtifactYouControlCount.instance
         ).setText("{this}'s power is equal to the number of artifacts you control")));
     }
 

--- a/Mage.Sets/src/mage/cards/f/FrodoSauronsBane.java
+++ b/Mage.Sets/src/mage/cards/f/FrodoSauronsBane.java
@@ -43,7 +43,7 @@ public final class FrodoSauronsBane extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(
                 new ConditionalOneShotEffect(new AddContinuousEffectToGame(
                         new AddCardSubTypeSourceEffect(Duration.Custom, SubType.HALFLING, SubType.SCOUT),
-                        new SetBasePowerToughnessSourceEffect(2, 3, Duration.Custom, SubLayer.SetPT_7b, true),
+                        new SetBasePowerToughnessSourceEffect(2, 3, Duration.Custom, SubLayer.SetPT_7b),
                         new GainAbilitySourceEffect(LifelinkAbility.getInstance(), Duration.Custom)
                 ), condition1, "if {this} is a Citizen, it becomes a Halfling Scout with base power and toughness 2/3 and lifelink"),
                 new ManaCostsImpl<>("{W/B}{W/B}")

--- a/Mage.Sets/src/mage/cards/f/FungalBehemoth.java
+++ b/Mage.Sets/src/mage/cards/f/FungalBehemoth.java
@@ -16,7 +16,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
@@ -39,7 +38,7 @@ public final class FungalBehemoth extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Fungal Behemoth's power and toughness are each equal to the number of +1/+1 counters on creatures you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new P1P1CountersOnControlledCreaturesCount(), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new P1P1CountersOnControlledCreaturesCount())));
 
         // Suspend X-{X}{G}{G}. X can't be 0.
         this.addAbility(new SuspendAbility(Integer.MAX_VALUE, new ManaCostsImpl<>("{G}{G}"), this, true));

--- a/Mage.Sets/src/mage/cards/g/GaeasAvenger.java
+++ b/Mage.Sets/src/mage/cards/g/GaeasAvenger.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.common.FilterArtifactPermanent;
@@ -37,7 +36,7 @@ public final class GaeasAvenger extends CardImpl {
 
         // Gaea's Avenger's power and toughness are each equal to 1 plus the number of artifacts your opponents control.
         
-        SetBasePowerToughnessSourceEffect effect = new SetBasePowerToughnessSourceEffect(new IntPlusDynamicValue(1, new PermanentsOnBattlefieldCount(filter)), Duration.EndOfGame);
+        SetBasePowerToughnessSourceEffect effect = new SetBasePowerToughnessSourceEffect(new IntPlusDynamicValue(1, new PermanentsOnBattlefieldCount(filter)));
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GaeasLiege.java
+++ b/Mage.Sets/src/mage/cards/g/GaeasLiege.java
@@ -48,8 +48,8 @@ public final class GaeasLiege extends CardImpl {
 
         // As long as Gaea's Liege isn't attacking, its power and toughness are each equal to the number of Forests you control. As long as Gaea's Liege is attacking, its power and toughness are each equal to the number of Forests defending player controls.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new ConditionalContinuousEffect(
-                new SetBasePowerToughnessSourceEffect(xValue2, Duration.EndOfGame),
-                new SetBasePowerToughnessSourceEffect(xValue1, Duration.EndOfGame),
+                new SetBasePowerToughnessSourceEffect(xValue2),
+                new SetBasePowerToughnessSourceEffect(xValue1),
                 SourceAttackingCondition.instance, "as long as {this} isn't attacking, " +
                 "its power and toughness are each equal to the number of Forests you control. " +
                 "As long as {this} is attacking, its power and toughness are each equal " +

--- a/Mage.Sets/src/mage/cards/g/GeistHonoredMonk.java
+++ b/Mage.Sets/src/mage/cards/g/GeistHonoredMonk.java
@@ -11,7 +11,6 @@ import mage.abilities.keyword.VigilanceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.permanent.token.SpiritWhiteToken;
@@ -34,7 +33,7 @@ public final class GeistHonoredMonk extends CardImpl {
         this.addAbility(VigilanceAbility.getInstance());
 
         // Geist-Honored Monk's power and toughness are each equal to the number of creatures you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance, Duration.EndOfGame))
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance))
                 .addHint(CreaturesYouControlHint.instance));
 
         // When Geist-Honored Monk enters the battlefield, create two 1/1 white Spirit creature tokens with flying.

--- a/Mage.Sets/src/mage/cards/g/Gigantiform.java
+++ b/Mage.Sets/src/mage/cards/g/Gigantiform.java
@@ -71,7 +71,7 @@ class GigantiformAbility extends StaticAbility {
         super(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(TrampleAbility.getInstance(), AttachmentType.AURA));
         Ability ability = new SimpleStaticAbility(
                 Zone.BATTLEFIELD,
-                new SetBasePowerToughnessSourceEffect(8, 8, Duration.WhileOnBattlefield, SubLayer.SetPT_7b, true)
+                new SetBasePowerToughnessSourceEffect(8, 8, Duration.WhileOnBattlefield, SubLayer.SetPT_7b)
         );
         this.addEffect(new GainAbilityAttachedEffect(ability, AttachmentType.AURA));
     }

--- a/Mage.Sets/src/mage/cards/g/Gigantoplasm.java
+++ b/Mage.Sets/src/mage/cards/g/Gigantoplasm.java
@@ -57,7 +57,7 @@ class GigantoplasmCopyApplier extends CopyApplier {
     @Override
     public boolean apply(Game game, MageObject blueprint, Ability source, UUID copyToObjectId) {
         DynamicValue variableMana = ManacostVariableValue.REGULAR;
-        Effect effect = new SetBasePowerToughnessSourceEffect(variableMana, Duration.WhileOnBattlefield, SubLayer.SetPT_7b, true);
+        Effect effect = new SetBasePowerToughnessSourceEffect(variableMana, variableMana, Duration.WhileOnBattlefield, SubLayer.SetPT_7b, true);
         effect.setText("This creature has base power and toughness X/X");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{X}"));
         blueprint.getAbilities().add(ability);

--- a/Mage.Sets/src/mage/cards/g/Gigantoplasm.java
+++ b/Mage.Sets/src/mage/cards/g/Gigantoplasm.java
@@ -57,7 +57,7 @@ class GigantoplasmCopyApplier extends CopyApplier {
     @Override
     public boolean apply(Game game, MageObject blueprint, Ability source, UUID copyToObjectId) {
         DynamicValue variableMana = ManacostVariableValue.REGULAR;
-        Effect effect = new SetBasePowerToughnessSourceEffect(variableMana, variableMana, Duration.WhileOnBattlefield, SubLayer.SetPT_7b, true);
+        Effect effect = new SetBasePowerToughnessSourceEffect(variableMana, variableMana, Duration.WhileOnBattlefield, SubLayer.SetPT_7b);
         effect.setText("This creature has base power and toughness X/X");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{X}"));
         blueprint.getAbilities().add(ability);

--- a/Mage.Sets/src/mage/cards/g/GreensleevesMaroSorcerer.java
+++ b/Mage.Sets/src/mage/cards/g/GreensleevesMaroSorcerer.java
@@ -40,7 +40,7 @@ public final class GreensleevesMaroSorcerer extends CardImpl {
 
         // Greensleeves, Maro-Sorcerer's power and toughness are each equal to the number of lands you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerToughnessSourceEffect(LandsYouControlCount.instance, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerToughnessSourceEffect(LandsYouControlCount.instance)
         ));
 
         // Whenever a land enters the battlefield under your control, create a 3/3 green Badger creature token.

--- a/Mage.Sets/src/mage/cards/h/Halfdane.java
+++ b/Mage.Sets/src/mage/cards/h/Halfdane.java
@@ -86,7 +86,7 @@ class HalfdaneUpkeepEffect extends OneShotEffect {
 class HalfdaneSetBasePowerToughnessEffect extends SetBasePowerToughnessSourceEffect {
 
     public HalfdaneSetBasePowerToughnessEffect(int power, int toughness) {
-        super(power, toughness, Duration.UntilYourNextTurn, SubLayer.SetPT_7b, true);
+        super(power, toughness, Duration.UntilYourNextTurn, SubLayer.SetPT_7b);
     }
 
     public HalfdaneSetBasePowerToughnessEffect(final HalfdaneSetBasePowerToughnessEffect effect) {

--- a/Mage.Sets/src/mage/cards/h/HaughtyDjinn.java
+++ b/Mage.Sets/src/mage/cards/h/HaughtyDjinn.java
@@ -6,7 +6,6 @@ import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.common.CardsInControllerGraveyardCount;
 import mage.abilities.effects.common.continuous.SetBasePowerSourceEffect;
 import mage.abilities.effects.common.cost.SpellsCostReductionControllerEffect;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -37,7 +36,7 @@ public final class HaughtyDjinn extends CardImpl {
         // Haughty Djinn's power is equal to the number of instant and sorcery cards in your graveyard.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBasePowerSourceEffect(new CardsInControllerGraveyardCount(filter), Duration.EndOfGame)
+                new SetBasePowerSourceEffect(new CardsInControllerGraveyardCount(filter))
         ));
 
         // Instant and sorcery spells you cast cost {1} less to cast.

--- a/Mage.Sets/src/mage/cards/h/HeedlessOne.java
+++ b/Mage.Sets/src/mage/cards/h/HeedlessOne.java
@@ -10,7 +10,6 @@ import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
@@ -38,7 +37,7 @@ public final class HeedlessOne extends CardImpl {
         // Trample
         this.addAbility(TrampleAbility.getInstance());
         // Heedless One's power and toughness are each equal to the number of Elves on the battlefield.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private HeedlessOne(final HeedlessOne card) {

--- a/Mage.Sets/src/mage/cards/h/HordeOfBoggarts.java
+++ b/Mage.Sets/src/mage/cards/h/HordeOfBoggarts.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.mageobject.ColorPredicate;
@@ -37,7 +36,7 @@ public final class HordeOfBoggarts extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Horde of Boggarts's power and toughness are each equal to the number of red permanents you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
         
         // Menace (This creature can't be blocked except by two or more creatures.)
         this.addAbility(new MenaceAbility());

--- a/Mage.Sets/src/mage/cards/i/IronrootWarlord.java
+++ b/Mage.Sets/src/mage/cards/i/IronrootWarlord.java
@@ -11,7 +11,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
@@ -37,7 +36,7 @@ public final class IronrootWarlord extends CardImpl {
         // Ironroot Warlord's power is equal to the number of creatures you control.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBasePowerSourceEffect(xValue, Duration.EndOfGame)
+                new SetBasePowerSourceEffect(xValue)
                         .setText("{this}'s power is equal to the number of creatures you control")
         ));
 

--- a/Mage.Sets/src/mage/cards/i/Ixidron.java
+++ b/Mage.Sets/src/mage/cards/i/Ixidron.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterCreaturePermanent;
@@ -46,7 +45,7 @@ public final class Ixidron extends CardImpl {
         this.addAbility(new AsEntersBattlefieldAbility(new BecomesFaceDownCreatureAllEffect(filterTurnFaceDown)));
 
         // Ixidron's power and toughness are each equal to the number of face-down creatures on the battlefield.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private Ixidron(final Ixidron card) {

--- a/Mage.Sets/src/mage/cards/j/JaggedScarArchers.java
+++ b/Mage.Sets/src/mage/cards/j/JaggedScarArchers.java
@@ -15,7 +15,6 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -45,7 +44,7 @@ public final class JaggedScarArchers extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Jagged-Scar Archers's power and toughness are each equal to the number of Elves you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(controlledElvesFilter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(controlledElvesFilter))));
         // {tap}: Jagged-Scar Archers deals damage equal to its power to target creature with flying.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(new SourcePermanentPowerCount()).setText("{this} deals damage equal to its power to target creature with flying"), new TapSourceCost());
         ability.addTarget(new TargetCreaturePermanent(flyingCreatureFilter));

--- a/Mage.Sets/src/mage/cards/k/KagemaroFirstToSuffer.java
+++ b/Mage.Sets/src/mage/cards/k/KagemaroFirstToSuffer.java
@@ -39,7 +39,7 @@ public final class KagemaroFirstToSuffer extends CardImpl {
 
         DynamicValue xValue = CardsInControllerHandCount.instance;
         // Kagemaro, First to Suffer's power and toughness are each equal to the number of cards in your hand.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)));
         // {B}, Sacrifice Kagemaro: All creatures get -X/-X until end of turn, where X is the number of cards in your hand.
 
         DynamicValue xMinusValue = new SignInversionDynamicValue(xValue);

--- a/Mage.Sets/src/mage/cards/k/KalonianTwingrove.java
+++ b/Mage.Sets/src/mage/cards/k/KalonianTwingrove.java
@@ -12,7 +12,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -39,7 +38,7 @@ public final class KalonianTwingrove extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Kalonian Twingrove's power and toughness are each equal to the number of Forests you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands))));
         // When Kalonian Twingrove enters the battlefield, create a green Treefolk Warrior creature token with "This creature's power and toughness are each equal to the number of Forests you control."
         Effect effect = new CreateTokenEffect(new KalonianTwingroveTreefolkWarriorToken());
         effect.setText("create a green Treefolk Warrior creature token with \"This creature's power and toughness are each equal to the number of Forests you control.\"");

--- a/Mage.Sets/src/mage/cards/k/KatildaDawnhartMartyr.java
+++ b/Mage.Sets/src/mage/cards/k/KatildaDawnhartMartyr.java
@@ -61,7 +61,7 @@ public final class KatildaDawnhartMartyr extends CardImpl {
 
         // Katilda, Dawnhart Martyr's power and toughness are each equal to the number of permanents you control that are Spirits and/or enchantments.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)
         ).addHint(hint));
 
         // Disturb {3}{W}{W}

--- a/Mage.Sets/src/mage/cards/k/KeldonWarlord.java
+++ b/Mage.Sets/src/mage/cards/k/KeldonWarlord.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledCreaturePermanent;
@@ -35,7 +34,7 @@ public final class KeldonWarlord extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Keldon Warlord's power and toughness are each equal to the number of non-Wall creatures you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private KeldonWarlord(final KeldonWarlord card) {

--- a/Mage.Sets/src/mage/cards/k/KineticAugur.java
+++ b/Mage.Sets/src/mage/cards/k/KineticAugur.java
@@ -11,7 +11,6 @@ import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
@@ -39,7 +38,7 @@ public final class KineticAugur extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Kinetic Augur's power is equal to the number of instant and sorcery cards in your graveyard.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(xValue)));
 
         // When Kinetic Augur enters the battlefield, discard up to two cards, then draw that many cards.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DiscardAndDrawThatManyEffect(2)));

--- a/Mage.Sets/src/mage/cards/k/KithkinRabble.java
+++ b/Mage.Sets/src/mage/cards/k/KithkinRabble.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.mageobject.ColorPredicate;
@@ -38,7 +37,7 @@ public final class KithkinRabble extends CardImpl {
 
         this.addAbility(VigilanceAbility.getInstance());
         // Kithkin Rabble's power and toughness are each equal to the number of white permanents you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private KithkinRabble(final KithkinRabble card) {

--- a/Mage.Sets/src/mage/cards/k/KiyomaroFirstToStand.java
+++ b/Mage.Sets/src/mage/cards/k/KiyomaroFirstToStand.java
@@ -43,7 +43,7 @@ public final class KiyomaroFirstToStand extends CardImpl {
 
         // Kiyomaro, First to Stand's power and toughness are each equal to the number of cards in your hand.
         DynamicValue xValue= CardsInControllerHandCount.instance;
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)));
         
         // As long as you have four or more cards in hand, Kiyomaro has vigilance.
         Condition condition = new CardsInHandCondition(ComparisonType.MORE_THAN,3);

--- a/Mage.Sets/src/mage/cards/k/KodamaOfTheCenterTree.java
+++ b/Mage.Sets/src/mage/cards/k/KodamaOfTheCenterTree.java
@@ -33,7 +33,7 @@ public final class KodamaOfTheCenterTree extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Kodama of the Center Tree's power and toughness are each equal to the number of Spirits you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
         
         // Kodama of the Center Tree has soulshift X, where X is the number of Spirits you control.
         this.addAbility(new SoulshiftAbility(new PermanentsOnBattlefieldCount(filter)));

--- a/Mage.Sets/src/mage/cards/k/KolaghanForerunners.java
+++ b/Mage.Sets/src/mage/cards/k/KolaghanForerunners.java
@@ -11,7 +11,6 @@ import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
@@ -34,7 +33,7 @@ public final class KolaghanForerunners extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Kolaghan Forerunners' power is equal to the number of creatures you control.
-        Effect effect = new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURES), Duration.EndOfGame);
+        Effect effect = new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect).addHint(CreaturesYouControlHint.instance));
 
         // Dash {2}{R} <i.(You may cast this spell for its dash cost. If you do it gains haste and it's returned to its owner's hand at the beginning of the next end step.)</i>

--- a/Mage.Sets/src/mage/cards/k/KorlashHeirToBlackblade.java
+++ b/Mage.Sets/src/mage/cards/k/KorlashHeirToBlackblade.java
@@ -43,7 +43,7 @@ public final class KorlashHeirToBlackblade extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Korlash, Heir to Blackblade's power and toughness are each equal to the number of Swamps you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterPermanent), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterPermanent))));
 
         // {1}{B}: Regenerate Korlash.
         Effect effect = new RegenerateSourceEffect();

--- a/Mage.Sets/src/mage/cards/k/KrovikanMist.java
+++ b/Mage.Sets/src/mage/cards/k/KrovikanMist.java
@@ -10,7 +10,6 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
@@ -38,7 +37,7 @@ public final class KrovikanMist extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // Krovikan Mist's power and toughness are each equal to the number of Illusions on the battlefield.
         this.addAbility(new SimpleStaticAbility(Zone.ALL,
-                new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(illusionsFilter), Duration.EndOfGame)));
+                new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(illusionsFilter))));
 
     }
 

--- a/Mage.Sets/src/mage/cards/l/Lhurgoyf.java
+++ b/Mage.Sets/src/mage/cards/l/Lhurgoyf.java
@@ -36,7 +36,7 @@ public final class Lhurgoyf extends CardImpl {
         // Lhurgoyf's power is equal to the number of creature cards in all graveyards and its toughness is equal to that number plus 1.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBasePowerToughnessSourceEffect(powerValue, toughnessValue, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a, false)
+                new SetBasePowerToughnessSourceEffect(powerValue, toughnessValue, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a)
                         .setText("{this}'s power is equal to the number of creature cards in all graveyards and its toughness is equal to that number plus 1")
         ));
     }

--- a/Mage.Sets/src/mage/cards/l/LivingLore.java
+++ b/Mage.Sets/src/mage/cards/l/LivingLore.java
@@ -45,7 +45,7 @@ public final class LivingLore extends CardImpl {
 
         // Living Lore's power and toughness are each equal to the exiled card's converted mana cost.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerToughnessSourceEffect(LivingLoreValue.instance, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerToughnessSourceEffect(LivingLoreValue.instance)
                 .setText("{this}'s power and toughness are each equal to the exiled card's mana value")
         ));
 

--- a/Mage.Sets/src/mage/cards/l/LordOfExtinction.java
+++ b/Mage.Sets/src/mage/cards/l/LordOfExtinction.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.players.Player;
@@ -31,7 +30,7 @@ public final class LordOfExtinction extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Lord of Extinction's power and toughness are each equal to the number of cards in all graveyards.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new LordOfExtinctionDynamicCount(), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new LordOfExtinctionDynamicCount())));
     }
 
     private LordOfExtinction(final LordOfExtinction card) {

--- a/Mage.Sets/src/mage/cards/l/LostOrderOfJarkeld.java
+++ b/Mage.Sets/src/mage/cards/l/LostOrderOfJarkeld.java
@@ -40,7 +40,7 @@ public final class LostOrderOfJarkeld extends CardImpl {
                 Zone.ALL,
                 new SetBasePowerToughnessSourceEffect(new AdditiveDynamicValue(
                         CreaturesControlledByChosenPlayer.instance, StaticValue.get(1)
-                ), Duration.EndOfGame)
+                ))
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/m/Magnivore.java
+++ b/Mage.Sets/src/mage/cards/m/Magnivore.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 
@@ -36,7 +35,7 @@ public final class Magnivore extends CardImpl {
         // Haste
         this.addAbility(HasteAbility.getInstance());
         // Magnivore's power and toughness are each equal to the number of sorcery cards in all graveyards.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CardsInAllGraveyardsCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CardsInAllGraveyardsCount(filter))));
 
 
     }

--- a/Mage.Sets/src/mage/cards/m/MajesticMyriarch.java
+++ b/Mage.Sets/src/mage/cards/m/MajesticMyriarch.java
@@ -35,7 +35,7 @@ public final class MajesticMyriarch extends CardImpl {
 
         // Majestic Myriarch's power and toughness are each equal to twice the number of creatures you control.
         DynamicValue xValue = new MultipliedValue(new PermanentsOnBattlefieldCount(new FilterControlledCreaturePermanent()), 2);
-        Effect effect = new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame);
+        Effect effect = new SetBasePowerToughnessSourceEffect(xValue);
         effect.setText("{this}'s power and toughness are each equal to twice the number of creatures you control");
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect));
 

--- a/Mage.Sets/src/mage/cards/m/Malignus.java
+++ b/Mage.Sets/src/mage/cards/m/Malignus.java
@@ -35,7 +35,7 @@ public final class Malignus extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Malignus's power and toughness are each equal to half the highest life total among your opponents, rounded up.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new HighestLifeTotalAmongOpponentsCount(), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new HighestLifeTotalAmongOpponentsCount())));
 
         // Damage that would be dealt by Malignus can't be prevented.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new MalignusEffect()));

--- a/Mage.Sets/src/mage/cards/m/MaraxusOfKeld.java
+++ b/Mage.Sets/src/mage/cards/m/MaraxusOfKeld.java
@@ -10,7 +10,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.SuperType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -43,7 +42,7 @@ public final class MaraxusOfKeld extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Maraxus of Keld's power and toughness are each equal to the number of untapped artifacts, creatures, and lands you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private MaraxusOfKeld(final MaraxusOfKeld card) {

--- a/Mage.Sets/src/mage/cards/m/Maro.java
+++ b/Mage.Sets/src/mage/cards/m/Maro.java
@@ -10,7 +10,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 
 /**
@@ -27,7 +26,7 @@ public final class Maro extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Maro's power and toughness are each equal to the number of cards in your hand.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance)));
     }
 
     private Maro(final Maro card) {

--- a/Mage.Sets/src/mage/cards/m/MarshFlitter.java
+++ b/Mage.Sets/src/mage/cards/m/MarshFlitter.java
@@ -44,7 +44,7 @@ public final class MarshFlitter extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new CreateTokenEffect(new GoblinRogueToken(), 2), false));
 
         // Sacrifice a Goblin: Marsh Flitter has base power and toughness 3/3 until end of turn.
-        Effect effect = new SetBasePowerToughnessSourceEffect(3, 3, Duration.EndOfTurn, SubLayer.SetPT_7b, true);
+        Effect effect = new SetBasePowerToughnessSourceEffect(3, 3, Duration.EndOfTurn, SubLayer.SetPT_7b);
         effect.setText("{this} has base power and toughness 3/3 until end of turn");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new SacrificeTargetCost(new TargetControlledPermanent(filter)));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/m/MasterOfEtherium.java
+++ b/Mage.Sets/src/mage/cards/m/MasterOfEtherium.java
@@ -37,7 +37,7 @@ public final class MasterOfEtherium extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Master of Etherium's power and toughness are each equal to the number of artifacts you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterCounted), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterCounted))));
 
         // Other artifact creatures you control get +1/+1.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostControlledEffect(1, 1, Duration.WhileOnBattlefield, filterBoosted, true)));

--- a/Mage.Sets/src/mage/cards/m/MasterOfWinds.java
+++ b/Mage.Sets/src/mage/cards/m/MasterOfWinds.java
@@ -79,7 +79,7 @@ class MasterOfWindsEffect extends OneShotEffect {
                 null, "4/1", "1/4", source, game
         ) ? 4 : 1;
         game.addEffect(new SetBasePowerToughnessSourceEffect(
-                power, 5 - power, Duration.EndOfTurn, SubLayer.SetPT_7b, true
+                power, 5 - power, Duration.EndOfTurn, SubLayer.SetPT_7b
         ), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/m/MasumaroFirstToLive.java
+++ b/Mage.Sets/src/mage/cards/m/MasumaroFirstToLive.java
@@ -13,7 +13,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.SuperType;
 import mage.constants.Zone;
 
@@ -33,7 +32,7 @@ public final class MasumaroFirstToLive extends CardImpl {
 
         // Masumaro, First to Live's power and toughness are each equal to twice the number of cards in your hand.
         DynamicValue xValue= new MultipliedValue(CardsInControllerHandCount.instance, 2);
-        Effect effect = new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame);
+        Effect effect = new SetBasePowerToughnessSourceEffect(xValue);
         effect.setText("{this}'s power and toughness are each equal to twice the number of cards in your hand");
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect));
 

--- a/Mage.Sets/src/mage/cards/m/MatcaRioters.java
+++ b/Mage.Sets/src/mage/cards/m/MatcaRioters.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 
 /**
@@ -30,7 +29,7 @@ public final class MatcaRioters extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Domain - Matca Rioters's power and toughness are each equal to the number of basic land types among lands you control.
-        Effect effect = new SetBasePowerToughnessSourceEffect(DomainValue.REGULAR, Duration.EndOfGame);
+        Effect effect = new SetBasePowerToughnessSourceEffect(DomainValue.REGULAR);
         effect.setText("<i>Domain</i> &mdash; {this}'s power and toughness are each equal to the number of basic land types among lands you control.");
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect).addHint(DomainHint.instance));
     }

--- a/Mage.Sets/src/mage/cards/m/MinionOfTheWastes.java
+++ b/Mage.Sets/src/mage/cards/m/MinionOfTheWastes.java
@@ -84,7 +84,7 @@ class MinionOfTheWastesEffect extends OneShotEffect {
         game.informPlayers((sourceCard != null ? sourceCard.getLogName() : "") + ": " + controller.getLogName() +
                 " pays " + payAmount + " life");
         game.addEffect(new SetBasePowerToughnessSourceEffect(
-                payAmount, payAmount, Duration.Custom, SubLayer.CharacteristicDefining_7a
+                payAmount, payAmount, Duration.Custom, SubLayer.CharacteristicDefining_7a, false
         ), source);
         permanent.addInfo("life paid", CardUtil.addToolTipMarkTags("Life paid: " + payAmount), game);
         return true;

--- a/Mage.Sets/src/mage/cards/m/MinionOfTheWastes.java
+++ b/Mage.Sets/src/mage/cards/m/MinionOfTheWastes.java
@@ -84,7 +84,7 @@ class MinionOfTheWastesEffect extends OneShotEffect {
         game.informPlayers((sourceCard != null ? sourceCard.getLogName() : "") + ": " + controller.getLogName() +
                 " pays " + payAmount + " life");
         game.addEffect(new SetBasePowerToughnessSourceEffect(
-                payAmount, payAmount, Duration.Custom, SubLayer.CharacteristicDefining_7a, false
+                payAmount, payAmount, Duration.Custom, SubLayer.CharacteristicDefining_7a
         ), source);
         permanent.addInfo("life paid", CardUtil.addToolTipMarkTags("Life paid: " + payAmount), game);
         return true;

--- a/Mage.Sets/src/mage/cards/m/MolimoMaroSorcerer.java
+++ b/Mage.Sets/src/mage/cards/m/MolimoMaroSorcerer.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.SuperType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledLandPermanent;
@@ -36,7 +35,7 @@ public final class MolimoMaroSorcerer extends CardImpl {
         // Trample
         this.addAbility(TrampleAbility.getInstance());
         // Molimo, Maro-Sorcerer's power and toughness are each equal to the number of lands you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private MolimoMaroSorcerer(final MolimoMaroSorcerer card) {

--- a/Mage.Sets/src/mage/cards/m/MoltenSentry.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenSentry.java
@@ -12,10 +12,7 @@ import mage.abilities.keyword.DefenderAbility;
 import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
+import mage.constants.*;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -82,7 +79,7 @@ class MoltenSentryEffect extends OneShotEffect {
             toughness = 5;
             gainedAbility = DefenderAbility.getInstance();
         }
-        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield), source);
+        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.CharacteristicDefining_7a), source);
         game.addEffect(new GainAbilitySourceEffect(gainedAbility, Duration.WhileOnBattlefield), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/m/MoltenSentry.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenSentry.java
@@ -82,7 +82,7 @@ class MoltenSentryEffect extends OneShotEffect {
             toughness = 5;
             gainedAbility = DefenderAbility.getInstance();
         }
-        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, true), source);
+        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield), source);
         game.addEffect(new GainAbilitySourceEffect(gainedAbility, Duration.WhileOnBattlefield), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/m/MonstrousWarLeech.java
+++ b/Mage.Sets/src/mage/cards/m/MonstrousWarLeech.java
@@ -16,7 +16,6 @@ import mage.abilities.keyword.KickerAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
@@ -58,7 +57,7 @@ public final class MonstrousWarLeech extends CardImpl {
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
                 new SetBasePowerToughnessSourceEffect(
-                        MonstrousWarLeechValue.instance, Duration.EndOfGame
+                        MonstrousWarLeechValue.instance
                 )
         ));
     }

--- a/Mage.Sets/src/mage/cards/m/MonstrousWarLeech.java
+++ b/Mage.Sets/src/mage/cards/m/MonstrousWarLeech.java
@@ -59,7 +59,7 @@ public final class MonstrousWarLeech extends CardImpl {
                 new SetBasePowerToughnessSourceEffect(
                         MonstrousWarLeechValue.instance
                 )
-        ));
+        ).addHint(hint));
     }
 
     private MonstrousWarLeech(final MonstrousWarLeech card) {

--- a/Mage.Sets/src/mage/cards/m/Mortivore.java
+++ b/Mage.Sets/src/mage/cards/m/Mortivore.java
@@ -14,7 +14,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.ColoredManaSymbol;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreatureCard;
 
@@ -30,7 +29,7 @@ public final class Mortivore extends CardImpl {
 
         this.power = new MageInt(0);
         this.toughness = new MageInt(0);
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CardsInAllGraveyardsCount(new FilterCreatureCard("creature cards")), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CardsInAllGraveyardsCount(new FilterCreatureCard("creature cards")))));
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new ColoredManaCost(ColoredManaSymbol.B)));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MultaniMaroSorcerer.java
+++ b/Mage.Sets/src/mage/cards/m/MultaniMaroSorcerer.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.SuperType;
 import mage.constants.Zone;
 
@@ -33,7 +32,7 @@ public final class MultaniMaroSorcerer extends CardImpl {
         this.addAbility(ShroudAbility.getInstance());
         
         // Multani, Maro-Sorcerer's power and toughness are each equal to the total number of cards in all players' hands.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInAllHandsCount.instance, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInAllHandsCount.instance)));
     }
 
     private MultaniMaroSorcerer(final MultaniMaroSorcerer card) {

--- a/Mage.Sets/src/mage/cards/m/MwonvuliOoze.java
+++ b/Mage.Sets/src/mage/cards/m/MwonvuliOoze.java
@@ -14,7 +14,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.game.Game;
@@ -34,7 +33,7 @@ public final class MwonvuliOoze extends CardImpl {
         // Cumulative upkeep {2}
         this.addAbility(new CumulativeUpkeepAbility(new ManaCostsImpl<>("{2}")));
         // Mwonvuli Ooze's power and toughness are each equal to 1 plus twice the number of age counters on it.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new MwonvuliOozePTValue(), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new MwonvuliOozePTValue())));
     }
 
     private MwonvuliOoze(final MwonvuliOoze card) {

--- a/Mage.Sets/src/mage/cards/m/MythRealized.java
+++ b/Mage.Sets/src/mage/cards/m/MythRealized.java
@@ -47,7 +47,7 @@ public final class MythRealized extends CardImpl {
         Effect effect = new BecomesCreatureSourceEffect(new MythRealizedToken(), null, Duration.EndOfTurn);
         effect.setText("Until end of turn, {this} becomes a Monk Avatar creature in addition to its other types ");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{W}"));
-        ability.addEffect(new SetBasePowerToughnessSourceEffect(loreCounterCount, loreCounterCount, Duration.EndOfTurn, SubLayer.SetPT_7b, false).setText("and gains \"This creature's power and toughness are each equal to the number of lore counters on it.\""));
+        ability.addEffect(new SetBasePowerToughnessSourceEffect(loreCounterCount, loreCounterCount, Duration.EndOfTurn, SubLayer.SetPT_7b).setText("and gains \"This creature's power and toughness are each equal to the number of lore counters on it.\""));
 
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/n/NamelessOne.java
+++ b/Mage.Sets/src/mage/cards/n/NamelessOne.java
@@ -11,7 +11,6 @@ import mage.abilities.keyword.MorphAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
@@ -36,7 +35,7 @@ public final class NamelessOne extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Nameless One's power and toughness are each equal to the number of Wizards on the battlefield.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
         // Morph {2}{U}
         this.addAbility(new MorphAbility(new ManaCostsImpl<>("{2}{U}")));
     }

--- a/Mage.Sets/src/mage/cards/n/NamelessRace.java
+++ b/Mage.Sets/src/mage/cards/n/NamelessRace.java
@@ -108,7 +108,7 @@ class NamelessRaceEffect extends OneShotEffect {
         game.informPlayers((sourceCard != null ? sourceCard.getLogName() : "") + ": " + controller.getLogName() +
                 " pays " + payAmount + " life");
         game.addEffect(new SetBasePowerToughnessSourceEffect(
-                payAmount, payAmount, Duration.Custom, SubLayer.CharacteristicDefining_7a, false
+                payAmount, payAmount, Duration.Custom, SubLayer.CharacteristicDefining_7a
         ), source);
         permanent.addInfo("life paid", CardUtil.addToolTipMarkTags("Life paid: " + payAmount), game);
         return true;

--- a/Mage.Sets/src/mage/cards/n/NamelessRace.java
+++ b/Mage.Sets/src/mage/cards/n/NamelessRace.java
@@ -108,7 +108,7 @@ class NamelessRaceEffect extends OneShotEffect {
         game.informPlayers((sourceCard != null ? sourceCard.getLogName() : "") + ": " + controller.getLogName() +
                 " pays " + payAmount + " life");
         game.addEffect(new SetBasePowerToughnessSourceEffect(
-                payAmount, payAmount, Duration.Custom, SubLayer.CharacteristicDefining_7a
+                payAmount, payAmount, Duration.Custom, SubLayer.CharacteristicDefining_7a, false
         ), source);
         permanent.addInfo("life paid", CardUtil.addToolTipMarkTags("Life paid: " + payAmount), game);
         return true;

--- a/Mage.Sets/src/mage/cards/n/Necrogoyf.java
+++ b/Mage.Sets/src/mage/cards/n/Necrogoyf.java
@@ -32,7 +32,7 @@ public final class Necrogoyf extends CardImpl {
 
         // Necrogoyf's power is equal to the number of creature cards in all graveyards.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerSourceEffect(xValue, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerSourceEffect(xValue)
         ));
 
         // At the beginning of each player's upkeep, that player discards a card.

--- a/Mage.Sets/src/mage/cards/n/NighthawkScavenger.java
+++ b/Mage.Sets/src/mage/cards/n/NighthawkScavenger.java
@@ -14,7 +14,6 @@ import mage.abilities.keyword.LifelinkAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -48,7 +47,7 @@ public final class NighthawkScavenger extends CardImpl {
 
         // Nighthawk Scavenger's power is equal to 1 plus the number of card types among cards in your opponents' graveyards.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerSourceEffect(xValue, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerSourceEffect(xValue)
                 .setText("{this}'s power is equal to 1 plus the number of " +
                         "card types among cards in your opponents' graveyards. " +
                         "<i>(Cards in graveyards have only the characteristics of their front face.)</i>")

--- a/Mage.Sets/src/mage/cards/n/Nightmare.java
+++ b/Mage.Sets/src/mage/cards/n/Nightmare.java
@@ -10,7 +10,6 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -39,7 +38,7 @@ public final class Nightmare extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         
         // Nightmare's power and toughness are each equal to the number of Swamps you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private Nightmare(final Nightmare card) {

--- a/Mage.Sets/src/mage/cards/n/NightskyMimic.java
+++ b/Mage.Sets/src/mage/cards/n/NightskyMimic.java
@@ -45,7 +45,7 @@ public final class NightskyMimic extends CardImpl {
 
         // Whenever you cast a spell that's both white and black, Nightsky Mimic has base power and toughness 4/4 until end of turn and gains flying until end of turn.
         Ability ability = new SpellCastControllerTriggeredAbility(
-                new SetBasePowerToughnessSourceEffect(4, 4, Duration.EndOfTurn, SubLayer.SetPT_7b, true),
+                new SetBasePowerToughnessSourceEffect(4, 4, Duration.EndOfTurn, SubLayer.SetPT_7b),
                 filter,
                 false,
                 rule);

--- a/Mage.Sets/src/mage/cards/n/NightstalkerEngine.java
+++ b/Mage.Sets/src/mage/cards/n/NightstalkerEngine.java
@@ -10,7 +10,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreatureCard;
 
@@ -28,7 +27,7 @@ public final class NightstalkerEngine extends CardImpl {
 
         // Nightstalker Engine's power is equal to the number of creature cards in your graveyard.
         CardsInControllerGraveyardCount count = new CardsInControllerGraveyardCount(new FilterCreatureCard("creature cards"));
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(count, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(count)));
     }
 
     private NightstalkerEngine(final NightstalkerEngine card) {

--- a/Mage.Sets/src/mage/cards/n/NishobaBrawler.java
+++ b/Mage.Sets/src/mage/cards/n/NishobaBrawler.java
@@ -30,7 +30,7 @@ public final class NishobaBrawler extends CardImpl {
 
         // Domain — Nishoba Brawler's power is equal to the number of basic land types among lands you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerSourceEffect(DomainValue.REGULAR, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerSourceEffect(DomainValue.REGULAR)
         ).setAbilityWord(AbilityWord.DOMAIN).addHint(DomainHint.instance));
     }
 

--- a/Mage.Sets/src/mage/cards/o/OldStickfingers.java
+++ b/Mage.Sets/src/mage/cards/o/OldStickfingers.java
@@ -34,7 +34,7 @@ public final class OldStickfingers extends CardImpl {
 
         // Old Stickfingers' power and toughness are equal to the number of creature cards in your graveyard.
         DynamicValue value = new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURES);
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(value, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(value)));
     }
 
     private OldStickfingers(final OldStickfingers card) {

--- a/Mage.Sets/src/mage/cards/o/OverbeingOfMyth.java
+++ b/Mage.Sets/src/mage/cards/o/OverbeingOfMyth.java
@@ -13,7 +13,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.TargetController;
 import mage.constants.Zone;
 
@@ -34,7 +33,7 @@ public final class OverbeingOfMyth extends CardImpl {
 
         // Overbeing of Myth's power and toughness are each equal to the number of cards in your hand.
         DynamicValue number = CardsInControllerHandCount.instance;
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(number, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(number)));
 
         // At the beginning of your draw step, draw an additional card.
         this.addAbility(new BeginningOfDrawTriggeredAbility(new DrawCardSourceControllerEffect(1).setText("draw an additional card"), TargetController.YOU, false));

--- a/Mage.Sets/src/mage/cards/p/PackRat.java
+++ b/Mage.Sets/src/mage/cards/p/PackRat.java
@@ -14,7 +14,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -54,7 +53,7 @@ public final class PackRat extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Pack Rat's power and toughness are each equal to the number of Rats you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
         // {2}{B}, Discard a card: Create a token that's a copy of Pack Rat.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new CreateTokenCopySourceEffect(), new ManaCostsImpl<>("{2}{B}"));
         ability.addCost(new DiscardCardCost());

--- a/Mage.Sets/src/mage/cards/p/Pallimud.java
+++ b/Mage.Sets/src/mage/cards/p/Pallimud.java
@@ -14,7 +14,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.common.FilterLandPermanent;
@@ -39,7 +38,7 @@ public final class Pallimud extends CardImpl {
         this.addAbility(new AsEntersBattlefieldAbility(new ChooseOpponentEffect(Outcome.Detriment)));
         
         // Pallimud's power is equal to the number of tapped lands the chosen player controls.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new AnathemancerCount(), Duration.Custom)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new AnathemancerCount())));
     }
 
     private Pallimud(final Pallimud card) {

--- a/Mage.Sets/src/mage/cards/p/PeopleOfTheWoods.java
+++ b/Mage.Sets/src/mage/cards/p/PeopleOfTheWoods.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.continuous.SetBaseToughnessSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -33,7 +32,7 @@ public final class PeopleOfTheWoods extends CardImpl {
         this.toughness = new MageInt(0);
 
         // People of the Woods's toughness is equal to the number of Forests you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBaseToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBaseToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands))));
     }
 
     private PeopleOfTheWoods(final PeopleOfTheWoods card) {

--- a/Mage.Sets/src/mage/cards/p/PestilenceRats.java
+++ b/Mage.Sets/src/mage/cards/p/PestilenceRats.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
@@ -35,7 +34,7 @@ public final class PestilenceRats extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Pestilence Rats's power is equal to the number of other Rats on the battlefield. (For example, as long as there are two other Rats on the battlefield, Pestilence Rats's power and toughness are 2/3.)
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private PestilenceRats(final PestilenceRats card) {

--- a/Mage.Sets/src/mage/cards/p/PlagueRats.java
+++ b/Mage.Sets/src/mage/cards/p/PlagueRats.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreaturePermanent;
@@ -36,7 +35,7 @@ public final class PlagueRats extends CardImpl {
 
         // Plague Rats's power and toughness are each equal to the number of creatures named Plague Rats on the battlefield.
         DynamicValue amount = new PermanentsOnBattlefieldCount(plagueRatsFilter);
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(amount, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(amount)));
     }
 
     private PlagueRats(final PlagueRats card) {

--- a/Mage.Sets/src/mage/cards/p/PrimalClay.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalClay.java
@@ -118,7 +118,7 @@ public final class PrimalClay extends CardImpl {
                     game.addEffect(new GainAbilitySourceEffect(DefenderAbility.getInstance(), Duration.Custom), source);
                     break;
             }
-            game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, true), source);
+            game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield), source);
             return false;
         }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalClay.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalClay.java
@@ -14,11 +14,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.choices.Choice;
 import mage.choices.ChoiceImpl;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.SubType;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
@@ -118,7 +114,7 @@ public final class PrimalClay extends CardImpl {
                     game.addEffect(new GainAbilitySourceEffect(DefenderAbility.getInstance(), Duration.Custom), source);
                     break;
             }
-            game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield), source);
+            game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.CharacteristicDefining_7a), source);
             return false;
         }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalPlasma.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalPlasma.java
@@ -76,9 +76,7 @@ public final class PrimalPlasma extends CardImpl {
         public boolean applies(GameEvent event, Ability source, Game game) {
             if (event.getTargetId().equals(source.getSourceId())) {
                 Permanent sourcePermanent = ((EntersTheBattlefieldEvent) event).getTarget();
-                if (sourcePermanent != null && !sourcePermanent.isFaceDown(game)) {
-                    return true;
-                }
+                return sourcePermanent != null && !sourcePermanent.isFaceDown(game);
             }
             return false;
         }
@@ -119,7 +117,7 @@ public final class PrimalPlasma extends CardImpl {
                         game.addEffect(new GainAbilitySourceEffect(DefenderAbility.getInstance(), Duration.Custom), source);
                         break;
                 }
-                game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, true), source);
+                game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield), source);
             }
             return false;
 

--- a/Mage.Sets/src/mage/cards/p/PrimalPlasma.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalPlasma.java
@@ -14,11 +14,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.choices.Choice;
 import mage.choices.ChoiceImpl;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.SubType;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
@@ -117,7 +113,7 @@ public final class PrimalPlasma extends CardImpl {
                         game.addEffect(new GainAbilitySourceEffect(DefenderAbility.getInstance(), Duration.Custom), source);
                         break;
                 }
-                game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield), source);
+                game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.CharacteristicDefining_7a), source);
             }
             return false;
 

--- a/Mage.Sets/src/mage/cards/p/Primalcrux.java
+++ b/Mage.Sets/src/mage/cards/p/Primalcrux.java
@@ -31,7 +31,7 @@ public final class Primalcrux extends CardImpl {
 
         // Chroma - Primalcrux's power and toughness are each equal to the number of green mana symbols in the mana costs of permanents you control.
         DynamicValue xValue = new ChromaCount(ManaType.GREEN);
-        Effect effect = new SetBasePowerToughnessSourceEffect(xValue, Duration.WhileOnBattlefield);
+        Effect effect = new SetBasePowerToughnessSourceEffect(xValue);
         effect.setText("<i>Chroma</i> &mdash; Primalcrux's power and toughness are each equal to the number of green mana symbols in the mana costs of permanents you control.");
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect)
                 .addHint(new ValueHint("Green mana symbols in your permanents", xValue))

--- a/Mage.Sets/src/mage/cards/p/PsychosisCrawler.java
+++ b/Mage.Sets/src/mage/cards/p/PsychosisCrawler.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 
 /**
@@ -29,7 +28,7 @@ public final class PsychosisCrawler extends CardImpl {
         this.power = new MageInt(0);
         this.toughness = new MageInt(0);
 
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance)));
         this.addAbility(new DrawCardControllerTriggeredAbility(new LoseLifeOpponentsEffect(1), false));
     }
 

--- a/Mage.Sets/src/mage/cards/q/QueenAllenalOfRuadach.java
+++ b/Mage.Sets/src/mage/cards/q/QueenAllenalOfRuadach.java
@@ -39,7 +39,7 @@ public final class QueenAllenalOfRuadach extends CardImpl {
         // Queen Allenal of Ruadach's power and toughness are each equal to the number of creatures you control.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBasePowerToughnessSourceEffect(count, Duration.EndOfGame)
+                new SetBasePowerToughnessSourceEffect(count)
         ));
 
         // If one or more creature tokens would be created under your control, those tokens plus a 1/1 white Soldier creature token are created instead.

--- a/Mage.Sets/src/mage/cards/r/RecklessOne.java
+++ b/Mage.Sets/src/mage/cards/r/RecklessOne.java
@@ -10,7 +10,6 @@ import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
@@ -38,7 +37,7 @@ public final class RecklessOne extends CardImpl {
         // Haste
         this.addAbility(HasteAbility.getInstance());
         // Reckless One's power and toughness are each equal to the number of Goblins on the battlefield.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private RecklessOne(final RecklessOne card) {

--- a/Mage.Sets/src/mage/cards/r/RenataCalledToTheHunt.java
+++ b/Mage.Sets/src/mage/cards/r/RenataCalledToTheHunt.java
@@ -33,7 +33,7 @@ public final class RenataCalledToTheHunt extends CardImpl {
         // Renata's power is equal to your devotion to green.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBasePowerSourceEffect(DevotionCount.G, Duration.EndOfGame)
+                new SetBasePowerSourceEffect(DevotionCount.G)
                         .setText("{this}'s power is equal to your devotion to green")
         ).addHint(DevotionCount.G.getHint()));
 

--- a/Mage.Sets/src/mage/cards/r/Revenant.java
+++ b/Mage.Sets/src/mage/cards/r/Revenant.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreatureCard;
 
@@ -32,7 +31,7 @@ public final class Revenant extends CardImpl {
         
         // Revenant's power and toughness are each equal to the number of creature cards in your graveyard.
         CardsInControllerGraveyardCount count = new CardsInControllerGraveyardCount(new FilterCreatureCard("creature cards"));
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(count, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(count)));
     }
 
     private Revenant(final Revenant card) {

--- a/Mage.Sets/src/mage/cards/r/RimefeatherOwl.java
+++ b/Mage.Sets/src/mage/cards/r/RimefeatherOwl.java
@@ -4,7 +4,6 @@ package mage.cards.r;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.Mode;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
@@ -55,7 +54,7 @@ public final class RimefeatherOwl extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Rimefeather Owl's power and toughness are each equal to the number of snow permanents on the battlefield.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter2), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter2))));
 
         // {1}{snow}: Put an ice counter on target permanent.
         Ability ability = new SimpleActivatedAbility(

--- a/Mage.Sets/src/mage/cards/r/RiptideMangler.java
+++ b/Mage.Sets/src/mage/cards/r/RiptideMangler.java
@@ -71,7 +71,7 @@ class RiptideManglerEffect extends OneShotEffect {
         if (permanent == null) {
             return false;
         }
-        game.addEffect(new SetBasePowerToughnessSourceEffect(StaticValue.get(permanent.getPower().getValue()), null, Duration.WhileOnBattlefield, SubLayer.SetPT_7b, true), source);
+        game.addEffect(new SetBasePowerToughnessSourceEffect(StaticValue.get(permanent.getPower().getValue()), null, Duration.WhileOnBattlefield, SubLayer.SetPT_7b), source);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RisenRiptide.java
+++ b/Mage.Sets/src/mage/cards/r/RisenRiptide.java
@@ -27,7 +27,7 @@ public final class RisenRiptide extends CardImpl {
 
         // Whenever you cast a kicked spell, Risen Riptide has base power and toughness 5/5 until end of turn.
         this.addAbility(new SpellCastControllerTriggeredAbility(
-                new SetBasePowerToughnessSourceEffect(5, 5, Duration.EndOfTurn, SubLayer.SetPT_7b, true)
+                new SetBasePowerToughnessSourceEffect(5, 5, Duration.EndOfTurn, SubLayer.SetPT_7b)
                         .setText("{this} has base power and toughness 5/5 until end of turn"),
                 StaticFilters.FILTER_SPELL_KICKED_A,
                 false)

--- a/Mage.Sets/src/mage/cards/r/RiverfallMimic.java
+++ b/Mage.Sets/src/mage/cards/r/RiverfallMimic.java
@@ -44,7 +44,7 @@ public final class RiverfallMimic extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Whenever you cast a spell that's both blue and red, Riverfall Mimic has base power and toughness 3/3 until end of turn and can't be blocked this turn.
-        Ability ability = new SpellCastControllerTriggeredAbility(new SetBasePowerToughnessSourceEffect(3, 3, Duration.EndOfTurn, SubLayer.SetPT_7b, true), filter, false, rule);
+        Ability ability = new SpellCastControllerTriggeredAbility(new SetBasePowerToughnessSourceEffect(3, 3, Duration.EndOfTurn, SubLayer.SetPT_7b), filter, false, rule);
         ability.addEffect(new GainAbilitySourceEffect(new CantBeBlockedSourceAbility(), Duration.EndOfTurn, false, true));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/r/RoilingHorror.java
+++ b/Mage.Sets/src/mage/cards/r/RoilingHorror.java
@@ -17,7 +17,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.game.Game;
@@ -39,7 +38,7 @@ public final class RoilingHorror extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Roiling Horror's power and toughness are each equal to your life total minus the life total of an opponent with the most life.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new RoilingHorrorDynamicValue(), Duration.EndOfGame)
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new RoilingHorrorDynamicValue())
                 .setText("{this}'s power and toughness are each equal to your life total minus the life total of an opponent with the most life.")
         ));
 

--- a/Mage.Sets/src/mage/cards/r/Rubblehulk.java
+++ b/Mage.Sets/src/mage/cards/r/Rubblehulk.java
@@ -33,7 +33,7 @@ public final class Rubblehulk extends CardImpl {
         DynamicValue controlledLands = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_PERMANENT_LANDS);
 
         // Rubblehulk's power and toughness are each equal to the number of lands you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(controlledLands, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(controlledLands)));
 
         // Bloodrush - 1{R}{G}, Discard Rubblehulk: Target attacking creature gets +X/+X until end of turn, where X is the number of lands you control.
         this.addAbility(new BloodrushAbility("{1}{R}{G}", new BoostTargetEffect(controlledLands, controlledLands, Duration.EndOfTurn)));

--- a/Mage.Sets/src/mage/cards/r/RustingGolem.java
+++ b/Mage.Sets/src/mage/cards/r/RustingGolem.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 
@@ -31,7 +30,7 @@ public final class RustingGolem extends CardImpl {
         this.addAbility(new FadingAbility(5, this));
         // Rusting Golem's power and toughness are each equal to the number of fade counters on it.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(
-            new CountersSourceCount(CounterType.FADE), Duration.EndOfGame)));
+            new CountersSourceCount(CounterType.FADE))));
     }
 
     private RustingGolem(final RustingGolem card) {

--- a/Mage.Sets/src/mage/cards/s/SageOfAncientLore.java
+++ b/Mage.Sets/src/mage/cards/s/SageOfAncientLore.java
@@ -14,7 +14,6 @@ import mage.abilities.keyword.TransformAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -38,7 +37,7 @@ public final class SageOfAncientLore extends CardImpl {
         // Sage of Ancient Lore's power and toughness are each equal to the number of cards in your hand.
         DynamicValue xValue = CardsInControllerHandCount.instance;
         this.addAbility(new SimpleStaticAbility(Zone.ALL,
-                new ConditionalContinuousEffect(new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame),
+                new ConditionalContinuousEffect(new SetBasePowerToughnessSourceEffect(xValue),
                         new TransformedCondition(true), "{this}'s power and toughness are each equal to the total number of cards in your hand")));
 
         // When Sage of Ancient Lore enters the battlefield, draw a card.

--- a/Mage.Sets/src/mage/cards/s/ScionOfTheWild.java
+++ b/Mage.Sets/src/mage/cards/s/ScionOfTheWild.java
@@ -10,7 +10,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 
@@ -25,7 +24,7 @@ public final class ScionOfTheWild extends CardImpl {
 
         this.power = new MageInt(0);
         this.toughness = new MageInt(0);
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURES), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_CREATURES))));
     }
 
     private ScionOfTheWild(final ScionOfTheWild card) {

--- a/Mage.Sets/src/mage/cards/s/ScourgeOfTheSkyclaves.java
+++ b/Mage.Sets/src/mage/cards/s/ScourgeOfTheSkyclaves.java
@@ -44,7 +44,7 @@ public final class ScourgeOfTheSkyclaves extends CardImpl {
         // Scourge of the Skyclaves's power and toughness are each equal to 20 minus the highest life total among players.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL, new SetBasePowerToughnessSourceEffect(
-                ScourgeOfTheSkyclavesValue.instance, Duration.EndOfGame
+                ScourgeOfTheSkyclavesValue.instance
         ).setText("{this}'s power and toughness are each equal to 20 minus the highest life total among players.")));
     }
 

--- a/Mage.Sets/src/mage/cards/s/Sentinel.java
+++ b/Mage.Sets/src/mage/cards/s/Sentinel.java
@@ -77,7 +77,7 @@ class SentinelEffect extends OneShotEffect {
         Permanent targetPermanent = getTargetPointer().getFirstTargetPermanentOrLKI(game, source);
         if (controller != null && targetPermanent != null) {
             int newToughness = CardUtil.overflowInc(targetPermanent.getPower().getValue(), 1);
-            game.addEffect(new SetBasePowerToughnessSourceEffect(null, StaticValue.get(newToughness), Duration.WhileOnBattlefield, SubLayer.SetPT_7b, true), source);
+            game.addEffect(new SetBasePowerToughnessSourceEffect(null, StaticValue.get(newToughness), Duration.WhileOnBattlefield, SubLayer.SetPT_7b), source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/SeraphOfTheMasses.java
+++ b/Mage.Sets/src/mage/cards/s/SeraphOfTheMasses.java
@@ -10,7 +10,6 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -33,7 +32,7 @@ public final class SeraphOfTheMasses extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // Seraph of the Masses's power and toughness are each equal to the number of creatures you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance, Duration.EndOfGame))
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance))
                 .addHint(CreaturesYouControlHint.instance));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SerpentOfTheEndlessSea.java
+++ b/Mage.Sets/src/mage/cards/s/SerpentOfTheEndlessSea.java
@@ -10,7 +10,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -36,7 +35,7 @@ public final class SerpentOfTheEndlessSea extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Serpent of the Endless Sea's power and toughness are each equal to the number of Islands you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
         // Serpent of the Endless Sea can't attack unless defending player controls an Island.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new CantAttackUnlessDefenderControllsPermanent(new FilterLandPermanent(SubType.ISLAND,"an Island"))));
     }

--- a/Mage.Sets/src/mage/cards/s/SerraAvatar.java
+++ b/Mage.Sets/src/mage/cards/s/SerraAvatar.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 
 /**
@@ -29,7 +28,7 @@ public final class SerraAvatar extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Serra Avatar's power and toughness are each equal to your life total.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(ControllerLifeCount.instance, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(ControllerLifeCount.instance)));
         
         // When Serra Avatar is put into a graveyard from anywhere, shuffle it into its owner's library.
         this.addAbility(new PutIntoGraveFromAnywhereSourceTriggeredAbility(new ShuffleIntoLibrarySourceEffect()));

--- a/Mage.Sets/src/mage/cards/s/SewerNemesis.java
+++ b/Mage.Sets/src/mage/cards/s/SewerNemesis.java
@@ -16,7 +16,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.game.Game;
@@ -40,7 +39,7 @@ public final class SewerNemesis extends CardImpl {
         // As Sewer Nemesis enters the battlefield, choose a player.
         this.addAbility(new AsEntersBattlefieldAbility(new ChoosePlayerEffect(Outcome.Detriment)));
         // Sewer Nemesis's power and toughness are each equal to the number of cards in the chosen player's graveyard.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CardsInTargetOpponentsGraveyardCount(), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CardsInTargetOpponentsGraveyardCount())));
         // Whenever the chosen player casts a spell, that player puts the top card of their library into their graveyard.
         this.addAbility(new SewerNemesisTriggeredAbility());
 

--- a/Mage.Sets/src/mage/cards/s/ShamblingSuit.java
+++ b/Mage.Sets/src/mage/cards/s/ShamblingSuit.java
@@ -35,7 +35,7 @@ public final class ShamblingSuit extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Shambling Suit's power is equal to the number of artifacts and/or enchantments you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(xValue)));
     }
 
     private ShamblingSuit(final ShamblingSuit card) {

--- a/Mage.Sets/src/mage/cards/s/ShapeStealer.java
+++ b/Mage.Sets/src/mage/cards/s/ShapeStealer.java
@@ -74,7 +74,7 @@ class ShapeStealerEffect extends OneShotEffect {
             return false;
         }
 
-        ContinuousEffect effect = new SetBasePowerToughnessSourceEffect(permanent.getPower().getValue(), permanent.getToughness().getValue(), Duration.EndOfTurn, SubLayer.SetPT_7b, true);
+        ContinuousEffect effect = new SetBasePowerToughnessSourceEffect(permanent.getPower().getValue(), permanent.getToughness().getValue(), Duration.EndOfTurn, SubLayer.SetPT_7b);
         game.addEffect(effect, source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/s/SharpshooterElf.java
+++ b/Mage.Sets/src/mage/cards/s/SharpshooterElf.java
@@ -14,7 +14,6 @@ import mage.abilities.keyword.ReachAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
@@ -51,7 +50,7 @@ public final class SharpshooterElf extends CardImpl {
 
         // Sharpshooter Elf's power is equal to the number of creatures you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerSourceEffect(CreaturesYouControlCount.instance, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerSourceEffect(CreaturesYouControlCount.instance)
         ));
 
         // When Sharpshooter Elf enters the battlefield, it deals damage equal to its power to target creature with flying an opponent controls.

--- a/Mage.Sets/src/mage/cards/s/ShorecrasherMimic.java
+++ b/Mage.Sets/src/mage/cards/s/ShorecrasherMimic.java
@@ -45,7 +45,7 @@ public final class ShorecrasherMimic extends CardImpl {
 
         // Whenever you cast a spell that's both green and blue, Shorecrasher Mimic has base power and toughness 5/3 until end of turn and gains trample until end of turn.
         Ability ability = new SpellCastControllerTriggeredAbility(
-                new SetBasePowerToughnessSourceEffect(5, 3, Duration.EndOfTurn, SubLayer.SetPT_7b, true),
+                new SetBasePowerToughnessSourceEffect(5, 3, Duration.EndOfTurn, SubLayer.SetPT_7b),
                 filter,
                 false,
                 rule);

--- a/Mage.Sets/src/mage/cards/s/SilverwingSquadron.java
+++ b/Mage.Sets/src/mage/cards/s/SilverwingSquadron.java
@@ -13,7 +13,6 @@ import mage.abilities.keyword.VigilanceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.permanent.token.KnightToken;
@@ -41,7 +40,7 @@ public final class SilverwingSquadron extends CardImpl {
 
         // Silverwing Squadron's power and toughness are each equal to the number of creatures you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance)
         ).addHint(CreaturesYouControlHint.instance));
 
         // Whenever Silverwing Squadron attacks, create a number of 2/2 white Knight creature tokens with vigilance equal to the number of opponents you have.

--- a/Mage.Sets/src/mage/cards/s/SimaYiWeiFieldMarshal.java
+++ b/Mage.Sets/src/mage/cards/s/SimaYiWeiFieldMarshal.java
@@ -32,7 +32,7 @@ public final class SimaYiWeiFieldMarshal extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Sima Yi, Wei Field Marshal's power is equal to the number of Swamps you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));                                                         }
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter))));                                                         }
 
     private SimaYiWeiFieldMarshal(final SimaYiWeiFieldMarshal card) {
         super(card);

--- a/Mage.Sets/src/mage/cards/s/SlagFiend.java
+++ b/Mage.Sets/src/mage/cards/s/SlagFiend.java
@@ -10,7 +10,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterArtifactCard;
 
@@ -28,7 +27,7 @@ public final class SlagFiend extends CardImpl {
         this.power = new MageInt(0);
         this.toughness = new MageInt(0);
 
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CardsInAllGraveyardsCount(new FilterArtifactCard("artifacts")), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CardsInAllGraveyardsCount(new FilterArtifactCard("artifacts")))));
     }
 
     private SlagFiend(final SlagFiend card) {

--- a/Mage.Sets/src/mage/cards/s/SoramaroFirstToDream.java
+++ b/Mage.Sets/src/mage/cards/s/SoramaroFirstToDream.java
@@ -17,7 +17,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.SuperType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledLandPermanent;
@@ -40,7 +39,7 @@ public final class SoramaroFirstToDream extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // Soramaro, First to Dream's power and toughness are each equal to the number of cards in your hand.
          DynamicValue xValue= CardsInControllerHandCount.instance;
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)));
 
         // {4}, Return a land you control to its owner's hand: Draw a card.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,

--- a/Mage.Sets/src/mage/cards/s/SoulOfEternity.java
+++ b/Mage.Sets/src/mage/cards/s/SoulOfEternity.java
@@ -9,7 +9,6 @@ import mage.abilities.keyword.EncoreAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -31,7 +30,7 @@ public final class SoulOfEternity extends CardImpl {
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
                 new SetBasePowerToughnessSourceEffect(
-                        ControllerLifeCount.instance, Duration.EndOfGame
+                        ControllerLifeCount.instance
                 ).setText("{this}'s power and toughness are each equal to your life total")
         ));
 

--- a/Mage.Sets/src/mage/cards/s/SoullessOne.java
+++ b/Mage.Sets/src/mage/cards/s/SoullessOne.java
@@ -11,7 +11,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
@@ -34,7 +33,7 @@ public final class SoullessOne extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Soulless One's power and toughness are each equal to the number of Zombies on the battlefield plus the number of Zombie cards in all graveyards.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new SoullessOneDynamicCount(), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new SoullessOneDynamicCount())));
     }
 
     private SoullessOne(final SoullessOne card) {

--- a/Mage.Sets/src/mage/cards/s/SoulsurgeElemental.java
+++ b/Mage.Sets/src/mage/cards/s/SoulsurgeElemental.java
@@ -10,7 +10,6 @@ import mage.abilities.keyword.FirstStrikeAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -32,7 +31,7 @@ public final class SoulsurgeElemental extends CardImpl {
         this.addAbility(FirstStrikeAbility.getInstance());
 
         // Soulsurge Elemental's power is equal to the number of creatures you control.
-        Effect effect = new SetBasePowerSourceEffect(CreaturesYouControlCount.instance, Duration.EndOfGame);
+        Effect effect = new SetBasePowerSourceEffect(CreaturesYouControlCount.instance);
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect)
                 .addHint(CreaturesYouControlHint.instance));
     }

--- a/Mage.Sets/src/mage/cards/s/SpellheartChimera.java
+++ b/Mage.Sets/src/mage/cards/s/SpellheartChimera.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterInstantOrSorceryCard;
 
@@ -35,7 +34,7 @@ public final class SpellheartChimera extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
         // Spellheart Chimera's power is equal to the number of instant and sorcery cards in your graveyard.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(
-                new CardsInControllerGraveyardCount(new FilterInstantOrSorceryCard("instant and sorcery cards in your graveyard")), Duration.EndOfGame)));
+                new CardsInControllerGraveyardCount(new FilterInstantOrSorceryCard("instant and sorcery cards in your graveyard")))));
     }
 
     private SpellheartChimera(final SpellheartChimera card) {

--- a/Mage.Sets/src/mage/cards/s/Splinterfright.java
+++ b/Mage.Sets/src/mage/cards/s/Splinterfright.java
@@ -13,7 +13,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreatureCard;
 import mage.game.events.GameEvent.EventType;
@@ -34,7 +33,7 @@ public final class Splinterfright extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
         // Splinterfright's power and toughness are each equal to the number of creature cards in your graveyard.
         CardsInControllerGraveyardCount count = new CardsInControllerGraveyardCount(new FilterCreatureCard("creature cards"));
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(count, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(count)));
         // At the beginning of your upkeep, put the top two cards of your library into your graveyard.
         this.addAbility(new OnEventTriggeredAbility(EventType.UPKEEP_STEP_PRE, "beginning of your upkeep", new MillCardsControllerEffect(2), false));
     }

--- a/Mage.Sets/src/mage/cards/s/SquelchingLeeches.java
+++ b/Mage.Sets/src/mage/cards/s/SquelchingLeeches.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -34,7 +33,7 @@ public final class SquelchingLeeches extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Squelching Leeches's power and toughness are each equal to the number of Swamps you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private SquelchingLeeches(final SquelchingLeeches card) {

--- a/Mage.Sets/src/mage/cards/s/Sturmgeist.java
+++ b/Mage.Sets/src/mage/cards/s/Sturmgeist.java
@@ -13,7 +13,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 
 /**
@@ -31,7 +30,7 @@ public final class Sturmgeist extends CardImpl {
 
         this.addAbility(FlyingAbility.getInstance());
         // Sturmgeist's power and toughness are each equal to the number of cards in your hand.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance)));
         // Whenever Sturmgeist deals combat damage to a player, draw a card.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new DrawCardSourceControllerEffect(1), false));
     }

--- a/Mage.Sets/src/mage/cards/s/SurgeEngine.java
+++ b/Mage.Sets/src/mage/cards/s/SurgeEngine.java
@@ -54,7 +54,7 @@ public final class SurgeEngine extends CardImpl {
                 new ManaCostsImpl<>("{2}{U}"), SurgeEngineCondition.instance
         );
         ability.addEffect(new SetBasePowerToughnessSourceEffect(
-                5, 4, Duration.Custom, SubLayer.SetPT_7b, true
+                5, 4, Duration.Custom, SubLayer.SetPT_7b
         ).setText("and has base power and toughness 5/4"));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/s/SurgeEngine.java
+++ b/Mage.Sets/src/mage/cards/s/SurgeEngine.java
@@ -54,7 +54,7 @@ public final class SurgeEngine extends CardImpl {
                 new ManaCostsImpl<>("{2}{U}"), SurgeEngineCondition.instance
         );
         ability.addEffect(new SetBasePowerToughnessSourceEffect(
-                5, 4, Duration.Custom, SubLayer.SetPT_7b
+                5, 4, Duration.Custom, SubLayer.SetPT_7b, true
         ).setText("and has base power and toughness 5/4"));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
+++ b/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
@@ -59,7 +59,7 @@ class SvogthosToken extends TokenImpl {
         power = new MageInt(0);
         toughness = new MageInt(0);
         CardsInControllerGraveyardCount count = new CardsInControllerGraveyardCount(new FilterCreatureCard("creature cards"));
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(count, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(count)));
     }
     public SvogthosToken(final SvogthosToken token) {
         super(token);

--- a/Mage.Sets/src/mage/cards/s/SwarmOfRats.java
+++ b/Mage.Sets/src/mage/cards/s/SwarmOfRats.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledCreaturePermanent;
@@ -34,7 +33,7 @@ public final class SwarmOfRats extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Swarm of Rats's power is equal to the number of Rats you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private SwarmOfRats(final SwarmOfRats card) {

--- a/Mage.Sets/src/mage/cards/s/SwornDefender.java
+++ b/Mage.Sets/src/mage/cards/s/SwornDefender.java
@@ -78,7 +78,7 @@ class SwornDefenderEffect extends OneShotEffect {
         if (controller != null && targetPermanent != null) {
             int newPower = CardUtil.overflowDec(targetPermanent.getToughness().getValue(), 1);
             int newToughness = CardUtil.overflowInc(targetPermanent.getPower().getValue(), 1);
-            game.addEffect(new SetBasePowerToughnessSourceEffect(newPower, newToughness, Duration.EndOfTurn, SubLayer.SetPT_7b), source);
+            game.addEffect(new SetBasePowerToughnessSourceEffect(newPower, newToughness, Duration.EndOfTurn, SubLayer.SetPT_7b, false), source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/SwornDefender.java
+++ b/Mage.Sets/src/mage/cards/s/SwornDefender.java
@@ -78,7 +78,7 @@ class SwornDefenderEffect extends OneShotEffect {
         if (controller != null && targetPermanent != null) {
             int newPower = CardUtil.overflowDec(targetPermanent.getToughness().getValue(), 1);
             int newToughness = CardUtil.overflowInc(targetPermanent.getPower().getValue(), 1);
-            game.addEffect(new SetBasePowerToughnessSourceEffect(newPower, newToughness, Duration.EndOfTurn, SubLayer.SetPT_7b, false), source);
+            game.addEffect(new SetBasePowerToughnessSourceEffect(newPower, newToughness, Duration.EndOfTurn, SubLayer.SetPT_7b), source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/SylvanYeti.java
+++ b/Mage.Sets/src/mage/cards/s/SylvanYeti.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 
 /**
@@ -27,7 +26,7 @@ public final class SylvanYeti extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Sylvan Yeti's power is equal to the number of cards in your hand.
-        Effect effect = new SetBasePowerSourceEffect(CardsInControllerHandCount.instance, Duration.EndOfGame);
+        Effect effect = new SetBasePowerSourceEffect(CardsInControllerHandCount.instance);
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SyrElenoraTheDiscerning.java
+++ b/Mage.Sets/src/mage/cards/s/SyrElenoraTheDiscerning.java
@@ -30,7 +30,7 @@ public final class SyrElenoraTheDiscerning extends CardImpl {
 
         // Syr Elenora the Discerning's power is equal to the number of cards in your hand.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerSourceEffect(CardsInControllerHandCount.instance, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerSourceEffect(CardsInControllerHandCount.instance)
         ));
 
         // When Syr Elenora enters the battlefield, draw a card.

--- a/Mage.Sets/src/mage/cards/t/Tarmogoyf.java
+++ b/Mage.Sets/src/mage/cards/t/Tarmogoyf.java
@@ -1,22 +1,15 @@
 package mage.cards.t;
 
 import mage.MageInt;
-import mage.MageObject;
-import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.AdditiveDynamicValue;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.CardTypesInGraveyardCount;
-import mage.abilities.dynamicvalue.common.CardsInAllGraveyardsCount;
 import mage.abilities.dynamicvalue.common.StaticValue;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
-import mage.abilities.hint.common.CardTypesInGraveyardHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.StaticFilters;
-import mage.game.Game;
 
 import java.util.UUID;
 
@@ -38,7 +31,7 @@ public final class Tarmogoyf extends CardImpl {
         // Tarmogoyf's power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBasePowerToughnessSourceEffect(powerValue, toughnessValue, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a, false)
+                new SetBasePowerToughnessSourceEffect(powerValue, toughnessValue, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a)
                         .setText("{this}'s power is equal to the number of creature cards in all graveyards and its toughness is equal to that number plus 1")
         ));
     }

--- a/Mage.Sets/src/mage/cards/t/Terravore.java
+++ b/Mage.Sets/src/mage/cards/t/Terravore.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterLandCard;
 
@@ -32,7 +31,7 @@ public final class Terravore extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
         // Terravore's power and toughness are each equal to the number of land cards in all graveyards.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(
-                new CardsInAllGraveyardsCount(new FilterLandCard("land cards")), Duration.EndOfGame)));
+                new CardsInAllGraveyardsCount(new FilterLandCard("land cards")))));
     }
 
     private Terravore(final Terravore card) {

--- a/Mage.Sets/src/mage/cards/t/TerritorialKavu.java
+++ b/Mage.Sets/src/mage/cards/t/TerritorialKavu.java
@@ -33,7 +33,7 @@ public final class TerritorialKavu extends CardImpl {
 
         // Domain — Territorial Kavu's power and toughness are each equal to the number of basic land types among lands you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerToughnessSourceEffect(DomainValue.REGULAR, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerToughnessSourceEffect(DomainValue.REGULAR)
         ).addHint(DomainHint.instance).setAbilityWord(AbilityWord.DOMAIN));
 
         // Whenever Territorial Kavu attacks, choose one —

--- a/Mage.Sets/src/mage/cards/t/TerritorialMaro.java
+++ b/Mage.Sets/src/mage/cards/t/TerritorialMaro.java
@@ -29,7 +29,7 @@ public final class TerritorialMaro extends CardImpl {
 
         // Domain — Territorial Maro's power and toughness are each equal to twice the number of basic land types among lands you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)
                 .setText("{this}'s power and toughness are each equal to twice the number of basic land types among lands you control")
         ).setAbilityWord(AbilityWord.DOMAIN).addHint(DomainHint.instance));
     }

--- a/Mage.Sets/src/mage/cards/t/TestamentOfFaith.java
+++ b/Mage.Sets/src/mage/cards/t/TestamentOfFaith.java
@@ -27,7 +27,7 @@ public final class TestamentOfFaith extends CardImpl {
 
         // {X}: Testament of Faith becomes an X/X Wall creature with defender in addition to its other types until end of turn.
         Ability ability = new SimpleActivatedAbility(new SetBasePowerToughnessSourceEffect(
-                ManacostVariableValue.REGULAR, Duration.EndOfTurn, SubLayer.SetPT_7b, true
+                ManacostVariableValue.REGULAR, ManacostVariableValue.REGULAR, Duration.EndOfTurn, SubLayer.SetPT_7b, true
         ).setText("{this} becomes an X/X"), new VariableManaCost(VariableCostType.NORMAL));
         ability.addEffect(new TestamentOfFaithEffect());
         ability.addEffect(new GainAbilitySourceEffect(

--- a/Mage.Sets/src/mage/cards/t/TestamentOfFaith.java
+++ b/Mage.Sets/src/mage/cards/t/TestamentOfFaith.java
@@ -27,7 +27,7 @@ public final class TestamentOfFaith extends CardImpl {
 
         // {X}: Testament of Faith becomes an X/X Wall creature with defender in addition to its other types until end of turn.
         Ability ability = new SimpleActivatedAbility(new SetBasePowerToughnessSourceEffect(
-                ManacostVariableValue.REGULAR, ManacostVariableValue.REGULAR, Duration.EndOfTurn, SubLayer.SetPT_7b, true
+                ManacostVariableValue.REGULAR, ManacostVariableValue.REGULAR, Duration.EndOfTurn, SubLayer.SetPT_7b
         ).setText("{this} becomes an X/X"), new VariableManaCost(VariableCostType.NORMAL));
         ability.addEffect(new TestamentOfFaithEffect());
         ability.addEffect(new GainAbilitySourceEffect(

--- a/Mage.Sets/src/mage/cards/t/Tidewalker.java
+++ b/Mage.Sets/src/mage/cards/t/Tidewalker.java
@@ -14,7 +14,6 @@ import mage.abilities.keyword.VanishingUpkeepAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
@@ -44,7 +43,7 @@ public final class Tidewalker extends CardImpl {
         this.addAbility(new VanishingUpkeepAbility(0));
         this.addAbility(new VanishingSacrificeAbility());
         // Tidewalker's power and toughness are each equal to the number of time counters on it.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CountersSourceCount(CounterType.TIME), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new CountersSourceCount(CounterType.TIME))));
     }
 
     private Tidewalker(final Tidewalker card) {

--- a/Mage.Sets/src/mage/cards/t/TishanaVoiceOfThunder.java
+++ b/Mage.Sets/src/mage/cards/t/TishanaVoiceOfThunder.java
@@ -33,7 +33,7 @@ public final class TishanaVoiceOfThunder extends CardImpl {
 
         // Tishana, Voice of Thunder's power and toughness are each equal to the number of cards in your hand.
         DynamicValue xValue = CardsInControllerHandCount.instance;
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)));
 
         // You have no maximum hand size.
         Effect effect = new MaximumHandSizeControllerEffect(Integer.MAX_VALUE, Duration.WhileOnBattlefield, MaximumHandSizeControllerEffect.HandSizeModification.SET);

--- a/Mage.Sets/src/mage/cards/t/TitaniaGaeaIncarnate.java
+++ b/Mage.Sets/src/mage/cards/t/TitaniaGaeaIncarnate.java
@@ -56,7 +56,7 @@ public final class TitaniaGaeaIncarnate extends MeldCard {
 
         // Titania, Gaea Incarnate's power and toughness are each equal to the number of lands you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerToughnessSourceEffect(LandsYouControlCount.instance, Duration.EndOfGame)
+                Zone.ALL, new SetBasePowerToughnessSourceEffect(LandsYouControlCount.instance)
         ));
 
         // When Titania, Gaea Incarnate enters the battlefield, return all land cards from your graveyard to the battlefield tapped.

--- a/Mage.Sets/src/mage/cards/t/ToweringGibbon.java
+++ b/Mage.Sets/src/mage/cards/t/ToweringGibbon.java
@@ -11,7 +11,6 @@ import mage.abilities.keyword.ReachAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
@@ -38,7 +37,7 @@ public final class ToweringGibbon extends CardImpl {
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
                 new SetBasePowerSourceEffect(
-                        ToweringGibbonValue.instance, Duration.EndOfGame
+                        ToweringGibbonValue.instance
                 ).setText("{this}'s power is equal to the greatest mana value among creatures you control")
         ));
     }

--- a/Mage.Sets/src/mage/cards/t/TraprootKami.java
+++ b/Mage.Sets/src/mage/cards/t/TraprootKami.java
@@ -11,7 +11,6 @@ import mage.abilities.keyword.ReachAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
@@ -38,7 +37,7 @@ public final class TraprootKami extends CardImpl {
         this.addAbility(DefenderAbility.getInstance());
         this.addAbility(ReachAbility.getInstance());
         // Traproot Kami's toughness is equal to the number of Forests on the battlefield.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBaseToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBaseToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
     }
 
     private TraprootKami(final TraprootKami card) {

--- a/Mage.Sets/src/mage/cards/t/TreeOfRedemption.java
+++ b/Mage.Sets/src/mage/cards/t/TreeOfRedemption.java
@@ -82,7 +82,7 @@ class TreeOfRedemptionEffect extends OneShotEffect {
             return false;
         }
         player.setLife(amount, game, source);
-        game.addEffect(new SetBasePowerToughnessSourceEffect(Integer.MIN_VALUE, life, Duration.WhileOnBattlefield, SubLayer.SetPT_7b, true), source);
+        game.addEffect(new SetBasePowerToughnessSourceEffect(Integer.MIN_VALUE, life, Duration.WhileOnBattlefield, SubLayer.SetPT_7b), source);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreefolkSeedlings.java
+++ b/Mage.Sets/src/mage/cards/t/TreefolkSeedlings.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.continuous.SetBaseToughnessSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -34,7 +33,7 @@ public final class TreefolkSeedlings extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Treefolk Seedlings's toughness is equal to the number of Forests you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBaseToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBaseToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands))));
     }
 
     private TreefolkSeedlings(final TreefolkSeedlings card) {

--- a/Mage.Sets/src/mage/cards/t/TrenchGorger.java
+++ b/Mage.Sets/src/mage/cards/t/TrenchGorger.java
@@ -86,7 +86,7 @@ class TrenchGorgerEffect extends OneShotEffect {
             }
         }
         controller.shuffleLibrary(source, game);
-        game.addEffect(new SetBasePowerToughnessSourceEffect(count, count, Duration.WhileOnBattlefield, SubLayer.SetPT_7b, true), source);
+        game.addEffect(new SetBasePowerToughnessSourceEffect(count, count, Duration.WhileOnBattlefield, SubLayer.SetPT_7b), source);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TymaretChosenFromDeath.java
+++ b/Mage.Sets/src/mage/cards/t/TymaretChosenFromDeath.java
@@ -35,7 +35,7 @@ public final class TymaretChosenFromDeath extends CardImpl {
 
         // Tymaret's toughness is equal to your devotion to black.
         this.addAbility(new SimpleStaticAbility(
-                        Zone.ALL, new SetBaseToughnessSourceEffect(DevotionCount.B, Duration.EndOfGame)
+                        Zone.ALL, new SetBaseToughnessSourceEffect(DevotionCount.B)
                         .setText("{this}'s toughness is equal to your devotion to black")
                 ).addHint(DevotionCount.B.getHint())
         );

--- a/Mage.Sets/src/mage/cards/u/Uchuulon.java
+++ b/Mage.Sets/src/mage/cards/u/Uchuulon.java
@@ -51,7 +51,7 @@ public final class Uchuulon extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Uchuulon's power is equal to the number of Crabs, Oozes, and/or Horrors you control.
-        this.addAbility(new SimpleStaticAbility(new SetBasePowerSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(new SetBasePowerSourceEffect(xValue)));
 
         // Horrific Symbiosis — At the beginning of your end step, exile up to one target creature card from an opponent's graveyard. If you, create a token that's a copy of Uchuulon.
         Ability ability = new BeginningOfEndStepTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/u/UktabiWildcats.java
+++ b/Mage.Sets/src/mage/cards/u/UktabiWildcats.java
@@ -14,7 +14,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -42,7 +41,7 @@ public final class UktabiWildcats extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Uktabi Wildcats's power and toughness are each equal to the number of Forests you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filter))));
         
         // {G}, Sacrifice a Forest: Regenerate Uktabi Wildcats.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new  RegenerateSourceEffect(), new ManaCostsImpl<>("{G}"));

--- a/Mage.Sets/src/mage/cards/u/UlvenwaldHydra.java
+++ b/Mage.Sets/src/mage/cards/u/UlvenwaldHydra.java
@@ -14,7 +14,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledLandPermanent;
@@ -42,7 +41,7 @@ public final class UlvenwaldHydra extends CardImpl {
         this.addAbility(ReachAbility.getInstance());
 
         // Ulvenwald Hydra's power and toughness are each equal to the number of lands you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(controlledLands, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(controlledLands)));
 
         // When Ulvenwald Hydra enters the battlefield, you may search your library for a land card, put it onto the battlefield tapped, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(new FilterLandCard());

--- a/Mage.Sets/src/mage/cards/u/UmbraStalker.java
+++ b/Mage.Sets/src/mage/cards/u/UmbraStalker.java
@@ -11,7 +11,6 @@ import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
@@ -33,7 +32,7 @@ public final class UmbraStalker extends CardImpl {
 
         // Chroma - Umbra Stalker's power and toughness are each equal to the number of black mana symbols in the mana costs of cards in your graveyard.
         DynamicValue xValue = new ChromaUmbraStalkerCount();
-        Effect effect = new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame);
+        Effect effect = new SetBasePowerToughnessSourceEffect(xValue);
         effect.setText("<i>Chroma</i> &mdash; Umbra Stalker's power and toughness are each equal to the number of black mana symbols in the mana costs of cards in your graveyard.");
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect)
                 .addHint(new ValueHint("Black mana symbols in your graveyard's permanents", xValue))

--- a/Mage.Sets/src/mage/cards/u/UnlicensedHearse.java
+++ b/Mage.Sets/src/mage/cards/u/UnlicensedHearse.java
@@ -15,7 +15,6 @@ import mage.abilities.keyword.CrewAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
@@ -82,7 +81,7 @@ public final class UnlicensedHearse extends CardImpl {
         this.addAbility(
                 new SimpleStaticAbility(
                         Zone.ALL,
-                        new SetBasePowerToughnessSourceEffect(UnlicensedHearseValue.instance, Duration.EndOfGame)
+                        new SetBasePowerToughnessSourceEffect(UnlicensedHearseValue.instance)
                 ).addHint(hint)
         );
 

--- a/Mage.Sets/src/mage/cards/u/UrborgLhurgoyf.java
+++ b/Mage.Sets/src/mage/cards/u/UrborgLhurgoyf.java
@@ -45,7 +45,7 @@ public final class UrborgLhurgoyf extends CardImpl {
         // Urborg Lhurgoyf's power is equal to the number of creature cards in your graveyard and its toughness is equal to that number plus 1.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBasePowerToughnessSourceEffect(powerValue, toughnessValue, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a, false)
+                new SetBasePowerToughnessSourceEffect(powerValue, toughnessValue, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a)
                         .setText("{this}'s power is equal to the number of creature cards in your graveyard and its toughness is equal to that number plus 1")
         ));
     }

--- a/Mage.Sets/src/mage/cards/u/UurgSpawnOfTurg.java
+++ b/Mage.Sets/src/mage/cards/u/UurgSpawnOfTurg.java
@@ -36,7 +36,7 @@ public final class UurgSpawnOfTurg extends CardImpl {
         this.toughness = new MageInt(5);
 
         // Uurg, Spawn of Turg's power is equal to the number of land cards in your graveyard.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(xValue)));
 
         // At the beginning of your upkeep, look at the top card of your library. You may put that card into your graveyard.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/v/VertexPaladin.java
+++ b/Mage.Sets/src/mage/cards/v/VertexPaladin.java
@@ -8,7 +8,6 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -34,7 +33,7 @@ public final class VertexPaladin extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Vertex Paladin's power and toughness are each equal to the number of creatures you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance, Duration.Custom)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance)));
     }
 
     private VertexPaladin(final VertexPaladin card) {

--- a/Mage.Sets/src/mage/cards/v/VeteranWarleader.java
+++ b/Mage.Sets/src/mage/cards/v/VeteranWarleader.java
@@ -54,7 +54,7 @@ public final class VeteranWarleader extends CardImpl {
 
         // Veteran Warleader's power and toughness are each equal to the number of creatures you control.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(
-                CreaturesYouControlCount.instance, Duration.EndOfGame))
+                CreaturesYouControlCount.instance))
                 .addHint(CreaturesYouControlHint.instance));
 
         // Tap another untapped Ally you control: Veteran Warleader gains your choice of first strike, vigilance, or trample until end of turn.

--- a/Mage.Sets/src/mage/cards/v/VileAggregate.java
+++ b/Mage.Sets/src/mage/cards/v/VileAggregate.java
@@ -14,7 +14,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.predicate.mageobject.ColorlessPredicate;
@@ -41,7 +40,7 @@ public final class VileAggregate extends CardImpl {
         // Devoid
         this.addAbility(new DevoidAbility(this.color));
         // Vile Aggregate's power is equal to the number of colorless creatures you control.
-        Effect effect = new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame);
+        Effect effect = new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter));
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect));
 
         // Trample

--- a/Mage.Sets/src/mage/cards/w/WallOfTombstones.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfTombstones.java
@@ -65,7 +65,7 @@ class WallOfTombstonesEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         int newToughness = CardUtil.overflowInc(1, new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURE).calculate(game, source, this));
-        game.addEffect(new SetBasePowerToughnessSourceEffect(null, StaticValue.get(newToughness), Duration.WhileOnBattlefield, SubLayer.SetPT_7b, true), source);
+        game.addEffect(new SetBasePowerToughnessSourceEffect(null, StaticValue.get(newToughness), Duration.WhileOnBattlefield, SubLayer.SetPT_7b), source);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/w/WardenOfTheFirstTree.java
+++ b/Mage.Sets/src/mage/cards/w/WardenOfTheFirstTree.java
@@ -43,7 +43,7 @@ public final class WardenOfTheFirstTree extends CardImpl {
                 Duration.Custom, SubType.HUMAN, SubType.WARRIOR
         ).setText("{this} becomes a Human Warrior"), new ManaCostsImpl<>("{1}{W/B}"));
         ability.addEffect(new SetBasePowerToughnessSourceEffect(
-                3, 3, Duration.Custom, SubLayer.SetPT_7b, true
+                3, 3, Duration.Custom, SubLayer.SetPT_7b
         ).setText("with base power and toughness 3/3"));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/w/WayfaringTemple.java
+++ b/Mage.Sets/src/mage/cards/w/WayfaringTemple.java
@@ -10,7 +10,6 @@ import mage.abilities.hint.common.CreaturesYouControlHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -29,7 +28,7 @@ public final class WayfaringTemple extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Wayfaring Temple's power and toughness are each equal to the number of creatures you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance, Duration.EndOfGame))
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance))
                 .addHint(CreaturesYouControlHint.instance));
 
         // Whenever Wayfaring Temple deals combat damage to a player, populate. (Create a token that's a copy of a creature token you control.)

--- a/Mage.Sets/src/mage/cards/w/WerewolfOfAncientHunger.java
+++ b/Mage.Sets/src/mage/cards/w/WerewolfOfAncientHunger.java
@@ -12,7 +12,6 @@ import mage.abilities.keyword.VigilanceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -40,7 +39,7 @@ public final class WerewolfOfAncientHunger extends CardImpl {
 
         // Werewolf of Ancient Hunger's power and toughness are each equal to the total number of cards in all players' hands.
         this.addAbility(new SimpleStaticAbility(Zone.ALL,
-                new ConditionalContinuousEffect(new SetBasePowerToughnessSourceEffect(CardsInAllHandsCount.instance, Duration.EndOfGame),
+                new ConditionalContinuousEffect(new SetBasePowerToughnessSourceEffect(CardsInAllHandsCount.instance),
                         new TransformedCondition(false), "{this}'s power and toughness are each equal to the total number of cards in all players' hands")));
 
         // At the beginning of each upkeep, if a player cast two or more spells last turn, transform Werewolf of Ancient Hunger.

--- a/Mage.Sets/src/mage/cards/w/WestvaleCultLeader.java
+++ b/Mage.Sets/src/mage/cards/w/WestvaleCultLeader.java
@@ -31,7 +31,7 @@ public final class WestvaleCultLeader extends CardImpl {
         this.nightCard = true;
 
         // Westvale Cult Leader's power and toughness are each equal to the number of creatures you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance, Duration.EndOfGame))
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CreaturesYouControlCount.instance))
                 .addHint(CreaturesYouControlHint.instance));
 
         // At the beginning of your end step, create a 1/1 white and black Human Cleric creature token.

--- a/Mage.Sets/src/mage/cards/w/WildernessElemental.java
+++ b/Mage.Sets/src/mage/cards/w/WildernessElemental.java
@@ -35,7 +35,7 @@ public final class WildernessElemental extends CardImpl {
         // Trample
         this.addAbility(TrampleAbility.getInstance());
         // Wilderness Elemental's power is equal to the number of nonbasic lands your opponents control.
-         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter), Duration.EndOfGame)));
+         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filter))));
    }
 
     private WildernessElemental(final WildernessElemental card) {

--- a/Mage.Sets/src/mage/cards/w/WinnowingForces.java
+++ b/Mage.Sets/src/mage/cards/w/WinnowingForces.java
@@ -7,7 +7,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -31,7 +30,7 @@ public final class WinnowingForces extends CardImpl {
 
         // Winnowing Forces's power and toughness are each equal to the number of lands you control.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerToughnessSourceEffect(LandsYouControlCount.instance, Duration.Custom)
+                Zone.ALL, new SetBasePowerToughnessSourceEffect(LandsYouControlCount.instance)
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/w/WintermoorCommander.java
+++ b/Mage.Sets/src/mage/cards/w/WintermoorCommander.java
@@ -51,7 +51,7 @@ public final class WintermoorCommander extends CardImpl {
         this.addAbility(DeathtouchAbility.getInstance());
 
         // Wintermoor Commander's toughness is equal to the number of Knights you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBaseToughnessSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBaseToughnessSourceEffect(xValue)));
 
         // Whenever Wintermoor Commander attacks, another target Knight you control gains indestructible until end of turn.
         Ability ability = new AttacksTriggeredAbility(new GainAbilityTargetEffect(

--- a/Mage.Sets/src/mage/cards/w/WoodElemental.java
+++ b/Mage.Sets/src/mage/cards/w/WoodElemental.java
@@ -95,7 +95,7 @@ class WoodElementalEffect extends OneShotEffect {
                             targetPermanent.sacrifice(source, game);
                         }
                     }
-                    game.addEffect(new SetBasePowerToughnessSourceEffect(sacrificedForests, sacrificedForests, Duration.Custom, SubLayer.SetPT_7b, false), source);
+                    game.addEffect(new SetBasePowerToughnessSourceEffect(sacrificedForests, sacrificedForests, Duration.Custom, SubLayer.SetPT_7b), source);
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/w/WoodElemental.java
+++ b/Mage.Sets/src/mage/cards/w/WoodElemental.java
@@ -95,7 +95,7 @@ class WoodElementalEffect extends OneShotEffect {
                             targetPermanent.sacrifice(source, game);
                         }
                     }
-                    game.addEffect(new SetBasePowerToughnessSourceEffect(sacrificedForests, sacrificedForests, Duration.Custom, SubLayer.SetPT_7b), source);
+                    game.addEffect(new SetBasePowerToughnessSourceEffect(sacrificedForests, sacrificedForests, Duration.Custom, SubLayer.SetPT_7b, false), source);
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/w/WoodlurkerMimic.java
+++ b/Mage.Sets/src/mage/cards/w/WoodlurkerMimic.java
@@ -44,7 +44,7 @@ public final class WoodlurkerMimic extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Whenever you cast a spell that's both black and green, Woodlurker Mimic has base power and toughness 4/5 until end of turn and gains wither until end of turn.
-        Ability ability = new SpellCastControllerTriggeredAbility(new SetBasePowerToughnessSourceEffect(4, 5, Duration.EndOfTurn, SubLayer.SetPT_7b, true), filter, false, rule);
+        Ability ability = new SpellCastControllerTriggeredAbility(new SetBasePowerToughnessSourceEffect(4, 5, Duration.EndOfTurn, SubLayer.SetPT_7b), filter, false, rule);
         ability.addEffect(new GainAbilitySourceEffect(WitherAbility.getInstance(), Duration.EndOfTurn, false, true));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/y/YavimayaKavu.java
+++ b/Mage.Sets/src/mage/cards/y/YavimayaKavu.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.ColorPredicate;
@@ -41,7 +40,7 @@ public final class YavimayaKavu extends CardImpl {
         // Yavimaya Kavu's power is equal to the number of red creatures on the battlefield.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filterRedCreature))));
         // Yavimaya Kavu's toughness is equal to the number of green creatures on the battlefield.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBaseToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterGreenCreature), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBaseToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterGreenCreature))));
     }
 
     private YavimayaKavu(final YavimayaKavu card) {

--- a/Mage.Sets/src/mage/cards/y/YavimayaKavu.java
+++ b/Mage.Sets/src/mage/cards/y/YavimayaKavu.java
@@ -39,7 +39,7 @@ public final class YavimayaKavu extends CardImpl {
         
 
         // Yavimaya Kavu's power is equal to the number of red creatures on the battlefield.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filterRedCreature), Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(new PermanentsOnBattlefieldCount(filterRedCreature))));
         // Yavimaya Kavu's toughness is equal to the number of green creatures on the battlefield.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBaseToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterGreenCreature), Duration.EndOfGame)));
     }

--- a/Mage.Sets/src/mage/cards/z/ZendikarIncarnate.java
+++ b/Mage.Sets/src/mage/cards/z/ZendikarIncarnate.java
@@ -10,7 +10,6 @@ import mage.abilities.effects.common.continuous.SetBasePowerSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledLandPermanent;
@@ -33,7 +32,7 @@ public final class ZendikarIncarnate extends CardImpl {
         DynamicValue controlledLands = new PermanentsOnBattlefieldCount(filter);
 
         // Zendikar Incarnate's power is equal to the amount of lands you control.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(controlledLands, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(controlledLands)));
     }
 
     private ZendikarIncarnate(final ZendikarIncarnate card) {

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerSourceEffect.java
@@ -19,13 +19,13 @@ public class SetBasePowerSourceEffect extends ContinuousEffectImpl {
 
     private final DynamicValue amount;
 
-    public SetBasePowerSourceEffect(DynamicValue amount, Duration duration) {
-        this(amount, duration, SubLayer.CharacteristicDefining_7a);
-    }
-
-    public SetBasePowerSourceEffect(DynamicValue amount, Duration duration, SubLayer subLayer) {
-        super(duration, Layer.PTChangingEffects_7, subLayer, Outcome.BoostCreature);
-        setCharacterDefining(subLayer == SubLayer.CharacteristicDefining_7a);
+    /**
+     *
+     * @param amount Power to set as a characteristic-defining ability
+     */
+    public SetBasePowerSourceEffect(DynamicValue amount) {
+        super(Duration.EndOfGame, Layer.PTChangingEffects_7, SubLayer.CharacteristicDefining_7a, Outcome.BoostCreature);
+        setCharacterDefining(true);
         this.amount = amount;
         staticText = "{this}'s power is equal to the number of " + amount.getMessage();
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessSourceEffect.java
@@ -37,34 +37,26 @@ public class SetBasePowerToughnessSourceEffect extends ContinuousEffectImpl {
         this.toughness = toughness;
         if (power == toughness) { // When power and toughness are equal, a previous constructor passes the same object for both power nad toughness, so use == instead of .equals
             this.staticText = "{this}'s " + (baseInText ? "base " : "") + "power and toughness are each equal to the number of " + power.getMessage();
-        } else {  // The only other constructor creates the power and toughenss dynamic values as static values from passed-in ints.
+        } else {  // The only other constructor creates the power and toughness dynamic values as static values from passed-in ints.
             String value = (power != null ? power.toString() : toughness.toString());
             this.staticText = "{this}'s " + (baseInText ? "base " : "") + "power and toughness is " + value + '/' + toughness + ' ' + duration.toString();
         }
     }
 
     public SetBasePowerToughnessSourceEffect(DynamicValue amount, Duration duration) {
-        this(amount, duration, SubLayer.CharacteristicDefining_7a, false);
+        this(amount, amount, duration);
     }
 
-    public SetBasePowerToughnessSourceEffect(DynamicValue amount, Duration duration, SubLayer subLayer) {
-        this(amount, duration, subLayer, true);
+    public SetBasePowerToughnessSourceEffect(DynamicValue power, DynamicValue toughness, Duration duration) {
+        this(power, toughness, duration, SubLayer.CharacteristicDefining_7a, false);
     }
 
-    public SetBasePowerToughnessSourceEffect(DynamicValue amount, Duration duration, SubLayer subLayer, boolean changeBaseValue) {
-        this(amount, amount, duration, subLayer, changeBaseValue);
+    public SetBasePowerToughnessSourceEffect(int power, int toughness, Duration duration) {
+        this(power, toughness, duration, SubLayer.CharacteristicDefining_7a, false);
     }
 
-    public SetBasePowerToughnessSourceEffect(int power, int toughness, Duration duration, boolean changeBaseValue) {
-        this(power, toughness, duration, SubLayer.CharacteristicDefining_7a, changeBaseValue);
-    }
-
-    public SetBasePowerToughnessSourceEffect(int power, int toughness, Duration duration, SubLayer subLayer) {
-        this(power, toughness, duration, subLayer, false);
-    }
-
-    public SetBasePowerToughnessSourceEffect(int power, int toughness, Duration duration, SubLayer subLayer, boolean changeBaseValue) {
-        this(StaticValue.get(power), StaticValue.get(toughness), duration, subLayer, changeBaseValue);
+    public SetBasePowerToughnessSourceEffect(int power, int toughness, Duration duration, SubLayer subLayer, boolean baseInText) {
+        this(StaticValue.get(power), StaticValue.get(toughness), duration, subLayer, baseInText);
     }
 
     public SetBasePowerToughnessSourceEffect(final SetBasePowerToughnessSourceEffect effect) {

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessSourceEffect.java
@@ -43,8 +43,11 @@ public class SetBasePowerToughnessSourceEffect extends ContinuousEffectImpl {
         }
     }
 
-    public SetBasePowerToughnessSourceEffect(DynamicValue amount, Duration duration) {
-        this(amount, amount, duration);
+    /**
+     * @param amount Power and toughness to set as a characteristic-defining ability
+     */
+    public SetBasePowerToughnessSourceEffect(DynamicValue amount) {
+        this(amount, amount, Duration.EndOfGame);
     }
 
     public SetBasePowerToughnessSourceEffect(DynamicValue power, DynamicValue toughness, Duration duration) {

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessSourceEffect.java
@@ -47,19 +47,21 @@ public class SetBasePowerToughnessSourceEffect extends ContinuousEffectImpl {
      * @param amount Power and toughness to set as a characteristic-defining ability
      */
     public SetBasePowerToughnessSourceEffect(DynamicValue amount) {
-        this(amount, amount, Duration.EndOfGame);
+        this(amount, amount);
     }
 
-    public SetBasePowerToughnessSourceEffect(DynamicValue power, DynamicValue toughness, Duration duration) {
-        this(power, toughness, duration, SubLayer.CharacteristicDefining_7a, false);
+    /**
+     *
+     * @param power Power to set as a characteristic-defining ability
+     * @param toughness Toughness to set as a characteristic-defining ability
+     */
+    public SetBasePowerToughnessSourceEffect(DynamicValue power, DynamicValue toughness) {
+        this(power, toughness, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a, false);
     }
 
-    public SetBasePowerToughnessSourceEffect(int power, int toughness, Duration duration) {
-        this(power, toughness, duration, SubLayer.CharacteristicDefining_7a, false);
-    }
-
-    public SetBasePowerToughnessSourceEffect(int power, int toughness, Duration duration, SubLayer subLayer, boolean baseInText) {
-        this(StaticValue.get(power), StaticValue.get(toughness), duration, subLayer, baseInText);
+    public SetBasePowerToughnessSourceEffect(int power, int toughness, Duration duration, SubLayer subLayer) {
+        this(StaticValue.get(power), StaticValue.get(toughness), duration, subLayer, true);
+        this.staticText = "{this} has base power and toughness " + power + '/' + toughness + ' ' + duration.toString();
     }
 
     public SetBasePowerToughnessSourceEffect(final SetBasePowerToughnessSourceEffect effect) {

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessSourceEffect.java
@@ -18,8 +18,8 @@ import mage.game.Game;
  */
 public class SetBasePowerToughnessSourceEffect extends ContinuousEffectImpl {
 
-    private DynamicValue power;
-    private DynamicValue toughness;
+    private final DynamicValue power;
+    private final DynamicValue toughness;
 
     /**
      * Note: Need to set text manually if calling this constructor directly

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessSourceEffect.java
@@ -14,7 +14,7 @@ import mage.game.Game;
 
 /**
  * RENAME
- * @author BetaSteward_at_googlemail.com, North, Alex-Vasile
+ * @author BetaSteward_at_googlemail.com, North, Alex-Vasile, xenohedron
  */
 public class SetBasePowerToughnessSourceEffect extends ContinuousEffectImpl {
 
@@ -22,45 +22,25 @@ public class SetBasePowerToughnessSourceEffect extends ContinuousEffectImpl {
     private DynamicValue toughness;
 
     /**
-     *
-     * @param power
-     * @param toughness
-     * @param duration
-     * @param subLayer
-     * @param baseInText    Whether or not the rules text should refer to "base power and toughness" or "power and toughness"
-     *                      Either way, it is always the based power and toughness that are set.
+     * Note: Need to set text manually if calling this constructor directly
      */
-    public SetBasePowerToughnessSourceEffect(DynamicValue power, DynamicValue toughness, Duration duration, SubLayer subLayer, boolean baseInText) {
+    public SetBasePowerToughnessSourceEffect(DynamicValue power, DynamicValue toughness, Duration duration, SubLayer subLayer) {
         super(duration, Layer.PTChangingEffects_7, subLayer, Outcome.BoostCreature);
         setCharacterDefining(subLayer == SubLayer.CharacteristicDefining_7a);
         this.power = power;
         this.toughness = toughness;
-        if (power == toughness) { // When power and toughness are equal, a previous constructor passes the same object for both power nad toughness, so use == instead of .equals
-            this.staticText = "{this}'s " + (baseInText ? "base " : "") + "power and toughness are each equal to the number of " + power.getMessage();
-        } else {  // The only other constructor creates the power and toughness dynamic values as static values from passed-in ints.
-            String value = (power != null ? power.toString() : toughness.toString());
-            this.staticText = "{this}'s " + (baseInText ? "base " : "") + "power and toughness is " + value + '/' + toughness + ' ' + duration.toString();
-        }
     }
 
     /**
      * @param amount Power and toughness to set as a characteristic-defining ability
      */
     public SetBasePowerToughnessSourceEffect(DynamicValue amount) {
-        this(amount, amount);
-    }
-
-    /**
-     *
-     * @param power Power to set as a characteristic-defining ability
-     * @param toughness Toughness to set as a characteristic-defining ability
-     */
-    public SetBasePowerToughnessSourceEffect(DynamicValue power, DynamicValue toughness) {
-        this(power, toughness, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a, false);
+        this(amount, amount, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a);
+        this.staticText = "{this}'s power and toughness are each equal to the number of " + amount.getMessage();
     }
 
     public SetBasePowerToughnessSourceEffect(int power, int toughness, Duration duration, SubLayer subLayer) {
-        this(StaticValue.get(power), StaticValue.get(toughness), duration, subLayer, true);
+        this(StaticValue.get(power), StaticValue.get(toughness), duration, subLayer);
         this.staticText = "{this} has base power and toughness " + power + '/' + toughness + ' ' + duration.toString();
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBaseToughnessSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBaseToughnessSourceEffect.java
@@ -19,12 +19,13 @@ public class SetBaseToughnessSourceEffect extends ContinuousEffectImpl {
 
     private final DynamicValue amount;
 
-    public SetBaseToughnessSourceEffect(DynamicValue amount, Duration duration) {
-        this(amount, duration, SubLayer.CharacteristicDefining_7a);
-    }
-
-    public SetBaseToughnessSourceEffect(DynamicValue amount, Duration duration, SubLayer subLayer) {
-        super(duration, Layer.PTChangingEffects_7, subLayer, Outcome.BoostCreature);
+    /**
+     *
+     * @param amount Toughness to set as a characteristic-defining ability
+     */
+    public SetBaseToughnessSourceEffect(DynamicValue amount) {
+        super(Duration.EndOfGame, Layer.PTChangingEffects_7, SubLayer.CharacteristicDefining_7a, Outcome.BoostCreature);
+        setCharacterDefining(true);
         this.amount = amount;
         staticText = "{this}'s toughness is equal to the number of " + amount.getMessage();
     }
@@ -46,10 +47,6 @@ public class SetBaseToughnessSourceEffect extends ContinuousEffectImpl {
             int value = amount.calculate(game, source, this);
             mageObject.getToughness().setModifiedBaseValue(value);
             return true;
-        } else {
-            if (duration == Duration.Custom) {
-                discard();
-            }
         }
         return false;
     }

--- a/Mage/src/main/java/mage/abilities/keyword/LevelerCardBuilder.java
+++ b/Mage/src/main/java/mage/abilities/keyword/LevelerCardBuilder.java
@@ -55,7 +55,7 @@ public class LevelerCardBuilder {
             staticAbility.setRuleVisible(false);
             constructed.add(staticAbility);
         }
-        ContinuousEffect effect = new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.SetPT_7b, true);
+        ContinuousEffect effect = new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.SetPT_7b);
         ConditionalContinuousEffect ptEffect = new ConditionalContinuousEffect(effect, condition, rule);
         constructed.add(new SimpleStaticAbility(Zone.BATTLEFIELD, ptEffect));
 

--- a/Mage/src/main/java/mage/game/permanent/token/AvatarToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/AvatarToken.java
@@ -4,7 +4,6 @@ import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.common.ControllerLifeCount;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 
 import java.util.Arrays;
@@ -20,7 +19,7 @@ public final class AvatarToken extends TokenImpl {
         subtype.add(SubType.AVATAR);
         color.setWhite(true);
         this.addAbility(new SimpleStaticAbility(new SetBasePowerToughnessSourceEffect(
-                ControllerLifeCount.instance, Duration.WhileOnBattlefield
+                ControllerLifeCount.instance
         ).setText("this creature's power and toughness are each equal to your life total")));
 
         availableImageSetCodes = Arrays.asList("LRW", "M10", "M11");

--- a/Mage/src/main/java/mage/game/permanent/token/AvatarToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/AvatarToken.java
@@ -5,7 +5,6 @@ import mage.abilities.dynamicvalue.common.ControllerLifeCount;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.SubLayer;
 import mage.constants.SubType;
 
 import java.util.Arrays;
@@ -21,8 +20,7 @@ public final class AvatarToken extends TokenImpl {
         subtype.add(SubType.AVATAR);
         color.setWhite(true);
         this.addAbility(new SimpleStaticAbility(new SetBasePowerToughnessSourceEffect(
-                ControllerLifeCount.instance, Duration.WhileOnBattlefield,
-                SubLayer.CharacteristicDefining_7a
+                ControllerLifeCount.instance, Duration.WhileOnBattlefield
         ).setText("this creature's power and toughness are each equal to your life total")));
 
         availableImageSetCodes = Arrays.asList("LRW", "M10", "M11");

--- a/Mage/src/main/java/mage/game/permanent/token/ConsumingBlobOozeToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/ConsumingBlobOozeToken.java
@@ -1,19 +1,13 @@
 package mage.game.permanent.token;
 
 import mage.MageInt;
-import mage.MageObject;
-import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.AdditiveDynamicValue;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.CardTypesInGraveyardCount;
 import mage.abilities.dynamicvalue.common.StaticValue;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
-import mage.abilities.hint.common.CardTypesInGraveyardHint;
 import mage.constants.*;
-import mage.filter.StaticFilters;
-import mage.game.Game;
 
 import java.util.Arrays;
 
@@ -37,7 +31,7 @@ public final class ConsumingBlobOozeToken extends TokenImpl {
         // This creature's power is equal to the number of card types among cards in your graveyard and its toughness is equal to that number plus 1.
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
-                new SetBasePowerToughnessSourceEffect(powerValue, toughnessValue, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a, false)
+                new SetBasePowerToughnessSourceEffect(powerValue, toughnessValue, Duration.EndOfGame, SubLayer.CharacteristicDefining_7a)
                         .setText("{this}'s power is equal to the number of creature cards in all graveyards and its toughness is equal to that number plus 1")
         ));
 

--- a/Mage/src/main/java/mage/game/permanent/token/DogIllusionToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/DogIllusionToken.java
@@ -7,7 +7,6 @@ import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
@@ -32,7 +31,7 @@ public final class DogIllusionToken extends TokenImpl {
 
         // This creature's power and toughness are each equal to twice the number of cards in your hand.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(
-                DogIllusionValue.instance, Duration.EndOfGame)
+                DogIllusionValue.instance)
                 .setText("this creature's power and toughness are each equal to twice the number of cards in your hand")
         ));
 

--- a/Mage/src/main/java/mage/game/permanent/token/DoomedArtisanToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/DoomedArtisanToken.java
@@ -6,7 +6,6 @@ import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.TargetController;
 import mage.filter.common.FilterCreaturePermanent;
@@ -36,7 +35,7 @@ public final class DoomedArtisanToken extends TokenImpl {
         toughness = new MageInt(0);
 
         // This creature's power and toughness are each equal to the number of Sculpturess you control.
-        this.addAbility(new SimpleStaticAbility(new SetBasePowerToughnessSourceEffect(xValue, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(new SetBasePowerToughnessSourceEffect(xValue)));
     }
 
     private DoomedArtisanToken(final DoomedArtisanToken token) {

--- a/Mage/src/main/java/mage/game/permanent/token/ElephantResurgenceToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/ElephantResurgenceToken.java
@@ -7,7 +7,6 @@ import mage.MageInt;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.common.CardsInControllerGraveyardCount;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreatureCard;
 
@@ -28,7 +27,7 @@ public final class ElephantResurgenceToken extends TokenImpl {
 
         this.addAbility(new SimpleStaticAbility(
                 Zone.BATTLEFIELD,
-                new SetBasePowerToughnessSourceEffect(new CardsInControllerGraveyardCount(new FilterCreatureCard()), Duration.EndOfGame)
+                new SetBasePowerToughnessSourceEffect(new CardsInControllerGraveyardCount(new FilterCreatureCard()))
                         .setText("This creature's power and toughness are each equal to the number of creature cards in its controller's graveyard.")
         ));
     }

--- a/Mage/src/main/java/mage/game/permanent/token/GutterGrimeToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/GutterGrimeToken.java
@@ -10,7 +10,6 @@ import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.game.Game;
@@ -35,7 +34,7 @@ public final class GutterGrimeToken extends TokenImpl {
         color.setGreen(true);
         power = new MageInt(0);
         toughness = new MageInt(0);
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new GutterGrimeCounters(sourceId), Duration.WhileOnBattlefield)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new GutterGrimeCounters(sourceId))));
     }
 
     public GutterGrimeToken(final GutterGrimeToken token) {

--- a/Mage/src/main/java/mage/game/permanent/token/KalonianTwingroveTreefolkWarriorToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/KalonianTwingroveTreefolkWarriorToken.java
@@ -6,7 +6,6 @@ import mage.MageInt;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
@@ -33,7 +32,7 @@ public final class KalonianTwingroveTreefolkWarriorToken extends TokenImpl {
         power = new MageInt(0);
         toughness = new MageInt(0);
 
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands), Duration.WhileOnBattlefield)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands))));
     }
 
     public KalonianTwingroveTreefolkWarriorToken(final KalonianTwingroveTreefolkWarriorToken token) {

--- a/Mage/src/main/java/mage/game/permanent/token/SaprolingBurstToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/SaprolingBurstToken.java
@@ -10,7 +10,6 @@ import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
-import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.game.Game;
@@ -33,7 +32,7 @@ public final class SaprolingBurstToken extends TokenImpl {
         this.color.setGreen(true);
         this.subtype.add(SubType.SAPROLING);
         this.cardType.add(CardType.CREATURE);
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new SaprolingBurstTokenDynamicValue(saprolingBurstMOR), Duration.WhileOnBattlefield)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new SaprolingBurstTokenDynamicValue(saprolingBurstMOR))));
     }
 
     public SaprolingBurstToken(final SaprolingBurstToken token) {

--- a/Mage/src/main/java/mage/game/permanent/token/SeizeTheStormElementalToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/SeizeTheStormElementalToken.java
@@ -9,7 +9,6 @@ import mage.abilities.hint.Hint;
 import mage.abilities.hint.StaticHint;
 import mage.abilities.keyword.TrampleAbility;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 
 import java.util.Arrays;
@@ -34,7 +33,7 @@ public final class SeizeTheStormElementalToken extends TokenImpl {
         toughness = new MageInt(0);
         this.addAbility(TrampleAbility.getInstance());
         this.addAbility(new SimpleStaticAbility(new SetBasePowerToughnessSourceEffect(
-                xValue, Duration.WhileOnBattlefield
+                xValue
         ).setText("this creature's power and toughness are each equal to the number of " +
                 "instant and sorcery cards in your graveyard, plus the number of cards with flashback you own in exile")
         ).addHint(hint));

--- a/Mage/src/main/java/mage/game/permanent/token/SpiritClericToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/SpiritClericToken.java
@@ -7,7 +7,6 @@ import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -31,7 +30,7 @@ public class SpiritClericToken extends TokenImpl {
         toughness = new MageInt(0);
 
         // This creature’s power and toughness are each equal to the number of Spirits you control.
-        this.addAbility(new SimpleStaticAbility(new SetBasePowerToughnessSourceEffect(SpiritClericTokenValue.instance, Duration.EndOfGame)));
+        this.addAbility(new SimpleStaticAbility(new SetBasePowerToughnessSourceEffect(SpiritClericTokenValue.instance)));
 
         availableImageSetCodes = Arrays.asList("VOW");
     }

--- a/Mage/src/main/java/mage/game/permanent/token/VoiceOfResurgenceToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/VoiceOfResurgenceToken.java
@@ -5,7 +5,6 @@ import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.common.CreaturesYouControlCount;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -29,7 +28,7 @@ public final class VoiceOfResurgenceToken extends TokenImpl {
 
         // This creature's power and toughness are each equal to the number of creatures you control.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(
-                CreaturesYouControlCount.instance, Duration.EndOfGame)));
+                CreaturesYouControlCount.instance)));
             
         availableImageSetCodes = Arrays.asList("DGM", "MM3", "2XM");
     }

--- a/Mage/src/main/java/mage/game/permanent/token/WrennAndSevenTreefolkToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/WrennAndSevenTreefolkToken.java
@@ -6,7 +6,6 @@ import mage.abilities.dynamicvalue.common.LandsYouControlCount;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
 import mage.abilities.keyword.ReachAbility;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 
@@ -26,7 +25,7 @@ public final class WrennAndSevenTreefolkToken extends TokenImpl {
         toughness = new MageInt(0);
         this.addAbility(ReachAbility.getInstance());
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(
-                LandsYouControlCount.instance, Duration.EndOfGame
+                LandsYouControlCount.instance
         ).setText("this creature's power and toughness are each equal to the number of lands you control")));
 
         availableImageSetCodes.addAll(Arrays.asList("MID"));


### PR DESCRIPTION
In an effort to fix the text on Brokers Initiate properly, I looked into the cause of the bad text generation and found a bunch of similar constructors with superfluous arguments. Most usages are characteristic-defining abilities which always have the same duration and sublayer, and for the other unusual usages it's better to call a constructor with all parameters to be sure of what the intended functionality is. I removed a confusing boolean argument that only affected card text, as unusual cards were just overriding the text anyway.

Simplified options for characteristic-defining abilities with auto text generation:
* `SetBasePowerToughnessSourceEffect(DynamicValue amount)`
* `SetBasePowerSourceEffect(DynamicValue amount)`
* `SetBaseToughnessSourceEffect(DynamicValue amount)`

Options for other abilities:
* `SetBasePowerToughnessSourceEffect(DynamicValue power, DynamicValue toughness, Duration duration, SubLayer subLayer)`
* `SetBasePowerToughnessSourceEffect(int power, int toughness, Duration duration, SubLayer subLayer)` with auto text generation

There are definitely remaining `.setText()` calls on individual cards that could now be removed if desired.

It might also be reasonable to separate CDAs from layer 7b effects entirely, but I didn't attempt to do that here.