### PR TITLE
Clean all copy constructors in cards starting W-X-Y-Z

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WaitingInTheWeeds.java
+++ b/Mage.Sets/src/mage/cards/w/WaitingInTheWeeds.java
@@ -53,7 +53,7 @@ class WaitingInTheWeedsEffect extends OneShotEffect {
         staticText = "Each player creates a 1/1 green Cat creature token for each untapped Forest they control";
     }
 
-    public WaitingInTheWeedsEffect(final WaitingInTheWeedsEffect effect) {
+    private WaitingInTheWeedsEffect(final WaitingInTheWeedsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WakeTheDead.java
+++ b/Mage.Sets/src/mage/cards/w/WakeTheDead.java
@@ -72,7 +72,7 @@ class WakeTheDeadReturnFromGraveyardToBattlefieldTargetEffect extends OneShotEff
         this.staticText = "Return X target creature cards from your graveyard to the battlefield. Sacrifice those creatures at the beginning of the next end step";
     }
 
-    public WakeTheDeadReturnFromGraveyardToBattlefieldTargetEffect(final WakeTheDeadReturnFromGraveyardToBattlefieldTargetEffect effect) {
+    private WakeTheDeadReturnFromGraveyardToBattlefieldTargetEffect(final WakeTheDeadReturnFromGraveyardToBattlefieldTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WakeThrasher.java
+++ b/Mage.Sets/src/mage/cards/w/WakeThrasher.java
@@ -52,7 +52,7 @@ class BecomesUntappedControlledPermanentTriggeredAbility extends TriggeredAbilit
         setTriggerPhrase("Whenever a permanent you control becomes untapped, ");
     }
 
-    public BecomesUntappedControlledPermanentTriggeredAbility(final BecomesUntappedControlledPermanentTriggeredAbility ability) {
+    private BecomesUntappedControlledPermanentTriggeredAbility(final BecomesUntappedControlledPermanentTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WakingNightmare.java
+++ b/Mage.Sets/src/mage/cards/w/WakingNightmare.java
@@ -25,7 +25,7 @@ public final class WakingNightmare extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPlayer());
     }
 
-    public WakingNightmare (final WakingNightmare card) {
+    private WakingNightmare(final WakingNightmare card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WalkingDesecration.java
+++ b/Mage.Sets/src/mage/cards/w/WalkingDesecration.java
@@ -55,7 +55,7 @@ class WalkingDesecrationEffect extends OneShotEffect {
         staticText = "Creatures of the creature type of your choice attack this turn if able";
     }
 
-    public WalkingDesecrationEffect(final WalkingDesecrationEffect effect) {
+    private WalkingDesecrationEffect(final WalkingDesecrationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfCaltrops.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfCaltrops.java
@@ -59,7 +59,7 @@ class WallOfCaltropsAbility extends BlocksCreatureTriggeredAbility {
         super(new GainAbilitySourceEffect(BandingAbility.getInstance(), Duration.EndOfTurn));
     }
 
-    public WallOfCaltropsAbility(WallOfCaltropsAbility ability) {
+    private WallOfCaltropsAbility(final WallOfCaltropsAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfDeceit.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfDeceit.java
@@ -57,7 +57,7 @@ class WallOfDeceitEffect extends OneShotEffect {
         this.staticText = "Turn {this} face down";
     }
 
-    public WallOfDeceitEffect(final WallOfDeceitEffect effect) {
+    private WallOfDeceitEffect(final WallOfDeceitEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfDenial.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfDenial.java
@@ -30,7 +30,7 @@ public final class WallOfDenial extends CardImpl {
         this.addAbility(ShroudAbility.getInstance());
     }
 
-    public WallOfDenial (final WallOfDenial card) {
+    private WallOfDenial(final WallOfDenial card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfDust.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfDust.java
@@ -54,7 +54,7 @@ class WallOfDustRestrictionEffect extends RestrictionEffect {
         staticText = "that creature can't attack during its controller's next turn";
     }
 
-    public WallOfDustRestrictionEffect(final WallOfDustRestrictionEffect effect) {
+    private WallOfDustRestrictionEffect(final WallOfDustRestrictionEffect effect) {
         super(effect);
         this.targetPermanentReference = effect.targetPermanentReference;
     }

--- a/Mage.Sets/src/mage/cards/w/WallOfEssence.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfEssence.java
@@ -55,7 +55,7 @@ class WallOfEssenceTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} is dealt combat damage, ");
     }
 
-    public WallOfEssenceTriggeredAbility(final WallOfEssenceTriggeredAbility effect) {
+    private WallOfEssenceTriggeredAbility(final WallOfEssenceTriggeredAbility effect) {
         super(effect);
     }
 
@@ -91,7 +91,7 @@ class PiousWarriorGainLifeEffect extends OneShotEffect {
         staticText = "you gain that much life";
     }
 
-    public PiousWarriorGainLifeEffect(final PiousWarriorGainLifeEffect effect) {
+    private PiousWarriorGainLifeEffect(final PiousWarriorGainLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfHope.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfHope.java
@@ -54,7 +54,7 @@ class WallOfHopeTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} is dealt damage, ");
     }
 
-    public WallOfHopeTriggeredAbility(final WallOfHopeTriggeredAbility effect) {
+    private WallOfHopeTriggeredAbility(final WallOfHopeTriggeredAbility effect) {
         super(effect);
     }
 
@@ -85,7 +85,7 @@ class WallOfHopeGainLifeEffect extends OneShotEffect {
         staticText = "you gain that much life";
     }
 
-    public WallOfHopeGainLifeEffect(final WallOfHopeGainLifeEffect effect) {
+    private WallOfHopeGainLifeEffect(final WallOfHopeGainLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfReverence.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfReverence.java
@@ -39,7 +39,7 @@ public final class WallOfReverence extends CardImpl {
         this.addAbility(ability);
     }
 
-    public WallOfReverence (final WallOfReverence card) {
+    private WallOfReverence(final WallOfReverence card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfShields.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfShields.java
@@ -31,7 +31,7 @@ public final class WallOfShields extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public WallOfShields (final WallOfShields card) {
+    private WallOfShields(final WallOfShields card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfSouls.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfSouls.java
@@ -55,7 +55,7 @@ class WallOfSoulsTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} is dealt combat damage, ");
     }
 
-    public WallOfSoulsTriggeredAbility(final WallOfSoulsTriggeredAbility effect) {
+    private WallOfSoulsTriggeredAbility(final WallOfSoulsTriggeredAbility effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfStolenIdentity.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfStolenIdentity.java
@@ -71,7 +71,7 @@ class WallOfStolenIdentityCopyEffect extends OneShotEffect {
         staticText = rule2;
     }
 
-    public WallOfStolenIdentityCopyEffect(final WallOfStolenIdentityCopyEffect effect) {
+    private WallOfStolenIdentityCopyEffect(final WallOfStolenIdentityCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfTanglecord.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfTanglecord.java
@@ -33,7 +33,7 @@ public final class WallOfTanglecord extends CardImpl {
                 new ManaCostsImpl<>("{G}")));
     }
 
-    public WallOfTanglecord (final WallOfTanglecord card) {
+    private WallOfTanglecord(final WallOfTanglecord card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfTombstones.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfTombstones.java
@@ -53,7 +53,7 @@ class WallOfTombstonesEffect extends OneShotEffect {
         this.staticText = "change {this}'s base toughness to 1 plus the number of creature cards in your graveyard";
     }
 
-    public WallOfTombstonesEffect(final WallOfTombstonesEffect effect) {
+    private WallOfTombstonesEffect(final WallOfTombstonesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfVipers.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfVipers.java
@@ -63,7 +63,7 @@ class WallOfVipersFilter extends FilterCreaturePermanent {
         super("creature {this} is blocking");
     }
     
-    public WallOfVipersFilter(final WallOfVipersFilter filter) {
+    private WallOfVipersFilter(final WallOfVipersFilter filter) {
         super(filter);
     }
     

--- a/Mage.Sets/src/mage/cards/w/WandOfDenial.java
+++ b/Mage.Sets/src/mage/cards/w/WandOfDenial.java
@@ -50,7 +50,7 @@ class WandOfDenialEffect extends OneShotEffect {
         this.staticText = "Look at the top card of target player's library. If it's a nonland card, you may pay 2 life. If you do, put it into that player's graveyard.";
     }
     
-    public WandOfDenialEffect(final WandOfDenialEffect effect) {
+    private WandOfDenialEffect(final WandOfDenialEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WandOfIth.java
+++ b/Mage.Sets/src/mage/cards/w/WandOfIth.java
@@ -52,7 +52,7 @@ class WandOfIthEffect extends OneShotEffect {
         staticText = "Target player reveals a card at random from their hand. If it's a land card, that player discards it unless they pay 1 life. If it isn't a land card, the player discards it unless they pay life equal to its mana value";
     }
 
-    public WandOfIthEffect(final WandOfIthEffect effect) {
+    private WandOfIthEffect(final WandOfIthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WanderingFumarole.java
+++ b/Mage.Sets/src/mage/cards/w/WanderingFumarole.java
@@ -64,7 +64,7 @@ class WanderingFumaroleToken extends TokenImpl {
         toughness = new MageInt(4);
         addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SwitchPowerToughnessSourceEffect(Duration.EndOfTurn), new ManaCostsImpl<>("{0}")));
     }
-    public WanderingFumaroleToken(final WanderingFumaroleToken token) {
+    private WanderingFumaroleToken(final WanderingFumaroleToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WanderingMage.java
+++ b/Mage.Sets/src/mage/cards/w/WanderingMage.java
@@ -88,7 +88,7 @@ class WanderingMageCost extends CostImpl {
         this.text = "Put a -1/-1 counter on a creature you control";
     }
 
-    public WanderingMageCost(WanderingMageCost cost) {
+    private WanderingMageCost(final WanderingMageCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WanderingOnes.java
+++ b/Mage.Sets/src/mage/cards/w/WanderingOnes.java
@@ -23,7 +23,7 @@ public final class WanderingOnes extends CardImpl {
         this.toughness = new MageInt(1);
     }
 
-    public WanderingOnes (final WanderingOnes card) {
+    private WanderingOnes(final WanderingOnes card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarElemental.java
+++ b/Mage.Sets/src/mage/cards/w/WarElemental.java
@@ -59,7 +59,7 @@ class WarElementalTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new WarElementalEffect(), false);
     }
 
-    public WarElementalTriggeredAbility(final WarElementalTriggeredAbility ability) {
+    private WarElementalTriggeredAbility(final WarElementalTriggeredAbility ability) {
         super(ability);
     }
 
@@ -94,7 +94,7 @@ class WarElementalEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public WarElementalEffect(final WarElementalEffect effect) {
+    private WarElementalEffect(final WarElementalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarElephant.java
+++ b/Mage.Sets/src/mage/cards/w/WarElephant.java
@@ -31,7 +31,7 @@ public final class WarElephant extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public WarElephant (final WarElephant card) {
+    private WarElephant(final WarElephant card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarFalcon.java
+++ b/Mage.Sets/src/mage/cards/w/WarFalcon.java
@@ -62,7 +62,7 @@ class WarFalconEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless you control a Knight or a Soldier";
     }
 
-    public WarFalconEffect(final WarFalconEffect effect) {
+    private WarFalconEffect(final WarFalconEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarReport.java
+++ b/Mage.Sets/src/mage/cards/w/WarReport.java
@@ -42,7 +42,7 @@ class WarReportEffect extends OneShotEffect {
         staticText = "You gain life equal to the number of creatures on the battlefield plus the number of artifacts on the battlefield";
     }
 
-    public WarReportEffect(final WarReportEffect effect) {
+    private WarReportEffect(final WarReportEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarRoomStarWars.java
+++ b/Mage.Sets/src/mage/cards/w/WarRoomStarWars.java
@@ -48,7 +48,7 @@ public class WarRoomStarWars extends CardImpl {
         this.addAbility(limitedTimesPerTurnActivatedAbility, new AttackedOrBlockedThisCombatWatcher());
     }
 
-    public WarRoomStarWars(final WarRoomStarWars card) {
+    private WarRoomStarWars(final WarRoomStarWars card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WardOfBones.java
+++ b/Mage.Sets/src/mage/cards/w/WardOfBones.java
@@ -55,7 +55,7 @@ class WardOfBonesEffect extends ContinuousRuleModifyingEffectImpl {
                 + "Each opponent who controls more lands than you can't play lands.";
     }
 
-    public WardOfBonesEffect(final WardOfBonesEffect effect) {
+    private WardOfBonesEffect(final WardOfBonesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WardOfPiety.java
+++ b/Mage.Sets/src/mage/cards/w/WardOfPiety.java
@@ -65,7 +65,7 @@ class WardOfPietyPreventDamageTargetEffect extends RedirectionEffect {
         staticText = "The next 1 damage that would be dealt to enchanted creature this turn is dealt to any target instead";
     }
 
-    public WardOfPietyPreventDamageTargetEffect(final WardOfPietyPreventDamageTargetEffect effect) {
+    private WardOfPietyPreventDamageTargetEffect(final WardOfPietyPreventDamageTargetEffect effect) {
         super(effect);
         this.redirectToObject = effect.redirectToObject;
     }

--- a/Mage.Sets/src/mage/cards/w/WardSliver.java
+++ b/Mage.Sets/src/mage/cards/w/WardSliver.java
@@ -66,7 +66,7 @@ class WardSliverGainAbilityControlledEffect extends ContinuousEffectImpl {
         staticText = "all Slivers have protection from the chosen color";
     }
 
-    public WardSliverGainAbilityControlledEffect(final WardSliverGainAbilityControlledEffect effect) {
+    private WardSliverGainAbilityControlledEffect(final WardSliverGainAbilityControlledEffect effect) {
         super(effect);
         protectionFilter = effect.protectionFilter;
     }

--- a/Mage.Sets/src/mage/cards/w/WardenOfTheWall.java
+++ b/Mage.Sets/src/mage/cards/w/WardenOfTheWall.java
@@ -63,7 +63,7 @@ class GargoyleToken extends TokenImpl {
         addAbility(FlyingAbility.getInstance());
     }
 
-    public GargoyleToken(final GargoyleToken token) {
+    private GargoyleToken(final GargoyleToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WardscaleDragon.java
+++ b/Mage.Sets/src/mage/cards/w/WardscaleDragon.java
@@ -55,7 +55,7 @@ class WardscaleDragonRuleEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "As long as {this} is attacking, defending player can't cast spells";
     }
 
-    public WardscaleDragonRuleEffect(final WardscaleDragonRuleEffect effect) {
+    private WardscaleDragonRuleEffect(final WardscaleDragonRuleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarmongersChariot.java
+++ b/Mage.Sets/src/mage/cards/w/WarmongersChariot.java
@@ -51,7 +51,7 @@ class WarmongersChariotEffect extends AsThoughEffectImpl {
         staticText = "As long as equipped creature has defender, it can attack as though it didn't have defender";
     }
 
-    public WarmongersChariotEffect(final WarmongersChariotEffect effect) {
+    private WarmongersChariotEffect(final WarmongersChariotEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarpWorld.java
+++ b/Mage.Sets/src/mage/cards/w/WarpWorld.java
@@ -52,7 +52,7 @@ class WarpWorldEffect extends OneShotEffect {
         this.staticText = "Each player shuffles all permanents they own into their library, then reveals that many cards from the top of their library. Each player puts all artifact, creature, and land cards revealed this way onto the battlefield, then does the same for enchantment cards, then puts all cards revealed this way that weren't put onto the battlefield on the bottom of their library";
     }
 
-    public WarpWorldEffect(final WarpWorldEffect effect) {
+    private WarpWorldEffect(final WarpWorldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarpedDevotion.java
+++ b/Mage.Sets/src/mage/cards/w/WarpedDevotion.java
@@ -43,7 +43,7 @@ class WarpedDevotionTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DiscardTargetEffect(1), false);
     }
 
-    public WarpedDevotionTriggeredAbility(final WarpedDevotionTriggeredAbility ability) {
+    private WarpedDevotionTriggeredAbility(final WarpedDevotionTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarrenPilferers.java
+++ b/Mage.Sets/src/mage/cards/w/WarrenPilferers.java
@@ -53,7 +53,7 @@ class WarrenPilferersReturnEffect extends OneShotEffect {
         staticText = "return target creature card from your graveyard to your hand. If that card is a Goblin card, Warren Pilferers gains haste until end of turn";
     }
 
-    public WarrenPilferersReturnEffect(final WarrenPilferersReturnEffect effect) {
+    private WarrenPilferersReturnEffect(final WarrenPilferersReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarsToll.java
+++ b/Mage.Sets/src/mage/cards/w/WarsToll.java
@@ -53,7 +53,7 @@ class WarsTollTapEffect extends OneShotEffect {
         staticText = "tap all lands that player controls";
     }
 
-    public WarsTollTapEffect(final WarsTollTapEffect effect) {
+    private WarsTollTapEffect(final WarsTollTapEffect effect) {
         super(effect);
     }
 
@@ -81,7 +81,7 @@ class WarsTollAttackRestrictionEffect extends RestrictionEffect {
         staticText = "If a creature an opponent controls attacks, all creatures that opponent controls attack if able";
     }
 
-    public WarsTollAttackRestrictionEffect(final WarsTollAttackRestrictionEffect effect) {
+    private WarsTollAttackRestrictionEffect(final WarsTollAttackRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarstormSurge.java
+++ b/Mage.Sets/src/mage/cards/w/WarstormSurge.java
@@ -47,7 +47,7 @@ class WarstormSurgeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new WarstormSurgeEffect(), false);
     }
 
-    public WarstormSurgeTriggeredAbility(WarstormSurgeTriggeredAbility ability) {
+    private WarstormSurgeTriggeredAbility(final WarstormSurgeTriggeredAbility ability) {
         super(ability);
     }
 
@@ -87,7 +87,7 @@ class WarstormSurgeEffect extends OneShotEffect {
         staticText = "it deals damage equal to its power to any target";
     }
 
-    public WarstormSurgeEffect(final WarstormSurgeEffect effect) {
+    private WarstormSurgeEffect(final WarstormSurgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WashOut.java
+++ b/Mage.Sets/src/mage/cards/w/WashOut.java
@@ -49,7 +49,7 @@ class WashOutEffect extends OneShotEffect {
         staticText = "Return all permanents of the color of your choice to their owners' hands";
     }
 
-    public WashOutEffect(final WashOutEffect effect) {
+    private WashOutEffect(final WashOutEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WasitoraNekoruQueen.java
+++ b/Mage.Sets/src/mage/cards/w/WasitoraNekoruQueen.java
@@ -64,7 +64,7 @@ class WasitoraNekoruQueenEffect extends OneShotEffect {
         staticText = "that player sacrifices a creature. If the player can't, you create a 3/3 black, red, and green Cat Dragon creature token with flying";
     }
 
-    public WasitoraNekoruQueenEffect(final WasitoraNekoruQueenEffect effect) {
+    private WasitoraNekoruQueenEffect(final WasitoraNekoruQueenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Watchdog.java
+++ b/Mage.Sets/src/mage/cards/w/Watchdog.java
@@ -55,7 +55,7 @@ class WatchdogFilter extends FilterAttackingCreature {
         super("creatures attacking you");
     }
 
-    public WatchdogFilter(final WatchdogFilter filter) {
+    private WatchdogFilter(final WatchdogFilter filter) {
         super(filter);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WatchersOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/w/WatchersOfTheDead.java
@@ -54,7 +54,7 @@ class WatchersOfTheDeadEffect extends OneShotEffect {
         this.staticText = "Each opponent chooses 2 cards in their graveyard and exiles the rest";
     }
 
-    public WatchersOfTheDeadEffect(final WatchersOfTheDeadEffect effect) {
+    private WatchersOfTheDeadEffect(final WatchersOfTheDeadEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Watchwolf.java
+++ b/Mage.Sets/src/mage/cards/w/Watchwolf.java
@@ -24,7 +24,7 @@ public final class Watchwolf extends CardImpl {
         this.toughness = new MageInt(3);
     }
 
-    public Watchwolf (final Watchwolf card) {
+    private Watchwolf(final Watchwolf card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WaveOfReckoning.java
+++ b/Mage.Sets/src/mage/cards/w/WaveOfReckoning.java
@@ -43,7 +43,7 @@ class WaveOfReckoningDamageEffect extends OneShotEffect {
             staticText = "each creature deals damage to itself equal to its power";
         }
 
-        public WaveOfReckoningDamageEffect(final WaveOfReckoningDamageEffect effect) {
+        private WaveOfReckoningDamageEffect(final WaveOfReckoningDamageEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/w/WaveOfVitriol.java
+++ b/Mage.Sets/src/mage/cards/w/WaveOfVitriol.java
@@ -64,7 +64,7 @@ class WaveOfVitriolEffect extends OneShotEffect {
         this.staticText = "Each player sacrifices all artifacts, enchantments, and nonbasic lands they control. For each land sacrificed this way, its controller may search their library for a basic land card and put it onto the battlefield tapped. Then each player who searched their library this way shuffles";
     }
 
-    public WaveOfVitriolEffect(final WaveOfVitriolEffect effect) {
+    private WaveOfVitriolEffect(final WaveOfVitriolEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WaveskimmerAven.java
+++ b/Mage.Sets/src/mage/cards/w/WaveskimmerAven.java
@@ -29,7 +29,7 @@ public final class WaveskimmerAven extends CardImpl {
         this.addAbility(new ExaltedAbility());
     }
 
-    public WaveskimmerAven (final WaveskimmerAven card) {
+    private WaveskimmerAven(final WaveskimmerAven card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Waylay.java
+++ b/Mage.Sets/src/mage/cards/w/Waylay.java
@@ -49,7 +49,7 @@ class WaylayEffect extends OneShotEffect {
         this.staticText = "Create three 2/2 white Knight creature tokens. Exile them at the beginning of the next cleanup step.";
     }
 
-    public WaylayEffect(final WaylayEffect effect) {
+    private WaylayEffect(final WaylayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WebOfInertia.java
+++ b/Mage.Sets/src/mage/cards/w/WebOfInertia.java
@@ -47,7 +47,7 @@ class WebOfInertiaEffect extends OneShotEffect {
         this.staticText = "that player may exile a card from their graveyard. If the player doesn't, creatures they control can't attack you this turn";
     }
 
-    public WebOfInertiaEffect(final WebOfInertiaEffect effect) {
+    private WebOfInertiaEffect(final WebOfInertiaEffect effect) {
         super(effect);
     }
 
@@ -87,7 +87,7 @@ class WebOfInertiaRestrictionEffect extends RestrictionEffect {
         this.attackerID = attackerID;
     }
 
-    public WebOfInertiaRestrictionEffect(final WebOfInertiaRestrictionEffect effect) {
+    private WebOfInertiaRestrictionEffect(final WebOfInertiaRestrictionEffect effect) {
         super(effect);
         this.attackerID = effect.attackerID;
     }

--- a/Mage.Sets/src/mage/cards/w/WeedStrangle.java
+++ b/Mage.Sets/src/mage/cards/w/WeedStrangle.java
@@ -47,7 +47,7 @@ class WeedStrangleEffect extends OneShotEffect {
         this.staticText = "Destroy target creature. Clash with an opponent. If you win, you gain life equal to that creature's toughness";
     }
 
-    public WeedStrangleEffect(final WeedStrangleEffect effect) {
+    private WeedStrangleEffect(final WeedStrangleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WeirdHarvest.java
+++ b/Mage.Sets/src/mage/cards/w/WeirdHarvest.java
@@ -48,7 +48,7 @@ class WeirdHarvestEffect extends OneShotEffect {
         this.staticText = "each player may search their library for up to X creature cards, reveal those cards, put them into their hand, then shuffle";
     }
 
-    public WeirdHarvestEffect(final WeirdHarvestEffect effect) {
+    private WeirdHarvestEffect(final WeirdHarvestEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WeldingJar.java
+++ b/Mage.Sets/src/mage/cards/w/WeldingJar.java
@@ -26,7 +26,7 @@ public final class WeldingJar extends CardImpl {
         this.addAbility(ability);
     }
 
-    public WeldingJar (final WeldingJar card) {
+    private WeldingJar(final WeldingJar card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WelkinTern.java
+++ b/Mage.Sets/src/mage/cards/w/WelkinTern.java
@@ -29,7 +29,7 @@ public final class WelkinTern extends CardImpl {
          this.addAbility(new CanBlockOnlyFlyingAbility());
     }
 
-    public WelkinTern (final WelkinTern card) {
+    private WelkinTern(final WelkinTern card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WellLaidPlans.java
+++ b/Mage.Sets/src/mage/cards/w/WellLaidPlans.java
@@ -44,7 +44,7 @@ class WellLaidPlansPreventionEffect extends PreventionEffectImpl {
         this.staticText = "Prevent all damage that would be dealt to a creature by another creature if they share a color";
     }
 
-    public WellLaidPlansPreventionEffect(final WellLaidPlansPreventionEffect effect) {
+    private WellLaidPlansPreventionEffect(final WellLaidPlansPreventionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WellOfKnowledge.java
+++ b/Mage.Sets/src/mage/cards/w/WellOfKnowledge.java
@@ -44,7 +44,7 @@ class WellOfKnowledgeConditionalActivatedAbility extends ActivatedAbilityImpl {
         condition = new IsStepCondition(PhaseStep.DRAW, false);
     }
 
-    public WellOfKnowledgeConditionalActivatedAbility(final WellOfKnowledgeConditionalActivatedAbility ability) {
+    private WellOfKnowledgeConditionalActivatedAbility(final WellOfKnowledgeConditionalActivatedAbility ability) {
         super(ability);
         this.condition = ability.condition;
     }
@@ -86,7 +86,7 @@ class WellOfKnowledgeEffect extends OneShotEffect {
         super(Outcome.DrawCard);
     }
 
-    public WellOfKnowledgeEffect(final WellOfKnowledgeEffect effect) {
+    private WellOfKnowledgeEffect(final WellOfKnowledgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WellOfLostDreams.java
+++ b/Mage.Sets/src/mage/cards/w/WellOfLostDreams.java
@@ -43,7 +43,7 @@ class WellOfLostDreamsEffect extends OneShotEffect {
         this.staticText = "you may pay {X}, where X is less than or equal to the amount of life you gained. If you do, draw X cards";
     }
 
-    public WellOfLostDreamsEffect(final WellOfLostDreamsEffect effect) {
+    private WellOfLostDreamsEffect(final WellOfLostDreamsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WheelOfSunAndMoon.java
+++ b/Mage.Sets/src/mage/cards/w/WheelOfSunAndMoon.java
@@ -63,7 +63,7 @@ class WheelOfSunAndMoonEffect extends ReplacementEffectImpl {
         staticText = "If a card would be put into enchanted player's graveyard from anywhere, instead that card is revealed and put on the bottom of that player's library";
     }
 
-    public WheelOfSunAndMoonEffect(final WheelOfSunAndMoonEffect effect) {
+    private WheelOfSunAndMoonEffect(final WheelOfSunAndMoonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WhenFluffyBunniesAttack.java
+++ b/Mage.Sets/src/mage/cards/w/WhenFluffyBunniesAttack.java
@@ -52,7 +52,7 @@ class WhenFluffyBunniesAttackEffect extends OneShotEffect {
         staticText = "Target creature gets -X/-X until end of turn, where X is the number of times the letter of your choice appears in that creature's name";
     }
 
-    public WhenFluffyBunniesAttackEffect(final WhenFluffyBunniesAttackEffect effect) {
+    private WhenFluffyBunniesAttackEffect(final WhenFluffyBunniesAttackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WhimsOfTheFates.java
+++ b/Mage.Sets/src/mage/cards/w/WhimsOfTheFates.java
@@ -50,7 +50,7 @@ class WhimsOfTheFateEffect extends OneShotEffect {
         this.staticText = "Starting with you, each player separates all permanents they control into three piles. Then each player chooses one of their piles at random and sacrifices those permanents.";
     }
 
-    public WhimsOfTheFateEffect(final WhimsOfTheFateEffect effect) {
+    private WhimsOfTheFateEffect(final WhimsOfTheFateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Whipkeeper.java
+++ b/Mage.Sets/src/mage/cards/w/Whipkeeper.java
@@ -53,7 +53,7 @@ class WhipkeeperEffect extends OneShotEffect {
         super(Outcome.Damage);
         staticText = "{this} deals damage to target creature equal to the damage already dealt to it this turn.";
     }
-    public WhipkeeperEffect(final WhipkeeperEffect effect) {
+    private WhipkeeperEffect(final WhipkeeperEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/w/WhiptongueHydra.java
+++ b/Mage.Sets/src/mage/cards/w/WhiptongueHydra.java
@@ -63,7 +63,7 @@ class WhiptongueHydraEffect extends OneShotEffect {
                 + "Put a +1/+1 counter on {this} for each creature destroyed this way";
     }
 
-    public WhiptongueHydraEffect(final WhiptongueHydraEffect effect) {
+    private WhiptongueHydraEffect(final WhiptongueHydraEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WhirlpoolWarrior.java
+++ b/Mage.Sets/src/mage/cards/w/WhirlpoolWarrior.java
@@ -62,7 +62,7 @@ class WhirlpoolWarriorActivatedEffect extends OneShotEffect {
         this.staticText = "Each player shuffles the cards from their hand into their library, then draws that many cards";
     }
 
-    public WhirlpoolWarriorActivatedEffect(final WhirlpoolWarriorActivatedEffect effect) {
+    private WhirlpoolWarriorActivatedEffect(final WhirlpoolWarriorActivatedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WhirlpoolWhelm.java
+++ b/Mage.Sets/src/mage/cards/w/WhirlpoolWhelm.java
@@ -46,7 +46,7 @@ class WhirlpoolWhelmEffect extends OneShotEffect {
         this.staticText = "Clash with an opponent, then return target creature to its owner's hand. If you win, you may put that creature on top of its owner's library instead";
     }
 
-    public WhirlpoolWhelmEffect(final WhirlpoolWhelmEffect effect) {
+    private WhirlpoolWhelmEffect(final WhirlpoolWhelmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WhisperingSnitch.java
+++ b/Mage.Sets/src/mage/cards/w/WhisperingSnitch.java
@@ -54,7 +54,7 @@ class WhisperingSnitchTriggeredAbility extends TriggeredAbilityImpl {
         this.addWatcher(new WhisperingSnitchWatcher());
     }
 
-    public WhisperingSnitchTriggeredAbility(final WhisperingSnitchTriggeredAbility ability) {
+    private WhisperingSnitchTriggeredAbility(final WhisperingSnitchTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WhiteSunsZenith.java
+++ b/Mage.Sets/src/mage/cards/w/WhiteSunsZenith.java
@@ -24,7 +24,7 @@ public final class WhiteSunsZenith extends CardImpl {
         this.getSpellAbility().addEffect(ShuffleSpellEffect.getInstance());
     }
 
-    public WhiteSunsZenith (final WhiteSunsZenith card) {
+    private WhiteSunsZenith(final WhiteSunsZenith card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WhitesunsPassage.java
+++ b/Mage.Sets/src/mage/cards/w/WhitesunsPassage.java
@@ -20,7 +20,7 @@ public final class WhitesunsPassage extends CardImpl {
         this.getSpellAbility().addEffect(new GainLifeEffect(5));
     }
 
-    public WhitesunsPassage (final WhitesunsPassage card) {
+    private WhitesunsPassage(final WhitesunsPassage card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WickedReward.java
+++ b/Mage.Sets/src/mage/cards/w/WickedReward.java
@@ -24,7 +24,7 @@ public final class WickedReward extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public WickedReward(WickedReward other) {
+    private WickedReward(final WickedReward other) {
         super(other);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WidespreadPanic.java
+++ b/Mage.Sets/src/mage/cards/w/WidespreadPanic.java
@@ -48,7 +48,7 @@ class WidespreadPanicTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a spell or ability causes its controller to shuffle their library, ");
     }
 
-    public WidespreadPanicTriggeredAbility(final WidespreadPanicTriggeredAbility ability) {
+    private WidespreadPanicTriggeredAbility(final WidespreadPanicTriggeredAbility ability) {
         super(ability);
     }
 
@@ -82,7 +82,7 @@ class WidespreadPanicEffect extends OneShotEffect {
         this.staticText = "that player puts a card from their hand on top of their library";
     }
 
-    public WidespreadPanicEffect(final WidespreadPanicEffect effect) {
+    private WidespreadPanicEffect(final WidespreadPanicEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildDefiance.java
+++ b/Mage.Sets/src/mage/cards/w/WildDefiance.java
@@ -45,7 +45,7 @@ class CreaturesYouControlBecomesTargetTriggeredAbility extends TriggeredAbilityI
         super(Zone.BATTLEFIELD, effect);
     }
 
-    public CreaturesYouControlBecomesTargetTriggeredAbility(final CreaturesYouControlBecomesTargetTriggeredAbility ability) {
+    private CreaturesYouControlBecomesTargetTriggeredAbility(final CreaturesYouControlBecomesTargetTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildDogs.java
+++ b/Mage.Sets/src/mage/cards/w/WildDogs.java
@@ -58,7 +58,7 @@ class WildDogsEffect extends OneShotEffect {
         this.staticText = "the player with the most life gains control of {this}";
     }
 
-    public WildDogsEffect(final WildDogsEffect effect) {
+    private WildDogsEffect(final WildDogsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildEvocation.java
+++ b/Mage.Sets/src/mage/cards/w/WildEvocation.java
@@ -55,7 +55,7 @@ class WildEvocationEffect extends OneShotEffect {
                 + "Otherwise, the player casts it without paying its mana cost if able";
     }
 
-    public WildEvocationEffect(final WildEvocationEffect effect) {
+    private WildEvocationEffect(final WildEvocationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildMagicSorcerer.java
+++ b/Mage.Sets/src/mage/cards/w/WildMagicSorcerer.java
@@ -58,7 +58,7 @@ class WildMagicSorcererGainCascadeFirstSpellCastFromExileEffect extends Continuo
         staticText = "The first spell you cast from exile each turn has cascade";
     }
 
-    public WildMagicSorcererGainCascadeFirstSpellCastFromExileEffect(final WildMagicSorcererGainCascadeFirstSpellCastFromExileEffect effect) {
+    private WildMagicSorcererGainCascadeFirstSpellCastFromExileEffect(final WildMagicSorcererGainCascadeFirstSpellCastFromExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildMammoth.java
+++ b/Mage.Sets/src/mage/cards/w/WildMammoth.java
@@ -54,7 +54,7 @@ class WildMammothEffect extends OneShotEffect {
         this.staticText = "if a player controls more creatures than each other player, the player who controls the most creatures gains control of {this}";
     }
 
-    public WildMammothEffect(final WildMammothEffect effect) {
+    private WildMammothEffect(final WildMammothEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildPair.java
+++ b/Mage.Sets/src/mage/cards/w/WildPair.java
@@ -63,7 +63,7 @@ class WildPairEffect extends OneShotEffect {
         this.staticText = "search your library for a creature card with the same total power and toughness and put it onto the battlefield";
     }
 
-    public WildPairEffect(final WildPairEffect effect) {
+    private WildPairEffect(final WildPairEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildSwing.java
+++ b/Mage.Sets/src/mage/cards/w/WildSwing.java
@@ -55,7 +55,7 @@ class WildSwingEffect extends OneShotEffect {
         this.staticText = "Choose three target nonenchantment permanents. Destroy one of them at random";
     }
 
-    public WildSwingEffect(final WildSwingEffect effect) {
+    private WildSwingEffect(final WildSwingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildWurm.java
+++ b/Mage.Sets/src/mage/cards/w/WildWurm.java
@@ -49,7 +49,7 @@ class WildWurmEffect extends OneShotEffect {
         staticText = "flip a coin. If you lose the flip, return {this} to its owner's hand";
     }
 
-    public WildWurmEffect(WildWurmEffect effect) {
+    private WildWurmEffect(final WildWurmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Wildcall.java
+++ b/Mage.Sets/src/mage/cards/w/Wildcall.java
@@ -48,7 +48,7 @@ class WildcallEffect extends OneShotEffect {
         this.staticText = "Manifest the top card of your library, then put X +1/+1 counters on it";
     }
 
-    public WildcallEffect(final WildcallEffect effect) {
+    private WildcallEffect(final WildcallEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildfieldBorderpost.java
+++ b/Mage.Sets/src/mage/cards/w/WildfieldBorderpost.java
@@ -48,7 +48,7 @@ public final class WildfieldBorderpost extends CardImpl {
         this.addAbility(new WhiteManaAbility());
     }
 
-    public WildfieldBorderpost (final WildfieldBorderpost card) {
+    private WildfieldBorderpost(final WildfieldBorderpost card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildwoodEscort.java
+++ b/Mage.Sets/src/mage/cards/w/WildwoodEscort.java
@@ -66,7 +66,7 @@ class WildwoodEscortEffect extends ReplacementEffectImpl {
         staticText = "if {this} would die, exile it instead";
     }
 
-    public WildwoodEscortEffect(final WildwoodEscortEffect effect) {
+    private WildwoodEscortEffect(final WildwoodEscortEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WillingTestSubject.java
+++ b/Mage.Sets/src/mage/cards/w/WillingTestSubject.java
@@ -62,7 +62,7 @@ class WillingTestSubjectTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()));
     }
 
-    public WillingTestSubjectTriggeredAbility(final WillingTestSubjectTriggeredAbility ability) {
+    private WillingTestSubjectTriggeredAbility(final WillingTestSubjectTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WindZendikon.java
+++ b/Mage.Sets/src/mage/cards/w/WindZendikon.java
@@ -67,7 +67,7 @@ public final class WindZendikon extends CardImpl {
             toughness = new MageInt(2);
             addAbility(FlyingAbility.getInstance());
         }
-        public WindZendikonElementalToken(final WindZendikonElementalToken token) {
+        private WindZendikonElementalToken(final WindZendikonElementalToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/w/WindreaderSphinx.java
+++ b/Mage.Sets/src/mage/cards/w/WindreaderSphinx.java
@@ -59,7 +59,7 @@ class WindreaderSphinxTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature with flying attacks, ");
     }
 
-    public WindreaderSphinxTriggeredAbility(final WindreaderSphinxTriggeredAbility ability) {
+    private WindreaderSphinxTriggeredAbility(final WindreaderSphinxTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WindriderEel.java
+++ b/Mage.Sets/src/mage/cards/w/WindriderEel.java
@@ -29,7 +29,7 @@ public final class WindriderEel extends CardImpl {
         this.addAbility(new LandfallAbility(new BoostSourceEffect(2, 2, Duration.EndOfTurn), false));
     }
 
-    public WindriderEel (final WindriderEel card) {
+    private WindriderEel(final WindriderEel card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WindsOfChange.java
+++ b/Mage.Sets/src/mage/cards/w/WindsOfChange.java
@@ -44,7 +44,7 @@ class WindsOfChangeEffect extends OneShotEffect {
         this.staticText = "Each player shuffles the cards from their hand into their library, then draws that many cards";
     }
 
-    public WindsOfChangeEffect(final WindsOfChangeEffect effect) {
+    private WindsOfChangeEffect(final WindsOfChangeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WingPuncture.java
+++ b/Mage.Sets/src/mage/cards/w/WingPuncture.java
@@ -55,7 +55,7 @@ class WingPunctureEffect extends OneShotEffect {
         staticText = "Target creature you control deals damage equal to its power to target creature with flying";
      }
 
-    public WingPunctureEffect(final WingPunctureEffect effect) {
+    private WingPunctureEffect(final WingPunctureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WingStorm.java
+++ b/Mage.Sets/src/mage/cards/w/WingStorm.java
@@ -49,7 +49,7 @@ class WingStormEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to each player equal to twice the number of creatures with flying that player controls";
     }
 
-    public WingStormEffect(final WingStormEffect effect) {
+    private WingStormEffect(final WingStormEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WingedCoatl.java
+++ b/Mage.Sets/src/mage/cards/w/WingedCoatl.java
@@ -30,7 +30,7 @@ public final class WingedCoatl extends CardImpl {
         this.addAbility(DeathtouchAbility.getInstance());
     }
 
-    public WingedCoatl (final WingedCoatl card) {
+    private WingedCoatl(final WingedCoatl card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WingedTempleOfOrazca.java
+++ b/Mage.Sets/src/mage/cards/w/WingedTempleOfOrazca.java
@@ -68,7 +68,7 @@ class WingedTempleOfOrazcaEffect extends OneShotEffect {
         this.staticText = "target creature you control gains flying and gets +X/+X until end of turn, where X is its power";
     }
 
-    public WingedTempleOfOrazcaEffect(final WingedTempleOfOrazcaEffect effect) {
+    private WingedTempleOfOrazcaEffect(final WingedTempleOfOrazcaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WingsOfHubris.java
+++ b/Mage.Sets/src/mage/cards/w/WingsOfHubris.java
@@ -66,7 +66,7 @@ class WingsOfHubrisEffect extends OneShotEffect {
         this.staticText = "Equipped creature can't be blocked this turn. Sacrifice it at the beginning of the next end step";
     }
 
-    public WingsOfHubrisEffect(final WingsOfHubrisEffect effect) {
+    private WingsOfHubrisEffect(final WingsOfHubrisEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Winnow.java
+++ b/Mage.Sets/src/mage/cards/w/Winnow.java
@@ -48,7 +48,7 @@ class WinnowEffect extends DestroyTargetEffect {
         staticText = "Destroy target nonland permanent if another permanent with the same name is on the battlefield";
     }
 
-    public WinnowEffect(final WinnowEffect effect) {
+    private WinnowEffect(final WinnowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WinterOrb.java
+++ b/Mage.Sets/src/mage/cards/w/WinterOrb.java
@@ -50,7 +50,7 @@ class WinterOrbEffect extends RestrictionUntapNotMoreThanEffect {
         staticText = "As long as Winter Orb is untapped, players can't untap more than one land during their untap steps";
     }
 
-    public WinterOrbEffect(final WinterOrbEffect effect) {
+    private WinterOrbEffect(final WinterOrbEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WinterSky.java
+++ b/Mage.Sets/src/mage/cards/w/WinterSky.java
@@ -43,7 +43,7 @@ class WinterSkyEffect extends OneShotEffect {
         staticText = "Flip a coin. If you win the flip, {this} deals 1 damage to each creature and each player. If you lose the flip, each player draws a card";
     }
 
-    public WinterSkyEffect(WinterSkyEffect effect) {
+    private WinterSkyEffect(final WinterSkyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WireSurgeons.java
+++ b/Mage.Sets/src/mage/cards/w/WireSurgeons.java
@@ -58,7 +58,7 @@ class WireSurgeonsEffect extends ContinuousEffectImpl {
                 "Its encore cost is equal to its mana cost.";
     }
 
-    public WireSurgeonsEffect(final WireSurgeonsEffect effect) {
+    private WireSurgeonsEffect(final WireSurgeonsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Wirecat.java
+++ b/Mage.Sets/src/mage/cards/w/Wirecat.java
@@ -47,7 +47,7 @@ public final class Wirecat extends CardImpl {
             staticText = "{this} can't attack or block if an enchantment is on the battlefield";
         }
 
-        public WirecatEffect(final WirecatEffect effect) {
+        private WirecatEffect(final WirecatEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/w/WishfulMerfolk.java
+++ b/Mage.Sets/src/mage/cards/w/WishfulMerfolk.java
@@ -51,7 +51,7 @@ class WishfulMerfolkEffect extends ContinuousEffectImpl {
         staticText = "{this} loses defender and becomes a Human until end of turn";
     }
 
-    public WishfulMerfolkEffect(final WishfulMerfolkEffect effect) {
+    private WishfulMerfolkEffect(final WishfulMerfolkEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Wishmonger.java
+++ b/Mage.Sets/src/mage/cards/w/Wishmonger.java
@@ -69,7 +69,7 @@ class WishmongerEffect extends OneShotEffect {
         staticText = "Target creature gains protection from the color of its controller's choice until end of turn";
     }
 
-    public WishmongerEffect(final WishmongerEffect effect) {
+    private WishmongerEffect(final WishmongerEffect effect) {
         super(effect);
     }
 
@@ -112,7 +112,7 @@ class ProtectionChosenColorTargetEffect extends ContinuousEffectImpl {
         super(Duration.EndOfTurn, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
     }
 
-    public ProtectionChosenColorTargetEffect(final ProtectionChosenColorTargetEffect effect) {
+    private ProtectionChosenColorTargetEffect(final ProtectionChosenColorTargetEffect effect) {
         super(effect);
         if (effect.chosenColor != null) {
             this.chosenColor = effect.chosenColor.copy();

--- a/Mage.Sets/src/mage/cards/w/WistfulSelkie.java
+++ b/Mage.Sets/src/mage/cards/w/WistfulSelkie.java
@@ -28,7 +28,7 @@ public final class WistfulSelkie extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DrawCardSourceControllerEffect(1)));
     }
 
-    public WistfulSelkie (final WistfulSelkie card) {
+    private WistfulSelkie(final WistfulSelkie card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WitchEngine.java
+++ b/Mage.Sets/src/mage/cards/w/WitchEngine.java
@@ -62,7 +62,7 @@ class WitchEngineEffect extends ContinuousEffectImpl {
         staticText = "target opponent gains control of {this}";
     }
 
-    public WitchEngineEffect(final WitchEngineEffect effect) {
+    private WitchEngineEffect(final WitchEngineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WitchHunt.java
+++ b/Mage.Sets/src/mage/cards/w/WitchHunt.java
@@ -61,7 +61,7 @@ class WitchHuntEffect extends ContinuousEffectImpl {
         staticText = "target opponent chosen at random gains control of {this}";
     }
 
-    public WitchHuntEffect(final WitchHuntEffect effect) {
+    private WitchHuntEffect(final WitchHuntEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WitchMawNephilim.java
+++ b/Mage.Sets/src/mage/cards/w/WitchMawNephilim.java
@@ -56,7 +56,7 @@ class WitchMawNephilimEffect extends OneShotEffect {
         this.staticText = "it gains trample until end of turn if its power is 10 or greater";
     }
 
-    public WitchMawNephilimEffect(final WitchMawNephilimEffect effect) {
+    private WitchMawNephilimEffect(final WitchMawNephilimEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WitchbaneOrb.java
+++ b/Mage.Sets/src/mage/cards/w/WitchbaneOrb.java
@@ -55,7 +55,7 @@ class WitchbaneOrbEffect extends OneShotEffect {
         staticText = "destroy all Curses attached to you";
     }
 
-    public WitchbaneOrbEffect(final WitchbaneOrbEffect effect) {
+    private WitchbaneOrbEffect(final WitchbaneOrbEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Witchstalker.java
+++ b/Mage.Sets/src/mage/cards/w/Witchstalker.java
@@ -63,7 +63,7 @@ class WitchstalkerTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false);
     }
 
-    public WitchstalkerTriggeredAbility(final WitchstalkerTriggeredAbility ability) {
+    private WitchstalkerTriggeredAbility(final WitchstalkerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WithengarUnbound.java
+++ b/Mage.Sets/src/mage/cards/w/WithengarUnbound.java
@@ -60,7 +60,7 @@ class WithengarUnboundTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance(13)), false);
     }
 
-    public WithengarUnboundTriggeredAbility(final WithengarUnboundTriggeredAbility ability) {
+    private WithengarUnboundTriggeredAbility(final WithengarUnboundTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WitheringGaze.java
+++ b/Mage.Sets/src/mage/cards/w/WitheringGaze.java
@@ -76,7 +76,7 @@ class WitheringGazeEffect extends OneShotEffect {
         return false;
     }
 
-    public WitheringGazeEffect(final WitheringGazeEffect effect) {
+    private WitheringGazeEffect(final WitheringGazeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WitheringWisps.java
+++ b/Mage.Sets/src/mage/cards/w/WitheringWisps.java
@@ -70,7 +70,7 @@ class WitheringWispsActivatedAbility extends ActivatedAbilityImpl {
 
     }
 
-    public WitheringWispsActivatedAbility(final WitheringWispsActivatedAbility ability) {
+    private WitheringWispsActivatedAbility(final WitheringWispsActivatedAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WoebringerDemon.java
+++ b/Mage.Sets/src/mage/cards/w/WoebringerDemon.java
@@ -58,7 +58,7 @@ class WoebringerDemonEffect extends OneShotEffect {
         this.staticText = "that player sacrifices a creature. If the player can't, sacrifice {this}";
     }
 
-    public WoebringerDemonEffect(final WoebringerDemonEffect effect) {
+    private WoebringerDemonEffect(final WoebringerDemonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WojekApothecary.java
+++ b/Mage.Sets/src/mage/cards/w/WojekApothecary.java
@@ -64,7 +64,7 @@ class WojekApothecaryEffect extends OneShotEffect {
         this.staticText = "Prevent the next 1 damage that would be dealt to target creature and each other creature that shares a color with it this turn";
     }
 
-    public WojekApothecaryEffect(final WojekApothecaryEffect effect) {
+    private WojekApothecaryEffect(final WojekApothecaryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WojekSiren.java
+++ b/Mage.Sets/src/mage/cards/w/WojekSiren.java
@@ -46,7 +46,7 @@ class WojekSirenBoostEffect extends ContinuousEffectImpl {
         staticText = "Target creature and each other creature that shares a color with it get +1/+1 until end of turn";
     }
 
-    public WojekSirenBoostEffect(final WojekSirenBoostEffect effect) {
+    private WojekSirenBoostEffect(final WojekSirenBoostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WolfcallersHowl.java
+++ b/Mage.Sets/src/mage/cards/w/WolfcallersHowl.java
@@ -47,7 +47,7 @@ class WolfcallersHowlEffect extends OneShotEffect {
         this.staticText = "create X 2/2 green Wolf creature tokens, where X is the number of your opponents with four or more cards in hand";
     }
 
-    public WolfcallersHowlEffect(final WolfcallersHowlEffect effect) {
+    private WolfcallersHowlEffect(final WolfcallersHowlEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WoodElemental.java
+++ b/Mage.Sets/src/mage/cards/w/WoodElemental.java
@@ -69,7 +69,7 @@ class WoodElementalEffect extends OneShotEffect {
         staticText = "sacrifice any number of untapped Forests";
     }
 
-    public WoodElementalEffect(final WoodElementalEffect effect) {
+    private WoodElementalEffect(final WoodElementalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WoodSage.java
+++ b/Mage.Sets/src/mage/cards/w/WoodSage.java
@@ -55,7 +55,7 @@ class WoodSageEffect extends OneShotEffect {
                 "and put all of them with that name into your hand. Put the rest into your graveyard";
     }
 
-    public WoodSageEffect(final WoodSageEffect effect) {
+    private WoodSageEffect(final WoodSageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WoodenSphere.java
+++ b/Mage.Sets/src/mage/cards/w/WoodenSphere.java
@@ -45,7 +45,7 @@ class WoodenSphereAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DoIfCostPaid(new GainLifeEffect(1), new GenericManaCost(1)), false);
     }
 
-    public WoodenSphereAbility(final WoodenSphereAbility ability) {
+    private WoodenSphereAbility(final WoodenSphereAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WoodenStake.java
+++ b/Mage.Sets/src/mage/cards/w/WoodenStake.java
@@ -55,7 +55,7 @@ class WoodenStakeBlocksOrBecomesBlockedTriggeredAbility extends TriggeredAbility
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(true), false);
     }
 
-    public WoodenStakeBlocksOrBecomesBlockedTriggeredAbility(final WoodenStakeBlocksOrBecomesBlockedTriggeredAbility ability) {
+    private WoodenStakeBlocksOrBecomesBlockedTriggeredAbility(final WoodenStakeBlocksOrBecomesBlockedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WoodlandSleuth.java
+++ b/Mage.Sets/src/mage/cards/w/WoodlandSleuth.java
@@ -60,7 +60,7 @@ class WoodlandSleuthEffect extends OneShotEffect {
         this.staticText = "return a creature card at random from your graveyard to your hand";
     }
 
-    public WoodlandSleuthEffect(final WoodlandSleuthEffect effect) {
+    private WoodlandSleuthEffect(final WoodlandSleuthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WoodlotCrawler.java
+++ b/Mage.Sets/src/mage/cards/w/WoodlotCrawler.java
@@ -32,7 +32,7 @@ public final class WoodlotCrawler extends CardImpl {
 
     }
 
-    public WoodlotCrawler (final WoodlotCrawler card) {
+    private WoodlotCrawler(final WoodlotCrawler card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WoodvineElemental.java
+++ b/Mage.Sets/src/mage/cards/w/WoodvineElemental.java
@@ -63,7 +63,7 @@ class WoodvineElementalEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public WoodvineElementalEffect(final WoodvineElementalEffect effect) {
+    private WoodvineElementalEffect(final WoodvineElementalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WoodwraithCorrupter.java
+++ b/Mage.Sets/src/mage/cards/w/WoodwraithCorrupter.java
@@ -71,7 +71,7 @@ class WoodwraithCorrupterToken extends TokenImpl {
         power = new MageInt(4);
         toughness = new MageInt(4);
     }
-    public WoodwraithCorrupterToken(final WoodwraithCorrupterToken token) {
+    private WoodwraithCorrupterToken(final WoodwraithCorrupterToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WordOfCommand.java
+++ b/Mage.Sets/src/mage/cards/w/WordOfCommand.java
@@ -61,7 +61,7 @@ class WordOfCommandEffect extends OneShotEffect {
         this.staticText = "Look at target opponent's hand and choose a card from it. You control that player until {this} finishes resolving. The player plays that card if able. While doing so, the player can activate mana abilities only if they're from lands that player controls and only if mana they produce is spent to activate other mana abilities of lands the player controls and/or to play that card. If the chosen card is cast as a spell, you control the player while that spell is resolving";
     }
 
-    public WordOfCommandEffect(final WordOfCommandEffect effect) {
+    private WordOfCommandEffect(final WordOfCommandEffect effect) {
         super(effect);
     }
 
@@ -196,7 +196,7 @@ class WordOfCommandCantActivateEffect extends RestrictionEffect {
         super(Duration.EndOfTurn);
     }
 
-    public WordOfCommandCantActivateEffect(final WordOfCommandCantActivateEffect effect) {
+    private WordOfCommandCantActivateEffect(final WordOfCommandCantActivateEffect effect) {
         super(effect);
     }
 
@@ -222,7 +222,7 @@ class WordOfCommandTestFlashEffect extends AsThoughEffectImpl {
         super(AsThoughEffectType.CAST_AS_INSTANT, Duration.EndOfTurn, Outcome.Benefit);
     }
 
-    public WordOfCommandTestFlashEffect(final WordOfCommandTestFlashEffect effect) {
+    private WordOfCommandTestFlashEffect(final WordOfCommandTestFlashEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WordOfUndoing.java
+++ b/Mage.Sets/src/mage/cards/w/WordOfUndoing.java
@@ -50,7 +50,7 @@ class WordOfUndoingReturnToHandEffect extends OneShotEffect {
         this.staticText = "Return target creature and all white Auras you own attached to it to their owners' hands.";
     }
 
-    public WordOfUndoingReturnToHandEffect(final WordOfUndoingReturnToHandEffect effect) {
+    private WordOfUndoingReturnToHandEffect(final WordOfUndoingReturnToHandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Wordmail.java
+++ b/Mage.Sets/src/mage/cards/w/Wordmail.java
@@ -58,7 +58,7 @@ class WordmailCount implements DynamicValue {
     public WordmailCount() {
     }
 
-    public WordmailCount(final WordmailCount dynamicValue) {
+    private WordmailCount(final WordmailCount dynamicValue) {
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/w/WordsOfWaste.java
+++ b/Mage.Sets/src/mage/cards/w/WordsOfWaste.java
@@ -48,7 +48,7 @@ class WordsOfWasteEffect extends ReplacementEffectImpl {
         staticText = "The next time you would draw a card this turn, each opponent discards a card instead";
     }
 
-    public WordsOfWasteEffect(final WordsOfWasteEffect effect) {
+    private WordsOfWasteEffect(final WordsOfWasteEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WordsOfWilding.java
+++ b/Mage.Sets/src/mage/cards/w/WordsOfWilding.java
@@ -48,7 +48,7 @@ class WordsOfWildingEffect extends ReplacementEffectImpl {
         staticText = "The next time you would draw a card this turn, create a 2/2 green Bear creature token instead";
     }
 
-    public WordsOfWildingEffect(final WordsOfWildingEffect effect) {
+    private WordsOfWildingEffect(final WordsOfWildingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WordsOfWind.java
+++ b/Mage.Sets/src/mage/cards/w/WordsOfWind.java
@@ -50,7 +50,7 @@ class WordsOfWindEffect extends ReplacementEffectImpl {
         staticText = "The next time you would draw a card this turn, each player returns a permanent they control to its owner's hand instead";
     }
 
-    public WordsOfWindEffect(final WordsOfWindEffect effect) {
+    private WordsOfWindEffect(final WordsOfWindEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WordsOfWisdom.java
+++ b/Mage.Sets/src/mage/cards/w/WordsOfWisdom.java
@@ -45,7 +45,7 @@ class WordsOfWisdomEffect extends OneShotEffect {
         this.staticText = ", then each other player draws a card";
     }
 
-    public WordsOfWisdomEffect(final WordsOfWisdomEffect effect) {
+    private WordsOfWisdomEffect(final WordsOfWisdomEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WorldAtWar.java
+++ b/Mage.Sets/src/mage/cards/w/WorldAtWar.java
@@ -52,7 +52,7 @@ class WorldAtWarEffect extends OneShotEffect {
         staticText = "After the first postcombat main phase this turn, there's an additional combat phase followed by an additional main phase. At the beginning of that combat, untap all creatures that attacked this turn";
     }
 
-    public WorldAtWarEffect(final WorldAtWarEffect effect) {
+    private WorldAtWarEffect(final WorldAtWarEffect effect) {
         super(effect);
     }
 
@@ -83,7 +83,7 @@ class UntapDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new UntapAttackingThisTurnEffect());
     }
 
-    public UntapDelayedTriggeredAbility(UntapDelayedTriggeredAbility ability) {
+    private UntapDelayedTriggeredAbility(final UntapDelayedTriggeredAbility ability) {
         super(ability);
         this.connectedTurnMod = ability.connectedTurnMod;
         this.enabled = ability.enabled;
@@ -130,7 +130,7 @@ class UntapAttackingThisTurnEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public UntapAttackingThisTurnEffect(final UntapAttackingThisTurnEffect effect) {
+    private UntapAttackingThisTurnEffect(final UntapAttackingThisTurnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WorldBottlingKit.java
+++ b/Mage.Sets/src/mage/cards/w/WorldBottlingKit.java
@@ -52,7 +52,7 @@ class WorldBottlingKitEffect extends OneShotEffect {
         this.staticText = "Choose a Magic set. Exile all permanents with that set's expansion symbol except for basic lands";
     }
 
-    public WorldBottlingKitEffect(final WorldBottlingKitEffect effect) {
+    private WorldBottlingKitEffect(final WorldBottlingKitEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WorldQueller.java
+++ b/Mage.Sets/src/mage/cards/w/WorldQueller.java
@@ -70,7 +70,7 @@ class WorldQuellerEffect extends OneShotEffect {
         staticText = "you may choose a card type. If you do, each player sacrifices a permanent of that type";
     }
 
-    public WorldQuellerEffect(final WorldQuellerEffect effect) {
+    private WorldQuellerEffect(final WorldQuellerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WorldShaper.java
+++ b/Mage.Sets/src/mage/cards/w/WorldShaper.java
@@ -56,7 +56,7 @@ class WorldShaperEffect extends OneShotEffect {
         this.staticText = "return all land cards from your graveyard to the battlefield tapped";
     }
 
-    public WorldShaperEffect(final WorldShaperEffect effect) {
+    private WorldShaperEffect(final WorldShaperEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Worldfire.java
+++ b/Mage.Sets/src/mage/cards/w/Worldfire.java
@@ -46,7 +46,7 @@ class WorldfireEffect extends OneShotEffect {
         staticText = "Exile all permanents. Exile all cards from all hands and graveyards. Each player's life total becomes 1";
     }
 
-    public WorldfireEffect(final WorldfireEffect effect) {
+    private WorldfireEffect(final WorldfireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WorldgorgerDragon.java
+++ b/Mage.Sets/src/mage/cards/w/WorldgorgerDragon.java
@@ -77,7 +77,7 @@ class WorldgorgerDragonEntersEffect extends OneShotEffect {
         staticText = "exile all other permanents you control";
     }
 
-    public WorldgorgerDragonEntersEffect(final WorldgorgerDragonEntersEffect effect) {
+    private WorldgorgerDragonEntersEffect(final WorldgorgerDragonEntersEffect effect) {
         super(effect);
     }
 
@@ -110,7 +110,7 @@ class WorldgorgerDragonLeavesEffect extends OneShotEffect {
         staticText = "return the exiled cards to the battlefield under their owners' control";
     }
 
-    public WorldgorgerDragonLeavesEffect(final WorldgorgerDragonLeavesEffect effect) {
+    private WorldgorgerDragonLeavesEffect(final WorldgorgerDragonLeavesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WorldheartPhoenix.java
+++ b/Mage.Sets/src/mage/cards/w/WorldheartPhoenix.java
@@ -64,7 +64,7 @@ public final class WorldheartPhoenix extends CardImpl {
             staticText = "You may cast {this} from your graveyard by paying {W}{U}{B}{R}{G} rather than paying its mana cost";
         }
 
-        public WorldheartPhoenixPlayEffect(final WorldheartPhoenixPlayEffect effect) {
+        private WorldheartPhoenixPlayEffect(final WorldheartPhoenixPlayEffect effect) {
             super(effect);
         }
 
@@ -102,7 +102,7 @@ public final class WorldheartPhoenix extends CardImpl {
             staticText = "If you do, it enters the battlefield with two +1/+1 counters on it";
         }
 
-        public WorldheartPhoenixEntersBattlefieldEffect(final WorldheartPhoenixEntersBattlefieldEffect effect) {
+        private WorldheartPhoenixEntersBattlefieldEffect(final WorldheartPhoenixEntersBattlefieldEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/w/WorldlyCounsel.java
+++ b/Mage.Sets/src/mage/cards/w/WorldlyCounsel.java
@@ -50,7 +50,7 @@ class WorldlyCounselEffect extends OneShotEffect {
         this.staticText = "<i>Domain</i> &mdash; Look at the top X cards of your library, where X is the number of basic land types among lands you control. Put one of those cards into your hand and the rest on the bottom of your library in any order";
     }
 
-    public WorldlyCounselEffect(final WorldlyCounselEffect effect) {
+    private WorldlyCounselEffect(final WorldlyCounselEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Worldpurge.java
+++ b/Mage.Sets/src/mage/cards/w/Worldpurge.java
@@ -51,7 +51,7 @@ class WorldpurgeEffect extends OneShotEffect {
         this.staticText = "Return all permanents to their owners' hands. Each player chooses up to seven cards in their hand, then shuffles the rest into their library. Each player loses all unspent mana";
     }
 
-    public WorldpurgeEffect(final WorldpurgeEffect effect) {
+    private WorldpurgeEffect(final WorldpurgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Worldslayer.java
+++ b/Mage.Sets/src/mage/cards/w/Worldslayer.java
@@ -88,7 +88,7 @@ class WorldslayerEffect extends OneShotEffect {
         staticText = "destroy all permanents other than {this}";
     }
 
-    public WorldslayerEffect(final WorldslayerEffect effect) {
+    private WorldslayerEffect(final WorldslayerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WormfangCrab.java
+++ b/Mage.Sets/src/mage/cards/w/WormfangCrab.java
@@ -63,7 +63,7 @@ class WormfangCrabExileEffect extends OneShotEffect {
         this.staticText = "an opponent chooses a permanent you control other than {this} and exiles it";
     }
 
-    public WormfangCrabExileEffect(final WormfangCrabExileEffect effect) {
+    private WormfangCrabExileEffect(final WormfangCrabExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WormsOfTheEarth.java
+++ b/Mage.Sets/src/mage/cards/w/WormsOfTheEarth.java
@@ -56,7 +56,7 @@ class WormsOfTheEarthPlayEffect extends ContinuousRuleModifyingEffectImpl {
         this.staticText = "Players can't play lands";
     }
 
-    public WormsOfTheEarthPlayEffect(final WormsOfTheEarthPlayEffect effect) {
+    private WormsOfTheEarthPlayEffect(final WormsOfTheEarthPlayEffect effect) {
         super(effect);
     }
 
@@ -88,7 +88,7 @@ class WormsOfTheEarthEnterEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Lands can't enter the battlefield";
     }
 
-    public WormsOfTheEarthEnterEffect(final WormsOfTheEarthEnterEffect effect) {
+    private WormsOfTheEarthEnterEffect(final WormsOfTheEarthEnterEffect effect) {
         super(effect);
     }
 
@@ -120,7 +120,7 @@ class WormsOfTheEarthDestroyEffect extends OneShotEffect {
         this.staticText = "any player may sacrifice two lands or have {this} deal 5 damage to that player. If a player does either, destroy {this}";
     }
 
-    public WormsOfTheEarthDestroyEffect(final WormsOfTheEarthDestroyEffect effect) {
+    private WormsOfTheEarthDestroyEffect(final WormsOfTheEarthDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Worship.java
+++ b/Mage.Sets/src/mage/cards/w/Worship.java
@@ -42,7 +42,7 @@ class WorshipReplacementEffect extends ReplacementEffectImpl {
         staticText = "If you control a creature, damage that would reduce your life total to less than 1 reduces it to 1 instead";
     }
 
-    public WorshipReplacementEffect(final WorshipReplacementEffect effect) {
+    private WorshipReplacementEffect(final WorshipReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WortTheRaidmother.java
+++ b/Mage.Sets/src/mage/cards/w/WortTheRaidmother.java
@@ -69,7 +69,7 @@ class WortGainConspireEffect extends ContinuousEffectImpl {
         this.conspireAbility = new ConspireAbility(ConspireAbility.ConspireTargets.MORE);
     }
 
-    public WortGainConspireEffect(final WortGainConspireEffect effect) {
+    private WortGainConspireEffect(final WortGainConspireEffect effect) {
         super(effect);
         this.conspireAbility = effect.conspireAbility;
     }

--- a/Mage.Sets/src/mage/cards/w/WoundReflection.java
+++ b/Mage.Sets/src/mage/cards/w/WoundReflection.java
@@ -45,7 +45,7 @@ class WoundReflectionEffect extends OneShotEffect {
         this.staticText = "each opponent loses life equal to the life they lost this turn";
     }
     
-    public WoundReflectionEffect(final WoundReflectionEffect effect) {
+    private WoundReflectionEffect(final WoundReflectionEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/w/WrackWithMadness.java
+++ b/Mage.Sets/src/mage/cards/w/WrackWithMadness.java
@@ -44,7 +44,7 @@ class WrackWithMadnessEffect extends OneShotEffect {
         this.staticText = "Target creature deals damage to itself equal to its power";
     }
 
-    public WrackWithMadnessEffect(final WrackWithMadnessEffect effect) {
+    private WrackWithMadnessEffect(final WrackWithMadnessEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WretchedBanquet.java
+++ b/Mage.Sets/src/mage/cards/w/WretchedBanquet.java
@@ -45,7 +45,7 @@ class WretchedBanquetEffect extends OneShotEffect {
         this.staticText = "Destroy target creature if it has the least power or is tied for least power among creatures on the battlefield";
     }
 
-    public WretchedBanquetEffect(final WretchedBanquetEffect effect) {
+    private WretchedBanquetEffect(final WretchedBanquetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WritOfPassage.java
+++ b/Mage.Sets/src/mage/cards/w/WritOfPassage.java
@@ -72,7 +72,7 @@ class WritOfPassageAttachedEffect extends RestrictionEffect {
         this.staticText = attachmentType.verb() + " creature can't be blocked";
     }
 
-    public WritOfPassageAttachedEffect(WritOfPassageAttachedEffect effect) {
+    private WritOfPassageAttachedEffect(final WritOfPassageAttachedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WriteIntoBeing.java
+++ b/Mage.Sets/src/mage/cards/w/WriteIntoBeing.java
@@ -49,7 +49,7 @@ class WriteIntoBeingEffect extends OneShotEffect {
                 + "<i>(To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)</i>";
     }
 
-    public WriteIntoBeingEffect(final WriteIntoBeingEffect effect) {
+    private WriteIntoBeingEffect(final WriteIntoBeingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Wurmcalling.java
+++ b/Mage.Sets/src/mage/cards/w/Wurmcalling.java
@@ -44,7 +44,7 @@ class WurmcallingEffect extends OneShotEffect {
         staticText = "Create an X/X green Wurm creature token";
     }
 
-    public WurmcallingEffect(WurmcallingEffect ability) {
+    private WurmcallingEffect(final WurmcallingEffect ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Wurmquake.java
+++ b/Mage.Sets/src/mage/cards/w/Wurmquake.java
@@ -52,7 +52,7 @@ class WurmquakeEffect extends OneShotEffect {
         this.staticText = AbilityWord.CORRUPTED.formatWord() + "Create an X/X green Phyrexian Wurm creature token with trample and toxic 1, where X is the amount of mana spent to cast this spell. Then for each opponent with three or more poison counters, you create another one of those tokens.";
     }
 
-    public WurmquakeEffect(final WurmquakeEffect effect) {
+    private WurmquakeEffect(final WurmquakeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WurmsTooth.java
+++ b/Mage.Sets/src/mage/cards/w/WurmsTooth.java
@@ -42,7 +42,7 @@ class WurmsToothAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainLifeEffect(1), true);
     }
 
-    public WurmsToothAbility(final WurmsToothAbility ability) {
+    private WurmsToothAbility(final WurmsToothAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/x/XanatharGuildKingpin.java
+++ b/Mage.Sets/src/mage/cards/x/XanatharGuildKingpin.java
@@ -142,7 +142,7 @@ class SpendManaAsAnyColorToCastTopOfLibraryTargetEffect extends AsThoughEffectIm
         super(AsThoughEffectType.SPEND_OTHER_MANA, Duration.EndOfTurn, Outcome.Benefit);
     }
 
-    public SpendManaAsAnyColorToCastTopOfLibraryTargetEffect(final SpendManaAsAnyColorToCastTopOfLibraryTargetEffect effect) {
+    private SpendManaAsAnyColorToCastTopOfLibraryTargetEffect(final SpendManaAsAnyColorToCastTopOfLibraryTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/x/XanthicStatue.java
+++ b/Mage.Sets/src/mage/cards/x/XanthicStatue.java
@@ -50,7 +50,7 @@ class XanthicStatueCreature extends TokenImpl {
 
         this.addAbility(TrampleAbility.getInstance());
     }
-    public XanthicStatueCreature(final XanthicStatueCreature token) {
+    private XanthicStatueCreature(final XanthicStatueCreature token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/x/XantidSwarm.java
+++ b/Mage.Sets/src/mage/cards/x/XantidSwarm.java
@@ -58,7 +58,7 @@ class XantidSwarmTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} attacks, ");
     }
 
-    public XantidSwarmTriggeredAbility(final XantidSwarmTriggeredAbility ability) {
+    private XantidSwarmTriggeredAbility(final XantidSwarmTriggeredAbility ability) {
         super(ability);
     }
 
@@ -90,7 +90,7 @@ class XantidSwarmReplacementEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "defending player can't cast spells this turn";
     }
 
-    public XantidSwarmReplacementEffect(final XantidSwarmReplacementEffect effect) {
+    private XantidSwarmReplacementEffect(final XantidSwarmReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/x/XathridDemon.java
+++ b/Mage.Sets/src/mage/cards/x/XathridDemon.java
@@ -60,7 +60,7 @@ class XathridDemonEffect extends OneShotEffect {
         this.staticText = "sacrifice a creature other than {this}, then each opponent loses life equal to the sacrificed creature's power. If you can't sacrifice a creature, tap {this} and you lose 7 life";
     }
 
-    public XathridDemonEffect(final XathridDemonEffect effect) {
+    private XathridDemonEffect(final XathridDemonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/x/XathridGorgon.java
+++ b/Mage.Sets/src/mage/cards/x/XathridGorgon.java
@@ -75,7 +75,7 @@ class XathridGorgonCantActivateEffect extends RestrictionEffect {
         staticText = "Its activated abilities can't be activated";
     }
 
-    public XathridGorgonCantActivateEffect(final XathridGorgonCantActivateEffect effect) {
+    private XathridGorgonCantActivateEffect(final XathridGorgonCantActivateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/x/XenagosTheReveler.java
+++ b/Mage.Sets/src/mage/cards/x/XenagosTheReveler.java
@@ -62,7 +62,7 @@ class XenagosManaEffect extends OneShotEffect {
         this.staticText = "Add X mana in any combination of {R} and/or {G}, where X is the number of creatures you control";
     }
 
-    public XenagosManaEffect(final XenagosManaEffect effect) {
+    private XenagosManaEffect(final XenagosManaEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class XenagosExileEffect extends OneShotEffect {
         this.staticText = "Exile the top seven cards of your library. You may put any number of creature and/or land cards from among them onto the battlefield";
     }
 
-    public XenagosExileEffect(final XenagosExileEffect effect) {
+    private XenagosExileEffect(final XenagosExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/x/XenicPoltergeist.java
+++ b/Mage.Sets/src/mage/cards/x/XenicPoltergeist.java
@@ -71,7 +71,7 @@ class XenicPoltergeistEffect extends ContinuousEffectImpl {
         staticText = "Until your next upkeep, target noncreature artifact becomes an artifact creature with power and toughness each equal to its mana value";
     }
 
-    public XenicPoltergeistEffect(final XenicPoltergeistEffect effect) {
+    private XenicPoltergeistEffect(final XenicPoltergeistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/x/Xenograft.java
+++ b/Mage.Sets/src/mage/cards/x/Xenograft.java
@@ -47,7 +47,7 @@ class XenograftAddSubtypeEffect extends ContinuousEffectImpl {
         staticText = "Each creature you control is the chosen type in addition to its other types";
     }
 
-    public XenograftAddSubtypeEffect(final XenograftAddSubtypeEffect effect) {
+    private XenograftAddSubtypeEffect(final XenograftAddSubtypeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/x/XyrisTheWrithingStorm.java
+++ b/Mage.Sets/src/mage/cards/x/XyrisTheWrithingStorm.java
@@ -58,7 +58,7 @@ class XyrisTheWrithingStormCombatDamageEffect extends OneShotEffect {
         this.staticText = "you and that player each draw that many cards.";
     }
 
-    public XyrisTheWrithingStormCombatDamageEffect(final XyrisTheWrithingStormCombatDamageEffect effect) {
+    private XyrisTheWrithingStormCombatDamageEffect(final XyrisTheWrithingStormCombatDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/x/XystonStarDestroyer.java
+++ b/Mage.Sets/src/mage/cards/x/XystonStarDestroyer.java
@@ -32,7 +32,7 @@ public class XystonStarDestroyer extends CardImpl {
         this.addAbility(ability);
     }
 
-    public XystonStarDestroyer(final XystonStarDestroyer card) {
+    private XystonStarDestroyer(final XystonStarDestroyer card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YasharnImplacableEarth.java
+++ b/Mage.Sets/src/mage/cards/y/YasharnImplacableEarth.java
@@ -119,7 +119,7 @@ class YasharnImplacableEarthEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Players can't pay life or sacrifice nonland permanents to cast spells or activate abilities";
     }
 
-    public YasharnImplacableEarthEffect(final YasharnImplacableEarthEffect effect) {
+    private YasharnImplacableEarthEffect(final YasharnImplacableEarthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YavimayaDryad.java
+++ b/Mage.Sets/src/mage/cards/y/YavimayaDryad.java
@@ -63,7 +63,7 @@ class YavimayaDryadEffect extends SearchEffect {
         staticText = "you may search your library for a Forest card, put it onto the battlefield tapped under target player's control, then shuffle";
     }
 
-    public YavimayaDryadEffect(final YavimayaDryadEffect effect) {
+    private YavimayaDryadEffect(final YavimayaDryadEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YawgmothDemon.java
+++ b/Mage.Sets/src/mage/cards/y/YawgmothDemon.java
@@ -55,7 +55,7 @@ class YawgmothDemonEffect extends OneShotEffect {
         this.staticText = "you may sacrifice an artifact. If you don't, tap {this} and it deals 2 damage to you";
     }
 
-    public YawgmothDemonEffect(final YawgmothDemonEffect effect) {
+    private YawgmothDemonEffect(final YawgmothDemonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YawgmothsVileOffering.java
+++ b/Mage.Sets/src/mage/cards/y/YawgmothsVileOffering.java
@@ -68,7 +68,7 @@ class YawgmothsVileOfferingEffect extends OneShotEffect {
         this.staticText = "Put up to one target creature or planeswalker card from a graveyard onto the battlefield under your control. Destroy up to one target creature or planeswalker";
     }
 
-    public YawgmothsVileOfferingEffect(final YawgmothsVileOfferingEffect effect) {
+    private YawgmothsVileOfferingEffect(final YawgmothsVileOfferingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YawgmothsWill.java
+++ b/Mage.Sets/src/mage/cards/y/YawgmothsWill.java
@@ -59,7 +59,7 @@ class CanPlayCardsFromGraveyardEffect extends ContinuousEffectImpl {
         staticText = "Until end of turn, you may play cards from your graveyard";
     }
 
-    public CanPlayCardsFromGraveyardEffect(final CanPlayCardsFromGraveyardEffect effect) {
+    private CanPlayCardsFromGraveyardEffect(final CanPlayCardsFromGraveyardEffect effect) {
         super(effect);
     }
 
@@ -87,7 +87,7 @@ class YawgmothsWillReplacementEffect extends ReplacementEffectImpl {
         this.staticText = "If a card would be put into your graveyard from anywhere this turn, exile that card instead";
     }
 
-    public YawgmothsWillReplacementEffect(final YawgmothsWillReplacementEffect effect) {
+    private YawgmothsWillReplacementEffect(final YawgmothsWillReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YdwenEfreet.java
+++ b/Mage.Sets/src/mage/cards/y/YdwenEfreet.java
@@ -51,7 +51,7 @@ class YdwenEfreetEffect extends OneShotEffect {
         staticText = "flip a coin. If you lose the flip, remove {this} from combat and it can't block. Creatures it was blocking that had become blocked by only {this} this combat become unblocked";
     }
 
-    public YdwenEfreetEffect(YdwenEfreetEffect effect) {
+    private YdwenEfreetEffect(final YdwenEfreetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YedoraGraveGardener.java
+++ b/Mage.Sets/src/mage/cards/y/YedoraGraveGardener.java
@@ -100,7 +100,7 @@ class YedoraGraveGardenerContinuousEffect extends ContinuousEffectImpl {
         super(Duration.Custom, Layer.CopyEffects_1, SubLayer.FaceDownEffects_1b, Outcome.Neutral);
     }
 
-    public YedoraGraveGardenerContinuousEffect(final YedoraGraveGardenerContinuousEffect effect) {
+    private YedoraGraveGardenerContinuousEffect(final YedoraGraveGardenerContinuousEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YennettCrypticSovereign.java
+++ b/Mage.Sets/src/mage/cards/y/YennettCrypticSovereign.java
@@ -70,7 +70,7 @@ class YennettCrypticSovereignEffect extends OneShotEffect {
                 "If you don't cast it, draw a card.";
     }
 
-    public YennettCrypticSovereignEffect(final YennettCrypticSovereignEffect effect) {
+    private YennettCrypticSovereignEffect(final YennettCrypticSovereignEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YidrisMaelstromWielder.java
+++ b/Mage.Sets/src/mage/cards/y/YidrisMaelstromWielder.java
@@ -56,7 +56,7 @@ class YidrisMaelstromWielderGainCascadeEffect extends ContinuousEffectImpl {
         staticText = "as you cast spells from your hand this turn, they gain cascade";
     }
 
-    public YidrisMaelstromWielderGainCascadeEffect(final YidrisMaelstromWielderGainCascadeEffect effect) {
+    private YidrisMaelstromWielderGainCascadeEffect(final YidrisMaelstromWielderGainCascadeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YisanTheWandererBard.java
+++ b/Mage.Sets/src/mage/cards/y/YisanTheWandererBard.java
@@ -66,7 +66,7 @@ class YisanTheWandererBardEffect extends OneShotEffect {
         this.staticText = "Search your library for a creature card with mana value equal to the number of verse counters on {this}, put it onto the battlefield, then shuffle";
     }
 
-    public YisanTheWandererBardEffect(final YisanTheWandererBardEffect effect) {
+    private YisanTheWandererBardEffect(final YisanTheWandererBardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YodaJediMaster.java
+++ b/Mage.Sets/src/mage/cards/y/YodaJediMaster.java
@@ -70,7 +70,7 @@ class YodaJediMasterEffect extends OneShotEffect {
         staticText = "Exile another target permanent you own. Return that card to the battlefield under your control at the beginning of your next end step";
     }
 
-    public YodaJediMasterEffect(final YodaJediMasterEffect effect) {
+    private YodaJediMasterEffect(final YodaJediMasterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YokedPlowbeast.java
+++ b/Mage.Sets/src/mage/cards/y/YokedPlowbeast.java
@@ -26,7 +26,7 @@ public final class YokedPlowbeast extends CardImpl {
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{2}")));
     }
 
-    public YokedPlowbeast (final YokedPlowbeast card) {
+    private YokedPlowbeast(final YokedPlowbeast card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YoseiTheMorningStar.java
+++ b/Mage.Sets/src/mage/cards/y/YoseiTheMorningStar.java
@@ -64,7 +64,7 @@ class YoseiTheMorningStarTarget extends TargetPermanent {
         super(0, 5, filterTemplate, false);
     }
 
-    public YoseiTheMorningStarTarget(final YoseiTheMorningStarTarget target) {
+    private YoseiTheMorningStarTarget(final YoseiTheMorningStarTarget target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YouLookUponTheTarrasque.java
+++ b/Mage.Sets/src/mage/cards/y/YouLookUponTheTarrasque.java
@@ -70,7 +70,7 @@ class YouLookUponTheTarrasqueEffect extends RequirementEffect {
         staticText = "All creatures your opponents control able to block that creature this turn do so";
     }
 
-    public YouLookUponTheTarrasqueEffect(final YouLookUponTheTarrasqueEffect effect) {
+    private YouLookUponTheTarrasqueEffect(final YouLookUponTheTarrasqueEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YukoraThePrisoner.java
+++ b/Mage.Sets/src/mage/cards/y/YukoraThePrisoner.java
@@ -67,7 +67,7 @@ class YukoraThePrisonerEffect extends OneShotEffect {
         this.staticText = "sacrifice all non-Ogre creatures you control";
     }
 
-    public YukoraThePrisonerEffect(final YukoraThePrisonerEffect effect) {
+    private YukoraThePrisonerEffect(final YukoraThePrisonerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YurikoTheTigersShadow.java
+++ b/Mage.Sets/src/mage/cards/y/YurikoTheTigersShadow.java
@@ -74,7 +74,7 @@ class YurikoTheTigersShadowEffect extends OneShotEffect {
                 + "equal to that card's mana value";
     }
 
-    public YurikoTheTigersShadowEffect(final YurikoTheTigersShadowEffect effect) {
+    private YurikoTheTigersShadowEffect(final YurikoTheTigersShadowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZamWesell.java
+++ b/Mage.Sets/src/mage/cards/z/ZamWesell.java
@@ -56,7 +56,7 @@ class ZamWesselEffect extends OneShotEffect {
         this.staticText = "";
     }
 
-    public ZamWesselEffect(final ZamWesselEffect effect) {
+    private ZamWesselEffect(final ZamWesselEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZameckGuildmage.java
+++ b/Mage.Sets/src/mage/cards/z/ZameckGuildmage.java
@@ -57,7 +57,7 @@ class ZameckGuildmageEntersBattlefieldEffect extends ReplacementEffectImpl {
         this.staticText = "This turn, each creature you control enters the battlefield with an additional +1/+1 counter on it";
     }
 
-    public ZameckGuildmageEntersBattlefieldEffect(ZameckGuildmageEntersBattlefieldEffect effect) {
+    private ZameckGuildmageEntersBattlefieldEffect(final ZameckGuildmageEntersBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZaxaraTheExemplary.java
+++ b/Mage.Sets/src/mage/cards/z/ZaxaraTheExemplary.java
@@ -67,7 +67,7 @@ class ZaxaraTheExemplaryHydraTokenAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you cast a spell with {X} in its mana cost");
     }
 
-    public ZaxaraTheExemplaryHydraTokenAbility(final ZaxaraTheExemplaryHydraTokenAbility ability) {
+    private ZaxaraTheExemplaryHydraTokenAbility(final ZaxaraTheExemplaryHydraTokenAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZedruuTheGreathearted.java
+++ b/Mage.Sets/src/mage/cards/z/ZedruuTheGreathearted.java
@@ -68,7 +68,7 @@ public final class ZedruuTheGreathearted extends CardImpl {
             this.staticText = "Target opponent gains control of target permanent you control";
         }
 
-        public ZedruuTheGreatheartedEffect(final ZedruuTheGreatheartedEffect effect) {
+        private ZedruuTheGreatheartedEffect(final ZedruuTheGreatheartedEffect effect) {
             super(effect);
             this.targetPermanentReference = effect.targetPermanentReference;
         }

--- a/Mage.Sets/src/mage/cards/z/ZirilanOfTheClaw.java
+++ b/Mage.Sets/src/mage/cards/z/ZirilanOfTheClaw.java
@@ -63,7 +63,7 @@ class ZirilanOfTheClawEffect extends OneShotEffect {
                 + " That Dragon gains haste until end of turn. Exile it at the beginning of the next end step";
     }
 
-    public ZirilanOfTheClawEffect(final ZirilanOfTheClawEffect effect) {
+    private ZirilanOfTheClawEffect(final ZirilanOfTheClawEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZombieApocalypse.java
+++ b/Mage.Sets/src/mage/cards/z/ZombieApocalypse.java
@@ -52,7 +52,7 @@ class ZombieApocalypseEffect extends OneShotEffect {
         this.staticText = "Return all Zombie creature cards from your graveyard to the battlefield tapped, then destroy all Humans.";
     }
 
-    public ZombieApocalypseEffect(final ZombieApocalypseEffect effect) {
+    private ZombieApocalypseEffect(final ZombieApocalypseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZombieCannibal.java
+++ b/Mage.Sets/src/mage/cards/z/ZombieCannibal.java
@@ -50,7 +50,7 @@ class ZombieCannibalTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ExileTargetEffect(null, "", Zone.GRAVEYARD), true);
     }
 
-    public ZombieCannibalTriggeredAbility(final ZombieCannibalTriggeredAbility ability) {
+    private ZombieCannibalTriggeredAbility(final ZombieCannibalTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZombieMob.java
+++ b/Mage.Sets/src/mage/cards/z/ZombieMob.java
@@ -58,7 +58,7 @@ class ZombieMobEffect extends OneShotEffect {
         staticText = "{this} enters the battlefield with a +1/+1 counter on it for each creature card in your graveyard. When {this} enters the battlefield, exile all creature cards from your graveyard.";
     }
 
-    public ZombieMobEffect(final ZombieMobEffect effect) {
+    private ZombieMobEffect(final ZombieMobEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/z/Zoologist.java
+++ b/Mage.Sets/src/mage/cards/z/Zoologist.java
@@ -56,7 +56,7 @@ class ZoologistEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of your library. If it's a creature card, put it onto the battlefield. Otherwise, put it into your graveyard";
     }
 
-    public ZoologistEffect(final ZoologistEffect effect) {
+    private ZoologistEffect(final ZoologistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZoriiBliss.java
+++ b/Mage.Sets/src/mage/cards/z/ZoriiBliss.java
@@ -39,7 +39,7 @@ public class ZoriiBliss extends CardImpl {
         this.addAbility(attacksTriggeredAbility);
     }
 
-    public ZoriiBliss(final ZoriiBliss card) {
+    private ZoriiBliss(final ZoriiBliss card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZurEternalSchemer.java
+++ b/Mage.Sets/src/mage/cards/z/ZurEternalSchemer.java
@@ -81,7 +81,7 @@ class ZurEternalSchemerEffect extends ContinuousEffectImpl {
                 "and has base power and base toughness each equal to its mana value.";
     }
 
-    public ZurEternalSchemerEffect(final ZurEternalSchemerEffect effect) {
+    private ZurEternalSchemerEffect(final ZurEternalSchemerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZzzyxassAbyss.java
+++ b/Mage.Sets/src/mage/cards/z/ZzzyxassAbyss.java
@@ -52,7 +52,7 @@ class ZzzyxassAbyssEffect extends OneShotEffect {
         this.staticText = "destroy all nonland permanents with the first name alphabetically among nonland permanents";
     }
 
-    public ZzzyxassAbyssEffect(final ZzzyxassAbyssEffect effect) {
+    private ZzzyxassAbyssEffect(final ZzzyxassAbyssEffect effect) {
         super(effect);
     }
 


### PR DESCRIPTION
Part of #11054 

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`public ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `private $1(final $1 $3`
