### PR TITLE
[MOM] fix Tribute to the World Tree

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TributeToTheWorldTree.java
+++ b/Mage.Sets/src/mage/cards/t/TributeToTheWorldTree.java
@@ -58,11 +58,15 @@ class TributeToTheWorldTreeEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Permanent permanentEntering = (Permanent) getValue("permanentEnteringBattlefield");
-        if (permanentEntering == null) return false;
+        if (permanentEntering == null) {
+            return false;
+        }
 
         // We need to ask the game for the actualized object for the entering permanent.
         Permanent permanent = game.getPermanent(permanentEntering.getId());
-        if (permanent == null) return false;
+        if (permanent == null) {
+            return false;
+        }
 
         int power = permanent.getPower().getValue();
         if (power < 3) {

--- a/Mage.Sets/src/mage/cards/t/TributeToTheWorldTree.java
+++ b/Mage.Sets/src/mage/cards/t/TributeToTheWorldTree.java
@@ -57,14 +57,20 @@ class TributeToTheWorldTreeEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Permanent permanent = (Permanent) getValue("permanentEnteringBattlefield");
-        if (permanent == null) {
-            return false;
-        }
-        if (permanent.getPower().getValue() < 3) {
+        Permanent permanentEntering = (Permanent) getValue("permanentEnteringBattlefield");
+        if (permanentEntering == null) return false;
+
+        // We need to ask the game for the actualized object for the entering permanent.
+        Permanent permanent = game.getPermanent(permanentEntering.getId());
+        if (permanent == null) return false;
+
+        int power = permanent.getPower().getValue();
+        if (power < 3) {
             return permanent.addCounters(CounterType.P1P1.createInstance(2), source, game);
         }
-        Player player = game.getPlayer(source.getControllerId());
-        return player != null && player.drawCards(1, source, game) > 0;
+        else {
+            Player player = game.getPlayer(source.getControllerId());
+            return player != null && player.drawCards(1, source, game) > 0;
+        }
     }
 }


### PR DESCRIPTION
My understanding of the issue was that getValue("permanentEnteringBattlefield") needed to be contextualized for the latest game state. Calling game.getPermanent() with the entering permanent uuid seems to be working.

I do not understand fully how apply was doing both effects at once, it seemed like there was only a single apply call anyway. If anyone got more insight on that, I am interested.