### PR TITLE
Fix Mindlink Mech (issue with MageObjectReference)

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MindlinkMech.java
+++ b/Mage.Sets/src/mage/cards/m/MindlinkMech.java
@@ -157,7 +157,7 @@ class MindlinkMechWatcher extends Watcher {
                 .getState()
                 .getWatcher(MindlinkMechWatcher.class)
                 .crewMap
-                .computeIfAbsent(new MageObjectReference(source), x -> new HashSet<>())
+                .computeIfAbsent(new MageObjectReference(game.getPermanent(source.getSourceId()), game), x -> new HashSet<>())
                 .stream()
                 .filter(mor -> {
                     Permanent permanent = mor.getPermanent(game);


### PR DESCRIPTION
Fixes #9204 and duplicates (closes #9787, closes #9838, closes #10270).

@theelk801 I'm concerned that this indicates a deeper problem with `MageObjectReference(Ability source)` not working as intended.