### PR TITLE
Adding chess timer

### DIFF
--- a/Mage.Client/src/main/java/mage/client/components/HoverButton.java
+++ b/Mage.Client/src/main/java/mage/client/components/HoverButton.java
@@ -57,6 +57,7 @@ public class HoverButton extends JPanel implements MouseListener {
     private Command observer = null;
     private Command onHover = null;
     private Color textColor = Color.white;
+    private Color topTextColor = null;
     private final Rectangle centerTextArea = new Rectangle(5, 18, 75, 40);
     private Color centerTextColor = new Color(200, 210, 0, 200);
     private Color origCenterTextColor = new Color(200, 210, 0, 200);
@@ -152,7 +153,7 @@ public class HoverButton extends JPanel implements MouseListener {
             topTextOffsetX = calculateOffsetForTop(g2d, topText);
             g2d.setColor(textBGColor);
             g2d.drawString(topText, topTextOffsetX + 1, 14);
-            g2d.setColor(textColor);
+            g2d.setColor(topTextColor != null ? topTextColor : textColor);
             g2d.drawString(topText, topTextOffsetX, 13);
         }
         if (topTextImage != null) {
@@ -233,6 +234,15 @@ public class HoverButton extends JPanel implements MouseListener {
 
     public void setTextColor(Color textColor) {
         this.textColor = textColor;
+    }
+
+    /**
+     * Overrides textColor for the upper text if non-null.
+     * If null, return back to textColor.
+     * @param textColor
+     */
+    public void setTopTextColor(Color textColor) {
+        this.topTextColor = textColor;
     }
 
     public void setOverlayImage(Image image) {

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.form
@@ -364,6 +364,14 @@
     </Component>
     <Component class="javax.swing.JComboBox" name="cbTimeLimit">
     </Component>
+    <Component class="javax.swing.JLabel" name="lbBufferTime">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Buffer Time:"/>
+        <Property name="toolTipText" type="java.lang.String" value="The extra time a player gets whenever the timer starts before their normal time limit starts going down."/>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JComboBox" name="cbBufferTime">
+    </Component>
     <Component class="javax.swing.JLabel" name="lblGameType">
       <Properties>
         <Property name="text" type="java.lang.String" value="Game Type:"/>

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.java
@@ -8,6 +8,7 @@ import mage.client.table.TablePlayerPanel;
 import mage.client.util.Event;
 import mage.client.util.IgnoreList;
 import mage.client.util.Listener;
+import mage.constants.MatchBufferTime;
 import mage.constants.MatchTimeLimit;
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.RangeOfInfluence;
@@ -85,6 +86,8 @@ public class NewTableDialog extends MageDialog {
         cbDeckType = new javax.swing.JComboBox();
         lbTimeLimit = new javax.swing.JLabel();
         cbTimeLimit = new javax.swing.JComboBox();
+        lbBufferTime = new javax.swing.JLabel();
+        cbBufferTime = new javax.swing.JComboBox();
         lblGameType = new javax.swing.JLabel();
         cbGameType = new javax.swing.JComboBox();
         chkRollbackTurnsAllowed = new javax.swing.JCheckBox();
@@ -189,6 +192,9 @@ public class NewTableDialog extends MageDialog {
 
         lbTimeLimit.setText("Time Limit:");
         lbTimeLimit.setToolTipText("The active time a player may use to finish the match. If their time runs out, the player looses the current game.");
+
+        lbBufferTime.setText("Buffer Time:");
+        lbBufferTime.setToolTipText("The extra time a player gets whenever the timer starts before their normal time limit starts going down.");
 
         lblGameType.setText("Game Type:");
 
@@ -332,7 +338,11 @@ public class NewTableDialog extends MageDialog {
                                                                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                                                                 .addComponent(lbTimeLimit)
                                                                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                                                                .addComponent(cbTimeLimit, javax.swing.GroupLayout.PREFERRED_SIZE, 102, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                                                .addComponent(cbTimeLimit, javax.swing.GroupLayout.PREFERRED_SIZE, 100, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                                                .addComponent(lbBufferTime)
+                                                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                                                .addComponent(cbBufferTime, javax.swing.GroupLayout.PREFERRED_SIZE, 100, javax.swing.GroupLayout.PREFERRED_SIZE)
                                                                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                                                                 .addComponent(lblPassword)
                                                                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -412,6 +422,8 @@ public class NewTableDialog extends MageDialog {
                                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                                                 .addComponent(cbTimeLimit)
                                                 .addComponent(lbTimeLimit)
+                                                .addComponent(cbBufferTime)
+                                                .addComponent(lbBufferTime)
                                                 .addComponent(lblPassword)
                                                 .addComponent(txtPassword)
                                                 .addComponent(chkSpectatorsAllowed)))
@@ -604,6 +616,7 @@ public class NewTableDialog extends MageDialog {
         }
         options.setDeckType((String) this.cbDeckType.getSelectedItem());
         options.setMatchTimeLimit((MatchTimeLimit) this.cbTimeLimit.getSelectedItem());
+        options.setMatchBufferTime((MatchBufferTime) this.cbBufferTime.getSelectedItem());
         options.setAttackOption((MultiplayerAttackOption) this.cbAttackOption.getSelectedItem());
         options.setSkillLevel((SkillLevel) this.cbSkillLevel.getSelectedItem());
         options.setRange((RangeOfInfluence) this.cbRange.getSelectedItem());
@@ -801,6 +814,7 @@ public class NewTableDialog extends MageDialog {
             cbDeckType.setModel(new DefaultComboBoxModel(SessionHandler.getDeckTypes()));
             selectLimitedByDefault();
             cbTimeLimit.setModel(new DefaultComboBoxModel(MatchTimeLimit.values()));
+            cbBufferTime.setModel(new DefaultComboBoxModel(MatchBufferTime.values()));
             cbRange.setModel(new DefaultComboBoxModel(RangeOfInfluence.values()));
             cbAttackOption.setModel(new DefaultComboBoxModel(MultiplayerAttackOption.values()));
             cbSkillLevel.setModel(new DefaultComboBoxModel(SkillLevel.values()));
@@ -878,6 +892,14 @@ public class NewTableDialog extends MageDialog {
         for (MatchTimeLimit mtl : MatchTimeLimit.values()) {
             if (mtl.getTimeLimit() == timeLimit) {
                 this.cbTimeLimit.setSelectedItem(mtl);
+                break;
+            }
+        }
+        // TODO: Rethink defaults with buffer time?
+        int bufferTime = Integer.parseInt(PreferencesDialog.getCachedValue(PreferencesDialog.KEY_NEW_TABLE_BUFFER_TIME + versionStr, "0"));
+        for (MatchBufferTime mtl : MatchBufferTime.values()) {
+            if (mtl.getBufferTime() == bufferTime) {
+                this.cbBufferTime.setSelectedItem(mtl);
                 break;
             }
         }
@@ -985,6 +1007,7 @@ public class NewTableDialog extends MageDialog {
     private javax.swing.JComboBox cbRange;
     private javax.swing.JComboBox cbSkillLevel;
     private javax.swing.JComboBox cbTimeLimit;
+    private javax.swing.JComboBox cbBufferTime;
     private javax.swing.JCheckBox chkPlaneChase;
     private javax.swing.JCheckBox chkRated;
     private javax.swing.JCheckBox chkRollbackTurnsAllowed;
@@ -996,6 +1019,7 @@ public class NewTableDialog extends MageDialog {
     private javax.swing.JSeparator jSeparator3;
     private javax.swing.JLabel lbDeckType;
     private javax.swing.JLabel lbTimeLimit;
+    private javax.swing.JLabel lbBufferTime;
     private javax.swing.JLabel lblAttack;
     private javax.swing.JLabel lblEdhPowerLevel;
     private javax.swing.JLabel lblFreeMulligans;

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.form
@@ -373,6 +373,20 @@
         <Property name="toolTipText" type="java.lang.String" value="The time a player has for the whole match. If a player runs out of time during a game, they lose the complete match. "/>
       </Properties>
     </Component>
+    <Component class="javax.swing.JLabel" name="lbBufferTime">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Buffer Time:"/>
+        <Property name="toolTipText" type="java.lang.String" value="The time a player gets whenever their timer starts before their match time starts going down. "/>
+      </Properties>
+      <BindingProperties>
+        <BindingProperty name="labelFor" source="cbBufferTime" target="lbBufferTime" targetPath="labelFor" updateStrategy="0" immediately="false"/>
+      </BindingProperties>
+    </Component>
+    <Component class="javax.swing.JComboBox" name="cbBufferTime">
+      <Properties>
+        <Property name="toolTipText" type="java.lang.String" value="The time a player gets whenever their timer starts before their match time starts going down. "/>
+      </Properties>
+    </Component>
     <Component class="javax.swing.JLabel" name="lbSkillLevel">
       <Properties>
         <Property name="text" type="java.lang.String" value="Skill Level:"/>

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
@@ -18,6 +18,7 @@ import mage.client.SessionHandler;
 import mage.client.table.TournamentPlayerPanel;
 import mage.client.util.IgnoreList;
 import mage.client.util.gui.FastSearchUtil;
+import mage.constants.MatchBufferTime;
 import mage.constants.MatchTimeLimit;
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.RangeOfInfluence;
@@ -85,6 +86,7 @@ public class NewTournamentDialog extends MageDialog {
             cbDeckType.setModel(new DefaultComboBoxModel(SessionHandler.getDeckTypes()));
 
             cbTimeLimit.setModel(new DefaultComboBoxModel(MatchTimeLimit.values()));
+            cbBufferTime.setModel(new DefaultComboBoxModel(MatchBufferTime.values()));
             cbSkillLevel.setModel(new DefaultComboBoxModel(SkillLevel.values()));
             cbDraftCube.setModel(new DefaultComboBoxModel(SessionHandler.getDraftCubes()));
             cbDraftTiming.setModel(new DefaultComboBoxModel(Arrays.stream(TimingOption.values())
@@ -131,6 +133,8 @@ public class NewTournamentDialog extends MageDialog {
         txtName = new javax.swing.JTextField();
         lbTimeLimit = new javax.swing.JLabel();
         cbTimeLimit = new javax.swing.JComboBox();
+        lbBufferTime = new javax.swing.JLabel();
+        cbBufferTime = new javax.swing.JComboBox();
         lbSkillLevel = new javax.swing.JLabel();
         cbSkillLevel = new javax.swing.JComboBox();
         lblPassword = new javax.swing.JLabel();
@@ -245,6 +249,16 @@ public class NewTournamentDialog extends MageDialog {
         bindingGroup.addBinding(binding);
 
         cbTimeLimit.setToolTipText("The time a player has for the whole match. If a player runs out of time during a game, they lose the complete match. ");
+
+        lbBufferTime.setText("Buffer Time:");
+        lbBufferTime.setToolTipText(
+                "The time a player gets whenever their timer starts before their match time starts going down. ");
+
+        org.jdesktop.beansbinding.Binding binding2 = org.jdesktop.beansbinding.Bindings.createAutoBinding( org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, cbBufferTime, org.jdesktop.beansbinding.ObjectProperty.create(), lbBufferTime, org.jdesktop.beansbinding.BeanProperty.create("labelFor"));
+        bindingGroup.addBinding(binding2);
+
+        cbBufferTime.setToolTipText(
+                "The time a player gets whenever their timer starts before their match time starts going down. ");
 
         lbSkillLevel.setText("Skill Level:");
         lbSkillLevel.setToolTipText("The time a player has for the whole match. If a player runs out of time during a game, they lose the complete match. ");
@@ -552,7 +566,11 @@ public class NewTournamentDialog extends MageDialog {
                                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                                 .addComponent(lbTimeLimit)
                                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                                .addComponent(cbTimeLimit, javax.swing.GroupLayout.PREFERRED_SIZE, 101, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                .addComponent(cbTimeLimit, javax.swing.GroupLayout.PREFERRED_SIZE, 90, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                .addComponent(lbBufferTime)
+                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                .addComponent(cbBufferTime, javax.swing.GroupLayout.PREFERRED_SIZE, 90, javax.swing.GroupLayout.PREFERRED_SIZE)
                                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                                 .addComponent(lblPassword)
                                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -573,6 +591,8 @@ public class NewTournamentDialog extends MageDialog {
                                         .addComponent(lblName)
                                         .addComponent(lbTimeLimit)
                                         .addComponent(cbTimeLimit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(lbBufferTime)
+                                        .addComponent(cbBufferTime, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                                         .addComponent(lblPassword)
                                         .addComponent(txtPassword, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                                         .addComponent(cbAllowSpectators, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
@@ -1338,6 +1358,7 @@ public class NewTournamentDialog extends MageDialog {
         tOptions.getMatchOptions().setBannedUsers(IgnoreList.getIgnoredUsers(serverAddress));
 
         tOptions.getMatchOptions().setMatchTimeLimit((MatchTimeLimit) this.cbTimeLimit.getSelectedItem());
+        tOptions.getMatchOptions().setMatchBufferTime((MatchBufferTime) this.cbBufferTime.getSelectedItem());
         tOptions.getMatchOptions().setSkillLevel((SkillLevel) this.cbSkillLevel.getSelectedItem());
         tOptions.getMatchOptions().setWinsNeeded((Integer) this.spnNumWins.getValue());
         tOptions.getMatchOptions().setFreeMulligans((Integer) this.spnFreeMulligans.getValue());
@@ -1359,6 +1380,14 @@ public class NewTournamentDialog extends MageDialog {
         for (MatchTimeLimit mtl : MatchTimeLimit.values()) {
             if (mtl.getTimeLimit() == timeLimit) {
                 this.cbTimeLimit.setSelectedItem(mtl);
+                break;
+            }
+        }
+        // TODO: Rethink default match time with buffer time.
+        int bufferTime = Integer.parseInt(PreferencesDialog.getCachedValue(PreferencesDialog.KEY_NEW_TOURNAMENT_BUFFER_TIME + versionStr, "0"));
+        for (MatchBufferTime mtl : MatchBufferTime.values()) {
+            if (mtl.getBufferTime() == bufferTime) {
+                this.cbBufferTime.setSelectedItem(mtl);
                 break;
             }
         }
@@ -1484,6 +1513,7 @@ public class NewTournamentDialog extends MageDialog {
     private javax.swing.JCheckBox cbPlaneChase;
     private javax.swing.JComboBox cbSkillLevel;
     private javax.swing.JComboBox cbTimeLimit;
+    private javax.swing.JComboBox cbBufferTime;
     private javax.swing.JComboBox cbTournamentType;
     private javax.swing.JCheckBox chkRated;
     private javax.swing.JCheckBox chkRollbackTurnsAllowed;
@@ -1491,6 +1521,7 @@ public class NewTournamentDialog extends MageDialog {
     private javax.swing.JLabel lbDeckType;
     private javax.swing.JLabel lbSkillLevel;
     private javax.swing.JLabel lbTimeLimit;
+    private javax.swing.JLabel lbBufferTime;
     private javax.swing.JLabel lblConstructionTime;
     private javax.swing.JLabel lblDraftCube;
     private javax.swing.JLabel lblFreeMulligans;

--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
@@ -196,6 +196,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
     public static final String KEY_NEW_TABLE_PASSWORD_JOIN = "newTablePasswordJoin";
     public static final String KEY_NEW_TABLE_DECK_TYPE = "newTableDeckType";
     public static final String KEY_NEW_TABLE_TIME_LIMIT = "newTableTimeLimit";
+    public static final String KEY_NEW_TABLE_BUFFER_TIME = "newTableBufferTime";
     public static final String KEY_NEW_TABLE_GAME_TYPE = "newTableGameType";
     public static final String KEY_NEW_TABLE_NUMBER_OF_WINS = "newTableNumberOfWins";
     public static final String KEY_NEW_TABLE_ROLLBACK_TURNS_ALLOWED = "newTableRollbackTurnsAllowed";
@@ -218,6 +219,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
     public static final String KEY_NEW_TOURNAMENT_NAME = "newTournamentName";
     public static final String KEY_NEW_TOURNAMENT_PASSWORD = "newTournamentPassword";
     public static final String KEY_NEW_TOURNAMENT_TIME_LIMIT = "newTournamentTimeLimit";
+    public static final String KEY_NEW_TOURNAMENT_BUFFER_TIME = "newTournamentBufferTime";
     public static final String KEY_NEW_TOURNAMENT_CONSTR_TIME = "newTournamentConstructionTime";
     public static final String KEY_NEW_TOURNAMENT_TYPE = "newTournamentType";
     public static final String KEY_NEW_TOURNAMENT_NUMBER_OF_FREE_MULLIGANS = "newTournamentNumberOfFreeMulligans";

--- a/Mage.Client/src/main/java/mage/client/game/GamePanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/GamePanel.java
@@ -603,8 +603,9 @@ public final class GamePanel extends javax.swing.JPanel {
             }
         }
         PlayerView player = game.getPlayers().get(playerSeat);
-        PlayAreaPanel playAreaPanel = new PlayAreaPanel(player, bigCard, gameId, game.getPriorityTime(), this,
-                new PlayAreaPanelOptions(game.isPlayer(), player.isHuman(), game.isPlayer(), game.isRollbackTurnsAllowed(), row == 0));
+        PlayAreaPanel playAreaPanel = new PlayAreaPanel(player, bigCard, gameId, game.getPriorityTime(),
+                game.getBufferTime(), this, new PlayAreaPanelOptions(game.isPlayer(), player.isHuman(), game.isPlayer(),
+                        game.isRollbackTurnsAllowed(), row == 0));
         players.put(player.getPlayerId(), playAreaPanel);
         playersWhoLeft.put(player.getPlayerId(), false);
         GridBagConstraints c = new GridBagConstraints();
@@ -647,8 +648,9 @@ public final class GamePanel extends javax.swing.JPanel {
                 col = numColumns - 1;
             }
             player = game.getPlayers().get(playerNum);
-            PlayAreaPanel playerPanel = new PlayAreaPanel(player, bigCard, gameId, game.getPriorityTime(), this,
-                    new PlayAreaPanelOptions(game.isPlayer(), player.isHuman(), false, game.isRollbackTurnsAllowed(), row == 0));
+            PlayAreaPanel playerPanel = new PlayAreaPanel(player, bigCard, gameId, game.getPriorityTime(),
+                    game.getBufferTime(), this, new PlayAreaPanelOptions(game.isPlayer(), player.isHuman(), false,
+                            game.isRollbackTurnsAllowed(), row == 0));
             players.put(player.getPlayerId(), playerPanel);
             playersWhoLeft.put(player.getPlayerId(), false);
             c = new GridBagConstraints();

--- a/Mage.Client/src/main/java/mage/client/game/GamePanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/GamePanel.java
@@ -603,8 +603,8 @@ public final class GamePanel extends javax.swing.JPanel {
             }
         }
         PlayerView player = game.getPlayers().get(playerSeat);
-        PlayAreaPanel playAreaPanel = new PlayAreaPanel(player, bigCard, gameId, game.getPriorityTime(),
-                game.getBufferTime(), this, new PlayAreaPanelOptions(game.isPlayer(), player.isHuman(), game.isPlayer(),
+        PlayAreaPanel playAreaPanel = new PlayAreaPanel(player, bigCard, gameId, game.getPriorityTime(), this,
+                new PlayAreaPanelOptions(game.isPlayer(), player.isHuman(), game.isPlayer(),
                         game.isRollbackTurnsAllowed(), row == 0));
         players.put(player.getPlayerId(), playAreaPanel);
         playersWhoLeft.put(player.getPlayerId(), false);
@@ -648,9 +648,9 @@ public final class GamePanel extends javax.swing.JPanel {
                 col = numColumns - 1;
             }
             player = game.getPlayers().get(playerNum);
-            PlayAreaPanel playerPanel = new PlayAreaPanel(player, bigCard, gameId, game.getPriorityTime(),
-                    game.getBufferTime(), this, new PlayAreaPanelOptions(game.isPlayer(), player.isHuman(), false,
-                            game.isRollbackTurnsAllowed(), row == 0));
+            PlayAreaPanel playerPanel = new PlayAreaPanel(player, bigCard, gameId, game.getPriorityTime(), this,
+                    new PlayAreaPanelOptions(game.isPlayer(), player.isHuman(), false, game.isRollbackTurnsAllowed(),
+                            row == 0));
             players.put(player.getPlayerId(), playerPanel);
             playersWhoLeft.put(player.getPlayerId(), false);
             c = new GridBagConstraints();

--- a/Mage.Client/src/main/java/mage/client/game/PlayAreaPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/PlayAreaPanel.java
@@ -57,8 +57,8 @@ public class PlayAreaPanel extends javax.swing.JPanel {
      * @param gamePanel
      * @param options
      */
-    public PlayAreaPanel(PlayerView player, BigCard bigCard, UUID gameId, int priorityTime, int bufferTime,
-            GamePanel gamePanel, PlayAreaPanelOptions options) {
+    public PlayAreaPanel(PlayerView player, BigCard bigCard, UUID gameId, int priorityTime, GamePanel gamePanel,
+            PlayAreaPanelOptions options) {
         this.gamePanel = gamePanel;
         this.options = options;
         initComponents();
@@ -74,7 +74,7 @@ public class PlayAreaPanel extends javax.swing.JPanel {
         this.add(popupMenu);
         setGUISize();
 
-        init(player, bigCard, gameId, priorityTime, bufferTime);
+        init(player, bigCard, gameId, priorityTime);
         update(null, player, null);
     }
 
@@ -510,8 +510,8 @@ public class PlayAreaPanel extends javax.swing.JPanel {
 
     }
 
-    public final void init(PlayerView player, BigCard bigCard, UUID gameId, int priorityTime, int bufferTime) {
-        this.playerPanel.init(gameId, player.getPlayerId(), player.getControlled(), bigCard, priorityTime, bufferTime);
+    public final void init(PlayerView player, BigCard bigCard, UUID gameId, int priorityTime) {
+        this.playerPanel.init(gameId, player.getPlayerId(), player.getControlled(), bigCard, priorityTime);
         this.battlefieldPanel.init(gameId, bigCard);
         this.gameId = gameId;
         this.playerId = player.getPlayerId();

--- a/Mage.Client/src/main/java/mage/client/game/PlayAreaPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/PlayAreaPanel.java
@@ -57,7 +57,8 @@ public class PlayAreaPanel extends javax.swing.JPanel {
      * @param gamePanel
      * @param options
      */
-    public PlayAreaPanel(PlayerView player, BigCard bigCard, UUID gameId, int priorityTime, GamePanel gamePanel, PlayAreaPanelOptions options) {
+    public PlayAreaPanel(PlayerView player, BigCard bigCard, UUID gameId, int priorityTime, int bufferTime,
+            GamePanel gamePanel, PlayAreaPanelOptions options) {
         this.gamePanel = gamePanel;
         this.options = options;
         initComponents();
@@ -73,7 +74,7 @@ public class PlayAreaPanel extends javax.swing.JPanel {
         this.add(popupMenu);
         setGUISize();
 
-        init(player, bigCard, gameId, priorityTime);
+        init(player, bigCard, gameId, priorityTime, bufferTime);
         update(null, player, null);
     }
 
@@ -509,8 +510,8 @@ public class PlayAreaPanel extends javax.swing.JPanel {
 
     }
 
-    public final void init(PlayerView player, BigCard bigCard, UUID gameId, int priorityTime) {
-        this.playerPanel.init(gameId, player.getPlayerId(), player.getControlled(), bigCard, priorityTime);
+    public final void init(PlayerView player, BigCard bigCard, UUID gameId, int priorityTime, int bufferTime) {
+        this.playerPanel.init(gameId, player.getPlayerId(), player.getControlled(), bigCard, priorityTime, bufferTime);
         this.battlefieldPanel.init(gameId, bigCard);
         this.gameId = gameId;
         this.playerId = player.getPlayerId();

--- a/Mage.Client/src/main/java/mage/client/game/PlayerPanelExt.java
+++ b/Mage.Client/src/main/java/mage/client/game/PlayerPanelExt.java
@@ -88,8 +88,7 @@ public class PlayerPanelExt extends javax.swing.JPanel {
         deadBackgroundColor = currentTheme.getPlayerPanel_deadBackgroundColor();
     }
 
-    public void init(UUID gameId, UUID playerId, boolean controlled, BigCard bigCard, int priorityTime,
-            int bufferTime) {
+    public void init(UUID gameId, UUID playerId, boolean controlled, BigCard bigCard, int priorityTime) {
         this.gameId = gameId;
         this.playerId = playerId;
         this.bigCard = bigCard;
@@ -99,15 +98,19 @@ public class PlayerPanelExt extends javax.swing.JPanel {
         if (priorityTime > 0) {
             long delay = 1000L;
 
-            timer = new PriorityTimer(priorityTime, bufferTime, delay, () -> {
+            timer = new PriorityTimer(priorityTime, delay, () -> {
                 // do nothing
             });
             final PriorityTimer pt = timer;
             timer.setTaskOnTick(() -> {
-                int priorityTimeValue = pt.getCount();
+                int priorityTimeValue = pt.getCount() + pt.getBufferCount();
                 String text = getPriorityTimeLeftString(priorityTimeValue);
+
                 PlayerPanelExt.this.avatar.setTopText(text);
+                PlayerPanelExt.this.avatar.setTopTextColor(pt.getBufferCount() > 0 ? Color.GREEN : null);
                 PlayerPanelExt.this.timerLabel.setText(text);
+                PlayerPanelExt.this.timerLabel
+                        .setForeground(pt.getBufferCount() > 0 ? Color.GREEN.darker().darker() : Color.BLACK);
                 PlayerPanelExt.this.avatar.repaint();
             });
             timer.init(gameId);
@@ -305,8 +308,13 @@ public class PlayerPanelExt extends javax.swing.JPanel {
             if (player.getPriorityTimeLeft() != Integer.MAX_VALUE) {
                 String priorityTimeValue = getPriorityTimeLeftString(player);
                 this.timer.setCount(player.getPriorityTimeLeft());
+                this.timer.setBufferCount(player.getBufferTimeLeft());
                 this.avatar.setTopText(priorityTimeValue);
                 this.timerLabel.setText(priorityTimeValue);
+
+                this.avatar.setTopTextColor(player.getBufferTimeLeft() > 0 ? Color.GREEN : null);
+                this.timerLabel
+                        .setForeground(player.getBufferTimeLeft() > 0 ? Color.GREEN.darker().darker() : Color.BLACK);
             }
             if (player.isTimerActive()) {
                 this.timer.resume();
@@ -397,7 +405,7 @@ public class PlayerPanelExt extends javax.swing.JPanel {
     }
 
     private String getPriorityTimeLeftString(PlayerView player) {
-        int priorityTimeLeft = player.getPriorityTimeLeft();
+        int priorityTimeLeft = player.getPriorityTimeLeft() + player.getBufferTimeLeft();
         return getPriorityTimeLeftString(priorityTimeLeft);
     }
 

--- a/Mage.Client/src/main/java/mage/client/game/PlayerPanelExt.java
+++ b/Mage.Client/src/main/java/mage/client/game/PlayerPanelExt.java
@@ -88,7 +88,8 @@ public class PlayerPanelExt extends javax.swing.JPanel {
         deadBackgroundColor = currentTheme.getPlayerPanel_deadBackgroundColor();
     }
 
-    public void init(UUID gameId, UUID playerId, boolean controlled, BigCard bigCard, int priorityTime) {
+    public void init(UUID gameId, UUID playerId, boolean controlled, BigCard bigCard, int priorityTime,
+            int bufferTime) {
         this.gameId = gameId;
         this.playerId = playerId;
         this.bigCard = bigCard;
@@ -98,7 +99,7 @@ public class PlayerPanelExt extends javax.swing.JPanel {
         if (priorityTime > 0) {
             long delay = 1000L;
 
-            timer = new PriorityTimer(priorityTime, delay, () -> {
+            timer = new PriorityTimer(priorityTime, bufferTime, delay, () -> {
                 // do nothing
             });
             final PriorityTimer pt = timer;

--- a/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
+++ b/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
@@ -1708,6 +1708,7 @@ public class TablesPanel extends javax.swing.JPanel {
             options.setRange(RangeOfInfluence.ONE);
             options.setWinsNeeded(2);
             options.setMatchTimeLimit(MatchTimeLimit.NONE);
+            options.setMatchBufferTime(MatchBufferTime.NONE);
             options.setFreeMulligans(2);
             options.setSkillLevel(SkillLevel.CASUAL);
             options.setRollbackTurnsAllowed(true);

--- a/Mage.Common/src/main/java/mage/utils/timer/PriorityTimer.java
+++ b/Mage.Common/src/main/java/mage/utils/timer/PriorityTimer.java
@@ -16,10 +16,9 @@ public class PriorityTimer extends TimerTask {
 
     private final long delay;
     private final Action taskOnTimeout;
-    private final int buffer;
 
     private int count;
-    private int bufferCount;
+    private int bufferCount = 0;
     private Action taskOnTick;
     private States state = States.NONE;
 
@@ -31,9 +30,8 @@ public class PriorityTimer extends TimerTask {
         FINISHED
     }
 
-    public PriorityTimer(int count, int buffer, long delay, Action taskOnTimeout) {
+    public PriorityTimer(int count, long delay, Action taskOnTimeout) {
         this.count = count;
-        this.buffer = buffer;
         this.delay = delay;
         this.taskOnTimeout = taskOnTimeout;
     }
@@ -53,8 +51,6 @@ public class PriorityTimer extends TimerTask {
             throw new IllegalStateException("Timer has already finished its work");
         }
         state = States.RUNNING;
-        // Set buffer time
-        this.bufferCount = buffer;
     }
 
     public void pause() {
@@ -71,8 +67,6 @@ public class PriorityTimer extends TimerTask {
             throw new IllegalStateException("Timer has already finished its work");
         }
         state = States.RUNNING;
-        // Reset buffer time whenever we resume
-        bufferCount = buffer;
     }
 
     public int getCount() {
@@ -81,6 +75,14 @@ public class PriorityTimer extends TimerTask {
 
     public void setCount(int count) {
         this.count = count;
+    }
+
+    public int getBufferCount() {
+        return bufferCount;
+    }
+
+    public void setBufferCount(int count) {
+        this.bufferCount = count;
     }
 
     public void setTaskOnTick(Action taskOnTick) {

--- a/Mage.Common/src/main/java/mage/view/GameView.java
+++ b/Mage.Common/src/main/java/mage/view/GameView.java
@@ -315,6 +315,10 @@ public class GameView implements Serializable {
         return priorityTime;
     }
 
+    public int getBufferTime() {
+        return bufferTime;
+    }
+
     public UUID getActivePlayerId() {
         return activePlayerId;
     }

--- a/Mage.Common/src/main/java/mage/view/GameView.java
+++ b/Mage.Common/src/main/java/mage/view/GameView.java
@@ -42,6 +42,7 @@ public class GameView implements Serializable {
 
     private static final Logger LOGGER = Logger.getLogger(GameView.class);
     private final int priorityTime;
+    private final int bufferTime;
     private final List<PlayerView> players = new ArrayList<>();
     private CardsView hand;
     private PlayableObjectsList canPlayObjects;
@@ -68,6 +69,7 @@ public class GameView implements Serializable {
         Player createdForPlayer = null;
         this.isPlayer = createdForPlayerId != null;
         this.priorityTime = game.getPriorityTime();
+        this.bufferTime = game.getBufferTime();
         for (Player player : state.getPlayers().values()) {
             players.add(new PlayerView(player, state, game, createdForPlayerId, watcherUserId));
             if (player.getId().equals(createdForPlayerId)) {

--- a/Mage.Common/src/main/java/mage/view/PlayerView.java
+++ b/Mage.Common/src/main/java/mage/view/PlayerView.java
@@ -47,6 +47,7 @@ public class PlayerView implements Serializable {
     private final List<UUID> attachments = new ArrayList<>();
     private final int statesSavedSize;
     private final int priorityTimeLeft;
+    private final int bufferTimeLeft;
     private final boolean passedTurn; // F4
     private final boolean passedUntilEndOfTurn; // F5
     private final boolean passedUntilNextMain; // F6
@@ -74,6 +75,7 @@ public class PlayerView implements Serializable {
         this.isActive = (player.getId().equals(state.getActivePlayerId()));
         this.hasPriority = player.getId().equals(state.getPriorityPlayerId());
         this.priorityTimeLeft = player.getPriorityTimeLeft();
+        this.bufferTimeLeft = player.getBufferTimeLeft();
         this.timerActive = (this.hasPriority && player.isGameUnderControl())
                 || (player.getPlayersUnderYourControl().contains(state.getPriorityPlayerId()))
                 || player.getId().equals(game.getState().getChoosingPlayerId());
@@ -273,6 +275,10 @@ public class PlayerView implements Serializable {
 
     public int getPriorityTimeLeft() {
         return priorityTimeLeft;
+    }
+
+    public int getBufferTimeLeft() {
+        return bufferTimeLeft;
     }
 
     public boolean hasPriority() {

--- a/Mage.Common/src/main/java/mage/view/TableView.java
+++ b/Mage.Common/src/main/java/mage/view/TableView.java
@@ -98,6 +98,7 @@ public class TableView implements Serializable {
             if (table.getMatch().getGames().isEmpty()) {
                 addInfo.append("Wins:").append(table.getMatch().getWinsNeeded());
                 addInfo.append(" Time: ").append(table.getMatch().getOptions().getMatchTimeLimit().toString());
+                addInfo.append(" Buffer: ").append(table.getMatch().getOptions().getMatchBufferTime().toString());
                 if (table.getMatch().getFreeMulligans() > 0) {
                     addInfo.append(" FM: ").append(table.getMatch().getFreeMulligans());
                 }
@@ -150,6 +151,7 @@ public class TableView implements Serializable {
                         stateText.append(" (").append(table.getTournament().getPlayers().size()).append('/').append(table.getNumberOfSeats()).append(')');
                     }
                     infoText.append(" Time: ").append(table.getTournament().getOptions().getMatchOptions().getMatchTimeLimit().toString());
+                    infoText.append(" Buffer: ").append(table.getTournament().getOptions().getMatchOptions().getMatchBufferTime().toString());
                     if (table.getTournament().getOptions().getMatchOptions().getFreeMulligans() > 0) {
                         infoText.append(" FM: ").append(table.getTournament().getOptions().getMatchOptions().getFreeMulligans());
                     }

--- a/Mage.Server/src/main/java/mage/server/game/GameController.java
+++ b/Mage.Server/src/main/java/mage/server/game/GameController.java
@@ -142,7 +142,7 @@ public class GameController implements GameCallback {
                                 if (initPlayerId == null) {
                                     throw new MageException("INIT_TIMER: playerId can't be null");
                                 }
-                                createPlayerTimer(event.getPlayerId(), game.getPriorityTime());
+                                createPlayerTimer(event.getPlayerId(), game.getPriorityTime(), game.getBufferTime());
                                 break;
                             case RESUME_TIMER:
                                 playerId = event.getPlayerId();
@@ -153,7 +153,8 @@ public class GameController implements GameCallback {
                                 if (timer == null) {
                                     Player player = game.getState().getPlayer(playerId);
                                     if (player != null) {
-                                        timer = createPlayerTimer(event.getPlayerId(), player.getPriorityTimeLeft());
+                                        timer = createPlayerTimer(event.getPlayerId(), player.getPriorityTimeLeft(),
+                                                game.getBufferTime());
                                     } else {
                                         throw new MageException("RESUME_TIMER: player can't be null");
                                     }
@@ -251,9 +252,10 @@ public class GameController implements GameCallback {
      *
      * @param playerId
      * @param count
+     * @param buffer The amount of buffer to tick down before ticking down count
      * @return
      */
-    private PriorityTimer createPlayerTimer(UUID playerId, int count) {
+    private PriorityTimer createPlayerTimer(UUID playerId, int count, int buffer) {
         final UUID initPlayerId = playerId;
         long delayMs = 250L; // run each 250 ms
 
@@ -262,7 +264,7 @@ public class GameController implements GameCallback {
             logger.debug("Player has no time left to end the match: " + initPlayerId + ". Conceding.");
         };
 
-        PriorityTimer timer = new PriorityTimer(count, delayMs, executeOnNoTimeLeft);
+        PriorityTimer timer = new PriorityTimer(count, buffer, delayMs, executeOnNoTimeLeft);
         timer.init(game.getId());
         timers.put(playerId, timer);
         return timer;

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -3838,6 +3838,16 @@ public class TestPlayer implements Player {
     }
 
     @Override
+    public void setBufferTimeLeft(int timeLeft) {
+        computerPlayer.setBufferTimeLeft(timeLeft);
+    }
+
+    @Override
+    public int getBufferTimeLeft() {
+        return computerPlayer.getBufferTimeLeft();
+    }
+
+    @Override
     public boolean hasQuit() {
         return computerPlayer.hasQuit();
     }

--- a/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
+++ b/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
@@ -1140,6 +1140,16 @@ public class PlayerStub implements Player {
     }
 
     @Override
+    public void setBufferTimeLeft(int timeLeft) {
+
+    }
+
+    @Override
+    public int getBufferTimeLeft() {
+        return 0;
+    }
+
+    @Override
     public void setReachedNextTurnAfterLeaving(boolean reachedNextTurnAfterLeaving) {
 
     }

--- a/Mage/src/main/java/mage/constants/MatchBufferTime.java
+++ b/Mage/src/main/java/mage/constants/MatchBufferTime.java
@@ -1,0 +1,38 @@
+package mage.constants;
+
+/**
+ * The time a player receives whenever the timer starts. This ticks down before their normal time,
+ * and refreshes to full every time the timer starts, creating a sort of buffer. Similar to how to
+ * chess clocks work.
+ * 
+ * Based off of MatchTimeLimit
+ *
+ * @author alexander-novo
+ */
+public enum MatchBufferTime {
+    NONE(0, "None"),
+    MIN__10(5, "5 Seconds"),
+    MIN__15(10, "10 Seconds"),
+    MIN__20(15, "15 Seconds");
+
+    private final int matchSeconds;
+    private final String name;
+
+    MatchBufferTime(int matchSeconds, String name) {
+        this.matchSeconds = matchSeconds;
+        this.name = name;
+    }
+
+    public int getBufferTime() {
+        return matchSeconds;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/Mage/src/main/java/mage/constants/MatchBufferTime.java
+++ b/Mage/src/main/java/mage/constants/MatchBufferTime.java
@@ -11,9 +11,12 @@ package mage.constants;
  */
 public enum MatchBufferTime {
     NONE(0, "None"),
-    MIN__10(5, "5 Seconds"),
-    MIN__15(10, "10 Seconds"),
-    MIN__20(15, "15 Seconds");
+    SEC__05(5, "5 Seconds"),
+    SEC__10(10, "10 Seconds"),
+    SEC__15(15, "15 Seconds"),
+    SEC__20(20, "20 Seconds"),
+    SEC__25(25, "25 Seconds"),
+    SEC__30(30, "30 Seconds");
 
     private final int matchSeconds;
     private final String name;

--- a/Mage/src/main/java/mage/game/Game.java
+++ b/Mage/src/main/java/mage/game/Game.java
@@ -528,6 +528,10 @@ public interface Game extends MageItem, Serializable, Copyable<Game> {
 
     void setPriorityTime(int priorityTime);
 
+    int getBufferTime();
+
+    void setBufferTime(int bufferTime);
+
     UUID getStartingPlayerId();
 
     void setStartingPlayerId(UUID startingPlayerId);

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -142,7 +142,8 @@ public abstract class GameImpl implements Game {
 
     private boolean scopeRelevant = false; // replacement effects: used to indicate that currently applied replacement effects have to check for scope relevance (614.12 13/01/18)
     private boolean saveGame = false; // replay code, not done
-    private int priorityTime; // match time limit
+    private int priorityTime; // Match time limit (per player). Set at the start of the match and only goes down.
+    private int bufferTime; // Buffer time before priority time starts going down. Buffer time is refreshed every time the timer starts.
     private final int startingLife;
     private final int startingHandSize;
     protected transient PlayerList playerList; // auto-generated from state, don't copy
@@ -250,6 +251,7 @@ public abstract class GameImpl implements Game {
         this.scopeRelevant = game.scopeRelevant;
         this.saveGame = game.saveGame;
         this.priorityTime = game.priorityTime;
+        this.bufferTime = game.bufferTime;
         this.startingLife = game.startingLife;
         this.startingHandSize = game.startingHandSize;
         //this.playerList = game.playerList; // auto-generated list, don't copy
@@ -3636,6 +3638,16 @@ public abstract class GameImpl implements Game {
     @Override
     public void setPriorityTime(int priorityTime) {
         this.priorityTime = priorityTime;
+    }
+
+    @Override
+    public int getBufferTime() {
+        return bufferTime;
+    }
+
+    @Override
+    public void setBufferTime(int bufferTime) {
+        this.bufferTime = bufferTime;
     }
 
     @Override

--- a/Mage/src/main/java/mage/game/match/MatchImpl.java
+++ b/Mage/src/main/java/mage/game/match/MatchImpl.java
@@ -201,9 +201,11 @@ public abstract class MatchImpl implements Match {
                 // set the priority time left for the match
                 if (games.isEmpty()) { // first game full time
                     matchPlayer.getPlayer().setPriorityTimeLeft(options.getPriorityTime());
+                    matchPlayer.getPlayer().setBufferTimeLeft(options.getBufferTime());
                 } else {
                     if (matchPlayer.getPriorityTimeLeft() > 0) {
                         matchPlayer.getPlayer().setPriorityTimeLeft(matchPlayer.getPriorityTimeLeft());
+                        matchPlayer.getPlayer().setBufferTimeLeft(options.getBufferTime());
                     }
                 }
             } else {

--- a/Mage/src/main/java/mage/game/match/MatchImpl.java
+++ b/Mage/src/main/java/mage/game/match/MatchImpl.java
@@ -213,6 +213,7 @@ public abstract class MatchImpl implements Match {
             }
         }
         game.setPriorityTime(options.getPriorityTime());
+        game.setBufferTime(options.getBufferTime());
     }
 
     protected void shufflePlayers() {

--- a/Mage/src/main/java/mage/game/match/MatchOptions.java
+++ b/Mage/src/main/java/mage/game/match/MatchOptions.java
@@ -1,6 +1,7 @@
 
 package mage.game.match;
 
+import mage.constants.MatchBufferTime;
 import mage.constants.MatchTimeLimit;
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.RangeOfInfluence;
@@ -48,6 +49,7 @@ public class MatchOptions implements Serializable {
      * Time each player has during the game to play using his\her priority.
      */
     protected MatchTimeLimit matchTimeLimit; // 0 = no priorityTime handling
+    protected MatchBufferTime matchBufferTime; // Amount of time each player gets before their normal time limit counts down. Refreshes each time the normal timer is invoked.
     protected MulliganType mulliganType;
 
     /*public MatchOptions(String name, String gameType) {
@@ -158,6 +160,21 @@ public class MatchOptions implements Serializable {
 
     public void setMatchTimeLimit(MatchTimeLimit matchTimeLimit) {
         this.matchTimeLimit = matchTimeLimit;
+    }
+
+    public int getBufferTime() {
+        if (matchBufferTime == null) {
+            return MatchBufferTime.NONE.getBufferTime();
+        }
+        return matchBufferTime.getBufferTime();
+    }
+
+    public MatchBufferTime getMatchBufferTime() {
+        return this.matchBufferTime;
+    }
+
+    public void setMatchBufferTime(MatchBufferTime matchBufferTime) {
+        this.matchBufferTime = matchBufferTime;
     }
 
     public String getPassword() {

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -829,6 +829,20 @@ public interface Player extends MageItem, Copyable<Player> {
      */
     int getPriorityTimeLeft();
 
+    /**
+     * Set seconds left before priority time starts ticking down.
+     *
+     * @param timeLeft
+     */
+    void setBufferTimeLeft(int timeLeft);
+
+    /**
+     * Returns seconds left before priority time starts ticking down.
+     *
+     * @return
+     */
+    int getBufferTimeLeft();
+
     void setReachedNextTurnAfterLeaving(boolean reachedNextTurnAfterLeaving);
 
     boolean hasReachedNextTurnAfterLeaving();

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -119,6 +119,7 @@ public abstract class PlayerImpl implements Player, Serializable {
     protected int turns;
     protected int storedBookmark = -1;
     protected int priorityTimeLeft = Integer.MAX_VALUE;
+    protected int bufferTimeLeft = 0;
 
     // conceded or connection lost game
     protected boolean left;
@@ -277,6 +278,7 @@ public abstract class PlayerImpl implements Player, Serializable {
         this.justActivatedType = player.justActivatedType;
 
         this.priorityTimeLeft = player.getPriorityTimeLeft();
+        this.bufferTimeLeft = player.getBufferTimeLeft();
         this.reachedNextTurnAfterLeaving = player.reachedNextTurnAfterLeaving;
 
         this.castSourceIdWithAlternateMana.addAll(player.getCastSourceIdWithAlternateMana());
@@ -4462,6 +4464,16 @@ public abstract class PlayerImpl implements Player, Serializable {
     @Override
     public int getPriorityTimeLeft() {
         return priorityTimeLeft;
+    }
+
+    @Override
+    public void setBufferTimeLeft(int timeLeft) {
+        bufferTimeLeft = timeLeft;
+    }
+
+    @Override
+    public int getBufferTimeLeft() {
+        return bufferTimeLeft;
     }
 
     @Override


### PR DESCRIPTION
Adding in a chess timer with a "buffer time" which is used before a player's normal time. This buffer time is refreshed every time the timer is invoked, similar to a chess clock. This way players can lower the normal player game time to prevent players from stalling out the game for too long without fear of a long game with many game actions running out their normal clocks.

Some thoughts on WIP stuff that I'd like people's opinions on:

- Current options for Buffer Time are just 5, 10, 15 seconds. Do we need anything longer than this? Or more granular options?
- The default match settings currently are the same game time and no buffer time. 
- I don't think I'm going to add a UI element for the buffer timer in game. It seems like too much work for what it's worth.

![image](https://github.com/magefree/mage/assets/11657716/876d3422-fbce-4e54-8dbc-fbf93b8027da)

![image](https://github.com/magefree/mage/assets/11657716/cac21edf-cd67-44d4-bb43-913036e5d5ef)

Closes #10597 
