### PR TITLE
Prevent DealsCombatDamageEquippedTriggeredAbility from triggering twice

### DIFF
--- a/Mage/src/main/java/mage/abilities/common/DealsCombatDamageEquippedTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DealsCombatDamageEquippedTriggeredAbility.java
@@ -10,7 +10,7 @@ import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 
 /**
- * @author TheElk801
+ * @author notgreat
  */
 public class DealsCombatDamageEquippedTriggeredAbility extends TriggeredAbilityImpl {
     private boolean usedInPhase;


### PR DESCRIPTION
Code is mostly copied from `DealsCombatDamageTriggeredAbility`

Fixes #10763