### PR TITLE
fix Unsettled Mariner + Field of Ruin (#10530)

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AmuletOfSafekeeping.java
+++ b/Mage.Sets/src/mage/cards/a/AmuletOfSafekeeping.java
@@ -1,9 +1,7 @@
 package mage.cards.a;
 
-import java.util.UUID;
-
-import mage.abilities.common.TargetOfOpponentsSpellOrAbilityTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.common.TargetOfOpponentsSpellOrAbilityTriggeredAbility;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.CounterUnlessPaysEffect;
 import mage.abilities.effects.common.continuous.BoostAllEffect;
@@ -13,6 +11,8 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
+
+import java.util.UUID;
 
 /**
  *
@@ -24,7 +24,7 @@ public final class AmuletOfSafekeeping extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
 
         // Whenever you become the target of a spell or ability an opponent controls, counter that spell or ability unless its controller pays {1}.
-        this.addAbility(new TargetOfOpponentsSpellOrAbilityTriggeredAbility(new CounterUnlessPaysEffect(new GenericManaCost(1)), Boolean.TRUE));
+        this.addAbility(new TargetOfOpponentsSpellOrAbilityTriggeredAbility(new CounterUnlessPaysEffect(new GenericManaCost(1)), false, true));
 
         // Creature tokens get -1/-0.
         this.addAbility(new SimpleStaticAbility(

--- a/Mage.Sets/src/mage/cards/l/LeovoldEmissaryOfTrest.java
+++ b/Mage.Sets/src/mage/cards/l/LeovoldEmissaryOfTrest.java
@@ -1,7 +1,6 @@
 
 package mage.cards.l;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
@@ -15,6 +14,8 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.players.Player;
 import mage.watchers.common.CardsAmountDrawnThisTurnWatcher;
+
+import java.util.UUID;
 
 /**
  *
@@ -34,7 +35,7 @@ public final class LeovoldEmissaryOfTrest extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new LeovoldEmissaryOfTrestEffect()), new CardsAmountDrawnThisTurnWatcher());
 
         // Whenever you or a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.
-        this.addAbility(new TargetOfOpponentsSpellOrAbilityTriggeredAbility(new DrawCardSourceControllerEffect(1), true));
+        this.addAbility(new TargetOfOpponentsSpellOrAbilityTriggeredAbility(new DrawCardSourceControllerEffect(1), true, false));
     }
 
     private LeovoldEmissaryOfTrest(final LeovoldEmissaryOfTrest card) {

--- a/Mage.Sets/src/mage/cards/r/RayneAcademyChancellor.java
+++ b/Mage.Sets/src/mage/cards/r/RayneAcademyChancellor.java
@@ -1,7 +1,6 @@
 
 package mage.cards.r;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.TargetOfOpponentsSpellOrAbilityTriggeredAbility;
 import mage.abilities.condition.common.EnchantedSourceCondition;
@@ -13,6 +12,8 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
+
+import java.util.UUID;
 
 /**
  *
@@ -32,12 +33,12 @@ public final class RayneAcademyChancellor extends CardImpl {
         // Whenever you or a permanent you control becomes the target of a spell or ability an opponent controls, you may draw a card.
         // You may draw an additional card if Rayne, Academy Chancellor is enchanted.
         Effect drawEffect = new ConditionalOneShotEffect(
-                new DrawCardSourceControllerEffect(2),
+                new DrawCardSourceControllerEffect(2), // TODO: This should allow to draw only one card.
                 new DrawCardSourceControllerEffect(1),
                 new EnchantedSourceCondition(),
                 "you may draw a card. You may draw an additional card if {this} is enchanted"
         );
-        this.addAbility(new TargetOfOpponentsSpellOrAbilityTriggeredAbility(drawEffect));
+        this.addAbility(new TargetOfOpponentsSpellOrAbilityTriggeredAbility(drawEffect, true, false));
     }
 
     private RayneAcademyChancellor(final RayneAcademyChancellor card) {

--- a/Mage/src/main/java/mage/abilities/common/TargetOfOpponentsSpellOrAbilityTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/TargetOfOpponentsSpellOrAbilityTriggeredAbility.java
@@ -80,7 +80,7 @@ public class TargetOfOpponentsSpellOrAbilityTriggeredAbility extends TriggeredAb
         }
 
         // Add target for effects which need it (e.g. the counter effect from AmuletOfSafekeeping)
-        this.getEffects().setTargetPointer(new FixedTarget(event.getSourceId(), game));
+        this.getEffects().setTargetPointer(new FixedTarget(event.getSourceId()));
         return true;
     }
 

--- a/Mage/src/main/java/mage/abilities/common/TargetOfOpponentsSpellOrAbilityTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/TargetOfOpponentsSpellOrAbilityTriggeredAbility.java
@@ -18,22 +18,13 @@ import mage.target.targetpointer.FixedTarget;
  */
 public class TargetOfOpponentsSpellOrAbilityTriggeredAbility extends TriggeredAbilityImpl {
 
-    private Boolean onlyController = Boolean.FALSE;
+    private boolean onlyController = false;
 
     public TargetOfOpponentsSpellOrAbilityTriggeredAbility(Effect effect) {
-        this(effect, false);
+        this(effect, false, false);
     }
 
-    // NOTE: Using Boolean instead of boolean in order to have a second constructor with (Effect, "boolean") signature
-    public TargetOfOpponentsSpellOrAbilityTriggeredAbility(Effect effect, Boolean onlyController) {
-        this(effect, false, onlyController);
-    }
-
-    public TargetOfOpponentsSpellOrAbilityTriggeredAbility(Effect effect, boolean optional) {
-        this(effect, optional, Boolean.FALSE);
-    }
-
-    public TargetOfOpponentsSpellOrAbilityTriggeredAbility(Effect effect, boolean optional, Boolean onlyController) {
+    public TargetOfOpponentsSpellOrAbilityTriggeredAbility(Effect effect, boolean optional, boolean onlyController) {
         super(Zone.BATTLEFIELD, effect, optional);
         this.onlyController = onlyController;
         if (this.onlyController) {
@@ -64,7 +55,7 @@ public class TargetOfOpponentsSpellOrAbilityTriggeredAbility extends TriggeredAb
         // Check if player was targeted
         if (controller.getId().equals(event.getTargetId())) {
             // Add target for effects which need it (e.g. the counter effect from AmuletOfSafekeeping)
-            this.getEffects().setTargetPointer(new FixedTarget(event.getSourceId(), game));
+            this.getEffects().setTargetPointer(new FixedTarget(event.getSourceId()));
             return true;
         }
 


### PR DESCRIPTION
There was something weird with zcc on TargetOfOpponentsSpellOrAbilityTriggeredAbility setting the target to the stack object for its triggered effect.

I do not entirely comprehend how FixedTarget works, in particular regarding zcc of stack objects. However all configurations of the trigger seem to work with the uninitialized FixedTarget constructor, instead of the one initialized with a game's zcc.