### PR TITLE
[WOE] Implement Mosswood Dreadknight

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MosswoodDreadknight.java
+++ b/Mage.Sets/src/mage/cards/m/MosswoodDreadknight.java
@@ -1,0 +1,91 @@
+package mage.cards.m;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DiesSourceTriggeredAbility;
+import mage.abilities.effects.AsThoughEffectImpl;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.LoseLifeSourceControllerEffect;
+import mage.abilities.keyword.TrampleAbility;
+import mage.cards.AdventureCard;
+import mage.cards.Card;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.game.Game;
+
+import java.util.UUID;
+
+/**
+ * @author Susucr
+ */
+public final class MosswoodDreadknight extends AdventureCard {
+
+
+    public MosswoodDreadknight(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, new CardType[]{CardType.SORCERY}, "{1}{G}", "Dread Whispers", "{1}{B}");
+
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.KNIGHT);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(2);
+
+        // Trample
+        this.addAbility(TrampleAbility.getInstance());
+
+        // When Mosswood Dreadknight dies, you may cast it from your graveyard as an Adventure until the end of your next turn.
+        this.addAbility(new DiesSourceTriggeredAbility(new MosswoodDreadknightEffect()));
+
+        // Dread Whispers
+        // You draw a card and you lose 1 life.
+        this.getSpellCard().getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1));
+        this.getSpellCard().getSpellAbility().addEffect(new LoseLifeSourceControllerEffect(1).concatBy("and"));
+    }
+
+    private MosswoodDreadknight(final MosswoodDreadknight card) {
+        super(card);
+    }
+
+    @Override
+    public MosswoodDreadknight copy() {
+        return new MosswoodDreadknight(this);
+    }
+}
+
+class MosswoodDreadknightEffect extends AsThoughEffectImpl {
+
+    MosswoodDreadknightEffect() {
+        super(AsThoughEffectType.CAST_ADVENTURE_FROM_NOT_OWN_HAND_ZONE, Duration.UntilEndOfYourNextTurn, Outcome.Benefit);
+        staticText = "you may cast it from your graveyard as an Adventure until the end of your next turn";
+    }
+
+    private MosswoodDreadknightEffect(final MosswoodDreadknightEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return true;
+    }
+
+    @Override
+    public MosswoodDreadknightEffect copy() {
+        return new MosswoodDreadknightEffect(this);
+    }
+
+    @Override
+    public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        if (!source.isControlledBy(affectedControllerId)) {
+            return false;
+        }
+        Card card = game.getCard(sourceId);
+        if (card == null || card.getMainCard() == null || !card.getMainCard().getId().equals(source.getSourceId())) {
+            return false;
+        }
+
+        Card sourceCard = game.getCard(source.getSourceId());
+
+        return sourceCard != null
+                && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD
+                && source.getSourceObjectZoneChangeCounter() == sourceCard.getZoneChangeCounter(game);
+    }
+}

--- a/Mage.Sets/src/mage/sets/WildsOfEldraine.java
+++ b/Mage.Sets/src/mage/sets/WildsOfEldraine.java
@@ -24,6 +24,7 @@ public final class WildsOfEldraine extends ExpansionSet {
         cards.add(new SetCardInfo("Forest", 266, Rarity.LAND, mage.cards.basiclands.Forest.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Island", 263, Rarity.LAND, mage.cards.basiclands.Island.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Moonshaker Cavalry", 21, Rarity.MYTHIC, mage.cards.m.MoonshakerCavalry.class));
+        cards.add(new SetCardInfo("Mosswood Dreadknight", 231, Rarity.RARE, mage.cards.m.MosswoodDreadknight.class));
         cards.add(new SetCardInfo("Mountain", 265, Rarity.LAND, mage.cards.basiclands.Mountain.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Plains", 262, Rarity.LAND, mage.cards.basiclands.Plains.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Restless Fortress", 259, Rarity.RARE, mage.cards.r.RestlessFortress.class));

--- a/Mage/src/main/java/mage/abilities/SpellAbility.java
+++ b/Mage/src/main/java/mage/abilities/SpellAbility.java
@@ -117,6 +117,11 @@ public class SpellAbility extends ActivatedAbilityImpl {
 
             // play from not own hand
             ApprovingObject approvingObject = game.getContinuousEffects().asThough(getSourceId(), AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, this, playerId, game);
+            if (approvingObject == null && getSpellAbilityType().equals(SpellAbilityType.ADVENTURE_SPELL)) {
+                // allowed to cast adventures from non-hand?
+                approvingObject = game.getContinuousEffects().asThough(getSourceId(), AsThoughEffectType.CAST_ADVENTURE_FROM_NOT_OWN_HAND_ZONE, this, playerId, game);
+            }
+
             if (approvingObject == null) {
                 Card card = game.getCard(sourceId);
                 if (!(card != null && card.isOwnedBy(playerId))) {

--- a/Mage/src/main/java/mage/constants/AsThoughEffectType.java
+++ b/Mage/src/main/java/mage/constants/AsThoughEffectType.java
@@ -36,6 +36,7 @@ public enum AsThoughEffectType {
     // 4. You must implement/override an applies method with "Ability affectedAbility" (e.g. check multiple play/cast abilities from all card's parts)
     // TODO: search all PLAY_FROM_NOT_OWN_HAND_ZONE and CAST_AS_INSTANT effects and add support of mainCard and objectId
     PLAY_FROM_NOT_OWN_HAND_ZONE(true, true),
+    CAST_ADVENTURE_FROM_NOT_OWN_HAND_ZONE(true, true),
     CAST_AS_INSTANT(true, true),
     //
     ACTIVATE_AS_INSTANT(true, false),

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -3851,6 +3851,12 @@ public abstract class PlayerImpl implements Player, Serializable {
                 // play hand from non hand zone (except battlefield - you can't play already played permanents)
                 approvingObject = game.getContinuousEffects().asThough(object.getId(),
                         AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, ability, this.getId(), game);
+
+                if (approvingObject == null && isPlaySpell
+                        && ((SpellAbility) ability).getSpellAbilityType().equals(SpellAbilityType.ADVENTURE_SPELL)) {
+                    approvingObject = game.getContinuousEffects().asThough(object.getId(),
+                            AsThoughEffectType.CAST_ADVENTURE_FROM_NOT_OWN_HAND_ZONE, ability, this.getId(), game);
+                }
             } else {
                 // other abilities from direct zones
                 approvingObject = null;


### PR DESCRIPTION
~~The card is not yet official, but here is the implementation anyway:~~

> Mosswood Dreadknight {1}{G}
> Creature - Human Knight
>
> Trample
> When Mosswood Dreadknight dies, you may cast it from your graveyard as as Adventure until the end of your next turn.
>
> 3/2
>
> //
>
> Dread Whispers {1}{B}
> Sorcery - Adventure
>
> You draw a card and you lose 1 life. (Then exile this card. You may cast the creature later from exile.)