### PR TITLE
Cleanup: BecomesCreatureSourceEffect

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AngelsTomb.java
+++ b/Mage.Sets/src/mage/cards/a/AngelsTomb.java
@@ -29,7 +29,7 @@ public final class AngelsTomb extends CardImpl {
                 .withColor("W")
                 .withSubType(SubType.ANGEL)
                 .withAbility(FlyingAbility.getInstance()),
-                "", Duration.EndOfTurn)
+                CardType.ARTIFACT, Duration.EndOfTurn)
                 .setText("have {this} become a 3/3 white Angel artifact creature with flying until end of turn");
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD,

--- a/Mage.Sets/src/mage/cards/a/AnsweredPrayers.java
+++ b/Mage.Sets/src/mage/cards/a/AnsweredPrayers.java
@@ -72,7 +72,7 @@ class AnsweredPrayersEffect extends OneShotEffect {
             return true;
         }
         game.addEffect(new BecomesCreatureSourceEffect(
-                new AnsweredPrayersToken(), "enchantment", Duration.EndOfTurn
+                new AnsweredPrayersToken(), CardType.ENCHANTMENT, Duration.EndOfTurn
         ), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/a/AtarkaMonument.java
+++ b/Mage.Sets/src/mage/cards/a/AtarkaMonument.java
@@ -36,7 +36,7 @@ public final class AtarkaMonument extends CardImpl {
                         .withSubType(SubType.DRAGON)
                         .withType(CardType.ARTIFACT)
                         .withAbility(FlyingAbility.getInstance()),
-                "", Duration.EndOfTurn), new ManaCostsImpl<>("{4}{R}{G}")));
+                CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{4}{R}{G}")));
     }
 
     private AtarkaMonument(final AtarkaMonument card) {

--- a/Mage.Sets/src/mage/cards/a/AzoriusKeyrune.java
+++ b/Mage.Sets/src/mage/cards/a/AzoriusKeyrune.java
@@ -36,7 +36,7 @@ public final class AzoriusKeyrune extends CardImpl {
                         .withSubType(SubType.BIRD)
                         .withType(CardType.ARTIFACT)
                         .withAbility(FlyingAbility.getInstance()),
-                "", Duration.EndOfTurn), new ManaCostsImpl<>("{W}{U}")));
+                CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{W}{U}")));
     }
 
     private AzoriusKeyrune(final AzoriusKeyrune card) {

--- a/Mage.Sets/src/mage/cards/b/BlinkmothNexus.java
+++ b/Mage.Sets/src/mage/cards/b/BlinkmothNexus.java
@@ -27,7 +27,7 @@ import mage.target.TargetPermanent;
  */
 public final class BlinkmothNexus extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent("Blinkmoth");
+    private static final FilterPermanent filter = new FilterPermanent("Blinkmoth creature");
 
     static {
         filter.add(SubType.BLINKMOTH.getPredicate());

--- a/Mage.Sets/src/mage/cards/b/BlinkmothNexus.java
+++ b/Mage.Sets/src/mage/cards/b/BlinkmothNexus.java
@@ -45,7 +45,7 @@ public final class BlinkmothNexus extends CardImpl {
                         .withSubType(SubType.BLINKMOTH)
                         .withType(CardType.ARTIFACT)
                         .withAbility(FlyingAbility.getInstance()),
-                "land", Duration.EndOfTurn), new GenericManaCost(1)));
+                CardType.LAND, Duration.EndOfTurn), new GenericManaCost(1)));
 
         // {1}, {T}: Target Blinkmoth creature gets +1/+1 until end of turn.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(1, 1, Duration.EndOfTurn), new GenericManaCost(1));

--- a/Mage.Sets/src/mage/cards/b/BogardanDragonheart.java
+++ b/Mage.Sets/src/mage/cards/b/BogardanDragonheart.java
@@ -33,7 +33,7 @@ public final class BogardanDragonheart extends CardImpl {
         // Sacrifice another creature: Until end of turn, Bogardan Dragonheart becomes a Dragon with base power and toughness 4/4, flying, and haste.
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
                 new BogardanDragonheartToken(), null, Duration.EndOfTurn, false,
-                false, null, null, false
+                false, false
         ), new SacrificeTargetCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE))));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BogardanDragonheart.java
+++ b/Mage.Sets/src/mage/cards/b/BogardanDragonheart.java
@@ -33,7 +33,7 @@ public final class BogardanDragonheart extends CardImpl {
         // Sacrifice another creature: Until end of turn, Bogardan Dragonheart becomes a Dragon with base power and toughness 4/4, flying, and haste.
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
                 new BogardanDragonheartToken(), CardType.CREATURE, Duration.EndOfTurn
-        ).withDurationRuleAtStart(true), new SacrificeTargetCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE))));
+        ), new SacrificeTargetCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE))));
     }
 
     private BogardanDragonheart(final BogardanDragonheart card) {

--- a/Mage.Sets/src/mage/cards/b/BogardanDragonheart.java
+++ b/Mage.Sets/src/mage/cards/b/BogardanDragonheart.java
@@ -32,7 +32,7 @@ public final class BogardanDragonheart extends CardImpl {
 
         // Sacrifice another creature: Until end of turn, Bogardan Dragonheart becomes a Dragon with base power and toughness 4/4, flying, and haste.
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
-                new BogardanDragonheartToken(), null, Duration.EndOfTurn
+                new BogardanDragonheartToken(), CardType.CREATURE, Duration.EndOfTurn
         ).withDurationRuleAtStart(true), new SacrificeTargetCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE))));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BogardanDragonheart.java
+++ b/Mage.Sets/src/mage/cards/b/BogardanDragonheart.java
@@ -32,9 +32,8 @@ public final class BogardanDragonheart extends CardImpl {
 
         // Sacrifice another creature: Until end of turn, Bogardan Dragonheart becomes a Dragon with base power and toughness 4/4, flying, and haste.
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
-                new BogardanDragonheartToken(), null, Duration.EndOfTurn, false,
-                false, false
-        ), new SacrificeTargetCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE))));
+                new BogardanDragonheartToken(), null, Duration.EndOfTurn
+        ).withDurationRuleAtStart(true), new SacrificeTargetCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE))));
     }
 
     private BogardanDragonheart(final BogardanDragonheart card) {

--- a/Mage.Sets/src/mage/cards/b/BorosKeyrune.java
+++ b/Mage.Sets/src/mage/cards/b/BorosKeyrune.java
@@ -36,7 +36,7 @@ public final class BorosKeyrune extends CardImpl {
                         .withSubType(SubType.SOLDIER)
                         .withType(CardType.ARTIFACT)
                         .withAbility(DoubleStrikeAbility.getInstance()),
-                "", Duration.EndOfTurn), new ManaCostsImpl<>("{R}{W}")));
+                CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{R}{W}")));
     }
 
     private BorosKeyrune(final BorosKeyrune card) {

--- a/Mage.Sets/src/mage/cards/c/CaveOfTheFrostDragon.java
+++ b/Mage.Sets/src/mage/cards/c/CaveOfTheFrostDragon.java
@@ -49,7 +49,7 @@ public final class CaveOfTheFrostDragon extends CardImpl {
                         .withColor("W")
                         .withSubType(SubType.DRAGON)
                         .withAbility(FlyingAbility.getInstance()),
-                "land", Duration.EndOfTurn), new ManaCostsImpl<>("{4}{W}")));
+                CardType.LAND, Duration.EndOfTurn), new ManaCostsImpl<>("{4}{W}")));
     }
 
     private CaveOfTheFrostDragon(final CaveOfTheFrostDragon card) {

--- a/Mage.Sets/src/mage/cards/c/CelestialColonnade.java
+++ b/Mage.Sets/src/mage/cards/c/CelestialColonnade.java
@@ -41,7 +41,7 @@ public final class CelestialColonnade extends CardImpl {
                         .withSubType(SubType.ELEMENTAL)
                         .withAbility(FlyingAbility.getInstance())
                         .withAbility(VigilanceAbility.getInstance()),
-                "land", Duration.EndOfTurn), new ManaCostsImpl<>("{3}{W}{U}")));
+                "land", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{W}{U}")));
     }
 
     private CelestialColonnade(final CelestialColonnade card) {

--- a/Mage.Sets/src/mage/cards/c/CelestialColonnade.java
+++ b/Mage.Sets/src/mage/cards/c/CelestialColonnade.java
@@ -41,7 +41,7 @@ public final class CelestialColonnade extends CardImpl {
                         .withSubType(SubType.ELEMENTAL)
                         .withAbility(FlyingAbility.getInstance())
                         .withAbility(VigilanceAbility.getInstance()),
-                "land", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{W}{U}")));
+                CardType.LAND, Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{W}{U}")));
     }
 
     private CelestialColonnade(final CelestialColonnade card) {

--- a/Mage.Sets/src/mage/cards/c/ChimericEgg.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericEgg.java
@@ -45,7 +45,7 @@ public final class ChimericEgg extends CardImpl {
                         .withSubType(SubType.CONSTRUCT)
                         .withType(CardType.ARTIFACT)
                         .withAbility(TrampleAbility.getInstance()),
-                "", Duration.EndOfTurn), new RemoveCountersSourceCost(new Counter(CounterType.CHARGE.getName(), 3))));
+                CardType.ARTIFACT, Duration.EndOfTurn), new RemoveCountersSourceCost(new Counter(CounterType.CHARGE.getName(), 3))));
     }
 
     private ChimericEgg(final ChimericEgg card) {

--- a/Mage.Sets/src/mage/cards/c/ChimericIdol.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericIdol.java
@@ -31,7 +31,7 @@ public final class ChimericIdol extends CardImpl {
                 new CreatureToken(3, 3, "3/3 Turtle artifact creature")
                         .withSubType(SubType.TURTLE)
                         .withType(CardType.ARTIFACT),
-                "", Duration.EndOfTurn));
+                CardType.ARTIFACT, Duration.EndOfTurn));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/c/ChimericMass.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericMass.java
@@ -38,7 +38,7 @@ public final class ChimericMass extends CardImpl {
                         .withType(CardType.ARTIFACT)
                         .withSubType(SubType.CONSTRUCT)
                         .withAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new CountersSourceCount(CounterType.CHARGE)))),
-                "", Duration.EndOfTurn, false, true, false), new GenericManaCost(1)));
+                "", Duration.EndOfTurn, false, false, true), new GenericManaCost(1)));
     }
 
     private ChimericMass(final ChimericMass card) {

--- a/Mage.Sets/src/mage/cards/c/ChimericMass.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericMass.java
@@ -38,7 +38,7 @@ public final class ChimericMass extends CardImpl {
                         .withType(CardType.ARTIFACT)
                         .withSubType(SubType.CONSTRUCT)
                         .withAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new CountersSourceCount(CounterType.CHARGE)))),
-                "", Duration.EndOfTurn, false, true), new GenericManaCost(1)));
+                "", Duration.EndOfTurn, false, true, false), new GenericManaCost(1)));
     }
 
     private ChimericMass(final ChimericMass card) {

--- a/Mage.Sets/src/mage/cards/c/ChimericMass.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericMass.java
@@ -38,7 +38,7 @@ public final class ChimericMass extends CardImpl {
                         .withType(CardType.ARTIFACT)
                         .withSubType(SubType.CONSTRUCT)
                         .withAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new CountersSourceCount(CounterType.CHARGE)))),
-                "", Duration.EndOfTurn, false, false, true).withDurationRuleAtStart(true), new GenericManaCost(1)));
+                "", Duration.EndOfTurn).withDurationRuleAtStart(true), new GenericManaCost(1)));
     }
 
     private ChimericMass(final ChimericMass card) {

--- a/Mage.Sets/src/mage/cards/c/ChimericMass.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericMass.java
@@ -13,10 +13,7 @@ import mage.abilities.effects.common.continuous.BecomesCreatureSourceEffect;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.Duration;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.counters.CounterType;
 import mage.game.permanent.token.custom.CreatureToken;
 
@@ -32,12 +29,12 @@ public final class ChimericMass extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(new EntersBattlefieldWithXCountersEffect(CounterType.CHARGE.createInstance())));
 
         // {1}: Until end of turn, Chimeric Mass becomes a Construct artifact creature with "This creature's power and toughness are each equal to the number of charge counters on it."
-        // set to character defining to prevent setting P/T again to 0 becuase already set by CDA of the token 
+        CountersSourceCount count = new CountersSourceCount(CounterType.CHARGE);
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(
                 new CreatureToken(0, 0, "Construct artifact creature with \"This creature's power and toughness are each equal to the number of charge counters on it.\"")
                         .withType(CardType.ARTIFACT)
                         .withSubType(SubType.CONSTRUCT)
-                        .withAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new CountersSourceCount(CounterType.CHARGE)))),
+                        .withAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(count, count, Duration.WhileOnBattlefield, SubLayer.SetPT_7b))),
                 CardType.ARTIFACT, Duration.EndOfTurn).withDurationRuleAtStart(true), new GenericManaCost(1)));
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChimericMass.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericMass.java
@@ -38,7 +38,7 @@ public final class ChimericMass extends CardImpl {
                         .withType(CardType.ARTIFACT)
                         .withSubType(SubType.CONSTRUCT)
                         .withAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new CountersSourceCount(CounterType.CHARGE)))),
-                "", Duration.EndOfTurn).withDurationRuleAtStart(true), new GenericManaCost(1)));
+                CardType.ARTIFACT, Duration.EndOfTurn).withDurationRuleAtStart(true), new GenericManaCost(1)));
     }
 
     private ChimericMass(final ChimericMass card) {

--- a/Mage.Sets/src/mage/cards/c/ChimericMass.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericMass.java
@@ -38,7 +38,7 @@ public final class ChimericMass extends CardImpl {
                         .withType(CardType.ARTIFACT)
                         .withSubType(SubType.CONSTRUCT)
                         .withAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new CountersSourceCount(CounterType.CHARGE)))),
-                "", Duration.EndOfTurn, false, false, true), new GenericManaCost(1)));
+                "", Duration.EndOfTurn, false, false, true).withDurationRuleAtStart(true), new GenericManaCost(1)));
     }
 
     private ChimericMass(final ChimericMass card) {

--- a/Mage.Sets/src/mage/cards/c/ChimericSphere.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericSphere.java
@@ -3,9 +3,11 @@ package mage.cards.c;
 
 import java.util.UUID;
 
+import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.continuous.BecomesCreatureSourceEffect;
+import mage.abilities.effects.common.continuous.LoseAbilitySourceEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -32,11 +34,14 @@ public final class ChimericSphere extends CardImpl {
                 CardType.ARTIFACT, Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{2}")));
 
         // {2}: Until end of turn, Chimeric Sphere becomes a 3/2 Construct artifact creature without flying.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(
-                new CreatureToken(3, 2, "3/2 Construct artifact creature and loses flying")
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(
+                new CreatureToken(3, 2, "3/2 Construct artifact creature")
                         .withSubType(SubType.CONSTRUCT)
                         .withType(CardType.ARTIFACT),
-                CardType.ARTIFACT, Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{2}")));
+                CardType.ARTIFACT, Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{2}"));
+        ability.addEffect(new LoseAbilitySourceEffect(FlyingAbility.getInstance(), Duration.EndOfTurn).setText("and loses flying"));
+        this.addAbility(ability);
+
     }
 
     private ChimericSphere(final ChimericSphere card) {

--- a/Mage.Sets/src/mage/cards/c/ChimericSphere.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericSphere.java
@@ -29,14 +29,14 @@ public final class ChimericSphere extends CardImpl {
                         .withSubType(SubType.CONSTRUCT)
                         .withType(CardType.ARTIFACT)
                         .withAbility(FlyingAbility.getInstance()),
-                "", Duration.EndOfTurn), new ManaCostsImpl<>("{2}")));
+                "", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{2}")));
 
         // {2}: Until end of turn, Chimeric Sphere becomes a 3/2 Construct artifact creature without flying.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(
-                new CreatureToken(3, 2, "3/2 Construct artifact creature without flying")
+                new CreatureToken(3, 2, "3/2 Construct artifact creature and loses flying")
                         .withSubType(SubType.CONSTRUCT)
                         .withType(CardType.ARTIFACT),
-                "", Duration.EndOfTurn), new ManaCostsImpl<>("{2}")));
+                "", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{2}")));
     }
 
     private ChimericSphere(final ChimericSphere card) {
@@ -48,4 +48,3 @@ public final class ChimericSphere extends CardImpl {
         return new ChimericSphere(this);
     }
 }
-

--- a/Mage.Sets/src/mage/cards/c/ChimericSphere.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericSphere.java
@@ -29,14 +29,14 @@ public final class ChimericSphere extends CardImpl {
                         .withSubType(SubType.CONSTRUCT)
                         .withType(CardType.ARTIFACT)
                         .withAbility(FlyingAbility.getInstance()),
-                "", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{2}")));
+                CardType.ARTIFACT, Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{2}")));
 
         // {2}: Until end of turn, Chimeric Sphere becomes a 3/2 Construct artifact creature without flying.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(
                 new CreatureToken(3, 2, "3/2 Construct artifact creature and loses flying")
                         .withSubType(SubType.CONSTRUCT)
                         .withType(CardType.ARTIFACT),
-                "", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{2}")));
+                CardType.ARTIFACT, Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{2}")));
     }
 
     private ChimericSphere(final ChimericSphere card) {

--- a/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
+++ b/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
@@ -47,7 +47,7 @@ public final class ChromiumTheMutable extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 new BecomesCreatureSourceEffect(
                         new ChromiumTheMutableToken(), null, Duration.EndOfTurn,
-                        false, true, false
+                        false, true
                 ).setText("Until end of turn, {this} becomes "
                         + "a Human with base power and toughness 1/1, "
                         + "loses all abilities, and gains hexproof"),

--- a/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
+++ b/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
@@ -46,9 +46,8 @@ public final class ChromiumTheMutable extends CardImpl {
         // Discard a card: Until end of turn, Chromium, the Mutable becomes a Human with base power and toughness 1/1, loses all abilities, and gains hexproof. It can't be blocked this turn.
         Ability ability = new SimpleActivatedAbility(
                 new BecomesCreatureSourceEffect(
-                        new ChromiumTheMutableToken(), null, Duration.EndOfTurn,
-                        false, true
-                ).setText("Until end of turn, {this} becomes "
+                        new ChromiumTheMutableToken(), null, Duration.EndOfTurn
+                ).andLoseAbilities(true).setText("Until end of turn, {this} becomes "
                         + "a Human with base power and toughness 1/1, "
                         + "loses all abilities, and gains hexproof"),
                 new DiscardCardCost()

--- a/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
+++ b/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
@@ -47,7 +47,7 @@ public final class ChromiumTheMutable extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 new BecomesCreatureSourceEffect(
                         new ChromiumTheMutableToken(), null, Duration.EndOfTurn,
-                        false, false, true
+                        false, true, false
                 ).setText("Until end of turn, {this} becomes "
                         + "a Human with base power and toughness 1/1, "
                         + "loses all abilities, and gains hexproof"),

--- a/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
+++ b/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
@@ -46,7 +46,7 @@ public final class ChromiumTheMutable extends CardImpl {
         // Discard a card: Until end of turn, Chromium, the Mutable becomes a Human with base power and toughness 1/1, loses all abilities, and gains hexproof. It can't be blocked this turn.
         Ability ability = new SimpleActivatedAbility(
                 new BecomesCreatureSourceEffect(
-                        new ChromiumTheMutableToken(), null, Duration.EndOfTurn
+                        new ChromiumTheMutableToken(), CardType.CREATURE, Duration.EndOfTurn
                 ).andLoseAbilities(true).setText("Until end of turn, {this} becomes "
                         + "a Human with base power and toughness 1/1, "
                         + "loses all abilities, and gains hexproof"),

--- a/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
+++ b/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
@@ -47,7 +47,7 @@ public final class ChromiumTheMutable extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 new BecomesCreatureSourceEffect(
                         new ChromiumTheMutableToken(), null, Duration.EndOfTurn,
-                        false, false, null, null, true
+                        false, false, true
                 ).setText("Until end of turn, {this} becomes "
                         + "a Human with base power and toughness 1/1, "
                         + "loses all abilities, and gains hexproof"),

--- a/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
+++ b/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
@@ -47,9 +47,7 @@ public final class ChromiumTheMutable extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 new BecomesCreatureSourceEffect(
                         new ChromiumTheMutableToken(), CardType.CREATURE, Duration.EndOfTurn
-                ).andLoseAbilities(true).setText("Until end of turn, {this} becomes "
-                        + "a Human with base power and toughness 1/1, "
-                        + "loses all abilities, and gains hexproof"),
+                ).andLoseAbilities(true),
                 new DiscardCardCost()
         );
         ability.addEffect(

--- a/Mage.Sets/src/mage/cards/c/ChronatogTotem.java
+++ b/Mage.Sets/src/mage/cards/c/ChronatogTotem.java
@@ -39,7 +39,7 @@ public final class ChronatogTotem extends CardImpl {
                         .withColor("U")
                         .withSubType(SubType.ATOG)
                         .withType(CardType.ARTIFACT),
-                "", Duration.EndOfTurn
+                CardType.ARTIFACT, Duration.EndOfTurn
         ), new ManaCostsImpl<>("{1}{U}")));
 
         // {0}: Chronatog Totem gets +3/+3 until end of turn. You skip your next turn. Activate this ability only once each turn and only if Chronatog Totem is a creature.

--- a/Mage.Sets/src/mage/cards/c/CrawlingBarrens.java
+++ b/Mage.Sets/src/mage/cards/c/CrawlingBarrens.java
@@ -73,7 +73,7 @@ class CrawlingBarrensEffect extends OneShotEffect {
         }
         game.addEffect(new BecomesCreatureSourceEffect(new CreatureToken(
                 0, 0, "0/0 Elemental creature"
-        ).withSubType(SubType.ELEMENTAL), "land", Duration.EndOfTurn), source);
+        ).withSubType(SubType.ELEMENTAL), CardType.LAND, Duration.EndOfTurn), source);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CreepingTarPit.java
+++ b/Mage.Sets/src/mage/cards/c/CreepingTarPit.java
@@ -36,11 +36,13 @@ public final class CreepingTarPit extends CardImpl {
 
         // {1}{U}{B}: Until end of turn, Creeping Tar Pit becomes a 3/2 blue and black Elemental creature and can't be blocked. It's still a land.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(
-                new CreatureToken(3, 2, "3/2 blue and black Elemental creature and can't be blocked")
+                new CreatureToken(3, 2, "3/2 blue and black Elemental creature")
                         .withColor("BU")
                         .withSubType(SubType.ELEMENTAL)
                         .withAbility(new CantBeBlockedSourceAbility()),
-                "land", Duration.EndOfTurn), new ManaCostsImpl<>("{1}{U}{B}")));
+                "land", Duration.EndOfTurn)
+                .setText("{this} becomes a 3/2 blue and black Elemental creature until end of turn and can't be blocked this turn. It's still a land"),
+                new ManaCostsImpl<>("{1}{U}{B}")));
     }
 
     private CreepingTarPit(final CreepingTarPit card) {

--- a/Mage.Sets/src/mage/cards/c/CreepingTarPit.java
+++ b/Mage.Sets/src/mage/cards/c/CreepingTarPit.java
@@ -40,7 +40,7 @@ public final class CreepingTarPit extends CardImpl {
                         .withColor("BU")
                         .withSubType(SubType.ELEMENTAL)
                         .withAbility(new CantBeBlockedSourceAbility()),
-                "land", Duration.EndOfTurn)
+                CardType.LAND, Duration.EndOfTurn)
                 .setText("{this} becomes a 3/2 blue and black Elemental creature until end of turn and can't be blocked this turn. It's still a land"),
                 new ManaCostsImpl<>("{1}{U}{B}")));
     }

--- a/Mage.Sets/src/mage/cards/d/DancingSword.java
+++ b/Mage.Sets/src/mage/cards/d/DancingSword.java
@@ -1,10 +1,10 @@
 package mage.cards.d;
 
-import mage.abilities.Ability;
+import mage.MageInt;
 import mage.abilities.common.DiesAttachedTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.effects.ContinuousEffectImpl;
+import mage.abilities.effects.common.continuous.BecomesCreatureSourceEffect;
 import mage.abilities.effects.common.continuous.BoostEquippedEffect;
 import mage.abilities.keyword.EquipAbility;
 import mage.abilities.keyword.FlyingAbility;
@@ -12,11 +12,10 @@ import mage.abilities.keyword.WardAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
+import mage.game.permanent.token.TokenImpl;
+import mage.target.common.TargetControlledCreaturePermanent;
 
 import java.util.UUID;
-import mage.target.common.TargetControlledCreaturePermanent;
 
 /**
  * @author TheElk801
@@ -33,7 +32,7 @@ public final class DancingSword extends CardImpl {
 
         // When equipped creature dies, you may have Dancing Sword become a 2/1 Construct artifact creature with flying and ward {1}. If you do, it isn't an Equipment.
         this.addAbility(new DiesAttachedTriggeredAbility(
-                new DancingSwordEffect(), "equipped creature", true
+                new BecomesCreatureSourceEffect(new DancingSwordToken(), CardType.ARTIFACT, Duration.WhileOnBattlefield).andNotEquipment(true), "equipped creature", true
         ).setTriggerPhrase("When equipped creature dies, "));
 
         // Equip {1}
@@ -50,65 +49,25 @@ public final class DancingSword extends CardImpl {
     }
 }
 
-class DancingSwordEffect extends ContinuousEffectImpl {
+class DancingSwordToken extends TokenImpl {
 
-    DancingSwordEffect() {
-        super(Duration.Custom, Outcome.Benefit);
-        staticText = "you may have {this} become a 2/1 Construct artifact creature " +
-                "with flying and ward {1}. If you do, it isn't an Equipment";
+    public DancingSwordToken() {
+        super("", "2/1 Construct artifact creature with flying and ward {1}. If you do, it isn't an Equipment");
+        cardType.add(CardType.ARTIFACT);
+        cardType.add(CardType.CREATURE);
+        subtype.add(SubType.CONSTRUCT);
+        power = new MageInt(2);
+        toughness = new MageInt(1);
+        this.addAbility(FlyingAbility.getInstance());
+        this.addAbility(new WardAbility(new GenericManaCost(1), false));
     }
 
-    private DancingSwordEffect(final DancingSwordEffect effect) {
-        super(effect);
+    private DancingSwordToken(final DancingSwordToken token) {
+        super(token);
     }
 
-    @Override
-    public DancingSwordEffect copy() {
-        return new DancingSwordEffect(this);
+    public DancingSwordToken copy() {
+        return new DancingSwordToken(this);
     }
 
-    @Override
-    public boolean apply(Layer layer, SubLayer sublayer, Ability source, Game game) {
-        Permanent permanent = source.getSourcePermanentIfItStillExists(game);
-        if (permanent == null) {
-            discard();
-            return false;
-        }
-        switch (layer) {
-            case TypeChangingEffects_4:
-                permanent.removeAllCardTypes();
-                permanent.addCardType(game, CardType.ARTIFACT);
-                permanent.addCardType(game, CardType.CREATURE);
-                permanent.removeAllSubTypes(game);
-                permanent.addSubType(game, SubType.CONSTRUCT);
-                return true;
-            case AbilityAddingRemovingEffects_6:
-                permanent.addAbility(FlyingAbility.getInstance(), source.getSourceId(), game);
-                permanent.addAbility(new WardAbility(new GenericManaCost(1)), source.getSourceId(), game);
-                return true;
-            case PTChangingEffects_7:
-                if (sublayer == SubLayer.SetPT_7b) {
-                    permanent.getPower().setModifiedBaseValue(2);
-                    permanent.getToughness().setModifiedBaseValue(1);
-                    return true;
-                }
-        }
-        return false;
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
-    public boolean hasLayer(Layer layer) {
-        switch (layer) {
-            case TypeChangingEffects_4:
-            case AbilityAddingRemovingEffects_6:
-            case PTChangingEffects_7:
-                return true;
-        }
-        return false;
-    }
 }

--- a/Mage.Sets/src/mage/cards/d/DarksteelBrute.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelBrute.java
@@ -32,7 +32,7 @@ public final class DarksteelBrute extends CardImpl {
                 new CreatureToken(2, 2, "2/2 Beast artifact creature")
                         .withSubType(SubType.BEAST)
                         .withType(CardType.ARTIFACT),
-                "", Duration.EndOfTurn), new GenericManaCost(3)));
+                CardType.ARTIFACT, Duration.EndOfTurn), new GenericManaCost(3)));
     }
 
     private DarksteelBrute(final DarksteelBrute card) {

--- a/Mage.Sets/src/mage/cards/d/DaxossTorment.java
+++ b/Mage.Sets/src/mage/cards/d/DaxossTorment.java
@@ -28,8 +28,7 @@ public final class DaxossTorment extends CardImpl {
                         .withSubType(SubType.DEMON)
                         .withAbility(FlyingAbility.getInstance())
                         .withAbility(HasteAbility.getInstance()),
-                CardType.ENCHANTMENT, Duration.EndOfTurn)
-                .setText("{this} becomes a 5/5 Demon creature with flying and haste in addition to its other types until end of turn")));
+                CardType.ENCHANTMENT, Duration.EndOfTurn)));
     }
 
     private DaxossTorment(final DaxossTorment card) {

--- a/Mage.Sets/src/mage/cards/d/DaxossTorment.java
+++ b/Mage.Sets/src/mage/cards/d/DaxossTorment.java
@@ -28,7 +28,7 @@ public final class DaxossTorment extends CardImpl {
                         .withSubType(SubType.DEMON)
                         .withAbility(FlyingAbility.getInstance())
                         .withAbility(HasteAbility.getInstance()),
-                "previous types", Duration.EndOfTurn)
+                CardType.ENCHANTMENT, Duration.EndOfTurn)
                 .setText("{this} becomes a 5/5 Demon creature with flying and haste in addition to its other types until end of turn")));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DaxossTorment.java
+++ b/Mage.Sets/src/mage/cards/d/DaxossTorment.java
@@ -28,7 +28,8 @@ public final class DaxossTorment extends CardImpl {
                         .withSubType(SubType.DEMON)
                         .withAbility(FlyingAbility.getInstance())
                         .withAbility(HasteAbility.getInstance()),
-                "previous types", Duration.EndOfTurn)));
+                "previous types", Duration.EndOfTurn)
+                .setText("{this} becomes a 5/5 Demon creature with flying and haste in addition to its other types until end of turn")));
     }
 
     private DaxossTorment(final DaxossTorment card) {

--- a/Mage.Sets/src/mage/cards/d/DenOfTheBugbear.java
+++ b/Mage.Sets/src/mage/cards/d/DenOfTheBugbear.java
@@ -53,11 +53,11 @@ public final class DenOfTheBugbear extends CardImpl {
                 "Whenever this creature attacks, create a 1/1 red Goblin creature token that's tapped and attacking."
         );
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(
-                new CreatureToken(3, 2, "3/2 red Goblin creature with \"Whenever this creature attacks, create a 1/1 red Goblin creature token that's tapped and attacking\"")
+                new CreatureToken(3, 2, "3/2 red Goblin creature with \"Whenever this creature attacks, create a 1/1 red Goblin creature token that's tapped and attacking.\"")
                         .withColor("R")
                         .withSubType(SubType.GOBLIN)
                         .withAbility(ability),
-                "land", Duration.EndOfTurn), new ManaCostsImpl<>("{3}{R}")));
+                "land", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{R}")));
     }
 
     private DenOfTheBugbear(final DenOfTheBugbear card) {

--- a/Mage.Sets/src/mage/cards/d/DenOfTheBugbear.java
+++ b/Mage.Sets/src/mage/cards/d/DenOfTheBugbear.java
@@ -57,7 +57,7 @@ public final class DenOfTheBugbear extends CardImpl {
                         .withColor("R")
                         .withSubType(SubType.GOBLIN)
                         .withAbility(ability),
-                "land", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{R}")));
+                CardType.LAND, Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{R}")));
     }
 
     private DenOfTheBugbear(final DenOfTheBugbear card) {

--- a/Mage.Sets/src/mage/cards/d/DimirKeyrune.java
+++ b/Mage.Sets/src/mage/cards/d/DimirKeyrune.java
@@ -35,7 +35,7 @@ public final class DimirKeyrune extends CardImpl {
                 .withColor("UB")
                 .withSubType(SubType.HORROR)
                 .withAbility(new CantBeBlockedSourceAbility()),
-                "", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{U}{B}")));
+                CardType.ARTIFACT, Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{U}{B}")));
     }
 
     private DimirKeyrune(final DimirKeyrune card) {

--- a/Mage.Sets/src/mage/cards/d/DimirKeyrune.java
+++ b/Mage.Sets/src/mage/cards/d/DimirKeyrune.java
@@ -35,7 +35,7 @@ public final class DimirKeyrune extends CardImpl {
                 .withColor("UB")
                 .withSubType(SubType.HORROR)
                 .withAbility(new CantBeBlockedSourceAbility()),
-                "", Duration.EndOfTurn), new ManaCostsImpl<>("{U}{B}")));
+                "", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{U}{B}")));
     }
 
     private DimirKeyrune(final DimirKeyrune card) {

--- a/Mage.Sets/src/mage/cards/d/DireMimic.java
+++ b/Mage.Sets/src/mage/cards/d/DireMimic.java
@@ -39,7 +39,7 @@ public final class DireMimic extends CardImpl {
                 new CreatureToken(
                         5, 5, "Shapeshifter artifact creature " +
                         "with base power and toughness 5/5", SubType.SHAPESHIFTER
-                ).withType(CardType.ARTIFACT), "", Duration.EndOfTurn
+                ).withType(CardType.ARTIFACT), CardType.ARTIFACT, Duration.EndOfTurn
         ), new GenericManaCost(3)));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreadStatuary.java
+++ b/Mage.Sets/src/mage/cards/d/DreadStatuary.java
@@ -25,7 +25,7 @@ public final class DreadStatuary extends CardImpl {
     public DreadStatuary(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.LAND},null);
         this.addAbility(new ColorlessManaAbility());
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new DreadStatuaryToken(), "land", Duration.EndOfTurn), new ManaCostsImpl<>("{4}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new DreadStatuaryToken(), CardType.LAND, Duration.EndOfTurn), new ManaCostsImpl<>("{4}")));
     }
 
     private DreadStatuary(final DreadStatuary card) {

--- a/Mage.Sets/src/mage/cards/d/DromokaMonument.java
+++ b/Mage.Sets/src/mage/cards/d/DromokaMonument.java
@@ -32,7 +32,7 @@ public final class DromokaMonument extends CardImpl {
         
         // {4}{G}{W}: Dromoka Monument becomes a 4/4 green and white Dragon artifact creature with flying until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect
-            (new DromokaMonumentToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{4}{G}{W}")));
+            (new DromokaMonumentToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{4}{G}{W}")));
     }
 
     private DromokaMonument(final DromokaMonument card) {
@@ -44,7 +44,7 @@ public final class DromokaMonument extends CardImpl {
         return new DromokaMonument(this);
     }
     
-    private class DromokaMonumentToken extends TokenImpl {
+    private static class DromokaMonumentToken extends TokenImpl {
         DromokaMonumentToken() {
             super("", "4/4 green and white Dragon artifact creature with flying");
             cardType.add(CardType.ARTIFACT);

--- a/Mage.Sets/src/mage/cards/e/EbonyFly.java
+++ b/Mage.Sets/src/mage/cards/e/EbonyFly.java
@@ -103,7 +103,7 @@ class EbonyFlyEffect extends OneShotEffect {
                 new CreatureToken(result, result)
                         .withType(CardType.ARTIFACT)
                         .withAbility(FlyingAbility.getInstance()),
-                "", Duration.EndOfTurn
+                CardType.ARTIFACT, Duration.EndOfTurn
         ), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/e/EbonyFly.java
+++ b/Mage.Sets/src/mage/cards/e/EbonyFly.java
@@ -103,7 +103,7 @@ class EbonyFlyEffect extends OneShotEffect {
                 new CreatureToken(result, result)
                         .withType(CardType.ARTIFACT)
                         .withAbility(FlyingAbility.getInstance()),
-                "", Duration.EndOfTurn, false, false
+                "", Duration.EndOfTurn, false, false, false
         ), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/e/EbonyFly.java
+++ b/Mage.Sets/src/mage/cards/e/EbonyFly.java
@@ -103,7 +103,7 @@ class EbonyFlyEffect extends OneShotEffect {
                 new CreatureToken(result, result)
                         .withType(CardType.ARTIFACT)
                         .withAbility(FlyingAbility.getInstance()),
-                "", Duration.EndOfTurn, false, false, false
+                "", Duration.EndOfTurn
         ), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/e/EnsouledScimitar.java
+++ b/Mage.Sets/src/mage/cards/e/EnsouledScimitar.java
@@ -30,7 +30,7 @@ public final class EnsouledScimitar extends CardImpl {
         this.subtype.add(SubType.EQUIPMENT);
 
         // {3}: Ensouled Scimitar becomes a 1/5 Spirit artifact creature with flying until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new EnsouledScimitarToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{3}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new EnsouledScimitarToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{3}")));
         // Equipped creature gets +1/+5.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEquippedEffect(1, 5)));
         // Equip {2}

--- a/Mage.Sets/src/mage/cards/e/EyeOfMalcator.java
+++ b/Mage.Sets/src/mage/cards/e/EyeOfMalcator.java
@@ -28,7 +28,7 @@ public class EyeOfMalcator extends CardImpl {
                 new BecomesCreatureSourceEffect(
                         new CreatureToken(
                                 4, 4, "4/4 Phyrexian Eye artifact creature", SubType.PHYREXIAN, SubType.EYE
-                        ).withType(CardType.ARTIFACT), "", Duration.EndOfTurn
+                        ).withType(CardType.ARTIFACT), CardType.ARTIFACT, Duration.EndOfTurn
                 ).setText("{this} becomes a 4/4 Phyrexian Eye artifact creature until end of turn"),
                 StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT
         ).setTriggerPhrase("Whenever another artifact enters the battlefield under your control, "));

--- a/Mage.Sets/src/mage/cards/f/FacelessHaven.java
+++ b/Mage.Sets/src/mage/cards/f/FacelessHaven.java
@@ -30,7 +30,7 @@ public final class FacelessHaven extends CardImpl {
 
         // {S}{S}{S}: Faceless Haven becomes a 4/3 creature with vigilance and all creature types until end of turn. It's still a land.
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
-                new FacelessHavenToken(), "land", Duration.EndOfTurn
+                new FacelessHavenToken(), CardType.LAND, Duration.EndOfTurn
         ).setText("{this} becomes a 4/3 creature with vigilance and all creature types until end of turn. It's still a land"), new ManaCostsImpl<>("{S}{S}{S}")));
     }
 

--- a/Mage.Sets/src/mage/cards/f/FaerieConclave.java
+++ b/Mage.Sets/src/mage/cards/f/FaerieConclave.java
@@ -27,7 +27,7 @@ public final class FaerieConclave extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.LAND},"");
         this.addAbility(new EntersBattlefieldTappedAbility());
         this.addAbility(new BlueManaAbility());
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new FaerieConclaveToken(), "land", Duration.EndOfTurn), new ManaCostsImpl<>("{1}{U}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new FaerieConclaveToken(), CardType.LAND, Duration.EndOfTurn), new ManaCostsImpl<>("{1}{U}")));
     }
 
     private FaerieConclave(final FaerieConclave card) {

--- a/Mage.Sets/src/mage/cards/f/ForbiddingWatchtower.java
+++ b/Mage.Sets/src/mage/cards/f/ForbiddingWatchtower.java
@@ -32,7 +32,7 @@ public final class ForbiddingWatchtower extends CardImpl {
         this.addAbility(new WhiteManaAbility());
 
         // {1}{W}: Forbidding Watchtower becomes a 1/5 white Soldier creature until end of turn. It's still a land.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new ForbiddingWatchtowerToken(), "land", Duration.EndOfTurn), new ManaCostsImpl<>("{1}{W}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new ForbiddingWatchtowerToken(), CardType.LAND, Duration.EndOfTurn), new ManaCostsImpl<>("{1}{W}")));
     }
 
     private ForbiddingWatchtower(final ForbiddingWatchtower card) {

--- a/Mage.Sets/src/mage/cards/f/ForiysianTotem.java
+++ b/Mage.Sets/src/mage/cards/f/ForiysianTotem.java
@@ -36,7 +36,7 @@ public final class ForiysianTotem extends CardImpl {
         this.addAbility(new RedManaAbility());
 
         // {4}{R}: Foriysian Totem becomes a 4/4 red Giant artifact creature with trample until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new ForiysianTotemToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{4}{R}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new ForiysianTotemToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{4}{R}")));
 
         // As long as Foriysian Totem is a creature, it can block an additional creature each combat.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new ConditionalContinuousEffect(new CanBlockAdditionalCreatureEffect(1), new SourceMatchesFilterCondition(new FilterCreaturePermanent()), ruleText)));

--- a/Mage.Sets/src/mage/cards/f/FountainOfIchor.java
+++ b/Mage.Sets/src/mage/cards/f/FountainOfIchor.java
@@ -27,7 +27,7 @@ public final class FountainOfIchor extends CardImpl {
 
         // {3}: Fountain of Ichor becomes a 3/3 Dinosaur artifact creature until end of turn.
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
-                new FountainOfIchorToken(), "", Duration.EndOfTurn
+                new FountainOfIchorToken(), CardType.ARTIFACT, Duration.EndOfTurn
         ), new GenericManaCost(3)));
     }
 

--- a/Mage.Sets/src/mage/cards/f/FrostwalkBastion.java
+++ b/Mage.Sets/src/mage/cards/f/FrostwalkBastion.java
@@ -35,7 +35,7 @@ public final class FrostwalkBastion extends CardImpl {
         // {1}{S}: Until end of turn, Frostwalk Bastion becomes a 2/3 Construct artifact creature. It's still a land.
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
                 new FrostwalkBastionToken(), "land", Duration.EndOfTurn
-        ), new ManaCostsImpl<>("{1}{S}")));
+        ).withDurationRuleAtStart(true), new ManaCostsImpl<>("{1}{S}")));
 
         // Whenever Frostwalk Bastion deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.
         Ability ability = new DealsDamageToACreatureTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/f/FrostwalkBastion.java
+++ b/Mage.Sets/src/mage/cards/f/FrostwalkBastion.java
@@ -34,7 +34,7 @@ public final class FrostwalkBastion extends CardImpl {
 
         // {1}{S}: Until end of turn, Frostwalk Bastion becomes a 2/3 Construct artifact creature. It's still a land.
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
-                new FrostwalkBastionToken(), "land", Duration.EndOfTurn
+                new FrostwalkBastionToken(), CardType.LAND, Duration.EndOfTurn
         ).withDurationRuleAtStart(true), new ManaCostsImpl<>("{1}{S}")));
 
         // Whenever Frostwalk Bastion deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.

--- a/Mage.Sets/src/mage/cards/g/GhituEncampment.java
+++ b/Mage.Sets/src/mage/cards/g/GhituEncampment.java
@@ -29,7 +29,7 @@ public final class GhituEncampment extends CardImpl {
         this.addAbility(new EntersBattlefieldTappedAbility());
         this.addAbility(new RedManaAbility());
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new BecomesCreatureSourceEffect(new GhituEncampmentToken(), "land", Duration.EndOfTurn),
+                new BecomesCreatureSourceEffect(new GhituEncampmentToken(), CardType.LAND, Duration.EndOfTurn),
                 new ManaCostsImpl<>("{1}{R}")));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GideonAllyOfZendikar.java
+++ b/Mage.Sets/src/mage/cards/g/GideonAllyOfZendikar.java
@@ -34,7 +34,7 @@ public final class GideonAllyOfZendikar extends CardImpl {
         this.setStartingLoyalty(4);
 
         // +1: Until end of turn, Gideon, Ally of Zendikar becomes a 5/5 Human Soldier Ally creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.
-        LoyaltyAbility ability = new LoyaltyAbility(new BecomesCreatureSourceEffect(new GideonAllyOfZendikarToken(), "planeswalker", Duration.EndOfTurn), 1);
+        LoyaltyAbility ability = new LoyaltyAbility(new BecomesCreatureSourceEffect(new GideonAllyOfZendikarToken(), CardType.PLANESWALKER, Duration.EndOfTurn), 1);
         Effect effect = new PreventAllDamageToSourceEffect(Duration.EndOfTurn);
         effect.setText("Prevent all damage that would be dealt to him this turn");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/g/GideonBattleForged.java
+++ b/Mage.Sets/src/mage/cards/g/GideonBattleForged.java
@@ -60,7 +60,7 @@ public final class GideonBattleForged extends CardImpl {
         this.addAbility(loyaltyAbility);
 
         // 0: Until end of turn, Gideon, Battle-Forged becomes a 4/4 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.
-        LoyaltyAbility ability3 = new LoyaltyAbility(new BecomesCreatureSourceEffect(new GideonBattleForgedToken(), "planeswalker", Duration.EndOfTurn), 0);
+        LoyaltyAbility ability3 = new LoyaltyAbility(new BecomesCreatureSourceEffect(new GideonBattleForgedToken(), CardType.PLANESWALKER, Duration.EndOfTurn), 0);
         effect = new PreventAllDamageToSourceEffect(Duration.EndOfTurn);
         effect.setText("Prevent all damage that would be dealt to him this turn");
         ability3.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/g/GideonBlackblade.java
+++ b/Mage.Sets/src/mage/cards/g/GideonBlackblade.java
@@ -57,7 +57,7 @@ public final class GideonBlackblade extends CardImpl {
         // As long as it's your turn, Gideon Blackblade is a 4/4 Human Soldier creature with indestructible that's still a planeswalker.
         this.addAbility(new SimpleStaticAbility(new ConditionalContinuousEffect(
                 new BecomesCreatureSourceEffect(
-                        new GideonBlackbladeToken(), "planeswalker", Duration.WhileOnBattlefield
+                        new GideonBlackbladeToken(), CardType.PLANESWALKER, Duration.WhileOnBattlefield
                 ), MyTurnCondition.instance, "As long as it's your turn, " +
                 "{this} is a 4/4 Human Soldier creature with indestructible that's still a planeswalker."
         )).addHint(MyTurnHint.instance));

--- a/Mage.Sets/src/mage/cards/g/GideonChampionOfJustice.java
+++ b/Mage.Sets/src/mage/cards/g/GideonChampionOfJustice.java
@@ -49,7 +49,7 @@ public final class GideonChampionOfJustice extends CardImpl {
         // 0: Until end of turn, Gideon becomes an indestructible Human Soldier creature with power and toughness each equal to the number of loyalty counters on him. He's still a planeswalker. Prevent all damage that would be dealt to him this turn.
         LockedInDynamicValue loyaltyCount = new LockedInDynamicValue(new CountersSourceCount(CounterType.LOYALTY));
         LoyaltyAbility ability2 = new LoyaltyAbility(new BecomesCreatureSourceEffect(
-                new GideonChampionOfJusticeToken(), "planeswalker", Duration.EndOfTurn).withDynamicPT(loyaltyCount, loyaltyCount)
+                new GideonChampionOfJusticeToken(), CardType.PLANESWALKER, Duration.EndOfTurn).withDynamicPT(loyaltyCount, loyaltyCount)
                 .setText("Until end of turn, {this} becomes a Human Soldier creature with power and toughness each equal to the number of loyalty counters on him and gains indestructible. He's still a planeswalker."), 0);
         ability2.addEffect(new PreventAllDamageToSourceEffect(Duration.EndOfTurn).setText("prevent all damage that would be dealt to him this turn"));
         this.addAbility(ability2);

--- a/Mage.Sets/src/mage/cards/g/GideonChampionOfJustice.java
+++ b/Mage.Sets/src/mage/cards/g/GideonChampionOfJustice.java
@@ -49,7 +49,7 @@ public final class GideonChampionOfJustice extends CardImpl {
         // 0: Until end of turn, Gideon becomes an indestructible Human Soldier creature with power and toughness each equal to the number of loyalty counters on him. He's still a planeswalker. Prevent all damage that would be dealt to him this turn.
         LockedInDynamicValue loyaltyCount = new LockedInDynamicValue(new CountersSourceCount(CounterType.LOYALTY));
         LoyaltyAbility ability2 = new LoyaltyAbility(new BecomesCreatureSourceEffect(
-                new GideonChampionOfJusticeToken(), "planeswalker", Duration.EndOfTurn, false, false, loyaltyCount, loyaltyCount)
+                new GideonChampionOfJusticeToken(), "planeswalker", Duration.EndOfTurn).withDynamicPT(loyaltyCount, loyaltyCount)
                 .setText("Until end of turn, {this} becomes a Human Soldier creature with power and toughness each equal to the number of loyalty counters on him and gains indestructible. He's still a planeswalker."), 0);
         ability2.addEffect(new PreventAllDamageToSourceEffect(Duration.EndOfTurn).setText("prevent all damage that would be dealt to him this turn"));
         this.addAbility(ability2);

--- a/Mage.Sets/src/mage/cards/g/GideonJura.java
+++ b/Mage.Sets/src/mage/cards/g/GideonJura.java
@@ -51,7 +51,7 @@ public final class GideonJura extends CardImpl {
         this.addAbility(ability2);
 
         // 0: Until end of turn, Gideon Jura becomes a 6/6 Human Soldier creature that's still a planeswalker. Prevent all damage that would be dealt to him this turn.
-        LoyaltyAbility ability3 = new LoyaltyAbility(new BecomesCreatureSourceEffect(new GideonJuraToken(), "planeswalker", Duration.EndOfTurn), 0);
+        LoyaltyAbility ability3 = new LoyaltyAbility(new BecomesCreatureSourceEffect(new GideonJuraToken(), CardType.PLANESWALKER, Duration.EndOfTurn), 0);
         Effect effect = new PreventAllDamageToSourceEffect(Duration.EndOfTurn);
         effect.setText("Prevent all damage that would be dealt to him this turn");
         ability3.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/g/GideonMartialParagon.java
+++ b/Mage.Sets/src/mage/cards/g/GideonMartialParagon.java
@@ -44,7 +44,7 @@ public final class GideonMartialParagon extends CardImpl {
 
         // 0: Until end of turn, Gideon, Martial Paragon, becomes a 5/5 Human Soldier creature with indestructible that's still a planeswalker.
         // Prevent all damage that would be dealt to him this turn.
-        ability = new LoyaltyAbility(new BecomesCreatureSourceEffect(new GideonMartialParagonToken(), "planeswalker", Duration.EndOfTurn), 0);
+        ability = new LoyaltyAbility(new BecomesCreatureSourceEffect(new GideonMartialParagonToken(), CardType.PLANESWALKER, Duration.EndOfTurn), 0);
         effect = new PreventAllDamageToSourceEffect(Duration.EndOfTurn);
         effect.setText("Prevent all damage that would be dealt to him this turn");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/g/GideonOfTheTrials.java
+++ b/Mage.Sets/src/mage/cards/g/GideonOfTheTrials.java
@@ -42,7 +42,7 @@ public final class GideonOfTheTrials extends CardImpl {
         this.addAbility(ability);
 
         // 0: Until end of turn, Gideon of the Trials becomes a 4/4 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.
-        ability = new LoyaltyAbility(new BecomesCreatureSourceEffect(new GideonOfTheTrialsToken(), "planeswalker", Duration.EndOfTurn), 0);
+        ability = new LoyaltyAbility(new BecomesCreatureSourceEffect(new GideonOfTheTrialsToken(), CardType.PLANESWALKER, Duration.EndOfTurn), 0);
         effect = new PreventAllDamageToSourceEffect(Duration.EndOfTurn);
         effect.setText("Prevent all damage that would be dealt to him this turn");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/g/GideonTheOathsworn.java
+++ b/Mage.Sets/src/mage/cards/g/GideonTheOathsworn.java
@@ -41,7 +41,7 @@ public final class GideonTheOathsworn extends CardImpl {
 
         // +2: Until end of turn, Gideon, the Oathsworn becomes a 5/5 white Soldier creature that's still a planeswalker. Prevent all damage that would be dealt to him this turn.
         Ability ability = new LoyaltyAbility(new BecomesCreatureSourceEffect(
-                new GideonTheOathswornToken(), "planeswalker", Duration.EndOfTurn
+                new GideonTheOathswornToken(), CardType.PLANESWALKER, Duration.EndOfTurn
         ), 2);
         ability.addEffect(new PreventAllDamageToSourceEffect(
                 Duration.EndOfTurn

--- a/Mage.Sets/src/mage/cards/g/GlintHawkIdol.java
+++ b/Mage.Sets/src/mage/cards/g/GlintHawkIdol.java
@@ -34,10 +34,10 @@ public final class GlintHawkIdol extends CardImpl {
         
         // Whenever another artifact enters the battlefield under your control, you may have {this} become a 2/2 Bird artifact creature with flying until end of turn.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
-                Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GlintHawkIdolToken(), "", Duration.EndOfTurn), filter, true));
+                Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GlintHawkIdolToken(), CardType.ARTIFACT, Duration.EndOfTurn), filter, true));
 
         // {W}: Glint Hawk Idol becomes a 2/2 Bird artifact creature with flying until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GlintHawkIdolToken(), "", Duration.EndOfTurn), new ColoredManaCost(ColoredManaSymbol.W)));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GlintHawkIdolToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ColoredManaCost(ColoredManaSymbol.W)));
     }
 
     public GlintHawkIdol (final GlintHawkIdol card) {

--- a/Mage.Sets/src/mage/cards/g/GolgariKeyrune.java
+++ b/Mage.Sets/src/mage/cards/g/GolgariKeyrune.java
@@ -30,7 +30,7 @@ public final class GolgariKeyrune extends CardImpl {
         this.addAbility(new GreenManaAbility());
 
         // {B}{G}: Golgari Keyrune becomes a 2/2 black and green Insect artifact creature with deathtouch until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GolgariKeyruneToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{B}{G}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GolgariKeyruneToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{B}{G}")));
     }
 
     private GolgariKeyrune(final GolgariKeyrune card) {

--- a/Mage.Sets/src/mage/cards/g/GruulKeyrune.java
+++ b/Mage.Sets/src/mage/cards/g/GruulKeyrune.java
@@ -31,7 +31,7 @@ public final class GruulKeyrune extends CardImpl {
         this.addAbility(new GreenManaAbility());
 
         // {R}{G}: Gruul Keyrune becomes a 3/2 red and green Beast artifact creature with trample until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GruulKeyruneToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{R}{G}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GruulKeyruneToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{R}{G}")));
     }
 
     private GruulKeyrune(final GruulKeyrune card) {

--- a/Mage.Sets/src/mage/cards/g/GruulWarPlow.java
+++ b/Mage.Sets/src/mage/cards/g/GruulWarPlow.java
@@ -30,7 +30,7 @@ public final class GruulWarPlow extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityControlledEffect(TrampleAbility.getInstance(), Duration.WhileOnBattlefield, StaticFilters.FILTER_PERMANENT_CREATURES)));
 
         // {1}{R}{G}: Gruul War Plow becomes a 4/4 Juggernaut artifact creature until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GruulWarPlowToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{1}{R}{G}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GruulWarPlowToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{1}{R}{G}")));
     }
 
     private GruulWarPlow(final GruulWarPlow card) {

--- a/Mage.Sets/src/mage/cards/g/GuardianIdol.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianIdol.java
@@ -46,7 +46,7 @@ public final class GuardianIdol extends CardImpl {
 class GuardianIdolGolemToken extends TokenImpl {
 
     public GuardianIdolGolemToken() {
-        super("Golem", "2/2 Golem artifact creature token");
+        super("Golem", "2/2 Golem artifact creature");
         cardType.add(CardType.ARTIFACT);
         cardType.add(CardType.CREATURE);
         subtype.add(SubType.GOLEM);

--- a/Mage.Sets/src/mage/cards/g/GuardianIdol.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianIdol.java
@@ -30,7 +30,7 @@ public final class GuardianIdol extends CardImpl {
         // {tap}: Add {C}.
         this.addAbility(new ColorlessManaAbility());
         // {2}: Guardian Idol becomes a 2/2 Golem artifact creature until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GuardianIdolGolemToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{2}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GuardianIdolGolemToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{2}")));
     }
 
     private GuardianIdol(final GuardianIdol card) {

--- a/Mage.Sets/src/mage/cards/h/HalcyonGlaze.java
+++ b/Mage.Sets/src/mage/cards/h/HalcyonGlaze.java
@@ -25,7 +25,7 @@ public final class HalcyonGlaze extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{U}{U}");
 
         // Whenever you cast a creature spell, Halcyon Glaze becomes a 4/4 Illusion creature with flying in addition to its other types until end of turn.
-        Effect effect = new BecomesCreatureSourceEffect(new HalcyonGlazeToken(), "enchantment", Duration.EndOfTurn);
+        Effect effect = new BecomesCreatureSourceEffect(new HalcyonGlazeToken(), CardType.ENCHANTMENT, Duration.EndOfTurn);
         effect.setText("{this} becomes a 4/4 Illusion creature with flying in addition to its other types until end of turn");
         this.addAbility(new SpellCastControllerTriggeredAbility(effect, StaticFilters.FILTER_SPELL_A_CREATURE, false));
     }

--- a/Mage.Sets/src/mage/cards/h/HalcyonGlaze.java
+++ b/Mage.Sets/src/mage/cards/h/HalcyonGlaze.java
@@ -26,7 +26,6 @@ public final class HalcyonGlaze extends CardImpl {
 
         // Whenever you cast a creature spell, Halcyon Glaze becomes a 4/4 Illusion creature with flying in addition to its other types until end of turn.
         Effect effect = new BecomesCreatureSourceEffect(new HalcyonGlazeToken(), CardType.ENCHANTMENT, Duration.EndOfTurn);
-        effect.setText("{this} becomes a 4/4 Illusion creature with flying in addition to its other types until end of turn");
         this.addAbility(new SpellCastControllerTriggeredAbility(effect, StaticFilters.FILTER_SPELL_A_CREATURE, false));
     }
 

--- a/Mage.Sets/src/mage/cards/h/HallOfStormGiants.java
+++ b/Mage.Sets/src/mage/cards/h/HallOfStormGiants.java
@@ -50,7 +50,7 @@ public final class HallOfStormGiants extends CardImpl {
                         .withColor("U")
                         .withSubType(SubType.GIANT)
                         .withAbility(new WardAbility(new GenericManaCost(3))),
-                "land", Duration.EndOfTurn).setText(
+                CardType.LAND, Duration.EndOfTurn).setText(
                         "Until end of turn, Hall of Storm Giants becomes a 7/7 blue Giant creature with ward {3}. " +
                                 "It's still a land. " +
                                 "<i>(Whenever it becomes the target of a spell or ability an opponent controls, " +

--- a/Mage.Sets/src/mage/cards/h/HauntedPlateMail.java
+++ b/Mage.Sets/src/mage/cards/h/HauntedPlateMail.java
@@ -37,7 +37,7 @@ public final class HauntedPlateMail extends CardImpl {
         // {0}: Until end of turn, Haunted Plate Mail becomes a 4/4 Spirit artifact creature that's no longer an Equipment. Activate this ability only if you control no creatures.
         Ability ability = new ConditionalActivatedAbility(
                 Zone.BATTLEFIELD,
-                new BecomesCreatureSourceEffect(new HauntedPlateMailToken(), "", Duration.EndOfTurn),
+                new BecomesCreatureSourceEffect(new HauntedPlateMailToken(), CardType.ARTIFACT, Duration.EndOfTurn),
                 new ManaCostsImpl<>("{0}"),
                 new PermanentsOnTheBattlefieldCondition(StaticFilters.FILTER_PERMANENT_CREATURE, ComparisonType.EQUAL_TO, 0),
                 "{0}: Until end of turn, Haunted Plate Mail becomes a 4/4 Spirit artifact creature that's no longer an Equipment. Activate only if you control no creatures.");

--- a/Mage.Sets/src/mage/cards/h/HauntedPlateMail.java
+++ b/Mage.Sets/src/mage/cards/h/HauntedPlateMail.java
@@ -37,7 +37,7 @@ public final class HauntedPlateMail extends CardImpl {
         // {0}: Until end of turn, Haunted Plate Mail becomes a 4/4 Spirit artifact creature that's no longer an Equipment. Activate this ability only if you control no creatures.
         Ability ability = new ConditionalActivatedAbility(
                 Zone.BATTLEFIELD,
-                new BecomesCreatureSourceEffect(new HauntedPlateMailToken(), CardType.ARTIFACT, Duration.EndOfTurn),
+                new BecomesCreatureSourceEffect(new HauntedPlateMailToken(), CardType.ARTIFACT, Duration.EndOfTurn).andNotEquipment(true),
                 new ManaCostsImpl<>("{0}"),
                 new PermanentsOnTheBattlefieldCondition(StaticFilters.FILTER_PERMANENT_CREATURE, ComparisonType.EQUAL_TO, 0),
                 "{0}: Until end of turn, Haunted Plate Mail becomes a 4/4 Spirit artifact creature that's no longer an Equipment. Activate only if you control no creatures.");

--- a/Mage.Sets/src/mage/cards/h/HiddenAncients.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenAncients.java
@@ -35,7 +35,7 @@ public final class HiddenAncients extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{G}");
 
         // When an opponent casts an enchantment spell, if Hidden Ancients is an enchantment, Hidden Ancients becomes a 5/5 Treefolk creature.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenAncientsTreefolkToken(), "", Duration.WhileOnBattlefield, true, false),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenAncientsTreefolkToken(), Duration.WhileOnBattlefield),
                 filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts an enchantment spell, if {this} is an enchantment, {this} becomes a 5/5 Treefolk creature."));

--- a/Mage.Sets/src/mage/cards/h/HiddenAncients.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenAncients.java
@@ -35,7 +35,7 @@ public final class HiddenAncients extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{G}");
 
         // When an opponent casts an enchantment spell, if Hidden Ancients is an enchantment, Hidden Ancients becomes a 5/5 Treefolk creature.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenAncientsTreefolkToken(), Duration.WhileOnBattlefield),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenAncientsTreefolkToken(), null, Duration.WhileOnBattlefield),
                 filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts an enchantment spell, if {this} is an enchantment, {this} becomes a 5/5 Treefolk creature."));

--- a/Mage.Sets/src/mage/cards/h/HiddenGibbons.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenGibbons.java
@@ -35,7 +35,7 @@ public final class HiddenGibbons extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{G}");
 
         // When an opponent casts an instant spell, if Hidden Gibbons is an enchantment, Hidden Gibbons becomes a 4/4 Ape creature.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenGibbonsApe(), Duration.WhileOnBattlefield),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenGibbonsApe(), null, Duration.WhileOnBattlefield),
                 filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts an instant spell, if {this} is an enchantment, {this} becomes a 4/4 Ape creature."));

--- a/Mage.Sets/src/mage/cards/h/HiddenGibbons.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenGibbons.java
@@ -35,7 +35,7 @@ public final class HiddenGibbons extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{G}");
 
         // When an opponent casts an instant spell, if Hidden Gibbons is an enchantment, Hidden Gibbons becomes a 4/4 Ape creature.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenGibbonsApe(), "", Duration.WhileOnBattlefield, true, false),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenGibbonsApe(), Duration.WhileOnBattlefield),
                 filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts an instant spell, if {this} is an enchantment, {this} becomes a 4/4 Ape creature."));

--- a/Mage.Sets/src/mage/cards/h/HiddenGuerrillas.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenGuerrillas.java
@@ -30,7 +30,7 @@ public final class HiddenGuerrillas extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{G}");
 
         // When an opponent casts an artifact spell, if Hidden Guerrillas is an enchantment, Hidden Guerrillas becomes a 5/3 Soldier creature with trample.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenGuerrillasSoldier(), Duration.WhileOnBattlefield),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenGuerrillasSoldier(), null, Duration.WhileOnBattlefield),
                 new FilterArtifactSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts an artifact spell, if {this} is an enchantment, {this} becomes a 5/3 Soldier creature with trample."));

--- a/Mage.Sets/src/mage/cards/h/HiddenGuerrillas.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenGuerrillas.java
@@ -30,7 +30,7 @@ public final class HiddenGuerrillas extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{G}");
 
         // When an opponent casts an artifact spell, if Hidden Guerrillas is an enchantment, Hidden Guerrillas becomes a 5/3 Soldier creature with trample.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenGuerrillasSoldier(), "", Duration.WhileOnBattlefield, true, false),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenGuerrillasSoldier(), Duration.WhileOnBattlefield),
                 new FilterArtifactSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts an artifact spell, if {this} is an enchantment, {this} becomes a 5/3 Soldier creature with trample."));

--- a/Mage.Sets/src/mage/cards/h/HiddenHerd.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenHerd.java
@@ -50,7 +50,7 @@ public final class HiddenHerd extends CardImpl {
 class HiddenHerdAbility extends TriggeredAbilityImpl {
 
     public HiddenHerdAbility() {
-        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new HiddenHerdBeast(), "", Duration.WhileOnBattlefield, true, false), false);
+        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new HiddenHerdBeast(), Duration.WhileOnBattlefield), false);
     }
 
     public HiddenHerdAbility(final HiddenHerdAbility ability) {

--- a/Mage.Sets/src/mage/cards/h/HiddenHerd.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenHerd.java
@@ -12,7 +12,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.constants.SuperType;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.game.Game;
@@ -50,7 +49,7 @@ public final class HiddenHerd extends CardImpl {
 class HiddenHerdAbility extends TriggeredAbilityImpl {
 
     public HiddenHerdAbility() {
-        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new HiddenHerdBeast(), Duration.WhileOnBattlefield), false);
+        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new HiddenHerdBeast(), null, Duration.WhileOnBattlefield), false);
     }
 
     public HiddenHerdAbility(final HiddenHerdAbility ability) {

--- a/Mage.Sets/src/mage/cards/h/HiddenPredators.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenPredators.java
@@ -46,7 +46,7 @@ class HiddenPredatorsStateTriggeredAbility extends StateTriggeredAbility {
     }
 
     public HiddenPredatorsStateTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new HiddenPredatorsToken(), "", Duration.Custom, true, false));
+        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new HiddenPredatorsToken(), Duration.Custom));
         setTriggerPhrase("When an opponent controls a creature with power 4 or greater, if {this} is an enchantment");
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiddenPredators.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenPredators.java
@@ -46,7 +46,7 @@ class HiddenPredatorsStateTriggeredAbility extends StateTriggeredAbility {
     }
 
     public HiddenPredatorsStateTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new HiddenPredatorsToken(), Duration.Custom));
+        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new HiddenPredatorsToken(), null, Duration.Custom));
         setTriggerPhrase("When an opponent controls a creature with power 4 or greater, if {this} is an enchantment, ");
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiddenPredators.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenPredators.java
@@ -47,7 +47,7 @@ class HiddenPredatorsStateTriggeredAbility extends StateTriggeredAbility {
 
     public HiddenPredatorsStateTriggeredAbility() {
         super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new HiddenPredatorsToken(), Duration.Custom));
-        setTriggerPhrase("When an opponent controls a creature with power 4 or greater, if {this} is an enchantment");
+        setTriggerPhrase("When an opponent controls a creature with power 4 or greater, if {this} is an enchantment, ");
     }
 
     public HiddenPredatorsStateTriggeredAbility(final HiddenPredatorsStateTriggeredAbility ability) {

--- a/Mage.Sets/src/mage/cards/h/HiddenSpider.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenSpider.java
@@ -38,7 +38,7 @@ public final class HiddenSpider extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{G}");
 
         // When an opponent casts a creature spell with flying, if Hidden Spider is an enchantment, Hidden Spider becomes a 3/5 Spider creature with reach.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenSpiderToken(), "", Duration.WhileOnBattlefield, true, false),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenSpiderToken(), Duration.WhileOnBattlefield),
                 filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts a creature spell with flying, if {this} is an enchantment, {this} becomes a 3/5 Spider creature with reach."));

--- a/Mage.Sets/src/mage/cards/h/HiddenSpider.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenSpider.java
@@ -38,7 +38,7 @@ public final class HiddenSpider extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{G}");
 
         // When an opponent casts a creature spell with flying, if Hidden Spider is an enchantment, Hidden Spider becomes a 3/5 Spider creature with reach.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenSpiderToken(), Duration.WhileOnBattlefield),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new HiddenSpiderToken(), null, Duration.WhileOnBattlefield),
                 filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts a creature spell with flying, if {this} is an enchantment, {this} becomes a 3/5 Spider creature with reach."));

--- a/Mage.Sets/src/mage/cards/h/HiddenStag.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenStag.java
@@ -29,7 +29,7 @@ public final class HiddenStag extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{G}");
 
         // Whenever an opponent plays a land, if Hidden Stag is an enchantment, Hidden Stag becomes a 3/2 Elk Beast creature.
-        Effect effect = new BecomesCreatureSourceEffect(new ElkBeastToken(), Duration.WhileOnBattlefield);
+        Effect effect = new BecomesCreatureSourceEffect(new ElkBeastToken(), null, Duration.WhileOnBattlefield);
         TriggeredAbility ability = new OpponentPlaysLandTriggeredAbility(Zone.BATTLEFIELD, effect, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "Whenever an opponent plays a land, if Hidden Stag is an enchantment, Hidden Stag becomes a 3/2 Elk Beast creature."));

--- a/Mage.Sets/src/mage/cards/h/HiddenStag.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenStag.java
@@ -29,7 +29,7 @@ public final class HiddenStag extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{G}");
 
         // Whenever an opponent plays a land, if Hidden Stag is an enchantment, Hidden Stag becomes a 3/2 Elk Beast creature.
-        Effect effect = new BecomesCreatureSourceEffect(new ElkBeastToken(), "", Duration.WhileOnBattlefield, true, false);
+        Effect effect = new BecomesCreatureSourceEffect(new ElkBeastToken(), Duration.WhileOnBattlefield);
         TriggeredAbility ability = new OpponentPlaysLandTriggeredAbility(Zone.BATTLEFIELD, effect, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "Whenever an opponent plays a land, if Hidden Stag is an enchantment, Hidden Stag becomes a 3/2 Elk Beast creature."));

--- a/Mage.Sets/src/mage/cards/h/HissingQuagmire.java
+++ b/Mage.Sets/src/mage/cards/h/HissingQuagmire.java
@@ -36,7 +36,7 @@ public final class HissingQuagmire extends CardImpl {
         this.addAbility(new GreenManaAbility());
 
         // {1}{B}{G}: Hissing Quagmire becomes a 2/2 black and green Elemental creature with deathtouch until end of turn. It's still a land.
-        Effect effect = new BecomesCreatureSourceEffect(new HissingQuagmireToken(), "land", Duration.EndOfTurn);
+        Effect effect = new BecomesCreatureSourceEffect(new HissingQuagmireToken(), CardType.LAND, Duration.EndOfTurn);
         effect.setText("{this} becomes a 2/2 black and green Elemental creature with deathtouch until end of turn. It's still a land");
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{1}{B}{G}")));
     }

--- a/Mage.Sets/src/mage/cards/h/HiveOfTheEyeTyrant.java
+++ b/Mage.Sets/src/mage/cards/h/HiveOfTheEyeTyrant.java
@@ -63,7 +63,7 @@ public final class HiveOfTheEyeTyrant extends CardImpl {
                         3, 3, "3/3 black Beholder creature with menace and " +
                         "\"Whenever this creature attacks, exile target card from defending player's graveyard.\""
                 ).withSubType(SubType.BEHOLDER).withColor("B").withAbility(new MenaceAbility()).withAbility(ability),
-                "land", Duration.EndOfTurn
+                CardType.LAND, Duration.EndOfTurn
         ).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{B}")));
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiveOfTheEyeTyrant.java
+++ b/Mage.Sets/src/mage/cards/h/HiveOfTheEyeTyrant.java
@@ -64,7 +64,7 @@ public final class HiveOfTheEyeTyrant extends CardImpl {
                         "\"Whenever this creature attacks, exile target card from defending player's graveyard.\""
                 ).withSubType(SubType.BEHOLDER).withColor("B").withAbility(new MenaceAbility()).withAbility(ability),
                 "land", Duration.EndOfTurn
-        ), new ManaCostsImpl<>("{3}{B}")));
+        ).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{B}")));
     }
 
     private HiveOfTheEyeTyrant(final HiveOfTheEyeTyrant card) {

--- a/Mage.Sets/src/mage/cards/h/HostileDesert.java
+++ b/Mage.Sets/src/mage/cards/h/HostileDesert.java
@@ -34,7 +34,7 @@ public final class HostileDesert extends CardImpl {
         // {2}, Exile a land card from your graveyard: Hostile Desert becomes a 3/4 Elemental creature until end of turn. It's still a land.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(
                 new CreatureToken(3, 4, "3/4 Elemental creature", SubType.ELEMENTAL),
-                "land", Duration.EndOfTurn), new GenericManaCost(2));
+                CardType.LAND, Duration.EndOfTurn), new GenericManaCost(2));
         ability.addCost(new ExileFromGraveCost(new TargetCardInYourGraveyard(new FilterLandCard("land card from your graveyard"))));
         addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/i/InkmothNexus.java
+++ b/Mage.Sets/src/mage/cards/i/InkmothNexus.java
@@ -32,7 +32,7 @@ public final class InkmothNexus extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
         
         // {1}: Inkmoth Nexus becomes a 1/1 Blinkmoth artifact creature with flying and infect until end of turn. It's still a land. (It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)
-        Effect effect = new BecomesCreatureSourceEffect(new InkmothNexusToken(), "land", Duration.EndOfTurn);
+        Effect effect = new BecomesCreatureSourceEffect(new InkmothNexusToken(), CardType.LAND, Duration.EndOfTurn);
         effect.setText("{this} becomes a 1/1 Phyrexian Blinkmoth artifact creature with flying and infect until end of turn. It's still a land. <i>(It deals damage to creatures in the form of -1/-1 counters and to players in the form of poison counters.)</i>");
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new GenericManaCost(1)));
     }

--- a/Mage.Sets/src/mage/cards/i/IzzetKeyrune.java
+++ b/Mage.Sets/src/mage/cards/i/IzzetKeyrune.java
@@ -31,7 +31,7 @@ public final class IzzetKeyrune extends CardImpl {
 
         // {U}{R}: Until end of turn, Izzet Keyrune becomes a 2/1 blue and red Elemental artifact creature.
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
-                new IzzetKeyruneToken(), "", Duration.EndOfTurn
+                new IzzetKeyruneToken(), CardType.ARTIFACT, Duration.EndOfTurn
         ).withDurationRuleAtStart(true), new ManaCostsImpl<>("{U}{R}")));
 
         // Whenever Izzet Keyrune deals combat damage to a player, you may draw a card. If you do, discard a card.

--- a/Mage.Sets/src/mage/cards/i/IzzetKeyrune.java
+++ b/Mage.Sets/src/mage/cards/i/IzzetKeyrune.java
@@ -32,7 +32,7 @@ public final class IzzetKeyrune extends CardImpl {
         // {U}{R}: Until end of turn, Izzet Keyrune becomes a 2/1 blue and red Elemental artifact creature.
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
                 new IzzetKeyruneToken(), "", Duration.EndOfTurn
-        ), new ManaCostsImpl<>("{U}{R}")));
+        ).withDurationRuleAtStart(true), new ManaCostsImpl<>("{U}{R}")));
 
         // Whenever Izzet Keyrune deals combat damage to a player, you may draw a card. If you do, discard a card.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/j/JadeIdol.java
+++ b/Mage.Sets/src/mage/cards/j/JadeIdol.java
@@ -21,7 +21,7 @@ public final class JadeIdol extends CardImpl {
 
     public JadeIdol(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{4}");
-        this.addAbility(new SpellCastControllerTriggeredAbility(new BecomesCreatureSourceEffect(new JadeIdolToken(), "", Duration.EndOfTurn), StaticFilters.FILTER_SPIRIT_OR_ARCANE_CARD, false));
+        this.addAbility(new SpellCastControllerTriggeredAbility(new BecomesCreatureSourceEffect(new JadeIdolToken(), CardType.ARTIFACT, Duration.EndOfTurn), StaticFilters.FILTER_SPIRIT_OR_ARCANE_CARD, false));
     }
 
     private JadeIdol(final JadeIdol card) {

--- a/Mage.Sets/src/mage/cards/j/JadeStatue.java
+++ b/Mage.Sets/src/mage/cards/j/JadeStatue.java
@@ -27,7 +27,7 @@ public final class JadeStatue extends CardImpl {
         
 
         // {2}: Jade Statue becomes a 3/6 Golem artifact creature until end of combat. Activate this ability only during combat.
-        this.addAbility(new ConditionalActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect (new JadeStatueToken(), "", Duration.EndOfCombat), new ManaCostsImpl<>("{2}"), new IsPhaseCondition(TurnPhase.COMBAT), "{2}: {this} becomes a 3/6 Golem artifact creature until end of combat. Activate only during combat."));
+        this.addAbility(new ConditionalActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect (new JadeStatueToken(), CardType.ARTIFACT, Duration.EndOfCombat), new ManaCostsImpl<>("{2}"), new IsPhaseCondition(TurnPhase.COMBAT), "{2}: {this} becomes a 3/6 Golem artifact creature until end of combat. Activate only during combat."));
     }
 
     private JadeStatue(final JadeStatue card) {

--- a/Mage.Sets/src/mage/cards/k/KolaghanMonument.java
+++ b/Mage.Sets/src/mage/cards/k/KolaghanMonument.java
@@ -32,7 +32,7 @@ public final class KolaghanMonument extends CardImpl {
         
         // {4}{B}{R}: Kolaghan Monument becomes a 4/4 black and red Dragon artifact creature with flying until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect
-            (new KolaghanMonumentToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{4}{B}{R}")));
+            (new KolaghanMonumentToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{4}{B}{R}")));
     }
 
     private KolaghanMonument(final KolaghanMonument card) {
@@ -44,7 +44,7 @@ public final class KolaghanMonument extends CardImpl {
         return new KolaghanMonument(this);
     }
     
-    private class KolaghanMonumentToken extends TokenImpl {
+    private static class KolaghanMonumentToken extends TokenImpl {
         KolaghanMonumentToken() {
             super("", "4/4 black and red Dragon artifact creature with flying");
             cardType.add(CardType.ARTIFACT);

--- a/Mage.Sets/src/mage/cards/l/LairOfTheHydra.java
+++ b/Mage.Sets/src/mage/cards/l/LairOfTheHydra.java
@@ -89,7 +89,7 @@ class LairOfTheHydraEffect extends OneShotEffect {
                 new CreatureToken(xValue, xValue, "X/X green Hydra creature")
                     .withColor("G")
                     .withSubType(SubType.HYDRA),
-                "land", Duration.EndOfTurn), source
+                CardType.LAND, Duration.EndOfTurn), source
         );
         return true;
     }

--- a/Mage.Sets/src/mage/cards/l/LavaclawReaches.java
+++ b/Mage.Sets/src/mage/cards/l/LavaclawReaches.java
@@ -36,7 +36,7 @@ public final class LavaclawReaches extends CardImpl {
         this.addAbility(new RedManaAbility());
 
         // {1}{B}{R}: Until end of turn, Lavaclaw Reaches becomes a 2/2 black and red Elemental creature with ": This creature gets +X/+0 until end of turn." It's still a land.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new LavaclawReachesToken(), "land", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{1}{B}{R}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new LavaclawReachesToken(), CardType.LAND, Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{1}{B}{R}")));
     }
 
     private LavaclawReaches(final LavaclawReaches card) {

--- a/Mage.Sets/src/mage/cards/l/LavaclawReaches.java
+++ b/Mage.Sets/src/mage/cards/l/LavaclawReaches.java
@@ -36,7 +36,7 @@ public final class LavaclawReaches extends CardImpl {
         this.addAbility(new RedManaAbility());
 
         // {1}{B}{R}: Until end of turn, Lavaclaw Reaches becomes a 2/2 black and red Elemental creature with ": This creature gets +X/+0 until end of turn." It's still a land.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new LavaclawReachesToken(), "land", Duration.EndOfTurn), new ManaCostsImpl<>("{1}{B}{R}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new LavaclawReachesToken(), "land", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{1}{B}{R}")));
     }
 
     private LavaclawReaches(final LavaclawReaches card) {

--- a/Mage.Sets/src/mage/cards/l/LevitatingStatue.java
+++ b/Mage.Sets/src/mage/cards/l/LevitatingStatue.java
@@ -38,7 +38,7 @@ public final class LevitatingStatue extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
                 new CreatureToken(
                         1, 1, "1/1 Construct artifact creature", SubType.CONSTRUCT
-                ).withType(CardType.ARTIFACT), "", Duration.EndOfTurn
+                ).withType(CardType.ARTIFACT), CardType.ARTIFACT, Duration.EndOfTurn
         ), new GenericManaCost(2)));
     }
 

--- a/Mage.Sets/src/mage/cards/l/LumberingFalls.java
+++ b/Mage.Sets/src/mage/cards/l/LumberingFalls.java
@@ -35,7 +35,7 @@ public final class LumberingFalls extends CardImpl {
         this.addAbility(new GreenManaAbility());
 
         // {2}{G}{U}: Lumbering Falls becomes a 3/3 green and blue Elemental creature with hexproof until end of turn. It's still a land.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new LumberingFallsToken(), "land", Duration.EndOfTurn), new ManaCostsImpl<>("{2}{G}{U}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new LumberingFallsToken(), CardType.LAND, Duration.EndOfTurn), new ManaCostsImpl<>("{2}{G}{U}")));
     }
 
     private LumberingFalls(final LumberingFalls card) {

--- a/Mage.Sets/src/mage/cards/l/LurkingEvil.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingEvil.java
@@ -32,7 +32,7 @@ public final class LurkingEvil extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{B}{B}{B}");
 
         // Pay half your life, rounded up: Lurking Evil becomes a 4/4 Horror creature with flying.
-        Effect effect = new BecomesCreatureSourceEffect(new LurkingEvilToken(), null, Duration.EndOfGame, true, false);
+        Effect effect = new BecomesCreatureSourceEffect(new LurkingEvilToken(), Duration.EndOfGame);
         effect.setText("{this} becomes a 4/4 Phyrexian Horror creature with flying");
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new LurkingEvilCost()));
     }

--- a/Mage.Sets/src/mage/cards/l/LurkingEvil.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingEvil.java
@@ -17,7 +17,6 @@ import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.game.Game;
-import mage.game.events.GameEvent;
 import mage.game.permanent.token.TokenImpl;
 import mage.players.Player;
 import mage.util.CardUtil;
@@ -32,7 +31,7 @@ public final class LurkingEvil extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{B}{B}{B}");
 
         // Pay half your life, rounded up: Lurking Evil becomes a 4/4 Horror creature with flying.
-        Effect effect = new BecomesCreatureSourceEffect(new LurkingEvilToken(), Duration.EndOfGame);
+        Effect effect = new BecomesCreatureSourceEffect(new LurkingEvilToken(), null, Duration.EndOfGame);
         effect.setText("{this} becomes a 4/4 Phyrexian Horror creature with flying");
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new LurkingEvilCost()));
     }

--- a/Mage.Sets/src/mage/cards/l/LurkingJackals.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingJackals.java
@@ -103,9 +103,9 @@ class LurkingJackalsStateTriggeredAbility extends StateTriggeredAbility {
 class LurkingJackalsToken extends TokenImpl {
 
     public LurkingJackalsToken() {
-        super("Dog", "3/2 Dog creature");
+        super("Dog", "3/2 Jackal creature");
         cardType.add(CardType.CREATURE);
-        subtype.add(SubType.DOG);
+        subtype.add(SubType.JACKAL);
         power = new MageInt(3);
         toughness = new MageInt(2);
     }

--- a/Mage.Sets/src/mage/cards/l/LurkingJackals.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingJackals.java
@@ -40,7 +40,7 @@ public final class LurkingJackals extends CardImpl {
 class LurkingJackalsStateTriggeredAbility extends StateTriggeredAbility {
 
     public LurkingJackalsStateTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new LurkingJackalsToken(), Duration.Custom));
+        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new LurkingJackalsToken(), null, Duration.Custom));
         setTriggerPhrase("When an opponent has 10 or less life, if {this} is an enchantment, ");
     }
 

--- a/Mage.Sets/src/mage/cards/l/LurkingJackals.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingJackals.java
@@ -40,7 +40,7 @@ public final class LurkingJackals extends CardImpl {
 class LurkingJackalsStateTriggeredAbility extends StateTriggeredAbility {
 
     public LurkingJackalsStateTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new LurkingJackalsToken(), "", Duration.Custom, true, false));
+        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new LurkingJackalsToken(), Duration.Custom));
         setTriggerPhrase("When an opponent has 10 or less life, if {this} is an enchantment, ");
     }
 

--- a/Mage.Sets/src/mage/cards/l/LurkingSkirge.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingSkirge.java
@@ -34,7 +34,7 @@ public final class LurkingSkirge extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{B}");
 
         // When a creature is put into an opponent's graveyard from the battlefield, if Lurking Skirge is an enchantment, Lurking Skirge becomes a 3/2 Imp creature with flying.
-        TriggeredAbility ability = new PutIntoGraveFromBattlefieldAllTriggeredAbility(new BecomesCreatureSourceEffect(new LurkingSkirgeToken(), Duration.WhileOnBattlefield), false, filter, false);
+        TriggeredAbility ability = new PutIntoGraveFromBattlefieldAllTriggeredAbility(new BecomesCreatureSourceEffect(new LurkingSkirgeToken(), null, Duration.WhileOnBattlefield), false, filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When a creature is put into an opponent's graveyard from the battlefield, if {this} is an enchantment, {this} becomes a 3/2 Phyrexian Imp creature with flying."));
     }

--- a/Mage.Sets/src/mage/cards/l/LurkingSkirge.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingSkirge.java
@@ -34,7 +34,7 @@ public final class LurkingSkirge extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{B}");
 
         // When a creature is put into an opponent's graveyard from the battlefield, if Lurking Skirge is an enchantment, Lurking Skirge becomes a 3/2 Imp creature with flying.
-        TriggeredAbility ability = new PutIntoGraveFromBattlefieldAllTriggeredAbility(new BecomesCreatureSourceEffect(new LurkingSkirgeToken(), "", Duration.WhileOnBattlefield, true, false), false, filter, false);
+        TriggeredAbility ability = new PutIntoGraveFromBattlefieldAllTriggeredAbility(new BecomesCreatureSourceEffect(new LurkingSkirgeToken(), Duration.WhileOnBattlefield), false, filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When a creature is put into an opponent's graveyard from the battlefield, if {this} is an enchantment, {this} becomes a 3/2 Phyrexian Imp creature with flying."));
     }

--- a/Mage.Sets/src/mage/cards/m/MishrasFactory.java
+++ b/Mage.Sets/src/mage/cards/m/MishrasFactory.java
@@ -39,7 +39,7 @@ public final class MishrasFactory extends CardImpl {
                         2, 2,
                         "2/2 Assembly-Worker artifact creature",
                         SubType.ASSEMBLY_WORKER
-                ).withType(CardType.ARTIFACT), "land", Duration.EndOfTurn
+                ).withType(CardType.ARTIFACT), CardType.LAND, Duration.EndOfTurn
         ), new GenericManaCost(1)));
 
         // {tap}: Target Assembly-Worker creature gets +1/+1 until end of turn.

--- a/Mage.Sets/src/mage/cards/m/MishrasFoundry.java
+++ b/Mage.Sets/src/mage/cards/m/MishrasFoundry.java
@@ -42,7 +42,7 @@ public final class MishrasFoundry extends CardImpl {
                         2, 2,
                         "2/2 Assembly-Worker artifact creature",
                         SubType.ASSEMBLY_WORKER
-                ).withType(CardType.ARTIFACT), "land", Duration.EndOfTurn
+                ).withType(CardType.ARTIFACT), CardType.LAND, Duration.EndOfTurn
         ), new GenericManaCost(2)));
 
         // {1}, {T}: Target attacking Assembly-Worker gets +2/+2 until end of turn.

--- a/Mage.Sets/src/mage/cards/m/MobilizedDistrict.java
+++ b/Mage.Sets/src/mage/cards/m/MobilizedDistrict.java
@@ -37,7 +37,7 @@ public final class MobilizedDistrict extends CardImpl {
 
         // {4}: Mobilized District becomes a 3/3 Citizen creature with vigilance until end of turn. It's still a land. This ability costs {1} less to activate for each legendary creature and planeswalker you control.
         Ability ability = new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
-                new MobilizedDistrictToken(), "land", Duration.EndOfTurn
+                new MobilizedDistrictToken(), CardType.LAND, Duration.EndOfTurn
         ).setText("{this} becomes a 3/3 Citizen creature with vigilance until end of turn. " +
                 "It's still a land. This ability costs {1} less to activate " +
                 "for each legendary creature and planeswalker you control."

--- a/Mage.Sets/src/mage/cards/m/MonumentToPerfection.java
+++ b/Mage.Sets/src/mage/cards/m/MonumentToPerfection.java
@@ -63,7 +63,7 @@ public final class MonumentToPerfection extends CardImpl {
                         .withAbility(IndestructibleAbility.getInstance())
                         .withAbility(new ToxicAbility(9)),
                         null, Duration.Custom, true,
-                        true, false
+                        true
                 ), new GenericManaCost(3), MonumentToPerfectionCondition.instance
         ).addHint(MonumentToPerfectionValue.getHint()));
     }

--- a/Mage.Sets/src/mage/cards/m/MonumentToPerfection.java
+++ b/Mage.Sets/src/mage/cards/m/MonumentToPerfection.java
@@ -63,7 +63,7 @@ public final class MonumentToPerfection extends CardImpl {
                 ).withType(CardType.ARTIFACT)
                         .withAbility(IndestructibleAbility.getInstance())
                         .withAbility(new ToxicAbility(9)),
-                        "", Duration.Custom
+                        CardType.ARTIFACT, Duration.Custom
                 ).andLoseAbilities(true), new GenericManaCost(3), MonumentToPerfectionCondition.instance
         ).addHint(MonumentToPerfectionValue.getHint()));
     }

--- a/Mage.Sets/src/mage/cards/m/MonumentToPerfection.java
+++ b/Mage.Sets/src/mage/cards/m/MonumentToPerfection.java
@@ -2,6 +2,7 @@ package mage.cards.m;
 
 import java.util.UUID;
 
+import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.ActivateIfConditionActivatedAbility;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -62,9 +63,8 @@ public final class MonumentToPerfection extends CardImpl {
                 ).withType(CardType.ARTIFACT)
                         .withAbility(IndestructibleAbility.getInstance())
                         .withAbility(new ToxicAbility(9)),
-                        null, Duration.Custom, true,
-                        true
-                ), new GenericManaCost(3), MonumentToPerfectionCondition.instance
+                        "", Duration.Custom
+                ).andLoseAbilities(true), new GenericManaCost(3), MonumentToPerfectionCondition.instance
         ).addHint(MonumentToPerfectionValue.getHint()));
     }
 
@@ -100,7 +100,7 @@ enum MonumentToPerfectionValue implements DynamicValue {
                 .getBattlefield()
                 .getActivePermanents(filter, sourceAbility.getControllerId(), game)
                 .stream()
-                .map(permanent -> permanent.getName())
+                .map(MageObject::getName)
                 .filter(s -> s.length() > 0)
                 .distinct()
                 .mapToInt(x -> 1)

--- a/Mage.Sets/src/mage/cards/m/MonumentToPerfection.java
+++ b/Mage.Sets/src/mage/cards/m/MonumentToPerfection.java
@@ -63,7 +63,7 @@ public final class MonumentToPerfection extends CardImpl {
                         .withAbility(IndestructibleAbility.getInstance())
                         .withAbility(new ToxicAbility(9)),
                         null, Duration.Custom, true,
-                        false, true
+                        true, false
                 ), new GenericManaCost(3), MonumentToPerfectionCondition.instance
         ).addHint(MonumentToPerfectionValue.getHint()));
     }

--- a/Mage.Sets/src/mage/cards/m/MonumentToPerfection.java
+++ b/Mage.Sets/src/mage/cards/m/MonumentToPerfection.java
@@ -21,13 +21,11 @@ import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterCard;
 import mage.filter.FilterPermanent;
-import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledLandPermanent;
 import mage.filter.common.FilterLandCard;
 import mage.filter.predicate.Predicates;
 import mage.game.Game;
 import mage.game.permanent.token.custom.CreatureToken;
-import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
 
 /**
@@ -65,7 +63,7 @@ public final class MonumentToPerfection extends CardImpl {
                         .withAbility(IndestructibleAbility.getInstance())
                         .withAbility(new ToxicAbility(9)),
                         null, Duration.Custom, true,
-                        false, null, null, true
+                        false, true
                 ), new GenericManaCost(3), MonumentToPerfectionCondition.instance
         ).addHint(MonumentToPerfectionValue.getHint()));
     }

--- a/Mage.Sets/src/mage/cards/m/Mutavault.java
+++ b/Mage.Sets/src/mage/cards/m/Mutavault.java
@@ -27,7 +27,7 @@ public final class Mutavault extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
         // {1}: Mutavault becomes a 2/2 creature with all creature types until end of turn. It's still a land.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new BecomesCreatureSourceEffect(new MutavaultToken(), "land", Duration.EndOfTurn),
+                new BecomesCreatureSourceEffect(new MutavaultToken(), CardType.LAND, Duration.EndOfTurn),
                 new ManaCostsImpl<>("{1}")));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MythRealized.java
+++ b/Mage.Sets/src/mage/cards/m/MythRealized.java
@@ -44,7 +44,7 @@ public final class MythRealized extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.LORE.createInstance()), new ManaCostsImpl<>("{2}{W}")));
 
         // {W}: Until end of turn, Myth Realized becomes a Monk Avatar creature in addition to its other types and gains "This creature's power and toughness are each equal to the number of lore counters on it."
-        Effect effect = new BecomesCreatureSourceEffect(new MythRealizedToken(), null, Duration.EndOfTurn);
+        Effect effect = new BecomesCreatureSourceEffect(new MythRealizedToken(), CardType.ENCHANTMENT, Duration.EndOfTurn);
         effect.setText("Until end of turn, {this} becomes a Monk Avatar creature in addition to its other types ");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{W}"));
         ability.addEffect(new SetBasePowerToughnessSourceEffect(loreCounterCount, loreCounterCount, Duration.EndOfTurn, SubLayer.SetPT_7b).setText("and gains \"This creature's power and toughness are each equal to the number of lore counters on it.\""));

--- a/Mage.Sets/src/mage/cards/m/MythRealized.java
+++ b/Mage.Sets/src/mage/cards/m/MythRealized.java
@@ -44,8 +44,7 @@ public final class MythRealized extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.LORE.createInstance()), new ManaCostsImpl<>("{2}{W}")));
 
         // {W}: Until end of turn, Myth Realized becomes a Monk Avatar creature in addition to its other types and gains "This creature's power and toughness are each equal to the number of lore counters on it."
-        Effect effect = new BecomesCreatureSourceEffect(new MythRealizedToken(), CardType.ENCHANTMENT, Duration.EndOfTurn);
-        effect.setText("Until end of turn, {this} becomes a Monk Avatar creature in addition to its other types ");
+        Effect effect = new BecomesCreatureSourceEffect(new MythRealizedToken(), CardType.ENCHANTMENT, Duration.EndOfTurn).withDurationRuleAtStart(true);
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{W}"));
         ability.addEffect(new SetBasePowerToughnessSourceEffect(loreCounterCount, loreCounterCount, Duration.EndOfTurn, SubLayer.SetPT_7b).setText("and gains \"This creature's power and toughness are each equal to the number of lore counters on it.\""));
 
@@ -65,7 +64,7 @@ public final class MythRealized extends CardImpl {
 class MythRealizedToken extends TokenImpl {
 
     public MythRealizedToken() {
-        super("", "Monk Avatar creature in addition to its other types and gains \"This creature's power and toughness are each equal to the number of lore counters on it.\"");
+        super("", "Monk Avatar creature");
         cardType.add(CardType.CREATURE);
         subtype.add(SubType.MONK);
         subtype.add(SubType.AVATAR);

--- a/Mage.Sets/src/mage/cards/n/NantukoMonastery.java
+++ b/Mage.Sets/src/mage/cards/n/NantukoMonastery.java
@@ -32,7 +32,7 @@ public final class NantukoMonastery extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
         // Threshold - {G}{W}: Nantuko Monastery becomes a 4/4 green and white Insect Monk creature with first strike until end of turn. It's still a land. Activate this ability only if seven or more cards are in your graveyard.
         Ability ability = new ConditionalActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(
-            new NantukoMonasteryToken(), "land", Duration.EndOfTurn), new ManaCostsImpl<>("{G}{W}"),
+            new NantukoMonasteryToken(), CardType.LAND, Duration.EndOfTurn), new ManaCostsImpl<>("{G}{W}"),
             new CardsInControllerGraveyardCondition(7));
         ability.setAbilityWord(AbilityWord.THRESHOLD);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/n/NeedleSpires.java
+++ b/Mage.Sets/src/mage/cards/n/NeedleSpires.java
@@ -36,7 +36,7 @@ public final class NeedleSpires extends CardImpl {
         this.addAbility(new WhiteManaAbility());
         
         // {2}{R}{W}: Needle Spires becomes a 2/1 red and white Elemental creature with double strike until end of turn. It's still a land.
-        Effect effect = new BecomesCreatureSourceEffect(new NeedleSpiresToken(), "land", Duration.EndOfTurn);
+        Effect effect = new BecomesCreatureSourceEffect(new NeedleSpiresToken(), CardType.LAND, Duration.EndOfTurn);
         effect.setText("{this} becomes a 2/1 red and white Elemental creature with double strike until end of turn. It's still a land");
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{2}{R}{W}")));
     }

--- a/Mage.Sets/src/mage/cards/n/NogiDracoZealot.java
+++ b/Mage.Sets/src/mage/cards/n/NogiDracoZealot.java
@@ -59,7 +59,7 @@ public final class NogiDracoZealot extends CardImpl {
                         new CreatureToken(5, 5, "Dragon with base power and toughness 5/5 and gains flying")
                                 .withSubType(SubType.DRAGON)
                                 .withAbility(FlyingAbility.getInstance()),
-                        "", Duration.EndOfTurn), false
+                        CardType.CREATURE, Duration.EndOfTurn), false
                 ), condition, "Whenever {this} attacks, if you control three or more Dragons, until end of turn, " +
                 "{this} becomes a Dragon with base power and toughness 5/5 and gains flying"
         );

--- a/Mage.Sets/src/mage/cards/o/OjutaiMonument.java
+++ b/Mage.Sets/src/mage/cards/o/OjutaiMonument.java
@@ -32,7 +32,7 @@ public final class OjutaiMonument extends CardImpl {
         
         // {4}{W}{U}: Ojutai Monument becomes a 4/4 white and blue Dragon artifact creature with flying until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect
-            (new OjutaiMonumentToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{4}{W}{U}")));
+            (new OjutaiMonumentToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{4}{W}{U}")));
     }
 
     private OjutaiMonument(final OjutaiMonument card) {

--- a/Mage.Sets/src/mage/cards/o/OpalAcrolith.java
+++ b/Mage.Sets/src/mage/cards/o/OpalAcrolith.java
@@ -36,7 +36,7 @@ public final class OpalAcrolith extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{W}");
 
         // Whenever an opponent casts a creature spell, if Opal Acrolith is an enchantment, Opal Acrolith becomes a 2/4 Soldier creature.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalAcrolithToken(), Duration.WhileOnBattlefield),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalAcrolithToken(), null, Duration.WhileOnBattlefield),
                 filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "Whenever an opponent casts a creature spell, if Opal Acrolith is an enchantment, Opal Acrolith becomes a 2/4 Soldier creature."));

--- a/Mage.Sets/src/mage/cards/o/OpalAcrolith.java
+++ b/Mage.Sets/src/mage/cards/o/OpalAcrolith.java
@@ -36,7 +36,7 @@ public final class OpalAcrolith extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{W}");
 
         // Whenever an opponent casts a creature spell, if Opal Acrolith is an enchantment, Opal Acrolith becomes a 2/4 Soldier creature.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalAcrolithToken(), "", Duration.WhileOnBattlefield, true, false),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalAcrolithToken(), Duration.WhileOnBattlefield),
                 filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "Whenever an opponent casts a creature spell, if Opal Acrolith is an enchantment, Opal Acrolith becomes a 2/4 Soldier creature."));

--- a/Mage.Sets/src/mage/cards/o/OpalArchangel.java
+++ b/Mage.Sets/src/mage/cards/o/OpalArchangel.java
@@ -31,7 +31,7 @@ public final class OpalArchangel extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{4}{W}");
 
         // When an opponent casts a creature spell, if Opal Archangel is an enchantment, Opal Archangel becomes a 5/5 Angel creature with flying and vigilance.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalArchangelToken(), Duration.WhileOnBattlefield),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalArchangelToken(), null, Duration.WhileOnBattlefield),
                 new FilterCreatureSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts a creature spell, if {this} is an enchantment, {this} becomes a 5/5 Angel creature with flying and vigilance."));

--- a/Mage.Sets/src/mage/cards/o/OpalArchangel.java
+++ b/Mage.Sets/src/mage/cards/o/OpalArchangel.java
@@ -31,7 +31,7 @@ public final class OpalArchangel extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{4}{W}");
 
         // When an opponent casts a creature spell, if Opal Archangel is an enchantment, Opal Archangel becomes a 5/5 Angel creature with flying and vigilance.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalArchangelToken(), "", Duration.WhileOnBattlefield, true, false),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalArchangelToken(), Duration.WhileOnBattlefield),
                 new FilterCreatureSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts a creature spell, if {this} is an enchantment, {this} becomes a 5/5 Angel creature with flying and vigilance."));

--- a/Mage.Sets/src/mage/cards/o/OpalAvenger.java
+++ b/Mage.Sets/src/mage/cards/o/OpalAvenger.java
@@ -40,7 +40,7 @@ public final class OpalAvenger extends CardImpl {
 class OpalAvengerStateTriggeredAbility extends StateTriggeredAbility {
 
     public OpalAvengerStateTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new OpalAvengerToken(), "", Duration.Custom, true, false));
+        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new OpalAvengerToken(), Duration.Custom));
         setTriggerPhrase("When you have 10 or less life, if {this} is an enchantment, ");
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpalAvenger.java
+++ b/Mage.Sets/src/mage/cards/o/OpalAvenger.java
@@ -40,7 +40,7 @@ public final class OpalAvenger extends CardImpl {
 class OpalAvengerStateTriggeredAbility extends StateTriggeredAbility {
 
     public OpalAvengerStateTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new OpalAvengerToken(), Duration.Custom));
+        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new OpalAvengerToken(), null, Duration.Custom));
         setTriggerPhrase("When you have 10 or less life, if {this} is an enchantment, ");
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpalCaryatid.java
+++ b/Mage.Sets/src/mage/cards/o/OpalCaryatid.java
@@ -29,7 +29,7 @@ public final class OpalCaryatid extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{W}");
 
         // When an opponent casts a creature spell, if Opal Caryatid is an enchantment, Opal Caryatid becomes a 2/2 Soldier creature.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalCaryatidSoldierToken(), "", Duration.WhileOnBattlefield, true, false),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalCaryatidSoldierToken(), Duration.WhileOnBattlefield),
                 new FilterCreatureSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts a creature spell, if {this} is an enchantment, {this} becomes a 2/2 Soldier creature."));

--- a/Mage.Sets/src/mage/cards/o/OpalCaryatid.java
+++ b/Mage.Sets/src/mage/cards/o/OpalCaryatid.java
@@ -29,7 +29,7 @@ public final class OpalCaryatid extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{W}");
 
         // When an opponent casts a creature spell, if Opal Caryatid is an enchantment, Opal Caryatid becomes a 2/2 Soldier creature.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalCaryatidSoldierToken(), Duration.WhileOnBattlefield),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalCaryatidSoldierToken(), null, Duration.WhileOnBattlefield),
                 new FilterCreatureSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts a creature spell, if {this} is an enchantment, {this} becomes a 2/2 Soldier creature."));

--- a/Mage.Sets/src/mage/cards/o/OpalChampion.java
+++ b/Mage.Sets/src/mage/cards/o/OpalChampion.java
@@ -30,7 +30,7 @@ public final class OpalChampion extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{2}{W}");
 
         // When an opponent casts a creature spell, if Opal Champion is an enchantment, Opal Champion becomes a 3/3 Knight creature with first strike.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalChampionKnight(), Duration.WhileOnBattlefield),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalChampionKnight(), null, Duration.WhileOnBattlefield),
                 new FilterCreatureSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts a creature spell, if {this} is an enchantment, {this} becomes a 3/3 Knight creature with first strike."));

--- a/Mage.Sets/src/mage/cards/o/OpalChampion.java
+++ b/Mage.Sets/src/mage/cards/o/OpalChampion.java
@@ -30,7 +30,7 @@ public final class OpalChampion extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{2}{W}");
 
         // When an opponent casts a creature spell, if Opal Champion is an enchantment, Opal Champion becomes a 3/3 Knight creature with first strike.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalChampionKnight(), "", Duration.WhileOnBattlefield, true, false),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalChampionKnight(), Duration.WhileOnBattlefield),
                 new FilterCreatureSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts a creature spell, if {this} is an enchantment, {this} becomes a 3/3 Knight creature with first strike."));

--- a/Mage.Sets/src/mage/cards/o/OpalGargoyle.java
+++ b/Mage.Sets/src/mage/cards/o/OpalGargoyle.java
@@ -30,7 +30,7 @@ public final class OpalGargoyle extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{W}");
 
         // When an opponent casts a creature spell, if Opal Gargoyle is an enchantment, Opal Gargoyle becomes a 2/2 Gargoyle creature with flying.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalGargoyleToken(), Duration.WhileOnBattlefield),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalGargoyleToken(), null, Duration.WhileOnBattlefield),
                 new FilterCreatureSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts a creature spell, if {this} is an enchantment, {this} becomes a 2/2 Gargoyle creature with flying."));

--- a/Mage.Sets/src/mage/cards/o/OpalGargoyle.java
+++ b/Mage.Sets/src/mage/cards/o/OpalGargoyle.java
@@ -30,7 +30,7 @@ public final class OpalGargoyle extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{W}");
 
         // When an opponent casts a creature spell, if Opal Gargoyle is an enchantment, Opal Gargoyle becomes a 2/2 Gargoyle creature with flying.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalGargoyleToken(), "", Duration.WhileOnBattlefield, true, false),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalGargoyleToken(), Duration.WhileOnBattlefield),
                 new FilterCreatureSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts a creature spell, if {this} is an enchantment, {this} becomes a 2/2 Gargoyle creature with flying."));

--- a/Mage.Sets/src/mage/cards/o/OpalGuardian.java
+++ b/Mage.Sets/src/mage/cards/o/OpalGuardian.java
@@ -32,7 +32,7 @@ public final class OpalGuardian extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{W}{W}{W}");
 
         // When an opponent casts a creature spell, if Opal Guardian is an enchantment, Opal Guardian becomes a 3/4 Gargoyle creature with flying and protection from red.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalGuardianGargoyle(), Duration.WhileOnBattlefield),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalGuardianGargoyle(), null, Duration.WhileOnBattlefield),
                 new FilterCreatureSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts a creature spell, if {this} is an enchantment, {this} becomes a 3/4 Gargoyle creature with flying and protection from red."));

--- a/Mage.Sets/src/mage/cards/o/OpalGuardian.java
+++ b/Mage.Sets/src/mage/cards/o/OpalGuardian.java
@@ -32,7 +32,7 @@ public final class OpalGuardian extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{W}{W}{W}");
 
         // When an opponent casts a creature spell, if Opal Guardian is an enchantment, Opal Guardian becomes a 3/4 Gargoyle creature with flying and protection from red.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalGuardianGargoyle(), "", Duration.WhileOnBattlefield, true, false),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new OpalGuardianGargoyle(), Duration.WhileOnBattlefield),
                 new FilterCreatureSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "When an opponent casts a creature spell, if {this} is an enchantment, {this} becomes a 3/4 Gargoyle creature with flying and protection from red."));

--- a/Mage.Sets/src/mage/cards/o/OrzhovKeyrune.java
+++ b/Mage.Sets/src/mage/cards/o/OrzhovKeyrune.java
@@ -30,7 +30,7 @@ public final class OrzhovKeyrune extends CardImpl {
         this.addAbility(new BlackManaAbility());
 
         // {W}{B}: Orzhov Keyrune becomes a 1/4 white and black Thrull artifact creature with lifelink until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new OrzhovKeyruneToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{W}{B}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new OrzhovKeyruneToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{W}{B}")));
     }
 
     private OrzhovKeyrune(final OrzhovKeyrune card) {

--- a/Mage.Sets/src/mage/cards/p/PhyrexianTotem.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianTotem.java
@@ -37,7 +37,7 @@ public final class PhyrexianTotem extends CardImpl {
         this.addAbility(new BlackManaAbility());
         // {2}{B}: {this} becomes a 5/5 black Horror artifact creature with trample until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(
-                new PhyrexianTotemToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{2}{B}")));
+                new PhyrexianTotemToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{2}{B}")));
         // Whenever {this} is dealt damage, if it's a creature, sacrifice that many permanents.
         this.addAbility(new PhyrexianTotemTriggeredAbility());
     }

--- a/Mage.Sets/src/mage/cards/r/RagingRavine.java
+++ b/Mage.Sets/src/mage/cards/r/RagingRavine.java
@@ -40,7 +40,7 @@ public final class RagingRavine extends CardImpl {
         this.addAbility(new RedManaAbility());
         Effect effect = new BecomesCreatureSourceEffect(
                 new CreatureToken(3, 3, "3/3 red and green Elemental creature", SubType.ELEMENTAL).withColor("RG"),
-                "land", Duration.EndOfTurn);
+                CardType.LAND, Duration.EndOfTurn);
         effect.setText("Until end of turn, {this} becomes a 3/3 red and green Elemental creature");
         // {2}{R}{G}: Until end of turn, Raging Ravine becomes a 3/3 red and green Elemental creature with "Whenever this creature attacks, put a +1/+1 counter on it." It's still a land.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{2}{R}{G}"));

--- a/Mage.Sets/src/mage/cards/r/RakdosKeyrune.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosKeyrune.java
@@ -30,7 +30,7 @@ public final class RakdosKeyrune extends CardImpl {
         this.addAbility(new RedManaAbility());
 
         // {B}{R}: Rakdos Keyrune becomes a 3/1 black and red Devil artifact creature with first strike until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new RakdosKeyruneToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{B}{R}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new RakdosKeyruneToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{B}{R}")));
     }
 
     private RakdosKeyrune(final RakdosKeyrune card) {

--- a/Mage.Sets/src/mage/cards/r/ReptilianReflection.java
+++ b/Mage.Sets/src/mage/cards/r/ReptilianReflection.java
@@ -24,7 +24,7 @@ public final class ReptilianReflection extends CardImpl {
 
         // Whenever you cycle a card, Reptilian Reflection becomes a 5/4 Dinosaur creature with trample and haste in addition to its other types until end of turn.
         this.addAbility(new CycleControllerTriggeredAbility(new BecomesCreatureSourceEffect(
-                new ReptilianReflectionToken(), "enchantment", Duration.EndOfTurn
+                new ReptilianReflectionToken(), CardType.ENCHANTMENT, Duration.EndOfTurn
         ).setText("have {this} become a 5/4 Dinosaur creature with trample and haste " +
                 "in addition to its other types until end of turn"), true));
     }

--- a/Mage.Sets/src/mage/cards/r/ReptilianReflection.java
+++ b/Mage.Sets/src/mage/cards/r/ReptilianReflection.java
@@ -24,9 +24,7 @@ public final class ReptilianReflection extends CardImpl {
 
         // Whenever you cycle a card, Reptilian Reflection becomes a 5/4 Dinosaur creature with trample and haste in addition to its other types until end of turn.
         this.addAbility(new CycleControllerTriggeredAbility(new BecomesCreatureSourceEffect(
-                new ReptilianReflectionToken(), CardType.ENCHANTMENT, Duration.EndOfTurn
-        ).setText("have {this} become a 5/4 Dinosaur creature with trample and haste " +
-                "in addition to its other types until end of turn"), true));
+                new ReptilianReflectionToken(), CardType.ENCHANTMENT, Duration.EndOfTurn), true));
     }
 
     private ReptilianReflection(final ReptilianReflection card) {

--- a/Mage.Sets/src/mage/cards/r/Riddleform.java
+++ b/Mage.Sets/src/mage/cards/r/Riddleform.java
@@ -37,7 +37,7 @@ public final class Riddleform extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{U}");
 
         // Whenever you cast a noncreature spell, you may have Riddleform become a 3/3 Sphinx creature with flying in addition to its other types until end of turn.
-        Effect effect = new BecomesCreatureSourceEffect(new RiddleformToken(), "", Duration.EndOfTurn);
+        Effect effect = new BecomesCreatureSourceEffect(new RiddleformToken(), CardType.ENCHANTMENT, Duration.EndOfTurn);
         effect.setText("have {this} become a 3/3 Sphinx creature with flying in addition to its other types until end of turn.");
         this.addAbility(new SpellCastControllerTriggeredAbility(Zone.BATTLEFIELD, effect, filterNonCreature, true, true));
 

--- a/Mage.Sets/src/mage/cards/r/Riddleform.java
+++ b/Mage.Sets/src/mage/cards/r/Riddleform.java
@@ -38,7 +38,6 @@ public final class Riddleform extends CardImpl {
 
         // Whenever you cast a noncreature spell, you may have Riddleform become a 3/3 Sphinx creature with flying in addition to its other types until end of turn.
         Effect effect = new BecomesCreatureSourceEffect(new RiddleformToken(), CardType.ENCHANTMENT, Duration.EndOfTurn);
-        effect.setText("have {this} become a 3/3 Sphinx creature with flying in addition to its other types until end of turn.");
         this.addAbility(new SpellCastControllerTriggeredAbility(Zone.BATTLEFIELD, effect, filterNonCreature, true, true));
 
         // {2}{U}: Scry 1.

--- a/Mage.Sets/src/mage/cards/r/RustedRelic.java
+++ b/Mage.Sets/src/mage/cards/r/RustedRelic.java
@@ -24,7 +24,7 @@ public final class RustedRelic extends CardImpl {
         // Metalcraft — Rusted Relic is a 5/5 Golem artifact creature as long as you control three or more artifacts.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD,
                 new ConditionalContinuousEffect(
-                        new BecomesCreatureSourceEffect(new RustedRelicToken(), "artifact", Duration.WhileOnBattlefield),
+                        new BecomesCreatureSourceEffect(new RustedRelicToken(), CardType.ARTIFACT, Duration.WhileOnBattlefield),
                         MetalcraftCondition.instance,
                         "{this} is a 5/5 Golem artifact creature as long as you control three or more artifacts"))
                 .setAbilityWord(AbilityWord.METALCRAFT)

--- a/Mage.Sets/src/mage/cards/s/SanguineStatuette.java
+++ b/Mage.Sets/src/mage/cards/s/SanguineStatuette.java
@@ -41,7 +41,7 @@ public final class SanguineStatuette extends CardImpl {
                         .withType(CardType.ARTIFACT)
                         .withSubType(SubType.VAMPIRE)
                         .withAbility(HasteAbility.getInstance()),
-                "", Duration.EndOfTurn
+                CardType.ARTIFACT, Duration.EndOfTurn
         ).setText("have {this} become a 3/3 Vampire artifact creature with haste until end of turn"), filter, false, true));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SelesnyaKeyrune.java
+++ b/Mage.Sets/src/mage/cards/s/SelesnyaKeyrune.java
@@ -29,7 +29,7 @@ public final class SelesnyaKeyrune extends CardImpl {
         this.addAbility(new WhiteManaAbility());
 
         // {G}{W}: Selesnya Keyrune becomes a 3/3 green and white Wolf artifact creature until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SelesnyaKeyruneToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{G}{W}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SelesnyaKeyruneToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{G}{W}")));
     }
 
     private SelesnyaKeyrune(final SelesnyaKeyrune card) {

--- a/Mage.Sets/src/mage/cards/s/ShamblingVent.java
+++ b/Mage.Sets/src/mage/cards/s/ShamblingVent.java
@@ -36,7 +36,7 @@ public final class ShamblingVent extends CardImpl {
 
         // {1}{W}{B}: Shambling Vent becomes a 2/3 white and black Elemental creature with lifelink until end of turn. It's still a land.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(
-                new ShamblingVentToken(), "land", Duration.EndOfTurn), new ManaCostsImpl<>("{1}{W}{B}")));
+                new ShamblingVentToken(), CardType.LAND, Duration.EndOfTurn), new ManaCostsImpl<>("{1}{W}{B}")));
     }
 
     private ShamblingVent(final ShamblingVent card) {

--- a/Mage.Sets/src/mage/cards/s/SilumgarMonument.java
+++ b/Mage.Sets/src/mage/cards/s/SilumgarMonument.java
@@ -32,7 +32,7 @@ public final class SilumgarMonument extends CardImpl {
         
         // {4}{U}{B}: Silumgar Monument becomes a 4/4 blue and black Dragon artifact creature with flying until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect
-            (new OjutaiMonumentToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{4}{U}{B}")));
+            (new OjutaiMonumentToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{4}{U}{B}")));
     }
 
     private SilumgarMonument(final SilumgarMonument card) {

--- a/Mage.Sets/src/mage/cards/s/SimicKeyrune.java
+++ b/Mage.Sets/src/mage/cards/s/SimicKeyrune.java
@@ -31,7 +31,7 @@ public final class SimicKeyrune extends CardImpl {
         this.addAbility(new BlueManaAbility());
 
         // {G}{U}: Simic Keyrune becomes a 2/3 green and blue Crab artifact creature with hexproof until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SimicKeyruneToken(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{G}{U}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SimicKeyruneToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ManaCostsImpl<>("{G}{U}")));
     }
 
     private SimicKeyrune(final SimicKeyrune card) {

--- a/Mage.Sets/src/mage/cards/s/Skinshifter.java
+++ b/Mage.Sets/src/mage/cards/s/Skinshifter.java
@@ -31,14 +31,14 @@ public final class Skinshifter extends CardImpl {
         this.toughness = new MageInt(1);
 
         Ability ability = new SimpleActivatedAbility(
-                new BecomesCreatureSourceEffect(new RhinoToken(), "", Duration.EndOfTurn),
+                new BecomesCreatureSourceEffect(new RhinoToken(), "", Duration.EndOfTurn).withDurationRuleAtStart(true),
                 new ManaCostsImpl<>("{G}"));
         ability.getModes().setChooseText("Choose one. Activate only once each turn.");
 
-        Mode mode = new Mode(new BecomesCreatureSourceEffect(new BirdToken(), "", Duration.EndOfTurn));
+        Mode mode = new Mode(new BecomesCreatureSourceEffect(new BirdToken(), "", Duration.EndOfTurn).withDurationRuleAtStart(true));
         ability.addMode(mode);
 
-        mode = new Mode(new BecomesCreatureSourceEffect(new PlantToken(), "", Duration.EndOfTurn));
+        mode = new Mode(new BecomesCreatureSourceEffect(new PlantToken(), "", Duration.EndOfTurn).withDurationRuleAtStart(true));
         ability.addMode(mode);
 
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/Skinshifter.java
+++ b/Mage.Sets/src/mage/cards/s/Skinshifter.java
@@ -31,14 +31,14 @@ public final class Skinshifter extends CardImpl {
         this.toughness = new MageInt(1);
 
         Ability ability = new SimpleActivatedAbility(
-                new BecomesCreatureSourceEffect(new RhinoToken(), CardType.CREATURE, Duration.EndOfTurn).withDurationRuleAtStart(true),
+                new BecomesCreatureSourceEffect(new RhinoToken(), CardType.CREATURE, Duration.EndOfTurn),
                 new ManaCostsImpl<>("{G}"));
         ability.getModes().setChooseText("Choose one. Activate only once each turn.");
 
-        Mode mode = new Mode(new BecomesCreatureSourceEffect(new BirdToken(), CardType.CREATURE, Duration.EndOfTurn).withDurationRuleAtStart(true));
+        Mode mode = new Mode(new BecomesCreatureSourceEffect(new BirdToken(), CardType.CREATURE, Duration.EndOfTurn));
         ability.addMode(mode);
 
-        mode = new Mode(new BecomesCreatureSourceEffect(new PlantToken(), CardType.CREATURE, Duration.EndOfTurn).withDurationRuleAtStart(true));
+        mode = new Mode(new BecomesCreatureSourceEffect(new PlantToken(), CardType.CREATURE, Duration.EndOfTurn));
         ability.addMode(mode);
 
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/Skinshifter.java
+++ b/Mage.Sets/src/mage/cards/s/Skinshifter.java
@@ -31,14 +31,14 @@ public final class Skinshifter extends CardImpl {
         this.toughness = new MageInt(1);
 
         Ability ability = new SimpleActivatedAbility(
-                new BecomesCreatureSourceEffect(new RhinoToken(), "", Duration.EndOfTurn).withDurationRuleAtStart(true),
+                new BecomesCreatureSourceEffect(new RhinoToken(), CardType.CREATURE, Duration.EndOfTurn).withDurationRuleAtStart(true),
                 new ManaCostsImpl<>("{G}"));
         ability.getModes().setChooseText("Choose one. Activate only once each turn.");
 
-        Mode mode = new Mode(new BecomesCreatureSourceEffect(new BirdToken(), "", Duration.EndOfTurn).withDurationRuleAtStart(true));
+        Mode mode = new Mode(new BecomesCreatureSourceEffect(new BirdToken(), CardType.CREATURE, Duration.EndOfTurn).withDurationRuleAtStart(true));
         ability.addMode(mode);
 
-        mode = new Mode(new BecomesCreatureSourceEffect(new PlantToken(), "", Duration.EndOfTurn).withDurationRuleAtStart(true));
+        mode = new Mode(new BecomesCreatureSourceEffect(new PlantToken(), CardType.CREATURE, Duration.EndOfTurn).withDurationRuleAtStart(true));
         ability.addMode(mode);
 
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/SpawningPool.java
+++ b/Mage.Sets/src/mage/cards/s/SpawningPool.java
@@ -22,7 +22,7 @@ public final class SpawningPool extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.LAND},"");
         this.addAbility(new EntersBattlefieldTappedAbility());
         this.addAbility(new BlackManaAbility());
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SkeletonRegenerateToken(), "land", Duration.EndOfTurn), new ManaCostsImpl<>("{1}{B}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SkeletonRegenerateToken(), CardType.LAND, Duration.EndOfTurn), new ManaCostsImpl<>("{1}{B}")));
     }
 
     private SpawningPool(final SpawningPool card) {

--- a/Mage.Sets/src/mage/cards/s/StalkingStones.java
+++ b/Mage.Sets/src/mage/cards/s/StalkingStones.java
@@ -23,7 +23,7 @@ public final class StalkingStones extends CardImpl {
     public StalkingStones(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.LAND},"");
         this.addAbility(new ColorlessManaAbility());
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StalkingStonesToken(), "land", Duration.WhileOnBattlefield)
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StalkingStonesToken(), CardType.LAND, Duration.WhileOnBattlefield)
                 .setText("{this} becomes a 3/3 Elemental artifact creature that's still a land"), new GenericManaCost(6)));
     }
 

--- a/Mage.Sets/src/mage/cards/s/StalkingStones.java
+++ b/Mage.Sets/src/mage/cards/s/StalkingStones.java
@@ -23,7 +23,8 @@ public final class StalkingStones extends CardImpl {
     public StalkingStones(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.LAND},"");
         this.addAbility(new ColorlessManaAbility());
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StalkingStonesToken(), "land", Duration.WhileOnBattlefield), new GenericManaCost(6)));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StalkingStonesToken(), "land", Duration.WhileOnBattlefield)
+                .setText("{this} becomes a 3/3 Elemental artifact creature that's still a land"), new GenericManaCost(6)));
     }
 
     private StalkingStones(final StalkingStones card) {
@@ -39,7 +40,7 @@ public final class StalkingStones extends CardImpl {
 class StalkingStonesToken extends TokenImpl {
 
     public StalkingStonesToken() {
-        super("Elemental", "3/3 Elemental artifact");
+        super("Elemental", "3/3 Elemental artifact creature");
         this.cardType.add(CardType.CREATURE);
         this.cardType.add(CardType.ARTIFACT);
 

--- a/Mage.Sets/src/mage/cards/s/StillLife.java
+++ b/Mage.Sets/src/mage/cards/s/StillLife.java
@@ -25,7 +25,7 @@ public final class StillLife extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{G}{G}");
 
         // {G}{G}: Still Life becomes a 4/3 Centaur creature until end of turn. It's still an enchantment.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StillLifeCentaur(), "", Duration.EndOfTurn)
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StillLifeCentaur(), CardType.ENCHANTMENT, Duration.EndOfTurn)
                 .setText("{this} becomes a 4/3 Centaur creature in addition to its other types until end of turn")
                 , new ManaCostsImpl<>("{G}{G}")));
     }

--- a/Mage.Sets/src/mage/cards/s/StillLife.java
+++ b/Mage.Sets/src/mage/cards/s/StillLife.java
@@ -25,9 +25,7 @@ public final class StillLife extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{G}{G}");
 
         // {G}{G}: Still Life becomes a 4/3 Centaur creature until end of turn. It's still an enchantment.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StillLifeCentaur(), CardType.ENCHANTMENT, Duration.EndOfTurn)
-                .setText("{this} becomes a 4/3 Centaur creature in addition to its other types until end of turn")
-                , new ManaCostsImpl<>("{G}{G}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StillLifeCentaur(), CardType.ENCHANTMENT, Duration.EndOfTurn), new ManaCostsImpl<>("{G}{G}")));
     }
 
     private StillLife(final StillLife card) {

--- a/Mage.Sets/src/mage/cards/s/StillLife.java
+++ b/Mage.Sets/src/mage/cards/s/StillLife.java
@@ -25,7 +25,9 @@ public final class StillLife extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{G}{G}");
 
         // {G}{G}: Still Life becomes a 4/3 Centaur creature until end of turn. It's still an enchantment.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StillLifeCentaur(), "", Duration.EndOfTurn), new ManaCostsImpl<>("{G}{G}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StillLifeCentaur(), "", Duration.EndOfTurn)
+                .setText("{this} becomes a 4/3 Centaur creature in addition to its other types until end of turn")
+                , new ManaCostsImpl<>("{G}{G}")));
     }
 
     private StillLife(final StillLife card) {
@@ -41,7 +43,7 @@ public final class StillLife extends CardImpl {
 class StillLifeCentaur extends TokenImpl {
 
     public StillLifeCentaur() {
-        super("Centaur", "4/3 Centaur creature token");
+        super("Centaur", "4/3 Centaur creature");
         cardType.add(CardType.CREATURE);
         subtype.add(SubType.CENTAUR);
         power = new MageInt(4);

--- a/Mage.Sets/src/mage/cards/s/StirringWildwood.java
+++ b/Mage.Sets/src/mage/cards/s/StirringWildwood.java
@@ -30,7 +30,7 @@ public final class StirringWildwood extends CardImpl {
         this.addAbility(new EntersBattlefieldTappedAbility());
         this.addAbility(new GreenManaAbility());
         this.addAbility(new WhiteManaAbility());
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StirringWildwoodToken(), "land", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{1}{G}{W}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StirringWildwoodToken(), CardType.LAND, Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{1}{G}{W}")));
     }
 
     private StirringWildwood(final StirringWildwood card) {

--- a/Mage.Sets/src/mage/cards/s/StirringWildwood.java
+++ b/Mage.Sets/src/mage/cards/s/StirringWildwood.java
@@ -30,7 +30,7 @@ public final class StirringWildwood extends CardImpl {
         this.addAbility(new EntersBattlefieldTappedAbility());
         this.addAbility(new GreenManaAbility());
         this.addAbility(new WhiteManaAbility());
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StirringWildwoodToken(), "land", Duration.EndOfTurn), new ManaCostsImpl<>("{1}{G}{W}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new StirringWildwoodToken(), "land", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{1}{G}{W}")));
     }
 
     private StirringWildwood(final StirringWildwood card) {

--- a/Mage.Sets/src/mage/cards/s/StuffedBear.java
+++ b/Mage.Sets/src/mage/cards/s/StuffedBear.java
@@ -22,7 +22,7 @@ public final class StuffedBear extends CardImpl {
 
         // {2}: Stuffed Bear becomes a 4/4 green Bear artifact creature until end of turn.
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
-                new CreatureToken(4, 4, "4/4 green Bear artifact creature until end of turn")
+                new CreatureToken(4, 4, "4/4 green Bear artifact creature")
                         .withColor("G")
                         .withSubType(SubType.BEAR)
                         .withType(CardType.ARTIFACT),

--- a/Mage.Sets/src/mage/cards/s/StuffedBear.java
+++ b/Mage.Sets/src/mage/cards/s/StuffedBear.java
@@ -26,7 +26,7 @@ public final class StuffedBear extends CardImpl {
                         .withColor("G")
                         .withSubType(SubType.BEAR)
                         .withType(CardType.ARTIFACT),
-                "", Duration.EndOfTurn
+                CardType.ARTIFACT, Duration.EndOfTurn
         ), new GenericManaCost(2)));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
+++ b/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
@@ -13,10 +13,7 @@ import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffec
 import mage.abilities.mana.ColorlessManaAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.Duration;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.filter.common.FilterCreatureCard;
 import mage.game.permanent.token.TokenImpl;
 
@@ -32,7 +29,6 @@ public final class SvogthosTheRestlessTomb extends CardImpl {
         // {tap}: Add {C}.
         this.addAbility(new ColorlessManaAbility());
         // {3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with "This creature's power and toughness are each equal to the number of creature cards in your graveyard." It's still a land.
-        // set to character defining to prevent setting P/T again to 0 becuase already set by CDA of the token
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SvogthosToken(), CardType.LAND, Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{B}{G}"));
         this.addAbility(ability);
     }
@@ -59,7 +55,7 @@ class SvogthosToken extends TokenImpl {
         power = new MageInt(0);
         toughness = new MageInt(0);
         CardsInControllerGraveyardCount count = new CardsInControllerGraveyardCount(new FilterCreatureCard("creature cards"));
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(count)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(count, count, Duration.WhileOnBattlefield, SubLayer.SetPT_7b)));
     }
     public SvogthosToken(final SvogthosToken token) {
         super(token);

--- a/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
+++ b/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
@@ -33,7 +33,7 @@ public final class SvogthosTheRestlessTomb extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
         // {3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with "This creature's power and toughness are each equal to the number of creature cards in your graveyard." It's still a land.
         // set to character defining to prevent setting P/T again to 0 becuase already set by CDA of the token
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SvogthosToken(), "land", Duration.EndOfTurn, false, true, false), new ManaCostsImpl<>("{3}{B}{G}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SvogthosToken(), "land", Duration.EndOfTurn, false, false, true), new ManaCostsImpl<>("{3}{B}{G}"));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
+++ b/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
@@ -33,7 +33,7 @@ public final class SvogthosTheRestlessTomb extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
         // {3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with "This creature's power and toughness are each equal to the number of creature cards in your graveyard." It's still a land.
         // set to character defining to prevent setting P/T again to 0 becuase already set by CDA of the token
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SvogthosToken(), "land", Duration.EndOfTurn, false, false, true).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{B}{G}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SvogthosToken(), "land", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{B}{G}"));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
+++ b/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
@@ -33,7 +33,7 @@ public final class SvogthosTheRestlessTomb extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
         // {3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with "This creature's power and toughness are each equal to the number of creature cards in your graveyard." It's still a land.
         // set to character defining to prevent setting P/T again to 0 becuase already set by CDA of the token
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SvogthosToken(), "land", Duration.EndOfTurn, false, false, true), new ManaCostsImpl<>("{3}{B}{G}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SvogthosToken(), "land", Duration.EndOfTurn, false, false, true).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{B}{G}"));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
+++ b/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
@@ -33,7 +33,7 @@ public final class SvogthosTheRestlessTomb extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
         // {3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with "This creature's power and toughness are each equal to the number of creature cards in your graveyard." It's still a land.
         // set to character defining to prevent setting P/T again to 0 becuase already set by CDA of the token
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SvogthosToken(), "land", Duration.EndOfTurn, false, true), new ManaCostsImpl<>("{3}{B}{G}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SvogthosToken(), "land", Duration.EndOfTurn, false, true, false), new ManaCostsImpl<>("{3}{B}{G}"));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
+++ b/Mage.Sets/src/mage/cards/s/SvogthosTheRestlessTomb.java
@@ -33,7 +33,7 @@ public final class SvogthosTheRestlessTomb extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
         // {3}{B}{G}: Until end of turn, Svogthos, the Restless Tomb becomes a black and green Plant Zombie creature with "This creature's power and toughness are each equal to the number of creature cards in your graveyard." It's still a land.
         // set to character defining to prevent setting P/T again to 0 becuase already set by CDA of the token
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SvogthosToken(), "land", Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{B}{G}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new SvogthosToken(), CardType.LAND, Duration.EndOfTurn).withDurationRuleAtStart(true), new ManaCostsImpl<>("{3}{B}{G}"));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThunderTotem.java
+++ b/Mage.Sets/src/mage/cards/t/ThunderTotem.java
@@ -32,7 +32,7 @@ public final class ThunderTotem extends CardImpl {
         // {1}{W}{W}: Thunder Totem becomes a 2/2 white Spirit artifact creature with flying and first strike until end of turn.
         this.addAbility(new SimpleActivatedAbility(
                 Zone.BATTLEFIELD, 
-                new BecomesCreatureSourceEffect(new ThunderTotemToken(), "", Duration.EndOfTurn),
+                new BecomesCreatureSourceEffect(new ThunderTotemToken(), CardType.ARTIFACT, Duration.EndOfTurn),
                 new ManaCostsImpl<>("{1}{W}{W}")));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreetopVillage.java
+++ b/Mage.Sets/src/mage/cards/t/TreetopVillage.java
@@ -32,7 +32,7 @@ public final class TreetopVillage extends CardImpl {
         this.addAbility(new GreenManaAbility());
 
         // {1}{G}: Treetop Village becomes a 3/3 green Ape creature with trample until end of turn. It’s still a land. (It can deal excess combat damage to the player or planeswalker it’s attacking.)
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new ApeToken(), "land", Duration.EndOfTurn), new ManaCostsImpl<>("{1}{G}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new ApeToken(), CardType.LAND, Duration.EndOfTurn), new ManaCostsImpl<>("{1}{G}")));
     }
 
     private TreetopVillage(final TreetopVillage card) {

--- a/Mage.Sets/src/mage/cards/v/VeilOfBirds.java
+++ b/Mage.Sets/src/mage/cards/v/VeilOfBirds.java
@@ -29,7 +29,7 @@ public final class VeilOfBirds extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{U}");
 
         // When an opponent casts a spell, if Veil of Birds is an enchantment, Veil of Birds becomes a 1/1 Bird creature with flying.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new VeilOfBirdsToken(), "", Duration.WhileOnBattlefield, true, false),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new VeilOfBirdsToken(), Duration.WhileOnBattlefield),
                 filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "Whenever an opponent casts a spell, if Veil of Birds is an enchantment, Veil of Birds becomes a 1/1 Bird creature with flying."));

--- a/Mage.Sets/src/mage/cards/v/VeilOfBirds.java
+++ b/Mage.Sets/src/mage/cards/v/VeilOfBirds.java
@@ -29,7 +29,7 @@ public final class VeilOfBirds extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{U}");
 
         // When an opponent casts a spell, if Veil of Birds is an enchantment, Veil of Birds becomes a 1/1 Bird creature with flying.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new VeilOfBirdsToken(), Duration.WhileOnBattlefield),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new VeilOfBirdsToken(), null, Duration.WhileOnBattlefield),
                 filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "Whenever an opponent casts a spell, if Veil of Birds is an enchantment, Veil of Birds becomes a 1/1 Bird creature with flying."));

--- a/Mage.Sets/src/mage/cards/v/VeiledApparition.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledApparition.java
@@ -35,7 +35,7 @@ public final class VeiledApparition extends CardImpl {
         
 
         // When an opponent casts a spell, if Veiled Apparition is an enchantment, Veiled Apparition becomes a 3/3 Illusion creature with flying and "At the beginning of your upkeep, sacrifice Veiled Apparition unless you pay {1}{U}."
-         TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new VeilApparitionToken(), Duration.WhileOnBattlefield),
+         TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new VeilApparitionToken(), null, Duration.WhileOnBattlefield),
                 filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "Whenever an opponent casts a spell, if Veiled Apparition is an enchantment, Veiled Apparition becomes a 3/3 Illusion creature with flying and \"At the beginning of your upkeep, sacrifice Veiled Apparition unless you pay {1}{U}."));

--- a/Mage.Sets/src/mage/cards/v/VeiledApparition.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledApparition.java
@@ -35,7 +35,7 @@ public final class VeiledApparition extends CardImpl {
         
 
         // When an opponent casts a spell, if Veiled Apparition is an enchantment, Veiled Apparition becomes a 3/3 Illusion creature with flying and "At the beginning of your upkeep, sacrifice Veiled Apparition unless you pay {1}{U}."
-         TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new VeilApparitionToken(), "", Duration.WhileOnBattlefield, true, false),
+         TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new VeilApparitionToken(), Duration.WhileOnBattlefield),
                 filter, false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "Whenever an opponent casts a spell, if Veiled Apparition is an enchantment, Veiled Apparition becomes a 3/3 Illusion creature with flying and \"At the beginning of your upkeep, sacrifice Veiled Apparition unless you pay {1}{U}."));

--- a/Mage.Sets/src/mage/cards/v/VeiledCrocodile.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledCrocodile.java
@@ -41,7 +41,7 @@ public final class VeiledCrocodile extends CardImpl {
 class VeiledCrocodileStateTriggeredAbility extends StateTriggeredAbility {
 
     public VeiledCrocodileStateTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new VeilCrocodileToken(), "", Duration.Custom, true, false));
+        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new VeilCrocodileToken(), Duration.Custom));
         setTriggerPhrase("When a player has no cards in hand, if {this} is an enchantment, ");
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeiledCrocodile.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledCrocodile.java
@@ -41,7 +41,7 @@ public final class VeiledCrocodile extends CardImpl {
 class VeiledCrocodileStateTriggeredAbility extends StateTriggeredAbility {
 
     public VeiledCrocodileStateTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new VeilCrocodileToken(), Duration.Custom));
+        super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new VeilCrocodileToken(), null, Duration.Custom));
         setTriggerPhrase("When a player has no cards in hand, if {this} is an enchantment, ");
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeiledSerpent.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledSerpent.java
@@ -32,7 +32,7 @@ public final class VeiledSerpent extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{U}");
 
         // When an opponent casts a spell, if Veiled Serpent is an enchantment, Veiled Serpent becomes a 4/4 Serpent creature that can't attack unless defending player controls an Island.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new VeiledSerpentToken(), Duration.WhileOnBattlefield),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new VeiledSerpentToken(), null, Duration.WhileOnBattlefield),
                 new FilterSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "Whenever an opponent casts a spell, if Veiled Serpent is an enchantment, Veiled Serpent becomes a 4/4 Serpent creature that can't attack unless defending player controls an Island."));

--- a/Mage.Sets/src/mage/cards/v/VeiledSerpent.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledSerpent.java
@@ -32,7 +32,7 @@ public final class VeiledSerpent extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{U}");
 
         // When an opponent casts a spell, if Veiled Serpent is an enchantment, Veiled Serpent becomes a 4/4 Serpent creature that can't attack unless defending player controls an Island.
-        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new VeiledSerpentToken(), "", Duration.WhileOnBattlefield, true, false),
+        TriggeredAbility ability = new SpellCastOpponentTriggeredAbility(new BecomesCreatureSourceEffect(new VeiledSerpentToken(), Duration.WhileOnBattlefield),
                 new FilterSpell(), false);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new SourceMatchesFilterCondition(StaticFilters.FILTER_PERMANENT_ENCHANTMENT),
                 "Whenever an opponent casts a spell, if Veiled Serpent is an enchantment, Veiled Serpent becomes a 4/4 Serpent creature that can't attack unless defending player controls an Island."));

--- a/Mage.Sets/src/mage/cards/w/WanderingFumarole.java
+++ b/Mage.Sets/src/mage/cards/w/WanderingFumarole.java
@@ -37,7 +37,7 @@ public final class WanderingFumarole extends CardImpl {
         
         // {2}{U}{R}: Until end of turn, Wandering Fumarole becomes a 1/4 blue and red Elemental creature with 
         // "0: Switch this creature's power and toughness until end of turn." It's still a land.
-        Effect effect = new BecomesCreatureSourceEffect(new WanderingFumaroleToken(), "land", Duration.EndOfTurn);
+        Effect effect = new BecomesCreatureSourceEffect(new WanderingFumaroleToken(), CardType.LAND, Duration.EndOfTurn);
         effect.setText("{this} becomes a 1/4 blue and red Elemental creature with \"0: Switch this creature's power and toughness until end of turn.\" It's still a land");
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{2}{U}{R}")));
     }

--- a/Mage.Sets/src/mage/cards/w/WardenOfTheWall.java
+++ b/Mage.Sets/src/mage/cards/w/WardenOfTheWall.java
@@ -35,7 +35,7 @@ public final class WardenOfTheWall extends CardImpl {
 
         // As long as it's not your turn, Warden of the Wall is a 2/3 Gargoyle artifact creature with flying.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new ConditionalContinuousEffect(
-                new BecomesCreatureSourceEffect(new GargoyleToken(), "", Duration.WhileOnBattlefield),
+                new BecomesCreatureSourceEffect(new GargoyleToken(), CardType.ARTIFACT, Duration.WhileOnBattlefield),
                 NotMyTurnCondition.instance,
                 "As long as it's not your turn, Warden of the Wall is a 2/3 Gargoyle artifact creature with flying"))
                 .addHint(NotMyTurnHint.instance));

--- a/Mage.Sets/src/mage/cards/w/WeatherseedTotem.java
+++ b/Mage.Sets/src/mage/cards/w/WeatherseedTotem.java
@@ -39,7 +39,7 @@ public final class WeatherseedTotem extends CardImpl {
                         .withSubType(SubType.TREEFOLK)
                         .withType(CardType.ARTIFACT)
                         .withAbility(TrampleAbility.getInstance()),
-                "", Duration.EndOfTurn
+                CardType.ARTIFACT, Duration.EndOfTurn
         ), new ManaCostsImpl<>("{2}{G}{G}{G}")));
 
         // When Weatherseed Totem is put into a graveyard from the battlefield, if it was a creature, return this card to its owner's hand.

--- a/Mage.Sets/src/mage/cards/x/XanthicStatue.java
+++ b/Mage.Sets/src/mage/cards/x/XanthicStatue.java
@@ -24,8 +24,9 @@ public final class XanthicStatue extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{8}");
 
         // {5}: Until end of turn, Xanthic Statue becomes an 8/8 Golem artifact creature with trample.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new XanthicStatueCreature(),
-            "", Duration.EndOfTurn), new ManaCostsImpl<>("{5}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new XanthicStatueCreature(), Duration.EndOfTurn)
+                .setText("until end of turn, {this} becomes an 8/8 Golem artifact creature with trample")
+                , new ManaCostsImpl<>("{5}")));
     }
 
     private XanthicStatue(final XanthicStatue card) {

--- a/Mage.Sets/src/mage/cards/x/XanthicStatue.java
+++ b/Mage.Sets/src/mage/cards/x/XanthicStatue.java
@@ -24,7 +24,7 @@ public final class XanthicStatue extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{8}");
 
         // {5}: Until end of turn, Xanthic Statue becomes an 8/8 Golem artifact creature with trample.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new XanthicStatueCreature(), Duration.EndOfTurn)
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new XanthicStatueCreature(), CardType.ARTIFACT, Duration.EndOfTurn)
                 .setText("until end of turn, {this} becomes an 8/8 Golem artifact creature with trample")
                 , new ManaCostsImpl<>("{5}")));
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -20,6 +20,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     protected boolean loseAbilities;
     protected DynamicValue power = null;
     protected DynamicValue toughness = null;
+    protected boolean durationRuleAtStart = false; // put duration rule at the start of the rules text rather than the end
 
     public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration) {
         this(token, theyAreStillType, duration, false, false);
@@ -59,6 +60,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
         if (effect.toughness != null) {
             this.toughness = effect.toughness.copy();
         }
+        this.durationRuleAtStart = effect.durationRuleAtStart;
     }
 
     @Override
@@ -145,11 +147,22 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     }
 
     private void setText() {
-        if (theyAreStillType != null && !theyAreStillType.isEmpty()) {
-            staticText = duration.toString() + ", {this} becomes a " + token.getDescription() + " that's still a " + this.theyAreStillType;
-        } else {
-            staticText = duration.toString() + ", {this} becomes a " + token.getDescription();
+        StringBuilder sb = new StringBuilder();
+        if (!duration.toString().isEmpty() && durationRuleAtStart) {
+            sb.append(duration.toString());
+            sb.append(", ");
         }
+        sb.append("{this} becomes a ");
+        sb.append(token.getDescription());
+        if (!duration.toString().isEmpty() && !durationRuleAtStart) {
+            sb.append(" ");
+            sb.append(duration.toString());
+        }
+        if (theyAreStillType != null && !theyAreStillType.isEmpty()) {
+            sb.append(". It's still a ");
+            sb.append(theyAreStillType);
+        }
+        staticText = sb.toString();
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -22,18 +22,33 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     protected DynamicValue toughness = null;
     protected boolean durationRuleAtStart = false; // put duration rule at the start of the rules text rather than the end
 
+    /**
+    Becomes a creature retaining its previous types
+     @param token Token as blueprint for creature to become
+     @param theyAreStillType String for rules text generation
+     @param duration Duration for the effect
+     */
     public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration) {
         this(token, theyAreStillType, duration, false, false, false);
     }
 
+    /**
+    Becomes a creature losing its previous types
+     @param token Token as blueprint for creature to become
+     @param duration Duration for the effect
+     */
     public BecomesCreatureSourceEffect(Token token, Duration duration) {
         this(token, "", duration, true, false, false);
     }
 
-    public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration, boolean losePreviousTypes, boolean characterDefining) {
-        this(token, theyAreStillType, duration, losePreviousTypes, characterDefining, false);
-    }
-
+    /**
+     @param token Token as blueprint for creature to become
+     @param theyAreStillType String for rules text generation
+     @param duration Duration for the effect
+     @param losePreviousTypes if true, permanent loses its previous types
+     @param characterDefining if true, effect applies on layer 7a (it probably shouldn't)
+     @param loseAbilities if true, permanent loses its other abilities
+     */
     public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration, boolean losePreviousTypes, boolean characterDefining, boolean loseAbilities) {
         super(duration, Outcome.BecomeCreature);
         this.characterDefining = characterDefining;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -14,6 +14,27 @@ import mage.game.permanent.token.Token;
  */
 public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements SourceEffect {
 
+    /*
+     * CR 2023-04-14
+     * 205.1a. Some effects set an object's card type. In most such cases, the new card type(s) replaces any existing
+     * card types. However, an object with either the instant or sorcery card type retains that type. Counters,
+     * stickers, effects, and damage marked on the object remain with it, even if they are meaningless to the new card
+     * type. Similarly, when an effect sets one or more of an object's subtypes, the new subtype(s) replaces any
+     * existing subtypes from the appropriate set (creature types, land types, artifact types, enchantment types,
+     * planeswalker types, or spell types). If an object's card type is removed, the subtypes correlated with that card
+     * type will remain if they are also the subtypes of a card type the object currently has; otherwise, they are also
+     * removed for the entire time the object's card type is removed. Removing an object's subtype doesn't affect its
+     * card types at all.
+     * 205.1b. Some effects change an object's card type, supertype, or subtype but specify that the object retains a
+     * prior card type, supertype, or subtype. In such cases, all the object's prior card types, supertypes, and
+     * subtypes are retained. This rule applies to effects that use the phrase "in addition to its types" or that state
+     * that something is "still a [type, supertype, or subtype]." Some effects state that an object becomes an
+     * "artifact creature"; these effects also allow the object to retain all of its prior card types and subtypes.
+     * Some effects state that an object becomes a "[creature type or types] artifact creature"; these effects also
+     * allow the object to retain all of its prior card types and subtypes other than creature types, but replace any
+     * existing creature types.
+     */
+
     protected Token token;
     protected String theyAreStillType;
     protected boolean losePreviousTypes;
@@ -23,19 +44,19 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     protected boolean durationRuleAtStart; // put duration rule at the start of the rules text rather than the end
 
     /**
-    Becomes a creature retaining its previous types
-     @param token Token as blueprint for creature to become
-     @param theyAreStillType String for rules text generation
-     @param duration Duration for the effect
+     * Becomes a creature retaining its previous types
+     * @param token            Token as blueprint for creature to become
+     * @param theyAreStillType String for rules text generation
+     * @param duration         Duration for the effect
      */
     public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration) {
         this(token, theyAreStillType, duration, false, false, false);
     }
 
     /**
-    Becomes a creature losing its previous types
-     @param token Token as blueprint for creature to become
-     @param duration Duration for the effect
+     * Becomes a creature losing its previous types
+     * @param token    Token as blueprint for creature to become
+     * @param duration Duration for the effect
      */
     public BecomesCreatureSourceEffect(Token token, Duration duration) {
         this(token, "", duration, true, false, false);

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -3,9 +3,7 @@ package mage.abilities.effects.common.continuous;
 import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.ContinuousEffectImpl;
-import mage.abilities.effects.Effect;
 import mage.constants.*;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -44,7 +42,6 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     protected DynamicValue power = null;
     protected DynamicValue toughness = null;
     protected boolean durationRuleAtStart; // put duration rule at the start of the rules text rather than the end
-    protected boolean hasCDA; // used when becoming a creature with an ability that sets P/T in layer 7a
 
     /**
      * @param token       Token as blueprint for creature to become
@@ -56,7 +53,6 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
         this.token = token;
         this.retainType = retainType;
         this.durationRuleAtStart = (retainType == CardType.PLANESWALKER || retainType == CardType.CREATURE);
-        this.hasCDA = checkTokenCDA();
         setText();
         this.addDependencyType(DependencyType.BecomeCreature);
     }
@@ -74,7 +70,6 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
             this.toughness = effect.toughness.copy();
         }
         this.durationRuleAtStart = effect.durationRuleAtStart;
-        this.hasCDA = effect.hasCDA;
     }
 
     @Override
@@ -138,7 +133,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
                 break;
 
             case PTChangingEffects_7:
-                if ((sublayer == SubLayer.SetPT_7b) && !hasCDA) {
+                if (sublayer == SubLayer.SetPT_7b) {
                     if (power != null) {
                         permanent.getPower().setModifiedBaseValue(power.calculate(game, source, this)); // check all other becomes to use calculate?
                     } else if (token.getPower() != null) {
@@ -224,23 +219,6 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
                 || layer == Layer.AbilityAddingRemovingEffects_6
                 || layer == Layer.ColorChangingEffects_5
                 || layer == Layer.TypeChangingEffects_4;
-    }
-
-    /**
-     * Check whether the token contains a characteristic-defining ability in layer 7a.
-     * If it does, then need to not overwrite P/T in layer 7b.
-     * (It might not really be a CDA, but applied as one for consistency with the effect type.)
-     * @return true if the token has an ability with an effect in layer 7a
-     */
-    private boolean checkTokenCDA() {
-        for (Ability ability : token.getAbilities()) {
-            for (Effect effect : ability.getEffects()) {
-                if (effect instanceof ContinuousEffect && ((ContinuousEffect) effect).getSublayer() == SubLayer.CharacteristicDefining_7a) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -38,22 +38,13 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
      */
 
     protected Token token;
-
-    /*
-     null for losing previous types
-     ARTIFACT for becoming an artifact creature (retains previous types)
-     LAND for "It's still a land"
-     ENCHANTMENT for "in addition to its other types"
-     PLANESWALKER for "that's still a planeswalker"
-     CREATURE for when only creature types are overwritten
-     */
-    protected CardType retainType;
+    protected CardType retainType; // if null, loses previous types
     protected boolean loseAbilities = false;
     protected DynamicValue power = null;
     protected DynamicValue toughness = null;
     protected boolean durationRuleAtStart; // put duration rule at the start of the rules text rather than the end
-    protected boolean hasCDA;
-
+    protected boolean hasCDA; // used when becoming a creature with an ability that sets P/T in layer 7a
+    
     /**
      * @param token       Token as blueprint for creature to become
      * @param retainType  If null, permanent loses its previous types, otherwise retains types with appropriate text
@@ -63,7 +54,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
         super(duration, Outcome.BecomeCreature);
         this.token = token;
         this.retainType = retainType;
-        this.durationRuleAtStart = (retainType == CardType.PLANESWALKER);
+        this.durationRuleAtStart = (retainType == CardType.PLANESWALKER || retainType == CardType.CREATURE);
         this.hasCDA = checkTokenCDA();
         setText();
         this.addDependencyType(DependencyType.BecomeCreature);
@@ -226,7 +217,8 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     /**
      * Check whether the token contains a characteristic-defining ability in layer 7a.
      * If it does, then need to not overwrite P/T in layer 7b.
-     * @return true if the token has a characteristic-defining ability
+     * (It might not really be a CDA, but applied as one for consistency with the effect type.)
+     * @return true if the token has an ability with an effect in layer 7a
      */
     private boolean checkTokenCDA() {
         for (Ability ability : token.getAbilities()) {

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -12,7 +12,7 @@ import mage.game.permanent.Permanent;
 import mage.game.permanent.token.Token;
 
 /**
- * @author BetaSteward_at_googlemail.com
+ * @author BetaSteward_at_googlemail.com, xenohedron
  */
 public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements SourceEffect {
 
@@ -40,11 +40,12 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     protected Token token;
     protected CardType retainType; // if null, loses previous types
     protected boolean loseAbilities = false;
+    protected boolean loseEquipmentType = false;
     protected DynamicValue power = null;
     protected DynamicValue toughness = null;
     protected boolean durationRuleAtStart; // put duration rule at the start of the rules text rather than the end
     protected boolean hasCDA; // used when becoming a creature with an ability that sets P/T in layer 7a
-    
+
     /**
      * @param token       Token as blueprint for creature to become
      * @param retainType  If null, permanent loses its previous types, otherwise retains types with appropriate text
@@ -65,6 +66,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
         this.token = effect.token.copy();
         this.retainType = effect.retainType;
         this.loseAbilities = effect.loseAbilities;
+        this.loseEquipmentType = effect.loseEquipmentType;
         if (effect.power != null) {
             this.power = effect.power.copy();
         }
@@ -110,6 +112,9 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
                 }
                 for (CardType cardType : token.getCardType(game)) {
                     permanent.addCardType(game, cardType);
+                }
+                if (loseEquipmentType) {
+                    permanent.removeSubType(game, SubType.EQUIPMENT);
                 }
                 if (retainType == CardType.CREATURE || retainType == CardType.ARTIFACT) {
                     permanent.removeAllCreatureTypes(game);
@@ -163,11 +168,18 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     }
 
     /**
-     * Source loses all other abilities as part of the effect
-     * Note: need to set text manually
+     * Source loses all other abilities as part of the effect. Need to set text elsewhere.
      */
     public BecomesCreatureSourceEffect andLoseAbilities(boolean loseAbilities) {
         this.loseAbilities = loseAbilities;
+        return this;
+    }
+
+    /**
+     * Source loses Equipment subtype as part of the effect. Need to set text manually.
+     */
+    public BecomesCreatureSourceEffect andNotEquipment(boolean notEquipment) {
+        this.loseEquipmentType = notEquipment;
         return this;
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -23,25 +23,23 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     protected boolean durationRuleAtStart = false; // put duration rule at the start of the rules text rather than the end
 
     public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration) {
-        this(token, theyAreStillType, duration, false, false);
+        this(token, theyAreStillType, duration, false, false, false);
+    }
+
+    public BecomesCreatureSourceEffect(Token token, Duration duration) {
+        this(token, "", duration, true, false, false);
     }
 
     public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration, boolean losePreviousTypes, boolean characterDefining) {
-        this(token, theyAreStillType, duration, losePreviousTypes, characterDefining, null, null);
+        this(token, theyAreStillType, duration, losePreviousTypes, characterDefining, false);
     }
 
-    public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration, boolean losePreviousTypes, boolean characterDefining, DynamicValue power, DynamicValue toughness) {
-        this(token, theyAreStillType, duration, losePreviousTypes, characterDefining, power, toughness, false);
-    }
-
-    public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration, boolean losePreviousTypes, boolean characterDefining, DynamicValue power, DynamicValue toughness, boolean loseAbilities) {
+    public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration, boolean losePreviousTypes, boolean characterDefining, boolean loseAbilities) {
         super(duration, Outcome.BecomeCreature);
         this.characterDefining = characterDefining;
         this.token = token;
         this.theyAreStillType = theyAreStillType;
         this.losePreviousTypes = losePreviousTypes;
-        this.power = power;
-        this.toughness = toughness;
         this.loseAbilities = loseAbilities;
         setText();
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -20,7 +20,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     protected boolean loseAbilities;
     protected DynamicValue power = null;
     protected DynamicValue toughness = null;
-    protected boolean durationRuleAtStart = false; // put duration rule at the start of the rules text rather than the end
+    protected boolean durationRuleAtStart; // put duration rule at the start of the rules text rather than the end
 
     /**
     Becomes a creature retaining its previous types
@@ -56,6 +56,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
         this.theyAreStillType = theyAreStillType;
         this.losePreviousTypes = losePreviousTypes;
         this.loseAbilities = loseAbilities;
+        this.durationRuleAtStart = (theyAreStillType != null && theyAreStillType.contains("planeswalker"));
         setText();
 
         this.addDependencyType(DependencyType.BecomeCreature);
@@ -167,6 +168,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
 
     public BecomesCreatureSourceEffect withDurationRuleAtStart(boolean durationRuleAtStart) {
         this.durationRuleAtStart = durationRuleAtStart;
+        setText();
         return this;
     }
 
@@ -183,7 +185,14 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
             sb.append(duration.toString());
         }
         if (theyAreStillType != null && !theyAreStillType.isEmpty()) {
-            sb.append(". It's still a ");
+            if (theyAreStillType.contains("planeswalker")) {
+                sb.append(" that's");
+            } else if (token.getDescription().endsWith("\"")) {
+                sb.append(" It's");
+            } else {
+                sb.append(". It's");
+            }
+            sb.append(" still a ");
             sb.append(theyAreStillType);
         }
         staticText = sb.toString();

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -40,7 +40,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     protected Token token;
     protected String theyAreStillType;
     protected boolean losePreviousTypes;
-    protected boolean loseAbilities;
+    protected boolean loseAbilities = false;
     protected DynamicValue power = null;
     protected DynamicValue toughness = null;
     protected boolean durationRuleAtStart; // put duration rule at the start of the rules text rather than the end
@@ -53,7 +53,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
      * @param duration         Duration for the effect
      */
     public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration) {
-        this(token, theyAreStillType, duration, false, false);
+        this(token, theyAreStillType, duration, false);
     }
 
     /**
@@ -62,7 +62,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
      * @param duration Duration for the effect
      */
     public BecomesCreatureSourceEffect(Token token, Duration duration) {
-        this(token, "", duration, true, false);
+        this(token, "", duration, true);
     }
 
     /**
@@ -70,14 +70,12 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
      * @param theyAreStillType  String for rules text generation
      * @param duration          Duration for the effect
      * @param losePreviousTypes if true, permanent loses its previous types
-     * @param loseAbilities     if true, permanent loses its other abilities
      */
-    public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration, boolean losePreviousTypes, boolean loseAbilities) {
+    public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration, boolean losePreviousTypes) {
         super(duration, Outcome.BecomeCreature);
         this.token = token;
         this.theyAreStillType = theyAreStillType;
         this.losePreviousTypes = losePreviousTypes;
-        this.loseAbilities = loseAbilities;
         this.durationRuleAtStart = (theyAreStillType != null && theyAreStillType.contains("planeswalker"));
         setText();
         this.hasCDA = checkTokenCDA();
@@ -186,6 +184,15 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     public BecomesCreatureSourceEffect withDynamicPT(DynamicValue power, DynamicValue toughness) {
         this.power = power;
         this.toughness = toughness;
+        return this;
+    }
+
+    /**
+     * Source loses all other abilities as part of the effect
+     * Note: need to set text manually
+     */
+    public BecomesCreatureSourceEffect andLoseAbilities(boolean loseAbilities) {
+        this.loseAbilities = loseAbilities;
         return this;
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -146,6 +146,17 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
         return false;
     }
 
+    public BecomesCreatureSourceEffect withDynamicPT(DynamicValue power, DynamicValue toughness) {
+        this.power = power;
+        this.toughness = toughness;
+        return this;
+    }
+
+    public BecomesCreatureSourceEffect withDurationRuleAtStart(boolean durationRuleAtStart) {
+        this.durationRuleAtStart = durationRuleAtStart;
+        return this;
+    }
+
     private void setText() {
         StringBuilder sb = new StringBuilder();
         if (!duration.toString().isEmpty() && durationRuleAtStart) {

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -42,14 +42,14 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements
     }
 
     /**
-     @param token Token as blueprint for creature to become
-     @param theyAreStillType String for rules text generation
-     @param duration Duration for the effect
-     @param losePreviousTypes if true, permanent loses its previous types
-     @param characterDefining if true, effect applies on layer 7a (it probably shouldn't)
-     @param loseAbilities if true, permanent loses its other abilities
+     * @param token             Token as blueprint for creature to become
+     * @param theyAreStillType  String for rules text generation
+     * @param duration          Duration for the effect
+     * @param losePreviousTypes if true, permanent loses its previous types
+     * @param loseAbilities     if true, permanent loses its other abilities
+     * @param characterDefining if true, effect applies on layer 7a (it probably shouldn't)
      */
-    public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration, boolean losePreviousTypes, boolean characterDefining, boolean loseAbilities) {
+    public BecomesCreatureSourceEffect(Token token, String theyAreStillType, Duration duration, boolean losePreviousTypes, boolean loseAbilities, boolean characterDefining) {
         super(duration, Outcome.BecomeCreature);
         this.characterDefining = characterDefining;
         this.token = token;


### PR DESCRIPTION
Fixing text generation. Full abilities check shows that ~50 cards no longer have wrong text.

~~Two primary constructors: one keeping previous types, the other losing previous types. Each calls the general constructor that includes some additional less-used parameters. (The strangest is applying as a CDA on a couple cards, seems like a bad workaround but I left it as is.)~~ [edit: now one constructor and no issues with CDAs.] Moved dynamic P/T setting to a chaining method (only used once and clutters the constructors), and added another chaining method for putting the duration text at the beginning.