### PR TITLE
[LTC] Implement Denethor, Stone Seer

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AetherCharge.java
+++ b/Mage.Sets/src/mage/cards/a/AetherCharge.java
@@ -110,7 +110,7 @@ class AetherChargeEffect extends OneShotEffect {
             creature = (Permanent) game.getLastKnownInformation(creatureId, Zone.BATTLEFIELD);
         }
         if (creature != null) {
-            return game.damagePlayerOrPlaneswalker(source.getFirstTarget(), 4, creature.getId(), source, game, false, true) > 0;
+            return game.damagePlayerOrPermanent(source.getFirstTarget(), 4, creature.getId(), source, game, false, true) > 0;
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/b/BonfireOfTheDamned.java
+++ b/Mage.Sets/src/mage/cards/b/BonfireOfTheDamned.java
@@ -59,7 +59,7 @@ class BonfireOfTheDamnedEffect extends OneShotEffect {
         if (damage < 1) {
             return false;
         }
-        game.damagePlayerOrPlaneswalker(source.getFirstTarget(), damage, source.getSourceId(), source, game, false, true);
+        game.damagePlayerOrPermanent(source.getFirstTarget(), damage, source.getSourceId(), source, game, false, true);
         Player player = game.getPlayerOrPlaneswalkerController(source.getFirstTarget());
         if (player == null) {
             return true;

--- a/Mage.Sets/src/mage/cards/c/CavalcadeOfCalamity.java
+++ b/Mage.Sets/src/mage/cards/c/CavalcadeOfCalamity.java
@@ -63,7 +63,7 @@ class CavalcadeOfCalamityEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        return game.damagePlayerOrPlaneswalker(
+        return game.damagePlayerOrPermanent(
                 game.getCombat().getDefenderId(targetPointer.getFirst(game, source)), 1,
                 source.getSourceId(), source, game, false, true
         ) > 0;

--- a/Mage.Sets/src/mage/cards/c/ChandraPyromaster.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraPyromaster.java
@@ -87,7 +87,7 @@ class ChandraPyromasterEffect1 extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        game.damagePlayerOrPlaneswalker(source.getTargets().get(0).getFirstTarget(),
+        game.damagePlayerOrPermanent(source.getTargets().get(0).getFirstTarget(),
                 1, source.getSourceId(), source, game, false, true);
         Permanent creature = game.getPermanent(source.getTargets().get(1).getFirstTarget());
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/c/ChanneledForce.java
+++ b/Mage.Sets/src/mage/cards/c/ChanneledForce.java
@@ -69,7 +69,7 @@ class ChanneledForceEffect extends OneShotEffect {
         if (player != null) {
             player.drawCards(xValue, source, game);
         }
-        game.damagePlayerOrPlaneswalker(
+        game.damagePlayerOrPermanent(
                 source.getTargets().get(1).getFirstTarget(), xValue,
                 source.getSourceId(), source, game, false, true
         );

--- a/Mage.Sets/src/mage/cards/d/DefiantThundermaw.java
+++ b/Mage.Sets/src/mage/cards/d/DefiantThundermaw.java
@@ -81,7 +81,7 @@ class DefiantThundermawEffect extends OneShotEffect {
         if (mor == null) {
             return false;
         }
-        game.damagePlayerOrPlaneswalker(
+        game.damagePlayerOrPermanent(
                 getTargetPointer().getFirst(game, source), 2,
                 mor.getSourceId(), source, game, false, true
         );

--- a/Mage.Sets/src/mage/cards/d/DenethorStoneSeer.java
+++ b/Mage.Sets/src/mage/cards/d/DenethorStoneSeer.java
@@ -81,7 +81,7 @@ class DenethorStoneSeerEffect extends OneShotEffect {
         if (player != null) {
             game.setMonarchId(source, player.getId());
         }
-        game.damagePlayerOrPlaneswalker(
+        game.damagePlayerOrPermanent(
                 source.getTargets().get(1).getFirstTarget(), 3,
                 source.getSourceId(), source, game, false, true
         );

--- a/Mage.Sets/src/mage/cards/d/DenethorStoneSeer.java
+++ b/Mage.Sets/src/mage/cards/d/DenethorStoneSeer.java
@@ -1,0 +1,90 @@
+package mage.cards.d;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.SacrificeSourceCost;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.keyword.ScryEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetPlayer;
+import mage.target.common.TargetAnyTarget;
+
+import java.util.UUID;
+
+/**
+ * @author Susucr
+ */
+public final class DenethorStoneSeer extends CardImpl {
+
+    public DenethorStoneSeer(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{U}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.NOBLE);
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(3);
+
+        // When Denethor, Stone Seer enters the battlefield, scry 2.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new ScryEffect(2)));
+
+        // {3}{R}, {T}, Sacrifice Denethor: Target player becomes the monarch. Denethor deals 3 damage to any target.
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
+                new DenethorStoneSeerEffect(),
+                new ManaCostsImpl<>("{3}{R}")
+        );
+        ability.addCost(new TapSourceCost());
+        ability.addCost(new SacrificeSourceCost());
+        ability.addTarget(new TargetPlayer());
+        ability.addTarget(new TargetAnyTarget());
+
+        this.addAbility(ability);
+    }
+
+    private DenethorStoneSeer(final DenethorStoneSeer card) {
+        super(card);
+    }
+
+    @Override
+    public DenethorStoneSeer copy() {
+        return new DenethorStoneSeer(this);
+    }
+}
+
+class DenethorStoneSeerEffect extends OneShotEffect {
+
+    DenethorStoneSeerEffect() {
+        super(Outcome.Benefit);
+        staticText = "Target player becomes the monarch. {this} deals 3 damage to any target.";
+    }
+
+    private DenethorStoneSeerEffect(final DenethorStoneSeerEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public DenethorStoneSeerEffect copy() {
+        return new DenethorStoneSeerEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getTargets().get(0).getFirstTarget());
+        if (player != null) {
+            game.setMonarchId(source, player.getId());
+        }
+        game.damagePlayerOrPlaneswalker(
+                source.getTargets().get(1).getFirstTarget(), 3,
+                source.getSourceId(), source, game, false, true
+        );
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/f/FathomFleetSwordjack.java
+++ b/Mage.Sets/src/mage/cards/f/FathomFleetSwordjack.java
@@ -69,7 +69,7 @@ class FathomFleetSwordjackEffect extends OneShotEffect {
                 StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT,
                 source.getControllerId(), source, game
         );
-        return artifactCount > 0 && game.damagePlayerOrPlaneswalker(
+        return artifactCount > 0 && game.damagePlayerOrPermanent(
                 game.getCombat().getDefenderId(source.getSourceId()), artifactCount,
                 source.getSourceId(), source, game, false, true
         ) > 0;

--- a/Mage.Sets/src/mage/cards/g/GarbageElementalD.java
+++ b/Mage.Sets/src/mage/cards/g/GarbageElementalD.java
@@ -73,7 +73,7 @@ class GarbageElementalDEffect extends OneShotEffect {
         Player opponent = game.getPlayer(source.getFirstTarget());
         if (controller != null && opponent != null) {
             int damage = controller.rollDice(outcome, source, game, 6);
-            return game.damagePlayerOrPlaneswalker(opponent.getId(), damage, source.getId(), source, game, false, true) > 0;
+            return game.damagePlayerOrPermanent(opponent.getId(), damage, source.getId(), source, game, false, true) > 0;
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/g/GoblinLyre.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinLyre.java
@@ -66,7 +66,7 @@ class GoblinLyreEffect extends OneShotEffect {
             if (controller.flipCoin(source, game, true)) {
                 int damage = CreaturesYouControlCount.instance.calculate(game, source, this);
                 if (opponent != null) {
-                    return game.damagePlayerOrPlaneswalker(source.getFirstTarget(), damage, source.getSourceId(), source, game, false, true) > 0;
+                    return game.damagePlayerOrPermanent(source.getFirstTarget(), damage, source.getSourceId(), source, game, false, true) > 0;
                 }
             } else {
                 int damage = game.getBattlefield().getAllActivePermanents(new FilterCreaturePermanent(), opponent.getId(), game).size();

--- a/Mage.Sets/src/mage/cards/i/InspiredUltimatum.java
+++ b/Mage.Sets/src/mage/cards/i/InspiredUltimatum.java
@@ -59,7 +59,7 @@ class InspiredUltimatumEffect extends OneShotEffect {
         if (player != null) {
             player.gainLife(5, game, source);
         }
-        game.damagePlayerOrPlaneswalker(
+        game.damagePlayerOrPermanent(
                 source.getTargets().get(1).getFirstTarget(), 5,
                 source.getSourceId(), source, game, false, true
         );

--- a/Mage.Sets/src/mage/cards/m/MageSlayer.java
+++ b/Mage.Sets/src/mage/cards/m/MageSlayer.java
@@ -62,7 +62,7 @@ class MageSlayerEffect extends OneShotEffect {
         if (attacker == null) {
             return false;
         }
-        game.damagePlayerOrPlaneswalker(
+        game.damagePlayerOrPermanent(
                 game.getCombat().getDefenderId(attacker.getId()),
                 attacker.getPower().getValue(),
                 attacker.getId(),

--- a/Mage.Sets/src/mage/cards/m/MyrBattlesphere.java
+++ b/Mage.Sets/src/mage/cards/m/MyrBattlesphere.java
@@ -142,7 +142,7 @@ class MyrBattlesphereEffect extends OneShotEffect {
                 // boost effect
                 game.addEffect(new BoostSourceEffect(tappedAmount, 0, Duration.EndOfTurn), source);
                 // damage to defender
-                return game.damagePlayerOrPlaneswalker(targetPointer.getFirst(game, source), tappedAmount, myr.getId(), source, game, false, true) > 0;
+                return game.damagePlayerOrPermanent(targetPointer.getFirst(game, source), tappedAmount, myr.getId(), source, game, false, true) > 0;
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/r/RageForger.java
+++ b/Mage.Sets/src/mage/cards/r/RageForger.java
@@ -85,7 +85,7 @@ class RageForgerDamageEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         Permanent attackingCreature = getTargetPointer().getFirstTargetPermanentOrLKI(game, source);
         if (controller != null && attackingCreature != null) {
-            game.damagePlayerOrPlaneswalker(source.getFirstTarget(), 1, attackingCreature.getId(), source, game, false, true);
+            game.damagePlayerOrPermanent(source.getFirstTarget(), 1, attackingCreature.getId(), source, game, false, true);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/r/RavagerOfTheFells.java
+++ b/Mage.Sets/src/mage/cards/r/RavagerOfTheFells.java
@@ -84,7 +84,7 @@ class RavagerOfTheFellsEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        game.damagePlayerOrPlaneswalker(source.getTargets().get(0).getFirstTarget(), 2, source.getSourceId(), source, game, false, true);
+        game.damagePlayerOrPermanent(source.getTargets().get(0).getFirstTarget(), 2, source.getSourceId(), source, game, false, true);
         Permanent creature = game.getPermanent(source.getTargets().get(1).getFirstTarget());
         if (creature != null) {
             creature.damage(2, source.getSourceId(), source, game, false, true);

--- a/Mage.Sets/src/mage/cards/r/RiteOfConsumption.java
+++ b/Mage.Sets/src/mage/cards/r/RiteOfConsumption.java
@@ -76,7 +76,7 @@ class RiteOfConsumptionEffect extends OneShotEffect {
             if (sacrificedCreature != null) {
                 int damage = sacrificedCreature.getPower().getValue();
                 if (damage > 0) {
-                    int damageDealt = game.damagePlayerOrPlaneswalker(source.getFirstTarget(), damage, source.getSourceId(), source, game, false, true);
+                    int damageDealt = game.damagePlayerOrPermanent(source.getFirstTarget(), damage, source.getSourceId(), source, game, false, true);
                     if (damageDealt > 0) {
                         controller.gainLife(damage, game, source);
                     }

--- a/Mage.Sets/src/mage/cards/s/SarkhanTheMad.java
+++ b/Mage.Sets/src/mage/cards/s/SarkhanTheMad.java
@@ -158,7 +158,7 @@ class SarkhanTheMadDragonDamageEffect extends OneShotEffect {
         List<Permanent> dragons = game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game);
         if (dragons != null && !dragons.isEmpty()) {
             for (Permanent dragon : dragons) {
-                game.damagePlayerOrPlaneswalker(source.getFirstTarget(), dragon.getPower().getValue(), dragon.getId(), source, game, false, true);
+                game.damagePlayerOrPermanent(source.getFirstTarget(), dragon.getPower().getValue(), dragon.getId(), source, game, false, true);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/s/ScepterOfEmpires.java
+++ b/Mage.Sets/src/mage/cards/s/ScepterOfEmpires.java
@@ -65,7 +65,7 @@ class ScepterOfEmpiresEffect extends OneShotEffect {
             }
         }
         int amount = throne && crown ? 3 : 1;
-        return game.damagePlayerOrPlaneswalker(source.getFirstTarget(), amount, source.getSourceId(), source, game, false, true) > 0;
+        return game.damagePlayerOrPermanent(source.getFirstTarget(), amount, source.getSourceId(), source, game, false, true) > 0;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/s/SearingBlaze.java
+++ b/Mage.Sets/src/mage/cards/s/SearingBlaze.java
@@ -76,7 +76,7 @@ class SearingBlazeEffect extends OneShotEffect {
         if (watcher != null && watcher.landPlayed(source.getControllerId())) {
             damage = 3;
         }
-        game.damagePlayerOrPlaneswalker(source.getTargets().get(0).getFirstTarget(), damage, source.getSourceId(), source, game, false, true);
+        game.damagePlayerOrPermanent(source.getTargets().get(0).getFirstTarget(), damage, source.getSourceId(), source, game, false, true);
         if (creature != null) {
             creature.damage(damage, source.getSourceId(), source, game, false, true);
         }

--- a/Mage.Sets/src/mage/cards/s/SoulOfShandalar.java
+++ b/Mage.Sets/src/mage/cards/s/SoulOfShandalar.java
@@ -84,7 +84,7 @@ class SoulOfShandalarEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        game.damagePlayerOrPlaneswalker(source.getTargets().get(0).getFirstTarget(), 3, source.getSourceId(), source, game, false, true);
+        game.damagePlayerOrPermanent(source.getTargets().get(0).getFirstTarget(), 3, source.getSourceId(), source, game, false, true);
         Permanent creature = game.getPermanent(source.getTargets().get(1).getFirstTarget());
         if (creature != null) {
             creature.damage(3, source.getSourceId(), source, game, false, true);

--- a/Mage.Sets/src/mage/cards/s/StalkingVengeance.java
+++ b/Mage.Sets/src/mage/cards/s/StalkingVengeance.java
@@ -66,7 +66,7 @@ class StalkingVengeanceDamageEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent creature = (Permanent) game.getLastKnownInformation(this.getTargetPointer().getFirst(game, source), Zone.BATTLEFIELD);
         if (creature != null) {
-            game.damagePlayerOrPlaneswalker(source.getFirstTarget(), creature.getPower().getValue(), creature.getId(), source, game, false, true);
+            game.damagePlayerOrPermanent(source.getFirstTarget(), creature.getPower().getValue(), creature.getId(), source, game, false, true);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/t/TIESilencer.java
+++ b/Mage.Sets/src/mage/cards/t/TIESilencer.java
@@ -66,7 +66,7 @@ class TIESilencerEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         UUID defender = game.getCombat().getDefendingPlayerId(source.getSourceId(), game);
         if(defender != null) {
-            game.damagePlayerOrPlaneswalker(defender, 1, source.getSourceId(), source, game, false, true);
+            game.damagePlayerOrPermanent(defender, 1, source.getSourceId(), source, game, false, true);
 
             UUID target = source.getTargets().getFirstTarget();
             Permanent permanent = game.getPermanent(target);

--- a/Mage.Sets/src/mage/cards/t/TheFallen.java
+++ b/Mage.Sets/src/mage/cards/t/TheFallen.java
@@ -62,7 +62,7 @@ class TheFallenEffect extends OneShotEffect {
         if (watcher != null && watcher.getPlayersAndWalkersDealtDamageThisGame(source.getSourceId()) != null) {
             for (UUID playerId : watcher.getPlayersAndWalkersDealtDamageThisGame(source.getSourceId())) {
                 if (!source.isControlledBy(playerId)) {
-                    game.damagePlayerOrPlaneswalker(playerId, 1, source.getSourceId(), source, game, false, true);
+                    game.damagePlayerOrPermanent(playerId, 1, source.getSourceId(), source, game, false, true);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/t/TitanHunter.java
+++ b/Mage.Sets/src/mage/cards/t/TitanHunter.java
@@ -81,7 +81,7 @@ class TitanHunterEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        return game.damagePlayerOrPlaneswalker(
+        return game.damagePlayerOrPermanent(
                 game.getActivePlayerId(), 4, source.getSourceId(),
                 source, game, false, true
         ) > 0;

--- a/Mage.Sets/src/mage/cards/v/VengefulArchon.java
+++ b/Mage.Sets/src/mage/cards/v/VengefulArchon.java
@@ -74,7 +74,7 @@ class VengefulArchonEffect extends PreventDamageToControllerEffect {
         PreventionEffectData preventionEffectData = super.preventDamageAction(event, source, game);
         int damage = preventionEffectData.getPreventedDamage();
         if (damage > 0) {
-            game.damagePlayerOrPlaneswalker(source.getFirstTarget(), damage, source.getSourceId(), source, game, false, true);
+            game.damagePlayerOrPermanent(source.getFirstTarget(), damage, source.getSourceId(), source, game, false, true);
         }
         return preventionEffectData;
     }

--- a/Mage.Sets/src/mage/sets/TalesOfMiddleEarthCommander.java
+++ b/Mage.Sets/src/mage/sets/TalesOfMiddleEarthCommander.java
@@ -67,6 +67,7 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Dearly Departed", 165, Rarity.RARE, mage.cards.d.DearlyDeparted.class));
         cards.add(new SetCardInfo("Decree of Pain", 199, Rarity.RARE, mage.cards.d.DecreeOfPain.class));
         cards.add(new SetCardInfo("Deep Analysis", 188, Rarity.COMMON, mage.cards.d.DeepAnalysis.class));
+        cards.add(new SetCardInfo("Denethor, Stone Seer", 20, Rarity.RARE, mage.cards.d.DenethorStoneSeer.class));
         cards.add(new SetCardInfo("Deserted Temple", 363, Rarity.MYTHIC, mage.cards.d.DesertedTemple.class));
         cards.add(new SetCardInfo("Desolate Lighthouse", 303, Rarity.RARE, mage.cards.d.DesolateLighthouse.class));
         cards.add(new SetCardInfo("Devastation Tide", 189, Rarity.RARE, mage.cards.d.DevastationTide.class));

--- a/Mage/src/main/java/mage/game/Game.java
+++ b/Mage/src/main/java/mage/game/Game.java
@@ -573,9 +573,9 @@ public interface Game extends MageItem, Serializable, Copyable<Game> {
      */
     void takeInitiative(Ability source, UUID initiativeId);
 
-    int damagePlayerOrPlaneswalker(UUID playerOrWalker, int damage, UUID attackerId, Ability source, Game game, boolean combatDamage, boolean preventable);
+    int damagePlayerOrPermanent(UUID playerOrPermanent, int damage, UUID attackerId, Ability source, Game game, boolean combatDamage, boolean preventable);
 
-    int damagePlayerOrPlaneswalker(UUID playerOrWalker, int damage, UUID attackerId, Ability source, Game game, boolean combatDamage, boolean preventable, List<UUID> appliedEffects);
+    int damagePlayerOrPermanent(UUID playerOrPermanent, int damage, UUID attackerId, Ability source, Game game, boolean combatDamage, boolean preventable, List<UUID> appliedEffects);
 
     Mulligan getMulligan();
 

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -3833,17 +3833,17 @@ public abstract class GameImpl implements Game {
     }
 
     @Override
-    public int damagePlayerOrPlaneswalker(UUID playerOrWalker, int damage, UUID attackerId, Ability source, Game game, boolean combatDamage, boolean preventable) {
-        return damagePlayerOrPlaneswalker(playerOrWalker, damage, attackerId, source, game, combatDamage, preventable, null);
+    public int damagePlayerOrPermanent(UUID playerOrPermanent, int damage, UUID attackerId, Ability source, Game game, boolean combatDamage, boolean preventable) {
+        return damagePlayerOrPermanent(playerOrPermanent, damage, attackerId, source, game, combatDamage, preventable, null);
     }
 
     @Override
-    public int damagePlayerOrPlaneswalker(UUID playerOrWalker, int damage, UUID attackerId, Ability source, Game game, boolean combatDamage, boolean preventable, List<UUID> appliedEffects) {
-        Player player = getPlayer(playerOrWalker);
+    public int damagePlayerOrPermanent(UUID playerOrPermanent, int damage, UUID attackerId, Ability source, Game game, boolean combatDamage, boolean preventable, List<UUID> appliedEffects) {
+        Player player = getPlayer(playerOrPermanent);
         if (player != null) {
             return player.damage(damage, attackerId, source, game, combatDamage, preventable, appliedEffects);
         }
-        Permanent permanent = getPermanent(playerOrWalker);
+        Permanent permanent = getPermanent(playerOrPermanent);
         if (permanent != null) {
             return permanent.damage(damage, attackerId, source, game, combatDamage, preventable, appliedEffects);
         }


### PR DESCRIPTION
I did rename the `damagePlayerOrPlaneswalker`, as there is no check being done on Planewalker status.

Effect calling it are responsible to check for the damaged permanent being a planeswalker if there is such restriction.
Either with a restrictive Target or an if check on the target.