### PR TITLE
[LGN] Rework Whipgrass Entangler

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WhipgrassEntangler.java
+++ b/Mage.Sets/src/mage/cards/w/WhipgrassEntangler.java
@@ -1,21 +1,20 @@
 
 package mage.cards.w;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
+import mage.abilities.common.LinkedSimpleStaticAbility;
 import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
-import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
 import mage.abilities.effects.common.combat.CantAttackBlockUnlessPaysSourceEffect;
+import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Duration;
+import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
 import mage.game.Game;
@@ -23,23 +22,24 @@ import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
- * @author emerald000 & L_J
+ * @author Susucr
  */
 public final class WhipgrassEntangler extends CardImpl {
 
     public WhipgrassEntangler(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{W}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{W}");
         this.subtype.add(SubType.HUMAN);
         this.subtype.add(SubType.CLERIC);
         this.power = new MageInt(1);
         this.toughness = new MageInt(3);
 
         // {1}{W}: Until end of turn, target creature gains "This creature can't attack or block unless its controller pays {1} for each Cleric on the battlefield."
-        Ability abilityToGain = new SimpleStaticAbility(Zone.BATTLEFIELD, new WhipgrassEntanglerCantAttackUnlessYouPayEffect());
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, 
-                new GainAbilityTargetEffect(abilityToGain, Duration.EndOfTurn).setText("Until end of turn, target creature gains \"This creature can't attack or block unless its controller pays {1} for each Cleric on the battlefield.\""), 
+        Ability gainedAbility = new LinkedSimpleStaticAbility(new WhipgrassEntanglerCantAttackUnlessYouPayEffect());
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
+                new GainAbilityTargetEffect(gainedAbility, Duration.EndOfTurn).setText("Until end of turn, target creature gains \"This creature can't attack or block unless its controller pays {1} for each Cleric on the battlefield.\""),
                 new ManaCostsImpl<>("{1}{W}"));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
@@ -56,9 +56,10 @@ public final class WhipgrassEntangler extends CardImpl {
     }
 }
 
-class WhipgrassEntanglerCantAttackUnlessYouPayEffect extends CantAttackBlockUnlessPaysSourceEffect {
+class WhipgrassEntanglerCantAttackUnlessYouPayEffect extends CantAttackBlockUnlessPaysSourceEffect implements LinkedSimpleStaticAbility.ChildEffect {
 
     private static final FilterPermanent filter = new FilterPermanent("Cleric on the battlefield");
+    private UUID parentLinkHandshake = null;
 
     static {
         filter.add(SubType.CLERIC.getPredicate());
@@ -69,13 +70,16 @@ class WhipgrassEntanglerCantAttackUnlessYouPayEffect extends CantAttackBlockUnle
         staticText = "This creature can't attack or block unless its controller pays {1} for each Cleric on the battlefield";
     }
 
-    WhipgrassEntanglerCantAttackUnlessYouPayEffect(WhipgrassEntanglerCantAttackUnlessYouPayEffect effect) {
+    private WhipgrassEntanglerCantAttackUnlessYouPayEffect(final WhipgrassEntanglerCantAttackUnlessYouPayEffect effect) {
         super(effect);
+        this.parentLinkHandshake = effect.parentLinkHandshake;
     }
 
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
-        return source.getSourceId().equals(event.getSourceId());
+        return source.getSourceId().equals(event.getSourceId())
+                && source instanceof LinkedSimpleStaticAbility
+                && ((LinkedSimpleStaticAbility) source).checkLinked(this.parentLinkHandshake);
     }
 
     @Override
@@ -95,4 +99,16 @@ class WhipgrassEntanglerCantAttackUnlessYouPayEffect extends CantAttackBlockUnle
         return new WhipgrassEntanglerCantAttackUnlessYouPayEffect(this);
     }
 
+    @Override
+    public void newId() {
+        // No id set this way. Parent Ability takes responsability of calling manualNewId()
+    }
+
+    public void manualNewId() {
+        super.newId();
+    }
+
+    public void setParentLinkHandshake(UUID parentLinkHandshake) {
+        this.parentLinkHandshake = parentLinkHandshake;
+    }
 }

--- a/Mage.Sets/src/mage/cards/w/WhipgrassEntangler.java
+++ b/Mage.Sets/src/mage/cards/w/WhipgrassEntangler.java
@@ -3,7 +3,7 @@ package mage.cards.w;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.LinkedSimpleStaticAbility;
+import mage.abilities.common.LinkedEffectIdStaticAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.costs.mana.ManaCostsImpl;
@@ -37,7 +37,7 @@ public final class WhipgrassEntangler extends CardImpl {
         this.toughness = new MageInt(3);
 
         // {1}{W}: Until end of turn, target creature gains "This creature can't attack or block unless its controller pays {1} for each Cleric on the battlefield."
-        Ability gainedAbility = new LinkedSimpleStaticAbility(new WhipgrassEntanglerCantAttackUnlessYouPayEffect());
+        Ability gainedAbility = new LinkedEffectIdStaticAbility(new WhipgrassEntanglerCantAttackUnlessYouPayEffect());
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new GainAbilityTargetEffect(gainedAbility, Duration.EndOfTurn).setText("Until end of turn, target creature gains \"This creature can't attack or block unless its controller pays {1} for each Cleric on the battlefield.\""),
                 new ManaCostsImpl<>("{1}{W}"));
@@ -56,7 +56,7 @@ public final class WhipgrassEntangler extends CardImpl {
     }
 }
 
-class WhipgrassEntanglerCantAttackUnlessYouPayEffect extends CantAttackBlockUnlessPaysSourceEffect implements LinkedSimpleStaticAbility.ChildEffect {
+class WhipgrassEntanglerCantAttackUnlessYouPayEffect extends CantAttackBlockUnlessPaysSourceEffect implements LinkedEffectIdStaticAbility.ChildEffect {
 
     private static final FilterPermanent filter = new FilterPermanent("Cleric on the battlefield");
     private UUID parentLinkHandshake = null;
@@ -78,8 +78,8 @@ class WhipgrassEntanglerCantAttackUnlessYouPayEffect extends CantAttackBlockUnle
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         return source.getSourceId().equals(event.getSourceId())
-                && source instanceof LinkedSimpleStaticAbility
-                && ((LinkedSimpleStaticAbility) source).checkLinked(this.parentLinkHandshake);
+                && source instanceof LinkedEffectIdStaticAbility
+                && ((LinkedEffectIdStaticAbility) source).checkLinked(this.parentLinkHandshake);
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/lgn/WhipgrassEntanglerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/lgn/WhipgrassEntanglerTest.java
@@ -1,0 +1,146 @@
+package org.mage.test.cards.single.lgn;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class WhipgrassEntanglerTest extends CardTestPlayerBase {
+
+    /**
+     * Whipgrass Entangler
+     * {2}{W}
+     * Creature — Human Cleric
+     * <p>
+     * {1}{W}: Until end of turn, target creature gains "This creature can't attack or block unless its controller pays {1} for each Cleric on the battlefield."
+     * <p>
+     * 1/3
+     */
+    private static final String entangler = "Whipgrass Entangler";
+
+    @Test
+    public void gainAbilityHimselfAndPay() {
+        setStrictChooseMode(true);
+        addCard(Zone.BATTLEFIELD, playerA, entangler);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 20);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}{W}: Until end of turn, ", entangler);
+        attack(1, playerA, entangler);
+        setChoice(playerA, true); // yes to "pay {1} for Entangler to attack"
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerB, 20 - 1);
+        assertTappedCount("Plains", true, 2 * 1 + 1 * 1);
+    }
+
+    @Test
+    public void gainAbilityTwiceAndPay() {
+        setStrictChooseMode(true);
+        addCard(Zone.BATTLEFIELD, playerA, entangler);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 20);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}{W}: Until end of turn, ", entangler);
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}{W}: Until end of turn, ", entangler);
+        attack(1, playerA, entangler);
+        setChoice(playerA, "Whipgrass Entangler"); // two of the same replacement effect to choose from.
+        setChoice(playerA, true); // yes to "pay {1} for Entangler to attack"
+        setChoice(playerA, true); // yes to "pay {1} for Entangler to attack"
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerB, 20 - 1);
+        assertTappedCount("Plains", true, 2 * 2 + 1 * 2);
+    }
+
+    @Test
+    public void gainAbilityWithTwoClericAndPay() {
+        setStrictChooseMode(true);
+        addCard(Zone.BATTLEFIELD, playerA, entangler);
+        addCard(Zone.BATTLEFIELD, playerA, "Akroma's Devoted"); // 2/4 Cleric
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 20);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}{W}: Until end of turn, ", entangler);
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}{W}: Until end of turn, ", "Akroma's Devoted");
+        attack(1, playerA, entangler);
+        setChoice(playerA, true); // yes to "pay {2} for Entangler to attack"
+        attack(1, playerA, "Akroma's Devoted");
+        setChoice(playerA, true); // yes to "pay {2} for Akroma's Devoted to attack"
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerB, 20 - 1 - 2);
+        assertTappedCount("Plains", true, 2 * 2 + 2 * 2);
+    }
+
+    @Test
+    public void gainAbilityFromTwoEntanglerAndPay() {
+        setStrictChooseMode(true);
+        addCard(Zone.BATTLEFIELD, playerA, "Akroma's Devoted"); // 2/4 Cleric
+        addCard(Zone.BATTLEFIELD, playerA, entangler, 1);
+
+        // In order to make sure the ability is activated from both entanglers, we exile one and play the second one after
+        addCard(Zone.HAND, playerA, entangler);
+        addCard(Zone.HAND, playerA, "Swords to Plowshares", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 20);
+
+        // Activate first entangler
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}{W}: Until end of turn, ", "Akroma's Devoted");
+        // Exile first entangler
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Swords to Plowshares", entangler, true);
+
+        // Cast second entangler
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, entangler, true);
+        // Activate second entangler
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}{W}: Until end of turn, ", "Akroma's Devoted");
+
+        attack(1, playerA, "Akroma's Devoted");
+        setChoice(playerA, "Akroma's Devoted"); // two of the same replacement effect to choose from.
+        setChoice(playerA, true); // yes to "pay {2} for Akroma's Devoted to attack"
+        setChoice(playerA, true); // yes to "pay {2} for Akroma's Devoted to attack"
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerB, 20 - 2);
+        assertTappedCount("Plains", true, 2 * 2 + 2 * 2 + 3 + 1);
+    }
+
+    @Test
+    public void gainAbilityWithCloneAndPay() {
+        setStrictChooseMode(true);
+        addCard(Zone.BATTLEFIELD, playerA, "Akroma's Devoted"); // 2/4 Cleric
+        addCard(Zone.BATTLEFIELD, playerA, entangler);
+        addCard(Zone.HAND, playerA, "Sakashima the Impostor"); // Clone with different name for easy targets
+
+        // In order to make sure the ability is activated from the clone, we exile the original one before activating Sakashima
+        addCard(Zone.HAND, playerA, "Swords to Plowshares", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Tundra", 20);
+
+        // Activate the original Entangler
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}{W}: Until end of turn, ", "Akroma's Devoted");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        // Cast Sakashima
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Sakashima the Impostor", true);
+        setChoice(playerA, true); // yes to clone.
+        setChoice(playerA, entangler); // copy entangler
+        // Exile original entangler
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Swords to Plowshares", entangler, true);
+        // Activate Sakashima.
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}{W}: Until end of turn, ", "Akroma's Devoted");
+
+        attack(1, playerA, "Akroma's Devoted");
+        setChoice(playerA, "Akroma's Devoted"); // two of the same replacement effect to choose from.
+        setChoice(playerA, true); // yes to "pay {2} for Akroma's Devoted to attack"
+        setChoice(playerA, true); // yes to "pay {2} for Akroma's Devoted to attack"
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerB, 20 - 2);
+        assertTappedCount("Tundra", true, 2 * 2 + 2 * 2 + 4 + 1);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/common/LinkedEffectIdStaticAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/LinkedEffectIdStaticAbility.java
@@ -15,7 +15,7 @@ import java.util.UUID;
  *
  * @author Susucr
  */
-public class LinkedSimpleStaticAbility extends SimpleStaticAbility {
+public class LinkedEffectIdStaticAbility extends SimpleStaticAbility {
 
     public interface ChildEffect extends Effect {
         /**
@@ -35,26 +35,26 @@ public class LinkedSimpleStaticAbility extends SimpleStaticAbility {
      */
     private UUID linkedHandshake;
 
-    public LinkedSimpleStaticAbility(ChildEffect effect) {
+    public LinkedEffectIdStaticAbility(ChildEffect effect) {
         this(Zone.BATTLEFIELD, effect);
     }
 
-    public LinkedSimpleStaticAbility(Zone zone, ChildEffect effect) {
+    public LinkedEffectIdStaticAbility(Zone zone, ChildEffect effect) {
         super(Zone.BATTLEFIELD, effect);
         this.linkedHandshake = UUID.randomUUID();
         initHandshake();
         setEffectIdManually();
     }
 
-    private LinkedSimpleStaticAbility(final LinkedSimpleStaticAbility effect) {
+    private LinkedEffectIdStaticAbility(final LinkedEffectIdStaticAbility effect) {
         super(effect);
         this.linkedHandshake = UUID.randomUUID();
         initHandshake();
     }
 
     @Override
-    public LinkedSimpleStaticAbility copy() {
-        return new LinkedSimpleStaticAbility(this);
+    public LinkedEffectIdStaticAbility copy() {
+        return new LinkedEffectIdStaticAbility(this);
     }
 
     private void initHandshake() {

--- a/Mage/src/main/java/mage/abilities/common/LinkedSimpleStaticAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/LinkedSimpleStaticAbility.java
@@ -1,0 +1,82 @@
+package mage.abilities.common;
+
+import mage.abilities.effects.Effect;
+import mage.constants.Zone;
+import mage.util.CardUtil;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Warning: please test with a lot of care when using this class for new things.
+ * <p>
+ * A static Ability linked to an Effect.
+ * The parent Ability does take responsability of setting the id for the child.
+ *
+ * @author Susucr
+ */
+public class LinkedSimpleStaticAbility extends SimpleStaticAbility {
+
+    public interface ChildEffect extends Effect {
+        /**
+         * Set the link for the child.
+         */
+        void setParentLinkHandshake(UUID parentLinkHandshake);
+
+        /**
+         * The child Id should only change on copy when the parent wants it to.
+         */
+        void manualNewId();
+    }
+
+
+    /**
+     * The handshake UUID between this parent ability and its child.
+     */
+    private UUID linkedHandshake;
+
+    public LinkedSimpleStaticAbility(ChildEffect effect) {
+        this(Zone.BATTLEFIELD, effect);
+    }
+
+    public LinkedSimpleStaticAbility(Zone zone, ChildEffect effect) {
+        super(Zone.BATTLEFIELD, effect);
+        this.linkedHandshake = UUID.randomUUID();
+        initHandshake();
+        setEffectIdManually();
+    }
+
+    private LinkedSimpleStaticAbility(final LinkedSimpleStaticAbility effect) {
+        super(effect);
+        this.linkedHandshake = UUID.randomUUID();
+        initHandshake();
+    }
+
+    @Override
+    public LinkedSimpleStaticAbility copy() {
+        return new LinkedSimpleStaticAbility(this);
+    }
+
+    private void initHandshake() {
+        this.linkedHandshake = UUID.randomUUID();
+        CardUtil.castStream(this.getEffects().stream(), ChildEffect.class)
+                .filter(Objects::nonNull)
+                .forEach(e -> e.setParentLinkHandshake(linkedHandshake));
+    }
+
+    public void setEffectIdManually() {
+        CardUtil.castStream(this.getEffects().stream(), ChildEffect.class)
+                .filter(Objects::nonNull)
+                .forEach(e -> e.manualNewId());
+    }
+
+    public boolean checkLinked(UUID handshake) {
+        return linkedHandshake.equals(handshake);
+    }
+
+    @Override
+    public void newId() {
+        super.newId();
+    }
+}
+

--- a/Mage/src/main/java/mage/abilities/effects/common/combat/CantAttackBlockUnlessPaysSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/combat/CantAttackBlockUnlessPaysSourceEffect.java
@@ -8,7 +8,6 @@ import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 
 /**
  * @author LevelX2
@@ -26,7 +25,7 @@ public class CantAttackBlockUnlessPaysSourceEffect extends PayCostToAttackBlockE
         staticText = "{this} can't " + restrictType.toString() + " unless you pay " + (manaCosts == null ? "" : manaCosts.getText());
     }
 
-    public CantAttackBlockUnlessPaysSourceEffect(CantAttackBlockUnlessPaysSourceEffect effect) {
+    protected CantAttackBlockUnlessPaysSourceEffect(final CantAttackBlockUnlessPaysSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilityTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilityTargetEffect.java
@@ -3,13 +3,12 @@ package mage.abilities.effects.common.continuous;
 import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.Mode;
+import mage.abilities.common.LinkedSimpleStaticAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.cards.Card;
 import mage.constants.*;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.target.Target;
-import mage.util.CardUtil;
 
 import java.util.*;
 
@@ -44,6 +43,8 @@ public class GainAbilityTargetEffect extends ContinuousEffectImpl {
     public GainAbilityTargetEffect(Ability ability, Duration duration, String rule, boolean useOnCard) {
         super(duration, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, ability.getEffects().getOutcome(ability, Outcome.AddAbility));
         this.ability = ability;
+        this.ability = copyAbility();
+        
         this.staticText = rule;
         this.useOnCard = useOnCard;
 
@@ -52,8 +53,7 @@ public class GainAbilityTargetEffect extends ContinuousEffectImpl {
 
     protected GainAbilityTargetEffect(final GainAbilityTargetEffect effect) {
         super(effect);
-        this.ability = effect.ability.copy();
-        this.ability.newId(); // This is needed if the effect is copied e.g. by a clone so the ability can be added multiple times to permanents
+        this.ability = effect.copyAbility();
         this.useOnCard = effect.useOnCard;
         this.waitingCardPermanent = effect.waitingCardPermanent;
         this.durationPhaseStep = effect.durationPhaseStep;
@@ -200,6 +200,15 @@ public class GainAbilityTargetEffect extends ContinuousEffectImpl {
             }
         }
         return affectedTargets > 0;
+    }
+
+    public Ability copyAbility() {
+        Ability ability = this.ability.copy();
+        ability.newId();
+        if (ability instanceof LinkedSimpleStaticAbility) {
+            ((LinkedSimpleStaticAbility) ability).setEffectIdManually();
+        }
+        return ability;
     }
 
     @Override


### PR DESCRIPTION
So the starting point was #8363.
Investigating that, I found out that the `ReplacementEffect` was changing `UUID` right after being paid.
Once I figured out how to stabilize that (more on that later), I started different tests, and multiple of the same activation of the same Entangler could be paid with a single cost paid. That one was due to the applies of the `ReplacementEffect` not identifying the parent ability differently from the others ones from the same source.

I did introduce a `LinkedSimpleStaticAbility` to solve both the issues:
-> It does share an handshake `UUID` with its `Effect`, and the `Effect` can use the handshake to identify its parent ability. That handshake changes on copy of the `Ability`, but both copy of parent and child do share the new handshake after copy.
-> For the `ReplacementEffect` having non-stable `UUID`, I did reinforce the ability field in `GainAbilityTargetEffect`, the main idea being that the ability should make a copy that has new ids for both the parent `Ability` and the child `Effect`. And there should be no `Id` change after that.

So the `LinkedSimpleStaticAbility` takes full responsibility of manually calling its Effect's `newId` method with a weird setup: the Effect's `newId` is overwritten to do nothing, and the parent Ability can call `manualNewId` instead, which call the inherited `newId` of the `Effect`.
That way, `GainAbilityTargetEffect` makes `UUID`-fresh-but-stable `LinkedSimpleStaticAbility` + `ReplacementEffect` in its constructors, which are later used in the `GainAbilityTargetEffect::apply` to add the `ReplacementEffect` to `Objects` (here the targetted Permanent).

The changes made do not alter any other card (there is that one copy + newId for the ability in the main public constructor of `GainAbilityTargetEffect`), so it is safe to merge, but any other use of `LinkedSimpleStaticAbility` will probably need careful consideration on if and when the `Effect`'s id must be reset to a fresh one.

fix #8363