### PR TITLE
Lint: fix 'declarations should use interfaces instead of classes' issues

### DIFF
--- a/Mage.Client/src/main/java/mage/client/components/ext/dlg/DlgParams.java
+++ b/Mage.Client/src/main/java/mage/client/components/ext/dlg/DlgParams.java
@@ -7,7 +7,10 @@ import mage.util.CardUtil;
 import mage.view.CardsView;
 
 import java.awt.*;
-import java.util.*;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * GUI: parameters for dialogs, uses to store useful data
@@ -102,7 +105,7 @@ public class DlgParams {
         return stringList;
     }
 
-    public void setStringList(ArrayList<String> stringList) {
+    public void setStringList(List<String> stringList) {
         this.stringList = stringList;
     }
 
@@ -118,7 +121,7 @@ public class DlgParams {
         return objectList;
     }
 
-    public void setObjectList(ArrayList<Object> objectList) {
+    public void setObjectList(List<Object> objectList) {
         this.objectList = objectList;
     }
 

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -1213,7 +1213,7 @@ public class HumanPlayer extends PlayerImpl {
                     Zone zone = game.getState().getZone(object.getId());
                     if (zone != null) {
                         // look at card or try to cast/activate abilities
-                        LinkedHashMap<UUID, ActivatedAbility> useableAbilities = new LinkedHashMap<>();
+                        Map<UUID, ActivatedAbility> useableAbilities = new LinkedHashMap<>();
 
                         Player actingPlayer = null;
                         if (playerId.equals(game.getPriorityPlayerId())) {
@@ -1559,7 +1559,7 @@ public class HumanPlayer extends PlayerImpl {
 
         Zone zone = game.getState().getZone(object.getId());
         if (zone != null) {
-            LinkedHashMap<UUID, ActivatedManaAbilityImpl> useableAbilities = getUseableManaAbilities(object, zone, game);
+            Map<UUID, ActivatedManaAbilityImpl> useableAbilities = getUseableManaAbilities(object, zone, game);
             if (!useableAbilities.isEmpty()) {
                 // Added to ensure that mana is not being autopaid for spells that care about the color of mana being paid
                 // See https://github.com/magefree/mage/issues/9070
@@ -2164,7 +2164,7 @@ public class HumanPlayer extends PlayerImpl {
         return super.activateAbility(ability, game);
     }
 
-    protected void activateAbility(LinkedHashMap<UUID, ? extends ActivatedAbility> abilities, MageObject object, Game game) {
+    protected void activateAbility(Map<UUID, ? extends ActivatedAbility> abilities, MageObject object, Game game) {
         if (gameInCheckPlayableState(game)) {
             return;
         }
@@ -2268,7 +2268,7 @@ public class HumanPlayer extends PlayerImpl {
         MageObject object = game.getObject(card.getId()); // must be object to find real abilities (example: commander)
         if (object != null) {
             String message = "Choose ability to cast" + (noMana ? " for FREE" : "") + "<br>" + object.getLogName();
-            LinkedHashMap<UUID, SpellAbility> useableAbilities = PlayerImpl.getCastableSpellAbilities(game, playerId, object, game.getState().getZone(object.getId()), noMana);
+            Map<UUID, SpellAbility> useableAbilities = PlayerImpl.getCastableSpellAbilities(game, playerId, object, game.getState().getZone(object.getId()), noMana);
             if (useableAbilities != null
                     && useableAbilities.size() == 1) {
                 return useableAbilities.values().iterator().next();

--- a/Mage.Server/src/main/java/mage/server/draft/DraftController.java
+++ b/Mage.Server/src/main/java/mage/server/draft/DraftController.java
@@ -33,7 +33,7 @@ public class DraftController {
     private final Draft draft;
     private final UUID tableId;
 
-    public DraftController(ManagerFactory managerFactory, Draft draft, ConcurrentHashMap<UUID, UUID> userPlayerMap, UUID tableId) {
+    public DraftController(ManagerFactory managerFactory, Draft draft, ConcurrentMap<UUID, UUID> userPlayerMap, UUID tableId) {
         this.managerFactory = managerFactory;
         draftSessionId = UUID.randomUUID();
         this.userPlayerMap = userPlayerMap;

--- a/Mage.Sets/src/mage/cards/f/FatalGrudge.java
+++ b/Mage.Sets/src/mage/cards/f/FatalGrudge.java
@@ -1,6 +1,7 @@
 package mage.cards.f;
 
 import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import mage.MageObject;
@@ -95,9 +96,9 @@ class FatalGrudgeEffect extends OneShotEffect {
 
 class FatalGrudgePredicate implements Predicate<MageObject> {
 
-    private final HashSet<CardType> types;
+    private final Set<CardType> types;
 
-    public FatalGrudgePredicate(HashSet<CardType> types) {
+    public FatalGrudgePredicate(Set<CardType> types) {
         this.types = types;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -3209,7 +3209,7 @@ public class TestPlayer implements Player {
     }
 
     @Override
-    public LinkedHashMap<UUID, ActivatedAbility> getPlayableActivatedAbilities(MageObject object, Zone zone, Game game) {
+    public Map<UUID, ActivatedAbility> getPlayableActivatedAbilities(MageObject object, Zone zone, Game game) {
         return computerPlayer.getPlayableActivatedAbilities(object, zone, game);
     }
 

--- a/Mage.Verify/src/main/java/mage/verify/mtgjson/MtgJsonService.java
+++ b/Mage.Verify/src/main/java/mage/verify/mtgjson/MtgJsonService.java
@@ -144,15 +144,15 @@ public final class MtgJsonService {
 
     private static final class AtomicCardsModel {
 
-        // list by card names, each name can havem multiple cards (two faces, different cards with same name from un-sets)
-        public HashMap<String, ArrayList<MtgJsonCard>> data;
+        // list by card names, each name can have multiple cards (two faces, different cards with same name from un-sets)
+        public Map<String, ArrayList<MtgJsonCard>> data;
 
         private boolean containsSameNames(ArrayList<MtgJsonCard> list) {
             Set<String> names = list.stream().map(MtgJsonCard::getNameAsFace).collect(Collectors.toSet());
             return names.size() == 1;
         }
 
-        public HashMap<String, MtgJsonCard> prepareIndex() {
+        public Map<String, MtgJsonCard> prepareIndex() {
             HashMap<String, MtgJsonCard> index = new HashMap<>();
             for (Map.Entry<String, ArrayList<MtgJsonCard>> rec : data.entrySet()) {
                 if (rec.getValue().size() == 1) {
@@ -179,7 +179,7 @@ public final class MtgJsonService {
     }
 
     private static final class AllPrintingsModel {
-        public HashMap<String, MtgJsonSet> data;
+        public Map<String, MtgJsonSet> data;
         public MtgJsonMetadata meta;
     }
 

--- a/Mage/src/main/java/mage/abilities/condition/common/EquippedHasSupertypeCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/EquippedHasSupertypeCondition.java
@@ -9,6 +9,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 
 import java.util.EnumSet;
+import java.util.Set;
 
 /**
  *
@@ -18,13 +19,13 @@ import java.util.EnumSet;
 public class EquippedHasSupertypeCondition implements Condition {
 
     private SuperType superType;
-    private EnumSet<SuperType> superTypes = EnumSet.noneOf(SuperType.class); // scope = Any
+    private Set<SuperType> superTypes = EnumSet.noneOf(SuperType.class); // scope = Any
 
     public EquippedHasSupertypeCondition(SuperType supertype) {
         this.superType = supertype;
     }
 
-    public EquippedHasSupertypeCondition(EnumSet<SuperType> superTypes) {
+    public EquippedHasSupertypeCondition(Set<SuperType> superTypes) {
         this.superTypes = superTypes;
     }
 

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -811,7 +811,7 @@ public interface Player extends MageItem, Copyable<Player> {
 
     PlayableObjectsList getPlayableObjects(Game game, Zone zone);
 
-    LinkedHashMap<UUID, ActivatedAbility> getPlayableActivatedAbilities(MageObject object, Zone zone, Game game);
+    Map<UUID, ActivatedAbility> getPlayableActivatedAbilities(MageObject object, Zone zone, Game game);
 
     boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game);
 

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1534,7 +1534,7 @@ public abstract class PlayerImpl implements Player, Serializable {
      * @param noMana
      * @return
      */
-    public static LinkedHashMap<UUID, SpellAbility> getCastableSpellAbilities(Game game, UUID playerId, MageObject object, Zone zone, boolean noMana) {
+    public static Map<UUID, SpellAbility> getCastableSpellAbilities(Game game, UUID playerId, MageObject object, Zone zone, boolean noMana) {
         // it uses simple check from spellCanBeActivatedRegularlyNow
         // reason: no approved info here (e.g. forced to choose spell ability from cast card)
         LinkedHashMap<UUID, SpellAbility> useable = new LinkedHashMap<>();
@@ -1607,7 +1607,7 @@ public abstract class PlayerImpl implements Player, Serializable {
     }
 
     @Override
-    public LinkedHashMap<UUID, ActivatedAbility> getPlayableActivatedAbilities(MageObject object, Zone zone, Game game) {
+    public Map<UUID, ActivatedAbility> getPlayableActivatedAbilities(MageObject object, Zone zone, Game game) {
         LinkedHashMap<UUID, ActivatedAbility> useable = new LinkedHashMap<>();
         // stack abilities - can't activate anything
         // spell ability - can activate additional abilities (example: "Lightning Storm")
@@ -1634,7 +1634,7 @@ public abstract class PlayerImpl implements Player, Serializable {
         return useable;
     }
 
-    protected LinkedHashMap<UUID, ActivatedManaAbilityImpl> getUseableManaAbilities(MageObject object, Zone zone, Game game) {
+    protected Map<UUID, ActivatedManaAbilityImpl> getUseableManaAbilities(MageObject object, Zone zone, Game game) {
         LinkedHashMap<UUID, ActivatedManaAbilityImpl> useable = new LinkedHashMap<>();
         boolean canUse = !(object instanceof Permanent) || ((Permanent) object).canUseActivatedAbilities(game);
         for (ActivatedManaAbilityImpl ability : object.getAbilities().getActivatedManaAbilities(zone)) {

--- a/Mage/src/main/java/mage/util/ManaUtil.java
+++ b/Mage/src/main/java/mage/util/ManaUtil.java
@@ -62,10 +62,10 @@ public final class ManaUtil {
      *
      * @param unpaid           Mana we need to pay. Can be null (it is for X costs now).
      * @param useableAbilities List of mana abilities permanent may produce
-     * @return List of mana abilities permanent may produce and are reasonable
+     * @return Map of mana abilities permanent may produce and are reasonable
      * for unpaid mana
      */
-    public static LinkedHashMap<UUID, ActivatedManaAbilityImpl> tryToAutoPay(ManaCost unpaid, LinkedHashMap<UUID, ActivatedManaAbilityImpl> useableAbilities) {
+    public static Map<UUID, ActivatedManaAbilityImpl> tryToAutoPay(ManaCost unpaid, Map<UUID, ActivatedManaAbilityImpl> useableAbilities) {
 
         // first check if we have only basic mana abilities
         for (ActivatedManaAbilityImpl ability : useableAbilities.values()) {
@@ -141,7 +141,7 @@ public final class ManaUtil {
         return false;
     }
 
-    private static LinkedHashMap<UUID, ActivatedManaAbilityImpl> getManaAbilitiesUsingManaSymbols(LinkedHashMap<UUID, ActivatedManaAbilityImpl> useableAbilities, ManaSymbols symbols, Mana unpaidMana) {
+    private static Map<UUID, ActivatedManaAbilityImpl> getManaAbilitiesUsingManaSymbols(Map<UUID, ActivatedManaAbilityImpl> useableAbilities, ManaSymbols symbols, Mana unpaidMana) {
         Set<ManaSymbol> countColored = new HashSet<>();
 
         ActivatedManaAbilityImpl chosenManaAbility = null;
@@ -355,7 +355,7 @@ public final class ManaUtil {
      * @param useableAbilities
      * @return
      */
-    private static LinkedHashMap<UUID, ActivatedManaAbilityImpl> getManaAbilitiesUsingMana(ManaCost unpaid, LinkedHashMap<UUID, ActivatedManaAbilityImpl> useableAbilities) {
+    private static Map<UUID, ActivatedManaAbilityImpl> getManaAbilitiesUsingMana(ManaCost unpaid, Map<UUID, ActivatedManaAbilityImpl> useableAbilities) {
         Mana mana = unpaid.getMana();
 
         int countColorfull = 0;
@@ -408,7 +408,7 @@ public final class ManaUtil {
         return replace(useableAbilities, chosenManaAbility);
     }
 
-    private static LinkedHashMap<UUID, ActivatedManaAbilityImpl> replace(LinkedHashMap<UUID, ActivatedManaAbilityImpl> useableAbilities, ActivatedManaAbilityImpl chosenManaAbility) {
+    private static Map<UUID, ActivatedManaAbilityImpl> replace(Map<UUID, ActivatedManaAbilityImpl> useableAbilities, ActivatedManaAbilityImpl chosenManaAbility) {
         // modify the map with the chosen mana ability
         useableAbilities.clear();
         useableAbilities.put(chosenManaAbility.getId(), chosenManaAbility);


### PR DESCRIPTION
Cleaned up SonarLint errors of type `Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"`