### PR TITLE
Clean all copy constructors in cards starting U-V

### DIFF
--- a/Mage.Sets/src/mage/cards/u/UbaMask.java
+++ b/Mage.Sets/src/mage/cards/u/UbaMask.java
@@ -95,7 +95,7 @@ class UbaMaskPlayEffect extends AsThoughEffectImpl {
         staticText = "Each player may play lands and cast spells from among cards they exiled with {this} this turn";
     }
 
-    public UbaMaskPlayEffect(final UbaMaskPlayEffect effect) {
+    private UbaMaskPlayEffect(final UbaMaskPlayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UginTheSpiritDragon.java
+++ b/Mage.Sets/src/mage/cards/u/UginTheSpiritDragon.java
@@ -74,7 +74,7 @@ class UginTheSpiritDragonEffect2 extends OneShotEffect {
         this.staticText = "exile each permanent with mana value X or less that's one or more colors";
     }
 
-    public UginTheSpiritDragonEffect2(final UginTheSpiritDragonEffect2 effect) {
+    private UginTheSpiritDragonEffect2(final UginTheSpiritDragonEffect2 effect) {
         super(effect);
     }
 
@@ -114,7 +114,7 @@ class UginTheSpiritDragonEffect3 extends OneShotEffect {
         this.staticText = "You gain 7 life, draw seven cards, then put up to seven permanent cards from your hand onto the battlefield";
     }
 
-    public UginTheSpiritDragonEffect3(final UginTheSpiritDragonEffect3 effect) {
+    private UginTheSpiritDragonEffect3(final UginTheSpiritDragonEffect3 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UginsInsight.java
+++ b/Mage.Sets/src/mage/cards/u/UginsInsight.java
@@ -42,7 +42,7 @@ class UginsInsightEffect extends OneShotEffect {
         this.staticText = "Scry X, where X is the highest mana value among permanents you control, then draw three cards";
     }
 
-    public UginsInsightEffect(final UginsInsightEffect effect) {
+    private UginsInsightEffect(final UginsInsightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UginsNexus.java
+++ b/Mage.Sets/src/mage/cards/u/UginsNexus.java
@@ -51,7 +51,7 @@ class UginsNexusSkipExtraTurnsEffect extends ReplacementEffectImpl {
         staticText = "If a player would begin an extra turn, that player skips that turn instead";
     }
 
-    public UginsNexusSkipExtraTurnsEffect(final UginsNexusSkipExtraTurnsEffect effect) {
+    private UginsNexusSkipExtraTurnsEffect(final UginsNexusSkipExtraTurnsEffect effect) {
         super(effect);
     }
 
@@ -89,7 +89,7 @@ class UginsNexusExileEffect extends ReplacementEffectImpl {
         staticText = "If {this} would be put into a graveyard from the battlefield, instead exile it and take an extra turn after this one";
     }
 
-    public UginsNexusExileEffect(final UginsNexusExileEffect effect) {
+    private UginsNexusExileEffect(final UginsNexusExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UglukOfTheWhiteHand.java
+++ b/Mage.Sets/src/mage/cards/u/UglukOfTheWhiteHand.java
@@ -74,7 +74,7 @@ class UglukOfTheWhiteHandEffect extends OneShotEffect {
             "If that creature was a Goblin or Orc, put two +1/+1 counters on Ugluk instead.";
     }
 
-    public UglukOfTheWhiteHandEffect(final UglukOfTheWhiteHandEffect effect) {
+    private UglukOfTheWhiteHandEffect(final UglukOfTheWhiteHandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UlamogTheCeaselessHunger.java
+++ b/Mage.Sets/src/mage/cards/u/UlamogTheCeaselessHunger.java
@@ -97,7 +97,7 @@ class UlamogAttackTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} attacks, ");
     }
 
-    public UlamogAttackTriggeredAbility(final UlamogAttackTriggeredAbility ability) {
+    private UlamogAttackTriggeredAbility(final UlamogAttackTriggeredAbility ability) {
         super(ability);
     }
 
@@ -132,7 +132,7 @@ class UlamogExileLibraryEffect extends OneShotEffect {
         this.staticText = "defending player exiles the top twenty cards of their library";
     }
 
-    public UlamogExileLibraryEffect(final UlamogExileLibraryEffect effect) {
+    private UlamogExileLibraryEffect(final UlamogExileLibraryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UlamogsCrusher.java
+++ b/Mage.Sets/src/mage/cards/u/UlamogsCrusher.java
@@ -26,7 +26,7 @@ public final class UlamogsCrusher extends CardImpl {
         this.addAbility(new AttacksEachCombatStaticAbility());
     }
 
-    public UlamogsCrusher (final UlamogsCrusher card) {
+    private UlamogsCrusher(final UlamogsCrusher card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UlamogsDespoiler.java
+++ b/Mage.Sets/src/mage/cards/u/UlamogsDespoiler.java
@@ -64,7 +64,7 @@ class UlamogsDespoilerEffect extends OneShotEffect {
         this.staticText = "you may put two cards your opponents own from exile into their owners' graveyards. If you do, {this} enters the battlefield with four +1/+1 counters on it";
     }
 
-    public UlamogsDespoilerEffect(final UlamogsDespoilerEffect effect) {
+    private UlamogsDespoilerEffect(final UlamogsDespoilerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UlamogsNullifier.java
+++ b/Mage.Sets/src/mage/cards/u/UlamogsNullifier.java
@@ -78,7 +78,7 @@ class UlamogsNullifierEffect extends OneShotEffect {
         this.staticText = "you may put two cards your opponents own from exile into their owners' graveyards. If you do, counter target spell.";
     }
 
-    public UlamogsNullifierEffect(final UlamogsNullifierEffect effect) {
+    private UlamogsNullifierEffect(final UlamogsNullifierEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UlvenwaldMysteries.java
+++ b/Mage.Sets/src/mage/cards/u/UlvenwaldMysteries.java
@@ -60,7 +60,7 @@ class UlvenwaldMysteriesTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you sacrifice a Clue, ");
     }
 
-    public UlvenwaldMysteriesTriggeredAbility(final UlvenwaldMysteriesTriggeredAbility ability) {
+    private UlvenwaldMysteriesTriggeredAbility(final UlvenwaldMysteriesTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/u/Umbilicus.java
+++ b/Mage.Sets/src/mage/cards/u/Umbilicus.java
@@ -47,7 +47,7 @@ class BloodClockEffect extends OneShotEffect {
         this.staticText = "that player returns a permanent they control to its owner's hand unless they pay 2 life";
     }
 
-    public BloodClockEffect(final BloodClockEffect effect) {
+    private BloodClockEffect(final BloodClockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnbenderTine.java
+++ b/Mage.Sets/src/mage/cards/u/UnbenderTine.java
@@ -58,7 +58,7 @@ class UnbenderTineEffect extends OneShotEffect {
         this.staticText = "Untap another target permanent";
     }
 
-    public UnbenderTineEffect(final UnbenderTineEffect effect) {
+    private UnbenderTineEffect(final UnbenderTineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnbreathingHorde.java
+++ b/Mage.Sets/src/mage/cards/u/UnbreathingHorde.java
@@ -63,7 +63,7 @@ class UnbreathingHordeEntersEffect extends OneShotEffect {
         staticText = "{this} enters the battlefield with a +1/+1 counter on it for each other Zombie you control and each Zombie card in your graveyard";
     }
 
-    public UnbreathingHordeEntersEffect(final UnbreathingHordeEntersEffect effect) {
+    private UnbreathingHordeEntersEffect(final UnbreathingHordeEntersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UncageTheMenagerie.java
+++ b/Mage.Sets/src/mage/cards/u/UncageTheMenagerie.java
@@ -46,7 +46,7 @@ class UncageTheMenagerieEffect extends OneShotEffect {
                 "that each have mana value X, reveal them, put them into your hand, then shuffle.";
     }
 
-    public UncageTheMenagerieEffect(final UncageTheMenagerieEffect effect) {
+    private UncageTheMenagerieEffect(final UncageTheMenagerieEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UncheckedGrowth.java
+++ b/Mage.Sets/src/mage/cards/u/UncheckedGrowth.java
@@ -48,7 +48,7 @@ public final class UncheckedGrowth extends CardImpl {
             staticText = "If it's a Spirit, it gains trample until end of turn";
         }
 
-        public UncheckedGrowthTrampleEffect(final UncheckedGrowthTrampleEffect effect) {
+        private UncheckedGrowthTrampleEffect(final UncheckedGrowthTrampleEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/u/UnconventionalTactics.java
+++ b/Mage.Sets/src/mage/cards/u/UnconventionalTactics.java
@@ -71,7 +71,7 @@ class UnconventionalTacticsTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.GRAVEYARD, new DoIfCostPaid(new ReturnToHandSourceEffect(), new ManaCostsImpl<>("{W}")), false);
     }
 
-    public UnconventionalTacticsTriggeredAbility(final UnconventionalTacticsTriggeredAbility ability) {
+    private UnconventionalTacticsTriggeredAbility(final UnconventionalTacticsTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UndeadAlchemist.java
+++ b/Mage.Sets/src/mage/cards/u/UndeadAlchemist.java
@@ -59,7 +59,7 @@ class UndeadAlchemistTriggeredAbility extends TriggeredAbilityImpl {
         this.addEffect(new CreateTokenEffect(new ZombieToken()));
     }
 
-    public UndeadAlchemistTriggeredAbility(final UndeadAlchemistTriggeredAbility ability) {
+    private UndeadAlchemistTriggeredAbility(final UndeadAlchemistTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UndercityInformer.java
+++ b/Mage.Sets/src/mage/cards/u/UndercityInformer.java
@@ -61,7 +61,7 @@ class UndercityInformerEffect extends OneShotEffect {
         this.staticText = "Target player reveals the top card of their library until they reveal a land card, then puts those cards into their graveyard";
     }
 
-    public UndercityInformerEffect(final UndercityInformerEffect effect) {
+    private UndercityInformerEffect(final UndercityInformerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnderrealmLich.java
+++ b/Mage.Sets/src/mage/cards/u/UnderrealmLich.java
@@ -69,7 +69,7 @@ class UnderrealmLichReplacementEffect extends ReplacementEffectImpl {
                 + "and the rest into your graveyard.";
     }
 
-    public UnderrealmLichReplacementEffect(final UnderrealmLichReplacementEffect effect) {
+    private UnderrealmLichReplacementEffect(final UnderrealmLichReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/Undertow.java
+++ b/Mage.Sets/src/mage/cards/u/Undertow.java
@@ -44,7 +44,7 @@ class UndertowEffect extends AsThoughEffectImpl {
         staticText = "Creatures with islandwalk can be blocked as though they didn't have islandwalk";
     }
 
-    public UndertowEffect(final UndertowEffect effect) {
+    private UndertowEffect(final UndertowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnderworldConnections.java
+++ b/Mage.Sets/src/mage/cards/u/UnderworldConnections.java
@@ -49,7 +49,7 @@ public final class UnderworldConnections extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(gainedAbility, AttachmentType.AURA, Duration.WhileOnBattlefield, rule)));
     }
 
-    public UnderworldConnections (final UnderworldConnections card) {
+    private UnderworldConnections(final UnderworldConnections card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnderworldSlums.java
+++ b/Mage.Sets/src/mage/cards/u/UnderworldSlums.java
@@ -47,7 +47,7 @@ public final class UnderworldSlums extends CardImpl {
 
     public static class UnderworldSlumsAbility extends ActivatedAbilityImpl {
 
-        public UnderworldSlumsAbility(UnderworldSlumsAbility ability) {
+        private UnderworldSlumsAbility(final UnderworldSlumsAbility ability) {
             super(ability);
         }
 

--- a/Mage.Sets/src/mage/cards/u/UndiscoveredParadise.java
+++ b/Mage.Sets/src/mage/cards/u/UndiscoveredParadise.java
@@ -49,7 +49,7 @@ class UndiscoveredParadiseEffect extends OneShotEffect {
         staticText = "During your next untap step, as you untap your permanents, return {this} to its owner's hand";
     }
 
-    public UndiscoveredParadiseEffect(final UndiscoveredParadiseEffect effect) {
+    private UndiscoveredParadiseEffect(final UndiscoveredParadiseEffect effect) {
         super(effect);
     }
 
@@ -78,7 +78,7 @@ class AtBeginningOfUntapDelayedTriggeredAbility extends DelayedTriggeredAbility 
         this.usesStack = false;
     }
 
-    public AtBeginningOfUntapDelayedTriggeredAbility(AtBeginningOfUntapDelayedTriggeredAbility ability) {
+    private AtBeginningOfUntapDelayedTriggeredAbility(final AtBeginningOfUntapDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UndyingBeast.java
+++ b/Mage.Sets/src/mage/cards/u/UndyingBeast.java
@@ -49,7 +49,7 @@ class UndyingBeastEffect extends OneShotEffect {
         staticText = "put it on top of its owner's library";
     }
 
-    public UndyingBeastEffect(final UndyingBeastEffect effect) {
+    private UndyingBeastEffect(final UndyingBeastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UndyingFlames.java
+++ b/Mage.Sets/src/mage/cards/u/UndyingFlames.java
@@ -50,7 +50,7 @@ class UndyingFlamesEffect extends OneShotEffect {
         staticText = "Exile cards from the top of your library until you exile a nonland card. {this} deals damage to any target equal to that card's mana value";
     }
 
-    public UndyingFlamesEffect(final UndyingFlamesEffect effect) {
+    private UndyingFlamesEffect(final UndyingFlamesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnexpectedResults.java
+++ b/Mage.Sets/src/mage/cards/u/UnexpectedResults.java
@@ -73,7 +73,7 @@ class UnexpectedResultEffect extends OneShotEffect {
                 + "and return {this} to its owner's hand";
     }
 
-    public UnexpectedResultEffect(final UnexpectedResultEffect effect) {
+    private UnexpectedResultEffect(final UnexpectedResultEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnexpectedlyAbsent.java
+++ b/Mage.Sets/src/mage/cards/u/UnexpectedlyAbsent.java
@@ -45,7 +45,7 @@ class UnexpectedlyAbsentEffect extends OneShotEffect {
         this.staticText = "Put target nonland permanent into its owner's library just beneath the top X cards of that library";
     }
 
-    public UnexpectedlyAbsentEffect(final UnexpectedlyAbsentEffect effect) {
+    private UnexpectedlyAbsentEffect(final UnexpectedlyAbsentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnholyIndenture.java
+++ b/Mage.Sets/src/mage/cards/u/UnholyIndenture.java
@@ -60,7 +60,7 @@ class UnholyIndentureReturnEffect extends OneShotEffect {
         staticText = "return that card to the battlefield under your control with a +1/+1 counter on it";
     }
 
-    public UnholyIndentureReturnEffect(final UnholyIndentureReturnEffect effect) {
+    private UnholyIndentureReturnEffect(final UnholyIndentureReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnifiedWill.java
+++ b/Mage.Sets/src/mage/cards/u/UnifiedWill.java
@@ -46,7 +46,7 @@ class UnifiedWillEffect extends OneShotEffect {
         staticText = "Counter target spell if you control more creatures than that spell's controller";
     }
 
-    public UnifiedWillEffect(final UnifiedWillEffect effect) {
+    private UnifiedWillEffect(final UnifiedWillEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnifyingTheory.java
+++ b/Mage.Sets/src/mage/cards/u/UnifyingTheory.java
@@ -49,7 +49,7 @@ class UnifyingTheoryEffect extends OneShotEffect {
         this.staticText = "that player may pay {2}. If the player does, they draw a card";
     }
 
-    public UnifyingTheoryEffect(final UnifyingTheoryEffect effect) {
+    private UnifyingTheoryEffect(final UnifyingTheoryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/Unmake.java
+++ b/Mage.Sets/src/mage/cards/u/Unmake.java
@@ -21,7 +21,7 @@ public final class Unmake extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public Unmake (final Unmake card) {
+    private Unmake(final Unmake card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnmarkedGrave.java
+++ b/Mage.Sets/src/mage/cards/u/UnmarkedGrave.java
@@ -51,7 +51,7 @@ class UnmarkedGraveEffect extends SearchEffect {
         staticText = "search your library for a nonlegendary card, put that card into your graveyard, then shuffle";
     }
 
-    public UnmarkedGraveEffect(final UnmarkedGraveEffect effect) {
+    private UnmarkedGraveEffect(final UnmarkedGraveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnmooredEgo.java
+++ b/Mage.Sets/src/mage/cards/u/UnmooredEgo.java
@@ -51,7 +51,7 @@ class UnmooredEgoEffect extends OneShotEffect {
         this.staticText = "Search target opponent's graveyard, hand, and library for up to four cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way";
     }
 
-    public UnmooredEgoEffect(final UnmooredEgoEffect effect) {
+    private UnmooredEgoEffect(final UnmooredEgoEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnnaturalPredation.java
+++ b/Mage.Sets/src/mage/cards/u/UnnaturalPredation.java
@@ -26,7 +26,7 @@ public final class UnnaturalPredation extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public UnnaturalPredation (final UnnaturalPredation card) {
+    private UnnaturalPredation(final UnnaturalPredation card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnnaturalSpeed.java
+++ b/Mage.Sets/src/mage/cards/u/UnnaturalSpeed.java
@@ -27,7 +27,7 @@ public final class UnnaturalSpeed extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public UnnaturalSpeed (final UnnaturalSpeed card) {
+    private UnnaturalSpeed(final UnnaturalSpeed card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnpleasantDiscovery.java
+++ b/Mage.Sets/src/mage/cards/u/UnpleasantDiscovery.java
@@ -24,7 +24,7 @@ public class UnpleasantDiscovery extends CardImpl {
                 .setText(" and mills two cards"));
     }
 
-    public UnpleasantDiscovery(final UnpleasantDiscovery card) {
+    private UnpleasantDiscovery(final UnpleasantDiscovery card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnscytheKillerOfKings.java
+++ b/Mage.Sets/src/mage/cards/u/UnscytheKillerOfKings.java
@@ -67,7 +67,7 @@ class UnscytheKillerOfKingsTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature dealt damage by equipped creature this turn dies, ");
     }
 
-    public UnscytheKillerOfKingsTriggeredAbility(final UnscytheKillerOfKingsTriggeredAbility ability) {
+    private UnscytheKillerOfKingsTriggeredAbility(final UnscytheKillerOfKingsTriggeredAbility ability) {
         super(ability);
     }
 
@@ -113,7 +113,7 @@ class UnscytheEffect extends OneShotEffect {
         this.staticText = "you may exile that card. If you do, create a 2/2 black Zombie creature token";
     }
 
-    public UnscytheEffect(final UnscytheEffect effect) {
+    private UnscytheEffect(final UnscytheEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnstableFooting.java
+++ b/Mage.Sets/src/mage/cards/u/UnstableFooting.java
@@ -70,7 +70,7 @@ class UnstableFootingEffect extends ReplacementEffectImpl {
         staticText = "Damage can't be prevented this turn";
     }
 
-    public UnstableFootingEffect(final UnstableFootingEffect effect) {
+    private UnstableFootingEffect(final UnstableFootingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnstableShapeshifter.java
+++ b/Mage.Sets/src/mage/cards/u/UnstableShapeshifter.java
@@ -61,7 +61,7 @@ class UnstableShapeshifterEffect extends OneShotEffect {
         this.staticText = "{this} becomes a copy of that creature, except it has this ability";
     }
 
-    public UnstableShapeshifterEffect(final UnstableShapeshifterEffect effect) {
+    private UnstableShapeshifterEffect(final UnstableShapeshifterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnwindingClock.java
+++ b/Mage.Sets/src/mage/cards/u/UnwindingClock.java
@@ -44,7 +44,7 @@ class UnwindingClockEffect extends ContinuousEffectImpl {
         staticText = "Untap all artifacts you control during each other player's untap step";
     }
 
-    public UnwindingClockEffect(final UnwindingClockEffect effect) {
+    private UnwindingClockEffect(final UnwindingClockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/Upwelling.java
+++ b/Mage.Sets/src/mage/cards/u/Upwelling.java
@@ -49,7 +49,7 @@ class UpwellingRuleEffect extends ContinuousEffectImpl {
         staticText = "Players don't lose unspent mana as steps and phases end";
     }
 
-    public UpwellingRuleEffect(final UpwellingRuleEffect effect) {
+    private UpwellingRuleEffect(final UpwellingRuleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrDrago.java
+++ b/Mage.Sets/src/mage/cards/u/UrDrago.java
@@ -49,7 +49,7 @@ class UrDragoEffect extends AsThoughEffectImpl {
         staticText = "Creatures with swampwalk can be blocked as though they didn't have swampwalk";
     }
 
-    public UrDragoEffect(final UrDragoEffect effect) {
+    private UrDragoEffect(final UrDragoEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrbanBurgeoning.java
+++ b/Mage.Sets/src/mage/cards/u/UrbanBurgeoning.java
@@ -57,7 +57,7 @@ class UrbanBurgeoningUntapEffect extends ContinuousEffectImpl {
         staticText = "Untap this land during each other player's untap step";
     }
 
-    public UrbanBurgeoningUntapEffect(final UrbanBurgeoningUntapEffect effect) {
+    private UrbanBurgeoningUntapEffect(final UrbanBurgeoningUntapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrgeToFeed.java
+++ b/Mage.Sets/src/mage/cards/u/UrgeToFeed.java
@@ -56,7 +56,7 @@ class UrgeToFeedEffect extends OneShotEffect {
         staticText = "You may tap any number of untapped Vampire creatures you control. If you do, put a +1/+1 counter on each of those Vampires";
     }
 
-    public UrgeToFeedEffect(UrgeToFeedEffect effect) {
+    private UrgeToFeedEffect(final UrgeToFeedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrgorosTheEmptyOne.java
+++ b/Mage.Sets/src/mage/cards/u/UrgorosTheEmptyOne.java
@@ -54,7 +54,7 @@ class UrgorosTheEmptyOneEffect extends OneShotEffect {
         this.staticText = "that player discards a card at random. If the player can't, you draw a card";
     }
 
-    public UrgorosTheEmptyOneEffect(final UrgorosTheEmptyOneEffect effect) {
+    private UrgorosTheEmptyOneEffect(final UrgorosTheEmptyOneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
+++ b/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
@@ -113,7 +113,7 @@ class UrzaAcademyHeadmasterRandomEffect extends OneShotEffect {
         }
     }
 
-    public UrzaAcademyHeadmasterRandomEffect(final UrzaAcademyHeadmasterRandomEffect effect) {
+    private UrzaAcademyHeadmasterRandomEffect(final UrzaAcademyHeadmasterRandomEffect effect) {
         super(effect);
         this.selection = effect.selection;
         this.setInfo = effect.setInfo.copy();
@@ -472,7 +472,7 @@ class UrzaAcademyHeadmasterManaEffect extends OneShotEffect {
         super(Outcome.PutManaInPool);
     }
 
-    public UrzaAcademyHeadmasterManaEffect(final UrzaAcademyHeadmasterManaEffect effect) {
+    private UrzaAcademyHeadmasterManaEffect(final UrzaAcademyHeadmasterManaEffect effect) {
         super(effect);
     }
 
@@ -536,7 +536,7 @@ class UrzaAcademyHeadmasterBrainstormEffect extends OneShotEffect {
         staticText = "draw three cards, then put a card from your hand on top of your library";
     }
 
-    public UrzaAcademyHeadmasterBrainstormEffect(final UrzaAcademyHeadmasterBrainstormEffect effect) {
+    private UrzaAcademyHeadmasterBrainstormEffect(final UrzaAcademyHeadmasterBrainstormEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrzaLordHighArtificer.java
+++ b/Mage.Sets/src/mage/cards/u/UrzaLordHighArtificer.java
@@ -112,7 +112,7 @@ class UrzaLordHighArtificerManaEffect extends BasicManaEffect {
         this.filter = filter;
     }
 
-    public UrzaLordHighArtificerManaEffect(final UrzaLordHighArtificerManaEffect effect) {
+    private UrzaLordHighArtificerManaEffect(final UrzaLordHighArtificerManaEffect effect) {
         super(effect);
         this.filter = effect.filter.copy();
     }

--- a/Mage.Sets/src/mage/cards/u/UrzaPlaneswalker.java
+++ b/Mage.Sets/src/mage/cards/u/UrzaPlaneswalker.java
@@ -100,7 +100,7 @@ class UrzaPlaneswalkerEffect extends ContinuousEffectImpl {
         staticText = "once during each of your turns, you may activate an additional loyalty ability of {this}";
     }
 
-    public UrzaPlaneswalkerEffect(final UrzaPlaneswalkerEffect effect) {
+    private UrzaPlaneswalkerEffect(final UrzaPlaneswalkerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrzasArmor.java
+++ b/Mage.Sets/src/mage/cards/u/UrzasArmor.java
@@ -43,7 +43,7 @@ class UrzasArmorEffect extends PreventionEffectImpl {
         this.staticText = "If a source would deal damage to you, prevent 1 of that damage";
     }
 
-    public UrzasArmorEffect(UrzasArmorEffect effect) {
+    private UrzasArmorEffect(final UrzasArmorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrzasAvenger.java
+++ b/Mage.Sets/src/mage/cards/u/UrzasAvenger.java
@@ -68,7 +68,7 @@ class UrzasAvengerEffect extends ContinuousEffectImpl {
         this.staticText = "{this} gets -1/-1 and gains your choice of banding, flying, first strike, or trample until end of turn";
     }
 
-    public UrzasAvengerEffect(final UrzasAvengerEffect effect) {
+    private UrzasAvengerEffect(final UrzasAvengerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrzasBauble.java
+++ b/Mage.Sets/src/mage/cards/u/UrzasBauble.java
@@ -56,7 +56,7 @@ class LookAtRandomCardEffect extends OneShotEffect {
         this.staticText = "Look at a card at random in target player's hand";
     }
 
-    public LookAtRandomCardEffect(final LookAtRandomCardEffect effect) {
+    private LookAtRandomCardEffect(final LookAtRandomCardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrzasChalice.java
+++ b/Mage.Sets/src/mage/cards/u/UrzasChalice.java
@@ -42,7 +42,7 @@ class UrzasChaliceAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DoIfCostPaid(new GainLifeEffect(1), new GenericManaCost(1)), false);
     }
 
-    public UrzasChaliceAbility(final UrzasChaliceAbility ability) {
+    private UrzasChaliceAbility(final UrzasChaliceAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrzasEngine.java
+++ b/Mage.Sets/src/mage/cards/u/UrzasEngine.java
@@ -43,7 +43,7 @@ public final class UrzasEngine extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new UrzasEngineEffect(), new ManaCostsImpl<>("{3}")));
     }
 
-    public UrzasEngine(final UrzasEngine card) {
+    private UrzasEngine(final UrzasEngine card) {
         super(card);
     }
 
@@ -61,7 +61,7 @@ class UrzasEngineEffect extends OneShotEffect {
         this.staticText = "Attacking creatures banded with {this} gain trample until end of turn";
     }
 
-    public UrzasEngineEffect(final UrzasEngineEffect effect) {
+    private UrzasEngineEffect(final UrzasEngineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrzasHotTub.java
+++ b/Mage.Sets/src/mage/cards/u/UrzasHotTub.java
@@ -53,7 +53,7 @@ class UrzasHotTubEffect extends OneShotEffect {
         this.staticText = "Search your library for a card that shares a complete word in its name with the discarded card, reveal it, put it into your hand, then shuffle";
     }
 
-    public UrzasHotTubEffect(final UrzasHotTubEffect effect) {
+    private UrzasHotTubEffect(final UrzasHotTubEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrzasScienceFairProject.java
+++ b/Mage.Sets/src/mage/cards/u/UrzasScienceFairProject.java
@@ -61,7 +61,7 @@ class UrzasScienceFairProjectEffect extends OneShotEffect {
                 "<br>6 - It gets +2/+2 until end of turn";
     }
 
-    public UrzasScienceFairProjectEffect(final UrzasScienceFairProjectEffect effect) {
+    private UrzasScienceFairProjectEffect(final UrzasScienceFairProjectEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrzasTome.java
+++ b/Mage.Sets/src/mage/cards/u/UrzasTome.java
@@ -51,7 +51,7 @@ class UrzasTomeEffect extends OneShotEffect {
         staticText = "Draw a card. Then discard a card unless you exile a historic card from your graveyard";
     }
 
-    public UrzasTomeEffect(final UrzasTomeEffect effect) {
+    private UrzasTomeEffect(final UrzasTomeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VaevictisAsmadiTheDire.java
+++ b/Mage.Sets/src/mage/cards/v/VaevictisAsmadiTheDire.java
@@ -64,7 +64,7 @@ class VaevictisAsmadiTheDireTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new VaevictisAsmadiTheDireEffect(), false);
     }
 
-    public VaevictisAsmadiTheDireTriggeredAbility(final VaevictisAsmadiTheDireTriggeredAbility ability) {
+    private VaevictisAsmadiTheDireTriggeredAbility(final VaevictisAsmadiTheDireTriggeredAbility ability) {
         super(ability);
     }
 
@@ -117,7 +117,7 @@ class VaevictisAsmadiTheDireEffect extends OneShotEffect {
                 + "then puts it onto the battlefield if it's a permanent card";
     }
 
-    public VaevictisAsmadiTheDireEffect(final VaevictisAsmadiTheDireEffect effect) {
+    private VaevictisAsmadiTheDireEffect(final VaevictisAsmadiTheDireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ValdukKeeperOfTheFlame.java
+++ b/Mage.Sets/src/mage/cards/v/ValdukKeeperOfTheFlame.java
@@ -56,7 +56,7 @@ class ValdukKeeperOfTheFlameEffect extends OneShotEffect {
         this.staticText = "for each Aura and Equipment attached to {this}, create a 3/1 red Elemental creature token with trample and haste. Exile those tokens at the beginning of the next end step";
     }
 
-    public ValdukKeeperOfTheFlameEffect(final ValdukKeeperOfTheFlameEffect effect) {
+    private ValdukKeeperOfTheFlameEffect(final ValdukKeeperOfTheFlameEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ValeronWardens.java
+++ b/Mage.Sets/src/mage/cards/v/ValeronWardens.java
@@ -52,7 +52,7 @@ class ValeronWardensTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
     }
 
-    public ValeronWardensTriggeredAbility(final ValeronWardensTriggeredAbility ability) {
+    private ValeronWardensTriggeredAbility(final ValeronWardensTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ValkiGodOfLies.java
+++ b/Mage.Sets/src/mage/cards/v/ValkiGodOfLies.java
@@ -150,7 +150,7 @@ class ValkiGodOfLiesCopyExiledEffect extends OneShotEffect {
         this.staticText = "Choose a creature card exiled with Valki with mana value X. Valki becomes a copy of that card.";
     }
 
-    public ValkiGodOfLiesCopyExiledEffect(final ValkiGodOfLiesCopyExiledEffect effect) {
+    private ValkiGodOfLiesCopyExiledEffect(final ValkiGodOfLiesCopyExiledEffect effect) {
         super(effect);
     }
 
@@ -193,7 +193,7 @@ class ExileTopCardEachPlayersLibrary extends OneShotEffect {
         this.staticText = "Exile the top card of each player's library";
     }
 
-    public ExileTopCardEachPlayersLibrary(final ExileTopCardEachPlayersLibrary effect) {
+    private ExileTopCardEachPlayersLibrary(final ExileTopCardEachPlayersLibrary effect) {
         super(effect);
     }
 
@@ -234,7 +234,7 @@ class ExileTargetArtifactOrCreatureEffect extends OneShotEffect {
         this.staticText = "Exile target artifact or creature";
     }
 
-    public ExileTargetArtifactOrCreatureEffect(final ExileTargetArtifactOrCreatureEffect effect) {
+    private ExileTargetArtifactOrCreatureEffect(final ExileTargetArtifactOrCreatureEffect effect) {
         super(effect);
     }
 
@@ -267,7 +267,7 @@ class ExileAllCardsFromAllGraveyards extends OneShotEffect {
         this.staticText = "Exile all graveyards. Add {R}{R}{R}";
     }
 
-    public ExileAllCardsFromAllGraveyards(final ExileAllCardsFromAllGraveyards effect) {
+    private ExileAllCardsFromAllGraveyards(final ExileAllCardsFromAllGraveyards effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ValorOfTheWorthy.java
+++ b/Mage.Sets/src/mage/cards/v/ValorOfTheWorthy.java
@@ -63,7 +63,7 @@ class LeavesTheBattlefieldAttachedTriggeredAbility extends ZoneChangeTriggeredAb
         super(Zone.BATTLEFIELD, new CreateTokenEffect(new SpiritWhiteToken()), "When enchanted creature leaves the battlefield, ", Boolean.FALSE);
     }
 
-    public LeavesTheBattlefieldAttachedTriggeredAbility(final LeavesTheBattlefieldAttachedTriggeredAbility ability) {
+    private LeavesTheBattlefieldAttachedTriggeredAbility(final LeavesTheBattlefieldAttachedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VampireNocturnus.java
+++ b/Mage.Sets/src/mage/cards/v/VampireNocturnus.java
@@ -76,7 +76,7 @@ class VampireNocturnusAbility extends StaticAbility {
                 new VampireNocturnusCondition(), ""));
     }
 
-    public VampireNocturnusAbility(VampireNocturnusAbility ability) {
+    private VampireNocturnusAbility(final VampireNocturnusAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VampireRevenant.java
+++ b/Mage.Sets/src/mage/cards/v/VampireRevenant.java
@@ -27,7 +27,7 @@ public final class VampireRevenant extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public VampireRevenant (final VampireRevenant card) {
+    private VampireRevenant(final VampireRevenant card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/Vampirism.java
+++ b/Mage.Sets/src/mage/cards/v/Vampirism.java
@@ -69,7 +69,7 @@ class VampirismBoostEnchantedEffect extends ContinuousEffectImpl {
         staticText = "Enchanted creature gets +1/+1 for each other creature you control";
     }
 
-    public VampirismBoostEnchantedEffect(final VampirismBoostEnchantedEffect effect) {
+    private VampirismBoostEnchantedEffect(final VampirismBoostEnchantedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VancesBlastingCannons.java
+++ b/Mage.Sets/src/mage/cards/v/VancesBlastingCannons.java
@@ -64,7 +64,7 @@ class VancesBlastingCannonsExileEffect extends OneShotEffect {
         this.staticText = "exile the top card of your library. If it's a nonland card, you may cast that card this turn";
     }
 
-    public VancesBlastingCannonsExileEffect(final VancesBlastingCannonsExileEffect effect) {
+    private VancesBlastingCannonsExileEffect(final VancesBlastingCannonsExileEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class CastFromNonHandZoneTargetEffect extends AsThoughEffectImpl {
         staticText = "If it's a nonland card, you may cast that card this turn";
     }
 
-    public CastFromNonHandZoneTargetEffect(final CastFromNonHandZoneTargetEffect effect) {
+    private CastFromNonHandZoneTargetEffect(final CastFromNonHandZoneTargetEffect effect) {
         super(effect);
     }
 
@@ -134,7 +134,7 @@ class VancesBlastingCannonsFlipTrigger extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new TransformSourceEffect(), true);
     }
 
-    public VancesBlastingCannonsFlipTrigger(final VancesBlastingCannonsFlipTrigger ability) {
+    private VancesBlastingCannonsFlipTrigger(final VancesBlastingCannonsFlipTrigger ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VanguardsShield.java
+++ b/Mage.Sets/src/mage/cards/v/VanguardsShield.java
@@ -57,7 +57,7 @@ class VanguardsShieldEffect extends ContinuousEffectImpl {
         staticText = "Equipped creature can block an additional creature each combat";
     }
 
-    public VanguardsShieldEffect(final VanguardsShieldEffect effect) {
+    private VanguardsShieldEffect(final VanguardsShieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VanishIntoMemory.java
+++ b/Mage.Sets/src/mage/cards/v/VanishIntoMemory.java
@@ -61,7 +61,7 @@ class VanishIntoMemoryEffect extends OneShotEffect {
         staticText = "Exile target creature. You draw cards equal to that creature's power. At the beginning of your next upkeep, return that card to the battlefield under its owner's control. If you do, discard cards equal to that creature's toughness";
     }
 
-    public VanishIntoMemoryEffect(final VanishIntoMemoryEffect effect) {
+    private VanishIntoMemoryEffect(final VanishIntoMemoryEffect effect) {
         super(effect);
     }
 
@@ -100,7 +100,7 @@ class VanishIntoMemoryReturnFromExileEffect extends OneShotEffect {
         staticText = "return that card to the battlefield under its owner's control";
     }
 
-    public VanishIntoMemoryReturnFromExileEffect(final VanishIntoMemoryReturnFromExileEffect effect) {
+    private VanishIntoMemoryReturnFromExileEffect(final VanishIntoMemoryReturnFromExileEffect effect) {
         super(effect);
     }
 
@@ -133,7 +133,7 @@ class VanishIntoMemoryEntersBattlefieldEffect extends ReplacementEffectImpl {
         staticText = "discard cards equal to that creature's toughness.";
     }
 
-    public VanishIntoMemoryEntersBattlefieldEffect(VanishIntoMemoryEntersBattlefieldEffect effect) {
+    private VanishIntoMemoryEntersBattlefieldEffect(final VanishIntoMemoryEntersBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VanquishersBanner.java
+++ b/Mage.Sets/src/mage/cards/v/VanquishersBanner.java
@@ -63,7 +63,7 @@ class DrawCardIfCreatureTypeAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
     }
 
-    public DrawCardIfCreatureTypeAbility(final DrawCardIfCreatureTypeAbility ability) {
+    private DrawCardIfCreatureTypeAbility(final DrawCardIfCreatureTypeAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VaporousDjinn.java
+++ b/Mage.Sets/src/mage/cards/v/VaporousDjinn.java
@@ -55,7 +55,7 @@ class VaporousDjinnEffect extends OneShotEffect {
         this.staticText = "{this} phases out unless you pay {U}{U}";
     }
 
-    public VaporousDjinnEffect(final VaporousDjinnEffect effect) {
+    private VaporousDjinnEffect(final VaporousDjinnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VarchildsWarRiders.java
+++ b/Mage.Sets/src/mage/cards/v/VarchildsWarRiders.java
@@ -59,7 +59,7 @@ class OpponentCreateSurvivorTokenCost extends CostImpl {
         this.text = "Have an opponent create a 1/1 red Survivor creature token";
     }
 
-    public OpponentCreateSurvivorTokenCost(OpponentCreateSurvivorTokenCost cost) {
+    private OpponentCreateSurvivorTokenCost(final OpponentCreateSurvivorTokenCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VarinaLichQueen.java
+++ b/Mage.Sets/src/mage/cards/v/VarinaLichQueen.java
@@ -72,7 +72,7 @@ class VarinaLichQueenTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null, false);
     }
 
-    public VarinaLichQueenTriggeredAbility(final VarinaLichQueenTriggeredAbility ability) {
+    private VarinaLichQueenTriggeredAbility(final VarinaLichQueenTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VassalsDuty.java
+++ b/Mage.Sets/src/mage/cards/v/VassalsDuty.java
@@ -56,7 +56,7 @@ class VassalsDutyPreventDamageTargetEffect extends RedirectionEffect {
         staticText = "The next " + amount + " damage that would be dealt to target legendary creature you control this turn is dealt to you instead";
     }
 
-    public VassalsDutyPreventDamageTargetEffect(final VassalsDutyPreventDamageTargetEffect effect) {
+    private VassalsDutyPreventDamageTargetEffect(final VassalsDutyPreventDamageTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VastwoodAnimist.java
+++ b/Mage.Sets/src/mage/cards/v/VastwoodAnimist.java
@@ -63,7 +63,7 @@ class VastwoodAnimistEffect extends OneShotEffect {
         this.staticText = "Target land you control becomes an X/X Elemental creature until end of turn, where X is the number of Allies you control. It's still a land.";
     }
 
-    public VastwoodAnimistEffect(final VastwoodAnimistEffect effect) {
+    private VastwoodAnimistEffect(final VastwoodAnimistEffect effect) {
         super(effect);
     }
 
@@ -91,7 +91,7 @@ class VastwoodAnimistElementalToken extends TokenImpl {
         power = new MageInt(amount);
         toughness = new MageInt(amount);
     }
-    public VastwoodAnimistElementalToken(final VastwoodAnimistElementalToken token) {
+    private VastwoodAnimistElementalToken(final VastwoodAnimistElementalToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VastwoodHydra.java
+++ b/Mage.Sets/src/mage/cards/v/VastwoodHydra.java
@@ -67,7 +67,7 @@ class VastwoodHydraDistributeEffect extends OneShotEffect {
         this.staticText = "distribute a number of +1/+1 counters equal to the number of +1/+1 counters on {this} among any number of creatures you control";
     }
 
-    public VastwoodHydraDistributeEffect(final VastwoodHydraDistributeEffect effect) {
+    private VastwoodHydraDistributeEffect(final VastwoodHydraDistributeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VaultOfWhispers.java
+++ b/Mage.Sets/src/mage/cards/v/VaultOfWhispers.java
@@ -19,7 +19,7 @@ public final class VaultOfWhispers extends CardImpl {
         this.addAbility(new BlackManaAbility());
     }
 
-    public VaultOfWhispers (final VaultOfWhispers card) {
+    private VaultOfWhispers(final VaultOfWhispers card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VaultSkyward.java
+++ b/Mage.Sets/src/mage/cards/v/VaultSkyward.java
@@ -26,7 +26,7 @@ public final class VaultSkyward extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public VaultSkyward (final VaultSkyward card) {
+    private VaultSkyward(final VaultSkyward card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VectisDominator.java
+++ b/Mage.Sets/src/mage/cards/v/VectisDominator.java
@@ -60,7 +60,7 @@ class VectisDominatorEffect extends OneShotEffect {
         this.cost = cost;
     }
 
-    public VectisDominatorEffect(final VectisDominatorEffect effect) {
+    private VectisDominatorEffect(final VectisDominatorEffect effect) {
         super(effect);
         this.cost = effect.cost.copy();
     }

--- a/Mage.Sets/src/mage/cards/v/VectisSilencers.java
+++ b/Mage.Sets/src/mage/cards/v/VectisSilencers.java
@@ -31,7 +31,7 @@ public final class VectisSilencers extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilitySourceEffect(DeathtouchAbility.getInstance(), Duration.EndOfTurn), new ManaCostsImpl<>("{2}{B}")));
     }
 
-    public VectisSilencers (final VectisSilencers card) {
+    private VectisSilencers(final VectisSilencers card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VectorAsp.java
+++ b/Mage.Sets/src/mage/cards/v/VectorAsp.java
@@ -30,7 +30,7 @@ public final class VectorAsp extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilitySourceEffect(InfectAbility.getInstance(), Duration.EndOfTurn), new ManaCostsImpl<>("{B}")));
     }
 
-    public VectorAsp (final VectorAsp card) {
+    private VectorAsp(final VectorAsp card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VedalkenEngineer.java
+++ b/Mage.Sets/src/mage/cards/v/VedalkenEngineer.java
@@ -94,7 +94,7 @@ class VedalkenEngineerEffect extends ManaEffect {
         staticText = "Add " + CardUtil.numberToText(amount) + " mana of any one color. " + manaBuilder.getRule();
     }
 
-    public VedalkenEngineerEffect(final VedalkenEngineerEffect effect) {
+    private VedalkenEngineerEffect(final VedalkenEngineerEffect effect) {
         super(effect);
         this.amount = effect.amount;
         this.manaBuilder = effect.manaBuilder;

--- a/Mage.Sets/src/mage/cards/v/VedalkenInfuser.java
+++ b/Mage.Sets/src/mage/cards/v/VedalkenInfuser.java
@@ -35,7 +35,7 @@ public final class VedalkenInfuser extends CardImpl {
         this.addAbility(ability);
     }
 
-    public VedalkenInfuser (final VedalkenInfuser card) {
+    private VedalkenInfuser(final VedalkenInfuser card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeilOfBirds.java
+++ b/Mage.Sets/src/mage/cards/v/VeilOfBirds.java
@@ -56,7 +56,7 @@ class VeilOfBirdsToken extends TokenImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public VeilOfBirdsToken(final VeilOfBirdsToken token) {
+    private VeilOfBirdsToken(final VeilOfBirdsToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeiledApparition.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledApparition.java
@@ -64,7 +64,7 @@ class VeilApparitionToken extends TokenImpl {
         this.addAbility(ability);
     }
 
-    public VeilApparitionToken(final VeilApparitionToken token) {
+    private VeilApparitionToken(final VeilApparitionToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeiledCrocodile.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledCrocodile.java
@@ -46,7 +46,7 @@ class VeiledCrocodileStateTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("When a player has no cards in hand, if {this} is an enchantment, ");
     }
 
-    public VeiledCrocodileStateTriggeredAbility(final VeiledCrocodileStateTriggeredAbility ability) {
+    private VeiledCrocodileStateTriggeredAbility(final VeiledCrocodileStateTriggeredAbility ability) {
         super(ability);
     }
 
@@ -112,7 +112,7 @@ class VeilCrocodileToken extends TokenImpl {
         toughness = new MageInt(4);
     }
 
-    public VeilCrocodileToken(final VeilCrocodileToken token) {
+    private VeilCrocodileToken(final VeilCrocodileToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeiledSentry.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledSentry.java
@@ -53,7 +53,7 @@ class VeiledSentryEffect extends ContinuousEffectImpl {
         staticText = "{this} becomes an Illusion creature with power and toughness equal to that spell's mana value";
     }
 
-    public VeiledSentryEffect(final VeiledSentryEffect effect) {
+    private VeiledSentryEffect(final VeiledSentryEffect effect) {
         super(effect);
         this.spellMV = effect.spellMV;
     }

--- a/Mage.Sets/src/mage/cards/v/VeiledSerpent.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledSerpent.java
@@ -65,7 +65,7 @@ class VeiledSerpentToken extends TokenImpl {
                         new FilterLandPermanent(SubType.ISLAND, "an Island"))));
     }
 
-    public VeiledSerpentToken(final VeiledSerpentToken token) {
+    private VeiledSerpentToken(final VeiledSerpentToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeilingOddity.java
+++ b/Mage.Sets/src/mage/cards/v/VeilingOddity.java
@@ -55,7 +55,7 @@ class VeilingOddityTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When the last time counter is removed from {this} while it's exiled, ");
     }
 
-    public VeilingOddityTriggeredAbility(final VeilingOddityTriggeredAbility ability) {
+    private VeilingOddityTriggeredAbility(final VeilingOddityTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeilstoneAmulet.java
+++ b/Mage.Sets/src/mage/cards/v/VeilstoneAmulet.java
@@ -47,7 +47,7 @@ class VeilstoneAmuletEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "creatures you control can't be the targets of spells or abilities your opponents control this turn";
     }
 
-    public VeilstoneAmuletEffect(final VeilstoneAmuletEffect effect) {
+    private VeilstoneAmuletEffect(final VeilstoneAmuletEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeinfireBorderpost.java
+++ b/Mage.Sets/src/mage/cards/v/VeinfireBorderpost.java
@@ -48,7 +48,7 @@ public final class VeinfireBorderpost extends CardImpl {
         this.addAbility(new RedManaAbility());
     }
 
-    public VeinfireBorderpost (final VeinfireBorderpost card) {
+    private VeinfireBorderpost(final VeinfireBorderpost card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VenarianGlimmer.java
+++ b/Mage.Sets/src/mage/cards/v/VenarianGlimmer.java
@@ -49,7 +49,7 @@ class VenarianGlimmerEffect extends OneShotEffect {
         this.staticText = "Target player reveals their hand. You choose a nonland card with mana value X or less from it. That player discards that card";
     }
 
-    public VenarianGlimmerEffect(final VenarianGlimmerEffect effect) {
+    private VenarianGlimmerEffect(final VenarianGlimmerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/Vendetta.java
+++ b/Mage.Sets/src/mage/cards/v/Vendetta.java
@@ -46,7 +46,7 @@ class VendettaEffect extends OneShotEffect {
         staticText = "You lose life equal to that creature's toughness";
     }
 
-    public VendettaEffect(final VendettaEffect effect) {
+    private VendettaEffect(final VendettaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeneratedTeacher.java
+++ b/Mage.Sets/src/mage/cards/v/VeneratedTeacher.java
@@ -53,7 +53,7 @@ class VeneratedTeacherEffect extends OneShotEffect {
         staticText = "put two level counters on each creature you control with level up";
     }
 
-    public VeneratedTeacherEffect(final VeneratedTeacherEffect effect) {
+    private VeneratedTeacherEffect(final VeneratedTeacherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VengefulArchon.java
+++ b/Mage.Sets/src/mage/cards/v/VengefulArchon.java
@@ -60,7 +60,7 @@ class VengefulArchonEffect extends PreventDamageToControllerEffect {
         staticText = "Prevent the next X damage that would be dealt to you this turn. If damage is prevented this way, {this} deals that much damage to target player or planeswalker";
     }
 
-    public VengefulArchonEffect(final VengefulArchonEffect effect) {
+    private VengefulArchonEffect(final VengefulArchonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VengefulPharaoh.java
+++ b/Mage.Sets/src/mage/cards/v/VengefulPharaoh.java
@@ -66,7 +66,7 @@ class VengefulPharaohTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetAttackingCreature());
     }
 
-    public VengefulPharaohTriggeredAbility(final VengefulPharaohTriggeredAbility ability) {
+    private VengefulPharaohTriggeredAbility(final VengefulPharaohTriggeredAbility ability) {
         super(ability);
         this.stepTriggeredPlansewalker = ability.stepTriggeredPlansewalker;
         this.turnTriggeredPlaneswalker = ability.turnTriggeredPlaneswalker;
@@ -133,7 +133,7 @@ class VengefulPharaohEffect extends OneShotEffect {
         this.staticText = "destroy target attacking creature, then put {this} on top of your library";
     }
 
-    public VengefulPharaohEffect(final VengefulPharaohEffect effect) {
+    private VengefulPharaohEffect(final VengefulPharaohEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VengefulRebirth.java
+++ b/Mage.Sets/src/mage/cards/v/VengefulRebirth.java
@@ -53,7 +53,7 @@ class VengefulRebirthEffect extends OneShotEffect {
                 "{this} deals damage equal to that card's mana value to any target";
     }
 
-    public VengefulRebirthEffect(final VengefulRebirthEffect effect) {
+    private VengefulRebirthEffect(final VengefulRebirthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/Vengevine.java
+++ b/Mage.Sets/src/mage/cards/v/Vengevine.java
@@ -52,7 +52,7 @@ class VengevineAbility extends TriggeredAbilityImpl {
         super(Zone.GRAVEYARD, new ReturnSourceFromGraveyardToBattlefieldEffect(), true);
     }
 
-    public VengevineAbility(final VengevineAbility ability) {
+    private VengevineAbility(final VengevineAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VenomousBreath.java
+++ b/Mage.Sets/src/mage/cards/v/VenomousBreath.java
@@ -53,7 +53,7 @@ class VenomousBreathCreateDelayedTriggeredAbilityEffect extends OneShotEffect {
         this.staticText = "At this turn's next end of combat, destroy all creatures that blocked or were blocked by it this turn";
     }
 
-    public VenomousBreathCreateDelayedTriggeredAbilityEffect(final VenomousBreathCreateDelayedTriggeredAbilityEffect effect) {
+    private VenomousBreathCreateDelayedTriggeredAbilityEffect(final VenomousBreathCreateDelayedTriggeredAbilityEffect effect) {
         super(effect);
     }
 
@@ -83,7 +83,7 @@ class VenomousBreathEffect extends OneShotEffect {
         this.targetCreature = targetCreature;
     }
 
-    public VenomousBreathEffect(final VenomousBreathEffect effect) {
+    private VenomousBreathEffect(final VenomousBreathEffect effect) {
         super(effect);
         targetCreature = effect.targetCreature;
     }

--- a/Mage.Sets/src/mage/cards/v/VensersDiffusion.java
+++ b/Mage.Sets/src/mage/cards/v/VensersDiffusion.java
@@ -31,7 +31,7 @@ public final class VensersDiffusion extends CardImpl {
         this.getSpellAbility().addEffect(new ReturnToHandTargetEffect());
     }
 
-    public VensersDiffusion (final VensersDiffusion card) {
+    private VensersDiffusion(final VensersDiffusion card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VerdantSuccession.java
+++ b/Mage.Sets/src/mage/cards/v/VerdantSuccession.java
@@ -63,7 +63,7 @@ class VerdantSuccessionTriggeredAbility extends TriggeredAbilityImpl {
         this.optional = true;
     }
 
-    public VerdantSuccessionTriggeredAbility(final VerdantSuccessionTriggeredAbility ability) {
+    private VerdantSuccessionTriggeredAbility(final VerdantSuccessionTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VerdantSunsAvatar.java
+++ b/Mage.Sets/src/mage/cards/v/VerdantSunsAvatar.java
@@ -53,7 +53,7 @@ class VerdantSunsAvatarTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} or another creature enters the battlefield under your control, ");
     }
 
-    public VerdantSunsAvatarTriggeredAbility(VerdantSunsAvatarTriggeredAbility ability) {
+    private VerdantSunsAvatarTriggeredAbility(final VerdantSunsAvatarTriggeredAbility ability) {
         super(ability);
     }
 
@@ -91,7 +91,7 @@ class VerdantSunsAvatarEffect extends OneShotEffect {
         staticText = "you gain life equal to that creature's toughness";
     }
 
-    public VerdantSunsAvatarEffect(final VerdantSunsAvatarEffect effect) {
+    private VerdantSunsAvatarEffect(final VerdantSunsAvatarEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VergeRangers.java
+++ b/Mage.Sets/src/mage/cards/v/VergeRangers.java
@@ -63,7 +63,7 @@ class VergeRangersEffect extends PlayTheTopCardEffect {
         staticText = "As long as an opponent controls more lands than you, you may play lands from the top of your library";
     }
 
-    public VergeRangersEffect(final VergeRangersEffect effect) {
+    private VergeRangersEffect(final VergeRangersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VesuvanDoppelganger.java
+++ b/Mage.Sets/src/mage/cards/v/VesuvanDoppelganger.java
@@ -62,7 +62,7 @@ class VesuvanDoppelgangerCopyEffect extends OneShotEffect {
         super(Outcome.Copy);
     }
 
-    public VesuvanDoppelgangerCopyEffect(final VesuvanDoppelgangerCopyEffect effect) {
+    private VesuvanDoppelgangerCopyEffect(final VesuvanDoppelgangerCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeteranBrawlers.java
+++ b/Mage.Sets/src/mage/cards/v/VeteranBrawlers.java
@@ -65,7 +65,7 @@ class VeteranBrawlersCantBlockEffect extends RestrictionEffect {
         staticText = "{this} can't block if you control " + filter.getMessage();
     }
 
-    public VeteranBrawlersCantBlockEffect(final VeteranBrawlersCantBlockEffect effect) {
+    private VeteranBrawlersCantBlockEffect(final VeteranBrawlersCantBlockEffect effect) {
         super(effect);
         this.filter = effect.filter;
     }

--- a/Mage.Sets/src/mage/cards/v/VeteranExplorer.java
+++ b/Mage.Sets/src/mage/cards/v/VeteranExplorer.java
@@ -59,7 +59,7 @@ class VeteranExplorerEffect extends OneShotEffect {
                 "put them onto the battlefield, then shuffle";
     }
 
-    public VeteranExplorerEffect(final VeteranExplorerEffect effect) {
+    private VeteranExplorerEffect(final VeteranExplorerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeteransReflexes.java
+++ b/Mage.Sets/src/mage/cards/v/VeteransReflexes.java
@@ -25,7 +25,7 @@ public final class VeteransReflexes extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public VeteransReflexes (final VeteransReflexes card) {
+    private VeteransReflexes(final VeteransReflexes card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/Vex.java
+++ b/Mage.Sets/src/mage/cards/v/Vex.java
@@ -43,7 +43,7 @@ class VexEffect extends OneShotEffect {
         this.staticText = "Counter target spell. That spell's controller may draw a card";
     }
 
-    public VexEffect(final VexEffect effect) {
+    private VexEffect(final VexEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VexingArcanix.java
+++ b/Mage.Sets/src/mage/cards/v/VexingArcanix.java
@@ -53,7 +53,7 @@ class VexingArcanixEffect extends OneShotEffect {
                 "the player puts it into their graveyard and {this} deals 2 damage to them";
     }
 
-    public VexingArcanixEffect(final VexingArcanixEffect effect) {
+    private VexingArcanixEffect(final VexingArcanixEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VexingShusher.java
+++ b/Mage.Sets/src/mage/cards/v/VexingShusher.java
@@ -60,7 +60,7 @@ class VexingShusherCantCounterTargetEffect extends ContinuousRuleModifyingEffect
         staticText = "Target spell can't be countered";
     }
 
-    public VexingShusherCantCounterTargetEffect(final VexingShusherCantCounterTargetEffect effect) {
+    private VexingShusherCantCounterTargetEffect(final VexingShusherCantCounterTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/Vexis.java
+++ b/Mage.Sets/src/mage/cards/v/Vexis.java
@@ -41,7 +41,7 @@ public class Vexis extends CardImpl {
                 VigilanceAbility.getInstance(), Duration.EndOfTurn), false, CounterType.P1P1));
     }
 
-    public Vexis(final Vexis card) {
+    private Vexis(final Vexis card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VhatiIlDal.java
+++ b/Mage.Sets/src/mage/cards/v/VhatiIlDal.java
@@ -55,7 +55,7 @@ class VhatiIlDalEffect extends OneShotEffect {
         this.staticText = "Until end of turn, target creature has base power 1 or base toughness 1";
     }
 
-    public VhatiIlDalEffect(final VhatiIlDalEffect effect) {
+    private VhatiIlDalEffect(final VhatiIlDalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VialSmasherTheFierce.java
+++ b/Mage.Sets/src/mage/cards/v/VialSmasherTheFierce.java
@@ -105,7 +105,7 @@ class VialSmasherTheFierceEffect extends OneShotEffect {
         this.staticText = "{this} choose an opponent at random. {this} deals damage equal to that spell's mana value to that player or a planeswalker that player controls";
     }
 
-    public VialSmasherTheFierceEffect(final VialSmasherTheFierceEffect effect) {
+    private VialSmasherTheFierceEffect(final VialSmasherTheFierceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ViashinoBey.java
+++ b/Mage.Sets/src/mage/cards/v/ViashinoBey.java
@@ -63,7 +63,7 @@ class ViashinoBeyEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public ViashinoBeyEffect(final ViashinoBeyEffect effect) {
+    private ViashinoBeyEffect(final ViashinoBeyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ViashinoHeretic.java
+++ b/Mage.Sets/src/mage/cards/v/ViashinoHeretic.java
@@ -57,7 +57,7 @@ class ViashinoHereticEffect extends OneShotEffect {
         this.staticText = "Destroy target artifact. Viashino Heretic deals damage to that artifact's controller equal to the artifact's mana value";
     }
 
-    public ViashinoHereticEffect(final ViashinoHereticEffect effect) {
+    private ViashinoHereticEffect(final ViashinoHereticEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ViashinoSandswimmer.java
+++ b/Mage.Sets/src/mage/cards/v/ViashinoSandswimmer.java
@@ -52,7 +52,7 @@ class ViashinoSandswimmerEffect extends OneShotEffect {
         staticText = "Flip a coin. If you win the flip, return {this} to its owner's hand. If you lose the flip, sacrifice {this}";
     }
 
-    public ViashinoSandswimmerEffect(ViashinoSandswimmerEffect effect) {
+    private ViashinoSandswimmerEffect(final ViashinoSandswimmerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ViashivanDragon.java
+++ b/Mage.Sets/src/mage/cards/v/ViashivanDragon.java
@@ -34,7 +34,7 @@ public final class ViashivanDragon extends CardImpl {
 
     }
 
-    public ViashivanDragon(ViashivanDragon other){
+    private ViashivanDragon(final ViashivanDragon other){
         super(other);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VictoryChimes.java
+++ b/Mage.Sets/src/mage/cards/v/VictoryChimes.java
@@ -55,7 +55,7 @@ class VictoryChimesManaEffect extends ManaEffect {
         this.staticText = "a player of your choice adds {C}";
     }
 
-    public VictoryChimesManaEffect(final VictoryChimesManaEffect effect) {
+    private VictoryChimesManaEffect(final VictoryChimesManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VictorysHerald.java
+++ b/Mage.Sets/src/mage/cards/v/VictorysHerald.java
@@ -36,7 +36,7 @@ public final class VictorysHerald extends CardImpl {
         this.addAbility(ability);
     }
 
-    public VictorysHerald (final VictorysHerald card) {
+    private VictorysHerald(final VictorysHerald card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VigeanHydropon.java
+++ b/Mage.Sets/src/mage/cards/v/VigeanHydropon.java
@@ -52,7 +52,7 @@ class VigeanHydroponEffect extends RestrictionEffect {
         staticText = "{this} can't attack or block";
     }
 
-    public VigeanHydroponEffect(final VigeanHydroponEffect effect) {
+    private VigeanHydroponEffect(final VigeanHydroponEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VigeanIntuition.java
+++ b/Mage.Sets/src/mage/cards/v/VigeanIntuition.java
@@ -60,7 +60,7 @@ class VigeanIntuitionEffect extends OneShotEffect {
         staticText = "Choose a card type, then reveal the top four cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest into your graveyard";
     }
 
-    public VigeanIntuitionEffect(final VigeanIntuitionEffect effect) {
+    private VigeanIntuitionEffect(final VigeanIntuitionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/Vigilance.java
+++ b/Mage.Sets/src/mage/cards/v/Vigilance.java
@@ -29,7 +29,7 @@ public final class Vigilance extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(VigilanceAbility.getInstance(), AttachmentType.AURA)));
     }
 
-    public Vigilance (final Vigilance card) {
+    private Vigilance(final Vigilance card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VigorousCharge.java
+++ b/Mage.Sets/src/mage/cards/v/VigorousCharge.java
@@ -58,7 +58,7 @@ class VigorousChargeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null);
     }
 
-    public VigorousChargeTriggeredAbility(final VigorousChargeTriggeredAbility ability) {
+    private VigorousChargeTriggeredAbility(final VigorousChargeTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VildinPackAlpha.java
+++ b/Mage.Sets/src/mage/cards/v/VildinPackAlpha.java
@@ -59,7 +59,7 @@ class VildinPackAlphaEffect extends OneShotEffect {
         this.staticText = "you may transform it";
     }
 
-    public VildinPackAlphaEffect(final VildinPackAlphaEffect effect) {
+    private VildinPackAlphaEffect(final VildinPackAlphaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VileRedeemer.java
+++ b/Mage.Sets/src/mage/cards/v/VileRedeemer.java
@@ -66,7 +66,7 @@ class VileRedeemerEffect extends OneShotEffect {
         this.staticText = "create a 1/1 colorless Eldrazi Scion creature token for each nontoken creature that died under your control this turn. They have \"Sacrifice this creature: Add {C}";
     }
 
-    public VileRedeemerEffect(final VileRedeemerEffect effect) {
+    private VileRedeemerEffect(final VileRedeemerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VillageCannibals.java
+++ b/Mage.Sets/src/mage/cards/v/VillageCannibals.java
@@ -50,7 +50,7 @@ class VillageCannibalsTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever another Human creature dies, ");
     }
 
-    public VillageCannibalsTriggeredAbility(final VillageCannibalsTriggeredAbility ability) {
+    private VillageCannibalsTriggeredAbility(final VillageCannibalsTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VillainousWealth.java
+++ b/Mage.Sets/src/mage/cards/v/VillainousWealth.java
@@ -52,7 +52,7 @@ class VillainousWealthEffect extends OneShotEffect {
                 + "or less from among them without paying their mana costs";
     }
 
-    public VillainousWealthEffect(final VillainousWealthEffect effect) {
+    private VillainousWealthEffect(final VillainousWealthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/Vindicate.java
+++ b/Mage.Sets/src/mage/cards/v/Vindicate.java
@@ -23,7 +23,7 @@ public final class Vindicate extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPermanent());
     }
 
-    public Vindicate (final Vindicate card) {
+    private Vindicate(final Vindicate card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VindictiveVampire.java
+++ b/Mage.Sets/src/mage/cards/v/VindictiveVampire.java
@@ -59,7 +59,7 @@ class VindictiveVampireTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever another creature you control dies, ");
     }
 
-    public VindictiveVampireTriggeredAbility(final VindictiveVampireTriggeredAbility ability) {
+    private VindictiveVampireTriggeredAbility(final VindictiveVampireTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ViolentUltimatum.java
+++ b/Mage.Sets/src/mage/cards/v/ViolentUltimatum.java
@@ -22,7 +22,7 @@ public final class ViolentUltimatum extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPermanent(3, StaticFilters.FILTER_PERMANENTS));
     }
 
-    public ViolentUltimatum(final ViolentUltimatum card) {
+    private ViolentUltimatum(final ViolentUltimatum card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ViridescentWisps.java
+++ b/Mage.Sets/src/mage/cards/v/ViridescentWisps.java
@@ -33,7 +33,7 @@ public final class ViridescentWisps extends CardImpl {
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1).concatBy("<br>"));
     }
 
-    public ViridescentWisps(final ViridescentWisps card) {
+    private ViridescentWisps(final ViridescentWisps card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ViridianClaw.java
+++ b/Mage.Sets/src/mage/cards/v/ViridianClaw.java
@@ -39,7 +39,7 @@ public final class ViridianClaw extends CardImpl {
         this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(1), false));
     }
 
-    public ViridianClaw (final ViridianClaw card) {
+    private ViridianClaw(final ViridianClaw card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ViridianCorrupter.java
+++ b/Mage.Sets/src/mage/cards/v/ViridianCorrupter.java
@@ -35,7 +35,7 @@ public final class ViridianCorrupter extends CardImpl {
         this.addAbility(ability);
     }
 
-    public ViridianCorrupter (final ViridianCorrupter card) {
+    private ViridianCorrupter(final ViridianCorrupter card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ViridianRevel.java
+++ b/Mage.Sets/src/mage/cards/v/ViridianRevel.java
@@ -29,7 +29,7 @@ public final class ViridianRevel extends CardImpl {
         this.addAbility(new ViridianRevelTriggeredAbility());
     }
 
-    public ViridianRevel (final ViridianRevel card) {
+    private ViridianRevel(final ViridianRevel card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/Viseling.java
+++ b/Mage.Sets/src/mage/cards/v/Viseling.java
@@ -50,7 +50,7 @@ class ViselingEffect extends OneShotEffect {
         this.staticText = "{this} deals X damage to that player, where X is the number of cards in their hand minus 4";
     }
 
-    public ViselingEffect(final ViselingEffect effect) {
+    private ViselingEffect(final ViselingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VisionsOfBeyond.java
+++ b/Mage.Sets/src/mage/cards/v/VisionsOfBeyond.java
@@ -42,7 +42,7 @@ class VisionsOfBeyondEffect extends OneShotEffect {
         staticText = "Draw a card. If a graveyard has twenty or more cards in it, draw three cards instead";
     }
 
-    public VisionsOfBeyondEffect(VisionsOfBeyondEffect effect) {
+    private VisionsOfBeyondEffect(final VisionsOfBeyondEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VisionsOfBrutality.java
+++ b/Mage.Sets/src/mage/cards/v/VisionsOfBrutality.java
@@ -65,7 +65,7 @@ class VisionsOfBrutalityEffect extends OneShotEffect {
         this.staticText = "its controller loses that much life";
     }
 
-    public VisionsOfBrutalityEffect(final VisionsOfBrutalityEffect effect) {
+    private VisionsOfBrutalityEffect(final VisionsOfBrutalityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VithianRenegades.java
+++ b/Mage.Sets/src/mage/cards/v/VithianRenegades.java
@@ -32,7 +32,7 @@ public final class VithianRenegades extends CardImpl {
         this.addAbility(ability);
     }
 
-    public VithianRenegades (final VithianRenegades card) {
+    private VithianRenegades(final VithianRenegades card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VizierOfDeferment.java
+++ b/Mage.Sets/src/mage/cards/v/VizierOfDeferment.java
@@ -66,7 +66,7 @@ class VizierOfDefermentEffect extends OneShotEffect {
                 "Return that card to the battlefield under its owner's control at the beginning of the next end step";
     }
 
-    public VizierOfDefermentEffect(final VizierOfDefermentEffect effect) {
+    private VizierOfDefermentEffect(final VizierOfDefermentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VizierOfRemedies.java
+++ b/Mage.Sets/src/mage/cards/v/VizierOfRemedies.java
@@ -49,7 +49,7 @@ class VizierOfRemediesReplacementEffect extends ReplacementEffectImpl {
         staticText = "If one or more -1/-1 counters would be put on a creature you control, that many -1/-1 counters minus one are put on it instead";
     }
 
-    public VizierOfRemediesReplacementEffect(final VizierOfRemediesReplacementEffect effect) {
+    private VizierOfRemediesReplacementEffect(final VizierOfRemediesReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VizierOfTheAnointed.java
+++ b/Mage.Sets/src/mage/cards/v/VizierOfTheAnointed.java
@@ -136,7 +136,7 @@ class SearchLibraryPutInGraveyard extends SearchEffect {
         staticText = "search your library for a creature card with eternalize or embalm, put that card into your graveyard, then shuffle.";
     }
 
-    public SearchLibraryPutInGraveyard(final SearchLibraryPutInGraveyard effect) {
+    private SearchLibraryPutInGraveyard(final SearchLibraryPutInGraveyard effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VizierOfTheMenagerie.java
+++ b/Mage.Sets/src/mage/cards/v/VizierOfTheMenagerie.java
@@ -62,7 +62,7 @@ class VizierOfTheMenagerieManaEffect extends AsThoughEffectImpl implements AsTho
         staticText = "You may spend mana as though it were mana of any type to cast creature spells";
     }
 
-    public VizierOfTheMenagerieManaEffect(final VizierOfTheMenagerieManaEffect effect) {
+    private VizierOfTheMenagerieManaEffect(final VizierOfTheMenagerieManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VizierOfTheTrue.java
+++ b/Mage.Sets/src/mage/cards/v/VizierOfTheTrue.java
@@ -54,7 +54,7 @@ class VizierOfTheTrueAbility extends TriggeredAbilityImpl {
         addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
     }
 
-    public VizierOfTheTrueAbility(final VizierOfTheTrueAbility ability) {
+    private VizierOfTheTrueAbility(final VizierOfTheTrueAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VizkopaConfessor.java
+++ b/Mage.Sets/src/mage/cards/v/VizkopaConfessor.java
@@ -64,7 +64,7 @@ class VizkopaConfessorEffect extends OneShotEffect {
         this.staticText = "pay any amount of life. Target opponent reveals that many cards from their hand. You choose one of them and exile it";
     }
 
-    public VizkopaConfessorEffect(final VizkopaConfessorEffect effect) {
+    private VizkopaConfessorEffect(final VizkopaConfessorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VizkopaGuildmage.java
+++ b/Mage.Sets/src/mage/cards/v/VizkopaGuildmage.java
@@ -70,7 +70,7 @@ class VizkopaGuildmageDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new OpponentsLoseLifeEffect(), Duration.EndOfTurn, false);
     }
 
-    public VizkopaGuildmageDelayedTriggeredAbility(VizkopaGuildmageDelayedTriggeredAbility ability) {
+    private VizkopaGuildmageDelayedTriggeredAbility(final VizkopaGuildmageDelayedTriggeredAbility ability) {
         super(ability);
     }
 
@@ -105,7 +105,7 @@ class OpponentsLoseLifeEffect extends OneShotEffect {
         super(Outcome.Damage);
     }
 
-    public OpponentsLoseLifeEffect(final OpponentsLoseLifeEffect effect) {
+    private OpponentsLoseLifeEffect(final OpponentsLoseLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VodalianWarMachine.java
+++ b/Mage.Sets/src/mage/cards/v/VodalianWarMachine.java
@@ -82,7 +82,7 @@ class VodalianWarMachineEffect extends OneShotEffect {
         staticText = "destroy all " + filter.getMessage();
     }
 
-    public VodalianWarMachineEffect(final VodalianWarMachineEffect effect) {
+    private VodalianWarMachineEffect(final VodalianWarMachineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VoidMaw.java
+++ b/Mage.Sets/src/mage/cards/v/VoidMaw.java
@@ -64,7 +64,7 @@ class VoidMawEffect extends ReplacementEffectImpl {
         staticText = "If another creature would die, exile it instead";
     }
 
-    public VoidMawEffect(final VoidMawEffect effect) {
+    private VoidMawEffect(final VoidMawEffect effect) {
         super(effect);
     }
 
@@ -127,7 +127,7 @@ class VoidMawCost extends CostImpl {
         this.text = "Put a card exiled with {this} into its owner's graveyard";
     }
 
-    public VoidMawCost(VoidMawCost cost) {
+    private VoidMawCost(final VoidMawCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VoidWinnower.java
+++ b/Mage.Sets/src/mage/cards/v/VoidWinnower.java
@@ -52,7 +52,7 @@ class VoidWinnowerCantCastEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Your opponents can't cast spells with even mana values. <i>(Zero is even.)</i>";
     }
 
-    public VoidWinnowerCantCastEffect(final VoidWinnowerCantCastEffect effect) {
+    private VoidWinnowerCantCastEffect(final VoidWinnowerCantCastEffect effect) {
         super(effect);
     }
 
@@ -100,7 +100,7 @@ class VoidWinnowerCantBlockEffect extends RestrictionEffect {
         staticText = "Your opponents can't block with creatures with even mana values";
     }
 
-    public VoidWinnowerCantBlockEffect(final VoidWinnowerCantBlockEffect effect) {
+    private VoidWinnowerCantBlockEffect(final VoidWinnowerCantBlockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VoidstoneGargoyle.java
+++ b/Mage.Sets/src/mage/cards/v/VoidstoneGargoyle.java
@@ -57,7 +57,7 @@ class VoidstoneGargoyleReplacementEffect1 extends ContinuousRuleModifyingEffectI
         staticText = "Spells with the chosen name can't be cast";
     }
 
-    public VoidstoneGargoyleReplacementEffect1(final VoidstoneGargoyleReplacementEffect1 effect) {
+    private VoidstoneGargoyleReplacementEffect1(final VoidstoneGargoyleReplacementEffect1 effect) {
         super(effect);
     }
 
@@ -99,7 +99,7 @@ class VoidstoneGargoyleRuleModifyingEffect2 extends ContinuousRuleModifyingEffec
         staticText = "Activated abilities of sources with the chosen name can't be activated";
     }
 
-    public VoidstoneGargoyleRuleModifyingEffect2(final VoidstoneGargoyleRuleModifyingEffect2 effect) {
+    private VoidstoneGargoyleRuleModifyingEffect2(final VoidstoneGargoyleRuleModifyingEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/Voidwalk.java
+++ b/Mage.Sets/src/mage/cards/v/Voidwalk.java
@@ -53,7 +53,7 @@ class VoidwalkEffect extends OneShotEffect {
         staticText = "Exile target creature. Return it to the battlefield under its owner's control at the beginning of the next end step";
     }
 
-    public VoidwalkEffect(final VoidwalkEffect effect) {
+    private VoidwalkEffect(final VoidwalkEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VolcanicEruption.java
+++ b/Mage.Sets/src/mage/cards/v/VolcanicEruption.java
@@ -62,7 +62,7 @@ class VolcanicEruptionEffect extends OneShotEffect {
         this.staticText = "Destroy X target Mountains. {this} deals damage to each creature and each player equal to the number of Mountains put into a graveyard this way.";
     }
 
-    public VolcanicEruptionEffect(final VolcanicEruptionEffect effect) {
+    private VolcanicEruptionEffect(final VolcanicEruptionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VolcanicVision.java
+++ b/Mage.Sets/src/mage/cards/v/VolcanicVision.java
@@ -57,7 +57,7 @@ class VolcanicVisionReturnToHandTargetEffect extends OneShotEffect {
         staticText = "Return target instant or sorcery card from your graveyard to your hand. {this} deals damage equal to that card's mana value to each creature your opponents control";
     }
 
-    public VolcanicVisionReturnToHandTargetEffect(final VolcanicVisionReturnToHandTargetEffect effect) {
+    private VolcanicVisionReturnToHandTargetEffect(final VolcanicVisionReturnToHandTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VolcanoHellion.java
+++ b/Mage.Sets/src/mage/cards/v/VolcanoHellion.java
@@ -57,7 +57,7 @@ class VolcanoHellionEffect extends OneShotEffect {
         this.staticText = "it deals an amount of damage of your choice to you and target creature. The damage can't be prevented";
     }
 
-    public VolcanoHellionEffect(final VolcanoHellionEffect effect) {
+    private VolcanoHellionEffect(final VolcanoHellionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VolitionReins.java
+++ b/Mage.Sets/src/mage/cards/v/VolitionReins.java
@@ -57,7 +57,7 @@ public final class VolitionReins extends CardImpl {
             staticText = "if enchanted permanent is tapped, untap it";
         }
 
-        public UntapVolitionReinsEffect(final UntapVolitionReinsEffect effect) {
+        private UntapVolitionReinsEffect(final UntapVolitionReinsEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/v/VolrathsCurse.java
+++ b/Mage.Sets/src/mage/cards/v/VolrathsCurse.java
@@ -73,7 +73,7 @@ class VolrathsCurseRestrictionEffect extends RestrictionEffect {
         this.staticText = "Enchanted creature can't attack or block";
     }
 
-    public VolrathsCurseRestrictionEffect(final VolrathsCurseRestrictionEffect effect) {
+    private VolrathsCurseRestrictionEffect(final VolrathsCurseRestrictionEffect effect) {
         super(effect);
     }
 
@@ -111,7 +111,7 @@ class VolrathsCurseCantActivateAbilitiesEffect extends ContinuousRuleModifyingEf
         staticText = ", and its activated abilities can't be activated";
     }
 
-    public VolrathsCurseCantActivateAbilitiesEffect(final VolrathsCurseCantActivateAbilitiesEffect effect) {
+    private VolrathsCurseCantActivateAbilitiesEffect(final VolrathsCurseCantActivateAbilitiesEffect effect) {
         super(effect);
     }
 
@@ -155,7 +155,7 @@ class VolrathsCurseSpecialAction extends SpecialAction {
         this.setMayActivate(TargetController.CONTROLLER_ATTACHED_TO);
     }
 
-    public VolrathsCurseSpecialAction(final VolrathsCurseSpecialAction ability) {
+    private VolrathsCurseSpecialAction(final VolrathsCurseSpecialAction ability) {
         super(ability);
     }
 
@@ -172,7 +172,7 @@ class VolrathsCurseIgnoreEffect extends OneShotEffect {
         this.staticText = "That creature's controller may sacrifice a permanent for that player to ignore this effect until end of turn";
     }
 
-    public VolrathsCurseIgnoreEffect(final VolrathsCurseIgnoreEffect effect) {
+    private VolrathsCurseIgnoreEffect(final VolrathsCurseIgnoreEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VolrathsDungeon.java
+++ b/Mage.Sets/src/mage/cards/v/VolrathsDungeon.java
@@ -61,7 +61,7 @@ class VolrathsDungeonEffect extends OneShotEffect {
         this.staticText = "Target player puts a card from their hand on top of their library";
     }
 
-    public VolrathsDungeonEffect(final VolrathsDungeonEffect effect) {
+    private VolrathsDungeonEffect(final VolrathsDungeonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VolrathsShapeshifter.java
+++ b/Mage.Sets/src/mage/cards/v/VolrathsShapeshifter.java
@@ -54,7 +54,7 @@ class VolrathsShapeshifterEffect extends ContinuousEffectImpl {
                 + "({this} has that card's name, mana cost, color, types, abilities, power, and toughness.) ";
     }
 
-    public VolrathsShapeshifterEffect(final VolrathsShapeshifterEffect effect) {
+    private VolrathsShapeshifterEffect(final VolrathsShapeshifterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VolunteerReserves.java
+++ b/Mage.Sets/src/mage/cards/v/VolunteerReserves.java
@@ -33,7 +33,7 @@ public final class VolunteerReserves extends CardImpl {
         this.addAbility(new CumulativeUpkeepAbility(new ManaCostsImpl<>("{1}")));
     }
 
-    public VolunteerReserves (final VolunteerReserves card) {
+    private VolunteerReserves(final VolunteerReserves card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VonasHunger.java
+++ b/Mage.Sets/src/mage/cards/v/VonasHunger.java
@@ -64,7 +64,7 @@ class VonasHungerEffect extends OneShotEffect {
         super(Outcome.Sacrifice);
     }
 
-    public VonasHungerEffect(final VonasHungerEffect effect) {
+    private VonasHungerEffect(final VonasHungerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VorelOfTheHullClade.java
+++ b/Mage.Sets/src/mage/cards/v/VorelOfTheHullClade.java
@@ -71,7 +71,7 @@ class VorelOfTheHullCladeEffect extends OneShotEffect {
         staticText = "double the number of each kind of counter on target artifact, creature, or land";
     }
 
-    public VorelOfTheHullCladeEffect(VorelOfTheHullCladeEffect effect) {
+    private VorelOfTheHullCladeEffect(final VorelOfTheHullCladeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VorracBattlehorns.java
+++ b/Mage.Sets/src/mage/cards/v/VorracBattlehorns.java
@@ -71,7 +71,7 @@ class CantBeBlockedByMoreThanOneAttachedEffect extends ContinuousEffectImpl {
         staticText = attachmentType.verb() + " creature can't be blocked by more than " + CardUtil.numberToText(amount) + " creature" + (amount==1 ?"":"s");
     }
 
-    public CantBeBlockedByMoreThanOneAttachedEffect(final CantBeBlockedByMoreThanOneAttachedEffect effect) {
+    private CantBeBlockedByMoreThanOneAttachedEffect(final CantBeBlockedByMoreThanOneAttachedEffect effect) {
         super(effect);
         this.amount = effect.amount;
         this.attachmentType = effect.attachmentType;

--- a/Mage.Sets/src/mage/cards/v/VortexElemental.java
+++ b/Mage.Sets/src/mage/cards/v/VortexElemental.java
@@ -63,7 +63,7 @@ class VortexElementalEffect extends OneShotEffect {
         this.staticText = "Put {this} and each creature blocking or blocked by it on top of their owners' libraries, then those players shuffle";
     }
 
-    public VortexElementalEffect(final VortexElementalEffect effect) {
+    private VortexElementalEffect(final VortexElementalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VotaryOfTheConclave.java
+++ b/Mage.Sets/src/mage/cards/v/VotaryOfTheConclave.java
@@ -29,7 +29,7 @@ public final class VotaryOfTheConclave extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new ManaCostsImpl<>("{2}{G}")));
     }
 
-    public VotaryOfTheConclave (final VotaryOfTheConclave card) {
+    private VotaryOfTheConclave(final VotaryOfTheConclave card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VoyagerStaff.java
+++ b/Mage.Sets/src/mage/cards/v/VoyagerStaff.java
@@ -53,7 +53,7 @@ class VoyagerStaffEffect extends OneShotEffect {
         staticText = "exile target creature. Return the exiled card to the battlefield under its owner's control at the beginning of the next end step";
     }
 
-    public VoyagerStaffEffect(final VoyagerStaffEffect effect) {
+    private VoyagerStaffEffect(final VoyagerStaffEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VraskaRegalGorgon.java
+++ b/Mage.Sets/src/mage/cards/v/VraskaRegalGorgon.java
@@ -72,7 +72,7 @@ class VraskaRegalGorgonEffect extends OneShotEffect {
                 + "put a +1/+1 counter on each creature you control.";
     }
 
-    public VraskaRegalGorgonEffect(final VraskaRegalGorgonEffect effect) {
+    private VraskaRegalGorgonEffect(final VraskaRegalGorgonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VraskaRelicSeeker.java
+++ b/Mage.Sets/src/mage/cards/v/VraskaRelicSeeker.java
@@ -66,7 +66,7 @@ class VraskaRelicSeekerLifeTotalEffect extends OneShotEffect {
         staticText = "Target player's life total becomes 1";
     }
 
-    public VraskaRelicSeekerLifeTotalEffect(VraskaRelicSeekerLifeTotalEffect effect) {
+    private VraskaRelicSeekerLifeTotalEffect(final VraskaRelicSeekerLifeTotalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VraskaSwarmsEminence.java
+++ b/Mage.Sets/src/mage/cards/v/VraskaSwarmsEminence.java
@@ -69,7 +69,7 @@ class VraskaSwarmsEminenceTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature you control with deathtouch deals damage to a player or planeswalker, ");
     }
 
-    public VraskaSwarmsEminenceTriggeredAbility(final VraskaSwarmsEminenceTriggeredAbility ability) {
+    private VraskaSwarmsEminenceTriggeredAbility(final VraskaSwarmsEminenceTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VraskaTheUnseen.java
+++ b/Mage.Sets/src/mage/cards/v/VraskaTheUnseen.java
@@ -70,7 +70,7 @@ class VraskaTheUnseenGainAbilityEffect extends ContinuousEffectImpl {
         staticText = "Until your next turn, whenever a creature deals combat damage to {this}, destroy that creature";
     }
 
-    public VraskaTheUnseenGainAbilityEffect(final VraskaTheUnseenGainAbilityEffect effect) {
+    private VraskaTheUnseenGainAbilityEffect(final VraskaTheUnseenGainAbilityEffect effect) {
         super(effect);
         this.ability = effect.ability.copy();
     }
@@ -102,7 +102,7 @@ class VraskaTheUnseenTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect());
     }
 
-    public VraskaTheUnseenTriggeredAbility(final VraskaTheUnseenTriggeredAbility ability) {
+    private VraskaTheUnseenTriggeredAbility(final VraskaTheUnseenTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VraskasStoneglare.java
+++ b/Mage.Sets/src/mage/cards/v/VraskasStoneglare.java
@@ -56,7 +56,7 @@ class VraskasStoneglareEffect extends OneShotEffect {
                 + "You gain life equal to its toughness";
     }
 
-    public VraskasStoneglareEffect(final VraskasStoneglareEffect effect) {
+    private VraskasStoneglareEffect(final VraskasStoneglareEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VulshokBattlegear.java
+++ b/Mage.Sets/src/mage/cards/v/VulshokBattlegear.java
@@ -27,7 +27,7 @@ public final class VulshokBattlegear extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEquippedEffect(3, 3)));
     }
 
-    public VulshokBattlegear (final VulshokBattlegear card) {
+    private VulshokBattlegear(final VulshokBattlegear card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VulshokBattlemaster.java
+++ b/Mage.Sets/src/mage/cards/v/VulshokBattlemaster.java
@@ -50,7 +50,7 @@ public final class VulshokBattlemaster extends CardImpl {
             this.staticText = "attach all Equipment on the battlefield to it";
         }
 
-        public VulshokBattlemasterEffect(final VulshokBattlemasterEffect effect) {
+        private VulshokBattlemasterEffect(final VulshokBattlemasterEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/v/VulshokGauntlets.java
+++ b/Mage.Sets/src/mage/cards/v/VulshokGauntlets.java
@@ -61,7 +61,7 @@ class VulshokGauntletsEffect extends ReplacementEffectImpl {
         staticText = "Equipped creature doesn't untap during its controller's untap step";
     }
 
-    public VulshokGauntletsEffect(final VulshokGauntletsEffect effect) {
+    private VulshokGauntletsEffect(final VulshokGauntletsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VulshokHeartstoker.java
+++ b/Mage.Sets/src/mage/cards/v/VulshokHeartstoker.java
@@ -32,7 +32,7 @@ public final class VulshokHeartstoker extends CardImpl {
         this.addAbility(ability);
     }
 
-    public VulshokHeartstoker (final VulshokHeartstoker card) {
+    private VulshokHeartstoker(final VulshokHeartstoker card) {
         super(card);
     }
 


### PR DESCRIPTION
Part of #11054 

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`public ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `private $1(final $1 $3`
