### PR TITLE
Simplify implementation and fix bugs of Kaito, Dancing Shadow

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BrineHag.java
+++ b/Mage.Sets/src/mage/cards/b/BrineHag.java
@@ -1,9 +1,10 @@
 
 package mage.cards.b;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
+import java.util.Set;
+import java.util.HashSet;
+
 import mage.MageInt;
 import mage.MageObjectReference;
 import mage.abilities.Ability;
@@ -16,9 +17,8 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.PermanentInListPredicate;
+import mage.filter.predicate.permanent.PermanentReferenceInCollectionPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -77,22 +77,10 @@ class BrineHagEffect extends OneShotEffect {
             return false;
         }
 
-        List<Permanent> list = new ArrayList<>();
-        for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
-            Player player = game.getPlayer(playerId);
-            if (player == null) {
-                continue;
-            }
-
-            for (Permanent creature : game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, playerId, game)) {
-                if (sourcePermanent.getDealtDamageByThisTurn().contains(new MageObjectReference(creature.getId(), game))) {
-                    list.add(creature);
-                }
-            }
-        }
-        if (!list.isEmpty()) {
+        Set<MageObjectReference> set = new HashSet<>(sourcePermanent.getDealtDamageByThisTurn());
+        if (!set.isEmpty()) {
             FilterCreaturePermanent filter = new FilterCreaturePermanent();
-            filter.add(new PermanentInListPredicate(list));
+            filter.add(new PermanentReferenceInCollectionPredicate(set));
             game.addEffect(new SetBasePowerToughnessAllEffect(0, 2, Duration.Custom, filter, true), source);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/k/KaitoDancingShadow.java
+++ b/Mage.Sets/src/mage/cards/k/KaitoDancingShadow.java
@@ -171,9 +171,11 @@ class KaitoDancingShadowIncreaseLoyaltyUseEffect extends ContinuousEffectImpl {
     @Override
     public boolean apply(Game game, Ability source) {
         Permanent kaito = source.getSourcePermanentIfItStillExists(game);
-        if (kaito != null) {
-            kaito.setLoyaltyActivationsAvailable(2);
+        if (kaito == null) {
+            discard();
+            return false;
         }
+        kaito.setLoyaltyActivationsAvailable(2);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/k/KaitoDancingShadow.java
+++ b/Mage.Sets/src/mage/cards/k/KaitoDancingShadow.java
@@ -170,7 +170,10 @@ class KaitoDancingShadowIncreaseLoyaltyUseEffect extends ContinuousEffectImpl {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        source.getSourcePermanentIfItStillExists(game).setLoyaltyActivationsAvailable(2);
+        Permanent kaito = source.getSourcePermanentIfItStillExists(game);
+        if (kaito != null) {
+            kaito.setLoyaltyActivationsAvailable(2);
+        }
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/k/KaitoDancingShadow.java
+++ b/Mage.Sets/src/mage/cards/k/KaitoDancingShadow.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 
 /**
  *
- * @author @stwalsh4118
+ * @author notgreat
  */
 public final class KaitoDancingShadow extends CardImpl {
 
@@ -146,10 +146,8 @@ class KaitoDancingShadowWatcher extends Watcher {
         }
         MageObjectReference mor = new MageObjectReference(creature, game);
         damageTarget.put(mor, event.getPlayerId());
-        game.debugMessage("damageTarget: "+damageTarget);
 
-        List<MageObjectReference> list;
-        list = permanents.computeIfAbsent(creature.getControllerId(), (key) -> new ArrayList<>());
+        List<MageObjectReference> list = permanents.computeIfAbsent(creature.getControllerId(), (key) -> new ArrayList<>());
         list.add(mor);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KaitoDancingShadow.java
+++ b/Mage.Sets/src/mage/cards/k/KaitoDancingShadow.java
@@ -1,34 +1,26 @@
 package mage.cards.k;
 
-import mage.constants.SubType;
-import mage.constants.SuperType;
-import mage.filter.Filter;
+import mage.constants.*;
+import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
 import mage.abilities.Ability;
 import mage.abilities.LoyaltyAbility;
-import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.common.DealCombatDamageControlledTriggeredAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.common.combat.CantAttackTargetEffect;
 import mage.abilities.effects.common.combat.CantBlockTargetEffect;
-import mage.constants.*;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.predicate.other.DamagedPlayerThisTurnPredicate;
 import mage.game.Game;
-import mage.game.events.DamagedEvent;
-import mage.game.events.DamagedPlayerBatchEvent;
-import mage.game.events.DamagedPlayerEvent;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.DroneToken;
 import mage.players.Player;
-import mage.target.TargetObject;
 import mage.target.TargetPermanent;
-import mage.watchers.Watcher;
 
 import java.util.*;
 
@@ -46,7 +38,7 @@ public final class KaitoDancingShadow extends CardImpl {
         this.setStartingLoyalty(3);
 
         // Whenever one or more creatures you control deal combat damage to a player, you may return one of them to its owner's hand. If you do, you may activate loyalty abilities of Kaito twice this turn rather than only once.
-        Ability ability = new KaitoDancingShadowTriggeredAbility();
+        Ability ability = new DealCombatDamageControlledTriggeredAbility(Zone.BATTLEFIELD, new KaitoDancingShadowEffect());
         this.addAbility(ability);
 
         // +1: Up to one target creature can't attack or block until your next turn.
@@ -72,45 +64,6 @@ public final class KaitoDancingShadow extends CardImpl {
     }
 }
 
-class KaitoDancingShadowTriggeredAbility extends TriggeredAbilityImpl {
-
-    KaitoDancingShadowTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new KaitoDancingShadowEffect());
-        this.setTriggerPhrase("Whenever one or more creatures you control deal combat damage to a player, ");
-        this.addWatcher(new KaitoDancingShadowWatcher());
-
-    }
-
-    private KaitoDancingShadowTriggeredAbility(final KaitoDancingShadowTriggeredAbility ability) {
-        super(ability);
-    }
-
-    @Override
-    public boolean checkEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.DAMAGED_PLAYER_BATCH;
-    }
-
-    @Override
-    public boolean checkTrigger(GameEvent event, Game game) {
-        DamagedPlayerBatchEvent dEvent = (DamagedPlayerBatchEvent) event;
-        for (DamagedEvent damagedEvent : dEvent.getEvents()) {
-            if (!damagedEvent.isCombatDamage()) {
-                continue;
-            }
-            Permanent permanent = game.getPermanent(damagedEvent.getSourceId());
-            if (permanent != null && permanent.isControlledBy(getControllerId())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public KaitoDancingShadowTriggeredAbility copy() {
-        return new KaitoDancingShadowTriggeredAbility(this);
-    }
-}
-
 class KaitoDancingShadowEffect extends OneShotEffect {
 
     KaitoDancingShadowEffect() {
@@ -129,17 +82,15 @@ class KaitoDancingShadowEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        KaitoDancingShadowWatcher watcher = game.getState().getWatcher(KaitoDancingShadowWatcher.class);
-        if (watcher == null) {
-            return false;
-        }
-        TargetCreatureThatDealtCombatDamage target = new TargetCreatureThatDealtCombatDamage(0, 1, watcher.getPermanents());
+        FilterPermanent filter = new FilterControlledCreaturePermanent();
+        filter.add(new DamagedPlayerThisTurnPredicate(TargetController.ANY));
+        TargetPermanent target = new TargetPermanent(1, 1, filter, true);
         Player controller = game.getPlayer(source.getControllerId());
         if (controller == null) {
             return false;
         }
-        if (controller.chooseUse(outcome, "Return a creature card that dealt damage to hand?", source, game) && target.chooseTarget(Outcome.ReturnToHand, source.getControllerId(), source, game)) {
-            Card card = game.getCard(target.getFirstTarget());
+        if (controller.chooseUse(outcome, "Return a creature that dealt damage to hand?", source, game) && target.chooseTarget(Outcome.ReturnToHand, source.getControllerId(), source, game)) {
+            Card card = game.getPermanent(target.getFirstTarget());
             if (card != null) {
                 controller.moveCards(card, Zone.HAND, source, game);
 
@@ -148,116 +99,6 @@ class KaitoDancingShadowEffect extends OneShotEffect {
             }
         }
         return true;
-    }
-}
-
-class KaitoDancingShadowWatcher extends Watcher {
-
-    private final List<Permanent> permanents = new ArrayList<>();
-
-    KaitoDancingShadowWatcher() {
-        super(WatcherScope.GAME);
-    }
-
-    @Override
-    public void watch(GameEvent event, Game game) {
-        if (event.getType() == GameEvent.EventType.COMBAT_DAMAGE_STEP_POST) {
-            permanents.clear();
-            return;
-        }
-        if (event.getType() != GameEvent.EventType.DAMAGED_PLAYER
-                || !((DamagedPlayerEvent) event).isCombatDamage()) {
-            return;
-        }
-        Permanent creature = game.getPermanent(event.getSourceId());
-        if (creature == null) {
-            return;
-        }
-        permanents.add(creature);
-    }
-
-    public List<Permanent> getPermanents() {
-        return permanents;
-    }
-}
-
-class TargetCreatureThatDealtCombatDamage extends TargetObject {
-
-    protected List<Permanent> permanents;
-    private Permanent firstTarget = null;
-
-    public TargetCreatureThatDealtCombatDamage() {
-        super();
-    }
-
-    public TargetCreatureThatDealtCombatDamage(final TargetCreatureThatDealtCombatDamage target) {
-        super(target);
-        this.firstTarget = target.firstTarget;
-    }
-
-
-    public TargetCreatureThatDealtCombatDamage(int minNumTargets, int maxNumTargets, List<Permanent> permanents) {
-        super(minNumTargets, maxNumTargets, Zone.BATTLEFIELD, true);
-        this.permanents = permanents;
-    }
-
-
-    @Override
-    public boolean canTarget(UUID id, Game game) {
-        Card card = game.getCard(id);
-        if (card != null && game.getState().getZone(card.getId()) == Zone.BATTLEFIELD) {
-            for (Permanent permanent : permanents) {
-                if (permanent.getId().equals(id)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public boolean chooseTarget(Outcome outcome, UUID playerId, Ability source, Game game) {
-        firstTarget = game.getPermanent(source.getFirstTarget());
-        return super.chooseTarget(Outcome.Benefit, playerId, source, game);
-    }
-
-
-    @Override
-    public TargetCreatureThatDealtCombatDamage copy() {
-        return new TargetCreatureThatDealtCombatDamage(this);
-    }
-
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        return permanents.size() > 0;
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
-        Set<UUID> possibleTargets = new HashSet<>();
-        for (Permanent permanent : permanents) {
-            if (permanent != null && permanent.isControlledBy(sourceControllerId)) {
-                possibleTargets.add(permanent.getId());
-            }
-        }
-        return possibleTargets;
-    }
-
-    @Override
-    public Filter getFilter() {
-        return null;
-    }
-
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Game game) {
-        // TODO Auto-generated method stub
-        return false;
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
-        // TODO Auto-generated method stub
-        return null;
     }
 }
 
@@ -278,13 +119,7 @@ class KaitoDancingShadowIncreaseLoyaltyUseEffect extends ContinuousEffectImpl {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        for (Permanent permanent : game.getBattlefield().getActivePermanents(
-            StaticFilters.FILTER_CONTROLLED_PERMANENT_PLANESWALKER,
-            source.getControllerId(), source, game
-        )) {
-            permanent.setLoyaltyActivationsAvailable(2);
-        }
-
+        source.getSourcePermanentIfItStillExists(game).setLoyaltyActivationsAvailable(2);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/r/RagingRiver.java
+++ b/Mage.Sets/src/mage/cards/r/RagingRiver.java
@@ -16,7 +16,7 @@ import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.AbilityPredicate;
-import mage.filter.predicate.permanent.PermanentInListPredicate;
+import mage.filter.predicate.permanent.PermanentReferenceInCollectionPredicate;
 import mage.game.Game;
 import mage.game.combat.CombatGroup;
 import mage.game.permanent.Permanent;
@@ -136,10 +136,10 @@ class RagingRiverEffect extends OneShotEffect {
 
 
                                 if (controller.choosePile(outcome, attacker.getName() + ": attacking " + defender.getName(), leftLog, rightLog, game)) {
-                                    filter.add(Predicates.not(Predicates.or(new AbilityPredicate(FlyingAbility.class), new PermanentInListPredicate(left))));
+                                    filter.add(Predicates.not(Predicates.or(new AbilityPredicate(FlyingAbility.class), new PermanentReferenceInCollectionPredicate(left, game))));
                                     game.informPlayers(attacker.getLogName() + ": attacks left (" + defender.getLogName() + ")");
                                 } else {
-                                    filter.add(Predicates.not(Predicates.or(new AbilityPredicate(FlyingAbility.class), new PermanentInListPredicate(right))));
+                                    filter.add(Predicates.not(Predicates.or(new AbilityPredicate(FlyingAbility.class), new PermanentReferenceInCollectionPredicate(right, game))));
                                     game.informPlayers(attacker.getLogName() + ": attacks right (" + defender.getLogName() + ")");
                                 }
                             }

--- a/Mage/src/main/java/mage/filter/predicate/permanent/PermanentInListPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/PermanentInListPredicate.java
@@ -20,6 +20,6 @@ public class PermanentInListPredicate implements Predicate<Permanent> {
 
     @Override
     public boolean apply(Permanent input, Game game) {
-        return permanents.contains(input);
+        return (permanents != null && permanents.contains(input));
     }
 }

--- a/Mage/src/main/java/mage/filter/predicate/permanent/PermanentReferenceInCollectionPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/PermanentReferenceInCollectionPredicate.java
@@ -1,0 +1,33 @@
+
+package mage.filter.predicate.permanent;
+
+import mage.MageObjectReference;
+import mage.filter.predicate.Predicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/**
+ *
+ * @author notgreat
+ */
+public class PermanentReferenceInCollectionPredicate implements Predicate<Permanent> {
+    private final Collection<MageObjectReference> references;
+
+    public PermanentReferenceInCollectionPredicate(Collection<MageObjectReference> references) {
+        //Note: it is assumed that the collection passed in isn't ever mutated afterwards
+        this.references = references;
+    }
+    public PermanentReferenceInCollectionPredicate(Collection<Permanent> permanents, Game game) {
+        this.references = permanents.stream().map((p) -> new MageObjectReference(p, game))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean apply(Permanent input, Game game) {
+        return (references != null &&
+                references.contains(new MageObjectReference(input, game)));
+    }
+}


### PR DESCRIPTION
Kaito, Dancing Shadow's triggered ability currently has two bugs:

1. Creature tokens can't be returned
2. It affects all planeswalkers you control rather than just Kaito

This fixes both bugs and massively simplifies the implementation by using the standard classes rather than re-implementing them.