### PR TITLE
Fix Hoarding Broodlord

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HoardingBroodlord.java
+++ b/Mage.Sets/src/mage/cards/h/HoardingBroodlord.java
@@ -88,7 +88,7 @@ class HoardingBroodlordEffect extends OneShotEffect {
         }
         TargetCardInLibrary target = new TargetCardInLibrary();
         player.searchLibrary(target, source, game);
-        Card card = player.getLibrary().getCard(target.getTargetController(), game);
+        Card card = player.getLibrary().getCard(target.getFirstTarget(), game);
         player.shuffleLibrary(source, game);
         if (card != null) {
             player.moveCards(card, Zone.EXILED, source, game);


### PR DESCRIPTION
Resolves #10235.

I did notice another oddity when testing: having a second Hoarding Broodlord gives spells from exile a second instance of convoke (redundant).