### PR TITLE
Text generation improvements for triggered abilities

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BallroomBrawlers.java
+++ b/Mage.Sets/src/mage/cards/b/BallroomBrawlers.java
@@ -39,7 +39,7 @@ public final class BallroomBrawlers extends CardImpl {
         this.toughness = new MageInt(5);
 
         // Whenever Ballroom Brawlers attacks, Ballroom Brawlers and up to one other target creature you control each gain your choice of first strike or lifelink until end of turn.
-        Ability ability = new AttacksTriggeredAbility(new BallroomBrawlersEffect());
+        Ability ability = new AttacksTriggeredAbility(new BallroomBrawlersEffect()).setReplaceRuleText(false);
         ability.addTarget(new TargetPermanent(0, 1, StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/h/Hecatomb.java
+++ b/Mage.Sets/src/mage/cards/h/Hecatomb.java
@@ -41,7 +41,9 @@ public final class Hecatomb extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{B}{B}");
 
         // When Hecatomb enters the battlefield, sacrifice Hecatomb unless you sacrifice four creatures.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SacrificeSourceUnlessPaysEffect(new SacrificeTargetCost(new TargetControlledPermanent(4, filter2)))));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SacrificeSourceUnlessPaysEffect(
+                new SacrificeTargetCost(new TargetControlledPermanent(4, filter2))))
+                .setReplaceRuleText(false));
         
         // Tap an untapped Swamp you control: Hecatomb deals 1 damage to any target.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(1), new TapTargetCost(new TargetControlledPermanent(1, 1, filter, true)));

--- a/Mage.Sets/src/mage/cards/h/HiddenPredators.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenPredators.java
@@ -47,6 +47,7 @@ class HiddenPredatorsStateTriggeredAbility extends StateTriggeredAbility {
 
     public HiddenPredatorsStateTriggeredAbility() {
         super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new HiddenPredatorsToken(), null, Duration.Custom));
+        this.replaceRuleText = false;
         setTriggerPhrase("When an opponent controls a creature with power 4 or greater, if {this} is an enchantment, ");
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpalAvenger.java
+++ b/Mage.Sets/src/mage/cards/o/OpalAvenger.java
@@ -41,6 +41,7 @@ class OpalAvengerStateTriggeredAbility extends StateTriggeredAbility {
 
     public OpalAvengerStateTriggeredAbility() {
         super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new OpalAvengerToken(), null, Duration.Custom));
+        this.replaceRuleText = false;
         setTriggerPhrase("When you have 10 or less life, if {this} is an enchantment, ");
     }
 

--- a/Mage.Sets/src/mage/cards/s/SerraInquisitors.java
+++ b/Mage.Sets/src/mage/cards/s/SerraInquisitors.java
@@ -35,7 +35,8 @@ public final class SerraInquisitors extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever Serra Inquisitors blocks or becomes blocked by one or more black creatures, Serra Inquisitors gets +2/+0 until end of turn.
-        this.addAbility(new BlocksOrBecomesBlockedByOneOrMoreTriggeredAbility(new BoostSourceEffect(2, 0, Duration.EndOfTurn), filter, false));
+        this.addAbility(new BlocksOrBecomesBlockedByOneOrMoreTriggeredAbility(new BoostSourceEffect(2, 0, Duration.EndOfTurn),
+                filter, false).setReplaceRuleText(false));
     }
 
     private SerraInquisitors(final SerraInquisitors card) {

--- a/Mage.Sets/src/mage/cards/v/VeiledCrocodile.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledCrocodile.java
@@ -42,6 +42,7 @@ class VeiledCrocodileStateTriggeredAbility extends StateTriggeredAbility {
 
     public VeiledCrocodileStateTriggeredAbility() {
         super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new VeilCrocodileToken(), null, Duration.Custom));
+        this.replaceRuleText = false;
         setTriggerPhrase("When a player has no cards in hand, if {this} is an enchantment, ");
     }
 

--- a/Mage.Sets/src/mage/cards/w/WormfangDrake.java
+++ b/Mage.Sets/src/mage/cards/w/WormfangDrake.java
@@ -43,7 +43,7 @@ public final class WormfangDrake extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(
                 new SacrificeSourceUnlessPaysEffect(new ExileTargetCost(new TargetControlledPermanent(filter))),
                 false
-        ));
+        ).setReplaceRuleText(false));
 
         // When Wormfang Drake leaves the battlefield, return the exiled card to the battlefield under its owner's control.
         this.addAbility(new LeavesBattlefieldTriggeredAbility(new ReturnFromExileForSourceEffect(Zone.BATTLEFIELD), false));

--- a/Mage.Sets/src/mage/cards/y/YuanShaosInfantry.java
+++ b/Mage.Sets/src/mage/cards/y/YuanShaosInfantry.java
@@ -28,7 +28,7 @@ public final class YuanShaosInfantry extends CardImpl {
         // Whenever Yuan Shao's Infantry attacks alone, Yuan Shao's Infantry can't be blocked this combat.
         Effect effect = new CantBeBlockedSourceEffect(Duration.EndOfCombat);
         effect.setText("{this} can't be blocked this combat");
-        this.addAbility(new AttacksAloneSourceTriggeredAbility(effect));
+        this.addAbility(new AttacksAloneSourceTriggeredAbility(effect).setReplaceRuleText(false));
     }
 
     private YuanShaosInfantry(final YuanShaosInfantry card) {

--- a/Mage/src/main/java/mage/abilities/TriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/TriggeredAbility.java
@@ -43,6 +43,10 @@ public interface TriggeredAbility extends Ability {
 
     TriggeredAbility setTriggersOnceEachTurn(boolean triggersOnce);
 
+    TriggeredAbility setDoOnlyOnceEachTurn(boolean doOnlyOnce);
+
+    TriggeredAbility setReplaceRuleText(boolean replaceRuleText);
+
     boolean checkInterveningIfClause(Game game);
 
     boolean isOptional();

--- a/Mage/src/main/java/mage/abilities/common/BecomesBlockedByCreatureTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/BecomesBlockedByCreatureTriggeredAbility.java
@@ -24,6 +24,7 @@ public class BecomesBlockedByCreatureTriggeredAbility extends TriggeredAbilityIm
     public BecomesBlockedByCreatureTriggeredAbility(Effect effect, FilterCreaturePermanent filter, boolean optional) {
         super(Zone.BATTLEFIELD, effect, optional);
         this.filter = filter;
+        this.replaceRuleText = false;
         setTriggerPhrase("Whenever {this} becomes blocked by " + CardUtil.addArticle(filter.getMessage()) + ", ");
     }
 

--- a/Mage/src/main/java/mage/abilities/common/BlocksOrBecomesBlockedByOneOrMoreTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/BlocksOrBecomesBlockedByOneOrMoreTriggeredAbility.java
@@ -32,6 +32,7 @@ public class BlocksOrBecomesBlockedByOneOrMoreTriggeredAbility extends Triggered
     public BlocksOrBecomesBlockedByOneOrMoreTriggeredAbility(Effect effect, FilterPermanent filter, boolean optional, String rule) {
         super(Zone.BATTLEFIELD, effect, optional);
         this.filter = filter;
+        this.replaceRuleText = false;
         this.rule = rule;
         setTriggerPhrase("Whenever {this} blocks or becomes blocked by one or more " + (filter != null ? filter.getMessage() : "creatures") + ", ");
     }

--- a/Mage/src/main/java/mage/abilities/keyword/HeroicAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/HeroicAbility.java
@@ -34,6 +34,7 @@ public class HeroicAbility extends TriggeredAbilityImpl {
         if (isHeroic) {
             this.setAbilityWord(AbilityWord.HEROIC);
         }
+        this.replaceRuleText = false;
         setTriggerPhrase("Whenever you cast a spell that targets {this}, ");
     }
 

--- a/Mage/src/main/java/mage/abilities/keyword/PackTacticsAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/PackTacticsAbility.java
@@ -17,6 +17,7 @@ public class PackTacticsAbility extends TriggeredAbilityImpl {
 
     public PackTacticsAbility(Effect effect) {
         super(Zone.BATTLEFIELD, effect, false);
+        this.replaceRuleText = false;
         this.setAbilityWord(AbilityWord.PACK_TACTICS);
         setTriggerPhrase("Whenever {this} attacks, if you attacked with creatures with total power 6 or greater this combat, ");
     }

--- a/Mage/src/main/java/mage/abilities/meta/OrTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/meta/OrTriggeredAbility.java
@@ -37,6 +37,7 @@ public class OrTriggeredAbility extends TriggeredAbilityImpl {
     public OrTriggeredAbility(Zone zone, Effect effect, boolean optional, String ruleTrigger, TriggeredAbility... abilities) {
         super(zone, effect, optional);
         this.ruleTrigger = ruleTrigger;
+        this.replaceRuleText = false;
         Collections.addAll(this.triggeredAbilities, abilities);
         for (TriggeredAbility ability : triggeredAbilities) {
             //Remove useless data


### PR DESCRIPTION
Fixes another ~70 cards:

Stats for 25168 cards checked for abilities text:
 - Cards with correct text:  23050 (91.58)
 - Cards with text errors:    2118 (8.42)

The framework can probably be used to fix a few more in the future.