### PR TITLE
Reimplement Primal Clay and similar cards

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AquamorphEntity.java
+++ b/Mage.Sets/src/mage/cards/a/AquamorphEntity.java
@@ -1,4 +1,3 @@
-
 package mage.cards.a;
 
 import mage.MageInt;
@@ -6,23 +5,21 @@ import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.ReplacementEffectImpl;
-import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
+import mage.abilities.effects.common.SelectCopiableCharacteristicsSourceEffect;
 import mage.abilities.keyword.MorphAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.choices.Choice;
-import mage.choices.ChoiceImpl;
 import mage.constants.*;
 import mage.game.Game;
 import mage.game.events.EntersTheBattlefieldEvent;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
-import mage.players.Player;
+import mage.game.permanent.token.TokenImpl;
 
 import java.util.UUID;
 
 /**
- * @author LevelX2
+ * @author xenohedron
  */
 public final class AquamorphEntity extends CardImpl {
 
@@ -53,9 +50,6 @@ public final class AquamorphEntity extends CardImpl {
 
 class AquamorphEntityReplacementEffect extends ReplacementEffectImpl {
 
-    private static final String choice51 = "a 5/1 creature";
-    private static final String choice15 = "a 1/5 creature";
-
     AquamorphEntityReplacementEffect() {
         super(Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "as {this} enters the battlefield or is turned face up, it becomes your choice of 5/1 or 1/5";
@@ -78,18 +72,18 @@ class AquamorphEntityReplacementEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
-        if (event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD) {
-            if (event.getTargetId().equals(source.getSourceId())) {
-                Permanent sourcePermanent = ((EntersTheBattlefieldEvent) event).getTarget();
-                if (sourcePermanent != null && !sourcePermanent.isFaceDown(game)) {
-                    return true;
+        switch (event.getType()) {
+            case ENTERS_THE_BATTLEFIELD:
+                if (!event.getTargetId().equals(source.getSourceId())) {
+                    return false;
                 }
-            }
+                Permanent sourcePermanent = ((EntersTheBattlefieldEvent) event).getTarget();
+                return sourcePermanent != null && !sourcePermanent.isFaceDown(game);
+            case TURNFACEUP:
+                return event.getTargetId().equals(source.getSourceId());
+            default:
+                return false;
         }
-        if (event.getType() == GameEvent.EventType.TURNFACEUP) {
-            return event.getTargetId().equals(source.getSourceId());
-        }
-        return false;
     }
 
     @Override
@@ -103,28 +97,9 @@ class AquamorphEntityReplacementEffect extends ReplacementEffectImpl {
         if (permanent == null) {
             return false;
         }
-        Choice choice = new ChoiceImpl(true);
-        choice.setMessage("Choose what the creature becomes to");
-        choice.getChoices().add(choice51);
-        choice.getChoices().add(choice15);
-        Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null && !controller.choose(Outcome.Neutral, choice, game)) {
-            discard();
-            return false;
-        }
-        int power = 0;
-        int toughness = 0;
-        switch (choice.getChoice()) {
-            case choice51:
-                power = 5;
-                toughness = 1;
-                break;
-            case choice15:
-                power = 1;
-                toughness = 5;
-                break;
-        }
-        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.CharacteristicDefining_7a), source);
+        new SelectCopiableCharacteristicsSourceEffect(
+                new AquamorphEntity51Token(), new AquamorphEntity15Token()
+        ).apply(game, source);
         return false;
     }
 
@@ -133,4 +108,38 @@ class AquamorphEntityReplacementEffect extends ReplacementEffectImpl {
         return new AquamorphEntityReplacementEffect(this);
     }
 
+}
+
+class AquamorphEntity51Token extends TokenImpl {
+
+    AquamorphEntity51Token() {
+        super("", "5/1");
+        power = new MageInt(5);
+        toughness = new MageInt(1);
+    }
+
+    private AquamorphEntity51Token(final AquamorphEntity51Token token) {
+        super(token);
+    }
+
+    public AquamorphEntity51Token copy() {
+        return new AquamorphEntity51Token(this);
+    }
+}
+
+class AquamorphEntity15Token extends TokenImpl {
+
+    AquamorphEntity15Token() {
+        super("", "1/5");
+        power = new MageInt(1);
+        toughness = new MageInt(5);
+    }
+
+    private AquamorphEntity15Token(final AquamorphEntity15Token token) {
+        super(token);
+    }
+
+    public AquamorphEntity15Token copy() {
+        return new AquamorphEntity15Token(this);
+    }
 }

--- a/Mage.Sets/src/mage/cards/m/MoltenSentry.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenSentry.java
@@ -1,30 +1,29 @@
-
 package mage.cards.m;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
-import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
+import mage.abilities.effects.common.continuous.SetCopiableCharacteristicsSourceEffect;
 import mage.abilities.keyword.DefenderAbility;
 import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
+import mage.game.permanent.token.Token;
+import mage.game.permanent.token.TokenImpl;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
- *
- * @author fireshoes
+ * @author xenohedron
  */
 public final class MoltenSentry extends CardImpl {
-
-    private static final String rule = "As {this} enters the battlefield, flip a coin. If the coin comes up heads, {this} enters the battlefield as a "
-            + "5/2 creature with haste. If it comes up tails, {this} enters the battlefield as a 2/5 creature with defender.";
 
     public MoltenSentry(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{R}");
@@ -34,7 +33,7 @@ public final class MoltenSentry extends CardImpl {
 
         // As Molten Sentry enters the battlefield, flip a coin. If the coin comes up heads, Molten Sentry enters the battlefield as a 5/2 creature with haste.
         // If it comes up tails, Molten Sentry enters the battlefield as a 2/5 creature with defender.
-        this.addAbility(new EntersBattlefieldAbility(new MoltenSentryEffect(), null, rule, ""));
+        this.addAbility(new AsEntersBattlefieldAbility(new MoltenSentryEffect()));
     }
 
     private MoltenSentry(final MoltenSentry card) {
@@ -49,11 +48,13 @@ public final class MoltenSentry extends CardImpl {
 
 class MoltenSentryEffect extends OneShotEffect {
 
-    public MoltenSentryEffect() {
-        super(Outcome.Damage);
+    MoltenSentryEffect() {
+        super(Outcome.AddAbility);
+        staticText = "flip a coin. If the coin comes up heads, {this} enters the battlefield as a 5/2 creature with haste." +
+                " If it comes up tails, {this} enters the battlefield as a 2/5 creature with defender.";
     }
 
-    public MoltenSentryEffect(MoltenSentryEffect effect) {
+    private MoltenSentryEffect(MoltenSentryEffect effect) {
         super(effect);
     }
 
@@ -65,27 +66,58 @@ class MoltenSentryEffect extends OneShotEffect {
             return false;
         }
 
-        int power;
-        int toughness;
-        Ability gainedAbility;
+        Token characteristics;
         if (controller.flipCoin(source, game, false)) {
             game.informPlayers("Heads: " + permanent.getLogName() + " enters the battlefield as a 5/2 creature with haste");
-            power = 5;
-            toughness = 2;
-            gainedAbility = HasteAbility.getInstance();
+            characteristics = new MoltenSentry52Token();
         } else {
             game.informPlayers("Tails: " + permanent.getLogName() + " enters the battlefield as a 2/5 creature with defender");
-            power = 2;
-            toughness = 5;
-            gainedAbility = DefenderAbility.getInstance();
+            characteristics = new MoltenSentry25Token();
         }
-        game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.CharacteristicDefining_7a), source);
-        game.addEffect(new GainAbilitySourceEffect(gainedAbility, Duration.WhileOnBattlefield), source);
+        game.addEffect(new SetCopiableCharacteristicsSourceEffect(characteristics), source);
         return true;
     }
 
     @Override
     public MoltenSentryEffect copy() {
         return new MoltenSentryEffect(this);
+    }
+}
+
+class MoltenSentry52Token extends TokenImpl {
+
+    MoltenSentry52Token() {
+        super("", "5/2 creature with haste");
+        cardType.add(CardType.CREATURE);
+        power = new MageInt(5);
+        toughness = new MageInt(2);
+        this.addAbility(HasteAbility.getInstance());
+    }
+
+    private MoltenSentry52Token(final MoltenSentry52Token token) {
+        super(token);
+    }
+
+    public MoltenSentry52Token copy() {
+        return new MoltenSentry52Token(this);
+    }
+}
+
+class MoltenSentry25Token extends TokenImpl {
+
+    MoltenSentry25Token() {
+        super("", "2/5 creature with defender");
+        cardType.add(CardType.CREATURE);
+        power = new MageInt(2);
+        toughness = new MageInt(5);
+        this.addAbility(DefenderAbility.getInstance());
+    }
+
+    private MoltenSentry25Token(final MoltenSentry25Token token) {
+        super(token);
+    }
+
+    public MoltenSentry25Token copy() {
+        return new MoltenSentry25Token(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PrimalClay.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalClay.java
@@ -1,29 +1,20 @@
-
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.Ability;
-import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
-import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
-import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
+import mage.abilities.common.AsEntersBattlefieldAbility;
+import mage.abilities.effects.common.SelectCopiableCharacteristicsSourceEffect;
 import mage.abilities.keyword.DefenderAbility;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.choices.Choice;
-import mage.choices.ChoiceImpl;
-import mage.constants.*;
-import mage.game.Game;
-import mage.game.events.EntersTheBattlefieldEvent;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.game.permanent.token.TokenImpl;
+
+import java.util.UUID;
 
 /**
- *
- * @author Loki
+ * @author xenohedron
  */
 public final class PrimalClay extends CardImpl {
 
@@ -35,7 +26,9 @@ public final class PrimalClay extends CardImpl {
         this.toughness = new MageInt(0);
 
         // As Primal Clay enters the battlefield, it becomes your choice of a 3/3 artifact creature, a 2/2 artifact creature with flying, or a 1/6 Wall artifact creature with defender in addition to its other types.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new PrimalPlasmaReplacementEffect()));
+        this.addAbility(new AsEntersBattlefieldAbility(new SelectCopiableCharacteristicsSourceEffect(
+                new PrimalClay33Token(), new PrimalClay22Token(), new PrimalClay16Token()
+        )));    
     }
 
     private PrimalClay(final PrimalClay card) {
@@ -47,81 +40,64 @@ public final class PrimalClay extends CardImpl {
         return new PrimalClay(this);
     }
 
-    static class PrimalPlasmaReplacementEffect extends ReplacementEffectImpl {
+}
 
-        private static final String choice33 = "a 3/3 artifact creature";
-        private static final String choice22 = "a 2/2 artifact creature with flying";
-        private static final String choice16 = "a 1/6 artifact creature with defender";
+class PrimalClay33Token extends TokenImpl {
 
-        public PrimalPlasmaReplacementEffect() {
-            super(Duration.WhileOnBattlefield, Outcome.Benefit);
-            staticText = "As {this} enters the battlefield, it becomes your choice of a 3/3 artifact creature, a 2/2 artifact creature with flying, or a 1/6 Wall artifact creature with defender in addition to its other types";
-        }
+    PrimalClay33Token() {
+        super("", "3/3 artifact creature");
+        cardType.add(CardType.ARTIFACT);
+        cardType.add(CardType.CREATURE);
+        power = new MageInt(3);
+        toughness = new MageInt(3);
+    }
 
-        public PrimalPlasmaReplacementEffect(PrimalPlasmaReplacementEffect effect) {
-            super(effect);
-        }
+    private PrimalClay33Token(final PrimalClay33Token token) {
+        super(token);
+    }
 
-        @Override
-        public boolean checksEventType(GameEvent event, Game game) {
-            return event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD;
-        }
+    public PrimalClay33Token copy() {
+        return new PrimalClay33Token(this);
+    }
+}
 
-        @Override
-        public boolean applies(GameEvent event, Ability source, Game game) {
-            if (!event.getTargetId().equals(source.getSourceId())) {
-                return false;
-            }
-            Permanent sourcePermanent = ((EntersTheBattlefieldEvent) event).getTarget();
-            return sourcePermanent != null && !sourcePermanent.isFaceDown(game);
-        }
+class PrimalClay22Token extends TokenImpl {
 
-        @Override
-        public boolean apply(Game game, Ability source) {
-            return false;
-        }
+    PrimalClay22Token() {
+        super("", "2/2 artifact creature with flying");
+        cardType.add(CardType.ARTIFACT);
+        cardType.add(CardType.CREATURE);
+        power = new MageInt(2);
+        toughness = new MageInt(2);
+        this.addAbility(FlyingAbility.getInstance());
+    }
 
-        @Override
-        public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-            Permanent permanent = ((EntersTheBattlefieldEvent) event).getTarget();
-            if (permanent == null) {
-                return false;
-            }
-            Choice choice = new ChoiceImpl(true);
-            choice.setMessage("Choose what " + permanent.getIdName() + " becomes to");
-            choice.getChoices().add(choice33);
-            choice.getChoices().add(choice22);
-            choice.getChoices().add(choice16);
-            Player controller = game.getPlayer(source.getControllerId());
-            if (controller != null && !controller.choose(Outcome.Neutral, choice, game)) {
-                return false;
-            }
-            int power = 0;
-            int toughness = 0;
-            switch (choice.getChoice()) {
-                case choice33:
-                    power = 3;
-                    toughness = 3;
-                    break;
-                case choice22:
-                    power = 2;
-                    toughness = 2;
-                    game.addEffect(new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.Custom), source);
-                    break;
-                case choice16:
-                    power = 1;
-                    toughness = 6;
-                    game.addEffect(new GainAbilitySourceEffect(DefenderAbility.getInstance(), Duration.Custom), source);
-                    break;
-            }
-            game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.CharacteristicDefining_7a), source);
-            return false;
-        }
+    private PrimalClay22Token(final PrimalClay22Token token) {
+        super(token);
+    }
 
-        @Override
-        public PrimalPlasmaReplacementEffect copy() {
-            return new PrimalPlasmaReplacementEffect(this);
-        }
+    public PrimalClay22Token copy() {
+        return new PrimalClay22Token(this);
+    }
+}
 
+class PrimalClay16Token extends TokenImpl {
+
+    PrimalClay16Token() {
+        super("", "1/6 Wall artifact creature with defender");
+        cardType.add(CardType.ARTIFACT);
+        cardType.add(CardType.CREATURE);
+        subtype.add(SubType.WALL);
+        power = new MageInt(1);
+        toughness = new MageInt(6);
+        this.addAbility(DefenderAbility.getInstance());
+    }
+
+    private PrimalClay16Token(final PrimalClay16Token token) {
+        super(token);
+    }
+
+    public PrimalClay16Token copy() {
+        return new PrimalClay16Token(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PrimalPlasma.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalPlasma.java
@@ -1,29 +1,20 @@
-
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.Ability;
-import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
-import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
-import mage.abilities.effects.common.continuous.SetBasePowerToughnessSourceEffect;
+import mage.abilities.common.AsEntersBattlefieldAbility;
+import mage.abilities.effects.common.SelectCopiableCharacteristicsSourceEffect;
 import mage.abilities.keyword.DefenderAbility;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.choices.Choice;
-import mage.choices.ChoiceImpl;
-import mage.constants.*;
-import mage.game.Game;
-import mage.game.events.EntersTheBattlefieldEvent;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.game.permanent.token.TokenImpl;
+
+import java.util.UUID;
 
 /**
- *
- * @author LevelX2
+ * @author xenohedron
  */
 public final class PrimalPlasma extends CardImpl {
 
@@ -36,7 +27,9 @@ public final class PrimalPlasma extends CardImpl {
         this.toughness = new MageInt(0);
 
         // As Primal Plasma enters the battlefield, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new PrimalPlasmaReplacementEffect()));
+        this.addAbility(new AsEntersBattlefieldAbility(new SelectCopiableCharacteristicsSourceEffect(
+                new PrimalPlasma33Token(), new PrimalPlasma22Token(), new PrimalPlasma16Token()
+        )));
     }
 
     private PrimalPlasma(final PrimalPlasma card) {
@@ -48,81 +41,60 @@ public final class PrimalPlasma extends CardImpl {
         return new PrimalPlasma(this);
     }
 
-    static class PrimalPlasmaReplacementEffect extends ReplacementEffectImpl {
+}
 
-        private static final String choice33 = "a 3/3 creature";
-        private static final String choice22 = "a 2/2 creature with flying";
-        private static final String choice16 = "a 1/6 creature with defender";
+class PrimalPlasma33Token extends TokenImpl {
 
-        public PrimalPlasmaReplacementEffect() {
-            super(Duration.WhileOnBattlefield, Outcome.Benefit);
-            staticText = "As {this} enters the battlefield, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender";
-        }
+    PrimalPlasma33Token() {
+        super("", "3/3 creature");
+        cardType.add(CardType.CREATURE);
+        power = new MageInt(3);
+        toughness = new MageInt(3);
+    }
 
-        public PrimalPlasmaReplacementEffect(PrimalPlasmaReplacementEffect effect) {
-            super(effect);
-        }
+    private PrimalPlasma33Token(final PrimalPlasma33Token token) {
+        super(token);
+    }
 
-        @Override
-        public boolean checksEventType(GameEvent event, Game game) {
-            return event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD;
-        }
+    public PrimalPlasma33Token copy() {
+        return new PrimalPlasma33Token(this);
+    }
+}
 
-        @Override
-        public boolean applies(GameEvent event, Ability source, Game game) {
-            if (event.getTargetId().equals(source.getSourceId())) {
-                Permanent sourcePermanent = ((EntersTheBattlefieldEvent) event).getTarget();
-                return sourcePermanent != null && !sourcePermanent.isFaceDown(game);
-            }
-            return false;
-        }
+class PrimalPlasma22Token extends TokenImpl {
 
-        @Override
-        public boolean apply(Game game, Ability source) {
-            return false;
-        }
+    PrimalPlasma22Token() {
+        super("", "2/2 creature with flying");
+        cardType.add(CardType.CREATURE);
+        power = new MageInt(2);
+        toughness = new MageInt(2);
+        this.addAbility(FlyingAbility.getInstance());
+    }
 
-        @Override
-        public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-            Permanent permanent = ((EntersTheBattlefieldEvent) event).getTarget();
-            Player controller = game.getPlayer(source.getControllerId());
-            if (permanent != null && controller != null) {
-                Choice choice = new ChoiceImpl(true);
-                choice.setMessage("Choose what " + permanent.getIdName() + " becomes to");
-                choice.getChoices().add(choice33);
-                choice.getChoices().add(choice22);
-                choice.getChoices().add(choice16);
-                if (!controller.choose(Outcome.Neutral, choice, game)) {
-                    return false;
-                }
-                int power = 0;
-                int toughness = 0;
-                switch (choice.getChoice()) {
-                    case choice33:
-                        power = 3;
-                        toughness = 3;
-                        break;
-                    case choice22:
-                        power = 2;
-                        toughness = 2;
-                        game.addEffect(new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.Custom), source);
-                        break;
-                    case choice16:
-                        power = 1;
-                        toughness = 6;
-                        game.addEffect(new GainAbilitySourceEffect(DefenderAbility.getInstance(), Duration.Custom), source);
-                        break;
-                }
-                game.addEffect(new SetBasePowerToughnessSourceEffect(power, toughness, Duration.WhileOnBattlefield, SubLayer.CharacteristicDefining_7a), source);
-            }
-            return false;
+    private PrimalPlasma22Token(final PrimalPlasma22Token token) {
+        super(token);
+    }
 
-        }
+    public PrimalPlasma22Token copy() {
+        return new PrimalPlasma22Token(this);
+    }
+}
 
-        @Override
-        public PrimalPlasmaReplacementEffect copy() {
-            return new PrimalPlasmaReplacementEffect(this);
-        }
+class PrimalPlasma16Token extends TokenImpl {
 
+    PrimalPlasma16Token() {
+        super("", "1/6 creature with defender");
+        cardType.add(CardType.CREATURE);
+        power = new MageInt(1);
+        toughness = new MageInt(6);
+        this.addAbility(DefenderAbility.getInstance());
+    }
+
+    private PrimalPlasma16Token(final PrimalPlasma16Token token) {
+        super(token);
+    }
+
+    public PrimalPlasma16Token copy() {
+        return new PrimalPlasma16Token(this);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/replacement/entersBattlefield/PrimalClayTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/replacement/entersBattlefield/PrimalClayTest.java
@@ -1,0 +1,286 @@
+package org.mage.test.cards.replacement.entersBattlefield;
+
+import mage.abilities.keyword.DefenderAbility;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.HasteAbility;
+import mage.constants.PhaseStep;
+import mage.constants.SubType;
+import mage.constants.Zone;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author xenohedron
+ */
+public class PrimalClayTest extends CardTestPlayerBase {
+
+    private static final String clay = "Primal Clay";
+    // As Primal Clay enters the battlefield, it becomes your choice of a 3/3 artifact creature, a 2/2 artifact creature
+    // with flying, or a 1/6 Wall artifact creature with defender in addition to its other types.
+    private static final String plasma = "Primal Plasma";
+    // As Primal Plasma enters the battlefield, it becomes your choice of a 3/3 creature, a 2/2 creature with flying,
+    // or a 1/6 creature with defender.
+    private static final String sentry = "Molten Sentry";
+    // As Molten Sentry enters the battlefield, flip a coin. If the coin comes up heads, Molten Sentry enters the battlefield
+    // as a 5/2 creature with haste. If it comes up tails, Molten Sentry enters the battlefield as a 2/5 creature with defender.
+    private static final String aquamorph = "Aquamorph Entity";
+    // As Aquamorph Entity enters the battlefield or is turned face up, it becomes your choice of 5/1 or 1/5.
+    private static final String tunnel = "Tunnel";
+    // Destroy target Wall. It can't be regenerated.
+    private static final String clone = "Clone";
+    // You may have Clone enter the battlefield as a copy of any creature on the battlefield.
+    private static final String cryptoplasm = "Cryptoplasm";
+    // At the beginning of your upkeep, you may have Cryptoplasm become a copy of another target creature, except it has this ability.
+    private static final String cloudshift = "Cloudshift";
+    // Exile target creature you control, then return that card to the battlefield under your control.
+
+    @Test
+    public void testClayPTSet() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 3/3 artifact creature");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, clay, 3, 3);
+    }
+
+    @Test
+    public void testClayAbilityGained() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 2/2 artifact creature with flying");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, clay, 2, 2);
+        assertAbility(playerA, clay, FlyingAbility.getInstance(), true);
+    }
+
+    @Test
+    public void testClaySubtypeGained() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 1/6 Wall artifact creature with defender");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, clay, 1, 6);
+        assertAbility(playerA, clay, DefenderAbility.getInstance(), true);
+        assertSubtype(clay, SubType.WALL);
+    }
+
+    @Test
+    public void testClayCopyPTOnBattlefield() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.HAND, playerA, cryptoplasm);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 7);
+        addCard(Zone.BATTLEFIELD, playerB, "Plains", 3);
+        addCard(Zone.HAND, playerB, "The Battle of Bywater", 1);
+        // Destroy all creatures with power 3 or greater. Then create a Food token for each creature you control.
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 3/3 artifact creature");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cryptoplasm);
+
+        // cryptoplasm trigger at next upkeep
+        setChoice(playerA, true); // whether to copy
+        addTarget(playerA, clay); // what to copy
+
+        castSpell(4, PhaseStep.PRECOMBAT_MAIN, playerB, "The Battle of Bywater");
+        // since cryptoplasm now a 3/3, both are destroyed
+
+        setStrictChooseMode(true);
+        setStopAt(4, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertGraveyardCount(playerA, clay, 1);
+        assertGraveyardCount(playerA, cryptoplasm, 1);
+    }
+
+    @Ignore("Chosen characteristics of Primal Clay should be copiable values")
+    @Test
+    public void testClayCopySubtypeOnBattlefield() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.HAND, playerA, cryptoplasm);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 7);
+        addCard(Zone.HAND, playerB, tunnel, 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 1/6 Wall artifact creature with defender");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cryptoplasm);
+
+        // cryptoplasm trigger at next upkeep
+        setChoice(playerA, true); // whether to copy
+        addTarget(playerA, clay); // what to copy
+
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerB, tunnel, clay);
+        waitStackResolved(3, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerB, tunnel, clay);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerA, clay, 1);
+        assertGraveyardCount(playerA, cryptoplasm, 1);
+    }
+
+    @Test
+    public void testPlasmaClone() {
+        addCard(Zone.HAND, playerA, plasma);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+        addCard(Zone.HAND, playerB, clone);
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, plasma);
+        setChoice(playerA, "a 1/6 creature with defender");
+
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, clone);
+        setChoice(playerB, true); // whether to copy
+        setChoice(playerB, plasma); // what to copy
+        setChoice(playerB, "a 2/2 creature with flying"); // new choice as ETB
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, plasma, 1, 6);
+        assertPowerToughness(playerB, plasma, 2, 2);
+        assertAbility(playerB, plasma, FlyingAbility.getInstance(), true);
+        //assertAbility(playerB, plasma, DefenderAbility.getInstance(), true); TODO: this is a copiable value
+    }
+
+    @Test
+    public void testMoltenSentryClone() {
+        addCard(Zone.HAND, playerA, sentry);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
+        addCard(Zone.HAND, playerB, clone);
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 4);
+
+        setFlipCoinResult(playerA, true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, sentry);
+
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, clone);
+        setChoice(playerB, true); // whether to copy
+        setFlipCoinResult(playerB, false);
+        setChoice(playerB, sentry); // what to copy
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, sentry, 5, 2);
+        assertAbility(playerA, sentry, HasteAbility.getInstance(), true);
+        assertPowerToughness(playerB, sentry, 2, 5);
+        assertAbility(playerB, sentry, DefenderAbility.getInstance(), true);
+    }
+
+    @Test
+    public void testAquamorphEntityETB() {
+        addCard(Zone.HAND, playerA, aquamorph);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, aquamorph);
+        setChoice(playerA, false); // not using morph
+        setChoice(playerA, "5/1");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, aquamorph, 5, 1);
+    }
+
+    @Test
+    public void testAquamorphEntityUnmorph() {
+        addCard(Zone.HAND, playerA, aquamorph);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 6);
+        addCard(Zone.HAND, playerA, "Island");
+        addCard(Zone.HAND, playerA, "Savage Swipe", 1);
+        // Target creature you control gets +2/+2 until end of turn if its power is 2. Then it fights target creature you don’t control.
+        addCard(Zone.BATTLEFIELD, playerB, "Siege Mastodon", 1); // 3/5 creature for fighting
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, aquamorph);
+        setChoice(playerA, true); // cast facedown as 2/2
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Savage Swipe");
+        addTarget(playerA, ""); // morph
+        addTarget(playerA, "Siege Mastodon");
+        // 2/2 becomes 4/4, fights 3/5, neither dies
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Island");
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}{U}: Turn"); // unmorph
+        setChoice(playerA, "1/5");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, aquamorph, 1 + 2, 5 + 2);
+        assertDamageReceived(playerA, aquamorph, 3);
+        assertDamageReceived(playerB, "Siege Mastodon", 4);
+    }
+
+    @Test
+    public void testClayFlicker() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.HAND, playerA, cloudshift);
+        addCard(Zone.BATTLEFIELD, playerA, "Waterkin Shaman");
+        // 2/1; Whenever a creature with flying enters the battlefield under your control, Waterkin Shaman gets +1/+1 until end of turn.
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 2/2 artifact creature with flying");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cloudshift, clay);
+        setChoice(playerA, "a 3/3 artifact creature");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, clay, 3, 3);
+        assertPowerToughness(playerA, "Waterkin Shaman", 2 + 1, 1 + 1);
+        assertAbility(playerA, clay, FlyingAbility.getInstance(), false);
+    }
+
+    @Test
+    public void testClayFlickerWall() {
+        addCard(Zone.HAND, playerA, clay);
+        addCard(Zone.HAND, playerA, cloudshift);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
+        setChoice(playerA, "a 1/6 Wall artifact creature with defender");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cloudshift, clay);
+        setChoice(playerA, "a 3/3 artifact creature");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, clay, 3, 3);
+        assertNotSubtype(clay, SubType.WALL);
+    }
+
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/replacement/entersBattlefield/PrimalClayTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/replacement/entersBattlefield/PrimalClayTest.java
@@ -41,7 +41,7 @@ public class PrimalClayTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
-        setChoice(playerA, "a 3/3 artifact creature");
+        setChoice(playerA, "3/3 artifact creature");
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
@@ -56,7 +56,7 @@ public class PrimalClayTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
-        setChoice(playerA, "a 2/2 artifact creature with flying");
+        setChoice(playerA, "2/2 artifact creature with flying");
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
@@ -72,7 +72,7 @@ public class PrimalClayTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
-        setChoice(playerA, "a 1/6 Wall artifact creature with defender");
+        setChoice(playerA, "1/6 Wall artifact creature with defender");
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
@@ -93,7 +93,7 @@ public class PrimalClayTest extends CardTestPlayerBase {
         // Destroy all creatures with power 3 or greater. Then create a Food token for each creature you control.
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
-        setChoice(playerA, "a 3/3 artifact creature");
+        setChoice(playerA, "3/3 artifact creature");
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cryptoplasm);
 
@@ -122,7 +122,7 @@ public class PrimalClayTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerB, "Mountain", 2);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
-        setChoice(playerA, "a 1/6 Wall artifact creature with defender");
+        setChoice(playerA, "1/6 Wall artifact creature with defender");
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cryptoplasm);
 
@@ -150,12 +150,12 @@ public class PrimalClayTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerB, "Island", 4);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, plasma);
-        setChoice(playerA, "a 1/6 creature with defender");
+        setChoice(playerA, "1/6 creature with defender");
 
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, clone);
         setChoice(playerB, true); // whether to copy
         setChoice(playerB, plasma); // what to copy
-        setChoice(playerB, "a 2/2 creature with flying"); // new choice as ETB
+        setChoice(playerB, "2/2 creature with flying"); // new choice as ETB
 
         setStrictChooseMode(true);
         setStopAt(2, PhaseStep.BEGIN_COMBAT);
@@ -247,11 +247,11 @@ public class PrimalClayTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
-        setChoice(playerA, "a 2/2 artifact creature with flying");
+        setChoice(playerA, "2/2 artifact creature with flying");
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cloudshift, clay);
-        setChoice(playerA, "a 3/3 artifact creature");
+        setChoice(playerA, "3/3 artifact creature");
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
@@ -269,11 +269,11 @@ public class PrimalClayTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, clay);
-        setChoice(playerA, "a 1/6 Wall artifact creature with defender");
+        setChoice(playerA, "1/6 Wall artifact creature with defender");
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cloudshift, clay);
-        setChoice(playerA, "a 3/3 artifact creature");
+        setChoice(playerA, "3/3 artifact creature");
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);

--- a/Mage/src/main/java/mage/abilities/effects/common/SelectCopiableCharacteristicsSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/SelectCopiableCharacteristicsSourceEffect.java
@@ -1,0 +1,107 @@
+package mage.abilities.effects.common;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.SetCopiableCharacteristicsSourceEffect;
+import mage.choices.Choice;
+import mage.choices.ChoiceImpl;
+import mage.constants.Outcome;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.game.permanent.token.Token;
+import mage.players.Player;
+import mage.util.CardUtil;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author xenohedron
+ */
+public class SelectCopiableCharacteristicsSourceEffect extends OneShotEffect {
+
+    private final List<Token> choices;
+
+    /**
+     * This effect should be used with "As ... enters the battlefield" and "as ... is turned face up" abilities
+     * to set copiable characteristics chosen by the source controller
+     *
+     * @param choices Tokens with the appropriate characteristics to select from
+     */
+    public SelectCopiableCharacteristicsSourceEffect(Token... choices) {
+        super(Outcome.AddAbility);
+        this.choices = Arrays.asList(choices);
+        staticText = makeText();
+    }
+
+    protected SelectCopiableCharacteristicsSourceEffect(final SelectCopiableCharacteristicsSourceEffect effect) {
+        super(effect);
+        this.choices = effect.choices;
+    }
+
+    @Override
+    public SelectCopiableCharacteristicsSourceEffect copy() {
+        return new SelectCopiableCharacteristicsSourceEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanentEntering(source.getSourceId());
+        if (permanent == null) {
+            permanent = game.getPermanent(source.getSourceId());
+        }
+        Player controller = game.getPlayer(source.getControllerId());
+        if (permanent == null || controller == null) {
+            return false;
+        }
+        Choice choice = new ChoiceImpl(true);
+        choice.setMessage("Choose characteristics for " + permanent.getIdName());
+        for (Token token : choices) {
+            choice.getChoices().add(token.getDescription());
+        }
+        if (!controller.choose(Outcome.Neutral, choice, game)) {
+            return false;
+        }
+        Token characteristics = null;
+        for (Token token : choices) {
+            if (token.getDescription().equals(choice.getChoice())) {
+                characteristics = token;
+                break;
+            }
+        }
+        if (characteristics == null) {
+            return false;
+        }
+        game.addEffect(new SetCopiableCharacteristicsSourceEffect(characteristics), source);
+        return true;
+    }
+
+    private String makeText() {
+        StringBuilder sb = new StringBuilder("it becomes your choice of ");
+        int i = 0;
+        int last = choices.size() - 1;
+        boolean setType = false;
+        for (Token token : choices) {
+            i++;
+            String description = token.getDescription();
+            if (description.contains("creature")) {
+                sb.append(CardUtil.addArticle(description));
+            } else {
+                sb.append(description);
+            }
+            if (i < last) {
+                sb.append(", ");
+            } else if (i == last) {
+                sb.append(", or ");
+            }
+            if (!token.getSubtype().isEmpty()) {
+                setType = true;
+            }
+        }
+        if (setType) {
+            sb.append(" in addition to its other types");
+        }
+        return sb.toString();
+    }
+
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/SetCopiableCharacteristicsSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/SetCopiableCharacteristicsSourceEffect.java
@@ -1,0 +1,75 @@
+package mage.abilities.effects.common.continuous;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.ContinuousEffectImpl;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.game.permanent.token.Token;
+
+/**
+ * @author xenohedron
+ */
+public class SetCopiableCharacteristicsSourceEffect extends ContinuousEffectImpl {
+
+    /*
+     * CR 2023-07-24
+     * 613.2a Layer 1a: Copiable effects are applied.
+     * "As ... enters the battlefield" and "as ... is turned face up" abilities generate copiable effects
+     * if they set power and toughness, even if they also define other characteristics.
+     */
+
+    protected final Token token;
+
+    /**
+     * Apply this continuous effect from a one-shot effect that selects characteristics
+     * as the creature enters the battlefield or is turned face up
+     *
+     * @param characteristics       Token as blueprint for creature to become.
+     */
+    public SetCopiableCharacteristicsSourceEffect(Token characteristics) {
+        super(Duration.Custom, Layer.CopyEffects_1, SubLayer.CopyEffects_1a, Outcome.AddAbility);
+        this.token = characteristics;
+        if (token == null || token.getPower() == null || token.getToughness() == null) {
+            throw new IllegalArgumentException("SetCopiableCharacteristics must set power and toughness");
+        }
+        staticText = "{this} becomes a " + token.getDescription()
+                + (token.getSubtype().isEmpty() ? "" : " in addition to its other types");
+    }
+
+    protected SetCopiableCharacteristicsSourceEffect(final SetCopiableCharacteristicsSourceEffect effect) {
+        super(effect);
+        this.token = effect.token.copy();
+    }
+
+    @Override
+    public SetCopiableCharacteristicsSourceEffect copy() {
+        return new SetCopiableCharacteristicsSourceEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanent(source.getSourceId());
+        if (permanent == null) {
+            permanent = game.getPermanentEntering(source.getSourceId());
+        }
+        if (permanent == null) {
+            discard();
+            return false;
+        }
+        for (CardType cardType : token.getCardType(game)) {
+            permanent.addCardType(game, cardType);
+        }
+        permanent.copySubTypesFrom(game, token);
+        if (token.getColor(game).hasColor()) {
+            permanent.getColor(game).setColor(token.getColor(game));
+        }
+        for (Ability ability : token.getAbilities()) {
+            permanent.addAbility(ability, source.getSourceId(), game);
+        }
+        permanent.getPower().setModifiedBaseValue(token.getPower().getValue());
+        permanent.getToughness().setModifiedBaseValue(token.getToughness().getValue());
+        return true;
+    }
+
+}


### PR DESCRIPTION
This is a better partial fix for #9444.

* Effects now apply in layer 1a. Future improvements (e.g. #10287 perhaps) will be able to use them as copiable values, but copy effects don't yet handle that.
* Fix so that Wall subtype is correctly added
* Fix so that the gained ability is lost when flickered
* Add several test cases (including one ignored pending future copy effect improvement)