### PR TITLE
Fix Cephalid Facetaker

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AdarkarValkyrie.java
+++ b/Mage.Sets/src/mage/cards/a/AdarkarValkyrie.java
@@ -17,8 +17,7 @@ import mage.constants.CardType;
 import mage.constants.SetTargetPointer;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 
 /**
@@ -26,12 +25,6 @@ import mage.target.TargetPermanent;
  * @author LevelX2
  */
 public final class AdarkarValkyrie extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public AdarkarValkyrie(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{W}{W}");
@@ -53,7 +46,7 @@ public final class AdarkarValkyrie extends CardImpl {
         );
         delayedAbility.setTriggerPhrase("When target creature other than {this} dies this turn, ");
         Ability ability = new SimpleActivatedAbility(new CreateDelayedTriggeredAbilityEffect(delayedAbility), new TapSourceCost());
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AkroanConscriptor.java
+++ b/Mage.Sets/src/mage/cards/a/AkroanConscriptor.java
@@ -15,8 +15,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -24,12 +23,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class AkroanConscriptor extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public AkroanConscriptor(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{R}");
@@ -47,7 +40,7 @@ public final class AkroanConscriptor extends CardImpl {
         effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("It gains haste until end of turn");
         ability.addEffect(effect);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/a/AngelOfCondemnation.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfCondemnation.java
@@ -20,8 +20,7 @@ import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -34,12 +33,6 @@ import java.util.UUID;
  * @author emerald000
  */
 public final class AngelOfCondemnation extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public AngelOfCondemnation(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{W}{W}");
@@ -59,14 +52,14 @@ public final class AngelOfCondemnation extends CardImpl {
                 new AngelOfCondemnationExileUntilEOTEffect(), new ManaCostsImpl<>("{2}{W}")
         );
         ability.addCost(new TapSourceCost());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
 
         // {2}{W}, {T}, Exert Angel of Condemnation: Exile another target creature until Angel of Condemnation leaves the battlefield.
         ability = new SimpleActivatedAbility(new ExileUntilSourceLeavesEffect(), new ManaCostsImpl<>("{2}{W}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new ExertSourceCost());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         ability.addEffect(new CreateDelayedTriggeredAbilityEffect(new OnLeaveReturnExiledToBattlefieldAbility()));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/a/AtzocanArcher.java
+++ b/Mage.Sets/src/mage/cards/a/AtzocanArcher.java
@@ -12,8 +12,7 @@ import mage.abilities.keyword.ReachAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -21,12 +20,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author TheElk801
  */
 public final class AtzocanArcher extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public AtzocanArcher(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}");
@@ -44,7 +37,7 @@ public final class AtzocanArcher extends CardImpl {
         effect.setText("you may have it fight another target creature. " +
                 "<i>(Each deals damage equal to its power to the other.)</i>");
         Ability ability = new EntersBattlefieldTriggeredAbility(effect, true);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvacynGuardianAngel.java
+++ b/Mage.Sets/src/mage/cards/a/AvacynGuardianAngel.java
@@ -14,8 +14,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.choices.ChoiceColor;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.players.Player;
@@ -28,12 +27,6 @@ import java.util.UUID;
  * @author LevelX2
  */
 public final class AvacynGuardianAngel extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public AvacynGuardianAngel(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{W}{W}{W}");
@@ -51,7 +44,7 @@ public final class AvacynGuardianAngel extends CardImpl {
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new AvacynGuardianAngelPreventToCreatureEffect(),
                 new ManaCostsImpl<>("{1}{W}"));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
 
         // {5}{W}{W}: Prevent all damage that would be dealt to target player this turn by sources of the color of your choice.

--- a/Mage.Sets/src/mage/cards/c/CephalidFacetaker.java
+++ b/Mage.Sets/src/mage/cards/c/CephalidFacetaker.java
@@ -39,7 +39,7 @@ public final class CephalidFacetaker extends CardImpl {
         Ability ability = new BeginningOfCombatTriggeredAbility(
                 new CephalidFacetakerEffect(), TargetController.YOU, true
         );
-        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CherishedHatchling.java
+++ b/Mage.Sets/src/mage/cards/c/CherishedHatchling.java
@@ -16,8 +16,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.FilterCard;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.stack.Spell;
@@ -62,12 +61,6 @@ public final class CherishedHatchling extends CardImpl {
 
 class CherishedHatchlingTriggeredAbility extends DelayedTriggeredAbility {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
-
     public CherishedHatchlingTriggeredAbility() {
         super(getEffectToAdd(), Duration.EndOfTurn, false);
         setTriggerPhrase("whenever you cast a Dinosaur spell this turn, ");
@@ -75,7 +68,7 @@ class CherishedHatchlingTriggeredAbility extends DelayedTriggeredAbility {
 
     private static Effect getEffectToAdd() {
         Ability abilityToAdd = new EntersBattlefieldTriggeredAbility(new FightTargetSourceEffect().setText("you may have it fight another target creature"), true);
-        abilityToAdd.addTarget(new TargetCreaturePermanent(filter));
+        abilityToAdd.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         Effect effect = new GainAbilityTargetEffect(abilityToAdd, Duration.EndOfTurn,
                 "it gains \"When this creature enters the battlefield, you may have it fight another target creature.\"", true);
         return effect;

--- a/Mage.Sets/src/mage/cards/d/DeadlyDancer.java
+++ b/Mage.Sets/src/mage/cards/d/DeadlyDancer.java
@@ -16,8 +16,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetPermanent;
@@ -28,12 +27,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class DeadlyDancer extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public DeadlyDancer(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "");
@@ -56,7 +49,7 @@ public final class DeadlyDancer extends CardImpl {
         ).setText("{this}"), new ManaCostsImpl<>("{R}{R}"));
         ability.addEffect(new BoostTargetEffect(1, 0)
                 .setText("and another target creature each get +1/+0 until end of turn"));
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EldraziDisplacer.java
+++ b/Mage.Sets/src/mage/cards/e/EldraziDisplacer.java
@@ -12,8 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
@@ -22,12 +21,6 @@ import java.util.UUID;
  * @author LevelX2
  */
 public final class EldraziDisplacer extends CardImpl {
-
-    private static final FilterCreaturePermanent FILTER = new FilterCreaturePermanent("another target creature");
-
-    static {
-        FILTER.add(AnotherPredicate.instance);
-    }
 
     public EldraziDisplacer(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{W}");
@@ -41,7 +34,7 @@ public final class EldraziDisplacer extends CardImpl {
         // {2}{C}: Exile another target creature, then return it to the battlefield tapped under its owner's control.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ExileTargetForSourceEffect(), new ManaCostsImpl<>("{2}{C}"));
         ability.addEffect(new ReturnToBattlefieldUnderOwnerControlTargetEffect(true, false, "it").concatBy(", then"));
-        ability.addTarget(new TargetCreaturePermanent(FILTER));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FelhideSpiritbinder.java
+++ b/Mage.Sets/src/mage/cards/f/FelhideSpiritbinder.java
@@ -17,8 +17,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Outcome;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
@@ -30,12 +29,6 @@ import mage.target.targetpointer.FixedTarget;
  */
 public final class FelhideSpiritbinder extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
-
     public FelhideSpiritbinder(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{R}");
         this.subtype.add(SubType.MINOTAUR);
@@ -46,7 +39,7 @@ public final class FelhideSpiritbinder extends CardImpl {
 
         // <i>Inspired</i> &mdash; Whenever Felhide Spiritbinder becomes untapped, you may pay {1}{R}. If you do, create a token that's a copy of another target creature except it's an enchantment in addition to its other types. It gains haste. Exile it at the beginning of the next end step.
         Ability ability = new InspiredAbility(new DoIfCostPaid(new FelhideSpiritbinderEffect(), new ManaCostsImpl<>("{1}{R}"), "Use effect of {this}?"));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GalepowderMage.java
+++ b/Mage.Sets/src/mage/cards/g/GalepowderMage.java
@@ -16,8 +16,7 @@ import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -31,12 +30,6 @@ import java.util.UUID;
  */
 public final class GalepowderMage extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
-
     public GalepowderMage(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{W}");
         this.subtype.add(SubType.KITHKIN);
@@ -49,7 +42,7 @@ public final class GalepowderMage extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // Whenever Galepowder Mage attacks, exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.
         Ability ability = new AttacksTriggeredAbility(new GalepowderMageEffect(), false);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GhostLitDrifter.java
+++ b/Mage.Sets/src/mage/cards/g/GhostLitDrifter.java
@@ -12,9 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
@@ -26,12 +24,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class GhostLitDrifter extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public GhostLitDrifter(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}");
@@ -48,7 +40,7 @@ public final class GhostLitDrifter extends CardImpl {
                 FlyingAbility.getInstance(), Duration.EndOfTurn,
                 "another target creature gains flying until end of turn"
         ), new ManaCostsImpl<>("{2}{U}"));
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
 
         // Channel — {X}{U}, Discard Ghost-Lit Drifter: X target creatures gain flying until end of turn.

--- a/Mage.Sets/src/mage/cards/g/GravityNegator.java
+++ b/Mage.Sets/src/mage/cards/g/GravityNegator.java
@@ -15,8 +15,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -24,12 +23,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author fireshoes
  */
 public final class GravityNegator extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public GravityNegator(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{U}");
@@ -47,7 +40,7 @@ public final class GravityNegator extends CardImpl {
         // Whenenever Gravity Negator attacks, you may pay {C}. If you do, another target creature gains flying until end of turn.
         Ability ability = new AttacksTriggeredAbility(new DoIfCostPaid(new GainAbilityTargetEffect(FlyingAbility.getInstance(), Duration.EndOfTurn), new ManaCostsImpl<>("{C}")), false,
                 "Whenever {this} attacks you may pay {C}. If you do, another target creature gains flying until end of turn.");
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IcefeatherAven.java
+++ b/Mage.Sets/src/mage/cards/i/IcefeatherAven.java
@@ -13,8 +13,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -22,12 +21,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class IcefeatherAven extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public IcefeatherAven(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{G}{U}");
@@ -43,7 +36,7 @@ public final class IcefeatherAven extends CardImpl {
         this.addAbility(new MorphAbility(new ManaCostsImpl<>("{1}{G}{U}")));
         // When Icefeather Aven is turned face up, you may return another target creature to its owner's hand.
         Ability ability = new TurnedFaceUpSourceTriggeredAbility(new ReturnToHandTargetEffect(), false, true);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/j/JediInstructor.java
+++ b/Mage.Sets/src/mage/cards/j/JediInstructor.java
@@ -12,8 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -21,12 +20,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author Styxo
  */
 public final class JediInstructor extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public JediInstructor(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{W}");
@@ -37,7 +30,7 @@ public final class JediInstructor extends CardImpl {
 
         // When Jedi Instructor enters the battlefield, you may put a +1/+1 counter on another target creature.
         EntersBattlefieldTriggeredAbility ability = new EntersBattlefieldTriggeredAbility(new AddCountersTargetEffect(CounterType.P1P1.createInstance()), true);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
 
         // Meditate {1}{W}

--- a/Mage.Sets/src/mage/cards/l/LegionGuildmage.java
+++ b/Mage.Sets/src/mage/cards/l/LegionGuildmage.java
@@ -13,8 +13,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.TargetController;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -22,13 +21,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author TheElk801
  */
 public final class LegionGuildmage extends CardImpl {
-
-    private static final FilterCreaturePermanent filter
-            = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public LegionGuildmage(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{R}{W}");
@@ -52,7 +44,7 @@ public final class LegionGuildmage extends CardImpl {
                 new ManaCostsImpl<>("{2}{W}")
         );
         ability.addCost(new TapSourceCost());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LivingTotem.java
+++ b/Mage.Sets/src/mage/cards/l/LivingTotem.java
@@ -12,8 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -21,12 +20,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author LevelX2
  */
 public final class LivingTotem extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public LivingTotem(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{G}");
@@ -40,7 +33,7 @@ public final class LivingTotem extends CardImpl {
         this.addAbility(new ConvokeAbility());
         // When Living Totem enters the battlefield, you may put a +1/+1 counter on another target creature.
         Ability ability = new EntersBattlefieldTriggeredAbility(new AddCountersTargetEffect(CounterType.P1P1.createInstance()), true);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LivioOathswornSentinel.java
+++ b/Mage.Sets/src/mage/cards/l/LivioOathswornSentinel.java
@@ -12,9 +12,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -30,12 +28,6 @@ import java.util.stream.Collectors;
  */
 public final class LivioOathswornSentinel extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
-
     public LivioOathswornSentinel(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{W}");
 
@@ -49,7 +41,7 @@ public final class LivioOathswornSentinel extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 new LivioOathswornSentinelExileEffect(), new ManaCostsImpl<>("{1}{W}")
         );
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
 
         // {2}{W}, {T}: Return all exiled cards with aegis counters on them to the battlefield under their owners' control.

--- a/Mage.Sets/src/mage/cards/n/NoxiousGearhulk.java
+++ b/Mage.Sets/src/mage/cards/n/NoxiousGearhulk.java
@@ -12,8 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Outcome;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -24,12 +23,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author fireshoes
  */
 public final class NoxiousGearhulk extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public NoxiousGearhulk(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT,CardType.CREATURE},"{4}{B}{B}");
@@ -42,7 +35,7 @@ public final class NoxiousGearhulk extends CardImpl {
 
         // When Noxious Gearhulk enters the battlefield, you may destroy another target creature. If a creature is destroyed this way, you gain life equal to its toughness.
         Ability ability = new EntersBattlefieldTriggeredAbility(new NoxiousGearhulkEffect());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimordialPlasm.java
+++ b/Mage.Sets/src/mage/cards/p/PrimordialPlasm.java
@@ -11,9 +11,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.TargetController;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -22,12 +20,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class PrimordialPlasm extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public PrimordialPlasm(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "");
@@ -46,7 +38,7 @@ public final class PrimordialPlasm extends CardImpl {
         );
         ability.addEffect(new LoseAllAbilitiesTargetEffect(Duration.EndOfTurn)
                 .setText("and loses all abilities until end of turn"));
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RhonasTheIndomitable.java
+++ b/Mage.Sets/src/mage/cards/r/RhonasTheIndomitable.java
@@ -15,8 +15,8 @@ import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.PowerPredicate;
 import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.Game;
@@ -30,12 +30,6 @@ import java.util.UUID;
  * @author fireshoes
  */
 public final class RhonasTheIndomitable extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public RhonasTheIndomitable(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}");
@@ -61,7 +55,7 @@ public final class RhonasTheIndomitable extends CardImpl {
         effect = new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("and gains trample until end of turn");
         ability.addEffect(effect);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoonOfTheHiddenRealm.java
+++ b/Mage.Sets/src/mage/cards/r/RoonOfTheHiddenRealm.java
@@ -15,8 +15,7 @@ import mage.abilities.keyword.VigilanceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -29,12 +28,6 @@ import java.util.UUID;
  * @author LevelX2
  */
 public final class RoonOfTheHiddenRealm extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public RoonOfTheHiddenRealm(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}{W}{U}");
@@ -51,7 +44,7 @@ public final class RoonOfTheHiddenRealm extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
         // {2}, {tap}: Exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new RoonOfTheHiddenRealmEffect(), new GenericManaCost(2));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/s/ScroungingBandar.java
+++ b/Mage.Sets/src/mage/cards/s/ScroungingBandar.java
@@ -15,8 +15,7 @@ import mage.constants.Outcome;
 import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -27,12 +26,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author Styxo
  */
 public final class ScroungingBandar extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public ScroungingBandar(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{G}");
@@ -47,7 +40,7 @@ public final class ScroungingBandar extends CardImpl {
 
         // At the beginning of you upkeep, you may move any number of +1/+1 counters from Scrounging Bandar onto another target creature.
         Ability ability = new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, new ScroungingBandarEffect(), TargetController.YOU, true);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/ShamelessCharlatan.java
+++ b/Mage.Sets/src/mage/cards/s/ShamelessCharlatan.java
@@ -9,10 +9,7 @@ import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
@@ -25,12 +22,6 @@ import java.util.UUID;
  */
 public final class ShamelessCharlatan extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
-
     public ShamelessCharlatan(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{U}");
 
@@ -39,7 +30,7 @@ public final class ShamelessCharlatan extends CardImpl {
 
         // Commander creatures you own have "{2}{U}: This creature becomes a copy of another target creature."
         Ability ability = new SimpleActivatedAbility(new ShamelessCharlatanEffect(), new ManaCostsImpl<>("{2}{U}"));
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(new SimpleStaticAbility(new GainAbilityAllEffect(
                 ability, Duration.WhileOnBattlefield, StaticFilters.FILTER_CREATURES_OWNED_COMMANDER
         )));

--- a/Mage.Sets/src/mage/cards/t/TheScorpionGod.java
+++ b/Mage.Sets/src/mage/cards/t/TheScorpionGod.java
@@ -23,8 +23,7 @@ import mage.constants.Outcome;
 import mage.constants.SuperType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
@@ -37,12 +36,6 @@ import mage.target.targetpointer.FixedTarget;
  * @author spjspj
  */
 public final class TheScorpionGod extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public TheScorpionGod(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{B}{R}");
@@ -57,7 +50,7 @@ public final class TheScorpionGod extends CardImpl {
 
         // {1}{B}{R}: Put a -1/-1 counter on another target creature.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.M1M1.createInstance()), new ManaCostsImpl<>("{1}{B}{R}"));
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
 
         // When The Scorpion God dies, return it to its owner's hand at the beginning of the next end step.

--- a/Mage.Sets/src/mage/cards/t/TideforceElemental.java
+++ b/Mage.Sets/src/mage/cards/t/TideforceElemental.java
@@ -16,8 +16,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.ColoredManaSymbol;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -25,12 +24,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author Loki
  */
 public final class TideforceElemental extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public TideforceElemental(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{U}");
@@ -45,7 +38,7 @@ public final class TideforceElemental extends CardImpl {
                 new MayTapOrUntapTargetEffect(), 
                 new ColoredManaCost(ColoredManaSymbol.U));
         ability.addCost(new TapSourceCost());
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
         // Landfall - Whenever a land enters the battlefield under your control, you may untap Tideforce Elemental.
         this.addAbility(new LandfallAbility(new UntapSourceEffect(), true));

--- a/Mage.Sets/src/mage/cards/w/WillowduskEssenceSeer.java
+++ b/Mage.Sets/src/mage/cards/w/WillowduskEssenceSeer.java
@@ -16,9 +16,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.target.TargetPermanent;
 import mage.watchers.common.PlayerGainedLifeWatcher;
@@ -30,12 +28,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class WillowduskEssenceSeer extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public WillowduskEssenceSeer(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{B}{G}");
@@ -53,7 +45,7 @@ public final class WillowduskEssenceSeer extends CardImpl {
                 "equal to the amount of life you gained this turn or the amount of " +
                 "life you lost this turn, whichever is greater"), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         ability.addHint(ControllerGotLifeCount.getHint());
         ability.addHint(WillowduskEssenceSeerHint.instance);
         this.addAbility(ability, new PlayerGainedLifeWatcher());

--- a/Mage.Sets/src/mage/cards/w/WookieeRaidleader.java
+++ b/Mage.Sets/src/mage/cards/w/WookieeRaidleader.java
@@ -12,8 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -21,12 +20,6 @@ import mage.target.common.TargetCreaturePermanent;
  * @author Styxo
  */
 public final class WookieeRaidleader extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another target creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public WookieeRaidleader(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{R/G}{R/G}");
@@ -37,7 +30,7 @@ public final class WookieeRaidleader extends CardImpl {
 
         // Whenever Wookiee Raidleader attacks, antoher target creature gains trample until end of turn
         Ability ability = new AttacksTriggeredAbility(new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn), false);
-        ability.addTarget(new TargetCreaturePermanent(filter));
+        ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE));
         this.addAbility(ability);
 
     }

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -555,6 +555,13 @@ public final class StaticFilters {
         FILTER_OPPONENTS_PERMANENT_ARTIFACT_OR_CREATURE.setLockedFilter(true);
     }
 
+    public static final FilterCreaturePermanent FILTER_ANOTHER_TARGET_CREATURE = new FilterCreaturePermanent("another target creature");
+
+    static {
+        FILTER_ANOTHER_TARGET_CREATURE.add(AnotherPredicate.instance);
+        FILTER_ANOTHER_TARGET_CREATURE.setLockedFilter(true);
+    }
+
     public static final FilterCreaturePermanent FILTER_ANOTHER_CREATURE_TARGET_2 = new FilterCreaturePermanent("another target creature");
 
     static {


### PR DESCRIPTION
As reported in discord, Cephalid Facetaker was incorrectly filtering to controlled permanents only.

Add new `StaticFilter.FILTER_ANOTHER_TARGET_CREATURE` and use it where appropriate.

(In future, could also make `FILTER_ANOTHER_CREATURE` for Soul Warden and similar cards.)