### PR TITLE
[GUI] Add Token on type line.

### DIFF
--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardRenderer.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardRenderer.java
@@ -1,7 +1,6 @@
 package org.mage.card.arcane;
 
 import mage.abilities.hint.HintUtils;
-import mage.cards.ArtRect;
 import mage.client.dialog.PreferencesDialog;
 import mage.constants.AbilityType;
 import mage.constants.CardType;
@@ -504,6 +503,10 @@ public abstract class CardRenderer {
 
     protected String getCardSuperTypeLine() {
         StringBuilder spType = new StringBuilder();
+        if (cardView.isToken()) {
+            // "Token" is shown on the token line of printed token.
+            spType.append("Token ");
+        }
         for (SuperType superType : cardView.getSuperTypes()) {
             spType.append(superType).append(' ');
         }

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardRenderer.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardRenderer.java
@@ -504,7 +504,7 @@ public abstract class CardRenderer {
     protected String getCardSuperTypeLine() {
         StringBuilder spType = new StringBuilder();
         if (cardView.isToken()) {
-            // "Token" is shown on the token line of printed token.
+            // "Token" is shown on the type line. As recent printing of tokens do.
             spType.append("Token ");
         }
         for (SuperType superType : cardView.getSuperTypes()) {

--- a/Mage.Client/src/main/java/org/mage/card/arcane/ModernCardRenderer.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/ModernCardRenderer.java
@@ -12,6 +12,7 @@ import mage.util.SubTypes;
 import mage.view.CardView;
 import mage.view.PermanentView;
 import org.apache.log4j.Logger;
+import static org.mage.card.arcane.ManaSymbols.getSizedManaSymbol;
 
 import javax.swing.*;
 import java.awt.*;
@@ -27,8 +28,6 @@ import java.text.CharacterIterator;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import static org.mage.card.arcane.ManaSymbols.getSizedManaSymbol;
 
 
 /*
@@ -964,6 +963,7 @@ public class ModernCardRenderer extends CardRenderer {
 
         // Replace "Legendary" in type line if there's not enough space
         if (g.getFontMetrics().stringWidth(types) > availableWidth) {
+            types = types.replace("Token", "T.");
             types = types.replace("Legendary", "L.");
         }
 


### PR DESCRIPTION
Minor tweak on the ModernCardRenderer: add Token (or T. if not enough space) in front of the type line, in order to differentiate (altough subtle) tokens from non-tokens.

![image](https://github.com/magefree/mage/assets/34709007/edf63fce-5286-4e6d-9653-d3ad2d954862)
![image](https://github.com/magefree/mage/assets/34709007/fdf69e18-7c68-45b1-8e99-d116f304c1b3)
