### PR TITLE
Remove unused dependency in Mage.Verify

### DIFF
--- a/Mage.Verify/pom.xml
+++ b/Mage.Verify/pom.xml
@@ -34,11 +34,6 @@
             <artifactId>mage-client</artifactId>
             <version>${mage-version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.13.3</version>
-        </dependency>
 
         <dependency>
             <groupId>org.reflections</groupId>


### PR DESCRIPTION
* This dependency was added in the very first version of the verify test 5ad58f59 for imports used in what became `VerifyCardDataTest`.
* The code using it was then moved to MtgJson.java in 26b8b889, 510f7a86.
* Still used as of e1806f80 after some reorganization.
* Appears to have been fully removed in ca254c65622c5f134a9f0518ea483e1dd1e43bae when moving to MtgJson v5.
* Current master has no instances of `com.fasterxml` besides the dependency in pom.xml.
* Will obsolete the dependabot PR #10984