### PR TITLE
Rework Primal Clay and similar cards

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MoltenSentry.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenSentry.java
@@ -1,10 +1,9 @@
-
 package mage.cards.m;
 
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
@@ -23,9 +22,6 @@ import mage.players.Player;
  */
 public final class MoltenSentry extends CardImpl {
 
-    private static final String rule = "As {this} enters the battlefield, flip a coin. If the coin comes up heads, {this} enters the battlefield as a "
-            + "5/2 creature with haste. If it comes up tails, {this} enters the battlefield as a 2/5 creature with defender.";
-
     public MoltenSentry(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{R}");
         this.subtype.add(SubType.ELEMENTAL);
@@ -34,7 +30,7 @@ public final class MoltenSentry extends CardImpl {
 
         // As Molten Sentry enters the battlefield, flip a coin. If the coin comes up heads, Molten Sentry enters the battlefield as a 5/2 creature with haste.
         // If it comes up tails, Molten Sentry enters the battlefield as a 2/5 creature with defender.
-        this.addAbility(new EntersBattlefieldAbility(new MoltenSentryEffect(), null, rule, ""));
+        this.addAbility(new AsEntersBattlefieldAbility(new MoltenSentryEffect()));
     }
 
     private MoltenSentry(final MoltenSentry card) {
@@ -49,11 +45,13 @@ public final class MoltenSentry extends CardImpl {
 
 class MoltenSentryEffect extends OneShotEffect {
 
-    public MoltenSentryEffect() {
-        super(Outcome.Damage);
+    MoltenSentryEffect() {
+        super(Outcome.Benefit);
+        staticText = "flip a coin. If the coin comes up heads, {this} enters the battlefield as a 5/2 creature with haste. " +
+                "If it comes up tails, {this} enters the battlefield as a 2/5 creature with defender";
     }
 
-    public MoltenSentryEffect(MoltenSentryEffect effect) {
+    private MoltenSentryEffect(MoltenSentryEffect effect) {
         super(effect);
     }
 
@@ -68,6 +66,14 @@ class MoltenSentryEffect extends OneShotEffect {
         int power;
         int toughness;
         Ability gainedAbility;
+        /* TODO: The chosen characteristics are copiable values; make sure this is handled correctly
+         * 707.2. When copying an object, the copy acquires the copiable values of the original object's characteristics...
+         * The copiable values are the values derived from the text printed on the object
+         * (that text being name, mana cost, color indicator, card type, subtype, supertype, rules text, power, toughness, and/or loyalty),
+         * as modified by other copy effects, by its face-down status,
+         * and by "as ... enters the battlefield" and "as ... is turned face up" abilities
+         * that set power and toughness (and may also set additional characteristics).
+         */
         if (controller.flipCoin(source, game, false)) {
             game.informPlayers("Heads: " + permanent.getLogName() + " enters the battlefield as a 5/2 creature with haste");
             power = 5;
@@ -79,7 +85,7 @@ class MoltenSentryEffect extends OneShotEffect {
             toughness = 5;
             gainedAbility = DefenderAbility.getInstance();
         }
-        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.CharacteristicDefining_7a), source);
+        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.SetPT_7b), source);
         game.addEffect(new GainAbilitySourceEffect(gainedAbility, Duration.WhileOnBattlefield), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/p/PrimalClay.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalClay.java
@@ -1,11 +1,11 @@
-
 package mage.cards.p;
 
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.common.AsEntersBattlefieldAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.AddCardSubTypeSourceEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
 import mage.abilities.keyword.DefenderAbility;
@@ -16,14 +16,11 @@ import mage.choices.Choice;
 import mage.choices.ChoiceImpl;
 import mage.constants.*;
 import mage.game.Game;
-import mage.game.events.EntersTheBattlefieldEvent;
-import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
 /**
- *
- * @author Loki
+ * @author xenohedron
  */
 public final class PrimalClay extends CardImpl {
 
@@ -35,7 +32,7 @@ public final class PrimalClay extends CardImpl {
         this.toughness = new MageInt(0);
 
         // As Primal Clay enters the battlefield, it becomes your choice of a 3/3 artifact creature, a 2/2 artifact creature with flying, or a 1/6 Wall artifact creature with defender in addition to its other types.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new PrimalPlasmaReplacementEffect()));
+        this.addAbility(new AsEntersBattlefieldAbility(new PrimalClayEffect()));
     }
 
     private PrimalClay(final PrimalClay card) {
@@ -47,81 +44,74 @@ public final class PrimalClay extends CardImpl {
         return new PrimalClay(this);
     }
 
-    static class PrimalPlasmaReplacementEffect extends ReplacementEffectImpl {
+}
 
-        private static final String choice33 = "a 3/3 artifact creature";
-        private static final String choice22 = "a 2/2 artifact creature with flying";
-        private static final String choice16 = "a 1/6 artifact creature with defender";
+class PrimalClayEffect extends OneShotEffect {
 
-        public PrimalPlasmaReplacementEffect() {
-            super(Duration.WhileOnBattlefield, Outcome.Benefit);
-            staticText = "As {this} enters the battlefield, it becomes your choice of a 3/3 artifact creature, a 2/2 artifact creature with flying, or a 1/6 Wall artifact creature with defender in addition to its other types";
-        }
+    private static final String choice33 = "a 3/3 artifact creature";
+    private static final String choice22 = "a 2/2 artifact creature with flying";
+    private static final String choice16 = "a 1/6 Wall artifact creature with defender";
 
-        public PrimalPlasmaReplacementEffect(PrimalPlasmaReplacementEffect effect) {
-            super(effect);
-        }
-
-        @Override
-        public boolean checksEventType(GameEvent event, Game game) {
-            return event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD;
-        }
-
-        @Override
-        public boolean applies(GameEvent event, Ability source, Game game) {
-            if (!event.getTargetId().equals(source.getSourceId())) {
-                return false;
-            }
-            Permanent sourcePermanent = ((EntersTheBattlefieldEvent) event).getTarget();
-            return sourcePermanent != null && !sourcePermanent.isFaceDown(game);
-        }
-
-        @Override
-        public boolean apply(Game game, Ability source) {
-            return false;
-        }
-
-        @Override
-        public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-            Permanent permanent = ((EntersTheBattlefieldEvent) event).getTarget();
-            if (permanent == null) {
-                return false;
-            }
-            Choice choice = new ChoiceImpl(true);
-            choice.setMessage("Choose what " + permanent.getIdName() + " becomes to");
-            choice.getChoices().add(choice33);
-            choice.getChoices().add(choice22);
-            choice.getChoices().add(choice16);
-            Player controller = game.getPlayer(source.getControllerId());
-            if (controller != null && !controller.choose(Outcome.Neutral, choice, game)) {
-                return false;
-            }
-            int power = 0;
-            int toughness = 0;
-            switch (choice.getChoice()) {
-                case choice33:
-                    power = 3;
-                    toughness = 3;
-                    break;
-                case choice22:
-                    power = 2;
-                    toughness = 2;
-                    game.addEffect(new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.Custom), source);
-                    break;
-                case choice16:
-                    power = 1;
-                    toughness = 6;
-                    game.addEffect(new GainAbilitySourceEffect(DefenderAbility.getInstance(), Duration.Custom), source);
-                    break;
-            }
-            game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.CharacteristicDefining_7a), source);
-            return false;
-        }
-
-        @Override
-        public PrimalPlasmaReplacementEffect copy() {
-            return new PrimalPlasmaReplacementEffect(this);
-        }
-
+    PrimalClayEffect() {
+        super(Outcome.Benefit);
+        staticText = "it becomes your choice of " + choice33 + ", " + choice22 + ", or " + choice16 + " in addition to its other types";
     }
+
+    private PrimalClayEffect(final PrimalClayEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public PrimalClayEffect copy() {
+        return new PrimalClayEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanentEntering(source.getSourceId());
+        Player controller = game.getPlayer(source.getControllerId());
+        if (permanent == null || controller == null) {
+            return false;
+        }
+        Choice choice = new ChoiceImpl(true);
+        choice.setMessage("Choose what " + permanent.getIdName() + " becomes as it enters the battlefield");
+        choice.getChoices().add(choice33);
+        choice.getChoices().add(choice22);
+        choice.getChoices().add(choice16);
+        if (!controller.choose(Outcome.Neutral, choice, game)) {
+            return false;
+        }
+        int power;
+        int toughness;
+        /* TODO: The chosen characteristics are copiable values; make sure this is handled correctly
+         * 707.2. When copying an object, the copy acquires the copiable values of the original object's characteristics...
+         * The copiable values are the values derived from the text printed on the object
+         * (that text being name, mana cost, color indicator, card type, subtype, supertype, rules text, power, toughness, and/or loyalty),
+         * as modified by other copy effects, by its face-down status,
+         * and by "as ... enters the battlefield" and "as ... is turned face up" abilities
+         * that set power and toughness (and may also set additional characteristics).
+         */
+        switch (choice.getChoice()) {
+            case choice33:
+                power = 3;
+                toughness = 3;
+                break;
+            case choice22:
+                power = 2;
+                toughness = 2;
+                game.addEffect(new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.WhileOnBattlefield), source);
+                break;
+            case choice16:
+                power = 1;
+                toughness = 6;
+                game.addEffect(new AddCardSubTypeSourceEffect(Duration.WhileOnBattlefield, SubType.WALL), source);
+                game.addEffect(new GainAbilitySourceEffect(DefenderAbility.getInstance(), Duration.WhileOnBattlefield), source);
+                break;
+            default:
+                return false;
+        }
+        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.SetPT_7b), source);
+        return true;
+    }
+
 }

--- a/Mage.Sets/src/mage/cards/p/PrimalPlasma.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalPlasma.java
@@ -1,11 +1,10 @@
-
 package mage.cards.p;
 
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.common.AsEntersBattlefieldAbility;
+import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
 import mage.abilities.keyword.DefenderAbility;
@@ -16,14 +15,11 @@ import mage.choices.Choice;
 import mage.choices.ChoiceImpl;
 import mage.constants.*;
 import mage.game.Game;
-import mage.game.events.EntersTheBattlefieldEvent;
-import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
 /**
- *
- * @author LevelX2
+ * @author xenohedron
  */
 public final class PrimalPlasma extends CardImpl {
 
@@ -36,7 +32,7 @@ public final class PrimalPlasma extends CardImpl {
         this.toughness = new MageInt(0);
 
         // As Primal Plasma enters the battlefield, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new PrimalPlasmaReplacementEffect()));
+        this.addAbility(new AsEntersBattlefieldAbility(new PrimalPlasmaEffect()));
     }
 
     private PrimalPlasma(final PrimalPlasma card) {
@@ -48,81 +44,73 @@ public final class PrimalPlasma extends CardImpl {
         return new PrimalPlasma(this);
     }
 
-    static class PrimalPlasmaReplacementEffect extends ReplacementEffectImpl {
+}
 
-        private static final String choice33 = "a 3/3 creature";
-        private static final String choice22 = "a 2/2 creature with flying";
-        private static final String choice16 = "a 1/6 creature with defender";
+class PrimalPlasmaEffect extends OneShotEffect {
 
-        public PrimalPlasmaReplacementEffect() {
-            super(Duration.WhileOnBattlefield, Outcome.Benefit);
-            staticText = "As {this} enters the battlefield, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender";
-        }
+    private static final String choice33 = "a 3/3 creature";
+    private static final String choice22 = "a 2/2 creature with flying";
+    private static final String choice16 = "a 1/6 creature with defender";
 
-        public PrimalPlasmaReplacementEffect(PrimalPlasmaReplacementEffect effect) {
-            super(effect);
-        }
-
-        @Override
-        public boolean checksEventType(GameEvent event, Game game) {
-            return event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD;
-        }
-
-        @Override
-        public boolean applies(GameEvent event, Ability source, Game game) {
-            if (event.getTargetId().equals(source.getSourceId())) {
-                Permanent sourcePermanent = ((EntersTheBattlefieldEvent) event).getTarget();
-                return sourcePermanent != null && !sourcePermanent.isFaceDown(game);
-            }
-            return false;
-        }
-
-        @Override
-        public boolean apply(Game game, Ability source) {
-            return false;
-        }
-
-        @Override
-        public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-            Permanent permanent = ((EntersTheBattlefieldEvent) event).getTarget();
-            Player controller = game.getPlayer(source.getControllerId());
-            if (permanent != null && controller != null) {
-                Choice choice = new ChoiceImpl(true);
-                choice.setMessage("Choose what " + permanent.getIdName() + " becomes to");
-                choice.getChoices().add(choice33);
-                choice.getChoices().add(choice22);
-                choice.getChoices().add(choice16);
-                if (!controller.choose(Outcome.Neutral, choice, game)) {
-                    return false;
-                }
-                int power = 0;
-                int toughness = 0;
-                switch (choice.getChoice()) {
-                    case choice33:
-                        power = 3;
-                        toughness = 3;
-                        break;
-                    case choice22:
-                        power = 2;
-                        toughness = 2;
-                        game.addEffect(new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.Custom), source);
-                        break;
-                    case choice16:
-                        power = 1;
-                        toughness = 6;
-                        game.addEffect(new GainAbilitySourceEffect(DefenderAbility.getInstance(), Duration.Custom), source);
-                        break;
-                }
-                game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.CharacteristicDefining_7a), source);
-            }
-            return false;
-
-        }
-
-        @Override
-        public PrimalPlasmaReplacementEffect copy() {
-            return new PrimalPlasmaReplacementEffect(this);
-        }
-
+    PrimalPlasmaEffect() {
+        super(Outcome.Benefit);
+        staticText = "it becomes your choice of " + choice33 + ", " + choice22 + ", or " + choice16;
     }
+
+    private PrimalPlasmaEffect(final PrimalPlasmaEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public PrimalPlasmaEffect copy() {
+        return new PrimalPlasmaEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanentEntering(source.getSourceId());
+        Player controller = game.getPlayer(source.getControllerId());
+        if (permanent == null || controller == null) {
+            return false;
+        }
+        Choice choice = new ChoiceImpl(true);
+        choice.setMessage("Choose what " + permanent.getIdName() + " becomes as it enters the battlefield");
+        choice.getChoices().add(choice33);
+        choice.getChoices().add(choice22);
+        choice.getChoices().add(choice16);
+        if (!controller.choose(Outcome.Neutral, choice, game)) {
+            return false;
+        }
+        int power;
+        int toughness;
+        /* TODO: The chosen characteristics are copiable values; make sure this is handled correctly
+         * 707.2. When copying an object, the copy acquires the copiable values of the original object's characteristics...
+         * The copiable values are the values derived from the text printed on the object
+         * (that text being name, mana cost, color indicator, card type, subtype, supertype, rules text, power, toughness, and/or loyalty),
+         * as modified by other copy effects, by its face-down status,
+         * and by "as ... enters the battlefield" and "as ... is turned face up" abilities
+         * that set power and toughness (and may also set additional characteristics).
+         */
+        switch (choice.getChoice()) {
+            case choice33:
+                power = 3;
+                toughness = 3;
+                break;
+            case choice22:
+                power = 2;
+                toughness = 2;
+                game.addEffect(new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.WhileOnBattlefield), source);
+                break;
+            case choice16:
+                power = 1;
+                toughness = 6;
+                game.addEffect(new GainAbilitySourceEffect(DefenderAbility.getInstance(), Duration.WhileOnBattlefield), source);
+                break;
+            default:
+                return false;
+        }
+        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.SetPT_7b), source);
+        return true;
+    }
+
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/replacement/entersBattlefield/PrimalClayTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/replacement/entersBattlefield/PrimalClayTest.java
@@ -1,0 +1,286 @@
+package org.mage.test.cards.replacement.entersBattlefield;
+
+import mage.abilities.keyword.DefenderAbility;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.HasteAbility;
+import mage.constants.PhaseStep;
+import mage.constants.SubType;
+import mage.constants.Zone;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author xenohedron
+ */
+public class PrimalClayTest extends CardTestPlayerBase {
+
+    private static final String clay = "Primal Clay";
+    // As Primal Clay enters the battlefield, it becomes your choice of a 3/3 artifact creature, a 2/2 artifact creature
+    // with flying, or a 1/6 Wall artifact creature with defender in addition to its other types.
+    private static final String plasma = "Primal Plasma";
+    // As Primal Plasma enters the battlefield, it becomes your choice of a 3/3 creature, a 2/2 creature with flying,
+    // or a 1/6 creature with defender.
+    private static final String sentry = "Molten Sentry";
+    // As Molten Sentry enters the battlefield, flip a coin. If the coin comes up heads, Molten Sentry enters the battlefield
+    // as a 5/2 creature with haste. If it comes up tails, Molten Sentry enters the battlefield as a 2/5 creature with defender.
+    private static final String aquamorph = "Aquamorph Entity";
+    // As Aquamorph Entity enters the battlefield or is turned face up, it becomes your choice of 5/1 or 1/5.
+    private static final String tunnel = "Tunnel";
+    // Destroy target Wall. It can't be regenerated.
+    private static final String clone = "Clone";
+    // You may have Clone enter the battlefield as a copy of any creature on the battlefield.
+    private static final String cryptoplasm = "Cryptoplasm";
+    // At the beginning of your upkeep, you may have Cryptoplasm become a copy of another target creature, except it has this ability.
+    private static final String cloudshift = "Cloudshift";
+    // Exile target creature you control, then return that card to the battlefield under your control.
+
+    @Test
+    public void testClayPTSet() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 3/3 artifact creature");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, clay, 3, 3);
+    }
+
+    @Test
+    public void testClayAbilityGained() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 2/2 artifact creature with flying");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, clay, 2, 2);
+        assertAbility(playerA, clay, FlyingAbility.getInstance(), true);
+    }
+
+    @Test
+    public void testClaySubtypeGained() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 1/6 Wall artifact creature with defender");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, clay, 1, 6);
+        assertAbility(playerA, clay, DefenderAbility.getInstance(), true);
+        assertSubtype(clay, SubType.WALL);
+    }
+
+    @Test
+    public void testClayCopyPTOnBattlefield() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.HAND, playerA, cryptoplasm);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 7);
+        addCard(Zone.BATTLEFIELD, playerB, "Plains", 3);
+        addCard(Zone.HAND, playerB, "The Battle of Bywater", 1);
+        // Destroy all creatures with power 3 or greater. Then create a Food token for each creature you control.
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 3/3 artifact creature");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cryptoplasm);
+
+        // cryptoplasm trigger at next upkeep
+        setChoice(playerA, true); // whether to copy
+        addTarget(playerA, clay); // what to copy
+
+        castSpell(4, PhaseStep.PRECOMBAT_MAIN, playerB, "The Battle of Bywater");
+        // since cryptoplasm now a 3/3, both are destroyed
+
+        setStrictChooseMode(true);
+        setStopAt(4, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertGraveyardCount(playerA, clay, 1);
+        assertGraveyardCount(playerA, cryptoplasm, 1);
+    }
+
+    @Ignore("Chosen characteristics of Primal Clay should be copiable values")
+    @Test
+    public void testClayCopySubtypeOnBattlefield() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.HAND, playerA, cryptoplasm);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 7);
+        addCard(Zone.HAND, playerB, tunnel, 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 1/6 Wall artifact creature with defender");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cryptoplasm);
+
+        // cryptoplasm trigger at next upkeep
+        setChoice(playerA, true); // whether to copy
+        addTarget(playerA, clay); // what to copy
+
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerB, tunnel, clay);
+        waitStackResolved(3, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerB, tunnel, clay);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerA, clay, 1);
+        assertGraveyardCount(playerA, cryptoplasm, 1);
+    }
+
+    @Test
+    public void testPlasmaClone() {
+        addCard(Zone.HAND, playerA, plasma);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+        addCard(Zone.HAND, playerB, clone);
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, plasma);
+        setChoice(playerA, "a 1/6 creature with defender");
+
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, clone);
+        setChoice(playerB, true); // whether to copy
+        setChoice(playerB, plasma); // what to copy
+        setChoice(playerB, "a 2/2 creature with flying"); // new choice as ETB
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, plasma, 1, 6);
+        assertPowerToughness(playerB, plasma, 2, 2);
+        assertAbility(playerB, plasma, FlyingAbility.getInstance(), true);
+        //assertAbility(playerB, plasma, DefenderAbility.getInstance(), true); TODO: this is a copiable value
+    }
+
+    @Test
+    public void testMoltenSentryClone() {
+        addCard(Zone.HAND, playerA, sentry);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
+        addCard(Zone.HAND, playerB, clone);
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 4);
+
+        setFlipCoinResult(playerA, true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, sentry);
+
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, clone);
+        setChoice(playerB, true); // whether to copy
+        setFlipCoinResult(playerB, false);
+        setChoice(playerB, sentry); // what to copy
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, sentry, 5, 2);
+        assertAbility(playerA, sentry, HasteAbility.getInstance(), true);
+        assertPowerToughness(playerB, sentry, 2, 5);
+        assertAbility(playerB, sentry, DefenderAbility.getInstance(), true);
+    }
+
+    @Test
+    public void testAquamorphEntityETB() {
+        addCard(Zone.HAND, playerA, aquamorph);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, aquamorph);
+        setChoice(playerA, false); // not using morph
+        setChoice(playerA, "5/1");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, aquamorph, 5, 1);
+    }
+
+    @Test
+    public void testAquamorphEntityUnmorph() {
+        addCard(Zone.HAND, playerA, aquamorph);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 6);
+        addCard(Zone.HAND, playerA, "Island");
+        addCard(Zone.HAND, playerA, "Savage Swipe", 1);
+        // Target creature you control gets +2/+2 until end of turn if its power is 2. Then it fights target creature you don’t control.
+        addCard(Zone.BATTLEFIELD, playerB, "Siege Mastodon", 1); // 3/5 creature for fighting
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, aquamorph);
+        setChoice(playerA, true); // cast facedown as 2/2
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Savage Swipe");
+        addTarget(playerA, ""); // morph
+        addTarget(playerA, "Siege Mastodon");
+        // 2/2 becomes 4/4, fights 3/5, neither dies
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Island");
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}{U}: Turn"); // unmorph
+        setChoice(playerA, "1/5");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, aquamorph, 1 + 2, 5 + 2);
+        assertDamageReceived(playerA, aquamorph, 3);
+        assertDamageReceived(playerB, "Siege Mastodon", 4);
+    }
+
+    @Test
+    public void testClayFlicker() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.HAND, playerA, cloudshift);
+        addCard(Zone.BATTLEFIELD, playerA, "Waterkin Shaman");
+        // 2/1; Whenever a creature with flying enters the battlefield under your control, Waterkin Shaman gets +1/+1 until end of turn.
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 2/2 artifact creature with flying");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cloudshift, clay);
+        setChoice(playerA, "a 3/3 artifact creature");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, clay, 3, 3);
+        assertPowerToughness(playerA, "Waterkin Shaman", 2 + 1, 1 + 1);
+        assertAbility(playerA, clay, FlyingAbility.getInstance(), false);
+    }
+
+    @Test
+    public void testClayFlickerWall() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.HAND, playerA, cloudshift);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 1/6 Wall artifact creature with defender");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cloudshift, clay);
+        setChoice(playerA, "a 3/3 artifact creature");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, clay, 3, 3);
+        assertNotSubtype(clay, SubType.WALL);
+    }
+
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilitySourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilitySourceEffect.java
@@ -106,6 +106,9 @@ public class GainAbilitySourceEffect extends ContinuousEffectImpl {
             if (permanent != null) {
                 permanent.addAbility(ability, source.getSourceId(), game);
                 return true;
+            } else {
+                this.discard();
+                return false;
             }
         }
         if (duration == Duration.Custom) {

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilitySourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilitySourceEffect.java
@@ -97,14 +97,11 @@ public class GainAbilitySourceEffect extends ContinuousEffectImpl {
             if (permanent != null) {
                 permanent.addAbility(ability, source.getSourceId(), game);
                 return true;
-            } else {
-                this.discard();
-                return false;
             }
         }
         if (duration == Duration.Custom) {
             this.discard();
         }
-        return true;
+        return false;
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilitySourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilitySourceEffect.java
@@ -97,11 +97,14 @@ public class GainAbilitySourceEffect extends ContinuousEffectImpl {
             if (permanent != null) {
                 permanent.addAbility(ability, source.getSourceId(), game);
                 return true;
+            } else {
+                this.discard();
+                return false;
             }
         }
         if (duration == Duration.Custom) {
             this.discard();
         }
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
This is a partial fix for #9444.

* Added a bunch of test cases.
* Fixed so that Wall subtype is correctly added
* Fixed so that the gained ability is lost when flickered
* Does not yet set the gained characteristics as copiable values (maybe #10287 can fix this?)