### PR TITLE
Fix Slayer's Cleaver block clause

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SlayersCleaver.java
+++ b/Mage.Sets/src/mage/cards/s/SlayersCleaver.java
@@ -60,7 +60,13 @@ class SlayersCleaverEffect extends RequirementEffect {
 
     @Override
     public boolean applies(Permanent permanent, Ability source, Game game) {
-        return permanent.canBlock(source.getSourceId(), game) && permanent.hasSubtype(SubType.ELDRAZI, game);
+        Permanent equipment = game.getPermanent(source.getSourceId());
+        if (equipment == null || equipment.getAttachedTo() == null) {
+            return false;
+        }
+        Permanent attachedCreature = game.getPermanent(equipment.getAttachedTo());
+        return attachedCreature != null && attachedCreature.isAttacking()
+                && permanent.canBlock(equipment.getAttachedTo(), game) && permanent.hasSubtype(SubType.ELDRAZI, game);
     }
 
     @Override


### PR DESCRIPTION
This fixes the [[Slayer's cleaver]] implementation to check if the attached permanent can be blocked instead of the equipment.