### PR TITLE
Fixed maddening hex

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MaddeningHex.java
+++ b/Mage.Sets/src/mage/cards/m/MaddeningHex.java
@@ -129,15 +129,18 @@ class MaddeningHexEffect extends OneShotEffect {
         }
         Set<UUID> opponents = game.getOpponents(source.getControllerId());
 
-        if (player != null)
+        if (player != null) {
             opponents.remove(player.getId());
+        }
 
         // If there is no one to re-attach to, then we're done
-        if (opponents.isEmpty())
+        if (opponents.isEmpty()) {
             return true;
+        }
 
-        if (player != null)
+        if (player != null) {
             player.removeAttachment(permanent, source, game);
+        }
 
         Player opponent = game.getPlayer(RandomUtil.randomFromCollection(opponents));
         if (opponent == null) {

--- a/Mage.Sets/src/mage/cards/m/MaddeningHex.java
+++ b/Mage.Sets/src/mage/cards/m/MaddeningHex.java
@@ -128,10 +128,17 @@ class MaddeningHexEffect extends OneShotEffect {
             return true;
         }
         Set<UUID> opponents = game.getOpponents(source.getControllerId());
-        if (player != null) {
+
+        if (player != null)
             opponents.remove(player.getId());
+
+        // If there is no one to re-attach to, then we're done
+        if (opponents.isEmpty())
+            return true;
+
+        if (player != null)
             player.removeAttachment(permanent, source, game);
-        }
+
         Player opponent = game.getPlayer(RandomUtil.randomFromCollection(opponents));
         if (opponent == null) {
             return true;

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/curses/MaddeningHexTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/curses/MaddeningHexTest.java
@@ -1,0 +1,67 @@
+package org.mage.test.cards.abilities.curses;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+
+/**
+ * {@link mage.cards.m.MaddeningHex Maddening Hex}
+ * {2}{R}
+ * Enchantment — Aura Curse
+ * Enchant player
+ * Whenever enchanted player casts a noncreature spell, roll a d6. Maddening Hex deals damage to that player equal to the result. Then attach Maddening Hex to another one of your opponents chosen at random.
+ *
+ * @author alexander-novo
+ */
+public class MaddeningHexTest extends CardTestPlayerBase {
+    private static final String hex = "Maddening Hex";
+
+    /**
+     * Reported bug: https://github.com/magefree/mage/issues/10302
+     * 
+     * If Maddening Hex is attached to the last one of your opponents (there are no other opponents to re-attach it to),
+     * then it simply dettachs itself and dies from state based actions. Instead it should keep itself attached to that
+     * opponent.
+     */
+    @Test
+    public void lastOpponentTest() {
+        // {R} - noncreature spell
+        String bolt = "Lightning Bolt";
+        String mountain = "Mountain";
+
+        // The roll result for maddening hex trigger
+        int hex_die_result = 6;
+
+        setStrictChooseMode(true);
+
+        // Necessary cards for the test
+        addCard(Zone.HAND, playerA, hex);
+        addCard(Zone.HAND, playerB, bolt);
+
+        // Mana so that players can play their cards
+        addCard(Zone.BATTLEFIELD, playerA, mountain, 3);
+        addCard(Zone.BATTLEFIELD, playerB, mountain, 1);
+
+        // Player A attaches hex to player B
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, hex, playerB);
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, 1);
+
+        // Player B casts a noncreature spell. Make sure hex triggers.
+        // For some reason this must be done on turn 2. If done on turn 1, the test will break.
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, bolt, playerA);
+        checkStackObject("after bolt", 2, PhaseStep.PRECOMBAT_MAIN, playerA,
+                "Whenever enchanted player casts a noncreature spell", 1);
+
+        this.setDieRollResult(playerA, hex_die_result);
+
+        setStopAt(2, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        // Make sure player B lost life
+        assertLife(playerB, 20 - hex_die_result);
+        assertPermanentCount(playerA, hex, 1);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -1183,7 +1183,11 @@ public class TestPlayer implements Player {
                         + (c.isPlaneswalker(game) ? " - L" + c.getCounters(game).getCount(CounterType.LOYALTY) : "")
                         + ", " + (c.isTapped() ? "Tapped" : "Untapped")
                         + getPrintableAliases(", [", c.getId(), "]")
-                        + (c.getAttachedTo() == null ? "" : ", attached to " + game.getPermanent(c.getAttachedTo()).getIdName())))
+                        + (c.getAttachedTo() == null ? ""
+                                : ", attached to "
+                                        + (game.getObject(c.getAttachedTo()) == null
+                                                ? game.getPlayer(c.getAttachedTo()).getName()
+                                                : game.getObject(c.getAttachedTo()).getIdName()))))
                 .sorted()
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
Fixes magefree/mage#10104 and Fixes magefree/mage#10302

Added a test, and fixed a bug in `printPermanents` for permanents which are attached to something other than a permanent