### PR TITLE
[CLB] Fix Baba Lysaga not counting added/removed types properly

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BabaLysagaNightWitch.java
+++ b/Mage.Sets/src/mage/cards/b/BabaLysagaNightWitch.java
@@ -8,19 +8,15 @@ import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.Outcome;
-import mage.constants.SubType;
-import mage.constants.SuperType;
+import mage.constants.*;
 import mage.filter.StaticFilters;
 import mage.game.Game;
+import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetControlledPermanent;
 import mage.util.CardUtil;
 
-import java.util.Collection;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * @author TheElk801
@@ -38,9 +34,7 @@ public final class BabaLysagaNightWitch extends CardImpl {
 
         // {T}, Sacrifice up to three permanents: If there were three or more card types among the sacrificed permanents, each opponent loses 3 life, you gain 3 life, and you draw three cards.
         Ability ability = new SimpleActivatedAbility(new BabaLysagaNightWitchEffect(), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(new TargetControlledPermanent(
-                0, 3, StaticFilters.FILTER_CONTROLLED_PERMANENTS, true
-        )));
+        ability.addCost(new BabaLysagaNightWitchSacrificeCost());
         this.addAbility(ability);
     }
 
@@ -51,6 +45,37 @@ public final class BabaLysagaNightWitch extends CardImpl {
     @Override
     public BabaLysagaNightWitch copy() {
         return new BabaLysagaNightWitch(this);
+    }
+}
+
+class BabaLysagaNightWitchSacrificeCost extends SacrificeTargetCost {
+
+    private Set<CardType> sacrificeTypes = new HashSet<>();
+
+    BabaLysagaNightWitchSacrificeCost() {
+        super(new TargetControlledPermanent(0, 3, StaticFilters.FILTER_CONTROLLED_PERMANENTS, true));
+        setText("Sacrifice up to three permanents");
+    }
+
+    private BabaLysagaNightWitchSacrificeCost(final BabaLysagaNightWitchSacrificeCost cost) {
+        super(cost);
+        this.sacrificeTypes.addAll(cost.sacrificeTypes);
+    }
+
+    @Override
+    public BabaLysagaNightWitchSacrificeCost copy() {
+        return new BabaLysagaNightWitchSacrificeCost(this);
+    }
+
+    Set<CardType> getCardTypes() {
+        return this.sacrificeTypes;
+    }
+
+    @Override
+    protected void addSacrificeTarget(Game game, Permanent permanent) {
+        super.addSacrificeTarget(game, permanent);
+        // The Permanent's types will lose the gained/lose types after the sacrifice, so they are stored right before.
+        this.sacrificeTypes.addAll(permanent.getCardType(game));
     }
 }
 
@@ -74,11 +99,9 @@ class BabaLysagaNightWitchEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         if (CardUtil
-                .castStream(source.getCosts().stream(), SacrificeTargetCost.class)
+                .castStream(source.getCosts().stream(), BabaLysagaNightWitchSacrificeCost.class)
                 .filter(Objects::nonNull)
-                .map(SacrificeTargetCost::getPermanents)
-                .flatMap(Collection::stream)
-                .map(permanent -> permanent.getCardType(game))
+                .map(BabaLysagaNightWitchSacrificeCost::getCardTypes)
                 .flatMap(Collection::stream)
                 .distinct()
                 .count() < 3) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/clb/BabaLysagaNightWitchTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/clb/BabaLysagaNightWitchTest.java
@@ -1,0 +1,60 @@
+package org.mage.test.cards.single.clb;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class BabaLysagaNightWitchTest extends CardTestPlayerBase {
+
+    /**
+     * Baba Lysaga, Night Witch {1}{B}{G}
+     * Legendary Creature — Human Warlock
+     * <p>
+     * {T}, Sacrifice up to three permanents: If there were three or more card types among the sacrificed permanents, each opponent loses 3 life, you gain 3 life, and you draw three cards.
+     */
+
+    private final static String baba = "Baba Lysaga, Night Witch";
+
+    @Test
+    public void SacrificeAnimatedMishra() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, baba);
+        addCard(Zone.BATTLEFIELD, playerA, "Mishra's Factory"); // animates into a Land Artifact Creature
+
+        activateAbility(1, PhaseStep.UPKEEP, playerA, "{1}: {this} becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.");
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}, Sacrifice up to three permanents: If there ");
+        setChoice(playerA, "Mishra's Factory");
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertLife(playerA, 20 + 3);
+        assertLife(playerB, 20 - 3);
+        assertHandCount(playerA, 3);
+        assertGraveyardCount(playerA, "Mishra's Factory", 1);
+    }
+
+    @Test
+    public void SacrificeNonAnimatedMishra() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, baba);
+        addCard(Zone.BATTLEFIELD, playerA, "Mishra's Factory"); // just a Land if not animated
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}, Sacrifice up to three permanents: If there ");
+        setChoice(playerA, "Mishra's Factory");
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+        assertHandCount(playerA, 0);
+        assertGraveyardCount(playerA, "Mishra's Factory", 1);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/costs/common/SacrificeTargetCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/SacrificeTargetCost.java
@@ -60,7 +60,7 @@ public class SacrificeTargetCost extends CostImpl implements SacrificeCost {
                 if (permanent == null) {
                     return false;
                 }
-                permanents.add(permanent.copy());
+                addSacrificeTarget(game, permanent);
                 paid |= permanent.sacrifice(source, game);
             }
             if (!paid && targets.get(0).getNumberOfTargets() == 0) {
@@ -68,6 +68,10 @@ public class SacrificeTargetCost extends CostImpl implements SacrificeCost {
             }
         }
         return paid;
+    }
+
+    protected void addSacrificeTarget(Game game, Permanent permanent) {
+        permanents.add(permanent.copy());
     }
 
     @Override


### PR DESCRIPTION
So the issue of Baba Lysaga and Card Types was the following:
The `SacrificeTargetCost` is making a copy of the sacrificed permanents, but once the ability does resolve, `permanent.getCardTypes(game)` was only returning the card's types, not taking account of type added/removed by Continuous Effects.
My workaround around the issue is to store the card types right before the actual sacrifice, exposing a function overriden in a custom Cost for Baba Lysaga.

fix #9703 
fix #10210