### PR TITLE
Lynde QOL fixes

### DIFF
--- a/Mage.Sets/src/mage/cards/l/LyndeCheerfulTormentor.java
+++ b/Mage.Sets/src/mage/cards/l/LyndeCheerfulTormentor.java
@@ -25,6 +25,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetOpponent;
+import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -91,7 +92,9 @@ class LyndeCheerfulTormentorCurseDiesTriggeredAbility extends TriggeredAbilityIm
         if (zEvent.isDiesEvent()) {
             Permanent permanent = zEvent.getTarget();
             if (permanent != null && permanent.hasSubtype(SubType.CURSE, game) && permanent.isOwnedBy(controllerId)) {
-                getEffects().setValue("curse", new MageObjectReference(game.getCard(zEvent.getTargetId()), game));
+                MageObjectReference curse = new MageObjectReference(game.getCard(zEvent.getTargetId()), game);
+                getEffects().setValue("curse", curse);
+                getEffects().setTargetPointer(new FixedTarget(curse));
                 return true;
             }
         }


### PR DESCRIPTION
Some QOL fixes for a card I've been playing a lot. The biggest thing is that ordering her triggers on the end step is a nightmare, because those triggers don't reference which card is coming back, and are considered "identical" for purposes of auto-trigger ordering.

I think the auto-trigger ordering system needs a little bit of an overhaul, because there are plenty of effects which differ by something other than their rules text... such as referenced objects. Right now my idea is only to look at targets, but it may make sense to look at keys/values?