### PR TITLE
Remove unused marker interface

### DIFF
--- a/Mage.Sets/src/mage/cards/e/Excavator.java
+++ b/Mage.Sets/src/mage/cards/e/Excavator.java
@@ -10,7 +10,6 @@ import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.effects.ContinuousEffectImpl;
-import mage.abilities.effects.common.continuous.SourceEffect;
 import mage.abilities.keyword.*;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -53,7 +52,7 @@ public final class Excavator extends CardImpl {
     }
 }
 
-class ExcavatorEffect extends ContinuousEffectImpl implements SourceEffect {
+class ExcavatorEffect extends ContinuousEffectImpl {
 
     private Abilities<Ability> abilities = new AbilitiesImpl();
 

--- a/Mage.Sets/src/mage/cards/o/OpalTitan.java
+++ b/Mage.Sets/src/mage/cards/o/OpalTitan.java
@@ -8,7 +8,6 @@ import mage.abilities.common.SpellCastOpponentTriggeredAbility;
 import mage.abilities.condition.common.SourceMatchesFilterCondition;
 import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
-import mage.abilities.effects.common.continuous.SourceEffect;
 import mage.abilities.keyword.ProtectionAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -46,7 +45,7 @@ public final class OpalTitan extends CardImpl {
     }
 }
 
-class OpalTitanBecomesCreatureEffect extends ContinuousEffectImpl implements SourceEffect {
+class OpalTitanBecomesCreatureEffect extends ContinuousEffectImpl {
 
     public OpalTitanBecomesCreatureEffect() {
         super(Duration.WhileOnBattlefield, Outcome.BecomeCreature);

--- a/Mage.Sets/src/mage/cards/s/Soulflayer.java
+++ b/Mage.Sets/src/mage/cards/s/Soulflayer.java
@@ -5,7 +5,6 @@ import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
-import mage.abilities.effects.common.continuous.SourceEffect;
 import mage.abilities.keyword.*;
 import mage.cards.Card;
 import mage.cards.CardImpl;
@@ -49,7 +48,7 @@ public final class Soulflayer extends CardImpl {
     }
 }
 
-class SoulflayerEffect extends ContinuousEffectImpl implements SourceEffect {
+class SoulflayerEffect extends ContinuousEffectImpl {
 
     private Set<Ability> abilitiesToAdd;
     private MageObjectReference objectReference = null;

--- a/Mage/src/main/java/mage/abilities/common/AnimateDeadTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/AnimateDeadTriggeredAbility.java
@@ -6,7 +6,6 @@ import mage.abilities.DelayedTriggeredAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.SacrificeTargetEffect;
-import mage.abilities.effects.common.continuous.SourceEffect;
 import mage.abilities.keyword.EnchantAbility;
 import mage.cards.Card;
 import mage.constants.*;
@@ -63,7 +62,7 @@ public class AnimateDeadTriggeredAbility extends EntersBattlefieldTriggeredAbili
     }
 }
 
-class AnimateDeadReplaceAbilityEffect extends ContinuousEffectImpl implements SourceEffect {
+class AnimateDeadReplaceAbilityEffect extends ContinuousEffectImpl {
 
     private final boolean becomesAura;
     private Ability newAbility;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesAuraSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesAuraSourceEffect.java
@@ -13,7 +13,7 @@ import mage.target.Target;
 /**
  * @author LevelX2
  */
-public class BecomesAuraSourceEffect extends ContinuousEffectImpl implements SourceEffect {
+public class BecomesAuraSourceEffect extends ContinuousEffectImpl {
 
     private final Ability newAbility;
     private final Target target;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -12,7 +12,7 @@ import mage.game.permanent.token.Token;
 /**
  * @author BetaSteward_at_googlemail.com
  */
-public class BecomesCreatureSourceEffect extends ContinuousEffectImpl implements SourceEffect {
+public class BecomesCreatureSourceEffect extends ContinuousEffectImpl {
 
     protected Token token;
     protected String theyAreStillType;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesEnchantmentSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesEnchantmentSourceEffect.java
@@ -10,7 +10,7 @@ import mage.game.permanent.Permanent;
 /**
  * @author jeffwadsworth
  */
-public class BecomesEnchantmentSourceEffect extends ContinuousEffectImpl implements SourceEffect {
+public class BecomesEnchantmentSourceEffect extends ContinuousEffectImpl {
 
     public BecomesEnchantmentSourceEffect() {
         super(Duration.Custom, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.AddAbility);

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesFaceDownCreatureAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesFaceDownCreatureAllEffect.java
@@ -18,7 +18,7 @@ import java.util.*;
  * @author LevelX2
  */
 
-public class BecomesFaceDownCreatureAllEffect extends ContinuousEffectImpl implements SourceEffect {
+public class BecomesFaceDownCreatureAllEffect extends ContinuousEffectImpl {
 
     protected Map<UUID, Ability> turnFaceUpAbilityMap = new HashMap<>();
     protected FilterPermanent filter;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesFaceDownCreatureEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesFaceDownCreatureEffect.java
@@ -23,7 +23,7 @@ import java.util.List;
  *
  * @author LevelX2
  */
-public class BecomesFaceDownCreatureEffect extends ContinuousEffectImpl implements SourceEffect {
+public class BecomesFaceDownCreatureEffect extends ContinuousEffectImpl {
 
     public enum FaceDownType {
         MANIFESTED,

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostSourceEffect.java
@@ -17,7 +17,7 @@ import org.apache.log4j.Logger;
 /**
  * @author BetaSteward_at_googlemail.com
  */
-public class BoostSourceEffect extends ContinuousEffectImpl implements SourceEffect {
+public class BoostSourceEffect extends ContinuousEffectImpl {
     private DynamicValue power;
     private DynamicValue toughness;
     private final boolean lockedIn;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilitySourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilitySourceEffect.java
@@ -14,7 +14,7 @@ import mage.game.permanent.Permanent;
 /**
  * @author BetaSteward_at_googlemail.com
  */
-public class GainAbilitySourceEffect extends ContinuousEffectImpl implements SourceEffect {
+public class GainAbilitySourceEffect extends ContinuousEffectImpl {
 
     protected Ability ability;
     // shall a card gain the ability (otherwise permanent)

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainClassAbilitySourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainClassAbilitySourceEffect.java
@@ -14,7 +14,7 @@ import mage.game.permanent.Permanent;
 /**
  * @author TheElk801
  */
-public class GainClassAbilitySourceEffect extends ContinuousEffectImpl implements SourceEffect {
+public class GainClassAbilitySourceEffect extends ContinuousEffectImpl {
 
     private final Ability ability;
     private final int level;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainSuspendEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainSuspendEffect.java
@@ -18,7 +18,7 @@ import mage.game.Game;
  * @author LevelX2
  */
 
-public class GainSuspendEffect extends ContinuousEffectImpl implements SourceEffect {
+public class GainSuspendEffect extends ContinuousEffectImpl {
 
     MageObjectReference mor;
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/LoseCreatureTypeSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/LoseCreatureTypeSourceEffect.java
@@ -11,7 +11,7 @@ import mage.util.CardUtil;
 /**
  * @author LevelX2
  */
-public class LoseCreatureTypeSourceEffect extends ContinuousEffectImpl implements SourceEffect {
+public class LoseCreatureTypeSourceEffect extends ContinuousEffectImpl {
 
     private final DynamicValue dynamicValue;
     private final int lessThan;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/SourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/SourceEffect.java
@@ -1,9 +1,0 @@
-package mage.abilities.effects.common.continuous;
-
-/**
- * Marker interface
- *
- * @author magenoxx_at_gmail.com
- */
-public interface SourceEffect {
-}


### PR DESCRIPTION
This marker interface was not consistently used and was never checked anyway, so I propose removing it entirely.