### PR TITLE
Wait 2 seconds before making the draft pick for a timed out player

### DIFF
--- a/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
+++ b/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
@@ -62,15 +62,13 @@
      private List<String> setCodes;
 
      // Number of the current booster (for draft log writing).
-     // starts with 1
-     private int packNo;
+     private int packNo = 1;
 
      // Number of the current card pick (for draft log writing).
-     // starts with 1
-     private int pickNo;
+     private int pickNo = 1;
      
      // Number of the latest card pick for which the timeout has been set.
-     private int setTimeoutPickNo;
+     private int timeoutPickNo = 0;
 
      // Cached booster data to be written into the log (see logLastPick).
      private String[] currentBooster;
@@ -300,13 +298,16 @@
              MageTray.instance.displayMessage("Pick the next card.");
              MageTray.instance.blink();
          }
-
-         countdown.stop();
          
-         this.timeout = draftPickView.getTimeout();
-         setTimeout(timeout);
-         if (timeout != 0) {
-             countdown.start();
+         int newTimeout = draftPickView.getTimeout();
+         if (pickNo != timeoutPickNo || newTimeout < timeout) { // if the timeout would increase the current pick's timer, don't set it (might happen if the client or server is lagging)
+             timeoutPickNo = pickNo;
+             countdown.stop();
+             timeout = newTimeout;
+             setTimeout(timeout);
+             if (timeout != 0) {
+                 countdown.start();
+             }
          }
          
          if (!draftBooster.isEmptyGrid()) {

--- a/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
+++ b/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
@@ -68,6 +68,9 @@
      // Number of the current card pick (for draft log writing).
      // starts with 1
      private int pickNo;
+     
+     // Number of the latest card pick for which the timeout has been set.
+     private int setTimeoutPickNo;
 
      // Cached booster data to be written into the log (see logLastPick).
      private String[] currentBooster;
@@ -299,6 +302,7 @@
          }
 
          countdown.stop();
+         
          this.timeout = draftPickView.getTimeout();
          setTimeout(timeout);
          if (timeout != 0) {

--- a/Mage.Server/src/main/java/mage/server/draft/DraftSession.java
+++ b/Mage.Server/src/main/java/mage/server/draft/DraftSession.java
@@ -102,7 +102,7 @@ public class DraftSession {
                     () -> {
                         try {
                             if (timeoutCardNum == draft.getCardNum()) {
-                                if (timeoutCounter++ >= AUTOPICK_BUFFER) { // the autopick happens after n seconds (to account for client timer possibly lagging behind server)
+                                if (timeoutCounter++ > AUTOPICK_BUFFER) { // the autopick happens after n seconds (to account for client timer possibly lagging behind server)
                                     managerFactory.draftManager().timeout(draft.getId(), userId);
                                 }
                                 setupTimeout(1); // The timeout keeps happening at a 1 second interval to make sure that the draft moves onto the next pick

--- a/Mage.Server/src/main/java/mage/server/draft/DraftSession.java
+++ b/Mage.Server/src/main/java/mage/server/draft/DraftSession.java
@@ -31,7 +31,10 @@ public class DraftSession {
     protected final Draft draft;
     protected boolean killed = false;
     protected UUID markedCard;
+    
     protected int timeoutCardNum; // the pick number for which the current timeout has been set up
+    protected int timeoutCounter = 0; // increments every second that the player has run out of picking time
+    protected final int AUTOPICK_TIMER = 5;	// seconds - when the player has run out of picking time, the autopick happens after this many seconds (to account for client timer possibly lagging behind server)
 
     private ScheduledFuture<?> futureTimeout;
     protected final ScheduledExecutorService timeoutExecutor;
@@ -92,11 +95,16 @@ public class DraftSession {
     private synchronized void setupTimeout(int seconds) {
         cancelTimeout();
         if (seconds > 0) {
+            if (seconds > 1 ) {
+                timeoutCounter = 0;
+            }
             futureTimeout = timeoutExecutor.schedule(
                     () -> {
                         try {
                             if (timeoutCardNum == draft.getCardNum()) {
-                                managerFactory.draftManager().timeout(draft.getId(), userId);
+                                if (timeoutCounter++ >= AUTOPICK_TIMER) { // the autopick happens after n seconds (to account for client timer possibly lagging behind server)
+                                    managerFactory.draftManager().timeout(draft.getId(), userId);
+                                }
                                 setupTimeout(1); // The timeout keeps happening at a 1 second interval to make sure that the draft moves onto the next pick
                             }
                         } catch (Exception e) {

--- a/Mage.Server/src/main/java/mage/server/draft/DraftSession.java
+++ b/Mage.Server/src/main/java/mage/server/draft/DraftSession.java
@@ -34,7 +34,7 @@ public class DraftSession {
     
     protected int timeoutCardNum; // the pick number for which the current timeout has been set up
     protected int timeoutCounter = 0; // increments every second that the player has run out of picking time
-    protected final int AUTOPICK_TIMER = 5; // seconds - when the player has run out of picking time, the autopick happens after this many seconds (to account for client timer possibly lagging behind server)
+    protected final int AUTOPICK_BUFFER = 5; // seconds - when the player has run out of picking time, the autopick happens after this many seconds (to account for client timer possibly lagging behind server)
 
     private ScheduledFuture<?> futureTimeout;
     protected final ScheduledExecutorService timeoutExecutor;
@@ -102,7 +102,7 @@ public class DraftSession {
                     () -> {
                         try {
                             if (timeoutCardNum == draft.getCardNum()) {
-                                if (timeoutCounter++ >= AUTOPICK_TIMER) { // the autopick happens after n seconds (to account for client timer possibly lagging behind server)
+                                if (timeoutCounter++ >= AUTOPICK_BUFFER) { // the autopick happens after n seconds (to account for client timer possibly lagging behind server)
                                     managerFactory.draftManager().timeout(draft.getId(), userId);
                                 }
                                 setupTimeout(1); // The timeout keeps happening at a 1 second interval to make sure that the draft moves onto the next pick

--- a/Mage.Server/src/main/java/mage/server/draft/DraftSession.java
+++ b/Mage.Server/src/main/java/mage/server/draft/DraftSession.java
@@ -34,7 +34,7 @@ public class DraftSession {
     
     protected int timeoutCardNum; // the pick number for which the current timeout has been set up
     protected int timeoutCounter = 0; // increments every second that the player has run out of picking time
-    protected final int AUTOPICK_TIMER = 5;	// seconds - when the player has run out of picking time, the autopick happens after this many seconds (to account for client timer possibly lagging behind server)
+    protected final int AUTOPICK_TIMER = 5; // seconds - when the player has run out of picking time, the autopick happens after this many seconds (to account for client timer possibly lagging behind server)
 
     private ScheduledFuture<?> futureTimeout;
     protected final ScheduledExecutorService timeoutExecutor;

--- a/Mage.Server/src/main/java/mage/server/draft/DraftSession.java
+++ b/Mage.Server/src/main/java/mage/server/draft/DraftSession.java
@@ -34,7 +34,7 @@ public class DraftSession {
     
     protected int timeoutCardNum; // the pick number for which the current timeout has been set up
     protected int timeoutCounter = 0; // increments every second that the player has run out of picking time
-    protected final int AUTOPICK_BUFFER = 5; // seconds - when the player has run out of picking time, the autopick happens after this many seconds (to account for client timer possibly lagging behind server)
+    protected final int AUTOPICK_BUFFER = 2; // seconds - when the player has run out of picking time, the autopick happens after this many seconds (to account for client timer possibly lagging behind server)
 
     private ScheduledFuture<?> futureTimeout;
     protected final ScheduledExecutorService timeoutExecutor;

--- a/Mage/src/main/java/mage/game/draft/DraftImpl.java
+++ b/Mage/src/main/java/mage/game/draft/DraftImpl.java
@@ -34,7 +34,7 @@ public abstract class DraftImpl implements Draft {
     protected int cardNum = 1; // starts with card number 1, increases by +1 after each picking
     protected TimingOption timing;
     protected int boosterLoadingCounter; // number of times the boosters have been sent to players until all are confirmed to have received them
-    protected final int BOOSTER_LOADING_INTERVAL = 3; // interval in seconds
+    protected final int BOOSTER_LOADING_INTERVAL = 2; // interval in seconds
 
     protected boolean abort = false;
     protected boolean started = false;


### PR DESCRIPTION
Sometimes there's a short time discrepancy between the server's draft timer and the timer shown by a player's client. When it happens it's always so that the player has less actual time to make the pick than their client's timer shows.

Current behavior:
The server makes the pick for the player immediately when its timer hits 0 - the player's pick might not register even if they made it before their client's timer hit 0.

New behavior:
The server waits for 2 more seconds before making the pick for the player. This should hopefully be enough for the player to be able to make their pick before the server makes it for them, but if not this time can be increased later.

I also added a check to ```DraftPanel.java``` that can prevent a possible cause of the timer discrepancy: Sometimes there might be lag during the passing of the boosters, and the server's system that ensures that the clients get their boosters might send the same booster twice. The new check makes sure that the client's timer isn't ever increased by this.

Lastly, because of the above check it should be possible to lower the ```BOOSTER_LOADING_INTERVAL``` that determines how often a booster gets sent to a player that hasn't yet received it. I lowered it from 3 to 2 seconds for now.