### PR TITLE
GUI: add basic hint for goaded by a player.

### DIFF
--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -341,6 +341,14 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                     }
                 }
 
+                // Goaded hints.
+                for (UUID playerId : getGoadingPlayers()) {
+                    Player player = game.getPlayer(playerId);
+                    if (player != null) {
+                        restrictHints.add(HintUtils.prepareText("Goaded by " + player.getLogName(), null, HintUtils.HINT_ICON_REQUIRE));
+                    }
+                }
+
                 restrictHints.sort(String::compareTo);
             }
 


### PR DESCRIPTION
There was no feedback at all that a permanent is currently goaded.
This adds a very simple hint.

![image](https://github.com/magefree/mage/assets/34709007/e6edd5e5-bb7d-4fb7-9657-ebaeafa87afe)

closes #10640, as it was last task.
closes #9133

