### PR TITLE
bugfix: hide `Packs:` label for constructed rather than hiding panel twice

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
@@ -1001,7 +1001,7 @@ public class NewTournamentDialog extends MageDialog {
             // construced
             this.lblDraftCube.setVisible(false);
             this.cbDraftCube.setVisible(false);
-            this.pnlPacks.setVisible(false);
+            this.lblPacks.setVisible(false);
             this.pnlPacks.setVisible(false);
             this.pnlRandomPacks.setVisible(false);
         }


### PR DESCRIPTION
tiny fix, shouldn't conflict with #10768 