### PR TITLE
Added attachment controller info

### DIFF
--- a/Mage.Client/src/main/java/mage/client/util/gui/GuiDisplayUtil.java
+++ b/Mage.Client/src/main/java/mage/client/util/gui/GuiDisplayUtil.java
@@ -334,6 +334,9 @@ public final class GuiDisplayUtil {
                 buffer.append("[only controlled] ");
             }
         }
+        if (card instanceof PermanentView && ((PermanentView) card).isAttachedToDifferentlyControlledPermanent()) {
+            buffer.append('(').append(((PermanentView) card).getNameController()).append(") ");
+        }
         if (card.getMageObjectType() != MageObjectType.NULL) {
             buffer.append(card.getMageObjectType().toString());
         }

--- a/Mage.Common/src/main/java/mage/view/PermanentView.java
+++ b/Mage.Common/src/main/java/mage/view/PermanentView.java
@@ -29,11 +29,14 @@ public class PermanentView extends CardView {
     private final CardView original; // original card before transforms and modifications (null for opponents face down cards)
     private final boolean copy;
     private final String nameOwner; // only filled if != controller
+    private final String nameController;
     private final boolean controlled;
     private final UUID attachedTo;
     private final boolean morphed;
     private final boolean manifested;
     private final boolean attachedToPermanent;
+    // If this card is attached to a permanent which is controlled by a player other than the one which controls this permanent
+    private final boolean attachedControllerDiffers;
 
     public PermanentView(Permanent permanent, Card card, UUID createdForPlayerId, Game game) {
         super(permanent, game, permanent.getControllerId() != null && permanent.getControllerId().equals(createdForPlayerId));
@@ -89,6 +92,13 @@ public class PermanentView extends CardView {
             this.nameOwner = "";
         }
 
+        Player controller = game.getPlayer(permanent.getControllerId());
+        if (controller != null) {
+            nameController = controller.getName();
+        } else {
+            nameController = "";
+        }
+
         // add info for face down permanents
         if (permanent.isFaceDown(game) && card != null) {
             if (showFaceDownInfo) {
@@ -116,10 +126,13 @@ public class PermanentView extends CardView {
             }
         }
         // determines if shown in it's own column
-        if (permanent.getAttachedTo() != null) {
-            attachedToPermanent = game.getPermanent(permanent.getAttachedTo()) != null;
+        Permanent attachment = game.getPermanent(permanent.getAttachedTo());
+        if (attachment != null) {
+            attachedToPermanent = true;
+            attachedControllerDiffers = !attachment.getControllerId().equals(permanent.getControllerId());
         } else {
             attachedToPermanent = false;
+            attachedControllerDiffers = false;
         }
     }
 
@@ -163,6 +176,10 @@ public class PermanentView extends CardView {
         return nameOwner;
     }
 
+    public String getNameController() {
+        return nameController;
+    }
+
     public boolean isControlled() {
         return controlled;
     }
@@ -177,6 +194,10 @@ public class PermanentView extends CardView {
 
     public boolean isAttachedToPermanent() {
         return attachedToPermanent;
+    }
+
+    public boolean isAttachedToDifferentlyControlledPermanent() {
+        return attachedControllerDiffers;
     }
 
     public boolean isMorphed() {


### PR DESCRIPTION
Fixes magefree/mage#9971

![image](https://github.com/magefree/mage/assets/11657716/18d1e8f5-d89a-4599-a04f-aa1c00b21102)

I added it in the same spot as the owner would be displayed if it were controlled by someone other than the owner. The owner is shown in square brackets, so I thought parentheses would be good. Any opinions?

It only shows if the permanent is

1) Attached to another permanent

2) The controllers of those two permanents differ

I thought that this is probably the only way for a permanent to be drawn on another person's board even if they don't control it?