### PR TITLE
[ONE] Fix Elesh Norn, Mother of Machines preventing triggers from non-permanents.

### DIFF
--- a/Mage.Sets/src/mage/cards/e/EleshNornMotherOfMachines.java
+++ b/Mage.Sets/src/mage/cards/e/EleshNornMotherOfMachines.java
@@ -119,13 +119,26 @@ class EleshNornMotherOfMachinesPreventionEffect extends ContinuousRuleModifyingE
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         Ability ability = (Ability) getValue("targetAbility");
-        if (ability != null && ability.getAbilityType() == AbilityType.TRIGGERED && game.getOpponents(source.getControllerId()).contains(ability.getControllerId())) {
-            Permanent enteringPermanent = ((EntersTheBattlefieldEvent) event).getTarget();
-            if (enteringPermanent != null) {
-                return (((TriggeredAbility) ability).checkTrigger(event, game));
-            }
+        if(ability == null || ability.getAbilityType() != AbilityType.TRIGGERED) {
+            return false;
         }
-        return false;
+
+        // Elesh Norn should not prevent Bloodghast trigger from the graveyard.
+        // This checks that the trigger originated from a permanent.
+        if(ability.getSourcePermanentOrLKI(game) == null) {
+            return false;
+        }
+
+        if (!game.getOpponents(source.getControllerId()).contains(ability.getControllerId())) {
+            return false;
+        }
+
+        Permanent enteringPermanent = ((EntersTheBattlefieldEvent) event).getTarget();
+        if (enteringPermanent == null) {
+            return false;
+        }
+
+        return (((TriggeredAbility) ability).checkTrigger(event, game));
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/one/EleshNornMotherOfMachinesTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/one/EleshNornMotherOfMachinesTest.java
@@ -28,8 +28,11 @@ public class EleshNornMotherOfMachinesTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Arashin Cleric");
+
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        setStrictChooseMode(true);
         execute();
+
         assertLife(playerA, 20);
     }
 
@@ -59,6 +62,7 @@ public class EleshNornMotherOfMachinesTest extends CardTestPlayerBase {
         setChoice(playerA, true); // Yes to the bloodghast trigger.
 
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        setStrictChooseMode(true);
         execute();
 
         assertPermanentCount(playerA, "Bloodghast", 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/one/EleshNornMotherOfMachinesTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/one/EleshNornMotherOfMachinesTest.java
@@ -1,0 +1,67 @@
+package org.mage.test.cards.single.one;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author Susucr
+ */
+public class EleshNornMotherOfMachinesTest extends CardTestPlayerBase {
+
+    @Test
+    public void test_EleshNorn_PreventEtb() {
+        // Elesh Norn, Mother of Machines
+        // Vigilance
+        // If a permanent entering the battlefield causes a triggered ability of a
+        // permanent you control to trigger, that ability triggers an additional time.
+        //
+        // Permanents entering the battlefield don't cause abilities of permanents
+        // your opponents control to trigger.
+        addCard(Zone.BATTLEFIELD, playerB, "Elesh Norn, Mother of Machines");
+
+        // Arashin Cleric - {1}[W}
+        // When Arashin Cleric enters the battlefield, you gain 3 life.
+        addCard(Zone.HAND, playerA, "Arashin Cleric");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Arashin Cleric");
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+        assertLife(playerA, 20);
+    }
+
+
+    @Test
+    public void test_EleshNorn_DoNotStopBloodghast() {
+        // Elesh Norn, Mother of Machines
+        //
+        // Vigilance
+        // If a permanent entering the battlefield causes a triggered ability of a
+        // permanent you control to trigger, that ability triggers an additional time.
+        //
+        // Permanents entering the battlefield don't cause abilities of permanents
+        // your opponents control to trigger.
+        addCard(Zone.BATTLEFIELD, playerB, "Elesh Norn, Mother of Machines");
+
+        // Bloodghast
+        //
+        // Bloodghast can't block.
+        // Bloodghast has haste as long as an opponent has 10 or less life.
+        // Landfall — Whenever a land enters the battlefield under your control,
+        // you may return Bloodghast from your graveyard to the battlefield.
+        addCard(Zone.GRAVEYARD, playerA, "Bloodghast");
+        addCard(Zone.HAND, playerA, "Forest");
+
+        playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Forest");
+        setChoice(playerA, true); // Yes to the bloodghast trigger.
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Bloodghast", 1);
+    }
+
+}


### PR DESCRIPTION
Elesh Norn, Mother of Machines has a weirdly worded replacement effect.
There was no check that the source of the trigger was a permanent.

This caused Bloodghast (and there may be others?) to not trigger on landfall, altough it should not be prevented.