### PR TITLE
Fix: not owned artifacts triggering Psychomancers ability

### DIFF
--- a/Mage.Sets/src/mage/cards/p/Psychomancer.java
+++ b/Mage.Sets/src/mage/cards/p/Psychomancer.java
@@ -80,6 +80,7 @@ class PsychomancerTriggeredAbility extends TriggeredAbilityImpl {
                 && (zEvent.getToZone() == Zone.GRAVEYARD || zEvent.getToZone() == Zone.EXILED)
                 && zEvent.getTarget() != null
                 && (zEvent.getTargetId().equals(getSourceId())
-                || zEvent.getTarget().isArtifact(game) && !(zEvent.getTarget() instanceof PermanentToken));
+                || zEvent.getTarget().isArtifact(game) && !(zEvent.getTarget() instanceof PermanentToken)
+                && zEvent.getTarget().getControllerId().equals(getControllerId()));
     }
 }


### PR DESCRIPTION
This fixes that all artifacts that leave the battlefield trigger Psychomancer's ability, regardless of whether you or your opponent controls them.