### PR TITLE
Fix Consuming Ferocity (closes #10807)

### DIFF
--- a/Mage.Sets/src/mage/cards/c/ConsumingFerocity.java
+++ b/Mage.Sets/src/mage/cards/c/ConsumingFerocity.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.effects.common.DestroyTargetEffect;
 import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
 import mage.abilities.effects.common.counter.AddCountersAttachedEffect;
-import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -52,9 +51,8 @@ public final class ConsumingFerocity extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(1, 0, Duration.WhileOnBattlefield)));
 
         // At the beginning of your upkeep, put a +1/+0 counter on enchanted creature. If that creature has three or more +1/+0 counters on it, it deals damage equal to its power to its controller, then destroy that creature and it can't be regenerated.
-        Effect effect = new ConsumingFerocityEffect();
         Ability upkeepAbility = new BeginningOfUpkeepTriggeredAbility(new AddCountersAttachedEffect(CounterType.P1P0.createInstance(), "enchanted creature"), TargetController.YOU, false);
-        upkeepAbility.addEffect(effect);
+        upkeepAbility.addEffect(new ConsumingFerocityEffect());
         this.addAbility(upkeepAbility);
     }
 
@@ -72,7 +70,7 @@ class ConsumingFerocityEffect extends OneShotEffect {
 
     public ConsumingFerocityEffect() {
         super(Outcome.Benefit);
-        staticText = "put a +1/+0 counter on enchanted creature. If that creature has three or more +1/+0 counters on it, it deals damage equal to its power to its controller, then destroy that creature and it can't be regenerated";
+        staticText = "If that creature has three or more +1/+0 counters on it, it deals damage equal to its power to its controller, then destroy that creature and it can't be regenerated";
     }
 
     public ConsumingFerocityEffect(final ConsumingFerocityEffect effect) {
@@ -87,17 +85,19 @@ class ConsumingFerocityEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Permanent permanent = game.getPermanentOrLKIBattlefield(source.getSourceId());
-        if (permanent != null && permanent.getAttachedTo() != null) {
+        if (permanent != null) {
             Permanent creature = game.getPermanent(permanent.getAttachedTo());
-            if (creature.getCounters(game).getCount(CounterType.P1P0) > 2) {
-                Player player = game.getPlayer(creature.getControllerId());
-                if (player != null) {
-                    player.damage(creature.getPower().getValue(), creature.getId(), source, game);
+            if (creature != null) {
+                if (creature.getCounters(game).getCount(CounterType.P1P0) > 2) {
+                    Player player = game.getPlayer(creature.getControllerId());
+                    if (player != null) {
+                        player.damage(creature.getPower().getValue(), creature.getId(), source, game);
+                    }
+                    Effect effect = new DestroyTargetEffect(true);
+                    effect.setTargetPointer(new FixedTarget(creature, game));
+                    effect.apply(game, source);
+                    return true;
                 }
-                Effect effect = new DestroyTargetEffect(true);
-                effect.setTargetPointer(new FixedTarget(creature, game));
-                effect.apply(game, source);
-                return true;
             }
         }
         return false;


### PR DESCRIPTION
Consuming Ferocity had a custom effect where it added the counters, and wasn't properly getting the attached creature such that it always showed it as null. I changed the counter adding to use the normal class, and updated the targeting to correctly get the attached creature.