### PR TITLE
[LTR] Implement Witch-king of Angmar

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WitchKingOfAngmar.java
+++ b/Mage.Sets/src/mage/cards/w/WitchKingOfAngmar.java
@@ -27,10 +27,10 @@ public final class WitchKingOfAngmar extends CardImpl {
 
     private static final FilterCreaturePermanent filter
             // TODO: get this to be the right text
-            = new FilterCreaturePermanent("creature that dealt combat damage to {this}'s owner this turn");
+            = new FilterCreaturePermanent("creature that dealt combat damage to the creature's controller this turn");
 
     static {
-        filter.add(new DamagedPlayerThisTurnPredicate(TargetController.OWNER, true));
+        filter.add(new DamagedPlayerThisTurnPredicate(TargetController.CONTROLLER, true));
     }
 
     public WitchKingOfAngmar(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/w/WitchKingOfAngmar.java
+++ b/Mage.Sets/src/mage/cards/w/WitchKingOfAngmar.java
@@ -26,10 +26,11 @@ import java.util.UUID;
 public final class WitchKingOfAngmar extends CardImpl {
 
     private static final FilterCreaturePermanent filter
-            = new FilterCreaturePermanent("creature that dealt combat damage to you this turn");
+            // TODO: get this to be the right text
+            = new FilterCreaturePermanent("creature that dealt combat damage to {this}'s owner this turn");
 
     static {
-        filter.add(new DamagedPlayerThisTurnPredicate(TargetController.YOU, true));
+        filter.add(new DamagedPlayerThisTurnPredicate(TargetController.OWNER, true));
     }
 
     public WitchKingOfAngmar(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/w/WitchKingOfAngmar.java
+++ b/Mage.Sets/src/mage/cards/w/WitchKingOfAngmar.java
@@ -6,6 +6,7 @@ import mage.abilities.common.CombatDamageDealtToYouTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.DiscardCardCost;
 import mage.abilities.effects.common.SacrificeOpponentsEffect;
+import mage.abilities.effects.common.TapSourceEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
 import mage.abilities.effects.keyword.TheRingTemptsYouEffect;
 import mage.abilities.keyword.FlyingAbility;
@@ -20,7 +21,7 @@ import java.util.UUID;
 
 /**
  *
- * @author bobby.mccann
+ * @author bobby-mccann
  */
 public final class WitchKingOfAngmar extends CardImpl {
 
@@ -44,15 +45,21 @@ public final class WitchKingOfAngmar extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Whenever one or more creatures deal combat damage to you, each opponent sacrifices a creature that dealt combat damage to you this turn. The Ring tempts you.
-        Ability ability = new CombatDamageDealtToYouTriggeredAbility(new SacrificeOpponentsEffect(filter));
-        ability.addEffect(new TheRingTemptsYouEffect());
-        this.addAbility(ability);
+        {
+            Ability ability = new CombatDamageDealtToYouTriggeredAbility(new SacrificeOpponentsEffect(filter));
+            ability.addEffect(new TheRingTemptsYouEffect());
+            this.addAbility(ability);
+        }
 
         // Discard a card: Witch-king of Angmar gains indestructible until end of turn. Tap it.
-        this.addAbility(new SimpleActivatedAbility(
-                new GainAbilitySourceEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn),
-                new DiscardCardCost()
-        ));
+        {
+            Ability ability = new SimpleActivatedAbility(
+                    new GainAbilitySourceEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn),
+                    new DiscardCardCost()
+            );
+            ability.addEffect(new TapSourceEffect().setText("tap it"));
+            this.addAbility(ability);
+        }
     }
 
     private WitchKingOfAngmar(final WitchKingOfAngmar card) {

--- a/Mage.Sets/src/mage/cards/w/WitchKingOfAngmar.java
+++ b/Mage.Sets/src/mage/cards/w/WitchKingOfAngmar.java
@@ -26,11 +26,10 @@ import java.util.UUID;
 public final class WitchKingOfAngmar extends CardImpl {
 
     private static final FilterCreaturePermanent filter
-            // TODO: get this to be the right text
-            = new FilterCreaturePermanent("creature that dealt combat damage to the creature's controller this turn");
+            = new FilterCreaturePermanent("creature that dealt combat damage to this ability's controller this turn");
 
     static {
-        filter.add(new DamagedPlayerThisTurnPredicate(TargetController.CONTROLLER, true));
+        filter.add(new DamagedPlayerThisTurnPredicate(TargetController.SOURCE_CONTROLLER, true));
     }
 
     public WitchKingOfAngmar(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/w/WitchKingOfAngmar.java
+++ b/Mage.Sets/src/mage/cards/w/WitchKingOfAngmar.java
@@ -1,0 +1,66 @@
+package mage.cards.w;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.CombatDamageDealtToYouTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.DiscardCardCost;
+import mage.abilities.effects.common.SacrificeOpponentsEffect;
+import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
+import mage.abilities.effects.keyword.TheRingTemptsYouEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.IndestructibleAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.other.DamagedPlayerThisTurnPredicate;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author bobby.mccann
+ */
+public final class WitchKingOfAngmar extends CardImpl {
+
+    private static final FilterCreaturePermanent filter
+            = new FilterCreaturePermanent("creature that dealt combat damage to you this turn");
+
+    static {
+        filter.add(new DamagedPlayerThisTurnPredicate(TargetController.YOU, true));
+    }
+
+    public WitchKingOfAngmar(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{B}{B}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.WRAITH);
+        this.subtype.add(SubType.NOBLE);
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(3);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Whenever one or more creatures deal combat damage to you, each opponent sacrifices a creature that dealt combat damage to you this turn. The Ring tempts you.
+        Ability ability = new CombatDamageDealtToYouTriggeredAbility(new SacrificeOpponentsEffect(filter));
+        ability.addEffect(new TheRingTemptsYouEffect());
+        this.addAbility(ability);
+
+        // Discard a card: Witch-king of Angmar gains indestructible until end of turn. Tap it.
+        this.addAbility(new SimpleActivatedAbility(
+                new GainAbilitySourceEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn),
+                new DiscardCardCost()
+        ));
+    }
+
+    private WitchKingOfAngmar(final WitchKingOfAngmar card) {
+        super(card);
+    }
+
+    @Override
+    public WitchKingOfAngmar copy() {
+        return new WitchKingOfAngmar(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/TheLordOfTheRingsTalesOfMiddleEarth.java
+++ b/Mage.Sets/src/mage/sets/TheLordOfTheRingsTalesOfMiddleEarth.java
@@ -278,6 +278,7 @@ public final class TheLordOfTheRingsTalesOfMiddleEarth extends ExpansionSet {
         cards.add(new SetCardInfo("Warbeast of Gorgoroth", 152, Rarity.COMMON, mage.cards.w.WarbeastOfGorgoroth.class));
         cards.add(new SetCardInfo("Westfold Rider", 37, Rarity.COMMON, mage.cards.w.WestfoldRider.class));
         cards.add(new SetCardInfo("Willow-Wind", 76, Rarity.COMMON, mage.cards.w.WillowWind.class));
+        cards.add(new SetCardInfo("Witch-king of Angmar", 114, Rarity.MYTHIC, mage.cards.w.WitchKingOfAngmar.class));
         cards.add(new SetCardInfo("Witch-king, Bringer of Ruin", 293, Rarity.RARE, mage.cards.w.WitchKingBringerOfRuin.class));
         cards.add(new SetCardInfo("Wizard's Rockets", 252, Rarity.COMMON, mage.cards.w.WizardsRockets.class));
         cards.add(new SetCardInfo("Wose Pathfinder", 190, Rarity.COMMON, mage.cards.w.WosePathfinder.class));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ltr/WitchKingOfAngmarTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ltr/WitchKingOfAngmarTest.java
@@ -42,7 +42,7 @@ public class WitchKingOfAngmarTest extends CardTestPlayerBase {
 
     @Test
     public void testIndestructible() {
-        addCard(Zone.BATTLEFIELD, playerA, witchKing, 1, true);
+        addCard(Zone.BATTLEFIELD, playerA, witchKing, 1);
         addCard(Zone.HAND, playerA, "Swamp", 5);
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Discard a card:");

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ltr/WitchKingOfAngmarTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ltr/WitchKingOfAngmarTest.java
@@ -1,0 +1,62 @@
+package org.mage.test.cards.single.ltr;
+
+import mage.abilities.keyword.IndestructibleAbility;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class WitchKingOfAngmarTest extends CardTestPlayerBase {
+    static final String witchKing = "Witch-king of Angmar";
+    @Test
+    public void testSacrifice() {
+        setStrictChooseMode(true);
+
+        String watchwolf = "Watchwolf";
+        String swallower = "Simic Sky Swallower"; // Has shroud - should still be a choice
+
+        addCard(Zone.BATTLEFIELD, playerA, witchKing, 1, true);
+        addCard(Zone.HAND, playerA, "Swamp", 5);
+
+        addCard(Zone.BATTLEFIELD, playerB, watchwolf, 1);
+        addCard(Zone.BATTLEFIELD, playerB, swallower, 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Nivix Cyclops", 1);
+
+        attack(2, playerB, watchwolf);
+        attack(2, playerB, swallower);
+        checkStackObject("Sacrifice trigger check", 2, PhaseStep.COMBAT_DAMAGE, playerB, "Whenever one or more creatures deal combat damage to you", 1);
+
+        // Choose which creature to sacrifice
+        addTarget(playerB, watchwolf);
+
+        // The ring tempts you choice:
+        setChoice(playerA, witchKing);
+
+        setStopAt(2, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertLife(playerA, 20 - 3 - 6);
+        // Player B had to sacrifice one permanent:
+        assertPermanentCount(playerB, 2);
+    }
+
+    @Test
+    public void testIndestructible() {
+        addCard(Zone.BATTLEFIELD, playerA, witchKing, 1, true);
+        addCard(Zone.HAND, playerA, "Swamp", 5);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Discard a card:");
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertAbility(playerA, witchKing, IndestructibleAbility.getInstance(), true);
+        assertTapped(witchKing, true);
+        assertHandCount(playerA, 4);
+
+        setStopAt(2, PhaseStep.UNTAP);
+        execute();
+
+        assertAbility(playerA, witchKing, IndestructibleAbility.getInstance(), false);
+    }
+}

--- a/Mage/src/main/java/mage/constants/TargetController.java
+++ b/Mage/src/main/java/mage/constants/TargetController.java
@@ -22,6 +22,7 @@ public enum TargetController {
     OPPONENT,
     TEAM,
     OWNER,
+    CONTROLLER,
     CONTROLLER_ATTACHED_TO,
     NEXT,
     EACH_PLAYER,

--- a/Mage/src/main/java/mage/constants/TargetController.java
+++ b/Mage/src/main/java/mage/constants/TargetController.java
@@ -22,13 +22,13 @@ public enum TargetController {
     OPPONENT,
     TEAM,
     OWNER,
-    CONTROLLER,
     CONTROLLER_ATTACHED_TO,
     NEXT,
     EACH_PLAYER,
     ENCHANTED,
     SOURCE_TARGETS,
-    MONARCH;
+    MONARCH,
+    SOURCE_CONTROLLER;
 
     private final OwnerPredicate ownerPredicate;
     private final PlayerPredicate playerPredicate;
@@ -79,6 +79,8 @@ public enum TargetController {
                 case ENCHANTED:
                     Permanent permanent = input.getSource().getSourcePermanentIfItStillExists(game);
                     return permanent != null && input.getObject().isOwnedBy(permanent.getAttachedTo());
+                case SOURCE_CONTROLLER:
+                    return card.isOwnedBy(input.getSource().getControllerId());
                 case SOURCE_TARGETS:
                     return card.isOwnedBy(input.getSource().getFirstTarget());
                 case MONARCH:
@@ -120,8 +122,10 @@ public enum TargetController {
                             game.getPlayer(playerId).hasOpponent(player.getId(), game);
                 case NOT_YOU:
                     return !player.getId().equals(playerId);
+                case SOURCE_CONTROLLER:
+                    return player.getId().equals(input.getSource().getControllerId());
                 case SOURCE_TARGETS:
-                    return player.equals(input.getSource().getFirstTarget());
+                    return player.getId().equals(input.getSource().getFirstTarget());
                 case MONARCH:
                     return player.getId().equals(game.getMonarchId());
                 default:
@@ -163,6 +167,8 @@ public enum TargetController {
                 case ENCHANTED:
                     Permanent permanent = input.getSource().getSourcePermanentIfItStillExists(game);
                     return permanent != null && input.getObject().isControlledBy(permanent.getAttachedTo());
+                case SOURCE_CONTROLLER:
+                    return object.isControlledBy(input.getSource().getControllerId());
                 case SOURCE_TARGETS:
                     return object.isControlledBy(input.getSource().getFirstTarget());
                 case MONARCH:

--- a/Mage/src/main/java/mage/filter/predicate/other/DamagedPlayerThisTurnPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/other/DamagedPlayerThisTurnPredicate.java
@@ -1,5 +1,6 @@
 package mage.filter.predicate.other;
 
+import mage.abilities.Ability;
 import mage.constants.TargetController;
 import mage.filter.predicate.ObjectSourcePlayer;
 import mage.filter.predicate.ObjectSourcePlayerPredicate;
@@ -35,24 +36,18 @@ public class DamagedPlayerThisTurnPredicate implements ObjectSourcePlayerPredica
 
         switch (controller) {
             case YOU:
-                if (playerDealtDamageBy(playerId, objectId, game)) {
-                    return true;
-                }
-                break;
-            case OWNER:
-                Permanent permanent = game.getPermanent(input.getSource().getSourceId());
-                UUID ownerId = permanent.getOwnerId();
-                if (playerDealtDamageBy(ownerId, objectId, game)) {
-                    return true;
-                }
-                break;
+                return playerDealtDamageBy(playerId, objectId, game);
+            case CONTROLLER:
+                return game.getAbility(input.getSource().getId(), input.getSourceId()).map(
+                        ability -> playerDealtDamageBy(ability.getControllerId(), objectId, game)
+                ).orElse(false);
             case OPPONENT:
                 for (UUID opponentId : game.getOpponents(playerId)) {
                     if (playerDealtDamageBy(opponentId, objectId, game)) {
                         return true;
                     }
                 }
-                break;
+                return false;
             case NOT_YOU:
                 for (UUID notYouId : game.getState().getPlayersInRange(playerId, game)) {
                     if (!notYouId.equals(playerId)) {
@@ -61,17 +56,17 @@ public class DamagedPlayerThisTurnPredicate implements ObjectSourcePlayerPredica
                         }
                     }
                 }
-                break;
+                return false;
             case ANY:
                 for (UUID anyId : game.getState().getPlayersInRange(playerId, game)) {
                     if (playerDealtDamageBy(anyId, objectId, game)) {
                         return true;
                     }
                 }
-                break;
+                return false;
+            default:
+                return false;
         }
-
-        return false;
     }
 
     private boolean playerDealtDamageBy(UUID playerId, UUID objectId, Game game) {

--- a/Mage/src/main/java/mage/filter/predicate/other/DamagedPlayerThisTurnPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/other/DamagedPlayerThisTurnPredicate.java
@@ -70,7 +70,7 @@ public class DamagedPlayerThisTurnPredicate implements ObjectSourcePlayerPredica
                 }
                 return false;
             default:
-                return false;
+                throw new UnsupportedOperationException("TargetController not supported");
         }
     }
 

--- a/Mage/src/main/java/mage/filter/predicate/other/DamagedPlayerThisTurnPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/other/DamagedPlayerThisTurnPredicate.java
@@ -30,26 +30,21 @@ public class DamagedPlayerThisTurnPredicate implements ObjectSourcePlayerPredica
     @Override
     public boolean apply(ObjectSourcePlayer<Controllable> input, Game game) {
         Controllable object = input.getObject();
+        UUID objectId = object.getId();
         UUID playerId = input.getPlayerId();
 
         switch (controller) {
             case YOU:
                 PlayerDamagedBySourceWatcher watcher = game.getState().getWatcher(PlayerDamagedBySourceWatcher.class, playerId);
                 if (watcher != null) {
-                    if (combatDamageOnly) {
-                        return watcher.hasSourceDoneCombatDamage(object.getId(), game);
-                    }
-                    return watcher.hasSourceDoneDamage(object.getId(), game);
+                    return watcherApplies(watcher, objectId, game);
                 }
                 break;
             case OPPONENT:
                 for (UUID opponentId : game.getOpponents(playerId)) {
                     watcher = game.getState().getWatcher(PlayerDamagedBySourceWatcher.class, opponentId);
                     if (watcher != null) {
-                        if (combatDamageOnly) {
-                            return watcher.hasSourceDoneCombatDamage(object.getId(), game);
-                        }
-                        return watcher.hasSourceDoneDamage(object.getId(), game);
+                        return watcherApplies(watcher, objectId, game);
                     }
                 }
                 break;
@@ -58,10 +53,7 @@ public class DamagedPlayerThisTurnPredicate implements ObjectSourcePlayerPredica
                     if (!notYouId.equals(playerId)) {
                         watcher = game.getState().getWatcher(PlayerDamagedBySourceWatcher.class, notYouId);
                         if (watcher != null) {
-                            if (combatDamageOnly) {
-                                return watcher.hasSourceDoneCombatDamage(object.getId(), game);
-                            }
-                            return watcher.hasSourceDoneDamage(object.getId(), game);
+                            return watcherApplies(watcher, objectId, game);
                         }
                     }
                 }
@@ -70,16 +62,20 @@ public class DamagedPlayerThisTurnPredicate implements ObjectSourcePlayerPredica
                 for (UUID anyId : game.getState().getPlayersInRange(playerId, game)) {
                     watcher = game.getState().getWatcher(PlayerDamagedBySourceWatcher.class, anyId);
                     if (watcher != null) {
-                        if (combatDamageOnly) {
-                            return watcher.hasSourceDoneCombatDamage(object.getId(), game);
-                        }
-                        return watcher.hasSourceDoneDamage(object.getId(), game);
+                        return watcherApplies(watcher, objectId, game);
                     }
                 }
                 return true;
         }
 
         return false;
+    }
+
+    private boolean watcherApplies(PlayerDamagedBySourceWatcher watcher, UUID objectId, Game game) {
+        if (combatDamageOnly) {
+            return watcher.hasSourceDoneCombatDamage(objectId, game);
+        }
+        return watcher.hasSourceDoneDamage(objectId, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/filter/predicate/other/DamagedPlayerThisTurnPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/other/DamagedPlayerThisTurnPredicate.java
@@ -5,6 +5,7 @@ import mage.filter.predicate.ObjectSourcePlayer;
 import mage.filter.predicate.ObjectSourcePlayerPredicate;
 import mage.game.Controllable;
 import mage.game.Game;
+import mage.game.permanent.Permanent;
 import mage.watchers.common.PlayerDamagedBySourceWatcher;
 
 import java.util.UUID;
@@ -35,6 +36,13 @@ public class DamagedPlayerThisTurnPredicate implements ObjectSourcePlayerPredica
         switch (controller) {
             case YOU:
                 if (playerDealtDamageBy(playerId, objectId, game)) {
+                    return true;
+                }
+                break;
+            case OWNER:
+                Permanent permanent = game.getPermanent(input.getSource().getSourceId());
+                UUID ownerId = permanent.getOwnerId();
+                if (playerDealtDamageBy(ownerId, objectId, game)) {
                     return true;
                 }
                 break;

--- a/Mage/src/main/java/mage/filter/predicate/other/DamagedPlayerThisTurnPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/other/DamagedPlayerThisTurnPredicate.java
@@ -16,8 +16,15 @@ public class DamagedPlayerThisTurnPredicate implements ObjectSourcePlayerPredica
 
     private final TargetController controller;
 
+    private final boolean combatDamageOnly;
+
     public DamagedPlayerThisTurnPredicate(TargetController controller) {
+        this(controller, false);
+    }
+
+    public DamagedPlayerThisTurnPredicate(TargetController controller, boolean combatDamageOnly) {
         this.controller = controller;
+        this.combatDamageOnly = combatDamageOnly;
     }
 
     @Override
@@ -29,6 +36,9 @@ public class DamagedPlayerThisTurnPredicate implements ObjectSourcePlayerPredica
             case YOU:
                 PlayerDamagedBySourceWatcher watcher = game.getState().getWatcher(PlayerDamagedBySourceWatcher.class, playerId);
                 if (watcher != null) {
+                    if (combatDamageOnly) {
+                        return watcher.hasSourceDoneCombatDamage(object.getId(), game);
+                    }
                     return watcher.hasSourceDoneDamage(object.getId(), game);
                 }
                 break;
@@ -36,6 +46,9 @@ public class DamagedPlayerThisTurnPredicate implements ObjectSourcePlayerPredica
                 for (UUID opponentId : game.getOpponents(playerId)) {
                     watcher = game.getState().getWatcher(PlayerDamagedBySourceWatcher.class, opponentId);
                     if (watcher != null) {
+                        if (combatDamageOnly) {
+                            return watcher.hasSourceDoneCombatDamage(object.getId(), game);
+                        }
                         return watcher.hasSourceDoneDamage(object.getId(), game);
                     }
                 }
@@ -45,6 +58,9 @@ public class DamagedPlayerThisTurnPredicate implements ObjectSourcePlayerPredica
                     if (!notYouId.equals(playerId)) {
                         watcher = game.getState().getWatcher(PlayerDamagedBySourceWatcher.class, notYouId);
                         if (watcher != null) {
+                            if (combatDamageOnly) {
+                                return watcher.hasSourceDoneCombatDamage(object.getId(), game);
+                            }
                             return watcher.hasSourceDoneDamage(object.getId(), game);
                         }
                     }
@@ -54,6 +70,9 @@ public class DamagedPlayerThisTurnPredicate implements ObjectSourcePlayerPredica
                 for (UUID anyId : game.getState().getPlayersInRange(playerId, game)) {
                     watcher = game.getState().getWatcher(PlayerDamagedBySourceWatcher.class, anyId);
                     if (watcher != null) {
+                        if (combatDamageOnly) {
+                            return watcher.hasSourceDoneCombatDamage(object.getId(), game);
+                        }
                         return watcher.hasSourceDoneDamage(object.getId(), game);
                     }
                 }

--- a/Mage/src/main/java/mage/watchers/common/PlayerDamagedBySourceWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/PlayerDamagedBySourceWatcher.java
@@ -6,8 +6,8 @@ import java.util.Set;
 import java.util.UUID;
 import mage.constants.WatcherScope;
 import mage.game.Game;
+import mage.game.events.DamagedEvent;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.util.CardUtil;
 import mage.watchers.Watcher;
 
@@ -19,6 +19,7 @@ import mage.watchers.Watcher;
 public class PlayerDamagedBySourceWatcher extends Watcher {
 
     private final Set<String> damageSourceIds = new HashSet<>();
+    private final Set<String> combatDamageSourceIds = new HashSet<>();
 
     public PlayerDamagedBySourceWatcher() {
         super(WatcherScope.PLAYER);
@@ -28,7 +29,11 @@ public class PlayerDamagedBySourceWatcher extends Watcher {
     public void watch(GameEvent event, Game game) {
         if (event.getType() == GameEvent.EventType.DAMAGED_PLAYER) {
             if (event.getTargetId().equals(controllerId)) {
-                damageSourceIds.add(CardUtil.getCardZoneString(null, event.getSourceId(), game));
+                String sourceId = CardUtil.getCardZoneString(null, event.getSourceId(), game);
+                damageSourceIds.add(sourceId);
+                if (((DamagedEvent) event).isCombatDamage()) {
+                    combatDamageSourceIds.add(sourceId);
+                }
             }
         }
     }
@@ -43,6 +48,10 @@ public class PlayerDamagedBySourceWatcher extends Watcher {
      */
     public boolean hasSourceDoneDamage(UUID sourceId, Game game) {
         return damageSourceIds.contains(CardUtil.getCardZoneString(null, sourceId, game));
+    }
+
+    public boolean hasSourceDoneCombatDamage(UUID sourceId, Game game) {
+        return combatDamageSourceIds.contains(CardUtil.getCardZoneString(null, sourceId, game));
     }
 
     @Override


### PR DESCRIPTION
Card was generated with `gen-card.pl`.

I added a boolean parameter to DamagedPlayerThisTurnPredicate which chooses whether to ignore non-combat damage. This was achieved by adding another method to PlayerDamagedBySourceWatcher.

The indestructible ability code was copied from [[Bloodsword Knight]], with the cost changed of course.

I've been testing on a local test server using the 'Quick 2 player' feature.

The opponent loves to discard cards to activate the ability constantly - not sure if this is something I need to fix or not.

The sacrifice choice wasn't working properly, which took me a while to debug but I eventually figured out that the filter in the SacrificeOpponentsEffect is relative to the player who is sacrificing, not the player who controls the permanent with the effect.

I think that the non-YOU cases in the DamagedPlayerThisTurnPredicate were wrong previously. This has not been noticed because those modes haven't been used on any cards yet. They were previously getting the first match and returning true or false based on that match, rather than OR'ing them together, which is what I'm doing now. Let me know if I'm wrong on this.

I'm happy to write some unit tests for this, just let me know what I need to do.