### PR TITLE
[WOE] Workaround for Johann's Stopgap

### DIFF
--- a/Mage.Sets/src/mage/cards/j/JohannsStopgap.java
+++ b/Mage.Sets/src/mage/cards/j/JohannsStopgap.java
@@ -1,0 +1,87 @@
+
+package mage.cards.j;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.CompoundCondition;
+import mage.abilities.condition.InvertCondition;
+import mage.abilities.condition.OrCondition;
+import mage.abilities.condition.common.ChoseToNotBargainCondition;
+import mage.abilities.condition.common.PastBargainingCondition;
+import mage.abilities.condition.common.PermanentsOnTheBattlefieldCondition;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.ReturnToHandTargetEffect;
+import mage.abilities.effects.common.cost.SpellCostIncreaseSourceEffect;
+import mage.abilities.effects.common.cost.SpellCostReductionSourceEffect;
+import mage.abilities.keyword.BargainAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.ComparisonType;
+import mage.constants.Zone;
+import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.permanent.TokenPredicate;
+import mage.target.common.TargetNonlandPermanent;
+
+import java.util.UUID;
+
+/**
+ * @author Susucr
+ */
+public final class JohannsStopgap extends CardImpl {
+
+    private static final FilterControlledPermanent filterBargain = new FilterControlledPermanent();
+
+    static {
+        filterBargain.add(Predicates.or(
+                CardType.ARTIFACT.getPredicate(),
+                CardType.ENCHANTMENT.getPredicate(),
+                TokenPredicate.TRUE
+        ));
+    }
+
+    public JohannsStopgap(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{U}");
+
+        // Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)
+        this.addAbility(new BargainAbility());
+
+        // This spell costs {2} less to cast if it's bargained.
+        //
+        // This is a workaround in order to allow casting when having one of {3}{U} or {1}{U}
+        // and an available bargainable permanent. We take the approach to by default reduce the cost by {2},
+        // and increase it by {2} if both the spell is not bargained and it is not possible to Bargain.
+        Ability ability = new SimpleStaticAbility(Zone.ALL, new SpellCostReductionSourceEffect(2)
+                .setText("This spell costs {2} less to cast if it's bargained"));
+        ability.setRuleAtTheTop(true);
+        this.addAbility(ability);
+        ability = new SimpleStaticAbility(Zone.ALL, new SpellCostIncreaseSourceEffect(2,
+                new OrCondition(
+                        new CompoundCondition(
+                                // We are before bargaining, and bargaining is not possible.
+                                new InvertCondition(PastBargainingCondition.instance),
+                                new PermanentsOnTheBattlefieldCondition(filterBargain, ComparisonType.EQUAL_TO, 0, true)
+                        ),
+                        // Choice was made to not bargain.
+                        ChoseToNotBargainCondition.instance
+                )
+        ));
+        this.addAbility(ability);
+
+        // Return target nonland permanent to its owner's hand. Draw a card.
+        this.getSpellAbility().addEffect(new ReturnToHandTargetEffect());
+        this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1));
+        this.getSpellAbility().addTarget(new TargetNonlandPermanent());
+    }
+
+    private JohannsStopgap(final JohannsStopgap card) {
+        super(card);
+    }
+
+    @Override
+    public JohannsStopgap copy() {
+        return new JohannsStopgap(this);
+    }
+}
+

--- a/Mage.Sets/src/mage/sets/WildsOfEldraine.java
+++ b/Mage.Sets/src/mage/sets/WildsOfEldraine.java
@@ -30,6 +30,7 @@ public final class WildsOfEldraine extends ExpansionSet {
         cards.add(new SetCardInfo("Glass Casket", 16, Rarity.UNCOMMON, mage.cards.g.GlassCasket.class));
         cards.add(new SetCardInfo("Greta, Sweettooth Scourge", 205, Rarity.UNCOMMON, mage.cards.g.GretaSweettoothScourge.class));
         cards.add(new SetCardInfo("Island", 263, Rarity.LAND, mage.cards.basiclands.Island.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Johann's Stopgap", 58, Rarity.COMMON, mage.cards.j.JohannsStopgap.class));
         cards.add(new SetCardInfo("Moonshaker Cavalry", 21, Rarity.MYTHIC, mage.cards.m.MoonshakerCavalry.class));
         cards.add(new SetCardInfo("Mountain", 265, Rarity.LAND, mage.cards.basiclands.Mountain.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Neva, Stalked by Nightmares", 209, Rarity.UNCOMMON, mage.cards.n.NevaStalkedByNightmares.class));

--- a/Mage/src/main/java/mage/abilities/condition/common/ChoseToNotBargainCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/ChoseToNotBargainCondition.java
@@ -1,0 +1,37 @@
+package mage.abilities.condition.common;
+
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.condition.Condition;
+import mage.abilities.keyword.BargainAbility;
+import mage.cards.Card;
+import mage.game.Game;
+
+/**
+ * Checks if the choice for the Bargain spell was to not Bargain
+ *
+ * @author Susucr
+ */
+public enum ChoseToNotBargainCondition implements Condition {
+
+    instance;
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        MageObject sourceObject = source.getSourceObject(game);
+        if (sourceObject instanceof Card) {
+            for (Ability ability : ((Card) sourceObject).getAbilities(game)) {
+                if (ability instanceof BargainAbility) {
+                    return ((BargainAbility) ability).choseToNotBargain(game, source);
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "{this} is bargaining";
+    }
+
+}

--- a/Mage/src/main/java/mage/abilities/condition/common/PastBargainingCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/PastBargainingCondition.java
@@ -1,0 +1,37 @@
+package mage.abilities.condition.common;
+
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.condition.Condition;
+import mage.abilities.keyword.BargainAbility;
+import mage.cards.Card;
+import mage.game.Game;
+
+/**
+ * Checks if the spell's Bargaining has started already.
+ *
+ * @author Susucr
+ */
+public enum PastBargainingCondition implements Condition {
+
+    instance;
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        MageObject sourceObject = source.getSourceObject(game);
+        if (sourceObject instanceof Card) {
+            for (Ability ability : ((Card) sourceObject).getAbilities(game)) {
+                if (ability instanceof BargainAbility) {
+                    return ((BargainAbility) ability).isBargaining(game, source);
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "{this} is bargaining";
+    }
+
+}

--- a/Mage/src/main/java/mage/abilities/keyword/BargainAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/BargainAbility.java
@@ -37,6 +37,9 @@ public class BargainAbility extends StaticAbility implements OptionalAdditionalS
     private static final String reminderText = "You may sacrifice an artifact, enchantment, or token as you cast this spell.";
     private final String rule;
 
+    private boolean pastBargaining;
+    private boolean choseToNotBargain;
+
     private String activationKey; // TODO: replace by Tag Cost Tracking.
 
     protected OptionalAdditionalCost additionalCost;
@@ -57,6 +60,8 @@ public class BargainAbility extends StaticAbility implements OptionalAdditionalS
         this.setRuleAtTheTop(true);
         this.addHint(BargainCostWasPaidHint.instance);
         this.activationKey = null;
+        this.pastBargaining = false;
+        this.choseToNotBargain = false;
     }
 
     private BargainAbility(final BargainAbility ability) {
@@ -64,6 +69,8 @@ public class BargainAbility extends StaticAbility implements OptionalAdditionalS
         this.rule = ability.rule;
         this.additionalCost = ability.additionalCost.copy();
         this.activationKey = ability.activationKey;
+        this.pastBargaining = ability.pastBargaining;
+        this.choseToNotBargain = ability.choseToNotBargain;
     }
 
     @Override
@@ -76,6 +83,8 @@ public class BargainAbility extends StaticAbility implements OptionalAdditionalS
             additionalCost.reset();
         }
         this.activationKey = null;
+        this.pastBargaining = false;
+        this.choseToNotBargain = false;
     }
 
     @Override
@@ -91,7 +100,10 @@ public class BargainAbility extends StaticAbility implements OptionalAdditionalS
 
         this.resetBargain();
         boolean canPay = additionalCost.canPay(ability, this, ability.getControllerId(), game);
-        if (!canPay || !player.chooseUse(Outcome.Sacrifice, promptString, ability, game)) {
+        boolean chooseToBargain = canPay && player.chooseUse(Outcome.Sacrifice, promptString, ability, game);
+        pastBargaining = true;
+        if (!chooseToBargain) {
+            choseToNotBargain = true;
             return;
         }
 
@@ -109,6 +121,15 @@ public class BargainAbility extends StaticAbility implements OptionalAdditionalS
 
     public boolean wasBargained(Game game, Ability source) {
         return activationKey != null && getActivationKey(source, game).equalsIgnoreCase(activationKey);
+    }
+
+    // Returns true if the bargain cost is activated.
+    public boolean isBargaining(Game game, Ability source) {
+        return pastBargaining;
+    }
+
+    public boolean choseToNotBargain(Game game, Ability source) {
+        return choseToNotBargain;
     }
 
 


### PR DESCRIPTION
So this does not look that great.
The main issue is for the card to be considered castable when having either {1}{U} and something to Bargain, or {3}{U}. Then reduce the cost only if bargained.
I did opt for the workaround to always apply the cost reducer then conditionally apply an opposite cost increase. But I am not that happy of the workaround overall.

Another option (that could be a lot cleaner) would be similar to the Defiler of Faith cycle, with Bargain having the option to apply a CostModificationEffectImpl that could adjust cost of spells if bargained. If someone wants to try that implementation path, I'm all for it.