### PR TITLE
Add starting hand size parameter to GameImpl constructor

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/TestCardRenderDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/TestCardRenderDialog.java
@@ -752,7 +752,7 @@ class TestGame extends GameImpl {
     private int numPlayers;
 
     public TestGame(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60);
+        super(attackOption, range, mulligan, startLife, 60, 7);
     }
 
     public TestGame(final TestGame game) {

--- a/Mage.Server.Plugins/Mage.Game.FreeForAll/src/mage/game/FreeForAll.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeForAll/src/mage/game/FreeForAll.java
@@ -15,7 +15,7 @@ public class FreeForAll extends GameImpl {
     private int numPlayers;
 
     public FreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60);
+        super(attackOption, range, mulligan, startLife, 60, 7);
     }
 
     public FreeForAll(final FreeForAll game) {

--- a/Mage.Server.Plugins/Mage.Game.MomirDuel/src/mage/game/MomirDuel.java
+++ b/Mage.Server.Plugins/Mage.Game.MomirDuel/src/mage/game/MomirDuel.java
@@ -1,7 +1,6 @@
 
 package mage.game;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.InfoEffect;
@@ -17,6 +16,8 @@ import mage.game.mulligan.Mulligan;
 import mage.game.turn.TurnMod;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
  *
  * @author nigelzor
@@ -24,7 +25,7 @@ import mage.players.Player;
 public class MomirDuel extends GameImpl {
 
     public MomirDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60);
+        super(attackOption, range, mulligan, startLife, 60, 7);
     }
 
     public MomirDuel(final MomirDuel game) {

--- a/Mage.Server.Plugins/Mage.Game.MomirGame/src/mage/game/MomirGame.java
+++ b/Mage.Server.Plugins/Mage.Game.MomirGame/src/mage/game/MomirGame.java
@@ -1,7 +1,6 @@
 
 package mage.game;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.InfoEffect;
@@ -17,6 +16,8 @@ import mage.game.mulligan.Mulligan;
 import mage.game.turn.TurnMod;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
  *
  * @author nigelzor
@@ -26,7 +27,7 @@ public class MomirGame extends GameImpl {
     private int numPlayers;
 
     public MomirGame(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60);
+        super(attackOption, range, mulligan, startLife, 60, 7);
     }
 
     public MomirGame(final MomirGame game) {

--- a/Mage.Server.Plugins/Mage.Game.TwoPlayerDuel/src/mage/game/TwoPlayerDuel.java
+++ b/Mage.Server.Plugins/Mage.Game.TwoPlayerDuel/src/mage/game/TwoPlayerDuel.java
@@ -16,7 +16,11 @@ public class TwoPlayerDuel extends GameImpl {
     }
 
     public TwoPlayerDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startingLife, int minimumDeckSize) {
-        super(attackOption, range, mulligan, startingLife, minimumDeckSize);
+        this(attackOption, range, mulligan, startingLife, minimumDeckSize, 7);
+    }
+
+    public TwoPlayerDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startingLife, int minimumDeckSize, int startingHandSize) {
+        super(attackOption, range, mulligan, startingLife, minimumDeckSize, startingHandSize);
     }
 
     public TwoPlayerDuel(final TwoPlayerDuel game) {

--- a/Mage/src/main/java/mage/game/GameCanadianHighlanderImpl.java
+++ b/Mage/src/main/java/mage/game/GameCanadianHighlanderImpl.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 public abstract class GameCanadianHighlanderImpl extends GameImpl {
 
     public GameCanadianHighlanderImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 100);
+        super(attackOption, range, mulligan, startLife, 100, 7);
     }
 
     public GameCanadianHighlanderImpl(final GameCanadianHighlanderImpl game) {

--- a/Mage/src/main/java/mage/game/GameCommanderImpl.java
+++ b/Mage/src/main/java/mage/game/GameCommanderImpl.java
@@ -32,7 +32,7 @@ public abstract class GameCommanderImpl extends GameImpl {
     protected boolean startingPlayerSkipsDraw = true;
 
     public GameCommanderImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startingLife, int minimumDeckSize) {
-        super(attackOption, range, mulligan, startingLife, minimumDeckSize);
+        super(attackOption, range, mulligan, startingLife, minimumDeckSize, 7);
     }
 
     public GameCommanderImpl(final GameCommanderImpl game) {

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -144,6 +144,7 @@ public abstract class GameImpl implements Game {
     private boolean saveGame = false; // replay code, not done
     private int priorityTime; // match time limit
     private final int startingLife;
+    private final int startingHandSize;
     private final int minimumDeckSize;
     protected transient PlayerList playerList; // auto-generated from state, don't copy
 
@@ -156,13 +157,14 @@ public abstract class GameImpl implements Game {
     // temporary store for income concede commands, don't copy
     private final LinkedList<UUID> concedingPlayers = new LinkedList<>();
 
-    public GameImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startingLife, int minimumDeckSize) {
+    public GameImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startingLife, int minimumDeckSize, int startingHandSize) {
         this.id = UUID.randomUUID();
         this.range = range;
         this.mulligan = mulligan;
         this.attackOption = attackOption;
         this.state = new GameState();
         this.startingLife = startingLife;
+        this.startingHandSize = startingHandSize;
         this.executingRollback = false;
         this.minimumDeckSize = minimumDeckSize;
 
@@ -251,6 +253,7 @@ public abstract class GameImpl implements Game {
         this.saveGame = game.saveGame;
         this.priorityTime = game.priorityTime;
         this.startingLife = game.startingLife;
+        this.startingHandSize = game.startingHandSize;
         this.minimumDeckSize = game.minimumDeckSize;
         //this.playerList = game.playerList; // auto-generated list, don't copy
 
@@ -1253,7 +1256,6 @@ public abstract class GameImpl implements Game {
         sendStartMessage(choosingPlayer, startingPlayer);
 
         //20091005 - 103.3
-        int startingHandSize = 7;
         for (UUID playerId : state.getPlayerList(startingPlayerId)) {
             Player player = getPlayer(playerId);
             if (!gameOptions.testMode || player.getLife() == 0) {

--- a/Mage/src/main/java/mage/game/GameTinyLeadersImpl.java
+++ b/Mage/src/main/java/mage/game/GameTinyLeadersImpl.java
@@ -17,7 +17,6 @@ import mage.game.turn.TurnMod;
 import mage.players.Player;
 import mage.util.CardUtil;
 import mage.watchers.common.CommanderInfoWatcher;
-import mage.watchers.common.CommanderPlaysCountWatcher;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -33,7 +32,7 @@ public abstract class GameTinyLeadersImpl extends GameImpl {
     protected boolean startingPlayerSkipsDraw = true;
 
     public GameTinyLeadersImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 50);
+        super(attackOption, range, mulligan, startLife, 50, 7);
     }
 
     public GameTinyLeadersImpl(final GameTinyLeadersImpl game) {


### PR DESCRIPTION
For now, it is 7 for every mode. However it may become an option in game/tournament settings (#10551).

I also have some custom game mode as server plugin that would want to have that value set to a different number.