### PR TITLE
Cleanup: ReturnFromExileForSourceEffect

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AngelOfSerenity.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfSerenity.java
@@ -55,7 +55,7 @@ public final class AngelOfSerenity extends CardImpl {
         this.addAbility(ability);
 
         // When Angel of Serenity leaves the battlefield, return the exiled cards to their owners' hands.
-        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.HAND), false));
+        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.HAND).withText(true, true), false));
     }
 
     private AngelOfSerenity(final AngelOfSerenity card) {

--- a/Mage.Sets/src/mage/cards/a/AngelOfSerenity.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfSerenity.java
@@ -55,7 +55,7 @@ public final class AngelOfSerenity extends CardImpl {
         this.addAbility(ability);
 
         // When Angel of Serenity leaves the battlefield, return the exiled cards to their owners' hands.
-        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.HAND, false, true), false));
+        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.HAND), false));
     }
 
     private AngelOfSerenity(final AngelOfSerenity card) {

--- a/Mage.Sets/src/mage/cards/a/AshioksErasure.java
+++ b/Mage.Sets/src/mage/cards/a/AshioksErasure.java
@@ -49,7 +49,7 @@ public final class AshioksErasure extends CardImpl {
 
         // When Ashiok's Erasure leaves the battlefield, return the exiled card to its owner's hand.
         this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(
-                Zone.HAND, false, true
+                Zone.HAND
         ).setText("return the exiled card to its owner's hand"), false));
     }
 

--- a/Mage.Sets/src/mage/cards/f/FacelessDevourer.java
+++ b/Mage.Sets/src/mage/cards/f/FacelessDevourer.java
@@ -47,8 +47,7 @@ public final class FacelessDevourer extends CardImpl {
         this.addAbility(ability);
 
         // When Faceless Devourer leaves the battlefield, return the exiled card to the battlefield under its owner's control.
-        ability = new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.BATTLEFIELD)
-                .withReturnName("card", "its owner's"), false);
+        ability = new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.BATTLEFIELD), false);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Gravegouger.java
+++ b/Mage.Sets/src/mage/cards/g/Gravegouger.java
@@ -34,7 +34,7 @@ public final class Gravegouger extends CardImpl {
         this.addAbility(ability);
 
         // When Gravegouger leaves the battlefield, return the exiled cards to their owner's graveyard.
-        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.GRAVEYARD), false));
+        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.GRAVEYARD).withText(true, false), false));
     }
 
     private Gravegouger(final Gravegouger card) {

--- a/Mage.Sets/src/mage/cards/i/IcyPrison.java
+++ b/Mage.Sets/src/mage/cards/i/IcyPrison.java
@@ -38,7 +38,7 @@ public final class IcyPrison extends CardImpl {
                 new DoUnlessAnyPlayerPaysEffect(new SacrificeSourceEffect(), new GenericManaCost(3)), TargetController.YOU, false));
 
         // When Icy Prison leaves the battlefield, return the exiled card to the battlefield under its owner's control.
-        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.BATTLEFIELD, false, true), false));
+        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.BATTLEFIELD), false));
 
     }
 

--- a/Mage.Sets/src/mage/cards/p/Petradon.java
+++ b/Mage.Sets/src/mage/cards/p/Petradon.java
@@ -38,8 +38,7 @@ public final class Petradon extends CardImpl {
         this.addAbility(ability);
 
         // When Petradon leaves the battlefield, return the exiled cards to the battlefield under their owners' control.
-        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.BATTLEFIELD)
-                .withReturnName("cards", "their owners'"), false));
+        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.BATTLEFIELD), false));
 
         // {R}: Petradon gets +1/+0 until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 0, Duration.EndOfTurn), new ManaCostsImpl<>("{R}")));

--- a/Mage.Sets/src/mage/cards/p/Petradon.java
+++ b/Mage.Sets/src/mage/cards/p/Petradon.java
@@ -38,7 +38,7 @@ public final class Petradon extends CardImpl {
         this.addAbility(ability);
 
         // When Petradon leaves the battlefield, return the exiled cards to the battlefield under their owners' control.
-        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.BATTLEFIELD), false));
+        this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.BATTLEFIELD).withText(true, true), false));
 
         // {R}: Petradon gets +1/+0 until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 0, Duration.EndOfTurn), new ManaCostsImpl<>("{R}")));

--- a/Mage.Sets/src/mage/cards/w/WormfangBehemoth.java
+++ b/Mage.Sets/src/mage/cards/w/WormfangBehemoth.java
@@ -37,7 +37,7 @@ public final class WormfangBehemoth extends CardImpl {
 
         // When Wormfang Behemoth leaves the battlefield, return the exiled cards to their owner's hand.
         this.addAbility(new LeavesBattlefieldTriggeredAbility(
-                new ReturnFromExileForSourceEffect(Zone.HAND), false
+                new ReturnFromExileForSourceEffect(Zone.HAND).withText(true, false), false
         ));
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnFromExileForSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnFromExileForSourceEffect.java
@@ -20,56 +20,25 @@ import java.util.UUID;
 public class ReturnFromExileForSourceEffect extends OneShotEffect {
 
     private final Zone returnToZone;
-    private final boolean tapped;
-    private final boolean previousZone;
-    private String returnName = "cards";
-    private String returnControlName;
+    private boolean pluralCards;
+    private boolean pluralOwners;
 
     /**
      * @param zone Zone the card should return to
      */
     public ReturnFromExileForSourceEffect(Zone zone) {
-        this(zone, false);
-    }
-
-    public ReturnFromExileForSourceEffect(Zone zone, boolean tapped) {
-        this(zone, tapped, true);
-    }
-
-    /**
-     * @param zone
-     * @param tapped
-     * @param previousZone if this is used from a dies leave battlefield or
-     *                     destroyed trigger, the exile zone is based on previous zone of the object
-     */
-    public ReturnFromExileForSourceEffect(Zone zone, boolean tapped, boolean previousZone) {
         super(Outcome.PutCardInPlay);
         this.returnToZone = zone;
-        this.tapped = tapped;
-        this.previousZone = previousZone;
-
-        // different default name for zones
-        switch (zone) {
-            case BATTLEFIELD:
-                this.returnControlName = "its owner's";
-                break;
-            default:
-                this.returnControlName = "their owner's";
-                break;
-        }
-
+        this.pluralCards = false;
+        this.pluralOwners = false;
         updateText();
     }
 
     public ReturnFromExileForSourceEffect(final ReturnFromExileForSourceEffect effect) {
         super(effect);
         this.returnToZone = effect.returnToZone;
-        this.tapped = effect.tapped;
-        this.previousZone = effect.previousZone;
-        this.returnName = effect.returnName;
-        this.returnControlName = effect.returnControlName;
-
-        updateText();
+        this.pluralCards = effect.pluralCards;
+        this.pluralOwners = effect.pluralOwners;
     }
 
     @Override
@@ -108,30 +77,32 @@ public class ReturnFromExileForSourceEffect extends OneShotEffect {
         return true;
     }
 
+    public ReturnFromExileForSourceEffect withText(boolean pluralCards, boolean pluralOwners) {
+        this.pluralCards = pluralCards;
+        this.pluralOwners = pluralOwners;
+        updateText();
+        return this;
+    }
+
     private void updateText() {
         StringBuilder sb = new StringBuilder();
-        sb.append("return the exiled ").append(this.returnName).append(" ");
+        sb.append("return the exiled ").append(pluralCards ? "cards" : "card").append(" to ");
+        if (returnToZone == Zone.BATTLEFIELD) {
+            sb.append("the battlefield under ");
+        }
+        sb.append(pluralCards ? "their " : "its ").append(pluralOwners ? "owners' " : "owner's ");
         switch (returnToZone) {
             case BATTLEFIELD:
-                sb.append("to the battlefield under ").append(this.returnControlName).append(" control");
-                if (tapped) {
-                    sb.append(" tapped");
-                }
+                sb.append("control");
                 break;
             case HAND:
-                sb.append("to ").append(this.returnControlName).append(" hand");
+                sb.append(pluralOwners ? "hands" : "hand");
                 break;
             case GRAVEYARD:
-                sb.append("to ").append(this.returnControlName).append(" graveyard");
+                sb.append(pluralOwners ? "graveyards" : "graveyard");
                 break;
         }
         staticText = sb.toString();
     }
 
-    public ReturnFromExileForSourceEffect withReturnName(String returnName, String returnControlName) {
-        this.returnName = returnName;
-        this.returnControlName = returnControlName;
-        updateText();
-        return this;
-    }
 }


### PR DESCRIPTION
Removing unused parameters and streamlining text generation.

There are still several cards implementing this type of effect with custom classes that ought to be refactored to common classes, but that's a separate scope.