### PR TITLE
Fix RevealTargetFromHandCost when no target in hand

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MartyrOfBones.java
+++ b/Mage.Sets/src/mage/cards/m/MartyrOfBones.java
@@ -86,7 +86,7 @@ class RevealVariableBlackCardsFromHandCost extends VariableCostImpl {
 
     RevealVariableBlackCardsFromHandCost() {
         super(VariableCostType.NORMAL, "black cards to reveal");
-        this.text = "Reveal " + xText + " black cards from {this}";
+        this.text = "Reveal " + xText + " black cards from your hand";
     }
 
     RevealVariableBlackCardsFromHandCost(final RevealVariableBlackCardsFromHandCost cost) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/SerraAscendantTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/SerraAscendantTest.java
@@ -44,7 +44,7 @@ public class SerraAscendantTest extends CardTestPlayerBase {
         
         playLand(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Plains");
         castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Martyr of Sands", true);
-        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}, You may reveal X white cards from your hand");
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}, Reveal X white cards from your hand");
         setChoice(playerA, "Silvercoat Lion");
         setChoice(playerA, "Silvercoat Lion");
         setChoice(playerA, "Silvercoat Lion");

--- a/Mage/src/main/java/mage/abilities/costs/common/RevealTargetFromHandCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/RevealTargetFromHandCost.java
@@ -1,8 +1,5 @@
 package mage.abilities.costs.common;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.costs.Cost;
@@ -15,6 +12,10 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 /**
  *
  * @author jeffwadsworth
@@ -25,9 +26,12 @@ public class RevealTargetFromHandCost extends CostImpl {
     protected int numberCardsRevealed = 0;
     protected List<Card> revealedCards;
 
+    private boolean allowNoReveal;
+
     public RevealTargetFromHandCost(TargetCardInHand target) {
         this.addTarget(target);
-        this.text = (target.getNumberOfTargets() == 0 ? "you may reveal " : "reveal ") + target.getDescription();
+        this.allowNoReveal = target.getNumberOfTargets() == 0;
+        this.text = (this.allowNoReveal ? "you may reveal " : "reveal ") + target.getDescription();
         this.revealedCards = new ArrayList<>();
     }
 
@@ -36,6 +40,7 @@ public class RevealTargetFromHandCost extends CostImpl {
         this.manaValues = cost.manaValues;
         this.numberCardsRevealed = cost.numberCardsRevealed;
         this.revealedCards = new ArrayList<>(cost.revealedCards);
+        this.allowNoReveal = cost.allowNoReveal;
     }
 
     @Override
@@ -62,7 +67,11 @@ public class RevealTargetFromHandCost extends CostImpl {
                 paid = true; // e.g. for optional additional costs.  example: Dragonlord's Prerogative also true if 0 cards shown
                 return paid;
             }
+        } else if(allowNoReveal) {
+            paid = true; // optional reveal with nothing to reveal.
+            return paid;
         }
+
         paid = false;
         return paid;
     }
@@ -81,7 +90,7 @@ public class RevealTargetFromHandCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return targets.canChoose(controllerId, source, game);
+        return allowNoReveal || targets.canChoose(controllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/costs/common/RevealTargetFromHandCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/RevealTargetFromHandCost.java
@@ -31,7 +31,7 @@ public class RevealTargetFromHandCost extends CostImpl {
     public RevealTargetFromHandCost(TargetCardInHand target) {
         this.addTarget(target);
         this.allowNoReveal = target.getNumberOfTargets() == 0;
-        this.text = (this.allowNoReveal ? "you may reveal " : "reveal ") + target.getDescription();
+        this.text = "reveal " + target.getDescription();
         this.revealedCards = new ArrayList<>();
     }
 


### PR DESCRIPTION
The decision of payment was not quite right when there was no valid choice for the target filtered cards, on optional cost.

fix #10590 