### PR TITLE
Clean up triggered ability text generation

### DIFF
--- a/Mage.Sets/src/mage/cards/a/ArchpriestOfShadows.java
+++ b/Mage.Sets/src/mage/cards/a/ArchpriestOfShadows.java
@@ -2,7 +2,7 @@ package mage.cards.a;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrBattleTriggeredAbility;
 import mage.abilities.effects.common.ReturnFromGraveyardToBattlefieldTargetEffect;
 import mage.abilities.keyword.BackupAbility;
 import mage.abilities.keyword.DeathtouchAbility;
@@ -36,9 +36,9 @@ public final class ArchpriestOfShadows extends CardImpl {
         backupAbility.addAbility(DeathtouchAbility.getInstance());
 
         // Whenever this creature deals combat damage to a player or battle, return target creature card from your graveyard to the battlefield.
-        Ability ability = new DealsCombatDamageToAPlayerTriggeredAbility(
+        Ability ability = new DealsCombatDamageToAPlayerOrBattleTriggeredAbility(
                 new ReturnFromGraveyardToBattlefieldTargetEffect(), false
-        ).setOrBattle(true).setTriggerPhrase("Whenever this creature deals combat damage to a player or battle, ");
+        ).setTriggerPhrase("Whenever this creature deals combat damage to a player or battle, ");
         ability.addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD));
         backupAbility.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/a/AttentiveSkywarden.java
+++ b/Mage.Sets/src/mage/cards/a/AttentiveSkywarden.java
@@ -2,7 +2,7 @@ package mage.cards.a;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrBattleTriggeredAbility;
 import mage.abilities.effects.common.TransformTargetEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -39,9 +39,7 @@ public final class AttentiveSkywarden extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Whenever Attentive Skywarden deals combat damage to a player or battle, transform up to one target Incubator token you control.
-        Ability ability = new DealsCombatDamageToAPlayerTriggeredAbility(
-                new TransformTargetEffect(), false
-        ).setOrBattle(true);
+        Ability ability = new DealsCombatDamageToAPlayerOrBattleTriggeredAbility(new TransformTargetEffect(), false);
         ability.addTarget(new TargetPermanent(0, 1, filter));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BladewingDeathlessTyrant.java
+++ b/Mage.Sets/src/mage/cards/b/BladewingDeathlessTyrant.java
@@ -1,7 +1,7 @@
 package mage.cards.b;
 
 import mage.MageInt;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility;
 import mage.abilities.dynamicvalue.common.CardsInControllerGraveyardCount;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.keyword.FlyingAbility;
@@ -38,14 +38,9 @@ public final class BladewingDeathlessTyrant extends CardImpl {
 
         // Whenever Bladewing, Deathless Tyrant deals combat damage to a player or planeswalker,
         // for each creature card in your graveyard, create a 2/2 black Zombie Knight creature token with menace.
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new CreateTokenEffect(
-                        new ZombieKnightToken(),
-                        new CardsInControllerGraveyardCount(
-                                StaticFilters.FILTER_CARD_CREATURE
-                        )
-                ), false
-        ).setOrPlaneswalker(true));
+        this.addAbility(new DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(
+                new CreateTokenEffect(new ZombieKnightToken(),
+                        new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURE)), false));
     }
 
     private BladewingDeathlessTyrant(final BladewingDeathlessTyrant card) {

--- a/Mage.Sets/src/mage/cards/c/CovertTechnician.java
+++ b/Mage.Sets/src/mage/cards/c/CovertTechnician.java
@@ -37,7 +37,7 @@ public final class CovertTechnician extends CardImpl {
 
         // Whenever Covert Technician deals combat damage to a player, you may put an artifact card with mana value less than or equal to that damage from your hand onto the battlefield.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new CovertTechnicianEffect(), false, true, false
+                new CovertTechnicianEffect(), false, true
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeeprootWayfinder.java
+++ b/Mage.Sets/src/mage/cards/d/DeeprootWayfinder.java
@@ -2,7 +2,7 @@ package mage.cards.d;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrBattleTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
@@ -33,7 +33,7 @@ public final class DeeprootWayfinder extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever Deeproot Wayfinder deals combat damage to a player or battle, surveil 1, then you may return a land card from your graveyard to the battlefield tapped.
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new DeeprootWayfinderEffect(), false).setOrBattle(true));
+        this.addAbility(new DealsCombatDamageToAPlayerOrBattleTriggeredAbility(new DeeprootWayfinderEffect(), false));
     }
 
     private DeeprootWayfinder(final DeeprootWayfinder card) {

--- a/Mage.Sets/src/mage/cards/d/DoomskarWarrior.java
+++ b/Mage.Sets/src/mage/cards/d/DoomskarWarrior.java
@@ -1,7 +1,7 @@
 package mage.cards.d;
 
 import mage.MageInt;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrBattleTriggeredAbility;
 import mage.abilities.dynamicvalue.common.SavedDamageValue;
 import mage.abilities.effects.common.LookLibraryAndPickControllerEffect;
 import mage.abilities.keyword.BackupAbility;
@@ -36,13 +36,13 @@ public final class DoomskarWarrior extends CardImpl {
         backupAbility.addAbility(TrampleAbility.getInstance());
 
         // Whenever this creature deals combat damage to a player or battle, look at that many cards from the top of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
-        backupAbility.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
+        backupAbility.addAbility(new DealsCombatDamageToAPlayerOrBattleTriggeredAbility(
                 new LookLibraryAndPickControllerEffect(
                         SavedDamageValue.MANY, 1,
                         StaticFilters.FILTER_CARD_CREATURE_OR_LAND,
                         PutCards.HAND, PutCards.BOTTOM_RANDOM
                 ), false
-        ).setOrBattle(true).setTriggerPhrase("Whenever this creature deals combat damage to a player or battle, "));
+        ).setTriggerPhrase("Whenever this creature deals combat damage to a player or battle, "));
     }
 
     private DoomskarWarrior(final DoomskarWarrior card) {

--- a/Mage.Sets/src/mage/cards/d/DreadhordeButcher.java
+++ b/Mage.Sets/src/mage/cards/d/DreadhordeButcher.java
@@ -2,7 +2,7 @@ package mage.cards.d;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility;
 import mage.abilities.common.DiesSourceTriggeredAbility;
 import mage.abilities.dynamicvalue.common.SourcePermanentPowerCount;
 import mage.abilities.effects.common.DamageTargetEffect;
@@ -34,9 +34,9 @@ public final class DreadhordeButcher extends CardImpl {
         this.addAbility(HasteAbility.getInstance());
 
         // Whenever Dreadhorde Butcher deals combat damage to a player or planeswalker, put a +1/+1 counter on Dreadhorde Butcher.
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new AddCountersSourceEffect(
+        this.addAbility(new DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(new AddCountersSourceEffect(
                 CounterType.P1P1.createInstance()
-        ), false).setOrPlaneswalker(true));
+        ), false));
 
         // When Dreadhorde Butcher dies, it deals damage equal to its power to any target.
         Ability ability = new DiesSourceTriggeredAbility(new DamageTargetEffect(

--- a/Mage.Sets/src/mage/cards/f/FurnaceReins.java
+++ b/Mage.Sets/src/mage/cards/f/FurnaceReins.java
@@ -1,6 +1,6 @@
 package mage.cards.f;
 
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrBattleTriggeredAbility;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.UntapTargetEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
@@ -30,9 +30,9 @@ public final class FurnaceReins extends CardImpl {
                 HasteAbility.getInstance(), Duration.EndOfTurn
         ).setText("Until end of turn, it gains haste"));
         this.getSpellAbility().addEffect(new GainAbilityTargetEffect(
-                new DealsCombatDamageToAPlayerTriggeredAbility(
+                new DealsCombatDamageToAPlayerOrBattleTriggeredAbility(
                         new CreateTokenEffect(new TreasureToken()), false
-                ).setOrBattle(true), Duration.EndOfTurn
+                ), Duration.EndOfTurn
         ).setText("and \"Whenever this creature deals combat damage to a player or battle, create a Treasure token.\""));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }

--- a/Mage.Sets/src/mage/cards/g/GarruksHarbinger.java
+++ b/Mage.Sets/src/mage/cards/g/GarruksHarbinger.java
@@ -1,7 +1,7 @@
 package mage.cards.g;
 
 import mage.MageInt;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility;
 import mage.abilities.dynamicvalue.common.SavedDamageValue;
 import mage.abilities.effects.common.LookLibraryAndPickControllerEffect;
 import mage.abilities.keyword.HexproofFromBlackAbility;
@@ -45,9 +45,9 @@ public final class GarruksHarbinger extends CardImpl {
         // Whenever Garruk's Harbinger deals combat damage to a player or planeswalker, look at that many cards from the top of your library.
         // You may reveal a creature card or Garruk planeswalker card from among them and put it into your hand.
         // Put the rest on the bottom of your library in a random order.
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
+        this.addAbility(new DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(
                 new LookLibraryAndPickControllerEffect(SavedDamageValue.MANY, 1, filter, PutCards.HAND, PutCards.BOTTOM_RANDOM),
-                false, true).setOrPlaneswalker(true));
+                false));
     }
 
     private GarruksHarbinger(final GarruksHarbinger card) {

--- a/Mage.Sets/src/mage/cards/g/GitaxianMindstinger.java
+++ b/Mage.Sets/src/mage/cards/g/GitaxianMindstinger.java
@@ -1,7 +1,7 @@
 package mage.cards.g;
 
 import mage.MageInt;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrBattleTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.keyword.DeathtouchAbility;
 import mage.cards.CardImpl;
@@ -31,7 +31,7 @@ public final class GitaxianMindstinger extends CardImpl {
         this.addAbility(DeathtouchAbility.getInstance());
 
         // Whenever Gitaxian Mindstinger deals combat damage to a player or battle, draw a card.
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new DrawCardSourceControllerEffect(1),false).setOrBattle(true));
+        this.addAbility(new DealsCombatDamageToAPlayerOrBattleTriggeredAbility(new DrawCardSourceControllerEffect(1),false));
     }
 
     private GitaxianMindstinger(final GitaxianMindstinger card) {

--- a/Mage.Sets/src/mage/cards/g/GratefulApparition.java
+++ b/Mage.Sets/src/mage/cards/g/GratefulApparition.java
@@ -1,7 +1,7 @@
 package mage.cards.g;
 
 import mage.MageInt;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility;
 import mage.abilities.effects.common.counter.ProliferateEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -27,9 +27,7 @@ public final class GratefulApparition extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Whenever Grateful Apparition deals combat damage to a player or planeswalker, proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new ProliferateEffect(), false
-        ).setOrPlaneswalker(true));
+        this.addAbility(new DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(new ProliferateEffect(), false));
     }
 
     private GratefulApparition(final GratefulApparition card) {

--- a/Mage.Sets/src/mage/cards/g/GuildpactInformant.java
+++ b/Mage.Sets/src/mage/cards/g/GuildpactInformant.java
@@ -1,7 +1,7 @@
 package mage.cards.g;
 
 import mage.MageInt;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility;
 import mage.abilities.effects.common.counter.ProliferateEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -29,9 +29,7 @@ public final class GuildpactInformant extends CardImpl {
 
         // Whenever Guildpact Informant deals combat damage to a player or planeswalker,
         // proliferate. (Choose any number of permanents and/or players, then give each another counter of each kind already there.)
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new ProliferateEffect(), false
-        ).setOrPlaneswalker(true));
+        this.addAbility(new DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(new ProliferateEffect(), false));
     }
 
     private GuildpactInformant(final GuildpactInformant card) {

--- a/Mage.Sets/src/mage/cards/i/IG88B.java
+++ b/Mage.Sets/src/mage/cards/i/IG88B.java
@@ -1,4 +1,3 @@
-
 package mage.cards.i;
 
 import java.util.UUID;
@@ -39,10 +38,10 @@ public final class IG88B extends CardImpl {
 
         // <i>Bounty</i> &mdash; Whenever IF-88B deals combat damage to a player, that player loses life equal to the number of bounty counters on creatures they control.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new LoseLifeTargetEffect(new CountersOnDefendingPlayerCreaturesCount(CounterType.BOUNTY)),
+                new LoseLifeTargetEffect(new CountersOnDefendingPlayerCreaturesCount(CounterType.BOUNTY))
+                        .setText("that player loses life equal to the number of bounty counters on creatures they control"),
                 false,
-                "<i>Bounty</i> &mdash; Whenever {this} deals combat damage to a player, that player loses life equal to the number of bounty counters on creatures they control",
-                true)
+                true).withFlavorWord("Bounty")
         );
 
         // Repair 3

--- a/Mage.Sets/src/mage/cards/n/NehebDreadhordeChampion.java
+++ b/Mage.Sets/src/mage/cards/n/NehebDreadhordeChampion.java
@@ -3,7 +3,7 @@ package mage.cards.n;
 import mage.MageInt;
 import mage.Mana;
 import mage.abilities.Ability;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
@@ -33,9 +33,7 @@ public final class NehebDreadhordeChampion extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Whenever Neheb, Dreadhorde Champion deals combat damage to a player or planeswalker, you may discard any number of cards. If you do, draw that many cards and add that much {R}. Until end of turn, you don't lose this mana as steps and phases end.
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new NehebDreadhordeChampionEffect(), true).setOrPlaneswalker(true)
-        );
+        this.addAbility(new DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(new NehebDreadhordeChampionEffect(), true));
     }
 
     private NehebDreadhordeChampion(final NehebDreadhordeChampion card) {

--- a/Mage.Sets/src/mage/cards/o/OtrimiTheEverPlayful.java
+++ b/Mage.Sets/src/mage/cards/o/OtrimiTheEverPlayful.java
@@ -29,9 +29,6 @@ public final class OtrimiTheEverPlayful extends CardImpl {
         filter.add(new AbilityPredicate(MutateAbility.class));
     }
 
-    private static final String rule = "Whenever this creature deals combat damage to a player, " +
-            "return target creature card with mutate from your graveyard to your hand.";
-
     public OtrimiTheEverPlayful(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{B}{G}{U}");
 
@@ -49,9 +46,8 @@ public final class OtrimiTheEverPlayful extends CardImpl {
 
         // Whenever this creature deals combat damage to a player, return target creature card with mutate from your graveyard to your hand.
         Ability ability = new DealsCombatDamageToAPlayerTriggeredAbility(
-                new ReturnFromGraveyardToHandTargetEffect(),
-                false, rule, false
-        );
+                new ReturnFromGraveyardToHandTargetEffect(), false
+        ).setTriggerPhrase("Whenever this creature deals combat damage to a player, ");
         ability.addTarget(new TargetCardInYourGraveyard(filter));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/r/RankleAndTorbran.java
+++ b/Mage.Sets/src/mage/cards/r/RankleAndTorbran.java
@@ -3,7 +3,7 @@ package mage.cards.r;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.Mode;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrBattleTriggeredAbility;
 import mage.abilities.effects.ReplacementEffectImpl;
 import mage.abilities.effects.common.CreateTokenAllEffect;
 import mage.abilities.effects.common.SacrificeAllEffect;
@@ -48,9 +48,8 @@ public final class RankleAndTorbran extends CardImpl {
 
         // Whenever Rankle and Torbran deals combat damage to a player or battle, choose any number --
         // * Each player creates a Treasure token.
-        Ability ability = new DealsCombatDamageToAPlayerTriggeredAbility(
-                new CreateTokenAllEffect(new TreasureToken(), TargetController.EACH_PLAYER), false
-        ).setOrBattle(true);
+        Ability ability = new DealsCombatDamageToAPlayerOrBattleTriggeredAbility(
+                new CreateTokenAllEffect(new TreasureToken(), TargetController.EACH_PLAYER), false);
         ability.getModes().setMinModes(0);
         ability.getModes().setMaxModes(3);
 

--- a/Mage.Sets/src/mage/cards/r/RooftopSaboteurs.java
+++ b/Mage.Sets/src/mage/cards/r/RooftopSaboteurs.java
@@ -1,7 +1,7 @@
 package mage.cards.r;
 
 import mage.MageInt;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrBattleTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -30,9 +30,8 @@ public final class RooftopSaboteurs extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Whenever Rooftop Saboteurs deals combat damage to a player or battle, draw a card.
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new DrawCardSourceControllerEffect(1), false
-        ).setOrBattle(true));
+        this.addAbility(new DealsCombatDamageToAPlayerOrBattleTriggeredAbility(
+                new DrawCardSourceControllerEffect(1), false));
     }
 
     private RooftopSaboteurs(final RooftopSaboteurs card) {

--- a/Mage.Sets/src/mage/cards/s/SilentSubmersible.java
+++ b/Mage.Sets/src/mage/cards/s/SilentSubmersible.java
@@ -1,7 +1,7 @@
 package mage.cards.s;
 
 import mage.MageInt;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.keyword.CrewAbility;
 import mage.cards.CardImpl;
@@ -23,10 +23,10 @@ public final class SilentSubmersible extends CardImpl {
         this.power = new MageInt(2);
         this.toughness = new MageInt(3);
 
-        // Whenever Silent Submarine deals combat damage to a player or planeswalker, draw a card.
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
+        // Whenever Silent Submersible deals combat damage to a player or planeswalker, draw a card.
+        this.addAbility(new DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(
                 new DrawCardSourceControllerEffect(1), false
-        ).setOrPlaneswalker(true));
+        ));
 
         // Crew 2
         this.addAbility(new CrewAbility(2));

--- a/Mage.Sets/src/mage/cards/s/StormTheCitadel.java
+++ b/Mage.Sets/src/mage/cards/s/StormTheCitadel.java
@@ -1,7 +1,7 @@
 package mage.cards.s;
 
 import mage.abilities.Ability;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility;
 import mage.abilities.effects.common.DestroyTargetEffect;
 import mage.abilities.effects.common.continuous.BoostControlledEffect;
 import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
@@ -37,9 +37,8 @@ public final class StormTheCitadel extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{G}");
 
         // Until end of turn, creatures you control get +2/+2 and gain "Whenever this creature deals combat damage to a creature or planeswalker, destroy target artifact or enchantment defending player controls."
-        Ability ability = new DealsCombatDamageToAPlayerTriggeredAbility(
-                new DestroyTargetEffect(), false
-        ).setOrPlaneswalker(true);
+        Ability ability = new DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(
+                new DestroyTargetEffect(), false);
         ability.addTarget(new TargetPermanent(filter));
 
         this.getSpellAbility().addEffect(new BoostControlledEffect(

--- a/Mage.Sets/src/mage/cards/s/StorrevDevkarinLich.java
+++ b/Mage.Sets/src/mage/cards/s/StorrevDevkarinLich.java
@@ -3,7 +3,7 @@ package mage.cards.s;
 import mage.MageInt;
 import mage.MageObjectReference;
 import mage.abilities.Ability;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility;
 import mage.abilities.effects.common.ReturnToHandTargetEffect;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.Card;
@@ -54,9 +54,8 @@ public final class StorrevDevkarinLich extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Whenever Storrev, Devkarin Lich deals combat damage to a player or planeswalker, return to your hand target creature or planeswalker card in your graveyard that wasn't put there this combat.
-        Ability ability = new DealsCombatDamageToAPlayerTriggeredAbility(
-                new ReturnToHandTargetEffect(), false
-        ).setOrPlaneswalker(true);
+        Ability ability = new DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(
+                new ReturnToHandTargetEffect(), false);
         ability.addTarget(new TargetCardInYourGraveyard(filter));
         this.addAbility(ability, new StorrevDevkarinLichWatcher());
     }

--- a/Mage.Sets/src/mage/cards/t/TemperedSliver.java
+++ b/Mage.Sets/src/mage/cards/t/TemperedSliver.java
@@ -30,8 +30,10 @@ public final class TemperedSliver extends CardImpl {
         // Sliver creatures you control have "Whenever this creature deals combat damage to a player, put a +1/+1 counter on it."
         this.addAbility(new SimpleStaticAbility(new GainAbilityControlledEffect(
                 new DealsCombatDamageToAPlayerTriggeredAbility(
-                        new AddCountersSourceEffect(CounterType.P1P1.createInstance(1)), false,"Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.",false
-                ), Duration.WhileOnBattlefield, StaticFilters.FILTER_PERMANENT_SLIVERS
+                        new AddCountersSourceEffect(CounterType.P1P1.createInstance(1))
+                                .setText("put a +1/+1 counter on it"), false
+                ).setTriggerPhrase("Whenever this creature deals combat damage to a player, ")
+                , Duration.WhileOnBattlefield, StaticFilters.FILTER_PERMANENT_SLIVERS
         )));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheReaverCleaver.java
+++ b/Mage.Sets/src/mage/cards/t/TheReaverCleaver.java
@@ -1,7 +1,7 @@
 package mage.cards.t;
 
 import mage.abilities.Ability;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.dynamicvalue.common.SavedDamageValue;
@@ -38,9 +38,8 @@ public final class TheReaverCleaver extends CardImpl {
                 "and has trample"
         ));
         ability.addEffect(new GainAbilityAttachedEffect(
-                new DealsCombatDamageToAPlayerTriggeredAbility(
-                        new CreateTokenEffect(new TreasureToken(), SavedDamageValue.MANY), false
-                ).setOrPlaneswalker(true),
+                new DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(
+                        new CreateTokenEffect(new TreasureToken(), SavedDamageValue.MANY), false),
                 AttachmentType.EQUIPMENT,
                 Duration.WhileOnBattlefield,
                 " and \"Whenever this creature deals combat damage to a player or planeswalker, create that many Treasure tokens.\""

--- a/Mage.Sets/src/mage/cards/t/TimotharBaronOfBats.java
+++ b/Mage.Sets/src/mage/cards/t/TimotharBaronOfBats.java
@@ -3,21 +3,15 @@ package mage.cards.t;
 import mage.MageInt;
 import mage.MageObjectReference;
 import mage.abilities.Ability;
+import mage.abilities.TriggeredAbility;
 import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
 import mage.abilities.common.DiesCreatureTriggeredAbility;
-import mage.abilities.costs.Cost;
-import mage.abilities.costs.CostAdjuster;
-import mage.abilities.costs.Costs;
-import mage.abilities.costs.CostsImpl;
 import mage.abilities.costs.common.DiscardCardCost;
-import mage.abilities.costs.common.ExileFromGraveCost;
 import mage.abilities.costs.mana.ManaCost;
 import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.CreateTokenEffect;
-import mage.abilities.effects.common.DoIfCostPaid;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
 import mage.abilities.hint.StaticHint;
@@ -26,15 +20,12 @@ import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.FilterCard;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
-import mage.filter.predicate.mageobject.CardIdPredicate;
 import mage.game.Game;
 import mage.game.permanent.token.BatToken;
 import mage.players.Player;
-import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTargets;
 
 import java.util.UUID;
@@ -79,6 +70,7 @@ public class TimotharBaronOfBats extends CardImpl {
 }
 
 class TimotharBaronOfBatsCreateBatEffect extends OneShotEffect {
+    // TODO: this could be reworked to use DoIfCostPaid rather than reimplementing that functionality
 
     TimotharBaronOfBatsCreateBatEffect() {
         super(Outcome.Benefit);
@@ -118,13 +110,10 @@ class TimotharBaronOfBatsCreateBatEffect extends OneShotEffect {
         BatToken bat = new BatToken();
         bat.putOntoBattlefield(1, game, source);
 
-        DealsCombatDamageToAPlayerTriggeredAbility sacAndReturnAbility = new DealsCombatDamageToAPlayerTriggeredAbility(
-                new SacrificeSourceEffect(),
-                false,
-                "When this creature deals combat damage to a player, " +
-                        "sacrifice it and return the exiled card to the battlefield tapped",
-                false);
-        sacAndReturnAbility.addEffect(new TimotharBaronOfBatsReturnEffect(new MageObjectReference(vampireCard, game)));
+        TriggeredAbility sacAndReturnAbility = new DealsCombatDamageToAPlayerTriggeredAbility(
+                new SacrificeSourceEffect().setText("sacrifice it"),
+                false).setTriggerPhrase("When this creature deals combat damage to a player, ");
+        sacAndReturnAbility.addEffect(new TimotharBaronOfBatsReturnEffect(new MageObjectReference(vampireCard, game)).concatBy("and"));
         sacAndReturnAbility.addHint(new StaticHint("Exiled card: " + vampireCard.getName()));
 
         GainAbilityTargetEffect gainAbilityTargetEffect = new GainAbilityTargetEffect(sacAndReturnAbility, Duration.Custom);

--- a/Mage.Sets/src/mage/cards/t/TrickstersTalisman.java
+++ b/Mage.Sets/src/mage/cards/t/TrickstersTalisman.java
@@ -69,13 +69,14 @@ class TrickstersTalismanEffect extends GainAbilityWithAttachmentEffect {
 
     @Override
     protected Ability makeAbility(Game game, Ability source) {
-        if (game == null || source == null) {
+        if (game == null || source == null || source.getSourcePermanentIfItStillExists(game) == null) {
             return null;
         }
         return new DealsCombatDamageToAPlayerTriggeredAbility(new DoIfCostPaid(
-                new CreateTokenCopySourceEffect(), useAttachedCost.setMageObjectReference(source, game)
-        ), false, "Whenever this creature deals combat damage to a player, you may sacrifice "
-                + source.getSourcePermanentIfItStillExists(game).getName()
-                + ". If you do, create a token that's a copy of this creature.", false);
+                new CreateTokenCopySourceEffect().setText("create a token that's a copy of this creature"),
+                useAttachedCost.setMageObjectReference(source, game)
+        ).setText("you may sacrifice " + source.getSourcePermanentIfItStillExists(game).getName()
+                + ". If you do, create a token that's a copy of this creature"
+        ), false).setTriggerPhrase("Whenever this creature deals combat damage to a player, ");
     }
 }

--- a/Mage.Sets/src/mage/cards/v/VraskaSchemingGorgon.java
+++ b/Mage.Sets/src/mage/cards/v/VraskaSchemingGorgon.java
@@ -2,7 +2,8 @@ package mage.cards.v;
 
 import mage.abilities.LoyaltyAbility;
 import mage.abilities.TriggeredAbility;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DestroyTargetEffect;
 import mage.abilities.effects.common.LoseGameTargetPlayerEffect;
 import mage.abilities.effects.common.continuous.BoostControlledEffect;
@@ -10,11 +11,12 @@ import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
 import mage.abilities.keyword.DeathtouchAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.SubType;
-import mage.constants.SuperType;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.events.DamagedEvent;
+import mage.game.events.GameEvent;
 import mage.target.common.TargetCreaturePermanent;
+import mage.target.targetpointer.FixedTarget;
 
 import java.util.UUID;
 
@@ -41,7 +43,7 @@ public final class VraskaSchemingGorgon extends CardImpl {
         // -10: Until end of turn, creatures you control gain deathtouch and "Whenever this creature deals damage to an opponent, that player loses the game."
         loyaltyAbility = new LoyaltyAbility(new GainAbilityControlledEffect(DeathtouchAbility.getInstance(), Duration.EndOfTurn)
                 .setText("Until end of turn, creatures you control gain deathtouch"), -10);
-        TriggeredAbility triggeredAbility = new DealsCombatDamageToAPlayerTriggeredAbility(new LoseGameTargetPlayerEffect(), false, true, true);
+        TriggeredAbility triggeredAbility = new VraskaSchemingGorgonTriggeredAbility(new LoseGameTargetPlayerEffect());
         loyaltyAbility.addEffect(new GainAbilityControlledEffect(triggeredAbility, Duration.EndOfTurn)
                 .setText("and \"Whenever this creature deals damage to an opponent, that player loses the game.\""));
         this.addAbility(loyaltyAbility);
@@ -55,4 +57,41 @@ public final class VraskaSchemingGorgon extends CardImpl {
     public VraskaSchemingGorgon copy() {
         return new VraskaSchemingGorgon(this);
     }
+}
+
+class VraskaSchemingGorgonTriggeredAbility extends TriggeredAbilityImpl {
+
+    VraskaSchemingGorgonTriggeredAbility(Effect effect) {
+        super(Zone.BATTLEFIELD, effect, false);
+        setTriggerPhrase("Whenever this creature deals damage to an opponent, ");
+    }
+
+    private VraskaSchemingGorgonTriggeredAbility(final VraskaSchemingGorgonTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public VraskaSchemingGorgonTriggeredAbility copy() {
+        return new VraskaSchemingGorgonTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DAMAGED_PLAYER;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        if (!event.getSourceId().equals(getSourceId())
+                || !((DamagedEvent) event).isCombatDamage()) {
+            return false;
+        }
+        if (!game.getOpponents(getControllerId()).contains(event.getTargetId())) {
+            return false;
+        }
+        getAllEffects().setTargetPointer(new FixedTarget(event.getPlayerId()));
+        return true;
+    }
+
+
 }

--- a/Mage.Sets/src/mage/cards/v/VraskaSchemingGorgon.java
+++ b/Mage.Sets/src/mage/cards/v/VraskaSchemingGorgon.java
@@ -12,6 +12,7 @@ import mage.abilities.keyword.DeathtouchAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.DamagedEvent;
 import mage.game.events.GameEvent;
@@ -41,10 +42,10 @@ public final class VraskaSchemingGorgon extends CardImpl {
         this.addAbility(loyaltyAbility);
 
         // -10: Until end of turn, creatures you control gain deathtouch and "Whenever this creature deals damage to an opponent, that player loses the game."
-        loyaltyAbility = new LoyaltyAbility(new GainAbilityControlledEffect(DeathtouchAbility.getInstance(), Duration.EndOfTurn)
+        loyaltyAbility = new LoyaltyAbility(new GainAbilityControlledEffect(DeathtouchAbility.getInstance(), Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES)
                 .setText("Until end of turn, creatures you control gain deathtouch"), -10);
         TriggeredAbility triggeredAbility = new VraskaSchemingGorgonTriggeredAbility(new LoseGameTargetPlayerEffect());
-        loyaltyAbility.addEffect(new GainAbilityControlledEffect(triggeredAbility, Duration.EndOfTurn)
+        loyaltyAbility.addEffect(new GainAbilityControlledEffect(triggeredAbility, Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES)
                 .setText("and \"Whenever this creature deals damage to an opponent, that player loses the game.\""));
         this.addAbility(loyaltyAbility);
     }

--- a/Mage/src/main/java/mage/abilities/TriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/TriggeredAbility.java
@@ -58,12 +58,5 @@ public interface TriggeredAbility extends Ability {
 
     GameEvent getTriggerEvent();
 
-    /**
-     * Don't override this. Use setTriggerPhrase instead and let the base class handle it.
-     * @return
-     */
-    @Deprecated
-    String getTriggerPhrase();
-
     TriggeredAbility setTriggerPhrase(String triggerPhrase);
 }

--- a/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
@@ -27,7 +27,7 @@ public abstract class TriggeredAbilityImpl extends AbilityImpl implements Trigge
     private boolean triggersOnceEachTurn = false;
     private boolean doOnlyOnceEachTurn = false;
     private GameEvent triggerEvent = null;
-    private String triggerPhrase = null; // TODO: This should be change to final and all constructers to set a value
+    private String triggerPhrase = null; // TODO: This could be changed to final if all constructors set a value
 
     protected TriggeredAbilityImpl(Zone zone, Effect effect) {
         this(zone, effect, false);
@@ -67,7 +67,7 @@ public abstract class TriggeredAbilityImpl extends AbilityImpl implements Trigge
         }
     }
 
-    private final void setLastTrigger(Game game) {
+    private void setLastTrigger(Game game) {
         if (!triggersOnceEachTurn) {
             return;
         }
@@ -188,7 +188,7 @@ public abstract class TriggeredAbilityImpl extends AbilityImpl implements Trigge
         }
         sb.append(prefix);
 
-        sb.append(triggerPhrase == null ? getTriggerPhrase() : triggerPhrase);
+        sb.append(triggerPhrase == null ? "" : triggerPhrase);
 
         String superRule = super.getRule(true);
         if (!superRule.isEmpty()) {
@@ -248,12 +248,6 @@ public abstract class TriggeredAbilityImpl extends AbilityImpl implements Trigge
         }
 
         return sb.toString();
-    }
-
-    @Override
-    @Deprecated
-    public String getTriggerPhrase() {
-        return "";
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerOrBattleTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerOrBattleTriggeredAbility.java
@@ -19,7 +19,7 @@ public class DealsCombatDamageToAPlayerOrBattleTriggeredAbility extends Triggere
     }
 
 
-    public DealsCombatDamageToAPlayerOrBattleTriggeredAbility(final DealsCombatDamageToAPlayerOrBattleTriggeredAbility ability) {
+    protected DealsCombatDamageToAPlayerOrBattleTriggeredAbility(final DealsCombatDamageToAPlayerOrBattleTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerOrBattleTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerOrBattleTriggeredAbility.java
@@ -1,0 +1,53 @@
+package mage.abilities.common;
+
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.effects.Effect;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.DamagedEvent;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+
+/**
+ * @author xenohedron
+ */
+public class DealsCombatDamageToAPlayerOrBattleTriggeredAbility extends TriggeredAbilityImpl {
+
+    public DealsCombatDamageToAPlayerOrBattleTriggeredAbility(Effect effect, boolean optional) {
+        super(Zone.BATTLEFIELD, effect, optional);
+        setTriggerPhrase("Whenever {this} deals combat damage to a player or battle, ");
+    }
+
+
+    public DealsCombatDamageToAPlayerOrBattleTriggeredAbility(final DealsCombatDamageToAPlayerOrBattleTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public DealsCombatDamageToAPlayerOrBattleTriggeredAbility copy() {
+        return new DealsCombatDamageToAPlayerOrBattleTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DAMAGED_PLAYER
+                || event.getType() == GameEvent.EventType.DAMAGED_PERMANENT;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        if (!event.getSourceId().equals(getSourceId())
+                || !((DamagedEvent) event).isCombatDamage()) {
+            return false;
+        }
+        if (event.getType() == GameEvent.EventType.DAMAGED_PERMANENT) {
+            Permanent permanent = game.getPermanent(event.getTargetId());
+            if (permanent == null || !permanent.isBattle(game)) {
+                return false;
+            }
+        }
+        getAllEffects().setValue("damage", event.getAmount());
+        return true;
+    }
+
+}

--- a/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility.java
@@ -19,7 +19,7 @@ public class DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility extends Tr
     }
 
 
-    public DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(final DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility ability) {
+    protected DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(final DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility.java
@@ -1,0 +1,53 @@
+package mage.abilities.common;
+
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.effects.Effect;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.DamagedEvent;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+
+/**
+ * @author xenohedron
+ */
+public class DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility extends TriggeredAbilityImpl {
+
+    public DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(Effect effect, boolean optional) {
+        super(Zone.BATTLEFIELD, effect, optional);
+        setTriggerPhrase("Whenever {this} deals combat damage to a player or planeswalker, ");
+    }
+
+
+    public DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(final DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility copy() {
+        return new DealsCombatDamageToAPlayerOrPlaneswalkerTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DAMAGED_PLAYER
+                || event.getType() == GameEvent.EventType.DAMAGED_PERMANENT;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        if (!event.getSourceId().equals(getSourceId())
+                || !((DamagedEvent) event).isCombatDamage()) {
+            return false;
+        }
+        if (event.getType() == GameEvent.EventType.DAMAGED_PERMANENT) {
+            Permanent permanent = game.getPermanent(event.getTargetId());
+            if (permanent == null || !permanent.isPlaneswalker(game)) {
+                return false;
+            }
+        }
+        getAllEffects().setValue("damage", event.getAmount());
+        return true;
+    }
+
+}

--- a/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerTriggeredAbility.java
@@ -14,7 +14,6 @@ import mage.target.targetpointer.FixedTarget;
 public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbilityImpl {
 
     protected final boolean setTargetPointer;
-    protected String text;
     protected boolean onlyOpponents;
 
     public DealsCombatDamageToAPlayerTriggeredAbility(Effect effect, boolean optional) {
@@ -31,15 +30,8 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
         this.onlyOpponents = onlyOpponents;
     }
 
-    public DealsCombatDamageToAPlayerTriggeredAbility(Effect effect, boolean optional, String text, boolean setTargetPointer) {
-        super(Zone.BATTLEFIELD, effect, optional);
-        this.text = text;
-        this.setTargetPointer = setTargetPointer;
-    }
-
     public DealsCombatDamageToAPlayerTriggeredAbility(final DealsCombatDamageToAPlayerTriggeredAbility ability) {
         super(ability);
-        this.text = ability.text;
         this.setTargetPointer = ability.setTargetPointer;
         this.onlyOpponents = ability.onlyOpponents;
     }
@@ -68,14 +60,6 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
             getAllEffects().setTargetPointer(new FixedTarget(event.getPlayerId()));
         }
         return true;
-    }
-
-    @Override
-    public String getRule() {
-        if (text == null || text.isEmpty()) {
-            return super.getRule();
-        }
-        return text;
     }
 
     // TODO: This class needs refactoring to specify onlyOppontns and OrPLaneswalkers in constructor

--- a/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerTriggeredAbility.java
@@ -25,7 +25,7 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
         setTriggerPhrase("Whenever {this} deals combat damage to a player, ");
     }
 
-    public DealsCombatDamageToAPlayerTriggeredAbility(final DealsCombatDamageToAPlayerTriggeredAbility ability) {
+    protected DealsCombatDamageToAPlayerTriggeredAbility(final DealsCombatDamageToAPlayerTriggeredAbility ability) {
         super(ability);
         this.setTargetPointer = ability.setTargetPointer;
     }

--- a/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerTriggeredAbility.java
@@ -6,7 +6,6 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.DamagedEvent;
 import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
 import mage.target.targetpointer.FixedTarget;
 
 /**
@@ -17,7 +16,6 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
     protected final boolean setTargetPointer;
     protected String text;
     protected boolean onlyOpponents;
-    private boolean orPlaneswalker = false;
 
     public DealsCombatDamageToAPlayerTriggeredAbility(Effect effect, boolean optional) {
         this(effect, optional, false);
@@ -44,12 +42,6 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
         this.text = ability.text;
         this.setTargetPointer = ability.setTargetPointer;
         this.onlyOpponents = ability.onlyOpponents;
-        this.orPlaneswalker = ability.orPlaneswalker;
-    }
-
-    public DealsCombatDamageToAPlayerTriggeredAbility setOrPlaneswalker(boolean orPlaneswalker) {
-        this.orPlaneswalker = orPlaneswalker;
-        return this;
     }
 
     @Override
@@ -59,8 +51,7 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
 
     @Override
     public boolean checkEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.DAMAGED_PLAYER
-                || event.getType() == GameEvent.EventType.DAMAGED_PERMANENT;
+        return event.getType() == GameEvent.EventType.DAMAGED_PLAYER;
     }
 
     @Override
@@ -69,18 +60,8 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
                 || !((DamagedEvent) event).isCombatDamage()) {
             return false;
         }
-        switch (event.getType()) {
-            case DAMAGED_PLAYER:
-                if (onlyOpponents && !game.getOpponents(getControllerId()).contains(event.getTargetId())) {
-                    return false;
-                }
-                break;
-            case DAMAGED_PERMANENT:
-                Permanent permanent = game.getPermanent(event.getTargetId());
-                if (permanent == null
-                        || (!orPlaneswalker || !permanent.isPlaneswalker(game))) {
-                    return false;
-                }
+        if (onlyOpponents && !game.getOpponents(getControllerId()).contains(event.getTargetId())) {
+            return false;
         }
         getAllEffects().setValue("damage", event.getAmount());
         if (setTargetPointer) {
@@ -102,7 +83,6 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
     public String getTriggerPhrase() {
         return "Whenever {this} deals combat damage to "
                 + (onlyOpponents ? "an opponent" : "a player")
-                + (orPlaneswalker ? " or planeswalker" : "")
                 + ", ";
     }
 }

--- a/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerTriggeredAbility.java
@@ -14,26 +14,20 @@ import mage.target.targetpointer.FixedTarget;
 public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbilityImpl {
 
     protected final boolean setTargetPointer;
-    protected boolean onlyOpponents;
 
     public DealsCombatDamageToAPlayerTriggeredAbility(Effect effect, boolean optional) {
         this(effect, optional, false);
     }
 
     public DealsCombatDamageToAPlayerTriggeredAbility(Effect effect, boolean optional, boolean setTargetPointer) {
-        this(effect, optional, setTargetPointer, false);
-    }
-
-    public DealsCombatDamageToAPlayerTriggeredAbility(Effect effect, boolean optional, boolean setTargetPointer, boolean onlyOpponents) {
         super(Zone.BATTLEFIELD, effect, optional);
         this.setTargetPointer = setTargetPointer;
-        this.onlyOpponents = onlyOpponents;
+        setTriggerPhrase("Whenever {this} deals combat damage to a player, ");
     }
 
     public DealsCombatDamageToAPlayerTriggeredAbility(final DealsCombatDamageToAPlayerTriggeredAbility ability) {
         super(ability);
         this.setTargetPointer = ability.setTargetPointer;
-        this.onlyOpponents = ability.onlyOpponents;
     }
 
     @Override
@@ -52,9 +46,6 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
                 || !((DamagedEvent) event).isCombatDamage()) {
             return false;
         }
-        if (onlyOpponents && !game.getOpponents(getControllerId()).contains(event.getTargetId())) {
-            return false;
-        }
         getAllEffects().setValue("damage", event.getAmount());
         if (setTargetPointer) {
             getAllEffects().setTargetPointer(new FixedTarget(event.getPlayerId()));
@@ -62,11 +53,4 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
         return true;
     }
 
-    // TODO: This class needs refactoring to specify onlyOppontns and OrPLaneswalkers in constructor
-    @Override
-    public String getTriggerPhrase() {
-        return "Whenever {this} deals combat damage to "
-                + (onlyOpponents ? "an opponent" : "a player")
-                + ", ";
-    }
 }

--- a/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DealsCombatDamageToAPlayerTriggeredAbility.java
@@ -18,7 +18,6 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
     protected String text;
     protected boolean onlyOpponents;
     private boolean orPlaneswalker = false;
-    private boolean orBattle = false;
 
     public DealsCombatDamageToAPlayerTriggeredAbility(Effect effect, boolean optional) {
         this(effect, optional, false);
@@ -46,16 +45,10 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
         this.setTargetPointer = ability.setTargetPointer;
         this.onlyOpponents = ability.onlyOpponents;
         this.orPlaneswalker = ability.orPlaneswalker;
-        this.orBattle = ability.orBattle;
     }
 
     public DealsCombatDamageToAPlayerTriggeredAbility setOrPlaneswalker(boolean orPlaneswalker) {
         this.orPlaneswalker = orPlaneswalker;
-        return this;
-    }
-
-    public DealsCombatDamageToAPlayerTriggeredAbility setOrBattle(boolean orBattle) {
-        this.orBattle = orBattle;
         return this;
     }
 
@@ -85,8 +78,7 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
             case DAMAGED_PERMANENT:
                 Permanent permanent = game.getPermanent(event.getTargetId());
                 if (permanent == null
-                        || (!orPlaneswalker || !permanent.isPlaneswalker(game))
-                        && (!orBattle || !permanent.isBattle(game))) {
+                        || (!orPlaneswalker || !permanent.isPlaneswalker(game))) {
                     return false;
                 }
         }
@@ -111,7 +103,6 @@ public class DealsCombatDamageToAPlayerTriggeredAbility extends TriggeredAbility
         return "Whenever {this} deals combat damage to "
                 + (onlyOpponents ? "an opponent" : "a player")
                 + (orPlaneswalker ? " or planeswalker" : "")
-                + (orBattle ? " or battle" : "")
                 + ", ";
     }
 }


### PR DESCRIPTION
* Simplify DealsCombatDamageToAPlayerTriggeredAbility
    - create separate classes for planeswalkers, battles also
    - remove strange custom text setting
    - custom ability for Vraska (specifies opponents)
 * Remove deprecated getTriggerPhrase
    - Completes the followup TODO from #9343