### PR TITLE
[LTR] Implement King of the Oathbreakers

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AngelicProtector.java
+++ b/Mage.Sets/src/mage/cards/a/AngelicProtector.java
@@ -1,7 +1,7 @@
 package mage.cards.a;
 
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -25,7 +25,7 @@ public final class AngelicProtector extends CardImpl {
         this.toughness = new MageInt(2);
 
         this.addAbility(FlyingAbility.getInstance());
-        this.addAbility(new BecomesTargetTriggeredAbility(
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(
                 new BoostSourceEffect(0, 3, Duration.EndOfTurn)
         ).setTriggerPhrase("Whenever {this} becomes the target of a spell or ability, "));
     }

--- a/Mage.Sets/src/mage/cards/b/BonecrusherGiant.java
+++ b/Mage.Sets/src/mage/cards/b/BonecrusherGiant.java
@@ -1,7 +1,7 @@
 package mage.cards.b;
 
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.continuous.DamageCantBePreventedEffect;
 import mage.cards.AdventureCard;
@@ -28,7 +28,7 @@ public final class BonecrusherGiant extends AdventureCard {
         this.toughness = new MageInt(3);
 
         // Whenever Bonecrusher Giant becomes the target of a spell, Bonecrusher Giant deals 2 damage to that spell's controller.
-        this.addAbility(new BecomesTargetTriggeredAbility(
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(
                 new DamageTargetEffect(
                         2, true, "that spell's controller", "{this}"
                 ), StaticFilters.FILTER_SPELL_A, SetTargetPointer.PLAYER

--- a/Mage.Sets/src/mage/cards/b/BoneshardSlasher.java
+++ b/Mage.Sets/src/mage/cards/b/BoneshardSlasher.java
@@ -4,7 +4,7 @@ package mage.cards.b;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.condition.common.CardsInControllerGraveyardCondition;
 import mage.abilities.decorator.ConditionalContinuousEffect;
@@ -35,7 +35,7 @@ public final class BoneshardSlasher extends CardImpl {
         Ability ability = new SimpleStaticAbility(Zone.BATTLEFIELD, new ConditionalContinuousEffect(
             new BoostSourceEffect(2, 2, Duration.WhileOnBattlefield), new CardsInControllerGraveyardCondition(7),
             "As long as seven or more cards are in your graveyard, {this} gets +2/+2"));
-        Effect effect = new ConditionalContinuousEffect(new GainAbilitySourceEffect(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect())),
+        Effect effect = new ConditionalContinuousEffect(new GainAbilitySourceEffect(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect())),
             new CardsInControllerGraveyardCondition(7), "and has \"When {this} becomes the target of a spell or ability, sacrifice it.\"");
         ability.addEffect(effect);
         ability.setAbilityWord(AbilityWord.THRESHOLD);

--- a/Mage.Sets/src/mage/cards/c/CephalidAristocrat.java
+++ b/Mage.Sets/src/mage/cards/c/CephalidAristocrat.java
@@ -1,7 +1,7 @@
 package mage.cards.c;
 
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.MillCardsControllerEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -22,7 +22,7 @@ public final class CephalidAristocrat extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever Cephalid Aristocrat becomes the target of a spell or ability, put the top two cards of your library into your graveyard.
-        this.addAbility(new BecomesTargetTriggeredAbility(new MillCardsControllerEffect(2)));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new MillCardsControllerEffect(2)));
     }
 
     private CephalidAristocrat(final CephalidAristocrat card) {

--- a/Mage.Sets/src/mage/cards/c/CephalidIllusionist.java
+++ b/Mage.Sets/src/mage/cards/c/CephalidIllusionist.java
@@ -4,7 +4,7 @@ package mage.cards.c;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
@@ -35,7 +35,7 @@ public final class CephalidIllusionist extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Whenever Cephalid Illusionist becomes the target of a spell or ability, put the top three cards of your library into your graveyard.
-        this.addAbility(new BecomesTargetTriggeredAbility(new MillCardsControllerEffect(3)));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new MillCardsControllerEffect(3)));
         
         // {2}{U}, {tap}: Prevent all combat damage that would be dealt to
         Effect effect = new PreventDamageToTargetEffect(Duration.EndOfTurn, true);

--- a/Mage.Sets/src/mage/cards/c/CrystallineNautilus.java
+++ b/Mage.Sets/src/mage/cards/c/CrystallineNautilus.java
@@ -4,7 +4,7 @@ package mage.cards.c;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.SacrificeSourceEffect;
@@ -36,13 +36,13 @@ public final class CrystallineNautilus extends CardImpl {
         this.addAbility(new BestowAbility(this, "{3}{U}{U}"));
         
         // When Crystalline Nautilus becomes the target of a spell or ability, sacrifice it.
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
         
         // Enchanted creature gets +4/+4 and has "When this creature becomes the target of a spell or ability, sacrifice it."        
         Effect effect = new BoostEnchantedEffect(4,4,Duration.WhileOnBattlefield);
         effect.setText("Enchanted creature gets +4/+4");
         Ability ability = new SimpleStaticAbility(Zone.BATTLEFIELD, effect);
-        effect = new GainAbilityAttachedEffect(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect()), AttachmentType.AURA, Duration.WhileOnBattlefield);
+        effect = new GainAbilityAttachedEffect(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect()), AttachmentType.AURA, Duration.WhileOnBattlefield);
         effect.setText("and has \"When this creature becomes the target of a spell or ability, sacrifice it.\"");
         ability.addEffect(effect);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/c/CursedMonstrosity.java
+++ b/Mage.Sets/src/mage/cards/c/CursedMonstrosity.java
@@ -3,7 +3,7 @@ package mage.cards.c;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.costs.common.DiscardTargetCost;
 import mage.abilities.effects.common.SacrificeSourceUnlessPaysEffect;
 import mage.abilities.keyword.FlyingAbility;
@@ -30,7 +30,7 @@ public final class CursedMonstrosity extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // Whenever Cursed Monstrosity becomes the target of a spell or ability, sacrifice it unless you discard a land card.
-        this.addAbility(new BecomesTargetTriggeredAbility(
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(
                             new SacrificeSourceUnlessPaysEffect(
                             new DiscardTargetCost(new TargetCardInHand(new FilterLandCard()))
                 )));

--- a/Mage.Sets/src/mage/cards/d/DepartedDeckhand.java
+++ b/Mage.Sets/src/mage/cards/d/DepartedDeckhand.java
@@ -2,7 +2,7 @@ package mage.cards.d;
 
 import java.util.UUID;
 import mage.abilities.Ability;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
@@ -43,7 +43,7 @@ public final class DepartedDeckhand extends CardImpl {
         this.toughness = new MageInt(2);
 
         // When Departed Deckhand becomes the target of a spell, sacrifice it.
-        this.addAbility(new BecomesTargetTriggeredAbility(
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(
                 new SacrificeSourceEffect(),
                 StaticFilters.FILTER_SPELL_A
         ));

--- a/Mage.Sets/src/mage/cards/d/DismissIntoDream.java
+++ b/Mage.Sets/src/mage/cards/d/DismissIntoDream.java
@@ -3,8 +3,7 @@ package mage.cards.d;
 
 import java.util.UUID;
 import mage.abilities.Ability;
-import mage.abilities.Mode;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.abilities.effects.common.continuous.CreaturesBecomeOtherTypeEffect;
@@ -73,7 +72,7 @@ class DismissIntoDreamEffect extends CreaturesBecomeOtherTypeEffect {
 
         if (layer == Layer.AbilityAddingRemovingEffects_6) {
             for (Permanent object: game.getBattlefield().getActivePermanents(this.filter, source.getControllerId(), game)) {
-                object.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect()), source.getSourceId(), game);
+                object.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect()), source.getSourceId(), game);
             }
         }
 

--- a/Mage.Sets/src/mage/cards/d/DreamStrix.java
+++ b/Mage.Sets/src/mage/cards/d/DreamStrix.java
@@ -2,7 +2,7 @@ package mage.cards.d;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.DiesSourceTriggeredAbility;
 import mage.abilities.effects.common.LearnEffect;
 import mage.abilities.effects.common.SacrificeSourceEffect;
@@ -32,7 +32,7 @@ public final class DreamStrix extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // When Dream Strix becomes the target of a spell, sacrifice it.
-        this.addAbility(new BecomesTargetTriggeredAbility(
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(
                 new SacrificeSourceEffect().setText("sacrifice it"), StaticFilters.FILTER_SPELL_A
         ));
 

--- a/Mage.Sets/src/mage/cards/f/ForceProjection.java
+++ b/Mage.Sets/src/mage/cards/f/ForceProjection.java
@@ -2,9 +2,7 @@ package mage.cards.f;
 
 import java.util.UUID;
 import mage.abilities.Ability;
-import mage.abilities.TriggeredAbility;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
-import mage.abilities.effects.Effect;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
 import mage.abilities.effects.common.SacrificeSourceEffect;
@@ -78,7 +76,7 @@ class ForceProjectionEffect extends OneShotEffect {
             effect.setAdditionalSubType(SubType.SPIRIT);
 
             // and gains "When this creature becomes the target of a spell, sacrifice it."
-            effect.addAdditionalAbilities(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect(), new FilterSpell()));
+            effect.addAdditionalAbilities(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect(), new FilterSpell()));
 
             return effect.apply(game, source);
         }

--- a/Mage.Sets/src/mage/cards/f/FrostWalker.java
+++ b/Mage.Sets/src/mage/cards/f/FrostWalker.java
@@ -3,7 +3,7 @@ package mage.cards.f;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -23,7 +23,7 @@ public final class FrostWalker extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Frost Walker becomes the target of a spell or ability, sacrifice it.
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
     }
 
     private FrostWalker(final FrostWalker card) {

--- a/Mage.Sets/src/mage/cards/f/FugitiveDruid.java
+++ b/Mage.Sets/src/mage/cards/f/FugitiveDruid.java
@@ -3,7 +3,7 @@ package mage.cards.f;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -31,7 +31,7 @@ public final class FugitiveDruid extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever Fugitive Druid becomes the target of an Aura spell, you draw a card.
-        this.addAbility(new BecomesTargetTriggeredAbility(new DrawCardSourceControllerEffect(1), filter));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new DrawCardSourceControllerEffect(1), filter));
     }
 
     private FugitiveDruid(final FugitiveDruid card) {

--- a/Mage.Sets/src/mage/cards/g/GossamerPhantasm.java
+++ b/Mage.Sets/src/mage/cards/g/GossamerPhantasm.java
@@ -1,7 +1,7 @@
 package mage.cards.g;
 
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -26,7 +26,7 @@ public final class GossamerPhantasm extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // When Gossamer Phantasm becomes the target of a spell or ability, sacrifice it.
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect().setText("sacrifice it")));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect().setText("sacrifice it")));
     }
 
     private GossamerPhantasm(final GossamerPhantasm card) {

--- a/Mage.Sets/src/mage/cards/i/IlluminatorVirtuoso.java
+++ b/Mage.Sets/src/mage/cards/i/IlluminatorVirtuoso.java
@@ -1,7 +1,7 @@
 package mage.cards.i;
 
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.keyword.ConniveSourceEffect;
 import mage.abilities.keyword.DoubleStrikeAbility;
 import mage.cards.CardImpl;
@@ -36,7 +36,7 @@ public final class IlluminatorVirtuoso extends CardImpl {
         this.addAbility(DoubleStrikeAbility.getInstance());
 
         // Whenever Illuminator Virtuoso becomes the target of a spell you control, it connives.
-        this.addAbility(new BecomesTargetTriggeredAbility(
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(
                 new ConniveSourceEffect(), filter
         ).setTriggerPhrase("Whenever {this} becomes the target of a spell you control, "));
     }

--- a/Mage.Sets/src/mage/cards/i/IllusionaryServant.java
+++ b/Mage.Sets/src/mage/cards/i/IllusionaryServant.java
@@ -3,7 +3,7 @@ package mage.cards.i;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -25,7 +25,7 @@ public final class IllusionaryServant extends CardImpl {
         this.toughness = new MageInt(4);
 
         this.addAbility(FlyingAbility.getInstance());
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect().setText("sacrifice it")));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect().setText("sacrifice it")));
     }
 
     private IllusionaryServant(final IllusionaryServant card) {

--- a/Mage.Sets/src/mage/cards/k/KingOfTheOathbreakers.java
+++ b/Mage.Sets/src/mage/cards/k/KingOfTheOathbreakers.java
@@ -1,0 +1,43 @@
+package mage.cards.k;
+
+import mage.MageInt;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author Susucr
+ */
+public final class KingOfTheOathbreakers extends CardImpl {
+
+    public KingOfTheOathbreakers(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{W}{B}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.SPIRIT);
+        this.subtype.add(SubType.NOBLE);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(3);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Whenever King of the Oathbreakers or another Spirit you control becomes the target of a spell, it phases out.
+        // Whenever King of the Oathbreakers or another Spirit you control phases in, create a tapped 1/1 white Spirit creature token with flying.
+    }
+
+    private KingOfTheOathbreakers(final KingOfTheOathbreakers card) {
+        super(card);
+    }
+
+    @Override
+    public KingOfTheOathbreakers copy() {
+        return new KingOfTheOathbreakers(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/k/KingOfTheOathbreakers.java
+++ b/Mage.Sets/src/mage/cards/k/KingOfTheOathbreakers.java
@@ -42,15 +42,13 @@ public final class KingOfTheOathbreakers extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
 
-        // Whenever King of the Oathbreakers or another Spirit you control
-        // becomes the target of a spell, it phases out.
+        // Whenever King of the Oathbreakers or another Spirit you control becomes the target of a spell, it phases out.
         this.addAbility(new BecomesTargetTriggeredAbility(
             new PhaseOutTargetEffect("it"),
             filter, StaticFilters.FILTER_SPELL_A
         ));
 
-        // Whenever King of the Oathbreakers or another Spirit you control phases in,
-        // create a tapped 1/1 white Spirit creature token with flying.
+        // Whenever King of the Oathbreakers or another Spirit you control phases in, create a tapped 1/1 white Spirit creature token with flying.
         this.addAbility(new PhaseInTriggeredAbility(
             new CreateTokenEffect(new SpiritWhiteToken(), 1, true),
             filter

--- a/Mage.Sets/src/mage/cards/k/KingOfTheOathbreakers.java
+++ b/Mage.Sets/src/mage/cards/k/KingOfTheOathbreakers.java
@@ -1,12 +1,21 @@
 package mage.cards.k;
 
 import mage.MageInt;
+import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.PhaseInTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.PhaseOutTargetEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
+import mage.filter.FilterPermanent;
+import mage.filter.FilterPermanentThisOrAnother;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.game.permanent.token.SpiritWhiteToken;
 
 import java.util.UUID;
 
@@ -15,6 +24,11 @@ import java.util.UUID;
  * @author Susucr
  */
 public final class KingOfTheOathbreakers extends CardImpl {
+
+    private static final FilterPermanent filter =
+        new FilterPermanentThisOrAnother(
+            new FilterControlledCreaturePermanent(SubType.SPIRIT),
+            true);
 
     public KingOfTheOathbreakers(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{W}{B}");
@@ -28,8 +42,19 @@ public final class KingOfTheOathbreakers extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
 
-        // Whenever King of the Oathbreakers or another Spirit you control becomes the target of a spell, it phases out.
-        // Whenever King of the Oathbreakers or another Spirit you control phases in, create a tapped 1/1 white Spirit creature token with flying.
+        // Whenever King of the Oathbreakers or another Spirit you control
+        // becomes the target of a spell, it phases out.
+        this.addAbility(new BecomesTargetTriggeredAbility(
+            new PhaseOutTargetEffect("it"),
+            filter, StaticFilters.FILTER_SPELL_A
+        ));
+
+        // Whenever King of the Oathbreakers or another Spirit you control phases in,
+        // create a tapped 1/1 white Spirit creature token with flying.
+        this.addAbility(new PhaseInTriggeredAbility(
+            new CreateTokenEffect(new SpiritWhiteToken(), 1, true),
+            filter
+        ));
     }
 
     private KingOfTheOathbreakers(final KingOfTheOathbreakers card) {

--- a/Mage.Sets/src/mage/cards/l/LivewireLash.java
+++ b/Mage.Sets/src/mage/cards/l/LivewireLash.java
@@ -1,7 +1,7 @@
 package mage.cards.l;
 
 import mage.abilities.Ability;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.DamageTargetEffect;
@@ -30,7 +30,7 @@ public final class LivewireLash extends CardImpl {
 
         // Equipped creature gets +2/+0 and has "Whenever this creature becomes the target of a spell, this creature deals 2 damage to any target."
         Ability ability = new SimpleStaticAbility(new BoostEquippedEffect(2, 0));
-        Ability ability2 = new BecomesTargetTriggeredAbility(
+        Ability ability2 = new SourceBecomesTargetTriggeredAbility(
                 new DamageTargetEffect(2, "it"), StaticFilters.FILTER_SPELL_A
         ).setTriggerPhrase("Whenever this creature becomes the target of a spell, ");
         ability2.addTarget(new TargetAnyTarget());

--- a/Mage.Sets/src/mage/cards/m/MakeshiftMannequin.java
+++ b/Mage.Sets/src/mage/cards/m/MakeshiftMannequin.java
@@ -2,7 +2,7 @@ package mage.cards.m;
 
 import java.util.UUID;
 import mage.abilities.Ability;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.ContinuousEffectImpl;
@@ -116,7 +116,7 @@ class MakeshiftMannequinGainAbilityEffect extends ContinuousEffectImpl {
         Permanent permanent = game.getPermanent(this.getTargetPointer().getFirst(game, source));
         if (permanent != null) {
             permanent.addAbility(
-                    new BecomesTargetTriggeredAbility(
+                    new SourceBecomesTargetTriggeredAbility(
                             new SacrificeSourceEffect()),
                     source.getSourceId(), game);
             return true;

--- a/Mage.Sets/src/mage/cards/m/Mirozel.java
+++ b/Mage.Sets/src/mage/cards/m/Mirozel.java
@@ -3,7 +3,7 @@ package mage.cards.m;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.ReturnToHandSourceEffect;
 import mage.constants.SubType;
 import mage.abilities.keyword.FlyingAbility;
@@ -28,7 +28,7 @@ public final class Mirozel extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // When Mirozel becomes the target of a spell or ability, return Mirozel to its owner's hand.
-        this.addAbility(new BecomesTargetTriggeredAbility(new ReturnToHandSourceEffect(true)));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new ReturnToHandSourceEffect(true)));
     }
 
     private Mirozel(final Mirozel card) {

--- a/Mage.Sets/src/mage/cards/m/MyriadConstruct.java
+++ b/Mage.Sets/src/mage/cards/m/MyriadConstruct.java
@@ -2,7 +2,7 @@ package mage.cards.m;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.condition.common.KickedCondition;
 import mage.abilities.dynamicvalue.DynamicValue;
@@ -60,7 +60,7 @@ public final class MyriadConstruct extends CardImpl {
         ));
 
         // When Myriad Construct becomes the target of a spell, sacrifice it and create a number of 1/1 colourless Construct artifact creature tokens equal to its power.
-        Ability ability = new BecomesTargetTriggeredAbility(
+        Ability ability = new SourceBecomesTargetTriggeredAbility(
                 new SacrificeSourceEffect().setText("sacrifice it"), StaticFilters.FILTER_SPELL_A
         );
         ability.addEffect(new CreateTokenEffect(new ConstructToken(), xValue2)

--- a/Mage.Sets/src/mage/cards/p/Petrahydrox.java
+++ b/Mage.Sets/src/mage/cards/p/Petrahydrox.java
@@ -3,7 +3,7 @@ package mage.cards.p;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.ReturnToHandSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -24,7 +24,7 @@ public final class Petrahydrox extends CardImpl {
         this.toughness = new MageInt(3);
 
         // When Petrahydrox becomes the target of a spell or ability, return Petrahydrox to its owner's hand.
-        this.addAbility(new BecomesTargetTriggeredAbility(new ReturnToHandSourceEffect(true)));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new ReturnToHandSourceEffect(true)));
     }
 
     private Petrahydrox(final Petrahydrox card) {

--- a/Mage.Sets/src/mage/cards/p/PhantasmalAbomination.java
+++ b/Mage.Sets/src/mage/cards/p/PhantasmalAbomination.java
@@ -3,7 +3,7 @@ package mage.cards.p;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.abilities.keyword.DefenderAbility;
 import mage.cards.CardImpl;
@@ -25,7 +25,7 @@ public final class PhantasmalAbomination extends CardImpl {
         this.toughness = new MageInt(5);
 
         this.addAbility(DefenderAbility.getInstance());
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect().setText("sacrifice it")));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect().setText("sacrifice it")));
     }
 
     private PhantasmalAbomination(final PhantasmalAbomination card) {

--- a/Mage.Sets/src/mage/cards/p/PhantasmalBear.java
+++ b/Mage.Sets/src/mage/cards/p/PhantasmalBear.java
@@ -3,7 +3,7 @@ package mage.cards.p;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -25,7 +25,7 @@ public final class PhantasmalBear extends CardImpl {
         this.toughness = new MageInt(2);
 
         // When Phantasmal Bear becomes the target of a spell or ability, sacrifice it.
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
     }
 
     private PhantasmalBear(final PhantasmalBear card) {

--- a/Mage.Sets/src/mage/cards/p/PhantasmalDragon.java
+++ b/Mage.Sets/src/mage/cards/p/PhantasmalDragon.java
@@ -3,7 +3,7 @@ package mage.cards.p;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -26,7 +26,7 @@ public final class PhantasmalDragon extends CardImpl {
         this.toughness = new MageInt(5);
 
         this.addAbility(FlyingAbility.getInstance());
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
     }
 
     private PhantasmalDragon(final PhantasmalDragon card) {

--- a/Mage.Sets/src/mage/cards/p/PhantasmalDreadmaw.java
+++ b/Mage.Sets/src/mage/cards/p/PhantasmalDreadmaw.java
@@ -1,7 +1,7 @@
 package mage.cards.p;
 
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
@@ -28,7 +28,7 @@ public final class PhantasmalDreadmaw extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // When Phantasmal Dreadmaw becomes the target of a spell or ability, sacrifice it.
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect().setText("sacrifice it")));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect().setText("sacrifice it")));
     }
 
     private PhantasmalDreadmaw(final PhantasmalDreadmaw card) {

--- a/Mage.Sets/src/mage/cards/p/PhantasmalImage.java
+++ b/Mage.Sets/src/mage/cards/p/PhantasmalImage.java
@@ -4,7 +4,7 @@ package mage.cards.p;
 import mage.MageInt;
 import mage.MageObject;
 import mage.abilities.Ability;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.CopyPermanentEffect;
@@ -31,7 +31,7 @@ public final class PhantasmalImage extends CardImpl {
         public boolean apply(Game game, MageObject blueprint, Ability source, UUID copyToObjectId) {
             // Add directly because the created permanent is only used to copy from, so there is no need to add the ability to e.g. TriggeredAbilities
             blueprint.addSubType(SubType.ILLUSION);
-            blueprint.getAbilities().add(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
+            blueprint.getAbilities().add(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
             return true;
         }
     };

--- a/Mage.Sets/src/mage/cards/p/PhantomBeast.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomBeast.java
@@ -4,7 +4,7 @@ package mage.cards.p;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -26,7 +26,7 @@ public final class PhantomBeast extends CardImpl {
         this.power = new MageInt(4);
         this.toughness = new MageInt(5);
 
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
     }
 
     private PhantomBeast(final PhantomBeast card) {

--- a/Mage.Sets/src/mage/cards/s/SegmentedWurm.java
+++ b/Mage.Sets/src/mage/cards/s/SegmentedWurm.java
@@ -3,7 +3,7 @@ package mage.cards.s;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -24,7 +24,7 @@ public final class SegmentedWurm extends CardImpl {
         this.power = new MageInt(5);
         this.toughness = new MageInt(5);
 
-        this.addAbility(new BecomesTargetTriggeredAbility(new AddCountersSourceEffect(CounterType.M1M1.createInstance())));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new AddCountersSourceEffect(CounterType.M1M1.createInstance())));
     }
 
     private SegmentedWurm(final SegmentedWurm card) {

--- a/Mage.Sets/src/mage/cards/s/ShimmeringEfreet.java
+++ b/Mage.Sets/src/mage/cards/s/ShimmeringEfreet.java
@@ -3,7 +3,7 @@ package mage.cards.s;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.PhaseInTriggeredAbility;
+import mage.abilities.common.SourcePhaseInTriggeredAbility;
 import mage.abilities.effects.common.PhaseOutTargetEffect;
 import mage.constants.SubType;
 import mage.abilities.keyword.FlyingAbility;
@@ -33,7 +33,7 @@ public final class ShimmeringEfreet extends CardImpl {
         this.addAbility(PhasingAbility.getInstance());
 
         // Whenever Shimmering Efreet phases in, target creature phases out.
-        Ability ability = new PhaseInTriggeredAbility(new PhaseOutTargetEffect(), false);
+        Ability ability = new SourcePhaseInTriggeredAbility(new PhaseOutTargetEffect(), false);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SkulkingFugitive.java
+++ b/Mage.Sets/src/mage/cards/s/SkulkingFugitive.java
@@ -4,7 +4,7 @@ package mage.cards.s;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -26,7 +26,7 @@ public final class SkulkingFugitive extends CardImpl {
         this.toughness = new MageInt(4);
 
         // When Skulking Fugitive becomes the target of a spell or ability, sacrifice it.
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
     }
 
     private SkulkingFugitive(final SkulkingFugitive card) {

--- a/Mage.Sets/src/mage/cards/s/SkulkingGhost.java
+++ b/Mage.Sets/src/mage/cards/s/SkulkingGhost.java
@@ -3,7 +3,7 @@ package mage.cards.s;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -26,7 +26,7 @@ public final class SkulkingGhost extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // When Skulking Ghost becomes the target of a spell or ability, sacrifice it.
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
     }
 
     private SkulkingGhost(final SkulkingGhost card) {

--- a/Mage.Sets/src/mage/cards/s/SkulkingKnight.java
+++ b/Mage.Sets/src/mage/cards/s/SkulkingKnight.java
@@ -3,7 +3,7 @@ package mage.cards.s;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.abilities.keyword.FlankingAbility;
 import mage.cards.CardImpl;
@@ -28,7 +28,7 @@ public final class SkulkingKnight extends CardImpl {
         // Flanking
         this.addAbility(new FlankingAbility());
         // When Skulking Knight becomes the target of a spell or ability, sacrifice it.
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect().setText("sacrifice it")));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect().setText("sacrifice it")));
     }
 
     private SkulkingKnight(final SkulkingKnight card) {

--- a/Mage.Sets/src/mage/cards/s/StormchaserDrake.java
+++ b/Mage.Sets/src/mage/cards/s/StormchaserDrake.java
@@ -1,7 +1,7 @@
 package mage.cards.s;
 
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -35,7 +35,7 @@ public final class StormchaserDrake extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Whenever Stormchaser Drake becomes the target of a spell you control, draw a card.
-        this.addAbility(new BecomesTargetTriggeredAbility(
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(
                 new DrawCardSourceControllerEffect(1), filter
         ).setTriggerPhrase("Whenever {this} becomes the target of a spell you control, "));
     }

--- a/Mage.Sets/src/mage/cards/t/TarPitWarrior.java
+++ b/Mage.Sets/src/mage/cards/t/TarPitWarrior.java
@@ -3,7 +3,7 @@ package mage.cards.t;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -24,7 +24,7 @@ public final class TarPitWarrior extends CardImpl {
         this.toughness = new MageInt(4);
 
         // When Tar Pit Warrior becomes the target of a spell or ability, sacrifice it.
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect()));
     }
 
     private TarPitWarrior(final TarPitWarrior card) {

--- a/Mage.Sets/src/mage/cards/t/TaskForce.java
+++ b/Mage.Sets/src/mage/cards/t/TaskForce.java
@@ -1,7 +1,7 @@
 package mage.cards.t;
 
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -25,7 +25,7 @@ public final class TaskForce extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever Task Force becomes the target of a spell or ability, it gets +0/+3 until end of turn.
-        this.addAbility(new BecomesTargetTriggeredAbility(
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(
                 new BoostSourceEffect(0, 3, Duration.EndOfTurn, "it")
         ).setTriggerPhrase("Whenever {this} becomes the target of a spell or ability, "));
     }

--- a/Mage.Sets/src/mage/cards/t/TetheredSkirge.java
+++ b/Mage.Sets/src/mage/cards/t/TetheredSkirge.java
@@ -3,7 +3,7 @@ package mage.cards.t;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.LoseLifeSourceControllerEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -28,7 +28,7 @@ public final class TetheredSkirge extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // Whenever Tethered Skirge becomes the target of a spell or ability, you lose 1 life.
-        this.addAbility(new BecomesTargetTriggeredAbility(new LoseLifeSourceControllerEffect(1)));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new LoseLifeSourceControllerEffect(1)));
     }
 
     private TetheredSkirge(final TetheredSkirge card) {

--- a/Mage.Sets/src/mage/cards/t/TheHowlingAbomination.java
+++ b/Mage.Sets/src/mage/cards/t/TheHowlingAbomination.java
@@ -2,7 +2,7 @@ package mage.cards.t;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.condition.Condition;
 import mage.abilities.decorator.ConditionalContinuousEffect;
@@ -45,7 +45,7 @@ public final class TheHowlingAbomination extends CardImpl {
         )).withFlavorWord("Rolling Attack"));
 
         // Electric Thunder—Whenever Blanka becomes the target of a spell, he gets +2/+2 until end of turn and deals 2 damage to each opponent.
-        Ability ability = new BecomesTargetTriggeredAbility(new BoostSourceEffect(
+        Ability ability = new SourceBecomesTargetTriggeredAbility(new BoostSourceEffect(
                 2, 2, Duration.EndOfTurn
         ).setText("he gets +2/+2 until end of turn"), StaticFilters.FILTER_SPELL_A).setTriggerPhrase("Whenever {this} becomes the target of a spell, ");
         ability.addEffect(new DamagePlayersEffect(2, TargetController.OPPONENT)

--- a/Mage.Sets/src/mage/cards/t/ThornLieutenant.java
+++ b/Mage.Sets/src/mage/cards/t/ThornLieutenant.java
@@ -1,7 +1,7 @@
 package mage.cards.t;
 
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.CreateTokenEffect;
@@ -30,7 +30,7 @@ public final class ThornLieutenant extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever Thorn Lieutenant becomes the target of a spell or ability an opponent controls, create a 1/1 green Elf Warrior creature token.
-        this.addAbility(new BecomesTargetTriggeredAbility(
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(
                 new CreateTokenEffect(new ElfWarriorToken()),
                 StaticFilters.FILTER_SPELL_OR_ABILITY_OPPONENTS
         ).setTriggerPhrase("Whenever {this} becomes the target of a spell or ability an opponent controls, "));

--- a/Mage.Sets/src/mage/cards/t/TreacherousBlessing.java
+++ b/Mage.Sets/src/mage/cards/t/TreacherousBlessing.java
@@ -1,6 +1,6 @@
 package mage.cards.t;
 
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SpellCastControllerTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
@@ -29,7 +29,7 @@ public final class TreacherousBlessing extends CardImpl {
         ));
 
         // When Treacherous Blessing becomes the target of a spell or ability, sacrifice it.
-        this.addAbility(new BecomesTargetTriggeredAbility(new SacrificeSourceEffect().setText("sacrifice it")));
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(new SacrificeSourceEffect().setText("sacrifice it")));
     }
 
     private TreacherousBlessing(final TreacherousBlessing card) {

--- a/Mage.Sets/src/mage/cards/w/WardenOfTheWoods.java
+++ b/Mage.Sets/src/mage/cards/w/WardenOfTheWoods.java
@@ -1,7 +1,7 @@
 package mage.cards.w;
 
 import mage.MageInt;
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.keyword.VigilanceAbility;
 import mage.cards.CardImpl;
@@ -29,7 +29,7 @@ public final class WardenOfTheWoods extends CardImpl {
         this.addAbility(VigilanceAbility.getInstance());
 
         // Whenever Warden of the Woods becomes the target of a spell or ability an opponent controls, you may draw two cards.
-        this.addAbility(new BecomesTargetTriggeredAbility(
+        this.addAbility(new SourceBecomesTargetTriggeredAbility(
                 new DrawCardSourceControllerEffect(2),
                 StaticFilters.FILTER_SPELL_OR_ABILITY_OPPONENTS,
                 SetTargetPointer.NONE, true

--- a/Mage.Sets/src/mage/cards/w/WarpingWurm.java
+++ b/Mage.Sets/src/mage/cards/w/WarpingWurm.java
@@ -1,20 +1,21 @@
 package mage.cards.w;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
-import mage.abilities.common.PhaseInTriggeredAbility;
+import mage.abilities.common.SourcePhaseInTriggeredAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.DoUnlessControllerPaysEffect;
 import mage.abilities.effects.common.PhaseOutSourceEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
-import mage.constants.SubType;
 import mage.abilities.keyword.PhasingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.SubType;
 import mage.constants.TargetController;
 import mage.counters.CounterType;
+
+import java.util.UUID;
 
 /**
  *
@@ -42,7 +43,7 @@ public final class WarpingWurm extends CardImpl {
         ));
 
         // When Warping Wurm phases in, put a +1/+1 counter on it.
-        this.addAbility(new PhaseInTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false));
+        this.addAbility(new SourcePhaseInTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false));
     }
 
     private WarpingWurm(final WarpingWurm card) {

--- a/Mage.Sets/src/mage/sets/TheLordOfTheRingsTalesOfMiddleEarth.java
+++ b/Mage.Sets/src/mage/sets/TheLordOfTheRingsTalesOfMiddleEarth.java
@@ -148,6 +148,7 @@ public final class TheLordOfTheRingsTalesOfMiddleEarth extends ExpansionSet {
         cards.add(new SetCardInfo("Island", 264, Rarity.LAND, mage.cards.basiclands.Island.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Isolation at Orthanc", 57, Rarity.COMMON, mage.cards.i.IsolationAtOrthanc.class));
         cards.add(new SetCardInfo("Ithilien Kingfisher", 58, Rarity.COMMON, mage.cards.i.IthilienKingfisher.class));
+        cards.add(new SetCardInfo("King of the Oathbreakers", 211, Rarity.RARE, mage.cards.k.KingOfTheOathbreakers.class));
         cards.add(new SetCardInfo("Knight of the Keep", 291, Rarity.COMMON, mage.cards.k.KnightOfTheKeep.class));
         cards.add(new SetCardInfo("Knights of Dol Amroth", 59, Rarity.COMMON, mage.cards.k.KnightsOfDolAmroth.class));
         cards.add(new SetCardInfo("Landroval, Horizon Witness", 21, Rarity.UNCOMMON, mage.cards.l.LandrovalHorizonWitness.class));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/copy/PhantasmalImageTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/copy/PhantasmalImageTest.java
@@ -1,6 +1,6 @@
 package org.mage.test.cards.copy;
 
-import mage.abilities.common.BecomesTargetTriggeredAbility;
+import mage.abilities.common.SourceBecomesTargetTriggeredAbility;
 import mage.abilities.keyword.IndestructibleAbility;
 import mage.abilities.keyword.LifelinkAbility;
 import mage.constants.PhaseStep;
@@ -629,7 +629,7 @@ public class PhantasmalImageTest extends CardTestPlayerBase {
         assertTrue("Phantasmal Image should not be a creature", !staffA.isCreature(currentGame));
         assertTrue("Phantasmal Image should not be an Illusion", !staffA.hasSubtype(SubType.ILLUSION, currentGame));
         assertTrue("Phantasmal Image should not be a Construct", !staffA.hasSubtype(SubType.CONSTRUCT, currentGame));
-        assertTrue("Phantasmal Image should have the sacrifice trigger", staffA.getAbilities(currentGame).containsClass(BecomesTargetTriggeredAbility.class));
+        assertTrue("Phantasmal Image should have the sacrifice trigger", staffA.getAbilities(currentGame).containsClass(SourceBecomesTargetTriggeredAbility.class));
 
         Permanent staffB = getPermanent("Chimeric Staff", playerB);
         assertTrue("Chimeric Staff should be an artifact", staffB.isArtifact(currentGame));
@@ -659,7 +659,7 @@ public class PhantasmalImageTest extends CardTestPlayerBase {
         assertTrue("Phantasmal Image should be a Rogue", cloakA.hasSubtype(SubType.ROGUE, currentGame));
         assertTrue("Phantasmal Image should be an Illusion", cloakA.hasSubtype(SubType.ILLUSION, currentGame));
         assertTrue("Phantasmal Image should be an Equipment", cloakA.hasSubtype(SubType.EQUIPMENT, currentGame));
-        assertTrue("Phantasmal Image should have the sacrifice trigger", cloakA.getAbilities(currentGame).containsClass(BecomesTargetTriggeredAbility.class));
+        assertTrue("Phantasmal Image should have the sacrifice trigger", cloakA.getAbilities(currentGame).containsClass(SourceBecomesTargetTriggeredAbility.class));
 
         Permanent cloakB = getPermanent("Cloak and Dagger", playerB);
         assertTrue("Cloak and Dagger should be an artifact", cloakB.isArtifact(currentGame));

--- a/Mage/src/main/java/mage/abilities/common/BecomesTargetTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/BecomesTargetTriggeredAbility.java
@@ -2,7 +2,6 @@ package mage.abilities.common;
 
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
-import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
 import mage.filter.FilterStackObject;
@@ -20,27 +19,20 @@ public class BecomesTargetTriggeredAbility extends TriggeredAbilityImpl {
 
     private final FilterPermanent filterTarget;
     private final FilterStackObject filterStack;
-    private final SetTargetPointer setTargetPointer;
 
     public BecomesTargetTriggeredAbility(Effect effect, FilterPermanent filterTarget) {
         this(effect, filterTarget, StaticFilters.FILTER_SPELL_OR_ABILITY_A);
     }
 
     public BecomesTargetTriggeredAbility(Effect effect, FilterPermanent filterTarget, FilterStackObject filterStack) {
-        this(effect, filterTarget, filterStack, SetTargetPointer.NONE);
+        this(effect, filterTarget, filterStack, false);
     }
 
     public BecomesTargetTriggeredAbility(Effect effect, FilterPermanent filterTarget, FilterStackObject filterStack,
-                                         SetTargetPointer setTargetPointer) {
-        this(effect, filterTarget, filterStack, setTargetPointer, false);
-    }
-
-    public BecomesTargetTriggeredAbility(Effect effect, FilterPermanent filterTarget, FilterStackObject filterStack,
-                                         SetTargetPointer setTargetPointer, boolean optional) {
+                                         boolean optional) {
         super(Zone.BATTLEFIELD, effect, optional);
         this.filterTarget = filterTarget;
         this.filterStack = filterStack;
-        this.setTargetPointer = setTargetPointer;
         setTriggerPhrase("Whenever " + filterTarget.getMessage() + " becomes the target of "
                                      + filterStack.getMessage() + ", ");
     }
@@ -49,7 +41,6 @@ public class BecomesTargetTriggeredAbility extends TriggeredAbilityImpl {
         super(ability);
         this.filterTarget = ability.filterTarget;
         this.filterStack = ability.filterStack;
-        this.setTargetPointer = ability.setTargetPointer;
     }
 
     @Override
@@ -75,20 +66,7 @@ public class BecomesTargetTriggeredAbility extends TriggeredAbilityImpl {
             return false;
         }
 
-        switch (setTargetPointer) {
-            case PLAYER:
-                this.getEffects().stream()
-                        .forEach(effect -> effect.setTargetPointer(
-                                new FixedTarget(sourceObject.getControllerId(), game)
-                        ));
-                break;
-            case SPELL:
-                this.getEffects().stream()
-                        .forEach(effect -> effect.setTargetPointer(
-                                new FixedTarget(sourceObject.getId(), game)
-                        ));
-                break;
-        }
+        getEffects().setTargetPointer(new FixedTarget(event.getTargetId()));
 
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/common/PhaseInTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/PhaseInTriggeredAbility.java
@@ -3,8 +3,10 @@ package mage.abilities.common;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
 import mage.constants.Zone;
+import mage.filter.FilterPermanent;
 import mage.game.Game;
 import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
 
 /**
  *
@@ -12,9 +14,16 @@ import mage.game.events.GameEvent;
  */
 public class PhaseInTriggeredAbility extends TriggeredAbilityImpl {
 
-    public PhaseInTriggeredAbility(Effect effect, boolean optional) {
+    private FilterPermanent filter;
+
+    public PhaseInTriggeredAbility(Effect effect, FilterPermanent filter) {
+        this(effect, filter, false);
+    }
+
+    public PhaseInTriggeredAbility(Effect effect, FilterPermanent filter, boolean optional) {
         super(Zone.BATTLEFIELD, effect, optional);
-        setTriggerPhrase("When {this} phases in, ");
+        this.filter = filter;
+        setTriggerPhrase("Whenever " + filter.getMessage() + " phases in, ");
     }
 
     public PhaseInTriggeredAbility(final PhaseInTriggeredAbility ability) {
@@ -33,6 +42,7 @@ public class PhaseInTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        return getSourceId().equals(event.getTargetId());
+        Permanent permanent = game.getPermanent(event.getTargetId());
+        return permanent != null && filter.match(permanent, getControllerId(), this, game);
     }
 }

--- a/Mage/src/main/java/mage/abilities/common/SourceBecomesTargetTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/SourceBecomesTargetTriggeredAbility.java
@@ -1,0 +1,80 @@
+package mage.abilities.common;
+
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.effects.Effect;
+import mage.constants.SetTargetPointer;
+import mage.constants.Zone;
+import mage.filter.FilterStackObject;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.stack.StackObject;
+import mage.target.targetpointer.FixedTarget;
+
+/**
+ * @author North
+ */
+public class SourceBecomesTargetTriggeredAbility extends TriggeredAbilityImpl {
+
+    private final FilterStackObject filter;
+    private final SetTargetPointer setTargetPointer;
+
+    public SourceBecomesTargetTriggeredAbility(Effect effect) {
+        this(effect, StaticFilters.FILTER_SPELL_OR_ABILITY_A);
+    }
+
+    public SourceBecomesTargetTriggeredAbility(Effect effect, FilterStackObject filter) {
+        this(effect, filter, SetTargetPointer.NONE);
+    }
+
+    public SourceBecomesTargetTriggeredAbility(Effect effect, FilterStackObject filter, SetTargetPointer setTargetPointer) {
+        this(effect, filter, setTargetPointer, false);
+    }
+
+    public SourceBecomesTargetTriggeredAbility(Effect effect, FilterStackObject filter, SetTargetPointer setTargetPointer, boolean optional) {
+        super(Zone.BATTLEFIELD, effect, optional);
+        this.filter = filter;
+        this.setTargetPointer = setTargetPointer;
+        setTriggerPhrase("When {this} becomes the target of " + filter.getMessage() + ", ");
+    }
+
+    public SourceBecomesTargetTriggeredAbility(final SourceBecomesTargetTriggeredAbility ability) {
+        super(ability);
+        this.filter = ability.filter;
+        this.setTargetPointer = ability.setTargetPointer;
+    }
+
+    @Override
+    public SourceBecomesTargetTriggeredAbility copy() {
+        return new SourceBecomesTargetTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.TARGETED;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        StackObject sourceObject = game.getStack().getStackObject(event.getSourceId());
+        if (!event.getTargetId().equals(getSourceId())
+                || !filter.match(sourceObject, getControllerId(), this, game)) {
+            return false;
+        }
+        switch (setTargetPointer) {
+            case PLAYER:
+                this.getEffects().stream()
+                        .forEach(effect -> effect.setTargetPointer(
+                                new FixedTarget(sourceObject.getControllerId(), game)
+                        ));
+                break;
+            case SPELL:
+                this.getEffects().stream()
+                        .forEach(effect -> effect.setTargetPointer(
+                                new FixedTarget(sourceObject.getId(), game)
+                        ));
+                break;
+        }
+        return true;
+    }
+}

--- a/Mage/src/main/java/mage/abilities/common/SourcePhaseInTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/SourcePhaseInTriggeredAbility.java
@@ -1,0 +1,38 @@
+package mage.abilities.common;
+
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.effects.Effect;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+
+/**
+ *
+ * @author TheElk801
+ */
+public class SourcePhaseInTriggeredAbility extends TriggeredAbilityImpl {
+
+    public SourcePhaseInTriggeredAbility(Effect effect, boolean optional) {
+        super(Zone.BATTLEFIELD, effect, optional);
+        setTriggerPhrase("When {this} phases in, ");
+    }
+
+    public SourcePhaseInTriggeredAbility(final SourcePhaseInTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public SourcePhaseInTriggeredAbility copy() {
+        return new SourcePhaseInTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.PHASED_IN;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        return getSourceId().equals(event.getTargetId());
+    }
+}


### PR DESCRIPTION
Most of [those cards](https://scryfall.com/search?q=o%3Awhenever+o%3A%22becomes+the+target+of%22+game%3Apaper+-o%3A%22whenever+%7E+becomes%22&unique=cards&as=grid&order=released) could be refactored using the double filters `BecomesTargetTriggeredAbility`. Those that want to trigger on non permanents (usually players) will not work with it.