### PR TITLE
cleanup discard effects

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AbandonHope.java
+++ b/Mage.Sets/src/mage/cards/a/AbandonHope.java
@@ -6,7 +6,7 @@ import mage.abilities.costs.CostAdjuster;
 import mage.abilities.costs.common.DiscardTargetCost;
 import mage.abilities.dynamicvalue.common.ManacostVariableValue;
 import mage.abilities.effects.common.InfoEffect;
-import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
+import mage.abilities.effects.common.discard.LookTargetHandChooseDiscardEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -34,9 +34,7 @@ public final class AbandonHope extends CardImpl {
         this.addAbility(ability);
 
         // Look at target opponent's hand and choose X cards from it. That player discards those cards.
-        this.getSpellAbility().addEffect(
-                new DiscardCardYouChooseTargetEffect(ManacostVariableValue.REGULAR, StaticFilters.FILTER_CARD_CARDS)
-                .setText("Look at target opponent's hand and choose X cards from it. That player discards those cards"));
+        this.getSpellAbility().addEffect(new LookTargetHandChooseDiscardEffect(false, ManacostVariableValue.REGULAR));
         this.getSpellAbility().addTarget(new TargetOpponent());
         this.getSpellAbility().setCostAdjuster(AbandonHopeAdjuster.instance);
     }

--- a/Mage.Sets/src/mage/cards/a/AbandonHope.java
+++ b/Mage.Sets/src/mage/cards/a/AbandonHope.java
@@ -10,7 +10,6 @@ import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.game.Game;
@@ -36,7 +35,7 @@ public final class AbandonHope extends CardImpl {
 
         // Look at target opponent's hand and choose X cards from it. That player discards those cards.
         this.getSpellAbility().addEffect(
-                new DiscardCardYouChooseTargetEffect(ManacostVariableValue.REGULAR, TargetController.ANY)
+                new DiscardCardYouChooseTargetEffect(ManacostVariableValue.REGULAR, StaticFilters.FILTER_CARD_CARDS)
                 .setText("Look at target opponent's hand and choose X cards from it. That player discards those cards"));
         this.getSpellAbility().addTarget(new TargetOpponent());
         this.getSpellAbility().setCostAdjuster(AbandonHopeAdjuster.instance);

--- a/Mage.Sets/src/mage/cards/a/AcquisitionsExpert.java
+++ b/Mage.Sets/src/mage/cards/a/AcquisitionsExpert.java
@@ -10,7 +10,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.target.common.TargetOpponent;
 
 import java.util.UUID;
@@ -30,7 +29,7 @@ public final class AcquisitionsExpert extends CardImpl {
 
         // When Acquisitions Expert enters the battlefield, target opponent reveals a number of cards from their hand equal to the number of creatures in your party. You choose one of those cards. That player discards that card.
         Ability ability = new EntersBattlefieldTriggeredAbility(
-                new DiscardCardYouChooseTargetEffect(TargetController.OPPONENT, PartyCount.instance)
+                new DiscardCardYouChooseTargetEffect(PartyCount.instance)
                         .setText("target opponent reveals a number of cards from their hand " +
                                 "equal to the number of creatures in your party. You choose one of those cards. " +
                                 "That player discards that card. " + PartyCount.getReminder())

--- a/Mage.Sets/src/mage/cards/b/BalaGedThief.java
+++ b/Mage.Sets/src/mage/cards/b/BalaGedThief.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.filter.common.FilterControlledPermanent;
 import mage.target.TargetPlayer;
 
@@ -34,7 +33,7 @@ public final class BalaGedThief extends CardImpl {
         // Whenever Bala Ged Thief or another Ally enters the battlefield under your control,
         // target player reveals a number of cards from their hand equal to the number of Allies you control.
         // You choose one of them. That player discards that card.
-        Ability ability = new AllyEntersBattlefieldTriggeredAbility(new DiscardCardYouChooseTargetEffect(TargetController.ANY, xValue), false);
+        Ability ability = new AllyEntersBattlefieldTriggeredAbility(new DiscardCardYouChooseTargetEffect(xValue), false);
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability.setAbilityWord(null));
     }

--- a/Mage.Sets/src/mage/cards/b/Blackmail.java
+++ b/Mage.Sets/src/mage/cards/b/Blackmail.java
@@ -6,7 +6,6 @@ import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.target.TargetPlayer;
 
 /**
@@ -20,7 +19,7 @@ public final class Blackmail extends CardImpl {
 
 
         // Target player reveals three cards from their hand and you choose one of them. That player discards that card.
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(TargetController.ANY, 3));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(3));
         this.getSpellAbility().addTarget(new TargetPlayer());
     }
 

--- a/Mage.Sets/src/mage/cards/c/CabalInterrogator.java
+++ b/Mage.Sets/src/mage/cards/c/CabalInterrogator.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.target.TargetPlayer;
 
 import java.util.UUID;
@@ -32,7 +31,7 @@ public final class CabalInterrogator extends CardImpl {
         // {X}{B}, {tap}: Target player reveals X cards from their hand and you choose one of them. That player discards that card.
         // Activate only as a sorcery.
         Ability ability = new ActivateAsSorceryActivatedAbility(
-                new DiscardCardYouChooseTargetEffect(TargetController.ANY, ManacostVariableValue.REGULAR),
+                new DiscardCardYouChooseTargetEffect(ManacostVariableValue.REGULAR),
                 new ManaCostsImpl<>("{X}{B}"));
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetPlayer());

--- a/Mage.Sets/src/mage/cards/c/CollectiveBrutality.java
+++ b/Mage.Sets/src/mage/cards/c/CollectiveBrutality.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicates;
 import mage.target.common.TargetCreaturePermanent;
@@ -45,7 +44,7 @@ public final class CollectiveBrutality extends CardImpl {
         this.getSpellAbility().getModes().setMaxModes(3);
 
         // Target opponent reveals their hand. You choose an instant or sorcery card from it. That player discards that card.
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(filter, TargetController.OPPONENT));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(filter));
         this.getSpellAbility().addTarget(new TargetOpponent().withChooseHint("reveals hand, you choose to discard"));
 
         // Target creature gets -2/-2 until end of turn.

--- a/Mage.Sets/src/mage/cards/d/DiscipleOfPhenax.java
+++ b/Mage.Sets/src/mage/cards/d/DiscipleOfPhenax.java
@@ -9,7 +9,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.target.TargetPlayer;
 
 import java.util.UUID;
@@ -29,7 +28,7 @@ public final class DiscipleOfPhenax extends CardImpl {
 
         // When Disciple of Phenax enters the battlefield, target player reveals a number of cards
         // from their hand equal to your devotion to black. You choose one of them. That player discards that card.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new DiscardCardYouChooseTargetEffect(TargetController.ANY, DevotionCount.B));
+        Ability ability = new EntersBattlefieldTriggeredAbility(new DiscardCardYouChooseTargetEffect(DevotionCount.B));
         ability.addTarget(new TargetPlayer());
         ability.addHint(DevotionCount.B.getHint());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/d/DiscordantDirge.java
+++ b/Mage.Sets/src/mage/cards/d/DiscordantDirge.java
@@ -7,19 +7,16 @@ import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.effects.common.discard.LookTargetHandChooseDiscardEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.cards.CardsImpl;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.FilterCard;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.players.Player;
-import mage.target.TargetCard;
 import mage.target.common.TargetOpponent;
 
 import java.util.UUID;
@@ -74,20 +71,7 @@ class DiscordantDirgeEffect extends OneShotEffect {
             return false;
         }
         int verseCounters = discordantDirge.getCounters(game).getCount(CounterType.VERSE);
-        Player targetOpponent = game.getPlayer(source.getFirstTarget());
-        Player controller = game.getPlayer(source.getControllerId());
-        if (targetOpponent == null
-                || controller == null) {
-            return false;
-        }
-        controller.lookAtCards(targetOpponent.getName() + " hand", targetOpponent.getHand(), game);
-        TargetCard target = new TargetCard(0, verseCounters, Zone.HAND, new FilterCard());
-        target.setNotTarget(true);
-        if (!controller.choose(Outcome.Benefit, targetOpponent.getHand(), target, source, game)) {
-            return false;
-        }
-        targetOpponent.discard(new CardsImpl(target.getTargets()), false, source, game);
-        return true;
+        return new LookTargetHandChooseDiscardEffect(true, verseCounters).apply(game, source);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/d/Distress.java
+++ b/Mage.Sets/src/mage/cards/d/Distress.java
@@ -6,7 +6,6 @@ import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.filter.StaticFilters;
 import mage.target.TargetPlayer;
 
@@ -21,7 +20,7 @@ public final class Distress extends CardImpl {
 
         // Target player reveals their hand. You choose a nonland card from it. That player discards that card.
         this.getSpellAbility().addTarget(new TargetPlayer());
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_NON_LAND, TargetController.ANY));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_NON_LAND));
     }
 
     private Distress(final Distress card) {

--- a/Mage.Sets/src/mage/cards/d/Divest.java
+++ b/Mage.Sets/src/mage/cards/d/Divest.java
@@ -7,7 +7,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.StaticFilters;
-import mage.constants.TargetController;
 import mage.target.TargetPlayer;
 
 /**
@@ -22,7 +21,7 @@ public final class Divest extends CardImpl {
 
         // Target player reveals their hand. You choose an artifact or creature card from it. That player discards that card.
         this.getSpellAbility().addTarget(new TargetPlayer());
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_ARTIFACT_OR_CREATURE, TargetController.ANY));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_ARTIFACT_OR_CREATURE));
     }
 
     private Divest(final Divest card) {

--- a/Mage.Sets/src/mage/cards/d/DoomsdaySpecter.java
+++ b/Mage.Sets/src/mage/cards/d/DoomsdaySpecter.java
@@ -1,4 +1,3 @@
-
 package mage.cards.d;
 
 import java.util.UUID;
@@ -7,7 +6,7 @@ import mage.ObjectColor;
 import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.effects.common.ReturnToHandChosenControlledPermanentEffect;
-import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
+import mage.abilities.effects.common.discard.LookTargetHandChooseDiscardEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -20,11 +19,10 @@ import mage.filter.predicate.mageobject.ColorPredicate;
 /**
  *
  * @author LoneFox
-
  */
 public final class DoomsdaySpecter extends CardImpl {
 
-    static final private FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("blue or black creature you control");
+    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("blue or black creature you control");
 
     static {
         filter.add(Predicates.or(new ColorPredicate(ObjectColor.BLUE), new ColorPredicate(ObjectColor.BLACK)));
@@ -41,7 +39,7 @@ public final class DoomsdaySpecter extends CardImpl {
         // When Doomsday Specter enters the battlefield, return a blue or black creature you control to its owner's hand.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new ReturnToHandChosenControlledPermanentEffect(filter), false));
         // Whenever Doomsday Specter deals combat damage to a player, look at that player's hand and choose a card from it. The player discards that card.
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new DiscardCardYouChooseTargetEffect(), false, true));
+        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new LookTargetHandChooseDiscardEffect(), false, true));
     }
 
     private DoomsdaySpecter(final DoomsdaySpecter card) {

--- a/Mage.Sets/src/mage/cards/d/DreadFugue.java
+++ b/Mage.Sets/src/mage/cards/d/DreadFugue.java
@@ -29,13 +29,13 @@ public final class DreadFugue extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{B}");
 
         // Cleave {2}{B}
-        Ability ability = new CleaveAbility(this, new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_NON_LAND, TargetController.ANY), "{2}{B}");
+        Ability ability = new CleaveAbility(this, new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_NON_LAND), "{2}{B}");
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
 
         // Target player reveals their hand. Choose a nonland card from it [with mana value 2 or less]. That player discards that card.
         this.getSpellAbility().addTarget(new TargetPlayer());
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(filter, TargetController.ANY));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(filter));
     }
 
     private DreadFugue(final DreadFugue card) {

--- a/Mage.Sets/src/mage/cards/d/DrillBit.java
+++ b/Mage.Sets/src/mage/cards/d/DrillBit.java
@@ -6,7 +6,6 @@ import mage.abilities.keyword.SpectacleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.filter.StaticFilters;
 import mage.target.TargetPlayer;
 
@@ -22,7 +21,7 @@ public final class DrillBit extends CardImpl {
 
         // Target player reveals their hand. You choose a nonland card from it. That player discards that card.
         this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(
-                StaticFilters.FILTER_CARD_NON_LAND, TargetController.ANY
+                StaticFilters.FILTER_CARD_NON_LAND
         ));
         this.getSpellAbility().addTarget(new TargetPlayer());
 

--- a/Mage.Sets/src/mage/cards/e/Encroach.java
+++ b/Mage.Sets/src/mage/cards/e/Encroach.java
@@ -7,7 +7,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SuperType;
-import mage.constants.TargetController;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicates;
 import mage.target.TargetPlayer;
@@ -29,7 +28,7 @@ public final class Encroach extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{B}");
 
         // Target player reveals their hand. You choose a nonbasic land card from it. That player discards that card.
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(filter, TargetController.ANY));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(filter));
         this.getSpellAbility().addTarget(new TargetPlayer());
    }
 

--- a/Mage.Sets/src/mage/cards/e/Extortion.java
+++ b/Mage.Sets/src/mage/cards/e/Extortion.java
@@ -1,18 +1,10 @@
 package mage.cards.e;
 
-import mage.abilities.Ability;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.discard.LookTargetHandChooseDiscardEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.cards.CardsImpl;
 import mage.constants.CardType;
-import mage.constants.Outcome;
-import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.players.Player;
-import mage.target.TargetCard;
 import mage.target.TargetPlayer;
-import mage.target.common.TargetCardInHand;
 
 import java.util.UUID;
 
@@ -25,7 +17,7 @@ public final class Extortion extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{B}{B}");
 
         // Look at target player's hand and choose up to two cards from it. That player discards those cards.
-        this.getSpellAbility().addEffect(new ExtortionEffect());
+        this.getSpellAbility().addEffect(new LookTargetHandChooseDiscardEffect(true, 2));
         this.getSpellAbility().addTarget(new TargetPlayer());
     }
 
@@ -36,37 +28,5 @@ public final class Extortion extends CardImpl {
     @Override
     public Extortion copy() {
         return new Extortion(this);
-    }
-}
-
-class ExtortionEffect extends OneShotEffect {
-
-    ExtortionEffect() {
-        super(Outcome.Discard);
-        staticText = "Look at target player's hand and choose up to two cards from it. That player discards those cards.";
-    }
-
-    private ExtortionEffect(final ExtortionEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player targetPlayer = game.getPlayer(source.getFirstTarget());
-        Player you = game.getPlayer(source.getControllerId());
-        if (targetPlayer == null || you == null) {
-            return false;
-        }
-        you.lookAtCards("Discard", targetPlayer.getHand(), game);
-        TargetCard target = new TargetCardInHand(0, 2, StaticFilters.FILTER_CARD_CARDS);
-        target.setNotTarget(true);
-        you.choose(Outcome.Discard, targetPlayer.getHand(), target, source, game);
-        targetPlayer.discard(new CardsImpl(target.getTargets()), false, source, game);
-        return true;
-    }
-
-    @Override
-    public ExtortionEffect copy() {
-        return new ExtortionEffect(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/e/ExtractTheTruth.java
+++ b/Mage.Sets/src/mage/cards/e/ExtractTheTruth.java
@@ -30,9 +30,7 @@ public final class ExtractTheTruth extends CardImpl {
 
         // Choose one—
         // • Target opponent reveals their hand. You may choose a creature, enchantment, or planeswalker card from it. That player discards that card.
-        DiscardCardYouChooseTargetEffect effect = new DiscardCardYouChooseTargetEffect(filter);
-        effect.setOptional(true);
-        this.getSpellAbility().addEffect(effect);
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(filter).setOptional(true));
         this.getSpellAbility().addTarget(new TargetOpponent());
 
         // • Target opponent sacrifices an enchantment.

--- a/Mage.Sets/src/mage/cards/g/GixsCaress.java
+++ b/Mage.Sets/src/mage/cards/g/GixsCaress.java
@@ -5,7 +5,6 @@ import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.filter.StaticFilters;
 import mage.game.permanent.token.PowerstoneToken;
 import mage.target.common.TargetOpponent;
@@ -22,7 +21,7 @@ public final class GixsCaress extends CardImpl {
 
         // Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.
         this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(
-                StaticFilters.FILTER_CARD_NON_LAND, TargetController.OPPONENT
+                StaticFilters.FILTER_CARD_NON_LAND
         ));
         this.getSpellAbility().addTarget(new TargetOpponent());
 

--- a/Mage.Sets/src/mage/cards/g/Grief.java
+++ b/Mage.Sets/src/mage/cards/g/Grief.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
 import mage.filter.predicate.mageobject.ColorPredicate;
@@ -45,7 +44,7 @@ public final class Grief extends CardImpl {
 
         // When Grief enters the battlefield, target opponent reveals their hand. You choose a nonland card from it. That player discards that card.
         Ability ability = new EntersBattlefieldTriggeredAbility(
-                new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_NON_LAND, TargetController.OPPONENT)
+                new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_NON_LAND)
         );
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/g/GruesomeDiscovery.java
+++ b/Mage.Sets/src/mage/cards/g/GruesomeDiscovery.java
@@ -1,6 +1,5 @@
 package mage.cards.g;
 
-import mage.abilities.Ability;
 import mage.abilities.condition.common.MorbidCondition;
 import mage.abilities.decorator.ConditionalOneShotEffect;
 import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
@@ -9,7 +8,6 @@ import mage.abilities.hint.common.MorbidHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.filter.StaticFilters;
 import mage.target.TargetPlayer;
 
@@ -26,7 +24,7 @@ public final class GruesomeDiscovery extends CardImpl {
         // Target player discards two cards.
         // <i>Morbid</i> &mdash; If a creature died this turn, instead that player reveals their hand, you choose two cards from it, then that player discards those cards.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new DiscardCardYouChooseTargetEffect(2, TargetController.ANY), new DiscardTargetEffect(2),
+                new DiscardCardYouChooseTargetEffect(2, StaticFilters.FILTER_CARD_CARDS), new DiscardTargetEffect(2),
                 MorbidCondition.instance, "Target player discards two cards. " +
                 "<br><i>Morbid</i> &mdash; If a creature died this turn, instead that player reveals their hand, " +
                 "you choose two cards from it, then that player discards those cards"

--- a/Mage.Sets/src/mage/cards/h/HollowSpecter.java
+++ b/Mage.Sets/src/mage/cards/h/HollowSpecter.java
@@ -10,12 +10,10 @@ import mage.cards.*;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.game.Game;
 import mage.players.Player;
 import mage.util.ManaUtil;
 
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -72,7 +70,7 @@ class HollowSpecterEffect extends OneShotEffect {
         if (targetPlayer != null && controller != null && controller.chooseUse(Outcome.Benefit, "Pay {X}?", source, game)) {
             int payCount = ManaUtil.playerPaysXGenericMana(true, "Hollow Specter", controller, source, game);
             if (payCount > 0) {
-                return new DiscardCardYouChooseTargetEffect(TargetController.ANY, payCount).setTargetPointer(targetPointer).apply(game, source);
+                return new DiscardCardYouChooseTargetEffect(payCount).setTargetPointer(targetPointer).apply(game, source);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/h/Humiliate.java
+++ b/Mage.Sets/src/mage/cards/h/Humiliate.java
@@ -7,7 +7,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
@@ -29,7 +28,7 @@ public final class Humiliate extends CardImpl {
 
         // Target opponent reveals their hand. You choose a nonland card from it. That player discards that card. Put a +1/+1 counter on a creature you control.
         this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(
-                StaticFilters.FILTER_CARD_NON_LAND, TargetController.OPPONENT
+                StaticFilters.FILTER_CARD_NON_LAND
         ));
         this.getSpellAbility().addEffect(new HumiliateEffect());
         this.getSpellAbility().addTarget(new TargetOpponent());

--- a/Mage.Sets/src/mage/cards/i/InquisitionOfKozilek.java
+++ b/Mage.Sets/src/mage/cards/i/InquisitionOfKozilek.java
@@ -8,7 +8,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.ComparisonType;
-import mage.constants.TargetController;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.ManaValuePredicate;
@@ -31,7 +30,7 @@ public final class InquisitionOfKozilek extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{B}");
 
         this.getSpellAbility().addTarget(new TargetPlayer());
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(filter, TargetController.ANY));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(filter));
     }
 
     private InquisitionOfKozilek(final InquisitionOfKozilek card) {

--- a/Mage.Sets/src/mage/cards/j/JandorsRing.java
+++ b/Mage.Sets/src/mage/cards/j/JandorsRing.java
@@ -16,7 +16,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.constants.WatcherScope;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
@@ -77,7 +76,7 @@ class JandorsRingEffect extends OneShotEffect {
             if (card != null) {
                 FilterCard filter = new FilterCard(card.getName());
                 filter.add(new CardIdPredicate(card.getId()));
-                DiscardCardYouChooseTargetEffect effect = new DiscardCardYouChooseTargetEffect(filter, TargetController.YOU);
+                DiscardCardYouChooseTargetEffect effect = new DiscardCardYouChooseTargetEffect(filter);
                 if (effect.apply(game, source)) {//Conditional was already checked, card should be in hand, but if for some weird reason it fails, the card won't be drawn, although the cost will already be paid
                     Player controller = game.getPlayer(source.getControllerId());
                     if(controller != null) {

--- a/Mage.Sets/src/mage/cards/l/LastRites.java
+++ b/Mage.Sets/src/mage/cards/l/LastRites.java
@@ -9,7 +9,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicates;
 import mage.game.Game;
@@ -73,7 +72,7 @@ class LastRitesEffect extends OneShotEffect {
         FilterCard filter = new FilterCard((discardCount > 1 ? "" : "a")
                 + " nonland card" + (discardCount > 1 ? "s" : ""));
         filter.add(Predicates.not(CardType.LAND.getPredicate()));
-        Effect effect = new DiscardCardYouChooseTargetEffect(StaticValue.get(discardCount), filter, TargetController.ANY);
+        Effect effect = new DiscardCardYouChooseTargetEffect(StaticValue.get(discardCount), filter);
         effect.setTargetPointer(new FixedTarget(targetPlayer.getId()));
         effect.apply(game, source);
         return true;

--- a/Mage.Sets/src/mage/cards/l/LeshracsSigil.java
+++ b/Mage.Sets/src/mage/cards/l/LeshracsSigil.java
@@ -1,4 +1,3 @@
-
 package mage.cards.l;
 
 import java.util.UUID;
@@ -8,7 +7,7 @@ import mage.abilities.common.SpellCastOpponentTriggeredAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.DoIfCostPaid;
 import mage.abilities.effects.common.ReturnToHandSourceEffect;
-import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
+import mage.abilities.effects.common.discard.LookTargetHandChooseDiscardEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -34,7 +33,7 @@ public final class LeshracsSigil extends CardImpl {
 
         // Whenever an opponent casts a green spell, you may pay {B}{B}. If you do, look at that player's hand and choose a card from it. The player discards that card.
         this.addAbility(new SpellCastOpponentTriggeredAbility(
-                Zone.BATTLEFIELD, new DoIfCostPaid(new DiscardCardYouChooseTargetEffect(), new ManaCostsImpl<>("{B}{B}")), filter, false, SetTargetPointer.PLAYER));
+                Zone.BATTLEFIELD, new DoIfCostPaid(new LookTargetHandChooseDiscardEffect(), new ManaCostsImpl<>("{B}{B}")), filter, false, SetTargetPointer.PLAYER));
 
         // {B}{B}: Return Leshrac's Sigil to its owner's hand.
         this.addAbility(new SimpleActivatedAbility(new ReturnToHandSourceEffect(true), new ManaCostsImpl<>("{B}{B}")));

--- a/Mage.Sets/src/mage/cards/m/MemoryTheft.java
+++ b/Mage.Sets/src/mage/cards/m/MemoryTheft.java
@@ -8,7 +8,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
@@ -66,7 +65,7 @@ class MemoryTheftEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         new DiscardCardYouChooseTargetEffect(
-                StaticFilters.FILTER_CARD_NON_LAND, TargetController.ANY
+                StaticFilters.FILTER_CARD_NON_LAND
         ).apply(game, source);
         Player controller = game.getPlayer(source.getControllerId());
         Player player = game.getPlayer(source.getFirstTarget());

--- a/Mage.Sets/src/mage/cards/m/MindWarp.java
+++ b/Mage.Sets/src/mage/cards/m/MindWarp.java
@@ -1,18 +1,11 @@
 package mage.cards.m;
 
-import mage.abilities.Ability;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.dynamicvalue.common.ManacostVariableValue;
+import mage.abilities.effects.common.discard.LookTargetHandChooseDiscardEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.cards.CardsImpl;
 import mage.constants.CardType;
-import mage.constants.Outcome;
-import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.players.Player;
-import mage.target.TargetCard;
 import mage.target.TargetPlayer;
-import mage.target.common.TargetCardInHand;
 
 import java.util.UUID;
 
@@ -25,7 +18,7 @@ public final class MindWarp extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{X}{3}{B}");
 
         // Look at target player's hand and choose X cards from it. That player discards those cards.
-        this.getSpellAbility().addEffect(new MindWarpEffect());
+        this.getSpellAbility().addEffect(new LookTargetHandChooseDiscardEffect(false, ManacostVariableValue.REGULAR));
         this.getSpellAbility().addTarget(new TargetPlayer());
     }
 
@@ -36,36 +29,5 @@ public final class MindWarp extends CardImpl {
     @Override
     public MindWarp copy() {
         return new MindWarp(this);
-    }
-}
-
-class MindWarpEffect extends OneShotEffect {
-
-    MindWarpEffect() {
-        super(Outcome.Discard);
-        staticText = "Look at target player's hand and choose X cards from it. That player discards those cards.";
-    }
-
-    private MindWarpEffect(final MindWarpEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player targetPlayer = game.getPlayer(source.getFirstTarget());
-        Player you = game.getPlayer(source.getControllerId());
-        if (targetPlayer == null || you == null) {
-            return false;
-        }
-        int amountToDiscard = source.getManaCostsToPay().getX();
-        TargetCard target = new TargetCardInHand(amountToDiscard, StaticFilters.FILTER_CARD_CARDS);
-        you.choose(outcome, targetPlayer.getHand(), target, source, game);
-        targetPlayer.discard(new CardsImpl(target.getTargets()), false, source, game);
-        return true;
-    }
-
-    @Override
-    public MindWarpEffect copy() {
-        return new MindWarpEffect(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/m/MiresToll.java
+++ b/Mage.Sets/src/mage/cards/m/MiresToll.java
@@ -31,7 +31,7 @@ public final class MiresToll extends CardImpl {
 
         // Target player reveals a number of cards from their hand equal to the number of Swamps you control. You choose one of them. That player discards that card.
         this.getSpellAbility().addTarget(new TargetPlayer());
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(TargetController.ANY, new PermanentsOnBattlefieldCount(filter)));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(new PermanentsOnBattlefieldCount(filter)));
 
     }
 

--- a/Mage.Sets/src/mage/cards/n/NightmareVoid.java
+++ b/Mage.Sets/src/mage/cards/n/NightmareVoid.java
@@ -7,7 +7,6 @@ import mage.abilities.keyword.DredgeAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.target.TargetPlayer;
 
 /**
@@ -22,7 +21,7 @@ public final class NightmareVoid extends CardImpl {
 
         // Target player reveals their hand. You choose a card from it. That player discards that card.
         this.getSpellAbility().addTarget(new TargetPlayer());
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(TargetController.ANY));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect());
         // Dredge 2
         this.addAbility(new DredgeAbility(2));
     }

--- a/Mage.Sets/src/mage/cards/n/NogginWhack.java
+++ b/Mage.Sets/src/mage/cards/n/NogginWhack.java
@@ -1,16 +1,13 @@
 package mage.cards.n;
 
-import mage.abilities.Ability;
 import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
 import mage.abilities.keyword.ProwlAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.target.TargetPlayer;
 
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -25,7 +22,7 @@ public final class NogginWhack extends CardImpl {
         // Prowl {1}{B}
         this.addAbility(new ProwlAbility(this, "{1}{B}"));
         // Target player reveals three cards from their hand. You choose two of them. That player discards those cards.
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(2, TargetController.ANY, 3));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(2, 3));
         this.getSpellAbility().addTarget(new TargetPlayer());
     }
 

--- a/Mage.Sets/src/mage/cards/p/Pilfer.java
+++ b/Mage.Sets/src/mage/cards/p/Pilfer.java
@@ -4,7 +4,6 @@ import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetOpponent;
 
@@ -20,7 +19,7 @@ public final class Pilfer extends CardImpl {
 
         // Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.
         this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(
-                StaticFilters.FILTER_CARD_NON_LAND, TargetController.ANY
+                StaticFilters.FILTER_CARD_NON_LAND
         ));
         this.getSpellAbility().addTarget(new TargetOpponent());
     }

--- a/Mage.Sets/src/mage/cards/p/PilferingImp.java
+++ b/Mage.Sets/src/mage/cards/p/PilferingImp.java
@@ -13,7 +13,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetOpponent;
@@ -38,8 +37,7 @@ public final class PilferingImp extends CardImpl {
         Ability ability = new ActivateAsSorceryActivatedAbility(
                 Zone.BATTLEFIELD,
                 new DiscardCardYouChooseTargetEffect(
-                        StaticFilters.FILTER_CARD_NON_LAND,
-                        TargetController.OPPONENT
+                        StaticFilters.FILTER_CARD_NON_LAND
                 ), new ManaCostsImpl<>("{1}{B}")
         );
         ability.addCost(new TapSourceCost());

--- a/Mage.Sets/src/mage/cards/p/PsychicSpear.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicSpear.java
@@ -7,7 +7,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicates;
 import mage.target.TargetPlayer;
@@ -30,7 +29,7 @@ public final class PsychicSpear extends CardImpl {
 
         // Target player reveals their hand. You choose a Spirit or Arcane card from it. That player discards that card.
         this.getSpellAbility().addTarget(new TargetPlayer());
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(filter, TargetController.ANY));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(filter));
     }
 
     private PsychicSpear(final PsychicSpear card) {

--- a/Mage.Sets/src/mage/cards/p/PulseOfTheDross.java
+++ b/Mage.Sets/src/mage/cards/p/PulseOfTheDross.java
@@ -10,7 +10,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.players.Player;
@@ -26,7 +25,7 @@ public final class PulseOfTheDross extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{1}{B}{B}");
 
         // Target player reveals three cards from their hand and you choose one of them. That player discards that card.
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(TargetController.ANY, 3));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(3));
         this.getSpellAbility().addEffect(new PulseOfTheDrossReturnToHandEffect());
         this.getSpellAbility().addTarget(new TargetPlayer());
     }

--- a/Mage.Sets/src/mage/cards/r/RiversGrasp.java
+++ b/Mage.Sets/src/mage/cards/r/RiversGrasp.java
@@ -1,6 +1,5 @@
 package mage.cards.r;
 
-import mage.abilities.Ability;
 import mage.abilities.condition.common.ManaWasSpentCondition;
 import mage.abilities.decorator.ConditionalOneShotEffect;
 import mage.abilities.effects.common.InfoEffect;
@@ -9,8 +8,6 @@ import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.ColoredManaSymbol;
-import mage.constants.TargetController;
 import mage.filter.StaticFilters;
 import mage.target.TargetPlayer;
 import mage.target.common.TargetCreaturePermanent;
@@ -32,7 +29,7 @@ public final class RiversGrasp extends CardImpl {
                 ManaWasSpentCondition.BLUE,
                 "If {U} was spent to cast this spell, return up to one target creature to its owner's hand"));
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_NON_LAND, TargetController.ANY),
+                new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_NON_LAND),
                 ManaWasSpentCondition.BLACK,
                 "If {B} was spent to cast this spell, target player reveals their hand, you choose a nonland card from it, then that player discards that card")
                 .setTargetPointer(new SecondTargetPointer()));

--- a/Mage.Sets/src/mage/cards/s/SeersVision.java
+++ b/Mage.Sets/src/mage/cards/s/SeersVision.java
@@ -1,4 +1,3 @@
-
 package mage.cards.s;
 
 import java.util.UUID;
@@ -7,7 +6,7 @@ import mage.abilities.common.ActivateAsSorceryActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.effects.common.continuous.PlayWithHandRevealedEffect;
-import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
+import mage.abilities.effects.common.discard.LookTargetHandChooseDiscardEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -27,7 +26,7 @@ public final class SeersVision extends CardImpl {
         // Your opponents play with their hands revealed.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PlayWithHandRevealedEffect(TargetController.OPPONENT)));
         // Sacrifice Seer's Vision: Look at target player's hand and choose a card from it. That player discards that card. Activate this ability only any time you could cast a sorcery.
-        Ability ability = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new DiscardCardYouChooseTargetEffect().setText("look at target player's hand and choose a card from it. That player discards that card"), new SacrificeSourceCost());
+        Ability ability = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new LookTargetHandChooseDiscardEffect(), new SacrificeSourceCost());
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SeersVision.java
+++ b/Mage.Sets/src/mage/cards/s/SeersVision.java
@@ -27,7 +27,7 @@ public final class SeersVision extends CardImpl {
         // Your opponents play with their hands revealed.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PlayWithHandRevealedEffect(TargetController.OPPONENT)));
         // Sacrifice Seer's Vision: Look at target player's hand and choose a card from it. That player discards that card. Activate this ability only any time you could cast a sorcery.
-        Ability ability = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new DiscardCardYouChooseTargetEffect(TargetController.ANY).setText("look at target player's hand and choose a card from it. That player discards that card"), new SacrificeSourceCost());
+        Ability ability = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new DiscardCardYouChooseTargetEffect().setText("look at target player's hand and choose a card from it. That player discards that card"), new SacrificeSourceCost());
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SplittingHeadache.java
+++ b/Mage.Sets/src/mage/cards/s/SplittingHeadache.java
@@ -6,7 +6,6 @@ import mage.abilities.effects.common.discard.DiscardTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.target.TargetPlayer;
 
 import java.util.UUID;
@@ -26,7 +25,7 @@ public final class SplittingHeadache extends CardImpl {
         this.getSpellAbility().addEffect(new DiscardTargetEffect(2));
 
         // • Target player reveals their hand. You choose a card from it. That player discards that card.
-        Mode mode = new Mode(new DiscardCardYouChooseTargetEffect(TargetController.ANY));
+        Mode mode = new Mode(new DiscardCardYouChooseTargetEffect());
         mode.addTarget(new TargetPlayer());
         this.getSpellAbility().addMode(mode);
     }

--- a/Mage.Sets/src/mage/cards/t/ThievingSprite.java
+++ b/Mage.Sets/src/mage/cards/t/ThievingSprite.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.filter.common.FilterControlledPermanent;
 import mage.target.TargetPlayer;
 
@@ -41,7 +40,7 @@ public final class ThievingSprite extends CardImpl {
         // When Thieving Sprite enters the battlefield, target player reveals X cards from their hand,
         // where X is the number of Faeries you control. You choose one of those cards.
         // That player discards that card.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new DiscardCardYouChooseTargetEffect(TargetController.ANY, xValue).setText(rule));
+        Ability ability = new EntersBattlefieldTriggeredAbility(new DiscardCardYouChooseTargetEffect(xValue).setText(rule));
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/t/Thoughtseize.java
+++ b/Mage.Sets/src/mage/cards/t/Thoughtseize.java
@@ -6,7 +6,6 @@ import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.filter.StaticFilters;
 import mage.target.TargetPlayer;
 
@@ -21,7 +20,7 @@ public final class Thoughtseize extends CardImpl {
 
         // Target player reveals their hand. You choose a nonland card from it. That player discards that card. You lose 2 life.
         this.getSpellAbility().addTarget(new TargetPlayer());
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_NON_LAND, TargetController.ANY));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_NON_LAND));
         this.getSpellAbility().addEffect(new LoseLifeSourceControllerEffect(2));
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThrullSurgeon.java
+++ b/Mage.Sets/src/mage/cards/t/ThrullSurgeon.java
@@ -1,4 +1,3 @@
-
 package mage.cards.t;
 
 import mage.MageInt;
@@ -6,24 +5,18 @@ import mage.abilities.Ability;
 import mage.abilities.common.ActivateAsSorceryActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.OneShotEffect;
-import mage.cards.Card;
+import mage.abilities.effects.common.discard.LookTargetHandChooseDiscardEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterCard;
-import mage.game.Game;
-import mage.players.Player;
-import mage.target.TargetCard;
 import mage.target.TargetPlayer;
 
 import java.util.UUID;
 
 /**
- * @author jeffwadsworth
+ * @author xenohedron
  */
 public final class ThrullSurgeon extends CardImpl {
 
@@ -35,7 +28,7 @@ public final class ThrullSurgeon extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {1}{B}, Sacrifice Thrull Surgeon: Look at target player's hand and choose a card from it. That player discards that card. Activate this ability only any time you could cast a sorcery.
-        Ability ability = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new ThrullSurgeonEffect(), new ManaCostsImpl<>("{1}{B}"));
+        Ability ability = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new LookTargetHandChooseDiscardEffect(), new ManaCostsImpl<>("{1}{B}"));
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
@@ -48,40 +41,5 @@ public final class ThrullSurgeon extends CardImpl {
     @Override
     public ThrullSurgeon copy() {
         return new ThrullSurgeon(this);
-    }
-}
-
-class ThrullSurgeonEffect extends OneShotEffect {
-
-    public ThrullSurgeonEffect() {
-        super(Outcome.Discard);
-        staticText = "Look at target player's hand and choose a card from it. That player discards that card.";
-    }
-
-    public ThrullSurgeonEffect(final ThrullSurgeonEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player targetPlayer = game.getPlayer(source.getFirstTarget());
-        Player you = game.getPlayer(source.getControllerId());
-        if (targetPlayer != null && you != null) {
-            you.lookAtCards("Discard", targetPlayer.getHand(), game);
-            TargetCard target = new TargetCard(Zone.HAND, new FilterCard());
-            target.setNotTarget(true);
-            if (you.choose(Outcome.Benefit, targetPlayer.getHand(), target, source, game)) {
-                Card card = targetPlayer.getHand().get(target.getFirstTarget(), game);
-                return targetPlayer.discard(card, false, source, game);
-
-            }
-
-        }
-        return false;
-    }
-
-    @Override
-    public ThrullSurgeonEffect copy() {
-        return new ThrullSurgeonEffect(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/u/Unmask.java
+++ b/Mage.Sets/src/mage/cards/u/Unmask.java
@@ -7,7 +7,6 @@ import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TargetController;
 import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
 import mage.filter.predicate.mageobject.ColorPredicate;
@@ -35,7 +34,7 @@ public final class Unmask extends CardImpl {
 
         // Target player reveals their hand. You choose a nonland card from it. That player discards that card.
         this.getSpellAbility().addTarget(new TargetPlayer());
-        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_NON_LAND, TargetController.ANY));
+        this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(StaticFilters.FILTER_CARD_NON_LAND));
     }
 
     private Unmask(final Unmask card) {

--- a/Mage.Sets/src/mage/cards/v/VenarianGlimmer.java
+++ b/Mage.Sets/src/mage/cards/v/VenarianGlimmer.java
@@ -11,7 +11,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.ComparisonType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.filter.FilterCard;
 import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.mageobject.ManaValuePredicate;
@@ -65,7 +64,7 @@ class VenarianGlimmerEffect extends OneShotEffect {
         if (player != null) {
             FilterCard filter = new FilterNonlandCard();
             filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, source.getManaCostsToPay().getX() + 1));
-            Effect effect = new DiscardCardYouChooseTargetEffect(filter, TargetController.ANY);
+            Effect effect = new DiscardCardYouChooseTargetEffect(filter);
             effect.setTargetPointer(targetPointer);
             effect.apply(game, source);
             return true;

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
@@ -37,10 +37,6 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
         this(StaticFilters.FILTER_CARD_A);
     }
 
-    public DiscardCardYouChooseTargetEffect(TargetController targetController) {
-        this(StaticFilters.FILTER_CARD_A, targetController);
-    }
-
     public DiscardCardYouChooseTargetEffect(FilterCard filter) {
         this(filter, TargetController.OPPONENT);
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
@@ -38,11 +38,7 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
     }
 
     public DiscardCardYouChooseTargetEffect(FilterCard filter) {
-        this(filter, TargetController.OPPONENT);
-    }
-
-    public DiscardCardYouChooseTargetEffect(FilterCard filter, TargetController targetController) {
-        this(StaticValue.get(1), filter, targetController);
+        this(StaticValue.get(1), filter, TargetController.OPPONENT);
     }
 
     public DiscardCardYouChooseTargetEffect(int numberCardsToDiscard, TargetController targetController) {

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
@@ -9,7 +9,6 @@ import mage.cards.Card;
 import mage.cards.Cards;
 import mage.cards.CardsImpl;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
@@ -27,7 +26,6 @@ import java.util.UUID;
 public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
 
     private final FilterCard filter;
-    private final TargetController targetController;
     private DynamicValue numberCardsToReveal;
     private final DynamicValue numberCardsToDiscard;
     private final boolean revealAllCards;
@@ -47,7 +45,6 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
 
     public DiscardCardYouChooseTargetEffect(DynamicValue numberCardsToDiscard, FilterCard filter) {
         super(Outcome.Discard);
-        this.targetController = TargetController.OPPONENT;
         this.filter = filter;
 
         this.numberCardsToDiscard = numberCardsToDiscard;
@@ -55,21 +52,20 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
         this.revealAllCards = true;
     }
 
-    public DiscardCardYouChooseTargetEffect(TargetController targetController, int numberCardsToReveal) {
-        this(targetController, StaticValue.get(numberCardsToReveal));
+    public DiscardCardYouChooseTargetEffect(int numberCardsToReveal) {
+        this(StaticValue.get(numberCardsToReveal));
     }
 
-    public DiscardCardYouChooseTargetEffect(TargetController targetController, DynamicValue numberCardsToReveal) {
-        this(StaticValue.get(1), StaticFilters.FILTER_CARD_A, targetController, numberCardsToReveal);
+    public DiscardCardYouChooseTargetEffect(DynamicValue numberCardsToReveal) {
+        this(StaticValue.get(1), StaticFilters.FILTER_CARD_A, numberCardsToReveal);
     }
 
-    public DiscardCardYouChooseTargetEffect(int numberCardsToDiscard, TargetController targetController, int numberCardsToReveal) {
-        this(StaticValue.get(numberCardsToDiscard), StaticFilters.FILTER_CARD_CARDS, targetController, StaticValue.get(numberCardsToReveal));
+    public DiscardCardYouChooseTargetEffect(int numberCardsToDiscard, int numberCardsToReveal) {
+        this(StaticValue.get(numberCardsToDiscard), StaticFilters.FILTER_CARD_CARDS, StaticValue.get(numberCardsToReveal));
     }
 
-    public DiscardCardYouChooseTargetEffect(DynamicValue numberCardsToDiscard, FilterCard filter, TargetController targetController, DynamicValue numberCardsToReveal) {
+    public DiscardCardYouChooseTargetEffect(DynamicValue numberCardsToDiscard, FilterCard filter, DynamicValue numberCardsToReveal) {
         super(Outcome.Discard);
-        this.targetController = targetController;
         this.filter = filter;
 
         this.revealAllCards = false;
@@ -80,7 +76,6 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
     protected DiscardCardYouChooseTargetEffect(final DiscardCardYouChooseTargetEffect effect) {
         super(effect);
         this.filter = effect.filter;
-        this.targetController = effect.targetController;
         this.numberCardsToDiscard = effect.numberCardsToDiscard;
         this.numberCardsToReveal = effect.numberCardsToReveal;
         this.revealAllCards = effect.revealAllCards;

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
@@ -82,8 +82,9 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
         this.optional = effect.optional;
     }
 
-    public void setOptional(boolean optional) {
+    public DiscardCardYouChooseTargetEffect setOptional(boolean optional) {
         this.optional = optional;
+        return this;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
@@ -1,6 +1,7 @@
 package mage.abilities.effects.common.discard;
 
 import mage.abilities.Ability;
+import mage.abilities.Mode;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.OneShotEffect;
@@ -65,8 +66,6 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
         this.numberCardsToDiscard = numberCardsToDiscard;
         this.numberCardsToReveal = null;
         this.revealAllCards = true;
-
-        staticText = this.setText();
     }
 
     public DiscardCardYouChooseTargetEffect(TargetController targetController, int numberCardsToReveal) {
@@ -89,8 +88,6 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
         this.revealAllCards = false;
         this.numberCardsToReveal = numberCardsToReveal;
         this.numberCardsToDiscard = numberCardsToDiscard;
-
-        staticText = this.setText();
     }
 
     protected DiscardCardYouChooseTargetEffect(final DiscardCardYouChooseTargetEffect effect) {
@@ -105,7 +102,6 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
 
     public void setOptional(boolean optional) {
         this.optional = optional;
-        staticText = this.setText();
     }
 
     @Override
@@ -165,19 +161,13 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
         return new DiscardCardYouChooseTargetEffect(this);
     }
 
-    private String setText() {
-        boolean discardMultipleCards = !numberCardsToDiscard.toString().equals("1");
-        StringBuilder sb = new StringBuilder("target ");
-        switch (targetController) {
-            case OPPONENT:
-                sb.append("opponent");
-                break;
-            case ANY:
-                sb.append("player");
-                break;
-            default:
-                throw new UnsupportedOperationException("target controller not supported");
+    @Override
+    public String getText(Mode mode) {
+        if (staticText != null && !staticText.isEmpty()) {
+            return staticText;
         }
+        boolean discardMultipleCards = !numberCardsToDiscard.toString().equals("1");
+        StringBuilder sb = new StringBuilder(getTargetPointer().describeTargets(mode.getTargets(), "that player"));
         sb.append(" reveals ");
         if (revealAllCards) {
             sb.append("their hand. You ");

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/DiscardCardYouChooseTargetEffect.java
@@ -38,21 +38,16 @@ public class DiscardCardYouChooseTargetEffect extends OneShotEffect {
     }
 
     public DiscardCardYouChooseTargetEffect(FilterCard filter) {
-        this(StaticValue.get(1), filter, TargetController.OPPONENT);
+        this(1, filter);
     }
 
-    public DiscardCardYouChooseTargetEffect(int numberCardsToDiscard, TargetController targetController) {
-        this(StaticValue.get(numberCardsToDiscard), targetController);
+    public DiscardCardYouChooseTargetEffect(int numberCardsToDiscard, FilterCard filter) {
+        this(StaticValue.get(numberCardsToDiscard), filter);
     }
 
-    public DiscardCardYouChooseTargetEffect(DynamicValue numberCardsToDiscard, TargetController targetController) {
-        this(numberCardsToDiscard, StaticFilters.FILTER_CARD_CARDS, targetController);
-    }
-
-    public DiscardCardYouChooseTargetEffect(DynamicValue numberCardsToDiscard,
-                                            FilterCard filter, TargetController targetController) {
+    public DiscardCardYouChooseTargetEffect(DynamicValue numberCardsToDiscard, FilterCard filter) {
         super(Outcome.Discard);
-        this.targetController = targetController;
+        this.targetController = TargetController.OPPONENT;
         this.filter = filter;
 
         this.numberCardsToDiscard = numberCardsToDiscard;

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/LookTargetHandChooseDiscardEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/LookTargetHandChooseDiscardEffect.java
@@ -1,0 +1,85 @@
+package mage.abilities.effects.common.discard;
+
+import mage.abilities.Ability;
+import mage.abilities.Mode;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.StaticValue;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.CardsImpl;
+import mage.constants.Outcome;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetCard;
+import mage.target.common.TargetCardInHand;
+import mage.util.CardUtil;
+
+/**
+ * @author xenohedron
+ */
+public class LookTargetHandChooseDiscardEffect extends OneShotEffect {
+
+    private final boolean upTo;
+    private final DynamicValue numberToDiscard;
+
+    public LookTargetHandChooseDiscardEffect() {
+        this(false, 1);
+    }
+
+    public LookTargetHandChooseDiscardEffect(boolean upTo, int numberToDiscard) {
+        this(upTo, StaticValue.get(numberToDiscard));
+    }
+
+    public LookTargetHandChooseDiscardEffect(boolean upTo, DynamicValue numberToDiscard) {
+        super(Outcome.Discard);
+        this.upTo = upTo;
+        this.numberToDiscard = numberToDiscard;
+    }
+
+    protected LookTargetHandChooseDiscardEffect(final LookTargetHandChooseDiscardEffect effect) {
+        super(effect);
+        this.upTo = effect.upTo;
+        this.numberToDiscard = effect.numberToDiscard;
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(getTargetPointer().getFirst(game, source));
+        Player controller = game.getPlayer(source.getControllerId());
+        if (player == null || controller == null) {
+            return false;
+        }
+        int num = numberToDiscard.calculate(game, source, this);
+        if (num == 0) {
+            if (!player.getHand().isEmpty()) {
+                controller.lookAtCards("Looking at hand", player.getHand(), game);
+            }
+            return true;
+        }
+        TargetCard target = new TargetCardInHand(upTo ? 0 : num, num, num > 1 ? StaticFilters.FILTER_CARD_CARDS : StaticFilters.FILTER_CARD);
+        if (controller.choose(Outcome.Discard, player.getHand(), target, source, game)) {
+            player.discard(new CardsImpl(target.getTargets()), false, source, game);
+        }
+        return true;
+    }
+
+    @Override
+    public LookTargetHandChooseDiscardEffect copy() {
+        return new LookTargetHandChooseDiscardEffect(this);
+    }
+
+    @Override
+    public String getText(Mode mode) {
+        if (staticText != null && !staticText.isEmpty()) {
+            return staticText;
+        }
+        String numberValue = numberToDiscard instanceof StaticValue ?
+                CardUtil.numberToText(((StaticValue) numberToDiscard).getValue(), "a") : "X";
+        boolean plural = !numberValue.equals("a");
+        String targetDescription = getTargetPointer().describeTargets(mode.getTargets(), "that player");
+        return "look at " + targetDescription + "'s hand and choose " + (upTo ? "up to " : "") + numberValue
+                + (plural ? " cards" : " card") + " from it. "
+                + (targetDescription.equals("that player") ? "The" : "That")
+                + " player discards " + (plural ? "those cards." : "that card.");
+    }
+}


### PR DESCRIPTION
closes #10903

refactor: remove TargetController parameter from `DiscardCardYouChooseTargetEffect`
* parameter only used for setting text, but it should just use the target to set text
* cleaned up the constructors

made new class `LookTargetHandChooseDiscardEffect` for effects that don't involve revealing and manually tested it