### PR TITLE
[don't merge] Subability copy bug

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DefendersOfHumanity.java
+++ b/Mage.Sets/src/mage/cards/d/DefendersOfHumanity.java
@@ -49,7 +49,7 @@ public final class DefendersOfHumanity extends CardImpl {
         Ability ability = new ActivateIfConditionActivatedAbility(
                 Zone.BATTLEFIELD,
                 new CreateTokenEffect(
-                        new WhiteAstartesWarriorToken(), GetXValue.instance
+                        new WhiteAstartesWarriorToken(), ManacostVariableValue.REGULAR
                 ), new ManaCostsImpl<>("{X}{2}{W}"), condition
         ).addHint(CreaturesYouControlHint.instance).addHint(MyTurnHint.instance);
         ability.addCost(new ExileSourceCost());

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BlitzTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BlitzTest.java
@@ -6,6 +6,7 @@ import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import mage.game.permanent.Permanent;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -63,6 +64,45 @@ public class BlitzTest extends CardTestPlayerBase {
         execute();
 
         assertPermanentCount(playerA, decoy, 0);
+        assertGraveyardCount(playerA, decoy, 1);
+        assertHandCount(playerA, 1);
+    }
+    @Ignore //Copies of a Blitz creature should have Blitz activated, currently do not
+    @Test
+    public void testBlitzCopy() {
+        addCard(Zone.BATTLEFIELD, playerA, "Tropical Island", 6);
+        addCard(Zone.HAND, playerA, decoy);
+        addCard(Zone.HAND, playerA, "Double Major");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, decoy + withBlitz);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Double Major",decoy);
+
+        //Auto-stack triggers without StrictChooseMode
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, decoy, 0);
+        assertGraveyardCount(playerA, decoy, 1);
+        assertGraveyardCount(playerA, "Double Major", 1);
+        assertHandCount(playerA, 2);
+    }
+    @Test
+    public void testBlitzClone() {
+        addCard(Zone.BATTLEFIELD, playerA, "Tropical Island", 8);
+        addCard(Zone.HAND, playerA, decoy);
+        addCard(Zone.HAND, playerA, "Clone");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, decoy + withBlitz);
+        waitStackResolved(1,PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Clone");
+        setChoice(playerA,true);
+        setChoice(playerA,decoy);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, decoy, 1);
         assertGraveyardCount(playerA, decoy, 1);
         assertHandCount(playerA, 1);
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ConvokeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ConvokeTest.java
@@ -349,4 +349,115 @@ public class ConvokeTest extends CardTestPlayerBaseWithAIHelps {
 
         assertPermanentCount(playerA, "Soldier Token", 1);
     }
+
+    // Ancient Imperiosaur
+    @Test
+    public void test_AncientImperiosaur_Convoke() {
+        // Ancient Imperiosaur {5}{G}{G}
+        // Convoke, Trample, ward {2}
+        // Ancient Imperiosaur enters the battlefield with two +1/+1 counters on it for each creature that convoked it.
+        // 6/6
+        addCard(Zone.HAND, playerA, "Ancient Imperiosaur", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Grizzly Bears", 6);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 1);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ancient Imperiosaur");
+        addTarget(playerA, "Grizzly Bears", 6);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+        assertPowerToughness(playerA,"Ancient Imperiosaur",18,18);
+    }
+
+    @Ignore //Copies must place counters on the convoked creatures, but currently do not
+    @Test
+    public void test_Copy_Counters_Convoke() {
+        // Venerated Loxodon {4}{W}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creatureΓÇÖs color.)
+        // When Venerated Loxodon enters the battlefield, put a +1/+1 counter on each creature that convoked it.
+        addCard(Zone.HAND, playerA, "Venerated Loxodon", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Memnite", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Grizzly Bears", 2);
+
+        addCard(Zone.HAND, playerA, "Double Major", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 1);
+
+        addCard(Zone.HAND, playerB, "Hideous Laughter", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Swamp", 4);
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {W}", 3);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Venerated Loxodon");
+        setChoice(playerA, "White", 3); // pay WWW
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, "Memnite"); // pay 4 as convoke
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, "Grizzly Bears"); // pay 5 as convoke
+
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {U}", 1);
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {G}", 1);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Double Major", "Venerated Loxodon");
+        setChoice(playerA, "Blue", 1);
+        setChoice(playerA, "Green", 1);
+
+        waitStackResolved(1,PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Hideous Laughter");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+        assertGraveyardCount(playerA,"Memnite",1);
+        assertGraveyardCount(playerA,"Grizzly Bears",1);
+        assertPowerToughness(playerA,"Memnite", 1, 1);
+        assertPowerToughness(playerA,"Grizzly Bears", 2, 2);
+        assertPermanentCount(playerA,"Venerated Loxodon",2);
+    }
+    // Checks that Venerated Loxodon clone doesn't put counters on anything
+    @Test
+    public void test_Clone_Counters_Convoke() {
+        // Venerated Loxodon {4}{W}
+        // Convoke (Your creatures can help cast this spell. Each creature you tap while casting this spell pays for {1} or one mana of that creatureΓÇÖs color.)
+        // When Venerated Loxodon enters the battlefield, put a +1/+1 counter on each creature that convoked it.
+        addCard(Zone.HAND, playerA, "Venerated Loxodon", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Memnite", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Grizzly Bears", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 3);
+
+        addCard(Zone.HAND, playerA, "Clone", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Swamp", 4);
+        addCard(Zone.HAND, playerB, "Hideous Laughter", 1);
+
+        // use special action to pay (need disabled auto-payment and prepared mana pool)
+        disableManaAutoPayment(playerA);
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {W}", 3);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Venerated Loxodon");
+        setChoice(playerA, "White", 3); //Pay WWW
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, "Memnite"); // pay 4 as convoke
+        setChoice(playerA, "Convoke");
+        addTarget(playerA, "Grizzly Bears"); // pay 5 as convoke
+
+        waitStackResolved(1,PhaseStep.PRECOMBAT_MAIN);
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {U}", 4);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Clone");
+        setChoice(playerA, "Blue", 4);
+        setChoice(playerA,true);
+        setChoice(playerA,"Venerated Loxodon");
+
+        waitStackResolved(1,PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Hideous Laughter");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+        assertGraveyardCount(playerA,"Memnite",2);
+        assertGraveyardCount(playerA,"Grizzly Bears",1);
+        assertPowerToughness(playerA,"Grizzly Bears", 1, 1);
+        assertPermanentCount(playerA,"Venerated Loxodon",2);
+    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/EchoTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/EchoTest.java
@@ -70,5 +70,35 @@ public class EchoTest extends CardTestPlayerBase {
         assertTappedCount("Mountain", true, 0);
     }
 
+    //Deranged Hermit has been cloned with Phantasmal Image.
+    //The Phantasmal Image version of the Deranged Hermit had to pay the echo cost multiple times.
+    @Test
+    public void testEchoTriggerClone() {
+        addCard(Zone.BATTLEFIELD, playerA, "Tropical Island", 15);
+        // Deranged Hermit {3}{G}{G}
+        // Echo
+        addCard(Zone.HAND, playerA, "Deranged Hermit");
+        addCard(Zone.HAND, playerA, "Phantasmal Image");
+        addCard(Zone.HAND, playerA, "Double Major");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Deranged Hermit");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Double Major", "Deranged Hermit");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Phantasmal Image");
+        setChoice(playerA, true);
+        setChoice(playerA, "Deranged Hermit");
+
+        //There should be 3 copies, 3 echo costs, let the AI stack them
+        //setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+
+        assertPermanentCount(playerA, "Deranged Hermit", 3);
+        assertTappedCount("Tropical Island", true, 15);
+
+    }
 
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SpectacleTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SpectacleTest.java
@@ -1,0 +1,147 @@
+package org.mage.test.cards.abilities.keywords;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author notgreat
+ */
+public class SpectacleTest extends CardTestPlayerBase {
+
+    /**
+     *
+     */
+    @Test
+    public void testWithoutSpectacle1() {
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
+        addCard(Zone.HAND, playerA, "Spikewheel Acrobat"); // {3}{R}
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Spikewheel Acrobat");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        setStrictChooseMode(true);
+        execute();
+
+        assertPermanentCount(playerA,"Spikewheel Acrobat",1);
+        assertTappedCount("Mountain",true,4);
+    }
+    @Test
+    public void testWithoutSpectacle2() {
+        // Rafter Demon {2}{B}{R}
+        // Spectacle {3}{B}{R}
+        // When Rafter Demon enters the battlefield, if its spectacle cost was paid, each opponent discards a card.
+        addCard(Zone.BATTLEFIELD, playerA, "Badlands", 6);
+        addCard(Zone.HAND, playerA, "Lightning Bolt"); // {R}
+        addCard(Zone.HAND, playerA, "Rafter Demon"); // {2}{B}{R}
+        addCard(Zone.HAND, playerB, "Darksteel Relic",5);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt",playerB);
+        waitStackResolved(1,PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Rafter Demon");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        setStrictChooseMode(true);
+        execute();
+
+        assertPermanentCount(playerA,"Rafter Demon",1);
+        assertTappedCount("Badlands",true,5);
+        assertGraveyardCount(playerA, "Lightning Bolt", 1);
+        assertLife(playerB, 17);
+        assertGraveyardCount(playerB, "Darksteel Relic", 0);
+        assertHandCount(playerB, "Darksteel Relic", 5);
+    }
+
+    @Test
+    public void testWithSpectacle() {
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
+        addCard(Zone.HAND, playerA, "Lightning Bolt"); // {R}
+        addCard(Zone.HAND, playerA, "Spikewheel Acrobat"); // Surge {2}{R}
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt",playerB);
+        waitStackResolved(1,PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Spikewheel Acrobat with spectacle");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        setStrictChooseMode(true);
+        execute();
+
+        assertPermanentCount(playerA,"Spikewheel Acrobat",1);
+        assertTappedCount("Mountain",true,4);
+        assertGraveyardCount(playerA, "Lightning Bolt", 1);
+        assertLife(playerB, 17);
+    }
+
+    @Ignore //currently fails
+    @Test
+    public void testRafterDemonCopy() {
+        addCard(Zone.BATTLEFIELD, playerA, "Badlands", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Tropical Island", 4);
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 5);
+        // Rafter Demon {2}{B}{R}
+        // Spectacle {3}{B}{R}
+        // When Rafter Demon enters the battlefield, if its spectacle cost was paid, each opponent discards a card.
+        addCard(Zone.HAND, playerA, "Rafter Demon");
+        addCard(Zone.HAND, playerA, "Lightning Bolt");
+        addCard(Zone.HAND, playerB, "Darksteel Relic",4);
+
+        addCard(Zone.HAND, playerA, "Double Major");
+        addCard(Zone.HAND, playerA, "Clone");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Rafter Demon with spectacle");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Double Major");
+        addTarget(playerA, "Rafter Demon");
+        addTarget(playerB, "Darksteel Relic",2);
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        setStrictChooseMode(true);
+        execute();
+
+        assertGraveyardCount(playerA, 1); //Lightning Bolt
+        assertGraveyardCount(playerB, 2); //Darksteel Relic x2
+        assertHandCount(playerB, "Darksteel Relic", 2);
+        assertPermanentCount(playerA, "Rafter Demon", 2);
+
+        assertLife(playerB, 17);
+    }
+    @Test
+    public void testRafterDemonClone() {
+        addCard(Zone.BATTLEFIELD, playerA, "Badlands", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Tropical Island", 4);
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 5);
+        // Rafter Demon {2}{B}{R}
+        // Spectacle {3}{B}{R}
+        // When Rafter Demon enters the battlefield, if its spectacle cost was paid, each opponent discards a card.
+        addCard(Zone.HAND, playerA, "Rafter Demon");
+        addCard(Zone.HAND, playerA, "Lightning Bolt");
+        addCard(Zone.HAND, playerB, "Darksteel Relic",4);
+
+        addCard(Zone.HAND, playerA, "Clone");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Rafter Demon with spectacle");
+        addTarget(playerB, "Darksteel Relic");
+
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Clone");
+        setChoice(playerA, true); // copy
+        setChoice(playerA, "Rafter Demon");
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        setStrictChooseMode(true);
+        execute();
+
+        assertGraveyardCount(playerA,  1); //Lightning Bolt
+        assertGraveyardCount(playerB,  1); //Darksteel Relic x1
+        assertHandCount(playerB, "Darksteel Relic", 3);
+        assertPermanentCount(playerA, "Rafter Demon", 2);
+
+        assertLife(playerB, 17);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SquadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SquadTest.java
@@ -198,9 +198,7 @@ public class SquadTest extends CardTestPlayerBase {
     }
 
     // The squad status is a copiable value of the spell, and should be carried over on copy.
-    @Ignore
     @Test
-    //TODO: Enable after fixing subability copying twice bug
     public void test_CopyingSpellMustKeepSquadStatus() {
 
         addCard(Zone.HAND, playerA, flagellant, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/copy/CopyPermanentSpellTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/copy/CopyPermanentSpellTest.java
@@ -78,7 +78,6 @@ public class CopyPermanentSpellTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Dead Weight", 2);
     }
 
-    @Ignore // currently fails
     @Test
     public void testKickerTrigger() {
         makeTester();
@@ -96,7 +95,6 @@ public class CopyPermanentSpellTest extends CardTestPlayerBase {
         assertPowerToughness(playerA, "Grizzly Bears", 4, 2);
     }
 
-    @Ignore // currently fails
     @Test
     public void testKickerReplacement() {
         makeTester();
@@ -122,6 +120,7 @@ public class CopyPermanentSpellTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, "Reckless Bushwhacker");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Memnite");
+        waitStackResolved(1,PhaseStep.PRECOMBAT_MAIN);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Reckless Bushwhacker with surge");
 
         setStopAt(1, PhaseStep.END_TURN);

--- a/Mage/src/main/java/mage/abilities/Ability.java
+++ b/Mage/src/main/java/mage/abilities/Ability.java
@@ -326,6 +326,8 @@ public interface Ability extends Controllable, Serializable {
 
     /**
      * Gets the list of sub-abilities associated with this ability.
+     * When copying, subabilities are copied separately and thus the list is desynced.
+     * Do not interact with the subabilities list during a game!
      *
      * @return
      */

--- a/Mage/src/main/java/mage/game/permanent/Permanent.java
+++ b/Mage/src/main/java/mage/game/permanent/Permanent.java
@@ -214,6 +214,7 @@ public interface Permanent extends Card, Controllable {
      * @return can be null for exists abilities
      */
     Ability addAbility(Ability ability, UUID sourceId, Game game);
+    Ability addAbility(Ability ability, UUID sourceId, Game game, boolean withSubabilities);
 
     void removeAllAbilities(UUID sourceId, Game game);
 

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -380,6 +380,10 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
 
     @Override
     public Ability addAbility(Ability ability, UUID sourceId, Game game) {
+        return addAbility(ability, sourceId, game, true);
+    }
+    @Override
+    public Ability addAbility(Ability ability, UUID sourceId, Game game, boolean withSubabilities) {
         // singleton abilities -- only one instance
         // other abilities -- any amount of instances
         if (!abilities.containsKey(ability.getId())) {
@@ -394,7 +398,9 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                 game.getState().addAbility(copyAbility, sourceId, this);
             }
             abilities.add(copyAbility);
-            abilities.addAll(ability.getSubAbilities());
+            if (withSubabilities) {
+                abilities.addAll(copyAbility.getSubAbilities());
+            }
             return copyAbility;
         }
         return null;

--- a/Mage/src/main/java/mage/game/permanent/PermanentToken.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentToken.java
@@ -89,7 +89,8 @@ public class PermanentToken extends PermanentImpl {
             // first time -> create ContinuousEffects only once
             // so sourceId must be null (keep triggered abilities forever?)
             for (Ability ability : token.getAbilities()) {
-                this.addAbility(ability, null, game);
+                //Don't add subabilities since the original token already has them in its abilities list
+                this.addAbility(ability, null, game, false);
             }
         }
         this.abilities.setControllerId(this.controllerId);

--- a/Mage/src/main/java/mage/game/permanent/token/Token.java
+++ b/Mage/src/main/java/mage/game/permanent/token/Token.java
@@ -22,6 +22,7 @@ public interface Token extends MageObject {
     List<UUID> getLastAddedTokenIds();
 
     void addAbility(Ability ability);
+    void addAbility(Ability ability, boolean withSubabilities);
 
     void removeAbility(Ability abilityToRemove);
 

--- a/Mage/src/main/java/mage/game/permanent/token/TokenImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/token/TokenImpl.java
@@ -79,13 +79,20 @@ public abstract class TokenImpl extends MageObjectImpl implements Token {
 
     @Override
     public void addAbility(Ability ability) {
+        addAbility(ability, true);
+    }
+    @Override
+    public void addAbility(Ability ability, boolean withSubabilities) {
         ability.setSourceId(this.getId());
         abilities.add(ability);
-        abilities.addAll(ability.getSubAbilities());
+        if (withSubabilities) {
+            abilities.addAll(ability.getSubAbilities());
+        }
 
         // TODO: remove all override and backFace changes (bug example: active transform ability in back face)
         if (backFace != null) {
             backFace.addAbility(ability);
+            // Maybe supposed to add subabilities here too?
         }
     }
 

--- a/Mage/src/main/java/mage/util/functions/CopyTokenFunction.java
+++ b/Mage/src/main/java/mage/util/functions/CopyTokenFunction.java
@@ -130,8 +130,8 @@ public class CopyTokenFunction {
             // otherwise there are problems to check for created continuous effects to check if
             // the source (the Token) has still this ability
             ability.newOriginalId();
-
-            target.addAbility(ability);
+            //Don't re-add subabilities since they've already in sourceObj's abilities list
+            target.addAbility(ability, false);
         }
 
         target.setPower(sourceObj.getPower().getBaseValue());
@@ -142,7 +142,6 @@ public class CopyTokenFunction {
 
     private Token from(Card source, Game game, Spell spell) {
         apply(source, game);
-
         // token's ZCC must be synced with original card to keep abilities settings
         // Example: kicker ability and kicked status
         if (spell != null) {


### PR DESCRIPTION
This is a subset of the changes in #10546 that are logically unconnected (beyond both involving copy interactions), solving the subability copying bug.

I also included a bunch of tests (some currently failing). Since the cost tags PR is taking a while to be reviewed (quite understandably, it's a lot of changes) I figured I'd separate out this set of changes.

Fixes #10526
Fixes #7736

Also has a tiny fix for Defenders of Humanity that I noticed during testing.