### PR TITLE
[CLB] fix Druid of the Emeral Grove

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DruidOfTheEmeraldGrove.java
+++ b/Mage.Sets/src/mage/cards/d/DruidOfTheEmeraldGrove.java
@@ -108,7 +108,7 @@ class DruidOfTheEmeraldGroveEffect extends RollDieWithResultTableEffect {
                     break;
                 default:
                     TargetCard target = new TargetCardInLibrary();
-                    player.choose(outcome, target, source, game);
+                    player.choose(outcome, cards, target, source, game);
                     card = cards.get(target.getFirstTarget(), game);
             }
             if (card != null) {
@@ -119,7 +119,7 @@ class DruidOfTheEmeraldGroveEffect extends RollDieWithResultTableEffect {
                 cards.remove(card);
             }
             player.moveCards(cards, Zone.HAND, source, game);
-        } else if (amount != 20) {
+        } else {
             player.moveCards(
                     cards.getCards(game), Zone.BATTLEFIELD, source, game,
                     true, false, false, null


### PR DESCRIPTION
10-19 locked the game in a choose action with no choice.
20 was broken due to a wrong boolean logic.

fix #10581