### PR TITLE
fixed haktos protection

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HaktosTheUnscarred.java
+++ b/Mage.Sets/src/mage/cards/h/HaktosTheUnscarred.java
@@ -95,7 +95,7 @@ class HaktosTheUnscarredChooseEffect extends OneShotEffect {
         }
         int number = 2 + RandomUtil.nextInt(3);
         game.informPlayers(permanent.getLogName() + ": " + controller.getLogName() + " has chosen " + number + " at random");
-        game.getState().setValue(permanent.getId() + "" + (permanent.getZoneChangeCounter(game) + 1) + "_haktos_number", number);
+        game.getState().setValue(permanent.getId() + "" + source.getSourceObjectZoneChangeCounter() + "_haktos_number", number);
         permanent.addInfo("chosen number", CardUtil.addToolTipMarkTags("Chosen number: " + number), game);
         return true;
     }


### PR DESCRIPTION
So, Haktos the Unscarred currently has protection from absolutely nothing.

When he comes into play we set state to track what converted mana cost he has protection from using, in part:
```
permanent.getZoneChangeCounter(game) + 1
```

And then when something interacts with him we check for protection with something completely different:
```
input.getSource().getSourceObjectZoneChangeCounter()
```

The result is always null when we test for proection so all sorts of terrible things happen to Mr. Haktos when they really shouldn't. 

Instead, this patch changes the protection setter to use:
```
source.getSourceObjectZoneChangeCounter()
```
so that the set and the get match, and the test finds the value for the protection check.

I've tested this change to ensure that blocking works correctly. I've tested this change to ensure that targeting works correctly. I've tested this change to ensure damage prevention works correctly.

Haktos appears to have had some issues with protection in the past, seemingly he was just immune from everything. That's not the case here, he's very vulnerable to the appropriate converted casting cost.

I was worried about issues arising from zone changes with this fix, so I used a Flickerwisp to move Haktos around and make sure that the protection correctly tracked with his changing number, and that seems to work correctly.


If there's a better approach to this issue, I'm happy to take feedback and address this issue in whatever way you feel is most appropriate.

Thank you for creating and maintaining this awesome project and thanks in advance for considering my patch. :-)
