### PR TITLE
Clean all copy constructors in cards starting T

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TIESilencer.java
+++ b/Mage.Sets/src/mage/cards/t/TIESilencer.java
@@ -58,7 +58,7 @@ class TIESilencerEffect extends OneShotEffect {
         staticText = "it deals 1 damage to defending player and 1 damage to up to one target creature that player controls";
     }
 
-    public TIESilencerEffect(final TIESilencerEffect effect) {
+    private TIESilencerEffect(final TIESilencerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TabletOfTheGuilds.java
+++ b/Mage.Sets/src/mage/cards/t/TabletOfTheGuilds.java
@@ -58,7 +58,7 @@ class TabletOfTheGuildsEntersBattlefieldEffect extends OneShotEffect {
         staticText = "choose two colors";
     }
 
-    public TabletOfTheGuildsEntersBattlefieldEffect(final TabletOfTheGuildsEntersBattlefieldEffect effect) {
+    private TabletOfTheGuildsEntersBattlefieldEffect(final TabletOfTheGuildsEntersBattlefieldEffect effect) {
         super(effect);
     }
 
@@ -102,7 +102,7 @@ class TabletOfTheGuildsGainLifeEffect extends OneShotEffect {
         staticText = "if it's at least one of the chosen colors, you gain 1 life for each of the chosen colors it is";
     }
 
-    public TabletOfTheGuildsGainLifeEffect(final TabletOfTheGuildsGainLifeEffect effect) {
+    private TabletOfTheGuildsGainLifeEffect(final TabletOfTheGuildsGainLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TaigamOjutaiMaster.java
+++ b/Mage.Sets/src/mage/cards/t/TaigamOjutaiMaster.java
@@ -116,7 +116,7 @@ class TaigamOjutaiMasterGainReboundEffect extends ContinuousEffectImpl {
         staticText = "that spell gains rebound";
     }
 
-    public TaigamOjutaiMasterGainReboundEffect(final TaigamOjutaiMasterGainReboundEffect effect) {
+    private TaigamOjutaiMasterGainReboundEffect(final TaigamOjutaiMasterGainReboundEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TaintedPact.java
+++ b/Mage.Sets/src/mage/cards/t/TaintedPact.java
@@ -45,7 +45,7 @@ class TaintedPactEffect extends OneShotEffect {
         this.staticText = "Exile the top card of your library. You may put that card into your hand unless it has the same name as another card exiled this way. Repeat this process until you put a card into your hand or you exile two cards with the same name, whichever comes first";
     }
 
-    public TaintedPactEffect(final TaintedPactEffect effect) {
+    private TaintedPactEffect(final TaintedPactEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TaintedRemedy.java
+++ b/Mage.Sets/src/mage/cards/t/TaintedRemedy.java
@@ -46,7 +46,7 @@ class TaintedRemedyReplacementEffect extends ReplacementEffectImpl {
         staticText = "If an opponent would gain life, that player loses that much life instead";
     }
 
-    public TaintedRemedyReplacementEffect(final TaintedRemedyReplacementEffect effect) {
+    private TaintedRemedyReplacementEffect(final TaintedRemedyReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TaintedStrike.java
+++ b/Mage.Sets/src/mage/cards/t/TaintedStrike.java
@@ -26,7 +26,7 @@ public final class TaintedStrike extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public TaintedStrike (final TaintedStrike card) {
+    private TaintedStrike(final TaintedStrike card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TajuruPreserver.java
+++ b/Mage.Sets/src/mage/cards/t/TajuruPreserver.java
@@ -48,7 +48,7 @@ class TajuruPreserverEffect extends ReplacementEffectImpl {
         staticText = "Spells and abilities your opponents control can't cause you to sacrifice permanents";
     }
 
-    public TajuruPreserverEffect(final TajuruPreserverEffect effect) {
+    private TajuruPreserverEffect(final TajuruPreserverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TakenoSamuraiGeneral.java
+++ b/Mage.Sets/src/mage/cards/t/TakenoSamuraiGeneral.java
@@ -58,7 +58,7 @@ class TakenoSamuraiGeneralEffect extends ContinuousEffectImpl {
         staticText = "Each other Samurai creature you control gets +1/+1 for each point of bushido it has";
     }
 
-    public TakenoSamuraiGeneralEffect(final TakenoSamuraiGeneralEffect effect) {
+    private TakenoSamuraiGeneralEffect(final TakenoSamuraiGeneralEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TakenumaBleeder.java
+++ b/Mage.Sets/src/mage/cards/t/TakenumaBleeder.java
@@ -51,7 +51,7 @@ class TakenumaBleederEffect extends OneShotEffect {
         this.staticText = "you lose 1 life if you don't control a Demon";
     }
     
-    public TakenumaBleederEffect(final TakenumaBleederEffect effect) {
+    private TakenumaBleederEffect(final TakenumaBleederEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/t/TalarasBane.java
+++ b/Mage.Sets/src/mage/cards/t/TalarasBane.java
@@ -60,7 +60,7 @@ class TalarasBaneEffect extends OneShotEffect {
         this.staticText = "Target opponent reveals their hand. You choose a green or white creature card from it. You gain life equal to that creature card's toughness, then that player discards that card";
     }
 
-    public TalarasBaneEffect(final TalarasBaneEffect effect) {
+    private TalarasBaneEffect(final TalarasBaneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TalentOfTheTelepath.java
+++ b/Mage.Sets/src/mage/cards/t/TalentOfTheTelepath.java
@@ -62,7 +62,7 @@ class TalentOfTheTelepathEffect extends OneShotEffect {
                 "instant and/or sorcery spells from among the revealed cards instead of one.";
     }
 
-    public TalentOfTheTelepathEffect(final TalentOfTheTelepathEffect effect) {
+    private TalentOfTheTelepathEffect(final TalentOfTheTelepathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TalonOfPain.java
+++ b/Mage.Sets/src/mage/cards/t/TalonOfPain.java
@@ -67,7 +67,7 @@ class TalonOfPainTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a source you control other than {this} deals damage to an opponent, ");
     }
 
-    public TalonOfPainTriggeredAbility(final TalonOfPainTriggeredAbility ability) {
+    private TalonOfPainTriggeredAbility(final TalonOfPainTriggeredAbility ability) {
         super(ability);
     }
 
@@ -128,7 +128,7 @@ class TalonOfPainRemoveVariableCountersSourceCost extends VariableCostImpl {
         }
     }
 
-    public TalonOfPainRemoveVariableCountersSourceCost(final TalonOfPainRemoveVariableCountersSourceCost cost) {
+    private TalonOfPainRemoveVariableCountersSourceCost(final TalonOfPainRemoveVariableCountersSourceCost cost) {
         super(cost);
         this.minimalCountersToPay = cost.minimalCountersToPay;
         this.counterName = cost.counterName;

--- a/Mage.Sets/src/mage/cards/t/TalonTrooper.java
+++ b/Mage.Sets/src/mage/cards/t/TalonTrooper.java
@@ -27,7 +27,7 @@ public final class TalonTrooper extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public TalonTrooper (final TalonTrooper card) {
+    private TalonTrooper(final TalonTrooper card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TalruumPiper.java
+++ b/Mage.Sets/src/mage/cards/t/TalruumPiper.java
@@ -49,7 +49,7 @@ class TalruumPiperEffect extends RequirementEffect {
         staticText = "All creatures with flying able to block {this} do so";
     }
 
-    public TalruumPiperEffect(TalruumPiperEffect effect) {
+    private TalruumPiperEffect(final TalruumPiperEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TalusPaladin.java
+++ b/Mage.Sets/src/mage/cards/t/TalusPaladin.java
@@ -102,7 +102,7 @@ class TalusPaladinEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
     
-    public TalusPaladinEffect(final TalusPaladinEffect effect) {
+    private TalusPaladinEffect(final TalusPaladinEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/t/Tamanoa.java
+++ b/Mage.Sets/src/mage/cards/t/Tamanoa.java
@@ -52,7 +52,7 @@ class TamanoaDealsDamageTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a noncreature source you control deals damage, ");
     }
 
-    public TamanoaDealsDamageTriggeredAbility(final TamanoaDealsDamageTriggeredAbility ability) {
+    private TamanoaDealsDamageTriggeredAbility(final TamanoaDealsDamageTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TamiyoFieldResearcher.java
+++ b/Mage.Sets/src/mage/cards/t/TamiyoFieldResearcher.java
@@ -86,7 +86,7 @@ class TamiyoFieldResearcherEffect1 extends OneShotEffect {
         this.staticText = "Choose up to two target creatures. Until your next turn, whenever either of those creatures deals combat damage, you draw a card";
     }
 
-    public TamiyoFieldResearcherEffect1(final TamiyoFieldResearcherEffect1 effect) {
+    private TamiyoFieldResearcherEffect1(final TamiyoFieldResearcherEffect1 effect) {
         super(effect);
     }
 
@@ -124,7 +124,7 @@ class TamiyoFieldResearcherDelayedTriggeredAbility extends DelayedTriggeredAbili
         this.startingTurn = startingTurn;
     }
 
-    public TamiyoFieldResearcherDelayedTriggeredAbility(final TamiyoFieldResearcherDelayedTriggeredAbility ability) {
+    private TamiyoFieldResearcherDelayedTriggeredAbility(final TamiyoFieldResearcherDelayedTriggeredAbility ability) {
         super(ability);
         this.creatures = ability.creatures;
         this.startingTurn = ability.startingTurn;

--- a/Mage.Sets/src/mage/cards/t/Tangle.java
+++ b/Mage.Sets/src/mage/cards/t/Tangle.java
@@ -60,7 +60,7 @@ class TangleEffect extends OneShotEffect {
         this.staticText = "Each attacking creature doesn't untap during its controller's next untap step";
     }
 
-    public TangleEffect(final TangleEffect effect) {
+    private TangleEffect(final TangleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TangleHulk.java
+++ b/Mage.Sets/src/mage/cards/t/TangleHulk.java
@@ -28,7 +28,7 @@ public final class TangleHulk extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new ManaCostsImpl<>("{2}{G}")));
     }
 
-    public TangleHulk (final TangleHulk card) {
+    private TangleHulk(final TangleHulk card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TangleKelp.java
+++ b/Mage.Sets/src/mage/cards/t/TangleKelp.java
@@ -68,7 +68,7 @@ class DontUntapIfAttackedLastTurnEnchantedEffect extends ContinuousRuleModifying
         staticText = "Enchanted creature doesn't untap during its controller's untap step if it attacked during its controller's last turn";
     }
 
-    public DontUntapIfAttackedLastTurnEnchantedEffect(final DontUntapIfAttackedLastTurnEnchantedEffect effect) {
+    private DontUntapIfAttackedLastTurnEnchantedEffect(final DontUntapIfAttackedLastTurnEnchantedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TangleMantis.java
+++ b/Mage.Sets/src/mage/cards/t/TangleMantis.java
@@ -25,7 +25,7 @@ public final class TangleMantis extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
     }
 
-    public TangleMantis (final TangleMantis card) {
+    private TangleMantis(final TangleMantis card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Taniwha.java
+++ b/Mage.Sets/src/mage/cards/t/Taniwha.java
@@ -63,7 +63,7 @@ class TaniwhaEffect extends OneShotEffect {
         this.staticText = "all lands you control phase out";
     }
 
-    public TaniwhaEffect(final TaniwhaEffect effect) {
+    private TaniwhaEffect(final TaniwhaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TarielReckonerOfSouls.java
+++ b/Mage.Sets/src/mage/cards/t/TarielReckonerOfSouls.java
@@ -60,7 +60,7 @@ class TarielReckonerOfSoulsEffect extends OneShotEffect {
         this.staticText = "Choose a creature card at random from target opponent's graveyard. Put that card onto the battlefield under your control";
     }
 
-    public TarielReckonerOfSoulsEffect(final TarielReckonerOfSoulsEffect effect) {
+    private TarielReckonerOfSoulsEffect(final TarielReckonerOfSoulsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Tariff.java
+++ b/Mage.Sets/src/mage/cards/t/Tariff.java
@@ -54,7 +54,7 @@ class TariffEffect extends OneShotEffect {
         this.staticText = "Each player sacrifices the creature they control with the highest mana value unless they pay that creature's mana cost. If two or more creatures a player controls are tied for highest, that player chooses one.";
     }
 
-    public TariffEffect(final TariffEffect effect) {
+    private TariffEffect(final TariffEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TaskMageAssembly.java
+++ b/Mage.Sets/src/mage/cards/t/TaskMageAssembly.java
@@ -55,7 +55,7 @@ class TaskMageAssemblyStateTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("When there are no creatures on the battlefield, ");
     }
 
-    public TaskMageAssemblyStateTriggeredAbility(final TaskMageAssemblyStateTriggeredAbility ability) {
+    private TaskMageAssemblyStateTriggeredAbility(final TaskMageAssemblyStateTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TatsumasaTheDragonsFang.java
+++ b/Mage.Sets/src/mage/cards/t/TatsumasaTheDragonsFang.java
@@ -65,7 +65,7 @@ class TatsumaTheDragonsFangEffect extends OneShotEffect {
                 "Return {this} to the battlefield under its owner's control when that token dies";
     }
 
-    public TatsumaTheDragonsFangEffect(final TatsumaTheDragonsFangEffect effect) {
+    private TatsumaTheDragonsFangEffect(final TatsumaTheDragonsFangEffect effect) {
         super(effect);
     }
 
@@ -92,7 +92,7 @@ class TatsumaTheDragonsFangTriggeredAbility extends DelayedTriggeredAbility {
         tokens.addAll(token.getLastAddedTokenIds());
     }
 
-    public TatsumaTheDragonsFangTriggeredAbility(final TatsumaTheDragonsFangTriggeredAbility ability) {
+    private TatsumaTheDragonsFangTriggeredAbility(final TatsumaTheDragonsFangTriggeredAbility ability) {
         super(ability);
         tokens.addAll(ability.tokens);
     }

--- a/Mage.Sets/src/mage/cards/t/TatteredDrake.java
+++ b/Mage.Sets/src/mage/cards/t/TatteredDrake.java
@@ -31,7 +31,7 @@ public final class TatteredDrake extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new ManaCostsImpl<>("{B}")));
     }
 
-    public TatteredDrake (final TatteredDrake card) {
+    private TatteredDrake(final TatteredDrake card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TavernSwindler.java
+++ b/Mage.Sets/src/mage/cards/t/TavernSwindler.java
@@ -54,7 +54,7 @@ class TavernSwindlerEffect extends OneShotEffect {
         staticText = "Flip a coin. If you win the flip, you gain 6 life";
     }
 
-    public TavernSwindlerEffect(TavernSwindlerEffect effect) {
+    private TavernSwindlerEffect(final TavernSwindlerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TawnossCoffin.java
+++ b/Mage.Sets/src/mage/cards/t/TawnossCoffin.java
@@ -69,7 +69,7 @@ class TawnossCoffinTriggeredAbility extends LeavesBattlefieldTriggeredAbility {
         setTriggerPhrase("When {this} leaves the battlefield or becomes untapped, ");
     }
 
-    public TawnossCoffinTriggeredAbility(final TawnossCoffinTriggeredAbility ability) {
+    private TawnossCoffinTriggeredAbility(final TawnossCoffinTriggeredAbility ability) {
         super(ability);
     }
 
@@ -107,7 +107,7 @@ class TawnossCoffinEffect extends OneShotEffect {
                           "Note the number and kind of counters that were on that creature";
     }
 
-    public TawnossCoffinEffect(final TawnossCoffinEffect effect) {
+    private TawnossCoffinEffect(final TawnossCoffinEffect effect) {
         super(effect);
     }
 
@@ -151,7 +151,7 @@ class TawnossCoffinReturnEffect extends OneShotEffect {
                           "If you do, return the exiled Aura cards to the battlefield under their owner's control attached to that permanent";
     }
 
-    public TawnossCoffinReturnEffect(final TawnossCoffinReturnEffect effect) {
+    private TawnossCoffinReturnEffect(final TawnossCoffinReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TayamLuminousEnigma.java
+++ b/Mage.Sets/src/mage/cards/t/TayamLuminousEnigma.java
@@ -85,7 +85,7 @@ class TayamLuminousEnigmaCost extends RemoveCounterCost {
         super(new TargetPermanent(1, 1, filter, true), null, 3);
     }
 
-    public TayamLuminousEnigmaCost(TayamLuminousEnigmaCost cost) {
+    private TayamLuminousEnigmaCost(final TayamLuminousEnigmaCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TearsOfRage.java
+++ b/Mage.Sets/src/mage/cards/t/TearsOfRage.java
@@ -58,7 +58,7 @@ class TearsOfRageEffect extends OneShotEffect {
         this.staticText = "Sacrifice those creatures at the beginning of the next end step";
     }
 
-    public TearsOfRageEffect(final TearsOfRageEffect effect) {
+    private TearsOfRageEffect(final TearsOfRageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TeferiMageOfZhalfir.java
+++ b/Mage.Sets/src/mage/cards/t/TeferiMageOfZhalfir.java
@@ -59,7 +59,7 @@ class TeferiMageOfZhalfirAddFlashEffect extends ContinuousEffectImpl {
         this.staticText = "Creature cards you own that aren't on the battlefield have flash";
     }
 
-    public TeferiMageOfZhalfirAddFlashEffect(final TeferiMageOfZhalfirAddFlashEffect effect) {
+    private TeferiMageOfZhalfirAddFlashEffect(final TeferiMageOfZhalfirAddFlashEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TeferisProtection.java
+++ b/Mage.Sets/src/mage/cards/t/TeferisProtection.java
@@ -78,7 +78,7 @@ class TeferisProtectionEffect extends OneShotEffect {
         staticText = " and you gain protection from everything";
     }
 
-    public TeferisProtectionEffect(final TeferisProtectionEffect effect) {
+    private TeferisProtectionEffect(final TeferisProtectionEffect effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class TeferisProtectionPhaseOutEffect extends OneShotEffect {
         this.staticText = "All permanents you control phase out. <i>(While they're phased out, they're treated as though they don't exist. They phase in before you untap during your untap step.)</i><br>";
     }
 
-    public TeferisProtectionPhaseOutEffect(final TeferisProtectionPhaseOutEffect effect) {
+    private TeferisProtectionPhaseOutEffect(final TeferisProtectionPhaseOutEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TeferisPuzzleBox.java
+++ b/Mage.Sets/src/mage/cards/t/TeferisPuzzleBox.java
@@ -45,7 +45,7 @@ class TeferisPuzzleBoxEffect extends OneShotEffect {
         staticText = "that player puts the cards in their hand on the bottom of their library in any order, then draws that many cards";
     }
 
-    public TeferisPuzzleBoxEffect(final TeferisPuzzleBoxEffect effect) {
+    private TeferisPuzzleBoxEffect(final TeferisPuzzleBoxEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TeferisRealm.java
+++ b/Mage.Sets/src/mage/cards/t/TeferisRealm.java
@@ -63,7 +63,7 @@ class TeferisRealmEffect extends OneShotEffect {
         this.staticText = "that player chooses artifact, creature, land, or non-Aura enchantment. All nontoken permanents of that type phase out";
     }
 
-    public TeferisRealmEffect(final TeferisRealmEffect effect) {
+    private TeferisRealmEffect(final TeferisRealmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TeferisResponse.java
+++ b/Mage.Sets/src/mage/cards/t/TeferisResponse.java
@@ -58,7 +58,7 @@ class TeferisResponseEffect extends OneShotEffect {
         this.staticText = "Counter target spell or ability an opponent controls that targets a land you control. If a permanent's ability is countered this way, destroy that permanent";
     }
         
-    public TeferisResponseEffect(final TeferisResponseEffect effect) {
+    private TeferisResponseEffect(final TeferisResponseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TelJiladFallen.java
+++ b/Mage.Sets/src/mage/cards/t/TelJiladFallen.java
@@ -30,7 +30,7 @@ public final class TelJiladFallen extends CardImpl {
         this.addAbility(new ProtectionAbility(new FilterArtifactCard("artifacts")));
     }
 
-    public TelJiladFallen (final TelJiladFallen card) {
+    private TelJiladFallen(final TelJiladFallen card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TeleminPerformance.java
+++ b/Mage.Sets/src/mage/cards/t/TeleminPerformance.java
@@ -47,7 +47,7 @@ class TeleminPerformanceEffect extends OneShotEffect {
         this.staticText = "Target opponent reveals cards from the top of their library until they reveal a creature card. That player puts all noncreature cards revealed this way into their graveyard, then you put the creature card onto the battlefield under your control";
     }
 
-    public TeleminPerformanceEffect(final TeleminPerformanceEffect effect) {
+    private TeleminPerformanceEffect(final TeleminPerformanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Teleportal.java
+++ b/Mage.Sets/src/mage/cards/t/Teleportal.java
@@ -56,7 +56,7 @@ class TeleportalEffect extends OneShotEffect {
         staticText = "each creature you control can't be blocked this turn";
     }
 
-    public TeleportalEffect(final TeleportalEffect effect) {
+    private TeleportalEffect(final TeleportalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TellingTime.java
+++ b/Mage.Sets/src/mage/cards/t/TellingTime.java
@@ -49,7 +49,7 @@ class TellingTimeEffect extends OneShotEffect {
         this.staticText = "Look at the top three cards of your library. Put one of those cards into your hand, one on top of your library, and one on the bottom of your library.";
     }
 
-    public TellingTimeEffect(final TellingTimeEffect effect) {
+    private TellingTimeEffect(final TellingTimeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TempOfTheDamned.java
+++ b/Mage.Sets/src/mage/cards/t/TempOfTheDamned.java
@@ -55,7 +55,7 @@ class TempOfTheDamnedEffect extends OneShotEffect {
         staticText = "roll a six-sided die. {this} enters the battlefield with a number of funk counters on it equal to the result";
     }
 
-    public TempOfTheDamnedEffect(final TempOfTheDamnedEffect effect) {
+    private TempOfTheDamnedEffect(final TempOfTheDamnedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Temper.java
+++ b/Mage.Sets/src/mage/cards/t/Temper.java
@@ -55,7 +55,7 @@ class TemperPreventDamageTargetEffect extends PreventionEffectImpl {
         staticText = "Prevent the next X damage that would be dealt to target creature this turn. For each 1 damage prevented this way, put a +1/+1 counter on that creature";
     }
 
-    public TemperPreventDamageTargetEffect(final TemperPreventDamageTargetEffect effect) {
+    private TemperPreventDamageTargetEffect(final TemperPreventDamageTargetEffect effect) {
         super(effect);
         this.amount = effect.amount;
         this.dVal = effect.dVal;

--- a/Mage.Sets/src/mage/cards/t/TemperedSteel.java
+++ b/Mage.Sets/src/mage/cards/t/TemperedSteel.java
@@ -29,7 +29,7 @@ public final class TemperedSteel extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostControlledEffect(2, 2, Duration.WhileOnBattlefield, filter, false)));
     }
 
-    public TemperedSteel (final TemperedSteel card) {
+    private TemperedSteel(final TemperedSteel card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TempleAcolyte.java
+++ b/Mage.Sets/src/mage/cards/t/TempleAcolyte.java
@@ -27,7 +27,7 @@ public final class TempleAcolyte extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new GainLifeEffect(3)));
     }
 
-    public TempleAcolyte (final TempleAcolyte card) {
+    private TempleAcolyte(final TempleAcolyte card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TempleAltisaur.java
+++ b/Mage.Sets/src/mage/cards/t/TempleAltisaur.java
@@ -51,7 +51,7 @@ class TempleAltisaurPreventEffect extends PreventionEffectImpl {
         consumable = false;
     }
 
-    public TempleAltisaurPreventEffect(TempleAltisaurPreventEffect effect) {
+    private TempleAltisaurPreventEffect(final TempleAltisaurPreventEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TempleOfAclazotz.java
+++ b/Mage.Sets/src/mage/cards/t/TempleOfAclazotz.java
@@ -58,7 +58,7 @@ class TempleOfAclazotzEffect extends OneShotEffect {
         this.staticText = "You gain life equal to the sacrificed creature's toughness";
     }
 
-    public TempleOfAclazotzEffect(final TempleOfAclazotzEffect effect) {
+    private TempleOfAclazotzEffect(final TempleOfAclazotzEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemporalAperture.java
+++ b/Mage.Sets/src/mage/cards/t/TemporalAperture.java
@@ -58,7 +58,7 @@ class TemporalApertureEffect extends OneShotEffect {
                 + "paying its mana cost";
     }
 
-    public TemporalApertureEffect(final TemporalApertureEffect effect) {
+    private TemporalApertureEffect(final TemporalApertureEffect effect) {
         super(effect);
     }
 
@@ -96,7 +96,7 @@ class TemporalApertureTopCardCastEffect extends AsThoughEffectImpl {
                 + "of your library, you may cast it without paying its mana costs";
     }
 
-    public TemporalApertureTopCardCastEffect(final TemporalApertureTopCardCastEffect effect) {
+    private TemporalApertureTopCardCastEffect(final TemporalApertureTopCardCastEffect effect) {
         super(effect);
         this.card = effect.card;
     }

--- a/Mage.Sets/src/mage/cards/t/TemporalCascade.java
+++ b/Mage.Sets/src/mage/cards/t/TemporalCascade.java
@@ -51,7 +51,7 @@ class TemporalCascadeDrawEffect extends OneShotEffect {
         staticText = "Each player draws seven cards";
     }
 
-    public TemporalCascadeDrawEffect(final TemporalCascadeDrawEffect effect) {
+    private TemporalCascadeDrawEffect(final TemporalCascadeDrawEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemporalDistortion.java
+++ b/Mage.Sets/src/mage/cards/t/TemporalDistortion.java
@@ -69,7 +69,7 @@ class TemporalDistortionRemovalEffect extends OneShotEffect {
         staticText = "remove all hourglass counters from permanents that player controls";
     }
 
-    public TemporalDistortionRemovalEffect(final TemporalDistortionRemovalEffect effect) {
+    private TemporalDistortionRemovalEffect(final TemporalDistortionRemovalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemporalExtortion.java
+++ b/Mage.Sets/src/mage/cards/t/TemporalExtortion.java
@@ -48,7 +48,7 @@ class TemporalExtortionCounterSourceEffect extends OneShotEffect {
         staticText = "any player may pay half their life, rounded up. If a player does, counter {this}";
     }
 
-    public TemporalExtortionCounterSourceEffect(final TemporalExtortionCounterSourceEffect effect) {
+    private TemporalExtortionCounterSourceEffect(final TemporalExtortionCounterSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemporaryInsanity.java
+++ b/Mage.Sets/src/mage/cards/t/TemporaryInsanity.java
@@ -59,7 +59,7 @@ class TargetCreatureWithPowerLessThanNumberOfCardsInYourGraveyard extends Target
         targetName = "creature with power less than the number of cards in your graveyard";
     }
 
-    public TargetCreatureWithPowerLessThanNumberOfCardsInYourGraveyard(final TargetCreatureWithPowerLessThanNumberOfCardsInYourGraveyard target) {
+    private TargetCreatureWithPowerLessThanNumberOfCardsInYourGraveyard(final TargetCreatureWithPowerLessThanNumberOfCardsInYourGraveyard target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemptWithDiscovery.java
+++ b/Mage.Sets/src/mage/cards/t/TemptWithDiscovery.java
@@ -50,7 +50,7 @@ class TemptWithDiscoveryEffect extends OneShotEffect {
         this.staticText = "<i>Tempting offer</i> &mdash; Search your library for a land card and put it onto the battlefield. Each opponent may search their library for a land card and put it onto the battlefield. For each opponent who searches a library this way, search your library for a land card and put it onto the battlefield. Then each player who searched a library this way shuffles";
     }
 
-    public TemptWithDiscoveryEffect(final TemptWithDiscoveryEffect effect) {
+    private TemptWithDiscoveryEffect(final TemptWithDiscoveryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemptWithGlory.java
+++ b/Mage.Sets/src/mage/cards/t/TemptWithGlory.java
@@ -48,7 +48,7 @@ class TemptWithGloryEffect extends OneShotEffect {
         this.staticText = "<i>Tempting offer</i> &mdash; Put a +1/+1 counter on each creature you control. Each opponent may put a +1/+1 counter on each creature they control. For each opponent who does, put a +1/+1 counter on each creature you control";
     }
 
-    public TemptWithGloryEffect(final TemptWithGloryEffect effect) {
+    private TemptWithGloryEffect(final TemptWithGloryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemptWithImmortality.java
+++ b/Mage.Sets/src/mage/cards/t/TemptWithImmortality.java
@@ -50,7 +50,7 @@ class TemptWithImmortalityEffect extends OneShotEffect {
 
     }
 
-    public TemptWithImmortalityEffect(final TemptWithImmortalityEffect effect) {
+    private TemptWithImmortalityEffect(final TemptWithImmortalityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemptWithReflections.java
+++ b/Mage.Sets/src/mage/cards/t/TemptWithReflections.java
@@ -48,7 +48,7 @@ class TemptWithReflectionsEffect extends OneShotEffect {
         this.staticText = "<i>Tempting offer</i> &mdash; Choose target creature you control. Create a token that's a copy of that creature. Each opponent may create a token that's a copy of that creature. For each opponent who does, create a token that's a copy of that creature";
     }
 
-    public TemptWithReflectionsEffect(final TemptWithReflectionsEffect effect) {
+    private TemptWithReflectionsEffect(final TemptWithReflectionsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemptWithVengeance.java
+++ b/Mage.Sets/src/mage/cards/t/TemptWithVengeance.java
@@ -43,7 +43,7 @@ class TemptWithVengeanceEffect extends OneShotEffect {
         this.staticText = "<i>Tempting offer</i> &mdash; Create X 1/1 red Elemental creature tokens with haste. Each opponent may create X 1/1 red Elemental creature tokens with haste. For each opponent who does, create X 1/1 red Elemental creature tokens with haste";
     }
 
-    public TemptWithVengeanceEffect(final TemptWithVengeanceEffect effect) {
+    private TemptWithVengeanceEffect(final TemptWithVengeanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemurSabertooth.java
+++ b/Mage.Sets/src/mage/cards/t/TemurSabertooth.java
@@ -56,7 +56,7 @@ class TemurSabertoothEffect extends OneShotEffect {
         this.staticText = "You may return another creature you control to its owner's hand. If you do, {this} gains indestructible until end of turn";
     }
 
-    public TemurSabertoothEffect(final TemurSabertoothEffect effect) {
+    private TemurSabertoothEffect(final TemurSabertoothEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TerashisGrasp.java
+++ b/Mage.Sets/src/mage/cards/t/TerashisGrasp.java
@@ -50,7 +50,7 @@ public final class TerashisGrasp extends CardImpl {
             staticText = "You gain life equal to its mana value";
         }
 
-        public TerashisGraspEffect(TerashisGraspEffect effect) {
+        private TerashisGraspEffect(final TerashisGraspEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/t/Terastodon.java
+++ b/Mage.Sets/src/mage/cards/t/Terastodon.java
@@ -65,7 +65,7 @@ class TerastodonEffect extends OneShotEffect {
         this.staticText = "you may destroy up to three target noncreature permanents. For each permanent put into a graveyard this way, its controller creates a 3/3 green Elephant creature token";
     }
 
-    public TerastodonEffect(final TerastodonEffect effect) {
+    private TerastodonEffect(final TerastodonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TeremkoGriffin.java
+++ b/Mage.Sets/src/mage/cards/t/TeremkoGriffin.java
@@ -31,7 +31,7 @@ public final class TeremkoGriffin extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public TeremkoGriffin (final TeremkoGriffin card) {
+    private TeremkoGriffin(final TeremkoGriffin card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TergridGodOfFright.java
+++ b/Mage.Sets/src/mage/cards/t/TergridGodOfFright.java
@@ -142,7 +142,7 @@ class TergridGodOfFrightEffect extends OneShotEffect {
         super(Outcome.Neutral);
     }
 
-    public TergridGodOfFrightEffect(final TergridGodOfFrightEffect effect) {
+    private TergridGodOfFrightEffect(final TergridGodOfFrightEffect effect) {
         super(effect);
     }
 
@@ -177,7 +177,7 @@ class TergridsLaternEffect extends OneShotEffect {
         staticText = "Target player loses 3 life unless they sacrifice a nonland permanent or discard a card";
     }
 
-    public TergridsLaternEffect(final TergridsLaternEffect effect) {
+    private TergridsLaternEffect(final TergridsLaternEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Terminus.java
+++ b/Mage.Sets/src/mage/cards/t/Terminus.java
@@ -49,7 +49,7 @@ class TerminusEffect extends OneShotEffect {
         this.staticText = "Put all creatures on the bottom of their owners' libraries";
     }
 
-    public TerminusEffect(final TerminusEffect effect) {
+    private TerminusEffect(final TerminusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TerrifyingPresence.java
+++ b/Mage.Sets/src/mage/cards/t/TerrifyingPresence.java
@@ -44,7 +44,7 @@ class TerrifyingPresenceEffect extends PreventionEffectImpl {
         this.staticText = "Prevent all combat damage that would be dealt by creatures other than target creature this turn";
     }
 
-    public TerrifyingPresenceEffect(final TerrifyingPresenceEffect effect) {
+    private TerrifyingPresenceEffect(final TerrifyingPresenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TerritorialDispute.java
+++ b/Mage.Sets/src/mage/cards/t/TerritorialDispute.java
@@ -56,7 +56,7 @@ class TerritorialDisputeEffect extends ContinuousRuleModifyingEffectImpl {
         this.staticText = "Players can't play lands";
     }
     
-    public TerritorialDisputeEffect(final TerritorialDisputeEffect effect) {
+    private TerritorialDisputeEffect(final TerritorialDisputeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TerritorialHellkite.java
+++ b/Mage.Sets/src/mage/cards/t/TerritorialHellkite.java
@@ -103,7 +103,7 @@ class AttackIfAbleTargetRandoOpponentSourceEffect extends OneShotEffect {
         this.staticText = "choose an opponent at random that {this} didn't attack during your last combat. {this} attacks that player this combat if able. If you can't choose an opponent this way, tap {this}";
     }
 
-    public AttackIfAbleTargetRandoOpponentSourceEffect(final AttackIfAbleTargetRandoOpponentSourceEffect effect) {
+    private AttackIfAbleTargetRandoOpponentSourceEffect(final AttackIfAbleTargetRandoOpponentSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TesharAncestorsApostle.java
+++ b/Mage.Sets/src/mage/cards/t/TesharAncestorsApostle.java
@@ -52,7 +52,7 @@ public final class TesharAncestorsApostle extends CardImpl {
 
     }
 
-    public TesharAncestorsApostle(final TesharAncestorsApostle TesharAncestorsApostle) {
+    private TesharAncestorsApostle(final TesharAncestorsApostle TesharAncestorsApostle) {
         super(TesharAncestorsApostle);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TestOfFaith.java
+++ b/Mage.Sets/src/mage/cards/t/TestOfFaith.java
@@ -49,7 +49,7 @@ class TestOfFaithPreventDamageTargetEffect extends PreventionEffectImpl {
         staticText = "Prevent the next 3 damage that would be dealt to target creature this turn. For each 1 damage prevented this way, put a +1/+1 counter on that creature";
     }
 
-    public TestOfFaithPreventDamageTargetEffect(final TestOfFaithPreventDamageTargetEffect effect) {
+    private TestOfFaithPreventDamageTargetEffect(final TestOfFaithPreventDamageTargetEffect effect) {
         super(effect);
         this.amount = effect.amount;
     }

--- a/Mage.Sets/src/mage/cards/t/Tetravus.java
+++ b/Mage.Sets/src/mage/cards/t/Tetravus.java
@@ -86,7 +86,7 @@ class TetravusCreateTokensEffect extends OneShotEffect {
                 + "They each have flying and \"This creature can't be enchanted.\"";
     }
 
-    public TetravusCreateTokensEffect(final TetravusCreateTokensEffect effect) {
+    private TetravusCreateTokensEffect(final TetravusCreateTokensEffect effect) {
         super(effect);
     }
 
@@ -137,7 +137,7 @@ class TetravusAddCountersEffect extends OneShotEffect {
                 + "If you do, put that many +1/+1 counters on {this}";
     }
 
-    public TetravusAddCountersEffect(final TetravusAddCountersEffect effect) {
+    private TetravusAddCountersEffect(final TetravusAddCountersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TetsuoUmezawa.java
+++ b/Mage.Sets/src/mage/cards/t/TetsuoUmezawa.java
@@ -72,7 +72,7 @@ class TetsuoUmezawaEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "{this} can't be the target of Aura spells";
     }
 
-    public TetsuoUmezawaEffect(final TetsuoUmezawaEffect effect) {
+    private TetsuoUmezawaEffect(final TetsuoUmezawaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TeysaEnvoyOfGhosts.java
+++ b/Mage.Sets/src/mage/cards/t/TeysaEnvoyOfGhosts.java
@@ -65,7 +65,7 @@ class TeysaEnvoyOfGhostsTriggeredAbility extends TriggeredAbilityImpl {
         this.addEffect(new CreateTokenEffect(new WhiteBlackSpiritToken(), 1));
     }
 
-    public TeysaEnvoyOfGhostsTriggeredAbility(final TeysaEnvoyOfGhostsTriggeredAbility ability) {
+    private TeysaEnvoyOfGhostsTriggeredAbility(final TeysaEnvoyOfGhostsTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TezzeretAgentOfBolas.java
+++ b/Mage.Sets/src/mage/cards/t/TezzeretAgentOfBolas.java
@@ -72,7 +72,7 @@ class TezzeretAgentOfBolasEffect2 extends OneShotEffect {
         staticText = "Target player loses X life and you gain X life, where X is twice the number of artifacts you control";
     }
 
-    public TezzeretAgentOfBolasEffect2(final TezzeretAgentOfBolasEffect2 effect) {
+    private TezzeretAgentOfBolasEffect2(final TezzeretAgentOfBolasEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TezzeretCruelMachinist.java
+++ b/Mage.Sets/src/mage/cards/t/TezzeretCruelMachinist.java
@@ -71,7 +71,7 @@ class TezzeretCruelMachinistEffect extends OneShotEffect {
         this.staticText = "put any number of cards from your hand onto the battlefield face down. They're 5/5 artifact creatures";
     }
 
-    public TezzeretCruelMachinistEffect(final TezzeretCruelMachinistEffect effect) {
+    private TezzeretCruelMachinistEffect(final TezzeretCruelMachinistEffect effect) {
         super(effect);
     }
 
@@ -113,7 +113,7 @@ class TezzeretCruelMachinistCardTypeEffect extends ContinuousEffectImpl {
         super(Duration.Custom, Layer.CopyEffects_1, SubLayer.FaceDownEffects_1b, Outcome.Neutral);
     }
 
-    public TezzeretCruelMachinistCardTypeEffect(final TezzeretCruelMachinistCardTypeEffect effect) {
+    private TezzeretCruelMachinistCardTypeEffect(final TezzeretCruelMachinistCardTypeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TezzeretMasterOfMetal.java
+++ b/Mage.Sets/src/mage/cards/t/TezzeretMasterOfMetal.java
@@ -73,7 +73,7 @@ class TezzeretMasterOfMetalEffect extends OneShotEffect {
         this.staticText = "Gain control of all artifacts and creatures target opponent controls";
     }
 
-    public TezzeretMasterOfMetalEffect(final TezzeretMasterOfMetalEffect effect) {
+    private TezzeretMasterOfMetalEffect(final TezzeretMasterOfMetalEffect effect) {
         super(effect);
     }
 
@@ -103,7 +103,7 @@ class TezzeretMasterOfMetalControlEffect extends ContinuousEffectImpl {
         this.controllerId = controllerId;
     }
 
-    public TezzeretMasterOfMetalControlEffect(final TezzeretMasterOfMetalControlEffect effect) {
+    private TezzeretMasterOfMetalControlEffect(final TezzeretMasterOfMetalControlEffect effect) {
         super(effect);
         this.controllerId = effect.controllerId;
     }

--- a/Mage.Sets/src/mage/cards/t/TezzeretTheSeeker.java
+++ b/Mage.Sets/src/mage/cards/t/TezzeretTheSeeker.java
@@ -63,7 +63,7 @@ class TezzeretTheSeekerEffect2 extends OneShotEffect {
         this.staticText = "Search your library for an artifact card with mana value X or less, put it onto the battlefield, then shuffle";
     }
 
-    public TezzeretTheSeekerEffect2(final TezzeretTheSeekerEffect2 effect) {
+    private TezzeretTheSeekerEffect2(final TezzeretTheSeekerEffect2 effect) {
         super(effect);
     }
 
@@ -110,7 +110,7 @@ class TezzeretTheSeekerEffect3 extends ContinuousEffectImpl {
         this.staticText = "Artifacts you control become artifact creatures with base power and toughness 5/5 until end of turn";
     }
 
-    public TezzeretTheSeekerEffect3(final TezzeretTheSeekerEffect3 effect) {
+    private TezzeretTheSeekerEffect3(final TezzeretTheSeekerEffect3 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThallidOmnivore.java
+++ b/Mage.Sets/src/mage/cards/t/ThallidOmnivore.java
@@ -64,7 +64,7 @@ class ThallidOmnivoreEffect extends OneShotEffect {
         this.staticText = "If a Saproling was sacrificed this way, you gain 2 life";
     }
 
-    public ThallidOmnivoreEffect(final ThallidOmnivoreEffect effect) {
+    private ThallidOmnivoreEffect(final ThallidOmnivoreEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThassasEmissary.java
+++ b/Mage.Sets/src/mage/cards/t/ThassasEmissary.java
@@ -58,7 +58,7 @@ class ThassasEmissaryTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} or enchanted creature deals combat damage to a player, ");
     }
 
-    public ThassasEmissaryTriggeredAbility(final ThassasEmissaryTriggeredAbility ability) {
+    private ThassasEmissaryTriggeredAbility(final ThassasEmissaryTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThatcherRevolt.java
+++ b/Mage.Sets/src/mage/cards/t/ThatcherRevolt.java
@@ -48,7 +48,7 @@ class ThatcherRevoltEffect extends OneShotEffect {
         this.staticText = "Create three 1/1 red Human creature tokens with haste. Sacrifice those tokens at the beginning of the next end step";
     }
 
-    public ThatcherRevoltEffect(final ThatcherRevoltEffect effect) {
+    private ThatcherRevoltEffect(final ThatcherRevoltEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheAntiquitiesWar.java
+++ b/Mage.Sets/src/mage/cards/t/TheAntiquitiesWar.java
@@ -56,7 +56,7 @@ class TheAntiquitiesWarEffect extends ContinuousEffectImpl {
         this.staticText = "Artifacts you control become artifact creatures with base power and toughness 5/5 until end of turn";
     }
 
-    public TheAntiquitiesWarEffect(final TheAntiquitiesWarEffect effect) {
+    private TheAntiquitiesWarEffect(final TheAntiquitiesWarEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheBattleOfNaboo.java
+++ b/Mage.Sets/src/mage/cards/t/TheBattleOfNaboo.java
@@ -59,7 +59,7 @@ class TheBattleOfNabooEffect extends OneShotEffect {
         staticText = "Draw twice that many cards";
     }
 
-    public TheBattleOfNabooEffect(final TheBattleOfNabooEffect effect) {
+    private TheBattleOfNabooEffect(final TheBattleOfNabooEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheBattleOfYavin.java
+++ b/Mage.Sets/src/mage/cards/t/TheBattleOfYavin.java
@@ -49,7 +49,7 @@ class TheBattleOfYavinEffect extends OneShotEffect {
         this.staticText = "For each nonland permanent target opponent controls, that player sacrificies it unless they pay X life";
     }
 
-    public TheBattleOfYavinEffect(final TheBattleOfYavinEffect effect) {
+    private TheBattleOfYavinEffect(final TheBattleOfYavinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheBigIdea.java
+++ b/Mage.Sets/src/mage/cards/t/TheBigIdea.java
@@ -108,7 +108,7 @@ class TheBigIdeaEffect extends OneShotEffect {
         this.staticText = "Roll a six-sided die. Create a number of 1/1 red Brainiac creature tokens equal to the result";
     }
 
-    public TheBigIdeaEffect(final TheBigIdeaEffect effect) {
+    private TheBigIdeaEffect(final TheBigIdeaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheBookOfVileDarkness.java
+++ b/Mage.Sets/src/mage/cards/t/TheBookOfVileDarkness.java
@@ -95,7 +95,7 @@ class TheBookOfVileDarknessCost extends CostImpl {
         this.text = "exile {this} and artifacts you control named Eye of Vecna and Hand of Vecna";
     }
 
-    public TheBookOfVileDarknessCost(final TheBookOfVileDarknessCost cost) {
+    private TheBookOfVileDarknessCost(final TheBookOfVileDarknessCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheBrothersWar.java
+++ b/Mage.Sets/src/mage/cards/t/TheBrothersWar.java
@@ -114,7 +114,7 @@ class TheBrothersWarRequirementEffect extends RequirementEffect {
         this.defendingPlayerId = defender.getId();
     }
 
-    public TheBrothersWarRequirementEffect(final TheBrothersWarRequirementEffect effect) {
+    private TheBrothersWarRequirementEffect(final TheBrothersWarRequirementEffect effect) {
         super(effect);
         this.attackingPlayerId = effect.attackingPlayerId;
         this.defendingPlayerId = effect.defendingPlayerId;

--- a/Mage.Sets/src/mage/cards/t/TheChainVeil.java
+++ b/Mage.Sets/src/mage/cards/t/TheChainVeil.java
@@ -95,7 +95,7 @@ class TheChainVeilIncreaseLoyaltyUseEffect extends ContinuousEffectImpl {
         staticText = "For each planeswalker you control, you may activate one of its loyalty abilities once this turn as though none of its loyalty abilities have been activated this turn";
     }
 
-    public TheChainVeilIncreaseLoyaltyUseEffect(final TheChainVeilIncreaseLoyaltyUseEffect effect) {
+    private TheChainVeilIncreaseLoyaltyUseEffect(final TheChainVeilIncreaseLoyaltyUseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheCheeseStandsAlone.java
+++ b/Mage.Sets/src/mage/cards/t/TheCheeseStandsAlone.java
@@ -56,7 +56,7 @@ class CheeseStandsAloneContinuousEffect extends ContinuousRuleModifyingEffectImp
         staticText = "When you control no permanents other than {this} and have no cards in hand, you win the game";
     }
 
-    public CheeseStandsAloneContinuousEffect(final CheeseStandsAloneContinuousEffect effect) {
+    private CheeseStandsAloneContinuousEffect(final CheeseStandsAloneContinuousEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheEternalWanderer.java
+++ b/Mage.Sets/src/mage/cards/t/TheEternalWanderer.java
@@ -89,7 +89,7 @@ class TheEternalWandererExileEffect extends OneShotEffect {
                 "under its owner's control at the beginning of that player's next end step.";
     }
 
-    public TheEternalWandererExileEffect(final TheEternalWandererExileEffect effect) {
+    private TheEternalWandererExileEffect(final TheEternalWandererExileEffect effect) {
         super(effect);
     }
 
@@ -126,7 +126,7 @@ class TheEternalWandererSacrificeEffect extends OneShotEffect {
         staticText = "For each player, choose a creature that player controls. Each player sacrifices all creatures they control not chosen this way";
     }
 
-    public TheEternalWandererSacrificeEffect(final TheEternalWandererSacrificeEffect effect) {
+    private TheEternalWandererSacrificeEffect(final TheEternalWandererSacrificeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheFallen.java
+++ b/Mage.Sets/src/mage/cards/t/TheFallen.java
@@ -47,7 +47,7 @@ class TheFallenEffect extends OneShotEffect {
         this.staticText = "{this} deals 1 damage to each opponent or planeswalker it has dealt damage to this game";
     }
 
-    public TheFallenEffect(final TheFallenEffect effect) {
+    private TheFallenEffect(final TheFallenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheFallenApart.java
+++ b/Mage.Sets/src/mage/cards/t/TheFallenApart.java
@@ -57,7 +57,7 @@ class TheFallenApartEntersEffect extends OneShotEffect {
         staticText = "with two arms and two legs";
     }
 
-    public TheFallenApartEntersEffect(final TheFallenApartEntersEffect effect) {
+    private TheFallenApartEntersEffect(final TheFallenApartEntersEffect effect) {
         super(effect);
     }
 
@@ -91,7 +91,7 @@ class TheFallenApartToggleEffect extends OneShotEffect {
         staticText = "remove an arm or a leg from it";
     }
 
-    public TheFallenApartToggleEffect(final TheFallenApartToggleEffect effect) {
+    private TheFallenApartToggleEffect(final TheFallenApartToggleEffect effect) {
         super(effect);
     }
 
@@ -147,7 +147,7 @@ class TheFallenApartRestrictionEffect extends RestrictionEffect {
         staticText = "{this} can't attack if it has no legs and can't block if it has no arms";
     }
 
-    public TheFallenApartRestrictionEffect(final TheFallenApartRestrictionEffect effect) {
+    private TheFallenApartRestrictionEffect(final TheFallenApartRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheFlameOfKeld.java
+++ b/Mage.Sets/src/mage/cards/t/TheFlameOfKeld.java
@@ -59,7 +59,7 @@ class TheFlameOfKeldDamageEffect extends ReplacementEffectImpl {
         this.staticText = "If a red source you control would deal damage to a permanent or player this turn, it deals that much damage plus 2 to that permanent or player instead";
     }
 
-    public TheFlameOfKeldDamageEffect(final TheFlameOfKeldDamageEffect effect) {
+    private TheFlameOfKeldDamageEffect(final TheFlameOfKeldDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheGitrogMonster.java
+++ b/Mage.Sets/src/mage/cards/t/TheGitrogMonster.java
@@ -63,7 +63,7 @@ class TheGitrogMonsterTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
     }
 
-    public TheGitrogMonsterTriggeredAbility(final TheGitrogMonsterTriggeredAbility ability) {
+    private TheGitrogMonsterTriggeredAbility(final TheGitrogMonsterTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheGoldenThrone.java
+++ b/Mage.Sets/src/mage/cards/t/TheGoldenThrone.java
@@ -54,7 +54,7 @@ class TheGoldenThroneEffect extends ReplacementEffectImpl {
         staticText = "if you would lose the game, instead exile {this} and your life total becomes 1";
     }
 
-    public TheGoldenThroneEffect(final TheGoldenThroneEffect effect) {
+    private TheGoldenThroneEffect(final TheGoldenThroneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheGreatAurora.java
+++ b/Mage.Sets/src/mage/cards/t/TheGreatAurora.java
@@ -50,7 +50,7 @@ class TheGreatAuroraEffect extends OneShotEffect {
         this.staticText = "Each player shuffles all cards from their hand and all permanents they own into their library, then draws that many cards. Each player may put any number of land cards from their hand onto the battlefield";
     }
 
-    public TheGreatAuroraEffect(final TheGreatAuroraEffect effect) {
+    private TheGreatAuroraEffect(final TheGreatAuroraEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheGreatSynthesis.java
+++ b/Mage.Sets/src/mage/cards/t/TheGreatSynthesis.java
@@ -77,7 +77,7 @@ class TheGreatSynthesisCastEffect extends OneShotEffect {
         this.staticText = "you may cast any number of spells from your hand without paying their mana costs";
     }
 
-    public TheGreatSynthesisCastEffect(final TheGreatSynthesisCastEffect effect) {
+    private TheGreatSynthesisCastEffect(final TheGreatSynthesisCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheImmortalSun.java
+++ b/Mage.Sets/src/mage/cards/t/TheImmortalSun.java
@@ -61,7 +61,7 @@ class TheImmortalSunCantActivateEffect extends ContinuousRuleModifyingEffectImpl
         staticText = "Players can't activate planeswalkers' loyalty abilities";
     }
 
-    public TheImmortalSunCantActivateEffect(final TheImmortalSunCantActivateEffect effect) {
+    private TheImmortalSunCantActivateEffect(final TheImmortalSunCantActivateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheMendingOfDominaria.java
+++ b/Mage.Sets/src/mage/cards/t/TheMendingOfDominaria.java
@@ -59,7 +59,7 @@ class TheMendingOfDominariaFirstEffect extends OneShotEffect {
         this.staticText = "Mill two cards, then you may return a creature card from your graveyard to your hand";
     }
 
-    public TheMendingOfDominariaFirstEffect(final TheMendingOfDominariaFirstEffect effect) {
+    private TheMendingOfDominariaFirstEffect(final TheMendingOfDominariaFirstEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheMirariConjecture.java
+++ b/Mage.Sets/src/mage/cards/t/TheMirariConjecture.java
@@ -77,7 +77,7 @@ class TheMirariConjectureDelayedTriggeredAbility extends DelayedTriggeredAbility
         super(new CopyTargetSpellEffect(true), Duration.EndOfTurn, false);
     }
 
-    public TheMirariConjectureDelayedTriggeredAbility(final TheMirariConjectureDelayedTriggeredAbility ability) {
+    private TheMirariConjectureDelayedTriggeredAbility(final TheMirariConjectureDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheMycosynthGardens.java
+++ b/Mage.Sets/src/mage/cards/t/TheMycosynthGardens.java
@@ -74,7 +74,7 @@ class TheMycosynthGardensCopyEffect extends OneShotEffect {
         this.staticText = "{this} becomes a copy of target nontoken artifact you control with mana value X.";
     }
 
-    public TheMycosynthGardensCopyEffect(final TheMycosynthGardensCopyEffect effect) {
+    private TheMycosynthGardensCopyEffect(final TheMycosynthGardensCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheRack.java
+++ b/Mage.Sets/src/mage/cards/t/TheRack.java
@@ -48,7 +48,7 @@ class TheRackTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("At the beginning of the chosen player's upkeep, ");
     }
 
-    public TheRackTriggeredAbility(final TheRackTriggeredAbility ability) {
+    private TheRackTriggeredAbility(final TheRackTriggeredAbility ability) {
         super(ability);
     }
 
@@ -75,7 +75,7 @@ class TheRackEffect extends OneShotEffect {
         this.staticText = "{this} deals X damage to that player, where X is 3 minus the number of cards in their hand";
     }
 
-    public TheRackEffect(final TheRackEffect effect) {
+    private TheRackEffect(final TheRackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheScarabGod.java
+++ b/Mage.Sets/src/mage/cards/t/TheScarabGod.java
@@ -87,7 +87,7 @@ class TheScarabGodEffect extends OneShotEffect {
         staticText = "each opponent loses X life and you scry X, where X is the number of Zombies you control";
     }
 
-    public TheScarabGodEffect(final TheScarabGodEffect effect) {
+    private TheScarabGodEffect(final TheScarabGodEffect effect) {
         super(effect);
         this.numOfZombies = effect.numOfZombies;
     }
@@ -125,7 +125,7 @@ class TheScarabGodEffect2 extends OneShotEffect {
         this.staticText = "Exile target creature card from a graveyard. Create a token that's a copy of it, except it's a 4/4 black Zombie.";
     }
 
-    public TheScarabGodEffect2(final TheScarabGodEffect2 effect) {
+    private TheScarabGodEffect2(final TheScarabGodEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheScorpionGod.java
+++ b/Mage.Sets/src/mage/cards/t/TheScorpionGod.java
@@ -73,7 +73,7 @@ class TheScorpionGodTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
     }
 
-    public TheScorpionGodTriggeredAbility(TheScorpionGodTriggeredAbility ability) {
+    private TheScorpionGodTriggeredAbility(final TheScorpionGodTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheUrDragon.java
+++ b/Mage.Sets/src/mage/cards/t/TheUrDragon.java
@@ -74,7 +74,7 @@ class TheUrDragonTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null, false);
     }
 
-    public TheUrDragonTriggeredAbility(final TheUrDragonTriggeredAbility ability) {
+    private TheUrDragonTriggeredAbility(final TheUrDragonTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheftOfDreams.java
+++ b/Mage.Sets/src/mage/cards/t/TheftOfDreams.java
@@ -47,7 +47,7 @@ class TheftOfDreamsEffect extends OneShotEffect {
         this.staticText = "Draw a card for each tapped creature target opponent controls";
     }
 
-    public TheftOfDreamsEffect(final TheftOfDreamsEffect effect) {
+    private TheftOfDreamsEffect(final TheftOfDreamsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheloniteDruid.java
+++ b/Mage.Sets/src/mage/cards/t/TheloniteDruid.java
@@ -70,7 +70,7 @@ class TheloniteDruidLandToken extends TokenImpl {
         power = new MageInt(2);
         toughness = new MageInt(3);
     }
-    public TheloniteDruidLandToken(final TheloniteDruidLandToken token) {
+    private TheloniteDruidLandToken(final TheloniteDruidLandToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThelonsChant.java
+++ b/Mage.Sets/src/mage/cards/t/ThelonsChant.java
@@ -57,7 +57,7 @@ class ThelonsChantEffect extends OneShotEffect {
         staticText = "{this} deals 3 damage to that player unless they put a -1/-1 counter on a creature they control";
     }
 
-    public ThelonsChantEffect(final ThelonsChantEffect effect) {
+    private ThelonsChantEffect(final ThelonsChantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThermalFlux.java
+++ b/Mage.Sets/src/mage/cards/t/ThermalFlux.java
@@ -71,7 +71,7 @@ class ThermalFluxEffect extends ContinuousEffectImpl {
         this.staticText = "Target " + (addSnow ? "non" : "") + "snow permanent " + (addSnow ? "becomes" : "isn't") + " snow until end of turn";
     }
 
-    public ThermalFluxEffect(final ThermalFluxEffect effect) {
+    private ThermalFluxEffect(final ThermalFluxEffect effect) {
         super(effect);
         this.addSnow = effect.addSnow;
     }

--- a/Mage.Sets/src/mage/cards/t/Thermokarst.java
+++ b/Mage.Sets/src/mage/cards/t/Thermokarst.java
@@ -44,7 +44,7 @@ class ThermokarstEffect extends OneShotEffect {
         this.staticText = "Destroy target land. If that land was a snow land, you gain 1 life.";
     }
 
-    public ThermokarstEffect(final ThermokarstEffect effect) {
+    private ThermokarstEffect(final ThermokarstEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThespiansStage.java
+++ b/Mage.Sets/src/mage/cards/t/ThespiansStage.java
@@ -55,7 +55,7 @@ class ThespiansStageCopyEffect extends OneShotEffect {
         this.staticText = "{this} becomes a copy of target land, except it has this ability";
     }
 
-    public ThespiansStageCopyEffect(final ThespiansStageCopyEffect effect) {
+    private ThespiansStageCopyEffect(final ThespiansStageCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThickSkinnedGoblin.java
+++ b/Mage.Sets/src/mage/cards/t/ThickSkinnedGoblin.java
@@ -54,7 +54,7 @@ class ThickSkinnedGoblinCostModificationEffect extends AsThoughEffectImpl {
         this.staticText = "You may pay {0} rather than pay the echo cost for permanents you control.";
     }
 
-    public ThickSkinnedGoblinCostModificationEffect(ThickSkinnedGoblinCostModificationEffect effect) {
+    private ThickSkinnedGoblinCostModificationEffect(final ThickSkinnedGoblinCostModificationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThornbowArcher.java
+++ b/Mage.Sets/src/mage/cards/t/ThornbowArcher.java
@@ -55,7 +55,7 @@ class ThornbowArcherEffect extends OneShotEffect {
         this.staticText = "each opponent who doesn't control an Elf loses 1 life";
     }
 
-    public ThornbowArcherEffect(final ThornbowArcherEffect effect) {
+    private ThornbowArcherEffect(final ThornbowArcherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThoughtDissector.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtDissector.java
@@ -56,7 +56,7 @@ class ThoughtDissectorEffect extends OneShotEffect {
         staticText = "Target opponent reveals cards from the top of their library until an artifact card or X cards are revealed, whichever comes first. If an artifact card is revealed this way, put it onto the battlefield under your control and sacrifice {this}. Put the rest of the revealed cards into that player's graveyard.";
     }
 
-    public ThoughtDissectorEffect(final ThoughtDissectorEffect effect) {
+    private ThoughtDissectorEffect(final ThoughtDissectorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThoughtHemorrhage.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtHemorrhage.java
@@ -66,7 +66,7 @@ class ThoughtHemorrhageEffect extends OneShotEffect {
         staticText = rule;
     }
 
-    public ThoughtHemorrhageEffect(final ThoughtHemorrhageEffect effect) {
+    private ThoughtHemorrhageEffect(final ThoughtHemorrhageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThoughtPrison.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtPrison.java
@@ -68,7 +68,7 @@ class ThoughtPrisonImprintEffect extends OneShotEffect {
         staticText = "have target player reveal their hand. If you do, choose a nonland card from it and exile that card";
     }
 
-    public ThoughtPrisonImprintEffect(ThoughtPrisonImprintEffect effect) {
+    private ThoughtPrisonImprintEffect(final ThoughtPrisonImprintEffect effect) {
         super(effect);
     }
 
@@ -115,7 +115,7 @@ class ThoughtPrisonTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a player casts a spell that shares a color or mana value with the exiled card, ");
     }
 
-    public ThoughtPrisonTriggeredAbility(final ThoughtPrisonTriggeredAbility ability) {
+    private ThoughtPrisonTriggeredAbility(final ThoughtPrisonTriggeredAbility ability) {
         super(ability);
     }
 
@@ -179,7 +179,7 @@ class ThoughtPrisonDamageEffect extends OneShotEffect {
         staticText = "{this} deals 2 damage to that player";
     }
 
-    public ThoughtPrisonDamageEffect(final ThoughtPrisonDamageEffect effect) {
+    private ThoughtPrisonDamageEffect(final ThoughtPrisonDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThoughtReflection.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtReflection.java
@@ -48,7 +48,7 @@ class ThoughtReflectionReplacementEffect extends ReplacementEffectImpl {
         staticText = "If you would draw a card, draw two cards instead";
     }
 
-    public ThoughtReflectionReplacementEffect(final ThoughtReflectionReplacementEffect effect) {
+    private ThoughtReflectionReplacementEffect(final ThoughtReflectionReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThoughtboundPhantasm.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtboundPhantasm.java
@@ -70,7 +70,7 @@ class ThoughtboundPhantasmTriggeredAbility extends TriggeredAbilityImpl {
         ), false);
     }
 
-    public ThoughtboundPhantasmTriggeredAbility(final ThoughtboundPhantasmTriggeredAbility ability) {
+    private ThoughtboundPhantasmTriggeredAbility(final ThoughtboundPhantasmTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThoughtboundPrimoc.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtboundPrimoc.java
@@ -62,7 +62,7 @@ class ThoughtboundPrimocEffect extends OneShotEffect {
         this.staticText = "the player who controls the most Wizards gains control of {this}";
     }
 
-    public ThoughtboundPrimocEffect(final ThoughtboundPrimocEffect effect) {
+    private ThoughtboundPrimocEffect(final ThoughtboundPrimocEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThoughtsOfRuin.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtsOfRuin.java
@@ -52,7 +52,7 @@ class ThoughtsOfRuinEffect extends OneShotEffect {
         this.staticText = "Each player sacrifices a land for each card in your hand";
     }
 
-    public ThoughtsOfRuinEffect(final ThoughtsOfRuinEffect effect) {
+    private ThoughtsOfRuinEffect(final ThoughtsOfRuinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThoughtweftGambit.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtweftGambit.java
@@ -47,7 +47,7 @@ class ThoughtweftGambitEffect extends OneShotEffect {
         staticText = "Tap all creatures your opponents control and untap all creatures you control";
     }
 
-    public ThoughtweftGambitEffect(final ThoughtweftGambitEffect effect) {
+    private ThoughtweftGambitEffect(final ThoughtweftGambitEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThousandYearElixir.java
+++ b/Mage.Sets/src/mage/cards/t/ThousandYearElixir.java
@@ -57,7 +57,7 @@ class ThousandYearElixirEffect extends AsThoughEffectImpl {
         staticText = "You may activate abilities of creatures you control as though those creatures had haste";
     }
 
-    public ThousandYearElixirEffect(final ThousandYearElixirEffect effect) {
+    private ThousandYearElixirEffect(final ThousandYearElixirEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThousandYearStorm.java
+++ b/Mage.Sets/src/mage/cards/t/ThousandYearStorm.java
@@ -51,7 +51,7 @@ class ThousandYearStormAbility extends SpellCastControllerTriggeredAbility {
         this.stormCountInfo = null;
     }
 
-    public ThousandYearStormAbility(final ThousandYearStormAbility ability) {
+    private ThousandYearStormAbility(final ThousandYearStormAbility ability) {
         super(ability);
         this.stormCountInfo = ability.stormCountInfo;
     }
@@ -109,7 +109,7 @@ class ThousandYearStormEffect extends OneShotEffect {
         this.staticText = "copy it for each other instant and sorcery spell you've cast before it this turn. You may choose new targets for the copies";
     }
 
-    public ThousandYearStormEffect(final ThousandYearStormEffect effect) {
+    private ThousandYearStormEffect(final ThousandYearStormEffect effect) {
         super(effect);
         this.stormCount = effect.stormCount;
     }

--- a/Mage.Sets/src/mage/cards/t/ThranPortal.java
+++ b/Mage.Sets/src/mage/cards/t/ThranPortal.java
@@ -81,7 +81,7 @@ class ThranPortalManaAbilityContinousEffect extends ContinuousEffectImpl {
         staticText = "mana abilities of {this} cost an additional 1 life to activate";
     }
 
-    public ThranPortalManaAbilityContinousEffect(final ThranPortalManaAbilityContinousEffect effect) {
+    private ThranPortalManaAbilityContinousEffect(final ThranPortalManaAbilityContinousEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThranTome.java
+++ b/Mage.Sets/src/mage/cards/t/ThranTome.java
@@ -51,7 +51,7 @@ class ThranTomeEffect extends OneShotEffect {
         this.staticText = "Reveal the top three cards of your library. Target opponent chooses one of those cards. Put that card into your graveyard, then draw two cards";
     }
 
-    public ThranTomeEffect(final ThranTomeEffect effect) {
+    private ThranTomeEffect(final ThranTomeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThranTurbine.java
+++ b/Mage.Sets/src/mage/cards/t/ThranTurbine.java
@@ -54,7 +54,7 @@ class ThranTurbineEffect extends OneShotEffect {
         staticText = "add {C}{C}. You can't spend this mana to cast spells";
     }
 
-    public ThranTurbineEffect(final ThranTurbineEffect effect) {
+    private ThranTurbineEffect(final ThranTurbineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThranWeaponry.java
+++ b/Mage.Sets/src/mage/cards/t/ThranWeaponry.java
@@ -55,7 +55,7 @@ class ThranWeaponryEffect extends BoostAllEffect{
         staticText = "All creatures get +2/+2 for as long as Thran Weaponry remains tapped";
     }
 
-    public ThranWeaponryEffect(final ThranWeaponryEffect effect) {
+    private ThranWeaponryEffect(final ThranWeaponryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThrashingMossdog.java
+++ b/Mage.Sets/src/mage/cards/t/ThrashingMossdog.java
@@ -35,7 +35,7 @@ public final class ThrashingMossdog extends CardImpl {
 
     }
 
-    public ThrashingMossdog (final ThrashingMossdog card) {
+    private ThrashingMossdog(final ThrashingMossdog card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThrashingMudspawn.java
+++ b/Mage.Sets/src/mage/cards/t/ThrashingMudspawn.java
@@ -56,7 +56,7 @@ class ThrashingMudspawnEffect extends OneShotEffect {
         this.staticText = "you lose that much life";
     }
 
-    public ThrashingMudspawnEffect(final ThrashingMudspawnEffect effect) {
+    private ThrashingMudspawnEffect(final ThrashingMudspawnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThrasiosTritonHero.java
+++ b/Mage.Sets/src/mage/cards/t/ThrasiosTritonHero.java
@@ -55,7 +55,7 @@ class ThrasiosTritonHeroEffect extends OneShotEffect {
                 "If it's a land card, put it onto the battlefield tapped. Otherwise, draw a card";
     }
 
-    public ThrasiosTritonHeroEffect(final ThrasiosTritonHeroEffect effect) {
+    private ThrasiosTritonHeroEffect(final ThrasiosTritonHeroEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Thraximundar.java
+++ b/Mage.Sets/src/mage/cards/t/Thraximundar.java
@@ -70,7 +70,7 @@ class ThraximundarTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SacrificeEffect(filter, 1, "defending player"));
     }
 
-    public ThraximundarTriggeredAbility(final ThraximundarTriggeredAbility ability) {
+    private ThraximundarTriggeredAbility(final ThraximundarTriggeredAbility ability) {
         super(ability);
     }
 
@@ -108,7 +108,7 @@ class PlayerSacrificesCreatureTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a player sacrifices a creature, ");
     }
 
-    public PlayerSacrificesCreatureTriggeredAbility(final PlayerSacrificesCreatureTriggeredAbility ability) {
+    private PlayerSacrificesCreatureTriggeredAbility(final PlayerSacrificesCreatureTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThreeWishes.java
+++ b/Mage.Sets/src/mage/cards/t/ThreeWishes.java
@@ -57,7 +57,7 @@ class ThreeWishesExileEffect extends OneShotEffect {
         staticText = "Exile the top three cards of your library face down. Until your next turn, you may play those cards. At the beginning of your next upkeep, put any of those cards you didn't play into your graveyard";
     }
 
-    public ThreeWishesExileEffect(final ThreeWishesExileEffect effect) {
+    private ThreeWishesExileEffect(final ThreeWishesExileEffect effect) {
         super(effect);
     }
 
@@ -95,7 +95,7 @@ class ThreeWishesPutIntoGraveyardEffect extends OneShotEffect {
         staticText = "At the beginning of your next upkeep, put any of those cards you didn't play into your graveyard";
     }
 
-    public ThreeWishesPutIntoGraveyardEffect(final ThreeWishesPutIntoGraveyardEffect effect) {
+    private ThreeWishesPutIntoGraveyardEffect(final ThreeWishesPutIntoGraveyardEffect effect) {
         super(effect);
     }
 
@@ -126,7 +126,7 @@ class ThreeWishesLookAtCardEffect extends AsThoughEffectImpl {
         staticText = "You may look at cards exiled with {this} as long as they remain exiled";
     }
 
-    public ThreeWishesLookAtCardEffect(final ThreeWishesLookAtCardEffect effect) {
+    private ThreeWishesLookAtCardEffect(final ThreeWishesLookAtCardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThroneOfBone.java
+++ b/Mage.Sets/src/mage/cards/t/ThroneOfBone.java
@@ -45,7 +45,7 @@ class ThroneOfBoneAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DoIfCostPaid(new GainLifeEffect(1), new GenericManaCost(1)), false);
     }
 
-    public ThroneOfBoneAbility(final ThroneOfBoneAbility ability) {
+    private ThroneOfBoneAbility(final ThroneOfBoneAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThroneOfEmpires.java
+++ b/Mage.Sets/src/mage/cards/t/ThroneOfEmpires.java
@@ -48,7 +48,7 @@ class ThroneOfEmpiresEffect extends OneShotEffect {
         staticText = "Create a 1/1 white Soldier creature token. Create five of those tokens instead if you control artifacts named Crown of Empires and Scepter of Empires";
     }
 
-    public ThroneOfEmpiresEffect(ThroneOfEmpiresEffect effect) {
+    private ThroneOfEmpiresEffect(final ThroneOfEmpiresEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThunderTotem.java
+++ b/Mage.Sets/src/mage/cards/t/ThunderTotem.java
@@ -57,7 +57,7 @@ public final class ThunderTotem extends CardImpl {
             this.addAbility(FlyingAbility.getInstance());
             this.addAbility(FirstStrikeAbility.getInstance());
         }
-        public ThunderTotemToken(final ThunderTotemToken token) {
+        private ThunderTotemToken(final ThunderTotemToken token) {
             super(token);
         }
     

--- a/Mage.Sets/src/mage/cards/t/ThunderbladeCharge.java
+++ b/Mage.Sets/src/mage/cards/t/ThunderbladeCharge.java
@@ -61,7 +61,7 @@ class ThunderbladeChargeCastEffect extends OneShotEffect {
         this.staticText = "you may cast {this} without paying its mana cost";
     }
 
-    public ThunderbladeChargeCastEffect(final ThunderbladeChargeCastEffect effect) {
+    private ThunderbladeChargeCastEffect(final ThunderbladeChargeCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThunderbreakRegent.java
+++ b/Mage.Sets/src/mage/cards/t/ThunderbreakRegent.java
@@ -59,7 +59,7 @@ class ThunderbreakRegentTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect);
     }
 
-    public ThunderbreakRegentTriggeredAbility(final ThunderbreakRegentTriggeredAbility ability) {
+    private ThunderbreakRegentTriggeredAbility(final ThunderbreakRegentTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Thunderheads.java
+++ b/Mage.Sets/src/mage/cards/t/Thunderheads.java
@@ -45,7 +45,7 @@ class ThunderheadsEffect extends OneShotEffect {
         this.staticText = "Create a 3/3 blue Weird creature token with defender and flying. Exile it at the beginning of the next end step.";
     }
 
-    public ThunderheadsEffect(ThunderheadsEffect effect) {
+    private ThunderheadsEffect(final ThunderheadsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThundermawHellkite.java
+++ b/Mage.Sets/src/mage/cards/t/ThundermawHellkite.java
@@ -72,7 +72,7 @@ class TapAllEffect extends OneShotEffect {
         staticText = "Tap those creatures";
     }
 
-    public TapAllEffect(final TapAllEffect effect) {
+    private TapAllEffect(final TapAllEffect effect) {
         super(effect);
         this.filter = effect.filter.copy();
     }

--- a/Mage.Sets/src/mage/cards/t/Thunderstaff.java
+++ b/Mage.Sets/src/mage/cards/t/Thunderstaff.java
@@ -55,7 +55,7 @@ class ThunderstaffPreventionEffect extends PreventionEffectImpl {
         staticText = "As long as {this} is untapped, if a creature would deal combat damage to you, prevent 1 of that damage";
     }
 
-    public ThunderstaffPreventionEffect(final ThunderstaffPreventionEffect effect) {
+    private ThunderstaffPreventionEffect(final ThunderstaffPreventionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TidalFlats.java
+++ b/Mage.Sets/src/mage/cards/t/TidalFlats.java
@@ -64,7 +64,7 @@ class TidalFlatsEffect extends OneShotEffect {
         this.staticText = "For each attacking creature without flying, its controller may pay {1}. If they don't, creatures you control blocking that creature gain first strike until end of turn";
     }
 
-    public TidalFlatsEffect(final TidalFlatsEffect effect) {
+    private TidalFlatsEffect(final TidalFlatsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TidalInfluence.java
+++ b/Mage.Sets/src/mage/cards/t/TidalInfluence.java
@@ -92,7 +92,7 @@ class TidalInfluenceTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("Whenever there are four tide counters on {this}, ");
     }
 
-    public TidalInfluenceTriggeredAbility(final TidalInfluenceTriggeredAbility ability) {
+    private TidalInfluenceTriggeredAbility(final TidalInfluenceTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TidalWave.java
+++ b/Mage.Sets/src/mage/cards/t/TidalWave.java
@@ -46,7 +46,7 @@ class TidalWaveEffect extends OneShotEffect {
         this.staticText = "Create a 5/5 blue Wall creature token with defender. Sacrifice it at the beginning of the next end step.";
     }
 
-    public TidalWaveEffect(TidalWaveEffect effect) {
+    private TidalWaveEffect(final TidalWaveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TideOfWar.java
+++ b/Mage.Sets/src/mage/cards/t/TideOfWar.java
@@ -51,7 +51,7 @@ class BlocksTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever one or more creatures block, ");
     }
 
-    public BlocksTriggeredAbility(final BlocksTriggeredAbility ability) {
+    private BlocksTriggeredAbility(final BlocksTriggeredAbility ability) {
         super(ability);
     }
 
@@ -83,7 +83,7 @@ class TideOfWarEffect extends OneShotEffect {
         this.staticText = "flip a coin. If you win the flip, each blocking creature is sacrificed by its controller. If you lose the flip, each blocked creature is sacrificed by its controller";
     }
 
-    public TideOfWarEffect(final TideOfWarEffect effect) {
+    private TideOfWarEffect(final TideOfWarEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TidehollowSculler.java
+++ b/Mage.Sets/src/mage/cards/t/TidehollowSculler.java
@@ -62,7 +62,7 @@ class TidehollowScullerExileEffect extends OneShotEffect {
         this.staticText = "target opponent reveals their hand and you choose a nonland card from it. Exile that card";
     }
 
-    public TidehollowScullerExileEffect(final TidehollowScullerExileEffect effect) {
+    private TidehollowScullerExileEffect(final TidehollowScullerExileEffect effect) {
         super(effect);
     }
 
@@ -109,7 +109,7 @@ class TidehollowScullerLeaveEffect extends OneShotEffect {
         this.staticText = "return the exiled card to its owner's hand";
     }
 
-    public TidehollowScullerLeaveEffect(final TidehollowScullerLeaveEffect effect) {
+    private TidehollowScullerLeaveEffect(final TidehollowScullerLeaveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TilonallisSkinshifter.java
+++ b/Mage.Sets/src/mage/cards/t/TilonallisSkinshifter.java
@@ -71,7 +71,7 @@ class TilonallisSkinshifterCopyEffect extends OneShotEffect {
         this.staticText = "it becomes a copy of another target nonlegendary attacking creature until end of turn";
     }
 
-    public TilonallisSkinshifterCopyEffect(final TilonallisSkinshifterCopyEffect effect) {
+    private TilonallisSkinshifterCopyEffect(final TilonallisSkinshifterCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TilonallisSummoner.java
+++ b/Mage.Sets/src/mage/cards/t/TilonallisSummoner.java
@@ -63,7 +63,7 @@ class TilonallisSummonerEffect extends OneShotEffect {
         this.staticText = "you may pay {X}{R}. If you do, create X 1/1 red Elemental creature tokens that are tapped and attacking. At the beginning of the next end step, exile those tokens unless you have the city's blessing";
     }
 
-    public TilonallisSummonerEffect(final TilonallisSummonerEffect effect) {
+    private TilonallisSummonerEffect(final TilonallisSummonerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TimberWolves.java
+++ b/Mage.Sets/src/mage/cards/t/TimberWolves.java
@@ -27,7 +27,7 @@ public final class TimberWolves extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public TimberWolves (final TimberWolves card) {
+    private TimberWolves(final TimberWolves card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TimberpackWolf.java
+++ b/Mage.Sets/src/mage/cards/t/TimberpackWolf.java
@@ -55,7 +55,7 @@ public final class TimberpackWolf extends CardImpl {
             staticText = "{this} gets +1/+1 for each other creature you control named Timberpack Wolf";
         }
 
-        public TimberpackWolfEffect(final TimberpackWolfEffect effect) {
+        private TimberpackWolfEffect(final TimberpackWolfEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/t/TimeOut.java
+++ b/Mage.Sets/src/mage/cards/t/TimeOut.java
@@ -53,7 +53,7 @@ class TimeOutEffect extends OneShotEffect {
         this.staticText = "Roll a six-sided die. Put target nonland permanent into its owner's library just beneath the top X cards of that library, where X is the result";
     }
 
-    public TimeOutEffect(final TimeOutEffect effect) {
+    private TimeOutEffect(final TimeOutEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TimeSpiral.java
+++ b/Mage.Sets/src/mage/cards/t/TimeSpiral.java
@@ -51,7 +51,7 @@ class TimeSpiralEffect extends OneShotEffect {
         staticText = "Each player shuffles their hand and graveyard into their library";
     }
 
-    public TimeSpiralEffect(final TimeSpiralEffect effect) {
+    private TimeSpiralEffect(final TimeSpiralEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TimeStretch.java
+++ b/Mage.Sets/src/mage/cards/t/TimeStretch.java
@@ -45,7 +45,7 @@ class TimeStretchEffect extends OneShotEffect {
         staticText = "Target player takes two extra turns after this one";
     }
 
-    public TimeStretchEffect(final TimeStretchEffect effect) {
+    private TimeStretchEffect(final TimeStretchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TimeWarp.java
+++ b/Mage.Sets/src/mage/cards/t/TimeWarp.java
@@ -44,7 +44,7 @@ class TimeWarpEffect extends OneShotEffect {
         staticText = "Target player takes an extra turn after this one";
     }
 
-    public TimeWarpEffect(final TimeWarpEffect effect) {
+    private TimeWarpEffect(final TimeWarpEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TimelyReinforcements.java
+++ b/Mage.Sets/src/mage/cards/t/TimelyReinforcements.java
@@ -46,7 +46,7 @@ class TimelyReinforcementsEffect extends OneShotEffect {
         staticText = "If you have less life than an opponent, you gain 6 life. If you control fewer creatures than an opponent, create three 1/1 white Soldier creature tokens";
     }
 
-    public TimelyReinforcementsEffect(TimelyReinforcementsEffect effect) {
+    private TimelyReinforcementsEffect(final TimelyReinforcementsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TineShrike.java
+++ b/Mage.Sets/src/mage/cards/t/TineShrike.java
@@ -28,7 +28,7 @@ public final class TineShrike extends CardImpl {
         this.addAbility(InfectAbility.getInstance());
     }
 
-    public TineShrike (final TineShrike card) {
+    private TineShrike(final TineShrike card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TitaniasChosen.java
+++ b/Mage.Sets/src/mage/cards/t/TitaniasChosen.java
@@ -52,7 +52,7 @@ class TitaniasChosenAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()));
     }
 
-    public TitaniasChosenAbility(final TitaniasChosenAbility ability) {
+    private TitaniasChosenAbility(final TitaniasChosenAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TitaniasSong.java
+++ b/Mage.Sets/src/mage/cards/t/TitaniasSong.java
@@ -58,7 +58,7 @@ class TitaniasSongEffect extends ContinuousEffectImpl {
         staticText = "Each noncreature artifact loses its abilities and is an artifact creature with power and toughness each equal to its mana value";
     }
 
-    public TitaniasSongEffect(final TitaniasSongEffect effect) {
+    private TitaniasSongEffect(final TitaniasSongEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TitansPresence.java
+++ b/Mage.Sets/src/mage/cards/t/TitansPresence.java
@@ -60,7 +60,7 @@ class TitansPresenceEffect extends OneShotEffect {
         staticText = "Exile target creature if its power is less than or equal to the revealed card's power";
     }
 
-    public TitansPresenceEffect(TitansPresenceEffect effect) {
+    private TitansPresenceEffect(final TitansPresenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TobiasBeckett.java
+++ b/Mage.Sets/src/mage/cards/t/TobiasBeckett.java
@@ -61,7 +61,7 @@ class TobiasBeckettEffect extends OneShotEffect {
         staticText = "exile the top card of that player's library. You may cast cards exiled this way and spend mana as though it were mana of any type to cast that spell";
     }
 
-    public TobiasBeckettEffect(final TobiasBeckettEffect effect) {
+    private TobiasBeckettEffect(final TobiasBeckettEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Togglodyte.java
+++ b/Mage.Sets/src/mage/cards/t/Togglodyte.java
@@ -63,7 +63,7 @@ class TogglodyteEntersEffect extends OneShotEffect {
         staticText = "turned on";
     }
 
-    public TogglodyteEntersEffect(final TogglodyteEntersEffect effect) {
+    private TogglodyteEntersEffect(final TogglodyteEntersEffect effect) {
         super(effect);
     }
 
@@ -97,7 +97,7 @@ class TogglodyteToggleEffect extends OneShotEffect {
         staticText = "toggle {this}'s ON/OFF switch";
     }
 
-    public TogglodyteToggleEffect(final TogglodyteToggleEffect effect) {
+    private TogglodyteToggleEffect(final TogglodyteToggleEffect effect) {
         super(effect);
     }
 
@@ -129,7 +129,7 @@ class TogglodyteRestrictionEffect extends RestrictionEffect {
         staticText = "";
     }
 
-    public TogglodyteRestrictionEffect(final TogglodyteRestrictionEffect effect) {
+    private TogglodyteRestrictionEffect(final TogglodyteRestrictionEffect effect) {
         super(effect);
     }
 
@@ -161,7 +161,7 @@ class TogglodytePreventionEffect extends PreventionEffectImpl {
         staticText = "As long as {this} is turned off, it can't attack or block, and prevent all damage it would deal";
     }
 
-    public TogglodytePreventionEffect(final TogglodytePreventionEffect effect) {
+    private TogglodytePreventionEffect(final TogglodytePreventionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ToilsOfNightAndDay.java
+++ b/Mage.Sets/src/mage/cards/t/ToilsOfNightAndDay.java
@@ -48,7 +48,7 @@ public final class ToilsOfNightAndDay extends CardImpl {
             this.staticText = "You may tap or untap target permanent, then you may tap or untap another target permanent";
         }
 
-        public ToilsOfNightAndDayEffect(final ToilsOfNightAndDayEffect effect) {
+        private ToilsOfNightAndDayEffect(final ToilsOfNightAndDayEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/t/TolarianEntrancer.java
+++ b/Mage.Sets/src/mage/cards/t/TolarianEntrancer.java
@@ -48,7 +48,7 @@ public final class TolarianEntrancer extends CardImpl {
             super(new GainControlTargetEffect(Duration.EndOfGame));
         }
 
-        public TolarianEntrancerDelayedTriggeredAbility(final TolarianEntrancerDelayedTriggeredAbility ability) {
+        private TolarianEntrancerDelayedTriggeredAbility(final TolarianEntrancerDelayedTriggeredAbility ability) {
             super(ability);
         }
 

--- a/Mage.Sets/src/mage/cards/t/TombOfTheDuskRose.java
+++ b/Mage.Sets/src/mage/cards/t/TombOfTheDuskRose.java
@@ -68,7 +68,7 @@ class TombOfTheDuskRoseEffect extends OneShotEffect {
         this.staticText = "Put a creature card exiled with this permanent onto the battlefield under your control";
     }
 
-    public TombOfTheDuskRoseEffect(final TombOfTheDuskRoseEffect effect) {
+    private TombOfTheDuskRoseEffect(final TombOfTheDuskRoseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Tombfire.java
+++ b/Mage.Sets/src/mage/cards/t/Tombfire.java
@@ -55,7 +55,7 @@ class TombfireEffect extends OneShotEffect {
         staticText = "Target player exiles all cards with flashback from their graveyard";
     }
 
-    public TombfireEffect(final TombfireEffect effect) {
+    private TombfireEffect(final TombfireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TooGreedilyTooDeep.java
+++ b/Mage.Sets/src/mage/cards/t/TooGreedilyTooDeep.java
@@ -50,7 +50,7 @@ class TooGreedilyTooDeepEffect extends OneShotEffect {
         this.staticText = "put target creature card from a graveyard onto the battlefield under your control. That creature deals damage equal to its power to each other creature";
     }
 
-    public TooGreedilyTooDeepEffect(final TooGreedilyTooDeepEffect effect) {
+    private TooGreedilyTooDeepEffect(final TooGreedilyTooDeepEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ToothAndNail.java
+++ b/Mage.Sets/src/mage/cards/t/ToothAndNail.java
@@ -56,7 +56,7 @@ class ToothAndNailPutCreatureOnBattlefieldEffect extends OneShotEffect {
         this.staticText = "Put up to two creature cards from your hand onto the battlefield";
     }
 
-    public ToothAndNailPutCreatureOnBattlefieldEffect(final ToothAndNailPutCreatureOnBattlefieldEffect effect) {
+    private ToothAndNailPutCreatureOnBattlefieldEffect(final ToothAndNailPutCreatureOnBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ToothCollector.java
+++ b/Mage.Sets/src/mage/cards/t/ToothCollector.java
@@ -68,7 +68,7 @@ class ToothCollectorAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new BoostTargetEffect(-1, -1, Duration.EndOfTurn));
     }
 
-    public ToothCollectorAbility(final ToothCollectorAbility ability) {
+    private ToothCollectorAbility(final ToothCollectorAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ToothyImaginaryFriend.java
+++ b/Mage.Sets/src/mage/cards/t/ToothyImaginaryFriend.java
@@ -64,7 +64,7 @@ class ToothyImaginaryFriendCountersCount implements DynamicValue {
         this.counterName = counter.getName();
     }
 
-    public ToothyImaginaryFriendCountersCount(final ToothyImaginaryFriendCountersCount countersCount) {
+    private ToothyImaginaryFriendCountersCount(final ToothyImaginaryFriendCountersCount countersCount) {
         this.counterName = countersCount.counterName;
     }
 

--- a/Mage.Sets/src/mage/cards/t/Topple.java
+++ b/Mage.Sets/src/mage/cards/t/Topple.java
@@ -45,7 +45,7 @@ class ToppleTargetCreature extends TargetCreaturePermanent {
         setTargetName("creature with the greatest power among creatures on the battlefield");
     }
 
-    public ToppleTargetCreature(final ToppleTargetCreature target) {
+    private ToppleTargetCreature(final ToppleTargetCreature target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Topplegeist.java
+++ b/Mage.Sets/src/mage/cards/t/Topplegeist.java
@@ -70,7 +70,7 @@ class TopplegeistAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new TapTargetEffect());
     }
 
-    public TopplegeistAbility(final TopplegeistAbility ability) {
+    private TopplegeistAbility(final TopplegeistAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TorchDrake.java
+++ b/Mage.Sets/src/mage/cards/t/TorchDrake.java
@@ -32,7 +32,7 @@ public final class TorchDrake extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 0, Duration.EndOfTurn), new ManaCostsImpl<>("{1}{R}")));
     }
 
-    public TorchDrake (final TorchDrake card) {
+    private TorchDrake(final TorchDrake card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TorgaarFamineIncarnate.java
+++ b/Mage.Sets/src/mage/cards/t/TorgaarFamineIncarnate.java
@@ -64,7 +64,7 @@ class TorgaarFamineIncarnateEffect extends OneShotEffect {
         this.staticText = "up to one target player's life total becomes half their starting life total, rounded down";
     }
 
-    public TorgaarFamineIncarnateEffect(final TorgaarFamineIncarnateEffect effect) {
+    private TorgaarFamineIncarnateEffect(final TorgaarFamineIncarnateEffect effect) {
         super(effect);
     }
 
@@ -91,7 +91,7 @@ class TorgaarFamineIncarnateEffectCostReductionEffect extends CostModificationEf
         staticText = "This spell costs {2} less to cast for each creature sacrificed this way";
     }
 
-    public TorgaarFamineIncarnateEffectCostReductionEffect(final TorgaarFamineIncarnateEffectCostReductionEffect effect) {
+    private TorgaarFamineIncarnateEffectCostReductionEffect(final TorgaarFamineIncarnateEffectCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TormentOfHailfire.java
+++ b/Mage.Sets/src/mage/cards/t/TormentOfHailfire.java
@@ -45,7 +45,7 @@ class TormentOfHailfireEffect extends OneShotEffect {
         this.staticText = "Repeat the following process X times. Each opponent loses 3 life unless that player sacrifices a nonland permanent or discards a card";
     }
     
-    public TormentOfHailfireEffect(final TormentOfHailfireEffect effect) {
+    private TormentOfHailfireEffect(final TormentOfHailfireEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/t/TormentOfVenom.java
+++ b/Mage.Sets/src/mage/cards/t/TormentOfVenom.java
@@ -53,7 +53,7 @@ class TormentOfVenomEffect extends OneShotEffect {
         this.staticText = "Put three -1/-1 counters on target creature. Its controller loses 3 life unless they sacrifice another nonland permanent or discards a card";
     }
 
-    public TormentOfVenomEffect(final TormentOfVenomEffect effect) {
+    private TormentOfVenomEffect(final TormentOfVenomEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TormentedHero.java
+++ b/Mage.Sets/src/mage/cards/t/TormentedHero.java
@@ -51,7 +51,7 @@ class EachOpponentLosesYouGainSumLifeEffect extends OneShotEffect {
         staticText = "Each opponent loses 1 life. You gain life equal to the life lost this way";
     }
 
-    public EachOpponentLosesYouGainSumLifeEffect(final EachOpponentLosesYouGainSumLifeEffect effect) {
+    private EachOpponentLosesYouGainSumLifeEffect(final EachOpponentLosesYouGainSumLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TormentedThoughts.java
+++ b/Mage.Sets/src/mage/cards/t/TormentedThoughts.java
@@ -52,7 +52,7 @@ class TormentedThoughtsDiscardEffect extends OneShotEffect {
         this.staticText = "Target player discards a number of cards equal to the sacrificed creature's power";
     }
 
-    public TormentedThoughtsDiscardEffect(final TormentedThoughtsDiscardEffect effect) {
+    private TormentedThoughtsDiscardEffect(final TormentedThoughtsDiscardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TorrentElemental.java
+++ b/Mage.Sets/src/mage/cards/t/TorrentElemental.java
@@ -78,7 +78,7 @@ class ReturnSourceFromExileToBattlefieldEffect extends OneShotEffect {
         setText();
     }
 
-    public ReturnSourceFromExileToBattlefieldEffect(final ReturnSourceFromExileToBattlefieldEffect effect) {
+    private ReturnSourceFromExileToBattlefieldEffect(final ReturnSourceFromExileToBattlefieldEffect effect) {
         super(effect);
         this.tapped = effect.tapped;
         this.ownerControl = effect.ownerControl;

--- a/Mage.Sets/src/mage/cards/t/TorrentOfSouls.java
+++ b/Mage.Sets/src/mage/cards/t/TorrentOfSouls.java
@@ -67,7 +67,7 @@ class TorrentOfSoulsEffect extends OneShotEffect {
         super(Outcome.BoostCreature);
     }
 
-    public TorrentOfSoulsEffect(final TorrentOfSoulsEffect effect) {
+    private TorrentOfSoulsEffect(final TorrentOfSoulsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TortureChamber.java
+++ b/Mage.Sets/src/mage/cards/t/TortureChamber.java
@@ -66,7 +66,7 @@ class TortureChamberEffect1 extends OneShotEffect {
         this.staticText = "{this} deals damage to you equal to the number of pain counters on it";
     }
 
-    public TortureChamberEffect1(final TortureChamberEffect1 effect) {
+    private TortureChamberEffect1(final TortureChamberEffect1 effect) {
         super(effect);
     }
 
@@ -95,7 +95,7 @@ class TortureChamberEffect2 extends OneShotEffect {
         this.staticText = "{this} deals damage to target creature equal to the number of pain counters removed this way";
     }
 
-    public TortureChamberEffect2(final TortureChamberEffect2 effect) {
+    private TortureChamberEffect2(final TortureChamberEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TotalWar.java
+++ b/Mage.Sets/src/mage/cards/t/TotalWar.java
@@ -48,7 +48,7 @@ class TotalWarTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a player attacks with one or more creatures, ");
     }
 
-    public TotalWarTriggeredAbility(final TotalWarTriggeredAbility ability) {
+    private TotalWarTriggeredAbility(final TotalWarTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TouchOfMoonglove.java
+++ b/Mage.Sets/src/mage/cards/t/TouchOfMoonglove.java
@@ -61,7 +61,7 @@ class TouchOfMoongloveAddTriggerEffect extends OneShotEffect {
         this.staticText = "Whenever a creature dealt damage by that creature dies this turn, its controller loses 2 life";
     }
 
-    public TouchOfMoongloveAddTriggerEffect(final TouchOfMoongloveAddTriggerEffect effect) {
+    private TouchOfMoongloveAddTriggerEffect(final TouchOfMoongloveAddTriggerEffect effect) {
         super(effect);
     }
 
@@ -90,7 +90,7 @@ class TouchOfMoongloveDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.creatureToCheck = creatureToCheck;
     }
 
-    public TouchOfMoongloveDelayedTriggeredAbility(TouchOfMoongloveDelayedTriggeredAbility ability) {
+    private TouchOfMoongloveDelayedTriggeredAbility(final TouchOfMoongloveDelayedTriggeredAbility ability) {
         super(ability);
         this.creatureToCheck = ability.creatureToCheck;
     }

--- a/Mage.Sets/src/mage/cards/t/TouchOfTheEternal.java
+++ b/Mage.Sets/src/mage/cards/t/TouchOfTheEternal.java
@@ -43,7 +43,7 @@ class TouchOfTheEternalEffect extends OneShotEffect {
         this.staticText = "count the number of permanents you control. Your life total becomes that number";
     }
 
-    public TouchOfTheEternalEffect(final TouchOfTheEternalEffect effect) {
+    private TouchOfTheEternalEffect(final TouchOfTheEternalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TourachsChant.java
+++ b/Mage.Sets/src/mage/cards/t/TourachsChant.java
@@ -57,7 +57,7 @@ class TourachsChantEffect extends OneShotEffect {
         staticText = "{this} deals 3 damage to that player unless they put a -1/-1 counter on a creature they control";
     }
 
-    public TourachsChantEffect(final TourachsChantEffect effect) {
+    private TourachsChantEffect(final TourachsChantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TowerAbove.java
+++ b/Mage.Sets/src/mage/cards/t/TowerAbove.java
@@ -55,7 +55,7 @@ class TowerAboveEffect extends OneShotEffect {
         staticText = "Until end of turn, target creature gets +4/+4 and gains trample, wither, and \"When this creature attacks, target creature blocks it this turn if able.\"";
     }
 
-    public TowerAboveEffect(final TowerAboveEffect effect) {
+    private TowerAboveEffect(final TowerAboveEffect effect) {
         super(effect);
     }
 
@@ -94,7 +94,7 @@ class TowerAboveTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new MustBeBlockedByTargetSourceEffect(Duration.EndOfTurn), false);
     }
 
-    public TowerAboveTriggeredAbility(final TowerAboveTriggeredAbility ability) {
+    private TowerAboveTriggeredAbility(final TowerAboveTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TowerOfCalamities.java
+++ b/Mage.Sets/src/mage/cards/t/TowerOfCalamities.java
@@ -28,7 +28,7 @@ public final class TowerOfCalamities extends CardImpl {
         this.addAbility(ability);
     }
 
-    public TowerOfCalamities (final TowerOfCalamities card) {
+    private TowerOfCalamities(final TowerOfCalamities card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TowerOfChampions.java
+++ b/Mage.Sets/src/mage/cards/t/TowerOfChampions.java
@@ -29,7 +29,7 @@ public final class TowerOfChampions extends CardImpl {
         this.addAbility(ability);
     }
 
-    public TowerOfChampions (final TowerOfChampions card) {
+    private TowerOfChampions(final TowerOfChampions card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TowerOfEons.java
+++ b/Mage.Sets/src/mage/cards/t/TowerOfEons.java
@@ -26,7 +26,7 @@ public final class TowerOfEons extends CardImpl {
         this.addAbility(ability);
     }
 
-    public TowerOfEons (final TowerOfEons card) {
+    private TowerOfEons(final TowerOfEons card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TowerOfMurmurs.java
+++ b/Mage.Sets/src/mage/cards/t/TowerOfMurmurs.java
@@ -28,7 +28,7 @@ public final class TowerOfMurmurs extends CardImpl {
         this.addAbility(ability);
     }
 
-    public TowerOfMurmurs (final TowerOfMurmurs card) {
+    private TowerOfMurmurs(final TowerOfMurmurs card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Toymaker.java
+++ b/Mage.Sets/src/mage/cards/t/Toymaker.java
@@ -68,7 +68,7 @@ class ToymakerEffect extends ContinuousEffectImpl {
         staticText = "Target noncreature artifact becomes an artifact creature with power and toughness each equal to its mana value until end of turn";
     }
 
-    public ToymakerEffect(final ToymakerEffect effect) {
+    private ToymakerEffect(final ToymakerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrackDown.java
+++ b/Mage.Sets/src/mage/cards/t/TrackDown.java
@@ -45,7 +45,7 @@ class TrackDownEffect extends OneShotEffect {
         this.staticText = "reveal the top card of your library. If it's a creature or land card, draw a card";
     }
 
-    public TrackDownEffect(final TrackDownEffect effect) {
+    private TrackDownEffect(final TrackDownEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TradeSecrets.java
+++ b/Mage.Sets/src/mage/cards/t/TradeSecrets.java
@@ -46,7 +46,7 @@ class TradeSecretsEffect extends OneShotEffect {
         this.staticText = "Target opponent draws two cards, then you draw up to four cards. That opponent may repeat this process as many times as they choose";
     }
 
-    public TradeSecretsEffect(final TradeSecretsEffect effect) {
+    private TradeSecretsEffect(final TradeSecretsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TragicArrogance.java
+++ b/Mage.Sets/src/mage/cards/t/TragicArrogance.java
@@ -52,7 +52,7 @@ class TragicArroganceffect extends OneShotEffect {
         this.staticText = "For each player, you choose from among the permanents that player controls an artifact, a creature, an enchantment, and a planeswalker. Then each player sacrifices all other nonland permanents they control";
     }
 
-    public TragicArroganceffect(final TragicArroganceffect effect) {
+    private TragicArroganceffect(final TragicArroganceffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TragicLesson.java
+++ b/Mage.Sets/src/mage/cards/t/TragicLesson.java
@@ -47,7 +47,7 @@ class TragicLessonEffect extends OneShotEffect {
         staticText = "Then discard a card unless you return a land you control to its owner's hand.";
     }
 
-    public TragicLessonEffect(final TragicLessonEffect effect) {
+    private TragicLessonEffect(final TragicLessonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrailOfMystery.java
+++ b/Mage.Sets/src/mage/cards/t/TrailOfMystery.java
@@ -56,7 +56,7 @@ class TrailOfMysteryTriggeredAbility extends TurnedFaceUpAllTriggeredAbility {
         super(new BoostTargetEffect(2, 2, Duration.EndOfTurn), new FilterControlledCreaturePermanent(), true);
     }
 
-    public TrailOfMysteryTriggeredAbility(final TrailOfMysteryTriggeredAbility ability) {
+    private TrailOfMysteryTriggeredAbility(final TrailOfMysteryTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrainingDroid.java
+++ b/Mage.Sets/src/mage/cards/t/TrainingDroid.java
@@ -23,7 +23,7 @@ public class TrainingDroid extends CardImpl {
         this.addAbility(new RepairAbility(2));
     }
 
-    public TrainingDroid(final TrainingDroid card) {
+    private TrainingDroid(final TrainingDroid card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrainingDrone.java
+++ b/Mage.Sets/src/mage/cards/t/TrainingDrone.java
@@ -49,7 +49,7 @@ class TrainingDroneEffect extends RestrictionEffect {
         staticText = "{this} can't attack or block unless it's equipped";
     }
 
-    public TrainingDroneEffect(final TrainingDroneEffect effect) {
+    private TrainingDroneEffect(final TrainingDroneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TraitorsRoar.java
+++ b/Mage.Sets/src/mage/cards/t/TraitorsRoar.java
@@ -56,7 +56,7 @@ class TraitorsRoarEffect extends OneShotEffect {
         this.staticText = "Tap target untapped creature. It deals damage equal to its power to its controller";
     }
 
-    public TraitorsRoarEffect(final TraitorsRoarEffect effect) {
+    private TraitorsRoarEffect(final TraitorsRoarEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Transmogrify.java
+++ b/Mage.Sets/src/mage/cards/t/Transmogrify.java
@@ -49,7 +49,7 @@ class TransmogrifyEffect extends OneShotEffect {
         staticText = "That creature's controller reveals cards from the top of their library until they reveal a creature card. That player puts that card onto the battlefield, then shuffles the rest into their library";
     }
 
-    public TransmogrifyEffect(final TransmogrifyEffect effect) {
+    private TransmogrifyEffect(final TransmogrifyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TransmuteArtifact.java
+++ b/Mage.Sets/src/mage/cards/t/TransmuteArtifact.java
@@ -49,7 +49,7 @@ class TransmuteArtifactEffect extends SearchEffect {
         staticText = "Sacrifice an artifact. If you do, search your library for an artifact card. If that card's mana value is less than or equal to the sacrificed artifact's mana value, put it onto the battlefield. If it's greater, you may pay {X}, where X is the difference. If you do, put it onto the battlefield. If you don't, put it into its owner's graveyard. Then shuffle";
     }
 
-    public TransmuteArtifactEffect(final TransmuteArtifactEffect effect) {
+    private TransmuteArtifactEffect(final TransmuteArtifactEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TravelingPlague.java
+++ b/Mage.Sets/src/mage/cards/t/TravelingPlague.java
@@ -77,7 +77,7 @@ class TravelingPlagueTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When enchanted creature leaves the battlefield, ");
     }
 
-    public TravelingPlagueTriggeredAbility(final TravelingPlagueTriggeredAbility ability) {
+    private TravelingPlagueTriggeredAbility(final TravelingPlagueTriggeredAbility ability) {
         super(ability);
     }
 
@@ -117,7 +117,7 @@ class TravelingPlagueEffect extends OneShotEffect {
         staticText = "that creature's controller returns {this} from its owner's graveyard to the battlefield";
     }
 
-    public TravelingPlagueEffect(final TravelingPlagueEffect effect) {
+    private TravelingPlagueEffect(final TravelingPlagueEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TraverseTheOutlands.java
+++ b/Mage.Sets/src/mage/cards/t/TraverseTheOutlands.java
@@ -49,7 +49,7 @@ class TraverseTheOutlandsEffect extends OneShotEffect {
         this.staticText = "Search your library for up to X basic land cards, where X is the greatest power among creatures you control. Put those cards onto the battlefield tapped, then shuffle.";
     }
 
-    public TraverseTheOutlandsEffect(final TraverseTheOutlandsEffect effect) {
+    private TraverseTheOutlandsEffect(final TraverseTheOutlandsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreacherousLink.java
+++ b/Mage.Sets/src/mage/cards/t/TreacherousLink.java
@@ -59,7 +59,7 @@ class TreacherousLinkEffect extends ReplacementEffectImpl {
         staticText = "All damage that would be dealt to enchanted creature is dealt to its controller instead";
     }
 
-    public TreacherousLinkEffect(final TreacherousLinkEffect effect) {
+    private TreacherousLinkEffect(final TreacherousLinkEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreacherousPitDweller.java
+++ b/Mage.Sets/src/mage/cards/t/TreacherousPitDweller.java
@@ -54,7 +54,7 @@ class TreacherousPitDwellerEffect extends ContinuousEffectImpl {
         staticText = "target opponent gains control of {this}";
     }
 
-    public TreacherousPitDwellerEffect(final TreacherousPitDwellerEffect effect) {
+    private TreacherousPitDwellerEffect(final TreacherousPitDwellerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreacherousTerrain.java
+++ b/Mage.Sets/src/mage/cards/t/TreacherousTerrain.java
@@ -48,7 +48,7 @@ class TreacherousTerrainEffect extends OneShotEffect {
         staticText = "{this} deals damage to each opponent equal to the number of lands that player controls";
     }
 
-    public TreacherousTerrainEffect(final TreacherousTerrainEffect effect) {
+    private TreacherousTerrainEffect(final TreacherousTerrainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreacherousUrge.java
+++ b/Mage.Sets/src/mage/cards/t/TreacherousUrge.java
@@ -56,7 +56,7 @@ class TreacherousUrgeEffect extends OneShotEffect {
         this.staticText = "Target opponent reveals their hand. You may put a creature card from it onto the battlefield under your control. That creature gains haste. Sacrifice it at the beginning of the next end step";
     }
 
-    public TreacherousUrgeEffect(final TreacherousUrgeEffect effect) {
+    private TreacherousUrgeEffect(final TreacherousUrgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreasureHunt.java
+++ b/Mage.Sets/src/mage/cards/t/TreasureHunt.java
@@ -44,7 +44,7 @@ class TreasureHuntEffect extends OneShotEffect {
         this.staticText = "Reveal cards from the top of your library until you reveal a nonland card, then put all cards revealed this way into your hand";
     }
 
-    public TreasureHuntEffect(final TreasureHuntEffect effect) {
+    private TreasureHuntEffect(final TreasureHuntEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreasureKeeper.java
+++ b/Mage.Sets/src/mage/cards/t/TreasureKeeper.java
@@ -54,7 +54,7 @@ class TreasureKeeperEffect extends OneShotEffect {
                 + "cards not cast this way on the bottom of your library in a random order";
     }
 
-    public TreasureKeeperEffect(TreasureKeeperEffect effect) {
+    private TreasureKeeperEffect(final TreasureKeeperEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreasureMage.java
+++ b/Mage.Sets/src/mage/cards/t/TreasureMage.java
@@ -44,7 +44,7 @@ public final class TreasureMage extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(effect, true));
     }
 
-    public TreasureMage (final TreasureMage card) {
+    private TreasureMage(final TreasureMage card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreeOfPerdition.java
+++ b/Mage.Sets/src/mage/cards/t/TreeOfPerdition.java
@@ -55,7 +55,7 @@ class TreeOfPerditionEffect extends OneShotEffect {
         staticText = "Exchange target opponent's life total with {this}'s toughness";
     }
 
-    public TreeOfPerditionEffect(final TreeOfPerditionEffect effect) {
+    private TreeOfPerditionEffect(final TreeOfPerditionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreeOfRedemption.java
+++ b/Mage.Sets/src/mage/cards/t/TreeOfRedemption.java
@@ -51,7 +51,7 @@ class TreeOfRedemptionEffect extends OneShotEffect {
         staticText = "Exchange your life total with {this}'s toughness";
     }
 
-    public TreeOfRedemptionEffect(final TreeOfRedemptionEffect effect) {
+    private TreeOfRedemptionEffect(final TreeOfRedemptionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreeOfTales.java
+++ b/Mage.Sets/src/mage/cards/t/TreeOfTales.java
@@ -19,7 +19,7 @@ public final class TreeOfTales extends CardImpl {
         this.addAbility(new GreenManaAbility());
     }
 
-    public TreeOfTales (final TreeOfTales card) {
+    private TreeOfTales(final TreeOfTales card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TreetopVillage.java
+++ b/Mage.Sets/src/mage/cards/t/TreetopVillage.java
@@ -56,7 +56,7 @@ class ApeToken extends TokenImpl {
         this.addAbility(TrampleAbility.getInstance());
     }
 
-    public ApeToken(final ApeToken token) {
+    private ApeToken(final ApeToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrenchBehemoth.java
+++ b/Mage.Sets/src/mage/cards/t/TrenchBehemoth.java
@@ -65,7 +65,7 @@ class TrenchBehemothEffect extends RequirementEffect {
         staticText = "target creature an opponent controls attacks during its controller's next combat phase if able";
     }
 
-    public TrenchBehemothEffect(final TrenchBehemothEffect effect) {
+    private TrenchBehemothEffect(final TrenchBehemothEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrenchGorger.java
+++ b/Mage.Sets/src/mage/cards/t/TrenchGorger.java
@@ -55,7 +55,7 @@ class TrenchGorgerEffect extends OneShotEffect {
                 "If you do, {this} has base power and base toughness each equal to the number of cards exiled this way";
     }
 
-    public TrenchGorgerEffect(final TrenchGorgerEffect effect) {
+    private TrenchGorgerEffect(final TrenchGorgerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrepanationBlade.java
+++ b/Mage.Sets/src/mage/cards/t/TrepanationBlade.java
@@ -58,7 +58,7 @@ class TrepanationBladeDiscardEffect extends OneShotEffect {
         this.staticText = "defending player reveals cards from the top of their library until they reveal a land card. The creature gets +1/+0 until end of turn for each card revealed this way. That player puts the revealed cards into their graveyard";
     }
 
-    public TrepanationBladeDiscardEffect(final TrepanationBladeDiscardEffect effect) {
+    private TrepanationBladeDiscardEffect(final TrepanationBladeDiscardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrespassersCurse.java
+++ b/Mage.Sets/src/mage/cards/t/TrespassersCurse.java
@@ -60,7 +60,7 @@ class TrespassersCurseTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature enters the battlefield under enchanted player's control, ");
     }
 
-    public TrespassersCurseTriggeredAbility(final TrespassersCurseTriggeredAbility ability) {
+    private TrespassersCurseTriggeredAbility(final TrespassersCurseTriggeredAbility ability) {
         super(ability);
     }
 
@@ -97,7 +97,7 @@ class TrespassersCurseEffect extends OneShotEffect {
         this.staticText = "that player loses 1 life and you gain 1 life.";
     }
 
-    public TrespassersCurseEffect(final TrespassersCurseEffect effect) {
+    private TrespassersCurseEffect(final TrespassersCurseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrevaTheRenewer.java
+++ b/Mage.Sets/src/mage/cards/t/TrevaTheRenewer.java
@@ -58,7 +58,7 @@ class TrevaTheRenewerEffect extends OneShotEffect {
         this.staticText = "choose a color, then you gain 1 life for each permanent of that color.";
     }
 
-    public TrevaTheRenewerEffect(final TrevaTheRenewerEffect effect) {
+    private TrevaTheRenewerEffect(final TrevaTheRenewerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TriadOfFates.java
+++ b/Mage.Sets/src/mage/cards/t/TriadOfFates.java
@@ -85,7 +85,7 @@ class DrawCardControllerTargetEffect extends OneShotEffect {
         this.staticText = "Its controller draws two cards";
     }
 
-    public DrawCardControllerTargetEffect(final DrawCardControllerTargetEffect effect) {
+    private DrawCardControllerTargetEffect(final DrawCardControllerTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrialError.java
+++ b/Mage.Sets/src/mage/cards/t/TrialError.java
@@ -67,7 +67,7 @@ class TrialEffect extends OneShotEffect {
         this.staticText = "Return all creatures blocking or blocked by target creature to their owner's hand";
     }
 
-    public TrialEffect(final TrialEffect effect) {
+    private TrialEffect(final TrialEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TribalUnity.java
+++ b/Mage.Sets/src/mage/cards/t/TribalUnity.java
@@ -52,7 +52,7 @@ class TribalUnityEffect extends OneShotEffect {
         this.amount = amount;
     }
 
-    public TribalUnityEffect(final TribalUnityEffect effect) {
+    private TribalUnityEffect(final TribalUnityEffect effect) {
         super(effect);
         this.amount = effect.amount;
     }

--- a/Mage.Sets/src/mage/cards/t/Trickbind.java
+++ b/Mage.Sets/src/mage/cards/t/Trickbind.java
@@ -51,7 +51,7 @@ class TrickbindCounterEffect extends OneShotEffect {
         staticText = "Counter target activated or triggered ability. If a permanent's ability is countered this way, activated abilities of that permanent can't be activated this turn";
     }
 
-    public TrickbindCounterEffect(final TrickbindCounterEffect effect) {
+    private TrickbindCounterEffect(final TrickbindCounterEffect effect) {
         super(effect);
     }
 
@@ -81,7 +81,7 @@ class TrickbindCantActivateEffect extends RestrictionEffect {
         staticText = "Activated abilities of that permanent can't be activated this turn";
     }
 
-    public TrickbindCantActivateEffect(final TrickbindCantActivateEffect effect) {
+    private TrickbindCantActivateEffect(final TrickbindCantActivateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrigonOfCorruption.java
+++ b/Mage.Sets/src/mage/cards/t/TrigonOfCorruption.java
@@ -49,7 +49,7 @@ public final class TrigonOfCorruption extends CardImpl {
         this.addAbility(ability2);
     }
 
-    public TrigonOfCorruption (final TrigonOfCorruption card) {
+    private TrigonOfCorruption(final TrigonOfCorruption card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Triskaidekaphobia.java
+++ b/Mage.Sets/src/mage/cards/t/Triskaidekaphobia.java
@@ -49,7 +49,7 @@ class TriskaidekaphobiaGainLifeEffect extends OneShotEffect {
         this.staticText = "Each player with exactly 13 life loses the game, then each player gains 1 life";
     }
 
-    public TriskaidekaphobiaGainLifeEffect(final TriskaidekaphobiaGainLifeEffect effect) {
+    private TriskaidekaphobiaGainLifeEffect(final TriskaidekaphobiaGainLifeEffect effect) {
         super(effect);
     }
 
@@ -88,7 +88,7 @@ class TriskaidekaphobiaLoseLifeEffect extends OneShotEffect {
         this.staticText = "Each player with exactly 13 life loses the game, then each player loses 1 life";
     }
 
-    public TriskaidekaphobiaLoseLifeEffect(final TriskaidekaphobiaLoseLifeEffect effect) {
+    private TriskaidekaphobiaLoseLifeEffect(final TriskaidekaphobiaLoseLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TritonTactics.java
+++ b/Mage.Sets/src/mage/cards/t/TritonTactics.java
@@ -57,7 +57,7 @@ class TritonTacticsUntapEffect extends OneShotEffect {
                 "by one of those creatures this turn and it doesn't untap during its controller's next untap step";
     }
 
-    public TritonTacticsUntapEffect(final TritonTacticsUntapEffect effect) {
+    private TritonTacticsUntapEffect(final TritonTacticsUntapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrollAscetic.java
+++ b/Mage.Sets/src/mage/cards/t/TrollAscetic.java
@@ -30,7 +30,7 @@ public final class TrollAscetic extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new ManaCostsImpl<>("{1}{G}")));
     }
 
-    public TrollAscetic (final TrollAscetic card) {
+    private TrollAscetic(final TrollAscetic card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Trollhide.java
+++ b/Mage.Sets/src/mage/cards/t/Trollhide.java
@@ -50,7 +50,7 @@ public final class Trollhide extends CardImpl {
         this.addAbility(ability);
     }
 
-    public Trollhide (final Trollhide card) {
+    private Trollhide(final Trollhide card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Tromokratis.java
+++ b/Mage.Sets/src/mage/cards/t/Tromokratis.java
@@ -67,7 +67,7 @@ class CantBeBlockedUnlessAllEffect extends RestrictionEffect {
         staticText = "{this} can't be blocked unless all creatures defending player controls block it";
     }
 
-    public CantBeBlockedUnlessAllEffect(final CantBeBlockedUnlessAllEffect effect) {
+    private CantBeBlockedUnlessAllEffect(final CantBeBlockedUnlessAllEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrostaniSelesnyasVoice.java
+++ b/Mage.Sets/src/mage/cards/t/TrostaniSelesnyasVoice.java
@@ -65,7 +65,7 @@ class TrostaniSelesnyasVoiceTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever another creature enters the battlefield under your control, ");
     }
 
-    public TrostaniSelesnyasVoiceTriggeredAbility(TrostaniSelesnyasVoiceTriggeredAbility ability) {
+    private TrostaniSelesnyasVoiceTriggeredAbility(final TrostaniSelesnyasVoiceTriggeredAbility ability) {
         super(ability);
     }
 
@@ -104,7 +104,7 @@ class TrostaniSelesnyasVoiceEffect extends OneShotEffect {
         staticText = "you gain life equal to that creature's toughness";
     }
 
-    public TrostaniSelesnyasVoiceEffect(final TrostaniSelesnyasVoiceEffect effect) {
+    private TrostaniSelesnyasVoiceEffect(final TrostaniSelesnyasVoiceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TroveOfTemptation.java
+++ b/Mage.Sets/src/mage/cards/t/TroveOfTemptation.java
@@ -50,7 +50,7 @@ class TroveOfTemptationForceAttackEffect extends RequirementEffect {
         staticText = "Each opponent must attack you or a planeswalker you control with at least one creature each combat if able";
     }
 
-    public TroveOfTemptationForceAttackEffect(final TroveOfTemptationForceAttackEffect effect) {
+    private TroveOfTemptationForceAttackEffect(final TroveOfTemptationForceAttackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrueNameNemesis.java
+++ b/Mage.Sets/src/mage/cards/t/TrueNameNemesis.java
@@ -66,7 +66,7 @@ class ProtectionFromPlayerAbility extends ProtectionAbility {
         super(new FilterCard());
     }
 
-    public ProtectionFromPlayerAbility(final ProtectionFromPlayerAbility ability) {
+    private ProtectionFromPlayerAbility(final ProtectionFromPlayerAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TruthOrTale.java
+++ b/Mage.Sets/src/mage/cards/t/TruthOrTale.java
@@ -47,7 +47,7 @@ class TruthOrTaleEffect extends OneShotEffect {
         this.staticText = "Reveal the top five cards of your library and separate them into two piles. An opponent chooses one of those piles. Put a card from the chosen pile into your hand, then put all other cards revealed this way on the bottom of your library in any order";
     }
 
-    public TruthOrTaleEffect(final TruthOrTaleEffect effect) {
+    private TruthOrTaleEffect(final TruthOrTaleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrygonPredator.java
+++ b/Mage.Sets/src/mage/cards/t/TrygonPredator.java
@@ -56,7 +56,7 @@ class TrygonPredatorTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), true);
     }
 
-    public TrygonPredatorTriggeredAbility(final TrygonPredatorTriggeredAbility ability) {
+    private TrygonPredatorTriggeredAbility(final TrygonPredatorTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TsabosAssassin.java
+++ b/Mage.Sets/src/mage/cards/t/TsabosAssassin.java
@@ -59,7 +59,7 @@ class TsabosAssasinEffect extends OneShotEffect {
         this.staticText = "Destroy target creature if it shares a color with the most common color among all permanents or a color tied for most common. A creature destroyed this way can't be regenerated.";
     }
 
-    public TsabosAssasinEffect(final TsabosAssasinEffect effect) {
+    private TsabosAssasinEffect(final TsabosAssasinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TsabosWeb.java
+++ b/Mage.Sets/src/mage/cards/t/TsabosWeb.java
@@ -53,7 +53,7 @@ class TsabosWebPreventUntapEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Each land with an activated ability that isn't a mana ability doesn't untap during its controller's untap step";
     }
 
-    public TsabosWebPreventUntapEffect(final TsabosWebPreventUntapEffect effect) {
+    private TsabosWebPreventUntapEffect(final TsabosWebPreventUntapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TuktukScrapper.java
+++ b/Mage.Sets/src/mage/cards/t/TuktukScrapper.java
@@ -54,7 +54,7 @@ class TuktukScrapperTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetArtifactPermanent());
     }
 
-    public TuktukScrapperTriggeredAbility(final TuktukScrapperTriggeredAbility ability) {
+    private TuktukScrapperTriggeredAbility(final TuktukScrapperTriggeredAbility ability) {
         super(ability);
     }
 
@@ -104,7 +104,7 @@ class TuktukScrapperEffect extends OneShotEffect {
         super(Outcome.DestroyPermanent);
     }
 
-    public TuktukScrapperEffect(final TuktukScrapperEffect effect) {
+    private TuktukScrapperEffect(final TuktukScrapperEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TundraKavu.java
+++ b/Mage.Sets/src/mage/cards/t/TundraKavu.java
@@ -55,7 +55,7 @@ class TundraKavuEffect extends BecomesBasicLandTargetEffect {
         staticText = "Target land becomes a Plains or an Island until end of turn.";
     }
 
-    public TundraKavuEffect(final TundraKavuEffect effect) {
+    private TundraKavuEffect(final TundraKavuEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TunnelVision.java
+++ b/Mage.Sets/src/mage/cards/t/TunnelVision.java
@@ -51,7 +51,7 @@ class TunnelVisionEffect extends OneShotEffect {
                 + "Otherwise, the player shuffles";
     }
 
-    public TunnelVisionEffect(final TunnelVisionEffect effect) {
+    private TunnelVisionEffect(final TunnelVisionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TurfWound.java
+++ b/Mage.Sets/src/mage/cards/t/TurfWound.java
@@ -49,7 +49,7 @@ class TurfWoundEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Target player can't play land cards this turn";
     }
 
-    public TurfWoundEffect(final TurfWoundEffect effect) {
+    private TurfWoundEffect(final TurfWoundEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TurnBurn.java
+++ b/Mage.Sets/src/mage/cards/t/TurnBurn.java
@@ -60,7 +60,7 @@ public final class TurnBurn extends SplitCard {
             power = new MageInt(0);
             toughness = new MageInt(1);
         }
-        public WeirdToken(final WeirdToken token) {
+        private WeirdToken(final WeirdToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/t/TurnTheTables.java
+++ b/Mage.Sets/src/mage/cards/t/TurnTheTables.java
@@ -45,7 +45,7 @@ class TurnTheTablesEffect extends RedirectionEffect {
         staticText = "All combat damage that would be dealt to you this turn is dealt to target attacking creature instead";
     }
 
-    public TurnTheTablesEffect(final TurnTheTablesEffect effect) {
+    private TurnTheTablesEffect(final TurnTheTablesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TurnTheTide.java
+++ b/Mage.Sets/src/mage/cards/t/TurnTheTide.java
@@ -21,7 +21,7 @@ public final class TurnTheTide extends CardImpl {
         this.getSpellAbility().addEffect(new BoostOpponentsEffect(-2, 0, Duration.EndOfTurn));
     }
 
-    public TurnTheTide (final TurnTheTide card) {
+    private TurnTheTide(final TurnTheTide card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TurnToSlag.java
+++ b/Mage.Sets/src/mage/cards/t/TurnToSlag.java
@@ -25,7 +25,7 @@ public final class TurnToSlag extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public TurnToSlag (final TurnToSlag card) {
+    private TurnToSlag(final TurnToSlag card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Turnabout.java
+++ b/Mage.Sets/src/mage/cards/t/Turnabout.java
@@ -57,7 +57,7 @@ class TurnaboutEffect extends OneShotEffect {
         staticText = "Choose artifact, creature, or land. Tap all untapped permanents of the chosen type target player controls, or untap all tapped permanents of that type that player controls";
     }
 
-    public TurnaboutEffect(final TurnaboutEffect effect) {
+    private TurnaboutEffect(final TurnaboutEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TurntimberSower.java
+++ b/Mage.Sets/src/mage/cards/t/TurntimberSower.java
@@ -69,7 +69,7 @@ class TurntimberSowerTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CreateTokenEffect(new PlantToken()), false);
     }
 
-    public TurntimberSowerTriggeredAbility(final TurntimberSowerTriggeredAbility ability) {
+    private TurntimberSowerTriggeredAbility(final TurntimberSowerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TuvasaTheSunlit.java
+++ b/Mage.Sets/src/mage/cards/t/TuvasaTheSunlit.java
@@ -74,7 +74,7 @@ class TuvasaTheSunlitTriggeredAbility extends SpellCastControllerTriggeredAbilit
                 StaticFilters.FILTER_SPELL_AN_ENCHANTMENT, false, SetTargetPointer.SPELL);
     }
 
-    public TuvasaTheSunlitTriggeredAbility(final TuvasaTheSunlitTriggeredAbility ability) {
+    private TuvasaTheSunlitTriggeredAbility(final TuvasaTheSunlitTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TwilightMire.java
+++ b/Mage.Sets/src/mage/cards/t/TwilightMire.java
@@ -38,7 +38,7 @@ public final class TwilightMire extends CardImpl {
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);        }
 
-    public TwilightMire (final TwilightMire card) {
+    private TwilightMire(final TwilightMire card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TwilightProphet.java
+++ b/Mage.Sets/src/mage/cards/t/TwilightProphet.java
@@ -68,7 +68,7 @@ class TwilightProphetEffect extends OneShotEffect {
                 + "Each opponent loses X life and you gain X life, where X is that card's mana value.";
     }
 
-    public TwilightProphetEffect(final TwilightProphetEffect effect) {
+    private TwilightProphetEffect(final TwilightProphetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TwilightsCall.java
+++ b/Mage.Sets/src/mage/cards/t/TwilightsCall.java
@@ -54,7 +54,7 @@ class TwilightsCallEffect extends OneShotEffect {
         staticText = "Each player returns all creature cards from their graveyard to the battlefield";
     }
 
-    public TwilightsCallEffect(TwilightsCallEffect copy) {
+    private TwilightsCallEffect(final TwilightsCallEffect copy) {
         super(copy);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Twinflame.java
+++ b/Mage.Sets/src/mage/cards/t/Twinflame.java
@@ -57,7 +57,7 @@ class TwinflameCopyEffect extends OneShotEffect {
         this.staticText = "choose any number of target creatures you control. For each of them, create a token that's a copy of that creature, except it has haste. Exile those tokens at the beginning of the next end step";
     }
 
-    public TwinflameCopyEffect(final TwinflameCopyEffect effect) {
+    private TwinflameCopyEffect(final TwinflameCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TwistAllegiance.java
+++ b/Mage.Sets/src/mage/cards/t/TwistAllegiance.java
@@ -51,7 +51,7 @@ class TwistAllegianceEffect extends OneShotEffect {
         this.staticText = "You and target opponent each gain control of all creatures the other controls until end of turn. Untap those creatures. Those creatures gain haste until end of turn";
     }
 
-    public TwistAllegianceEffect(final TwistAllegianceEffect effect) {
+    private TwistAllegianceEffect(final TwistAllegianceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TwistedImage.java
+++ b/Mage.Sets/src/mage/cards/t/TwistedImage.java
@@ -25,7 +25,7 @@ public final class TwistedImage extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public TwistedImage (final TwistedImage card) {
+    private TwistedImage(final TwistedImage card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TwoHeadedGiant.java
+++ b/Mage.Sets/src/mage/cards/t/TwoHeadedGiant.java
@@ -54,7 +54,7 @@ class TwoHeadedGiantEffect extends OneShotEffect {
                 + " If both coins come up tails, {this} gains menace until end of turn";
     }
 
-    public TwoHeadedGiantEffect(final TwoHeadedGiantEffect effect) {
+    private TwoHeadedGiantEffect(final TwoHeadedGiantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TymnaTheWeaver.java
+++ b/Mage.Sets/src/mage/cards/t/TymnaTheWeaver.java
@@ -63,7 +63,7 @@ class TymnaTheWeaverEffect extends OneShotEffect {
         this.staticText = "you may pay X life, where X is the number of opponents that were dealt combat damage this turn. If you do, draw X cards";
     }
 
-    public TymnaTheWeaverEffect(final TymnaTheWeaverEffect effect) {
+    private TymnaTheWeaverEffect(final TymnaTheWeaverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TyrantOfDiscord.java
+++ b/Mage.Sets/src/mage/cards/t/TyrantOfDiscord.java
@@ -52,7 +52,7 @@ class TyrantOfDiscordEffect extends OneShotEffect {
         this.staticText = "target opponent chooses a permanent they control at random and sacrifices it. If a nonland permanent is sacrificed this way, repeat this process";
     }
 
-    public TyrantOfDiscordEffect(final TyrantOfDiscordEffect effect) {
+    private TyrantOfDiscordEffect(final TyrantOfDiscordEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TyvarJubilantBrawler.java
+++ b/Mage.Sets/src/mage/cards/t/TyvarJubilantBrawler.java
@@ -68,7 +68,7 @@ class TyvarJubilantBrawlerHasteEffect extends AsThoughEffectImpl {
         staticText = "you may activate abilities of creatures you control as though those creatures had haste";
     }
 
-    public TyvarJubilantBrawlerHasteEffect(final TyvarJubilantBrawlerHasteEffect effect) {
+    private TyvarJubilantBrawlerHasteEffect(final TyvarJubilantBrawlerHasteEffect effect) {
         super(effect);
     }
 


### PR DESCRIPTION
Part of #11054 

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`public ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `private $1(final $1 $3`
