### PR TITLE
Fixing https://github.com/magefree/mage/issues/10419

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DarksteelSplicer.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelSplicer.java
@@ -13,7 +13,6 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.filter.predicate.permanent.TokenPredicate;
 import mage.game.permanent.token.PhyrexianGolemToken;
 
@@ -27,7 +26,6 @@ public final class DarksteelSplicer extends CardImpl {
     private static final FilterPermanent filter = new FilterPermanent(SubType.PHYREXIAN, "nontoken Phyrexian");
 
     static {
-        filter.add(AnotherPredicate.instance);
         filter.add(TokenPredicate.FALSE);
     }
 


### PR DESCRIPTION
Extra filter line was blocking initial trigger of the card. Removing caused card to behave as expected (triggering for both its summon and subsequent summons).