### PR TITLE
Fix Gandalf, Wayward Voyager

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GandalfWestwardVoyager.java
+++ b/Mage.Sets/src/mage/cards/g/GandalfWestwardVoyager.java
@@ -14,9 +14,7 @@ import mage.game.Game;
 import mage.game.stack.Spell;
 import mage.players.Player;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * @author Susucr
@@ -93,7 +91,7 @@ class GandalfWestwardVoyagerEffect extends OneShotEffect {
             // each opponent reveals the top card of their library.
             player.revealCards(source, " — " + player.getName(), new CardsImpl(card), game, true);
 
-            List<CardType> types = card.getCardType(game);
+            Set<CardType> types = new HashSet<>(card.getCardType(game));
             types.retainAll(typesSpell);
             foundCard |= !types.isEmpty();
         }


### PR DESCRIPTION
Stupid mistake on my part, `getCardType` was returning the actual card's types, and removing elements from it had consequences on the original card.

fix #11043
