### PR TITLE
Enable booster generation for DMR

### DIFF
--- a/Mage.Sets/src/mage/sets/DominariaRemastered.java
+++ b/Mage.Sets/src/mage/sets/DominariaRemastered.java
@@ -17,8 +17,13 @@ public class DominariaRemastered extends ExpansionSet {
 
     private DominariaRemastered() {
         super("Dominaria Remastered", "DMR", ExpansionSet.buildDate(2023, 1, 13), SetType.SUPPLEMENTAL);
-        this.hasBoosters = false; // needs to be configured
+        this.hasBoosters = true;
         this.hasBasicLands = true;
+        this.maxCardNumberInBooster = 261;
+        this.numBoosterCommon = 10; // Frame/art variants not yet implemented for booster generation
+        this.numBoosterUncommon = 3;
+        this.numBoosterRare = 1;
+        this.ratioBoosterMythic = 7; // 60 rare, 20 mythic
 
         cards.add(new SetCardInfo("Absorb", 186, Rarity.RARE, mage.cards.a.Absorb.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Absorb", 354, Rarity.RARE, mage.cards.a.Absorb.class, NON_FULL_USE_VARIOUS));

--- a/Mage.Sets/src/mage/sets/DoubleMasters.java
+++ b/Mage.Sets/src/mage/sets/DoubleMasters.java
@@ -32,6 +32,7 @@ public final class DoubleMasters extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 2;
         this.ratioBoosterMythic = 8;
+        this.maxCardNumberInBooster = 332;
 
         cards.add(new SetCardInfo("Abrade", 114, Rarity.COMMON, mage.cards.a.Abrade.class));
         cards.add(new SetCardInfo("Academy Ruins", 309, Rarity.RARE, mage.cards.a.AcademyRuins.class, NON_FULL_USE_VARIOUS));


### PR DESCRIPTION
I looked into the collation for Dominaria Remastered, which has a lot of convoluted pack options for various alternate frame art treatments. I decided it makes more sense to just enable standard booster generation for now.

Also fixing the max card number parameter on 2XM (relevant for Remixed Draft). Couldn't find any other sets that need the parameter and don't already have it.

Stats for DMR:
```
Dominaria Remastered - boosters opened: 100000. Found cards: 1400000
C Counterspell: 10162
C Kjeldoran Gargoyle: 10155
C Solar Blast: 10119
C Festering Goblin: 10106
C Goblin Medics: 10098
C Aquamoeba: 10079
C Twisted Experiment: 10067
C Phyrexian Debaser: 10067
C Cloud of Faeries: 10060
C Chain Lightning: 10058
C Horseshoe Crab: 10051
C Leaden Fists: 10050
C Giant Spider: 10047
C Goblin Turncoat: 10042
C Radiant's Judgment: 10041
C Fa'adiyah Seer: 10039
C Peregrine Drake: 10034
C Subterranean Scout: 10033
C Battlefield Scrounger: 10029
C Elvish Aberration: 10027
C Empty the Warrens: 10023
C Spirit Link: 10022
C Orim's Thunder: 10021
C Duress: 10021
C Wild Growth: 10019
C Primal Boost: 10015
C Urborg Syphon-Mage: 10009
C Symbiotic Beast: 10000
C Sun Clasp: 9992
C Break Asunder: 9992
C Ember Beast: 9988
C Impulse: 9987
C Frantic Search: 9983
C Krosan Restorer: 9983
C Mystic Zealot: 9982
C Savannah Lions: 9981
C Goblin Matron: 9975
C Hermetic Study: 9974
C Whitemane Lion: 9974
C Nightscape Familiar: 9973
C Wild Dogs: 9966
C Undying Rage: 9963
C Skirk Prospector: 9962
C Remedy: 9960
C Man-o'-War: 9960
C Ichor Slick: 9954
C Penumbra Bobcat: 9952
C Werebear: 9950
C Stonewood Invoker: 9948
C Urborg Uprising: 9943
C Howl from Beyond: 9938
C Terror: 9935
C Cackling Fiend: 9931
C Emerald Charm: 9930
C Cleric of the Forward Order: 9920
C Vigilant Sentry: 9917
C Pacifism: 9914
C Lightning Reflexes: 9909
C Ridgetop Raptor: 9899
C Grapeshot: 9894
C Mogg War Marshal: 9892
C Auramancer: 9888
C Glintwing Invoker: 9887
C Lull: 9886
C Macetail Hystrodon: 9881
C Avarax: 9879
C Icatian Javelineers: 9874
C Nomad Decoy: 9868
C Evil Eye of Orms-by-Gore: 9864
C Wretched Anurid: 9864
C Sandstorm: 9861
C Renewed Faith: 9860
C Obsessive Search: 9854
C Wormfang Drake: 9852
C Coal Stoker: 9850
C Spark Spray: 9845
C Deep Analysis: 9840
C Phyrexian Ghoul: 9838
C Hyalopterous Lemure: 9828
C Momentary Blink: 9826
C Seton's Desire: 9807
C Veiled Serpent: 9803
C Phantom Flock: 9787
C Ovinize: 9783
C Phyrexian Rager: 9777
C Street Wraith: 9759
C Kavu Primarch: 9746
C Snap: 9737
C Aven Fisher: 9701
C Suq'Ata Lancer: 9678
C Smoldering Crater: 9669
C Mind Stone: 9648
C Slippery Karst: 9636
C Remote Isle: 9599
C Dragon Engine: 9587
C Jalum Tome: 9578
C Juggernaut: 9577
C Polluted Mire: 9515
C Terminal Moraine: 9495
C Ornithopter: 9481
C Drifting Meadow: 9377
U Night // Day: 3935
U Tiana, Ship's Caretaker: 3877
U Millikin: 3875
U Pain // Suffering: 3866
U Thieving Magpie: 3852
U Stand // Deliver: 3846
U Fire // Ice: 3845
U Dark Withering: 3840
U Fact or Fiction: 3830
U Griffin Guide: 3830
U Wax // Wane: 3829
U Tormod's Crypt: 3825
U Tatyova, Benthic Druid: 3821
U Battle Screech: 3817
U Call of the Herd: 3815
U Faceless Butcher: 3802
U Chainer's Edict: 3799
U Gerrard's Verdict: 3798
U Serra Angel: 3792
U Flametongue Kavu: 3791
U Rith's Grove: 3778
U Radha, Heir to Keld: 3777
U Phyrexian Scuta: 3775
U Congregate: 3772
U Zombie Infestation: 3770
U Nature's Lore: 3769
U Nantuko Monastery: 3768
U Recoil: 3767
U Sawtooth Loon: 3766
U Dodecapod: 3764
U Swords to Plowshares: 3760
U Crosis's Catacombs: 3759
U Dralnu's Crusade: 3758
U Thran Golem: 3756
U Gempalm Incinerator: 3756
U Deadwood Treefolk: 3756
U Illusion // Reality: 3755
U Mesa Enchantress: 3752
U Floodgate: 3751
U Mishra's Factory: 3750
U Slice and Dice: 3750
U Aven Fateshaper: 3748
U Assault // Battery: 3746
U Squirrel Nest: 3746
U Wall of Junk: 3745
U Quicksilver Dagger: 3745
U Confiscate: 3744
U Ovinomancer: 3744
U High Tide: 3740
U Spectral Lynx: 3738
U Storm Entity: 3735
U Elvish Spirit Guide: 3730
U Spiritmonger: 3729
U Circular Logic: 3724
U Icy Manipulator: 3722
U Terravore: 3719
U Damping Sphere: 3718
U Spite // Malice: 3716
U Treva's Ruins: 3715
U Voice of All: 3714
U Mystic Enforcer: 3708
U Life // Death: 3701
U Gamekeeper: 3701
U Valduk, Keeper of the Flame: 3700
U Order // Chaos: 3693
U Dragon Whelp: 3693
U Lightning Rift: 3686
U Undead Gladiator: 3684
U Invigorating Boon: 3680
U Flesh Reaver: 3680
U Darigaaz's Caldera: 3678
U Necrosavant: 3673
U Deadapult: 3669
U Dromar's Cavern: 3650
U Dread Return: 3646
U Dragon Blood: 3642
U Fireblast: 3638
U Turnabout: 3637
U Improvised Armor: 3625
U Crop Rotation: 3604
R Gemstone Mine: 1528
R Enlightened Tutor: 1512
R Arcanis the Omnipotent: 1493
R Nantuko Shade: 1490
R Siege-Gang Commander: 1487
R Maze of Ith: 1484
R Cryptic Gateway: 1484
R Worldly Tutor: 1478
R Lieutenant Kirtar: 1474
R Sulfuric Vortex: 1473
R Absorb: 1471
R Denizen of the Deep: 1469
R Exploration: 1467
R Jolrael, Mwonvuli Recluse: 1465
R Urza's Blueprints: 1463
R Royal Assassin: 1458
R Windborn Muse: 1449
R Sevinne's Reclamation: 1444
R Sulfur Falls: 1439
R Helm of Awakening: 1438
R Decimate: 1438
R Triskelion: 1436
R Chainer, Dementia Master: 1435
R Sol'kanar the Swamp King: 1434
R Overmaster: 1434
R Oversold Cemetery: 1430
R Birds of Paradise: 1429
R Umbilicus: 1429
R Woodland Cemetery: 1428
R Crawlspace: 1428
R Arboria: 1426
R Mystic Remora: 1426
R Body Snatcher: 1426
R Grim Lavamancer: 1425
R Opposition: 1423
R Glory: 1423
R Pashalik Mons: 1418
R Zur the Enchanter: 1414
R Spinal Embrace: 1414
R Gamble: 1413
R Mystical Tutor: 1413
R Entomb: 1412
R Clifftop Retreat: 1410
R Saproling Symbiosis: 1410
R Vexing Sphinx: 1410
R Isolated Chapel: 1406
R Arcades Sabboth: 1406
R Rith, the Awakener: 1405
R Shivan Dragon: 1405
R Wrath of God: 1402
R Divine Sacrament: 1402
R Lotus Blossom: 1394
R Xira Arien: 1392
R Forgotten Ancient: 1377
R Pyre Zombie: 1375
R Phantom Nishoba: 1369
R Mindslicer: 1368
R Stroke of Genius: 1368
R Jester's Cap: 1368
R Hinterland Harbor: 1344
M Hunting Grounds: 743
M Kamahl, Fist of Krosa: 738
M Yawgmoth, Thran Physician: 737
M Force of Will: 734
M Test of Endurance: 724
M Vampiric Tutor: 723
M Lyra Dawnbringer: 723
M Gauntlet of Power: 721
M Nut Collector: 721
M Time Stretch: 719
M Legacy Weapon: 708
M No Mercy: 708
M Urza's Incubator: 706
M Last Chance: 695
M Urza, Lord High Artificer: 691
M Dark Depths: 689
M Sneak Attack: 686
M Serra Avatar: 683
M Sylvan Library: 681
M Worldgorger Dragon: 639
```