### PR TITLE
[CMM] Implement Cacophony Unleashed

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CacophonyUnleashed.java
+++ b/Mage.Sets/src/mage/cards/c/CacophonyUnleashed.java
@@ -49,7 +49,8 @@ public final class CacophonyUnleashed extends CardImpl {
         this.addAbility(
             new EntersBattlefieldThisOrAnotherTriggeredAbility(
                 new BecomesCreatureSourceEffect(new CacophonyUnleashedToken(), CardType.ENCHANTMENT, Duration.EndOfTurn)
-                    .setText("until end of turn, Cacophony Unleashed becomes a legendary 6/6 Nightmare God creature with menace and deathtouch. It's still an enchantment."),
+                    .setText("until end of turn, Cacophony Unleashed becomes a legendary 6/6 Nightmare God "
+                        + "creature with menace and deathtouch. It's still an enchantment."),
                 StaticFilters.FILTER_PERMANENT_ENCHANTMENT,
                 false, true
             )
@@ -68,7 +69,7 @@ public final class CacophonyUnleashed extends CardImpl {
 
 class CacophonyUnleashedToken extends TokenImpl {
 
-    public CacophonyUnleashedToken() {
+    CacophonyUnleashedToken() {
         super("", "legendary 6/6 Nightmare God creature with menace and deathtouch");
         supertype.add(SuperType.LEGENDARY);
         cardType.add(CardType.CREATURE);
@@ -80,7 +81,7 @@ class CacophonyUnleashedToken extends TokenImpl {
         addAbility(DeathtouchAbility.getInstance());
     }
 
-    public CacophonyUnleashedToken(final CacophonyUnleashedToken token) {
+    private CacophonyUnleashedToken(final CacophonyUnleashedToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CacophonyUnleashed.java
+++ b/Mage.Sets/src/mage/cards/c/CacophonyUnleashed.java
@@ -1,0 +1,90 @@
+package mage.cards.c;
+
+import mage.MageInt;
+import mage.abilities.common.EntersBattlefieldThisOrAnotherTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.condition.common.CastFromEverywhereSourceCondition;
+import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
+import mage.abilities.effects.common.DestroyAllEffect;
+import mage.abilities.effects.common.continuous.BecomesCreatureSourceEffect;
+import mage.abilities.keyword.DeathtouchAbility;
+import mage.abilities.keyword.MenaceAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.Predicates;
+import mage.game.permanent.token.TokenImpl;
+
+import java.util.UUID;
+
+/**
+ * @author Susucr
+ */
+public final class CacophonyUnleashed extends CardImpl {
+
+    private static final FilterPermanent filter = new FilterCreaturePermanent("nonenchantment creatures");
+
+    static {
+        filter.add(Predicates.not(CardType.ENCHANTMENT.getPredicate()));
+    }
+
+    public CacophonyUnleashed(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{5}{B}{B}");
+
+
+        // When Cacophony Unleashed enters the battlefield, if you cast it, destroy all nonenchantment creatures.
+        this.addAbility(new ConditionalInterveningIfTriggeredAbility(
+            new EntersBattlefieldTriggeredAbility(new DestroyAllEffect(filter)),
+            CastFromEverywhereSourceCondition.instance,
+            "When {this} enters the battlefield, if you cast it, destroy all nonenchantment creatures."
+        ));
+
+        // Whenever Cacophony Unleashed or another enchantment enters the battlefield under your control, until end of turn, Cacophony Unleashed becomes a legendary 6/6 Nightmare God creature with menace and deathtouch. It's still an enchantment.
+        this.addAbility(
+            new EntersBattlefieldThisOrAnotherTriggeredAbility(
+                new BecomesCreatureSourceEffect(new CacophonyUnleashedToken(), CardType.ENCHANTMENT, Duration.EndOfTurn)
+                    .setText("until end of turn, Cacophony Unleashed becomes a legendary 6/6 Nightmare God creature with menace and deathtouch. It's still an enchantment."),
+                StaticFilters.FILTER_PERMANENT_ENCHANTMENT,
+                false, true
+            )
+        );
+    }
+
+    private CacophonyUnleashed(final CacophonyUnleashed card) {
+        super(card);
+    }
+
+    @Override
+    public CacophonyUnleashed copy() {
+        return new CacophonyUnleashed(this);
+    }
+}
+
+class CacophonyUnleashedToken extends TokenImpl {
+
+    public CacophonyUnleashedToken() {
+        super("", "legendary 6/6 Nightmare God creature with menace and deathtouch");
+        supertype.add(SuperType.LEGENDARY);
+        cardType.add(CardType.CREATURE);
+        subtype.add(SubType.NIGHTMARE);
+        subtype.add(SubType.GOD);
+        power = new MageInt(6);
+        toughness = new MageInt(6);
+        addAbility(new MenaceAbility(false));
+        addAbility(DeathtouchAbility.getInstance());
+    }
+
+    public CacophonyUnleashedToken(final CacophonyUnleashedToken token) {
+        super(token);
+    }
+
+    public CacophonyUnleashedToken copy() {
+        return new CacophonyUnleashedToken(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/e/ExtinguishAllHope.java
+++ b/Mage.Sets/src/mage/cards/e/ExtinguishAllHope.java
@@ -1,13 +1,15 @@
 
 package mage.cards.e;
 
-import java.util.UUID;
 import mage.abilities.effects.common.DestroyAllEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.FilterPermanent;
+import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicates;
+
+import java.util.UUID;
 
 /**
  *
@@ -15,10 +17,9 @@ import mage.filter.predicate.Predicates;
  */
 public final class ExtinguishAllHope extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent("nonenchantment creatures");
+    private static final FilterPermanent filter = new FilterCreaturePermanent("nonenchantment creatures");
     
     static {
-        filter.add(CardType.CREATURE.getPredicate());
         filter.add(Predicates.not(CardType.ENCHANTMENT.getPredicate()));
     }
     

--- a/Mage.Sets/src/mage/sets/CommanderMasters.java
+++ b/Mage.Sets/src/mage/sets/CommanderMasters.java
@@ -91,6 +91,7 @@ public final class CommanderMasters extends ExpansionSet {
         cards.add(new SetCardInfo("Brood Sliver", 887, Rarity.RARE, mage.cards.b.BroodSliver.class));
         cards.add(new SetCardInfo("Burnished Hart", 373, Rarity.UNCOMMON, mage.cards.b.BurnishedHart.class));
         cards.add(new SetCardInfo("Cabal Patriarch", 140, Rarity.UNCOMMON, mage.cards.c.CabalPatriarch.class));
+        cards.add(new SetCardInfo("Cacophony Unleashed", 730, Rarity.RARE, mage.cards.c.CacophonyUnleashed.class));
         cards.add(new SetCardInfo("Cadaver Imp", 141, Rarity.COMMON, mage.cards.c.CadaverImp.class));
         cards.add(new SetCardInfo("Calix, Destiny's Hand", 918, Rarity.MYTHIC, mage.cards.c.CalixDestinysHand.class));
         cards.add(new SetCardInfo("Campfire", 374, Rarity.COMMON, mage.cards.c.Campfire.class));

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -105,6 +105,9 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl {
                     permanent.removeAllCardTypes(game);
                     permanent.removeAllSubTypes(game);
                 }
+                for (SuperType superType : token.getSuperType(game)) {
+                    permanent.addSuperType(game, superType);
+                }
                 for (CardType cardType : token.getCardType(game)) {
                     permanent.addCardType(game, cardType);
                 }


### PR DESCRIPTION
I think the fix for supertype in `BecomesCreatureSourceEffect` would have helped other cards? Like Genju of the Realm or Awakening of Vitu-Ghazi. Those are hard to search.

Edit: both of those are using `BecomesCreatureTargetEffect`, which is handling supertypes properly.