### PR TITLE
Add image number support for command objects

### DIFF
--- a/Mage.Common/src/main/java/mage/view/CardView.java
+++ b/Mage.Common/src/main/java/mage/view/CardView.java
@@ -706,7 +706,7 @@ public class CardView extends SimpleCardView {
         this.frameStyle = FrameStyle.M15_NORMAL;
         this.expansionSetCode = emblem.getExpansionSetCode();
         this.cardNumber = "";
-        this.imageNumber = 0;
+        this.imageNumber = emblem.getImageNumber();
         this.rarity = Rarity.COMMON;
 
         this.playableStats = emblem.playableStats.copy();

--- a/Mage.Common/src/main/java/mage/view/CommandObjectView.java
+++ b/Mage.Common/src/main/java/mage/view/CommandObjectView.java
@@ -14,5 +14,7 @@ public interface CommandObjectView extends SelectableObjectView {
 
     UUID getId();
 
+    int getImageNumber();
+
     List<String> getRules();
 }

--- a/Mage.Common/src/main/java/mage/view/DungeonView.java
+++ b/Mage.Common/src/main/java/mage/view/DungeonView.java
@@ -14,6 +14,7 @@ public class DungeonView implements CommandObjectView, Serializable {
 
     protected UUID id;
     protected String name;
+    protected int imageNum;
     protected String expansionSetCode;
     protected List<String> rules;
     protected PlayableObjectStats playableStats = new PlayableObjectStats();
@@ -21,6 +22,7 @@ public class DungeonView implements CommandObjectView, Serializable {
     public DungeonView(Dungeon dungeon) {
         this.id = dungeon.getId();
         this.name = dungeon.getName();
+        this.imageNum = dungeon.getImageNumber();
         this.expansionSetCode = dungeon.getExpansionSetCode();
         this.rules = dungeon.getRules();
     }
@@ -38,6 +40,11 @@ public class DungeonView implements CommandObjectView, Serializable {
     @Override
     public UUID getId() {
         return id;
+    }
+
+    @Override
+    public int getImageNumber() {
+        return imageNum;
     }
 
     @Override

--- a/Mage.Common/src/main/java/mage/view/EmblemView.java
+++ b/Mage.Common/src/main/java/mage/view/EmblemView.java
@@ -15,6 +15,7 @@ public class EmblemView implements CommandObjectView, Serializable {
 
     protected UUID id;
     protected String name;
+    protected int imageNum;
     protected String expansionSetCode;
     protected List<String> rules;
     protected PlayableObjectStats playableStats = new PlayableObjectStats();
@@ -22,6 +23,7 @@ public class EmblemView implements CommandObjectView, Serializable {
     public EmblemView(Emblem emblem) {
         this.id = emblem.getId();
         this.name = emblem.getName();
+        this.imageNum = emblem.getImageNumber();
         this.expansionSetCode = emblem.getExpansionSetCode();
         this.rules = emblem.getAbilities().getRules(emblem.getName());
     }
@@ -39,6 +41,11 @@ public class EmblemView implements CommandObjectView, Serializable {
     @Override
     public UUID getId() {
         return id;
+    }
+
+    @Override
+    public int getImageNumber() {
+        return imageNum;
     }
 
     @Override

--- a/Mage.Common/src/main/java/mage/view/PlaneView.java
+++ b/Mage.Common/src/main/java/mage/view/PlaneView.java
@@ -15,6 +15,7 @@ public class PlaneView implements CommandObjectView, Serializable {
 
     protected UUID id;
     protected String name;
+    protected int imageNum;
     protected String expansionSetCode;
     protected List<String> rules;
     protected PlayableObjectStats playableStats = new PlayableObjectStats();
@@ -22,6 +23,7 @@ public class PlaneView implements CommandObjectView, Serializable {
     public PlaneView(Plane plane) {
         this.id = plane.getId();
         this.name = plane.getName();
+        this.imageNum = plane.getImageNumber();
         this.expansionSetCode = plane.getExpansionSetCode();
         this.rules = plane.getAbilities().getRules(plane.getName());
     }
@@ -39,6 +41,11 @@ public class PlaneView implements CommandObjectView, Serializable {
     @Override
     public UUID getId() {
         return id;
+    }
+
+    @Override
+    public int getImageNumber() {
+        return imageNum;
     }
 
     @Override


### PR DESCRIPTION
Adds to command objects what was already the case with tokens, specifically for emblems. Allows for multiple identically-named emblems in a set, as is true in the case of CMM with its [two Chandra emblems](https://scryfall.com/search?q=set%3ATCMM+t%3Aemblem+Chandra&unique=cards&as=grid&order=set), to still be correctly assigned images.

Planes' and dungeons' image numbers currently still default to 0 as this isn't immediately relevant to them yet but can change if necessary.