### PR TITLE
[don't merge] Refactor: many sets contains wrong block and parent set info

### DIFF
--- a/Mage.Sets/src/mage/sets/AdventuresInTheForgottenRealms.java
+++ b/Mage.Sets/src/mage/sets/AdventuresInTheForgottenRealms.java
@@ -24,7 +24,6 @@ public final class AdventuresInTheForgottenRealms extends ExpansionSet {
 
     private AdventuresInTheForgottenRealms() {
         super("Adventures in the Forgotten Realms", "AFR", ExpansionSet.buildDate(2021, 7, 23), SetType.EXPANSION);
-        this.blockName = "Adventures in the Forgotten Realms";
         this.hasBoosters = true;
         this.hasBasicLands = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/AetherRevolt.java
+++ b/Mage.Sets/src/mage/sets/AetherRevolt.java
@@ -28,7 +28,6 @@ public final class AetherRevolt extends ExpansionSet {
     private AetherRevolt() {
         super("Aether Revolt", "AER", ExpansionSet.buildDate(2017, 1, 20), SetType.EXPANSION);
         this.blockName = "Kaladesh";
-        this.parentSet = Kaladesh.getInstance();
         this.hasBoosters = true;
         this.hasBasicLands = false;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/AetherRevoltPromos.java
+++ b/Mage.Sets/src/mage/sets/AetherRevoltPromos.java
@@ -18,6 +18,7 @@ public class AetherRevoltPromos extends ExpansionSet {
     private AetherRevoltPromos() {
         super("Aether Revolt Promos", "PAER", ExpansionSet.buildDate(2017, 1, 21), SetType.PROMOTIONAL);
         this.blockName = "Kaladesh";
+        this.parentSet = AetherRevolt.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/AetherRevoltPromos.java
+++ b/Mage.Sets/src/mage/sets/AetherRevoltPromos.java
@@ -17,6 +17,7 @@ public class AetherRevoltPromos extends ExpansionSet {
 
     private AetherRevoltPromos() {
         super("Aether Revolt Promos", "PAER", ExpansionSet.buildDate(2017, 1, 21), SetType.PROMOTIONAL);
+        this.blockName = "Kaladesh";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/AlaraReborn.java
+++ b/Mage.Sets/src/mage/sets/AlaraReborn.java
@@ -19,7 +19,7 @@ public final class AlaraReborn extends ExpansionSet {
 
     private AlaraReborn() {
         super("Alara Reborn", "ARB", ExpansionSet.buildDate(2009, 3, 25), SetType.EXPANSION);
-        this.blockName = "Shards of Alara";
+        this.blockName = "Alara";
         this.parentSet = ShardsOfAlara.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;

--- a/Mage.Sets/src/mage/sets/AlaraReborn.java
+++ b/Mage.Sets/src/mage/sets/AlaraReborn.java
@@ -20,7 +20,6 @@ public final class AlaraReborn extends ExpansionSet {
     private AlaraReborn() {
         super("Alara Reborn", "ARB", ExpansionSet.buildDate(2009, 3, 25), SetType.EXPANSION);
         this.blockName = "Alara";
-        this.parentSet = ShardsOfAlara.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/AlchemyInnistrad.java
+++ b/Mage.Sets/src/mage/sets/AlchemyInnistrad.java
@@ -17,7 +17,7 @@ public final class AlchemyInnistrad extends ExpansionSet {
 
     private AlchemyInnistrad() {
         super("Alchemy: Innistrad", "YMID", ExpansionSet.buildDate(2021, 12, 9), SetType.MAGIC_ARENA);
-        this.blockName = "Alchemy";
+        this.blockName = "Alchemy 2022";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Alliances.java
+++ b/Mage.Sets/src/mage/sets/Alliances.java
@@ -15,7 +15,6 @@ public final class Alliances extends ExpansionSet {
     private Alliances() {
         super("Alliances", "ALL", ExpansionSet.buildDate(1996, 6, 10), SetType.EXPANSION);
         this.blockName = "Ice Age";
-        this.parentSet = IceAge.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/AmonkhetInvocations.java
+++ b/Mage.Sets/src/mage/sets/AmonkhetInvocations.java
@@ -20,7 +20,7 @@ public final class AmonkhetInvocations extends ExpansionSet {
 
     private AmonkhetInvocations() {
         super("Amonkhet Invocations", "MP2", ExpansionSet.buildDate(2017, 4, 28), SetType.PROMOTIONAL);
-        this.blockName = "Masterpiece Series";
+        this.blockName = "Amonkhet";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/AmonkhetInvocations.java
+++ b/Mage.Sets/src/mage/sets/AmonkhetInvocations.java
@@ -21,6 +21,7 @@ public final class AmonkhetInvocations extends ExpansionSet {
     private AmonkhetInvocations() {
         super("Amonkhet Invocations", "MP2", ExpansionSet.buildDate(2017, 4, 28), SetType.PROMOTIONAL);
         this.blockName = "Amonkhet";
+        this.parentSet = Amonkhet.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/AmonkhetPromos.java
+++ b/Mage.Sets/src/mage/sets/AmonkhetPromos.java
@@ -17,6 +17,7 @@ public class AmonkhetPromos extends ExpansionSet {
 
     private AmonkhetPromos() {
         super("Amonkhet Promos", "PAKH", ExpansionSet.buildDate(2017, 4, 28), SetType.PROMOTIONAL);
+        this.blockName = "Amonkhet";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/AmonkhetPromos.java
+++ b/Mage.Sets/src/mage/sets/AmonkhetPromos.java
@@ -18,6 +18,7 @@ public class AmonkhetPromos extends ExpansionSet {
     private AmonkhetPromos() {
         super("Amonkhet Promos", "PAKH", ExpansionSet.buildDate(2017, 4, 28), SetType.PROMOTIONAL);
         this.blockName = "Amonkhet";
+        this.parentSet = Amonkhet.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Apocalypse.java
+++ b/Mage.Sets/src/mage/sets/Apocalypse.java
@@ -15,7 +15,6 @@ public final class Apocalypse extends ExpansionSet {
     private Apocalypse() {
         super("Apocalypse", "APC", ExpansionSet.buildDate(2001, 5, 1), SetType.EXPANSION);
         this.blockName = "Invasion";
-        this.parentSet = Invasion.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/Archenemy.java
+++ b/Mage.Sets/src/mage/sets/Archenemy.java
@@ -19,7 +19,7 @@ public final class Archenemy extends ExpansionSet {
 
     private Archenemy() {
         super("Archenemy", "ARC", ExpansionSet.buildDate(2010, 6, 18), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+
         cards.add(new SetCardInfo("Aether Spellbomb", 102, Rarity.COMMON, mage.cards.a.AetherSpellbomb.class));
         cards.add(new SetCardInfo("Agony Warp", 76, Rarity.COMMON, mage.cards.a.AgonyWarp.class));
         cards.add(new SetCardInfo("Architects of Will", 77, Rarity.COMMON, mage.cards.a.ArchitectsOfWill.class));

--- a/Mage.Sets/src/mage/sets/ArchenemyNicolBolas.java
+++ b/Mage.Sets/src/mage/sets/ArchenemyNicolBolas.java
@@ -19,7 +19,6 @@ public final class ArchenemyNicolBolas extends ExpansionSet {
 
     private ArchenemyNicolBolas() {
         super("Archenemy: Nicol Bolas", "E01", ExpansionSet.buildDate(2017, 6, 16), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
 
         cards.add(new SetCardInfo("Aegis Angel", 1, Rarity.RARE, mage.cards.a.AegisAngel.class));
         cards.add(new SetCardInfo("Aerial Responder", 2, Rarity.UNCOMMON, mage.cards.a.AerialResponder.class));

--- a/Mage.Sets/src/mage/sets/ArenaLeague1996.java
+++ b/Mage.Sets/src/mage/sets/ArenaLeague1996.java
@@ -17,6 +17,7 @@ public class ArenaLeague1996 extends ExpansionSet {
 
     private ArenaLeague1996() {
         super("Arena League 1996", "PARL", ExpansionSet.buildDate(1996, 8, 2), SetType.PROMOTIONAL);
+        this.blockName = "Arena League";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/ArenaLeague1999.java
+++ b/Mage.Sets/src/mage/sets/ArenaLeague1999.java
@@ -17,6 +17,7 @@ public class ArenaLeague1999 extends ExpansionSet {
 
     private ArenaLeague1999() {
         super("Arena League 1999", "PAL99", ExpansionSet.buildDate(1999, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Arena League";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/ArenaLeague2000.java
+++ b/Mage.Sets/src/mage/sets/ArenaLeague2000.java
@@ -17,6 +17,7 @@ public class ArenaLeague2000 extends ExpansionSet {
 
     private ArenaLeague2000() {
         super("Arena League 2000", "PAL00", ExpansionSet.buildDate(2000, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Arena League";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/ArenaLeague2001.java
+++ b/Mage.Sets/src/mage/sets/ArenaLeague2001.java
@@ -17,6 +17,7 @@ public class ArenaLeague2001 extends ExpansionSet {
 
     private ArenaLeague2001() {
         super("Arena League 2001", "PAL01", ExpansionSet.buildDate(2001, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Arena League";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/ArenaLeague2002.java
+++ b/Mage.Sets/src/mage/sets/ArenaLeague2002.java
@@ -17,6 +17,7 @@ public class ArenaLeague2002 extends ExpansionSet {
 
     private ArenaLeague2002() {
         super("Arena League 2002", "PAL02", ExpansionSet.buildDate(2002, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Arena League";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/ArenaLeague2003.java
+++ b/Mage.Sets/src/mage/sets/ArenaLeague2003.java
@@ -17,6 +17,7 @@ public class ArenaLeague2003 extends ExpansionSet {
 
     private ArenaLeague2003() {
         super("Arena League 2003", "PAL03", ExpansionSet.buildDate(2003, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Arena League";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/ArenaLeague2004.java
+++ b/Mage.Sets/src/mage/sets/ArenaLeague2004.java
@@ -17,6 +17,7 @@ public class ArenaLeague2004 extends ExpansionSet {
 
     private ArenaLeague2004() {
         super("Arena League 2004", "PAL04", ExpansionSet.buildDate(2004, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Arena League";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/ArenaLeague2005.java
+++ b/Mage.Sets/src/mage/sets/ArenaLeague2005.java
@@ -17,6 +17,7 @@ public class ArenaLeague2005 extends ExpansionSet {
 
     private ArenaLeague2005() {
         super("Arena League 2005", "PAL05", ExpansionSet.buildDate(2005, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Arena League";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/ArenaLeague2006.java
+++ b/Mage.Sets/src/mage/sets/ArenaLeague2006.java
@@ -17,6 +17,7 @@ public class ArenaLeague2006 extends ExpansionSet {
 
     private ArenaLeague2006() {
         super("Arena League 2006", "PAL06", ExpansionSet.buildDate(2006, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Arena League";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/ArenaNewPlayerExperienceCards.java
+++ b/Mage.Sets/src/mage/sets/ArenaNewPlayerExperienceCards.java
@@ -17,6 +17,7 @@ public final class ArenaNewPlayerExperienceCards extends ExpansionSet {
 
     private ArenaNewPlayerExperienceCards() {
         super("Arena New Player Experience Cards", "OANA", ExpansionSet.buildDate(2018, 7, 14), SetType.MAGIC_ONLINE);
+        this.parentSet = ArenaNewPlayerExperience.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ArenaNewPlayerExperienceExtras.java
+++ b/Mage.Sets/src/mage/sets/ArenaNewPlayerExperienceExtras.java
@@ -17,6 +17,7 @@ public final class ArenaNewPlayerExperienceExtras extends ExpansionSet {
 
     private ArenaNewPlayerExperienceExtras() {
         super("Arena New Player Experience Extras", "XANA", ExpansionSet.buildDate(2018, 7, 14), SetType.MAGIC_ONLINE);
+        this.parentSet = ArenaNewPlayerExperience.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/AvacynRestored.java
+++ b/Mage.Sets/src/mage/sets/AvacynRestored.java
@@ -26,7 +26,6 @@ public final class AvacynRestored extends ExpansionSet {
     private AvacynRestored() {
         super("Avacyn Restored", "AVR", ExpansionSet.buildDate(2012, 4, 4), SetType.EXPANSION);
         this.blockName = "Innistrad";
-        this.parentSet = Innistrad.getInstance();
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/AvacynRestoredPromos.java
+++ b/Mage.Sets/src/mage/sets/AvacynRestoredPromos.java
@@ -17,6 +17,7 @@ public class AvacynRestoredPromos extends ExpansionSet {
 
     private AvacynRestoredPromos() {
         super("Avacyn Restored Promos", "PAVR", ExpansionSet.buildDate(2012, 4, 28), SetType.PROMOTIONAL);
+        this.blockName = "Innistrad";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/AvacynRestoredPromos.java
+++ b/Mage.Sets/src/mage/sets/AvacynRestoredPromos.java
@@ -18,6 +18,7 @@ public class AvacynRestoredPromos extends ExpansionSet {
     private AvacynRestoredPromos() {
         super("Avacyn Restored Promos", "PAVR", ExpansionSet.buildDate(2012, 4, 28), SetType.PROMOTIONAL);
         this.blockName = "Innistrad";
+        this.parentSet =  AvacynRestored.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/BFZStandardSeries.java
+++ b/Mage.Sets/src/mage/sets/BFZStandardSeries.java
@@ -18,6 +18,7 @@ public class BFZStandardSeries extends ExpansionSet {
     private BFZStandardSeries() {
         super("BFZ Standard Series", "PSS1", ExpansionSet.buildDate(2015, 10, 2), SetType.PROMOTIONAL);
         this.blockName = "Battle for Zendikar";
+        this.parentSet = BattleForZendikar.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/BFZStandardSeries.java
+++ b/Mage.Sets/src/mage/sets/BFZStandardSeries.java
@@ -17,6 +17,7 @@ public class BFZStandardSeries extends ExpansionSet {
 
     private BFZStandardSeries() {
         super("BFZ Standard Series", "PSS1", ExpansionSet.buildDate(2015, 10, 2), SetType.PROMOTIONAL);
+        this.blockName = "Battle for Zendikar";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/BattleForZendikarPromos.java
+++ b/Mage.Sets/src/mage/sets/BattleForZendikarPromos.java
@@ -18,6 +18,7 @@ public class BattleForZendikarPromos extends ExpansionSet {
     private BattleForZendikarPromos() {
         super("Battle for Zendikar Promos", "PBFZ", ExpansionSet.buildDate(2015, 10, 3), SetType.PROMOTIONAL);
         this.blockName = "Battle for Zendikar";
+        this.parentSet = BattleForZendikar.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/BattleForZendikarPromos.java
+++ b/Mage.Sets/src/mage/sets/BattleForZendikarPromos.java
@@ -17,6 +17,7 @@ public class BattleForZendikarPromos extends ExpansionSet {
 
     private BattleForZendikarPromos() {
         super("Battle for Zendikar Promos", "PBFZ", ExpansionSet.buildDate(2015, 10, 3), SetType.PROMOTIONAL);
+        this.blockName = "Battle for Zendikar";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Battlebond.java
+++ b/Mage.Sets/src/mage/sets/Battlebond.java
@@ -25,7 +25,6 @@ public final class Battlebond extends ExpansionSet {
 
     private Battlebond() {
         super("Battlebond", "BBD", ExpansionSet.buildDate(2018, 6, 8), SetType.SUPPLEMENTAL);
-        this.blockName = "Battlebond";
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/BattlebondPromos.java
+++ b/Mage.Sets/src/mage/sets/BattlebondPromos.java
@@ -17,6 +17,7 @@ public class BattlebondPromos extends ExpansionSet {
 
     private BattlebondPromos() {
         super("Battlebond Promos", "PBBD", ExpansionSet.buildDate(2018, 6, 9), SetType.PROMOTIONAL);
+        this.parentSet = Battlebond.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/BetrayersOfKamigawa.java
+++ b/Mage.Sets/src/mage/sets/BetrayersOfKamigawa.java
@@ -20,7 +20,6 @@ public final class BetrayersOfKamigawa extends ExpansionSet {
     private BetrayersOfKamigawa() {
         super("Betrayers of Kamigawa", "BOK", ExpansionSet.buildDate(2005, 1, 4), SetType.EXPANSION);
         this.blockName = "Kamigawa";
-        this.parentSet = ChampionsOfKamigawa.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/BornOfTheGods.java
+++ b/Mage.Sets/src/mage/sets/BornOfTheGods.java
@@ -26,7 +26,6 @@ public final class BornOfTheGods extends ExpansionSet {
     private BornOfTheGods() {
         super("Born of the Gods", "BNG", ExpansionSet.buildDate(2014, 2, 7), SetType.EXPANSION);
         this.blockName = "Theros";
-        this.parentSet = Theros.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/BornOfTheGodsPromos.java
+++ b/Mage.Sets/src/mage/sets/BornOfTheGodsPromos.java
@@ -17,6 +17,7 @@ public class BornOfTheGodsPromos extends ExpansionSet {
 
     private BornOfTheGodsPromos() {
         super("Born of the Gods Promos", "PBNG", ExpansionSet.buildDate(2014, 2, 1), SetType.PROMOTIONAL);
+        this.blockName = "Theros";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/BornOfTheGodsPromos.java
+++ b/Mage.Sets/src/mage/sets/BornOfTheGodsPromos.java
@@ -18,6 +18,7 @@ public class BornOfTheGodsPromos extends ExpansionSet {
     private BornOfTheGodsPromos() {
         super("Born of the Gods Promos", "PBNG", ExpansionSet.buildDate(2014, 2, 1), SetType.PROMOTIONAL);
         this.blockName = "Theros";
+        this.parentSet = BornOfTheGods.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Chronicles.java
+++ b/Mage.Sets/src/mage/sets/Chronicles.java
@@ -17,7 +17,6 @@ public final class Chronicles extends ExpansionSet {
 
     private Chronicles() {
         super("Chronicles", "CHR", ExpansionSet.buildDate(1995, 6, 1), SetType.SUPPLEMENTAL);
-        this.blockName = "Reprint";
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/ClassicSixthEdition.java
+++ b/Mage.Sets/src/mage/sets/ClassicSixthEdition.java
@@ -17,6 +17,7 @@ public final class ClassicSixthEdition extends ExpansionSet {
 
     private ClassicSixthEdition() {
         super("Classic Sixth Edition", "6ED", ExpansionSet.buildDate(1999, 3, 28), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;

--- a/Mage.Sets/src/mage/sets/Coldsnap.java
+++ b/Mage.Sets/src/mage/sets/Coldsnap.java
@@ -29,7 +29,6 @@ public final class Coldsnap extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
-        this.parentSet = IceAge.getInstance();
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Adarkar Valkyrie", 1, Rarity.RARE, mage.cards.a.AdarkarValkyrie.class));

--- a/Mage.Sets/src/mage/sets/ColdsnapThemeDecks.java
+++ b/Mage.Sets/src/mage/sets/ColdsnapThemeDecks.java
@@ -18,6 +18,7 @@ public class ColdsnapThemeDecks extends ExpansionSet {
     private ColdsnapThemeDecks() {
         super("Coldsnap Theme Decks", "CST", ExpansionSet.buildDate(2006, 7, 21), SetType.SUPPLEMENTAL);
         this.blockName = "Ice Age";
+        this.parentSet = Coldsnap.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/ColdsnapThemeDecks.java
+++ b/Mage.Sets/src/mage/sets/ColdsnapThemeDecks.java
@@ -17,6 +17,7 @@ public class ColdsnapThemeDecks extends ExpansionSet {
 
     private ColdsnapThemeDecks() {
         super("Coldsnap Theme Decks", "CST", ExpansionSet.buildDate(2006, 7, 21), SetType.SUPPLEMENTAL);
+        this.blockName = "Ice Age";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/Commander.java
+++ b/Mage.Sets/src/mage/sets/Commander.java
@@ -19,7 +19,8 @@ public final class Commander extends ExpansionSet {
 
     private Commander() {
         super("Commander", "CMD", ExpansionSet.buildDate(2011, 6, 17), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
+
         cards.add(new SetCardInfo("Acidic Slime", 140, Rarity.UNCOMMON, mage.cards.a.AcidicSlime.class));
         cards.add(new SetCardInfo("Acorn Catapult", 241, Rarity.RARE, mage.cards.a.AcornCatapult.class));
         cards.add(new SetCardInfo("Aethersnipe", 39, Rarity.COMMON, mage.cards.a.Aethersnipe.class));

--- a/Mage.Sets/src/mage/sets/Commander2011LaunchParty.java
+++ b/Mage.Sets/src/mage/sets/Commander2011LaunchParty.java
@@ -17,6 +17,7 @@ public class Commander2011LaunchParty extends ExpansionSet {
 
     private Commander2011LaunchParty() {
         super("Commander 2011 Launch Party", "PCMD", ExpansionSet.buildDate(2011, 6, 17), SetType.PROMOTIONAL);
+        this.blockName = "Commander";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Commander2011LaunchParty.java
+++ b/Mage.Sets/src/mage/sets/Commander2011LaunchParty.java
@@ -18,6 +18,7 @@ public class Commander2011LaunchParty extends ExpansionSet {
     private Commander2011LaunchParty() {
         super("Commander 2011 Launch Party", "PCMD", ExpansionSet.buildDate(2011, 6, 17), SetType.PROMOTIONAL);
         this.blockName = "Commander";
+        this.parentSet = Commander.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Commander2013Edition.java
+++ b/Mage.Sets/src/mage/sets/Commander2013Edition.java
@@ -17,7 +17,7 @@ public final class Commander2013Edition extends ExpansionSet {
 
     private Commander2013Edition() {
         super("Commander 2013 Edition", "C13", ExpansionSet.buildDate(2013, 11, 1), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
 
         cards.add(new SetCardInfo("Acidic Slime", 134, Rarity.UNCOMMON, mage.cards.a.AcidicSlime.class));
         cards.add(new SetCardInfo("Act of Authority", 1, Rarity.RARE, mage.cards.a.ActOfAuthority.class));

--- a/Mage.Sets/src/mage/sets/Commander2014Edition.java
+++ b/Mage.Sets/src/mage/sets/Commander2014Edition.java
@@ -19,7 +19,8 @@ public final class Commander2014Edition extends ExpansionSet {
 
     private Commander2014Edition() {
         super("Commander 2014 Edition", "C14", ExpansionSet.buildDate(2014, 11, 7), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
+
         cards.add(new SetCardInfo("Abyssal Persecutor", 132, Rarity.MYTHIC, mage.cards.a.AbyssalPersecutor.class));
         cards.add(new SetCardInfo("Adarkar Valkyrie", 63, Rarity.RARE, mage.cards.a.AdarkarValkyrie.class));
         cards.add(new SetCardInfo("Aether Gale", 11, Rarity.RARE, mage.cards.a.AetherGale.class));

--- a/Mage.Sets/src/mage/sets/Commander2015Edition.java
+++ b/Mage.Sets/src/mage/sets/Commander2015Edition.java
@@ -19,7 +19,8 @@ public final class Commander2015Edition extends ExpansionSet {
 
     private Commander2015Edition() {
         super("Commander 2015 Edition", "C15", ExpansionSet.buildDate(2015, 11, 13), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
+
         cards.add(new SetCardInfo("Acidic Slime", 173, Rarity.UNCOMMON, mage.cards.a.AcidicSlime.class));
         cards.add(new SetCardInfo("Act of Aggression", 141, Rarity.UNCOMMON, mage.cards.a.ActOfAggression.class));
         cards.add(new SetCardInfo("Aetherize", 85, Rarity.UNCOMMON, mage.cards.a.Aetherize.class));

--- a/Mage.Sets/src/mage/sets/Commander2016Edition.java
+++ b/Mage.Sets/src/mage/sets/Commander2016Edition.java
@@ -19,7 +19,8 @@ public final class Commander2016Edition extends ExpansionSet {
 
     private Commander2016Edition() {
         super("Commander 2016 Edition", "C16", ExpansionSet.buildDate(2016, 11, 11), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
+
         cards.add(new SetCardInfo("Abzan Charm", 177, Rarity.UNCOMMON, mage.cards.a.AbzanCharm.class));
         cards.add(new SetCardInfo("Abzan Falconer", 57, Rarity.UNCOMMON, mage.cards.a.AbzanFalconer.class));
         cards.add(new SetCardInfo("Academy Elite", 81, Rarity.RARE, mage.cards.a.AcademyElite.class));

--- a/Mage.Sets/src/mage/sets/Commander2017Edition.java
+++ b/Mage.Sets/src/mage/sets/Commander2017Edition.java
@@ -17,7 +17,7 @@ public final class Commander2017Edition extends ExpansionSet {
 
     private Commander2017Edition() {
         super("Commander 2017 Edition", "C17", ExpansionSet.buildDate(2017, 8, 25), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
 
         cards.add(new SetCardInfo("Abundance", 145, Rarity.RARE, mage.cards.a.Abundance.class));
         cards.add(new SetCardInfo("Akoum Refuge", 233, Rarity.UNCOMMON, mage.cards.a.AkoumRefuge.class));

--- a/Mage.Sets/src/mage/sets/Commander2018Edition.java
+++ b/Mage.Sets/src/mage/sets/Commander2018Edition.java
@@ -17,7 +17,7 @@ public final class Commander2018Edition extends ExpansionSet {
 
     private Commander2018Edition() {
         super("Commander 2018 Edition", "C18", ExpansionSet.buildDate(2018, 8, 10), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
 
         cards.add(new SetCardInfo("Acidic Slime", 127, Rarity.UNCOMMON, mage.cards.a.AcidicSlime.class));
         cards.add(new SetCardInfo("Adarkar Valkyrie", 60, Rarity.RARE, mage.cards.a.AdarkarValkyrie.class));

--- a/Mage.Sets/src/mage/sets/Commander2019Edition.java
+++ b/Mage.Sets/src/mage/sets/Commander2019Edition.java
@@ -17,7 +17,7 @@ public final class Commander2019Edition extends ExpansionSet {
 
     private Commander2019Edition() {
         super("Commander 2019 Edition", "C19", ExpansionSet.buildDate(2019, 8, 23), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
 
         cards.add(new SetCardInfo("Ainok Survivalist", 156, Rarity.COMMON, mage.cards.a.AinokSurvivalist.class));
         cards.add(new SetCardInfo("Aeon Engine", 52, Rarity.RARE, mage.cards.a.AeonEngine.class));

--- a/Mage.Sets/src/mage/sets/Commander2020Edition.java
+++ b/Mage.Sets/src/mage/sets/Commander2020Edition.java
@@ -27,7 +27,7 @@ public final class Commander2020Edition extends ExpansionSet {
 
     private Commander2020Edition() {
         super("Commander 2020 Edition", "C20", ExpansionSet.buildDate(2020, 4, 24), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abandoned Sarcophagus", 236, Rarity.RARE, mage.cards.a.AbandonedSarcophagus.class));

--- a/Mage.Sets/src/mage/sets/Commander2021Edition.java
+++ b/Mage.Sets/src/mage/sets/Commander2021Edition.java
@@ -17,7 +17,7 @@ public final class Commander2021Edition extends ExpansionSet {
 
     private Commander2021Edition() {
         super("Commander 2021 Edition", "C21", ExpansionSet.buildDate(2021, 4, 23), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Adrix and Nev, Twincasters", 336, Rarity.MYTHIC, mage.cards.a.AdrixAndNevTwincasters.class, NON_FULL_USE_VARIOUS));

--- a/Mage.Sets/src/mage/sets/CommanderAnthology.java
+++ b/Mage.Sets/src/mage/sets/CommanderAnthology.java
@@ -17,7 +17,7 @@ public final class CommanderAnthology extends ExpansionSet {
 
     private CommanderAnthology() {
         super("Commander Anthology", "CMA", ExpansionSet.buildDate(2017, 6, 9), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Acidic Slime", 90, Rarity.UNCOMMON, mage.cards.a.AcidicSlime.class));

--- a/Mage.Sets/src/mage/sets/CommanderAnthologyVolumeII.java
+++ b/Mage.Sets/src/mage/sets/CommanderAnthologyVolumeII.java
@@ -17,7 +17,7 @@ public class CommanderAnthologyVolumeII extends ExpansionSet {
 
     private CommanderAnthologyVolumeII() {
         super("Commander Anthology Volume II", "CM2", ExpansionSet.buildDate(2018, 6, 8), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Abzan Falconer", 15, Rarity.UNCOMMON, mage.cards.a.AbzanFalconer.class));

--- a/Mage.Sets/src/mage/sets/CommanderLegends.java
+++ b/Mage.Sets/src/mage/sets/CommanderLegends.java
@@ -17,7 +17,6 @@ public final class CommanderLegends extends ExpansionSet {
 
     private CommanderLegends() {
         super("Commander Legends", "CMR", ExpansionSet.buildDate(2020, 11, 1), SetType.SUPPLEMENTAL);
-        this.blockName = "Commander Legends";
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/CommanderLegendsBattleForBaldursGate.java
+++ b/Mage.Sets/src/mage/sets/CommanderLegendsBattleForBaldursGate.java
@@ -17,7 +17,6 @@ public final class CommanderLegendsBattleForBaldursGate extends ExpansionSet {
 
     private CommanderLegendsBattleForBaldursGate() {
         super("Commander Legends: Battle for Baldur's Gate", "CLB", ExpansionSet.buildDate(2022, 6, 10), SetType.SUPPLEMENTAL);
-        this.blockName = "Commander Legends";
         this.hasBasicLands = true;
         this.hasBoosters = false; // temporary
 

--- a/Mage.Sets/src/mage/sets/CommanderMasters.java
+++ b/Mage.Sets/src/mage/sets/CommanderMasters.java
@@ -14,7 +14,6 @@ public final class CommanderMasters extends ExpansionSet {
 
     private CommanderMasters() {
         super("Commander Masters", "CMM", ExpansionSet.buildDate(2023, 8, 4), SetType.SUPPLEMENTAL);
-        this.blockName = "Commander Masters";
         this.hasBasicLands = true;
         this.hasBoosters = false; //temporary
 

--- a/Mage.Sets/src/mage/sets/CommandersArsenal.java
+++ b/Mage.Sets/src/mage/sets/CommandersArsenal.java
@@ -18,7 +18,7 @@ public final class CommandersArsenal extends ExpansionSet {
 
     private CommandersArsenal() {
         super("Commander's Arsenal", "CM1", ExpansionSet.buildDate(2012, 11, 2), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Chaos Warp", 1, Rarity.RARE, mage.cards.c.ChaosWarp.class));

--- a/Mage.Sets/src/mage/sets/Conflux.java
+++ b/Mage.Sets/src/mage/sets/Conflux.java
@@ -19,7 +19,7 @@ public final class Conflux extends ExpansionSet {
 
     private Conflux() {
         super("Conflux", "CON", ExpansionSet.buildDate(2009, 0, 31), SetType.EXPANSION);
-        this.blockName = "Shards of Alara";
+        this.blockName = "Alara";
         this.parentSet = ShardsOfAlara.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;

--- a/Mage.Sets/src/mage/sets/Conflux.java
+++ b/Mage.Sets/src/mage/sets/Conflux.java
@@ -20,7 +20,6 @@ public final class Conflux extends ExpansionSet {
     private Conflux() {
         super("Conflux", "CON", ExpansionSet.buildDate(2009, 0, 31), SetType.EXPANSION);
         this.blockName = "Alara";
-        this.parentSet = ShardsOfAlara.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/CoreSet2019.java
+++ b/Mage.Sets/src/mage/sets/CoreSet2019.java
@@ -24,6 +24,7 @@ public final class CoreSet2019 extends ExpansionSet {
 
     private CoreSet2019() {
         super("Core Set 2019", "M19", ExpansionSet.buildDate(2018, 7, 13), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.hasBasicLands = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/CoreSet2019Promos.java
+++ b/Mage.Sets/src/mage/sets/CoreSet2019Promos.java
@@ -17,6 +17,7 @@ public class CoreSet2019Promos extends ExpansionSet {
 
     private CoreSet2019Promos() {
         super("Core Set 2019 Promos", "PM19", ExpansionSet.buildDate(2018, 7, 13), SetType.PROMOTIONAL);
+        this.parentSet = CoreSet2019.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/CoreSet2020.java
+++ b/Mage.Sets/src/mage/sets/CoreSet2020.java
@@ -24,6 +24,7 @@ public final class CoreSet2020 extends ExpansionSet {
 
     private CoreSet2020() {
         super("Core Set 2020", "M20", ExpansionSet.buildDate(2019, 7, 12), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.hasBasicLands = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/CoreSet2020Promos.java
+++ b/Mage.Sets/src/mage/sets/CoreSet2020Promos.java
@@ -17,6 +17,7 @@ public final class CoreSet2020Promos extends ExpansionSet {
 
     private CoreSet2020Promos() {
         super("Core Set 2020 Promos", "PM20", ExpansionSet.buildDate(2019, 7, 12), SetType.PROMOTIONAL);
+        this.parentSet = CoreSet2020.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/CoreSet2021.java
+++ b/Mage.Sets/src/mage/sets/CoreSet2021.java
@@ -25,6 +25,7 @@ public final class CoreSet2021 extends ExpansionSet {
 
     private CoreSet2021() {
         super("Core Set 2021", "M21", ExpansionSet.buildDate(2020, 7, 3), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.hasBasicLands = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/CrimsonVowCommander.java
+++ b/Mage.Sets/src/mage/sets/CrimsonVowCommander.java
@@ -18,6 +18,7 @@ public final class CrimsonVowCommander extends ExpansionSet {
     private CrimsonVowCommander() {
         super("Crimson Vow Commander", "VOC", ExpansionSet.buildDate(2021, 11, 19), SetType.SUPPLEMENTAL);
         this.blockName = "Commander";
+        this.parentSet = InnistradCrimsonVow.getInstance();
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Ancient Craving", 117, Rarity.UNCOMMON, mage.cards.a.AncientCraving.class));

--- a/Mage.Sets/src/mage/sets/CrimsonVowCommander.java
+++ b/Mage.Sets/src/mage/sets/CrimsonVowCommander.java
@@ -17,6 +17,7 @@ public final class CrimsonVowCommander extends ExpansionSet {
 
     private CrimsonVowCommander() {
         super("Crimson Vow Commander", "VOC", ExpansionSet.buildDate(2021, 11, 19), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Ancient Craving", 117, Rarity.UNCOMMON, mage.cards.a.AncientCraving.class));

--- a/Mage.Sets/src/mage/sets/DarkAscension.java
+++ b/Mage.Sets/src/mage/sets/DarkAscension.java
@@ -38,8 +38,8 @@ public final class DarkAscension extends ExpansionSet {
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
         this.numBoosterDoubleFaced = 1;
-        this.parentSet = Innistrad.getInstance();
         this.hasBasicLands = false;
+
         cards.add(new SetCardInfo("Afflicted Deserter", 81, Rarity.UNCOMMON, mage.cards.a.AfflictedDeserter.class));
         cards.add(new SetCardInfo("Alpha Brawl", 82, Rarity.RARE, mage.cards.a.AlphaBrawl.class));
         cards.add(new SetCardInfo("Altar of the Lost", 144, Rarity.UNCOMMON, mage.cards.a.AltarOfTheLost.class));

--- a/Mage.Sets/src/mage/sets/DarkAscensionPromos.java
+++ b/Mage.Sets/src/mage/sets/DarkAscensionPromos.java
@@ -17,6 +17,7 @@ public class DarkAscensionPromos extends ExpansionSet {
 
     private DarkAscensionPromos() {
         super("Dark Ascension Promos", "PDKA", ExpansionSet.buildDate(2012, 1, 28), SetType.PROMOTIONAL);
+        this.blockName = "Innistrad";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/DarkAscensionPromos.java
+++ b/Mage.Sets/src/mage/sets/DarkAscensionPromos.java
@@ -18,6 +18,7 @@ public class DarkAscensionPromos extends ExpansionSet {
     private DarkAscensionPromos() {
         super("Dark Ascension Promos", "PDKA", ExpansionSet.buildDate(2012, 1, 28), SetType.PROMOTIONAL);
         this.blockName = "Innistrad";
+        this.parentSet = DarkAscension.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Darksteel.java
+++ b/Mage.Sets/src/mage/sets/Darksteel.java
@@ -15,7 +15,6 @@ public final class Darksteel extends ExpansionSet {
     public Darksteel() {
         super("Darksteel", "DST", ExpansionSet.buildDate(2004, 1, 6), SetType.EXPANSION);
         this.blockName = "Mirrodin";
-        this.parentSet = Mirrodin.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -23,6 +22,7 @@ public final class Darksteel extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Aether Snap", 37, Rarity.RARE, mage.cards.a.AetherSnap.class));
         cards.add(new SetCardInfo("Aether Vial", 91, Rarity.UNCOMMON, mage.cards.a.AetherVial.class));
         cards.add(new SetCardInfo("Ageless Entity", 73, Rarity.RARE, mage.cards.a.AgelessEntity.class));

--- a/Mage.Sets/src/mage/sets/Dissension.java
+++ b/Mage.Sets/src/mage/sets/Dissension.java
@@ -19,7 +19,6 @@ public final class Dissension extends ExpansionSet {
     private Dissension() {
         super("Dissension", "DIS", ExpansionSet.buildDate(2006, 4, 5), SetType.EXPANSION);
         this.blockName = "Ravnica";
-        this.parentSet = RavnicaCityOfGuilds.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -27,6 +26,7 @@ public final class Dissension extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Aethermage's Touch", 101, Rarity.RARE, mage.cards.a.AethermagesTouch.class));
         cards.add(new SetCardInfo("Anthem of Rakdos", 102, Rarity.RARE, mage.cards.a.AnthemOfRakdos.class));
         cards.add(new SetCardInfo("Aquastrand Spider", 80, Rarity.COMMON, mage.cards.a.AquastrandSpider.class));

--- a/Mage.Sets/src/mage/sets/Dominaria.java
+++ b/Mage.Sets/src/mage/sets/Dominaria.java
@@ -31,7 +31,6 @@ public final class Dominaria extends ExpansionSet {
 
     private Dominaria() {
         super("Dominaria", "DOM", ExpansionSet.buildDate(2018, 4, 27), SetType.EXPANSION);
-        this.blockName = "Dominaria";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/DominariaPromos.java
+++ b/Mage.Sets/src/mage/sets/DominariaPromos.java
@@ -17,6 +17,7 @@ public class DominariaPromos extends ExpansionSet {
 
     private DominariaPromos() {
         super("Dominaria Promos", "PDOM", ExpansionSet.buildDate(2018, 4, 27), SetType.PROMOTIONAL);
+        this.parentSet = Dominaria.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/DominariaUnited.java
+++ b/Mage.Sets/src/mage/sets/DominariaUnited.java
@@ -29,7 +29,6 @@ public final class DominariaUnited extends ExpansionSet {
 
     private DominariaUnited() {
         super("Dominaria United", "DMU", ExpansionSet.buildDate(2022, 9, 9), SetType.EXPANSION);
-        this.blockName = "Dominaria United";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/DominariaUnitedCommander.java
+++ b/Mage.Sets/src/mage/sets/DominariaUnitedCommander.java
@@ -18,6 +18,7 @@ public final class DominariaUnitedCommander extends ExpansionSet {
     private DominariaUnitedCommander() {
         super("Dominaria United Commander", "DMC", ExpansionSet.buildDate(2022, 9, 9), SetType.SUPPLEMENTAL);
         this.blockName = "Commander";
+        this.parentSet = DominariaUnited.getInstance();
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abundant Growth", 128, Rarity.COMMON, mage.cards.a.AbundantGrowth.class));

--- a/Mage.Sets/src/mage/sets/DominariaUnitedCommander.java
+++ b/Mage.Sets/src/mage/sets/DominariaUnitedCommander.java
@@ -17,6 +17,7 @@ public final class DominariaUnitedCommander extends ExpansionSet {
 
     private DominariaUnitedCommander() {
         super("Dominaria United Commander", "DMC", ExpansionSet.buildDate(2022, 9, 9), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abundant Growth", 128, Rarity.COMMON, mage.cards.a.AbundantGrowth.class));

--- a/Mage.Sets/src/mage/sets/DoubleMasters.java
+++ b/Mage.Sets/src/mage/sets/DoubleMasters.java
@@ -24,7 +24,6 @@ public final class DoubleMasters extends ExpansionSet {
 
     private DoubleMasters() {
         super("Double Masters", "2XM", ExpansionSet.buildDate(2020, 8, 7), SetType.SUPPLEMENTAL);
-        this.blockName = "Reprint";
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/DoubleMasters2022.java
+++ b/Mage.Sets/src/mage/sets/DoubleMasters2022.java
@@ -17,7 +17,6 @@ public final class DoubleMasters2022 extends ExpansionSet {
 
     private DoubleMasters2022() {
         super("Double Masters 2022", "2X2", ExpansionSet.buildDate(2020, 7, 8), SetType.SUPPLEMENTAL);
-        this.blockName = "Reprint";
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/DragonsMaze.java
+++ b/Mage.Sets/src/mage/sets/DragonsMaze.java
@@ -38,8 +38,8 @@ public final class DragonsMaze extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
-        this.parentSet = ReturnToRavnica.getInstance();
         this.hasBasicLands = false;
+
         cards.add(new SetCardInfo("Advent of the Wurm", 51, Rarity.RARE, mage.cards.a.AdventOfTheWurm.class));
         cards.add(new SetCardInfo("Aetherling", 11, Rarity.RARE, mage.cards.a.Aetherling.class));
         cards.add(new SetCardInfo("Alive // Well", 121, Rarity.UNCOMMON, mage.cards.a.AliveWell.class));

--- a/Mage.Sets/src/mage/sets/DragonsMazePromos.java
+++ b/Mage.Sets/src/mage/sets/DragonsMazePromos.java
@@ -18,6 +18,7 @@ public class DragonsMazePromos extends ExpansionSet {
     private DragonsMazePromos() {
         super("Dragon's Maze Promos", "PDGM", ExpansionSet.buildDate(2013, 4, 27), SetType.PROMOTIONAL);
         this.blockName = "Return to Ravnica";
+        this.parentSet = DragonsMaze.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/DragonsMazePromos.java
+++ b/Mage.Sets/src/mage/sets/DragonsMazePromos.java
@@ -17,6 +17,7 @@ public class DragonsMazePromos extends ExpansionSet {
 
     private DragonsMazePromos() {
         super("Dragon's Maze Promos", "PDGM", ExpansionSet.buildDate(2013, 4, 27), SetType.PROMOTIONAL);
+        this.blockName = "Return to Ravnica";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/DragonsOfTarkirPromos.java
+++ b/Mage.Sets/src/mage/sets/DragonsOfTarkirPromos.java
@@ -17,6 +17,7 @@ public class DragonsOfTarkirPromos extends ExpansionSet {
 
     private DragonsOfTarkirPromos() {
         super("Dragons of Tarkir Promos", "PDTK", ExpansionSet.buildDate(2015, 3, 28), SetType.PROMOTIONAL);
+        this.blockName = "Khans of Tarkir";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/DragonsOfTarkirPromos.java
+++ b/Mage.Sets/src/mage/sets/DragonsOfTarkirPromos.java
@@ -18,6 +18,7 @@ public class DragonsOfTarkirPromos extends ExpansionSet {
     private DragonsOfTarkirPromos() {
         super("Dragons of Tarkir Promos", "PDTK", ExpansionSet.buildDate(2015, 3, 28), SetType.PROMOTIONAL);
         this.blockName = "Khans of Tarkir";
+        this.parentSet = DragonsOfTarkir.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/DuelDecksAjaniVsNicolBolas.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksAjaniVsNicolBolas.java
@@ -18,7 +18,6 @@ public final class DuelDecksAjaniVsNicolBolas extends ExpansionSet {
 
     private DuelDecksAjaniVsNicolBolas() {
         super("Duel Decks: Ajani vs. Nicol Bolas", "DDH", ExpansionSet.buildDate(2011, 9, 2), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Ageless Entity", 18, Rarity.RARE, mage.cards.a.AgelessEntity.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksAnthologyDivineVsDemonic.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksAnthologyDivineVsDemonic.java
@@ -17,7 +17,6 @@ public final class DuelDecksAnthologyDivineVsDemonic extends ExpansionSet {
 
     private DuelDecksAnthologyDivineVsDemonic() {
         super("Duel Decks: Anthology, Divine vs. Demonic", "DVD", ExpansionSet.buildDate(2014, 12, 5), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks: Anthology";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Abyssal Gatekeeper", 31, Rarity.COMMON, mage.cards.a.AbyssalGatekeeper.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksAnthologyElvesVsGoblins.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksAnthologyElvesVsGoblins.java
@@ -18,7 +18,6 @@ public final class DuelDecksAnthologyElvesVsGoblins extends ExpansionSet {
     private DuelDecksAnthologyElvesVsGoblins() {
         super("Duel Decks: Anthology, Elves vs. Goblins", "EVG", ExpansionSet.buildDate(2014, 12, 5),
                 SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks: Anthology";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Akki Coalflinger", 33, Rarity.UNCOMMON, mage.cards.a.AkkiCoalflinger.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksAnthologyGarrukVsLiliana.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksAnthologyGarrukVsLiliana.java
@@ -19,7 +19,6 @@ public final class DuelDecksAnthologyGarrukVsLiliana extends ExpansionSet {
     private DuelDecksAnthologyGarrukVsLiliana() {
         super("Duel Decks: Anthology, Garruk vs. Liliana", "GVL", ExpansionSet.buildDate(2014, 12, 5),
                 SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks: Anthology";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Albino Troll", 3, Rarity.UNCOMMON, mage.cards.a.AlbinoTroll.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksAnthologyJaceVsChandra.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksAnthologyJaceVsChandra.java
@@ -19,7 +19,6 @@ public final class DuelDecksAnthologyJaceVsChandra extends ExpansionSet {
     private DuelDecksAnthologyJaceVsChandra() {
         super("Duel Decks: Anthology, Jace vs. Chandra", "JVC", ExpansionSet.buildDate(2014, 12, 5),
                 SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks: Anthology";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Aethersnipe", 17, Rarity.COMMON, mage.cards.a.Aethersnipe.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksBlessedVsCursed.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksBlessedVsCursed.java
@@ -18,7 +18,6 @@ public final class DuelDecksBlessedVsCursed extends ExpansionSet {
 
     private DuelDecksBlessedVsCursed() {
         super("Duel Decks: Blessed vs. Cursed", "DDQ", ExpansionSet.buildDate(2016, 2, 26), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Abattoir Ghoul", 50, Rarity.UNCOMMON, mage.cards.a.AbattoirGhoul.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksDivineVsDemonic.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksDivineVsDemonic.java
@@ -17,7 +17,6 @@ public final class DuelDecksDivineVsDemonic extends ExpansionSet {
 
     private DuelDecksDivineVsDemonic() {
         super("Duel Decks: Divine vs. Demonic", "DDC", ExpansionSet.buildDate(2009, 4, 10), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Abyssal Gatekeeper", 31, Rarity.COMMON, mage.cards.a.AbyssalGatekeeper.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksElspethVsKiora.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksElspethVsKiora.java
@@ -18,7 +18,6 @@ public final class DuelDecksElspethVsKiora extends ExpansionSet {
 
     private DuelDecksElspethVsKiora() {
         super("Duel Decks: Elspeth vs. Kiora", "DDO", ExpansionSet.buildDate(2015, 2, 27), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Accumulated Knowledge", 35, Rarity.COMMON, mage.cards.a.AccumulatedKnowledge.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksElspethVsTezzeret.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksElspethVsTezzeret.java
@@ -14,7 +14,6 @@ public final class DuelDecksElspethVsTezzeret extends ExpansionSet {
 
     private DuelDecksElspethVsTezzeret() {
         super("Duel Decks: Elspeth vs. Tezzeret", "DDF", ExpansionSet.buildDate(2010, 8, 3), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Abolish", 29, Rarity.UNCOMMON, mage.cards.a.Abolish.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksElvesVsGoblins.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksElvesVsGoblins.java
@@ -17,7 +17,6 @@ public final class DuelDecksElvesVsGoblins extends ExpansionSet {
 
     private DuelDecksElvesVsGoblins() {
         super("Duel Decks: Elves vs. Goblins", "DD1", ExpansionSet.buildDate(2007, 11, 16), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Akki Coalflinger", 33, Rarity.UNCOMMON, mage.cards.a.AkkiCoalflinger.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksElvesVsInventors.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksElvesVsInventors.java
@@ -18,7 +18,6 @@ public final class DuelDecksElvesVsInventors extends ExpansionSet {
 
     private DuelDecksElvesVsInventors() {
         super("Duel Decks: Elves vs. Inventors", "DDU", ExpansionSet.buildDate(2018, 4, 6), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
 
         cards.add(new SetCardInfo("Artificer's Epiphany", 36, Rarity.COMMON, mage.cards.a.ArtificersEpiphany.class));
         cards.add(new SetCardInfo("Barrage Ogre", 44, Rarity.UNCOMMON, mage.cards.b.BarrageOgre.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksGarrukVsLiliana.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksGarrukVsLiliana.java
@@ -17,7 +17,6 @@ public final class DuelDecksGarrukVsLiliana extends ExpansionSet {
 
     private DuelDecksGarrukVsLiliana() {
         super("Duel Decks: Garruk vs. Liliana", "DDD", ExpansionSet.buildDate(2009, 10, 30), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Albino Troll", 3, Rarity.UNCOMMON, mage.cards.a.AlbinoTroll.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksHeroesVsMonsters.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksHeroesVsMonsters.java
@@ -18,7 +18,6 @@ public final class DuelDecksHeroesVsMonsters extends ExpansionSet {
 
     private DuelDecksHeroesVsMonsters() {
         super("Duel Decks: Heroes vs. Monsters", "DDL", ExpansionSet.buildDate(2013, 9, 6), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Anax and Cymede", 11, Rarity.RARE, mage.cards.a.AnaxAndCymede.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksIzzetVsGolgari.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksIzzetVsGolgari.java
@@ -18,7 +18,6 @@ public final class DuelDecksIzzetVsGolgari extends ExpansionSet {
 
     private DuelDecksIzzetVsGolgari() {
         super("Duel Decks: Izzet vs. Golgari", "DDJ", ExpansionSet.buildDate(2012, 9, 7), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Barren Moor", 78, Rarity.COMMON, mage.cards.b.BarrenMoor.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksJaceVsChandra.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksJaceVsChandra.java
@@ -17,7 +17,6 @@ public final class DuelDecksJaceVsChandra extends ExpansionSet {
 
     private DuelDecksJaceVsChandra() {
         super("Duel Decks: Jace vs. Chandra", "DD2", ExpansionSet.buildDate(2008, 11, 7), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Aethersnipe", 17, Rarity.COMMON, mage.cards.a.Aethersnipe.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksJaceVsVraska.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksJaceVsVraska.java
@@ -18,7 +18,6 @@ public final class DuelDecksJaceVsVraska extends ExpansionSet {
 
     private DuelDecksJaceVsVraska() {
         super("Duel Decks: Jace vs. Vraska", "DDM", ExpansionSet.buildDate(2014, 3, 14), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Acidic Slime", 64, Rarity.UNCOMMON, mage.cards.a.AcidicSlime.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksKnightsVsDragons.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksKnightsVsDragons.java
@@ -18,7 +18,6 @@ public final class DuelDecksKnightsVsDragons extends ExpansionSet {
 
     private DuelDecksKnightsVsDragons() {
         super("Duel Decks: Knights vs. Dragons", "DDG", ExpansionSet.buildDate(2011, 4, 1), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Alaborn Cavalier", 18, Rarity.UNCOMMON, mage.cards.a.AlabornCavalier.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksMerfolkVsGoblins.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksMerfolkVsGoblins.java
@@ -18,7 +18,6 @@ public final class DuelDecksMerfolkVsGoblins extends ExpansionSet {
 
     private DuelDecksMerfolkVsGoblins() {
         super("Duel Decks: Merfolk vs. Goblins", "DDT", ExpansionSet.buildDate(2017, 11, 10), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Aquitect's Will", 2, Rarity.COMMON, mage.cards.a.AquitectsWill.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksMindVsMight.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksMindVsMight.java
@@ -17,7 +17,6 @@ public final class DuelDecksMindVsMight extends ExpansionSet {
 
     private DuelDecksMindVsMight() {
         super("Duel Decks: Mind vs. Might", "DDS", ExpansionSet.buildDate(2017, 3, 31), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Ambassador Oak", 42, Rarity.COMMON, mage.cards.a.AmbassadorOak.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksNissaVsObNixilis.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksNissaVsObNixilis.java
@@ -17,7 +17,6 @@ public final class DuelDecksNissaVsObNixilis extends ExpansionSet {
 
     private DuelDecksNissaVsObNixilis() {
         super("Duel Decks: Nissa vs. Ob Nixilis", "DDR", ExpansionSet.buildDate(2016, 9, 2), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Abundance", 2, Rarity.RARE, mage.cards.a.Abundance.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksPhyrexiaVsTheCoalition.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksPhyrexiaVsTheCoalition.java
@@ -19,7 +19,6 @@ public final class DuelDecksPhyrexiaVsTheCoalition extends ExpansionSet {
     private DuelDecksPhyrexiaVsTheCoalition() {
         super("Duel Decks: Phyrexia vs. the Coalition", "DDE", ExpansionSet.buildDate(2010, 3, 19),
                 SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Allied Strategies", 63, Rarity.UNCOMMON, mage.cards.a.AlliedStrategies.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksSorinVsTibalt.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksSorinVsTibalt.java
@@ -18,7 +18,6 @@ public final class DuelDecksSorinVsTibalt extends ExpansionSet {
 
     private DuelDecksSorinVsTibalt() {
         super("Duel Decks: Sorin vs. Tibalt", "DDK", ExpansionSet.buildDate(2013, 3, 15), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Absorb Vis", 31, Rarity.COMMON, mage.cards.a.AbsorbVis.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksSpeedVsCunning.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksSpeedVsCunning.java
@@ -18,7 +18,6 @@ public final class DuelDecksSpeedVsCunning extends ExpansionSet {
 
     private DuelDecksSpeedVsCunning() {
         super("Duel Decks: Speed vs. Cunning", "DDN", ExpansionSet.buildDate(2014, 9, 5), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Act of Treason", 26, Rarity.COMMON, mage.cards.a.ActOfTreason.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksVenserVsKoth.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksVenserVsKoth.java
@@ -17,7 +17,6 @@ public final class DuelDecksVenserVsKoth extends ExpansionSet {
 
     private DuelDecksVenserVsKoth() {
         super("Duel Decks: Venser vs. Koth", "DDI", ExpansionSet.buildDate(2012, 3, 30), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Aether Membrane", 48, Rarity.UNCOMMON, mage.cards.a.AetherMembrane.class));

--- a/Mage.Sets/src/mage/sets/DuelDecksZendikarVsEldrazi.java
+++ b/Mage.Sets/src/mage/sets/DuelDecksZendikarVsEldrazi.java
@@ -17,7 +17,6 @@ public final class DuelDecksZendikarVsEldrazi extends ExpansionSet {
 
     private DuelDecksZendikarVsEldrazi() {
         super("Duel Decks: Zendikar vs. Eldrazi", "DDP", ExpansionSet.buildDate(2015, 8, 28), SetType.SUPPLEMENTAL);
-        this.blockName = "Duel Decks";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Affa Guard Hound", 2, Rarity.UNCOMMON, mage.cards.a.AffaGuardHound.class));

--- a/Mage.Sets/src/mage/sets/EighthEdition.java
+++ b/Mage.Sets/src/mage/sets/EighthEdition.java
@@ -17,6 +17,7 @@ public final class EighthEdition extends ExpansionSet {
 
     private EighthEdition() {
         super("Eighth Edition", "8ED", ExpansionSet.buildDate(2003, 7, 28), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/EldritchMoon.java
+++ b/Mage.Sets/src/mage/sets/EldritchMoon.java
@@ -30,7 +30,6 @@ public final class EldritchMoon extends ExpansionSet {
     private EldritchMoon() {
         super("Eldritch Moon", "EMN", ExpansionSet.buildDate(2016, 7, 22), SetType.EXPANSION);
         this.blockName = "Shadows over Innistrad";
-        this.parentSet = ShadowsOverInnistrad.getInstance();
         this.hasBoosters = true;
         this.hasBasicLands = false;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/EldritchMoonPromos.java
+++ b/Mage.Sets/src/mage/sets/EldritchMoonPromos.java
@@ -18,6 +18,7 @@ public class EldritchMoonPromos extends ExpansionSet {
     private EldritchMoonPromos() {
         super("Eldritch Moon Promos", "PEMN", ExpansionSet.buildDate(2016, 7, 22), SetType.PROMOTIONAL);
         this.blockName = "Shadows over Innistrad";
+        this.parentSet = EldritchMoon.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/EldritchMoonPromos.java
+++ b/Mage.Sets/src/mage/sets/EldritchMoonPromos.java
@@ -17,6 +17,7 @@ public class EldritchMoonPromos extends ExpansionSet {
 
     private EldritchMoonPromos() {
         super("Eldritch Moon Promos", "PEMN", ExpansionSet.buildDate(2016, 7, 22), SetType.PROMOTIONAL);
+        this.blockName = "Shadows over Innistrad";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/EternalMasters.java
+++ b/Mage.Sets/src/mage/sets/EternalMasters.java
@@ -24,7 +24,6 @@ public final class EternalMasters extends ExpansionSet {
 
     private EternalMasters() {
         super("Eternal Masters", "EMA", ExpansionSet.buildDate(2016, 6, 10), SetType.SUPPLEMENTAL);
-        this.blockName = "Reprint";
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/Eventide.java
+++ b/Mage.Sets/src/mage/sets/Eventide.java
@@ -15,7 +15,6 @@ public final class Eventide extends ExpansionSet {
     private Eventide() {
         super("Eventide", "EVE", ExpansionSet.buildDate(2008, 6, 25), SetType.EXPANSION);
         this.blockName = "Shadowmoor";
-        this.parentSet = Shadowmoor.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -23,6 +22,7 @@ public final class Eventide extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Aerie Ouphes", 65, Rarity.COMMON, mage.cards.a.AerieOuphes.class));
         cards.add(new SetCardInfo("Altar Golem", 166, Rarity.RARE, mage.cards.a.AltarGolem.class));
         cards.add(new SetCardInfo("Antler Skulkin", 167, Rarity.COMMON, mage.cards.a.AntlerSkulkin.class));

--- a/Mage.Sets/src/mage/sets/Exodus.java
+++ b/Mage.Sets/src/mage/sets/Exodus.java
@@ -20,7 +20,6 @@ public final class Exodus extends ExpansionSet {
     private Exodus() {
         super("Exodus", "EXO", ExpansionSet.buildDate(1998, 6, 15), SetType.EXPANSION);
         this.blockName = "Tempest";
-        this.parentSet = Tempest.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -28,6 +27,7 @@ public final class Exodus extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Aether Tide", 27, Rarity.COMMON, mage.cards.a.AetherTide.class));
         cards.add(new SetCardInfo("Allay", 1, Rarity.COMMON, mage.cards.a.Allay.class));
         cards.add(new SetCardInfo("Anarchist", 79, Rarity.COMMON, mage.cards.a.Anarchist.class));

--- a/Mage.Sets/src/mage/sets/ExplorersOfIxalan.java
+++ b/Mage.Sets/src/mage/sets/ExplorersOfIxalan.java
@@ -18,7 +18,6 @@ public final class ExplorersOfIxalan extends ExpansionSet {
 
     private ExplorersOfIxalan() {
         super("Explorers of Ixalan", "E02", ExpansionSet.buildDate(2017, 11, 24), SetType.SUPPLEMENTAL);
-        this.blockName = "Explorers of Ixalan";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Adaptive Automaton", 42, Rarity.RARE, mage.cards.a.AdaptiveAutomaton.class));

--- a/Mage.Sets/src/mage/sets/FateReforged.java
+++ b/Mage.Sets/src/mage/sets/FateReforged.java
@@ -31,7 +31,6 @@ public final class FateReforged extends ExpansionSet {
     private FateReforged() {
         super("Fate Reforged", "FRF", ExpansionSet.buildDate(2015, 1, 23), SetType.EXPANSION);
         this.blockName = "Khans of Tarkir";
-        this.parentSet = KhansOfTarkir.getInstance();
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterSpecial = 1;

--- a/Mage.Sets/src/mage/sets/FateReforgedClashPack.java
+++ b/Mage.Sets/src/mage/sets/FateReforgedClashPack.java
@@ -18,6 +18,7 @@ public class FateReforgedClashPack extends ExpansionSet {
     private FateReforgedClashPack() {
         super("Fate Reforged Clash Pack", "CP2", ExpansionSet.buildDate(2015, 1, 23), SetType.PROMOTIONAL);
         this.blockName = "Khans of Tarkir";
+        this.parentSet = FateReforged.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FateReforgedClashPack.java
+++ b/Mage.Sets/src/mage/sets/FateReforgedClashPack.java
@@ -17,6 +17,7 @@ public class FateReforgedClashPack extends ExpansionSet {
 
     private FateReforgedClashPack() {
         super("Fate Reforged Clash Pack", "CP2", ExpansionSet.buildDate(2015, 1, 23), SetType.PROMOTIONAL);
+        this.blockName = "Khans of Tarkir";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FateReforgedPromos.java
+++ b/Mage.Sets/src/mage/sets/FateReforgedPromos.java
@@ -18,6 +18,7 @@ public class FateReforgedPromos extends ExpansionSet {
     private FateReforgedPromos() {
         super("Fate Reforged Promos", "PFRF", ExpansionSet.buildDate(2015, 1, 24), SetType.PROMOTIONAL);
         this.blockName = "Khans of Tarkir";
+        this.parentSet = FateReforged.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FateReforgedPromos.java
+++ b/Mage.Sets/src/mage/sets/FateReforgedPromos.java
@@ -17,6 +17,7 @@ public class FateReforgedPromos extends ExpansionSet {
 
     private FateReforgedPromos() {
         super("Fate Reforged Promos", "PFRF", ExpansionSet.buildDate(2015, 1, 24), SetType.PROMOTIONAL);
+        this.blockName = "Khans of Tarkir";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FifthDawn.java
+++ b/Mage.Sets/src/mage/sets/FifthDawn.java
@@ -20,7 +20,6 @@ public final class FifthDawn extends ExpansionSet {
     private FifthDawn() {
         super("Fifth Dawn", "5DN", ExpansionSet.buildDate(2004, 5, 4), SetType.EXPANSION);
         this.blockName = "Mirrodin";
-        this.parentSet = Mirrodin.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/FifthEdition.java
+++ b/Mage.Sets/src/mage/sets/FifthEdition.java
@@ -14,6 +14,7 @@ public final class FifthEdition extends ExpansionSet {
 
     private FifthEdition() {
         super("Fifth Edition", "5ED", ExpansionSet.buildDate(1997, 3, 1), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;

--- a/Mage.Sets/src/mage/sets/ForgottenRealmsCommander.java
+++ b/Mage.Sets/src/mage/sets/ForgottenRealmsCommander.java
@@ -17,6 +17,7 @@ public final class ForgottenRealmsCommander extends ExpansionSet {
 
     private ForgottenRealmsCommander() {
         super("Forgotten Realms Commander", "AFC", ExpansionSet.buildDate(2021, 7, 23), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abundant Growth", 150, Rarity.COMMON, mage.cards.a.AbundantGrowth.class));

--- a/Mage.Sets/src/mage/sets/ForgottenRealmsCommander.java
+++ b/Mage.Sets/src/mage/sets/ForgottenRealmsCommander.java
@@ -18,6 +18,7 @@ public final class ForgottenRealmsCommander extends ExpansionSet {
     private ForgottenRealmsCommander() {
         super("Forgotten Realms Commander", "AFC", ExpansionSet.buildDate(2021, 7, 23), SetType.SUPPLEMENTAL);
         this.blockName = "Commander";
+        this.parentSet = AdventuresInTheForgottenRealms.getInstance();
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abundant Growth", 150, Rarity.COMMON, mage.cards.a.AbundantGrowth.class));

--- a/Mage.Sets/src/mage/sets/FourthEdition.java
+++ b/Mage.Sets/src/mage/sets/FourthEdition.java
@@ -17,6 +17,7 @@ public final class FourthEdition extends ExpansionSet {
 
     private FourthEdition() {
         super("Fourth Edition", "4ED", ExpansionSet.buildDate(1995, 3, 1), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2000.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2000.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2000 extends ExpansionSet {
 
     private FridayNightMagic2000() {
         super("Friday Night Magic 2000", "FNM", ExpansionSet.buildDate(2000, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2001.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2001.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2001 extends ExpansionSet {
 
     private FridayNightMagic2001() {
         super("Friday Night Magic 2001", "F01", ExpansionSet.buildDate(2001, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2002.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2002.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2002 extends ExpansionSet {
 
     private FridayNightMagic2002() {
         super("Friday Night Magic 2002", "F02", ExpansionSet.buildDate(2002, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2003.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2003.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2003 extends ExpansionSet {
 
     private FridayNightMagic2003() {
         super("Friday Night Magic 2003", "F03", ExpansionSet.buildDate(2003, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2004.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2004.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2004 extends ExpansionSet {
 
     private FridayNightMagic2004() {
         super("Friday Night Magic 2004", "F04", ExpansionSet.buildDate(2004, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2005.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2005.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2005 extends ExpansionSet {
 
     private FridayNightMagic2005() {
         super("Friday Night Magic 2005", "F05", ExpansionSet.buildDate(2005, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2006.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2006.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2006 extends ExpansionSet {
 
     private FridayNightMagic2006() {
         super("Friday Night Magic 2006", "F06", ExpansionSet.buildDate(2006, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2007.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2007.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2007 extends ExpansionSet {
 
     private FridayNightMagic2007() {
         super("Friday Night Magic 2007", "F07", ExpansionSet.buildDate(2007, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2008.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2008.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2008 extends ExpansionSet {
 
     private FridayNightMagic2008() {
         super("Friday Night Magic 2008", "F08", ExpansionSet.buildDate(2008, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2009.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2009.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2009 extends ExpansionSet {
 
     private FridayNightMagic2009() {
         super("Friday Night Magic 2009", "F09", ExpansionSet.buildDate(2009, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2010.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2010.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2010 extends ExpansionSet {
 
     private FridayNightMagic2010() {
         super("Friday Night Magic 2010", "F10", ExpansionSet.buildDate(2010, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2011.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2011.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2011 extends ExpansionSet {
 
     private FridayNightMagic2011() {
         super("Friday Night Magic 2011", "F11", ExpansionSet.buildDate(2011, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2012.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2012.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2012 extends ExpansionSet {
 
     private FridayNightMagic2012() {
         super("Friday Night Magic 2012", "F12", ExpansionSet.buildDate(2012, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2013.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2013.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2013 extends ExpansionSet {
 
     private FridayNightMagic2013() {
         super("Friday Night Magic 2013", "F13", ExpansionSet.buildDate(2013, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2014.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2014.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2014 extends ExpansionSet {
 
     private FridayNightMagic2014() {
         super("Friday Night Magic 2014", "F14", ExpansionSet.buildDate(2014, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2015.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2015.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2015 extends ExpansionSet {
 
     private FridayNightMagic2015() {
         super("Friday Night Magic 2015", "F15", ExpansionSet.buildDate(2015, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2016.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2016.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2016 extends ExpansionSet {
 
     private FridayNightMagic2016() {
         super("Friday Night Magic 2016", "F16", ExpansionSet.buildDate(2016, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FridayNightMagic2017.java
+++ b/Mage.Sets/src/mage/sets/FridayNightMagic2017.java
@@ -17,6 +17,7 @@ public class FridayNightMagic2017 extends ExpansionSet {
 
     private FridayNightMagic2017() {
         super("Friday Night Magic 2017", "F17", ExpansionSet.buildDate(2017, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Friday Night Magic";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/FutureSight.java
+++ b/Mage.Sets/src/mage/sets/FutureSight.java
@@ -20,7 +20,6 @@ public final class FutureSight extends ExpansionSet {
     private FutureSight() {
         super("Future Sight", "FUT", ExpansionSet.buildDate(2007, 4, 4), SetType.EXPANSION);
         this.blockName = "Time Spiral";
-        this.parentSet = TimeSpiral.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -28,6 +27,7 @@ public final class FutureSight extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Akroma's Memorial", 159, Rarity.RARE, mage.cards.a.AkromasMemorial.class));
         cards.add(new SetCardInfo("Angel of Salvation", 1, Rarity.RARE, mage.cards.a.AngelOfSalvation.class));
         cards.add(new SetCardInfo("Arcanum Wings", 48, Rarity.UNCOMMON, mage.cards.a.ArcanumWings.class));

--- a/Mage.Sets/src/mage/sets/GRNRavnicaWeekend.java
+++ b/Mage.Sets/src/mage/sets/GRNRavnicaWeekend.java
@@ -18,6 +18,7 @@ public class GRNRavnicaWeekend extends ExpansionSet {
     private GRNRavnicaWeekend() {
         super("GRN Ravnica Weekend", "PRWK", ExpansionSet.buildDate(2018, 10, 5), SetType.PROMOTIONAL);
         this.blockName = "Guilds of Ravnica";
+        this.parentSet = GuildsOfRavnica.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/GRNRavnicaWeekend.java
+++ b/Mage.Sets/src/mage/sets/GRNRavnicaWeekend.java
@@ -17,6 +17,7 @@ public class GRNRavnicaWeekend extends ExpansionSet {
 
     private GRNRavnicaWeekend() {
         super("GRN Ravnica Weekend", "PRWK", ExpansionSet.buildDate(2018, 10, 5), SetType.PROMOTIONAL);
+        this.blockName = "Guilds of Ravnica";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/Gatecrash.java
+++ b/Mage.Sets/src/mage/sets/Gatecrash.java
@@ -26,7 +26,6 @@ public final class Gatecrash extends ExpansionSet {
     private Gatecrash() {
         super("Gatecrash", "GTC", ExpansionSet.buildDate(2013, 2, 1), SetType.EXPANSION);
         this.blockName = "Return to Ravnica";
-        this.parentSet = ReturnToRavnica.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 1;
@@ -34,6 +33,7 @@ public final class Gatecrash extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Act of Treason", 85, Rarity.COMMON, mage.cards.a.ActOfTreason.class));
         cards.add(new SetCardInfo("Adaptive Snapjaw", 113, Rarity.COMMON, mage.cards.a.AdaptiveSnapjaw.class));
         cards.add(new SetCardInfo("Aerial Maneuver", 1, Rarity.COMMON, mage.cards.a.AerialManeuver.class));

--- a/Mage.Sets/src/mage/sets/GatecrashPromos.java
+++ b/Mage.Sets/src/mage/sets/GatecrashPromos.java
@@ -17,6 +17,7 @@ public class GatecrashPromos extends ExpansionSet {
 
     private GatecrashPromos() {
         super("Gatecrash Promos", "PGTC", ExpansionSet.buildDate(2013, 1, 26), SetType.PROMOTIONAL);
+        this.blockName = "Return to Ravnica";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/GatecrashPromos.java
+++ b/Mage.Sets/src/mage/sets/GatecrashPromos.java
@@ -18,6 +18,7 @@ public class GatecrashPromos extends ExpansionSet {
     private GatecrashPromos() {
         super("Gatecrash Promos", "PGTC", ExpansionSet.buildDate(2013, 1, 26), SetType.PROMOTIONAL);
         this.blockName = "Return to Ravnica";
+        this.parentSet = Gatecrash.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/GlobalSeriesJiangYangguAndMuYanling.java
+++ b/Mage.Sets/src/mage/sets/GlobalSeriesJiangYangguAndMuYanling.java
@@ -17,7 +17,6 @@ public final class GlobalSeriesJiangYangguAndMuYanling extends ExpansionSet {
 
     private GlobalSeriesJiangYangguAndMuYanling() {
         super("Global Series: Jiang Yanggu & Mu Yanling", "GS1", ExpansionSet.buildDate(2018, 6, 22), SetType.SUPPLEMENTAL);
-        this.blockName = "Global Series";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Aggressive Instinct", 34, Rarity.COMMON, mage.cards.a.AggressiveInstinct.class));

--- a/Mage.Sets/src/mage/sets/Guildpact.java
+++ b/Mage.Sets/src/mage/sets/Guildpact.java
@@ -19,7 +19,6 @@ public final class Guildpact extends ExpansionSet {
     private Guildpact() {
         super("Guildpact", "GPT", ExpansionSet.buildDate(2006, 1, 3), SetType.EXPANSION);
         this.blockName = "Ravnica";
-        this.parentSet = RavnicaCityOfGuilds.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -27,6 +26,7 @@ public final class Guildpact extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Absolver Thrull", 1, Rarity.COMMON, mage.cards.a.AbsolverThrull.class));
         cards.add(new SetCardInfo("Abyssal Nocturnus", 43, Rarity.RARE, mage.cards.a.AbyssalNocturnus.class));
         cards.add(new SetCardInfo("Aetherplasm", 22, Rarity.UNCOMMON, mage.cards.a.Aetherplasm.class));

--- a/Mage.Sets/src/mage/sets/GuildsOfRavnicaGuildKits.java
+++ b/Mage.Sets/src/mage/sets/GuildsOfRavnicaGuildKits.java
@@ -18,7 +18,6 @@ public final class GuildsOfRavnicaGuildKits extends ExpansionSet {
 
     private GuildsOfRavnicaGuildKits() {
         super("Guilds of Ravnica Guild Kits", "GK1", ExpansionSet.buildDate(2018, 11, 2), SetType.SUPPLEMENTAL);
-        this.blockName = "Guild Kits";
         this.hasBasicLands = true;
         
         cards.add(new SetCardInfo("Abrupt Decay", 57, Rarity.RARE, mage.cards.a.AbruptDecay.class));

--- a/Mage.Sets/src/mage/sets/GuildsOfRavnicaPromos.java
+++ b/Mage.Sets/src/mage/sets/GuildsOfRavnicaPromos.java
@@ -17,6 +17,7 @@ public class GuildsOfRavnicaPromos extends ExpansionSet {
 
     private GuildsOfRavnicaPromos() {
         super("Guilds of Ravnica Promos", "PGRN", ExpansionSet.buildDate(2018, 10, 5), SetType.PROMOTIONAL);
+        this.blockName = "Guilds of Ravnica";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/GuildsOfRavnicaPromos.java
+++ b/Mage.Sets/src/mage/sets/GuildsOfRavnicaPromos.java
@@ -18,6 +18,7 @@ public class GuildsOfRavnicaPromos extends ExpansionSet {
     private GuildsOfRavnicaPromos() {
         super("Guilds of Ravnica Promos", "PGRN", ExpansionSet.buildDate(2018, 10, 5), SetType.PROMOTIONAL);
         this.blockName = "Guilds of Ravnica";
+        this.parentSet = GuildsOfRavnica.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/HistoricAnthology3.java
+++ b/Mage.Sets/src/mage/sets/HistoricAnthology3.java
@@ -17,7 +17,6 @@ public final class HistoricAnthology3 extends ExpansionSet {
 
     private HistoricAnthology3() {
         super("Historic Anthology 3", "HA3", ExpansionSet.buildDate(2020, 5, 21), SetType.MAGIC_ARENA);
-        this.blockName = "Reprint";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/HistoricAnthology4.java
+++ b/Mage.Sets/src/mage/sets/HistoricAnthology4.java
@@ -17,7 +17,6 @@ public final class HistoricAnthology4 extends ExpansionSet {
 
     private HistoricAnthology4() {
         super("Historic Anthology 4", "HA4", ExpansionSet.buildDate(2021, 3, 11), SetType.MAGIC_ARENA);
-        this.blockName = "Reprint";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/HistoricAnthology5.java
+++ b/Mage.Sets/src/mage/sets/HistoricAnthology5.java
@@ -17,7 +17,6 @@ public final class HistoricAnthology5 extends ExpansionSet {
 
     private HistoricAnthology5() {
         super("Historic Anthology 5", "HA5", ExpansionSet.buildDate(2021, 5, 27), SetType.MAGIC_ARENA);
-        this.blockName = "Reprint";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/HourOfDevastation.java
+++ b/Mage.Sets/src/mage/sets/HourOfDevastation.java
@@ -28,7 +28,6 @@ public final class HourOfDevastation extends ExpansionSet {
     private HourOfDevastation() {
         super("Hour of Devastation", "HOU", ExpansionSet.buildDate(2017, 7, 14), SetType.EXPANSION);
         this.blockName = "Amonkhet";
-        this.parentSet = Amonkhet.getInstance();
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/HourOfDevastationPromos.java
+++ b/Mage.Sets/src/mage/sets/HourOfDevastationPromos.java
@@ -18,6 +18,7 @@ public class HourOfDevastationPromos extends ExpansionSet {
     private HourOfDevastationPromos() {
         super("Hour of Devastation Promos", "PHOU", ExpansionSet.buildDate(2017, 7, 14), SetType.PROMOTIONAL);
         this.blockName = "Amonkhet";
+        this.parentSet = HourOfDevastation.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/HourOfDevastationPromos.java
+++ b/Mage.Sets/src/mage/sets/HourOfDevastationPromos.java
@@ -17,6 +17,7 @@ public class HourOfDevastationPromos extends ExpansionSet {
 
     private HourOfDevastationPromos() {
         super("Hour of Devastation Promos", "PHOU", ExpansionSet.buildDate(2017, 7, 14), SetType.PROMOTIONAL);
+        this.blockName = "Amonkhet";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/IconicMasters.java
+++ b/Mage.Sets/src/mage/sets/IconicMasters.java
@@ -24,7 +24,6 @@ public final class IconicMasters extends ExpansionSet {
 
     private IconicMasters() {
         super("Iconic Masters", "IMA", ExpansionSet.buildDate(2017, 11, 17), SetType.SUPPLEMENTAL);
-        this.blockName = "Reprint";
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/IkoriaLairOfBehemoths.java
+++ b/Mage.Sets/src/mage/sets/IkoriaLairOfBehemoths.java
@@ -54,7 +54,6 @@ public final class IkoriaLairOfBehemoths extends ExpansionSet {
 
     private IkoriaLairOfBehemoths() {
         super("Ikoria: Lair of Behemoths", "IKO", ExpansionSet.buildDate(2020, 4, 24), SetType.EXPANSION);
-        this.blockName = "Ikoria: Lair of Behemoths";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/InnistradCrimsonVow.java
+++ b/Mage.Sets/src/mage/sets/InnistradCrimsonVow.java
@@ -25,7 +25,7 @@ public final class InnistradCrimsonVow extends ExpansionSet {
 
     private InnistradCrimsonVow() {
         super("Innistrad: Crimson Vow", "VOW", ExpansionSet.buildDate(2021, 11, 19), SetType.EXPANSION);
-        this.blockName = "Innistrad: Midnight Hunt";
+        this.blockName = "Innistrad: Double Feature";
         this.hasBoosters = true;
         this.hasBasicLands = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/InnistradMidnightHunt.java
+++ b/Mage.Sets/src/mage/sets/InnistradMidnightHunt.java
@@ -25,7 +25,7 @@ public final class InnistradMidnightHunt extends ExpansionSet {
 
     private InnistradMidnightHunt() {
         super("Innistrad: Midnight Hunt", "MID", ExpansionSet.buildDate(2021, 9, 24), SetType.EXPANSION);
-        this.blockName = "Innistrad: Midnight Hunt";
+        this.blockName = "Innistrad: Double Feature";
         this.hasBoosters = true;
         this.hasBasicLands = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/InnistradPromos.java
+++ b/Mage.Sets/src/mage/sets/InnistradPromos.java
@@ -17,6 +17,7 @@ public class InnistradPromos extends ExpansionSet {
 
     private InnistradPromos() {
         super("Innistrad Promos", "PISD", ExpansionSet.buildDate(2011, 9, 24), SetType.PROMOTIONAL);
+        this.blockName = "Innistrad";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/InnistradPromos.java
+++ b/Mage.Sets/src/mage/sets/InnistradPromos.java
@@ -18,6 +18,7 @@ public class InnistradPromos extends ExpansionSet {
     private InnistradPromos() {
         super("Innistrad Promos", "PISD", ExpansionSet.buildDate(2011, 9, 24), SetType.PROMOTIONAL);
         this.blockName = "Innistrad";
+        this.parentSet = Innistrad.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/IxalanPromos.java
+++ b/Mage.Sets/src/mage/sets/IxalanPromos.java
@@ -18,6 +18,7 @@ public class IxalanPromos extends ExpansionSet {
     private IxalanPromos() {
         super("Ixalan Promos", "PXLN", ExpansionSet.buildDate(2017, 9, 29), SetType.PROMOTIONAL);
         this.blockName = "Ixalan";
+        this.parentSet = Ixalan.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/IxalanPromos.java
+++ b/Mage.Sets/src/mage/sets/IxalanPromos.java
@@ -17,6 +17,7 @@ public class IxalanPromos extends ExpansionSet {
 
     private IxalanPromos() {
         super("Ixalan Promos", "PXLN", ExpansionSet.buildDate(2017, 9, 29), SetType.PROMOTIONAL);
+        this.blockName = "Ixalan";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/IxalanStandardShowdown.java
+++ b/Mage.Sets/src/mage/sets/IxalanStandardShowdown.java
@@ -18,6 +18,7 @@ public class IxalanStandardShowdown extends ExpansionSet {
     private IxalanStandardShowdown() {
         super("Ixalan Standard Showdown", "PSS2", ExpansionSet.buildDate(2017, 9, 29), SetType.PROMOTIONAL);
         this.blockName = "Ixalan";
+        this.parentSet = Ixalan.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/IxalanStandardShowdown.java
+++ b/Mage.Sets/src/mage/sets/IxalanStandardShowdown.java
@@ -17,6 +17,7 @@ public class IxalanStandardShowdown extends ExpansionSet {
 
     private IxalanStandardShowdown() {
         super("Ixalan Standard Showdown", "PSS2", ExpansionSet.buildDate(2017, 9, 29), SetType.PROMOTIONAL);
+        this.blockName = "Ixalan";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/IxalanTreasureChest.java
+++ b/Mage.Sets/src/mage/sets/IxalanTreasureChest.java
@@ -17,6 +17,7 @@ public class IxalanTreasureChest extends ExpansionSet {
 
     private IxalanTreasureChest() {
         super("Ixalan Treasure Chest", "PXTC", ExpansionSet.buildDate(2017, 11, 24), SetType.PROMOTIONAL);
+        this.blockName = "Ixalan";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/IxalanTreasureChest.java
+++ b/Mage.Sets/src/mage/sets/IxalanTreasureChest.java
@@ -18,6 +18,7 @@ public class IxalanTreasureChest extends ExpansionSet {
     private IxalanTreasureChest() {
         super("Ixalan Treasure Chest", "PXTC", ExpansionSet.buildDate(2017, 11, 24), SetType.PROMOTIONAL);
         this.blockName = "Ixalan";
+        this.parentSet = Ixalan.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JourneyIntoNyx.java
+++ b/Mage.Sets/src/mage/sets/JourneyIntoNyx.java
@@ -26,7 +26,6 @@ public final class JourneyIntoNyx extends ExpansionSet {
     private JourneyIntoNyx() {
         super("Journey into Nyx", "JOU", ExpansionSet.buildDate(2014, 5, 2), SetType.EXPANSION);
         this.blockName = "Theros";
-        this.parentSet = Theros.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 1;
@@ -34,6 +33,7 @@ public final class JourneyIntoNyx extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Aegis of the Gods", 1, Rarity.RARE, mage.cards.a.AegisOfTheGods.class));
         cards.add(new SetCardInfo("Aerial Formation", 30, Rarity.COMMON, mage.cards.a.AerialFormation.class));
         cards.add(new SetCardInfo("Agent of Erebos", 59, Rarity.UNCOMMON, mage.cards.a.AgentOfErebos.class));

--- a/Mage.Sets/src/mage/sets/JourneyIntoNyxPromos.java
+++ b/Mage.Sets/src/mage/sets/JourneyIntoNyxPromos.java
@@ -18,6 +18,7 @@ public class JourneyIntoNyxPromos extends ExpansionSet {
     private JourneyIntoNyxPromos() {
         super("Journey into Nyx Promos", "PJOU", ExpansionSet.buildDate(2014, 4, 26), SetType.PROMOTIONAL);
         this.blockName = "Theros";
+        this.parentSet = JourneyIntoNyx.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JourneyIntoNyxPromos.java
+++ b/Mage.Sets/src/mage/sets/JourneyIntoNyxPromos.java
@@ -17,6 +17,7 @@ public class JourneyIntoNyxPromos extends ExpansionSet {
 
     private JourneyIntoNyxPromos() {
         super("Journey into Nyx Promos", "PJOU", ExpansionSet.buildDate(2014, 4, 26), SetType.PROMOTIONAL);
+        this.blockName = "Theros";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards1998.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards1998.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards1998 extends ExpansionSet {
 
     private JudgeGiftCards1998() {
         super("Judge Gift Cards 1998", "JGP", ExpansionSet.buildDate(1998, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards1999.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards1999.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards1999 extends ExpansionSet {
 
     private JudgeGiftCards1999() {
         super("Judge Gift Cards 1999", "G99", ExpansionSet.buildDate(1999, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2000.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2000.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2000 extends ExpansionSet {
 
     private JudgeGiftCards2000() {
         super("Judge Gift Cards 2000", "G00", ExpansionSet.buildDate(2000, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2001.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2001.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2001 extends ExpansionSet {
 
     private JudgeGiftCards2001() {
         super("Judge Gift Cards 2001", "G01", ExpansionSet.buildDate(2001, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2002.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2002.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2002 extends ExpansionSet {
 
     private JudgeGiftCards2002() {
         super("Judge Gift Cards 2002", "G02", ExpansionSet.buildDate(2002, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2003.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2003.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2003 extends ExpansionSet {
 
     private JudgeGiftCards2003() {
         super("Judge Gift Cards 2003", "G03", ExpansionSet.buildDate(2003, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2004.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2004.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2004 extends ExpansionSet {
 
     private JudgeGiftCards2004() {
         super("Judge Gift Cards 2004", "G04", ExpansionSet.buildDate(2004, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2005.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2005.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2005 extends ExpansionSet {
 
     private JudgeGiftCards2005() {
         super("Judge Gift Cards 2005", "G05", ExpansionSet.buildDate(2005, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2006.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2006.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2006 extends ExpansionSet {
 
     private JudgeGiftCards2006() {
         super("Judge Gift Cards 2006", "G06", ExpansionSet.buildDate(2006, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2007.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2007.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2007 extends ExpansionSet {
 
     private JudgeGiftCards2007() {
         super("Judge Gift Cards 2007", "G07", ExpansionSet.buildDate(2007, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2008.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2008.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2008 extends ExpansionSet {
 
     private JudgeGiftCards2008() {
         super("Judge Gift Cards 2008", "G08", ExpansionSet.buildDate(2008, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2009.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2009.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2009 extends ExpansionSet {
 
     private JudgeGiftCards2009() {
         super("Judge Gift Cards 2009", "G09", ExpansionSet.buildDate(2009, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2010.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2010.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2010 extends ExpansionSet {
 
     private JudgeGiftCards2010() {
         super("Judge Gift Cards 2010", "G10", ExpansionSet.buildDate(2010, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2011.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2011.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2011 extends ExpansionSet {
 
     private JudgeGiftCards2011() {
         super("Judge Gift Cards 2011", "G11", ExpansionSet.buildDate(2011, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2012.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2012.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2012 extends ExpansionSet {
 
     private JudgeGiftCards2012() {
         super("Judge Gift Cards 2012", "J12", ExpansionSet.buildDate(2012, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2013.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2013.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2013 extends ExpansionSet {
 
     private JudgeGiftCards2013() {
         super("Judge Gift Cards 2013", "J13", ExpansionSet.buildDate(2013, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2014.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2014.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2014 extends ExpansionSet {
 
     private JudgeGiftCards2014() {
         super("Judge Gift Cards 2014", "J14", ExpansionSet.buildDate(2014, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2015.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2015.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2015 extends ExpansionSet {
 
     private JudgeGiftCards2015() {
         super("Judge Gift Cards 2015", "J15", ExpansionSet.buildDate(2015, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2016.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2016.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2016 extends ExpansionSet {
 
     private JudgeGiftCards2016() {
         super("Judge Gift Cards 2016", "J16", ExpansionSet.buildDate(2016, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2017.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2017.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2017 extends ExpansionSet {
 
     private JudgeGiftCards2017() {
         super("Judge Gift Cards 2017", "J17", ExpansionSet.buildDate(2017, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2018.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2018.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2018 extends ExpansionSet {
 
     private JudgeGiftCards2018() {
         super("Judge Gift Cards 2018", "J18", ExpansionSet.buildDate(2018, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2019.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2019.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2019 extends ExpansionSet {
 
     private JudgeGiftCards2019() {
         super("Judge Gift Cards 2019", "J19", ExpansionSet.buildDate(2019, 4, 10), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/JudgeGiftCards2020.java
+++ b/Mage.Sets/src/mage/sets/JudgeGiftCards2020.java
@@ -17,6 +17,7 @@ public class JudgeGiftCards2020 extends ExpansionSet {
 
     private JudgeGiftCards2020() {
         super("Judge Gift Cards 2020", "J20", ExpansionSet.buildDate(2020, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Judge Gift Cards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Judgment.java
+++ b/Mage.Sets/src/mage/sets/Judgment.java
@@ -20,7 +20,6 @@ public final class Judgment extends ExpansionSet {
     private Judgment() {
         super("Judgment", "JUD", ExpansionSet.buildDate(2002, 5, 27), SetType.EXPANSION);
         this.blockName = "Odyssey";
-        this.parentSet = Odyssey.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -29,6 +28,7 @@ public final class Judgment extends ExpansionSet {
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
         this.hasUnbalancedColors = true;
+
         cards.add(new SetCardInfo("Ancestor's Chosen", 1, Rarity.UNCOMMON, mage.cards.a.AncestorsChosen.class));
         cards.add(new SetCardInfo("Anger", 77, Rarity.UNCOMMON, mage.cards.a.Anger.class));
         cards.add(new SetCardInfo("Anurid Barkripper", 104, Rarity.COMMON, mage.cards.a.AnuridBarkripper.class));

--- a/Mage.Sets/src/mage/sets/Jumpstart.java
+++ b/Mage.Sets/src/mage/sets/Jumpstart.java
@@ -17,7 +17,6 @@ public final class Jumpstart extends ExpansionSet {
 
     private Jumpstart() {
         super("Jumpstart", "JMP", ExpansionSet.buildDate(2020, 7, 17), SetType.SUPPLEMENTAL);
-        this.blockName = "Jumpstart";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Act of Treason", 289, Rarity.COMMON, mage.cards.a.ActOfTreason.class));

--- a/Mage.Sets/src/mage/sets/Jumpstart2022.java
+++ b/Mage.Sets/src/mage/sets/Jumpstart2022.java
@@ -17,7 +17,6 @@ public final class Jumpstart2022 extends ExpansionSet {
 
     private Jumpstart2022() {
         super("Jumpstart 2022", "J22", ExpansionSet.buildDate(2020, 12, 2), SetType.SUPPLEMENTAL);
-        this.blockName = "Jumpstart";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Academy Journeymage", 267, Rarity.COMMON, mage.cards.a.AcademyJourneymage.class));

--- a/Mage.Sets/src/mage/sets/KaladeshInventions.java
+++ b/Mage.Sets/src/mage/sets/KaladeshInventions.java
@@ -22,6 +22,7 @@ public final class KaladeshInventions extends ExpansionSet {
     private KaladeshInventions() {
         super("Kaladesh Inventions", "MPS", ExpansionSet.buildDate(2016, 9, 30), SetType.PROMOTIONAL);
         this.blockName = "Kaladesh";
+        this.parentSet = Kaladesh.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/KaladeshInventions.java
+++ b/Mage.Sets/src/mage/sets/KaladeshInventions.java
@@ -21,7 +21,7 @@ public final class KaladeshInventions extends ExpansionSet {
 
     private KaladeshInventions() {
         super("Kaladesh Inventions", "MPS", ExpansionSet.buildDate(2016, 9, 30), SetType.PROMOTIONAL);
-        this.blockName = "Masterpiece Series";
+        this.blockName = "Kaladesh";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/KaladeshPromos.java
+++ b/Mage.Sets/src/mage/sets/KaladeshPromos.java
@@ -18,6 +18,7 @@ public class KaladeshPromos extends ExpansionSet {
     private KaladeshPromos() {
         super("Kaladesh Promos", "PKLD", ExpansionSet.buildDate(2016, 9, 30), SetType.PROMOTIONAL);
         this.blockName = "Kaladesh";
+        this.parentSet = Kaladesh.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/KaladeshPromos.java
+++ b/Mage.Sets/src/mage/sets/KaladeshPromos.java
@@ -17,6 +17,7 @@ public class KaladeshPromos extends ExpansionSet {
 
     private KaladeshPromos() {
         super("Kaladesh Promos", "PKLD", ExpansionSet.buildDate(2016, 9, 30), SetType.PROMOTIONAL);
+        this.blockName = "Kaladesh";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Kaldheim.java
+++ b/Mage.Sets/src/mage/sets/Kaldheim.java
@@ -25,7 +25,6 @@ public final class Kaldheim extends ExpansionSet {
 
     private Kaldheim() {
         super("Kaldheim", "KHM", ExpansionSet.buildDate(2021, 2, 5), SetType.EXPANSION);
-        this.blockName = "Kaldheim";
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/KaldheimCommander.java
+++ b/Mage.Sets/src/mage/sets/KaldheimCommander.java
@@ -18,6 +18,7 @@ public final class KaldheimCommander extends ExpansionSet {
     private KaldheimCommander() {
         super("Kaldheim Commander", "KHC", ExpansionSet.buildDate(2021, 2, 5), SetType.SUPPLEMENTAL);
         this.blockName = "Commander";
+        this.parentSet = Kaldheim.getInstance();
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abomination of Llanowar", 81, Rarity.UNCOMMON, mage.cards.a.AbominationOfLlanowar.class));

--- a/Mage.Sets/src/mage/sets/KaldheimCommander.java
+++ b/Mage.Sets/src/mage/sets/KaldheimCommander.java
@@ -17,6 +17,7 @@ public final class KaldheimCommander extends ExpansionSet {
 
     private KaldheimCommander() {
         super("Kaldheim Commander", "KHC", ExpansionSet.buildDate(2021, 2, 5), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abomination of Llanowar", 81, Rarity.UNCOMMON, mage.cards.a.AbominationOfLlanowar.class));

--- a/Mage.Sets/src/mage/sets/KamigawaNeonDynasty.java
+++ b/Mage.Sets/src/mage/sets/KamigawaNeonDynasty.java
@@ -27,7 +27,6 @@ public final class KamigawaNeonDynasty extends ExpansionSet {
 
     private KamigawaNeonDynasty() {
         super("Kamigawa: Neon Dynasty", "NEO", ExpansionSet.buildDate(2022, 2, 18), SetType.EXPANSION);
-        this.blockName = "Kamigawa: Neon Dynasty";
         this.hasBoosters = true;
         this.hasBasicLands = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/KhansOfTarkirPromos.java
+++ b/Mage.Sets/src/mage/sets/KhansOfTarkirPromos.java
@@ -18,6 +18,7 @@ public class KhansOfTarkirPromos extends ExpansionSet {
     private KhansOfTarkirPromos() {
         super("Khans of Tarkir Promos", "PKTK", ExpansionSet.buildDate(2014, 9, 27), SetType.PROMOTIONAL);
         this.blockName = "Khans of Tarkir";
+        this.parentSet = KhansOfTarkir.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/KhansOfTarkirPromos.java
+++ b/Mage.Sets/src/mage/sets/KhansOfTarkirPromos.java
@@ -17,6 +17,7 @@ public class KhansOfTarkirPromos extends ExpansionSet {
 
     private KhansOfTarkirPromos() {
         super("Khans of Tarkir Promos", "PKTK", ExpansionSet.buildDate(2014, 9, 27), SetType.PROMOTIONAL);
+        this.blockName = "Khans of Tarkir";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Legions.java
+++ b/Mage.Sets/src/mage/sets/Legions.java
@@ -20,7 +20,6 @@ public final class Legions extends ExpansionSet {
     private Legions() {
         super("Legions", "LGN", ExpansionSet.buildDate(2003, 1, 25), SetType.EXPANSION);
         this.blockName = "Onslaught";
-        this.parentSet = Onslaught.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -28,6 +27,7 @@ public final class Legions extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Akroma, Angel of Wrath", 1, Rarity.RARE, mage.cards.a.AkromaAngelOfWrath.class));
         cards.add(new SetCardInfo("Akroma's Devoted", 2, Rarity.UNCOMMON, mage.cards.a.AkromasDevoted.class));
         cards.add(new SetCardInfo("Aphetto Exterminator", 59, Rarity.UNCOMMON, mage.cards.a.AphettoExterminator.class));

--- a/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
@@ -20,12 +20,14 @@ public final class LimitedEditionAlpha extends ExpansionSet {
 
     private LimitedEditionAlpha() {
         super("Limited Edition Alpha", "LEA", ExpansionSet.buildDate(1993, 8, 5), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Air Elemental", 46, Rarity.UNCOMMON, mage.cards.a.AirElemental.class));
         cards.add(new SetCardInfo("Ancestral Recall", 47, Rarity.RARE, mage.cards.a.AncestralRecall.class));
         cards.add(new SetCardInfo("Animate Artifact", 48, Rarity.UNCOMMON, mage.cards.a.AnimateArtifact.class));

--- a/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
@@ -20,12 +20,14 @@ public final class LimitedEditionBeta extends ExpansionSet {
 
     private LimitedEditionBeta() {
         super("Limited Edition Beta", "LEB", ExpansionSet.buildDate(1993, 10, 1), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Air Elemental", 47, Rarity.UNCOMMON, mage.cards.a.AirElemental.class));
         cards.add(new SetCardInfo("Ancestral Recall", 48, Rarity.RARE, mage.cards.a.AncestralRecall.class));
         cards.add(new SetCardInfo("Animate Artifact", 49, Rarity.UNCOMMON, mage.cards.a.AnimateArtifact.class));

--- a/Mage.Sets/src/mage/sets/M19GiftPack.java
+++ b/Mage.Sets/src/mage/sets/M19GiftPack.java
@@ -18,6 +18,7 @@ public final class M19GiftPack extends ExpansionSet {
 
     private M19GiftPack() {
         super("M19 Gift Pack", "G18", ExpansionSet.buildDate(2018, 11, 16), SetType.SUPPLEMENTAL_STANDARD_LEGAL);
+        this.parentSet = CoreSet2019.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = false;
 

--- a/Mage.Sets/src/mage/sets/M19StandardShowdown.java
+++ b/Mage.Sets/src/mage/sets/M19StandardShowdown.java
@@ -17,6 +17,7 @@ public class M19StandardShowdown extends ExpansionSet {
 
     private M19StandardShowdown() {
         super("M19 Standard Showdown", "PSS3", ExpansionSet.buildDate(2018, 7, 13), SetType.PROMOTIONAL);
+        this.parentSet = CoreSet2019.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/M20PromoPacks.java
+++ b/Mage.Sets/src/mage/sets/M20PromoPacks.java
@@ -18,6 +18,7 @@ public final class M20PromoPacks extends ExpansionSet {
     private M20PromoPacks() {
         super("M20 Promo Packs", "PPP1", ExpansionSet.buildDate(2019, 7, 12), SetType.PROMOTIONAL);
         this.blockName = "Core Set";
+        this.parentSet = CoreSet2020.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/M20PromoPacks.java
+++ b/Mage.Sets/src/mage/sets/M20PromoPacks.java
@@ -17,6 +17,7 @@ public final class M20PromoPacks extends ExpansionSet {
 
     private M20PromoPacks() {
         super("M20 Promo Packs", "PPP1", ExpansionSet.buildDate(2019, 7, 12), SetType.PROMOTIONAL);
+        this.blockName = "Core Set";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/Magic2010.java
+++ b/Mage.Sets/src/mage/sets/Magic2010.java
@@ -19,12 +19,14 @@ public final class Magic2010 extends ExpansionSet {
 
     private Magic2010() {
         super("Magic 2010", "M10", ExpansionSet.buildDate(2009, 7, 17), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Acidic Slime", 165, Rarity.UNCOMMON, mage.cards.a.AcidicSlime.class));
         cards.add(new SetCardInfo("Acolyte of Xathrid", 83, Rarity.COMMON, mage.cards.a.AcolyteOfXathrid.class));
         cards.add(new SetCardInfo("Act of Treason", 124, Rarity.UNCOMMON, mage.cards.a.ActOfTreason.class));

--- a/Mage.Sets/src/mage/sets/Magic2010.java
+++ b/Mage.Sets/src/mage/sets/Magic2010.java
@@ -20,6 +20,7 @@ public final class Magic2010 extends ExpansionSet {
     private Magic2010() {
         super("Magic 2010", "M10", ExpansionSet.buildDate(2009, 7, 17), SetType.CORE);
         this.blockName = "Core Set";
+        this.parentSet = Magic2010.getInstance();
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/Magic2010Promos.java
+++ b/Mage.Sets/src/mage/sets/Magic2010Promos.java
@@ -17,6 +17,7 @@ public class Magic2010Promos extends ExpansionSet {
 
     private Magic2010Promos() {
         super("Magic 2010 Promos", "PM10", ExpansionSet.buildDate(2009, 7, 16), SetType.PROMOTIONAL);
+        this.parentSet = Magic2010.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Magic2011.java
+++ b/Mage.Sets/src/mage/sets/Magic2011.java
@@ -19,6 +19,7 @@ public final class Magic2011 extends ExpansionSet {
     private Magic2011() {
         super("Magic 2011", "M11", ExpansionSet.buildDate(2010, 7, 16), SetType.CORE);
         this.blockName = "Core Set";
+        this.parentSet = Magic2011.getInstance();
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/Magic2011.java
+++ b/Mage.Sets/src/mage/sets/Magic2011.java
@@ -18,12 +18,14 @@ public final class Magic2011 extends ExpansionSet {
 
     private Magic2011() {
         super("Magic 2011", "M11", ExpansionSet.buildDate(2010, 7, 16), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Acidic Slime", 161, Rarity.UNCOMMON, mage.cards.a.AcidicSlime.class));
         cards.add(new SetCardInfo("Act of Treason", 121, Rarity.COMMON, mage.cards.a.ActOfTreason.class));
         cards.add(new SetCardInfo("Aether Adept", 41, Rarity.COMMON, mage.cards.a.AetherAdept.class));

--- a/Mage.Sets/src/mage/sets/Magic2011Promos.java
+++ b/Mage.Sets/src/mage/sets/Magic2011Promos.java
@@ -17,6 +17,7 @@ public class Magic2011Promos extends ExpansionSet {
 
     private Magic2011Promos() {
         super("Magic 2011 Promos", "PM11", ExpansionSet.buildDate(2010, 7, 15), SetType.PROMOTIONAL);
+        this.parentSet = Magic2011.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Magic2012.java
+++ b/Mage.Sets/src/mage/sets/Magic2012.java
@@ -18,12 +18,14 @@ public final class Magic2012 extends ExpansionSet {
 
     private Magic2012() {
         super("Magic 2012", "M12", ExpansionSet.buildDate(2011, 7, 15), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Acidic Slime", 161, Rarity.UNCOMMON, mage.cards.a.AcidicSlime.class));
         cards.add(new SetCardInfo("Act of Treason", 121, Rarity.COMMON, mage.cards.a.ActOfTreason.class));
         cards.add(new SetCardInfo("Adaptive Automaton", 201, Rarity.RARE, mage.cards.a.AdaptiveAutomaton.class));

--- a/Mage.Sets/src/mage/sets/Magic2012.java
+++ b/Mage.Sets/src/mage/sets/Magic2012.java
@@ -19,6 +19,7 @@ public final class Magic2012 extends ExpansionSet {
     private Magic2012() {
         super("Magic 2012", "M12", ExpansionSet.buildDate(2011, 7, 15), SetType.CORE);
         this.blockName = "Core Set";
+        this.parentSet = Magic2012.getInstance();
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/Magic2012Promos.java
+++ b/Mage.Sets/src/mage/sets/Magic2012Promos.java
@@ -17,6 +17,7 @@ public class Magic2012Promos extends ExpansionSet {
 
     private Magic2012Promos() {
         super("Magic 2012 Promos", "PM12", ExpansionSet.buildDate(2011, 7, 14), SetType.PROMOTIONAL);
+        this.parentSet = Magic2012.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Magic2013.java
+++ b/Mage.Sets/src/mage/sets/Magic2013.java
@@ -26,6 +26,7 @@ public final class Magic2013 extends ExpansionSet {
     private Magic2013() {
         super("Magic 2013", "M13", ExpansionSet.buildDate(2012, 7, 13), SetType.CORE);
         this.blockName = "Core Set";
+        this.parentSet = Magic2013.getInstance();
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/Magic2013.java
+++ b/Mage.Sets/src/mage/sets/Magic2013.java
@@ -25,12 +25,14 @@ public final class Magic2013 extends ExpansionSet {
 
     private Magic2013() {
         super("Magic 2013", "M13", ExpansionSet.buildDate(2012, 7, 13), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Acidic Slime", 159, Rarity.UNCOMMON, mage.cards.a.AcidicSlime.class));
         cards.add(new SetCardInfo("Ajani, Caller of the Pride", 1, Rarity.MYTHIC, mage.cards.a.AjaniCallerOfThePride.class));
         cards.add(new SetCardInfo("Ajani's Sunstriker", 2, Rarity.COMMON, mage.cards.a.AjanisSunstriker.class));

--- a/Mage.Sets/src/mage/sets/Magic2013Promos.java
+++ b/Mage.Sets/src/mage/sets/Magic2013Promos.java
@@ -17,6 +17,7 @@ public class Magic2013Promos extends ExpansionSet {
 
     private Magic2013Promos() {
         super("Magic 2013 Promos", "PM13", ExpansionSet.buildDate(2012, 7, 12), SetType.PROMOTIONAL);
+        this.parentSet = Magic2013.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Magic2014.java
+++ b/Mage.Sets/src/mage/sets/Magic2014.java
@@ -25,12 +25,14 @@ public final class Magic2014 extends ExpansionSet {
 
     private Magic2014() {
         super("Magic 2014", "M14", ExpansionSet.buildDate(2013, 7, 19), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Academy Raider", 124, Rarity.COMMON, mage.cards.a.AcademyRaider.class));
         cards.add(new SetCardInfo("Accorder's Shield", 204, Rarity.UNCOMMON, mage.cards.a.AccordersShield.class));
         cards.add(new SetCardInfo("Accursed Spirit", 83, Rarity.COMMON, mage.cards.a.AccursedSpirit.class));

--- a/Mage.Sets/src/mage/sets/Magic2014.java
+++ b/Mage.Sets/src/mage/sets/Magic2014.java
@@ -26,6 +26,7 @@ public final class Magic2014 extends ExpansionSet {
     private Magic2014() {
         super("Magic 2014", "M14", ExpansionSet.buildDate(2013, 7, 19), SetType.CORE);
         this.blockName = "Core Set";
+        this.parentSet = Magic2014.getInstance();
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/Magic2014Promos.java
+++ b/Mage.Sets/src/mage/sets/Magic2014Promos.java
@@ -17,6 +17,7 @@ public class Magic2014Promos extends ExpansionSet {
 
     private Magic2014Promos() {
         super("Magic 2014 Promos", "PM14", ExpansionSet.buildDate(2013, 7, 18), SetType.PROMOTIONAL);
+        this.parentSet = Magic2014.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Magic2015.java
+++ b/Mage.Sets/src/mage/sets/Magic2015.java
@@ -26,6 +26,7 @@ public final class Magic2015 extends ExpansionSet {
     private Magic2015() {
         super("Magic 2015", "M15", ExpansionSet.buildDate(2014, 7, 18), SetType.CORE);
         this.blockName = "Core Set";
+        this.parentSet = Magic2015.getInstance();
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/Magic2015.java
+++ b/Mage.Sets/src/mage/sets/Magic2015.java
@@ -25,6 +25,7 @@ public final class Magic2015 extends ExpansionSet {
 
     private Magic2015() {
         super("Magic 2015", "M15", ExpansionSet.buildDate(2014, 7, 18), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
@@ -32,6 +33,7 @@ public final class Magic2015 extends ExpansionSet {
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
         this.maxCardNumberInBooster = 269;
+
         cards.add(new SetCardInfo("Accursed Spirit", 85, Rarity.COMMON, mage.cards.a.AccursedSpirit.class));
         cards.add(new SetCardInfo("Act on Impulse", 126, Rarity.UNCOMMON, mage.cards.a.ActOnImpulse.class));
         cards.add(new SetCardInfo("Aegis Angel", 270, Rarity.RARE, mage.cards.a.AegisAngel.class));

--- a/Mage.Sets/src/mage/sets/Magic2015ClashPack.java
+++ b/Mage.Sets/src/mage/sets/Magic2015ClashPack.java
@@ -17,6 +17,7 @@ public class Magic2015ClashPack extends ExpansionSet {
 
     private Magic2015ClashPack() {
         super("Magic 2015 Clash Pack", "CP1", ExpansionSet.buildDate(2014, 7, 18), SetType.PROMOTIONAL);
+        this.parentSet = Magic2015.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Magic2015Promos.java
+++ b/Mage.Sets/src/mage/sets/Magic2015Promos.java
@@ -17,6 +17,7 @@ public class Magic2015Promos extends ExpansionSet {
 
     private Magic2015Promos() {
         super("Magic 2015 Promos", "PM15", ExpansionSet.buildDate(2014, 7, 17), SetType.PROMOTIONAL);
+        this.parentSet = Magic2015.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MagicOrigins.java
+++ b/Mage.Sets/src/mage/sets/MagicOrigins.java
@@ -25,6 +25,7 @@ public final class MagicOrigins extends ExpansionSet {
 
     private MagicOrigins() {
         super("Magic Origins", "ORI", ExpansionSet.buildDate(2015, 7, 17), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
@@ -33,6 +34,7 @@ public final class MagicOrigins extends ExpansionSet {
         this.ratioBoosterMythic = 8;
         this.numBoosterDoubleFaced = -1;
         this.maxCardNumberInBooster = 272;
+
         cards.add(new SetCardInfo("Abbot of Keral Keep", 127, Rarity.RARE, mage.cards.a.AbbotOfKeralKeep.class));
         cards.add(new SetCardInfo("Acolyte of the Inferno", 128, Rarity.UNCOMMON, mage.cards.a.AcolyteOfTheInferno.class));
         cards.add(new SetCardInfo("Act of Treason", 129, Rarity.COMMON, mage.cards.a.ActOfTreason.class));

--- a/Mage.Sets/src/mage/sets/MagicOriginsClashPack.java
+++ b/Mage.Sets/src/mage/sets/MagicOriginsClashPack.java
@@ -17,6 +17,7 @@ public class MagicOriginsClashPack extends ExpansionSet {
 
     private MagicOriginsClashPack() {
         super("Magic Origins Clash Pack", "CP3", ExpansionSet.buildDate(2015, 7, 17), SetType.PROMOTIONAL);
+        this.parentSet = MagicOrigins.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MagicOriginsPromos.java
+++ b/Mage.Sets/src/mage/sets/MagicOriginsPromos.java
@@ -17,6 +17,7 @@ public class MagicOriginsPromos extends ExpansionSet {
 
     private MagicOriginsPromos() {
         super("Magic Origins Promos", "PORI", ExpansionSet.buildDate(2015, 7, 17), SetType.PROMOTIONAL);
+        this.parentSet = MagicOrigins.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MagicPlayerRewards2001.java
+++ b/Mage.Sets/src/mage/sets/MagicPlayerRewards2001.java
@@ -17,6 +17,7 @@ public class MagicPlayerRewards2001 extends ExpansionSet {
 
     private MagicPlayerRewards2001() {
         super("Magic Player Rewards 2001", "MPR", ExpansionSet.buildDate(2001, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Magic Player Rewards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MagicPlayerRewards2003.java
+++ b/Mage.Sets/src/mage/sets/MagicPlayerRewards2003.java
@@ -17,6 +17,7 @@ public class MagicPlayerRewards2003 extends ExpansionSet {
 
     private MagicPlayerRewards2003() {
         super("Magic Player Rewards 2003", "P03", ExpansionSet.buildDate(2003, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Magic Player Rewards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MagicPlayerRewards2004.java
+++ b/Mage.Sets/src/mage/sets/MagicPlayerRewards2004.java
@@ -17,6 +17,7 @@ public class MagicPlayerRewards2004 extends ExpansionSet {
 
     private MagicPlayerRewards2004() {
         super("Magic Player Rewards 2004", "P04", ExpansionSet.buildDate(2004, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Magic Player Rewards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MagicPlayerRewards2005.java
+++ b/Mage.Sets/src/mage/sets/MagicPlayerRewards2005.java
@@ -19,6 +19,7 @@ public class MagicPlayerRewards2005 extends ExpansionSet {
 
     private MagicPlayerRewards2005() {
         super("Magic Player Rewards 2005", "P05", ExpansionSet.buildDate(2005, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Magic Player Rewards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MagicPlayerRewards2006.java
+++ b/Mage.Sets/src/mage/sets/MagicPlayerRewards2006.java
@@ -19,6 +19,7 @@ public class MagicPlayerRewards2006 extends ExpansionSet {
 
     private MagicPlayerRewards2006() {
         super("Magic Player Rewards 2006", "P06", ExpansionSet.buildDate(2006, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Magic Player Rewards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MagicPlayerRewards2007.java
+++ b/Mage.Sets/src/mage/sets/MagicPlayerRewards2007.java
@@ -19,6 +19,7 @@ public class MagicPlayerRewards2007 extends ExpansionSet {
 
     private MagicPlayerRewards2007() {
         super("Magic Player Rewards 2007", "P07", ExpansionSet.buildDate(2007, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Magic Player Rewards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MagicPlayerRewards2008.java
+++ b/Mage.Sets/src/mage/sets/MagicPlayerRewards2008.java
@@ -19,6 +19,7 @@ public class MagicPlayerRewards2008 extends ExpansionSet {
 
     private MagicPlayerRewards2008() {
         super("Magic Player Rewards 2008", "P08", ExpansionSet.buildDate(2008, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Magic Player Rewards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MagicPlayerRewards2009.java
+++ b/Mage.Sets/src/mage/sets/MagicPlayerRewards2009.java
@@ -19,6 +19,7 @@ public class MagicPlayerRewards2009 extends ExpansionSet {
 
     private MagicPlayerRewards2009() {
         super("Magic Player Rewards 2009", "P09", ExpansionSet.buildDate(2009, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Magic Player Rewards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MagicPlayerRewards2010.java
+++ b/Mage.Sets/src/mage/sets/MagicPlayerRewards2010.java
@@ -19,6 +19,7 @@ public class MagicPlayerRewards2010 extends ExpansionSet {
 
     private MagicPlayerRewards2010() {
         super("Magic Player Rewards 2010", "P10", ExpansionSet.buildDate(2010, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Magic Player Rewards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MagicPlayerRewards2011.java
+++ b/Mage.Sets/src/mage/sets/MagicPlayerRewards2011.java
@@ -19,6 +19,7 @@ public class MagicPlayerRewards2011 extends ExpansionSet {
 
     private MagicPlayerRewards2011() {
         super("Magic Player Rewards 2011", "P11", ExpansionSet.buildDate(2011, 1, 1), SetType.PROMOTIONAL);
+        this.blockName = "Magic Player Rewards";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MarchOfTheMachine.java
+++ b/Mage.Sets/src/mage/sets/MarchOfTheMachine.java
@@ -21,7 +21,6 @@ public final class MarchOfTheMachine extends ExpansionSet {
 
     private MarchOfTheMachine() {
         super("March of the Machine", "MOM", ExpansionSet.buildDate(2023, 4, 21), SetType.EXPANSION);
-        this.blockName = "March of the Machine";
         this.hasBoosters = true;
         this.numBoosterLands = 0; // TODO: 50% chance basic, 50% chance dual land (currently just adding extra commons)
         this.numBoosterCommon = 10; // TODO: Should be 8 commons, 1 battle, 1 DFC, 3 uncommon+

--- a/Mage.Sets/src/mage/sets/MarchOfTheMachineCommander.java
+++ b/Mage.Sets/src/mage/sets/MarchOfTheMachineCommander.java
@@ -17,6 +17,7 @@ public final class MarchOfTheMachineCommander extends ExpansionSet {
 
     private MarchOfTheMachineCommander() {
         super("March of the Machine Commander", "MOC", ExpansionSet.buildDate(2023, 4, 21), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abzan Battle Priest", 164, Rarity.UNCOMMON, mage.cards.a.AbzanBattlePriest.class));

--- a/Mage.Sets/src/mage/sets/MarchOfTheMachineCommander.java
+++ b/Mage.Sets/src/mage/sets/MarchOfTheMachineCommander.java
@@ -18,6 +18,7 @@ public final class MarchOfTheMachineCommander extends ExpansionSet {
     private MarchOfTheMachineCommander() {
         super("March of the Machine Commander", "MOC", ExpansionSet.buildDate(2023, 4, 21), SetType.SUPPLEMENTAL);
         this.blockName = "Commander";
+        this.parentSet = MarchOfTheMachine.getInstance();
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abzan Battle Priest", 164, Rarity.UNCOMMON, mage.cards.a.AbzanBattlePriest.class));

--- a/Mage.Sets/src/mage/sets/MarchOfTheMachineTheAftermath.java
+++ b/Mage.Sets/src/mage/sets/MarchOfTheMachineTheAftermath.java
@@ -17,7 +17,6 @@ public final class MarchOfTheMachineTheAftermath extends ExpansionSet {
 
     private MarchOfTheMachineTheAftermath() {
         super("March of the Machine: The Aftermath", "MAT", ExpansionSet.buildDate(2023, 5, 12), SetType.SUPPLEMENTAL_STANDARD_LEGAL);
-        this.blockName = "March of the Machine";
         this.hasBasicLands = false;
         this.hasBoosters = false; // temporary
 

--- a/Mage.Sets/src/mage/sets/Masters25.java
+++ b/Mage.Sets/src/mage/sets/Masters25.java
@@ -24,7 +24,6 @@ public final class Masters25 extends ExpansionSet {
 
     private Masters25() {
         super("Masters 25", "A25", ExpansionSet.buildDate(2018, 3, 16), SetType.SUPPLEMENTAL);
-        this.blockName = "Reprint";
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/MidnightHuntCommander.java
+++ b/Mage.Sets/src/mage/sets/MidnightHuntCommander.java
@@ -17,6 +17,7 @@ public final class MidnightHuntCommander extends ExpansionSet {
 
     private MidnightHuntCommander() {
         super("Midnight Hunt Commander", "MIC", ExpansionSet.buildDate(2021, 9, 24), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abzan Falconer", 77, Rarity.UNCOMMON, mage.cards.a.AbzanFalconer.class));

--- a/Mage.Sets/src/mage/sets/MidnightHuntCommander.java
+++ b/Mage.Sets/src/mage/sets/MidnightHuntCommander.java
@@ -18,6 +18,7 @@ public final class MidnightHuntCommander extends ExpansionSet {
     private MidnightHuntCommander() {
         super("Midnight Hunt Commander", "MIC", ExpansionSet.buildDate(2021, 9, 24), SetType.SUPPLEMENTAL);
         this.blockName = "Commander";
+        this.parentSet = InnistradMidnightHunt.getInstance();
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abzan Falconer", 77, Rarity.UNCOMMON, mage.cards.a.AbzanFalconer.class));

--- a/Mage.Sets/src/mage/sets/MirrodinBesieged.java
+++ b/Mage.Sets/src/mage/sets/MirrodinBesieged.java
@@ -20,13 +20,13 @@ public final class MirrodinBesieged extends ExpansionSet {
     private MirrodinBesieged() {
         super("Mirrodin Besieged", "MBS", ExpansionSet.buildDate(2011, 1, 4), SetType.EXPANSION);
         this.blockName = "Scars of Mirrodin";
-        this.parentSet = ScarsOfMirrodin.getInstance();
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Accorder Paladin", 1, Rarity.UNCOMMON, mage.cards.a.AccorderPaladin.class));
         cards.add(new SetCardInfo("Ardent Recruit", 2, Rarity.COMMON, mage.cards.a.ArdentRecruit.class));
         cards.add(new SetCardInfo("Banishment Decree", 3, Rarity.COMMON, mage.cards.b.BanishmentDecree.class));

--- a/Mage.Sets/src/mage/sets/MirrodinBesiegedPromos.java
+++ b/Mage.Sets/src/mage/sets/MirrodinBesiegedPromos.java
@@ -18,6 +18,7 @@ public class MirrodinBesiegedPromos extends ExpansionSet {
     private MirrodinBesiegedPromos() {
         super("Mirrodin Besieged Promos", "PMBS", ExpansionSet.buildDate(2011, 2, 3), SetType.PROMOTIONAL);
         this.blockName = "Scars of Mirrodin";
+        this.parentSet = MirrodinBesieged.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MirrodinBesiegedPromos.java
+++ b/Mage.Sets/src/mage/sets/MirrodinBesiegedPromos.java
@@ -17,6 +17,7 @@ public class MirrodinBesiegedPromos extends ExpansionSet {
 
     private MirrodinBesiegedPromos() {
         super("Mirrodin Besieged Promos", "PMBS", ExpansionSet.buildDate(2011, 2, 3), SetType.PROMOTIONAL);
+        this.blockName = "Scars of Mirrodin";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ModernHorizons.java
+++ b/Mage.Sets/src/mage/sets/ModernHorizons.java
@@ -24,7 +24,6 @@ public final class ModernHorizons extends ExpansionSet {
 
     private ModernHorizons() {
         super("Modern Horizons", "MH1", ExpansionSet.buildDate(2019, 6, 14), SetType.SUPPLEMENTAL_MODERN_LEGAL);
-        this.blockName = "Modern Horizons";
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/ModernHorizons1Timeshifts.java
+++ b/Mage.Sets/src/mage/sets/ModernHorizons1Timeshifts.java
@@ -17,6 +17,7 @@ public final class ModernHorizons1Timeshifts extends ExpansionSet {
 
     private ModernHorizons1Timeshifts() {
         super("Modern Horizons 1 Timeshifts", "H1R", ExpansionSet.buildDate(2021, 6, 11), SetType.SUPPLEMENTAL);
+        this.parentSet = ModernHorizons2.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = false;
 

--- a/Mage.Sets/src/mage/sets/ModernHorizons2.java
+++ b/Mage.Sets/src/mage/sets/ModernHorizons2.java
@@ -29,7 +29,6 @@ public final class ModernHorizons2 extends ExpansionSet {
 
     private ModernHorizons2() {
         super("Modern Horizons 2", "MH2", ExpansionSet.buildDate(2021, 6, 11), SetType.SUPPLEMENTAL_MODERN_LEGAL);
-        this.blockName = "Modern Horizons 2";
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/ModernHorizonsPromos.java
+++ b/Mage.Sets/src/mage/sets/ModernHorizonsPromos.java
@@ -17,6 +17,7 @@ public class ModernHorizonsPromos extends ExpansionSet {
 
     private ModernHorizonsPromos() {
         super("Modern Horizons Promos", "PMH1", ExpansionSet.buildDate(2019, 6, 14), SetType.PROMOTIONAL);
+        this.parentSet = ModernHorizons.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ModernMasters.java
+++ b/Mage.Sets/src/mage/sets/ModernMasters.java
@@ -24,7 +24,6 @@ public final class ModernMasters extends ExpansionSet {
 
     private ModernMasters() {
         super("Modern Masters", "MMA", ExpansionSet.buildDate(2013, 6, 7), SetType.SUPPLEMENTAL_MODERN_LEGAL);
-        this.blockName = "Reprint";
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/ModernMasters2015.java
+++ b/Mage.Sets/src/mage/sets/ModernMasters2015.java
@@ -24,7 +24,6 @@ public final class ModernMasters2015 extends ExpansionSet {
 
     private ModernMasters2015() {
         super("Modern Masters 2015", "MM2", ExpansionSet.buildDate(2015, 5, 22), SetType.SUPPLEMENTAL_MODERN_LEGAL);
-        this.blockName = "Reprint";
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -32,6 +31,7 @@ public final class ModernMasters2015 extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Aethersnipe", 39, Rarity.COMMON, mage.cards.a.Aethersnipe.class));
         cards.add(new SetCardInfo("Agony Warp", 170, Rarity.UNCOMMON, mage.cards.a.AgonyWarp.class));
         cards.add(new SetCardInfo("Air Servant", 40, Rarity.UNCOMMON, mage.cards.a.AirServant.class));

--- a/Mage.Sets/src/mage/sets/ModernMasters2017.java
+++ b/Mage.Sets/src/mage/sets/ModernMasters2017.java
@@ -24,7 +24,6 @@ public final class ModernMasters2017 extends ExpansionSet {
 
     private ModernMasters2017() {
         super("Modern Masters 2017", "MM3", ExpansionSet.buildDate(2017, 3, 17), SetType.SUPPLEMENTAL_MODERN_LEGAL);
-        this.blockName = "Reprint";
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -32,6 +31,7 @@ public final class ModernMasters2017 extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Abrupt Decay", 146, Rarity.RARE, mage.cards.a.AbruptDecay.class));
         cards.add(new SetCardInfo("Abyssal Specter", 59, Rarity.UNCOMMON, mage.cards.a.AbyssalSpecter.class));
         cards.add(new SetCardInfo("Advent of the Wurm", 147, Rarity.RARE, mage.cards.a.AdventOfTheWurm.class));

--- a/Mage.Sets/src/mage/sets/MultiverseLegends.java
+++ b/Mage.Sets/src/mage/sets/MultiverseLegends.java
@@ -17,6 +17,7 @@ public final class MultiverseLegends extends ExpansionSet {
 
     private MultiverseLegends() {
         super("Multiverse Legends", "MUL", ExpansionSet.buildDate(2023, 4, 21), SetType.SUPPLEMENTAL);
+        this.parentSet = MarchOfTheMachine.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MysteryBoosterPlaytest.java
+++ b/Mage.Sets/src/mage/sets/MysteryBoosterPlaytest.java
@@ -20,6 +20,7 @@ public class MysteryBoosterPlaytest extends ExpansionSet {
 
     private MysteryBoosterPlaytest() {
         super("Mystery Booster Playtest", "CMB1", ExpansionSet.buildDate(2019, 11, 7), SetType.JOKESET);
+        this.parentSet = MysteryBooster.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MysteryBoosterRetailEditionFoils.java
+++ b/Mage.Sets/src/mage/sets/MysteryBoosterRetailEditionFoils.java
@@ -17,6 +17,7 @@ public class MysteryBoosterRetailEditionFoils extends ExpansionSet {
 
     private MysteryBoosterRetailEditionFoils() {
         super("Mystery Booster Retail Edition Foils", "FMB1", ExpansionSet.buildDate(2020, 3, 8), SetType.SUPPLEMENTAL);
+        this.parentSet = MysteryBooster.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Nemesis.java
+++ b/Mage.Sets/src/mage/sets/Nemesis.java
@@ -20,7 +20,6 @@ public final class Nemesis extends ExpansionSet {
     private Nemesis() {
         super("Nemesis", "NEM", ExpansionSet.buildDate(2000, 1, 5), SetType.EXPANSION);
         this.blockName = "Masques";
-        this.parentSet = MercadianMasques.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -28,6 +27,7 @@ public final class Nemesis extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Accumulated Knowledge", 26, Rarity.COMMON, mage.cards.a.AccumulatedKnowledge.class));
         cards.add(new SetCardInfo("Aether Barrier", 27, Rarity.RARE, mage.cards.a.AetherBarrier.class));
         cards.add(new SetCardInfo("Air Bladder", 28, Rarity.COMMON, mage.cards.a.AirBladder.class));

--- a/Mage.Sets/src/mage/sets/NeonDynastyCommander.java
+++ b/Mage.Sets/src/mage/sets/NeonDynastyCommander.java
@@ -18,6 +18,7 @@ public final class NeonDynastyCommander extends ExpansionSet {
     private NeonDynastyCommander() {
         super("Neon Dynasty Commander", "NEC", ExpansionSet.buildDate(2022, 2, 18), SetType.SUPPLEMENTAL);
         this.blockName = "Commander";
+        this.parentSet = KamigawaNeonDynasty.getInstance();
         this.hasBasicLands = false;
 
         // 122, Nissa, Voice of Zendikar - omitted from set due scryfall support

--- a/Mage.Sets/src/mage/sets/NeonDynastyCommander.java
+++ b/Mage.Sets/src/mage/sets/NeonDynastyCommander.java
@@ -17,6 +17,7 @@ public final class NeonDynastyCommander extends ExpansionSet {
 
     private NeonDynastyCommander() {
         super("Neon Dynasty Commander", "NEC", ExpansionSet.buildDate(2022, 2, 18), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         // 122, Nissa, Voice of Zendikar - omitted from set due scryfall support

--- a/Mage.Sets/src/mage/sets/NewCapennaCommander.java
+++ b/Mage.Sets/src/mage/sets/NewCapennaCommander.java
@@ -17,6 +17,7 @@ public final class NewCapennaCommander extends ExpansionSet {
 
     private NewCapennaCommander() {
         super("New Capenna Commander", "NCC", ExpansionSet.buildDate(2022, 4, 29), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Aether Snap", 241, Rarity.RARE, mage.cards.a.AetherSnap.class));

--- a/Mage.Sets/src/mage/sets/NewCapennaCommander.java
+++ b/Mage.Sets/src/mage/sets/NewCapennaCommander.java
@@ -18,6 +18,7 @@ public final class NewCapennaCommander extends ExpansionSet {
     private NewCapennaCommander() {
         super("New Capenna Commander", "NCC", ExpansionSet.buildDate(2022, 4, 29), SetType.SUPPLEMENTAL);
         this.blockName = "Commander";
+        this.parentSet = StreetsOfNewCapenna.getInstance();
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Aether Snap", 241, Rarity.RARE, mage.cards.a.AetherSnap.class));

--- a/Mage.Sets/src/mage/sets/NewPhyrexia.java
+++ b/Mage.Sets/src/mage/sets/NewPhyrexia.java
@@ -15,13 +15,13 @@ public final class NewPhyrexia extends ExpansionSet {
     private NewPhyrexia() {
         super("New Phyrexia", "NPH", ExpansionSet.buildDate(2011, 4, 4), SetType.EXPANSION);
         this.blockName = "Scars of Mirrodin";
-        this.parentSet = ScarsOfMirrodin.getInstance();
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Act of Aggression", 78, Rarity.UNCOMMON, mage.cards.a.ActOfAggression.class));
         cards.add(new SetCardInfo("Alloy Myr", 129, Rarity.UNCOMMON, mage.cards.a.AlloyMyr.class));
         cards.add(new SetCardInfo("Apostle's Blessing", 2, Rarity.COMMON, mage.cards.a.ApostlesBlessing.class));

--- a/Mage.Sets/src/mage/sets/NewPhyrexiaPromos.java
+++ b/Mage.Sets/src/mage/sets/NewPhyrexiaPromos.java
@@ -18,6 +18,7 @@ public class NewPhyrexiaPromos extends ExpansionSet {
     private NewPhyrexiaPromos() {
         super("New Phyrexia Promos", "PNPH", ExpansionSet.buildDate(2011, 5, 12), SetType.PROMOTIONAL);
         this.blockName = "Scars of Mirrodin";
+        this.parentSet = NewPhyrexia.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/NewPhyrexiaPromos.java
+++ b/Mage.Sets/src/mage/sets/NewPhyrexiaPromos.java
@@ -17,6 +17,7 @@ public class NewPhyrexiaPromos extends ExpansionSet {
 
     private NewPhyrexiaPromos() {
         super("New Phyrexia Promos", "PNPH", ExpansionSet.buildDate(2011, 5, 12), SetType.PROMOTIONAL);
+        this.blockName = "Scars of Mirrodin";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/NinthEdition.java
+++ b/Mage.Sets/src/mage/sets/NinthEdition.java
@@ -17,6 +17,7 @@ public final class NinthEdition extends ExpansionSet {
 
     private NinthEdition() {
         super("Ninth Edition", "9ED", ExpansionSet.buildDate(2005, 7, 29), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/OathOfTheGatewatch.java
+++ b/Mage.Sets/src/mage/sets/OathOfTheGatewatch.java
@@ -28,7 +28,6 @@ public final class OathOfTheGatewatch extends ExpansionSet {
     private OathOfTheGatewatch() {
         super("Oath of the Gatewatch", "OGW", ExpansionSet.buildDate(2016, 1, 22), SetType.EXPANSION);
         this.blockName = "Battle for Zendikar";
-        this.parentSet = BattleForZendikar.getInstance();
         this.hasBoosters = true;
         this.hasBasicLands = false;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/OathOfTheGatewatchPromos.java
+++ b/Mage.Sets/src/mage/sets/OathOfTheGatewatchPromos.java
@@ -18,6 +18,7 @@ public class OathOfTheGatewatchPromos extends ExpansionSet {
     private OathOfTheGatewatchPromos() {
         super("Oath of the Gatewatch Promos", "POGW", ExpansionSet.buildDate(2016, 1, 23), SetType.PROMOTIONAL);
         this.blockName = "Battle for Zendikar";
+        this.parentSet = OathOfTheGatewatch.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/OathOfTheGatewatchPromos.java
+++ b/Mage.Sets/src/mage/sets/OathOfTheGatewatchPromos.java
@@ -17,6 +17,7 @@ public class OathOfTheGatewatchPromos extends ExpansionSet {
 
     private OathOfTheGatewatchPromos() {
         super("Oath of the Gatewatch Promos", "POGW", ExpansionSet.buildDate(2016, 1, 23), SetType.PROMOTIONAL);
+        this.blockName = "Battle for Zendikar";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/OpenTheHelvault.java
+++ b/Mage.Sets/src/mage/sets/OpenTheHelvault.java
@@ -17,6 +17,7 @@ public class OpenTheHelvault extends ExpansionSet {
 
     private OpenTheHelvault() {
         super("Open the Helvault", "PHEL", ExpansionSet.buildDate(2012, 4, 28), SetType.PROMOTIONAL);
+        this.parentSet = AvacynRestored.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOne.java
+++ b/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOne.java
@@ -17,7 +17,6 @@ public final class PhyrexiaAllWillBeOne extends ExpansionSet {
 
     private PhyrexiaAllWillBeOne() {
         super("Phyrexia: All Will Be One", "ONE", ExpansionSet.buildDate(2023, 1, 10), SetType.EXPANSION);
-        this.blockName = "Phyrexia: All Will Be One";
         this.hasBoosters = true;
         this.hasBasicLands = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOneCommander.java
+++ b/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOneCommander.java
@@ -18,6 +18,7 @@ public final class PhyrexiaAllWillBeOneCommander extends ExpansionSet {
     private PhyrexiaAllWillBeOneCommander() {
         super("Phyrexia: All Will Be One Commander", "ONC", ExpansionSet.buildDate(2023, 1, 10), SetType.SUPPLEMENTAL);
         this.blockName = "Commander";
+        this.parentSet = PhyrexiaAllWillBeOne.getInstance();
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Adriana, Captain of the Guard", 114, Rarity.RARE, mage.cards.a.AdrianaCaptainOfTheGuard.class));

--- a/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOneCommander.java
+++ b/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOneCommander.java
@@ -17,6 +17,7 @@ public final class PhyrexiaAllWillBeOneCommander extends ExpansionSet {
 
     private PhyrexiaAllWillBeOneCommander() {
         super("Phyrexia: All Will Be One Commander", "ONC", ExpansionSet.buildDate(2023, 1, 10), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Adriana, Captain of the Guard", 114, Rarity.RARE, mage.cards.a.AdrianaCaptainOfTheGuard.class));

--- a/Mage.Sets/src/mage/sets/PlanarChaos.java
+++ b/Mage.Sets/src/mage/sets/PlanarChaos.java
@@ -20,7 +20,6 @@ public final class PlanarChaos extends ExpansionSet {
     private PlanarChaos() {
         super("Planar Chaos", "PLC", ExpansionSet.buildDate(2007, 1, 2), SetType.EXPANSION);
         this.blockName = "Time Spiral";
-        this.parentSet = TimeSpiral.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -28,6 +27,7 @@ public final class PlanarChaos extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Aeon Chronicler", 32, Rarity.RARE, mage.cards.a.AeonChronicler.class));
         cards.add(new SetCardInfo("Aether Membrane", 93, Rarity.UNCOMMON, mage.cards.a.AetherMembrane.class));
         cards.add(new SetCardInfo("Akroma, Angel of Fury", 94, Rarity.RARE, mage.cards.a.AkromaAngelOfFury.class));

--- a/Mage.Sets/src/mage/sets/Planechase.java
+++ b/Mage.Sets/src/mage/sets/Planechase.java
@@ -19,7 +19,7 @@ public final class Planechase extends ExpansionSet {
 
     private Planechase() {
         super("Planechase", "HOP", ExpansionSet.buildDate(2009, 8, 4), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
+
         cards.add(new SetCardInfo("Akroma's Vengeance", 1, Rarity.RARE, mage.cards.a.AkromasVengeance.class));
         cards.add(new SetCardInfo("Ancient Den", 130, Rarity.COMMON, mage.cards.a.AncientDen.class));
         cards.add(new SetCardInfo("Arc Lightning", 46, Rarity.COMMON, mage.cards.a.ArcLightning.class));

--- a/Mage.Sets/src/mage/sets/Planechase2012Edition.java
+++ b/Mage.Sets/src/mage/sets/Planechase2012Edition.java
@@ -17,7 +17,6 @@ public final class Planechase2012Edition extends ExpansionSet {
 
     private Planechase2012Edition() {
         super("Planechase 2012 Edition", "PC2", ExpansionSet.buildDate(2012, 6, 1), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
 
         cards.add(new SetCardInfo("Arc Trail", 39, Rarity.UNCOMMON, mage.cards.a.ArcTrail.class));
         cards.add(new SetCardInfo("Armillary Sphere", 108, Rarity.COMMON, mage.cards.a.ArmillarySphere.class));

--- a/Mage.Sets/src/mage/sets/PlanechaseAnthology.java
+++ b/Mage.Sets/src/mage/sets/PlanechaseAnthology.java
@@ -19,7 +19,6 @@ public final class PlanechaseAnthology extends ExpansionSet {
 
     private PlanechaseAnthology() {
         super("Planechase Anthology", "PCA", ExpansionSet.buildDate(2016, 11, 25), SetType.SUPPLEMENTAL);
-        this.blockName = "Command Zone";
 
         cards.add(new SetCardInfo("Arc Trail", 39, Rarity.UNCOMMON, mage.cards.a.ArcTrail.class));
         cards.add(new SetCardInfo("Armillary Sphere", 108, Rarity.COMMON, mage.cards.a.ArmillarySphere.class));

--- a/Mage.Sets/src/mage/sets/Planeshift.java
+++ b/Mage.Sets/src/mage/sets/Planeshift.java
@@ -19,7 +19,6 @@ public final class Planeshift extends ExpansionSet {
     private Planeshift() {
         super("Planeshift", "PLS", ExpansionSet.buildDate(2001, 1, 5), SetType.EXPANSION);
         this.blockName = "Invasion";
-        this.parentSet = Invasion.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/Portal.java
+++ b/Mage.Sets/src/mage/sets/Portal.java
@@ -17,7 +17,6 @@ public final class Portal extends ExpansionSet {
 
     private Portal() {
         super("Portal", "POR", ExpansionSet.buildDate(1997, 5, 1), SetType.SUPPLEMENTAL);
-        this.blockName = "Beginner";
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/PortalSecondAge.java
+++ b/Mage.Sets/src/mage/sets/PortalSecondAge.java
@@ -19,7 +19,6 @@ public final class PortalSecondAge extends ExpansionSet {
 
     private PortalSecondAge() {
         super("Portal Second Age", "P02", ExpansionSet.buildDate(1998, 6, 24), SetType.SUPPLEMENTAL);
-        this.blockName = "Beginner";
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -27,6 +26,7 @@ public final class PortalSecondAge extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Abyssal Nightstalker", 61, Rarity.UNCOMMON, mage.cards.a.AbyssalNightstalker.class));
         cards.add(new SetCardInfo("Air Elemental", 31, Rarity.UNCOMMON, mage.cards.a.AirElemental.class));
         cards.add(new SetCardInfo("Alaborn Cavalier", 1, Rarity.UNCOMMON, mage.cards.a.AlabornCavalier.class));

--- a/Mage.Sets/src/mage/sets/PortalThreeKingdoms.java
+++ b/Mage.Sets/src/mage/sets/PortalThreeKingdoms.java
@@ -17,7 +17,6 @@ public final class PortalThreeKingdoms extends ExpansionSet {
 
     private PortalThreeKingdoms() {
         super("Portal Three Kingdoms", "PTK", ExpansionSet.buildDate(1999, 5, 1), SetType.SUPPLEMENTAL);
-        this.blockName = "Beginner";
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterLands = 2;
@@ -25,6 +24,7 @@ public final class PortalThreeKingdoms extends ExpansionSet {
         this.numBoosterUncommon = 2;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Alert Shu Infantry", 1, Rarity.UNCOMMON, mage.cards.a.AlertShuInfantry.class));
         cards.add(new SetCardInfo("Ambition's Cost", 67, Rarity.RARE, mage.cards.a.AmbitionsCost.class));
         cards.add(new SetCardInfo("Balance of Power", 34, Rarity.RARE, mage.cards.b.BalanceOfPower.class));

--- a/Mage.Sets/src/mage/sets/Prophecy.java
+++ b/Mage.Sets/src/mage/sets/Prophecy.java
@@ -20,7 +20,6 @@ public final class Prophecy extends ExpansionSet {
     private Prophecy() {
         super("Prophecy", "PCY", ExpansionSet.buildDate(2000, 4, 27), SetType.EXPANSION);
         this.blockName = "Masques";
-        this.parentSet = MercadianMasques.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -28,6 +27,7 @@ public final class Prophecy extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Abolish", 1, Rarity.UNCOMMON, mage.cards.a.Abolish.class));
         cards.add(new SetCardInfo("Agent of Shauku", 55, Rarity.COMMON, mage.cards.a.AgentOfShauku.class));
         cards.add(new SetCardInfo("Alexi's Cloak", 29, Rarity.COMMON, mage.cards.a.AlexisCloak.class));

--- a/Mage.Sets/src/mage/sets/RavnicaAllegianceGuildKits.java
+++ b/Mage.Sets/src/mage/sets/RavnicaAllegianceGuildKits.java
@@ -17,7 +17,6 @@ public final class RavnicaAllegianceGuildKits extends ExpansionSet {
 
     private RavnicaAllegianceGuildKits() {
         super("Ravnica Allegiance Guild Kits", "GK2", ExpansionSet.buildDate(2019, 2, 15), SetType.SUPPLEMENTAL);
-        this.blockName = "Guild Kits";
         this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Isperia, Supreme Judge", 1, Rarity.MYTHIC, mage.cards.i.IsperiaSupremeJudge.class));

--- a/Mage.Sets/src/mage/sets/RavnicaAllegiancePromos.java
+++ b/Mage.Sets/src/mage/sets/RavnicaAllegiancePromos.java
@@ -18,6 +18,7 @@ public class RavnicaAllegiancePromos extends ExpansionSet {
     private RavnicaAllegiancePromos() {
         super("Ravnica Allegiance Promos", "PRNA", ExpansionSet.buildDate(2019, 1, 25), SetType.PROMOTIONAL);
         this.blockName = "Guilds of Ravnica";
+        this.parentSet = RavnicaAllegiance.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/RavnicaAllegiancePromos.java
+++ b/Mage.Sets/src/mage/sets/RavnicaAllegiancePromos.java
@@ -17,6 +17,7 @@ public class RavnicaAllegiancePromos extends ExpansionSet {
 
     private RavnicaAllegiancePromos() {
         super("Ravnica Allegiance Promos", "PRNA", ExpansionSet.buildDate(2019, 1, 25), SetType.PROMOTIONAL);
+        this.blockName = "Guilds of Ravnica";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/RavnicaAllegianceRavnicaWeekend.java
+++ b/Mage.Sets/src/mage/sets/RavnicaAllegianceRavnicaWeekend.java
@@ -18,6 +18,7 @@ public class RavnicaAllegianceRavnicaWeekend extends ExpansionSet {
     private RavnicaAllegianceRavnicaWeekend() {
         super("Ravnica Allegiance Ravnica Weekend", "PRW2", ExpansionSet.buildDate(2019, 2, 16), SetType.PROMOTIONAL);
         this.blockName = "Guilds of Ravnica";
+        this.parentSet = RavnicaAllegiance.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/RavnicaAllegianceRavnicaWeekend.java
+++ b/Mage.Sets/src/mage/sets/RavnicaAllegianceRavnicaWeekend.java
@@ -17,6 +17,7 @@ public class RavnicaAllegianceRavnicaWeekend extends ExpansionSet {
 
     private RavnicaAllegianceRavnicaWeekend() {
         super("Ravnica Allegiance Ravnica Weekend", "PRW2", ExpansionSet.buildDate(2019, 2, 16), SetType.PROMOTIONAL);
+        this.blockName = "Guilds of Ravnica";
         this.hasBoosters = false;
         this.hasBasicLands = true;
 

--- a/Mage.Sets/src/mage/sets/ReturnToRavnicaPromos.java
+++ b/Mage.Sets/src/mage/sets/ReturnToRavnicaPromos.java
@@ -17,6 +17,7 @@ public class ReturnToRavnicaPromos extends ExpansionSet {
 
     private ReturnToRavnicaPromos() {
         super("Return to Ravnica Promos", "PRTR", ExpansionSet.buildDate(2012, 10, 5), SetType.PROMOTIONAL);
+        this.blockName = "Return to Ravnica";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ReturnToRavnicaPromos.java
+++ b/Mage.Sets/src/mage/sets/ReturnToRavnicaPromos.java
@@ -18,6 +18,7 @@ public class ReturnToRavnicaPromos extends ExpansionSet {
     private ReturnToRavnicaPromos() {
         super("Return to Ravnica Promos", "PRTR", ExpansionSet.buildDate(2012, 10, 5), SetType.PROMOTIONAL);
         this.blockName = "Return to Ravnica";
+        this.parentSet = ReturnToRavnica.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/RevisedEdition.java
+++ b/Mage.Sets/src/mage/sets/RevisedEdition.java
@@ -20,6 +20,7 @@ public final class RevisedEdition extends ExpansionSet {
 
     private RevisedEdition() {
         super("Revised Edition", "3ED", ExpansionSet.buildDate(1994, 3, 1), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;

--- a/Mage.Sets/src/mage/sets/RiseOfTheEldrazi.java
+++ b/Mage.Sets/src/mage/sets/RiseOfTheEldrazi.java
@@ -26,13 +26,13 @@ public final class RiseOfTheEldrazi extends ExpansionSet {
     private RiseOfTheEldrazi() {
         super("Rise of the Eldrazi", "ROE", ExpansionSet.buildDate(2010, 3, 17), SetType.EXPANSION);
         this.blockName = "Zendikar";
-        this.parentSet = Zendikar.getInstance();
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Affa Guard Hound", 14, Rarity.UNCOMMON, mage.cards.a.AffaGuardHound.class));
         cards.add(new SetCardInfo("Akoum Boulderfoot", 134, Rarity.UNCOMMON, mage.cards.a.AkoumBoulderfoot.class));
         cards.add(new SetCardInfo("All Is Dust", 1, Rarity.MYTHIC, mage.cards.a.AllIsDust.class));

--- a/Mage.Sets/src/mage/sets/RiseOfTheEldraziPromos.java
+++ b/Mage.Sets/src/mage/sets/RiseOfTheEldraziPromos.java
@@ -17,6 +17,7 @@ public class RiseOfTheEldraziPromos extends ExpansionSet {
 
     private RiseOfTheEldraziPromos() {
         super("Rise of the Eldrazi Promos", "PROE", ExpansionSet.buildDate(2010, 7, 30), SetType.PROMOTIONAL);
+        this.blockName = "Zendikar";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/RiseOfTheEldraziPromos.java
+++ b/Mage.Sets/src/mage/sets/RiseOfTheEldraziPromos.java
@@ -18,6 +18,7 @@ public class RiseOfTheEldraziPromos extends ExpansionSet {
     private RiseOfTheEldraziPromos() {
         super("Rise of the Eldrazi Promos", "PROE", ExpansionSet.buildDate(2010, 7, 30), SetType.PROMOTIONAL);
         this.blockName = "Zendikar";
+        this.parentSet = RiseOfTheEldrazi.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/RivalsOfIxalan.java
+++ b/Mage.Sets/src/mage/sets/RivalsOfIxalan.java
@@ -25,7 +25,6 @@ public final class RivalsOfIxalan extends ExpansionSet {
     private RivalsOfIxalan() {
         super("Rivals of Ixalan", "RIX", ExpansionSet.buildDate(2018, 1, 19), SetType.EXPANSION);
         this.blockName = "Ixalan";
-        this.parentSet = Ixalan.getInstance();
         this.hasBoosters = true;
         this.hasBasicLands = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/RivalsOfIxalanPromos.java
+++ b/Mage.Sets/src/mage/sets/RivalsOfIxalanPromos.java
@@ -17,6 +17,7 @@ public class RivalsOfIxalanPromos extends ExpansionSet {
 
     private RivalsOfIxalanPromos() {
         super("Rivals of Ixalan Promos", "PRIX", ExpansionSet.buildDate(2018, 1, 19), SetType.PROMOTIONAL);
+        this.blockName = "Ixalan";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/RivalsOfIxalanPromos.java
+++ b/Mage.Sets/src/mage/sets/RivalsOfIxalanPromos.java
@@ -18,6 +18,7 @@ public class RivalsOfIxalanPromos extends ExpansionSet {
     private RivalsOfIxalanPromos() {
         super("Rivals of Ixalan Promos", "PRIX", ExpansionSet.buildDate(2018, 1, 19), SetType.PROMOTIONAL);
         this.blockName = "Ixalan";
+        this.parentSet = RivalsOfIxalan.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/SaviorsOfKamigawa.java
+++ b/Mage.Sets/src/mage/sets/SaviorsOfKamigawa.java
@@ -20,7 +20,6 @@ public final class SaviorsOfKamigawa extends ExpansionSet {
     private SaviorsOfKamigawa() {
         super("Saviors of Kamigawa", "SOK", ExpansionSet.buildDate(2005, 5, 3), SetType.EXPANSION);
         this.blockName = "Kamigawa";
-        this.parentSet = ChampionsOfKamigawa.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -28,6 +27,7 @@ public final class SaviorsOfKamigawa extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Adamaro, First to Desire", 91, Rarity.RARE, mage.cards.a.AdamaroFirstToDesire.class));
         cards.add(new SetCardInfo("Aether Shockwave", 1, Rarity.UNCOMMON, mage.cards.a.AetherShockwave.class));
         cards.add(new SetCardInfo("Akki Drillmaster", 92, Rarity.COMMON, mage.cards.a.AkkiDrillmaster.class));

--- a/Mage.Sets/src/mage/sets/ScarsOfMirrodinPromos.java
+++ b/Mage.Sets/src/mage/sets/ScarsOfMirrodinPromos.java
@@ -17,6 +17,7 @@ public class ScarsOfMirrodinPromos extends ExpansionSet {
 
     private ScarsOfMirrodinPromos() {
         super("Scars of Mirrodin Promos", "PSOM", ExpansionSet.buildDate(2010, 9, 30), SetType.PROMOTIONAL);
+        this.blockName = "Scars of Mirrodin";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ScarsOfMirrodinPromos.java
+++ b/Mage.Sets/src/mage/sets/ScarsOfMirrodinPromos.java
@@ -18,6 +18,7 @@ public class ScarsOfMirrodinPromos extends ExpansionSet {
     private ScarsOfMirrodinPromos() {
         super("Scars of Mirrodin Promos", "PSOM", ExpansionSet.buildDate(2010, 9, 30), SetType.PROMOTIONAL);
         this.blockName = "Scars of Mirrodin";
+        this.parentSet = ScarsOfMirrodin.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Scourge.java
+++ b/Mage.Sets/src/mage/sets/Scourge.java
@@ -20,7 +20,6 @@ public final class Scourge extends ExpansionSet {
     private Scourge() {
         super("Scourge", "SCG", ExpansionSet.buildDate(2003, 5, 17), SetType.EXPANSION);
         this.blockName = "Onslaught";
-        this.parentSet = Onslaught.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -28,6 +27,7 @@ public final class Scourge extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Accelerated Mutation", 109, Rarity.COMMON, mage.cards.a.AcceleratedMutation.class));
         cards.add(new SetCardInfo("Ageless Sentinels", 1, Rarity.RARE, mage.cards.a.AgelessSentinels.class));
         cards.add(new SetCardInfo("Alpha Status", 110, Rarity.UNCOMMON, mage.cards.a.AlphaStatus.class));

--- a/Mage.Sets/src/mage/sets/SecretLair30thAnniversaryCountdownKit.java
+++ b/Mage.Sets/src/mage/sets/SecretLair30thAnniversaryCountdownKit.java
@@ -17,6 +17,7 @@ public class SecretLair30thAnniversaryCountdownKit extends ExpansionSet {
 
     private SecretLair30thAnniversaryCountdownKit() {
         super("Secret Lair 30th Anniversary Countdown Kit", "SLC", ExpansionSet.buildDate(2022, 11, 1), SetType.PROMOTIONAL);
+        this.parentSet = SecretLairDrop.getInstance();
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Arclight Phoenix", 2018, Rarity.RARE, mage.cards.a.ArclightPhoenix.class));

--- a/Mage.Sets/src/mage/sets/SecretLairUltimateEdition.java
+++ b/Mage.Sets/src/mage/sets/SecretLairUltimateEdition.java
@@ -17,6 +17,7 @@ public class SecretLairUltimateEdition extends ExpansionSet {
 
     private SecretLairUltimateEdition() {
         super("Secret Lair: Ultimate Edition", "SLU", ExpansionSet.buildDate(2020, 5, 29), SetType.PROMOTIONAL);
+        this.parentSet = SecretLairDrop.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/SeventhEdition.java
+++ b/Mage.Sets/src/mage/sets/SeventhEdition.java
@@ -18,6 +18,7 @@ public final class SeventhEdition extends ExpansionSet {
 
     private SeventhEdition() {
         super("Seventh Edition", "7ED", ExpansionSet.buildDate(2001, 3, 11), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/ShadowsOverInnistradPromos.java
+++ b/Mage.Sets/src/mage/sets/ShadowsOverInnistradPromos.java
@@ -18,6 +18,7 @@ public class ShadowsOverInnistradPromos extends ExpansionSet {
     private ShadowsOverInnistradPromos() {
         super("Shadows over Innistrad Promos", "PSOI", ExpansionSet.buildDate(2016, 4, 9), SetType.PROMOTIONAL);
         this.blockName = "Shadows over Innistrad";
+        this.parentSet = ShadowsOverInnistrad.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ShadowsOverInnistradPromos.java
+++ b/Mage.Sets/src/mage/sets/ShadowsOverInnistradPromos.java
@@ -17,6 +17,7 @@ public class ShadowsOverInnistradPromos extends ExpansionSet {
 
     private ShadowsOverInnistradPromos() {
         super("Shadows over Innistrad Promos", "PSOI", ExpansionSet.buildDate(2016, 4, 9), SetType.PROMOTIONAL);
+        this.blockName = "Shadows over Innistrad";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ShardsOfAlara.java
+++ b/Mage.Sets/src/mage/sets/ShardsOfAlara.java
@@ -26,7 +26,7 @@ public final class ShardsOfAlara extends ExpansionSet {
     private ShardsOfAlara() {
         // release date of Shards of Alara was October 3rd, 2008. Was previously entered as August 27.
         super("Shards of Alara", "ALA", ExpansionSet.buildDate(2008, 10, 3), SetType.EXPANSION);
-        this.blockName = "Shards of Alara";
+        this.blockName = "Alara";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/ShardsOfAlaraPromos.java
+++ b/Mage.Sets/src/mage/sets/ShardsOfAlaraPromos.java
@@ -20,6 +20,7 @@ public final class ShardsOfAlaraPromos extends ExpansionSet {
     private ShardsOfAlaraPromos() {
         super("Shards of Alara Promos", "PALA", ExpansionSet.buildDate(2008, 10, 3), SetType.PROMOTIONAL);
         this.blockName = "Alara";
+        this.parentSet = ShardsOfAlara.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ShardsOfAlaraPromos.java
+++ b/Mage.Sets/src/mage/sets/ShardsOfAlaraPromos.java
@@ -19,7 +19,7 @@ public final class ShardsOfAlaraPromos extends ExpansionSet {
 
     private ShardsOfAlaraPromos() {
         super("Shards of Alara Promos", "PALA", ExpansionSet.buildDate(2008, 10, 3), SetType.PROMOTIONAL);
-        this.blockName = "Shards of Alara";
+        this.blockName = "Alara";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Starter1999.java
+++ b/Mage.Sets/src/mage/sets/Starter1999.java
@@ -18,7 +18,6 @@ public final class Starter1999 extends ExpansionSet {
 
     private Starter1999() {
         super("Starter 1999", "S99", ExpansionSet.buildDate(1999, 7, 1), SetType.SUPPLEMENTAL);
-        this.blockName = "Beginner";
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterLands = 2;
@@ -26,6 +25,7 @@ public final class Starter1999 extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Abyssal Horror", 63, Rarity.RARE, mage.cards.a.AbyssalHorror.class));
         cards.add(new SetCardInfo("Air Elemental", 32, Rarity.UNCOMMON, mage.cards.a.AirElemental.class));
         cards.add(new SetCardInfo("Alluring Scent", 124, Rarity.RARE, mage.cards.a.AlluringScent.class));

--- a/Mage.Sets/src/mage/sets/Starter2000.java
+++ b/Mage.Sets/src/mage/sets/Starter2000.java
@@ -19,7 +19,6 @@ public final class Starter2000 extends ExpansionSet {
 
     private Starter2000() {
         super("Starter 2000", "S00", ExpansionSet.buildDate(2000, 7, 1), SetType.SUPPLEMENTAL);
-        this.blockName = "Beginner";
         this.hasBasicLands = false;
         this.hasBoosters = false;
 

--- a/Mage.Sets/src/mage/sets/StreetsOfNewCapenna.java
+++ b/Mage.Sets/src/mage/sets/StreetsOfNewCapenna.java
@@ -24,7 +24,6 @@ public final class StreetsOfNewCapenna extends ExpansionSet {
 
     private StreetsOfNewCapenna() {
         super("Streets of New Capenna", "SNC", ExpansionSet.buildDate(2022, 4, 29), SetType.EXPANSION);
-        this.blockName = "Streets of New Capenna";
         this.hasBoosters = true;
         this.hasBasicLands = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/StrixhavenMysticalArchive.java
+++ b/Mage.Sets/src/mage/sets/StrixhavenMysticalArchive.java
@@ -17,6 +17,7 @@ public final class StrixhavenMysticalArchive extends ExpansionSet {
 
     private StrixhavenMysticalArchive() {
         super("Strixhaven Mystical Archive", "STA", ExpansionSet.buildDate(2021, 4, 23), SetType.SUPPLEMENTAL);
+        this.parentSet = StrixhavenSchoolOfMages.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
         this.maxCardNumberInBooster = 63;

--- a/Mage.Sets/src/mage/sets/StrixhavenSchoolOfMages.java
+++ b/Mage.Sets/src/mage/sets/StrixhavenSchoolOfMages.java
@@ -30,7 +30,6 @@ public final class StrixhavenSchoolOfMages extends ExpansionSet {
 
     private StrixhavenSchoolOfMages() {
         super("Strixhaven: School of Mages", "STX", ExpansionSet.buildDate(2021, 4, 23), SetType.EXPANSION);
-        this.blockName = "Strixhaven: School of Mages";
         this.hasBoosters = true;
         this.hasBasicLands = true;
         this.numBoosterCommon = 9;

--- a/Mage.Sets/src/mage/sets/Stronghold.java
+++ b/Mage.Sets/src/mage/sets/Stronghold.java
@@ -18,7 +18,6 @@ public final class Stronghold extends ExpansionSet {
     private Stronghold() {
         super("Stronghold", "STH", ExpansionSet.buildDate(1998, 3, 2), SetType.EXPANSION);
         this.blockName = "Tempest";
-        this.parentSet = Tempest.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/SummerMagic.java
+++ b/Mage.Sets/src/mage/sets/SummerMagic.java
@@ -17,6 +17,7 @@ public class SummerMagic extends ExpansionSet {
 
     private SummerMagic() {
         super("Summer Magic", "SUM", ExpansionSet.buildDate(1994, 6, 21), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;

--- a/Mage.Sets/src/mage/sets/TalesOfMiddleEarthCommander.java
+++ b/Mage.Sets/src/mage/sets/TalesOfMiddleEarthCommander.java
@@ -14,6 +14,7 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
 
     private TalesOfMiddleEarthCommander() {
         super("Tales of Middle-earth Commander", "LTC", ExpansionSet.buildDate(2023, 6, 23), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Access Tunnel", 294, Rarity.UNCOMMON, mage.cards.a.AccessTunnel.class));

--- a/Mage.Sets/src/mage/sets/TalesOfMiddleEarthCommander.java
+++ b/Mage.Sets/src/mage/sets/TalesOfMiddleEarthCommander.java
@@ -15,6 +15,7 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
     private TalesOfMiddleEarthCommander() {
         super("Tales of Middle-earth Commander", "LTC", ExpansionSet.buildDate(2023, 6, 23), SetType.SUPPLEMENTAL);
         this.blockName = "Commander";
+        this.parentSet = TheLordOfTheRingsTalesOfMiddleEarth.getInstance();
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Access Tunnel", 294, Rarity.UNCOMMON, mage.cards.a.AccessTunnel.class));

--- a/Mage.Sets/src/mage/sets/TarkirDragonfury.java
+++ b/Mage.Sets/src/mage/sets/TarkirDragonfury.java
@@ -18,6 +18,7 @@ public class TarkirDragonfury extends ExpansionSet {
     private TarkirDragonfury() {
         super("Tarkir Dragonfury", "PTKDF", ExpansionSet.buildDate(2015, 4, 3), SetType.PROMOTIONAL);
         this.blockName = "Khans of Tarkir";
+        this.parentSet = DragonsOfTarkir.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/TarkirDragonfury.java
+++ b/Mage.Sets/src/mage/sets/TarkirDragonfury.java
@@ -17,6 +17,7 @@ public class TarkirDragonfury extends ExpansionSet {
 
     private TarkirDragonfury() {
         super("Tarkir Dragonfury", "PTKDF", ExpansionSet.buildDate(2015, 4, 3), SetType.PROMOTIONAL);
+        this.blockName = "Khans of Tarkir";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/TenthEdition.java
+++ b/Mage.Sets/src/mage/sets/TenthEdition.java
@@ -17,6 +17,7 @@ public final class TenthEdition extends ExpansionSet {
 
     private TenthEdition() {
         super("Tenth Edition", "10E", ExpansionSet.buildDate(2007, 6, 14), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/TenthEditionPromos.java
+++ b/Mage.Sets/src/mage/sets/TenthEditionPromos.java
@@ -17,6 +17,7 @@ public class TenthEditionPromos extends ExpansionSet {
 
     private TenthEditionPromos() {
         super("Tenth Edition Promos", "P10E", ExpansionSet.buildDate(2007, 7, 13), SetType.PROMOTIONAL);
+        this.parentSet = TenthEdition.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/TheBrothersWar.java
+++ b/Mage.Sets/src/mage/sets/TheBrothersWar.java
@@ -24,7 +24,6 @@ public final class TheBrothersWar extends ExpansionSet {
 
     private TheBrothersWar() {
         super("The Brothers' War", "BRO", ExpansionSet.buildDate(2022, 11, 18), SetType.EXPANSION);
-        this.blockName = "The Brothers' War";
         this.hasBoosters = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 10; // TODO: someone can make it so 1/4 of the time a common is replaced by a basic land in the future if they want to

--- a/Mage.Sets/src/mage/sets/TheBrothersWarCommander.java
+++ b/Mage.Sets/src/mage/sets/TheBrothersWarCommander.java
@@ -18,6 +18,7 @@ public final class TheBrothersWarCommander extends ExpansionSet {
     private TheBrothersWarCommander() {
         super("The Brothers' War Commander", "BRC", ExpansionSet.buildDate(2022, 11, 18), SetType.SUPPLEMENTAL);
         this.blockName = "Commander";
+        this.parentSet = TheBrothersWar.getInstance();
 
         cards.add(new SetCardInfo("Abrade", 111, Rarity.UNCOMMON, mage.cards.a.Abrade.class));
         cards.add(new SetCardInfo("Alela, Artful Provocateur", 119, Rarity.MYTHIC, mage.cards.a.AlelaArtfulProvocateur.class));

--- a/Mage.Sets/src/mage/sets/TheBrothersWarCommander.java
+++ b/Mage.Sets/src/mage/sets/TheBrothersWarCommander.java
@@ -17,6 +17,7 @@ public final class TheBrothersWarCommander extends ExpansionSet {
 
     private TheBrothersWarCommander() {
         super("The Brothers' War Commander", "BRC", ExpansionSet.buildDate(2022, 11, 18), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
 
         cards.add(new SetCardInfo("Abrade", 111, Rarity.UNCOMMON, mage.cards.a.Abrade.class));
         cards.add(new SetCardInfo("Alela, Artful Provocateur", 119, Rarity.MYTHIC, mage.cards.a.AlelaArtfulProvocateur.class));

--- a/Mage.Sets/src/mage/sets/TheBrothersWarRetroArtifacts.java
+++ b/Mage.Sets/src/mage/sets/TheBrothersWarRetroArtifacts.java
@@ -17,6 +17,7 @@ public final class TheBrothersWarRetroArtifacts extends ExpansionSet {
 
     private TheBrothersWarRetroArtifacts() {
         super("The Brothers' War Retro Artifacts", "BRR", ExpansionSet.buildDate(2022, 11, 18), SetType.SUPPLEMENTAL);
+        this.parentSet = TheBrothersWar.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
         this.maxCardNumberInBooster = 63;

--- a/Mage.Sets/src/mage/sets/TheLordOfTheRingsTalesOfMiddleEarth.java
+++ b/Mage.Sets/src/mage/sets/TheLordOfTheRingsTalesOfMiddleEarth.java
@@ -14,7 +14,6 @@ public final class TheLordOfTheRingsTalesOfMiddleEarth extends ExpansionSet {
 
     private TheLordOfTheRingsTalesOfMiddleEarth() {
         super("The Lord of the Rings: Tales of Middle-earth", "LTR", ExpansionSet.buildDate(2023, 6, 23), SetType.SUPPLEMENTAL_MODERN_LEGAL);
-        this.blockName = "The Lord of the Rings: Tales of Middle-earth";
         this.hasBasicLands = true;
         this.hasBoosters = false; // temporary
 

--- a/Mage.Sets/src/mage/sets/TherosBeyondDeath.java
+++ b/Mage.Sets/src/mage/sets/TherosBeyondDeath.java
@@ -24,7 +24,6 @@ public final class TherosBeyondDeath extends ExpansionSet {
 
     private TherosBeyondDeath() {
         super("Theros Beyond Death", "THB", ExpansionSet.buildDate(2020, 1, 24), SetType.EXPANSION);
-        this.blockName = "Theros Beyond Death";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/TherosBeyondDeathPromos.java
+++ b/Mage.Sets/src/mage/sets/TherosBeyondDeathPromos.java
@@ -17,6 +17,7 @@ public class TherosBeyondDeathPromos extends ExpansionSet {
 
     private TherosBeyondDeathPromos() {
         super("Theros Beyond Death Promos", "PTHB", ExpansionSet.buildDate(2020, 1, 24), SetType.PROMOTIONAL);
+        this.parentSet = TherosBeyondDeath.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/TherosPromos.java
+++ b/Mage.Sets/src/mage/sets/TherosPromos.java
@@ -18,6 +18,7 @@ public class TherosPromos extends ExpansionSet {
     private TherosPromos() {
         super("Theros Promos", "PTHS", ExpansionSet.buildDate(2013, 9, 21), SetType.PROMOTIONAL);
         this.blockName = "Theros";
+        this.parentSet = Theros.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/TherosPromos.java
+++ b/Mage.Sets/src/mage/sets/TherosPromos.java
@@ -17,6 +17,7 @@ public class TherosPromos extends ExpansionSet {
 
     private TherosPromos() {
         super("Theros Promos", "PTHS", ExpansionSet.buildDate(2013, 9, 21), SetType.PROMOTIONAL);
+        this.blockName = "Theros";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ThroneOfEldraine.java
+++ b/Mage.Sets/src/mage/sets/ThroneOfEldraine.java
@@ -24,7 +24,6 @@ public final class ThroneOfEldraine extends ExpansionSet {
 
     private ThroneOfEldraine() {
         super("Throne of Eldraine", "ELD", ExpansionSet.buildDate(2019, 10, 4), SetType.EXPANSION);
-        this.blockName = "Throne of Eldraine";
         this.hasBoosters = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;

--- a/Mage.Sets/src/mage/sets/ThroneOfEldrainePromos.java
+++ b/Mage.Sets/src/mage/sets/ThroneOfEldrainePromos.java
@@ -17,6 +17,7 @@ public class ThroneOfEldrainePromos extends ExpansionSet {
 
     private ThroneOfEldrainePromos() {
         super("Throne of Eldraine Promos", "PELD", ExpansionSet.buildDate(2019, 10, 4), SetType.PROMOTIONAL);
+        this.parentSet = ThroneOfEldraine.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Torment.java
+++ b/Mage.Sets/src/mage/sets/Torment.java
@@ -20,7 +20,6 @@ public final class Torment extends ExpansionSet {
     private Torment() {
         super("Torment", "TOR", ExpansionSet.buildDate(2002, 1, 26), SetType.EXPANSION);
         this.blockName = "Odyssey";
-        this.parentSet = Odyssey.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -29,6 +28,7 @@ public final class Torment extends ExpansionSet {
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
         this.hasUnbalancedColors = true;
+
         cards.add(new SetCardInfo("Accelerate", 90, Rarity.COMMON, mage.cards.a.Accelerate.class));
         cards.add(new SetCardInfo("Acorn Harvest", 118, Rarity.COMMON, mage.cards.a.AcornHarvest.class));
         cards.add(new SetCardInfo("Ambassador Laquatus", 23, Rarity.RARE, mage.cards.a.AmbassadorLaquatus.class));

--- a/Mage.Sets/src/mage/sets/Transformers.java
+++ b/Mage.Sets/src/mage/sets/Transformers.java
@@ -17,6 +17,7 @@ public final class Transformers extends ExpansionSet {
 
     private Transformers() {
         super("Transformers", "BOT", ExpansionSet.buildDate(2022, 11, 18), SetType.SUPPLEMENTAL);
+        this.parentSet = TheBrothersWar.getInstance();
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Arcee, Acrobatic Coupe", 7, Rarity.MYTHIC, mage.cards.a.ArceeAcrobaticCoupe.class));

--- a/Mage.Sets/src/mage/sets/UginsFate.java
+++ b/Mage.Sets/src/mage/sets/UginsFate.java
@@ -18,6 +18,7 @@ public final class UginsFate extends ExpansionSet {
 
     private UginsFate() {
         super("Ugin's Fate", "UGIN", ExpansionSet.buildDate(2015, 1, 16), SetType.PROMOTIONAL);
+        this.blockName = "Khans of Tarkir";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/UginsFate.java
+++ b/Mage.Sets/src/mage/sets/UginsFate.java
@@ -19,6 +19,7 @@ public final class UginsFate extends ExpansionSet {
     private UginsFate() {
         super("Ugin's Fate", "UGIN", ExpansionSet.buildDate(2015, 1, 16), SetType.PROMOTIONAL);
         this.blockName = "Khans of Tarkir";
+        this.parentSet = FateReforged.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/UltimateBoxTopperPromos.java
+++ b/Mage.Sets/src/mage/sets/UltimateBoxTopperPromos.java
@@ -18,6 +18,7 @@ public final class UltimateBoxTopperPromos extends ExpansionSet {
 
     private UltimateBoxTopperPromos() {
         super("Ultimate Box Topper Promos", "PUMA", ExpansionSet.buildDate(2018, 12, 7), SetType.PROMOTIONAL);
+        this.parentSet = UltimateMasters.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = false;
 

--- a/Mage.Sets/src/mage/sets/UltimateMasters.java
+++ b/Mage.Sets/src/mage/sets/UltimateMasters.java
@@ -24,7 +24,6 @@ public final class UltimateMasters extends ExpansionSet {
 
     private UltimateMasters() {
         super("Ultimate Masters", "UMA", ExpansionSet.buildDate(2018, 12, 7), SetType.SUPPLEMENTAL);
-        this.blockName = "Reprint";
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;

--- a/Mage.Sets/src/mage/sets/UniversesWithin.java
+++ b/Mage.Sets/src/mage/sets/UniversesWithin.java
@@ -18,6 +18,7 @@ public final class UniversesWithin extends ExpansionSet {
     private UniversesWithin() {
         // The set name is a placeholder and will likely change
         super("Universes Within", "SLX", ExpansionSet.buildDate(2022, 3, 3), SetType.SUPPLEMENTAL);
+        this.parentSet = SecretLairDrop.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = false;
 

--- a/Mage.Sets/src/mage/sets/UnlimitedEdition.java
+++ b/Mage.Sets/src/mage/sets/UnlimitedEdition.java
@@ -20,6 +20,7 @@ public final class UnlimitedEdition extends ExpansionSet {
 
     private UnlimitedEdition() {
         super("Unlimited Edition", "2ED", ExpansionSet.buildDate(1993, 11, 1), SetType.CORE);
+        this.blockName = "Core Set";
         this.hasBoosters = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;

--- a/Mage.Sets/src/mage/sets/UnstablePromos.java
+++ b/Mage.Sets/src/mage/sets/UnstablePromos.java
@@ -17,6 +17,7 @@ public class UnstablePromos extends ExpansionSet {
 
     private UnstablePromos() {
         super("Unstable Promos", "PUST", ExpansionSet.buildDate(2017, 11, 13), SetType.JOKESET);
+        this.parentSet = Unstable.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/UrzasDestiny.java
+++ b/Mage.Sets/src/mage/sets/UrzasDestiny.java
@@ -20,7 +20,6 @@ public final class UrzasDestiny extends ExpansionSet {
     private UrzasDestiny() {
         super("Urza's Destiny", "UDS", ExpansionSet.buildDate(1999, 6, 7), SetType.EXPANSION);
         this.blockName = "Urza";
-        this.parentSet = UrzasSaga.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -28,6 +27,7 @@ public final class UrzasDestiny extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Academy Rector", 1, Rarity.RARE, mage.cards.a.AcademyRector.class));
         cards.add(new SetCardInfo("Aether Sting", 76, Rarity.UNCOMMON, mage.cards.a.AetherSting.class));
         cards.add(new SetCardInfo("Ancient Silverback", 101, Rarity.RARE, mage.cards.a.AncientSilverback.class));

--- a/Mage.Sets/src/mage/sets/UrzasLegacy.java
+++ b/Mage.Sets/src/mage/sets/UrzasLegacy.java
@@ -20,7 +20,6 @@ public final class UrzasLegacy extends ExpansionSet {
     private UrzasLegacy() {
         super("Urza's Legacy", "ULG", ExpansionSet.buildDate(1999, 2, 15), SetType.EXPANSION);
         this.blockName = "Urza";
-        this.parentSet = UrzasSaga.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -28,6 +27,7 @@ public final class UrzasLegacy extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("About Face", 73, Rarity.COMMON, mage.cards.a.AboutFace.class));
         cards.add(new SetCardInfo("Angel's Trumpet", 121, Rarity.UNCOMMON, mage.cards.a.AngelsTrumpet.class));
         cards.add(new SetCardInfo("Angelic Curator", 1, Rarity.COMMON, mage.cards.a.AngelicCurator.class));

--- a/Mage.Sets/src/mage/sets/Visions.java
+++ b/Mage.Sets/src/mage/sets/Visions.java
@@ -19,7 +19,6 @@ public final class Visions extends ExpansionSet {
     private Visions() {
         super("Visions", "VIS", ExpansionSet.buildDate(1997, 1, 11), SetType.EXPANSION);
         this.blockName = "Mirage";
-        this.parentSet = Mirage.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -27,6 +26,7 @@ public final class Visions extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Aku Djinn", 51, Rarity.RARE, mage.cards.a.AkuDjinn.class));
         cards.add(new SetCardInfo("Anvil of Bogardan", 141, Rarity.RARE, mage.cards.a.AnvilOfBogardan.class));
         cards.add(new SetCardInfo("Archangel", 1, Rarity.RARE, mage.cards.a.Archangel.class));

--- a/Mage.Sets/src/mage/sets/WarOfTheSparkPromos.java
+++ b/Mage.Sets/src/mage/sets/WarOfTheSparkPromos.java
@@ -17,6 +17,7 @@ public class WarOfTheSparkPromos extends ExpansionSet {
 
     private WarOfTheSparkPromos() {
         super("War of the Spark Promos", "PWAR", ExpansionSet.buildDate(2019, 5, 4), SetType.PROMOTIONAL);
+        this.parentSet = WarOfTheSpark.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/Warhammer40000.java
+++ b/Mage.Sets/src/mage/sets/Warhammer40000.java
@@ -20,6 +20,7 @@ public final class Warhammer40000 extends ExpansionSet {
 
     private Warhammer40000() {
         super("Warhammer 40,000", "40K", ExpansionSet.buildDate(2022, 4, 29), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
         this.hasBasicLands = true;
         this.hasBoosters = false;
 

--- a/Mage.Sets/src/mage/sets/Weatherlight.java
+++ b/Mage.Sets/src/mage/sets/Weatherlight.java
@@ -19,7 +19,6 @@ public final class Weatherlight extends ExpansionSet {
     private Weatherlight() {
         super("Weatherlight", "WTH", ExpansionSet.buildDate(1997, 5, 31), SetType.EXPANSION);
         this.blockName = "Mirage";
-        this.parentSet = Mirage.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 0;
@@ -27,6 +26,7 @@ public final class Weatherlight extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Abduction", 30, Rarity.UNCOMMON, mage.cards.a.Abduction.class));
         cards.add(new SetCardInfo("Abeyance", 1, Rarity.RARE, mage.cards.a.Abeyance.class));
         cards.add(new SetCardInfo("Abjure", 31, Rarity.COMMON, mage.cards.a.Abjure.class));

--- a/Mage.Sets/src/mage/sets/Worldwake.java
+++ b/Mage.Sets/src/mage/sets/Worldwake.java
@@ -26,7 +26,6 @@ public final class Worldwake extends ExpansionSet {
     private Worldwake() {
         super("Worldwake", "WWK", ExpansionSet.buildDate(2010, 1, 30), SetType.EXPANSION);
         this.blockName = "Zendikar";
-        this.parentSet = Zendikar.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 1;
@@ -34,6 +33,7 @@ public final class Worldwake extends ExpansionSet {
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Abyssal Persecutor", 47, Rarity.MYTHIC, mage.cards.a.AbyssalPersecutor.class));
         cards.add(new SetCardInfo("Admonition Angel", 1, Rarity.MYTHIC, mage.cards.a.AdmonitionAngel.class));
         cards.add(new SetCardInfo("Aether Tradewinds", 24, Rarity.COMMON, mage.cards.a.AetherTradewinds.class));

--- a/Mage.Sets/src/mage/sets/WorldwakePromos.java
+++ b/Mage.Sets/src/mage/sets/WorldwakePromos.java
@@ -17,6 +17,7 @@ public class WorldwakePromos extends ExpansionSet {
 
     private WorldwakePromos() {
         super("Worldwake Promos", "PWWK", ExpansionSet.buildDate(2010, 7, 30), SetType.PROMOTIONAL);
+        this.blockName = "Zendikar";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/WorldwakePromos.java
+++ b/Mage.Sets/src/mage/sets/WorldwakePromos.java
@@ -18,6 +18,7 @@ public class WorldwakePromos extends ExpansionSet {
     private WorldwakePromos() {
         super("Worldwake Promos", "PWWK", ExpansionSet.buildDate(2010, 7, 30), SetType.PROMOTIONAL);
         this.blockName = "Zendikar";
+        this.parentSet = Worldwake.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ZendikarExpeditions.java
+++ b/Mage.Sets/src/mage/sets/ZendikarExpeditions.java
@@ -18,7 +18,7 @@ public final class ZendikarExpeditions extends ExpansionSet {
 
     private ZendikarExpeditions() {
         super("Zendikar Expeditions", "EXP", ExpansionSet.buildDate(2015, 10, 2), SetType.PROMOTIONAL);
-        this.blockName = "Masterpiece Series";
+        this.blockName = "Battle for Zendikar";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ZendikarExpeditions.java
+++ b/Mage.Sets/src/mage/sets/ZendikarExpeditions.java
@@ -19,6 +19,7 @@ public final class ZendikarExpeditions extends ExpansionSet {
     private ZendikarExpeditions() {
         super("Zendikar Expeditions", "EXP", ExpansionSet.buildDate(2015, 10, 2), SetType.PROMOTIONAL);
         this.blockName = "Battle for Zendikar";
+        this.parentSet = BattleForZendikar.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ZendikarPromos.java
+++ b/Mage.Sets/src/mage/sets/ZendikarPromos.java
@@ -18,6 +18,7 @@ public class ZendikarPromos extends ExpansionSet {
     private ZendikarPromos() {
         super("Zendikar Promos", "PZEN", ExpansionSet.buildDate(2009, 10, 2), SetType.PROMOTIONAL);
         this.blockName = "Zendikar";
+        this.parentSet = Zendikar.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ZendikarPromos.java
+++ b/Mage.Sets/src/mage/sets/ZendikarPromos.java
@@ -17,6 +17,7 @@ public class ZendikarPromos extends ExpansionSet {
 
     private ZendikarPromos() {
         super("Zendikar Promos", "PZEN", ExpansionSet.buildDate(2009, 10, 2), SetType.PROMOTIONAL);
+        this.blockName = "Zendikar";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ZendikarRising.java
+++ b/Mage.Sets/src/mage/sets/ZendikarRising.java
@@ -27,7 +27,6 @@ public final class ZendikarRising extends ExpansionSet {
 
     private ZendikarRising() {
         super("Zendikar Rising", "ZNR", ExpansionSet.buildDate(2020, 9, 25), SetType.EXPANSION);
-        this.blockName = "Zendikar Rising";
         this.hasBasicLands = true;
         this.hasBoosters = true;
         this.numBoosterLands = 1;

--- a/Mage.Sets/src/mage/sets/ZendikarRisingCommander.java
+++ b/Mage.Sets/src/mage/sets/ZendikarRisingCommander.java
@@ -17,6 +17,7 @@ public final class ZendikarRisingCommander extends ExpansionSet {
 
     private ZendikarRisingCommander() {
         super("Zendikar Rising Commander", "ZNC", ExpansionSet.buildDate(2020, 9, 25), SetType.SUPPLEMENTAL);
+        this.blockName = "Commander";
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abundance", 58, Rarity.RARE, mage.cards.a.Abundance.class));

--- a/Mage.Sets/src/mage/sets/ZendikarRisingCommander.java
+++ b/Mage.Sets/src/mage/sets/ZendikarRisingCommander.java
@@ -18,6 +18,7 @@ public final class ZendikarRisingCommander extends ExpansionSet {
     private ZendikarRisingCommander() {
         super("Zendikar Rising Commander", "ZNC", ExpansionSet.buildDate(2020, 9, 25), SetType.SUPPLEMENTAL);
         this.blockName = "Commander";
+        this.parentSet = ZendikarRising.getInstance();
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Abundance", 58, Rarity.RARE, mage.cards.a.Abundance.class));

--- a/Mage.Sets/src/mage/sets/ZendikarRisingExpeditions.java
+++ b/Mage.Sets/src/mage/sets/ZendikarRisingExpeditions.java
@@ -17,6 +17,7 @@ public final class ZendikarRisingExpeditions extends ExpansionSet {
 
     private ZendikarRisingExpeditions() {
         super("Zendikar Rising Expeditions", "ZNE", ExpansionSet.buildDate(2020, 9, 25), SetType.PROMOTIONAL);
+        this.parentSet = ZendikarRising.getInstance();
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/ZendikarRisingExpeditions.java
+++ b/Mage.Sets/src/mage/sets/ZendikarRisingExpeditions.java
@@ -17,7 +17,6 @@ public final class ZendikarRisingExpeditions extends ExpansionSet {
 
     private ZendikarRisingExpeditions() {
         super("Zendikar Rising Expeditions", "ZNE", ExpansionSet.buildDate(2020, 9, 25), SetType.PROMOTIONAL);
-        this.blockName = "Masterpiece Series";
         this.hasBoosters = false;
         this.hasBasicLands = false;
 


### PR DESCRIPTION
Fixed wrong block and parent set info according to the tests. This changed a lot of files but the changes were small in each one.

fix #10184