### PR TITLE
Adds set symbol support for recent sets (past m20)

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/GathererSets.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/GathererSets.java
@@ -97,7 +97,13 @@ public class GathererSets implements Iterable<DownloadJob> {
             "GS1", "BBD", "C18",
             "GNT", "UMA", "GRN",
             "RNA", "WAR", "MH1",
-            "M20"
+            "M20",
+            "C19","ELD","MB1","GN2","J20","THB","UND","C20","IKO","M21",
+            "JMP","2XM","ZNR","KLR","CMR","KHC","KHM","TSR","STX","STA",
+            "C21","MH2","AFR","AFC","J21","MID","MIC","VOW","VOC","YMID",
+            "NEC","NEO","SNC","NCC","CLB","2X2","DMU","DMC","40K","GN3",
+            "UNF","BRO","BRC","BOT","30A","J22","SCD","DMR","ONE","ONC",
+            "MOM","MOC","MUL","MAT","LTR","CMM","WOE","WHO","RVR","WOT","WOC" 
             // "HHO", "ANA" -- do not exist on gatherer
     };
 


### PR DESCRIPTION
I wish there was a better way to update this without adding every set that has set symbols manually to an array, but alas. This should fix most sets past m20 not having set symbols in xmage.