### PR TITLE
[WOE] Implement Sharae of Numbing Depths

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SharaeOfNumbingDepths.java
+++ b/Mage.Sets/src/mage/cards/s/SharaeOfNumbingDepths.java
@@ -1,0 +1,90 @@
+package mage.cards.s;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.TapTargetEffect;
+import mage.abilities.effects.common.counter.AddCountersTargetEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.target.common.TargetOpponentsCreaturePermanent;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author Susucr
+ */
+public final class SharaeOfNumbingDepths extends CardImpl {
+
+    public SharaeOfNumbingDepths(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{W}{U}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.MERFOLK);
+        this.subtype.add(SubType.WIZARD);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(3);
+
+        // When Sharae of Numbing Depths enters the battlefield, tap target creature an opponent controls and put a stun counter on it.
+        Ability ability = new EntersBattlefieldTriggeredAbility(new TapTargetEffect());
+        ability.addEffect(new AddCountersTargetEffect(CounterType.STUN.createInstance()).setText("and put a stun counter on it"));
+        ability.addTarget(new TargetOpponentsCreaturePermanent());
+        this.addAbility(ability);
+
+        // Whenever you tap one or more untapped creatures your opponents control, draw a card. This ability triggers only once each turn.
+        this.addAbility(new SharaeOfNumbingDepthsTriggeredAbility());
+    }
+
+    private SharaeOfNumbingDepths(final SharaeOfNumbingDepths card) {
+        super(card);
+    }
+
+    @Override
+    public SharaeOfNumbingDepths copy() {
+        return new SharaeOfNumbingDepths(this);
+    }
+}
+
+class SharaeOfNumbingDepthsTriggeredAbility extends TriggeredAbilityImpl {
+
+    SharaeOfNumbingDepthsTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1));
+        this.setTriggersOnceEachTurn(true);
+        setTriggerPhrase("Whenever you tap one or more untapped creatures your opponents control, ");
+    }
+
+    private SharaeOfNumbingDepthsTriggeredAbility(final SharaeOfNumbingDepthsTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public SharaeOfNumbingDepthsTriggeredAbility copy() {
+        return new SharaeOfNumbingDepthsTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.TAPPED_BY;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        Permanent permanent = game.getPermanent(event.getTargetId());
+        if (permanent != null && game.getOpponents(controllerId).contains(permanent.getControllerId())) {
+            return controllerId.equals(event.getPlayerId());
+        }
+
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SharaeOfNumbingDepths.java
+++ b/Mage.Sets/src/mage/cards/s/SharaeOfNumbingDepths.java
@@ -75,7 +75,7 @@ class SharaeOfNumbingDepthsTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.TAPPED_BY;
+        return event.getType() == GameEvent.EventType.TAPPED;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/s/SharaeOfNumbingDepths.java
+++ b/Mage.Sets/src/mage/cards/s/SharaeOfNumbingDepths.java
@@ -14,6 +14,7 @@ import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
@@ -81,10 +82,8 @@ class SharaeOfNumbingDepthsTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         Permanent permanent = game.getPermanent(event.getTargetId());
-        if (permanent != null && game.getOpponents(controllerId).contains(permanent.getControllerId())) {
-            return controllerId.equals(event.getPlayerId());
-        }
-
-        return false;
+        return permanent != null
+                && StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE.match(permanent, game)
+                && isControlledBy(event.getPlayerId());
     }
 }

--- a/Mage.Sets/src/mage/sets/WildsOfEldraine.java
+++ b/Mage.Sets/src/mage/sets/WildsOfEldraine.java
@@ -38,6 +38,7 @@ public final class WildsOfEldraine extends ExpansionSet {
         cards.add(new SetCardInfo("Rat Out", 103, Rarity.COMMON, mage.cards.r.RatOut.class));
         cards.add(new SetCardInfo("Restless Fortress", 259, Rarity.RARE, mage.cards.r.RestlessFortress.class));
         cards.add(new SetCardInfo("Ruby, Daring Tracker", 212, Rarity.UNCOMMON, mage.cards.r.RubyDaringTracker.class));
+        cards.add(new SetCardInfo("Sharae of Numbing Depths", 213, Rarity.UNCOMMON, mage.cards.s.SharaeOfNumbingDepths.class));
         cards.add(new SetCardInfo("Skybeast Tracker", 185, Rarity.COMMON, mage.cards.s.SkybeastTracker.class));
         cards.add(new SetCardInfo("Sleight of Hand", 67, Rarity.COMMON, mage.cards.s.SleightOfHand.class));
         cards.add(new SetCardInfo("Swamp", 264, Rarity.LAND, mage.cards.basiclands.Swamp.class, NON_FULL_USE_VARIOUS));

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -339,19 +339,11 @@ public class GameEvent implements Serializable {
         /* TAPPED,
          targetId    tapped permanent
          sourceId    id of the ability's source (can be null for standard tap actions like combat)
-         playerId    controller of the tapped permanent
+         playerId    source's controller, null if no source
          amount      not used for this event
          flag        is it tapped for combat
          */
         TAPPED,
-        /* TAPPED,
-         targetId    tapped permanent
-         sourceId    id of the ability's source (can be null for standard tap actions like combat)
-         playerId    controller of the **source** ability
-         amount      not used for this event
-         flag        is it tapped for combat
-         */
-        TAPPED_BY,
         TAPPED_FOR_MANA,
         /* TAPPED_FOR_MANA
          During calculation of the available mana for a player the "TappedForMana" event is fired to simulate triggered mana production.

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -344,6 +344,14 @@ public class GameEvent implements Serializable {
          flag        is it tapped for combat
          */
         TAPPED,
+        /* TAPPED,
+         targetId    tapped permanent
+         sourceId    id of the ability's source (can be null for standard tap actions like combat)
+         playerId    controller of the **source** ability
+         amount      not used for this event
+         flag        is it tapped for combat
+         */
+        TAPPED_BY,
         TAPPED_FOR_MANA,
         /* TAPPED_FOR_MANA
          During calculation of the available mana for a player the "TappedForMana" event is fired to simulate triggered mana production.

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -559,8 +559,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
         //20091005 - 701.15a
         if (!tapped && !replaceEvent(EventType.TAP, game)) {
             this.tapped = true;
-            game.fireEvent(new GameEvent(GameEvent.EventType.TAPPED, objectId, source, controllerId, 0, forCombat));
-            game.fireEvent(new GameEvent(GameEvent.EventType.TAPPED_BY, objectId, source, source == null ? null : source.getControllerId(), 0, forCombat));
+            game.fireEvent(new GameEvent(GameEvent.EventType.TAPPED, objectId, source, source == null ? null : source.getControllerId(), 0, forCombat));
             return true;
         }
         return false;

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -560,6 +560,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
         if (!tapped && !replaceEvent(EventType.TAP, game)) {
             this.tapped = true;
             game.fireEvent(new GameEvent(GameEvent.EventType.TAPPED, objectId, source, controllerId, 0, forCombat));
+            game.fireEvent(new GameEvent(GameEvent.EventType.TAPPED_BY, objectId, source, source == null ? null : source.getControllerId(), 0, forCombat));
             return true;
         }
         return false;


### PR DESCRIPTION
There might be an alternative to adding the event TAPPED_BY? That is not even batched like intended, but is working thanks to the only per turn clause.
I did not find anything to cleanly retrieve the controller of a given sourceId, without more context. Does that exists somewhere? That would make using the TAPPED event possible.