### PR TITLE
[LTR] Implement Sting, the Glinting Dagger

### DIFF
--- a/Mage.Sets/src/mage/cards/s/StingTheGlintingDagger.java
+++ b/Mage.Sets/src/mage/cards/s/StingTheGlintingDagger.java
@@ -57,7 +57,7 @@ public final class StingTheGlintingDagger extends CardImpl {
         )));
 
         // Equip {2}
-        this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(2)));
+        this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(2), false));
     }
 
     private StingTheGlintingDagger(final StingTheGlintingDagger card) {

--- a/Mage.Sets/src/mage/cards/s/StingTheGlintingDagger.java
+++ b/Mage.Sets/src/mage/cards/s/StingTheGlintingDagger.java
@@ -1,0 +1,118 @@
+package mage.cards.s;
+
+import mage.abilities.Ability;
+import mage.abilities.common.BeginningOfCombatTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.Condition;
+import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.decorator.ConditionalContinuousEffect;
+import mage.abilities.effects.common.UntapEnchantedEffect;
+import mage.abilities.effects.common.continuous.BoostEquippedEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
+import mage.abilities.keyword.EquipAbility;
+import mage.abilities.keyword.FirstStrikeAbility;
+import mage.abilities.keyword.HasteAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.Predicates;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.watchers.common.BlockingOrBlockedWatcher;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author Susucr
+ */
+public final class StingTheGlintingDagger extends CardImpl {
+
+    public StingTheGlintingDagger(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.EQUIPMENT);
+
+        // Equipped creature gets +1/+1 and has haste.
+        Ability ability = new SimpleStaticAbility(new BoostEquippedEffect(1, 1));
+        ability.addEffect(new GainAbilityAttachedEffect(
+            HasteAbility.getInstance(), AttachmentType.EQUIPMENT
+        ).setText("and has haste"));
+        this.addAbility(ability);
+
+        // At the beginning of each combat, untap equipped creature.
+        this.addAbility(new BeginningOfCombatTriggeredAbility(
+            new UntapEnchantedEffect().setText("untap equipped creature"), //TODO: rename the effect and add AttachmentType to it?
+            TargetController.ANY, false));
+
+        // Equipped creature has first strike as long as it's blocking or blocked by a Goblin or Orc.
+        this.addAbility(new SimpleStaticAbility(
+            new ConditionalContinuousEffect(
+                new GainAbilityAttachedEffect(FirstStrikeAbility.getInstance(), AttachmentType.EQUIPMENT),
+                StingTheGlintingDaggerCondition.instance,
+                "Equipped creature has first strike as long as it's blocking or blocked by a Goblin or Orc."
+        )));
+
+        // Equip {2}
+        this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(2)));
+    }
+
+    private StingTheGlintingDagger(final StingTheGlintingDagger card) {
+        super(card);
+    }
+
+    @Override
+    public StingTheGlintingDagger copy() {
+        return new StingTheGlintingDagger(this);
+    }
+}
+
+enum StingTheGlintingDaggerCondition implements Condition {
+    instance;
+
+    public static final FilterPermanent filterOrcOrGoblin = new FilterCreaturePermanent();
+
+    static {
+        filterOrcOrGoblin.add(Predicates.or(
+            SubType.GOBLIN.getPredicate(),
+            SubType.ORC.getPredicate()
+        ));
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent sting = game.getPermanent(source.getSourceId());
+        if(sting == null){
+            return false;
+        }
+
+        Permanent equippedCreature = game.getPermanent(sting.getAttachedTo());
+        if(equippedCreature == null){
+            return false;
+        }
+
+        if(equippedCreature.isAttacking() && equippedCreature.isBlocked(game)){
+            // equipped creature is currently blocked, time to look for blocking goblin or orc.
+            UUID controllerId = equippedCreature.getControllerId();
+
+            return game.getBattlefield()
+                .getActivePermanents(filterOrcOrGoblin, controllerId, game)
+                .stream()
+                .anyMatch(p -> BlockingOrBlockedWatcher.check(equippedCreature, p, game));
+
+        } else if(equippedCreature.getBlocking() > 0) {
+            // equipped creature is currently blocking, time to look for blocked goblin or orc.
+            UUID controllerId = equippedCreature.getControllerId();
+
+            return game.getBattlefield()
+                .getActivePermanents(filterOrcOrGoblin, controllerId, game)
+                .stream()
+                .anyMatch(p -> BlockingOrBlockedWatcher.check(p, equippedCreature, game));
+        }
+        // creature is neither blocking nor blocked, no first strike from Sting.
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/TheLordOfTheRingsTalesOfMiddleEarth.java
+++ b/Mage.Sets/src/mage/sets/TheLordOfTheRingsTalesOfMiddleEarth.java
@@ -251,6 +251,7 @@ public final class TheLordOfTheRingsTalesOfMiddleEarth extends ExpansionSet {
         cards.add(new SetCardInfo("Stalwarts of Osgiliath", 33, Rarity.COMMON, mage.cards.s.StalwartsOfOsgiliath.class));
         cards.add(new SetCardInfo("Stern Scolding", 71, Rarity.UNCOMMON, mage.cards.s.SternScolding.class));
         cards.add(new SetCardInfo("Stew the Coneys", 189, Rarity.UNCOMMON, mage.cards.s.StewTheConeys.class));
+        cards.add(new SetCardInfo("Sting, the Glinting Dagger", 250, Rarity.RARE, mage.cards.s.StingTheGlintingDagger.class));
         cards.add(new SetCardInfo("Stone of Erech", 251, Rarity.UNCOMMON, mage.cards.s.StoneOfErech.class));
         cards.add(new SetCardInfo("Storm of Saruman", 72, Rarity.MYTHIC, mage.cards.s.StormOfSaruman.class));
         cards.add(new SetCardInfo("Strider, Ranger of the North", 232, Rarity.UNCOMMON, mage.cards.s.StriderRangerOfTheNorth.class));


### PR DESCRIPTION
As an unrelated question with the current code, I did stumble upon something strange.

At that point, I was trying to make a custom predicate `IsBlockedByGoblinAndOrc`.
My idea then was to have the equipped creature been checked by a filter that was
basically `new FilterCreaturePerment().add(IsBlockedByGoblinAndOrc.instance)`.
I had that filter used in a call `filter.match(equippedCreature, game)`, and that
match always returned `true`, to my surprise.

After digging a little, we have `FilterPermanent extends FilterObject<Permanent> extends FilterImpl<Permanent>`
`FilterImpl<>` has a 2 argument match, and `FilterPermanent`, which has all the `extraPredicates`
logic, does not override that one, but instead has a 4 argument one, with an extra `source` and `playerId`
that are used to evaluate the extra predicates. So I do wonder if the 2 argument match from FilterImpl<> should
be protected instead of public. There are currently 68 usage of the 2 argument match outside class that
extend FilterImpl<>, and I feel like half of them could actually have `extraPredicates` that are not
checked, but should?

For instance this method from Battlefield.java does not check `extraPredicates`:
![filtermatch](https://github.com/magefree/mage/assets/34709007/a29c1273-6fc8-4712-87e3-f75afe6494f1)

Other that this potential source of Predicate bugs, Sting is working well, should probably make a separate issue. 
