### PR TITLE
Improvements to effects that use ADD_COUNTERS GameEvent

### DIFF
--- a/Mage.Sets/src/mage/cards/b/Blightbeetle.java
+++ b/Mage.Sets/src/mage/cards/b/Blightbeetle.java
@@ -75,14 +75,14 @@ class BlightbeetleEffect extends ContinuousRuleModifyingEffectImpl {
         if (!event.getData().equals(CounterType.P1P1.getName())) {
             return false;
         }
-        Permanent permanent = game.getPermanent(event.getTargetId());
+        Permanent permanent = game.getPermanentEntering(event.getTargetId());
+        if (permanent == null) {
+            permanent = game.getPermanent(event.getTargetId());
+        }
         if (permanent == null || !permanent.isCreature(game)) {
             return false;
         }
         Player player = game.getPlayer(permanent.getControllerId());
-        if (player == null || !player.hasOpponent(source.getControllerId(), game)) {
-            return false;
-        }
-        return true;
+        return player != null && player.hasOpponent(source.getControllerId(), game);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CorpsejackMenace.java
+++ b/Mage.Sets/src/mage/cards/c/CorpsejackMenace.java
@@ -11,6 +11,7 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -63,7 +64,7 @@ class CorpsejackMenaceReplacementEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmountForCounters(event.getAmount() * 2, true);
+        event.setAmountForCounters(CardUtil.overflowMultiply(event.getAmount(), 2), true);
         return false;
     }
 

--- a/Mage.Sets/src/mage/cards/d/DoublingSeason.java
+++ b/Mage.Sets/src/mage/cards/d/DoublingSeason.java
@@ -81,8 +81,6 @@ class DoublingSeasonTokenEffect extends ReplacementEffectImpl {
 
 class DoublingSeasonCounterEffect extends ReplacementEffectImpl {
 
-    private boolean landPlayed = false; // a played land is not an effect
-
     DoublingSeasonCounterEffect() {
         super(Duration.WhileOnBattlefield, Outcome.BoostCreature, false);
         staticText = "If an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead";
@@ -111,13 +109,13 @@ class DoublingSeasonCounterEffect extends ReplacementEffectImpl {
         }
         if (permanent == null) {
             permanent = game.getPermanentEntering(event.getTargetId());
-            landPlayed = (permanent != null
-                    && permanent.isLand(game));  // a played land is not an effect
+            if (permanent != null && permanent.isLand(game)) {
+                return false; // a played land is not an effect (e.g. Gemstone Mine)
+            }
         }
         return permanent != null
                 && permanent.isControlledBy(source.getControllerId())
-                && event.getAmount() > 0
-                && !landPlayed;  // example: gemstone mine being played as a land drop
+                && event.getAmount() > 0;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/d/DoublingSeason.java
+++ b/Mage.Sets/src/mage/cards/d/DoublingSeason.java
@@ -12,6 +12,7 @@ import mage.game.Game;
 import mage.game.events.CreateTokenEvent;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -93,7 +94,7 @@ class DoublingSeasonCounterEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmountForCounters(event.getAmount() * 2, true);
+        event.setAmountForCounters(CardUtil.overflowMultiply(event.getAmount(), 2), true);
         return false;
     }
 

--- a/Mage.Sets/src/mage/cards/l/LaezelVlaakithsChampion.java
+++ b/Mage.Sets/src/mage/cards/l/LaezelVlaakithsChampion.java
@@ -70,7 +70,7 @@ class LaezelVlaakithsChampionEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
-        if (!source.isControlledBy(event.getPlayerId())) {
+        if (event.getAmount() <= 0 || !source.isControlledBy(event.getPlayerId())) {
             return false;
         }
         if (source.isControlledBy(event.getTargetId())) {

--- a/Mage.Sets/src/mage/cards/l/LaezelVlaakithsChampion.java
+++ b/Mage.Sets/src/mage/cards/l/LaezelVlaakithsChampion.java
@@ -11,6 +11,7 @@ import mage.constants.*;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -59,7 +60,7 @@ class LaezelVlaakithsChampionEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmountForCounters(event.getAmount() + 1, true);
+        event.setAmountForCounters(CardUtil.overflowInc(event.getAmount(), 1), true);
         return false;
     }
 

--- a/Mage.Sets/src/mage/cards/m/MowuLoyalCompanion.java
+++ b/Mage.Sets/src/mage/cards/m/MowuLoyalCompanion.java
@@ -13,6 +13,7 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -63,7 +64,7 @@ class MowuLoyalCompanionEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmountForCounters(event.getAmount() + 1, true);
+        event.setAmountForCounters(CardUtil.overflowInc(event.getAmount(), 1), true);
         return false;
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalVigor.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalVigor.java
@@ -14,6 +14,7 @@ import mage.game.Game;
 import mage.game.events.CreateTokenEvent;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -96,7 +97,7 @@ class PrimalVigorCounterEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmountForCounters(event.getAmount() * 2, true);
+        event.setAmountForCounters(CardUtil.overflowMultiply(event.getAmount(), 2), true);
         return false;
     }
 

--- a/Mage.Sets/src/mage/cards/v/VizierOfRemedies.java
+++ b/Mage.Sets/src/mage/cards/v/VizierOfRemedies.java
@@ -10,6 +10,7 @@ import mage.constants.*;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
 
 import java.util.UUID;
 
@@ -70,11 +71,14 @@ class VizierOfRemediesReplacementEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
-        if (source != null && source.getControllerId() != null) {
-            return source.isControlledBy(game.getControllerId(event.getTargetId()))
-                    && event.getData() != null && event.getData().equals(CounterType.M1M1.getName())
-                    && event.getAmount() > 0;
+        if (event.getAmount() <= 0 || !event.getData().equals(CounterType.M1M1.getName())) {
+            return false;
         }
-        return false;
+        Permanent permanent = game.getPermanent(event.getTargetId());
+        if (permanent == null) {
+            permanent = game.getPermanentEntering(event.getTargetId());
+        }
+        return permanent != null && permanent.isControlledBy(source.getControllerId())
+                && permanent.isCreature(game);
     }
 }

--- a/Mage.Sets/src/mage/cards/v/VorinclexMonstrousRaider.java
+++ b/Mage.Sets/src/mage/cards/v/VorinclexMonstrousRaider.java
@@ -14,6 +14,7 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -73,7 +74,7 @@ class VorinclexMonstrousRaiderEffect extends ReplacementEffectImpl {
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         if (source.isControlledBy(event.getPlayerId())) {
-            event.setAmountForCounters(2 * event.getAmount(), true);
+            event.setAmountForCounters(CardUtil.overflowMultiply(event.getAmount(), 2), true);
         } else if (game.getOpponents(event.getPlayerId()).contains(source.getControllerId())) {
             event.setAmountForCounters(Math.floorDiv(event.getAmount(), 2), true);
         }

--- a/Mage.Sets/src/mage/cards/w/WindingConstrictor.java
+++ b/Mage.Sets/src/mage/cards/w/WindingConstrictor.java
@@ -15,6 +15,7 @@ import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.players.Player;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -62,7 +63,7 @@ class WindingConstrictorPlayerEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmountForCounters(event.getAmount() + 1, true);
+        event.setAmountForCounters(CardUtil.overflowInc(event.getAmount(), 1), true);
         return false;
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZabazTheGlimmerwasp.java
+++ b/Mage.Sets/src/mage/cards/z/ZabazTheGlimmerwasp.java
@@ -20,6 +20,7 @@ import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.game.stack.StackObject;
 import mage.target.TargetPermanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -77,7 +78,7 @@ class ZabazTheGlimmerwaspEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmountForCounters(event.getAmount() + 1, true);
+        event.setAmountForCounters(CardUtil.overflowInc(event.getAmount(), 1), true);
         return false;
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/replacement/ModifyCountersAddedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/replacement/ModifyCountersAddedEffect.java
@@ -36,7 +36,7 @@ public class ModifyCountersAddedEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmountForCounters(event.getAmount() + 1, true);
+        event.setAmountForCounters(CardUtil.overflowInc(event.getAmount(), 1), true);
         return false;
     }
 


### PR DESCRIPTION
Following up on #10472
* Check permanent entering for Blightbeetle, Vizier of Remedies
* Confirm more than 0 counters
* Make increments/multiplication overflow safe
* Remove superfluous field in Doubling Season effect

I checked Rasputin Dreamweaver and I believe it is correct as is to use `ADD_COUNTER`, as it needs to reject counters beyond the seventh so it looks at the individual events rather than the batched event.

(Although there's some redundancy in these effects, I don't see an obvious refactor given the subtle variations among them... maybe in the future.)