### PR TITLE
Fix Mungha Wurm's effect currently affecting all players

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MunghaWurm.java
+++ b/Mage.Sets/src/mage/cards/m/MunghaWurm.java
@@ -1,7 +1,6 @@
 
 package mage.cards.m;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
@@ -9,13 +8,15 @@ import mage.abilities.effects.RestrictionUntapNotMoreThanEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Duration;
+import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledLandPermanent;
 import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
 import mage.players.Player;
+
+import java.util.UUID;
 
 /**
  *
@@ -50,7 +51,7 @@ class MunghaWurmEffect extends RestrictionUntapNotMoreThanEffect {
 
     public MunghaWurmEffect() {
         super(Duration.WhileOnBattlefield, 1, filter);
-        staticText = "Players can't untap more than one land during their untap steps";
+        staticText = "you can't untap more than one land during your untap step";
     }
 
     public MunghaWurmEffect(final MunghaWurmEffect effect) {
@@ -59,8 +60,7 @@ class MunghaWurmEffect extends RestrictionUntapNotMoreThanEffect {
 
     @Override
     public boolean applies(Player player, Ability source, Game game) {
-        // applied to all players
-        return true;
+        return player != null && player.getId().equals(source.getControllerId());
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/m/MunghaWurm.java
+++ b/Mage.Sets/src/mage/cards/m/MunghaWurm.java
@@ -60,7 +60,7 @@ class MunghaWurmEffect extends RestrictionUntapNotMoreThanEffect {
 
     @Override
     public boolean applies(Player player, Ability source, Game game) {
-        return player != null && player.getId().equals(source.getControllerId());
+        return player.getId().equals(source.getControllerId());
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/pcy/MunghaWurmTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/pcy/MunghaWurmTest.java
@@ -34,15 +34,16 @@ public class MunghaWurmTest extends CardTestPlayerBase {
 
         addCard(Zone.BATTLEFIELD, playerA, wurm);
         addCard(Zone.BATTLEFIELD, playerA, meadow, 10);
-        addCard(Zone.BATTLEFIELD, playerA, guildgate, 1);
+        //addCard(Zone.BATTLEFIELD, playerA, guildgate, 1);
         addCard(Zone.BATTLEFIELD, playerB, treeline, 10);
 
         //setChoice(playerA, guildgate);
         setStopAt(3, PhaseStep.UPKEEP);
         execute();
 
-        assertTappedCount(meadow, true, 10);
-        assertTappedCount(guildgate, false, 1);
+        assertTappedCount(meadow, true, 10 - 1);
+        assertTappedCount(meadow, false, 1);
+        //assertTappedCount(guildgate, false, 1);
         assertTappedCount(treeline, false, 10);
     }
 
@@ -54,7 +55,7 @@ public class MunghaWurmTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, wurm);
         addCard(Zone.BATTLEFIELD, playerA, meadow, 10);
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
-        addCard(Zone.BATTLEFIELD, playerA, guildgate, 1);
+        //addCard(Zone.BATTLEFIELD, playerA, guildgate, 1);
         addCard(Zone.BATTLEFIELD, playerB, treeline, 10);
 
         // Killing the wurm, get rid of the untap replacement effect.
@@ -65,7 +66,7 @@ public class MunghaWurmTest extends CardTestPlayerBase {
         execute();
 
         assertTappedCount(meadow, false, 10);
-        assertTappedCount(guildgate, false, 1);
+        //assertTappedCount(guildgate, false, 1);
         assertTappedCount(treeline, false, 10);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/pcy/MunghaWurmTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/pcy/MunghaWurmTest.java
@@ -1,0 +1,71 @@
+package org.mage.test.cards.single.pcy;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class MunghaWurmTest extends CardTestPlayerBase {
+
+    /**
+     * Mungha Wurm
+     * {2}{G}{G}
+     * Creature — Wurm
+     * <p>
+     * You can’t untap more than one land during your untap step.
+     * 6/5
+     */
+    private static final String wurm = "Mungha Wurm";
+
+    // etb tapped lands
+    private static final String meadow = "Alpine Meadow";
+    private static final String treeline = "Arctic Treeline";
+    private static final String guildgate = "Azorius Guildgate";
+
+    // destroy the wurm
+    private static final String doomBlade = "Doom Blade";
+
+    @Test
+    public void wurmEffect() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, wurm);
+        addCard(Zone.BATTLEFIELD, playerA, meadow, 10);
+        addCard(Zone.BATTLEFIELD, playerA, guildgate, 1);
+        addCard(Zone.BATTLEFIELD, playerB, treeline, 10);
+
+        //setChoice(playerA, guildgate);
+        setStopAt(3, PhaseStep.UPKEEP);
+        execute();
+
+        assertTappedCount(meadow, true, 10);
+        assertTappedCount(guildgate, false, 1);
+        assertTappedCount(treeline, false, 10);
+    }
+
+    @Test
+    public void wurmDying() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.HAND, playerA, doomBlade);
+        addCard(Zone.BATTLEFIELD, playerA, wurm);
+        addCard(Zone.BATTLEFIELD, playerA, meadow, 10);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
+        addCard(Zone.BATTLEFIELD, playerA, guildgate, 1);
+        addCard(Zone.BATTLEFIELD, playerB, treeline, 10);
+
+        // Killing the wurm, get rid of the untap replacement effect.
+        castSpell(2, PhaseStep.END_TURN, playerA, doomBlade, wurm);
+
+        //setChoice(playerA, guildgate);
+        setStopAt(3, PhaseStep.UPKEEP);
+        execute();
+
+        assertTappedCount(meadow, false, 10);
+        assertTappedCount(guildgate, false, 1);
+        assertTappedCount(treeline, false, 10);
+    }
+}


### PR DESCRIPTION
Mungha Wurm should have its untap replacement effect only affect its controller.