### PR TITLE
Ogre Marauder fixes

### DIFF
--- a/Mage.Sets/src/mage/cards/o/OgreMarauder.java
+++ b/Mage.Sets/src/mage/cards/o/OgreMarauder.java
@@ -10,7 +10,8 @@ import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.combat.CantBeBlockedSourceEffect;
+import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
+import mage.abilities.keyword.CantBeBlockedSourceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -73,13 +74,17 @@ class OgreMarauderEffect extends OneShotEffect {
         Player defender = game.getPlayer(defendingPlayerId);
         if (defender != null && sourceObject != null) {
             Cost cost = new SacrificeTargetCost(new TargetControlledCreaturePermanent(FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+            boolean paid = false;
             if (cost.canPay(source, source, defendingPlayerId, game)
-                    && defender.chooseUse(Outcome.LoseAbility, "Sacrifice a creature to prevent that " + sourceObject.getLogName() + " can't be blocked?", source, game)) {
-                if (!cost.pay(source, game, source, defendingPlayerId, false, null)) {
-                    // cost was not payed - so source can't be blocked
-                    ContinuousEffect effect = new CantBeBlockedSourceEffect(Duration.EndOfTurn);
-                    game.addEffect(effect, source);
-                }
+                    && defender.chooseUse(Outcome.LoseAbility, "Sacrifice a creature to prevent "
+                            + sourceObject.getLogName() + " from gaining \"" + sourceObject.getName() + " can't be blocked\"?",
+                    source, game)) {
+                paid = cost.pay(source, game, source, defendingPlayerId, false, null);
+            }
+            if (!paid) {
+                // cost was not paid - so source gains "this can't be blocked"
+                ContinuousEffect effect = new GainAbilitySourceEffect(new CantBeBlockedSourceAbility(), Duration.EndOfTurn);
+                game.addEffect(effect, source);
             }
             return true;
         }


### PR DESCRIPTION
- performs effect even if opponent can't pay or chose not to pay
- grants "can't be blocked" ability, rather than creating continuous effect, as per Oracle text