### PR TITLE
fix VanishingUpkeepAbility missing a copy for a field

### DIFF
--- a/Mage/src/main/java/mage/abilities/keyword/VanishingUpkeepAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/VanishingUpkeepAbility.java
@@ -27,9 +27,10 @@ public class VanishingUpkeepAbility extends BeginningOfUpkeepTriggeredAbility {
         this.permanentType = permanentType;
     }
 
-    public VanishingUpkeepAbility(final VanishingUpkeepAbility ability) {
+    protected VanishingUpkeepAbility(final VanishingUpkeepAbility ability) {
         super(ability);
         this.vanishingAmount = ability.vanishingAmount;
+        this.permanentType = ability.permanentType;
     }
 
     @Override


### PR DESCRIPTION
@JayDi85 how about doing some recursive check on fields?

I was curious on if I could have detected the copy error in #10747, and indeed I can!
Found the VanishingUpkeepAbility right after on verifying all cards.

The prototype testing code I used:
![image](https://github.com/magefree/mage/assets/34709007/0ef533aa-b950-498c-9985-5bb3b255e624)