### PR TITLE
[LTR] Implement Sharkey, Tyrant of the Shire

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DampingMatrix.java
+++ b/Mage.Sets/src/mage/cards/d/DampingMatrix.java
@@ -1,8 +1,6 @@
 
 package mage.cards.d;
 
-import java.util.Optional;
-import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
@@ -18,8 +16,10 @@ import mage.filter.FilterPermanent;
 import mage.filter.predicate.Predicates;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
+
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  *
@@ -80,7 +80,7 @@ class DampingMatrixEffect extends ReplacementEffectImpl {
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         MageObject object = game.getObject(event.getSourceId());
-        if (object instanceof Permanent && filter.match((Permanent)object, game)) {
+        if (object instanceof Permanent && filter.match((Permanent)object, source.getControllerId(), source, game)) {
             Optional<Ability> ability = object.getAbilities().get(event.getTargetId());
             if (ability.isPresent() && !(ability.get() instanceof ActivatedManaAbilityImpl)) {
                 return true;

--- a/Mage.Sets/src/mage/cards/s/SharkeyTyrantOfTheShire.java
+++ b/Mage.Sets/src/mage/cards/s/SharkeyTyrantOfTheShire.java
@@ -75,7 +75,7 @@ class SharkeyTyrantOfTheShireReplacementEffect extends ReplacementEffectImpl {
         staticText = "Activated abilities of lands your opponents control can't be activated unless they're mana abilities";
     }
 
-    public SharkeyTyrantOfTheShireReplacementEffect(final SharkeyTyrantOfTheShireReplacementEffect effect) {
+    private SharkeyTyrantOfTheShireReplacementEffect(final SharkeyTyrantOfTheShireReplacementEffect effect) {
         super(effect);
         this.filter = effect.filter;
     }

--- a/Mage.Sets/src/mage/cards/s/SharkeyTyrantOfTheShire.java
+++ b/Mage.Sets/src/mage/cards/s/SharkeyTyrantOfTheShire.java
@@ -1,0 +1,155 @@
+package mage.cards.s;
+
+import mage.MageInt;
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.ContinuousEffectImpl;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.mana.ActivatedManaAbilityImpl;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.FilterPermanent;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ *
+ * @author Susucr
+ */
+public final class SharkeyTyrantOfTheShire extends CardImpl {
+
+    private static final FilterPermanent filter = new FilterPermanent("lands your opponents control");
+    static {
+        filter.add(CardType.LAND.getPredicate());
+        filter.add(TargetController.OPPONENT.getControllerPredicate());
+    }
+
+    public SharkeyTyrantOfTheShire(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}{B}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.AVATAR);
+        this.subtype.add(SubType.ROGUE);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(4);
+
+        // Activated abilities of lands your opponents control can't be activated unless they're mana abilities.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SharkeyTyrantOfTheShireReplacementEffect(filter)));
+
+        // Sharkey, Tyrant of the Shire has all activated abilities of lands your opponents control except mana abilities.
+        this.addAbility(new SimpleStaticAbility(new SharkeyTyrantOfTheShireContinousEffect(filter)));
+
+        // Mana of any type can be spent to activate Sharkey's abilities.
+        // TODO.
+    }
+
+    private SharkeyTyrantOfTheShire(final SharkeyTyrantOfTheShire card) {
+        super(card);
+    }
+
+    @Override
+    public SharkeyTyrantOfTheShire copy() {
+        return new SharkeyTyrantOfTheShire(this);
+    }
+}
+
+class SharkeyTyrantOfTheShireReplacementEffect extends ReplacementEffectImpl {
+
+    private FilterPermanent filter;
+
+    SharkeyTyrantOfTheShireReplacementEffect(FilterPermanent filter) {
+        super(Duration.WhileOnBattlefield, Outcome.Detriment);
+        this.filter = filter;
+        staticText = "Activated abilities of lands your opponents control can't be activated unless they're mana abilities";
+    }
+
+    public SharkeyTyrantOfTheShireReplacementEffect(final SharkeyTyrantOfTheShireReplacementEffect effect) {
+        super(effect);
+        this.filter = effect.filter;
+    }
+
+    @Override
+    public SharkeyTyrantOfTheShireReplacementEffect copy() {
+        return new SharkeyTyrantOfTheShireReplacementEffect(this);
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        return true;
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.ACTIVATE_ABILITY;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        MageObject object = game.getObject(event.getSourceId());
+        if (object instanceof Permanent && filter.match((Permanent)object, game)) {
+            Optional<Ability> ability = object.getAbilities().get(event.getTargetId());
+            if (ability.isPresent() && !(ability.get() instanceof ActivatedManaAbilityImpl)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}
+
+
+class SharkeyTyrantOfTheShireContinousEffect extends ContinuousEffectImpl {
+
+    private FilterPermanent filter;
+
+    SharkeyTyrantOfTheShireContinousEffect(FilterPermanent filter) {
+        super(Duration.WhileOnBattlefield, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
+        this.filter = filter;
+        staticText = "{this} has all activated abilities of " + filter.getMessage() + " except mana abilities.";
+        this.addDependencyType(DependencyType.AddingAbility);
+    }
+
+    private SharkeyTyrantOfTheShireContinousEffect(final SharkeyTyrantOfTheShireContinousEffect effect) {
+        super(effect);
+        this.filter = effect.filter;
+    }
+
+    @Override
+    public SharkeyTyrantOfTheShireContinousEffect copy() {
+        return new SharkeyTyrantOfTheShireContinousEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent perm = game.getPermanent(source.getSourceId());
+        if (perm == null) {
+            return false;
+        }
+        for (Ability ability : game.getState()
+            .getBattlefield()
+            .getActivePermanents(filter, source.getControllerId(), source, game)
+            .stream()
+            .map(permanent -> permanent.getAbilities(game))
+            .flatMap(Collection::stream)
+            .filter(Objects::nonNull)
+            .filter(ability -> ability.getAbilityType() == AbilityType.ACTIVATED) // Mana abilities are separated in their own AbilityType.Mana
+            .collect(Collectors.toList())) {
+            // optimization to disallow the adding of duplicate
+            if(perm.getAbilities(game)
+                .stream()
+                .noneMatch(ability.getClass()::isInstance)) {
+                perm.addAbility(ability, source.getSourceId(), game);
+            }
+        }
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/sets/TheLordOfTheRingsTalesOfMiddleEarth.java
+++ b/Mage.Sets/src/mage/sets/TheLordOfTheRingsTalesOfMiddleEarth.java
@@ -239,6 +239,7 @@ public final class TheLordOfTheRingsTalesOfMiddleEarth extends ExpansionSet {
         cards.add(new SetCardInfo("Shadow of the Enemy", 107, Rarity.MYTHIC, mage.cards.s.ShadowOfTheEnemy.class));
         cards.add(new SetCardInfo("Shadowfax, Lord of Horses", 227, Rarity.UNCOMMON, mage.cards.s.ShadowfaxLordOfHorses.class));
         cards.add(new SetCardInfo("Shagrat, Loot Bearer", 228, Rarity.RARE, mage.cards.s.ShagratLootBearer.class));
+        cards.add(new SetCardInfo("Sharkey, Tyrant of the Shire", 229, Rarity.RARE, mage.cards.s.SharkeyTyrantOfTheShire.class));
         cards.add(new SetCardInfo("Shelob's Ambush", 108, Rarity.COMMON, mage.cards.s.ShelobsAmbush.class));
         cards.add(new SetCardInfo("Shelob, Child of Ungoliant", 230, Rarity.RARE, mage.cards.s.ShelobChildOfUngoliant.class));
         cards.add(new SetCardInfo("Shire Scarecrow", 249, Rarity.COMMON, mage.cards.s.ShireScarecrow.class));


### PR DESCRIPTION
I understand why we use (for cards I looked at at least) a replacement effect for "XXX can't be activated" abilities, but the ability still shows on the activation menu, and upon click, it does nothing silently. I consider improving those out of scope for Sharkey implementation. Issue already mentioned in the comments of https://github.com/magefree/mage/issues/8960 
![activationmenu](https://github.com/magefree/mage/assets/34709007/c23ef09f-527c-4448-822b-23d3e130012b)
