### PR TITLE
clean combat watchers on Cleanup step, in case of 'end the turn' effect

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AnowonTheRuinThief.java
+++ b/Mage.Sets/src/mage/cards/a/AnowonTheRuinThief.java
@@ -151,7 +151,8 @@ class AnowonTheRuinThiefWatcher extends Watcher {
 
     @Override
     public void watch(GameEvent event, Game game) {
-        if (event.getType() == GameEvent.EventType.COMBAT_DAMAGE_STEP_POST) {
+        if (event.getType() == GameEvent.EventType.COMBAT_DAMAGE_STEP_POST
+                || event.getType() == GameEvent.EventType.CLEANUP_STEP_POST) {
             damageMap.clear();
             return;
         }

--- a/Mage.Sets/src/mage/cards/q/QuartzwoodCrasher.java
+++ b/Mage.Sets/src/mage/cards/q/QuartzwoodCrasher.java
@@ -134,7 +134,8 @@ class QuartzwoodCrasherWatcher extends Watcher {
 
     @Override
     public void watch(GameEvent event, Game game) {
-        if (event.getType() == GameEvent.EventType.COMBAT_DAMAGE_STEP_POST) {
+        if (event.getType() == GameEvent.EventType.COMBAT_DAMAGE_STEP_POST
+                || event.getType() == GameEvent.EventType.CLEANUP_STEP_POST) {
             damageMap.clear();
             return;
         }


### PR DESCRIPTION
Discussed in https://github.com/magefree/mage/pull/10700#discussion_r1278481503
The watchers that reset post combat damage step should also be reset on cleanup step as 'end the turn' effects bypass those events.

Did not find any other Watcher to clean except for those two.