### PR TITLE
[don't merge] Fix Manifest throwing an exception when the top card is a split/aftermath card

### DIFF
--- a/Mage/src/main/java/mage/game/ZonesHandler.java
+++ b/Mage/src/main/java/mage/game/ZonesHandler.java
@@ -347,7 +347,16 @@ public final class ZonesHandler {
                 card = takeAttributesFromSpell(card, event, game);
                 // controlling player can be replaced so use event player now
                 Permanent permanent;
-                if (card instanceof MeldCard) {
+                if (card.isFaceDown(game)) {
+                    // TODO: this should be allowed. Main reason it is not is that caller does not have
+                    //       the permanent UUID to set as Morph/Manifest/Other
+                    if (card instanceof ModalDoubleFacedCardHalf) {
+                        // main mdf card must be processed before that call (e.g. only halfes can be moved to battlefield)
+                        throw new IllegalStateException("Unexpected trying of move mdf card to battlefield facedown instead half");
+                    }
+                    // If facedown, we do not really care for any kind of mdfc or meld.
+                    permanent = new PermanentCard(card, event.getPlayerId(), game, true);
+                } else if (card instanceof MeldCard) {
                     permanent = new PermanentMeld(card, event.getPlayerId(), game);
                 } else if (card instanceof ModalDoubleFacedCard) {
                     // main mdf card must be processed before that call (e.g. only halfes can be moved to battlefield)
@@ -355,7 +364,7 @@ public final class ZonesHandler {
                 } else if (card instanceof Permanent) {
                     throw new IllegalStateException("Unexpected trying of move permanent to battlefield instead card");
                 } else {
-                    permanent = new PermanentCard(card, event.getPlayerId(), game);
+                    permanent = new PermanentCard(card, event.getPlayerId(), game, false);
                 }
 
                 // put onto battlefield with possible counters

--- a/Mage/src/main/java/mage/game/permanent/PermanentCard.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentCard.java
@@ -35,22 +35,28 @@ public class PermanentCard extends PermanentImpl {
     protected int zoneChangeCounter;
 
     public PermanentCard(Card card, UUID controllerId, Game game) {
+        this(card, controllerId, game, false);
+    }
+
+    public PermanentCard(Card card, UUID controllerId, Game game, boolean facedownSoSkipChecks) {
         super(card.getId(), card.getOwnerId(), controllerId, card.getName());
 
-        // usage check: you must put to play only real card's part
-        // if you use it in test code then call CardUtil.getDefaultCardSideForBattlefield for default side
-        // it's a basic check and still allows to create permanent from instant or sorcery
-        boolean goodForBattlefield = true;
-        if (card instanceof ModalDoubleFacedCard) {
-            goodForBattlefield = false;
-        } else if (card instanceof SplitCard) {
-            // fused spells allowed (it uses main card)
-            if (card.getSpellAbility() != null && !card.getSpellAbility().getSpellAbilityType().equals(SpellAbilityType.SPLIT_FUSED)) {
+        if (!facedownSoSkipChecks) {
+            // usage check: you must put to play only real card's part
+            // if you use it in test code then call CardUtil.getDefaultCardSideForBattlefield for default side
+            // it's a basic check and still allows to create permanent from instant or sorcery
+            boolean goodForBattlefield = true;
+            if (card instanceof ModalDoubleFacedCard) {
                 goodForBattlefield = false;
+            } else if (card instanceof SplitCard) {
+                // fused spells allowed (it uses main card)
+                if (card.getSpellAbility() != null && !card.getSpellAbility().getSpellAbilityType().equals(SpellAbilityType.SPLIT_FUSED)) {
+                    goodForBattlefield = false;
+                }
             }
-        }
-        if (!goodForBattlefield) {
-            throw new IllegalArgumentException("ERROR, can't create permanent card from split or mdf: " + card.getName());
+            if (!goodForBattlefield) {
+                throw new IllegalArgumentException("ERROR, can't create permanent card from split or mdf: " + card.getName());
+            }
         }
 
         this.card = card;


### PR DESCRIPTION
MDFC can not be manifested in the current version, there is an ongoing issue with retrieving the UUID of the permanent the MDFC card becomes.

fix #10608