### PR TITLE
Fix Blaze of Glory

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AerialSurveyor.java
+++ b/Mage.Sets/src/mage/cards/a/AerialSurveyor.java
@@ -19,7 +19,7 @@ import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterBasicLandCard;
 import mage.filter.common.FilterLandPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.game.Controllable;
 import mage.game.Game;
 import mage.target.common.TargetCardInLibrary;
@@ -73,7 +73,7 @@ enum AerialSurveyorCondition implements Condition {
     private static final FilterPermanent filter = new FilterLandPermanent();
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/a/AetherstormRoc.java
+++ b/Mage.Sets/src/mage/cards/a/AetherstormRoc.java
@@ -19,7 +19,7 @@ import mage.counters.CounterType;
 import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -33,7 +33,7 @@ public final class AetherstormRoc extends CardImpl {
             = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public AetherstormRoc(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/a/AncientHellkite.java
+++ b/Mage.Sets/src/mage/cards/a/AncientHellkite.java
@@ -1,7 +1,6 @@
 
 package mage.cards.a;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.condition.common.SourceAttackingCondition;
@@ -15,11 +14,12 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public final class AncientHellkite extends CardImpl {
@@ -28,7 +28,7 @@ public final class AncientHellkite extends CardImpl {
 
     static {
         filter.add(CardType.CREATURE.getPredicate());
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public AncientHellkite(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/a/ArmixFiligreeThrasher.java
+++ b/Mage.Sets/src/mage/cards/a/ArmixFiligreeThrasher.java
@@ -20,7 +20,7 @@ import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -33,7 +33,7 @@ public final class ArmixFiligreeThrasher extends CardImpl {
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     private static final DynamicValue xValue = new SignInversionDynamicValue(new AdditiveDynamicValue(
@@ -53,7 +53,7 @@ public final class ArmixFiligreeThrasher extends CardImpl {
         ReflexiveTriggeredAbility ability = new ReflexiveTriggeredAbility(
                 new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn), false,
                 "target creature defending player controls gets -X/-X until end of turn, " +
-                "where X is the number of artifacts you control plus the number of artifact cards in your graveyard"
+                        "where X is the number of artifacts you control plus the number of artifact cards in your graveyard"
         );
         ability.addTarget(new TargetPermanent(filter));
         this.addAbility(new AttacksTriggeredAbility(new DoWhenCostPaid(

--- a/Mage.Sets/src/mage/cards/a/AyeshaTanakaArmorer.java
+++ b/Mage.Sets/src/mage/cards/a/AyeshaTanakaArmorer.java
@@ -19,7 +19,7 @@ import mage.filter.common.FilterArtifactCard;
 import mage.filter.common.FilterControlledArtifactPermanent;
 import mage.filter.predicate.ObjectSourcePlayer;
 import mage.filter.predicate.ObjectSourcePlayerPredicate;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.game.Game;
 
 import java.util.Objects;
@@ -38,7 +38,7 @@ public final class AyeshaTanakaArmorer extends CardImpl {
 
     static {
         filter.add(AyeshaTanakaArmorerPredicate.instance);
-        filter2.add(DefendingPlayerControlsPredicate.instance);
+        filter2.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     private static final Condition condition = new PermanentsOnTheBattlefieldCondition(
@@ -53,9 +53,7 @@ public final class AyeshaTanakaArmorer extends CardImpl {
         this.power = new MageInt(2);
         this.toughness = new MageInt(4);
 
-        // Whenever Ayesha Tanaka, Armorer attacks, look at the top four cards of your library.
-        // You may put any number of artifact cards with mana value less than or equal to Ayesha's power
-        // from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.
+        // Whenever Ayesha Tanaka, Armorer attacks, look at the top four cards of your library. You may put any number of artifact cards with mana value less than or equal to Ayesha's power from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.
         this.addAbility(new AttacksTriggeredAbility(new LookLibraryAndPickControllerEffect(
                 4, Integer.MAX_VALUE, filter, PutCards.BATTLEFIELD_TAPPED, PutCards.BOTTOM_RANDOM
         )));

--- a/Mage.Sets/src/mage/cards/b/BlazeOfGlory.java
+++ b/Mage.Sets/src/mage/cards/b/BlazeOfGlory.java
@@ -11,7 +11,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.TurnPhase;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsNoSourcePredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
@@ -26,7 +26,7 @@ public final class BlazeOfGlory extends CardImpl {
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsNoSourcePredicate.instance);
     }
 
     public BlazeOfGlory(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/b/BlazeOfGlory.java
+++ b/Mage.Sets/src/mage/cards/b/BlazeOfGlory.java
@@ -11,7 +11,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.TurnPhase;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;

--- a/Mage.Sets/src/mage/cards/c/CleverDistraction.java
+++ b/Mage.Sets/src/mage/cards/c/CleverDistraction.java
@@ -17,7 +17,7 @@ import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -32,7 +32,7 @@ public final class CleverDistraction extends CardImpl {
             = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public CleverDistraction(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/c/CoastlineMarauders.java
+++ b/Mage.Sets/src/mage/cards/c/CoastlineMarauders.java
@@ -16,7 +16,7 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterLandPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 
 import java.util.UUID;
 
@@ -28,7 +28,7 @@ public final class CoastlineMarauders extends CardImpl {
     private static final FilterPermanent filter = new FilterLandPermanent();
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(filter);

--- a/Mage.Sets/src/mage/cards/c/ColossalWhale.java
+++ b/Mage.Sets/src/mage/cards/c/ColossalWhale.java
@@ -1,6 +1,5 @@
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
@@ -12,11 +11,12 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author awjackson
  */
 public final class ColossalWhale extends CardImpl {
@@ -24,11 +24,11 @@ public final class ColossalWhale extends CardImpl {
     private static final FilterPermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public ColossalWhale(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{5}{U}{U}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{U}{U}");
         this.subtype.add(SubType.WHALE);
 
         this.power = new MageInt(5);

--- a/Mage.Sets/src/mage/cards/c/CovetedPeacock.java
+++ b/Mage.Sets/src/mage/cards/c/CovetedPeacock.java
@@ -11,7 +11,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -24,7 +24,7 @@ public final class CovetedPeacock extends CardImpl {
     public static final FilterPermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public CovetedPeacock(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/d/DecimatorBeetle.java
+++ b/Mage.Sets/src/mage/cards/d/DecimatorBeetle.java
@@ -15,7 +15,7 @@ import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.counters.CounterType;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetControlledCreaturePermanent;
@@ -32,7 +32,7 @@ public final class DecimatorBeetle extends CardImpl {
     public static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public DecimatorBeetle(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/d/DistractingGeist.java
+++ b/Mage.Sets/src/mage/cards/d/DistractingGeist.java
@@ -12,7 +12,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -26,7 +26,7 @@ public final class DistractingGeist extends CardImpl {
             = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public DistractingGeist(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/e/ElturelSurvivors.java
+++ b/Mage.Sets/src/mage/cards/e/ElturelSurvivors.java
@@ -15,7 +15,7 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterLandPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 
 import java.util.UUID;
 
@@ -27,7 +27,7 @@ public final class ElturelSurvivors extends CardImpl {
     private static final FilterPermanent filter = new FilterLandPermanent();
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(filter);

--- a/Mage.Sets/src/mage/cards/f/FalseOrders.java
+++ b/Mage.Sets/src/mage/cards/f/FalseOrders.java
@@ -37,7 +37,7 @@ public final class FalseOrders extends CardImpl {
 
     static {
         filter.add(CardType.CREATURE.getPredicate());
-        filter.add(FalseOrdersDefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsPredicate.instance);
     }
 
     public FalseOrders(UUID ownerId, CardSetInfo setInfo) {
@@ -61,15 +61,6 @@ public final class FalseOrders extends CardImpl {
         return new FalseOrders(this);
     }
 
-}
-
-enum FalseOrdersDefendingPlayerControlsPredicate implements ObjectSourcePlayerPredicate<Controllable> {
-    instance;
-
-    @Override
-    public boolean apply(ObjectSourcePlayer<Controllable> input, Game game) {
-        return game.getCombat().getPlayerDefenders(game).contains(input.getObject().getControllerId());
-    }
 }
 
 class FalseOrdersUnblockEffect extends OneShotEffect {

--- a/Mage.Sets/src/mage/cards/f/FalseOrders.java
+++ b/Mage.Sets/src/mage/cards/f/FalseOrders.java
@@ -13,10 +13,8 @@ import mage.constants.Outcome;
 import mage.constants.PhaseStep;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterAttackingCreature;
-import mage.filter.predicate.ObjectSourcePlayer;
-import mage.filter.predicate.ObjectSourcePlayerPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsNoSourcePredicate;
 import mage.filter.predicate.permanent.PermanentInListPredicate;
-import mage.game.Controllable;
 import mage.game.Game;
 import mage.game.combat.CombatGroup;
 import mage.game.events.BlockerDeclaredEvent;
@@ -37,7 +35,7 @@ public final class FalseOrders extends CardImpl {
 
     static {
         filter.add(CardType.CREATURE.getPredicate());
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsNoSourcePredicate.instance);
     }
 
     public FalseOrders(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/f/FiendBinder.java
+++ b/Mage.Sets/src/mage/cards/f/FiendBinder.java
@@ -1,6 +1,7 @@
 package mage.cards.f;
 
 import java.util.UUID;
+
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
@@ -10,11 +11,10 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
- *
  * @author LevelX2
  */
 public final class FiendBinder extends CardImpl {
@@ -22,7 +22,7 @@ public final class FiendBinder extends CardImpl {
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public FiendBinder(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/f/FloralSpuzzem.java
+++ b/Mage.Sets/src/mage/cards/f/FloralSpuzzem.java
@@ -1,23 +1,23 @@
 
 package mage.cards.f;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksAndIsNotBlockedTriggeredAbility;
 import mage.abilities.effects.common.DestroyTargetEffect;
 import mage.abilities.effects.common.continuous.AssignNoCombatDamageSourceEffect;
-import mage.constants.SubType;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
+import mage.constants.SubType;
 import mage.filter.FilterPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author TheElk801
  */
 public final class FloralSpuzzem extends CardImpl {
@@ -26,7 +26,7 @@ public final class FloralSpuzzem extends CardImpl {
 
     static {
         filter.add(CardType.ARTIFACT.getPredicate());
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public FloralSpuzzem(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/f/FrenziedTrapbreaker.java
+++ b/Mage.Sets/src/mage/cards/f/FrenziedTrapbreaker.java
@@ -15,7 +15,7 @@ import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterArtifactOrEnchantmentPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -29,7 +29,7 @@ public final class FrenziedTrapbreaker extends CardImpl {
             = new FilterArtifactOrEnchantmentPermanent("artifact or enchantment defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public FrenziedTrapbreaker(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/g/GaeasLiege.java
+++ b/Mage.Sets/src/mage/cards/g/GaeasLiege.java
@@ -19,7 +19,7 @@ import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.common.TargetLandPermanent;
 
 import java.util.UUID;
@@ -33,7 +33,7 @@ public final class GaeasLiege extends CardImpl {
     private static final FilterPermanent filter2 = new FilterPermanent(SubType.FOREST, "");
 
     static {
-        filter2.add(DefendingPlayerControlsPredicate.instance);
+        filter2.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     private static final DynamicValue xValue1 = new PermanentsOnBattlefieldCount(filter);

--- a/Mage.Sets/src/mage/cards/g/GenestealerPatriarch.java
+++ b/Mage.Sets/src/mage/cards/g/GenestealerPatriarch.java
@@ -17,7 +17,7 @@ import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
@@ -39,7 +39,7 @@ public final class GenestealerPatriarch extends CardImpl {
             = new FilterCreaturePermanent("a creature with an infection counter on it");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
         filter2.add(CounterType.INFECTION.getPredicate());
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinRacketeer.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinRacketeer.java
@@ -9,7 +9,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
@@ -22,7 +22,7 @@ public final class GoblinRacketeer extends CardImpl {
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public GoblinRacketeer(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/g/GrimgrinCorpseBorn.java
+++ b/Mage.Sets/src/mage/cards/g/GrimgrinCorpseBorn.java
@@ -19,7 +19,7 @@ import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -33,7 +33,7 @@ public final class GrimgrinCorpseBorn extends CardImpl {
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public GrimgrinCorpseBorn(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/h/HammerheadCorvette.java
+++ b/Mage.Sets/src/mage/cards/h/HammerheadCorvette.java
@@ -1,6 +1,7 @@
 package mage.cards.h;
 
 import java.util.UUID;
+
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
@@ -14,25 +15,24 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
- *
  * @author NinthWorld
  */
 public final class HammerheadCorvette extends CardImpl {
 
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Starship creature defending player controls");
-    
+
     static {
         filter.add(SubType.STARSHIP.getPredicate());
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
-    
+
     public HammerheadCorvette(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{3}{G}");
-        
+
         this.subtype.add(SubType.REBEL);
         this.subtype.add(SubType.STARSHIP);
         this.power = new MageInt(3);
@@ -40,7 +40,7 @@ public final class HammerheadCorvette extends CardImpl {
 
         // Spaceflight
         this.addAbility(SpaceflightAbility.getInstance());
-        
+
         // Whenever Hammerhead Corvette attacks, you may untap target Starship creature defending player controls and have that creature block Hammerhead Corvette this turn if able.
         Effect effect1 = new UntapTargetEffect();
         Effect effect2 = new MustBeBlockedByTargetSourceEffect(Duration.EndOfTurn);

--- a/Mage.Sets/src/mage/cards/h/HellkiteWhelp.java
+++ b/Mage.Sets/src/mage/cards/h/HellkiteWhelp.java
@@ -1,21 +1,21 @@
 package mage.cards.h;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
 import mage.abilities.effects.common.DamageTargetEffect;
-import mage.constants.SubType;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.SubType;
 import mage.filter.FilterPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author TheElk801
  */
 public final class HellkiteWhelp extends CardImpl {
@@ -24,7 +24,7 @@ public final class HellkiteWhelp extends CardImpl {
 
     static {
         filter.add(CardType.CREATURE.getPredicate());
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public HellkiteWhelp(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/k/KoglaTheTitanApe.java
+++ b/Mage.Sets/src/mage/cards/k/KoglaTheTitanApe.java
@@ -21,7 +21,7 @@ import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterArtifactOrEnchantmentPermanent;
 import mage.filter.common.FilterControlledPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -37,7 +37,7 @@ public final class KoglaTheTitanApe extends CardImpl {
             = new FilterControlledPermanent(SubType.HUMAN);
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public KoglaTheTitanApe(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/k/KukemssaPirates.java
+++ b/Mage.Sets/src/mage/cards/k/KukemssaPirates.java
@@ -12,7 +12,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.common.FilterArtifactPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.common.TargetArtifactPermanent;
 
 import java.util.UUID;
@@ -25,7 +25,7 @@ public final class KukemssaPirates extends CardImpl {
     private static final FilterArtifactPermanent filter = new FilterArtifactPermanent("artifact defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public KukemssaPirates(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/k/KyloRen.java
+++ b/Mage.Sets/src/mage/cards/k/KyloRen.java
@@ -1,9 +1,7 @@
 package mage.cards.k;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.Mode;
 import mage.abilities.common.AttacksEachCombatStaticAbility;
 import mage.abilities.common.AttacksTriggeredAbility;
 import mage.abilities.dynamicvalue.common.CardsInControllerGraveyardCount;
@@ -11,21 +9,25 @@ import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.TapTargetEffect;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
-import mage.constants.*;
-import mage.abilities.keyword.HasteAbility;
 import mage.abilities.keyword.FirstStrikeAbility;
+import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.constants.SuperType;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author NinthWorld
  */
 public final class KyloRen extends CardImpl {
@@ -33,12 +35,12 @@ public final class KyloRen extends CardImpl {
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public KyloRen(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{U}{B}{R}");
-        
+
         this.supertype.add(SuperType.LEGENDARY);
         this.subtype.add(SubType.HUMAN);
         this.subtype.add(SubType.SITH);
@@ -94,8 +96,8 @@ class KyloRenTapTargetEffect extends TapTargetEffect {
     public boolean apply(Game game, Ability source) {
         Permanent permanent = game.getPermanent(source.getSourceId());
         Player player = game.getPlayer(source.getControllerId());
-        if(player != null && permanent != null) {
-            if(player.chooseUse(outcome, "Tap target creature defending player controls (" + permanent.getLogName() + ")", source, game)) {
+        if (player != null && permanent != null) {
+            if (player.chooseUse(outcome, "Tap target creature defending player controls (" + permanent.getLogName() + ")", source, game)) {
                 super.apply(game, source);
             }
         }

--- a/Mage.Sets/src/mage/cards/m/MasterOfDiversion.java
+++ b/Mage.Sets/src/mage/cards/m/MasterOfDiversion.java
@@ -1,6 +1,7 @@
 package mage.cards.m;
 
 import java.util.UUID;
+
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
@@ -10,11 +11,10 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
- *
  * @author jeffwadsworth
  */
 public final class MasterOfDiversion extends CardImpl {
@@ -22,7 +22,7 @@ public final class MasterOfDiversion extends CardImpl {
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public MasterOfDiversion(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/o/OrcishSquatters.java
+++ b/Mage.Sets/src/mage/cards/o/OrcishSquatters.java
@@ -11,7 +11,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.common.FilterLandPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -24,7 +24,7 @@ public final class OrcishSquatters extends CardImpl {
     private static final FilterLandPermanent filter = new FilterLandPermanent("land defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public OrcishSquatters(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/p/PurifyingDragon.java
+++ b/Mage.Sets/src/mage/cards/p/PurifyingDragon.java
@@ -12,7 +12,7 @@ import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
@@ -28,7 +28,7 @@ public final class PurifyingDragon extends CardImpl {
             = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public PurifyingDragon(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/r/RadhasFirebrand.java
+++ b/Mage.Sets/src/mage/cards/r/RadhasFirebrand.java
@@ -17,7 +17,7 @@ import mage.filter.FilterPermanent;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.ObjectSourcePlayer;
 import mage.filter.predicate.ObjectSourcePlayerPredicate;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
@@ -33,7 +33,7 @@ public final class RadhasFirebrand extends CardImpl {
             = new FilterCreaturePermanent("creature defending player controls with power less than {this}'s power");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
         filter.add(RadhasFirebrandPredicate.instance);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RustScarab.java
+++ b/Mage.Sets/src/mage/cards/r/RustScarab.java
@@ -1,6 +1,7 @@
 package mage.cards.r;
 
 import java.util.UUID;
+
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.BecomesBlockedSourceTriggeredAbility;
@@ -11,11 +12,10 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterArtifactOrEnchantmentPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
 /**
- *
  * @author LevelX2
  */
 public final class RustScarab extends CardImpl {
@@ -24,11 +24,11 @@ public final class RustScarab extends CardImpl {
             = new FilterArtifactOrEnchantmentPermanent("artifact or enchantment defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public RustScarab(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{G}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{G}");
         this.subtype.add(SubType.INSECT);
 
         this.power = new MageInt(4);

--- a/Mage.Sets/src/mage/cards/s/ScaldingSalamander.java
+++ b/Mage.Sets/src/mage/cards/s/ScaldingSalamander.java
@@ -2,6 +2,7 @@
 package mage.cards.s;
 
 import java.util.UUID;
+
 import mage.MageInt;
 import mage.abilities.common.AttacksTriggeredAbility;
 import mage.abilities.effects.common.DamageAllEffect;
@@ -13,10 +14,9 @@ import mage.constants.CardType;
 import mage.filter.FilterPermanent;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.AbilityPredicate;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 
 /**
- *
  * @author TheElk801
  */
 public final class ScaldingSalamander extends CardImpl {
@@ -25,7 +25,7 @@ public final class ScaldingSalamander extends CardImpl {
 
     static {
         filter.add(CardType.CREATURE.getPredicate());
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
         filter.add(Predicates.not(new AbilityPredicate(FlyingAbility.class)));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SidarJabari.java
+++ b/Mage.Sets/src/mage/cards/s/SidarJabari.java
@@ -1,6 +1,7 @@
 package mage.cards.s;
 
 import java.util.UUID;
+
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
@@ -12,11 +13,10 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
- *
  * @author fireshoes
  */
 public final class SidarJabari extends CardImpl {
@@ -24,7 +24,7 @@ public final class SidarJabari extends CardImpl {
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public SidarJabari(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/s/StarCrownedStag.java
+++ b/Mage.Sets/src/mage/cards/s/StarCrownedStag.java
@@ -1,6 +1,7 @@
 package mage.cards.s;
 
 import java.util.UUID;
+
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
@@ -10,11 +11,10 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
- *
  * @author TheElk801
  */
 public final class StarCrownedStag extends CardImpl {
@@ -22,7 +22,7 @@ public final class StarCrownedStag extends CardImpl {
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public StarCrownedStag(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/s/StormTheCitadel.java
+++ b/Mage.Sets/src/mage/cards/s/StormTheCitadel.java
@@ -12,7 +12,7 @@ import mage.constants.Duration;
 import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.filter.predicate.Predicates;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -30,7 +30,7 @@ public final class StormTheCitadel extends CardImpl {
                 CardType.ARTIFACT.getPredicate(),
                 CardType.ENCHANTMENT.getPredicate()
         ));
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public StormTheCitadel(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/t/TerraRavager.java
+++ b/Mage.Sets/src/mage/cards/t/TerraRavager.java
@@ -14,7 +14,7 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterLandPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 
 import java.util.UUID;
 
@@ -26,7 +26,7 @@ public final class TerraRavager extends CardImpl {
     private static final FilterPermanent filter = new FilterLandPermanent("lands defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(filter, null);

--- a/Mage.Sets/src/mage/cards/t/TheTarrasque.java
+++ b/Mage.Sets/src/mage/cards/t/TheTarrasque.java
@@ -17,7 +17,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.stack.Spell;
@@ -37,7 +37,7 @@ public final class TheTarrasque extends CardImpl {
             = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public TheTarrasque(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/t/TyrantsFamiliar.java
+++ b/Mage.Sets/src/mage/cards/t/TyrantsFamiliar.java
@@ -2,6 +2,7 @@
 package mage.cards.t;
 
 import java.util.UUID;
+
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.abilityword.LieutenantAbility;
@@ -16,11 +17,10 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.TargetPermanent;
 
 /**
- *
  * @author emerald000
  */
 public final class TyrantsFamiliar extends CardImpl {
@@ -29,7 +29,7 @@ public final class TyrantsFamiliar extends CardImpl {
 
     static {
         filter.add(CardType.CREATURE.getPredicate());
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public TyrantsFamiliar(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/w/WarkiteMarauder.java
+++ b/Mage.Sets/src/mage/cards/w/WarkiteMarauder.java
@@ -2,6 +2,7 @@
 package mage.cards.w;
 
 import java.util.UUID;
+
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
@@ -14,11 +15,10 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.DefendingPlayerControlsPredicate;
+import mage.filter.predicate.permanent.DefendingPlayerControlsSourceAttackingPredicate;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
- *
  * @author LevelX2
  */
 public final class WarkiteMarauder extends CardImpl {
@@ -26,7 +26,7 @@ public final class WarkiteMarauder extends CardImpl {
     private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature defending player controls");
 
     static {
-        filter.add(DefendingPlayerControlsPredicate.instance);
+        filter.add(DefendingPlayerControlsSourceAttackingPredicate.instance);
     }
 
     public WarkiteMarauder(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage/src/main/java/mage/filter/predicate/permanent/DefendingPlayerControlsNoSourcePredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/DefendingPlayerControlsNoSourcePredicate.java
@@ -14,8 +14,6 @@ import mage.game.permanent.Permanent;
  * If not, let's go for a ride on rule interpretation of very old cards hiding in
  * a corner of a gray area of the rules.
  * <p>
- * Use it sparingly, mostly in triggers e.g. 'when [...] attacks, target creature defending player [...]'
- * <p>
  * 506.2. During the combat phase, the active player is the attacking player; creatures that player controls
  * may attack. During the combat phase of a two-player game, the nonactive player is the defending
  * player; that player, planeswalkers they control, and battles they protect may be attacked.

--- a/Mage/src/main/java/mage/filter/predicate/permanent/DefendingPlayerControlsNoSourcePredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/DefendingPlayerControlsNoSourcePredicate.java
@@ -1,0 +1,77 @@
+package mage.filter.predicate.permanent;
+
+import mage.constants.TurnPhase;
+import mage.filter.predicate.ObjectSourcePlayer;
+import mage.filter.predicate.ObjectSourcePlayerPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+/**
+ * DefendingPlayerControlsSourceAttackingPredicate is maybe what you are looking for,
+ * for modern usage of "defending player", inside an attack trigger, where the 'defending
+ * player' makes sense, it is the player attacked by the source of the ability.
+ * <p>
+ * If not, let's go for a ride on rule interpretation of very old cards hiding in
+ * a corner of a gray area of the rules.
+ * <p>
+ * Use it sparingly, mostly in triggers e.g. 'when [...] attacks, target creature defending player [...]'
+ * <p>
+ * 506.2. During the combat phase, the active player is the attacking player; creatures that player controls
+ * may attack. During the combat phase of a two-player game, the nonactive player is the defending
+ * player; that player, planeswalkers they control, and battles they protect may be attacked.
+ * 506.2a During the combat phase of a multiplayer game, there may be one or more defending
+ * players, depending on the variant being played and the options chosen for it. Unless all the
+ * attacking player’s opponents automatically become defending players during the combat phase,
+ * the attacking player chooses one of their opponents as a turn-based action during the beginning
+ * of combat step. (Note that the choice may be dictated by the variant being played or the options
+ * chosen for it.) That player becomes the defending player. See rule 802, “Attack Multiple Players
+ * Option,” rule 803, “Attack Left and Attack Right Options,” and rule 809, “Emperor Varian
+ * <p>
+ * 802. Attack Multiple Players Option
+ * 802.1. Some multiplayer games allow the active player to attack multiple other players. If this option is
+ * used, a player can also choose to attack only one player during a particular combat.
+ * 802.2. As the combat phase starts, the attacking player doesn’t choose an opponent to become the
+ * defending player. Instead, all the attacking player’s opponents are defending players during the
+ * combat phase.
+ * 802.2a Any rule, object, or effect that refers to a “defending player” refers to one specific defending
+ * player, not to all of the defending players. If an ability of an attacking creature refers to a
+ * defending player, or a spell or ability refers to both an attacking creature and a defending player,
+ * then unless otherwise specified, the defending player it’s referring to is the player that creature
+ * is attacking, the controller of the planeswalker that creature is attacking, or the protector of the
+ * battle that player is attacking. If that creature is no longer attacking, the defending player it’s
+ * referring to is the player that creature was attacking before it was removed from combat, the
+ * controller of the planeswalker that creature was attacking before it was removed from combat,
+ * or the protector of the battle that player was attacking before it was removed from combat. If a
+ * spell or ability could apply to multiple attacking creatures, the appropriate defending player is
+ * individually determined for each of those attacking creatures. If there are multiple defending
+ * players that could be chosen, the controller of the spell or ability chooses one.
+ * <p>
+ * So after those walls of text, let's go back to the weird case of effects mentioning
+ * 'defending player', when the source is not attacking.
+ * <p>
+ * For instance with: Blaze of Glory
+ * Instant {W}
+ * Cast this spell only during combat before blockers are declared.
+ * Target creature defending player controls can block any number of creatures this turn. It blocks each attacking creature this turn if able.
+ * <p>
+ * <p>
+ * For that card, it does not matter (at least I'm interpreting it that way) that an opponent of the active player
+ * be attacked for their creatures to be targettable by Blaze of Glory, as long as it is during the combat step.
+ *
+ * @author Susucr
+ */
+public enum DefendingPlayerControlsNoSourcePredicate implements ObjectSourcePlayerPredicate<Permanent> {
+    instance;
+
+    @Override
+    public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
+        return game.getState().getTurnPhaseType() == TurnPhase.COMBAT &&
+                game.getOpponents(game.getActivePlayerId())
+                        .contains(input.getObject().getControllerId());
+    }
+
+    @Override
+    public String toString() {
+        return "";
+    }
+}

--- a/Mage/src/main/java/mage/filter/predicate/permanent/DefendingPlayerControlsSourceAttackingPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/DefendingPlayerControlsSourceAttackingPredicate.java
@@ -6,9 +6,12 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 
 /**
- * @author TheElk801
+ * This predicate only works when source is an attacking creature.
+ * Use it sparingly, mostly in triggers e.g. 'when [...] attacks, target creature defending player [...]'
+ *
+ * @author Susucr
  */
-public enum DefendingPlayerControlsPredicate implements ObjectSourcePlayerPredicate<Permanent> {
+public enum DefendingPlayerControlsSourceAttackingPredicate implements ObjectSourcePlayerPredicate<Permanent> {
     instance;
 
     @Override

--- a/Mage/src/main/java/mage/filter/predicate/permanent/DefendingPlayerControlsSourceAttackingPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/DefendingPlayerControlsSourceAttackingPredicate.java
@@ -9,7 +9,7 @@ import mage.game.permanent.Permanent;
  * This predicate can only apply when source is an attacking creature.
  * <p>
  * It should be used when the source is an attacking creature during an effect
- * 'when {this} attacks, target creature defending player [...]'
+ * e.g. 'when {this} attacks, target creature defending player controls can't block this turn.'
  *
  * @author Susucr
  */

--- a/Mage/src/main/java/mage/filter/predicate/permanent/DefendingPlayerControlsSourceAttackingPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/DefendingPlayerControlsSourceAttackingPredicate.java
@@ -6,8 +6,10 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 
 /**
- * This predicate only works when source is an attacking creature.
- * Use it sparingly, mostly in triggers e.g. 'when [...] attacks, target creature defending player [...]'
+ * This predicate can only apply when source is an attacking creature.
+ * <p>
+ * It should be used when the source is an attacking creature during an effect
+ * 'when {this} attacks, target creature defending player [...]'
  *
  * @author Susucr
  */


### PR DESCRIPTION
This PR started with trying to understand why Blaze of Glory was bugged, it wasn't castable at any point during combat.

So there are two very distinct "defending player" in card effects:

- When the source effect is attacking, it is the defending player for that creature. This is the usual effect, inside a trigger or sometimes linked to a condition of the source being attacking. This was `DefendingPlayerControlsPredicate`, and has been renamed to `DefendingPlayerControlsSourceAttackingPredicate`
- Some old cards, here [[Blaze of Glory]] and [[False Orders]], do use the term while the source is not an attacking creature (it is even a spell for those two). In that case, 'defending player' does refer to,  during combat phase only, the opponents of the active player. This is using a new `DefendingPlayerControlsNoSourcePredicate`

It should be easier to implement the old cards like [[Kjeldoran Guard]], [[Arcum's Sleight]], [[Yare]]

There is also [[Mercadia's Downfall]] and [[Kusari-Gama]]. That are implemented, but I think are wrong in multiplayer.
[[Stand or Fall]] seems correct.