### PR TITLE
Refactor search library effect classes to clean up text generation

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AcademyRector.java
+++ b/Mage.Sets/src/mage/cards/a/AcademyRector.java
@@ -31,7 +31,7 @@ public final class AcademyRector extends CardImpl {
         // When Academy Rector dies, you may exile it. If you do, search your library for an enchantment card, put that card onto the battlefield, then shuffle your library.
         this.addAbility(new DiesSourceTriggeredAbility(
                 new DoIfCostPaid(
-                        new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterEnchantmentCard())),
+                        new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterEnchantmentCard()), false, true),
                         new ExileSourceFromGraveCost(),
                         "Exile to search for an enchantment?"
                 ), false

--- a/Mage.Sets/src/mage/cards/a/AinokGuide.java
+++ b/Mage.Sets/src/mage/cards/a/AinokGuide.java
@@ -35,7 +35,7 @@ public final class AinokGuide extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()));
 
         // * Search your library for a basic land card, reveal it, then shuffle your library and put that card on top of it.
-        Mode mode = new Mode(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true));
+        Mode mode = new Mode(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true));
         ability.addMode(mode);
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/a/AlpineGuide.java
+++ b/Mage.Sets/src/mage/cards/a/AlpineGuide.java
@@ -38,7 +38,7 @@ public final class AlpineGuide extends CardImpl {
 
         // When Alpine Guide enters the battlefield, you may search your library for a Mountain card, put that card onto the battlefield tapped, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(
-                new TargetCardInLibrary(filter), true
+                new TargetCardInLibrary(filter), true, true
         ), true));
 
         // Alpine Guide attacks each combat if able.

--- a/Mage.Sets/src/mage/cards/a/AlpineHoundmaster.java
+++ b/Mage.Sets/src/mage/cards/a/AlpineHoundmaster.java
@@ -51,7 +51,7 @@ public final class AlpineHoundmaster extends CardImpl {
 
         // When Alpine Houndmaster enters the battlefield, you may search your library for a card named Alpine Watchdog and/or a card named Igneous Cur, reveal them, put them into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardWithDifferentNameInLibrary(0, 2, filter2), true, true
+                new TargetCardWithDifferentNameInLibrary(0, 2, filter2), true
         ).setText("search your library for a card named Alpine Watchdog and/or a card named Igneous Cur, reveal them, put them into your hand, then shuffle"), true));
 
         // Whenever Alpine Houndmaster attacks, it gets +X/+0 until end of turn, where X is the number of other attacking creatures.

--- a/Mage.Sets/src/mage/cards/a/ArmillarySphere.java
+++ b/Mage.Sets/src/mage/cards/a/ArmillarySphere.java
@@ -27,7 +27,7 @@ public final class ArmillarySphere extends CardImpl {
 
         // {2}, {tap}, Sacrifice Armillary Sphere: Search your library for up to two basic land cards, reveal them, and put them into your hand. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS), true, true),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS), true),
                 new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());

--- a/Mage.Sets/src/mage/cards/a/AssemblyHall.java
+++ b/Mage.Sets/src/mage/cards/a/AssemblyHall.java
@@ -87,6 +87,6 @@ class AssemblyHallEffect extends OneShotEffect {
         String nameToSearch = CardUtil.getCardNameForSameNameSearch(cardToReveal);
         FilterCard filterCard = new FilterCard("card named " + nameToSearch);
         filterCard.add(new NamePredicate(nameToSearch));
-        return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filterCard), true, true).apply(game, source);
+        return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filterCard), true).apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/a/Avarax.java
+++ b/Mage.Sets/src/mage/cards/a/Avarax.java
@@ -40,7 +40,7 @@ public final class Avarax extends CardImpl {
 
         // When Avarax enters the battlefield, you may search your library for a card named Avarax, reveal it, and put it into your hand. If you do, shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(1, filter), true, true
+                new TargetCardInLibrary(1, filter), true
         ), true));
 
         // {1}{R}: Avarax gets +1/+0 until end of turn.

--- a/Mage.Sets/src/mage/cards/a/AyarasOathsworn.java
+++ b/Mage.Sets/src/mage/cards/a/AyarasOathsworn.java
@@ -47,7 +47,7 @@ public final class AyarasOathsworn extends CardImpl {
                 "search your library for a card, put it into your hand, then shuffle."
         );
         ability.addEffect(new ConditionalOneShotEffect(
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary()), condition2
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false), condition2
         ));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BantPanorama.java
+++ b/Mage.Sets/src/mage/cards/b/BantPanorama.java
@@ -40,7 +40,7 @@ public final class BantPanorama extends CardImpl {
 
         // {1}, {T}, Sacrifice Bant Panorama: Search your library for a basic Forest, Plains, or Island card and put it onto the battlefield tapped. Then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true, Outcome.PutLandInPlay), new GenericManaCost(1));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/b/BattalionFootSoldier.java
+++ b/Mage.Sets/src/mage/cards/b/BattalionFootSoldier.java
@@ -34,7 +34,7 @@ public final class BattalionFootSoldier extends CardImpl {
 
         // When Battalion Foot Soldier enters the battlefield, you may search your library for any number of cards named Battalion Foot Soldier, reveal them, put them into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(0, Integer.MAX_VALUE, filter), true, true
+                new TargetCardInLibrary(0, Integer.MAX_VALUE, filter), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BeginTheInvasion.java
+++ b/Mage.Sets/src/mage/cards/b/BeginTheInvasion.java
@@ -62,7 +62,7 @@ class BeginTheInvasionEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         int xValue = source.getManaCostsToPay().getX();
         return new SearchLibraryPutInPlayEffect(
-                new TargetCardWithDifferentNameInLibrary(0, xValue, filter), false, true
+                new TargetCardWithDifferentNameInLibrary(0, xValue, filter), false
         ).apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/b/BeholdTheBeyond.java
+++ b/Mage.Sets/src/mage/cards/b/BeholdTheBeyond.java
@@ -23,7 +23,7 @@ public final class BeholdTheBeyond extends CardImpl {
         // Discard your hand. Search your library for three cards and put those cards into your hand. Then shuffle your library.
         this.getSpellAbility().addEffect(new DiscardHandControllerEffect());
         TargetCardInLibrary target = new TargetCardInLibrary(0, 3, new FilterCard("cards"));
-        Effect effect = new SearchLibraryPutInHandEffect(target);
+        Effect effect = new SearchLibraryPutInHandEffect(target, false);
         effect.setText("Search your library for three cards, put those cards into your hand, then shuffle");
         this.getSpellAbility().addEffect(effect);
     }

--- a/Mage.Sets/src/mage/cards/b/BeneathTheSands.java
+++ b/Mage.Sets/src/mage/cards/b/BeneathTheSands.java
@@ -22,7 +22,7 @@ public final class BeneathTheSands extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{G}");
 
         // Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true));
 
         // Cycling {2}
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{2}")));

--- a/Mage.Sets/src/mage/cards/b/BeseechTheQueen.java
+++ b/Mage.Sets/src/mage/cards/b/BeseechTheQueen.java
@@ -27,7 +27,7 @@ public final class BeseechTheQueen extends CardImpl {
 
         // <i>({2B} can be paid with any two mana or with {B}. This card's converted mana cost is 6.)</i>
         // Search your library for a card with converted mana cost less than or equal to the number of lands you control, reveal it, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true));
     }
 
     private BeseechTheQueen(final BeseechTheQueen card) {

--- a/Mage.Sets/src/mage/cards/b/BibFortuna.java
+++ b/Mage.Sets/src/mage/cards/b/BibFortuna.java
@@ -30,7 +30,7 @@ public final class BibFortuna extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Bib Fortuna enters the battlefield search your library for a card then shuffle your library and put in on top. You lose 1 life.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary()), false);
+        Ability ability = new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(), false), false);
         ability.addEffect(new LoseLifeSourceControllerEffect(1));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/b/BitterthornNissasAnimus.java
+++ b/Mage.Sets/src/mage/cards/b/BitterthornNissasAnimus.java
@@ -35,7 +35,7 @@ public final class BitterthornNissasAnimus extends CardImpl {
 
         // Whenever equipped creature attacks, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle.
         this.addAbility(new AttacksAttachedTriggeredAbility(new SearchLibraryPutInPlayEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND_A), true, true
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND_A), true
         ), true));
 
         // Equip {3}

--- a/Mage.Sets/src/mage/cards/b/BlightedWoodland.java
+++ b/Mage.Sets/src/mage/cards/b/BlightedWoodland.java
@@ -31,7 +31,7 @@ public final class BlightedWoodland extends CardImpl {
 
         // {3}{G}, {T}, Sacrifice Blighted Woodland: Search your library for up to two basic land cards and put them onto the battlefield tapped. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS), true, true),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS), true),
                 new ManaCostsImpl<>("{3}{G}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());

--- a/Mage.Sets/src/mage/cards/b/BloodSpeaker.java
+++ b/Mage.Sets/src/mage/cards/b/BloodSpeaker.java
@@ -43,7 +43,7 @@ public final class BloodSpeaker extends CardImpl {
         // At the beginning of your upkeep, you may sacrifice Blood Speaker. If you do, search your library for a Demon card, reveal that card, and put it into your hand. Then shuffle your library.
         Ability ability = new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD,
                 new DoIfCostPaid(
-                        new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filterCard), true, true, "search your library for "),
+                        new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filterCard), true),
                         new SacrificeSourceCost()
                 ),
                 TargetController.YOU,

--- a/Mage.Sets/src/mage/cards/b/BloodSpeaker.java
+++ b/Mage.Sets/src/mage/cards/b/BloodSpeaker.java
@@ -43,7 +43,7 @@ public final class BloodSpeaker extends CardImpl {
         // At the beginning of your upkeep, you may sacrifice Blood Speaker. If you do, search your library for a Demon card, reveal that card, and put it into your hand. Then shuffle your library.
         Ability ability = new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD,
                 new DoIfCostPaid(
-                        new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filterCard), true),
+                        new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filterCard), true, true),
                         new SacrificeSourceCost()
                 ),
                 TargetController.YOU,

--- a/Mage.Sets/src/mage/cards/b/BogbrewWitch.java
+++ b/Mage.Sets/src/mage/cards/b/BogbrewWitch.java
@@ -11,7 +11,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
@@ -40,7 +39,7 @@ public final class BogbrewWitch extends CardImpl {
         // {2}, {T}: Search your library for a card named Festering Newt or Bubbling Cauldron, put it onto the battlefield tapped, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(1, 1, new FilterCard(filter));
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInPlayEffect(target, true, true, Outcome.PutCardInPlay),
+                new SearchLibraryPutInPlayEffect(target, true, true),
                 new ManaCostsImpl<>("{2}"));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/b/BogbrewWitch.java
+++ b/Mage.Sets/src/mage/cards/b/BogbrewWitch.java
@@ -39,7 +39,7 @@ public final class BogbrewWitch extends CardImpl {
         // {2}, {T}: Search your library for a card named Festering Newt or Bubbling Cauldron, put it onto the battlefield tapped, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(1, 1, new FilterCard(filter));
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInPlayEffect(target, true, true),
+                new SearchLibraryPutInPlayEffect(target, true),
                 new ManaCostsImpl<>("{2}"));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/b/BoggartHarbinger.java
+++ b/Mage.Sets/src/mage/cards/b/BoggartHarbinger.java
@@ -34,7 +34,7 @@ public final class BoggartHarbinger extends CardImpl {
         // When Boggart Harbinger enters the battlefield, you may search your library for a Goblin card, reveal it,
         // then shuffle your library and put that card on top of it.
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(target, true, true),true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(target, true),true));
     }
 
     private BoggartHarbinger(final BoggartHarbinger card) {

--- a/Mage.Sets/src/mage/cards/b/BorderlandRanger.java
+++ b/Mage.Sets/src/mage/cards/b/BorderlandRanger.java
@@ -27,7 +27,7 @@ public final class BorderlandRanger extends CardImpl {
         this.toughness = new MageInt(2);
 
         // When Borderland Ranger enters the battlefield, you may search your library for a basic land card, reveal it, and put it into your hand. If you do, shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), true));
     }
 
     private BorderlandRanger(final BorderlandRanger card) {

--- a/Mage.Sets/src/mage/cards/b/BoseijuReachesSkyward.java
+++ b/Mage.Sets/src/mage/cards/b/BoseijuReachesSkyward.java
@@ -45,7 +45,7 @@ public final class BoseijuReachesSkyward extends CardImpl {
                 this, SagaChapter.CHAPTER_I,
                 new SearchLibraryPutInHandEffect(new TargetCardInLibrary(
                         0, 2, filter
-                ), true, true)
+                ), true)
         );
 
         // II — Put up to one target land card from your graveyard on top of your library.

--- a/Mage.Sets/src/mage/cards/b/Bossk.java
+++ b/Mage.Sets/src/mage/cards/b/Bossk.java
@@ -44,7 +44,7 @@ public final class Bossk extends CardImpl {
         this.addAbility(new BosskTriggeredAbility());
 
         // <i>Bounty</i> &mdash; Whenever a creature an opponent controls with a bounty counter on it dies, you may search your library for a basic land card, reveal it, and put it in to your hand. If you do, shuffle your library.
-        this.addAbility(new BountyAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), true));
+        this.addAbility(new BountyAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), true));
     }
 
     private Bossk(final Bossk card) {

--- a/Mage.Sets/src/mage/cards/b/BraidwoodSextant.java
+++ b/Mage.Sets/src/mage/cards/b/BraidwoodSextant.java
@@ -27,7 +27,7 @@ public final class BraidwoodSextant extends CardImpl {
 
         // {2}, {tap}, Sacrifice Braidwood Sextant: Search your library for a basic land card, reveal that card, and put it into your hand. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, 
-            new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
+            new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true),
             new ManaCostsImpl<>("{2}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());

--- a/Mage.Sets/src/mage/cards/b/BraidwoodSextant.java
+++ b/Mage.Sets/src/mage/cards/b/BraidwoodSextant.java
@@ -27,7 +27,7 @@ public final class BraidwoodSextant extends CardImpl {
 
         // {2}, {tap}, Sacrifice Braidwood Sextant: Search your library for a basic land card, reveal that card, and put it into your hand. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, 
-            new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true),
+            new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
             new ManaCostsImpl<>("{2}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());

--- a/Mage.Sets/src/mage/cards/b/BringerOfTheBlackDawn.java
+++ b/Mage.Sets/src/mage/cards/b/BringerOfTheBlackDawn.java
@@ -37,7 +37,7 @@ public final class BringerOfTheBlackDawn extends CardImpl {
         // Trample
         this.addAbility(TrampleAbility.getInstance());
         // At the beginning of your upkeep, you may pay 2 life. If you do, search your library for a card, then shuffle your library and put that card on top of it.
-        Ability ability = new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, new DoIfCostPaid(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary()), new PayLifeCost(2)), TargetController.YOU, false);
+        Ability ability = new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, new DoIfCostPaid(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(), false), new PayLifeCost(2)), TargetController.YOU, false);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrokersHideout.java
+++ b/Mage.Sets/src/mage/cards/b/BrokersHideout.java
@@ -39,7 +39,7 @@ public final class BrokersHideout extends CardImpl {
 
         // When Brokers Hideout enters the battlefield, sacrifice it. When you do, search your library for a basic Forest, Plains, or Island card, put it onto the battlefield tapped, then shuffle and you gain 1 life.
         ReflexiveTriggeredAbility ability = new ReflexiveTriggeredAbility(new SearchLibraryPutInPlayEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), false);
         ability.addEffect(new GainLifeEffect(1).concatBy("and"));
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoWhenCostPaid(

--- a/Mage.Sets/src/mage/cards/b/BrutalizerExarch.java
+++ b/Mage.Sets/src/mage/cards/b/BrutalizerExarch.java
@@ -45,7 +45,7 @@ public final class BrutalizerExarch extends CardImpl {
         // When Brutalizer Exarch enters the battlefield, choose one
         // - Search your library for a creature card, reveal it, then shuffle your library and put that card on top of it;
         TargetCardInLibrary target = new TargetCardInLibrary(new FilterCreatureCard("a creature card"));
-        Ability ability = new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(target, true, true), false);
+        Ability ability = new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(target, true), false);
         // or put target noncreature permanent on the bottom of its owner's library.
         Mode mode = new Mode(new BrutalizerExarchEffect2());
         mode.addTarget(new TargetPermanent(filter));

--- a/Mage.Sets/src/mage/cards/b/BurnishedHart.java
+++ b/Mage.Sets/src/mage/cards/b/BurnishedHart.java
@@ -33,7 +33,7 @@ public final class BurnishedHart extends CardImpl {
         // {3}, Sacrifice Burnished Hart: Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.
         Ability ability = new SimpleActivatedAbility(
                 Zone.BATTLEFIELD,
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0,2, StaticFilters.FILTER_CARD_BASIC_LANDS), true, true),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0,2, StaticFilters.FILTER_CARD_BASIC_LANDS), true),
                 new GenericManaCost(3));
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/c/CabarettiCourtyard.java
+++ b/Mage.Sets/src/mage/cards/c/CabarettiCourtyard.java
@@ -38,7 +38,7 @@ public final class CabarettiCourtyard extends CardImpl {
 
         // When Cabaretti Courtyard enters the battlefield, sacrifice it. When you do, search your library for a basic Mountain, Forest, or Plains card, put it onto the battlefield tapped, then shuffle and you gain 1 life.
         ReflexiveTriggeredAbility ability = new ReflexiveTriggeredAbility(new SearchLibraryPutInPlayEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), false);
         ability.addEffect(new GainLifeEffect(1).concatBy("and"));
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoWhenCostPaid(

--- a/Mage.Sets/src/mage/cards/c/CampusGuide.java
+++ b/Mage.Sets/src/mage/cards/c/CampusGuide.java
@@ -26,7 +26,7 @@ public final class CampusGuide extends CardImpl {
 
         // When Campus Guide enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/c/CaptainPhasma.java
+++ b/Mage.Sets/src/mage/cards/c/CaptainPhasma.java
@@ -51,7 +51,7 @@ public final class CaptainPhasma extends CardImpl {
                 new GainAbilityControlledEffect(ability, Duration.WhileOnBattlefield, filter, false)));
 
         // {W}{U}{B}{R}{G}: Search your library for a Trooper creature card, reveal it, put it into your hand, then shuffle your library.
-        this.addAbility(new SimpleActivatedAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filterCard), true, true), new ManaCostsImpl<>("{W}{U}{B}{R}{G}")));
+        this.addAbility(new SimpleActivatedAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filterCard), true), new ManaCostsImpl<>("{W}{U}{B}{R}{G}")));
     }
 
     private CaptainPhasma(final CaptainPhasma card) {

--- a/Mage.Sets/src/mage/cards/c/CaptainSisay.java
+++ b/Mage.Sets/src/mage/cards/c/CaptainSisay.java
@@ -37,7 +37,7 @@ public final class CaptainSisay extends CardImpl {
         this.toughness = new MageInt(2);
 
         // {tap}: Search your library for a legendary card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true), new TapSourceCost()));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true), new TapSourceCost()));
     }
 
     private CaptainSisay(final CaptainSisay card) {

--- a/Mage.Sets/src/mage/cards/c/CaptainSisay.java
+++ b/Mage.Sets/src/mage/cards/c/CaptainSisay.java
@@ -37,7 +37,7 @@ public final class CaptainSisay extends CardImpl {
         this.toughness = new MageInt(2);
 
         // {tap}: Search your library for a legendary card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true), new TapSourceCost()));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true), new TapSourceCost()));
     }
 
     private CaptainSisay(final CaptainSisay card) {

--- a/Mage.Sets/src/mage/cards/c/CateranSummons.java
+++ b/Mage.Sets/src/mage/cards/c/CateranSummons.java
@@ -28,7 +28,7 @@ public final class CateranSummons extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{B}");
 
         // Search your library for a Mercenary card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true));
     }
 
     private CateranSummons(final CateranSummons card) {

--- a/Mage.Sets/src/mage/cards/c/CentaurRootcaster.java
+++ b/Mage.Sets/src/mage/cards/c/CentaurRootcaster.java
@@ -28,7 +28,7 @@ public final class CentaurRootcaster extends CardImpl {
 
         // Whenever Centaur Rootcaster deals combat damage to a player, you may search your library for a basic land card and put that card onto the battlefield tapped. If you do, shuffle your library.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true),
                 true));
     }
 

--- a/Mage.Sets/src/mage/cards/c/CentaurRootcaster.java
+++ b/Mage.Sets/src/mage/cards/c/CentaurRootcaster.java
@@ -28,7 +28,7 @@ public final class CentaurRootcaster extends CardImpl {
 
         // Whenever Centaur Rootcaster deals combat damage to a player, you may search your library for a basic land card and put that card onto the battlefield tapped. If you do, shuffle your library.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
                 true));
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConduitOfRuin.java
+++ b/Mage.Sets/src/mage/cards/c/ConduitOfRuin.java
@@ -52,7 +52,7 @@ public final class ConduitOfRuin extends CardImpl {
 
         // When you cast Conduit of Ruin, you may search your library for a colorless creature card with converted mana cost 7 or greater, then shuffle your library and put that card on top of it.
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        this.addAbility(new CastSourceTriggeredAbility(new SearchLibraryPutOnLibraryEffect(target, true, true), true));
+        this.addAbility(new CastSourceTriggeredAbility(new SearchLibraryPutOnLibraryEffect(target, true), true));
 
         // The first creature spell you cast each turn costs {2} less to cast.
         Effect effect = new SpellsCostReductionControllerEffect(filterCost, 2);

--- a/Mage.Sets/src/mage/cards/c/Conflux.java
+++ b/Mage.Sets/src/mage/cards/c/Conflux.java
@@ -23,7 +23,7 @@ public final class Conflux extends CardImpl {
 
         // Search your library for a white card, a blue card, a black card, a red card, and a green card. Reveal those cards and put them into your hand. Then shuffle your library.
         this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(
-                new ConfluxTarget(), true, true
+                new ConfluxTarget(), true
         ).setText("search your library for a white card, a blue card, a black card, a red card, and a green card. " +
                 "Reveal those cards, put them into your hand, then shuffle"));
     }

--- a/Mage.Sets/src/mage/cards/c/CovetedPrize.java
+++ b/Mage.Sets/src/mage/cards/c/CovetedPrize.java
@@ -39,7 +39,7 @@ public final class CovetedPrize extends CardImpl {
         ).addHint(PartyCountHint.instance).setRuleAtTheTop(true));
 
         // Search your library for a card, put it into your hand, then shuffle your library. If you have a full party, you may cast a spell with converted mana cost 4 or less from your hand without paying its mana cost.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary()));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
                 new CastFromHandForFreeEffect(filter),
                 FullPartyCondition.instance, "If you have a full party, " +

--- a/Mage.Sets/src/mage/cards/c/CropRotation.java
+++ b/Mage.Sets/src/mage/cards/c/CropRotation.java
@@ -26,7 +26,7 @@ public final class CropRotation extends CardImpl {
         this.getSpellAbility().addCost(new SacrificeTargetCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)));
 
         // Search your library for a land card and put that card onto the battlefield. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterLandCard()), false));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterLandCard()), false, true));
     }
 
     private CropRotation(final CropRotation card) {

--- a/Mage.Sets/src/mage/cards/c/CropRotation.java
+++ b/Mage.Sets/src/mage/cards/c/CropRotation.java
@@ -7,7 +7,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterLandCard;
 import mage.target.common.TargetCardInLibrary;
@@ -27,7 +26,7 @@ public final class CropRotation extends CardImpl {
         this.getSpellAbility().addCost(new SacrificeTargetCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)));
 
         // Search your library for a land card and put that card onto the battlefield. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterLandCard()), false, Outcome.PutLandInPlay));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterLandCard()), false));
     }
 
     private CropRotation(final CropRotation card) {

--- a/Mage.Sets/src/mage/cards/c/CruelTutor.java
+++ b/Mage.Sets/src/mage/cards/c/CruelTutor.java
@@ -21,7 +21,7 @@ public final class CruelTutor extends CardImpl {
 
         // Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.
         TargetCardInLibrary target = new TargetCardInLibrary();
-        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(target, false, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(target, false));
         this.getSpellAbility().addEffect(new LoseLifeSourceControllerEffect(2));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkPetition.java
+++ b/Mage.Sets/src/mage/cards/d/DarkPetition.java
@@ -23,7 +23,7 @@ public final class DarkPetition extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{3}{B}{B}");
 
         // Search your library for a card and put that card into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true));
 
         // <i>Spell mastery</i> &mdash; If there are two or more instant and/or sorcery cards in your graveyard, add {B}{B}{B}.
         Effect effect = new ConditionalOneShotEffect(new AddManaToManaPoolSourceControllerEffect(Mana.BlackMana(3)),

--- a/Mage.Sets/src/mage/cards/d/DarkPetition.java
+++ b/Mage.Sets/src/mage/cards/d/DarkPetition.java
@@ -23,7 +23,7 @@ public final class DarkPetition extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{3}{B}{B}");
 
         // Search your library for a card and put that card into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary()));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
 
         // <i>Spell mastery</i> &mdash; If there are two or more instant and/or sorcery cards in your graveyard, add {B}{B}{B}.
         Effect effect = new ConditionalOneShotEffect(new AddManaToManaPoolSourceControllerEffect(Mana.BlackMana(3)),

--- a/Mage.Sets/src/mage/cards/d/DaruCavalier.java
+++ b/Mage.Sets/src/mage/cards/d/DaruCavalier.java
@@ -39,7 +39,7 @@ public final class DaruCavalier extends CardImpl {
         
         // When Daru Cavalier enters the battlefield, you may search your library for a card named Daru Cavalier, reveal it, and put it into your hand. If you do, shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(0, 1, filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
     }
 
     private DaruCavalier(final DaruCavalier card) {

--- a/Mage.Sets/src/mage/cards/d/DeadeyeQuartermaster.java
+++ b/Mage.Sets/src/mage/cards/d/DeadeyeQuartermaster.java
@@ -38,7 +38,7 @@ public final class DeadeyeQuartermaster extends CardImpl {
 
         // When Deadeye Quartermaster enters the battlefield, you may search your library for an Equipment or a Vehicle card and put it into your hand. If you do, shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(1, 1, filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
     }
 
     private DeadeyeQuartermaster(final DeadeyeQuartermaster card) {

--- a/Mage.Sets/src/mage/cards/d/DeepGnomeTerramancer.java
+++ b/Mage.Sets/src/mage/cards/d/DeepGnomeTerramancer.java
@@ -56,7 +56,7 @@ class DeepGnomeTerramancerTriggeredAbility extends TriggeredAbilityImpl {
         FilterCard filter = new FilterCard("Plains card");
         filter.add(SubType.PLAINS.getPredicate());
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        addEffect(new SearchLibraryPutInPlayEffect(target, true, true));
+        addEffect(new SearchLibraryPutInPlayEffect(target, true));
     }
 
     DeepGnomeTerramancerTriggeredAbility(DeepGnomeTerramancerTriggeredAbility ability) {

--- a/Mage.Sets/src/mage/cards/d/DeepGnomeTerramancer.java
+++ b/Mage.Sets/src/mage/cards/d/DeepGnomeTerramancer.java
@@ -7,7 +7,6 @@ import mage.abilities.TriggeredAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
@@ -57,7 +56,7 @@ class DeepGnomeTerramancerTriggeredAbility extends TriggeredAbilityImpl {
         FilterCard filter = new FilterCard("Plains card");
         filter.add(SubType.PLAINS.getPredicate());
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        addEffect(new SearchLibraryPutInPlayEffect(target, true, true, Outcome.PutLandInPlay));
+        addEffect(new SearchLibraryPutInPlayEffect(target, true, true));
     }
 
     DeepGnomeTerramancerTriggeredAbility(DeepGnomeTerramancerTriggeredAbility ability) {

--- a/Mage.Sets/src/mage/cards/d/DeepReconnaissance.java
+++ b/Mage.Sets/src/mage/cards/d/DeepReconnaissance.java
@@ -7,7 +7,6 @@ import mage.abilities.keyword.FlashbackAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TimingRule;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCardInLibrary;
 
@@ -24,7 +23,7 @@ public final class DeepReconnaissance extends CardImpl {
 
 
         // Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true));
         // Flashback {4}{G}
         this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{4}{G}")));
     }

--- a/Mage.Sets/src/mage/cards/d/DeepReconnaissance.java
+++ b/Mage.Sets/src/mage/cards/d/DeepReconnaissance.java
@@ -23,7 +23,7 @@ public final class DeepReconnaissance extends CardImpl {
 
 
         // Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true));
         // Flashback {4}{G}
         this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{4}{G}")));
     }

--- a/Mage.Sets/src/mage/cards/d/DefenseOfTheHeart.java
+++ b/Mage.Sets/src/mage/cards/d/DefenseOfTheHeart.java
@@ -12,7 +12,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
@@ -30,7 +29,7 @@ public final class DefenseOfTheHeart extends CardImpl {
 
         // At the beginning of your upkeep, if an opponent controls three or more creatures, sacrifice Defense of the Heart, search your library for up to two creature cards, and put those cards onto the battlefield. Then shuffle your library.
         TriggeredAbility ability = new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, new SacrificeSourceEffect(), TargetController.YOU, false);
-        ability.addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_CREATURE), false, Outcome.PutLandInPlay));
+        ability.addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_CREATURE), false));
         DefenseOfTheHeartCondition contition = new DefenseOfTheHeartCondition();
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, contition, "At the beginning of your upkeep, if an opponent controls three or more creatures, sacrifice {this}, search your library for up to two creature cards, put those cards onto the battlefield, then shuffle"));
 

--- a/Mage.Sets/src/mage/cards/d/DemolitionField.java
+++ b/Mage.Sets/src/mage/cards/d/DemolitionField.java
@@ -54,7 +54,7 @@ public final class DemolitionField extends CardImpl {
         ));
         ability.addEffect(new SearchLibraryPutInPlayEffect(
                 new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND_A),
-                false, true, true, Outcome.PutLandInPlay
+                false, true, true
         ));
         ability.addTarget(new TargetLandPermanent(filter));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/d/DemolitionField.java
+++ b/Mage.Sets/src/mage/cards/d/DemolitionField.java
@@ -54,7 +54,7 @@ public final class DemolitionField extends CardImpl {
         ));
         ability.addEffect(new SearchLibraryPutInPlayEffect(
                 new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND_A),
-                false, true, true
+                false, true
         ));
         ability.addTarget(new TargetLandPermanent(filter));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/d/DemolitionField.java
+++ b/Mage.Sets/src/mage/cards/d/DemolitionField.java
@@ -54,7 +54,7 @@ public final class DemolitionField extends CardImpl {
         ));
         ability.addEffect(new SearchLibraryPutInPlayEffect(
                 new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND_A),
-                false, true
+                false, false, true
         ));
         ability.addTarget(new TargetLandPermanent(filter));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/d/DemonicCollusion.java
+++ b/Mage.Sets/src/mage/cards/d/DemonicCollusion.java
@@ -26,7 +26,7 @@ public final class DemonicCollusion extends CardImpl {
         this.addAbility(new BuybackAbility(new DiscardTargetCost(new TargetCardInHand(2, StaticFilters.FILTER_CARD_CARDS))));
 
         // Search your library for a card and put that card into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(),false));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(),false, true));
     }
 
     private DemonicCollusion(final DemonicCollusion card) {

--- a/Mage.Sets/src/mage/cards/d/DemonicTutor.java
+++ b/Mage.Sets/src/mage/cards/d/DemonicTutor.java
@@ -17,7 +17,7 @@ public final class DemonicTutor extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{B}");
 
         // Search your library for a card and put that card into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true));
     }
 
     private DemonicTutor(final DemonicTutor card) {

--- a/Mage.Sets/src/mage/cards/d/DemonicTutor.java
+++ b/Mage.Sets/src/mage/cards/d/DemonicTutor.java
@@ -17,7 +17,7 @@ public final class DemonicTutor extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{B}");
 
         // Search your library for a card and put that card into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary()));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
     }
 
     private DemonicTutor(final DemonicTutor card) {

--- a/Mage.Sets/src/mage/cards/d/DiabolicIntent.java
+++ b/Mage.Sets/src/mage/cards/d/DiabolicIntent.java
@@ -24,7 +24,7 @@ public final class DiabolicIntent extends CardImpl {
         this.getSpellAbility().addCost(new SacrificeTargetCost(new TargetControlledCreaturePermanent(FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
 
         // Search your library for a card and put that card into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary()));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
     }
 
     private DiabolicIntent(final DiabolicIntent card) {

--- a/Mage.Sets/src/mage/cards/d/DiabolicIntent.java
+++ b/Mage.Sets/src/mage/cards/d/DiabolicIntent.java
@@ -24,7 +24,7 @@ public final class DiabolicIntent extends CardImpl {
         this.getSpellAbility().addCost(new SacrificeTargetCost(new TargetControlledCreaturePermanent(FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
 
         // Search your library for a card and put that card into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true));
     }
 
     private DiabolicIntent(final DiabolicIntent card) {

--- a/Mage.Sets/src/mage/cards/d/DiabolicTutor.java
+++ b/Mage.Sets/src/mage/cards/d/DiabolicTutor.java
@@ -19,7 +19,7 @@ public final class DiabolicTutor extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{B}{B}");
 
         TargetCardInLibrary target = new TargetCardInLibrary();
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(target, false));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(target, false, true));
     }
 
     private DiabolicTutor(final DiabolicTutor card) {

--- a/Mage.Sets/src/mage/cards/d/DiabolicTutor.java
+++ b/Mage.Sets/src/mage/cards/d/DiabolicTutor.java
@@ -19,7 +19,7 @@ public final class DiabolicTutor extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{B}{B}");
 
         TargetCardInLibrary target = new TargetCardInLibrary();
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(target));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(target, false));
     }
 
     private DiabolicTutor(final DiabolicTutor card) {

--- a/Mage.Sets/src/mage/cards/d/DigUp.java
+++ b/Mage.Sets/src/mage/cards/d/DigUp.java
@@ -19,7 +19,7 @@ public final class DigUp extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{G}");
 
         // Cleave {1}{B}{B}{G}
-        this.addAbility(new CleaveAbility(this, new SearchLibraryPutInHandEffect(new TargetCardInLibrary()), "{1}{B}{B}{G}"));
+        this.addAbility(new CleaveAbility(this, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false), "{1}{B}{B}{G}"));
 
         // Search your library for a [basic land] card, [reveal it,] put it into your hand, then shuffle.
         this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(

--- a/Mage.Sets/src/mage/cards/d/DiligentFarmhand.java
+++ b/Mage.Sets/src/mage/cards/d/DiligentFarmhand.java
@@ -31,7 +31,7 @@ public final class DiligentFarmhand extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {1}{G}, Sacrifice Diligent Farmhand: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), new ManaCostsImpl<>("{1}{G}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), new ManaCostsImpl<>("{1}{G}"));
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);
         // If Diligent Farmhand is in a graveyard, effects from spells named Muscle Burst count it as a card named Muscle Burst.

--- a/Mage.Sets/src/mage/cards/d/DiscipleOfDeceit.java
+++ b/Mage.Sets/src/mage/cards/d/DiscipleOfDeceit.java
@@ -87,7 +87,7 @@ class DiscipleOfDeceitEffect extends OneShotEffect {
                     String targetName = "card with mana value of " + card.getManaValue();
                     FilterCard filter = new FilterCard(targetName);
                     filter.add(new ManaValuePredicate(ComparisonType.EQUAL_TO, card.getManaValue()));
-                    return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true).apply(game, source);                    
+                    return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true).apply(game, source);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/d/DistrictGuide.java
+++ b/Mage.Sets/src/mage/cards/d/DistrictGuide.java
@@ -42,7 +42,7 @@ public final class DistrictGuide extends CardImpl {
         // When District Guide enters the battlefield, you may search your library for a basic land card or Gate card, reveal it, put it into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(
                 new SearchLibraryPutInHandEffect(
-                        new TargetCardInLibrary(filter), true, true
+                        new TargetCardInLibrary(filter), true
                 ), true
         ));
     }

--- a/Mage.Sets/src/mage/cards/d/DjeruWithEyesOpen.java
+++ b/Mage.Sets/src/mage/cards/d/DjeruWithEyesOpen.java
@@ -48,7 +48,7 @@ public final class DjeruWithEyesOpen extends CardImpl {
         this.addAbility(VigilanceAbility.getInstance());
 
         // When Djeru, With Eyes Open enters the battlefield, you may search your library for a planeswalker card, reveal it, put it into your hand, then shuffle your library.
-        Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 1, filter), true, true);
+        Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 1, filter), true);
         effect.setText("you may search your library for a planeswalker card, reveal it, put it into your hand, then shuffle");
         this.addAbility(new EntersBattlefieldTriggeredAbility(effect, true));
 

--- a/Mage.Sets/src/mage/cards/d/DoricNaturesWarden.java
+++ b/Mage.Sets/src/mage/cards/d/DoricNaturesWarden.java
@@ -45,7 +45,7 @@ public final class DoricNaturesWarden extends CardImpl {
 
         // When Doric, Nature's Warden enters the battlefield, search your library for a Forest card, put it into the battlefield tapped, then shuffle.
         this.addAbility(new EntersBattlefieldTriggeredAbility(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true, true)
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true)
         ));
 
         // Whenever Doric attacks, you may pay {1}{G}. If you do, transform her.

--- a/Mage.Sets/src/mage/cards/d/DraconicMuralists.java
+++ b/Mage.Sets/src/mage/cards/d/DraconicMuralists.java
@@ -33,7 +33,7 @@ public final class DraconicMuralists extends CardImpl {
 
         // When Draconic Muralists dies, you may search your library for a Dragon card, reveal it, put it into your hand, then shuffle.
         this.addAbility(new DiesSourceTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreamscapeArtist.java
+++ b/Mage.Sets/src/mage/cards/d/DreamscapeArtist.java
@@ -13,7 +13,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledLandPermanent;
@@ -39,7 +38,7 @@ public final class DreamscapeArtist extends CardImpl {
         TargetCardInLibrary target = new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS);
         Ability ability = new SimpleActivatedAbility(
                 Zone.BATTLEFIELD,
-                new SearchLibraryPutInPlayEffect(target, false, Outcome.PutLandInPlay),
+                new SearchLibraryPutInPlayEffect(target, false),
                 new ManaCostsImpl<>("{2}{U}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new DiscardCardCost());

--- a/Mage.Sets/src/mage/cards/d/DroidFactory.java
+++ b/Mage.Sets/src/mage/cards/d/DroidFactory.java
@@ -64,7 +64,7 @@ public final class DroidFactory extends CardImpl {
             filter.add(Predicates.or(subtypePredicates));
             filter.add(SuperType.BASIC.getPredicate());
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true, true));
+            addEffect(new SearchLibraryPutInPlayEffect(target, true));
         }
 
         @Override

--- a/Mage.Sets/src/mage/cards/d/DroidFactory.java
+++ b/Mage.Sets/src/mage/cards/d/DroidFactory.java
@@ -64,7 +64,7 @@ public final class DroidFactory extends CardImpl {
             filter.add(Predicates.or(subtypePredicates));
             filter.add(SuperType.BASIC.getPredicate());
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true, true, Outcome.PutLandInPlay));
+            addEffect(new SearchLibraryPutInPlayEffect(target, true, true));
         }
 
         @Override

--- a/Mage.Sets/src/mage/cards/d/DuneMover.java
+++ b/Mage.Sets/src/mage/cards/d/DuneMover.java
@@ -31,7 +31,7 @@ public final class DuneMover extends CardImpl {
 
         // When Dune Mover enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND_A), true, true
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND_A), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/e/EerieProcession.java
+++ b/Mage.Sets/src/mage/cards/e/EerieProcession.java
@@ -29,7 +29,7 @@ public final class EerieProcession extends CardImpl {
 
 
         // Search your library for an Arcane card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true));
     }
 
     private EerieProcession(final EerieProcession card) {

--- a/Mage.Sets/src/mage/cards/e/EladamrisCall.java
+++ b/Mage.Sets/src/mage/cards/e/EladamrisCall.java
@@ -25,7 +25,7 @@ public final class EladamrisCall extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{G}{W}");
 
         // Search your library for a creature card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true));
     }
 
     private EladamrisCall(final EladamrisCall card) {

--- a/Mage.Sets/src/mage/cards/e/EladamrisCall.java
+++ b/Mage.Sets/src/mage/cards/e/EladamrisCall.java
@@ -25,7 +25,7 @@ public final class EladamrisCall extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{G}{W}");
 
         // Search your library for a creature card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true));
     }
 
     private EladamrisCall(final EladamrisCall card) {

--- a/Mage.Sets/src/mage/cards/e/ElfhameSanctuary.java
+++ b/Mage.Sets/src/mage/cards/e/ElfhameSanctuary.java
@@ -28,7 +28,7 @@ public final class ElfhameSanctuary extends CardImpl {
 
         // At the beginning of your upkeep, you may search your library for a basic land card, reveal that card, and put it into your hand. If you do, you skip your draw step this turn and shuffle your library.
         Ability ability = new BeginningOfUpkeepTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true
         ), TargetController.YOU, true);
         ability.addEffect(new SkipDrawStepThisTurn());
 

--- a/Mage.Sets/src/mage/cards/e/ElvishHarbinger.java
+++ b/Mage.Sets/src/mage/cards/e/ElvishHarbinger.java
@@ -33,7 +33,7 @@ public final class ElvishHarbinger extends CardImpl {
         this.toughness = new MageInt(2);
 
         // When Elvish Harbinger enters the battlefield, you may search your library for an Elf card, reveal it, then shuffle your library and put that card on top of it.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true), true));
         // {tap}: Add one mana of any color.
         this.addAbility(new AnyColorManaAbility(new TapSourceCost()));
     }

--- a/Mage.Sets/src/mage/cards/e/EmbermageGoblin.java
+++ b/Mage.Sets/src/mage/cards/e/EmbermageGoblin.java
@@ -41,7 +41,7 @@ public final class EmbermageGoblin extends CardImpl {
 
         // When Embermage Goblin enters the battlefield, you may search your library for a card named Embermage Goblin, reveal it, and put it into your hand. If you do, shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(1, 1, filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
         
         // {tap}: Embermage Goblin deals 1 damage to any target.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(1), new TapSourceCost());

--- a/Mage.Sets/src/mage/cards/e/EnlightenedTutor.java
+++ b/Mage.Sets/src/mage/cards/e/EnlightenedTutor.java
@@ -28,7 +28,7 @@ public final class EnlightenedTutor extends CardImpl {
 
 
         // Search your library for an artifact or enchantment card and reveal that card. Shuffle your library, then put the card on top of it.
-        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true));
     }
 
     private EnlightenedTutor(final EnlightenedTutor card) {

--- a/Mage.Sets/src/mage/cards/e/EsperPanorama.java
+++ b/Mage.Sets/src/mage/cards/e/EsperPanorama.java
@@ -38,7 +38,7 @@ public final class EsperPanorama extends CardImpl {
 
         this.addAbility(new ColorlessManaAbility());
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true, Outcome.PutLandInPlay), new GenericManaCost(1));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/e/EverbarkShaman.java
+++ b/Mage.Sets/src/mage/cards/e/EverbarkShaman.java
@@ -11,7 +11,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
@@ -41,7 +40,7 @@ public final class EverbarkShaman extends CardImpl {
         this.toughness = new MageInt(5);
 
         // {T}, Exile a Treefolk card from your graveyard: Search your library for up to two Forest cards and put them onto the battlefield tapped. Then shuffle your library.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, filterForest), true, Outcome.PutLandInPlay), new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, filterForest), true), new TapSourceCost());
         ability.addCost(new ExileFromGraveCost(new TargetCardInYourGraveyard(filterTreefolk)));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/e/EverythingamajigE.java
+++ b/Mage.Sets/src/mage/cards/e/EverythingamajigE.java
@@ -92,7 +92,7 @@ class UrzasHotTubEffect extends OneShotEffect {
                 if (discardedCard != null) {
                     FilterCard filter = new FilterCard();
                     filter.add(new UrzasHotTubPredicate(discardedCard.getName()));
-                    return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true).apply(game, source);
+                    return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true).apply(game, source);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/e/EvolutionCharm.java
+++ b/Mage.Sets/src/mage/cards/e/EvolutionCharm.java
@@ -25,7 +25,7 @@ public final class EvolutionCharm extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{G}");
 
         // Choose one - Search your library for a basic land card, reveal it, put it into your hand, then shuffle your library;
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 1, StaticFilters.FILTER_CARD_BASIC_LAND), true, true).setText("Search your library for a basic land card, reveal it, put it into your hand, then shuffle"));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 1, StaticFilters.FILTER_CARD_BASIC_LAND), true).setText("Search your library for a basic land card, reveal it, put it into your hand, then shuffle"));
 
         // or return target creature card from your graveyard to your hand;
         Mode mode = new Mode(new ReturnFromGraveyardToHandTargetEffect());

--- a/Mage.Sets/src/mage/cards/e/ExplodingBorders.java
+++ b/Mage.Sets/src/mage/cards/e/ExplodingBorders.java
@@ -23,7 +23,7 @@ public final class ExplodingBorders extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{R}{G}");
 
         // Domain - Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library. Exploding Borders deals X damage to target player, where X is the number of basic land types among lands you control.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true));
         this.getSpellAbility().addEffect(new DamageTargetEffect(DomainValue.REGULAR));
         this.getSpellAbility().addTarget(new TargetPlayerOrPlaneswalker());
         this.getSpellAbility().addHint(DomainHint.instance);

--- a/Mage.Sets/src/mage/cards/f/FaerieHarbinger.java
+++ b/Mage.Sets/src/mage/cards/f/FaerieHarbinger.java
@@ -37,7 +37,7 @@ public final class FaerieHarbinger extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // When Faerie Harbinger enters the battlefield, you may search your library for a Faerie card, reveal it, then shuffle your library and put that card on top of it.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true), true));
     }
 
     private FaerieHarbinger(final FaerieHarbinger card) {

--- a/Mage.Sets/src/mage/cards/f/FarWanderings.java
+++ b/Mage.Sets/src/mage/cards/f/FarWanderings.java
@@ -26,8 +26,8 @@ public final class FarWanderings extends CardImpl {
         // Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library.
         // Threshold - If seven or more cards are in your graveyard, instead search your library for up to three basic land cards, put them onto the battlefield tapped, then shuffle your library.
         Effect effect = new ConditionalOneShotEffect(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 3, StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 1, StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 3, StaticFilters.FILTER_CARD_BASIC_LAND), true),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 1, StaticFilters.FILTER_CARD_BASIC_LAND), true),
                 new CardsInControllerGraveyardCondition(7),
                 "Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle.<br/><br/><i>Threshold</i> &mdash; If seven or more cards are in your graveyard, instead search your library for up to three basic land cards, put them onto the battlefield tapped, then shuffle.");
         this.getSpellAbility().addEffect(effect);

--- a/Mage.Sets/src/mage/cards/f/Farfinder.java
+++ b/Mage.Sets/src/mage/cards/f/Farfinder.java
@@ -30,7 +30,7 @@ public final class Farfinder extends CardImpl {
 
         // When Farfinder etners the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/f/FarhavenElf.java
+++ b/Mage.Sets/src/mage/cards/f/FarhavenElf.java
@@ -28,7 +28,7 @@ public final class FarhavenElf extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Farhaven Elf enters the battlefield, you may search your library for a basic land card and put it onto the battlefield tapped. If you do, shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), true));
     }
 
     private FarhavenElf(final FarhavenElf card) {

--- a/Mage.Sets/src/mage/cards/f/Farseek.java
+++ b/Mage.Sets/src/mage/cards/f/Farseek.java
@@ -6,7 +6,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicates;
@@ -33,7 +32,7 @@ public final class Farseek extends CardImpl {
 
 
         // Search your library for a Plains, Island, Swamp, or Mountain card and put it onto the battlefield tapped. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true, Outcome.PutLandInPlay));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true));
     }
 
     private Farseek(final Farseek card) {

--- a/Mage.Sets/src/mage/cards/f/Fertilid.java
+++ b/Mage.Sets/src/mage/cards/f/Fertilid.java
@@ -38,7 +38,7 @@ public final class Fertilid extends CardImpl {
         
         // {1}{G}, Remove a +1/+1 counter from Fertilid: Target player searches their library for a basic land card and puts it onto the battlefield tapped. Then that player shuffles their library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, 
-                new SearchLibraryPutInPlayTargetPlayerEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), new ManaCostsImpl<>("{1}{G}"));
+                new SearchLibraryPutInPlayTargetPlayerEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), new ManaCostsImpl<>("{1}{G}"));
         ability.addCost(new RemoveCountersSourceCost(CounterType.P1P1.createInstance(1)));
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/f/FertilidsFavor.java
+++ b/Mage.Sets/src/mage/cards/f/FertilidsFavor.java
@@ -24,7 +24,7 @@ public final class FertilidsFavor extends CardImpl {
 
         // Target player searches their library for a basic land card, puts it onto the battlefield tapped, then shuffles. Put two +1/+1 counters on up to one target artifact or creature.
         this.getSpellAbility().addEffect(new SearchLibraryPutInPlayTargetPlayerEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true
         ));
         this.getSpellAbility().addTarget(new TargetPlayer());
         this.getSpellAbility().addEffect(new AddCountersTargetEffect(CounterType.P1P1.createInstance(2))

--- a/Mage.Sets/src/mage/cards/f/FieldTrip.java
+++ b/Mage.Sets/src/mage/cards/f/FieldTrip.java
@@ -29,7 +29,7 @@ public final class FieldTrip extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{G}");
 
         // Search your library for a basic Forest card, put that card onto the battlefield tapped, then shuffle.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true, true));
 
         // Learn.
         this.getSpellAbility().addEffect(new LearnEffect().concatBy("<br>"));

--- a/Mage.Sets/src/mage/cards/f/FierceEmpath.java
+++ b/Mage.Sets/src/mage/cards/f/FierceEmpath.java
@@ -34,7 +34,7 @@ public final class FierceEmpath extends CardImpl {
 
         // When Fierce Empath enters the battlefield, you may search your library for a creature card with converted mana cost 6 or greater, reveal it, put it into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true)
+                new TargetCardInLibrary(filter), true)
                     .setText("search your library for a creature card with mana value 6 or greater, reveal it, put it into your hand, then shuffle"),
                 true));
     }

--- a/Mage.Sets/src/mage/cards/f/FlagstonesOfTrokair.java
+++ b/Mage.Sets/src/mage/cards/f/FlagstonesOfTrokair.java
@@ -32,7 +32,7 @@ public final class FlagstonesOfTrokair extends CardImpl {
         this.addAbility(new WhiteManaAbility());
 
         // When Flagstones of Trokair is put into a graveyard from the battlefield, you may search your library for a Plains card and put it onto the battlefield tapped. If you do, shuffle your library.
-        this.addAbility(new PutIntoGraveFromBattlefieldSourceTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(FILTER), true, true), true, false));
+        this.addAbility(new PutIntoGraveFromBattlefieldSourceTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(FILTER), true), true, false));
     }
 
     private FlagstonesOfTrokair(final FlagstonesOfTrokair card) {

--- a/Mage.Sets/src/mage/cards/f/FlamekinHarbinger.java
+++ b/Mage.Sets/src/mage/cards/f/FlamekinHarbinger.java
@@ -35,7 +35,7 @@ public final class FlamekinHarbinger extends CardImpl {
         // When Flamekin Harbinger enters the battlefield, you may search your library for an Elemental card,
         // reveal it, then shuffle your library and put that card on top of it.
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(target, true), true));
     }
 
     private FlamekinHarbinger(final FlamekinHarbinger card) {

--- a/Mage.Sets/src/mage/cards/f/FlowerFlourish.java
+++ b/Mage.Sets/src/mage/cards/f/FlowerFlourish.java
@@ -38,7 +38,7 @@ public final class FlowerFlourish extends SplitCard {
         // Search your library for a basic Forest or Plains card, reveal it, put it into your hand, then shuffle your library.
         this.getLeftHalfCard().getSpellAbility().addEffect(
                 new SearchLibraryPutInHandEffect(
-                        new TargetCardInLibrary(filter), true, true
+                        new TargetCardInLibrary(filter), true
                 )
         );
 

--- a/Mage.Sets/src/mage/cards/f/FontOfFertility.java
+++ b/Mage.Sets/src/mage/cards/f/FontOfFertility.java
@@ -27,7 +27,7 @@ public final class FontOfFertility extends CardImpl {
 
         // {1}{G}, Sacrifice Font of Fertility: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true, true), new ManaCostsImpl<>("{1}{G}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true), new ManaCostsImpl<>("{1}{G}"));
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/f/FontOfFertility.java
+++ b/Mage.Sets/src/mage/cards/f/FontOfFertility.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCardInLibrary;
@@ -28,7 +27,7 @@ public final class FontOfFertility extends CardImpl {
 
         // {1}{G}, Sacrifice Font of Fertility: Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true, true, Outcome.PutLandInPlay), new ManaCostsImpl<>("{1}{G}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true, true), new ManaCostsImpl<>("{1}{G}"));
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/f/ForerunnerOfTheCoalition.java
+++ b/Mage.Sets/src/mage/cards/f/ForerunnerOfTheCoalition.java
@@ -41,7 +41,7 @@ public final class ForerunnerOfTheCoalition extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(
                 new SearchLibraryPutOnLibraryEffect(
                         new TargetCardInLibrary(new FilterBySubtypeCard(SubType.PIRATE)),
-                        true, true), true));
+                        true), true));
 
         // Whenever another Pirate enters the battlefield under your control, each opponent loses 1 life.
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/f/ForerunnerOfTheEmpire.java
+++ b/Mage.Sets/src/mage/cards/f/ForerunnerOfTheEmpire.java
@@ -43,7 +43,6 @@ public final class ForerunnerOfTheEmpire extends CardImpl {
                 new EntersBattlefieldTriggeredAbility(
                         new SearchLibraryPutOnLibraryEffect(
                                 new TargetCardInLibrary(new FilterBySubtypeCard(SubType.DINOSAUR)),
-                                true,
                                 true
                         ),
                         true

--- a/Mage.Sets/src/mage/cards/f/ForerunnerOfTheHeralds.java
+++ b/Mage.Sets/src/mage/cards/f/ForerunnerOfTheHeralds.java
@@ -45,7 +45,6 @@ public final class ForerunnerOfTheHeralds extends CardImpl {
                 new EntersBattlefieldTriggeredAbility(
                         new SearchLibraryPutOnLibraryEffect(
                                 new TargetCardInLibrary(new FilterBySubtypeCard(SubType.MERFOLK)),
-                                true,
                                 true
                         ),
                 true

--- a/Mage.Sets/src/mage/cards/f/ForerunnerOfTheLegion.java
+++ b/Mage.Sets/src/mage/cards/f/ForerunnerOfTheLegion.java
@@ -42,7 +42,6 @@ public final class ForerunnerOfTheLegion extends CardImpl {
                 new EntersBattlefieldTriggeredAbility(
                         new SearchLibraryPutOnLibraryEffect(
                                 new TargetCardInLibrary(new FilterBySubtypeCard(SubType.VAMPIRE)),
-                                true,
                                 true
                         ),
                         true

--- a/Mage.Sets/src/mage/cards/f/FrenziedTilling.java
+++ b/Mage.Sets/src/mage/cards/f/FrenziedTilling.java
@@ -25,7 +25,7 @@ public final class FrenziedTilling extends CardImpl {
         // Destroy target land. Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
         this.getSpellAbility().addEffect(new DestroyTargetEffect());
         this.getSpellAbility().addTarget(new TargetLandPermanent());
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true));
     }
 
     private FrenziedTilling(final FrenziedTilling card) {

--- a/Mage.Sets/src/mage/cards/f/FromBeyond.java
+++ b/Mage.Sets/src/mage/cards/f/FromBeyond.java
@@ -43,7 +43,7 @@ public final class FromBeyond extends CardImpl {
 
         // {1}{G}, Sacrifice From Beyond: Search your library for an Eldrazi card, reveal it, put it into your hand, then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true),
                 new ManaCostsImpl<>("{1}{G}"));
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/f/FrostpyreArcanist.java
+++ b/Mage.Sets/src/mage/cards/f/FrostpyreArcanist.java
@@ -65,7 +65,7 @@ public final class FrostpyreArcanist extends CardImpl {
 
         // When Frostpyre Arcanist enters the battlefield, search your library for an instant or sorcery card with the same name as a card in your graveyard, reveal it, put it into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter2), true, true
+                new TargetCardInLibrary(filter2), true
         )));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GaeasBounty.java
+++ b/Mage.Sets/src/mage/cards/g/GaeasBounty.java
@@ -26,7 +26,7 @@ public final class GaeasBounty extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{G}");
 
         // Search your library for up to two Forest cards, reveal those cards, and put them into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 2, filter), false));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 2, filter), false, true));
     }
 
     private GaeasBounty(final GaeasBounty card) {

--- a/Mage.Sets/src/mage/cards/g/Gamble.java
+++ b/Mage.Sets/src/mage/cards/g/Gamble.java
@@ -21,7 +21,7 @@ public final class Gamble extends CardImpl {
 
 
         // Search your library for a card, put that card into your hand, discard a card at random, then shuffle your library.
-        Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true);
+        Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false);
         effect.setText("Search your library for a card, put that card into your hand");        
         this.getSpellAbility().addEffect(effect);
         effect = new DiscardControllerEffect(1, true);

--- a/Mage.Sets/src/mage/cards/g/GarrukTheVeilCursed.java
+++ b/Mage.Sets/src/mage/cards/g/GarrukTheVeilCursed.java
@@ -49,7 +49,7 @@ public final class GarrukTheVeilCursed extends CardImpl {
         this.addAbility(new LoyaltyAbility(new DoIfCostPaid(
                 new SearchLibraryPutInHandEffect(new TargetCardInLibrary(
                         StaticFilters.FILTER_CARD_CREATURE_A
-                ), true, true),
+                ), true),
                 null,
                 new SacrificeTargetCost(new TargetControlledPermanent(
                         StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT

--- a/Mage.Sets/src/mage/cards/g/GatecreeperVine.java
+++ b/Mage.Sets/src/mage/cards/g/GatecreeperVine.java
@@ -45,7 +45,7 @@ public final class GatecreeperVine extends CardImpl {
 
         // When Gatecreeper Vine enters the battlefield, you may search your library for a basic land card or a Gate card, reveal it, put it into your hand, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
     }
 
     private GatecreeperVine(final GatecreeperVine card) {

--- a/Mage.Sets/src/mage/cards/g/GatheringThrong.java
+++ b/Mage.Sets/src/mage/cards/g/GatheringThrong.java
@@ -34,7 +34,7 @@ public final class GatheringThrong extends CardImpl {
 
         // When Gathering Throng enters the battlefield, you may search your library for any number of cards named Gathering Throng, reveal them, put them into your hand, then shuffle.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(0, Integer.MAX_VALUE, filter), true, true
+                new TargetCardInLibrary(0, Integer.MAX_VALUE, filter), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GeneralTazri.java
+++ b/Mage.Sets/src/mage/cards/g/GeneralTazri.java
@@ -43,7 +43,7 @@ public final class GeneralTazri extends CardImpl {
 
         // When General Tazri enters the battlefield, you may search your library for an Ally creature card, reveal it, put it into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true), true));
+                new TargetCardInLibrary(filter), true), true));
         // {W}{U}{B}{R}{G}: Ally creatures you control get +X/+X until end of turn, where X is the number of colors among those creatures.
         DynamicValue xValue = new GeneralTazriColorCount();
         BoostControlledEffect effect = new BoostControlledEffect(xValue, xValue, Duration.EndOfTurn, new FilterCreaturePermanent(SubType.ALLY, "Ally creatures"), false);

--- a/Mage.Sets/src/mage/cards/g/GiantHarbinger.java
+++ b/Mage.Sets/src/mage/cards/g/GiantHarbinger.java
@@ -31,7 +31,7 @@ public final class GiantHarbinger extends CardImpl {
         this.toughness = new MageInt(4);
 
         // When Giant Harbinger enters the battlefield, you may search your library for a Giant card, reveal it, then shuffle your library and put that card on top of it.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true), true));
     }
 
     private GiantHarbinger(final GiantHarbinger card) {

--- a/Mage.Sets/src/mage/cards/g/GiantLadybug.java
+++ b/Mage.Sets/src/mage/cards/g/GiantLadybug.java
@@ -30,7 +30,7 @@ public final class GiantLadybug extends CardImpl {
 
         // When Giant Ladybug enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle and put that card on top.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND_A), true, true
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND_A), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinMatron.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinMatron.java
@@ -32,7 +32,7 @@ public final class GoblinMatron extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Goblin Matron enters the battlefield, you may search your library for a Goblin card, reveal that card, and put it into your hand. If you do, shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true), true));
     }
 
     private GoblinMatron(final GoblinMatron card) {

--- a/Mage.Sets/src/mage/cards/g/GodoBanditWarlord.java
+++ b/Mage.Sets/src/mage/cards/g/GodoBanditWarlord.java
@@ -44,7 +44,7 @@ public final class GodoBanditWarlord extends CardImpl {
         this.toughness = new MageInt(3);
 
         // When Godo, Bandit Warlord enters the battlefield, you may search your library for an Equipment card and put it onto the battlefield. If you do, shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false), true));
 
         // Whenever Godo attacks for the first time each turn, untap it and all Samurai you control. After this phase, there is an additional combat phase.
         Ability ability = new AttacksFirstTimeTriggeredAbility(new UntapSourceEffect().setText("untap it"), false);

--- a/Mage.Sets/src/mage/cards/g/GolosTirelessPilgrim.java
+++ b/Mage.Sets/src/mage/cards/g/GolosTirelessPilgrim.java
@@ -35,7 +35,7 @@ public final class GolosTirelessPilgrim extends CardImpl {
 
         // When Golos, Tireless Pilgrim enters the battlefield, you may search your library for a land card, put that card onto the battlefield tapped, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_LAND_A), true
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_LAND_A), true, true
         ), true));
 
         // {2}{W}{U}{B}{R}{G}: Exile the top three cards of your library. You may play them this turn without paying their mana costs.

--- a/Mage.Sets/src/mage/cards/g/Greenseeker.java
+++ b/Mage.Sets/src/mage/cards/g/Greenseeker.java
@@ -33,7 +33,7 @@ public final class Greenseeker extends CardImpl {
 
         // {G}, {tap}, Discard a card: Search your library for a basic land card, reveal it, and put it into your hand. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(1, 1, StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(1, 1, StaticFilters.FILTER_CARD_BASIC_LAND), true),
                 new ManaCostsImpl<>("{G}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new DiscardCardCost());

--- a/Mage.Sets/src/mage/cards/g/GrimTutor.java
+++ b/Mage.Sets/src/mage/cards/g/GrimTutor.java
@@ -18,7 +18,7 @@ public final class GrimTutor extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{B}{B}");
 
         // Search your library for a card and put that card into your hand, then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary()));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
 
         // You lose 3 life.
         this.getSpellAbility().addEffect(new LoseLifeSourceControllerEffect(3));

--- a/Mage.Sets/src/mage/cards/g/GrimTutor.java
+++ b/Mage.Sets/src/mage/cards/g/GrimTutor.java
@@ -18,7 +18,7 @@ public final class GrimTutor extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{B}{B}");
 
         // Search your library for a card and put that card into your hand, then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true));
 
         // You lose 3 life.
         this.getSpellAbility().addEffect(new LoseLifeSourceControllerEffect(3));

--- a/Mage.Sets/src/mage/cards/g/GrixisPanorama.java
+++ b/Mage.Sets/src/mage/cards/g/GrixisPanorama.java
@@ -38,7 +38,7 @@ public final class GrixisPanorama extends CardImpl {
 
         this.addAbility(new ColorlessManaAbility());
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true, Outcome.PutLandInPlay), new GenericManaCost(1));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/g/GrowFromTheAshes.java
+++ b/Mage.Sets/src/mage/cards/g/GrowFromTheAshes.java
@@ -26,8 +26,8 @@ public final class GrowFromTheAshes extends CardImpl {
 
         // Search you library for a basic land card, put it onto the battlefield, then shuffle your library. If this spell was kicked, instead search your library for two basic land cards, put them onto the battlefield, then shuffle your library.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LAND), false, true),
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 1, StaticFilters.FILTER_CARD_BASIC_LAND), false, true),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LAND), false),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 1, StaticFilters.FILTER_CARD_BASIC_LAND), false),
                 KickedCondition.ONCE,
                 "Search your library for a basic land card, put it onto the battlefield, then shuffle. If this spell was kicked, instead search your library for two basic land cards, put them onto the battlefield, then shuffle."));
     }

--- a/Mage.Sets/src/mage/cards/g/Grozoth.java
+++ b/Mage.Sets/src/mage/cards/g/Grozoth.java
@@ -42,7 +42,7 @@ public final class Grozoth extends CardImpl {
 
         // When Grozoth enters the battlefield, you may search your library for any number of cards that have converted mana cost 9, reveal them, and put them into your hand. If you do, shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(0, Integer.MAX_VALUE, filter), true, true
+                new TargetCardInLibrary(0, Integer.MAX_VALUE, filter), true
         ), true));
 
         // {4}: Grozoth loses defender until end of turn.

--- a/Mage.Sets/src/mage/cards/h/Harrow.java
+++ b/Mage.Sets/src/mage/cards/h/Harrow.java
@@ -6,7 +6,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetControlledPermanent;
@@ -26,7 +25,7 @@ public final class Harrow extends CardImpl {
 
         // Search your library for up to two basic land cards and put them onto the battlefield. Then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS);
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(target, false, Outcome.PutLandInPlay));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(target, false));
     }
 
     private Harrow(final Harrow card) {

--- a/Mage.Sets/src/mage/cards/h/HeliodsPilgrim.java
+++ b/Mage.Sets/src/mage/cards/h/HeliodsPilgrim.java
@@ -34,7 +34,7 @@ public final class HeliodsPilgrim extends CardImpl {
         this.toughness = new MageInt(2);
 
         // When Heliod's Pilgrim enters the battlefield, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true), true));
 
     }
 

--- a/Mage.Sets/src/mage/cards/h/HerdMigration.java
+++ b/Mage.Sets/src/mage/cards/h/HerdMigration.java
@@ -37,7 +37,7 @@ public final class HerdMigration extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 Zone.HAND,
                 new SearchLibraryPutInHandEffect(
-                        new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND_A), true, true
+                        new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND_A), true
                 ), new ManaCostsImpl<>("{1}{G}")
         );
         ability.addCost(new DiscardSourceCost());

--- a/Mage.Sets/src/mage/cards/h/HigureTheStillWind.java
+++ b/Mage.Sets/src/mage/cards/h/HigureTheStillWind.java
@@ -7,7 +7,6 @@ import mage.abilities.Ability;
 import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.combat.CantBeBlockedTargetEffect;
 import mage.abilities.effects.common.search.SearchLibraryPutInHandEffect;
 import mage.abilities.keyword.NinjutsuAbility;
@@ -49,7 +48,7 @@ public final class HigureTheStillWind extends CardImpl {
         this.addAbility(new NinjutsuAbility("{2}{U}{U}"));
 
         // Whenever Higure, the Still Wind deals combat damage to a player, you may search your library for a Ninja card, reveal it, and put it into your hand. If you do, shuffle your library.
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, false), true));
+        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true), true));
 
         // {2}: Target Ninja creature can't be blocked this turn.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new CantBeBlockedTargetEffect(), new GenericManaCost(2));

--- a/Mage.Sets/src/mage/cards/h/HiveheartShaman.java
+++ b/Mage.Sets/src/mage/cards/h/HiveheartShaman.java
@@ -52,7 +52,7 @@ public final class HiveheartShaman extends CardImpl {
 
         // Whenever Hiveheart Shaman attacks, you may search your library for a basic land card that doesn't share a land type with a land you control, put that card onto the battlefield, then shuffle.
         this.addAbility(new AttacksTriggeredAbility(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), true
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, true), true
         ));
 
         // {5}{G}: Create a 1/1 green Insect creature token. Put X +1/+1 counters on it, where X is the number of basic land types among lands you control. Activate only as a sorcery.

--- a/Mage.Sets/src/mage/cards/h/HowlingWolf.java
+++ b/Mage.Sets/src/mage/cards/h/HowlingWolf.java
@@ -33,7 +33,7 @@ public final class HowlingWolf extends CardImpl {
 
         // When Howling Wolf enters the battlefield, you may search your library for up to three cards named Howling Wolf, reveal them, and put them into your hand. If you do, shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(0, 3, filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
     }
 
     private HowlingWolf(final HowlingWolf card) {

--- a/Mage.Sets/src/mage/cards/h/HuntingCheetah.java
+++ b/Mage.Sets/src/mage/cards/h/HuntingCheetah.java
@@ -31,7 +31,7 @@ public final class HuntingCheetah extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever Hunting Cheetah deals damage to an opponent, you may search your library for a Forest card, reveal that card, put it into your hand, then shuffle your library.
-        this.addAbility(new DealsDamageToOpponentTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true), true));
+        this.addAbility(new DealsDamageToOpponentTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true), true));
     }
 
     private HuntingCheetah(final HuntingCheetah card) {

--- a/Mage.Sets/src/mage/cards/i/IllicitShipment.java
+++ b/Mage.Sets/src/mage/cards/i/IllicitShipment.java
@@ -21,7 +21,7 @@ public final class IllicitShipment extends CardImpl {
         this.addAbility(new CasualtyAbility(3));
 
         // Search your library for a card, put that card into your hand, then shuffle.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary()));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
     }
 
     private IllicitShipment(final IllicitShipment card) {

--- a/Mage.Sets/src/mage/cards/i/ImperialHellkite.java
+++ b/Mage.Sets/src/mage/cards/i/ImperialHellkite.java
@@ -35,7 +35,7 @@ public final class ImperialHellkite extends CardImpl {
         this.addAbility(new MorphAbility(new ManaCostsImpl<>("{6}{R}{R}")));
         
         // When Imperial Hellkite is turned face up, you may search your library for a Dragon card, reveal it, and put it into your hand. If you do, shuffle your library.
-        Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 1, new FilterBySubtypeCard(SubType.DRAGON)), true, true);
+        Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 1, new FilterBySubtypeCard(SubType.DRAGON)), true);
         effect.setText("you may search your library for a Dragon card, reveal it, and put it into your hand. If you do, shuffle");
         this.addAbility(new TurnedFaceUpSourceTriggeredAbility(effect));
     }

--- a/Mage.Sets/src/mage/cards/i/ImperialRecruiter.java
+++ b/Mage.Sets/src/mage/cards/i/ImperialRecruiter.java
@@ -35,7 +35,7 @@ public final class ImperialRecruiter extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Imperial Recruiter enters the battlefield, search your library for a creature card with power 2 or less, reveal it, and put it into your hand. Then shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true)));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true)));
     }
 
     private ImperialRecruiter(final ImperialRecruiter card) {

--- a/Mage.Sets/src/mage/cards/i/ImperialSeal.java
+++ b/Mage.Sets/src/mage/cards/i/ImperialSeal.java
@@ -20,7 +20,7 @@ public final class ImperialSeal extends CardImpl {
 
 
         // Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.
-        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary()));
+        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(), false));
         this.getSpellAbility().addEffect(new LoseLifeSourceControllerEffect(2));
     }
 

--- a/Mage.Sets/src/mage/cards/i/IncreasingAmbition.java
+++ b/Mage.Sets/src/mage/cards/i/IncreasingAmbition.java
@@ -9,7 +9,6 @@ import mage.abilities.keyword.FlashbackAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TimingRule;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.game.Game;
@@ -28,8 +27,8 @@ public final class IncreasingAmbition extends CardImpl {
 
         // Search your library for a card and put that card into your hand. If this spell was cast from a graveyard, instead search your library for two cards and put those cards into your hand. Then shuffle your library.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(2, StaticFilters.FILTER_CARD)),
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary()),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(2, StaticFilters.FILTER_CARD), false),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false),
                 IncreasingAmbitionCondition.instance, "Search your library for a card " +
                 "and put that card into your hand. If this spell was cast from a graveyard, " +
                 "instead search your library for two cards and put those cards into your hand. " +

--- a/Mage.Sets/src/mage/cards/i/InfectiousBloodlust.java
+++ b/Mage.Sets/src/mage/cards/i/InfectiousBloodlust.java
@@ -55,7 +55,7 @@ public final class InfectiousBloodlust extends CardImpl {
 
         // When enchanted creature dies, you may search your library for a card named Infectious Bloodlust, reveal it, put it into your hand, then shuffle your library.
         this.addAbility(new DiesAttachedTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), "enchanted creature", true));
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfernalTutor.java
+++ b/Mage.Sets/src/mage/cards/i/InfernalTutor.java
@@ -37,7 +37,7 @@ public final class InfernalTutor extends CardImpl {
         this.getSpellAbility().addEffect(new InfernalTutorEffect());
         // Hellbent - If you have no cards in hand, instead search your library for a card, put it into your hand, then shuffle your library.
         Effect effect = new ConditionalOneShotEffect(
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD), false, true),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD), false),
                 HellbentCondition.instance,
                 "<br/><br/><i>Hellbent</i> &mdash; If you have no cards in hand, instead search your library for a card, put it into your hand, then shuffle");
         this.getSpellAbility().addEffect(effect);
@@ -95,7 +95,7 @@ class InfernalTutorEffect extends OneShotEffect {
                 } else {
                     filterCard = new FilterCard();
                 }
-                return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filterCard), true, true).apply(game, source);
+                return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filterCard), true).apply(game, source);
 
             }
             return true;

--- a/Mage.Sets/src/mage/cards/i/IntoTheNorth.java
+++ b/Mage.Sets/src/mage/cards/i/IntoTheNorth.java
@@ -6,7 +6,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SuperType;
 import mage.filter.common.FilterLandCard;
 import mage.target.common.TargetCardInLibrary;
@@ -28,7 +27,7 @@ public final class IntoTheNorth extends CardImpl {
 
 
         // Search your library for a snow land card and put it onto the battlefield tapped. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true, Outcome.PutLandInPlay));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true));
         
     }
 

--- a/Mage.Sets/src/mage/cards/i/InvasionOfTheros.java
+++ b/Mage.Sets/src/mage/cards/i/InvasionOfTheros.java
@@ -40,7 +40,7 @@ public final class InvasionOfTheros extends CardImpl {
 
         // When Invasion of Theros enters the battlefield, search your library for an Aura, God, or Demigod card, reveal it, put it into your hand, then shuffle.
         this.addAbility(new EntersBattlefieldTriggeredAbility(
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true)
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true)
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/i/IsperiaTheInscrutable.java
+++ b/Mage.Sets/src/mage/cards/i/IsperiaTheInscrutable.java
@@ -83,7 +83,7 @@ class IsperiaTheInscrutableEffect extends OneShotEffect {
             player.revealCards(player.getLogName() + " hand", player.getHand(), game, true);
             for (Card card : player.getHand().getCards(game)) {
                 if (CardUtil.haveSameNames(card, cardName, game)) {
-                    return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true).apply(game, source);
+                    return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true).apply(game, source);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/i/IthorianInitiate.java
+++ b/Mage.Sets/src/mage/cards/i/IthorianInitiate.java
@@ -29,7 +29,7 @@ public final class IthorianInitiate extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Ithorian Initiate enters the battlefield, you may search your library for a basic land, reveal it, and put it into your hand. If you do shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), true));
 
         // Meditate {1}{G}
         this.addAbility(new MeditateAbility(new ManaCostsImpl<>("{1}{G}")));

--- a/Mage.Sets/src/mage/cards/j/JediEnclave.java
+++ b/Mage.Sets/src/mage/cards/j/JediEnclave.java
@@ -64,7 +64,7 @@ public final class JediEnclave extends CardImpl {
             filter.add(Predicates.or(subtypePredicates));
             filter.add(SuperType.BASIC.getPredicate());
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true, true));
+            addEffect(new SearchLibraryPutInPlayEffect(target, true));
         }
 
         @Override

--- a/Mage.Sets/src/mage/cards/j/JediEnclave.java
+++ b/Mage.Sets/src/mage/cards/j/JediEnclave.java
@@ -64,7 +64,7 @@ public final class JediEnclave extends CardImpl {
             filter.add(Predicates.or(subtypePredicates));
             filter.add(SuperType.BASIC.getPredicate());
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true, true, Outcome.PutLandInPlay));
+            addEffect(new SearchLibraryPutInPlayEffect(target, true, true));
         }
 
         @Override

--- a/Mage.Sets/src/mage/cards/j/JohnnyComboPlayer.java
+++ b/Mage.Sets/src/mage/cards/j/JohnnyComboPlayer.java
@@ -30,7 +30,7 @@ public final class JohnnyComboPlayer extends CardImpl {
         this.toughness = new MageInt(1);
         
         // {4}: Search your library for a card, put that card into your hand, then shuffle your library.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(new FilterCard("a card")), false, true), new ManaCostsImpl<>("{4}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(new FilterCard("a card")), false), new ManaCostsImpl<>("{4}")));
     }
 
     private JohnnyComboPlayer(final JohnnyComboPlayer card) {

--- a/Mage.Sets/src/mage/cards/j/JundPanorama.java
+++ b/Mage.Sets/src/mage/cards/j/JundPanorama.java
@@ -38,7 +38,7 @@ public final class JundPanorama extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.LAND},null);
         this.addAbility(new ColorlessManaAbility());
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true, Outcome.PutLandInPlay), new GenericManaCost(1));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/j/JungleVillage.java
+++ b/Mage.Sets/src/mage/cards/j/JungleVillage.java
@@ -64,7 +64,7 @@ public final class JungleVillage extends CardImpl {
             filter.add(Predicates.or(subtypePredicates));
             filter.add(SuperType.BASIC.getPredicate());
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true, true, Outcome.PutLandInPlay));
+            addEffect(new SearchLibraryPutInPlayEffect(target, true, true));
         }
 
         @Override

--- a/Mage.Sets/src/mage/cards/j/JungleVillage.java
+++ b/Mage.Sets/src/mage/cards/j/JungleVillage.java
@@ -64,7 +64,7 @@ public final class JungleVillage extends CardImpl {
             filter.add(Predicates.or(subtypePredicates));
             filter.add(SuperType.BASIC.getPredicate());
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true, true));
+            addEffect(new SearchLibraryPutInPlayEffect(target, true));
         }
 
         @Override

--- a/Mage.Sets/src/mage/cards/k/KeeperOfTheAccord.java
+++ b/Mage.Sets/src/mage/cards/k/KeeperOfTheAccord.java
@@ -53,7 +53,7 @@ public final class KeeperOfTheAccord extends CardImpl {
         // At the beginning of each opponent's end step, if that player controls more lands than you, you may search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle your library.
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(
                 new BeginningOfEndStepTriggeredAbility(new SearchLibraryPutInPlayEffect(
-                        new TargetCardInLibrary(filter), true, true
+                        new TargetCardInLibrary(filter), true
                 ), TargetController.OPPONENT, true),
                 KeeperOfTheAccordCondition.LANDS, "At the beginning of each opponent's end step, " +
                 "if that player controls more lands than you, you may search your library for a basic Plains card, " +

--- a/Mage.Sets/src/mage/cards/k/KhalniHeartExpedition.java
+++ b/Mage.Sets/src/mage/cards/k/KhalniHeartExpedition.java
@@ -10,7 +10,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCardInLibrary;
@@ -30,7 +29,7 @@ public final class KhalniHeartExpedition extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(
                 new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(
                         0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS
-                ), true, Outcome.PutLandInPlay),
+                ), true),
                 new CompositeCost(
                         new RemoveCountersSourceCost(CounterType.QUEST.createInstance(3)),
                         new SacrificeSourceCost(),

--- a/Mage.Sets/src/mage/cards/k/KithkinHarbinger.java
+++ b/Mage.Sets/src/mage/cards/k/KithkinHarbinger.java
@@ -32,7 +32,7 @@ public final class KithkinHarbinger extends CardImpl {
         this.toughness = new MageInt(3);
 
         // When Kithkin Harbinger enters the battlefield, you may search your library for a Kithkin card, reveal it, then shuffle your library and put that card on top of it.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true), true));
     }
 
     private KithkinHarbinger(final KithkinHarbinger card) {

--- a/Mage.Sets/src/mage/cards/k/KnightOfTheReliquary.java
+++ b/Mage.Sets/src/mage/cards/k/KnightOfTheReliquary.java
@@ -52,7 +52,7 @@ public final class KnightOfTheReliquary extends CardImpl {
         Costs<Cost> costs = new CostsImpl<>();
         costs.add(new TapSourceCost());
         costs.add(new SacrificeTargetCost(new TargetControlledPermanent(1, 1, filter, false)));
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, false, Outcome.PutLandInPlay), costs));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, false), costs));
     }
 
     private KnightOfTheReliquary(final KnightOfTheReliquary card) {

--- a/Mage.Sets/src/mage/cards/k/KorlashHeirToBlackblade.java
+++ b/Mage.Sets/src/mage/cards/k/KorlashHeirToBlackblade.java
@@ -51,7 +51,7 @@ public final class KorlashHeirToBlackblade extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{1}{B}")));
         
         // Grandeur - Discard another card named Korlash, Heir to Blackblade: Search your library for up to two Swamp cards, put them onto the battlefield tapped, then shuffle your library.
-        effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, filterCard), true, true);
+        effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, filterCard), true);
         effect.setText("Search your library for up to two Swamp cards, put them onto the battlefield tapped, then shuffle.");
         this.addAbility(new GrandeurAbility(effect, "Korlash, Heir to Blackblade"));
     }

--- a/Mage.Sets/src/mage/cards/k/KrosanTusker.java
+++ b/Mage.Sets/src/mage/cards/k/KrosanTusker.java
@@ -32,7 +32,7 @@ public final class KrosanTusker extends CardImpl {
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{2}{G}")));
         // When you cycle Krosan Tusker, you may search your library for a basic land card, reveal that card, put it into your hand, then shuffle your library.
         this.addAbility(new CycleTriggeredAbility(
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true),
                 true));
     }
 

--- a/Mage.Sets/src/mage/cards/k/KrosanTusker.java
+++ b/Mage.Sets/src/mage/cards/k/KrosanTusker.java
@@ -32,7 +32,7 @@ public final class KrosanTusker extends CardImpl {
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{2}{G}")));
         // When you cycle Krosan Tusker, you may search your library for a basic land card, reveal that card, put it into your hand, then shuffle your library.
         this.addAbility(new CycleTriggeredAbility(
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
                 true));
     }
 

--- a/Mage.Sets/src/mage/cards/k/KrosanVerge.java
+++ b/Mage.Sets/src/mage/cards/k/KrosanVerge.java
@@ -11,7 +11,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.abilities.mana.ColorlessManaAbility;
 import mage.cards.*;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicates;
@@ -36,7 +35,7 @@ public final class KrosanVerge extends CardImpl {
 
         // {2}, {T}, Sacrifice Krosan Verge: Search your library for a Forest card and a Plains card and put them onto the battlefield tapped. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(
-                new KrosanVergeTarget(), true, Outcome.PutLandInPlay
+                new KrosanVergeTarget(), true
         ).setText("search your library for a Forest card and a Plains card, put them onto the battlefield tapped, then shuffle"), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());

--- a/Mage.Sets/src/mage/cards/k/KyscuDrake.java
+++ b/Mage.Sets/src/mage/cards/k/KyscuDrake.java
@@ -49,7 +49,7 @@ public final class KyscuDrake extends CardImpl {
         this.addAbility(new LimitedTimesPerTurnActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(0, 1, Duration.EndOfTurn), new ManaCostsImpl<>("{G}")));
 
         // Sacrifice Kyscu Drake and a creature named Spitting Drake: Search your library for a card named Viashivan Dragon and put that card onto the battlefield. Then shuffle your library.
-        this.addAbility(new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(1, 1, filter), false, true, Outcome.PutCardInPlay), new CompositeCost(new SacrificeSourceCost(), new SacrificeTargetCost(new TargetControlledCreaturePermanent(1, 1, filterSpitting, false)), "sacrifice {this} and a creature named Spitting Drake")));
+        this.addAbility(new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(1, 1, filter), false, true), new CompositeCost(new SacrificeSourceCost(), new SacrificeTargetCost(new TargetControlledCreaturePermanent(1, 1, filterSpitting, false)), "sacrifice {this} and a creature named Spitting Drake")));
     }
 
     private KyscuDrake(final KyscuDrake card) {

--- a/Mage.Sets/src/mage/cards/k/KyscuDrake.java
+++ b/Mage.Sets/src/mage/cards/k/KyscuDrake.java
@@ -49,7 +49,7 @@ public final class KyscuDrake extends CardImpl {
         this.addAbility(new LimitedTimesPerTurnActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(0, 1, Duration.EndOfTurn), new ManaCostsImpl<>("{G}")));
 
         // Sacrifice Kyscu Drake and a creature named Spitting Drake: Search your library for a card named Viashivan Dragon and put that card onto the battlefield. Then shuffle your library.
-        this.addAbility(new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(1, 1, filter), false), new CompositeCost(new SacrificeSourceCost(), new SacrificeTargetCost(new TargetControlledCreaturePermanent(1, 1, filterSpitting, false)), "sacrifice {this} and a creature named Spitting Drake")));
+        this.addAbility(new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(1, 1, filter), false, true), new CompositeCost(new SacrificeSourceCost(), new SacrificeTargetCost(new TargetControlledCreaturePermanent(1, 1, filterSpitting, false)), "sacrifice {this} and a creature named Spitting Drake")));
     }
 
     private KyscuDrake(final KyscuDrake card) {

--- a/Mage.Sets/src/mage/cards/k/KyscuDrake.java
+++ b/Mage.Sets/src/mage/cards/k/KyscuDrake.java
@@ -49,7 +49,7 @@ public final class KyscuDrake extends CardImpl {
         this.addAbility(new LimitedTimesPerTurnActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(0, 1, Duration.EndOfTurn), new ManaCostsImpl<>("{G}")));
 
         // Sacrifice Kyscu Drake and a creature named Spitting Drake: Search your library for a card named Viashivan Dragon and put that card onto the battlefield. Then shuffle your library.
-        this.addAbility(new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(1, 1, filter), false, true), new CompositeCost(new SacrificeSourceCost(), new SacrificeTargetCost(new TargetControlledCreaturePermanent(1, 1, filterSpitting, false)), "sacrifice {this} and a creature named Spitting Drake")));
+        this.addAbility(new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(1, 1, filter), false), new CompositeCost(new SacrificeSourceCost(), new SacrificeTargetCost(new TargetControlledCreaturePermanent(1, 1, filterSpitting, false)), "sacrifice {this} and a creature named Spitting Drake")));
     }
 
     private KyscuDrake(final KyscuDrake card) {

--- a/Mage.Sets/src/mage/cards/l/LagomosHandOfHatred.java
+++ b/Mage.Sets/src/mage/cards/l/LagomosHandOfHatred.java
@@ -43,7 +43,7 @@ public final class LagomosHandOfHatred extends CardImpl {
         // {T}: Search your library for a card, put it into your hand, then shuffle. Activate only if five or more creatures died this turn.
         this.addAbility(new ConditionalActivatedAbility(
                 Zone.BATTLEFIELD,
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary()),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false),
                 new TapSourceCost(),
                 LagomosHandOfHatredCondition.instance
         ));

--- a/Mage.Sets/src/mage/cards/l/LandGrant.java
+++ b/Mage.Sets/src/mage/cards/l/LandGrant.java
@@ -38,7 +38,7 @@ public final class LandGrant extends CardImpl {
             "If you have no land cards in hand, you may reveal your hand rather than pay this spell's mana cost."));
 
         // Search your library for a Forest card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true));
     }
 
     private LandGrant(final LandGrant card) {

--- a/Mage.Sets/src/mage/cards/l/LandGrant.java
+++ b/Mage.Sets/src/mage/cards/l/LandGrant.java
@@ -38,7 +38,7 @@ public final class LandGrant extends CardImpl {
             "If you have no land cards in hand, you may reveal your hand rather than pay this spell's mana cost."));
 
         // Search your library for a Forest card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true));
     }
 
     private LandGrant(final LandGrant card) {

--- a/Mage.Sets/src/mage/cards/l/LandTax.java
+++ b/Mage.Sets/src/mage/cards/l/LandTax.java
@@ -25,7 +25,7 @@ public final class LandTax extends CardImpl {
 
         // At the beginning of your upkeep, if an opponent controls more lands than you, you may search your library for up to three basic land cards, reveal them, and put them into your hand. If you do, shuffle your library.
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(
-                new BeginningOfUpkeepTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 3, StaticFilters.FILTER_CARD_BASIC_LAND), true, true), TargetController.YOU, true),
+                new BeginningOfUpkeepTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 3, StaticFilters.FILTER_CARD_BASIC_LAND), true), TargetController.YOU, true),
                 new OpponentControlsMoreCondition(StaticFilters.FILTER_LANDS),
                 "At the beginning of your upkeep, if an opponent controls more lands than you, you may search your library for up to three basic land cards, reveal them, put them into your hand, then shuffle."
         ));

--- a/Mage.Sets/src/mage/cards/l/LegionConquistador.java
+++ b/Mage.Sets/src/mage/cards/l/LegionConquistador.java
@@ -36,7 +36,7 @@ public final class LegionConquistador extends CardImpl {
 
         // When Legion Conquistador enters the battlefield, you may search your library for any number of cards named Legion Conquistador, reveal them, put them into your hand, then shuffle your library
         TargetCardInLibrary target = new TargetCardInLibrary(0, Integer.MAX_VALUE, filter);
-        Effect effect = new SearchLibraryPutInHandEffect(target, true, true);
+        Effect effect = new SearchLibraryPutInHandEffect(target, true);
         effect.setText("you may search your library for any number of cards named Legion Conquistador, reveal them, put them into your hand, then shuffle");
         this.addAbility(new EntersBattlefieldTriggeredAbility(effect, true));
     }

--- a/Mage.Sets/src/mage/cards/l/LibraryOfLatNam.java
+++ b/Mage.Sets/src/mage/cards/l/LibraryOfLatNam.java
@@ -28,7 +28,7 @@ public final class LibraryOfLatNam extends CardImpl {
         this.getSpellAbility().addEffect(new CreateDelayedTriggeredAbilityEffect(new AtTheBeginOfNextUpkeepDelayedTriggeredAbility(new DrawCardSourceControllerEffect(3).setText("you draw three cards")), false));
 
         // or you search your library for a card, put that card into your hand, then shuffle your library.
-        this.getSpellAbility().addMode(new Mode(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true).setText("you search your library for a card, put that card into your hand, then shuffle")));
+        this.getSpellAbility().addMode(new Mode(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false).setText("you search your library for a card, put that card into your hand, then shuffle")));
     }
 
     private LibraryOfLatNam(final LibraryOfLatNam card) {

--- a/Mage.Sets/src/mage/cards/l/LilianaVess.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaVess.java
@@ -40,7 +40,7 @@ public final class LilianaVess extends CardImpl {
         this.addAbility(ability1);
 
         // -2: Search your library for a card, then shuffle your library and put that card on top of it.
-        this.addAbility(new LoyaltyAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary()), -2));
+        this.addAbility(new LoyaltyAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(), false), -2));
 
         // -8: Put all creature cards from all graveyards onto the battlefield under your control.
         this.addAbility(new LoyaltyAbility(new LilianaVessEffect(), -8));

--- a/Mage.Sets/src/mage/cards/l/LilianasShade.java
+++ b/Mage.Sets/src/mage/cards/l/LilianasShade.java
@@ -37,7 +37,7 @@ public final class LilianasShade extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Liliana's Shade enters the battlefield, you may search your library for a Swamp card, reveal it, put it into your hand, then shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true), true));
         // {B}: Liliana's Shade gets +1/+1 until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn), new ManaCostsImpl<>("{B}")));
     }

--- a/Mage.Sets/src/mage/cards/l/LlanowarSentinel.java
+++ b/Mage.Sets/src/mage/cards/l/LlanowarSentinel.java
@@ -34,7 +34,7 @@ public final class LlanowarSentinel extends CardImpl {
 
         // When Llanowar Sentinel enters the battlefield, you may pay {1}{G}. If you do, search your library for a card named Llanowar Sentinel and put that card onto the battlefield. Then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoIfCostPaid(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new ManaCostsImpl<>("{1}{G}")
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, true), new ManaCostsImpl<>("{1}{G}")
         )));
     }
 

--- a/Mage.Sets/src/mage/cards/l/LoamLarva.java
+++ b/Mage.Sets/src/mage/cards/l/LoamLarva.java
@@ -27,7 +27,7 @@ public final class LoamLarva extends CardImpl {
 
         // When Loam Larva enters the battlefield, you may search your library for a basic land card, reveal it, then shuffle your library and put that card on top of it.
         TargetCardInLibrary target = new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(target, true), true));
     }
 
     private LoamLarva(final LoamLarva card) {

--- a/Mage.Sets/src/mage/cards/l/LoyalWarhound.java
+++ b/Mage.Sets/src/mage/cards/l/LoyalWarhound.java
@@ -42,7 +42,7 @@ public final class LoyalWarhound extends CardImpl {
         // When Loyal Warhound enters the battlefield, if an opponent controls more lands than you,
         // search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle.
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(
-                new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true, true)),
+                new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true)),
                 new OpponentControlsMoreCondition(StaticFilters.FILTER_LANDS),
                 "When {this} enters the battlefield, if an opponent controls more lands than you, "
                 + "search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle."

--- a/Mage.Sets/src/mage/cards/m/MaestrosTheater.java
+++ b/Mage.Sets/src/mage/cards/m/MaestrosTheater.java
@@ -38,7 +38,7 @@ public final class MaestrosTheater extends CardImpl {
 
         // When Maestros Theater enters the battlefield, sacrifice it. When you do, search your library for a basic Island, Swamp, or Mountain card, put it onto the battlefield tapped, then shuffle and you gain 1 life.
         ReflexiveTriggeredAbility ability = new ReflexiveTriggeredAbility(new SearchLibraryPutInPlayEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), false);
         ability.addEffect(new GainLifeEffect(1).concatBy("and"));
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoWhenCostPaid(

--- a/Mage.Sets/src/mage/cards/m/MagdaBrazenOutlaw.java
+++ b/Mage.Sets/src/mage/cards/m/MagdaBrazenOutlaw.java
@@ -58,7 +58,7 @@ public final class MagdaBrazenOutlaw extends CardImpl {
 
         // Sacrifice five Treasures: Search your library for an artifact or Dragon card, put that card onto the battlefield, then shuffle your library.
         this.addAbility(new SimpleActivatedAbility(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter3)),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter3), false, true),
                 new SacrificeTargetCost(new TargetControlledPermanent(5, filter4))
         ));
     }

--- a/Mage.Sets/src/mage/cards/m/MagusOfTheOrder.java
+++ b/Mage.Sets/src/mage/cards/m/MagusOfTheOrder.java
@@ -50,7 +50,7 @@ public final class MagusOfTheOrder extends CardImpl {
 
         // {G}, {T}, Sacrifice Magus of the Order and another green creature: Search your library for a green creature card and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(
-                new TargetCardInLibrary(1, filter), false, true
+                new TargetCardInLibrary(1, filter), false
         ), new ManaCostsImpl<>("{G}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new CompositeCost(

--- a/Mage.Sets/src/mage/cards/m/MastermindsAcquisition.java
+++ b/Mage.Sets/src/mage/cards/m/MastermindsAcquisition.java
@@ -21,7 +21,7 @@ public final class MastermindsAcquisition extends CardImpl {
 
         // Choose one - 
         // Search your library for a card and put that card into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary()));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
 
         // Put a card you own from outside the game into your hand.
         Mode mode = new Mode(new WishEffect().setText("put a card you own from outside the game into your hand"));

--- a/Mage.Sets/src/mage/cards/m/MerchantScroll.java
+++ b/Mage.Sets/src/mage/cards/m/MerchantScroll.java
@@ -29,7 +29,7 @@ public final class MerchantScroll extends CardImpl {
 
 
         // Search your library for a blue instant card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(1, 1, filter), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(1, 1, filter), true, true));
     }
 
     private MerchantScroll(final MerchantScroll card) {

--- a/Mage.Sets/src/mage/cards/m/MerrowHarbinger.java
+++ b/Mage.Sets/src/mage/cards/m/MerrowHarbinger.java
@@ -36,7 +36,7 @@ public final class MerrowHarbinger extends CardImpl {
         // Islandwalk
         this.addAbility(new IslandwalkAbility());
         // When Merrow Harbinger enters the battlefield, you may search your library for a Merfolk card, reveal it, then shuffle your library and put that card on top of it.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true), true));
     }
 
     private MerrowHarbinger(final MerrowHarbinger card) {

--- a/Mage.Sets/src/mage/cards/m/Micromancer.java
+++ b/Mage.Sets/src/mage/cards/m/Micromancer.java
@@ -37,7 +37,7 @@ public final class Micromancer extends CardImpl {
 
         // When Micromancer enters the battlefield, you may search your library for an instant or sorcery card with mana value 1, reveal it, put it into your hand, then shuffle.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MomirVigSimicVisionary.java
+++ b/Mage.Sets/src/mage/cards/m/MomirVigSimicVisionary.java
@@ -50,7 +50,7 @@ public final class MomirVigSimicVisionary extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever you cast a green creature spell, you may search your library for a creature card and reveal it. If you do, shuffle your library and put that card on top of it.
-        Effect effect = new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true, true);
+        Effect effect = new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true);
         effect.setText("search your library for a creature card, reveal it, then shuffle and put that card on top");
         this.addAbility(new SpellCastControllerTriggeredAbility(effect, filter, true));
 

--- a/Mage.Sets/src/mage/cards/m/MoonBlessedCleric.java
+++ b/Mage.Sets/src/mage/cards/m/MoonBlessedCleric.java
@@ -32,7 +32,7 @@ public final class MoonBlessedCleric extends CardImpl {
         // Divine Intervention — When Moon-Blessed Cleric enters the battlefield, you may search your library for an enchantment card, reveal it, then shuffle and put that card on top.
         this.addAbility(new EntersBattlefieldTriggeredAbility(
                 new SearchLibraryPutOnLibraryEffect(
-                        new TargetCardInLibrary(filter), true, true
+                        new TargetCardInLibrary(filter), true
                 ), true
         ).withFlavorWord("Divine Intervention"));
     }

--- a/Mage.Sets/src/mage/cards/m/MoonsilverKey.java
+++ b/Mage.Sets/src/mage/cards/m/MoonsilverKey.java
@@ -35,7 +35,7 @@ public final class MoonsilverKey extends CardImpl {
 
         // {1}, {T}, Sacrifice Moonsilver Key: Search your library for an artifact card with a mana ability or a basic land card, reveal it, put it into your hand, then shuffle.
         Ability ability = new SimpleActivatedAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());

--- a/Mage.Sets/src/mage/cards/m/MwonvuliAcidMoss.java
+++ b/Mage.Sets/src/mage/cards/m/MwonvuliAcidMoss.java
@@ -31,7 +31,7 @@ public final class MwonvuliAcidMoss extends CardImpl {
         // Destroy target land. Search your library for a Forest card and put that card onto the battlefield tapped. Then shuffle your library.
         this.getSpellAbility().addEffect(new DestroyTargetEffect());
         this.getSpellAbility().addTarget(new TargetPermanent(new FilterLandPermanent()));
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filterForest), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filterForest), true));
     }
 
     private MwonvuliAcidMoss(final MwonvuliAcidMoss card) {

--- a/Mage.Sets/src/mage/cards/m/MwonvuliAcidMoss.java
+++ b/Mage.Sets/src/mage/cards/m/MwonvuliAcidMoss.java
@@ -31,7 +31,7 @@ public final class MwonvuliAcidMoss extends CardImpl {
         // Destroy target land. Search your library for a Forest card and put that card onto the battlefield tapped. Then shuffle your library.
         this.getSpellAbility().addEffect(new DestroyTargetEffect());
         this.getSpellAbility().addTarget(new TargetPermanent(new FilterLandPermanent()));
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filterForest), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filterForest), true, true));
     }
 
     private MwonvuliAcidMoss(final MwonvuliAcidMoss card) {

--- a/Mage.Sets/src/mage/cards/m/MwonvuliBeastTracker.java
+++ b/Mage.Sets/src/mage/cards/m/MwonvuliBeastTracker.java
@@ -44,7 +44,7 @@ public final class MwonvuliBeastTracker extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Mwonvuli Beast Tracker enters the battlefield, search your library for a creature card with deathtouch, hexproof, reach, or trample and reveal it. Shuffle your library and put that card on top of it.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true, true)));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true)));
     }
 
     private MwonvuliBeastTracker(final MwonvuliBeastTracker card) {
@@ -56,4 +56,3 @@ public final class MwonvuliBeastTracker extends CardImpl {
         return new MwonvuliBeastTracker(this);
     }
 }
-

--- a/Mage.Sets/src/mage/cards/m/MycosynthWellspring.java
+++ b/Mage.Sets/src/mage/cards/m/MycosynthWellspring.java
@@ -22,7 +22,7 @@ public final class MycosynthWellspring extends CardImpl {
         // When Mycosynth Wellspring enters the battlefield or is put into a graveyard from the battlefield,
         // you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldOrDiesSourceTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true
         ), true, false));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MyrKinsmith.java
+++ b/Mage.Sets/src/mage/cards/m/MyrKinsmith.java
@@ -32,7 +32,7 @@ public final class MyrKinsmith extends CardImpl {
 
         // When Myr Kinsmith enters the battlefield, you may search your library for a Myr card, reveal it, put it into your hand, then shuffle.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MysticalTeachings.java
+++ b/Mage.Sets/src/mage/cards/m/MysticalTeachings.java
@@ -9,7 +9,6 @@ import mage.abilities.keyword.FlashbackAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TimingRule;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.AbilityPredicate;
@@ -35,7 +34,7 @@ public final class MysticalTeachings extends CardImpl {
 
 
         // Search your library for an instant card or a card with flash, reveal it, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true));
         // Flashback {5}{B}
         this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{5}{B}")));
     }

--- a/Mage.Sets/src/mage/cards/m/MysticalTutor.java
+++ b/Mage.Sets/src/mage/cards/m/MysticalTutor.java
@@ -28,7 +28,7 @@ public final class MysticalTutor extends CardImpl {
 
 
         // Search your library for an instant or sorcery card and reveal that card. Shuffle your library, then put the card on top of it.
-        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true));
     }
 
     private MysticalTutor(final MysticalTutor card) {

--- a/Mage.Sets/src/mage/cards/n/NaturalOrder.java
+++ b/Mage.Sets/src/mage/cards/n/NaturalOrder.java
@@ -35,7 +35,7 @@ public final class NaturalOrder extends CardImpl {
         // As an additional cost to cast Natural Order, sacrifice a green creature.
         this.getSpellAbility().addCost(new SacrificeTargetCost(new TargetControlledCreaturePermanent(1,1,filter, true)));
         // Search your library for a green creature card and put it onto the battlefield. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(1 , filterCard), false, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(1 , filterCard), false));
     }
 
     private NaturalOrder(final NaturalOrder card) {

--- a/Mage.Sets/src/mage/cards/n/NaturesLore.java
+++ b/Mage.Sets/src/mage/cards/n/NaturesLore.java
@@ -28,7 +28,7 @@ public final class NaturesLore extends CardImpl {
 
 
         // Search your library for a Forest card and put that card onto the battlefield. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, true));
     }
 
     private NaturesLore(final NaturesLore card) {

--- a/Mage.Sets/src/mage/cards/n/NaturesLore.java
+++ b/Mage.Sets/src/mage/cards/n/NaturesLore.java
@@ -28,7 +28,7 @@ public final class NaturesLore extends CardImpl {
 
 
         // Search your library for a Forest card and put that card onto the battlefield. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false));
     }
 
     private NaturesLore(final NaturesLore card) {

--- a/Mage.Sets/src/mage/cards/n/NayaPanorama.java
+++ b/Mage.Sets/src/mage/cards/n/NayaPanorama.java
@@ -39,7 +39,7 @@ public final class NayaPanorama extends CardImpl {
 
         this.addAbility(new ColorlessManaAbility());
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true, Outcome.PutLandInPlay), new GenericManaCost(1));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/n/NazahnReveredBladesmith.java
+++ b/Mage.Sets/src/mage/cards/n/NazahnReveredBladesmith.java
@@ -57,7 +57,7 @@ public final class NazahnReveredBladesmith extends CardImpl {
 
         // When Nazahn, Revered Bladesmith enters the battlefield, search your library for an Equipment card and reveal it. If you reveal a card named Hammer of Nazahn this way, put it onto the battlefield. Otherwise, put that card into your hand. Then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(1, 1, filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandOrOnBattlefieldEffect(target, true, true, "Hammer of Nazahn"), false));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandOrOnBattlefieldEffect(target, true, "Hammer of Nazahn"), false));
 
         // Whenever an equipped creature you control attacks, you may tap target creature defending player controls.
         Ability ability = new AttacksCreatureYouControlTriggeredAbility(new NazahnTapEffect(), true, equippedFilter, true);

--- a/Mage.Sets/src/mage/cards/n/NestingWurm.java
+++ b/Mage.Sets/src/mage/cards/n/NestingWurm.java
@@ -38,7 +38,7 @@ public final class NestingWurm extends CardImpl {
 
         // When Nesting Wurm enters the battlefield, you may search your library for up to three cards named Nesting Wurm, reveal them, and put them into your hand. If you do, shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(0, 3, filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
     }
 
     private NestingWurm(final NestingWurm card) {

--- a/Mage.Sets/src/mage/cards/n/NissaVastwoodSeer.java
+++ b/Mage.Sets/src/mage/cards/n/NissaVastwoodSeer.java
@@ -41,7 +41,7 @@ public final class NissaVastwoodSeer extends CardImpl {
         this.secondSideCardClazz = mage.cards.n.NissaSageAnimist.class;
 
         // When Nissa, Vastwood Seer enters the battlefield, you may search your library for a basic Forest card, reveal it, put it into your hand, then shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true), true));
 
         // Whenever a land enters the battlefield under your control, if you control seven or more lands, exile Nissa, then return her to the battlefield transformed under her owner's control.
         this.addAbility(new TransformAbility());

--- a/Mage.Sets/src/mage/cards/n/NissasExpedition.java
+++ b/Mage.Sets/src/mage/cards/n/NissasExpedition.java
@@ -23,7 +23,7 @@ public final class NissasExpedition extends CardImpl {
         // Convoke
         this.addAbility(new ConvokeAbility());
         // Search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0,2, StaticFilters.FILTER_CARD_BASIC_LANDS), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0,2, StaticFilters.FILTER_CARD_BASIC_LANDS), true));
     }
 
     private NissasExpedition(final NissasExpedition card) {

--- a/Mage.Sets/src/mage/cards/n/NissasTriumph.java
+++ b/Mage.Sets/src/mage/cards/n/NissasTriumph.java
@@ -39,10 +39,10 @@ public final class NissasTriumph extends CardImpl {
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
                 new SearchLibraryPutInHandEffect(new TargetCardInLibrary(
                         0, 3, StaticFilters.FILTER_CARD_LAND
-                ), true, true),
+                ), true),
                 new SearchLibraryPutInHandEffect(new TargetCardInLibrary(
                         0, 2, filter
-                ), true, true),
+                ), true),
                 new PermanentsOnTheBattlefieldCondition(filter2),
                 "Search your library for up to two basic Forest cards. If you control a Nissa planeswalker, " +
                         "instead search your library for up to three land cards. " +

--- a/Mage.Sets/src/mage/cards/n/NyleasIntervention.java
+++ b/Mage.Sets/src/mage/cards/n/NyleasIntervention.java
@@ -79,6 +79,6 @@ class NyleasInterventionEffect extends OneShotEffect {
         int xValue = source.getManaCostsToPay().getX();
         return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(
                 0, xValue, StaticFilters.FILTER_CARD_LAND
-        ), true, true).apply(game, source);
+        ), true).apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/o/OathOfLieges.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfLieges.java
@@ -89,7 +89,7 @@ class OathOfLiegesEffect extends OneShotEffect {
         Player activePlayer = game.getPlayer(game.getActivePlayerId());
         if (activePlayer != null) {
             if (activePlayer.chooseUse(outcome, "Search your library for a basic land card, put that card onto the battlefield, then shuffle?", source, game)) {
-                Effect effect = new SearchLibraryPutInPlayTargetPlayerEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), false, false, Outcome.PutLandInPlay, true);
+                Effect effect = new SearchLibraryPutInPlayTargetPlayerEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), false, true);
                 effect.setTargetPointer(new FixedTarget(game.getActivePlayerId()));
                 return effect.apply(game, source);
             }

--- a/Mage.Sets/src/mage/cards/o/ObscuraStorefront.java
+++ b/Mage.Sets/src/mage/cards/o/ObscuraStorefront.java
@@ -38,7 +38,7 @@ public final class ObscuraStorefront extends CardImpl {
 
         // When Obscura Storefront enters the battlefield, sacrifice it. When you do, search your library for a basic Plains, Island, or Swamp card, put it onto the battlefield tapped, then shuffle and you gain 1 life.
         ReflexiveTriggeredAbility ability = new ReflexiveTriggeredAbility(new SearchLibraryPutInPlayEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), false);
         ability.addEffect(new GainLifeEffect(1).concatBy("and"));
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoWhenCostPaid(

--- a/Mage.Sets/src/mage/cards/o/OneWithNature.java
+++ b/Mage.Sets/src/mage/cards/o/OneWithNature.java
@@ -38,7 +38,7 @@ public final class OneWithNature extends CardImpl {
 
         // Whenever enchanted creature deals combat damage to a player, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library.
         ability = new DealsDamageToAPlayerAttachedTriggeredAbility(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true)
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true)
                         .setText("you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle."),
                 "enchanted creature", true, false, true, TargetController.ANY);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/o/OneWithNature.java
+++ b/Mage.Sets/src/mage/cards/o/OneWithNature.java
@@ -38,7 +38,7 @@ public final class OneWithNature extends CardImpl {
 
         // Whenever enchanted creature deals combat damage to a player, you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library.
         ability = new DealsDamageToAPlayerAttachedTriggeredAbility(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, Outcome.PutLandInPlay)
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true)
                         .setText("you may search your library for a basic land card, put that card onto the battlefield tapped, then shuffle."),
                 "enchanted creature", true, false, true, TargetController.ANY);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/o/OpenTheArmory.java
+++ b/Mage.Sets/src/mage/cards/o/OpenTheArmory.java
@@ -28,7 +28,7 @@ public final class OpenTheArmory extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{W}");
 
         // Search your library for an Aura or Equipment card, reveal it, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(1, 1, auraOrEquipmentTarget), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(1, 1, auraOrEquipmentTarget), true));
     }
 
     private OpenTheArmory(final OpenTheArmory card) {

--- a/Mage.Sets/src/mage/cards/o/OrdealOfNylea.java
+++ b/Mage.Sets/src/mage/cards/o/OrdealOfNylea.java
@@ -49,7 +49,7 @@ public final class OrdealOfNylea extends CardImpl {
         this.addAbility(ability);
         // When you sacrifice Ordeal of Nylea, search your library for up to two basic land cards, put them onto the battlefield tapped, then shuffle your library.
         ability = new SacrificeSourceTriggeredAbility(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0,2, StaticFilters.FILTER_CARD_BASIC_LANDS),true, true),false);
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0,2, StaticFilters.FILTER_CARD_BASIC_LANDS),true),false);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PathToTheFestival.java
+++ b/Mage.Sets/src/mage/cards/p/PathToTheFestival.java
@@ -28,11 +28,11 @@ public final class PathToTheFestival extends CardImpl {
 
         // Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle. Then if there are three or more basic land types among lands you control, scry 1.
         this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true
         ));
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
                 new ScryEffect(1), PathToTheFestivalCondition.instance,
-                "Then if there are three or more basic land types among lands you control, scry 1 " +
+                "Then if there are three or more basic land types among lands you control, scry 1. " +
                         "<i>(Look at the top card of your library. " +
                         "You may put that card on the bottom of your library.)</i>"
         ));

--- a/Mage.Sets/src/mage/cards/p/PatternMatcher.java
+++ b/Mage.Sets/src/mage/cards/p/PatternMatcher.java
@@ -88,7 +88,7 @@ class RegularExpression extends OneShotEffect {
                 = new FilterCard("a creature card with the same name as another creature you control");
         filter.add(Predicates.or(predicates));
         return new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ).apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PatternOfRebirth.java
+++ b/Mage.Sets/src/mage/cards/p/PatternOfRebirth.java
@@ -35,7 +35,7 @@ public final class PatternOfRebirth extends CardImpl {
         this.addAbility(ability);
 
         // When enchanted creature dies, that creature's controller may search their library for a creature card and put that card onto the battlefield. If that player does, they shuffle their library.
-        Effect effect = new SearchLibraryPutInPlayTargetPlayerEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), false, false, Outcome.PutCreatureInPlay);
+        Effect effect = new SearchLibraryPutInPlayTargetPlayerEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), false);
         effect.setText("that creature's controller may search their library for a creature card and put that card onto the battlefield. If that player does, they shuffle");
         this.addAbility(new DiesAttachedTriggeredAbility(effect, "enchanted creature", true, true, SetTargetPointer.ATTACHED_TO_CONTROLLER));
 

--- a/Mage.Sets/src/mage/cards/p/PerilousForays.java
+++ b/Mage.Sets/src/mage/cards/p/PerilousForays.java
@@ -10,7 +10,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import static mage.filter.StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT;
@@ -41,7 +40,7 @@ public final class PerilousForays extends CardImpl {
 
         // {1}, Sacrifice a creature: Search your library for a land card with a basic land type and put it onto the battlefield tapped. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true, Outcome.PutLandInPlay),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true),
                 new ManaCostsImpl<>("{1}"));
         ability.addCost(new SacrificeTargetCost(new TargetControlledCreaturePermanent(FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/p/PersonalTutor.java
+++ b/Mage.Sets/src/mage/cards/p/PersonalTutor.java
@@ -24,7 +24,7 @@ public final class PersonalTutor extends CardImpl {
 
 
         // Search your library for a sorcery card and reveal that card. Shuffle your library, then put the card on top of it.
-        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true));
     }
 
     private PersonalTutor(final PersonalTutor card) {

--- a/Mage.Sets/src/mage/cards/p/PilgrimOfTheAges.java
+++ b/Mage.Sets/src/mage/cards/p/PilgrimOfTheAges.java
@@ -38,7 +38,7 @@ public final class PilgrimOfTheAges extends CardImpl {
 
         // When Pilgrim of the Ages enters the battlefield, you may search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), true));
 
         // {6}: Return Pilgrim of the Ages from your graveyard to your hand.

--- a/Mage.Sets/src/mage/cards/p/PlanarPortal.java
+++ b/Mage.Sets/src/mage/cards/p/PlanarPortal.java
@@ -23,7 +23,7 @@ public final class PlanarPortal extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{6}");
 
         // {6}, {tap}: Search your library for a card and put that card into your hand. Then shuffle your library.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false), new ManaCostsImpl<>("{6}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true), new ManaCostsImpl<>("{6}"));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/p/PlanarPortal.java
+++ b/Mage.Sets/src/mage/cards/p/PlanarPortal.java
@@ -23,7 +23,7 @@ public final class PlanarPortal extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{6}");
 
         // {6}, {tap}: Search your library for a card and put that card into your hand. Then shuffle your library.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true), new ManaCostsImpl<>("{6}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false), new ManaCostsImpl<>("{6}"));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/p/PleaForGuidance.java
+++ b/Mage.Sets/src/mage/cards/p/PleaForGuidance.java
@@ -25,7 +25,7 @@ public final class PleaForGuidance extends CardImpl {
 
 
         // Search your library for up to two enchantment cards, reveal them, and put them into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0,2, filter), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0,2, filter), true));
     }
 
     private PleaForGuidance(final PleaForGuidance card) {

--- a/Mage.Sets/src/mage/cards/p/PriestOfTheWakeningSun.java
+++ b/Mage.Sets/src/mage/cards/p/PriestOfTheWakeningSun.java
@@ -52,7 +52,7 @@ public final class PriestOfTheWakeningSun extends CardImpl {
 
         // {3}{W}{W}, Sacrifice Priest of the Wakening Sun: Search your library for a Dinosaur card, reveal it, put it into your hand, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        Ability ability2 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(target), true, true), new ManaCostsImpl<>("{3}{W}{W}"));
+        Ability ability2 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(target), true), new ManaCostsImpl<>("{3}{W}{W}"));
         ability2.addCost(new SacrificeSourceCost());
         this.addAbility(ability2);
     }

--- a/Mage.Sets/src/mage/cards/p/PrimalCommand.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalCommand.java
@@ -54,7 +54,7 @@ public final class PrimalCommand extends CardImpl {
         mode.addTarget(new TargetPlayer());
         this.getSpellAbility().getModes().addMode(mode);
         // or search your library for a creature card, reveal it, put it into your hand, then shuffle your library.
-        mode = new Mode(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true, true));
+        mode = new Mode(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true));
         this.getSpellAbility().getModes().addMode(mode);
 
     }

--- a/Mage.Sets/src/mage/cards/p/PrimalGrowth.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalGrowth.java
@@ -30,8 +30,8 @@ public final class PrimalGrowth extends CardImpl {
         // Search your library for a basic land card, put that card onto the battlefield, then shuffle your library.
         // If Primal Growth was kicked, instead search your library for up to two basic land cards, put them onto the battlefield, then shuffle your library.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LAND), false, true),
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 1, StaticFilters.FILTER_CARD_BASIC_LAND), false, true),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LAND), false),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 1, StaticFilters.FILTER_CARD_BASIC_LAND), false),
                 KickedCondition.ONCE,
                 "Search your library for a basic land card, put that card onto the battlefield, then shuffle. If this spell was kicked, instead search your library for up to two basic land cards, put them onto the battlefield, then shuffle"));
     }

--- a/Mage.Sets/src/mage/cards/p/PrimevalTitan.java
+++ b/Mage.Sets/src/mage/cards/p/PrimevalTitan.java
@@ -10,7 +10,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Outcome;
 import mage.filter.common.FilterLandCard;
 import mage.target.common.TargetCardInLibrary;
 
@@ -31,7 +30,7 @@ public final class PrimevalTitan extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Whenever Primeval Titan enters the battlefield or attacks, you may search your library for up to two land cards, put them onto the battlefield tapped, then shuffle your library.
-        this.addAbility(new EntersBattlefieldOrAttacksSourceTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, new FilterLandCard("land cards")), true, Outcome.PutLandInPlay), true));
+        this.addAbility(new EntersBattlefieldOrAttacksSourceTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, new FilterLandCard("land cards")), true), true));
     }
 
     private PrimevalTitan(final PrimevalTitan card) {

--- a/Mage.Sets/src/mage/cards/p/ProfaneTutor.java
+++ b/Mage.Sets/src/mage/cards/p/ProfaneTutor.java
@@ -24,7 +24,7 @@ public final class ProfaneTutor extends CardImpl {
         this.addAbility(new SuspendAbility(2, new ManaCostsImpl<>("{1}{B}"), this));
 
         // Search your library for a card, put that card into your hand, then shuffle.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary()));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
     }
 
     private ProfaneTutor(final ProfaneTutor card) {

--- a/Mage.Sets/src/mage/cards/p/ProfaneTutor.java
+++ b/Mage.Sets/src/mage/cards/p/ProfaneTutor.java
@@ -24,7 +24,7 @@ public final class ProfaneTutor extends CardImpl {
         this.addAbility(new SuspendAbility(2, new ManaCostsImpl<>("{1}{B}"), this));
 
         // Search your library for a card, put that card into your hand, then shuffle.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true));
     }
 
     private ProfaneTutor(final ProfaneTutor card) {

--- a/Mage.Sets/src/mage/cards/q/QuirionTrailblazer.java
+++ b/Mage.Sets/src/mage/cards/q/QuirionTrailblazer.java
@@ -26,7 +26,7 @@ public final class QuirionTrailblazer extends CardImpl {
         this.toughness = new MageInt(2);
 
         // When Quirion Trailblazer enters the battlefield, you may search your library for a basic land card and put that card onto the battlefield tapped. If you do, shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), true));
     }
 
     private QuirionTrailblazer(final QuirionTrailblazer card) {

--- a/Mage.Sets/src/mage/cards/q/QuirionTrailblazer.java
+++ b/Mage.Sets/src/mage/cards/q/QuirionTrailblazer.java
@@ -26,7 +26,7 @@ public final class QuirionTrailblazer extends CardImpl {
         this.toughness = new MageInt(2);
 
         // When Quirion Trailblazer enters the battlefield, you may search your library for a basic land card and put that card onto the battlefield tapped. If you do, shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), true));
     }
 
     private QuirionTrailblazer(final QuirionTrailblazer card) {

--- a/Mage.Sets/src/mage/cards/r/RampantGrowth.java
+++ b/Mage.Sets/src/mage/cards/r/RampantGrowth.java
@@ -21,7 +21,7 @@ public final class RampantGrowth extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{1}{G}");
 
         // Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true));
     }
 
     private RampantGrowth(final RampantGrowth card) {

--- a/Mage.Sets/src/mage/cards/r/RangerOfEos.java
+++ b/Mage.Sets/src/mage/cards/r/RangerOfEos.java
@@ -40,7 +40,7 @@ public final class RangerOfEos extends CardImpl {
         // When Ranger of Eos enters the battlefield, you may search your library for up to two creature cards with converted mana cost 1 or less,
         // reveal them, and put them into your hand. If you do, shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(0, 2, filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
     }
 
     private RangerOfEos(final RangerOfEos card) {

--- a/Mage.Sets/src/mage/cards/r/Ratcatcher.java
+++ b/Mage.Sets/src/mage/cards/r/Ratcatcher.java
@@ -39,7 +39,7 @@ public final class Ratcatcher extends CardImpl {
         
         // At the beginning of your upkeep, you may search your library for a Rat card, reveal it, and put it into your hand. If you do, shuffle your library.
         TargetCardInLibrary targetCard = new TargetCardInLibrary(1, 1, filter);
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(targetCard, true, true), TargetController.YOU, true));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(targetCard, true), TargetController.YOU, true));
         
     }
 

--- a/Mage.Sets/src/mage/cards/r/RazakethTheFoulblooded.java
+++ b/Mage.Sets/src/mage/cards/r/RazakethTheFoulblooded.java
@@ -41,7 +41,7 @@ public final class RazakethTheFoulblooded extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Pay 2 life, Sacrifice another creature: Search your library for a card and put that card into your hand. Then shuffle your library.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false), new PayLifeCost(2));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true), new PayLifeCost(2));
         ability.addCost(new SacrificeTargetCost(
                 new TargetControlledCreaturePermanent(1, 1, StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false)));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/r/RazakethTheFoulblooded.java
+++ b/Mage.Sets/src/mage/cards/r/RazakethTheFoulblooded.java
@@ -41,7 +41,7 @@ public final class RazakethTheFoulblooded extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Pay 2 life, Sacrifice another creature: Search your library for a card and put that card into your hand. Then shuffle your library.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true), new PayLifeCost(2));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false), new PayLifeCost(2));
         ability.addCost(new SacrificeTargetCost(
                 new TargetControlledCreaturePermanent(1, 1, StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false)));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/r/RazakethsRite.java
+++ b/Mage.Sets/src/mage/cards/r/RazakethsRite.java
@@ -17,7 +17,7 @@ public final class RazakethsRite extends CardImpl {
         // Search your library for a card and put that card into your hand
         // Then shuffle your library
         TargetCardInLibrary target = new TargetCardInLibrary();
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(target));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(target, false));
 
         // Cycling {B}
 

--- a/Mage.Sets/src/mage/cards/r/RazakethsRite.java
+++ b/Mage.Sets/src/mage/cards/r/RazakethsRite.java
@@ -17,7 +17,7 @@ public final class RazakethsRite extends CardImpl {
         // Search your library for a card and put that card into your hand
         // Then shuffle your library
         TargetCardInLibrary target = new TargetCardInLibrary();
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(target, false));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(target, false, true));
 
         // Cycling {B}
 

--- a/Mage.Sets/src/mage/cards/r/ReapAndSow.java
+++ b/Mage.Sets/src/mage/cards/r/ReapAndSow.java
@@ -30,7 +30,7 @@ public final class ReapAndSow extends CardImpl {
         this.getSpellAbility().addEffect(new DestroyTargetEffect());
         this.getSpellAbility().addTarget(new TargetLandPermanent());
         //or search your library for a land card, put that card onto the battlefield, then shuffle your library.
-        Mode mode = new Mode(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterLandCard())));
+        Mode mode = new Mode(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterLandCard()), false, true));
         this.getSpellAbility().getModes().addMode(mode);
 
         // Entwine {1}{G}

--- a/Mage.Sets/src/mage/cards/r/RecklessHandling.java
+++ b/Mage.Sets/src/mage/cards/r/RecklessHandling.java
@@ -25,7 +25,7 @@ public final class RecklessHandling extends CardImpl {
 
         // Search your library for an artifact card, reveal it, put it into your hand, shuffle, then discard a card at random. If an artifact card was discarded this way, Reckless Handling deals 2 damage to each opponent.
         this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_ARTIFACT_AN), true, true
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_ARTIFACT_AN), true
         ).setText("search your library for an artifact card, reveal it, put it into your hand, shuffle"));
         this.getSpellAbility().addEffect(new RecklessHandlingEffect());
     }

--- a/Mage.Sets/src/mage/cards/r/RecruiterOfTheGuard.java
+++ b/Mage.Sets/src/mage/cards/r/RecruiterOfTheGuard.java
@@ -35,7 +35,7 @@ public final class RecruiterOfTheGuard extends CardImpl {
         // When Recruiter of the Guard enters the battlefield, you may search your library for a creature card with toughness 2 or less, 
         // reveal it, put it into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true), true));
+                new TargetCardInLibrary(filter), true), true));
     }
 
     private RecruiterOfTheGuard(final RecruiterOfTheGuard card) {

--- a/Mage.Sets/src/mage/cards/r/RelicSeeker.java
+++ b/Mage.Sets/src/mage/cards/r/RelicSeeker.java
@@ -38,7 +38,7 @@ public final class RelicSeeker extends CardImpl {
 
         // When Relic Seeker becomes renowned, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(1, 1, filter);
-        this.addAbility(new BecomesRenownedSourceTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new BecomesRenownedSourceTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
 
     }
 

--- a/Mage.Sets/src/mage/cards/r/Remembrance.java
+++ b/Mage.Sets/src/mage/cards/r/Remembrance.java
@@ -79,7 +79,7 @@ class RemembranceTriggeredAbility extends TriggeredAbilityImpl {
             filterCard.add(new NamePredicate(permanent.getName()));
             this.getEffects().clear();
             this.addEffect(new SearchLibraryPutInHandEffect(
-                    new TargetCardInLibrary(filterCard), true, true
+                    new TargetCardInLibrary(filterCard), true
             ));
             return true;
         }

--- a/Mage.Sets/src/mage/cards/r/Renewal.java
+++ b/Mage.Sets/src/mage/cards/r/Renewal.java
@@ -29,7 +29,7 @@ public final class Renewal extends CardImpl {
         this.getSpellAbility().addCost(new SacrificeTargetCost(new TargetControlledPermanent(new FilterControlledLandPermanent("a land"))));
         
         // Search your library for a basic land card and put that card onto the battlefield. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND)));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), false, true));
         
         // Draw a card at the beginning of the next turn's upkeep.
         this.getSpellAbility().addEffect(new CreateDelayedTriggeredAbilityEffect(new AtTheBeginOfNextUpkeepDelayedTriggeredAbility(new DrawCardSourceControllerEffect(1)), false).concatBy("<br>"));

--- a/Mage.Sets/src/mage/cards/r/ReshapeTheEarth.java
+++ b/Mage.Sets/src/mage/cards/r/ReshapeTheEarth.java
@@ -20,7 +20,7 @@ public final class ReshapeTheEarth extends CardImpl {
         // Search your library for up to ten land cards, put them onto the battlefield tapped, then shuffle your library.
         this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(
                 0, 10, StaticFilters.FILTER_CARD_LANDS
-        ), true, true));
+        ), true));
     }
 
     private ReshapeTheEarth(final ReshapeTheEarth card) {

--- a/Mage.Sets/src/mage/cards/r/RhysticTutor.java
+++ b/Mage.Sets/src/mage/cards/r/RhysticTutor.java
@@ -21,7 +21,7 @@ public final class RhysticTutor extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{B}");
 
         // Unless any player pays {2}, search your library for a card, put that card into your hand, then shuffle your library.
-        Effect effect = new DoUnlessAnyPlayerPaysEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary()), new ManaCostsImpl<>("{2}"));
+        Effect effect = new DoUnlessAnyPlayerPaysEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false), new ManaCostsImpl<>("{2}"));
         effect.setText("Unless any player pays {2}, search your library for a card, put that card into your hand, then shuffle");
         this.getSpellAbility().addEffect(effect);
     }

--- a/Mage.Sets/src/mage/cards/r/RingOfThreeWishes.java
+++ b/Mage.Sets/src/mage/cards/r/RingOfThreeWishes.java
@@ -29,7 +29,7 @@ public final class RingOfThreeWishes extends CardImpl {
         // Ring of Three Wishes enters the battlefield with three wish counters on it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.WISH.createInstance(3)), "with three wish counters on it"));
         // {5}, {T}, Remove a wish counter from Ring of Three Wishes: Search your library for a card and put that card into your hand. Then shuffle your library. 
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true), new ManaCostsImpl<>("{5}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false), new ManaCostsImpl<>("{5}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new RemoveCountersSourceCost(CounterType.WISH.createInstance()));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/r/RingOfThreeWishes.java
+++ b/Mage.Sets/src/mage/cards/r/RingOfThreeWishes.java
@@ -29,7 +29,7 @@ public final class RingOfThreeWishes extends CardImpl {
         // Ring of Three Wishes enters the battlefield with three wish counters on it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.WISH.createInstance(3)), "with three wish counters on it"));
         // {5}, {T}, Remove a wish counter from Ring of Three Wishes: Search your library for a card and put that card into your hand. Then shuffle your library. 
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false), new ManaCostsImpl<>("{5}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true), new ManaCostsImpl<>("{5}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new RemoveCountersSourceCost(CounterType.WISH.createInstance()));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/r/RiveteersOverlook.java
+++ b/Mage.Sets/src/mage/cards/r/RiveteersOverlook.java
@@ -38,7 +38,7 @@ public final class RiveteersOverlook extends CardImpl {
 
         // When Riveteers Overlook enters the battlefield, sacrifice it. When you do, search your library for a basic Swamp, Mountain, or Forest card, put it onto the battlefield tapped, then shuffle and you gain 1 life.
         ReflexiveTriggeredAbility ability = new ReflexiveTriggeredAbility(new SearchLibraryPutInPlayEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), false);
         ability.addEffect(new GainLifeEffect(1).concatBy("and"));
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoWhenCostPaid(

--- a/Mage.Sets/src/mage/cards/r/RuneScarredDemon.java
+++ b/Mage.Sets/src/mage/cards/r/RuneScarredDemon.java
@@ -29,7 +29,7 @@ public final class RuneScarredDemon extends CardImpl {
         this.toughness = new MageInt( 6);
         this.addAbility(FlyingAbility.getInstance());
         TargetCardInLibrary target = new TargetCardInLibrary();
-        Ability ability = new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target));
+        Ability ability = new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, false));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SakuraTribeElder.java
+++ b/Mage.Sets/src/mage/cards/s/SakuraTribeElder.java
@@ -10,7 +10,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCardInLibrary;
@@ -30,7 +29,7 @@ public final class SakuraTribeElder extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
         TargetCardInLibrary target = new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND);
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true, Outcome.PutLandInPlay), new SacrificeSourceCost()));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true), new SacrificeSourceCost()));
     }
 
     private SakuraTribeElder(final SakuraTribeElder card) {

--- a/Mage.Sets/src/mage/cards/s/SakuraTribeElder.java
+++ b/Mage.Sets/src/mage/cards/s/SakuraTribeElder.java
@@ -29,7 +29,7 @@ public final class SakuraTribeElder extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
         TargetCardInLibrary target = new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND);
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true), new SacrificeSourceCost()));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(target, true, true), new SacrificeSourceCost()));
     }
 
     private SakuraTribeElder(final SakuraTribeElder card) {

--- a/Mage.Sets/src/mage/cards/s/SamutTheTested.java
+++ b/Mage.Sets/src/mage/cards/s/SamutTheTested.java
@@ -51,7 +51,7 @@ public final class SamutTheTested extends CardImpl {
         this.addAbility(ability);
 
         // -7: Search your library for up to two creature and/or planeswalker cards, put them onto the battlefield, then shuffle your library.
-        effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, filter), false, true);
+        effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 2, filter), false);
         ability = new LoyaltyAbility(effect, -7);
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SarkhansTriumph.java
+++ b/Mage.Sets/src/mage/cards/s/SarkhansTriumph.java
@@ -26,7 +26,7 @@ public final class SarkhansTriumph extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{2}{R}");
 
         // Search your library for a Dragon creature card, reveal it, put it into your hand, then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true));
     }
 
     private SarkhansTriumph(final SarkhansTriumph card) {

--- a/Mage.Sets/src/mage/cards/s/ScoutThePerimeter.java
+++ b/Mage.Sets/src/mage/cards/s/ScoutThePerimeter.java
@@ -23,7 +23,7 @@ public final class ScoutThePerimeter extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{G}");
 
         // Search your library for a land card, put it onto the battlefield tapped, then suffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterLandCard()), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterLandCard()), true));
 
         // Put a bounty counter on up to one target creature an opponent controls.
         Effect effect = new AddCountersTargetEffect(CounterType.BOUNTY.createInstance());

--- a/Mage.Sets/src/mage/cards/s/ScreamingSeahawk.java
+++ b/Mage.Sets/src/mage/cards/s/ScreamingSeahawk.java
@@ -38,7 +38,7 @@ public final class ScreamingSeahawk extends CardImpl {
         
         // When Screaming Seahawk enters the battlefield, you may search your library for a card named Screaming Seahawk, reveal it, and put it into your hand. If you do, shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(1, 1, filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
     }
 
     private ScreamingSeahawk(final ScreamingSeahawk card) {

--- a/Mage.Sets/src/mage/cards/s/SearchForTomorrow.java
+++ b/Mage.Sets/src/mage/cards/s/SearchForTomorrow.java
@@ -7,7 +7,6 @@ import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCardInLibrary;
 
@@ -25,7 +24,7 @@ public final class SearchForTomorrow extends CardImpl {
 
         // Search your library for a basic land card and put it onto the battlefield. Then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND);
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(target, false, Outcome.PutLandInPlay));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(target, false));
         
         // Suspend 2-{G}
         this.addAbility(new SuspendAbility(2, new ManaCostsImpl<>("{G}"), this));

--- a/Mage.Sets/src/mage/cards/s/SecretSalvage.java
+++ b/Mage.Sets/src/mage/cards/s/SecretSalvage.java
@@ -77,6 +77,6 @@ class SecretSalvageEffect extends OneShotEffect {
         nameFilter.add(new NamePredicate(nameToSearch));
         return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(
                 0, Integer.MAX_VALUE, nameFilter
-        ), true, true).apply(game, source);
+        ), true).apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SeedguideAsh.java
+++ b/Mage.Sets/src/mage/cards/s/SeedguideAsh.java
@@ -8,7 +8,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.FilterCard;
 import mage.target.common.TargetCardInLibrary;
@@ -33,7 +32,7 @@ public final class SeedguideAsh extends CardImpl {
         this.power = new MageInt(4);
         this.toughness = new MageInt(4);
         // When Seedguide Ash dies, you may search your library for up to three Forest cards and put them onto the battlefield tapped. If you do, shuffle your library.
-        this.addAbility(new DiesSourceTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 3, filter), true, true, Outcome.PutLandInPlay), true));
+        this.addAbility(new DiesSourceTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 3, filter), true, true), true));
     }
 
     private SeedguideAsh(final SeedguideAsh card) {

--- a/Mage.Sets/src/mage/cards/s/SeedguideAsh.java
+++ b/Mage.Sets/src/mage/cards/s/SeedguideAsh.java
@@ -32,7 +32,7 @@ public final class SeedguideAsh extends CardImpl {
         this.power = new MageInt(4);
         this.toughness = new MageInt(4);
         // When Seedguide Ash dies, you may search your library for up to three Forest cards and put them onto the battlefield tapped. If you do, shuffle your library.
-        this.addAbility(new DiesSourceTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 3, filter), true, true), true));
+        this.addAbility(new DiesSourceTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 3, filter), true), true));
     }
 
     private SeedguideAsh(final SeedguideAsh card) {

--- a/Mage.Sets/src/mage/cards/s/SelfAssembler.java
+++ b/Mage.Sets/src/mage/cards/s/SelfAssembler.java
@@ -33,7 +33,7 @@ public final class SelfAssembler extends CardImpl {
 
         // When Self-Assembler enters the battlefield, you may search your library for an Assembly-Worker creature card, reveal it, put it into your hand,
         // then shuffle your library.
-        Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 1, filter), true, true);
+        Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 1, filter), true);
         effect.setText("you may search your library for an Assembly-Worker creature card, reveal it, put it into your hand, then shuffle");
         this.addAbility(new EntersBattlefieldTriggeredAbility(effect, true));
     }

--- a/Mage.Sets/src/mage/cards/s/ShadowbornApostle.java
+++ b/Mage.Sets/src/mage/cards/s/ShadowbornApostle.java
@@ -45,7 +45,7 @@ public final class ShadowbornApostle extends CardImpl {
         // A deck can have any number of cards named Shadowborn Apostle.
         this.getSpellAbility().addEffect(new InfoEffect("A deck can have any number of cards named Shadowborn Apostle."));
         // {B}, Sacrifice six creatures named Shadowborn Apostle: Search your library for a Demon creature and put it onto the battlefield. Then shuffle your library.
-        Effect effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, true);
+        Effect effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false);
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{B}"));
         ability.addCost(new SacrificeTargetCost(new TargetControlledCreaturePermanent(6,6,filterApostle, false)));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/SharedSummons.java
+++ b/Mage.Sets/src/mage/cards/s/SharedSummons.java
@@ -22,7 +22,7 @@ public final class SharedSummons extends CardImpl {
 
         // Search your library for up to two creature cards with different names, reveal them, put them into your hand, then shuffle your library.
         this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(
-                new TargetCardWithDifferentNameInLibrary(0, 2, filter), true, true
+                new TargetCardWithDifferentNameInLibrary(0, 2, filter), true
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/s/ShefetMonitor.java
+++ b/Mage.Sets/src/mage/cards/s/ShefetMonitor.java
@@ -44,7 +44,7 @@ public final class ShefetMonitor extends CardImpl {
 
         // When you cycle Shefet Monitor, you may search your library for a basic land card or a Desert card, put it onto the battlefield, then shuffle your library.
         this.addAbility(new CycleTriggeredAbility(
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, true),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false),
                 true));
     }
 

--- a/Mage.Sets/src/mage/cards/s/ShieldWallSentinel.java
+++ b/Mage.Sets/src/mage/cards/s/ShieldWallSentinel.java
@@ -38,7 +38,7 @@ public final class ShieldWallSentinel extends CardImpl {
 
         // When Shield-Wall Sentinel enters the battlefield, you may search your library for a creature card with defender, reveal it, put it into your hand, then shuffle.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/s/ShrineSteward.java
+++ b/Mage.Sets/src/mage/cards/s/ShrineSteward.java
@@ -36,7 +36,7 @@ public final class ShrineSteward extends CardImpl {
 
         // When Shrine Steward enters the battlefield, you may search your library for an Aura or Shrine card, reveal it, put it into your hand, then shuffle.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SidisiUndeadVizier.java
+++ b/Mage.Sets/src/mage/cards/s/SidisiUndeadVizier.java
@@ -36,7 +36,7 @@ public final class SidisiUndeadVizier extends CardImpl {
         this.addAbility(new ExploitAbility());
         
         // When Sidisi, Undead Vizier exploits a creature, you may search your library for a card, put it into your hand, then shuffle your library.
-        this.addAbility(new ExploitCreatureTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(new FilterCard("card")), false, true), false));
+        this.addAbility(new ExploitCreatureTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(new FilterCard("card")), false), false));
     }
 
     private SidisiUndeadVizier(final SidisiUndeadVizier card) {

--- a/Mage.Sets/src/mage/cards/s/SiftThroughSands.java
+++ b/Mage.Sets/src/mage/cards/s/SiftThroughSands.java
@@ -17,7 +17,6 @@ import mage.filter.common.FilterCreatureCard;
 import mage.filter.predicate.mageobject.NamePredicate;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.stack.Spell;
 import mage.target.common.TargetCardInLibrary;
 import mage.watchers.Watcher;
@@ -48,7 +47,7 @@ public final class SiftThroughSands extends CardImpl {
         this.getSpellAbility().addEffect(effect);
 
         // If you've cast a spell named Peer Through Depths and a spell named Reach Through Mists this turn, you may search your library for a card named The Unspeakable, put it onto the battlefield, then shuffle your library.
-        this.getSpellAbility().addEffect(new ConditionalOneShotEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, true), new SiftThroughSandsCondition(), rule));
+        this.getSpellAbility().addEffect(new ConditionalOneShotEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false), new SiftThroughSandsCondition(), rule));
         this.getSpellAbility().addWatcher(new SiftThroughSandsWatcher());
     }
 

--- a/Mage.Sets/src/mage/cards/s/SilkwingScout.java
+++ b/Mage.Sets/src/mage/cards/s/SilkwingScout.java
@@ -36,7 +36,7 @@ public final class SilkwingScout extends CardImpl {
         
         // {G}, Sacrifice Silkwing Scout: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, 
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
                 new ManaCostsImpl<>("{G}"));
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/SilkwingScout.java
+++ b/Mage.Sets/src/mage/cards/s/SilkwingScout.java
@@ -36,7 +36,7 @@ public final class SilkwingScout extends CardImpl {
         
         // {G}, Sacrifice Silkwing Scout: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, 
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true),
                 new ManaCostsImpl<>("{G}"));
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/SilvergladeElemental.java
+++ b/Mage.Sets/src/mage/cards/s/SilvergladeElemental.java
@@ -30,7 +30,7 @@ public final class SilvergladeElemental extends CardImpl {
 
         this.power = new MageInt(4);
         this.toughness = new MageInt(4);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, true), true));
     }
 
     private SilvergladeElemental(final SilvergladeElemental card) {

--- a/Mage.Sets/src/mage/cards/s/SilvergladeElemental.java
+++ b/Mage.Sets/src/mage/cards/s/SilvergladeElemental.java
@@ -30,7 +30,7 @@ public final class SilvergladeElemental extends CardImpl {
 
         this.power = new MageInt(4);
         this.toughness = new MageInt(4);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, false), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false), true));
     }
 
     private SilvergladeElemental(final SilvergladeElemental card) {

--- a/Mage.Sets/src/mage/cards/s/SilvergladePathfinder.java
+++ b/Mage.Sets/src/mage/cards/s/SilvergladePathfinder.java
@@ -33,7 +33,7 @@ public final class SilvergladePathfinder extends CardImpl {
 
         // {1}{G}, {tap}, Discard a card: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-            new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
+            new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true),
             new ManaCostsImpl<>("{1}{G}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new DiscardCardCost());

--- a/Mage.Sets/src/mage/cards/s/SilvergladePathfinder.java
+++ b/Mage.Sets/src/mage/cards/s/SilvergladePathfinder.java
@@ -33,7 +33,7 @@ public final class SilvergladePathfinder extends CardImpl {
 
         // {1}{G}, {tap}, Discard a card: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-            new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true),
+            new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
             new ManaCostsImpl<>("{1}{G}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new DiscardCardCost());

--- a/Mage.Sets/src/mage/cards/s/SithRuins.java
+++ b/Mage.Sets/src/mage/cards/s/SithRuins.java
@@ -64,7 +64,7 @@ public final class SithRuins extends CardImpl {
             filter.add(Predicates.or(subtypePredicates));
             filter.add(SuperType.BASIC.getPredicate());
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true, true));
+            addEffect(new SearchLibraryPutInPlayEffect(target, true));
         }
 
         @Override

--- a/Mage.Sets/src/mage/cards/s/SithRuins.java
+++ b/Mage.Sets/src/mage/cards/s/SithRuins.java
@@ -64,7 +64,7 @@ public final class SithRuins extends CardImpl {
             filter.add(Predicates.or(subtypePredicates));
             filter.add(SuperType.BASIC.getPredicate());
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true, true, Outcome.PutLandInPlay));
+            addEffect(new SearchLibraryPutInPlayEffect(target, true, true));
         }
 
         @Override

--- a/Mage.Sets/src/mage/cards/s/SithWayfinder.java
+++ b/Mage.Sets/src/mage/cards/s/SithWayfinder.java
@@ -23,7 +23,7 @@ public class SithWayfinder extends CardImpl {
         //{2}, {T}, Sacrifice Sith Wayfinder: Search your library for a land card, reveal it, and put it into your hand.
         //Then shuffle your library.
         SimpleActivatedAbility simpleActivatedAbility = new SimpleActivatedAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_LAND), true, true),
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_LAND), true),
                 new ManaCostsImpl<>("{2}"));
         simpleActivatedAbility.addCost(new TapSourceCost());
         simpleActivatedAbility.addCost(new SacrificeSourceCost());

--- a/Mage.Sets/src/mage/cards/s/SivitriDragonMaster.java
+++ b/Mage.Sets/src/mage/cards/s/SivitriDragonMaster.java
@@ -52,7 +52,7 @@ public final class SivitriDragonMaster extends CardImpl {
 
         // -3: Search your library for a Dragon card, reveal it, put it into your hand, then shuffle.
         this.addAbility(new LoyaltyAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), -3));
 
         // -7: Destroy all non-Dragon creatures.

--- a/Mage.Sets/src/mage/cards/s/SkitteringSurveyor.java
+++ b/Mage.Sets/src/mage/cards/s/SkitteringSurveyor.java
@@ -26,7 +26,7 @@ public final class SkitteringSurveyor extends CardImpl {
         this.toughness = new MageInt(2);
 
         // When Skittering Surveyor enters the battlefield, you may search your library for a basic land, reveal it, put it into your hand, then shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), true));
     }
 
     private SkitteringSurveyor(final SkitteringSurveyor card) {

--- a/Mage.Sets/src/mage/cards/s/SkyshroudSentinel.java
+++ b/Mage.Sets/src/mage/cards/s/SkyshroudSentinel.java
@@ -34,7 +34,7 @@ public final class SkyshroudSentinel extends CardImpl {
 
         // When Skyshroud Sentinel enters the battlefield, you may search your library for up to three cards named Skyshroud Sentinel, reveal them, and put them into your hand. If you do, shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(0, 3, filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
     }
 
     private SkyshroudSentinel(final SkyshroudSentinel card) {

--- a/Mage.Sets/src/mage/cards/s/SliverOverlord.java
+++ b/Mage.Sets/src/mage/cards/s/SliverOverlord.java
@@ -39,7 +39,7 @@ public final class SliverOverlord extends CardImpl {
         this.toughness = new MageInt(7);
 
         // {3}: Search your library for a Sliver card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true), new ManaCostsImpl<>("{3}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true), new ManaCostsImpl<>("{3}")));
         
         // {3}: Gain control of target Sliver.
         Ability ability = (new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainControlTargetEffect(Duration.Custom), new ManaCostsImpl<>("{3}")));

--- a/Mage.Sets/src/mage/cards/s/SliverOverlord.java
+++ b/Mage.Sets/src/mage/cards/s/SliverOverlord.java
@@ -39,7 +39,7 @@ public final class SliverOverlord extends CardImpl {
         this.toughness = new MageInt(7);
 
         // {3}: Search your library for a Sliver card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true), new ManaCostsImpl<>("{3}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true), new ManaCostsImpl<>("{3}")));
         
         // {3}: Gain control of target Sliver.
         Ability ability = (new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainControlTargetEffect(Duration.Custom), new ManaCostsImpl<>("{3}")));

--- a/Mage.Sets/src/mage/cards/s/SolveTheEquation.java
+++ b/Mage.Sets/src/mage/cards/s/SolveTheEquation.java
@@ -19,7 +19,7 @@ public final class SolveTheEquation extends CardImpl {
 
         // Search your library for an instant or sorcery card, reveal it, put it into your hand, then shuffle.
         this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_INSTANT_OR_SORCERY), true, true
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_INSTANT_OR_SORCERY), true
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpaceMarineScout.java
+++ b/Mage.Sets/src/mage/cards/s/SpaceMarineScout.java
@@ -50,7 +50,7 @@ public final class SpaceMarineScout extends CardImpl {
         // Concealed Position -- When Space Marine Scout enters the battlefield, if an opponent controls more lands than you, you may search your library for a Plains card, put it onto the battlefield tapped, then shuffle.
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(
                 new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(
-                        new TargetCardInLibrary(filter), true, true
+                        new TargetCardInLibrary(filter), true
                 ), true), condition, "When {this} enters the battlefield, if an opponent controls more lands " +
                 "than you, you may search your library for a basic Plains card, put it onto the battlefield tapped, then shuffle."
         ).withFlavorWord("Concealed Position"));

--- a/Mage.Sets/src/mage/cards/s/Spellseeker.java
+++ b/Mage.Sets/src/mage/cards/s/Spellseeker.java
@@ -36,7 +36,7 @@ public final class Spellseeker extends CardImpl {
 
         // When Spellseeker enters the battlefield, you may search your library for an instant or sorcery card with converted mana cost 2 or less, reveal it, put it into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true),
                 true
         ));
     }

--- a/Mage.Sets/src/mage/cards/s/SpoilsOfVictory.java
+++ b/Mage.Sets/src/mage/cards/s/SpoilsOfVictory.java
@@ -6,7 +6,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicates;
@@ -33,7 +32,7 @@ public final class SpoilsOfVictory extends CardImpl {
 
 
         // Search your library for a Plains, Island, Swamp, Mountain, or Forest card and put that card onto the battlefield. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, Outcome.PutLandInPlay));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false));
     }
 
     private SpoilsOfVictory(final SpoilsOfVictory card) {

--- a/Mage.Sets/src/mage/cards/s/Sporocyst.java
+++ b/Mage.Sets/src/mage/cards/s/Sporocyst.java
@@ -73,6 +73,6 @@ class SporocystEffect extends OneShotEffect {
         int xValue = ManacostVariableValue.ETB.calculate(game, source, this);
         return new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(
                 0, xValue, StaticFilters.FILTER_CARD_BASIC_LANDS
-        ), true, true).apply(game, source);
+        ), true).apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SpringbloomDruid.java
+++ b/Mage.Sets/src/mage/cards/s/SpringbloomDruid.java
@@ -8,7 +8,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCardInLibrary;
@@ -35,7 +34,7 @@ public final class SpringbloomDruid extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoIfCostPaid(
                 new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(
                         0, 2, StaticFilters.FILTER_CARD_BASIC_LAND
-                ), true, Outcome.PutLandInPlay
+                ), true
                 ).setText("search your library for up to two basic land cards, " +
                         "put them onto the battlefield tapped, then shuffle"
                 ), new SacrificeTargetCost(new TargetControlledPermanent(FILTER_CONTROLLED_LAND_SHORT_TEXT))

--- a/Mage.Sets/src/mage/cards/s/SproutingVines.java
+++ b/Mage.Sets/src/mage/cards/s/SproutingVines.java
@@ -22,7 +22,7 @@ public final class SproutingVines extends CardImpl {
 
 
         // Search your library for a basic land card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(1, 1, StaticFilters.FILTER_CARD_BASIC_LAND), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(1, 1, StaticFilters.FILTER_CARD_BASIC_LAND), true, true));
         // Storm
         this.addAbility(new StormAbility());
     }

--- a/Mage.Sets/src/mage/cards/s/SquadronHawk.java
+++ b/Mage.Sets/src/mage/cards/s/SquadronHawk.java
@@ -37,7 +37,7 @@ public final class SquadronHawk extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // When Squadron Hawk enters the battlefield, you may search your library for up to three cards named Squadron Hawk, reveal them, put them into your hand, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(0, 3, filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
     }
 
     private SquadronHawk(final SquadronHawk card) {

--- a/Mage.Sets/src/mage/cards/s/SteelshaperApprentice.java
+++ b/Mage.Sets/src/mage/cards/s/SteelshaperApprentice.java
@@ -41,7 +41,7 @@ public final class SteelshaperApprentice extends CardImpl {
 
         // {W}, {tap}, Return Steelshaper Apprentice to its owner's hand: Search your library for an Equipment card, reveal that card, and put it into your hand. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(1, 1, filter), true),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(1, 1, filter), true, true),
                 new ColoredManaCost(ColoredManaSymbol.W));
         ability.addCost(new TapSourceCost());
         ability.addCost(new ReturnToHandFromBattlefieldSourceCost());

--- a/Mage.Sets/src/mage/cards/s/SteelshapersGift.java
+++ b/Mage.Sets/src/mage/cards/s/SteelshapersGift.java
@@ -28,7 +28,7 @@ public final class SteelshapersGift extends CardImpl {
 
 
         // Search your library for an Equipment card, reveal that card, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true));
     }
 
     private SteelshapersGift(final SteelshapersGift card) {

--- a/Mage.Sets/src/mage/cards/s/SterlingGrove.java
+++ b/Mage.Sets/src/mage/cards/s/SterlingGrove.java
@@ -32,7 +32,7 @@ public final class SterlingGrove extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityControlledEffect(ShroudAbility.getInstance(), Duration.WhileOnBattlefield, new FilterEnchantmentPermanent("enchantments"), true)));
         
         // {1}, Sacrifice Sterling Grove: Search your library for an enchantment card and reveal that card. Shuffle your library, then put the card on top of it.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(new FilterEnchantmentCard("enchantment card")), true, true), new GenericManaCost(1));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(new FilterEnchantmentCard("enchantment card")), true), new GenericManaCost(1));
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/StoicFarmer.java
+++ b/Mage.Sets/src/mage/cards/s/StoicFarmer.java
@@ -45,7 +45,7 @@ public final class StoicFarmer extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(
                 new ConditionalOneShotEffect(
                         new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true),
-                        new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), false),
+                        new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true),
                         condition, "search your library for a basic Plains card and reveal it. " +
                         "If an opponent controls more lands than you, put it onto the battlefield tapped. " +
                         "Otherwise put it into your hand. Then shuffle"

--- a/Mage.Sets/src/mage/cards/s/StoicFarmer.java
+++ b/Mage.Sets/src/mage/cards/s/StoicFarmer.java
@@ -45,7 +45,7 @@ public final class StoicFarmer extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(
                 new ConditionalOneShotEffect(
                         new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true),
-                        new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter)),
+                        new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), false),
                         condition, "search your library for a basic Plains card and reveal it. " +
                         "If an opponent controls more lands than you, put it onto the battlefield tapped. " +
                         "Otherwise put it into your hand. Then shuffle"

--- a/Mage.Sets/src/mage/cards/s/StoneforgeMystic.java
+++ b/Mage.Sets/src/mage/cards/s/StoneforgeMystic.java
@@ -40,7 +40,7 @@ public final class StoneforgeMystic extends CardImpl {
 
         // When Stoneforge Mystic enters the battlefield, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(1, 1, filter);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
 
         // {1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.
         SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new PutCardFromHandOntoBattlefieldEffect(filter), new ManaCostsImpl<>("{1}{W}"));

--- a/Mage.Sets/src/mage/cards/s/SummonersPact.java
+++ b/Mage.Sets/src/mage/cards/s/SummonersPact.java
@@ -31,7 +31,7 @@ public final class SummonersPact extends CardImpl {
         this.color.setGreen(true);
         
         // Search your library for a green creature card, reveal it, and put it into your hand. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true));
         // At the beginning of your next upkeep, pay {2}{G}{G}. If you don't, you lose the game.
         this.getSpellAbility().addEffect(new CreateDelayedTriggeredAbilityEffect(new PactDelayedTriggeredAbility(new ManaCostsImpl<>("{2}{G}{G}"))));
     }

--- a/Mage.Sets/src/mage/cards/s/SunbladeSamurai.java
+++ b/Mage.Sets/src/mage/cards/s/SunbladeSamurai.java
@@ -43,7 +43,7 @@ public final class SunbladeSamurai extends CardImpl {
         Ability ability = new ChannelAbility(
                 "{2}",
                 new SearchLibraryPutInHandEffect(
-                        new TargetCardInLibrary(filter), true, true
+                        new TargetCardInLibrary(filter), true
                 )
         );
         ability.addEffect(new GainLifeEffect(2));

--- a/Mage.Sets/src/mage/cards/s/SurvivalOfTheFittest.java
+++ b/Mage.Sets/src/mage/cards/s/SurvivalOfTheFittest.java
@@ -27,7 +27,7 @@ public final class SurvivalOfTheFittest extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{G}");
 
         // {G}, Discard a creature card: Search your library for a creature card, reveal that card, and put it into your hand. Then shuffle your library.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true, true), new ColoredManaCost(ColoredManaSymbol.G));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true), new ColoredManaCost(ColoredManaSymbol.G));
         ability.addCost(new DiscardTargetCost(new TargetCardInHand(StaticFilters.FILTER_CARD_CREATURE)));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SurvivalOfTheFittest.java
+++ b/Mage.Sets/src/mage/cards/s/SurvivalOfTheFittest.java
@@ -27,7 +27,7 @@ public final class SurvivalOfTheFittest extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{G}");
 
         // {G}, Discard a creature card: Search your library for a creature card, reveal that card, and put it into your hand. Then shuffle your library.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true), new ColoredManaCost(ColoredManaSymbol.G));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true, true), new ColoredManaCost(ColoredManaSymbol.G));
         ability.addCost(new DiscardTargetCost(new TargetCardInHand(StaticFilters.FILTER_CARD_CREATURE)));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SylvanPrimordial.java
+++ b/Mage.Sets/src/mage/cards/s/SylvanPrimordial.java
@@ -113,9 +113,8 @@ class SylvanPrimordialEffect extends OneShotEffect {
             }
         }
         if (destroyedCreatures > 0) {
-            new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(destroyedCreatures, filterForest), true, true).apply(game, source);
+            new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(destroyedCreatures, filterForest), true).apply(game, source);
         }
         return result;
     }
 }
-

--- a/Mage.Sets/src/mage/cards/s/SylvanRanger.java
+++ b/Mage.Sets/src/mage/cards/s/SylvanRanger.java
@@ -31,7 +31,7 @@ public final class SylvanRanger extends CardImpl {
 
         // When Sylvan Ranger enters the battlefield, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND);
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
     }
 
     private SylvanRanger(final SylvanRanger card) {

--- a/Mage.Sets/src/mage/cards/s/SylvanTutor.java
+++ b/Mage.Sets/src/mage/cards/s/SylvanTutor.java
@@ -18,7 +18,7 @@ public final class SylvanTutor extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{G}");
 
         // Search your library for a creature card and reveal that card. Shuffle your library, then put the card on top of it.
-        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true));
     }
 
     private SylvanTutor(final SylvanTutor card) {

--- a/Mage.Sets/src/mage/cards/t/TajNarSwordsmith.java
+++ b/Mage.Sets/src/mage/cards/t/TajNarSwordsmith.java
@@ -71,7 +71,7 @@ class TajNarSwordsmithEffect extends OneShotEffect {
             FilterCard filter = new FilterCard("Equipment card with mana value {" + payCount + "} or less");
             filter.add(SubType.EQUIPMENT.getPredicate());
             filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, payCount + 1));
-            new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 1, filter), false, true).apply(game, source);
+            new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(0, 1, filter), false).apply(game, source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/t/Tallowisp.java
+++ b/Mage.Sets/src/mage/cards/t/Tallowisp.java
@@ -41,7 +41,7 @@ public final class Tallowisp extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever you cast a Spirit or Arcane spell, you may search your library for an Aura card with enchant creature, reveal it, and put it into your hand. If you do, shuffle your library.
-        this.addAbility(new SpellCastControllerTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filterAura), true, true), StaticFilters.FILTER_SPIRIT_OR_ARCANE_CARD, true));
+        this.addAbility(new SpellCastControllerTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filterAura), true), StaticFilters.FILTER_SPIRIT_OR_ARCANE_CARD, true));
     }
 
     private Tallowisp(final Tallowisp card) {

--- a/Mage.Sets/src/mage/cards/t/TamiyosJournal.java
+++ b/Mage.Sets/src/mage/cards/t/TamiyosJournal.java
@@ -36,7 +36,7 @@ public final class TamiyosJournal extends CardImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, new InvestigateEffect(), TargetController.YOU, false));
 
         // {T}, Sacrifice three Clues: Search your library for a card and put that card into your hand. Then shuffle your library.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true), new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false), new TapSourceCost());
         ability.addCost(new SacrificeTargetCost(new TargetControlledPermanent(3, 3, filter, false)));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/t/TamiyosJournal.java
+++ b/Mage.Sets/src/mage/cards/t/TamiyosJournal.java
@@ -36,7 +36,7 @@ public final class TamiyosJournal extends CardImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, new InvestigateEffect(), TargetController.YOU, false));
 
         // {T}, Sacrifice three Clues: Search your library for a card and put that card into your hand. Then shuffle your library.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false), new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true), new TapSourceCost());
         ability.addCost(new SacrificeTargetCost(new TargetControlledPermanent(3, 3, filter, false)));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/t/TerminalMoraine.java
+++ b/Mage.Sets/src/mage/cards/t/TerminalMoraine.java
@@ -29,7 +29,7 @@ public final class TerminalMoraine extends CardImpl {
         // {tap}: Add {C}.
         this.addAbility(new ColorlessManaAbility());
         // {2}, {tap}, Sacrifice Terminal Moraine: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), new ManaCostsImpl<>("{2}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), new ManaCostsImpl<>("{2}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/t/TerminalMoraine.java
+++ b/Mage.Sets/src/mage/cards/t/TerminalMoraine.java
@@ -29,7 +29,7 @@ public final class TerminalMoraine extends CardImpl {
         // {tap}: Add {C}.
         this.addAbility(new ColorlessManaAbility());
         // {2}, {tap}, Sacrifice Terminal Moraine: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), new ManaCostsImpl<>("{2}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), new ManaCostsImpl<>("{2}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/t/ThaliasLancers.java
+++ b/Mage.Sets/src/mage/cards/t/ThaliasLancers.java
@@ -38,7 +38,7 @@ public final class ThaliasLancers extends CardImpl {
         this.addAbility(FirstStrikeAbility.getInstance());
 
         // When Thalia's Lancers enters the battlefield, you may search your library for a legendary card, reveal it, put it into your hand, then shuffle your library.
-        Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 1, filter), true, true);
+        Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 1, filter), true);
         effect.setText("you may search your library for a legendary card, reveal it, put it into your hand, then shuffle");
         this.addAbility(new EntersBattlefieldTriggeredAbility(effect, true));
     }

--- a/Mage.Sets/src/mage/cards/t/ThawingGlaciers.java
+++ b/Mage.Sets/src/mage/cards/t/ThawingGlaciers.java
@@ -32,7 +32,7 @@ public final class ThawingGlaciers extends CardImpl {
         this.addAbility(new EntersBattlefieldTappedAbility());
         // {1}, {tap}: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library. Return Thawing Glaciers to its owner's hand at the beginning of the next cleanup step.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), new GenericManaCost(1));
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         ability.addEffect(new CreateDelayedTriggeredAbilityEffect(new AtTheBeginOfNextCleanupDelayedTriggeredAbility(new ReturnToHandSourceEffect(true))));
 

--- a/Mage.Sets/src/mage/cards/t/ThawingGlaciers.java
+++ b/Mage.Sets/src/mage/cards/t/ThawingGlaciers.java
@@ -13,7 +13,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCardInLibrary;
@@ -33,7 +32,7 @@ public final class ThawingGlaciers extends CardImpl {
         this.addAbility(new EntersBattlefieldTappedAbility());
         // {1}, {tap}: Search your library for a basic land card, put that card onto the battlefield tapped, then shuffle your library. Return Thawing Glaciers to its owner's hand at the beginning of the next cleanup step.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, Outcome.PutLandInPlay), new GenericManaCost(1));
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         ability.addEffect(new CreateDelayedTriggeredAbilityEffect(new AtTheBeginOfNextCleanupDelayedTriggeredAbility(new ReturnToHandSourceEffect(true))));
 

--- a/Mage.Sets/src/mage/cards/t/TheBirthOfMeletis.java
+++ b/Mage.Sets/src/mage/cards/t/TheBirthOfMeletis.java
@@ -39,7 +39,7 @@ public final class TheBirthOfMeletis extends CardImpl {
         // I — Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle your library.
         sagaAbility.addChapterEffect(
                 this, SagaChapter.CHAPTER_I, new SearchLibraryPutInHandEffect(
-                        new TargetCardInLibrary(filter), true, true
+                        new TargetCardInLibrary(filter), true
                 )
         );
 

--- a/Mage.Sets/src/mage/cards/t/TheCrueltyOfGix.java
+++ b/Mage.Sets/src/mage/cards/t/TheCrueltyOfGix.java
@@ -52,7 +52,7 @@ public final class TheCrueltyOfGix extends CardImpl {
         // II -- Search your library for a card, put that card into your hand, then shuffle. You lose 3 life.
         sagaAbility.addChapterEffect(
                 this, SagaChapter.CHAPTER_II,
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true),
                 new LoseLifeSourceControllerEffect(3)
         );
 

--- a/Mage.Sets/src/mage/cards/t/TheCrueltyOfGix.java
+++ b/Mage.Sets/src/mage/cards/t/TheCrueltyOfGix.java
@@ -52,7 +52,7 @@ public final class TheCrueltyOfGix extends CardImpl {
         // II -- Search your library for a card, put that card into your hand, then shuffle. You lose 3 life.
         sagaAbility.addChapterEffect(
                 this, SagaChapter.CHAPTER_II,
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary()),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false),
                 new LoseLifeSourceControllerEffect(3)
         );
 

--- a/Mage.Sets/src/mage/cards/t/TheRestorationOfEiganjo.java
+++ b/Mage.Sets/src/mage/cards/t/TheRestorationOfEiganjo.java
@@ -47,7 +47,7 @@ public final class TheRestorationOfEiganjo extends CardImpl {
         // I - Search your library for a basic Plains card, reveal it, put it into your hand, then shuffle.
         sagaAbility.addChapterEffect(
                 this, SagaChapter.CHAPTER_I, new SearchLibraryPutInHandEffect(
-                        new TargetCardInLibrary(filter), true, true
+                        new TargetCardInLibrary(filter), true
                 )
         );
 

--- a/Mage.Sets/src/mage/cards/t/ThreeDreams.java
+++ b/Mage.Sets/src/mage/cards/t/ThreeDreams.java
@@ -27,7 +27,7 @@ public final class ThreeDreams extends CardImpl {
         // Search your library for up to three Aura cards with different names, reveal them, and put them into your hand. Then shuffle your library.
         this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(
                 new TargetCardWithDifferentNameInLibrary(0, 3, aurafilter),
-                true, true
+                true
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThunderherdMigration.java
+++ b/Mage.Sets/src/mage/cards/t/ThunderherdMigration.java
@@ -37,7 +37,7 @@ public final class ThunderherdMigration extends CardImpl {
         ));
 
         // Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true));
     }
 
     private ThunderherdMigration(final ThunderherdMigration card) {

--- a/Mage.Sets/src/mage/cards/t/Tiamat.java
+++ b/Mage.Sets/src/mage/cards/t/Tiamat.java
@@ -47,7 +47,7 @@ public final class Tiamat extends CardImpl {
         // When Tiamat enters the battlefield, if you cast it, search your library for up to five Dragon cards named Tiama that each have different names, reveal them, put them into your hand, then shuffle.
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(new EntersBattlefieldTriggeredAbility(
                 new SearchLibraryPutInHandEffect(
-                        new TargetCardWithDifferentNameInLibrary(0, 5, filter), true, true
+                        new TargetCardWithDifferentNameInLibrary(0, 5, filter), true
                 )), CastFromEverywhereSourceCondition.instance, "When {this} enters the battlefield, " +
                 "if you cast it, search your library for up to five Dragon cards not named Tiamat " +
                 "that each have different names, reveal them, put them into your hand, then shuffle."

--- a/Mage.Sets/src/mage/cards/t/Tinker.java
+++ b/Mage.Sets/src/mage/cards/t/Tinker.java
@@ -25,7 +25,7 @@ public final class Tinker extends CardImpl {
         this.getSpellAbility().addCost(new SacrificeTargetCost(new TargetControlledPermanent(new FilterControlledArtifactPermanent("an artifact"))));
 
         // Search your library for an artifact card and put that card onto the battlefield. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterArtifactCard("an artifact card"))));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterArtifactCard("an artifact card")), false, true));
     }
 
     private Tinker(final Tinker card) {

--- a/Mage.Sets/src/mage/cards/t/TotemGuideHartebeest.java
+++ b/Mage.Sets/src/mage/cards/t/TotemGuideHartebeest.java
@@ -33,7 +33,7 @@ public final class TotemGuideHartebeest extends CardImpl {
         this.toughness = new MageInt(5);
 
         // When Totem-Guide Hartebeest enters the battlefield, you may search your library for an Aura card, reveal it, put it into your hand, then shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true), true));
     }
 
     private TotemGuideHartebeest(final TotemGuideHartebeest card) {

--- a/Mage.Sets/src/mage/cards/t/TrailOfMystery.java
+++ b/Mage.Sets/src/mage/cards/t/TrailOfMystery.java
@@ -33,7 +33,7 @@ public final class TrailOfMystery extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{G}");
 
         // Whenever a face-down creature enters the battlefield under your control, you may search your library for a basic land card, reveal it, put it into your hand, then shuffle your library.
-        Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true);
+        Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true);
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filter, true));
 
         // Whenever a permanent you control is turned face up, if it's a creature, it gets +2/+2 until end of turn.

--- a/Mage.Sets/src/mage/cards/t/TreasureMage.java
+++ b/Mage.Sets/src/mage/cards/t/TreasureMage.java
@@ -40,7 +40,7 @@ public final class TreasureMage extends CardImpl {
         // When Treasure Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 6 or greater,
         // reveal that card, and put it into your hand. If you do, shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(0, 1, filter);
-        SearchEffect effect = new SearchLibraryPutInHandEffect(target, true, true);
+        SearchEffect effect = new SearchLibraryPutInHandEffect(target, true);
         this.addAbility(new EntersBattlefieldTriggeredAbility(effect, true));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreefolkHarbinger.java
+++ b/Mage.Sets/src/mage/cards/t/TreefolkHarbinger.java
@@ -33,7 +33,7 @@ public final class TreefolkHarbinger extends CardImpl {
         this.toughness = new MageInt(3);
 
         // When Treefolk Harbinger enters the battlefield, you may search your library for a Treefolk or Forest card, reveal it, then shuffle your library and put that card on top of it.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(filter), true), true));
     }
 
     private TreefolkHarbinger(final TreefolkHarbinger card) {

--- a/Mage.Sets/src/mage/cards/t/TributeMage.java
+++ b/Mage.Sets/src/mage/cards/t/TributeMage.java
@@ -36,7 +36,7 @@ public final class TributeMage extends CardImpl {
 
         // When Tribute Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 2, reveal that card, put it into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true
+                new TargetCardInLibrary(filter), true, true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TributeMage.java
+++ b/Mage.Sets/src/mage/cards/t/TributeMage.java
@@ -36,7 +36,7 @@ public final class TributeMage extends CardImpl {
 
         // When Tribute Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 2, reveal that card, put it into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrinketMage.java
+++ b/Mage.Sets/src/mage/cards/t/TrinketMage.java
@@ -39,7 +39,7 @@ public final class TrinketMage extends CardImpl {
 
         // When Trinket Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 1 or less, reveal that card, and put it into your hand. If you do, shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        SearchEffect effect = new SearchLibraryPutInHandEffect(target, true, true);
+        SearchEffect effect = new SearchLibraryPutInHandEffect(target, true);
         this.addAbility(new EntersBattlefieldTriggeredAbility(effect, true));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrinketMage.java
+++ b/Mage.Sets/src/mage/cards/t/TrinketMage.java
@@ -39,7 +39,7 @@ public final class TrinketMage extends CardImpl {
 
         // When Trinket Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 1 or less, reveal that card, and put it into your hand. If you do, shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        SearchEffect effect = new SearchLibraryPutInHandEffect(target, true);
+        SearchEffect effect = new SearchLibraryPutInHandEffect(target, true, true);
         this.addAbility(new EntersBattlefieldTriggeredAbility(effect, true));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrophyMage.java
+++ b/Mage.Sets/src/mage/cards/t/TrophyMage.java
@@ -36,7 +36,7 @@ public final class TrophyMage extends CardImpl {
 
         // When Trophy Mage enters the battlefield, you may search your library for an artifact card with converted mana cost 3, reveal it, put it into your hand, then shuffle your library.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrugaCliffcharger.java
+++ b/Mage.Sets/src/mage/cards/t/TrugaCliffcharger.java
@@ -46,7 +46,7 @@ public final class TrugaCliffcharger extends CardImpl {
         // When Truga Cliffcharger enters the battlefield, you may discard a card. If you do, search your library for a land or battle card, reveal it, put it into your hand, then shuffle.
         this.addAbility(new EntersBattlefieldTriggeredAbility(
                 new DoIfCostPaid(new SearchLibraryPutInHandEffect(
-                        new TargetCardInLibrary(filter), true, true
+                        new TargetCardInLibrary(filter), true
                 ), new DiscardCardCost())
         ));
     }

--- a/Mage.Sets/src/mage/cards/u/UlvenwaldHydra.java
+++ b/Mage.Sets/src/mage/cards/u/UlvenwaldHydra.java
@@ -14,7 +14,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledLandPermanent;
 import mage.filter.common.FilterControlledPermanent;
@@ -45,7 +44,7 @@ public final class UlvenwaldHydra extends CardImpl {
 
         // When Ulvenwald Hydra enters the battlefield, you may search your library for a land card, put it onto the battlefield tapped, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(new FilterLandCard());
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(target, true, true, Outcome.PutLandInPlay), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(target, true, true), true));
     }
 
     private UlvenwaldHydra(final UlvenwaldHydra card) {

--- a/Mage.Sets/src/mage/cards/u/UlvenwaldHydra.java
+++ b/Mage.Sets/src/mage/cards/u/UlvenwaldHydra.java
@@ -44,7 +44,7 @@ public final class UlvenwaldHydra extends CardImpl {
 
         // When Ulvenwald Hydra enters the battlefield, you may search your library for a land card, put it onto the battlefield tapped, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(new FilterLandCard());
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(target, true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(target, true), true));
     }
 
     private UlvenwaldHydra(final UlvenwaldHydra card) {

--- a/Mage.Sets/src/mage/cards/u/UncageTheMenagerie.java
+++ b/Mage.Sets/src/mage/cards/u/UncageTheMenagerie.java
@@ -61,7 +61,7 @@ class UncageTheMenagerieEffect extends OneShotEffect {
         FilterCard filter = new FilterCreatureCard(xValue + " creature cards with different names that each have mana value " + xValue);
         filter.add(new ManaValuePredicate(ComparisonType.EQUAL_TO, xValue));
         return new SearchLibraryPutInHandEffect(
-                new TargetCardWithDifferentNameInLibrary(0, xValue, filter), true, true
+                new TargetCardWithDifferentNameInLibrary(0, xValue, filter), true
         ).apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/u/UnderworldSlums.java
+++ b/Mage.Sets/src/mage/cards/u/UnderworldSlums.java
@@ -64,7 +64,7 @@ public final class UnderworldSlums extends CardImpl {
             filter.add(Predicates.or(subtypePredicates));
             filter.add(SuperType.BASIC.getPredicate());
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true, true, Outcome.PutLandInPlay));
+            addEffect(new SearchLibraryPutInPlayEffect(target, true, true));
         }
 
         @Override

--- a/Mage.Sets/src/mage/cards/u/UnderworldSlums.java
+++ b/Mage.Sets/src/mage/cards/u/UnderworldSlums.java
@@ -64,7 +64,7 @@ public final class UnderworldSlums extends CardImpl {
             filter.add(Predicates.or(subtypePredicates));
             filter.add(SuperType.BASIC.getPredicate());
             TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true, true));
+            addEffect(new SearchLibraryPutInPlayEffect(target, true));
         }
 
         @Override

--- a/Mage.Sets/src/mage/cards/u/UntamedWilds.java
+++ b/Mage.Sets/src/mage/cards/u/UntamedWilds.java
@@ -20,7 +20,7 @@ public final class UntamedWilds extends CardImpl {
 
 
         // Search your library for a basic land card and put that card onto the battlefield. Then shuffle your library.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND)));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), false, true));
     }
 
     private UntamedWilds(final UntamedWilds card) {

--- a/Mage.Sets/src/mage/cards/u/UrborgPanther.java
+++ b/Mage.Sets/src/mage/cards/u/UrborgPanther.java
@@ -65,7 +65,7 @@ public class UrborgPanther extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(
                 new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(
                         1, 1, filterCard
-                )),
+                ), false, true),
                 new CompositeCost(new CompositeCost(
                         new SacrificeTargetCost(new TargetControlledCreaturePermanent(filter1)),
                         new SacrificeTargetCost(new TargetControlledCreaturePermanent(filter2)),

--- a/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
+++ b/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
@@ -286,7 +286,7 @@ class UrzaAcademyHeadmasterRandomEffect extends OneShotEffect {
                                 break;
                             case 12: // (altered) LILIANA VESS 2
                                 sb.append("Search your library for a card and put that card into your hand. Then shuffle.");
-                                effects.add(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(new FilterCard("a card")), false, true));
+                                effects.add(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(new FilterCard("a card")), false));
                                 break;
                             case 13: // (double) LILIANA OF THE VEIL 2
                                 sb.append("Target player sacrifices two creatures.");

--- a/Mage.Sets/src/mage/cards/u/UrzasHotTub.java
+++ b/Mage.Sets/src/mage/cards/u/UrzasHotTub.java
@@ -71,7 +71,7 @@ class UrzasHotTubEffect extends OneShotEffect {
                 if (discardedCard != null) {
                     FilterCard filter = new FilterCard();
                     filter.add(new UrzasHotTubPredicate(discardedCard.getName()));
-                    return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true).apply(game, source);
+                    return new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true).apply(game, source);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/u/UrzasSylex.java
+++ b/Mage.Sets/src/mage/cards/u/UrzasSylex.java
@@ -55,7 +55,7 @@ public final class UrzasSylex extends CardImpl {
                 Zone.BATTLEFIELD, Zone.EXILED,
                 new DoIfCostPaid(
                         new SearchLibraryPutInHandEffect(
-                                new TargetCardInLibrary(filter), true, true
+                                new TargetCardInLibrary(filter), true
                         ), new GenericManaCost(2)
                 ), "When {this} is put into exile from the battlefield, ", false
         ));

--- a/Mage.Sets/src/mage/cards/v/VampiricTutor.java
+++ b/Mage.Sets/src/mage/cards/v/VampiricTutor.java
@@ -20,7 +20,7 @@ public final class VampiricTutor extends CardImpl {
 
 
         // Search your library for a card, then shuffle your library and put that card on top of it. You lose 2 life.
-        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(), false, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(), false));
         this.getSpellAbility().addEffect(new LoseLifeSourceControllerEffect(2));
     }
 

--- a/Mage.Sets/src/mage/cards/v/VerdantCrescendo.java
+++ b/Mage.Sets/src/mage/cards/v/VerdantCrescendo.java
@@ -29,7 +29,7 @@ public final class VerdantCrescendo extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{G}");
 
         // Search your library for a basic land card and put it onto the battlefield tapped.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, false));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true));
 
         // Search your library and graveyard for a card named Nissa, Nature's Artisan, reveal it, and put it into your hand. Then shuffle your library.
         this.getSpellAbility().addEffect(new SearchLibraryGraveyardPutInHandEffect(filter, true));

--- a/Mage.Sets/src/mage/cards/v/VerdantCrescendo.java
+++ b/Mage.Sets/src/mage/cards/v/VerdantCrescendo.java
@@ -29,7 +29,8 @@ public final class VerdantCrescendo extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{G}");
 
         // Search your library for a basic land card and put it onto the battlefield tapped.
-        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true)
+                .setText("search your library for a basic land card and put it onto the battlefield tapped"));
 
         // Search your library and graveyard for a card named Nissa, Nature's Artisan, reveal it, and put it into your hand. Then shuffle your library.
         this.getSpellAbility().addEffect(new SearchLibraryGraveyardPutInHandEffect(filter, true));

--- a/Mage.Sets/src/mage/cards/v/VexingPuzzlebox.java
+++ b/Mage.Sets/src/mage/cards/v/VexingPuzzlebox.java
@@ -42,7 +42,7 @@ public final class VexingPuzzlebox extends CardImpl {
 
         // {T}, Remove 100 charge counters from Vexing Puzzlebox: Search your library for an artifact card, put that card onto the battlefield, then shuffle.
         Ability ability = new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(
-                new TargetCardInLibrary(StaticFilters.FILTER_CARD_ARTIFACT_AN)
+                new TargetCardInLibrary(StaticFilters.FILTER_CARD_ARTIFACT_AN), false, true
         ), new TapSourceCost());
         ability.addCost(new RemoveCountersSourceCost(CounterType.CHARGE.createInstance(100)));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/v/Vorinclex.java
+++ b/Mage.Sets/src/mage/cards/v/Vorinclex.java
@@ -49,7 +49,7 @@ public final class Vorinclex extends CardImpl {
 
         // When Vorinclex enters the battlefield, search your library for up to two Forest cards, reveal them, put them into your hand, then shuffle.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(0, 2, filter), true, true
+                new TargetCardInLibrary(0, 2, filter), true
         )));
 
         // {6}{G}{G}: Exile Vorinclex, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.

--- a/Mage.Sets/src/mage/cards/w/WarpedLandscape.java
+++ b/Mage.Sets/src/mage/cards/w/WarpedLandscape.java
@@ -31,7 +31,7 @@ public final class WarpedLandscape extends CardImpl {
 
         // {2}, {T}, Sacrifice Warped Landscape: Search your library for a basic land card and put it onto the battlefield tapped. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true),
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true),
                 new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());

--- a/Mage.Sets/src/mage/cards/w/WayfarersBauble.java
+++ b/Mage.Sets/src/mage/cards/w/WayfarersBauble.java
@@ -10,7 +10,6 @@ import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCardInLibrary;
@@ -28,7 +27,7 @@ public final class WayfarersBauble extends CardImpl {
 
         // {2}, {tap}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND),true, true, Outcome.PutLandInPlay), new GenericManaCost(2));
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND),true, true), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/w/WayfarersBauble.java
+++ b/Mage.Sets/src/mage/cards/w/WayfarersBauble.java
@@ -27,7 +27,7 @@ public final class WayfarersBauble extends CardImpl {
 
         // {2}, {tap}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND),true), new GenericManaCost(2));
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND),true, true), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/w/WayfarersBauble.java
+++ b/Mage.Sets/src/mage/cards/w/WayfarersBauble.java
@@ -27,7 +27,7 @@ public final class WayfarersBauble extends CardImpl {
 
         // {2}, {tap}, Sacrifice Wayfarer's Bauble: Search your library for a basic land card and put that card onto the battlefield tapped. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND),true, true), new GenericManaCost(2));
+                new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND),true), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/w/WeatheredWayfarer.java
+++ b/Mage.Sets/src/mage/cards/w/WeatheredWayfarer.java
@@ -36,7 +36,7 @@ public final class WeatheredWayfarer extends CardImpl {
         // {W}, {tap}: Search your library for a land card, reveal it, and put it into your hand. Then shuffle your library. Activate this ability only if an opponent controls more lands than you.
         Ability ability = new ActivateIfConditionActivatedAbility(
                 Zone.BATTLEFIELD,
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(new FilterLandCard()), true, true),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(new FilterLandCard()), true),
                 new ManaCostsImpl<>("{W}"),
                 new OpponentControlsMoreCondition(StaticFilters.FILTER_LANDS));
         ability.addCost(new TapSourceCost());

--- a/Mage.Sets/src/mage/cards/w/WelkinHawk.java
+++ b/Mage.Sets/src/mage/cards/w/WelkinHawk.java
@@ -37,7 +37,7 @@ public final class WelkinHawk extends CardImpl {
 
         // When Welkin Hawk dies, you may search your library for a card named Welkin Hawk, reveal that card, put it into your hand, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(1, 1, filter);
-        this.addAbility(new DiesSourceTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
+        this.addAbility(new DiesSourceTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
     }
 
     private WelkinHawk(final WelkinHawk card) {

--- a/Mage.Sets/src/mage/cards/w/WelkinHawk.java
+++ b/Mage.Sets/src/mage/cards/w/WelkinHawk.java
@@ -37,7 +37,7 @@ public final class WelkinHawk extends CardImpl {
 
         // When Welkin Hawk dies, you may search your library for a card named Welkin Hawk, reveal that card, put it into your hand, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(1, 1, filter);
-        this.addAbility(new DiesSourceTriggeredAbility(new SearchLibraryPutInHandEffect(target, true), true));
+        this.addAbility(new DiesSourceTriggeredAbility(new SearchLibraryPutInHandEffect(target, true, true), true));
     }
 
     private WelkinHawk(final WelkinHawk card) {

--- a/Mage.Sets/src/mage/cards/w/WhisperSquad.java
+++ b/Mage.Sets/src/mage/cards/w/WhisperSquad.java
@@ -35,7 +35,7 @@ public final class WhisperSquad extends CardImpl {
 
         // {1}{B}: Search your library for a card named Whisper Squad, put it onto the battlefield tapped, then shuffle your library.
         this.addAbility(new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), new ManaCostsImpl<>("{1}{B}")));
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildFieldScarecrow.java
+++ b/Mage.Sets/src/mage/cards/w/WildFieldScarecrow.java
@@ -34,7 +34,7 @@ public final class WildFieldScarecrow extends CardImpl {
 
         // {2}, Sacrifice Wild-Field Scarecrow: Search your library for up to two basic land cards, reveal them, and put them into your hand. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS), true, true),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS), true),
                 new GenericManaCost(2));
         ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/w/WildWanderer.java
+++ b/Mage.Sets/src/mage/cards/w/WildWanderer.java
@@ -27,7 +27,7 @@ public final class WildWanderer extends CardImpl {
         this.toughness = new MageInt(2);
 
         // When Wild Wanderer enters the battlefield, you may search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), true));
     }
 
     private WildWanderer(final WildWanderer card) {

--- a/Mage.Sets/src/mage/cards/w/WirewoodHerald.java
+++ b/Mage.Sets/src/mage/cards/w/WirewoodHerald.java
@@ -33,7 +33,7 @@ public final class WirewoodHerald extends CardImpl {
 
         // When Wirewood Herald dies, you may search your library for an Elf card, reveal that card, put it into your hand, then shuffle your library.
         this.addAbility(new DiesSourceTriggeredAbility(
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true),
                 true));
     }
 

--- a/Mage.Sets/src/mage/cards/w/WirewoodHerald.java
+++ b/Mage.Sets/src/mage/cards/w/WirewoodHerald.java
@@ -33,7 +33,7 @@ public final class WirewoodHerald extends CardImpl {
 
         // When Wirewood Herald dies, you may search your library for an Elf card, reveal that card, put it into your hand, then shuffle your library.
         this.addAbility(new DiesSourceTriggeredAbility(
-                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true),
+                new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true),
                 true));
     }
 

--- a/Mage.Sets/src/mage/cards/w/WishclawTalisman.java
+++ b/Mage.Sets/src/mage/cards/w/WishclawTalisman.java
@@ -66,7 +66,7 @@ public final class WishclawTalisman extends CardImpl {
 
 class WishclawTalismanEffect extends OneShotEffect {
 
-    private static final Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary());
+    private static final Effect effect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false);
 
     WishclawTalismanEffect() {
         super(Outcome.Benefit);

--- a/Mage.Sets/src/mage/cards/w/WoodElves.java
+++ b/Mage.Sets/src/mage/cards/w/WoodElves.java
@@ -33,7 +33,7 @@ public final class WoodElves extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Wood Elves enters the battlefield, search your library for a Forest card and put that card onto the battlefield. Then shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false)));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, true)));
     }
 
     private WoodElves(final WoodElves card) {

--- a/Mage.Sets/src/mage/cards/w/WoodElves.java
+++ b/Mage.Sets/src/mage/cards/w/WoodElves.java
@@ -33,7 +33,7 @@ public final class WoodElves extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Wood Elves enters the battlefield, search your library for a Forest card and put that card onto the battlefield. Then shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false, true)));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), false)));
     }
 
     private WoodElves(final WoodElves card) {

--- a/Mage.Sets/src/mage/cards/w/WorldlyTutor.java
+++ b/Mage.Sets/src/mage/cards/w/WorldlyTutor.java
@@ -18,7 +18,7 @@ public final class WorldlyTutor extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{G}");
 
         // Search your library for a creature card and reveal that card. Shuffle your library, then put the card on top of it.
-        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true, true));
+        this.getSpellAbility().addEffect(new SearchLibraryPutOnLibraryEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true));
     }
 
     private WorldlyTutor(final WorldlyTutor card) {

--- a/Mage.Sets/src/mage/cards/w/WretchedThrong.java
+++ b/Mage.Sets/src/mage/cards/w/WretchedThrong.java
@@ -34,7 +34,7 @@ public final class WretchedThrong extends CardImpl {
 
         // When Wretched Throng dies, you may search your library for a card named Wretched Throng, reveal it, put it into your hand, then shuffle.
         this.addAbility(new DiesSourceTriggeredAbility(new SearchLibraryPutInHandEffect(
-                new TargetCardInLibrary(filter), true, true
+                new TargetCardInLibrary(filter), true
         ), true));
     }
 

--- a/Mage.Sets/src/mage/cards/y/YavimayaGranger.java
+++ b/Mage.Sets/src/mage/cards/y/YavimayaGranger.java
@@ -31,7 +31,7 @@ public final class YavimayaGranger extends CardImpl {
         this.addAbility(new EchoAbility("{2}{G}"));
         //When Yavimaya Granger enters the battlefield, you may search your library for a basic land card,
         //put that card onto the battlefield tapped, then shuffle your library.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), true));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true, true), true));
     }
 
     private YavimayaGranger(final YavimayaGranger card) {

--- a/Mage.Sets/src/mage/cards/y/YouHappenOnAGlade.java
+++ b/Mage.Sets/src/mage/cards/y/YouHappenOnAGlade.java
@@ -28,7 +28,7 @@ public final class YouHappenOnAGlade extends CardImpl {
         // • Journey On — Search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle.
         this.getSpellAbility().addEffect(
                 new SearchLibraryPutInHandEffect(
-                        new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS), true, true)
+                        new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS), true)
         );
         this.getSpellAbility().withFirstModeFlavorWord("Journey On");
 

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/MageTestPlayerBase.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/MageTestPlayerBase.java
@@ -544,7 +544,7 @@ public abstract class MageTestPlayerBase {
         );
 
         // library
-        ability = new SimpleActivatedAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD)).setText("return from library"), new ManaCostsImpl<>(""));
+        ability = new SimpleActivatedAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD), false).setText("return from library"), new ManaCostsImpl<>(""));
         addCustomCardWithAbility(
                 "return from library for " + controller.getName(),
                 controller,

--- a/Mage/src/main/java/mage/abilities/common/FetchLandActivatedAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/FetchLandActivatedAbility.java
@@ -7,7 +7,6 @@ import mage.abilities.costs.common.PayLifeCost;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
-import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
@@ -33,7 +32,7 @@ public class FetchLandActivatedAbility extends ActivatedAbilityImpl {
         FilterCard filter = new FilterCard(subType1.getDescription() + " or " + subType2.getDescription() + " card");
         filter.add(Predicates.or(subType1.getPredicate(), subType2.getPredicate()));
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        addEffect(new SearchLibraryPutInPlayEffect(target, false, true, Outcome.PutLandInPlay));
+        addEffect(new SearchLibraryPutInPlayEffect(target, false, true));
     }
 
     private FetchLandActivatedAbility(FetchLandActivatedAbility ability) {

--- a/Mage/src/main/java/mage/abilities/common/FetchLandActivatedAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/FetchLandActivatedAbility.java
@@ -32,7 +32,7 @@ public class FetchLandActivatedAbility extends ActivatedAbilityImpl {
         FilterCard filter = new FilterCard(subType1.getDescription() + " or " + subType2.getDescription() + " card");
         filter.add(Predicates.or(subType1.getPredicate(), subType2.getPredicate()));
         TargetCardInLibrary target = new TargetCardInLibrary(filter);
-        addEffect(new SearchLibraryPutInPlayEffect(target, false, true));
+        addEffect(new SearchLibraryPutInPlayEffect(target, false));
     }
 
     private FetchLandActivatedAbility(FetchLandActivatedAbility ability) {

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInHandEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInHandEffect.java
@@ -19,23 +19,23 @@ import java.util.UUID;
  */
 public class SearchLibraryPutInHandEffect extends SearchEffect {
 
-    private boolean revealCards;
+    private boolean reveal;
     private boolean textThatCard;
 
-    public SearchLibraryPutInHandEffect(TargetCardInLibrary target, boolean revealCards) {
-        this(target, revealCards, false);
+    public SearchLibraryPutInHandEffect(TargetCardInLibrary target, boolean reveal) {
+        this(target, reveal, false);
     }
 
-    public SearchLibraryPutInHandEffect(TargetCardInLibrary target, boolean revealCards, boolean textThatCard) {
+    public SearchLibraryPutInHandEffect(TargetCardInLibrary target, boolean reveal, boolean textThatCard) {
         super(target, Outcome.DrawCard);
-        this.revealCards = revealCards;
+        this.reveal = reveal;
         this.textThatCard = textThatCard;
         setText();
     }
 
     public SearchLibraryPutInHandEffect(final SearchLibraryPutInHandEffect effect) {
         super(effect);
-        this.revealCards = effect.revealCards;
+        this.reveal = effect.reveal;
         this.textThatCard = effect.textThatCard;
     }
 
@@ -61,7 +61,7 @@ public class SearchLibraryPutInHandEffect extends SearchEffect {
                     }
                 }
                 controller.moveCards(cards, Zone.HAND, source, game);
-                if (revealCards) {
+                if (reveal) {
                     String name = "Reveal";
                     Card sourceCard = game.getCard(source.getSourceId());
                     if (sourceCard != null) {
@@ -82,7 +82,7 @@ public class SearchLibraryPutInHandEffect extends SearchEffect {
         sb.append("search your library for ");
         sb.append(target.getDescription());
         if (target.getMaxNumberOfTargets() > 1) {
-            if (revealCards) {
+            if (reveal) {
                 sb.append(", reveal ");
                 sb.append(textThatCard ? "those cards" : "them");
                 sb.append(", put them");
@@ -91,7 +91,7 @@ public class SearchLibraryPutInHandEffect extends SearchEffect {
                 sb.append(textThatCard ? "those cards" : "them");
             }
         } else {
-            if (revealCards) {
+            if (reveal) {
                 sb.append(", reveal ");
                 sb.append(textThatCard ? "that card" : "it");
                 sb.append(", put it");

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInHandEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInHandEffect.java
@@ -21,16 +21,23 @@ import java.util.UUID;
 public class SearchLibraryPutInHandEffect extends SearchEffect {
 
     private boolean revealCards;
+    private boolean textThatCard;
 
     public SearchLibraryPutInHandEffect(TargetCardInLibrary target, boolean revealCards) {
+        this(target, revealCards, false);
+    }
+
+    public SearchLibraryPutInHandEffect(TargetCardInLibrary target, boolean revealCards, boolean textThatCard) {
         super(target, Outcome.DrawCard);
         this.revealCards = revealCards;
+        this.textThatCard = textThatCard;
         setText();
     }
 
     public SearchLibraryPutInHandEffect(final SearchLibraryPutInHandEffect effect) {
         super(effect);
         this.revealCards = effect.revealCards;
+        this.textThatCard = effect.textThatCard;
     }
 
     @Override
@@ -77,13 +84,27 @@ public class SearchLibraryPutInHandEffect extends SearchEffect {
         if (target.getNumberOfTargets() == 0 && target.getMaxNumberOfTargets() > 0) {
             sb.append("up to ").append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(' ');
             sb.append(target.getTargetName());
-            sb.append(revealCards ? ", reveal them" : "");
-            sb.append(", put them into your hand, then shuffle");
+            if (revealCards) {
+                sb.append(", reveal ");
+                sb.append(textThatCard ? "those cards" : "them");
+                sb.append(", put them");
+            } else {
+                sb.append(", put ");
+                sb.append(textThatCard ? "those cards" : "them");
+            }
         } else {
             sb.append(CardUtil.addArticle(target.getTargetName()));
-            sb.append(revealCards ? ", reveal it, put it" : ", put that card");
-            sb.append(" into your hand, then shuffle");
+            if (revealCards) {
+                sb.append(", reveal ");
+                sb.append(textThatCard ? "that card" : "it");
+                sb.append(", put it");
+            } else {
+                sb.append(", put ");
+                sb.append(textThatCard ? "that card" : "it");
+            }
+
         }
+        sb.append(" into your hand, then shuffle");
         staticText = sb.toString();
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInHandEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInHandEffect.java
@@ -11,7 +11,6 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
-import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -81,9 +80,8 @@ public class SearchLibraryPutInHandEffect extends SearchEffect {
     private void setText() {
         StringBuilder sb = new StringBuilder();
         sb.append("search your library for ");
-        if (target.getNumberOfTargets() == 0 && target.getMaxNumberOfTargets() > 0) {
-            sb.append("up to ").append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(' ');
-            sb.append(target.getTargetName());
+        sb.append(target.getDescription());
+        if (target.getMaxNumberOfTargets() > 1) {
             if (revealCards) {
                 sb.append(", reveal ");
                 sb.append(textThatCard ? "those cards" : "them");
@@ -93,7 +91,6 @@ public class SearchLibraryPutInHandEffect extends SearchEffect {
                 sb.append(textThatCard ? "those cards" : "them");
             }
         } else {
-            sb.append(CardUtil.addArticle(target.getTargetName()));
             if (revealCards) {
                 sb.append(", reveal ");
                 sb.append(textThatCard ? "that card" : "it");
@@ -102,7 +99,6 @@ public class SearchLibraryPutInHandEffect extends SearchEffect {
                 sb.append(", put ");
                 sb.append(textThatCard ? "that card" : "it");
             }
-
         }
         sb.append(" into your hand, then shuffle");
         staticText = sb.toString();

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInHandEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInHandEffect.java
@@ -20,35 +20,17 @@ import java.util.UUID;
  */
 public class SearchLibraryPutInHandEffect extends SearchEffect {
 
-    private boolean revealCards = false;
-    private boolean forceShuffle;
-    private String rulePrefix;
-
-    public SearchLibraryPutInHandEffect(TargetCardInLibrary target) {
-        this(target, false, true);
-    }
+    private boolean revealCards;
 
     public SearchLibraryPutInHandEffect(TargetCardInLibrary target, boolean revealCards) {
-        this(target, revealCards, true);
-    }
-
-    public SearchLibraryPutInHandEffect(TargetCardInLibrary target, boolean revealCards, boolean forceShuffle) {
-        this(target, revealCards, forceShuffle, "search your library for ");
-    }
-
-    public SearchLibraryPutInHandEffect(TargetCardInLibrary target, boolean revealCards, boolean forceShuffle, String rulePrefix) {
         super(target, Outcome.DrawCard);
         this.revealCards = revealCards;
-        this.forceShuffle = forceShuffle;
-        this.rulePrefix = rulePrefix;
         setText();
     }
 
     public SearchLibraryPutInHandEffect(final SearchLibraryPutInHandEffect effect) {
         super(effect);
         this.revealCards = effect.revealCards;
-        this.forceShuffle = effect.forceShuffle;
-        this.rulePrefix = effect.rulePrefix;
     }
 
     @Override
@@ -85,34 +67,22 @@ public class SearchLibraryPutInHandEffect extends SearchEffect {
             controller.shuffleLibrary(source, game);
             return true;
         }
-        if (forceShuffle) {
-            controller.shuffleLibrary(source, game);
-        }
+        controller.shuffleLibrary(source, game);
         return false;
     }
 
     private void setText() {
         StringBuilder sb = new StringBuilder();
-        sb.append(rulePrefix);
+        sb.append("search your library for ");
         if (target.getNumberOfTargets() == 0 && target.getMaxNumberOfTargets() > 0) {
             sb.append("up to ").append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(' ');
             sb.append(target.getTargetName());
-            if (forceShuffle) {
-                sb.append(revealCards ? ", reveal them" : "");
-                sb.append(", put them into your hand, then shuffle");
-            } else {
-                sb.append(revealCards ? ", reveal them," : "");
-                sb.append(" and put them into your hand. If you do, shuffle");
-            }
+            sb.append(revealCards ? ", reveal them" : "");
+            sb.append(", put them into your hand, then shuffle");
         } else {
             sb.append(CardUtil.addArticle(target.getTargetName()));
-            if (forceShuffle) {
-                sb.append(revealCards ? ", reveal it, put it" : ", put that card");
-                sb.append(" into your hand, then shuffle");
-            } else {
-                sb.append(revealCards ? ", reveal it," : "");
-                sb.append(" and put that card into your hand. If you do, shuffle");
-            }
+            sb.append(revealCards ? ", reveal it, put it" : ", put that card");
+            sb.append(" into your hand, then shuffle");
         }
         staticText = sb.toString();
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInHandOrOnBattlefieldEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInHandOrOnBattlefieldEffect.java
@@ -20,28 +20,12 @@ import mage.util.CardUtil;
  */
 public class SearchLibraryPutInHandOrOnBattlefieldEffect extends SearchEffect {
 
-    private boolean revealCards = false;
-    private boolean forceShuffle;
-    private String rulePrefix;
-    private String nameToPutOnBattlefield = null;
-
-    public SearchLibraryPutInHandOrOnBattlefieldEffect(TargetCardInLibrary target, String nameToPutOnBattlefield) {
-        this(target, false, true, nameToPutOnBattlefield);
-    }
+    private boolean revealCards;
+    private String nameToPutOnBattlefield;
 
     public SearchLibraryPutInHandOrOnBattlefieldEffect(TargetCardInLibrary target, boolean revealCards, String nameToPutOnBattlefield) {
-        this(target, revealCards, true, nameToPutOnBattlefield);
-    }
-
-    public SearchLibraryPutInHandOrOnBattlefieldEffect(TargetCardInLibrary target, boolean revealCards, boolean forceShuffle, String nameToPutOnBattlefield) {
-        this(target, revealCards, forceShuffle, "search your library for ", nameToPutOnBattlefield);
-    }
-
-    public SearchLibraryPutInHandOrOnBattlefieldEffect(TargetCardInLibrary target, boolean revealCards, boolean forceShuffle, String rulePrefix, String nameToPutOnBattlefield) {
         super(target, Outcome.DrawCard);
         this.revealCards = revealCards;
-        this.forceShuffle = forceShuffle;
-        this.rulePrefix = rulePrefix;
         this.nameToPutOnBattlefield = nameToPutOnBattlefield;
         setText();
     }
@@ -49,8 +33,6 @@ public class SearchLibraryPutInHandOrOnBattlefieldEffect extends SearchEffect {
     public SearchLibraryPutInHandOrOnBattlefieldEffect(final SearchLibraryPutInHandOrOnBattlefieldEffect effect) {
         super(effect);
         this.revealCards = effect.revealCards;
-        this.forceShuffle = effect.forceShuffle;
-        this.rulePrefix = effect.rulePrefix;
         this.nameToPutOnBattlefield = effect.nameToPutOnBattlefield;
     }
 
@@ -98,15 +80,13 @@ public class SearchLibraryPutInHandOrOnBattlefieldEffect extends SearchEffect {
             controller.shuffleLibrary(source, game);
             return true;
         }
-        if (forceShuffle) {
-            controller.shuffleLibrary(source, game);
-        }
+        controller.shuffleLibrary(source, game);
         return false;
     }
 
     private void setText() {
         StringBuilder sb = new StringBuilder();
-        sb.append(rulePrefix);
+        sb.append("search your library for ");
         if (target.getNumberOfTargets() == 0 && target.getMaxNumberOfTargets() > 0) {
             sb.append("up to ").append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(' ');
             sb.append(target.getTargetName()).append(revealCards ? ", reveal them," : "").append(" and put them into your hand");
@@ -118,11 +98,7 @@ public class SearchLibraryPutInHandOrOnBattlefieldEffect extends SearchEffect {
             sb.append(nameToPutOnBattlefield);
             sb.append("this way, you may put it onto the battlefield instead");
         }
-        if (forceShuffle) {
-            sb.append(". Then shuffle");
-        } else {
-            sb.append(". If you do, shuffle");
-        }
+        sb.append(". Then shuffle");
         staticText = sb.toString();
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 public class SearchLibraryPutInPlayEffect extends SearchEffect {
 
     protected boolean tapped;
+    protected boolean textThatCard;
     protected boolean optional;
 
     public SearchLibraryPutInPlayEffect(TargetCardInLibrary target) {
@@ -28,27 +29,27 @@ public class SearchLibraryPutInPlayEffect extends SearchEffect {
         this(target, tapped, false);
     }
 
-    public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean optional) {
+    public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean textThatCard) {
+        this(target, tapped, textThatCard, false);
+    }
+
+    public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean textThatCard, boolean optional) {
         super(target, Outcome.PutCardInPlay);
         this.tapped = tapped;
+        this.textThatCard = textThatCard;
         this.optional = optional;
         if (target.getDescription().contains("land")) {
             this.outcome = Outcome.PutLandInPlay;
         } else if (target.getDescription().contains("creature")) {
             this.outcome = Outcome.PutCreatureInPlay;
         }
-        staticText = (optional ? "you may " : "")
-                + "search your library for "
-                + target.getDescription()
-                + ", "
-                + (target.getMaxNumberOfTargets() > 1 ? "put them onto the battlefield" : "put it onto the battlefield")
-                + (tapped ? " tapped" : "")
-                + ", then shuffle";
+        setText();
     }
 
     public SearchLibraryPutInPlayEffect(final SearchLibraryPutInPlayEffect effect) {
         super(effect);
         this.tapped = effect.tapped;
+        this.textThatCard = effect.textThatCard;
         this.optional = effect.optional;
     }
 
@@ -76,6 +77,27 @@ public class SearchLibraryPutInPlayEffect extends SearchEffect {
         }
         player.shuffleLibrary(source, game);
         return false;
+    }
+
+    private void setText() {
+        StringBuilder sb = new StringBuilder();
+        if (optional) {
+            sb.append("you may ");
+        }
+        sb.append("search your library for ");
+        sb.append(target.getDescription());
+        sb.append(", put");
+        if (target.getMaxNumberOfTargets() > 1) {
+            sb.append(textThatCard ? "those cards" : "them");
+        } else {
+            sb.append(textThatCard ? "that card" : "it");
+        }
+        sb.append(" onto the battlefield");
+        if (tapped) {
+            sb.append(" tapped");
+        }
+        sb.append( ", then shuffle");
+        staticText = sb.toString();
     }
 
     public List<UUID> getTargets() {

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
@@ -21,14 +21,10 @@ public class SearchLibraryPutInPlayEffect extends SearchEffect {
     protected boolean optional;
 
     public SearchLibraryPutInPlayEffect(TargetCardInLibrary target) {
-        this(target, false, true);
+        this(target, false);
     }
 
     public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped) {
-        this(target, tapped, true);
-    }
-
-    public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle) {
         this(target, tapped, true, false);
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
@@ -38,14 +38,19 @@ public class SearchLibraryPutInPlayEffect extends SearchEffect {
     }
 
     public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle, Outcome outcome) {
-        this(target, tapped, forceShuffle, false, outcome);
+        this(target, tapped, forceShuffle, false);
     }
 
-    public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle, boolean optional, Outcome outcome) {
-        super(target, outcome);
+    public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle, boolean optional) {
+        super(target, Outcome.PutCardInPlay);
         this.tapped = tapped;
         this.forceShuffle = forceShuffle;
         this.optional = optional;
+        if (target.getDescription().contains("land")) {
+            this.outcome = Outcome.PutLandInPlay;
+        } else if (target.getDescription().contains("creature")) {
+            this.outcome = Outcome.PutCreatureInPlay;
+        }
         staticText = (optional ? "you may " : "")
                 + "search your library for "
                 + target.getDescription()

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
@@ -86,7 +86,7 @@ public class SearchLibraryPutInPlayEffect extends SearchEffect {
         }
         sb.append("search your library for ");
         sb.append(target.getDescription());
-        sb.append(", put");
+        sb.append(", put ");
         if (target.getMaxNumberOfTargets() > 1) {
             sb.append(textThatCard ? "those cards" : "them");
         } else {

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
@@ -22,22 +22,18 @@ public class SearchLibraryPutInPlayEffect extends SearchEffect {
     protected boolean optional;
 
     public SearchLibraryPutInPlayEffect(TargetCardInLibrary target) {
-        this(target, false, true, Outcome.PutCardInPlay);
+        this(target, false, true);
     }
 
     public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped) {
-        this(target, tapped, true, Outcome.PutCardInPlay);
-    }
-
-    public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle) {
-        this(target, tapped, forceShuffle, Outcome.PutCardInPlay);
+        this(target, tapped, true);
     }
 
     public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, Outcome outcome) {
-        this(target, tapped, true, outcome);
+        this(target, tapped, true);
     }
 
-    public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle, Outcome outcome) {
+    public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle) {
         this(target, tapped, forceShuffle, false);
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
@@ -25,10 +25,10 @@ public class SearchLibraryPutInPlayEffect extends SearchEffect {
     }
 
     public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped) {
-        this(target, tapped, true, false);
+        this(target, tapped, false);
     }
 
-    public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle, boolean optional) {
+    public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean optional) {
         super(target, Outcome.PutCardInPlay);
         this.tapped = tapped;
         this.optional = optional;

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
@@ -18,7 +18,6 @@ import java.util.UUID;
 public class SearchLibraryPutInPlayEffect extends SearchEffect {
 
     protected boolean tapped;
-    protected boolean forceShuffle;
     protected boolean optional;
 
     public SearchLibraryPutInPlayEffect(TargetCardInLibrary target) {
@@ -30,13 +29,12 @@ public class SearchLibraryPutInPlayEffect extends SearchEffect {
     }
 
     public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle) {
-        this(target, tapped, forceShuffle, false);
+        this(target, tapped, true, false);
     }
 
     public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle, boolean optional) {
         super(target, Outcome.PutCardInPlay);
         this.tapped = tapped;
-        this.forceShuffle = forceShuffle;
         this.optional = optional;
         if (target.getDescription().contains("land")) {
             this.outcome = Outcome.PutLandInPlay;
@@ -46,16 +44,15 @@ public class SearchLibraryPutInPlayEffect extends SearchEffect {
         staticText = (optional ? "you may " : "")
                 + "search your library for "
                 + target.getDescription()
-                + (forceShuffle ? ", " : " and ")
+                + ", "
                 + (target.getMaxNumberOfTargets() > 1 ? "put them onto the battlefield" : "put it onto the battlefield")
                 + (tapped ? " tapped" : "")
-                + (forceShuffle ? ", then shuffle" : ". If you do, shuffle");
+                + ", then shuffle";
     }
 
     public SearchLibraryPutInPlayEffect(final SearchLibraryPutInPlayEffect effect) {
         super(effect);
         this.tapped = effect.tapped;
-        this.forceShuffle = effect.forceShuffle;
         this.optional = effect.optional;
     }
 
@@ -81,10 +78,8 @@ public class SearchLibraryPutInPlayEffect extends SearchEffect {
             player.shuffleLibrary(source, game);
             return true;
         }
-        if (forceShuffle) {
-            player.shuffleLibrary(source, game);
-        }
-        return true;
+        player.shuffleLibrary(source, game);
+        return false;
     }
 
     public List<UUID> getTargets() {

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayEffect.java
@@ -29,10 +29,6 @@ public class SearchLibraryPutInPlayEffect extends SearchEffect {
         this(target, tapped, true);
     }
 
-    public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, Outcome outcome) {
-        this(target, tapped, true);
-    }
-
     public SearchLibraryPutInPlayEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle) {
         this(target, tapped, forceShuffle, false);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayTargetPlayerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutInPlayTargetPlayerEffect.java
@@ -16,40 +16,26 @@ import mage.target.common.TargetCardInLibrary;
 public class SearchLibraryPutInPlayTargetPlayerEffect extends SearchEffect {
 
     protected boolean tapped;
-    protected boolean forceShuffle;
     protected boolean ownerIsController;
 
-    public SearchLibraryPutInPlayTargetPlayerEffect(TargetCardInLibrary target) {
-        this(target, false, true, Outcome.PutCardInPlay);
-    }
-
     public SearchLibraryPutInPlayTargetPlayerEffect(TargetCardInLibrary target, boolean tapped) {
-        this(target, tapped, true, Outcome.PutCardInPlay);
+        this(target, tapped, false);
     }
 
-    public SearchLibraryPutInPlayTargetPlayerEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle) {
-        this(target, tapped, forceShuffle, Outcome.PutCardInPlay);
-    }
-
-    public SearchLibraryPutInPlayTargetPlayerEffect(TargetCardInLibrary target, boolean tapped, Outcome outcome) {
-        this(target, tapped, true, outcome);
-    }
-
-    public SearchLibraryPutInPlayTargetPlayerEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle, Outcome outcome) {
-        this(target, tapped, forceShuffle, outcome, false);
-    }
-
-    public SearchLibraryPutInPlayTargetPlayerEffect(TargetCardInLibrary target, boolean tapped, boolean forceShuffle, Outcome outcome, boolean ownerIsController) {
-        super(target, outcome);
+    public SearchLibraryPutInPlayTargetPlayerEffect(TargetCardInLibrary target, boolean tapped, boolean ownerIsController) {
+        super(target, Outcome.PutCardInPlay);
         this.tapped = tapped;
-        this.forceShuffle = forceShuffle;
         this.ownerIsController = ownerIsController;
+        if (target.getDescription().contains("land")) {
+            this.outcome = Outcome.PutLandInPlay;
+        } else if (target.getDescription().contains("creature")) {
+            this.outcome = Outcome.PutCreatureInPlay;
+        }
     }
 
     public SearchLibraryPutInPlayTargetPlayerEffect(final SearchLibraryPutInPlayTargetPlayerEffect effect) {
         super(effect);
         this.tapped = effect.tapped;
-        this.forceShuffle = effect.forceShuffle;
         this.ownerIsController = effect.ownerIsController;
     }
 
@@ -70,12 +56,8 @@ public class SearchLibraryPutInPlayTargetPlayerEffect extends SearchEffect {
                 player.shuffleLibrary(source, game);
                 return true;
             }
-
-            if (forceShuffle) {
-                player.shuffleLibrary(source, game);
-            }
+            player.shuffleLibrary(source, game);
         }
-
         return false;
     }
 
@@ -87,9 +69,9 @@ public class SearchLibraryPutInPlayTargetPlayerEffect extends SearchEffect {
         return getTargetPointer().describeTargets(mode.getTargets(), "that player")
             + " searches their library for "
             + target.getDescription()
-            + (forceShuffle ? ", " : " and ")
+            + ", "
             + (target.getMaxNumberOfTargets() > 1 ? "puts them onto the battlefield" : "puts it onto the battlefield")
             + (tapped ? " tapped" : "")
-            + (forceShuffle ? ", then shuffles" : ". If that player does, they shuffle");
+            + ", then shuffles";
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutOnLibraryEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutOnLibraryEffect.java
@@ -19,11 +19,6 @@ public class SearchLibraryPutOnLibraryEffect extends SearchEffect {
 
     private boolean reveal;
 
-    public SearchLibraryPutOnLibraryEffect(TargetCardInLibrary target) {
-        this(target, false);
-        setText();
-    }
-
     public SearchLibraryPutOnLibraryEffect(TargetCardInLibrary target, boolean reveal) {
         super(target, Outcome.DrawCard);
         this.reveal = reveal;

--- a/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutOnLibraryEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/search/SearchLibraryPutOnLibraryEffect.java
@@ -18,24 +18,21 @@ import mage.util.CardUtil;
 public class SearchLibraryPutOnLibraryEffect extends SearchEffect {
 
     private boolean reveal;
-    private boolean forceShuffle;
 
     public SearchLibraryPutOnLibraryEffect(TargetCardInLibrary target) {
-        this(target, false, true);
+        this(target, false);
         setText();
     }
 
-    public SearchLibraryPutOnLibraryEffect(TargetCardInLibrary target, boolean reveal, boolean forceShuffle) {
+    public SearchLibraryPutOnLibraryEffect(TargetCardInLibrary target, boolean reveal) {
         super(target, Outcome.DrawCard);
         this.reveal = reveal;
-        this.forceShuffle = forceShuffle;
         setText();
     }
 
     public SearchLibraryPutOnLibraryEffect(final SearchLibraryPutOnLibraryEffect effect) {
         super(effect);
         this.reveal = effect.reveal;
-        this.forceShuffle = effect.forceShuffle;
     }
 
     @Override
@@ -55,16 +52,11 @@ public class SearchLibraryPutOnLibraryEffect extends SearchEffect {
             if (reveal && !foundCards.isEmpty()) {
                 controller.revealCards(sourceObject.getIdName(), foundCards, game);
             }
-            if (forceShuffle) {
-                controller.shuffleLibrary(source, game);
-            }
+            controller.shuffleLibrary(source, game);
             controller.putCardsOnTopOfLibrary(foundCards, game, source, reveal);
             return true;
         }
-        // shuffle
-        if (forceShuffle) {
-            controller.shuffleLibrary(source, game);
-        }
+        controller.shuffleLibrary(source, game);
         return false;
     }
 

--- a/Mage/src/main/java/mage/abilities/keyword/CyclingAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/CyclingAbility.java
@@ -27,7 +27,7 @@ public class CyclingAbility extends ActivatedAbilityImpl {
     }
 
     public CyclingAbility(Cost cost, FilterCard filter, String text) {
-        super(Zone.HAND, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true, true), cost);
+        super(Zone.HAND, new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true), cost);
         this.addCost(new CyclingDiscardCost());
         this.cost = cost;
         this.text = text;

--- a/Mage/src/main/java/mage/game/command/emblems/GarrukCallerOfBeastsEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/GarrukCallerOfBeastsEmblem.java
@@ -22,7 +22,7 @@ public final class GarrukCallerOfBeastsEmblem extends Emblem {
      */
     public GarrukCallerOfBeastsEmblem() {
         super("Emblem Garruk");
-        Effect effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterCreatureCard("creature card")), false, true);
+        Effect effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterCreatureCard("creature card")), false);
         Ability ability = new SpellCastControllerTriggeredAbility(Zone.COMMAND, effect, StaticFilters.FILTER_SPELL_A_CREATURE, true, false);
         this.getAbilities().add(ability);
     }

--- a/Mage/src/main/java/mage/game/command/emblems/GarrukCallerOfBeastsEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/GarrukCallerOfBeastsEmblem.java
@@ -4,7 +4,6 @@ import mage.abilities.Ability;
 import mage.abilities.common.SpellCastControllerTriggeredAbility;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
-import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreatureCard;
@@ -23,7 +22,7 @@ public final class GarrukCallerOfBeastsEmblem extends Emblem {
      */
     public GarrukCallerOfBeastsEmblem() {
         super("Emblem Garruk");
-        Effect effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterCreatureCard("creature card")), false, true, Outcome.PutCreatureInPlay);
+        Effect effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterCreatureCard("creature card")), false, true);
         Ability ability = new SpellCastControllerTriggeredAbility(Zone.COMMAND, effect, StaticFilters.FILTER_SPELL_A_CREATURE, true, false);
         this.getAbilities().add(ability);
     }

--- a/Mage/src/main/java/mage/game/command/emblems/GarrukUnleashedEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/GarrukUnleashedEmblem.java
@@ -3,7 +3,6 @@ package mage.game.command.emblems;
 import mage.abilities.common.BeginningOfYourEndStepTriggeredAbility;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
-import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.game.command.Emblem;
@@ -14,7 +13,7 @@ public class GarrukUnleashedEmblem extends Emblem {
     // At the beginning of your end step, you may search your library for a creature card, put it onto the battlefield, then shuffle your library.
     public GarrukUnleashedEmblem() {
         super("Emblem Garruk");
-        Effect effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), false, true, Outcome.PutCreatureInPlay)
+        Effect effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), false, true)
                 .setText("search your library for a creature card, put it onto the battlefield, then shuffle");
         this.getAbilities().add(new BeginningOfYourEndStepTriggeredAbility(Zone.COMMAND, effect, true));
     }

--- a/Mage/src/main/java/mage/game/command/emblems/GarrukUnleashedEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/GarrukUnleashedEmblem.java
@@ -13,7 +13,7 @@ public class GarrukUnleashedEmblem extends Emblem {
     // At the beginning of your end step, you may search your library for a creature card, put it onto the battlefield, then shuffle your library.
     public GarrukUnleashedEmblem() {
         super("Emblem Garruk");
-        Effect effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), false, true)
+        Effect effect = new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), false)
                 .setText("search your library for a creature card, put it onto the battlefield, then shuffle");
         this.getAbilities().add(new BeginningOfYourEndStepTriggeredAbility(Zone.COMMAND, effect, true));
     }

--- a/Mage/src/main/java/mage/game/command/planes/TrailOfTheMageRingsPlane.java
+++ b/Mage/src/main/java/mage/game/command/planes/TrailOfTheMageRingsPlane.java
@@ -49,7 +49,7 @@ public class TrailOfTheMageRingsPlane extends Plane {
         this.getAbilities().add(ability);
 
         // Active player can roll the planar die: Whenever you roll {CHAOS}, you may search your library for an instant or sorcery card, reveal it, put it into your hand, then shuffle your library
-        Effect chaosEffect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 1, new FilterInstantOrSorceryCard()), true, true);
+        Effect chaosEffect = new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 1, new FilterInstantOrSorceryCard()), true);
         Target chaosTarget = null;
 
         List<Effect> chaosEffects = new ArrayList<Effect>();


### PR DESCRIPTION
These classes had unnecessary parameters and a bunch of similar constructors, yet still couldn't reliably generate the correct text.
- `SearchLibraryPutOnLibraryEffect`
- `SearchLibraryPutInHandEffect`
- `SearchLibraryPutInHandOrOnBattlefieldEffect`
- `SearchLibraryPutInPlayEffect`
- `SearchLibraryPutInPlayTargetPlayerEffect`

Cleanup as follows:
- Remove Outcome from constructors. Set as `Outcome.PutCardInPlay` by default when calling the super, and then set as Land or Creature if the target description indicates
- Remove `forceShuffle` parameter that was always true (aside from one unusual case that wasn't being used correctly anyway)
- Add new parameter `textThatCard` so that the alternate templating (less common but still frequently used) can be set to fix the text without needing `.setText()`
- Rewrite string builders to generate text appropriately using target description.

I was able to use this to fix the text on a bunch of cards.