### PR TITLE
Fix Gitaxian Anatomist

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GitaxianAnatomist.java
+++ b/Mage.Sets/src/mage/cards/g/GitaxianAnatomist.java
@@ -1,14 +1,18 @@
 package mage.cards.g;
 
 import mage.MageInt;
+import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
-import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.costs.Cost;
+import mage.abilities.costs.CostImpl;
 import mage.abilities.effects.common.DoIfCostPaid;
 import mage.abilities.effects.common.counter.ProliferateEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
 
 import java.util.UUID;
 
@@ -27,7 +31,7 @@ public final class GitaxianAnatomist extends CardImpl {
 
         // When Gitaxian Anatomist enters the battlefield, you may tap it. If you do, proliferate.
         this.addAbility(new EntersBattlefieldTriggeredAbility(
-                new DoIfCostPaid(new ProliferateEffect(), new TapSourceCost().setText("tap it"))
+                new DoIfCostPaid(new ProliferateEffect(), new GitaxianAnatomistCost())
         ));
     }
 
@@ -38,5 +42,37 @@ public final class GitaxianAnatomist extends CardImpl {
     @Override
     public GitaxianAnatomist copy() {
         return new GitaxianAnatomist(this);
+    }
+}
+
+// TapSourceCost just does not work here as it is checking for permanent.canTap(game).
+class GitaxianAnatomistCost extends CostImpl {
+
+    public GitaxianAnatomistCost() {
+        this.text = "tap it";
+    }
+
+    public GitaxianAnatomistCost(GitaxianAnatomistCost cost) {
+        super(cost);
+    }
+
+    @Override
+    public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
+        Permanent permanent = game.getPermanent(source.getSourceId());
+        if (permanent != null) {
+            paid = permanent.tap(source, game);
+        }
+        return paid;
+    }
+
+    @Override
+    public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
+        Permanent permanent = game.getPermanent(source.getSourceId());
+        return permanent != null && !permanent.isTapped();
+    }
+
+    @Override
+    public GitaxianAnatomistCost copy() {
+        return new GitaxianAnatomistCost(this);
     }
 }


### PR DESCRIPTION
The trigger did not work properly, as TapSourceCost is looking as if the {T} cost is able to pay, and thus has the limitation to not work on a non-haste creature coming into play this turn.