### PR TITLE
Allow disabling test mode in development builds

### DIFF
--- a/Mage.Server/src/main/java/mage/server/Main.java
+++ b/Mage.Server/src/main/java/mage/server/Main.java
@@ -87,6 +87,10 @@ public final class Main {
         logger.info("Logging level: " + logger.getEffectiveLevel());
         logger.info("Default charset: " + Charset.defaultCharset());
         String adminPassword = "";
+
+        // enable test mode by default for developer build (if you run it from source code)
+        testMode |= version.isDeveloperBuild();
+
         for (String arg : args) {
             if (arg.startsWith(testModeArg)) {
                 testMode = Boolean.parseBoolean(arg.replace(testModeArg, ""));
@@ -97,9 +101,6 @@ public final class Main {
                 fastDbMode = Boolean.parseBoolean(arg.replace(fastDBModeArg, ""));
             }
         }
-
-        // enable test mode by default for developer build (if you run it from source code)
-        testMode |= version.isDeveloperBuild();
 
         final String configPath = Optional.ofNullable(System.getProperty(configPathProp))
                 .orElse(defaultConfigPath);


### PR DESCRIPTION
Moves the line enabling test mode by default in development builds to *before* command line argument parsing, so `-testMode=false` overrides that default.