### PR TITLE
Lazotep Convert fix

### DIFF
--- a/Mage.Sets/src/mage/cards/l/LazotepConvert.java
+++ b/Mage.Sets/src/mage/cards/l/LazotepConvert.java
@@ -63,7 +63,7 @@ class LazotepConvertCopyEffect extends OneShotEffect {
             blueprint.getPower().setModifiedBaseValue(4);
             blueprint.getToughness().setModifiedBaseValue(4);
             blueprint.addSubType(SubType.ZOMBIE);
-            blueprint.getColor().setColor(ObjectColor.BLACK);
+            blueprint.getColor().addColor(ObjectColor.BLACK);
             return true;
         }
     };
@@ -93,8 +93,11 @@ class LazotepConvertCopyEffect extends OneShotEffect {
         if (copyFromCard == null) {
             return true;
         }
+        Card modifiedCopy = copyFromCard.copy();
+        //Appliers must be applied before CopyEffect, its applier setting is just for copies of copies
+        applier.apply(game, modifiedCopy, source, source.getSourceId());
         game.addEffect(new CopyEffect(
-                Duration.Custom, copyFromCard, source.getSourceId()
+                Duration.Custom, modifiedCopy, source.getSourceId()
         ).setApplier(applier), source);
         return true;
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/copy/LazotepConvertTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/copy/LazotepConvertTest.java
@@ -1,0 +1,46 @@
+package org.mage.test.cards.copy;
+
+import mage.constants.PhaseStep;
+import mage.constants.SubType;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+import java.util.stream.Collectors;
+
+/**
+ * @author notgreat
+ */
+public class LazotepConvertTest extends CardTestPlayerBase {
+    @Test
+    public void testInvastionAmonkhetTransformed() {
+        addCard(Zone.BATTLEFIELD, playerA, "Badlands", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Underground Sea", 3);
+        addCard(Zone.GRAVEYARD, playerA, "Mutagen Connoisseur", 1);
+        addCard(Zone.HAND, playerA, "Invasion of Amonkhet");
+        addCard(Zone.HAND, playerA,"Char" );
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Invasion of Amonkhet");
+        waitStackResolved(1,PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Char", "Invasion of Amonkhet");
+        //setChoice(playerA,true);
+        //addTarget(playerA,"Mutagen Connoisseur");
+        //These are auto-chosen by the AI
+
+        //Should make a 4/4 BGU Vedalken Mutant Zombie
+        //And count as transformed, so it's a 5/4
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        currentGame.debugMessage("Graveyard: "+currentGame.getPlayer(playerA.getId()).getGraveyard().stream()
+                .map(x -> currentGame.getObject(x).getClass().getSimpleName()).collect(Collectors.toList()));
+
+        assertPermanentCount(playerA, "Mutagen Connoisseur", 1);
+        assertGraveyardCount(playerA, "Mutagen Connoisseur", 1);
+        assertSubtype("Mutagen Connoisseur", SubType.ZOMBIE);
+        assertSubtype("Mutagen Connoisseur", SubType.VEDALKEN);
+        assertColor(playerA,"Mutagen Connoisseur","BGU",true);
+        assertPowerToughness(playerA,"Mutagen Connoisseur",5,4);
+    }
+}
+

--- a/Mage/src/main/java/mage/abilities/effects/common/CopyEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CopyEffect.java
@@ -136,8 +136,14 @@ public class CopyEffect extends ContinuousEffectImpl {
         permanent.setStartingDefense(copyFromObject.getStartingDefense());
         if (copyFromObject instanceof Permanent) {
             Permanent targetPermanent = (Permanent) copyFromObject;
-            permanent.setTransformed(targetPermanent.isTransformed());
-            permanent.setSecondCardFace(targetPermanent.getSecondCardFace());
+            //707.2. When copying an object, the copy acquires the copiable values of the original object’s characteristics [..]
+            //110.5. A permanent's status is its physical state. There are four status categories, each of which has two possible values:
+            // tapped/untapped, flipped/unflipped, face up/face down, and phased in/phased out.
+            // Each permanent always has one of these values for each of these categories.
+            //110.5a Status is not a characteristic, though it may affect a permanent’s characteristics.
+            //Being transformed is not a copiable characteristic, nor is the back side of a DFC
+            //permanent.setTransformed(targetPermanent.isTransformed());
+            //permanent.setSecondCardFace(targetPermanent.getSecondCardFace());
             permanent.setFlipCard(targetPermanent.isFlipCard());
             permanent.setFlipCardName(targetPermanent.getFlipCardName());
         }


### PR DESCRIPTION
Lazotep Convert did not apply its blueprint modification and thus was not becoming a 4/4 black zombie. It also needed to use addColor rather than setColor.

In addition, Lazotep Convert wasn't counting as a transformed permanent. The "transformed" status is not a copiable characteristic and shouldn't be copied.

Fixes #10274