### PR TITLE
fix null SetTargetPointer

### DIFF
--- a/Mage/src/main/java/mage/abilities/common/SpellCastControllerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/SpellCastControllerTriggeredAbility.java
@@ -56,11 +56,11 @@ public class SpellCastControllerTriggeredAbility extends TriggeredAbilityImpl {
     }
 
     public static SpellCastControllerTriggeredAbility createWithFromZone(Effect effect, FilterSpell filter, boolean optional, Zone fromZone) {
-        return new SpellCastControllerTriggeredAbility(Zone.BATTLEFIELD, effect, filter, optional, null, null, fromZone);
+        return new SpellCastControllerTriggeredAbility(Zone.BATTLEFIELD, effect, filter, optional, SetTargetPointer.NONE, null, fromZone);
     }
 
     public static SpellCastControllerTriggeredAbility createWithRule(Effect effect, FilterSpell filter, boolean optional, String rule) {
-        return new SpellCastControllerTriggeredAbility(Zone.BATTLEFIELD, effect, filter, optional, null, rule, null);
+        return new SpellCastControllerTriggeredAbility(Zone.BATTLEFIELD, effect, filter, optional, SetTargetPointer.NONE, rule, null);
     }
 
     protected SpellCastControllerTriggeredAbility(final SpellCastControllerTriggeredAbility ability) {


### PR DESCRIPTION
bug introduced from refactoring in #10727 
fix #10769 

@Susucre anything else besides these two that should be checked?

side note: it would be nice to remove the manual rule setting altogether (prefer to just `setTriggerPhrase()` and `setText()`), but that can be done separately