### PR TITLE
Add logic to PlayerImpl for protection effects when damage can't be prevented

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/ConditionalPreventionTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/ConditionalPreventionTest.java
@@ -185,6 +185,24 @@ public class ConditionalPreventionTest extends CardTestPlayerBase {
     }
 
     @Test
+    public void test_UnpreventableCombatDamageToPlayer() {
+        // Combat damage that would be dealt by creatures you control can't be prevented.
+        addCard(Zone.BATTLEFIELD, playerB, "Questing Beast", 1);
+        // When The One Ring enters the battlefield, if you cast it, you gain protection from everything until your next turn.
+        addCard(Zone.HAND, playerA, "The One Ring", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "The One Ring");
+        attack(2, playerB, "Questing Beast");
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerA, 20 - 4); // Damage should not be prevented
+    }
+
+    @Test
     public void test_PreventSomeDamage_Normal() {
         // Kicker-Sacrifice a land.
         // Prevent the next 3 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose.

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2124,20 +2124,12 @@ public abstract class PlayerImpl implements Player, Serializable {
         if (damage < 1) {
             return 0;
         }
-        if (!canDamage(game.getObject(attackerId), game)) {
-            MageObject sourceObject = game.getObject(attackerId);
-            game.informPlayers(damage + " damage "
-                    + (sourceObject == null ? "" : "from " + sourceObject.getLogName())
-                    + " to " + getLogName()
-                    + (damage > 1 ? " were" : "was") + " prevented because of protection");
-            return 0;
-        }
         DamageEvent event = new DamagePlayerEvent(playerId, attackerId, playerId, damage, preventable, combatDamage);
         event.setAppliedEffects(appliedEffects);
         if (game.replaceEvent(event)) {
             return 0;
         }
-        int actualDamage = event.getAmount();
+        int actualDamage = checkProtectionAbilities(event, attackerId, source, game);
         if (actualDamage < 1) {
             return 0;
         }
@@ -2198,6 +2190,20 @@ public abstract class PlayerImpl implements Player, Serializable {
         game.fireEvent(damagedEvent);
         game.getState().addSimultaneousDamage(damagedEvent, game);
         return actualDamage;
+    }
+
+    private int checkProtectionAbilities(GameEvent event, UUID attackerId, Ability source, Game game) {
+        MageObject attacker = game.getObject(attackerId);
+        if (attacker != null && hasProtectionFrom(attacker, game)) {
+            GameEvent preventEvent = new PreventDamageEvent(playerId, attackerId, source, playerId, event.getAmount(), ((DamageEvent) event).isCombatDamage());
+            if (!game.replaceEvent(preventEvent)) {
+                int preventedDamage = event.getAmount();
+                event.setAmount(0);
+                game.fireEvent(new PreventedDamageEvent(playerId, attackerId, source, playerId, preventedDamage));
+                return 0;
+            }
+        }
+        return event.getAmount();
     }
 
     @Override
@@ -2265,15 +2271,6 @@ public abstract class PlayerImpl implements Player, Serializable {
         event.setData(name);
         event.setAmount(finalAmount);
         game.fireEvent(event);
-    }
-
-    protected boolean canDamage(MageObject source, Game game) {
-        for (ProtectionAbility ability : abilities.getProtectionAbilities()) {
-            if (!ability.canTarget(source, game)) {
-                return false;
-            }
-        }
-        return true;
     }
 
     @Override

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2200,6 +2200,8 @@ public abstract class PlayerImpl implements Player, Serializable {
                 int preventedDamage = event.getAmount();
                 event.setAmount(0);
                 game.fireEvent(new PreventedDamageEvent(playerId, attackerId, source, playerId, preventedDamage));
+                game.informPlayers(preventedDamage + " damage from " + attacker.getLogName() + " to " + getLogName()
+                        + (preventedDamage > 1 ? " were" : "was") + " prevented because of protection");
                 return 0;
             }
         }


### PR DESCRIPTION
Fixing a bug as reported on reddit where the ability of Questing Beast wasn't applying versus The One Ring.

https://www.reddit.com/r/XMage/comments/155b68t/the_one_ring_damage_prevention_bug_xmage_beta_1451/

Uses similar logic to PermanentImpl now.