### PR TITLE
[WOE] Implement Thunderous Debut

### DIFF
--- a/Mage.Sets/src/mage/cards/t/ThunderousDebut.java
+++ b/Mage.Sets/src/mage/cards/t/ThunderousDebut.java
@@ -1,0 +1,52 @@
+package mage.cards.t;
+
+import mage.abilities.condition.common.BargainedCondition;
+import mage.abilities.decorator.ConditionalOneShotEffect;
+import mage.abilities.effects.common.LookLibraryAndPickControllerEffect;
+import mage.abilities.keyword.BargainAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.PutCards;
+import mage.filter.FilterCard;
+import mage.filter.common.FilterCreatureCard;
+
+import java.util.UUID;
+
+/**
+ * @author Susucr
+ */
+public final class ThunderousDebut extends CardImpl {
+
+    private static final FilterCard filter = new FilterCreatureCard("up to two creature cards");
+
+    public ThunderousDebut(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{6}{G}{G}");
+
+        // Bargain
+        this.addAbility(new BargainAbility());
+
+        // Look at the top twenty cards of your library. You may reveal up to two creature cards from among them. If this spell was bargained, put the revealed cards onto the battlefield. Otherwise, put the revealed cards into your hand. Then shuffle.
+        this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
+                new LookLibraryAndPickControllerEffect(
+                        20, 2, filter,
+                        PutCards.BATTLEFIELD, PutCards.SHUFFLE, false),
+                new LookLibraryAndPickControllerEffect(
+                        20, 2, filter,
+                        PutCards.HAND, PutCards.SHUFFLE, false),
+                BargainedCondition.instance,
+                "Look at the top twenty cards of your library. You may reveal up to two creature cards "
+                        + "from among them. If this spell was bargained, put the revealed cards onto the battlefield. "
+                        + "Otherwise, put the revealed cards into your hand. Then shuffle."
+        ));
+    }
+
+    private ThunderousDebut(final ThunderousDebut card) {
+        super(card);
+    }
+
+    @Override
+    public ThunderousDebut copy() {
+        return new ThunderousDebut(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/WildsOfEldraine.java
+++ b/Mage.Sets/src/mage/sets/WildsOfEldraine.java
@@ -55,6 +55,7 @@ public final class WildsOfEldraine extends ExpansionSet {
         cards.add(new SetCardInfo("Tanglespan Lookout", 188, Rarity.UNCOMMON, mage.cards.t.TanglespanLookout.class));
         cards.add(new SetCardInfo("The Goose Mother", 204, Rarity.RARE, mage.cards.t.TheGooseMother.class));
         cards.add(new SetCardInfo("Three Blind Mice", 35, Rarity.RARE, mage.cards.t.ThreeBlindMice.class));
+        cards.add(new SetCardInfo("Thunderous Debut", 190, Rarity.RARE, mage.cards.t.ThunderousDebut.class));
         cards.add(new SetCardInfo("Torch the Tower", 153, Rarity.COMMON, mage.cards.t.TorchTheTower.class));
         cards.add(new SetCardInfo("Totentanz, Swarm Piper", 216, Rarity.UNCOMMON, mage.cards.t.TotentanzSwarmPiper.class));
         cards.add(new SetCardInfo("Tough Cookie", 193, Rarity.UNCOMMON, mage.cards.t.ToughCookie.class));


### PR DESCRIPTION
Another case for reducing some card movement logging:
![image](https://github.com/magefree/mage/assets/34709007/626c8518-542d-4f41-8368-ec44579256d9)
