### PR TITLE
Remove unused dependencies in common and Server pom

### DIFF
--- a/Mage.Common/pom.xml
+++ b/Mage.Common/pom.xml
@@ -42,13 +42,6 @@
             <artifactId>jboss-serialization</artifactId>
             <version>4.2.2.GA</version>
         </dependency>
-
-        <dependency>
-            <groupId>concurrent</groupId>
-            <artifactId>concurrent</artifactId>
-            <version>1.3.4</version>
-        </dependency>
-
         <dependency>
             <groupId>trove</groupId>
             <artifactId>trove</artifactId>

--- a/Mage.Server/pom.xml
+++ b/Mage.Server/pom.xml
@@ -227,26 +227,6 @@
             <version>1.8.0</version>
         </dependency>
         <dependency>
-            <groupId>com.google.api-client</groupId>
-            <artifactId>google-api-client</artifactId>
-            <version>1.31.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.apis</groupId>
-            <artifactId>google-api-services-gmail</artifactId>
-            <version>v1-rev20210614-1.32.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.oauth-client</groupId>
-            <artifactId>google-oauth-client-java6</artifactId>
-            <version>1.33.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.oauth-client</groupId>
-            <artifactId>google-oauth-client-jetty</artifactId>
-            <version>1.33.0</version>
-        </dependency>
-        <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
             <version>1.5.0-b01</version>


### PR DESCRIPTION
There are some in common that need some more digging into (especially trove), but here's some dependencies I've found that are no longer necessary. I'll be going through and checking other pom.xml files as well, but I'd like to get these cleaned up before doing some dep upgrades.

- concurrent is superseded by base Java classes as of 2006 (see https://gee.cs.oswego.edu/dl/classes/EDU/oswego/cs/dl/util/concurrent/intro.html) and is not used by the project. As far as I can tell, it was added as boilerplate when the project was created and has never actually been used.
- All of the gmail deps were added in an old PR (#1452) for sending emails on successful registration. The code using it was removed in #7158 and so is now completely useless.
