### PR TITLE
Tests: Add deep recursive test of copy method

### DIFF
--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -1643,6 +1643,9 @@ public class VerifyCardDataTest {
         }
     }
 
+    // "copy" fails means that the copy constructor are not correct inside a card.
+    // To fix those, try to find the class that did trigger the copy failure, and check
+    // that copy() exists, a copy constructor exists, and the copy constructor is right. 
     private void checkCardCanBeCopied(Card card1) {
         Card card2;
         try {
@@ -1765,7 +1768,8 @@ public class VerifyCardDataTest {
                     }
 
                     // Do check that the expected special fields were encountered.
-                    // If those field are no relevant, or were renamed, please modify the relevant code block above.
+                    // If those field are no relevant anymore, or were renamed, please modify the matching code
+                    // block above on how to loop into those fields.
                     if (class1 == CardImpl.class) {
                         if (!hasSpellAbilityField) {
                             fail(originalCard, "copy", "was expecting a spellAbility field, but found none " + msg + "]");

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -2,12 +2,15 @@ package mage.verify;
 
 import com.google.common.base.CharMatcher;
 import mage.MageObject;
+import mage.Mana;
 import mage.ObjectColor;
 import mage.abilities.Ability;
 import mage.abilities.AbilityImpl;
 import mage.abilities.Mode;
 import mage.abilities.common.*;
 import mage.abilities.condition.Condition;
+import mage.abilities.costs.Cost;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.FightTargetsEffect;
 import mage.abilities.effects.common.counter.ProliferateEffect;
@@ -18,6 +21,7 @@ import mage.cards.decks.CardNameUtil;
 import mage.cards.decks.DeckCardLists;
 import mage.cards.decks.importer.DeckImporter;
 import mage.cards.repository.*;
+import mage.choices.Choice;
 import mage.constants.CardType;
 import mage.constants.Rarity;
 import mage.constants.SubType;
@@ -31,6 +35,7 @@ import mage.game.permanent.token.TokenImpl;
 import mage.game.permanent.token.custom.CreatureToken;
 import mage.server.util.SystemUtil;
 import mage.sets.TherosBeyondDeath;
+import mage.target.targetpointer.TargetPointer;
 import mage.util.CardUtil;
 import mage.verify.mtgjson.MtgJsonCard;
 import mage.verify.mtgjson.MtgJsonService;
@@ -1666,7 +1671,8 @@ public class VerifyCardDataTest {
             }
             // Only recurse on those objects
             if (obj1 instanceof MageObject || obj1 instanceof Filter || obj1 instanceof Condition || obj1 instanceof Effect
-                    || obj1 instanceof Ability) {
+                    || obj1 instanceof Ability || obj1 instanceof Mana || obj1 instanceof Cost || obj1 instanceof DynamicValue
+                    || obj1 instanceof Choice || obj1 instanceof TargetPointer) {
                 //System.out.println(msg);
                 Class class1 = obj1.getClass();
                 Class class2 = obj2.getClass();

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -1667,7 +1667,7 @@ public class VerifyCardDataTest {
             // Only recurse on those objects
             if (obj1 instanceof MageObject || obj1 instanceof Filter || obj1 instanceof Condition || obj1 instanceof Effect
                     || obj1 instanceof Ability) {
-                System.out.println(msg);
+                //System.out.println(msg);
                 Class class1 = obj1.getClass();
                 Class class2 = obj2.getClass();
                 do {

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -1667,7 +1667,7 @@ public class VerifyCardDataTest {
             // Only recurse on those objects
             if (obj1 instanceof MageObject || obj1 instanceof Filter || obj1 instanceof Condition || obj1 instanceof Effect
                     || obj1 instanceof Ability) {
-                //System.out.println(msg);
+                System.out.println(msg);
                 Class class1 = obj1.getClass();
                 Class class2 = obj2.getClass();
                 do {
@@ -1705,6 +1705,11 @@ public class VerifyCardDataTest {
                                 if (field1.getName() == "watchers") {
                                     doFieldRecurse = false;
                                 }
+                                if (field1.getName() == "modes") {
+                                    //compareClassRecursive(((AbilityImpl) obj1).getModes(), ((AbilityImpl) obj2).getModes(), originalCard, msg + "<" + obj1.getClass() + ">" + "::" + field1.getName(), maxDepth - 1);
+                                    compareClassRecursive(((AbilityImpl) obj1).getEffects(), ((AbilityImpl) obj2).getEffects(), originalCard, msg + "<" + obj1.getClass() + ">" + "::" + field1.getName(), maxDepth - 1);
+                                    doFieldRecurse = false;
+                                }
                             }
                             if (doFieldRecurse) {
                                 compareClassRecursive(value1, value2, originalCard, msg + "<" + obj1.getClass() + ">" + "::" + field1.getName(), maxDepth - 1);
@@ -1726,6 +1731,15 @@ public class VerifyCardDataTest {
                     compareClassRecursive(it1.next(), it2.next(), originalCard, msg + "<" + obj1.getClass() + ">" + "[" + i++ + "]", maxDepth - 1);
                 }
                 if (it1.hasNext() || it2.hasNext()) {
+                    fail(originalCard, "copy", "not same size for " + msg + "]");
+                }
+            } else if (obj1 instanceof Map) {
+                Map map1 = (Map) obj1;
+                Map map2 = (Map) obj2;
+                map1.forEach((i, el1) -> {
+                    compareClassRecursive(el1, ((Map<?, ?>) obj2).get(i), originalCard, msg + "<" + obj1.getClass() + ">" + ".(" + i + ")", maxDepth - 1);
+                });
+                if (map1.size() != map2.size()) {
                     fail(originalCard, "copy", "not same size for " + msg + "]");
                 }
             }


### PR DESCRIPTION
This might need more fine tuning in what is a loopable field in a given class.

But it has found one more situation where the copy constructor was not set:
![image](https://github.com/magefree/mage/assets/34709007/50b564f3-1c5f-490a-9f1f-6415db901ff1)
