### PR TITLE
Fix Misstep; Pollen Lullaby; Icebreaker Kraken

### DIFF
--- a/Mage.Sets/src/mage/cards/e/Exhaustion.java
+++ b/Mage.Sets/src/mage/cards/e/Exhaustion.java
@@ -2,20 +2,13 @@
 package mage.cards.e;
 
 import java.util.UUID;
-import mage.abilities.Ability;
-import mage.abilities.effects.ContinuousEffect;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DontUntapInPlayersNextUntapStepAllEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
-import mage.game.Game;
-import mage.players.Player;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetOpponent;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -27,7 +20,9 @@ public final class Exhaustion extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{U}");
 
         // Creatures and lands target opponent controls don't untap during their next untap step.
-        this.getSpellAbility().addEffect(new ExhaustionEffect());
+        Effect effect = new DontUntapInPlayersNextUntapStepAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE_OR_LAND);
+        effect.setText("creatures and lands target opponent controls don't untap during their next untap step.");
+        this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetOpponent());
     }
 
@@ -38,41 +33,5 @@ public final class Exhaustion extends CardImpl {
     @Override
     public Exhaustion copy() {
         return new Exhaustion(this);
-    }
-}
-
-class ExhaustionEffect extends OneShotEffect {
-
-    private static final FilterPermanent filter = new FilterPermanent();
-
-    static {
-        filter.add(Predicates.or(CardType.CREATURE.getPredicate(), CardType.LAND.getPredicate()));
-    }
-
-    ExhaustionEffect() {
-        super(Outcome.Detriment);
-        this.staticText = "Creatures and lands target opponent controls don't untap during their next untap step.";
-    }
-
-    ExhaustionEffect(final ExhaustionEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public ExhaustionEffect copy() {
-        return new ExhaustionEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player player = game.getPlayer(source.getFirstTarget());
-   
-        if (player != null) {
-            ContinuousEffect effect = new DontUntapInPlayersNextUntapStepAllEffect(filter);
-            effect.setTargetPointer(new FixedTarget(player.getId()));
-            game.addEffect(effect, source);                      
-            return true;
-        }
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/i/IcebreakerKraken.java
+++ b/Mage.Sets/src/mage/cards/i/IcebreakerKraken.java
@@ -9,8 +9,7 @@ import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.ReturnToHandChosenControlledPermanentCost;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
-import mage.abilities.effects.ContinuousEffect;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DontUntapInPlayersNextUntapStepAllEffect;
 import mage.abilities.effects.common.ReturnToHandSourceEffect;
 import mage.abilities.effects.common.cost.SpellCostReductionForEachSourceEffect;
@@ -19,16 +18,11 @@ import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledLandPermanent;
 import mage.filter.common.FilterControlledPermanent;
-import mage.filter.predicate.Predicates;
-import mage.game.Game;
-import mage.players.Player;
 import mage.target.common.TargetControlledPermanent;
 import mage.target.common.TargetOpponent;
-import mage.target.targetpointer.FixedTarget;
-
 import java.util.UUID;
 
 /**
@@ -60,7 +54,9 @@ public final class IcebreakerKraken extends CardImpl {
         ).addHint(hint));
 
         // When Icebreaker Kraken enters the battlefield, artifacts and creatures target opponent controls don't untap during that player's next untap step.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new IcebreakerKrakenEffect());
+        Effect effect = new DontUntapInPlayersNextUntapStepAllEffect(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE);
+        effect.setText("artifacts and creatures target opponent controls don't untap during that player's next untap step");
+        Ability ability = new EntersBattlefieldTriggeredAbility(effect);
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);
 
@@ -77,41 +73,5 @@ public final class IcebreakerKraken extends CardImpl {
     @Override
     public IcebreakerKraken copy() {
         return new IcebreakerKraken(this);
-    }
-}
-
-class IcebreakerKrakenEffect extends OneShotEffect {
-
-    private static final FilterPermanent filter = new FilterPermanent();
-
-    static {
-        filter.add(Predicates.or(CardType.CREATURE.getPredicate(), CardType.ARTIFACT.getPredicate()));
-    }
-
-    IcebreakerKrakenEffect() {
-        super(Outcome.Detriment);
-        staticText = "Artifacts and creatures target opponent controls don't untap during that player's next untap step";
-    }
-
-    private IcebreakerKrakenEffect(final IcebreakerKrakenEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public IcebreakerKrakenEffect copy() {
-        return new IcebreakerKrakenEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player player = game.getPlayer(source.getFirstTarget());
-   
-        if (player != null) {
-            ContinuousEffect effect = new DontUntapInPlayersNextUntapStepAllEffect(filter);
-            effect.setTargetPointer(new FixedTarget(player.getId()));
-            game.addEffect(effect, source);                      
-            return true;
-        }
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/m/ManaVapors.java
+++ b/Mage.Sets/src/mage/cards/m/ManaVapors.java
@@ -2,7 +2,6 @@
 package mage.cards.m;
 
 import java.util.UUID;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DontUntapInPlayersNextUntapStepAllEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -20,9 +19,7 @@ public final class ManaVapors extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{U}");
 
         // Lands target player controls don't untap during their next untap step.
-        Effect effect = new DontUntapInPlayersNextUntapStepAllEffect(StaticFilters.FILTER_LAND);
-        effect.setText("lands target player controls don't untap during their next untap step");
-        getSpellAbility().addEffect(effect);
+        getSpellAbility().addEffect(new DontUntapInPlayersNextUntapStepAllEffect(StaticFilters.FILTER_LANDS));
         getSpellAbility().addTarget(new TargetPlayer());
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaVapors.java
+++ b/Mage.Sets/src/mage/cards/m/ManaVapors.java
@@ -10,8 +10,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
+import mage.filter.FilterPermanent;
 import mage.filter.common.FilterLandPermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetPlayer;
@@ -27,8 +27,8 @@ public final class ManaVapors extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{U}");
 
         // Lands target player controls don't untap during their next untap step.
-        getSpellAbility().addTarget(new TargetPlayer());
         getSpellAbility().addEffect(new ManaVaporsEffect());
+        getSpellAbility().addTarget(new TargetPlayer());
     }
 
     private ManaVapors(final ManaVapors card) {
@@ -43,8 +43,10 @@ public final class ManaVapors extends CardImpl {
 
 class ManaVaporsEffect extends OneShotEffect {
 
+    private static final FilterPermanent filter = new FilterLandPermanent();
+
     ManaVaporsEffect() {
-        super(Outcome.Benefit);
+        super(Outcome.Detriment);
         this.staticText = "Lands target player controls don't untap during their next untap step";
     }
 
@@ -59,12 +61,11 @@ class ManaVaporsEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Player targetPlayer = game.getPlayer(getTargetPointer().getFirst(game, source));
-        if (targetPlayer != null) {
-            FilterLandPermanent filter = new FilterLandPermanent();
-            filter.add(new ControllerIdPredicate(targetPlayer.getId()));
+        Player player = game.getPlayer(source.getFirstTarget());
+
+        if (player != null) {
             ContinuousEffect effect = new DontUntapInPlayersNextUntapStepAllEffect(filter);
-            effect.setTargetPointer(new FixedTarget(targetPlayer.getId()));
+            effect.setTargetPointer(new FixedTarget(player.getId()));
             game.addEffect(effect, source);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/m/ManaVapors.java
+++ b/Mage.Sets/src/mage/cards/m/ManaVapors.java
@@ -2,20 +2,13 @@
 package mage.cards.m;
 
 import java.util.UUID;
-import mage.abilities.Ability;
-import mage.abilities.effects.ContinuousEffect;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DontUntapInPlayersNextUntapStepAllEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterLandPermanent;
-import mage.game.Game;
-import mage.players.Player;
+import mage.filter.StaticFilters;
 import mage.target.TargetPlayer;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -27,7 +20,9 @@ public final class ManaVapors extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{U}");
 
         // Lands target player controls don't untap during their next untap step.
-        getSpellAbility().addEffect(new ManaVaporsEffect());
+        Effect effect = new DontUntapInPlayersNextUntapStepAllEffect(StaticFilters.FILTER_LAND);
+        effect.setText("lands target player controls don't untap during their next untap step");
+        getSpellAbility().addEffect(effect);
         getSpellAbility().addTarget(new TargetPlayer());
     }
 
@@ -38,37 +33,5 @@ public final class ManaVapors extends CardImpl {
     @Override
     public ManaVapors copy() {
         return new ManaVapors(this);
-    }
-}
-
-class ManaVaporsEffect extends OneShotEffect {
-
-    private static final FilterPermanent filter = new FilterLandPermanent();
-
-    ManaVaporsEffect() {
-        super(Outcome.Detriment);
-        this.staticText = "Lands target player controls don't untap during their next untap step";
-    }
-
-    ManaVaporsEffect(final ManaVaporsEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public ManaVaporsEffect copy() {
-        return new ManaVaporsEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player player = game.getPlayer(source.getFirstTarget());
-
-        if (player != null) {
-            ContinuousEffect effect = new DontUntapInPlayersNextUntapStepAllEffect(filter);
-            effect.setTargetPointer(new FixedTarget(player.getId()));
-            game.addEffect(effect, source);
-            return true;
-        }
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/m/Misstep.java
+++ b/Mage.Sets/src/mage/cards/m/Misstep.java
@@ -2,7 +2,6 @@
 package mage.cards.m;
 
 import java.util.UUID;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DontUntapInPlayersNextUntapStepAllEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -20,9 +19,7 @@ public final class Misstep extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{1}{U}");
 
         // Creatures target player controls don't untap during that player's next untap step.
-        Effect effect = new DontUntapInPlayersNextUntapStepAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE);
-        effect.setText("creatures target player controls don't untap during their next untap step");
-        this.getSpellAbility().addEffect(effect);
+        this.getSpellAbility().addEffect(new DontUntapInPlayersNextUntapStepAllEffect(StaticFilters.FILTER_PERMANENT_CREATURES));
         this.getSpellAbility().addTarget(new TargetPlayer());
     }
 

--- a/Mage.Sets/src/mage/cards/m/Misstep.java
+++ b/Mage.Sets/src/mage/cards/m/Misstep.java
@@ -2,20 +2,13 @@
 package mage.cards.m;
 
 import java.util.UUID;
-import mage.abilities.Ability;
-import mage.abilities.effects.ContinuousEffect;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DontUntapInPlayersNextUntapStepAllEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.game.Game;
-import mage.players.Player;
+import mage.filter.StaticFilters;
 import mage.target.TargetPlayer;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -27,7 +20,9 @@ public final class Misstep extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{1}{U}");
 
         // Creatures target player controls don't untap during that player's next untap step.
-        this.getSpellAbility().addEffect(new MisstepEffect());
+        Effect effect = new DontUntapInPlayersNextUntapStepAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE);
+        effect.setText("creatures target player controls don't untap during their next untap step");
+        this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetPlayer());
     }
 
@@ -38,37 +33,5 @@ public final class Misstep extends CardImpl {
     @Override
     public Misstep copy() {
         return new Misstep(this);
-    }
-}
-
-class MisstepEffect extends OneShotEffect {
-    
-    private static final FilterPermanent filter = new FilterCreaturePermanent();
-
-    MisstepEffect() {
-        super(Outcome.Detriment);
-        this.staticText = "Creatures target player controls don't untap during their next untap step";
-    }
-    
-    MisstepEffect(final MisstepEffect effect) {
-        super(effect);
-    }
-    
-    @Override
-    public MisstepEffect copy() {
-        return new MisstepEffect(this);
-    }
-    
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player player = game.getPlayer(source.getFirstTarget());
-
-        if (player != null) {
-            ContinuousEffect effect = new DontUntapInPlayersNextUntapStepAllEffect(filter);
-            effect.setTargetPointer(new FixedTarget(player.getId()));
-            game.addEffect(effect, source);
-            return true;
-        }
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/m/Misstep.java
+++ b/Mage.Sets/src/mage/cards/m/Misstep.java
@@ -1,23 +1,21 @@
 
 package mage.cards.m;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.DontUntapInControllersNextUntapStepTargetEffect;
+import mage.abilities.effects.common.DontUntapInPlayersNextUntapStepAllEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.filter.StaticFilters;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPlayer;
-import mage.target.targetpointer.FixedTargets;
+import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -45,6 +43,8 @@ public final class Misstep extends CardImpl {
 
 class MisstepEffect extends OneShotEffect {
     
+    private static final FilterPermanent filter = new FilterCreaturePermanent();
+
     MisstepEffect() {
         super(Outcome.Detriment);
         this.staticText = "Creatures target player controls don't untap during their next untap step";
@@ -61,20 +61,14 @@ class MisstepEffect extends OneShotEffect {
     
     @Override
     public boolean apply(Game game, Ability source) {
-    Player player = game.getPlayer(source.getFirstTarget());
-         if (player != null) {
-         List<Permanent> doNotUntapNextUntapStep = new ArrayList<>();
-         for (Permanent creature : game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURES, player.getId(), game)) {
-           doNotUntapNextUntapStep.add(creature); 
+        Player player = game.getPlayer(source.getFirstTarget());
+
+        if (player != null) {
+            ContinuousEffect effect = new DontUntapInPlayersNextUntapStepAllEffect(filter);
+            effect.setTargetPointer(new FixedTarget(player.getId()));
+            game.addEffect(effect, source);
+            return true;
         }
-        if (!doNotUntapNextUntapStep.isEmpty()) {
-                ContinuousEffect effect = new DontUntapInControllersNextUntapStepTargetEffect("", player.getId());
-                effect.setText("those creatures don't untap during that player's next untap step");
-                effect.setTargetPointer(new FixedTargets(doNotUntapNextUntapStep, game));
-                game.addEffect(effect, source);
-             }
-             return true;
-         }
         return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PollenLullaby.java
+++ b/Mage.Sets/src/mage/cards/p/PollenLullaby.java
@@ -2,6 +2,8 @@
 package mage.cards.p;
 
 import java.util.UUID;
+
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DoIfClashWonEffect;
 import mage.abilities.effects.common.DontUntapInPlayersNextUntapStepAllEffect;
 import mage.abilities.effects.common.PreventAllDamageByAllPermanentsEffect;
@@ -9,7 +11,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -22,9 +24,9 @@ public final class PollenLullaby extends CardImpl {
 
         // Prevent all combat damage that would be dealt this turn. Clash with an opponent. If you win, creatures that player controls don't untap during the player's next untap step.
         this.getSpellAbility().addEffect(new PreventAllDamageByAllPermanentsEffect(Duration.EndOfTurn, true));
-        this.getSpellAbility().addEffect(new DoIfClashWonEffect(
-            new DontUntapInPlayersNextUntapStepAllEffect(new FilterCreaturePermanent()), true)
-        );
+        Effect effect = new DontUntapInPlayersNextUntapStepAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE);
+        effect.setText("creatures that player controls don't untap during the player's next untap step");
+        this.getSpellAbility().addEffect(new DoIfClashWonEffect(effect, true));
     }
 
     private PollenLullaby(final PollenLullaby card) {

--- a/Mage.Sets/src/mage/cards/p/PollenLullaby.java
+++ b/Mage.Sets/src/mage/cards/p/PollenLullaby.java
@@ -1,25 +1,15 @@
 
 package mage.cards.p;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
-import mage.abilities.Ability;
-import mage.abilities.effects.ContinuousEffect;
-import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DoIfClashWonEffect;
-import mage.abilities.effects.common.DontUntapInControllersNextUntapStepTargetEffect;
+import mage.abilities.effects.common.DontUntapInPlayersNextUntapStepAllEffect;
 import mage.abilities.effects.common.PreventAllDamageByAllPermanentsEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
-import mage.target.targetpointer.FixedTargets;
+import mage.filter.common.FilterCreaturePermanent;
 
 /**
  *
@@ -32,7 +22,9 @@ public final class PollenLullaby extends CardImpl {
 
         // Prevent all combat damage that would be dealt this turn. Clash with an opponent. If you win, creatures that player controls don't untap during the player's next untap step.
         this.getSpellAbility().addEffect(new PreventAllDamageByAllPermanentsEffect(Duration.EndOfTurn, true));
-        this.getSpellAbility().addEffect(new DoIfClashWonEffect(new PollenLullabyEffect(), true));
+        this.getSpellAbility().addEffect(new DoIfClashWonEffect(
+            new DontUntapInPlayersNextUntapStepAllEffect(new FilterCreaturePermanent()), true)
+        );
     }
 
     private PollenLullaby(final PollenLullaby card) {
@@ -43,40 +35,4 @@ public final class PollenLullaby extends CardImpl {
     public PollenLullaby copy() {
         return new PollenLullaby(this);
     }
-}
-
-class PollenLullabyEffect extends OneShotEffect {
-
-    public PollenLullabyEffect() {
-        super(Outcome.Tap);
-        staticText = "creatures that player controls don't untap during the player's next untap step";
-    }
-
-    public PollenLullabyEffect(final PollenLullabyEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player player = game.getPlayer(getTargetPointer().getFirst(game, source));
-        if (player != null) {
-            List<Permanent> doNotUntapNextUntapStep = new ArrayList<>();
-            for (Permanent creature : game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, player.getId(), game)) {
-                doNotUntapNextUntapStep.add(creature);
-            }
-            if (!doNotUntapNextUntapStep.isEmpty()) {
-                ContinuousEffect effect = new DontUntapInControllersNextUntapStepTargetEffect("This creature");
-                effect.setTargetPointer(new FixedTargets(doNotUntapNextUntapStep, game));
-                game.addEffect(effect, source);
-            }
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    public PollenLullabyEffect copy() {
-        return new PollenLullabyEffect(this);
-    }
-
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/rules/DontUntapTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/rules/DontUntapTest.java
@@ -63,7 +63,7 @@ public class DontUntapTest extends CardTestPlayerBase {
         attack(1, playerA, "Sublime Archangel");
                 
         activateAbility(2, PhaseStep.POSTCOMBAT_MAIN, playerB, "+1: Target permanent doesn't","Sublime Archangel");
-                
+        
         setStopAt(3, PhaseStep.DRAW);
         execute();
 
@@ -89,6 +89,8 @@ public class DontUntapTest extends CardTestPlayerBase {
         attack(1, playerA, "Silvercoat Lion");
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Exhaustion", playerA);
         activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); //Reassembling Skeleton enters after spell is cast, should remain tapped
+
+        setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
         execute();
 
@@ -107,6 +109,8 @@ public class DontUntapTest extends CardTestPlayerBase {
         
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Mana Vapors", playerA);
+
+        setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
         execute();
 
@@ -125,6 +129,8 @@ public class DontUntapTest extends CardTestPlayerBase {
         attack(1, playerA, "Silvercoat Lion");
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Exhaustion", playerA);
         activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); //Reassembling Skeleton enters after spell is cast, should remain tapped
+
+        setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
         execute();
 
@@ -149,8 +155,13 @@ public class DontUntapTest extends CardTestPlayerBase {
 
         attack(1, playerA, "Silvercoat Lion");
         castSpell(1, PhaseStep.DECLARE_BLOCKERS, playerB, "Pollen Lullaby");
-        
+        setChoice(playerB, "PlayerA");
+        setChoice(playerB, false);
+        setChoice(playerA, false);
+
         activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); //Reassembling Skeleton enters after spell is cast, should remain tapped
+
+        setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
         execute();
 
@@ -173,8 +184,11 @@ public class DontUntapTest extends CardTestPlayerBase {
         attack(1, playerA, "Silvercoat Lion");
 
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Icebreaker Kraken");
+        addTarget(playerB, playerA);
+
         activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); //Reassembling Skeleton enters after Exhaustion is cast, should remain tapped
 
+        setStrictChooseMode(true);
         setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/rules/DontUntapTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/rules/DontUntapTest.java
@@ -73,5 +73,113 @@ public class DontUntapTest extends CardTestPlayerBase {
         assertTapped("Sublime Archangel", true);
 
     }
+     
+    /**
+     * Issue #10746: Incorrect implementations for Misstep; Pollen Lullaby; Icebreaker Kraken
+     */
+    @Test
+    public void testExhaustionEffect() {
+        addCard(Zone.BATTLEFIELD, playerA, "Silvercoat Lion", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
+        addCard(Zone.GRAVEYARD, playerA, "Reassembling Skeleton", 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 3);
+        addCard(Zone.HAND, playerB, "Exhaustion", 1);
         
+        attack(1, playerA, "Silvercoat Lion");
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Exhaustion", playerA);
+        activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); //Reassembling Skeleton enters after spell is cast, should remain tapped
+        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertTapped("Silvercoat Lion", true);
+        assertTapped("Reassembling Skeleton", true);
+        assertTapped("Swamp", true);
+    }
+
+    @Test
+    public void testManaVaporsEffect() {
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
+        addCard(Zone.HAND, playerA, "Lightning Bolt", 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+        addCard(Zone.HAND, playerB, "Mana Vapors", 1);
+        
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Mana Vapors", playerA);
+        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertTapped("Mountain", true);
+    }
+
+    @Test
+    public void testMisstepEffect() {
+        addCard(Zone.BATTLEFIELD, playerA, "Silvercoat Lion", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
+        addCard(Zone.GRAVEYARD, playerA, "Reassembling Skeleton", 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 3);
+        addCard(Zone.HAND, playerB, "Exhaustion", 1);
+        
+        attack(1, playerA, "Silvercoat Lion");
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Exhaustion", playerA);
+        activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); //Reassembling Skeleton enters after spell is cast, should remain tapped
+        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertTapped("Silvercoat Lion", true);
+        assertTapped("Reassembling Skeleton", true);
+    }
+
+    @Test
+    public void testPollenLullabyEffect() {
+        addCard(Zone.BATTLEFIELD, playerA, "Silvercoat Lion", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
+        addCard(Zone.GRAVEYARD, playerA, "Reassembling Skeleton", 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Plains", 2);
+        addCard(Zone.HAND, playerB, "Pollen Lullaby", 1);
+
+        removeAllCardsFromLibrary(playerA);
+        removeAllCardsFromLibrary(playerB);
+        addCard(Zone.LIBRARY, playerA, "Island", 8);
+        addCard(Zone.LIBRARY, playerB, "Silvercoat Lion", 8);
+        skipInitShuffling();
+
+        attack(1, playerA, "Silvercoat Lion");
+        castSpell(1, PhaseStep.DECLARE_BLOCKERS, playerB, "Pollen Lullaby");
+        
+        activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); //Reassembling Skeleton enters after spell is cast, should remain tapped
+        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertTapped("Silvercoat Lion", true);
+        assertTapped("Reassembling Skeleton", true);
+        assertLife(playerB, 20);
+    }
+
+    @Test
+    public void testIcebreakerKrakenEffect() {
+        addCard(Zone.BATTLEFIELD, playerA, "Silvercoat Lion", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Marble Chalice", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
+        addCard(Zone.GRAVEYARD, playerA, "Reassembling Skeleton", 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 12);
+        addCard(Zone.HAND, playerB, "Icebreaker Kraken", 1);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}:");
+        attack(1, playerA, "Silvercoat Lion");
+
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Icebreaker Kraken");
+        activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); //Reassembling Skeleton enters after Exhaustion is cast, should remain tapped
+
+        setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertTapped("Silvercoat Lion", true);
+        assertTapped("Marble Chalice", true);
+        assertTapped("Reassembling Skeleton", true);
+    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/rules/DontUntapTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/rules/DontUntapTest.java
@@ -88,7 +88,7 @@ public class DontUntapTest extends CardTestPlayerBase {
         
         attack(1, playerA, "Silvercoat Lion");
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Exhaustion", playerA);
-        activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); //Reassembling Skeleton enters after spell is cast, should remain tapped
+        activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); // Reassembling Skeleton enters after spell is cast, should remain tapped
 
         setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
@@ -124,11 +124,11 @@ public class DontUntapTest extends CardTestPlayerBase {
         addCard(Zone.GRAVEYARD, playerA, "Reassembling Skeleton", 1);
 
         addCard(Zone.BATTLEFIELD, playerB, "Island", 3);
-        addCard(Zone.HAND, playerB, "Exhaustion", 1);
+        addCard(Zone.HAND, playerB, "Misstep", 1);
         
         attack(1, playerA, "Silvercoat Lion");
-        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Exhaustion", playerA);
-        activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); //Reassembling Skeleton enters after spell is cast, should remain tapped
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Misstep", playerA);
+        activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); // Reassembling Skeleton enters after spell is cast, should remain tapped
 
         setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
@@ -154,12 +154,14 @@ public class DontUntapTest extends CardTestPlayerBase {
         skipInitShuffling();
 
         attack(1, playerA, "Silvercoat Lion");
+        // Prevent all combat damage that would be dealt this turn. Clash with an opponent. If you win, creatures that player controls don't untap during the player's next untap step.
         castSpell(1, PhaseStep.DECLARE_BLOCKERS, playerB, "Pollen Lullaby");
         setChoice(playerB, "PlayerA");
+        // Choose to keep cards on top
         setChoice(playerB, false);
         setChoice(playerA, false);
 
-        activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); //Reassembling Skeleton enters after spell is cast, should remain tapped
+        activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); // Reassembling Skeleton enters after spell is cast, should remain tapped
 
         setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
@@ -183,10 +185,11 @@ public class DontUntapTest extends CardTestPlayerBase {
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}:");
         attack(1, playerA, "Silvercoat Lion");
 
+        // When Icebreaker Kraken enters the battlefield, artifacts and creatures target opponent controls don't untap during that player's next untap step.
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Icebreaker Kraken");
         addTarget(playerB, playerA);
 
-        activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); //Reassembling Skeleton enters after Exhaustion is cast, should remain tapped
+        activateAbility(2, PhaseStep.END_TURN, playerA, "{1}{B}:"); // Reassembling Skeleton enters after effect is in play, should remain tapped
 
         setStrictChooseMode(true);
         setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);


### PR DESCRIPTION
This PR resolves #10746 by changing Misstep, Pollen Lullaby, and Icebreaker Kraken to add the "don't untap" effect as a continuous effect like Exhaustion and Mana Vapors, instead of using a list of permanents. Tests have also been added to confirm the effects have been fixed.