### PR TITLE
[LTR] fix Orcish Bowmaster

### DIFF
--- a/Mage.Sets/src/mage/cards/o/OrcishBowmasters.java
+++ b/Mage.Sets/src/mage/cards/o/OrcishBowmasters.java
@@ -15,7 +15,6 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.target.common.TargetAnyTarget;
-import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
 
@@ -40,8 +39,8 @@ public class OrcishBowmasters extends CardImpl {
                 new OrTriggeredAbility(Zone.BATTLEFIELD, new DamageTargetEffect(1, "{this}"),
                     new EntersBattlefieldTriggeredAbility(null, false),
                     new OpponentDrawCardExceptFirstCardDrawStepTriggeredAbility(Zone.BATTLEFIELD, null, false)
-                    .setTriggerPhrase("When {this} enters the battlefield and whenever an opponent draws a card " +
-                            "except the first one they draw in each of their draw steps, "));
+                ).setTriggerPhrase("When {this} enters the battlefield and whenever an opponent draws a card " +
+                    "except the first one they draw in each of their draw steps, ");
         triggeredAbility.addTarget(new TargetAnyTarget());
 
         Effect amass = new AmassEffect(1, SubType.ORC);

--- a/Mage/src/main/java/mage/abilities/meta/OrTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/meta/OrTriggeredAbility.java
@@ -41,6 +41,10 @@ public class OrTriggeredAbility extends TriggeredAbilityImpl {
         for (TriggeredAbility ability : triggeredAbilities) {
             //Remove useless data
             ability.getEffects().clear();
+
+            for(Watcher watcher : ability.getWatchers()) {
+                super.addWatcher(watcher);
+            }
         }
         setTriggerPhrase(generateTriggerPhrase());
     }


### PR DESCRIPTION
The "except the first one they draw in each of their draw steps" part of the trigger was not properly checked, and extra cards drawn on your draw step was never triggering an opposing Orcish Bowmasters.

`OpponentDrawCardExceptFirstCardDrawStepTriggeredAbility` is a triggered ability that initializes a watcher `CardsDrawnDuringDrawStepWatcher`. However `OrTriggeredAbility` was not exposing its sub triggers' watchers to the game engine. I am not sure the global fix to `OrTriggeredAbility` is better than a `triggeredAbility.addWatcher(...)` in OrcishBowmaster.java.

Also, the trigger text was not set at the proper level, which led to a duplicated "when {this} enters the battlefield".