### PR TITLE
Darksteel splicer non-token predicate

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DarksteelSplicer.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelSplicer.java
@@ -27,6 +27,7 @@ public final class DarksteelSplicer extends CardImpl {
 
     static {
         filter.add(AnotherPredicate.instance);
+        filter.add(TokenPredicate.FALSE); //non token
     }
 
     private static final FilterPermanent filter2 = new FilterPermanent(SubType.GOLEM, "Golems");


### PR DESCRIPTION
needs a non token predicate in order to not create infinite loops