### PR TITLE
Fix Pyrrhic Revival not adding -1/-1 counters on returned creatures.

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PyrrhicRevival.java
+++ b/Mage.Sets/src/mage/cards/p/PyrrhicRevival.java
@@ -15,14 +15,13 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTargets;
 
-import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
- *
  * @author jeffwadsworth
- *
  */
 public final class PyrrhicRevival extends CardImpl {
 
@@ -66,22 +65,22 @@ class PyrrhicRevivalEffect extends OneShotEffect {
         if (controller == null) {
             return false;
         }
-        Set<Card> toBattlefield = new HashSet<>();
-        for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {
-            Player player = game.getPlayer(playerId);
-            if (player != null) {
-                for (Card card : player.getGraveyard().getCards(game)) {
-                    if (card != null && card.isCreature(game)) {
-                        toBattlefield.add(card);
-                    }
-                }
-            }
-        }
+
+        Set<Card> toBattlefield =
+            game.getState().getPlayersInRange(source.getControllerId(), game)
+                .stream()
+                .map(game::getPlayer)
+                .filter(Objects::nonNull)
+                .flatMap(p -> p.getGraveyard().getCards(game).stream())
+                .filter(c -> c != null && c.isCreature(game))
+                .collect(Collectors.toSet());
+
         Effect returnEffect =
             new ReturnFromGraveyardToBattlefieldWithCounterTargetEffect(
                 CounterType.M1M1.createInstance(),
                 true,
                 true);
+
         returnEffect.setTargetPointer(new FixedTargets(toBattlefield, game));
         returnEffect.apply(game, source);
 

--- a/Mage.Sets/src/mage/cards/p/PyrrhicRevival.java
+++ b/Mage.Sets/src/mage/cards/p/PyrrhicRevival.java
@@ -1,25 +1,23 @@
 
 package mage.cards.p;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
 import mage.abilities.Ability;
-import mage.abilities.effects.ContinuousEffect;
-import mage.abilities.effects.EntersBattlefieldEffect;
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.counter.AddCountersTargetEffect;
+import mage.abilities.effects.common.ReturnFromGraveyardToBattlefieldWithCounterTargetEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.players.Player;
-import mage.target.targetpointer.FixedTarget;
+import mage.target.targetpointer.FixedTargets;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  *
@@ -75,15 +73,18 @@ class PyrrhicRevivalEffect extends OneShotEffect {
                 for (Card card : player.getGraveyard().getCards(game)) {
                     if (card != null && card.isCreature(game)) {
                         toBattlefield.add(card);
-                        ContinuousEffect effect = new EntersBattlefieldEffect(new AddCountersTargetEffect(CounterType.M1M1.createInstance()));
-                        effect.setDuration(Duration.OneUse);
-                        effect.setTargetPointer(new FixedTarget(card.getId()));
-                        game.addEffect(effect, source);
                     }
                 }
             }
         }
-        controller.moveCards(toBattlefield, Zone.BATTLEFIELD, source, game, false, false, true, null);
+        Effect returnEffect =
+            new ReturnFromGraveyardToBattlefieldWithCounterTargetEffect(
+                CounterType.M1M1.createInstance(),
+                true,
+                true);
+        returnEffect.setTargetPointer(new FixedTargets(toBattlefield, game));
+        returnEffect.apply(game, source);
+
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PyrrhicRevival.java
+++ b/Mage.Sets/src/mage/cards/p/PyrrhicRevival.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
- * @author jeffwadsworth
+ * @author jeffwadsworth, Susucr
  */
 public final class PyrrhicRevival extends CardImpl {
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/eve/PyrrhicRevivalTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/eve/PyrrhicRevivalTest.java
@@ -1,0 +1,47 @@
+package org.mage.test.cards.single.eve;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class PyrrhicRevivalTest extends CardTestPlayerBase {
+
+    // Pyrrhic Revival {3}{W/B}{W/B}{W/B}
+    // Sorcery
+    // Each player returns each creature card from their graveyard to the battlefield with an additional -1/-1 counter on it.
+    private static final String revival = "Pyrrhic Revival";
+    // Cathedral Sanctifier {W}
+    // Creature — Human Cleric
+    //
+    // When Cathedral Sanctifier enters the battlefield, you gain 3 life.
+    // 1/1
+    private static final String sanctifier = "Cathedral Sanctifier";
+
+    @Ignore
+    @Test
+    public void test_PyrrhicRevival() {
+        addCard(Zone.GRAVEYARD, playerA, sanctifier, 2);
+        addCard(Zone.GRAVEYARD, playerB, sanctifier, 1);
+        addCard(Zone.BATTLEFIELD, playerA, "plains", 6);
+        addCard(Zone.HAND, playerA, revival);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, revival);
+        setChoice(playerA, "When {this} enters the battlefield, you gain 3 life.");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, sanctifier, 0);
+        assertPermanentCount(playerB, sanctifier, 0);
+        assertGraveyardCount(playerA, sanctifier, 2);
+        assertGraveyardCount(playerB, sanctifier, 1);
+        assertLife(playerA, 20 + 6);
+        assertLife(playerB, 20 + 3);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/eve/PyrrhicRevivalTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/eve/PyrrhicRevivalTest.java
@@ -2,7 +2,6 @@ package org.mage.test.cards.single.eve;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -22,7 +21,6 @@ public class PyrrhicRevivalTest extends CardTestPlayerBase {
     // 1/1
     private static final String sanctifier = "Cathedral Sanctifier";
 
-    @Ignore
     @Test
     public void test_PyrrhicRevival() {
         addCard(Zone.GRAVEYARD, playerA, sanctifier, 2);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mh2/PersistTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mh2/PersistTest.java
@@ -1,0 +1,40 @@
+package org.mage.test.cards.single.mh2;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class PersistTest extends CardTestPlayerBase {
+
+    // Persist {1}{B}
+    // Sorcery
+    // Return target nonlegendary creature card from your graveyard to the battlefield with a -1/-1 counter on it.
+    private static final String persist = "Persist";
+    // Cathedral Sanctifier {W}
+    // Creature — Human Cleric
+    //
+    // When Cathedral Sanctifier enters the battlefield, you gain 3 life.
+    // 1/1
+    private static final String sanctifier = "Cathedral Sanctifier";
+
+    @Test
+    public void test_Persist_Card() {
+        addCard(Zone.GRAVEYARD, playerA, sanctifier, 1);
+        addCard(Zone.BATTLEFIELD, playerA, "swamp", 2);
+        addCard(Zone.HAND, playerA, persist);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, persist, sanctifier);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, sanctifier, 0);
+        assertGraveyardCount(playerA, sanctifier, 1);
+        assertLife(playerA, 20 + 3);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnFromGraveyardToBattlefieldTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnFromGraveyardToBattlefieldTargetEffect.java
@@ -23,6 +23,9 @@ public class ReturnFromGraveyardToBattlefieldTargetEffect extends OneShotEffect 
 
     private final boolean tapped;
     private final boolean attacking;
+    // If true, creatures are returned to their owner's control.
+    // If false, creatures are returned under the effect's controller control.
+    private final boolean underOwnerControl;
 
     public ReturnFromGraveyardToBattlefieldTargetEffect() {
         this(false);
@@ -31,17 +34,22 @@ public class ReturnFromGraveyardToBattlefieldTargetEffect extends OneShotEffect 
     public ReturnFromGraveyardToBattlefieldTargetEffect(boolean tapped) {
         this(tapped, false);
     }
-
     public ReturnFromGraveyardToBattlefieldTargetEffect(boolean tapped, boolean attacking) {
+        this(tapped, attacking, false);
+    }
+
+    public ReturnFromGraveyardToBattlefieldTargetEffect(boolean tapped, boolean attacking, boolean underOwnerControl) {
         super(Outcome.PutCreatureInPlay);
         this.tapped = tapped;
         this.attacking = attacking;
+        this.underOwnerControl = underOwnerControl;
     }
 
     protected ReturnFromGraveyardToBattlefieldTargetEffect(final ReturnFromGraveyardToBattlefieldTargetEffect effect) {
         super(effect);
         this.tapped = effect.tapped;
         this.attacking = effect.attacking;
+        this.underOwnerControl = effect.underOwnerControl;
     }
 
     @Override
@@ -60,7 +68,7 @@ public class ReturnFromGraveyardToBattlefieldTargetEffect extends OneShotEffect 
                     cardsToMove.add(card);
                 }
             }
-            controller.moveCards(cardsToMove, Zone.BATTLEFIELD, source, game, tapped, false, false, null);
+            controller.moveCards(cardsToMove, Zone.BATTLEFIELD, source, game, tapped, false, underOwnerControl, null);
             if (attacking) {
                 for (Card card : cardsToMove) {
                     game.getCombat().addAttackingCreature(card.getId(), game);
@@ -111,7 +119,12 @@ public class ReturnFromGraveyardToBattlefieldTargetEffect extends OneShotEffect 
             sb.append(" attacking");
         }
         if (!yourGrave) {
-            sb.append(" under your control");
+            if (underOwnerControl) {
+                sb.append("under their owner's control");
+            }
+            else {
+                sb.append(" under your control");
+            }
         }
         return sb.toString();
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnFromGraveyardToBattlefieldWithCounterTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnFromGraveyardToBattlefieldWithCounterTargetEffect.java
@@ -10,6 +10,10 @@ import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
+import mage.target.targetpointer.FirstTargetPointer;
+import mage.target.targetpointer.FixedTarget;
+
+import java.util.UUID;
 
 /**
  * @author weirddan455
@@ -24,7 +28,11 @@ public class ReturnFromGraveyardToBattlefieldWithCounterTargetEffect extends Ret
     }
 
     public ReturnFromGraveyardToBattlefieldWithCounterTargetEffect(Counter counter, boolean additional) {
-        super();
+        this(counter, additional,false);
+    }
+
+    public ReturnFromGraveyardToBattlefieldWithCounterTargetEffect(Counter counter, boolean additional, boolean underOwnerControl) {
+        super(false, false, underOwnerControl);
         this.counter = counter;
         this.additional = additional;
     }
@@ -42,8 +50,11 @@ public class ReturnFromGraveyardToBattlefieldWithCounterTargetEffect extends Ret
 
     @Override
     public boolean apply(Game game, Ability source) {
-        AddCounterTargetReplacementEffect counterEffect = new AddCounterTargetReplacementEffect(counter);
-        game.addEffect(counterEffect, source);
+        for (UUID targetId: getTargetPointer().getTargets(game, source)) {
+            AddCounterTargetReplacementEffect counterEffect = new AddCounterTargetReplacementEffect(counter);
+            counterEffect.setTargetPointer(new FixedTarget(targetId, game));
+            game.addEffect(counterEffect, source);
+        }
         return super.apply(game, source);
     }
 
@@ -69,7 +80,12 @@ public class ReturnFromGraveyardToBattlefieldWithCounterTargetEffect extends Ret
         if (counter.getCount() != 1) {
             sb.append('s');
         }
-        sb.append(" on it");
+        if(targetPointer instanceof FirstTargetPointer){
+            sb.append(" on it");
+        }
+        else {
+            sb.append(" on them");
+        }
         return sb.toString();
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnFromGraveyardToBattlefieldWithCounterTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnFromGraveyardToBattlefieldWithCounterTargetEffect.java
@@ -10,7 +10,6 @@ import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
-import mage.target.targetpointer.FirstTargetPointer;
 import mage.target.targetpointer.FixedTarget;
 
 import java.util.UUID;
@@ -28,7 +27,7 @@ public class ReturnFromGraveyardToBattlefieldWithCounterTargetEffect extends Ret
     }
 
     public ReturnFromGraveyardToBattlefieldWithCounterTargetEffect(Counter counter, boolean additional) {
-        this(counter, additional,false);
+        this(counter, additional, false);
     }
 
     public ReturnFromGraveyardToBattlefieldWithCounterTargetEffect(Counter counter, boolean additional, boolean underOwnerControl) {
@@ -50,7 +49,7 @@ public class ReturnFromGraveyardToBattlefieldWithCounterTargetEffect extends Ret
 
     @Override
     public boolean apply(Game game, Ability source) {
-        for (UUID targetId: getTargetPointer().getTargets(game, source)) {
+        for (UUID targetId : getTargetPointer().getTargets(game, source)) {
             AddCounterTargetReplacementEffect counterEffect = new AddCounterTargetReplacementEffect(counter);
             counterEffect.setTargetPointer(new FixedTarget(targetId, game));
             game.addEffect(counterEffect, source);
@@ -80,11 +79,10 @@ public class ReturnFromGraveyardToBattlefieldWithCounterTargetEffect extends Ret
         if (counter.getCount() != 1) {
             sb.append('s');
         }
-        if(targetPointer instanceof FirstTargetPointer){
-            sb.append(" on it");
-        }
-        else {
+        if (targetPointer.isPlural(mode.getTargets())) {
             sb.append(" on them");
+        } else {
+            sb.append(" on it");
         }
         return sb.toString();
     }


### PR DESCRIPTION
Pyrrhic Revival is bugged, all the creatures are moved from graveyard to the battlefield, but there is no -1/-1 added whatsoever.

A continuous effect is applied to each individual creature, and i guess it gets lost when the cards become permanent?
I could not pinpoint the real cause, so here is a failing, and ignored, test on it.