### PR TITLE
[CMM] Implement Darksteel Monolith

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DarksteelMonolith.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelMonolith.java
@@ -1,0 +1,143 @@
+package mage.cards.d;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.common.SourceIsSpellCondition;
+import mage.abilities.costs.AlternativeCostSourceAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.ContinuousEffectImpl;
+import mage.abilities.keyword.IndestructibleAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.FilterCard;
+import mage.filter.predicate.mageobject.ColorlessPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public final class DarksteelMonolith extends CardImpl {
+
+    public DarksteelMonolith(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{8}");
+        this.supertype.add(SuperType.LEGENDARY);
+
+        // Indestructible
+        this.addAbility(IndestructibleAbility.getInstance());
+
+        // Once each turn, you may pay {0} rather than pay the mana cost for a colorless spell that you cast from your hand.
+        this.addAbility(new SimpleStaticAbility(
+                Zone.BATTLEFIELD,
+                new DarksteelMonolithAddAltCostEffect()
+        ));
+    }
+
+    private DarksteelMonolith(final DarksteelMonolith card) {
+        super(card);
+    }
+
+    @Override
+    public DarksteelMonolith copy() {
+        return new DarksteelMonolith(this);
+    }
+}
+
+class DarksteelMonolithAlternativeCost extends AlternativeCostSourceAbility {
+
+    private static final FilterCard filter = new FilterCard();
+
+    static {
+        filter.add(ColorlessPredicate.instance);
+        //filter.add(new CastFromZonePredicate(Zone.HAND));
+    }
+
+    private boolean wasActivated;
+
+    DarksteelMonolithAlternativeCost() {
+        super(new ManaCostsImpl<>("{0}"), SourceIsSpellCondition.instance, null, filter, true);
+    }
+
+    private DarksteelMonolithAlternativeCost(final DarksteelMonolithAlternativeCost ability) {
+        super(ability);
+        this.wasActivated = ability.wasActivated;
+    }
+
+    @Override
+    public DarksteelMonolithAlternativeCost copy() {
+        return new DarksteelMonolithAlternativeCost(this);
+    }
+
+    @Override
+    public boolean askToActivateAlternativeCosts(Ability ability, Game game) {
+        Player controller = game.getPlayer(ability.getControllerId());
+        Permanent monolith = game.getPermanent(getSourceId());
+        if (controller != null
+                && monolith != null) {
+            if (controller.chooseUse(Outcome.Neutral, "Use "
+                    + monolith.getLogName() + " to pay the alternative cost?", ability, game)) {
+                wasActivated = super.askToActivateAlternativeCosts(ability, game);
+                if (wasActivated) {
+                    game.getState().setValue(monolith.getId().toString()
+                            + monolith.getZoneChangeCounter(game)
+                            + monolith.getTurnsOnBattlefield(), true);
+                }
+            }
+        }
+        return wasActivated;
+    }
+}
+
+class DarksteelMonolithAddAltCostEffect extends ContinuousEffectImpl {
+
+    public DarksteelMonolithAddAltCostEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.Benefit);
+        staticText = "Once each turn, you may pay {0} rather than pay the mana cost for a colorless spell you cast from your hand.";
+    }
+
+    public DarksteelMonolithAddAltCostEffect(final DarksteelMonolithAddAltCostEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public DarksteelMonolithAddAltCostEffect copy() {
+        return new DarksteelMonolithAddAltCostEffect(this);
+    }
+
+    @Override
+    public boolean apply(Layer layer, SubLayer sublayer, Ability source, Game game) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            Permanent sourcePermanent = game.getPermanent(source.getSourceId());
+            if (sourcePermanent != null) {
+                Boolean wasItUsed = (Boolean) game.getState().getValue(
+                        sourcePermanent.getId().toString()
+                                + sourcePermanent.getZoneChangeCounter(game)
+                                + sourcePermanent.getTurnsOnBattlefield());
+                // If we haven't used it yet this turn, give the option of using the zero alternative cost
+                if (wasItUsed == null) {
+                    DarksteelMonolithAlternativeCost alternateCostAbility = new DarksteelMonolithAlternativeCost();
+                    alternateCostAbility.setSourceId(source.getSourceId());
+                    controller.getAlternativeSourceCosts().add(alternateCostAbility);
+                }
+                // Return true even if we didn't add the alt cost. We still applied the effect
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return false;
+    }
+
+    @Override
+    public boolean hasLayer(Layer layer) {
+        return layer == Layer.RulesEffects;
+    }
+}

--- a/Mage.Sets/src/mage/cards/d/DarksteelMonolith.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelMonolith.java
@@ -28,7 +28,6 @@ public final class DarksteelMonolith extends CardImpl {
 
     public DarksteelMonolith(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{8}");
-        this.supertype.add(SuperType.LEGENDARY);
 
         // Indestructible
         this.addAbility(IndestructibleAbility.getInstance());

--- a/Mage.Sets/src/mage/sets/CommanderMasters.java
+++ b/Mage.Sets/src/mage/sets/CommanderMasters.java
@@ -145,6 +145,8 @@ public final class CommanderMasters extends ExpansionSet {
         cards.add(new SetCardInfo("Danitha Capashen, Paragon", 20, Rarity.UNCOMMON, mage.cards.d.DanithaCapashenParagon.class));
         cards.add(new SetCardInfo("Daretti, Scrap Savant", 213, Rarity.RARE, mage.cards.d.DarettiScrapSavant.class));
         cards.add(new SetCardInfo("Darksteel Ingot", 378, Rarity.UNCOMMON, mage.cards.d.DarksteelIngot.class));
+        cards.add(new SetCardInfo("Darksteel Monolith", 743, Rarity.RARE, mage.cards.d.DarksteelMonolith.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Darksteel Monolith", 778, Rarity.RARE, mage.cards.d.DarksteelMonolith.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Darksteel Mutation", 21, Rarity.UNCOMMON, mage.cards.d.DarksteelMutation.class));
         cards.add(new SetCardInfo("Day's Undoing", 85, Rarity.RARE, mage.cards.d.DaysUndoing.class));
         cards.add(new SetCardInfo("Deadly Recluse", 282, Rarity.COMMON, mage.cards.d.DeadlyRecluse.class));


### PR DESCRIPTION
Found an issue whilst implementing this pretty simple-looking card. Most of the code is lifted from As Foretold which has a similar ability, but Darksteel Monolith specifically only offers the alternative casting cost to spells cast from the hand. 

Used a filter in `DarksteelMonolithAlternativeCost` which filters affected cards by colourlessness, but the `filter.add(new CastFromZonePredicate(Zone.HAND));` predicate didn't work as expected. It correctly filters out cards that could be cast from exile, and correctly highlights the appropriate cards in hand as playable, but the player is not prompted to pay the alternative cost when they go to cast a spell. Without this predicate, the player *is* prompted to pay the alternative cost (good), but cards in exile can also be cast (bad).

It seems that cards meet the `CastFromZonePredicate(Zone.HAND)` predicate condition whilst in hand, presumably due to the else statement in CastFromZonePredicate below:
https://github.com/magefree/mage/blob/087e36b63d9c87b481c3d6447552092520fc0be9/Mage/src/main/java/mage/filter/predicate/card/CastFromZonePredicate.java#L20-L27
However they cease to meet either of the conditions in that predicate when the player puts the spell on the stack to pay for it, implying that the card's fromZone is not being updated until the card is cast, but the card is also no longer in the hand whilst being paid for, something I discovered when trying to use a custom condition (in place of `SourceIsSpellCondition`) which specifically checked that the card was in the player's hand (it was not). Any thoughts on this?