### PR TITLE
Fix aragorn tooltip and effect

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AragornKingOfGondor.java
+++ b/Mage.Sets/src/mage/cards/a/AragornKingOfGondor.java
@@ -19,6 +19,7 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.filter.StaticFilters;
+import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
 
@@ -47,6 +48,7 @@ public final class AragornKingOfGondor extends CardImpl {
 
         // Whenever Aragorn attacks, up to one target creature can't block this turn. If you're the monarch, creatures can't block this turn.
         Ability ability = new AttacksTriggeredAbility(new CantBlockTargetEffect(Duration.EndOfTurn));
+        ability.addTarget(new TargetCreaturePermanent(0, 1));
         ability.addEffect(new ConditionalOneShotEffect(new AddContinuousEffectToGame(
                 new CantBlockAllEffect(StaticFilters.FILTER_PERMANENT_CREATURES, Duration.EndOfTurn)
         ), MonarchIsSourceControllerCondition.instance, "If you're the monarch, creatures can't block this turn"));

--- a/Mage/src/main/java/mage/abilities/effects/common/combat/CantBlockTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/combat/CantBlockTargetEffect.java
@@ -50,7 +50,7 @@ public class CantBlockTargetEffect extends RestrictionEffect {
         if (target.getMaxNumberOfTargets() == Integer.MAX_VALUE) {
             sb.append("any number of ");
         } else if (target.getMaxNumberOfTargets() > 1) {
-            if (target.getMaxNumberOfTargets() != target.getNumberOfTargets()) {
+            if (target.getMinNumberOfTargets() == 0) {
                 sb.append("up to ");
             }
             sb.append(CardUtil.numberToText(target.getMaxNumberOfTargets())).append(' ');


### PR DESCRIPTION
Bug report from discord:

> When you're not the Monarch, Aaragon should still make one creature unable to block - but the hover text doesn't reflect that (and I suspect the mechanics don't either)

Ability was missing a target, and the tooltip text for `CantBlockTargetEffect` doesn't correctly render for "up to one" target.