### PR TITLE
Updated Kaito fixes

### DIFF
--- a/Mage.Sets/src/mage/cards/k/KaitoDancingShadow.java
+++ b/Mage.Sets/src/mage/cards/k/KaitoDancingShadow.java
@@ -152,8 +152,9 @@ class KaitoDancingShadowWatcher extends Watcher {
     }
 
     //Return the set of permanents that the controller controlled which dealt combat damage to the player
+    //Returns empty set if there were none
     public Set<MageObjectReference> getPermanents(UUID controllerID, UUID damagedPlayerID) {
-        return permanents.get(controllerID).stream()
+        return permanents.getOrDefault(controllerID, Collections.emptyList()).stream()
                 .filter((mor) -> damagedPlayerID.equals(damageTarget.get(mor)))
                 .collect(Collectors.toSet());
     }

--- a/Mage/src/main/java/mage/filter/predicate/permanent/PermanentInListPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/PermanentInListPredicate.java
@@ -20,6 +20,6 @@ public class PermanentInListPredicate implements Predicate<Permanent> {
 
     @Override
     public boolean apply(Permanent input, Game game) {
-        return (permanents != null && permanents.contains(input));
+        return (permanents.contains(input));
     }
 }

--- a/Mage/src/main/java/mage/filter/predicate/permanent/PermanentReferenceInCollectionPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/PermanentReferenceInCollectionPredicate.java
@@ -27,7 +27,6 @@ public class PermanentReferenceInCollectionPredicate implements Predicate<Perman
 
     @Override
     public boolean apply(Permanent input, Game game) {
-        return (references != null &&
-                references.contains(new MageObjectReference(input, game)));
+        return (references.contains(new MageObjectReference(input, game)));
     }
 }


### PR DESCRIPTION
Remove unwanted null checks, add one to Kaito's watcher (I think that one can't trigger, but I'd rather check there than risk a crash)

In response to comments from @JayDi85 