### PR TITLE
Cleanup: PreventDamageAndRemoveCountersEffect

### DIFF
--- a/Mage.Sets/src/mage/cards/o/OathswornKnight.java
+++ b/Mage.Sets/src/mage/cards/o/OathswornKnight.java
@@ -36,7 +36,7 @@ public final class OathswornKnight extends CardImpl {
         this.addAbility(new AttacksEachCombatStaticAbility());
 
         // If damage would be dealt to Oathsworn Knight while it has a +1/+1 counter on it, prevent that damage and remove a +1/+1 counter from it.
-        this.addAbility(new SimpleStaticAbility(new PreventDamageAndRemoveCountersEffect(false)));
+        this.addAbility(new SimpleStaticAbility(new PreventDamageAndRemoveCountersEffect(false, true, true)));
     }
 
     private OathswornKnight(final OathswornKnight card) {

--- a/Mage.Sets/src/mage/cards/p/PolukranosUnchained.java
+++ b/Mage.Sets/src/mage/cards/p/PolukranosUnchained.java
@@ -51,7 +51,7 @@ public final class PolukranosUnchained extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(new PolukranosUnchainedEffect()));
 
         // If damage would be dealt to Polukranos while it has a +1/+1 counter on it, prevent that damage and remove that many +1/+1 counters from it.
-        this.addAbility(new SimpleStaticAbility(new PreventDamageAndRemoveCountersEffect(true)));
+        this.addAbility(new SimpleStaticAbility(new PreventDamageAndRemoveCountersEffect(true, true, true)));
 
         // {1}{B}{G}: Polukranos fights another target creature.
         Ability ability = new SimpleActivatedAbility(new FightTargetSourceEffect(), new ManaCostsImpl<>("{1}{B}{G}"));

--- a/Mage.Sets/src/mage/cards/p/ProteanHydra.java
+++ b/Mage.Sets/src/mage/cards/p/ProteanHydra.java
@@ -19,7 +19,6 @@ import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 
 /**
  *
@@ -38,7 +37,7 @@ public final class ProteanHydra extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(new EntersBattlefieldWithXCountersEffect(CounterType.P1P1.createInstance())));
 
         // If damage would be dealt to Protean Hydra, prevent that damage and remove that many +1/+1 counters from it.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PreventDamageAndRemoveCountersEffect(true)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PreventDamageAndRemoveCountersEffect(true, false, true)));
 
         // Whenever a +1/+1 counter is removed from Protean Hydra, put two +1/+1 counters on it at the beginning of the next end step.
         this.addAbility(new ProteanHydraAbility());
@@ -76,10 +75,7 @@ public final class ProteanHydra extends CardImpl {
 
         @Override
         public boolean checkTrigger(GameEvent event, Game game) {
-            if (event.getData().equals("+1/+1") && event.getTargetId().equals(this.getSourceId())) {
-                return true;
-            }
-            return false;
+            return event.getData().equals("+1/+1") && event.getTargetId().equals(this.getSourceId());
         }
 
         @Override

--- a/Mage.Sets/src/mage/cards/u/UginsConjurant.java
+++ b/Mage.Sets/src/mage/cards/u/UginsConjurant.java
@@ -31,7 +31,7 @@ public final class UginsConjurant extends CardImpl {
         // Ugin’s Conjurant enters the battlefield with X +1/+1 counters on it.
         this.addAbility(new EntersBattlefieldAbility(new EntersBattlefieldWithXCountersEffect(CounterType.P1P1.createInstance())));
         // If damage would be dealt to Ugin’s Conjurant while it has a +1/+1 counter on it, prevent that damage and remove that many +1/+1 counters from Ugin’s Conjurant.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PreventDamageAndRemoveCountersEffect(true)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PreventDamageAndRemoveCountersEffect(true, true, false)));
     }
 
     private UginsConjurant(final UginsConjurant card) {

--- a/Mage.Sets/src/mage/cards/u/UndergrowthChampion.java
+++ b/Mage.Sets/src/mage/cards/u/UndergrowthChampion.java
@@ -3,23 +3,15 @@ package mage.cards.u;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.LandfallAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.PreventionEffectImpl;
+import mage.abilities.effects.PreventDamageAndRemoveCountersEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
-import mage.constants.PhaseStep;
-import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
-import mage.game.turn.Step;
 
 /**
  *
@@ -34,7 +26,7 @@ public final class UndergrowthChampion extends CardImpl {
         this.toughness = new MageInt(2);
 
         // If damage would be dealt to Undergrowth Champion while it has a +1/+1 counter on it, prevent that damage and remove a +1/+1 counter from Undergrowth Champion.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new UndergrowthChampionPreventionEffect()));
+        this.addAbility(new SimpleStaticAbility(new PreventDamageAndRemoveCountersEffect(false, true, false)));
 
         // <i>Landfall</i>-Whenever a land enters the battlefield under your control, put a +1/+1 counter on Undergrowth Champion.
         this.addAbility(new LandfallAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false));
@@ -48,71 +40,4 @@ public final class UndergrowthChampion extends CardImpl {
     public UndergrowthChampion copy() {
         return new UndergrowthChampion(this);
     }
-}
-
-class UndergrowthChampionPreventionEffect extends PreventionEffectImpl {
-
-    // remember turn and phase step to check if counter in this step was already removed
-    private int turn = 0;
-    private Step combatPhaseStep = null;
-
-    public UndergrowthChampionPreventionEffect() {
-        super(Duration.WhileOnBattlefield);
-        staticText = "If damage would be dealt to {this} while it has a +1/+1 counter on it, prevent that damage and remove a +1/+1 counter from {this}";
-    }
-
-    public UndergrowthChampionPreventionEffect(final UndergrowthChampionPreventionEffect effect) {
-        super(effect);
-        this.turn = effect.turn;
-        this.combatPhaseStep = effect.combatPhaseStep;
-    }
-
-    @Override
-    public UndergrowthChampionPreventionEffect copy() {
-        return new UndergrowthChampionPreventionEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        Permanent permanent = game.getPermanent(source.getSourceId());
-        if (permanent != null) {
-            boolean removeCounter = true;
-            // check if in the same combat damage step already a counter was removed
-            if (game.getTurn().getPhase().getStep().getType() == PhaseStep.COMBAT_DAMAGE) {
-                if (game.getTurnNum() == turn
-                        && game.getTurn().getStep().equals(combatPhaseStep)) {
-                    removeCounter = false;
-                } else {
-                    turn = game.getTurnNum();
-                    combatPhaseStep = game.getTurn().getStep();
-                }
-            }
-
-            if(removeCounter && permanent.getCounters(game).containsKey(CounterType.P1P1)) {
-                preventDamageAction(event, source, game);
-                StringBuilder sb = new StringBuilder(permanent.getName()).append(": ");
-                permanent.removeCounters(CounterType.P1P1.createInstance(), source, game);
-                sb.append("Removed a +1/+1 counter ");
-                game.informPlayers(sb.toString());
-            }
-        }
-
-        return false;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        if (super.applies(event, source, game)) {
-            if (event.getTargetId().equals(source.getSourceId())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/prevention/PreventDamageRemoveCountersTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/prevention/PreventDamageRemoveCountersTest.java
@@ -1,0 +1,78 @@
+package org.mage.test.cards.prevention;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class PreventDamageRemoveCountersTest extends CardTestPlayerBase {
+
+    @Test
+    public void testCounterRemoval() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        addCard(Zone.HAND, playerA, "Flame Slash", 1);
+        addCard(Zone.HAND, playerA, "Shock", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Oathsworn Knight", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Polukranos, Unchained", 1);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Flame Slash", "Oathsworn Knight");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Shock", "Polukranos, Unchained");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Oathsworn Knight", 1);
+        assertPermanentCount(playerA, "Polukranos, Unchained", 1);
+        assertPowerToughness(playerA, "Oathsworn Knight", 3, 3); // 1 counter removed
+        assertPowerToughness(playerA, "Polukranos, Unchained", 4, 4); // 2 counters removed
+
+    }
+
+    @Test
+    public void testMagmaPummeler() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 8);
+        addCard(Zone.HAND, playerA, "Magma Pummeler", 1);
+        addCard(Zone.HAND, playerA, "Shock", 1);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Magma Pummeler");
+        setChoice(playerA, "X=5");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Shock", "Magma Pummeler");
+        addTarget(playerA, playerB);
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Magma Pummeler", 1);
+        assertPowerToughness(playerA, "Magma Pummeler", 3, 3); // 2 counters removed
+        assertLife(playerB, 18); // 2 damage dealt
+
+    }
+
+    @Ignore // Need to refactor Protean Hydra as its damage prevention is not conditional on having counters
+    @Test
+    public void testProteanHydraBoosted() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Glorious Anthem", 1);
+        addCard(Zone.HAND, playerA, "Protean Hydra", 1);
+        addCard(Zone.HAND, playerA, "Hornet Sting", 1);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Protean Hydra");
+        setChoice(playerA, "X=0");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Hornet Sting", "Protean Hydra");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Protean Hydra", 1);
+        assertPowerToughness(playerA, "Protean Hydra", 1, 1);
+
+    }
+
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/prevention/PreventDamageRemoveCountersTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/prevention/PreventDamageRemoveCountersTest.java
@@ -53,7 +53,6 @@ public class PreventDamageRemoveCountersTest extends CardTestPlayerBase {
 
     }
 
-    @Ignore // Need to refactor Protean Hydra as its damage prevention is not conditional on having counters
     @Test
     public void testProteanHydraBoosted() {
         setStrictChooseMode(true);

--- a/Mage/src/main/java/mage/abilities/effects/PreventDamageAndRemoveCountersEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/PreventDamageAndRemoveCountersEffect.java
@@ -12,17 +12,23 @@ import mage.game.permanent.Permanent;
  */
 public class PreventDamageAndRemoveCountersEffect extends PreventionEffectImpl {
     private final boolean thatMany;
+    private final boolean whileHasCounter;
 
-    public PreventDamageAndRemoveCountersEffect(boolean thatMany) {
+    public PreventDamageAndRemoveCountersEffect(boolean thatMany, boolean whileHasCounter, boolean textFromIt) {
         super(Duration.WhileOnBattlefield, Integer.MAX_VALUE, false, false);
         this.thatMany = thatMany;
-        staticText = "If damage would be dealt to {this} while it has a +1/+1 counter on it, " +
-                "prevent that damage and remove " + (thatMany ? "that many +1/+1 counters" : "a +1/+1 counter") + " from it";
+        this.whileHasCounter = whileHasCounter;
+        staticText = "If damage would be dealt to {this}" +
+                (whileHasCounter ? " while it has a +1/+1 counter on it" : "") +
+                ", prevent that damage and remove " +
+                (thatMany ? "that many +1/+1 counters" : "a +1/+1 counter") +
+                " from " + (textFromIt ? "it" : "{this}");
     }
 
-    private PreventDamageAndRemoveCountersEffect(final PreventDamageAndRemoveCountersEffect effect) {
+    protected PreventDamageAndRemoveCountersEffect(final PreventDamageAndRemoveCountersEffect effect) {
         super(effect);
         this.thatMany = effect.thatMany;
+        this.whileHasCounter = effect.whileHasCounter;
     }
 
     @Override
@@ -56,6 +62,6 @@ public class PreventDamageAndRemoveCountersEffect extends PreventionEffectImpl {
         return super.applies(event, source, game)
                 && permanent != null
                 && event.getTargetId().equals(source.getSourceId())
-                && permanent.getCounters(game).containsKey(CounterType.P1P1);
+                && (!whileHasCounter || permanent.getCounters(game).containsKey(CounterType.P1P1));
     }
 }


### PR DESCRIPTION
* New unit tests to confirm existing functionality of Oathsworn Knight, Polukranos, Magma Pummeler
* New unit test for Protean Hydra (should prevent regardless of whether it has a counter)
* Adjust to accommodate all seven cards with [o:"prevent that damage and remove"](https://scryfall.com/search?q=o%3A%22prevent+that+damage+and+remove%22)
* Fix text generation accordingly
* Simplify Undergrowth Champion, Unbreathing Horde, Magma Pummeler to use/extend common class
* Fix Protean Hydra functionality, confirm unit test passes
* Tested remaining cards and confirmed correct text