### PR TITLE
Draft [ONC] Chiss-Goria, Forge Tyrant

### DIFF
--- a/Mage.Sets/src/mage/cards/c/ChissGoriaForgeTyrant.java
+++ b/Mage.Sets/src/mage/cards/c/ChissGoriaForgeTyrant.java
@@ -1,21 +1,17 @@
 package mage.cards.c;
 
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
+
 import mage.MageInt;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.SubType;
-import mage.constants.SuperType;
-import mage.constants.Zone;
+import mage.MageItem;
+import mage.MageObjectReference;
+import mage.constants.*;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
-import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ContinuousEffect;
-import mage.abilities.effects.common.asthought.CanPlayCardControllerEffect;
-import mage.abilities.effects.common.asthought.PlayFromNotOwnHandZoneTargetEffect;
-import mage.abilities.effects.common.continuous.GainAbilityControlledSpellsEffect;
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.asthought.CanPlayCardControllerEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.HasteAbility;
 import mage.abilities.keyword.AffinityForArtifactsAbility;
@@ -24,10 +20,18 @@ import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardsImpl;
 import mage.cards.CardSetInfo;
+import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterArtifactCard;
+import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.Predicates;
+import mage.game.ExileZone;
 import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.stack.Spell;
 import mage.players.Player;
 import mage.util.CardUtil;
+import mage.watchers.Watcher;
 
 /**
  *
@@ -35,24 +39,24 @@ import mage.util.CardUtil;
  */
 public final class ChissGoriaForgeTyrant extends CardImpl {
 
-    public ChissGoriaForgeTyrant(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{6}{R}{R}{R}");
+  public ChissGoriaForgeTyrant(UUID ownerId, CardSetInfo setInfo) {
+    super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{6}{R}{R}{R}");
         
-        this.supertype.add(SuperType.LEGENDARY);
-        this.subtype.add(SubType.DRAGON);
-        this.power = new MageInt(5);
-        this.toughness = new MageInt(4);
+    this.supertype.add(SuperType.LEGENDARY);
+    this.subtype.add(SubType.DRAGON);
+    this.power = new MageInt(5);
+    this.toughness = new MageInt(4);
 
         // Affinity for artifacts
-	this.addAbility(new AffinityForArtifactsAbility());
+    this.addAbility(new AffinityForArtifactsAbility());
         // Flying
-        this.addAbility(FlyingAbility.getInstance());
+    this.addAbility(FlyingAbility.getInstance());
 
         // Haste
-        this.addAbility(HasteAbility.getInstance());
+    this.addAbility(HasteAbility.getInstance());
 
         // Whenever Chiss-Goria, Forge Tyrant attacks, exile the top five cards of your library. You may cast an artifact spell from among them this turn. If you do, it has affinity for artifacts.
-	this.addAbility(new AttacksTriggeredAbility(new ChissGoriaForgeTyrantEffect(), false));
+    this.addAbility(new AttacksTriggeredAbility(new ChissGoriaForgeTyrantEffect(), false), new ChissGoriaForgeTyrantWatcher());
 
     }
 
@@ -67,68 +71,135 @@ public final class ChissGoriaForgeTyrant extends CardImpl {
 }
 
 class ChissGoriaForgeTyrantEffect extends OneShotEffect {
-	
-	public ChissGoriaForgeTyrantEffect() {
-	    super(Outcome.Benefit);
-	    staticText = "exile the top five cards of your library. " 
-		+ "You may cast an artifact spell from among them this turn. "
-		+ "If you do, it has affinity for artifacts.";
-	}
 
-	private ChissGoriaForgeTyrantEffect(final ChissGoriaForgeTyrantEffect effect) {
-	    super(effect);
-	}
+  public ChissGoriaForgeTyrantEffect() {
+      super(Outcome.Benefit);
+      staticText = "exile the top five cards of your library. " 
+    + "You may cast an artifact spell from among them this turn. "
+    + "If you do, it has affinity for artifacts.";
+  }
 
-	@Override
-	public ChissGoriaForgeTyrantEffect copy() {
-		return new ChissGoriaForgeTyrantEffect(this);
-	}
+  private ChissGoriaForgeTyrantEffect(final ChissGoriaForgeTyrantEffect effect) {
+    super(effect);
+  }
 
-	@Override
-	public boolean apply(Game game, Ability source) {
-		Player controller = game.getPlayer(source.getControllerId());
-		if (controller == null) {
-			return false;
-		}
-		
-		// move top 5 from library to exile
-		Cards cards = new CardsImpl(controller.getLibrary().getTopCards(game, 5));
-		if (cards.isEmpty()) {
-			return false;
-		}
+  @Override
+  public ChissGoriaForgeTyrantEffect copy() {
+    return new ChissGoriaForgeTyrantEffect(this);
+  }
 
-		controller.moveCards(cards, Zone.EXILED, source, game);
-		for (Card card : cards.getCards(game)) {
-			card.addAbility(new AffinityForArtifactsAbility());
-			game.addEffect(new ChissGoriaForgeTyrantCastEffect(game, card), source);
-		}
+  @Override
+  public boolean apply(Game game, Ability source) {
+    Player controller = game.getPlayer(source.getControllerId());
+    
+    FilterCard filter = new FilterArtifactCard("artifact");
+    filter.add(Predicates.not(CardType.LAND.getPredicate()));
 
-		return true;
-	}
+    // move top 5 from library to exile
+    Cards cards = new CardsImpl(controller.getLibrary().getTopCards(game, 5));
+    Set<Card> cardSet = cards.getCards(game);
+    controller.moveCardsToExile(cardSet, source, game, true, CardUtil.getExileZoneId(game, source), CardUtil.getSourceName(game, source));
+
+    ChissGoriaForgeTyrantWatcher.addCards(source, cardSet, game);
+    for (Card card : cardSet) {
+      if (filter.match(card, game)) {
+        game.addEffect(new ChissGoriaForgeTyrantCastEffect(card, game), source);
+        card.setOwnerId(source.getControllerId());
+        card.addAbility(new AffinityForArtifactsAbility());
+        card.setOwnerId(source.getControllerId());
+      }
+    }
+
+    return true;
+  }
 }
 
-// cast with affinity for artifacts
 class ChissGoriaForgeTyrantCastEffect extends CanPlayCardControllerEffect {
 
+    private final FilterControlledPermanent filter = StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT;
 
-	ChissGoriaForgeTyrantCastEffect(Game game, Card card) {
-		super(game, card.getId(), card.getZoneChangeCounter(game), Duration.EndOfTurn);
-	}
+    ChissGoriaForgeTyrantCastEffect(Card card, Game game) {
+        super(game, card.getMainCard().getId(), card.getZoneChangeCounter(game), Duration.EndOfTurn);
+    }
 
-	private ChissGoriaForgeTyrantCastEffect(final ChissGoriaForgeTyrantCastEffect effect) {
-		super(effect);
-	}
+    private ChissGoriaForgeTyrantCastEffect(final ChissGoriaForgeTyrantCastEffect effect) {
+        super(effect);
+    }
 
-	@Override
-	public ChissGoriaForgeTyrantCastEffect copy() {
-		return new ChissGoriaForgeTyrantCastEffect(this);
-	}
-	
-	@Override
-	public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
-		return super.applies(sourceId, source, affectedControllerId, game) && game.getCard(sourceId).hasCardTypeForDeckbuilding(CardType.ARTIFACT);
-	}
+    @Override
+    public ChissGoriaForgeTyrantCastEffect copy() {
+        return new ChissGoriaForgeTyrantCastEffect(this);
+    }
+
+    @Override
+    public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+      Player player = game.getPlayer(source.getControllerId());
+      if (!super.applies(objectId, source, affectedControllerId, game) || !ChissGoriaForgeTyrantWatcher.checkCard(game, source, mor)) {
+        return false;
+      }
+      return true;
+    }
 }
 
-		
-		
+class ChissGoriaForgeTyrantWatcher extends Watcher {
+
+    private final Map<MageObjectReference, Set<Set<MageObjectReference>>> morMap = new HashMap<>();
+
+    public ChissGoriaForgeTyrantWatcher() {
+        super(WatcherScope.GAME);
+    }
+
+    @Override
+    public void watch(GameEvent event, Game game) {
+        if (event.getType() == GameEvent.EventType.CLEANUP_STEP_POST) {
+            morMap.entrySet().removeIf(e -> !e.getKey().zoneCounterIsCurrent(game));
+            morMap.values()
+                    .stream()
+                    .flatMap(Collection::stream)
+                    .forEach(set -> set.removeIf(mor -> !mor.zoneCounterIsCurrent(game)));
+            morMap.values().removeIf(Set::isEmpty);
+            return;
+        }
+        if (event.getType() != GameEvent.EventType.SPELL_CAST || event.getAdditionalReference() == null) {
+            return;
+        }
+        Spell spell = game.getSpell(event.getTargetId());
+        if (spell == null) {
+            return;
+        }
+        morMap.getOrDefault(
+                event.getAdditionalReference().getApprovingMageObjectReference(), Collections.emptySet()
+        ).removeIf(set -> set
+                .stream()
+                .anyMatch(mor -> mor.getSourceId().equals(spell.getMainCard().getId())
+                        && mor.getZoneChangeCounter() + 1 == spell.getZoneChangeCounter(game)));
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        morMap.clear();
+    }
+
+    static void addCards(Ability source, Set<Card> cards, Game game) {
+        game.getState()
+                .getWatcher(ChissGoriaForgeTyrantWatcher.class)
+                .morMap
+                .computeIfAbsent(new MageObjectReference(source), x -> new HashSet<>())
+                .add(cards
+                        .stream()
+                        .map(card -> new MageObjectReference(card, game))
+                        .collect(Collectors.toSet()));
+    }
+
+    static boolean checkCard(Game game, Ability source, MageObjectReference mor) {
+        return game.getState()
+                .getWatcher(ChissGoriaForgeTyrantWatcher.class)
+                .morMap
+                .getOrDefault(new MageObjectReference(source), Collections.emptySet())
+                .stream()
+                .flatMap(Collection::stream)
+                .anyMatch(mor::equals);
+    }
+}
+

--- a/Mage.Sets/src/mage/cards/c/ChissGoriaForgeTyrant.java
+++ b/Mage.Sets/src/mage/cards/c/ChissGoriaForgeTyrant.java
@@ -3,16 +3,31 @@ package mage.cards.c;
 import java.util.UUID;
 import mage.MageInt;
 import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.SuperType;
+import mage.constants.Zone;
+import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
-import mage.abilites.common.continuous.GainAbilityControlledSpellsEffect;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.common.asthought.CanPlayCardControllerEffect;
+import mage.abilities.effects.common.asthought.PlayFromNotOwnHandZoneTargetEffect;
+import mage.abilities.effects.common.continuous.GainAbilityControlledSpellsEffect;
+import mage.abilities.effects.OneShotEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.HasteAbility;
 import mage.abilities.keyword.AffinityForArtifactsAbility;
+import mage.cards.Cards;
+import mage.cards.Card;
 import mage.cards.CardImpl;
+import mage.cards.CardsImpl;
 import mage.cards.CardSetInfo;
 import mage.filter.common.FilterArtifactCard;
+import mage.game.Game;
+import mage.players.Player;
+import mage.util.CardUtil;
 
 /**
  *
@@ -38,6 +53,7 @@ public final class ChissGoriaForgeTyrant extends CardImpl {
 
         // Whenever Chiss-Goria, Forge Tyrant attacks, exile the top five cards of your library. You may cast an artifact spell from among them this turn. If you do, it has affinity for artifacts.
 	this.addAbility(new AttacksTriggeredAbility(new ChissGoriaForgeTyrantEffect(), false));
+
     }
 
     private ChissGoriaForgeTyrant(final ChissGoriaForgeTyrant card) {
@@ -51,14 +67,12 @@ public final class ChissGoriaForgeTyrant extends CardImpl {
 }
 
 class ChissGoriaForgeTyrantEffect extends OneShotEffect {
-
-
-	private static final FilterArtifactCard filter = new FilterArtifactCard("an artifact spell");
 	
 	public ChissGoriaForgeTyrantEffect() {
 	    super(Outcome.Benefit);
 	    staticText = "exile the top five cards of your library. " 
-		+ "You may cast an artifact spell from among them this turn. ";
+		+ "You may cast an artifact spell from among them this turn. "
+		+ "If you do, it has affinity for artifacts.";
 	}
 
 	private ChissGoriaForgeTyrantEffect(final ChissGoriaForgeTyrantEffect effect) {
@@ -66,8 +80,8 @@ class ChissGoriaForgeTyrantEffect extends OneShotEffect {
 	}
 
 	@Override
-	public ChissGoryaForgeTyrantEffect copy() {
-		return new ChissGoryaForgeTyrantEffect(this);
+	public ChissGoriaForgeTyrantEffect copy() {
+		return new ChissGoriaForgeTyrantEffect(this);
 	}
 
 	@Override
@@ -78,15 +92,41 @@ class ChissGoriaForgeTyrantEffect extends OneShotEffect {
 		}
 		
 		// move top 5 from library to exile
-		Cards cards = new CardsImpl(controller.getLibrary().getFromTop(game, 5));
-		controller.moveCards(cards, Zone.EXILED, source, game);
+		Cards cards = new CardsImpl(controller.getLibrary().getTopCards(game, 5));
+		if (cards.isEmpty()) {
+			return false;
+		}
 
-		// cast one with affinity for artifacts
-		Ability ability = new SimpleStaticAbility(new GainAbilityControlledSpellsEffect(new AffinityForArtifactsAbility(), filter).setText("If you do, it has affinity for artifacts."));
-		cards.addAbility(ability);
-		CardUtil.castSingle(controller, source, game, cards);
+		controller.moveCards(cards, Zone.EXILED, source, game);
+		for (Card card : cards.getCards(game)) {
+			card.addAbility(new AffinityForArtifactsAbility());
+			game.addEffect(new ChissGoriaForgeTyrantCastEffect(game, card), source);
+		}
 
 		return true;
+	}
+}
+
+// cast with affinity for artifacts
+class ChissGoriaForgeTyrantCastEffect extends CanPlayCardControllerEffect {
+
+
+	ChissGoriaForgeTyrantCastEffect(Game game, Card card) {
+		super(game, card.getId(), card.getZoneChangeCounter(game), Duration.EndOfTurn);
+	}
+
+	private ChissGoriaForgeTyrantCastEffect(final ChissGoriaForgeTyrantCastEffect effect) {
+		super(effect);
+	}
+
+	@Override
+	public ChissGoriaForgeTyrantCastEffect copy() {
+		return new ChissGoriaForgeTyrantCastEffect(this);
+	}
+	
+	@Override
+	public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+		return super.applies(sourceId, source, affectedControllerId, game) && game.getCard(sourceId).hasCardTypeForDeckbuilding(CardType.ARTIFACT);
 	}
 }
 

--- a/Mage.Sets/src/mage/cards/c/ChissGoriaForgeTyrant.java
+++ b/Mage.Sets/src/mage/cards/c/ChissGoriaForgeTyrant.java
@@ -1,0 +1,94 @@
+package mage.cards.c;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.abilities.common.AttacksTriggeredAbility;
+import mage.abilites.common.continuous.GainAbilityControlledSpellsEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.HasteAbility;
+import mage.abilities.keyword.AffinityForArtifactsAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.filter.common.FilterArtifactCard;
+
+/**
+ *
+ * @author MorellThomas
+ */
+public final class ChissGoriaForgeTyrant extends CardImpl {
+
+    public ChissGoriaForgeTyrant(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{6}{R}{R}{R}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.DRAGON);
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(4);
+
+        // Affinity for artifacts
+	this.addAbility(new AffinityForArtifactsAbility());
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Haste
+        this.addAbility(HasteAbility.getInstance());
+
+        // Whenever Chiss-Goria, Forge Tyrant attacks, exile the top five cards of your library. You may cast an artifact spell from among them this turn. If you do, it has affinity for artifacts.
+	this.addAbility(new AttacksTriggeredAbility(new ChissGoriaForgeTyrantEffect(), false));
+    }
+
+    private ChissGoriaForgeTyrant(final ChissGoriaForgeTyrant card) {
+        super(card);
+    }
+
+    @Override
+    public ChissGoriaForgeTyrant copy() {
+        return new ChissGoriaForgeTyrant(this);
+    }
+}
+
+class ChissGoriaForgeTyrantEffect extends OneShotEffect {
+
+
+	private static final FilterArtifactCard filter = new FilterArtifactCard("an artifact spell");
+	
+	public ChissGoriaForgeTyrantEffect() {
+	    super(Outcome.Benefit);
+	    staticText = "exile the top five cards of your library. " 
+		+ "You may cast an artifact spell from among them this turn. ";
+	}
+
+	private ChissGoriaForgeTyrantEffect(final ChissGoriaForgeTyrantEffect effect) {
+	    super(effect);
+	}
+
+	@Override
+	public ChissGoryaForgeTyrantEffect copy() {
+		return new ChissGoryaForgeTyrantEffect(this);
+	}
+
+	@Override
+	public boolean apply(Game game, Ability source) {
+		Player controller = game.getPlayer(source.getControllerId());
+		if (controller == null) {
+			return false;
+		}
+		
+		// move top 5 from library to exile
+		Cards cards = new CardsImpl(controller.getLibrary().getFromTop(game, 5));
+		controller.moveCards(cards, Zone.EXILED, source, game);
+
+		// cast one with affinity for artifacts
+		Ability ability = new SimpleStaticAbility(new GainAbilityControlledSpellsEffect(new AffinityForArtifactsAbility(), filter).setText("If you do, it has affinity for artifacts."));
+		cards.addAbility(ability);
+		CardUtil.castSingle(controller, source, game, cards);
+
+		return true;
+	}
+}
+
+		
+		

--- a/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOneCommander.java
+++ b/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOneCommander.java
@@ -37,6 +37,7 @@ public final class PhyrexiaAllWillBeOneCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Castle Ardenvale", 149, Rarity.RARE, mage.cards.c.CastleArdenvale.class));
         cards.add(new SetCardInfo("Castle Embereth", 150, Rarity.RARE, mage.cards.c.CastleEmbereth.class));
         cards.add(new SetCardInfo("Chain Reaction", 97, Rarity.RARE, mage.cards.c.ChainReaction.class));
+        cards.add(new SetCardInfo("Chiss-Goria, Forge Tyrant", 25, Rarity.MYTHIC, mage.cards.c.ChissGoriaForgeTyrant.class));
         cards.add(new SetCardInfo("Chromatic Lantern", 127, Rarity.RARE, mage.cards.c.ChromaticLantern.class));
         cards.add(new SetCardInfo("Clever Concealment", 5, Rarity.RARE, mage.cards.c.CleverConcealment.class));
         cards.add(new SetCardInfo("Collective Effort", 61, Rarity.RARE, mage.cards.c.CollectiveEffort.class));

--- a/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOneCommander.java
+++ b/Mage.Sets/src/mage/sets/PhyrexiaAllWillBeOneCommander.java
@@ -37,7 +37,8 @@ public final class PhyrexiaAllWillBeOneCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Castle Ardenvale", 149, Rarity.RARE, mage.cards.c.CastleArdenvale.class));
         cards.add(new SetCardInfo("Castle Embereth", 150, Rarity.RARE, mage.cards.c.CastleEmbereth.class));
         cards.add(new SetCardInfo("Chain Reaction", 97, Rarity.RARE, mage.cards.c.ChainReaction.class));
-        cards.add(new SetCardInfo("Chiss-Goria, Forge Tyrant", 25, Rarity.MYTHIC, mage.cards.c.ChissGoriaForgeTyrant.class));
+        cards.add(new SetCardInfo("Chiss-Goria, Forge Tyrant", 25, Rarity.MYTHIC, mage.cards.c.ChissGoriaForgeTyrant.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Chiss-Goria, Forge Tyrant", 35, Rarity.MYTHIC, mage.cards.c.ChissGoriaForgeTyrant.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Chromatic Lantern", 127, Rarity.RARE, mage.cards.c.ChromaticLantern.class));
         cards.add(new SetCardInfo("Clever Concealment", 5, Rarity.RARE, mage.cards.c.CleverConcealment.class));
         cards.add(new SetCardInfo("Collective Effort", 61, Rarity.RARE, mage.cards.c.CollectiveEffort.class));


### PR DESCRIPTION
I have one problem here which I do not know how to solve:
All cards exiled with this ability, which are artifact spells, get the AffinityForArtifactsAbility.
For the artifact counting to work, I have to set the controllerId for each card to the correct controller, if I do so, I get the correct hint for the artifact count shown on the card.
But when I cast one of those cards the affiniy discount does not get applied.
Is there an issue with the initial controller when the card got the AffinityEffect?

Any help would be appreciated.