### PR TITLE
Fix Hints being shown twice on permanents.

### DIFF
--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -12,7 +12,6 @@ import mage.abilities.effects.Effect;
 import mage.abilities.effects.RequirementEffect;
 import mage.abilities.effects.RestrictionEffect;
 import mage.abilities.effects.common.RegenerateSourceEffect;
-import mage.abilities.hint.Hint;
 import mage.abilities.hint.HintUtils;
 import mage.abilities.keyword.*;
 import mage.cards.Card;
@@ -279,19 +278,6 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                 return rules;
             }
 
-            // ability hints
-            List<String> abilityHints = new ArrayList<>();
-            if (HintUtils.ABILITY_HINTS_ENABLE) {
-                for (Ability ability : getAbilities(game)) {
-                    for (Hint hint : ability.getHints()) {
-                        String s = hint.getText(game, ability);
-                        if (s != null && !s.isEmpty()) {
-                            abilityHints.add(s);
-                        }
-                    }
-                }
-            }
-
             // restrict hints
             List<String> restrictHints = new ArrayList<>();
             if (HintUtils.RESTRICT_HINTS_ENABLE) {
@@ -357,9 +343,8 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
             }
 
             // total hints
-            if (!abilityHints.isEmpty() || !restrictHints.isEmpty()) {
+            if (!restrictHints.isEmpty()) {
                 rules.add(HintUtils.HINT_START_MARK);
-                HintUtils.appendHints(rules, abilityHints);
                 HintUtils.appendHints(rules, restrictHints);
             }
 

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -278,6 +278,8 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                 return rules;
             }
 
+            // ability hints already collected in super call
+
             // restrict hints
             List<String> restrictHints = new ArrayList<>();
             if (HintUtils.RESTRICT_HINTS_ENABLE) {
@@ -344,7 +346,9 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
 
             // total hints
             if (!restrictHints.isEmpty()) {
-                rules.add(HintUtils.HINT_START_MARK);
+                if (rules.stream().noneMatch(s -> s.contains(HintUtils.HINT_START_MARK))) {
+                    rules.add(HintUtils.HINT_START_MARK);
+                }
                 HintUtils.appendHints(rules, restrictHints);
             }
 


### PR DESCRIPTION
`PermanentImpl->getRules` was adding ability hints twice: 

-  With the `super.getRules(game)` call on `Card->getRules`, that is calling `CardUtil->getCardRulesWithAdditionalInfo`
- Directly in the implementation, collecting `abilityHints`. (what this PR is cleaning up.)

This caused Permanents to have duplicated ability hints.

Removal of the `PermanentImpl` handling of ability hints did fix the issue, as `getAbilities(game)` and `super.getAbilities(game)` are always the same lists, there is no need to worry of abilities of `PermanentImpl` that would not have been handled already by `CardImpl`.
![singlehint](https://github.com/magefree/mage/assets/34709007/0bf9f95e-717d-46e6-b8e8-149c42efed46)

 fix #10312 