### PR TITLE
Clean all copy constructors in cards starting P-Q-R

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PackHunt.java
+++ b/Mage.Sets/src/mage/cards/p/PackHunt.java
@@ -48,7 +48,7 @@ class PackHuntEffect extends OneShotEffect {
         this.staticText = "Search your library for up to three cards with the same name as target creature, reveal them, and put them into your hand. Then shuffle";
     }
 
-    public PackHuntEffect(final PackHuntEffect effect) {
+    private PackHuntEffect(final PackHuntEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PainMagnification.java
+++ b/Mage.Sets/src/mage/cards/p/PainMagnification.java
@@ -42,7 +42,7 @@ class PainMagnificationTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DiscardTargetEffect(1), false);
     }
     
-    public PainMagnificationTriggeredAbility(final PainMagnificationTriggeredAbility ability) {
+    private PainMagnificationTriggeredAbility(final PainMagnificationTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/p/PainSeer.java
+++ b/Mage.Sets/src/mage/cards/p/PainSeer.java
@@ -49,7 +49,7 @@ class PainSeerEffect extends OneShotEffect {
         this.staticText = "reveal the top card of your library and put that card into your hand. You lose life equal to that card's mana value";
     }
 
-    public PainSeerEffect(final PainSeerEffect effect) {
+    private PainSeerEffect(final PainSeerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PainfulMemories.java
+++ b/Mage.Sets/src/mage/cards/p/PainfulMemories.java
@@ -48,7 +48,7 @@ class PainfulMemoriesEffect extends OneShotEffect {
         this.staticText = "Look at target opponent's hand and choose a card from it. Put that card on top of that player's library.";
     }
     
-    public PainfulMemoriesEffect(final PainfulMemoriesEffect effect) {
+    private PainfulMemoriesEffect(final PainfulMemoriesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PainfulQuandary.java
+++ b/Mage.Sets/src/mage/cards/p/PainfulQuandary.java
@@ -49,7 +49,7 @@ class PainfulQuandryEffect extends OneShotEffect {
         staticText = "that player loses 5 life unless they discard a card";
     }
 
-    public PainfulQuandryEffect(final PainfulQuandryEffect effect) {
+    private PainfulQuandryEffect(final PainfulQuandryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Painiac.java
+++ b/Mage.Sets/src/mage/cards/p/Painiac.java
@@ -52,7 +52,7 @@ class PainiacEffect extends OneShotEffect {
         this.staticText = "Roll a six-sided die. {this} gets +X/+0 until end of turn, where X is the result";
     }
 
-    public PainiacEffect(final PainiacEffect effect) {
+    private PainiacEffect(final PainiacEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PainsReward.java
+++ b/Mage.Sets/src/mage/cards/p/PainsReward.java
@@ -43,7 +43,7 @@ class PainsRewardEffect extends OneShotEffect {
         this.staticText = "Each player may bid life. You start the bidding with a bid of any number. In turn order, each player may top the high bid. The bidding ends if the high bid stands. The high bidder loses life equal to the high bid and draws four cards";
     }
 
-    public PainsRewardEffect(final PainsRewardEffect effect) {
+    private PainsRewardEffect(final PainsRewardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Painsmith.java
+++ b/Mage.Sets/src/mage/cards/p/Painsmith.java
@@ -37,7 +37,7 @@ public final class Painsmith extends CardImpl {
         this.addAbility(ability);
     }
 
-    public Painsmith (final Painsmith card) {
+    private Painsmith(final Painsmith card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PainwrackerOni.java
+++ b/Mage.Sets/src/mage/cards/p/PainwrackerOni.java
@@ -52,7 +52,7 @@ public final class PainwrackerOni extends CardImpl {
         ));
     }
 
-    public PainwrackerOni (final PainwrackerOni card) {
+    private PainwrackerOni(final PainwrackerOni card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PalaceJailer.java
+++ b/Mage.Sets/src/mage/cards/p/PalaceJailer.java
@@ -68,7 +68,7 @@ class PalaceJailerExileEffect extends OneShotEffect {
         this.staticText = "exile target creature an opponent controls until an opponent becomes the monarch. <i>(That creature returns under its owner's control.)</i>";
     }
 
-    public PalaceJailerExileEffect(final PalaceJailerExileEffect effect) {
+    private PalaceJailerExileEffect(final PalaceJailerExileEffect effect) {
         super(effect);
     }
 
@@ -95,7 +95,7 @@ class OnOpponentBecomesMonarchReturnExiledToBattlefieldAbility extends DelayedTr
         this.setRuleVisible(false);
     }
 
-    public OnOpponentBecomesMonarchReturnExiledToBattlefieldAbility(final OnOpponentBecomesMonarchReturnExiledToBattlefieldAbility ability) {
+    private OnOpponentBecomesMonarchReturnExiledToBattlefieldAbility(final OnOpponentBecomesMonarchReturnExiledToBattlefieldAbility ability) {
         super(ability);
     }
 
@@ -122,7 +122,7 @@ class PalaceJailerReturnExiledPermanentsEffect extends OneShotEffect {
         this.staticText = "Return exiled creature";
     }
 
-    public PalaceJailerReturnExiledPermanentsEffect(final PalaceJailerReturnExiledPermanentsEffect effect) {
+    private PalaceJailerReturnExiledPermanentsEffect(final PalaceJailerReturnExiledPermanentsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PaladinOfPrahv.java
+++ b/Mage.Sets/src/mage/cards/p/PaladinOfPrahv.java
@@ -62,7 +62,7 @@ class PaladinOfPrahvTriggeredAbility extends DelayedTriggeredAbility {
         setTriggerPhrase("Whenever target creature deals damage this turn, ");
     }
 
-    public PaladinOfPrahvTriggeredAbility(final PaladinOfPrahvTriggeredAbility ability) {
+    private PaladinOfPrahvTriggeredAbility(final PaladinOfPrahvTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PaleWayfarer.java
+++ b/Mage.Sets/src/mage/cards/p/PaleWayfarer.java
@@ -69,7 +69,7 @@ class PaleWayfarerEffect extends OneShotEffect {
         staticText = "Target creature gains protection from the color of its controller's choice until end of turn";
     }
 
-    public PaleWayfarerEffect(final PaleWayfarerEffect effect) {
+    private PaleWayfarerEffect(final PaleWayfarerEffect effect) {
         super(effect);
     }
 
@@ -112,7 +112,7 @@ class ProtectionChosenColorTargetEffect extends ContinuousEffectImpl {
         super(Duration.EndOfTurn, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
     }
 
-    public ProtectionChosenColorTargetEffect(final ProtectionChosenColorTargetEffect effect) {
+    private ProtectionChosenColorTargetEffect(final ProtectionChosenColorTargetEffect effect) {
         super(effect);
         if (effect.chosenColor != null) {
             this.chosenColor = effect.chosenColor.copy();

--- a/Mage.Sets/src/mage/cards/p/Pandemonium.java
+++ b/Mage.Sets/src/mage/cards/p/Pandemonium.java
@@ -67,7 +67,7 @@ class PandemoniumEffect extends OneShotEffect {
         this.staticText = "that creature's controller may have it deal damage equal to its power to any target of their choice";
     }
 
-    public PandemoniumEffect(final PandemoniumEffect effect) {
+    private PandemoniumEffect(final PandemoniumEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PanopticMirror.java
+++ b/Mage.Sets/src/mage/cards/p/PanopticMirror.java
@@ -55,7 +55,7 @@ class PanopticMirrorExileEffect extends OneShotEffect {
         this.staticText = "You may exile an instant or sorcery card with mana value X from your hand";
     }
 
-    public PanopticMirrorExileEffect(final PanopticMirrorExileEffect effect) {
+    private PanopticMirrorExileEffect(final PanopticMirrorExileEffect effect) {
         super(effect);
     }
 
@@ -102,7 +102,7 @@ class PanopticMirrorCastEffect extends OneShotEffect {
         this.staticText = "you may copy a card exiled with {this}. If you do, you may cast the copy without paying its mana cost";
     }
 
-    public PanopticMirrorCastEffect(final PanopticMirrorCastEffect effect) {
+    private PanopticMirrorCastEffect(final PanopticMirrorCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ParadisePlume.java
+++ b/Mage.Sets/src/mage/cards/p/ParadisePlume.java
@@ -58,7 +58,7 @@ class ParadisePlumeSpellCastTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a player casts a spell of the chosen color, ");
     }
 
-    public ParadisePlumeSpellCastTriggeredAbility(final ParadisePlumeSpellCastTriggeredAbility ability) {
+    private ParadisePlumeSpellCastTriggeredAbility(final ParadisePlumeSpellCastTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ParallectricFeedback.java
+++ b/Mage.Sets/src/mage/cards/p/ParallectricFeedback.java
@@ -44,7 +44,7 @@ class ParallectricFeedbackEffect extends OneShotEffect {
         staticText = "{this} deals damage to target spell's controller equal to that spell's mana value";
     }
 
-    public ParallectricFeedbackEffect(final ParallectricFeedbackEffect effect) {
+    private ParallectricFeedbackEffect(final ParallectricFeedbackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ParallelEvolution.java
+++ b/Mage.Sets/src/mage/cards/p/ParallelEvolution.java
@@ -58,7 +58,7 @@ class ParallelEvolutionEffect extends OneShotEffect {
         this.staticText = "For each creature token on the battlefield, its controller creates a token that's a copy of that creature";
     }
 
-    public ParallelEvolutionEffect(final ParallelEvolutionEffect effect) {
+    private ParallelEvolutionEffect(final ParallelEvolutionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Paralyze.java
+++ b/Mage.Sets/src/mage/cards/p/Paralyze.java
@@ -59,7 +59,7 @@ class ParalyzeEffect extends DoIfCostPaid {
         super(new UntapAttachedEffect(), new GenericManaCost(4));
     }
 
-    public ParalyzeEffect(final ParalyzeEffect effect) {
+    private ParalyzeEffect(final ParalyzeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Paraselene.java
+++ b/Mage.Sets/src/mage/cards/p/Paraselene.java
@@ -44,7 +44,7 @@ class ParaseleneEffect extends OneShotEffect {
         staticText = "Destroy all enchantments. You gain 1 life for each enchantment destroyed this way";
     }
 
-    public ParaseleneEffect(ParaseleneEffect effect) {
+    private ParaseleneEffect(final ParaseleneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ParasiticStrix.java
+++ b/Mage.Sets/src/mage/cards/p/ParasiticStrix.java
@@ -57,7 +57,7 @@ class ParasiticStrixTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetPlayer());
     }
 
-    public ParasiticStrixTriggeredAbility(final ParasiticStrixTriggeredAbility ability) {
+    private ParasiticStrixTriggeredAbility(final ParasiticStrixTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PardicDragon.java
+++ b/Mage.Sets/src/mage/cards/p/PardicDragon.java
@@ -68,7 +68,7 @@ class PardicDragonEffect extends OneShotEffect {
         this.staticText = "that player may put a time counter on Pardic Dragon";
     }
 
-    public PardicDragonEffect(final PardicDragonEffect effect) {
+    private PardicDragonEffect(final PardicDragonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PardicMiner.java
+++ b/Mage.Sets/src/mage/cards/p/PardicMiner.java
@@ -55,7 +55,7 @@ class PardicMinerEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Target player can't play lands this turn.";
     }
 
-    public PardicMinerEffect(final PardicMinerEffect effect) {
+    private PardicMinerEffect(final PardicMinerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PartingThoughts.java
+++ b/Mage.Sets/src/mage/cards/p/PartingThoughts.java
@@ -45,7 +45,7 @@ class PartingThoughtsEffect extends OneShotEffect {
         this.staticText = "Destroy target creature. You draw X cards and you lose X life, where X is the number of counters on that creature";
     }
 
-    public PartingThoughtsEffect(final PartingThoughtsEffect effect) {
+    private PartingThoughtsEffect(final PartingThoughtsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PastInFlames.java
+++ b/Mage.Sets/src/mage/cards/p/PastInFlames.java
@@ -47,7 +47,7 @@ class PastInFlamesEffect extends ContinuousEffectImpl {
         this.staticText = "Each instant and sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost";
     }
 
-    public PastInFlamesEffect(final PastInFlamesEffect effect) {
+    private PastInFlamesEffect(final PastInFlamesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PathOfPeace.java
+++ b/Mage.Sets/src/mage/cards/p/PathOfPeace.java
@@ -44,7 +44,7 @@ class PathOfPeaceEffect extends OneShotEffect {
         this.staticText = "Destroy target creature. Its owner gains 4 life";
     }
 
-    public PathOfPeaceEffect(final PathOfPeaceEffect effect) {
+    private PathOfPeaceEffect(final PathOfPeaceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PathbreakerIbex.java
+++ b/Mage.Sets/src/mage/cards/p/PathbreakerIbex.java
@@ -53,7 +53,7 @@ class PathbreakerIbexEffect extends OneShotEffect {
         this.staticText = "creatures you control gain trample and get +X/+X until end of turn, where X is the greatest power among creatures you control";
     }
 
-    public PathbreakerIbexEffect(final PathbreakerIbexEffect effect) {
+    private PathbreakerIbexEffect(final PathbreakerIbexEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PathwayArrows.java
+++ b/Mage.Sets/src/mage/cards/p/PathwayArrows.java
@@ -59,7 +59,7 @@ class PathwayArrowsEffect extends OneShotEffect {
         this.staticText = "This creature deals 1 damage to target creature. If a colorless creature is dealt damage this way, tap it";
     }
 
-    public PathwayArrowsEffect(final PathwayArrowsEffect effect) {
+    private PathwayArrowsEffect(final PathwayArrowsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PatientRebuilding.java
+++ b/Mage.Sets/src/mage/cards/p/PatientRebuilding.java
@@ -52,7 +52,7 @@ class PatientRebuildingEffect extends OneShotEffect {
                 + "then you draw a card for each land card put into that graveyard this way";
     }
 
-    public PatientRebuildingEffect(final PatientRebuildingEffect effect) {
+    private PatientRebuildingEffect(final PatientRebuildingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PatriarchsBidding.java
+++ b/Mage.Sets/src/mage/cards/p/PatriarchsBidding.java
@@ -48,7 +48,7 @@ class PatriarchsBiddingEffect extends OneShotEffect {
         this.staticText = "each player chooses a creature type. Each player returns all creature cards of a type chosen this way from their graveyard to the battlefield";
     }
 
-    public PatriarchsBiddingEffect(final PatriarchsBiddingEffect effect) {
+    private PatriarchsBiddingEffect(final PatriarchsBiddingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PatronOfTheNezumi.java
+++ b/Mage.Sets/src/mage/cards/p/PatronOfTheNezumi.java
@@ -60,7 +60,7 @@ class PatronOfTheNezumiTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect, false);
     }
 
-    public PatronOfTheNezumiTriggeredAbility(final PatronOfTheNezumiTriggeredAbility ability) {
+    private PatronOfTheNezumiTriggeredAbility(final PatronOfTheNezumiTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PatronOfTheOrochi.java
+++ b/Mage.Sets/src/mage/cards/p/PatronOfTheOrochi.java
@@ -72,7 +72,7 @@ class PatronOfTheOrochiEffect extends OneShotEffect {
         staticText = "Untap all Forests and all green creatures";
     }
 
-    public PatronOfTheOrochiEffect(final PatronOfTheOrochiEffect effect) {
+    private PatronOfTheOrochiEffect(final PatronOfTheOrochiEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PatronOfTheVein.java
+++ b/Mage.Sets/src/mage/cards/p/PatronOfTheVein.java
@@ -72,7 +72,7 @@ class PatronOfTheVeinCreatureDiesTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new PatronOfTheVeinExileCreatureEffect(), false);
     }
 
-    public PatronOfTheVeinCreatureDiesTriggeredAbility(final PatronOfTheVeinCreatureDiesTriggeredAbility ability) {
+    private PatronOfTheVeinCreatureDiesTriggeredAbility(final PatronOfTheVeinCreatureDiesTriggeredAbility ability) {
         super(ability);
     }
 
@@ -122,7 +122,7 @@ class PatronOfTheVeinExileCreatureEffect extends OneShotEffect {
         this.staticText = "exile it and put a +1/+1 counter on each Vampire you control";
     }
 
-    public PatronOfTheVeinExileCreatureEffect(final PatronOfTheVeinExileCreatureEffect effect) {
+    private PatronOfTheVeinExileCreatureEffect(final PatronOfTheVeinExileCreatureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PeaceStrider.java
+++ b/Mage.Sets/src/mage/cards/p/PeaceStrider.java
@@ -25,7 +25,7 @@ public final class PeaceStrider extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new GainLifeEffect(3)));
     }
 
-    public PeaceStrider (final PeaceStrider card) {
+    private PeaceStrider(final PeaceStrider card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PeaceTalks.java
+++ b/Mage.Sets/src/mage/cards/p/PeaceTalks.java
@@ -47,7 +47,7 @@ class PeaceTalksEffect extends OneShotEffect {
                 + "or activated abilities";
     }
 
-    public PeaceTalksEffect(final PeaceTalksEffect effect) {
+    private PeaceTalksEffect(final PeaceTalksEffect effect) {
         super(effect);
     }
 
@@ -81,7 +81,7 @@ class PeaceTalksCantAttackEffect extends RestrictionEffect {
         startedTurnNum = game.getTurnNum();
     }
 
-    public PeaceTalksCantAttackEffect(final PeaceTalksCantAttackEffect effect) {
+    private PeaceTalksCantAttackEffect(final PeaceTalksCantAttackEffect effect) {
         super(effect);
         this.startedTurnNum = effect.startedTurnNum;
     }
@@ -120,7 +120,7 @@ class PeaceTalksPlayersAndPermanentsCantBeTargetsOfSpellsOrActivatedAbilities ex
         staticText = "players and permanents can't be the targets of spells or activated abilities";
     }
 
-    public PeaceTalksPlayersAndPermanentsCantBeTargetsOfSpellsOrActivatedAbilities(final PeaceTalksPlayersAndPermanentsCantBeTargetsOfSpellsOrActivatedAbilities effect) {
+    private PeaceTalksPlayersAndPermanentsCantBeTargetsOfSpellsOrActivatedAbilities(final PeaceTalksPlayersAndPermanentsCantBeTargetsOfSpellsOrActivatedAbilities effect) {
         super(effect);
         this.startedTurnNum = effect.startedTurnNum;
     }

--- a/Mage.Sets/src/mage/cards/p/Peacekeeper.java
+++ b/Mage.Sets/src/mage/cards/p/Peacekeeper.java
@@ -51,7 +51,7 @@ class PeacekeeperCantAttackEffect extends RestrictionEffect {
         staticText = "Creatures can't attack";
     }
 
-    public PeacekeeperCantAttackEffect(final PeacekeeperCantAttackEffect effect) {
+    private PeacekeeperCantAttackEffect(final PeacekeeperCantAttackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PedanticLearning.java
+++ b/Mage.Sets/src/mage/cards/p/PedanticLearning.java
@@ -43,7 +43,7 @@ class PedanticLearningTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new ManaCostsImpl<>("{1}")), false);
     }
 
-    public PedanticLearningTriggeredAbility(final PedanticLearningTriggeredAbility ability) {
+    private PedanticLearningTriggeredAbility(final PedanticLearningTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PeerThroughDepths.java
+++ b/Mage.Sets/src/mage/cards/p/PeerThroughDepths.java
@@ -34,7 +34,7 @@ public final class PeerThroughDepths extends CardImpl {
         this.getSpellAbility().addEffect(new LookLibraryAndPickControllerEffect(5, 1, filter, PutCards.HAND, PutCards.BOTTOM_ANY));
     }
 
-    public PeerThroughDepths (final PeerThroughDepths card) {
+    private PeerThroughDepths(final PeerThroughDepths card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PemminsAura.java
+++ b/Mage.Sets/src/mage/cards/p/PemminsAura.java
@@ -76,7 +76,7 @@ class PemminsAuraBoostEnchantedEffect extends OneShotEffect {
         this.staticText = "Enchanted creature gets +1/-1 or -1/+1 until end of turn";
     }
 
-    public PemminsAuraBoostEnchantedEffect(final PemminsAuraBoostEnchantedEffect effect) {
+    private PemminsAuraBoostEnchantedEffect(final PemminsAuraBoostEnchantedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Penance.java
+++ b/Mage.Sets/src/mage/cards/p/Penance.java
@@ -51,7 +51,7 @@ class PenanceEffect extends PreventionEffectImpl {
         this.target = new TargetSource();
     }
 
-    public PenanceEffect(final PenanceEffect effect) {
+    private PenanceEffect(final PenanceEffect effect) {
         super(effect);
         this.target = effect.target.copy();
     }

--- a/Mage.Sets/src/mage/cards/p/Peregrination.java
+++ b/Mage.Sets/src/mage/cards/p/Peregrination.java
@@ -53,7 +53,7 @@ class PeregrinationEffect extends OneShotEffect {
         staticText = "Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Shuffle";
     }
 
-    public PeregrinationEffect(final PeregrinationEffect effect) {
+    private PeregrinationEffect(final PeregrinationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PerilousPredicament.java
+++ b/Mage.Sets/src/mage/cards/p/PerilousPredicament.java
@@ -49,7 +49,7 @@ class PerilousPredicamentSacrificeOpponentsEffect extends OneShotEffect {
         staticText = "Each opponent sacrifices an artifact creature and a nonartifact creature";
     }
 
-    public PerilousPredicamentSacrificeOpponentsEffect(final PerilousPredicamentSacrificeOpponentsEffect effect) {
+    private PerilousPredicamentSacrificeOpponentsEffect(final PerilousPredicamentSacrificeOpponentsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PerimeterCaptain.java
+++ b/Mage.Sets/src/mage/cards/p/PerimeterCaptain.java
@@ -55,7 +55,7 @@ class PerimeterCaptainTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature you control with defender blocks, ");
     }
 
-    public PerimeterCaptainTriggeredAbility(final PerimeterCaptainTriggeredAbility ability) {
+    private PerimeterCaptainTriggeredAbility(final PerimeterCaptainTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PerishTheThought.java
+++ b/Mage.Sets/src/mage/cards/p/PerishTheThought.java
@@ -49,7 +49,7 @@ class PerishTheThoughtEffect extends OneShotEffect {
         this.staticText = "Target opponent reveals their hand. You choose a card from it. That player shuffles that card into their library";
     }
 
-    public PerishTheThoughtEffect(final PerishTheThoughtEffect effect) {
+    private PerishTheThoughtEffect(final PerishTheThoughtEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PermeatingMass.java
+++ b/Mage.Sets/src/mage/cards/p/PermeatingMass.java
@@ -48,7 +48,7 @@ class PermeatingMassEffect extends OneShotEffect {
         this.staticText = "that creature becomes a copy of {this}.";
     }
 
-    public PermeatingMassEffect(final PermeatingMassEffect effect) {
+    private PermeatingMassEffect(final PermeatingMassEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PerniciousDeed.java
+++ b/Mage.Sets/src/mage/cards/p/PerniciousDeed.java
@@ -51,7 +51,7 @@ class PerniciousDeedEffect extends OneShotEffect {
         staticText = "Destroy each artifact, creature, and enchantment with mana value X or less";
     }
 
-    public PerniciousDeedEffect(final PerniciousDeedEffect effect) {
+    private PerniciousDeedEffect(final PerniciousDeedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PerplexingChimera.java
+++ b/Mage.Sets/src/mage/cards/p/PerplexingChimera.java
@@ -102,7 +102,7 @@ class PerplexingChimeraTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever an opponent casts a spell, ");
     }
 
-    public PerplexingChimeraTriggeredAbility(final PerplexingChimeraTriggeredAbility ability) {
+    private PerplexingChimeraTriggeredAbility(final PerplexingChimeraTriggeredAbility ability) {
         super(ability);
     }
 
@@ -135,7 +135,7 @@ class PerplexingChimeraControlExchangeEffect extends OneShotEffect {
         this.staticText = "exchange control of {this} and that spell. If you do, you may choose new targets for the spell";
     }
 
-    public PerplexingChimeraControlExchangeEffect(final PerplexingChimeraControlExchangeEffect effect) {
+    private PerplexingChimeraControlExchangeEffect(final PerplexingChimeraControlExchangeEffect effect) {
         super(effect);
     }
 
@@ -174,7 +174,7 @@ class PerplexingChimeraControlEffect extends ContinuousEffectImpl {
         staticText = "PerplexingChimeraControlEffect";
     }
 
-    public PerplexingChimeraControlEffect(final PerplexingChimeraControlEffect effect) {
+    private PerplexingChimeraControlEffect(final PerplexingChimeraControlEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PersonalIncarnation.java
+++ b/Mage.Sets/src/mage/cards/p/PersonalIncarnation.java
@@ -61,7 +61,7 @@ class PersonalIncarnationRedirectEffect extends RedirectionEffect {
         staticText = "The next 1 damage that would be dealt to {this} this turn is dealt to its owner instead.";
     }
 
-    public PersonalIncarnationRedirectEffect(final PersonalIncarnationRedirectEffect effect) {
+    private PersonalIncarnationRedirectEffect(final PersonalIncarnationRedirectEffect effect) {
         super(effect);
     }
 
@@ -89,7 +89,7 @@ class PersonalIncarnationLoseHalfLifeEffect extends OneShotEffect {
         staticText = "its owner lose half their life, rounded up";
     }
 
-    public PersonalIncarnationLoseHalfLifeEffect(final PersonalIncarnationLoseHalfLifeEffect effect) {
+    private PersonalIncarnationLoseHalfLifeEffect(final PersonalIncarnationLoseHalfLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PersonalSanctuary.java
+++ b/Mage.Sets/src/mage/cards/p/PersonalSanctuary.java
@@ -46,7 +46,7 @@ class PersonalSanctuaryEffect extends PreventionEffectImpl {
         staticText = "During your turn, prevent all damage that would be dealt to you";
     }
 
-    public PersonalSanctuaryEffect(PersonalSanctuaryEffect effect) {
+    private PersonalSanctuaryEffect(final PersonalSanctuaryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PetraSphinx.java
+++ b/Mage.Sets/src/mage/cards/p/PetraSphinx.java
@@ -54,7 +54,7 @@ class PetraSphinxEffect extends OneShotEffect {
         staticText = "Target player chooses a card name, then reveals the top card of their library. If that card has the chosen name, that player puts it into their hand. If it doesn't, the player puts it into their graveyard";
     }
 
-    public PetraSphinxEffect(final PetraSphinxEffect effect) {
+    private PetraSphinxEffect(final PetraSphinxEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Phantasmagorian.java
+++ b/Mage.Sets/src/mage/cards/p/Phantasmagorian.java
@@ -60,7 +60,7 @@ class CounterSourceEffect extends OneShotEffect {
         this.staticText = "any player may discard three cards. If a player does, counter {this}";
     }
 
-    public CounterSourceEffect(final CounterSourceEffect effect) {
+    private CounterSourceEffect(final CounterSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhantasmalSphere.java
+++ b/Mage.Sets/src/mage/cards/p/PhantasmalSphere.java
@@ -74,7 +74,7 @@ class PhantasmalSphereEffect extends OneShotEffect {
                 + "of +1/+1 counters on {this}";
     }
 
-    public PhantasmalSphereEffect(final PhantasmalSphereEffect effect) {
+    private PhantasmalSphereEffect(final PhantasmalSphereEffect effect) {
         super(effect);
     }
 
@@ -111,7 +111,7 @@ class PhantasmalSphereToken extends TokenImpl {
         addAbility(FlyingAbility.getInstance());
     }
 
-    public PhantasmalSphereToken(final PhantasmalSphereToken token) {
+    private PhantasmalSphereToken(final PhantasmalSphereToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhantomCarriage.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomCarriage.java
@@ -69,7 +69,7 @@ class PhantomCarriageEffect extends SearchEffect {
         staticText = "search your library for a card with flashback or disturb, put it into your graveyard, then shuffle";
     }
 
-    public PhantomCarriageEffect(final PhantomCarriageEffect effect) {
+    private PhantomCarriageEffect(final PhantomCarriageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhosphorescentFeast.java
+++ b/Mage.Sets/src/mage/cards/p/PhosphorescentFeast.java
@@ -44,7 +44,7 @@ class PhosphorescentFeastEffect extends OneShotEffect {
         super(Outcome.GainLife);
     }
 
-    public PhosphorescentFeastEffect(final PhosphorescentFeastEffect effect) {
+    private PhosphorescentFeastEffect(final PhosphorescentFeastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Phthisis.java
+++ b/Mage.Sets/src/mage/cards/p/Phthisis.java
@@ -51,7 +51,7 @@ class PhthisisEffect extends OneShotEffect {
         this.staticText = "Destroy target creature. Its controller loses life equal to its power plus its toughness";
     }
 
-    public PhthisisEffect(final PhthisisEffect effect) {
+    private PhthisisEffect(final PhthisisEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhylacteryLich.java
+++ b/Mage.Sets/src/mage/cards/p/PhylacteryLich.java
@@ -61,7 +61,7 @@ public final class PhylacteryLich extends CardImpl {
             super(Zone.BATTLEFIELD, new SacrificeSourceEffect());
         }
 
-        public PhylacteryLichAbility(final PhylacteryLichAbility ability) {
+        private PhylacteryLichAbility(final PhylacteryLichAbility ability) {
             super(ability);
         }
 
@@ -102,7 +102,7 @@ class PhylacteryLichEffect extends OneShotEffect {
         staticText = "put a phylactery counter on an artifact you control";
     }
 
-    public PhylacteryLichEffect(final PhylacteryLichEffect effect) {
+    private PhylacteryLichEffect(final PhylacteryLichEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Phyresis.java
+++ b/Mage.Sets/src/mage/cards/p/Phyresis.java
@@ -39,7 +39,7 @@ public final class Phyresis extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(InfectAbility.getInstance(), AttachmentType.AURA)));
     }
 
-    public Phyresis (final Phyresis card) {
+    private Phyresis(final Phyresis card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianDelver.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianDelver.java
@@ -57,7 +57,7 @@ class PhyrexianDelverEffect extends OneShotEffect {
         this.staticText = "return target creature card from your graveyard to the battlefield. You lose life equal to that card's mana value";
     }
 
-    public PhyrexianDelverEffect(final PhyrexianDelverEffect effect) {
+    private PhyrexianDelverEffect(final PhyrexianDelverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianDevourer.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianDevourer.java
@@ -61,7 +61,7 @@ class PhyrexianDevourerStateTriggeredAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new SacrificeSourceEffect());
     }
 
-    public PhyrexianDevourerStateTriggeredAbility(final PhyrexianDevourerStateTriggeredAbility ability) {
+    private PhyrexianDevourerStateTriggeredAbility(final PhyrexianDevourerStateTriggeredAbility ability) {
         super(ability);
     }
 
@@ -90,7 +90,7 @@ class PhyrexianDevourerEffect extends OneShotEffect {
         this.staticText = "Put X +1/+1 counters on {this}, where X is the exiled card's mana value";
     }
 
-    public PhyrexianDevourerEffect(final PhyrexianDevourerEffect effect) {
+    private PhyrexianDevourerEffect(final PhyrexianDevourerEffect effect) {
         super(effect);
     }
 
@@ -129,7 +129,7 @@ class ExileTopCardLibraryCost extends CostImpl {
         this.text = "Exile the top card of your library";
     }
 
-    public ExileTopCardLibraryCost(final ExileTopCardLibraryCost cost) {
+    private ExileTopCardLibraryCost(final ExileTopCardLibraryCost cost) {
         super(cost);
         this.card = cost.getCard();
     }

--- a/Mage.Sets/src/mage/cards/p/PhyrexianDigester.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianDigester.java
@@ -25,7 +25,7 @@ public final class PhyrexianDigester extends CardImpl {
         this.addAbility(InfectAbility.getInstance());
     }
 
-    public PhyrexianDigester (final PhyrexianDigester card) {
+    private PhyrexianDigester(final PhyrexianDigester card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianDreadnought.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianDreadnought.java
@@ -65,7 +65,7 @@ class PhyrexianDreadnoughtSacrificeCost extends CostImpl {
         this.text = "sacrifice any number of creatures with total power 12 or greater";
     }
 
-    public PhyrexianDreadnoughtSacrificeCost(final PhyrexianDreadnoughtSacrificeCost cost) {
+    private PhyrexianDreadnoughtSacrificeCost(final PhyrexianDreadnoughtSacrificeCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianFurnace.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianFurnace.java
@@ -60,7 +60,7 @@ class PhyrexianFurnaceEffect extends OneShotEffect {
         this.staticText = "exile the bottom card of target player's graveyard";
     }
 
-    public PhyrexianFurnaceEffect(final PhyrexianFurnaceEffect effect) {
+    private PhyrexianFurnaceEffect(final PhyrexianFurnaceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianGrimoire.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianGrimoire.java
@@ -56,7 +56,7 @@ class PhyrexianGrimoireEffect extends OneShotEffect {
         this.staticText = "Target opponent chooses one of the top two cards of your graveyard. Exile that card and put the other one into your hand";
     }
 
-    public PhyrexianGrimoireEffect(final PhyrexianGrimoireEffect effect) {
+    private PhyrexianGrimoireEffect(final PhyrexianGrimoireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianHydra.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianHydra.java
@@ -56,7 +56,7 @@ class PhyrexianHydraEffect extends PreventionEffectImpl {
         staticText = "If damage would be dealt to {this}, prevent that damage. Put a -1/-1 counter on {this} for each 1 damage prevented this way";
     }
 
-    public PhyrexianHydraEffect(final PhyrexianHydraEffect effect) {
+    private PhyrexianHydraEffect(final PhyrexianHydraEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianIngester.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianIngester.java
@@ -65,7 +65,7 @@ class PhyrexianIngesterImprintEffect extends OneShotEffect {
         this.staticText = "exile target nontoken creature";
     }
 
-    public PhyrexianIngesterImprintEffect(final PhyrexianIngesterImprintEffect effect) {
+    private PhyrexianIngesterImprintEffect(final PhyrexianIngesterImprintEffect effect) {
         super(effect);
     }
 
@@ -98,7 +98,7 @@ class PhyrexianIngesterBoostEffect extends ContinuousEffectImpl {
         this.staticText = "{this} gets +X/+Y, where X is the exiled creature card's power and Y is its toughness";
     }
 
-    public PhyrexianIngesterBoostEffect(final PhyrexianIngesterBoostEffect effect) {
+    private PhyrexianIngesterBoostEffect(final PhyrexianIngesterBoostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianJuggernaut.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianJuggernaut.java
@@ -27,7 +27,7 @@ public final class PhyrexianJuggernaut extends CardImpl {
         this.addAbility(new AttacksEachCombatStaticAbility());
     }
 
-    public PhyrexianJuggernaut (final PhyrexianJuggernaut card) {
+    private PhyrexianJuggernaut(final PhyrexianJuggernaut card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianPortal.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianPortal.java
@@ -54,7 +54,7 @@ class PhyrexianPortalEffect extends OneShotEffect {
         this.staticText = "If your library has ten or more cards in it, target opponent looks at the top ten cards of your library and separates them into two face-down piles. Exile one of those piles. Search the other pile for a card, put it into your hand, then shuffle the rest of that pile into your library";
     }
 
-    public PhyrexianPortalEffect(final PhyrexianPortalEffect effect) {
+    private PhyrexianPortalEffect(final PhyrexianPortalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianRevoker.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianRevoker.java
@@ -53,7 +53,7 @@ class PhyrexianRevokerEffect2 extends ContinuousRuleModifyingEffectImpl {
         staticText = "Activated abilities of sources with the chosen name can't be activated";
     }
 
-    public PhyrexianRevokerEffect2(final PhyrexianRevokerEffect2 effect) {
+    private PhyrexianRevokerEffect2(final PhyrexianRevokerEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianTotem.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianTotem.java
@@ -63,7 +63,7 @@ public final class PhyrexianTotem extends CardImpl {
             toughness = new MageInt(5);
             this.addAbility(TrampleAbility.getInstance());
         }
-        public PhyrexianTotemToken(final PhyrexianTotemToken token) {
+        private PhyrexianTotemToken(final PhyrexianTotemToken token) {
             super(token);
         }
 
@@ -79,7 +79,7 @@ class PhyrexianTotemTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SacrificeEffect(new FilterControlledPermanent(), 0,""));
     }
     
-    public PhyrexianTotemTriggeredAbility(final PhyrexianTotemTriggeredAbility ability) {
+    private PhyrexianTotemTriggeredAbility(final PhyrexianTotemTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/p/PhyrexianVatmother.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianVatmother.java
@@ -33,7 +33,7 @@ public final class PhyrexianVatmother extends CardImpl {
         ));
     }
 
-    public PhyrexianVatmother(final PhyrexianVatmother card) {
+    private PhyrexianVatmother(final PhyrexianVatmother card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PiasRevolution.java
+++ b/Mage.Sets/src/mage/cards/p/PiasRevolution.java
@@ -52,7 +52,7 @@ class PiasRevolutionReturnEffect extends OneShotEffect {
         this.staticText = "return that card to your hand unless target opponent has {this} deal 3 damage to them";
     }
 
-    public PiasRevolutionReturnEffect(final PiasRevolutionReturnEffect effect) {
+    private PiasRevolutionReturnEffect(final PiasRevolutionReturnEffect effect) {
         super(effect);
     }
 
@@ -99,7 +99,7 @@ class PiasRevolutionTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a nontoken artifact is put into your graveyard from the battlefield, ");
     }
 
-    public PiasRevolutionTriggeredAbility(PiasRevolutionTriggeredAbility ability) {
+    private PiasRevolutionTriggeredAbility(final PiasRevolutionTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PickTheBrain.java
+++ b/Mage.Sets/src/mage/cards/p/PickTheBrain.java
@@ -54,7 +54,7 @@ class PickTheBrainEffect extends SearchTargetGraveyardHandLibraryForCardNameAndE
                 + "with the same name as the exiled card, exile those cards, then that player shuffles";
     }
 
-    public PickTheBrainEffect(final PickTheBrainEffect effect) {
+    private PickTheBrainEffect(final PickTheBrainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PierceStrider.java
+++ b/Mage.Sets/src/mage/cards/p/PierceStrider.java
@@ -30,7 +30,7 @@ public final class PierceStrider extends CardImpl {
         this.addAbility(ability);
     }
 
-    public PierceStrider (final PierceStrider card) {
+    private PierceStrider(final PierceStrider card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Pikemen.java
+++ b/Mage.Sets/src/mage/cards/p/Pikemen.java
@@ -32,7 +32,7 @@ public final class Pikemen extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public Pikemen (final Pikemen card) {
+    private Pikemen(final Pikemen card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PilgrimOfJustice.java
+++ b/Mage.Sets/src/mage/cards/p/PilgrimOfJustice.java
@@ -70,7 +70,7 @@ class PilgrimOfJusticeEffect extends PreventionEffectImpl {
         staticText = "The next time a red source of your choice would deal damage to you this turn, prevent that damage";
     }
 
-    public PilgrimOfJusticeEffect(final PilgrimOfJusticeEffect effect) {
+    private PilgrimOfJusticeEffect(final PilgrimOfJusticeEffect effect) {
         super(effect);
         this.target = effect.target.copy();
     }

--- a/Mage.Sets/src/mage/cards/p/PilgrimOfVirtue.java
+++ b/Mage.Sets/src/mage/cards/p/PilgrimOfVirtue.java
@@ -70,7 +70,7 @@ class PilgrimOfVirtueEffect extends PreventionEffectImpl {
         staticText = "The next time a black source of your choice would deal damage to you this turn, prevent that damage";
     }
 
-    public PilgrimOfVirtueEffect(final PilgrimOfVirtueEffect effect) {
+    private PilgrimOfVirtueEffect(final PilgrimOfVirtueEffect effect) {
         super(effect);
         this.target = effect.target.copy();
     }

--- a/Mage.Sets/src/mage/cards/p/PilgrimsEye.java
+++ b/Mage.Sets/src/mage/cards/p/PilgrimsEye.java
@@ -31,7 +31,7 @@ public final class PilgrimsEye extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND), true), true));
     }
 
-    public PilgrimsEye(final PilgrimsEye card) {
+    private PilgrimsEye(final PilgrimsEye card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PillarTombsOfAku.java
+++ b/Mage.Sets/src/mage/cards/p/PillarTombsOfAku.java
@@ -54,7 +54,7 @@ class PillarTombsOfAkuEffect extends OneShotEffect {
                 + "player doesn't, they lose 5 life and you sacrifice {this}";
     }
 
-    public PillarTombsOfAkuEffect(final PillarTombsOfAkuEffect effect) {
+    private PillarTombsOfAkuEffect(final PillarTombsOfAkuEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PillarfieldOx.java
+++ b/Mage.Sets/src/mage/cards/p/PillarfieldOx.java
@@ -23,7 +23,7 @@ public final class PillarfieldOx extends CardImpl {
         this.toughness = new MageInt(4);
     }
 
-    public PillarfieldOx (final PillarfieldOx card) {
+    private PillarfieldOx(final PillarfieldOx card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PiousKitsune.java
+++ b/Mage.Sets/src/mage/cards/p/PiousKitsune.java
@@ -70,7 +70,7 @@ class PiousKitsuneEffect extends OneShotEffect {
         this.staticText = "put a devotion counter on Pious Kitsune. Then if a creature named Eight-and-a-Half-Tails is on the battlefield, you gain 1 life for each devotion counter on Pious Kitsune";
     }
 
-    public PiousKitsuneEffect(final PiousKitsuneEffect effect) {
+    private PiousKitsuneEffect(final PiousKitsuneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PiousWarrior.java
+++ b/Mage.Sets/src/mage/cards/p/PiousWarrior.java
@@ -53,7 +53,7 @@ class PiousWarriorTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} is dealt combat damage, ");
     }
 
-    public PiousWarriorTriggeredAbility(final PiousWarriorTriggeredAbility effect) {
+    private PiousWarriorTriggeredAbility(final PiousWarriorTriggeredAbility effect) {
         super(effect);
     }
 
@@ -85,7 +85,7 @@ class PiousWarriorGainLifeEffect extends OneShotEffect {
 		staticText = "you gain that much life";
 	}
 
-    public PiousWarriorGainLifeEffect(final PiousWarriorGainLifeEffect effect) {
+    private PiousWarriorGainLifeEffect(final PiousWarriorGainLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PistonSledge.java
+++ b/Mage.Sets/src/mage/cards/p/PistonSledge.java
@@ -43,7 +43,7 @@ public final class PistonSledge extends CardImpl {
         this.addAbility(new EquipAbility(Outcome.AddAbility, new SacrificeTargetCost(new TargetControlledPermanent(filter)), false));
     }
 
-    public PistonSledge(final PistonSledge card) {
+    private PistonSledge(final PistonSledge card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PistusStrike.java
+++ b/Mage.Sets/src/mage/cards/p/PistusStrike.java
@@ -55,7 +55,7 @@ class PoisonControllerTargetCreatureEffect extends OneShotEffect {
         staticText = "Its controller gets a poison counter";
     }
 
-    public PoisonControllerTargetCreatureEffect(final PoisonControllerTargetCreatureEffect effect) {
+    private PoisonControllerTargetCreatureEffect(final PoisonControllerTargetCreatureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PitchstoneWall.java
+++ b/Mage.Sets/src/mage/cards/p/PitchstoneWall.java
@@ -54,7 +54,7 @@ class PitchstoneWallTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you discard a card, ");
     }
 
-    public PitchstoneWallTriggeredAbility(final PitchstoneWallTriggeredAbility ability) {
+    private PitchstoneWallTriggeredAbility(final PitchstoneWallTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PithingNeedle.java
+++ b/Mage.Sets/src/mage/cards/p/PithingNeedle.java
@@ -52,7 +52,7 @@ class PithingNeedleEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Activated abilities of sources with the chosen name can't be activated unless they're mana abilities";
     }
 
-    public PithingNeedleEffect(final PithingNeedleEffect effect) {
+    private PithingNeedleEffect(final PithingNeedleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Plagiarize.java
+++ b/Mage.Sets/src/mage/cards/p/Plagiarize.java
@@ -46,7 +46,7 @@ class PlagiarizeEffect extends ReplacementEffectImpl {
         staticText = "Until end of turn, if target player would draw a card, instead that player skips that draw and you draw a card";
     }
     
-    public PlagiarizeEffect(final PlagiarizeEffect effect) {
+    private PlagiarizeEffect(final PlagiarizeEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/p/PlagueBoiler.java
+++ b/Mage.Sets/src/mage/cards/p/PlagueBoiler.java
@@ -60,7 +60,7 @@ class PlagueBoilerEffect extends OneShotEffect {
         this.staticText = "Put a plague counter on {this} or remove a plague counter from it";
     }
 
-    public PlagueBoilerEffect(final PlagueBoilerEffect effect) {
+    private PlagueBoilerEffect(final PlagueBoilerEffect effect) {
         super(effect);
     }
 
@@ -91,7 +91,7 @@ class PlagueBoilerTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When {this} has three or more plague counters on it, ");
     }
 
-    public PlagueBoilerTriggeredAbility(final PlagueBoilerTriggeredAbility ability) {
+    private PlagueBoilerTriggeredAbility(final PlagueBoilerTriggeredAbility ability) {
         super(ability);
     }
 
@@ -124,7 +124,7 @@ class PlagueBoilerSacrificeDestroyEffect extends OneShotEffect {
         this.staticText = "sacrifice it. If you do, destroy all nonland permanents";
     }
 
-    public PlagueBoilerSacrificeDestroyEffect(final PlagueBoilerSacrificeDestroyEffect effect) {
+    private PlagueBoilerSacrificeDestroyEffect(final PlagueBoilerSacrificeDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlagueDrone.java
+++ b/Mage.Sets/src/mage/cards/p/PlagueDrone.java
@@ -49,7 +49,7 @@ class PlagueDroneReplacementEffect extends ReplacementEffectImpl {
         staticText = "If an opponent would gain life, that player loses that much life instead";
     }
 
-    public PlagueDroneReplacementEffect(final PlagueDroneReplacementEffect effect) {
+    private PlagueDroneReplacementEffect(final PlagueDroneReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlagueFiend.java
+++ b/Mage.Sets/src/mage/cards/p/PlagueFiend.java
@@ -53,7 +53,7 @@ class PlagueFiendEffect extends OneShotEffect {
         this.cost = cost;
     }
 
-    public PlagueFiendEffect(final PlagueFiendEffect effect) {
+    private PlagueFiendEffect(final PlagueFiendEffect effect) {
         super(effect);
         this.cost = effect.cost.copy();
     }

--- a/Mage.Sets/src/mage/cards/p/PlagueMyr.java
+++ b/Mage.Sets/src/mage/cards/p/PlagueMyr.java
@@ -27,7 +27,7 @@ public final class PlagueMyr extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
     }
 
-    public PlagueMyr (final PlagueMyr card) {
+    private PlagueMyr(final PlagueMyr card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlagueOfVermin.java
+++ b/Mage.Sets/src/mage/cards/p/PlagueOfVermin.java
@@ -47,7 +47,7 @@ class PlagueOfVerminEffect extends OneShotEffect {
         this.staticText = "Starting with you, each player may pay any amount of life. Repeat this process until no one pays life. Each player creates a 1/1 black Rat creature token for each 1 life they paid this way.";
     }
 
-    public PlagueOfVerminEffect(final PlagueOfVerminEffect effect) {
+    private PlagueOfVerminEffect(final PlagueOfVerminEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlagueStinger.java
+++ b/Mage.Sets/src/mage/cards/p/PlagueStinger.java
@@ -29,7 +29,7 @@ public final class PlagueStinger extends CardImpl {
         this.addAbility(InfectAbility.getInstance());
     }
 
-    public PlagueStinger (final PlagueStinger card) {
+    private PlagueStinger(final PlagueStinger card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlanarChaos.java
+++ b/Mage.Sets/src/mage/cards/p/PlanarChaos.java
@@ -86,7 +86,7 @@ class PlanarChaosCastAllEffect extends OneShotEffect {
         this.staticText = "that player flips a coin. If they lose the flip, counter that spell";
     }
 
-    public PlanarChaosCastAllEffect(final PlanarChaosCastAllEffect effect) {
+    private PlanarChaosCastAllEffect(final PlanarChaosCastAllEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlanarGuide.java
+++ b/Mage.Sets/src/mage/cards/p/PlanarGuide.java
@@ -61,7 +61,7 @@ class PlanarGuideExileEffect extends OneShotEffect {
         staticText = "Exile all creatures. At the beginning of the next end step, return those cards to the battlefield under their owners' control";
     }
 
-    public PlanarGuideExileEffect(final PlanarGuideExileEffect effect) {
+    private PlanarGuideExileEffect(final PlanarGuideExileEffect effect) {
         super(effect);
     }
 
@@ -98,7 +98,7 @@ class PlanarGuideReturnFromExileEffect extends OneShotEffect {
         staticText = "At the beginning of the next end step, return those cards to the battlefield under their owners' control";
     }
 
-    public PlanarGuideReturnFromExileEffect(final PlanarGuideReturnFromExileEffect effect) {
+    private PlanarGuideReturnFromExileEffect(final PlanarGuideReturnFromExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlanarOverlay.java
+++ b/Mage.Sets/src/mage/cards/p/PlanarOverlay.java
@@ -45,7 +45,7 @@ class PlanarOverlayEffect extends OneShotEffect {
         this.staticText = "Each player chooses a land they control of each basic land type. Return those lands to their owners' hands";
     }
 
-    public PlanarOverlayEffect(final PlanarOverlayEffect effect) {
+    private PlanarOverlayEffect(final PlanarOverlayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlaneswalkersFavor.java
+++ b/Mage.Sets/src/mage/cards/p/PlaneswalkersFavor.java
@@ -59,7 +59,7 @@ class PlaneswalkersFavorEffect extends OneShotEffect {
         staticText = "Target opponent reveals a card at random from their hand. Target creature gets +X/+X until end of turn, where X is the revealed card's mana value";
     }
 
-    public PlaneswalkersFavorEffect(final PlaneswalkersFavorEffect effect) {
+    private PlaneswalkersFavorEffect(final PlaneswalkersFavorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlaneswalkersFury.java
+++ b/Mage.Sets/src/mage/cards/p/PlaneswalkersFury.java
@@ -45,7 +45,7 @@ class PlaneswalkersFuryEffect extends OneShotEffect {
         staticText = "Target opponent reveals a card at random from their hand. Planeswalker's Fury deals damage equal to that card's mana value to that player";
     }
 
-    public PlaneswalkersFuryEffect(final PlaneswalkersFuryEffect effect) {
+    private PlaneswalkersFuryEffect(final PlaneswalkersFuryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlaneswalkersMirth.java
+++ b/Mage.Sets/src/mage/cards/p/PlaneswalkersMirth.java
@@ -50,7 +50,7 @@ class PlaneswalkersMirthEffect extends OneShotEffect {
         staticText = "Target opponent reveals a card at random from their hand. You gain life equal to that card's mana value";
     }
 
-    public PlaneswalkersMirthEffect(final PlaneswalkersMirthEffect effect) {
+    private PlaneswalkersMirthEffect(final PlaneswalkersMirthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlaneswalkersMischief.java
+++ b/Mage.Sets/src/mage/cards/p/PlaneswalkersMischief.java
@@ -55,7 +55,7 @@ class PlaneswalkersMischiefEffect extends OneShotEffect {
         this.staticText = "Target opponent reveals a card at random from their hand. If it's an instant or sorcery card, exile it. You may cast it without paying its mana cost for as long as it remains exiled. At the beginning of the next end step, if you haven't cast it, return it to its owner's hand.";
     }
 
-    public PlaneswalkersMischiefEffect(final PlaneswalkersMischiefEffect effect) {
+    private PlaneswalkersMischiefEffect(final PlaneswalkersMischiefEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlaneswalkersScorn.java
+++ b/Mage.Sets/src/mage/cards/p/PlaneswalkersScorn.java
@@ -59,7 +59,7 @@ class PlaneswalkersScornEffect extends OneShotEffect {
         staticText = "Target opponent reveals a card at random from their hand. Target creature gets -X/-X until end of turn, where X is the revealed card's mana value";
     }
 
-    public PlaneswalkersScornEffect(final PlaneswalkersScornEffect effect) {
+    private PlaneswalkersScornEffect(final PlaneswalkersScornEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlarggDeanOfChaos.java
+++ b/Mage.Sets/src/mage/cards/p/PlarggDeanOfChaos.java
@@ -108,7 +108,7 @@ class PlarggDeanOfChaosEffect extends OneShotEffect {
                 + "cards not cast this way on the bottom of your library in a random order";
     }
 
-    public PlarggDeanOfChaosEffect(PlarggDeanOfChaosEffect effect) {
+    private PlarggDeanOfChaosEffect(final PlarggDeanOfChaosEffect effect) {
         super(effect);
     }
 
@@ -161,7 +161,7 @@ class AugustaDeanOfOrderEffect extends OneShotEffect {
         staticText = "tap any number of creatures you control";
     }
 
-    public AugustaDeanOfOrderEffect(AugustaDeanOfOrderEffect effect) {
+    private AugustaDeanOfOrderEffect(final AugustaDeanOfOrderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlasmCapture.java
+++ b/Mage.Sets/src/mage/cards/p/PlasmCapture.java
@@ -47,7 +47,7 @@ class PlasmCaptureCounterEffect extends OneShotEffect {
         this.staticText = "Counter target spell. At the beginning of your next precombat main phase, add X mana in any combination of colors, where X is that spell's mana value";
     }
 
-    public PlasmCaptureCounterEffect(final PlasmCaptureCounterEffect effect) {
+    private PlasmCaptureCounterEffect(final PlasmCaptureCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlatedGeopede.java
+++ b/Mage.Sets/src/mage/cards/p/PlatedGeopede.java
@@ -29,7 +29,7 @@ public final class PlatedGeopede extends CardImpl {
         this.addAbility(new LandfallAbility(new BoostSourceEffect(2, 2, Duration.EndOfTurn), false));
     }
 
-    public PlatedGeopede (final PlatedGeopede card) {
+    private PlatedGeopede(final PlatedGeopede card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlatedPegasus.java
+++ b/Mage.Sets/src/mage/cards/p/PlatedPegasus.java
@@ -58,7 +58,7 @@ class PlatedPegasusEffect extends PreventionEffectImpl {
         staticText = "If a spell would deal damage to a permanent or player, prevent 1 damage that spell would deal to that permanent or player.";
     }
 
-    public PlatedPegasusEffect(PlatedPegasusEffect effect) {
+    private PlatedPegasusEffect(final PlatedPegasusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlatedSeastrider.java
+++ b/Mage.Sets/src/mage/cards/p/PlatedSeastrider.java
@@ -23,7 +23,7 @@ public final class PlatedSeastrider extends CardImpl {
         this.toughness = new MageInt(4);
     }
 
-    public PlatedSeastrider (final PlatedSeastrider card) {
+    private PlatedSeastrider(final PlatedSeastrider card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlatinumAngel.java
+++ b/Mage.Sets/src/mage/cards/p/PlatinumAngel.java
@@ -47,7 +47,7 @@ public final class PlatinumAngel extends CardImpl {
             staticText = "You can't lose the game and your opponents can't win the game";
         }
 
-        public PlatinumAngelEffect(final PlatinumAngelEffect effect) {
+        private PlatinumAngelEffect(final PlatinumAngelEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/p/PolisCrusher.java
+++ b/Mage.Sets/src/mage/cards/p/PolisCrusher.java
@@ -70,7 +70,7 @@ class PolisCrusherTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), true);
     }
 
-    public PolisCrusherTriggeredAbility(final PolisCrusherTriggeredAbility ability) {
+    private PolisCrusherTriggeredAbility(final PolisCrusherTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PollenbrightWings.java
+++ b/Mage.Sets/src/mage/cards/p/PollenbrightWings.java
@@ -67,7 +67,7 @@ class PollenbrightWingsAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new PollenbrightWingsEffect());
     }
 
-    public PollenbrightWingsAbility(final PollenbrightWingsAbility ability) {
+    private PollenbrightWingsAbility(final PollenbrightWingsAbility ability) {
         super(ability);
     }
 
@@ -105,7 +105,7 @@ class PollenbrightWingsEffect extends OneShotEffect {
         this.staticText = "create that many 1/1 green Saproling creature tokens";
     }
 
-    public PollenbrightWingsEffect(final PollenbrightWingsEffect effect) {
+    private PollenbrightWingsEffect(final PollenbrightWingsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PolukranosWorldEater.java
+++ b/Mage.Sets/src/mage/cards/p/PolukranosWorldEater.java
@@ -90,7 +90,7 @@ class PolukranosWorldEaterEffect extends OneShotEffect {
         this.staticText = "it deals X damage divided as you choose among any number of target creatures your opponents control. Each of those creatures deals damage equal to its power to Polukranos";
     }
 
-    public PolukranosWorldEaterEffect(final PolukranosWorldEaterEffect effect) {
+    private PolukranosWorldEaterEffect(final PolukranosWorldEaterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Polymorph.java
+++ b/Mage.Sets/src/mage/cards/p/Polymorph.java
@@ -53,7 +53,7 @@ class PolymorphEffect extends OneShotEffect {
         this.staticText = "Its controller reveals cards from the top of their library until they reveal a creature card. The player puts that card onto the battlefield, then shuffles all other cards revealed this way into their library";
     }
 
-    public PolymorphEffect(final PolymorphEffect effect) {
+    private PolymorphEffect(final PolymorphEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PolymorphistsJest.java
+++ b/Mage.Sets/src/mage/cards/p/PolymorphistsJest.java
@@ -46,7 +46,7 @@ class PolymorphistsJestEffect extends ContinuousEffectImpl {
         staticText = "Until end of turn, each creature target player controls loses all abilities and becomes a blue Frog with base power and toughness 1/1";
     }
 
-    public PolymorphistsJestEffect(final PolymorphistsJestEffect effect) {
+    private PolymorphistsJestEffect(final PolymorphistsJestEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PolymorphousRush.java
+++ b/Mage.Sets/src/mage/cards/p/PolymorphousRush.java
@@ -53,7 +53,7 @@ class PolymorphousRushCopyEffect extends OneShotEffect {
         this.staticText = "Choose a creature on the battlefield. Any number of target creatures you control each become a copy of that creature until end of turn";
     }
 
-    public PolymorphousRushCopyEffect(final PolymorphousRushCopyEffect effect) {
+    private PolymorphousRushCopyEffect(final PolymorphousRushCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PonybackBrigade.java
+++ b/Mage.Sets/src/mage/cards/p/PonybackBrigade.java
@@ -57,7 +57,7 @@ class PonybackBrigadeAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When {this} enters the battlefield or is turned face up, ");
     }
 
-    public PonybackBrigadeAbility(final PonybackBrigadeAbility ability) {
+    private PonybackBrigadeAbility(final PonybackBrigadeAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PorcelainZealot.java
+++ b/Mage.Sets/src/mage/cards/p/PorcelainZealot.java
@@ -58,7 +58,7 @@ class PorcelainZealotEffect extends OneShotEffect {
         this.staticText = "target creature you control gets +1/+1 until end of turn. If that creature has toxic, instead it gets +2/+2 until end of turn.";
     }
 
-    public PorcelainZealotEffect(final PorcelainZealotEffect effect) {
+    private PorcelainZealotEffect(final PorcelainZealotEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PorphyryNodes.java
+++ b/Mage.Sets/src/mage/cards/p/PorphyryNodes.java
@@ -60,7 +60,7 @@ class PorphyryNodesEffect extends OneShotEffect {
         this.staticText = "destroy the creature with the least power. It can't be regenerated. If two or more creatures are tied for least power, you choose one of them";
     }
     
-    public PorphyryNodesEffect(final PorphyryNodesEffect effect) {
+    private PorphyryNodesEffect(final PorphyryNodesEffect effect) {
         super(effect);
     }
     
@@ -117,7 +117,7 @@ class PorphyryNodesStateTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("When there are no creatures on the battlefield, " );
     }
 
-    public PorphyryNodesStateTriggeredAbility(final PorphyryNodesStateTriggeredAbility ability) {
+    private PorphyryNodesStateTriggeredAbility(final PorphyryNodesStateTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PortalMage.java
+++ b/Mage.Sets/src/mage/cards/p/PortalMage.java
@@ -71,7 +71,7 @@ class PortalMageEffect extends OneShotEffect {
         this.staticText = "you may reselect which player or planeswalker target attacking creature is attacking";
     }
 
-    public PortalMageEffect(final PortalMageEffect effect) {
+    private PortalMageEffect(final PortalMageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Portcullis.java
+++ b/Mage.Sets/src/mage/cards/p/Portcullis.java
@@ -78,7 +78,7 @@ class PortcullisExileEffect extends OneShotEffect {
         this.staticText = "Whenever a creature enters the battlefield, if there are two or more other creatures on the battlefield, exile that creature";
     }
 
-    public PortcullisExileEffect(final PortcullisExileEffect effect) {
+    private PortcullisExileEffect(final PortcullisExileEffect effect) {
         super(effect);
     }
 
@@ -116,7 +116,7 @@ class PortcullisReturnToBattlefieldTriggeredAbility extends DelayedTriggeredAbil
         this.fixedTarget = fixedTarget;
     }
 
-    public PortcullisReturnToBattlefieldTriggeredAbility(final PortcullisReturnToBattlefieldTriggeredAbility ability) {
+    private PortcullisReturnToBattlefieldTriggeredAbility(final PortcullisReturnToBattlefieldTriggeredAbility ability) {
         super(ability);
         this.fixedTarget = ability.fixedTarget;
     }

--- a/Mage.Sets/src/mage/cards/p/Portent.java
+++ b/Mage.Sets/src/mage/cards/p/Portent.java
@@ -50,7 +50,7 @@ class PortentEffect extends OneShotEffect {
         this.staticText = "look at the top three cards of target player's library, then put them back in any order. You may have that player shuffle";
     }
 
-    public PortentEffect(final PortentEffect effect) {
+    private PortentEffect(final PortentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PossessedSkaab.java
+++ b/Mage.Sets/src/mage/cards/p/PossessedSkaab.java
@@ -65,7 +65,7 @@ class PossessedSkaabDiesEffect extends ReplacementEffectImpl {
         staticText = "If {this} would die, exile it instead";
     }
 
-    public PossessedSkaabDiesEffect(final PossessedSkaabDiesEffect effect) {
+    private PossessedSkaabDiesEffect(final PossessedSkaabDiesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PossibilityStorm.java
+++ b/Mage.Sets/src/mage/cards/p/PossibilityStorm.java
@@ -55,7 +55,7 @@ class PossibilityStormTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a player casts a spell from their hand, ");
     }
 
-    public PossibilityStormTriggeredAbility(final PossibilityStormTriggeredAbility ability) {
+    private PossibilityStormTriggeredAbility(final PossibilityStormTriggeredAbility ability) {
         super(ability);
     }
 
@@ -90,7 +90,7 @@ class PossibilityStormEffect extends OneShotEffect {
         staticText = "that player exiles it, then exiles cards from the top of their library until they exile a card that shares a card type with it. That player may cast that card without paying its mana cost. Then they put all cards exiled with {this} on the bottom of their library in a random order";
     }
 
-    public PossibilityStormEffect(final PossibilityStormEffect effect) {
+    private PossibilityStormEffect(final PossibilityStormEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PostmortemLunge.java
+++ b/Mage.Sets/src/mage/cards/p/PostmortemLunge.java
@@ -68,7 +68,7 @@ class PostmortemLungeEffect extends OneShotEffect {
         this.staticText = "Return target creature card with mana value X from your graveyard to the battlefield. It gains haste. Exile it at the beginning of the next end step";
     }
 
-    public PostmortemLungeEffect(final PostmortemLungeEffect effect) {
+    private PostmortemLungeEffect(final PostmortemLungeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PowderKeg.java
+++ b/Mage.Sets/src/mage/cards/p/PowderKeg.java
@@ -58,7 +58,7 @@ class PowderKegEffect extends OneShotEffect {
         staticText = "Destroy each artifact and creature with mana value equal to the number of fuse counters on {this}";
     }
 
-    public PowderKegEffect(final PowderKegEffect effect) {
+    private PowderKegEffect(final PowderKegEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PowerLeak.java
+++ b/Mage.Sets/src/mage/cards/p/PowerLeak.java
@@ -58,7 +58,7 @@ class PowerLeakEffect extends OneShotEffect {
         this.staticText = "that player may pay any amount of mana. {this} deals 2 damage to that player. Prevent X of that damage, where X is the amount of mana that player paid this way";
     }
 
-    public PowerLeakEffect(final PowerLeakEffect effect) {
+    private PowerLeakEffect(final PowerLeakEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PowerSink.java
+++ b/Mage.Sets/src/mage/cards/p/PowerSink.java
@@ -51,7 +51,7 @@ class PowerSinkCounterUnlessPaysEffect extends OneShotEffect {
         this.staticText = "Counter target spell unless its controller pays {X}. If that player doesn't, they tap all lands with mana abilities they control and lose all unspent mana";
     }
 
-    public PowerSinkCounterUnlessPaysEffect(final PowerSinkCounterUnlessPaysEffect effect) {
+    private PowerSinkCounterUnlessPaysEffect(final PowerSinkCounterUnlessPaysEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PowerSurge.java
+++ b/Mage.Sets/src/mage/cards/p/PowerSurge.java
@@ -46,7 +46,7 @@ class PowerSurgeDamageEffect extends OneShotEffect {
         this.staticText = "{this} deals X damage to that player where X is the number of untapped lands they controlled at the beginning of this turn";
     }
 
-    public PowerSurgeDamageEffect(PowerSurgeDamageEffect copy) {
+    private PowerSurgeDamageEffect(final PowerSurgeDamageEffect copy) {
         super(copy);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PowerstoneMinefield.java
+++ b/Mage.Sets/src/mage/cards/p/PowerstoneMinefield.java
@@ -46,7 +46,7 @@ class PowerstoneMinefieldTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(2), false);
     }
 
-    public PowerstoneMinefieldTriggeredAbility(PowerstoneMinefieldTriggeredAbility ability) {
+    private PowerstoneMinefieldTriggeredAbility(final PowerstoneMinefieldTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PraetorsCounsel.java
+++ b/Mage.Sets/src/mage/cards/p/PraetorsCounsel.java
@@ -49,7 +49,7 @@ class PraetorsCounselEffect extends OneShotEffect {
         this.staticText = "Return all cards from your graveyard to your hand";
     }
 
-    public PraetorsCounselEffect(final PraetorsCounselEffect effect) {
+    private PraetorsCounselEffect(final PraetorsCounselEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PraetorsGrasp.java
+++ b/Mage.Sets/src/mage/cards/p/PraetorsGrasp.java
@@ -50,7 +50,7 @@ class PraetorsGraspEffect extends OneShotEffect {
                 + "look at and play that card for as long as it remains exiled";
     }
 
-    public PraetorsGraspEffect(final PraetorsGraspEffect effect) {
+    private PraetorsGraspEffect(final PraetorsGraspEffect effect) {
         super(effect);
     }
 
@@ -103,7 +103,7 @@ class PraetorsGraspPlayEffect extends AsThoughEffectImpl {
         staticText = "You may look at and play that card for as long as it remains exiled";
     }
 
-    public PraetorsGraspPlayEffect(final PraetorsGraspPlayEffect effect) {
+    private PraetorsGraspPlayEffect(final PraetorsGraspPlayEffect effect) {
         super(effect);
         this.cardId = effect.cardId;
     }
@@ -150,7 +150,7 @@ class PraetorsGraspRevealEffect extends AsThoughEffectImpl {
         staticText = "You may look at and play that card for as long as it remains exiled";
     }
 
-    public PraetorsGraspRevealEffect(final PraetorsGraspRevealEffect effect) {
+    private PraetorsGraspRevealEffect(final PraetorsGraspRevealEffect effect) {
         super(effect);
         this.cardId = effect.cardId;
     }

--- a/Mage.Sets/src/mage/cards/p/Preacher.java
+++ b/Mage.Sets/src/mage/cards/p/Preacher.java
@@ -60,7 +60,7 @@ class PreacherEffect extends OneShotEffect {
         this.staticText = "Gain control of target creature of an opponent's choice that they control for as long as {this} remains tapped";
     }
 
-    public PreacherEffect(final PreacherEffect effect) {
+    private PreacherEffect(final PreacherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrecipiceOfMortis.java
+++ b/Mage.Sets/src/mage/cards/p/PrecipiceOfMortis.java
@@ -47,7 +47,7 @@ class PrecipiceOfMortisEffect extends ReplacementEffectImpl {
         staticText = "If a Jedi entering or leaving the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers additional time";
     }
 
-    public PrecipiceOfMortisEffect(final PrecipiceOfMortisEffect effect) {
+    private PrecipiceOfMortisEffect(final PrecipiceOfMortisEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Precognition.java
+++ b/Mage.Sets/src/mage/cards/p/Precognition.java
@@ -52,7 +52,7 @@ class PrecognitionEffect extends OneShotEffect {
         staticText = "";
     }
 
-    public PrecognitionEffect(final PrecognitionEffect effect) {
+    private PrecognitionEffect(final PrecognitionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrecognitionField.java
+++ b/Mage.Sets/src/mage/cards/p/PrecognitionField.java
@@ -65,7 +65,7 @@ class PrecognitionFieldExileEffect extends OneShotEffect {
         staticText = "exile the top card of your library";
     }
 
-    public PrecognitionFieldExileEffect(final PrecognitionFieldExileEffect effect) {
+    private PrecognitionFieldExileEffect(final PrecognitionFieldExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PredatoryFocus.java
+++ b/Mage.Sets/src/mage/cards/p/PredatoryFocus.java
@@ -44,7 +44,7 @@ class PredatoryFocusEffect extends AsThoughEffectImpl {
         this.staticText = "You may have creatures you control assign their combat damage this turn as though they weren't blocked.";
     }
 
-    public PredatoryFocusEffect(PredatoryFocusEffect effect) {
+    private PredatoryFocusEffect(final PredatoryFocusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PreeminentCaptain.java
+++ b/Mage.Sets/src/mage/cards/p/PreeminentCaptain.java
@@ -62,7 +62,7 @@ class PreeminentCaptainEffect extends OneShotEffect {
         this.staticText = "put a Soldier creature card from your hand onto the battlefield tapped and attacking";
     }
 
-    public PreeminentCaptainEffect(final PreeminentCaptainEffect effect) {
+    private PreeminentCaptainEffect(final PreeminentCaptainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PresenceOfTheMaster.java
+++ b/Mage.Sets/src/mage/cards/p/PresenceOfTheMaster.java
@@ -47,7 +47,7 @@ class PresenceOfTheMasterTriggeredAbility extends TriggeredAbilityImpl {
     }
 
 
-    public PresenceOfTheMasterTriggeredAbility(final PresenceOfTheMasterTriggeredAbility abiltity) {
+    private PresenceOfTheMasterTriggeredAbility(final PresenceOfTheMasterTriggeredAbility abiltity) {
         super(abiltity);
     }
 
@@ -86,7 +86,7 @@ class CounterEffect extends OneShotEffect {
         super(Outcome.Detriment);
     }
 
-    public CounterEffect(final CounterEffect effect) {
+    private CounterEffect(final CounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PreysVengeance.java
+++ b/Mage.Sets/src/mage/cards/p/PreysVengeance.java
@@ -25,7 +25,7 @@ public final class PreysVengeance extends CardImpl {
         this.addAbility(new ReboundAbility());
     }
 
-    public PreysVengeance (final PreysVengeance card) {
+    private PreysVengeance(final PreysVengeance card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PriceOfKnowledge.java
+++ b/Mage.Sets/src/mage/cards/p/PriceOfKnowledge.java
@@ -45,7 +45,7 @@ public final class PriceOfKnowledge extends CardImpl {
 
 class PriceOfKnowledgeEffect extends OneShotEffect {
 
-    public PriceOfKnowledgeEffect(final PriceOfKnowledgeEffect effect) {
+    private PriceOfKnowledgeEffect(final PriceOfKnowledgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PriceOfProgress.java
+++ b/Mage.Sets/src/mage/cards/p/PriceOfProgress.java
@@ -44,7 +44,7 @@ class PriceOfProgressEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to each player equal to twice the number of nonbasic lands that player controls";
     }
 
-    public PriceOfProgressEffect(final PriceOfProgressEffect effect) {
+    private PriceOfProgressEffect(final PriceOfProgressEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PriestsOfNorn.java
+++ b/Mage.Sets/src/mage/cards/p/PriestsOfNorn.java
@@ -28,7 +28,7 @@ public final class PriestsOfNorn extends CardImpl {
         this.addAbility(InfectAbility.getInstance());
     }
 
-    public PriestsOfNorn (final PriestsOfNorn card) {
+    private PriestsOfNorn(final PriestsOfNorn card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalClay.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalClay.java
@@ -58,7 +58,7 @@ public final class PrimalClay extends CardImpl {
             staticText = "As {this} enters the battlefield, it becomes your choice of a 3/3 artifact creature, a 2/2 artifact creature with flying, or a 1/6 Wall artifact creature with defender in addition to its other types";
         }
 
-        public PrimalPlasmaReplacementEffect(PrimalPlasmaReplacementEffect effect) {
+        private PrimalPlasmaReplacementEffect(final PrimalPlasmaReplacementEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalCocoon.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalCocoon.java
@@ -59,7 +59,7 @@ class PrimalCocoonAbility1 extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddPlusOneCountersAttachedEffect(1));
     }
 
-    public PrimalCocoonAbility1(final PrimalCocoonAbility1 ability) {
+    private PrimalCocoonAbility1(final PrimalCocoonAbility1 ability) {
         super(ability);
     }
 
@@ -90,7 +90,7 @@ class PrimalCocoonAbility2 extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroySourceEffect());
     }
 
-    public PrimalCocoonAbility2(final PrimalCocoonAbility2 ability) {
+    private PrimalCocoonAbility2(final PrimalCocoonAbility2 ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalCommand.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalCommand.java
@@ -76,7 +76,7 @@ class PrimalCommandShuffleGraveyardEffect extends OneShotEffect {
         this.staticText = "target player shuffles their graveyard into their library";
     }
 
-    public PrimalCommandShuffleGraveyardEffect(final PrimalCommandShuffleGraveyardEffect effect) {
+    private PrimalCommandShuffleGraveyardEffect(final PrimalCommandShuffleGraveyardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalInstinct.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalInstinct.java
@@ -45,7 +45,7 @@ class PrimalInstictEffect extends OneShotEffect {
         staticText = "Put a +1/+1 counter on target creature, then double the number of +1/+1 counters on that creature.";
     }
 
-    public PrimalInstictEffect(PrimalInstictEffect effect) {
+    private PrimalInstictEffect(final PrimalInstictEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalOrder.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalOrder.java
@@ -47,7 +47,7 @@ class PrimalOrderDamageTargetEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to that player equal to the number of nonbasic lands they control";
     }
 
-    public PrimalOrderDamageTargetEffect(PrimalOrderDamageTargetEffect copy) {
+    private PrimalOrderDamageTargetEffect(final PrimalOrderDamageTargetEffect copy) {
         super(copy);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalPlasma.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalPlasma.java
@@ -59,7 +59,7 @@ public final class PrimalPlasma extends CardImpl {
             staticText = "As {this} enters the battlefield, it becomes your choice of a 3/3 creature, a 2/2 creature with flying, or a 1/6 creature with defender";
         }
 
-        public PrimalPlasmaReplacementEffect(PrimalPlasmaReplacementEffect effect) {
+        private PrimalPlasmaReplacementEffect(final PrimalPlasmaReplacementEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalSurge.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalSurge.java
@@ -43,7 +43,7 @@ class PrimalSurgeEffect extends OneShotEffect {
         this.staticText = "Exile the top card of your library. If it's a permanent card, you may put it onto the battlefield. If you do, repeat this process";
     }
 
-    public PrimalSurgeEffect(final PrimalSurgeEffect effect) {
+    private PrimalSurgeEffect(final PrimalSurgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalVigor.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalVigor.java
@@ -50,7 +50,7 @@ class PrimalVigorTokenEffect extends ReplacementEffectImpl {
         staticText = "If one or more tokens would be created, twice that many of those tokens are created instead";
     }
 
-    public PrimalVigorTokenEffect(final PrimalVigorTokenEffect effect) {
+    private PrimalVigorTokenEffect(final PrimalVigorTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalWellspring.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalWellspring.java
@@ -60,7 +60,7 @@ class PyrimalWellspringTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When that mana is used to cast an instant or sorcery spell, ");
     }
 
-    public PyrimalWellspringTriggeredAbility(final PyrimalWellspringTriggeredAbility ability) {
+    private PyrimalWellspringTriggeredAbility(final PyrimalWellspringTriggeredAbility ability) {
         super(ability);
         this.abilityOriginalId = ability.abilityOriginalId;
     }

--- a/Mage.Sets/src/mage/cards/p/PrimevalSpawn.java
+++ b/Mage.Sets/src/mage/cards/p/PrimevalSpawn.java
@@ -67,7 +67,7 @@ class PrimevalSpawnReplacementEffect extends ReplacementEffectImpl {
                 "it wasn't cast or no mana was spent to cast it, exile it instead";
     }
 
-    public PrimevalSpawnReplacementEffect(final PrimevalSpawnReplacementEffect effect) {
+    private PrimevalSpawnReplacementEffect(final PrimevalSpawnReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimevalsGloriousRebirth.java
+++ b/Mage.Sets/src/mage/cards/p/PrimevalsGloriousRebirth.java
@@ -52,7 +52,7 @@ class PrimevalsGloriousRebirthEffect extends OneShotEffect {
         this.staticText = "Return all legendary permanent cards from your graveyard to the battlefield";
     }
 
-    public PrimevalsGloriousRebirthEffect(final PrimevalsGloriousRebirthEffect effect) {
+    private PrimevalsGloriousRebirthEffect(final PrimevalsGloriousRebirthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimordialMist.java
+++ b/Mage.Sets/src/mage/cards/p/PrimordialMist.java
@@ -71,7 +71,7 @@ class PrimordialMistCost extends CostImpl {
         this.text = "Exile a face-down permanent you control face-up";
     }
 
-    public PrimordialMistCost(final PrimordialMistCost cost) {
+    private PrimordialMistCost(final PrimordialMistCost cost) {
         super(cost);
         this.target = cost.target.copy();
     }
@@ -124,7 +124,7 @@ class PrimordialMistCastFromExileEffect extends AsThoughEffectImpl {
         staticText = "Exile a face-down permanent you control face up: You may play that card this turn.";
     }
 
-    public PrimordialMistCastFromExileEffect(final PrimordialMistCastFromExileEffect effect) {
+    private PrimordialMistCastFromExileEffect(final PrimordialMistCastFromExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimordialOoze.java
+++ b/Mage.Sets/src/mage/cards/p/PrimordialOoze.java
@@ -54,7 +54,7 @@ class PrimordialOozeEffect extends OneShotEffect {
         this.staticText = "Then you may pay {X}, where X is the number of +1/+1 counters on it. If you don't, tap {this} and it deals X damage to you";
     }
 
-    public PrimordialOozeEffect(final PrimordialOozeEffect effect) {
+    private PrimordialOozeEffect(final PrimordialOozeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrinceOfThralls.java
+++ b/Mage.Sets/src/mage/cards/p/PrinceOfThralls.java
@@ -94,7 +94,7 @@ class PrinceOfThrallsEffect extends OneShotEffect {
         this.staticText = "put that card onto the battlefield under your control unless that opponent pays 3 life";
     }
 
-    public PrinceOfThrallsEffect(final PrinceOfThrallsEffect effect) {
+    private PrinceOfThrallsEffect(final PrinceOfThrallsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrismRing.java
+++ b/Mage.Sets/src/mage/cards/p/PrismRing.java
@@ -47,7 +47,7 @@ class PrismRingTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainLifeEffect(1), false);
     }
 
-    public PrismRingTriggeredAbility(final PrismRingTriggeredAbility ability) {
+    private PrismRingTriggeredAbility(final PrismRingTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrismaticCircle.java
+++ b/Mage.Sets/src/mage/cards/p/PrismaticCircle.java
@@ -63,7 +63,7 @@ class PrismaticCircleEffect extends PreventNextDamageFromChosenSourceToYouEffect
         super.init(source, game);
     }
 
-    public PrismaticCircleEffect(PrismaticCircleEffect effect) {
+    private PrismaticCircleEffect(final PrismaticCircleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrismaticWard.java
+++ b/Mage.Sets/src/mage/cards/p/PrismaticWard.java
@@ -66,7 +66,7 @@ class PrismaticWardPreventDamageEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that would be dealt to enchanted creature by sources of the chosen color.";
     }
 
-    public PrismaticWardPreventDamageEffect(final PrismaticWardPreventDamageEffect effect) {
+    private PrismaticWardPreventDamageEffect(final PrismaticWardPreventDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrisonTerm.java
+++ b/Mage.Sets/src/mage/cards/p/PrisonTerm.java
@@ -73,7 +73,7 @@ class PrisonTermEffect extends OneShotEffect {
         super(Outcome.Detriment);
     }
 
-    public PrisonTermEffect(final PrisonTermEffect effect) {
+    private PrisonTermEffect(final PrisonTermEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ProfaneMemento.java
+++ b/Mage.Sets/src/mage/cards/p/ProfaneMemento.java
@@ -43,7 +43,7 @@ class ProfaneMementoTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature card is put into an opponent's graveyard from anywhere, ");
     }
     
-    public ProfaneMementoTriggeredAbility(final ProfaneMementoTriggeredAbility ability) {
+    private ProfaneMementoTriggeredAbility(final ProfaneMementoTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/p/ProfaneProcession.java
+++ b/Mage.Sets/src/mage/cards/p/ProfaneProcession.java
@@ -59,7 +59,7 @@ class ProfaneProcessionEffect extends OneShotEffect {
         this.staticText = "Exile target creature. Then if there are three or more cards exiled with {this}, transform it.";
     }
 
-    public ProfaneProcessionEffect(final ProfaneProcessionEffect effect) {
+    private ProfaneProcessionEffect(final ProfaneProcessionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ProfanerOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/p/ProfanerOfTheDead.java
@@ -55,7 +55,7 @@ class ProfanerOfTheDeadReturnEffect extends OneShotEffect {
         staticText = "return to their owners' hands all creatures your opponents control with toughness less than the exploited creature's toughness";
     }
 
-    public ProfanerOfTheDeadReturnEffect(final ProfanerOfTheDeadReturnEffect effect) {
+    private ProfanerOfTheDeadReturnEffect(final ProfanerOfTheDeadReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PromiseOfBunrei.java
+++ b/Mage.Sets/src/mage/cards/p/PromiseOfBunrei.java
@@ -47,7 +47,7 @@ class PromiseOfBunreiEffect extends OneShotEffect {
         this.staticText = "sacrifice {this}. If you do, create four 1/1 colorless Spirit creature tokens";
     }
 
-    public PromiseOfBunreiEffect(final PromiseOfBunreiEffect effect) {
+    private PromiseOfBunreiEffect(final PromiseOfBunreiEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PromiseOfLoyalty.java
+++ b/Mage.Sets/src/mage/cards/p/PromiseOfLoyalty.java
@@ -103,7 +103,7 @@ class PromiseOfLoyaltyAttackEffect extends RestrictionEffect {
         super(Duration.Custom);
     }
 
-    public PromiseOfLoyaltyAttackEffect(final PromiseOfLoyaltyAttackEffect effect) {
+    private PromiseOfLoyaltyAttackEffect(final PromiseOfLoyaltyAttackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PromiseOfPower.java
+++ b/Mage.Sets/src/mage/cards/p/PromiseOfPower.java
@@ -63,7 +63,7 @@ class PromiseOfPowerEffect extends OneShotEffect {
         staticText = "Create an X/X black Demon creature token with flying, where X is the number of cards in your hand";
     }
 
-    public PromiseOfPowerEffect(PromiseOfPowerEffect ability) {
+    private PromiseOfPowerEffect(final PromiseOfPowerEffect ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ProperBurial.java
+++ b/Mage.Sets/src/mage/cards/p/ProperBurial.java
@@ -42,7 +42,7 @@ class ProperBurialTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null);
     }
 
-    public ProperBurialTriggeredAbility(final ProperBurialTriggeredAbility ability) {
+    private ProperBurialTriggeredAbility(final ProperBurialTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Prophecy.java
+++ b/Mage.Sets/src/mage/cards/p/Prophecy.java
@@ -53,7 +53,7 @@ class ProphecyEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of target opponent's library. If it's a land, you gain 1 life. Then that player shuffles";
     }
 
-    public ProphecyEffect(final ProphecyEffect effect) {
+    private ProphecyEffect(final ProphecyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PropheticFlamespeaker.java
+++ b/Mage.Sets/src/mage/cards/p/PropheticFlamespeaker.java
@@ -62,7 +62,7 @@ class PropheticFlamespeakerExileEffect extends OneShotEffect {
         this.staticText = "exile the top card of your library. You may play it this turn";
     }
 
-    public PropheticFlamespeakerExileEffect(final PropheticFlamespeakerExileEffect effect) {
+    private PropheticFlamespeakerExileEffect(final PropheticFlamespeakerExileEffect effect) {
         super(effect);
     }
 
@@ -97,7 +97,7 @@ class PropheticFlamespeakerCastFromExileEffect extends AsThoughEffectImpl {
         staticText = "You may play the card from exile";
     }
 
-    public PropheticFlamespeakerCastFromExileEffect(final PropheticFlamespeakerCastFromExileEffect effect) {
+    private PropheticFlamespeakerCastFromExileEffect(final PropheticFlamespeakerCastFromExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ProteanHydra.java
+++ b/Mage.Sets/src/mage/cards/p/ProteanHydra.java
@@ -59,7 +59,7 @@ public final class ProteanHydra extends CardImpl {
             super(Zone.BATTLEFIELD, new CreateDelayedTriggeredAbilityEffect(new ProteanHydraDelayedTriggeredAbility()), false);
         }
 
-        public ProteanHydraAbility(final ProteanHydraAbility ability) {
+        private ProteanHydraAbility(final ProteanHydraAbility ability) {
             super(ability);
         }
 
@@ -91,7 +91,7 @@ public final class ProteanHydra extends CardImpl {
             super(new AddCountersSourceEffect(CounterType.P1P1.createInstance(2)));
         }
 
-        public ProteanHydraDelayedTriggeredAbility(final ProteanHydraDelayedTriggeredAbility ability) {
+        private ProteanHydraDelayedTriggeredAbility(final ProteanHydraDelayedTriggeredAbility ability) {
             super(ability);
         }
 

--- a/Mage.Sets/src/mage/cards/p/ProtectionOfTheHekma.java
+++ b/Mage.Sets/src/mage/cards/p/ProtectionOfTheHekma.java
@@ -44,7 +44,7 @@ class ProtectionOfTheHekmaEffect extends PreventionEffectImpl {
         this.staticText = "If a source an opponent controls would deal damage to you, prevent 1 of that damage";
     }
 
-    public ProtectionOfTheHekmaEffect(final ProtectionOfTheHekmaEffect effect) {
+    private ProtectionOfTheHekmaEffect(final ProtectionOfTheHekmaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ProtectiveSphere.java
+++ b/Mage.Sets/src/mage/cards/p/ProtectiveSphere.java
@@ -63,7 +63,7 @@ class ProtectiveSphereEffect extends PreventionEffectImpl {
         this.target = new TargetSource();
     }
 
-    public ProtectiveSphereEffect(final ProtectiveSphereEffect effect) {
+    private ProtectiveSphereEffect(final ProtectiveSphereEffect effect) {
         super(effect);
         this.target = effect.target.copy();
     }

--- a/Mage.Sets/src/mage/cards/p/ProvenCombatant.java
+++ b/Mage.Sets/src/mage/cards/p/ProvenCombatant.java
@@ -25,7 +25,7 @@ public final class ProvenCombatant extends CardImpl {
         addAbility(new EternalizeAbility(new ManaCostsImpl<>("{4}{U}{U}"), this));
     }
 
-    public ProvenCombatant(final ProvenCombatant provenCombatant){
+    private ProvenCombatant(final ProvenCombatant provenCombatant){
         super(provenCombatant);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PryingQuestions.java
+++ b/Mage.Sets/src/mage/cards/p/PryingQuestions.java
@@ -47,7 +47,7 @@ class PryingQuestionsEffect extends OneShotEffect {
         this.staticText = "puts a card from their hand on top of their library";
     }
 
-    public PryingQuestionsEffect(final PryingQuestionsEffect effect) {
+    private PryingQuestionsEffect(final PryingQuestionsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychicAllergy.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicAllergy.java
@@ -67,7 +67,7 @@ class PsychicAllergyEffect extends OneShotEffect {
         this.staticText = "{this} deals X damage to that player, where X is the number of nontoken permanents of the chosen color they control";
     }
 
-    public PsychicAllergyEffect(PsychicAllergyEffect copy) {
+    private PsychicAllergyEffect(final PsychicAllergyEffect copy) {
         super(copy);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychicBattle.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicBattle.java
@@ -51,7 +51,7 @@ class PsychicBattleTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new PsychicBattleEffect(), false);
     }
 
-    public PsychicBattleTriggeredAbility(PsychicBattleTriggeredAbility ability) {
+    private PsychicBattleTriggeredAbility(final PsychicBattleTriggeredAbility ability) {
         super(ability);
     }
 
@@ -90,7 +90,7 @@ class PsychicBattleEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public PsychicBattleEffect(final PsychicBattleEffect effect) {
+    private PsychicBattleEffect(final PsychicBattleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychicIntrusion.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicIntrusion.java
@@ -56,7 +56,7 @@ class PsychicIntrusionExileEffect extends OneShotEffect {
         this.staticText = "Target opponent reveals their hand. You choose a nonland card from that player's graveyard or hand and exile it. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell";
     }
 
-    public PsychicIntrusionExileEffect(final PsychicIntrusionExileEffect effect) {
+    private PsychicIntrusionExileEffect(final PsychicIntrusionExileEffect effect) {
         super(effect);
     }
 
@@ -128,7 +128,7 @@ class PsychicIntrusionCastFromExileEffect extends AsThoughEffectImpl {
         staticText = "You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell";
     }
 
-    public PsychicIntrusionCastFromExileEffect(final PsychicIntrusionCastFromExileEffect effect) {
+    private PsychicIntrusionCastFromExileEffect(final PsychicIntrusionCastFromExileEffect effect) {
         super(effect);
     }
 
@@ -164,7 +164,7 @@ class PsychicIntrusionSpendAnyManaEffect extends AsThoughEffectImpl implements A
         staticText = "you may spend mana as though it were mana of any color to cast it";
     }
 
-    public PsychicIntrusionSpendAnyManaEffect(final PsychicIntrusionSpendAnyManaEffect effect) {
+    private PsychicIntrusionSpendAnyManaEffect(final PsychicIntrusionSpendAnyManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychicPossession.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicPossession.java
@@ -62,7 +62,7 @@ class PsychicPossessionTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), true);
     }
 
-    public PsychicPossessionTriggeredAbility(final PsychicPossessionTriggeredAbility ability) {
+    private PsychicPossessionTriggeredAbility(final PsychicPossessionTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychicPurge.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicPurge.java
@@ -52,7 +52,7 @@ class PsychicPurgeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.GRAVEYARD, new LoseLifeTargetEffect(5), false);
     }
 
-    public PsychicPurgeTriggeredAbility(final PsychicPurgeTriggeredAbility ability) {
+    private PsychicPurgeTriggeredAbility(final PsychicPurgeTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychicRebuttal.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicRebuttal.java
@@ -61,7 +61,7 @@ class PsychicRebuttalEffect extends OneShotEffect {
                 + "<br><i>Spell mastery</i> &mdash; If there are two or more instant and/or sorcery cards in your graveyard, you may copy the spell countered this way. You may choose new targets for the copy";
     }
 
-    public PsychicRebuttalEffect(final PsychicRebuttalEffect effect) {
+    private PsychicRebuttalEffect(final PsychicRebuttalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychicSpiral.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicSpiral.java
@@ -42,7 +42,7 @@ class PsychicSpiralEffect extends OneShotEffect {
         staticText = "Shuffle all cards from your graveyard into your library. Target player mills that many cards";
     }
 
-    public PsychicSpiralEffect(final PsychicSpiralEffect effect) {
+    private PsychicSpiralEffect(final PsychicSpiralEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychicStrike.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicStrike.java
@@ -46,7 +46,7 @@ class PsychicStrikeEffect extends OneShotEffect {
         staticText = "Counter target spell. Its controller puts the top two cards of their library into their graveyard";
     }
 
-    public PsychicStrikeEffect(final PsychicStrikeEffect effect) {
+    private PsychicStrikeEffect(final PsychicStrikeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychicSurgery.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicSurgery.java
@@ -51,7 +51,7 @@ class PsychicSurgeryTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever an opponent shuffles their library, ");
     }
 
-    public PsychicSurgeryTriggeredAbility(final PsychicSurgeryTriggeredAbility ability) {
+    private PsychicSurgeryTriggeredAbility(final PsychicSurgeryTriggeredAbility ability) {
         super(ability);
     }
 
@@ -82,7 +82,7 @@ class PsychicSurgeryEffect extends OneShotEffect {
         this.staticText = "you may look at the top two cards of that library. You may exile one of those cards. Then put the rest on top of that library in any order";
     }
 
-    public PsychicSurgeryEffect(final PsychicSurgeryEffect effect) {
+    private PsychicSurgeryEffect(final PsychicSurgeryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PublicExecution.java
+++ b/Mage.Sets/src/mage/cards/p/PublicExecution.java
@@ -50,7 +50,7 @@ class PublicExecutionEffect extends OneShotEffect {
         staticText = "Each other creature that player controls gets -2/-0 until end of turn";
     }
 
-    public PublicExecutionEffect(final PublicExecutionEffect effect) {
+    private PublicExecutionEffect(final PublicExecutionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PucasMischief.java
+++ b/Mage.Sets/src/mage/cards/p/PucasMischief.java
@@ -58,7 +58,7 @@ class TargetControlledPermanentWithCMCGreaterOrLessThanOpponentPermanent extends
         setTargetName("nonland permanent you control");
     }
 
-    public TargetControlledPermanentWithCMCGreaterOrLessThanOpponentPermanent(final TargetControlledPermanentWithCMCGreaterOrLessThanOpponentPermanent target) {
+    private TargetControlledPermanentWithCMCGreaterOrLessThanOpponentPermanent(final TargetControlledPermanentWithCMCGreaterOrLessThanOpponentPermanent target) {
         super(target);
     }
 
@@ -94,7 +94,7 @@ class PucasMischiefSecondTarget extends TargetPermanent {
         setTargetName("permanent an opponent controls with an equal or lesser mana value");
     }
 
-    public PucasMischiefSecondTarget(final PucasMischiefSecondTarget target) {
+    private PucasMischiefSecondTarget(final PucasMischiefSecondTarget target) {
         super(target);
         this.firstTarget = target.firstTarget;
     }

--- a/Mage.Sets/src/mage/cards/p/PullFromEternity.java
+++ b/Mage.Sets/src/mage/cards/p/PullFromEternity.java
@@ -56,7 +56,7 @@ class PullFromEternityEffect extends OneShotEffect {
         this.staticText = "Put target face-up exiled card into its owner's graveyard.";
     }
 
-    public PullFromEternityEffect(final PullFromEternityEffect effect) {
+    private PullFromEternityEffect(final PullFromEternityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PullUnder.java
+++ b/Mage.Sets/src/mage/cards/p/PullUnder.java
@@ -26,7 +26,7 @@ public final class PullUnder extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public PullUnder (final PullUnder card) {
+    private PullUnder(final PullUnder card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PullingTeeth.java
+++ b/Mage.Sets/src/mage/cards/p/PullingTeeth.java
@@ -45,7 +45,7 @@ class PullingTeethEffect extends OneShotEffect {
         this.staticText = "Clash with an opponent. If you win, target player discards two cards. Otherwise, that player discards a card";
     }
 
-    public PullingTeethEffect(final PullingTeethEffect effect) {
+    private PullingTeethEffect(final PullingTeethEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PunishingFire.java
+++ b/Mage.Sets/src/mage/cards/p/PunishingFire.java
@@ -48,7 +48,7 @@ class PunishingFireTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever an opponent gains life, ");
     }
 
-    public PunishingFireTriggeredAbility(final PunishingFireTriggeredAbility ability) {
+    private PunishingFireTriggeredAbility(final PunishingFireTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PuppetsVerdict.java
+++ b/Mage.Sets/src/mage/cards/p/PuppetsVerdict.java
@@ -45,7 +45,7 @@ class PuppetsVerdictEffect extends OneShotEffect {
         staticText = "Flip a coin. If you win the flip, destroy all creatures with power 2 or less. If you lose the flip, destroy all creatures with power 3 or greater";
     }
 
-    public PuppetsVerdictEffect(PuppetsVerdictEffect effect) {
+    private PuppetsVerdictEffect(final PuppetsVerdictEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PureIntentions.java
+++ b/Mage.Sets/src/mage/cards/p/PureIntentions.java
@@ -56,7 +56,7 @@ class PureIntentionsAllTriggeredAbility extends DelayedTriggeredAbility {
         super(new ReturnFromGraveyardToHandTargetEffect(), Duration.EndOfTurn, false);
     }
 
-    public PureIntentionsAllTriggeredAbility(PureIntentionsAllTriggeredAbility ability) {
+    private PureIntentionsAllTriggeredAbility(final PureIntentionsAllTriggeredAbility ability) {
         super(ability);
     }
 
@@ -99,7 +99,7 @@ class PureIntentionsTriggeredAbility extends TriggeredAbilityImpl {
                 new AtTheBeginOfNextEndStepDelayedTriggeredAbility(new ReturnSourceFromGraveyardToHandEffect())), false);
     }
 
-    public PureIntentionsTriggeredAbility(final PureIntentionsTriggeredAbility ability) {
+    private PureIntentionsTriggeredAbility(final PureIntentionsTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PuresightMerrow.java
+++ b/Mage.Sets/src/mage/cards/p/PuresightMerrow.java
@@ -59,7 +59,7 @@ class PuresightMerrowEffect extends OneShotEffect {
         staticText = "Look at the top card of your library. You may exile that card";
     }
 
-    public PuresightMerrowEffect(final PuresightMerrowEffect effect) {
+    private PuresightMerrowEffect(final PuresightMerrowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Purgatory.java
+++ b/Mage.Sets/src/mage/cards/p/Purgatory.java
@@ -114,7 +114,7 @@ class PurgatoryExileEffect extends OneShotEffect {
         staticText = "exile that card";
     }
 
-    public PurgatoryExileEffect(PurgatoryExileEffect effect) {
+    private PurgatoryExileEffect(final PurgatoryExileEffect effect) {
         super(effect);
     }
     
@@ -148,7 +148,7 @@ class PurgatoryReturnEffect extends OneShotEffect {
         this.staticText = "return a card exiled with {this} to the battlefield";
     }
 
-    public PurgatoryReturnEffect(final PurgatoryReturnEffect effect) {
+    private PurgatoryReturnEffect(final PurgatoryReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PurgingScythe.java
+++ b/Mage.Sets/src/mage/cards/p/PurgingScythe.java
@@ -52,7 +52,7 @@ class PurgingScytheEffect extends OneShotEffect {
                 + "If two or more creatures are tied for least toughness, you choose one of them";
     }
 
-    public PurgingScytheEffect(final PurgingScytheEffect effect) {
+    private PurgingScytheEffect(final PurgingScytheEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PursuitOfKnowledge.java
+++ b/Mage.Sets/src/mage/cards/p/PursuitOfKnowledge.java
@@ -57,7 +57,7 @@ class PursuitOfKnowledgeEffect extends ReplacementEffectImpl {
         staticText = "If you would draw a card, you may put a study counter on {this} instead";
     }
 
-    public PursuitOfKnowledgeEffect(final PursuitOfKnowledgeEffect effect) {
+    private PursuitOfKnowledgeEffect(final PursuitOfKnowledgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Putrefaction.java
+++ b/Mage.Sets/src/mage/cards/p/Putrefaction.java
@@ -50,7 +50,7 @@ class PutrefactionTriggeredAbility extends SpellCastAllTriggeredAbility {
         super(new DiscardTargetEffect(1), filterGreenOrWhiteSpell, false);
     }
 
-    public PutrefactionTriggeredAbility(PutrefactionTriggeredAbility ability) {
+    private PutrefactionTriggeredAbility(final PutrefactionTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Putrefax.java
+++ b/Mage.Sets/src/mage/cards/p/Putrefax.java
@@ -34,7 +34,7 @@ public final class Putrefax extends CardImpl {
         this.addAbility(new OnEventTriggeredAbility(GameEvent.EventType.END_TURN_STEP_PRE, "beginning of the end step", true, new SacrificeSourceEffect()));
     }
 
-    public Putrefax (final Putrefax card) {
+    private Putrefax(final Putrefax card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Putrefy.java
+++ b/Mage.Sets/src/mage/cards/p/Putrefy.java
@@ -32,7 +32,7 @@ public final class Putrefy extends CardImpl {
         this.getSpellAbility().addEffect(new DestroyTargetEffect(true));
     }
 
-    public Putrefy (final Putrefy card) {
+    private Putrefy(final Putrefy card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PutridCyclops.java
+++ b/Mage.Sets/src/mage/cards/p/PutridCyclops.java
@@ -57,7 +57,7 @@ class PutridCyclopEffect extends OneShotEffect {
                 + " <i>(To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)</i>";
     }
 
-    public PutridCyclopEffect(final PutridCyclopEffect effect) {
+    private PutridCyclopEffect(final PutridCyclopEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PutridWarrior.java
+++ b/Mage.Sets/src/mage/cards/p/PutridWarrior.java
@@ -60,7 +60,7 @@ class PutridWarriorDealsDamageTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} deals damage, " );
     }
 
-    public PutridWarriorDealsDamageTriggeredAbility(final PutridWarriorDealsDamageTriggeredAbility ability) {
+    private PutridWarriorDealsDamageTriggeredAbility(final PutridWarriorDealsDamageTriggeredAbility ability) {
         super(ability);
     }
 
@@ -89,7 +89,7 @@ class PutridWarriorGainLifeEffect extends OneShotEffect {
         staticText = "Each player gains 1 life.";
     }
 
-    public PutridWarriorGainLifeEffect(final PutridWarriorGainLifeEffect effect) {
+    private PutridWarriorGainLifeEffect(final PutridWarriorGainLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Pyroblast.java
+++ b/Mage.Sets/src/mage/cards/p/Pyroblast.java
@@ -50,7 +50,7 @@ class PyroblastCounterTargetEffect extends OneShotEffect {
         this.staticText = "Counter target spell if it's blue";
     }
 
-    public PyroblastCounterTargetEffect(final PyroblastCounterTargetEffect effect) {
+    private PyroblastCounterTargetEffect(final PyroblastCounterTargetEffect effect) {
         super(effect);
     }
 
@@ -76,7 +76,7 @@ class PyroblastDestroyTargetEffect extends OneShotEffect {
         this.staticText = "Destroy target permanent if it's blue";
     }
 
-    public PyroblastDestroyTargetEffect(final PyroblastDestroyTargetEffect effect) {
+    private PyroblastDestroyTargetEffect(final PyroblastDestroyTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PyromancersGoggles.java
+++ b/Mage.Sets/src/mage/cards/p/PyromancersGoggles.java
@@ -67,7 +67,7 @@ class PyromancersGogglesTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When that mana is used to cast a red instant or sorcery spell, ");
     }
 
-    public PyromancersGogglesTriggeredAbility(final PyromancersGogglesTriggeredAbility ability) {
+    private PyromancersGogglesTriggeredAbility(final PyromancersGogglesTriggeredAbility ability) {
         super(ability);
         this.abilityOriginalId = ability.abilityOriginalId;
     }

--- a/Mage.Sets/src/mage/cards/p/PyrostaticPillar.java
+++ b/Mage.Sets/src/mage/cards/p/PyrostaticPillar.java
@@ -46,7 +46,7 @@ class PyrostaticPillarTriggeredAbility extends TriggeredAbilityImpl {
     }
 
 
-    public PyrostaticPillarTriggeredAbility(final PyrostaticPillarTriggeredAbility abiltity) {
+    private PyrostaticPillarTriggeredAbility(final PyrostaticPillarTriggeredAbility abiltity) {
         super(abiltity);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PyrrhicRevival.java
+++ b/Mage.Sets/src/mage/cards/p/PyrrhicRevival.java
@@ -50,7 +50,7 @@ class PyrrhicRevivalEffect extends OneShotEffect {
         staticText = "Each player returns each creature card from their graveyard to the battlefield with an additional -1/-1 counter on it";
     }
 
-    public PyrrhicRevivalEffect(final PyrrhicRevivalEffect effect) {
+    private PyrrhicRevivalEffect(final PyrrhicRevivalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PyxisOfPandemonium.java
+++ b/Mage.Sets/src/mage/cards/p/PyxisOfPandemonium.java
@@ -62,7 +62,7 @@ class PyxisOfPandemoniumExileEffect extends OneShotEffect {
         this.staticText = "Each player exiles the top card of their library face down";
     }
 
-    public PyxisOfPandemoniumExileEffect(final PyxisOfPandemoniumExileEffect effect) {
+    private PyxisOfPandemoniumExileEffect(final PyxisOfPandemoniumExileEffect effect) {
         super(effect);
     }
 
@@ -116,7 +116,7 @@ class PyxisOfPandemoniumPutOntoBattlefieldEffect extends OneShotEffect {
                 + "then puts all permanent cards among them onto the battlefield";
     }
 
-    public PyxisOfPandemoniumPutOntoBattlefieldEffect(final PyxisOfPandemoniumPutOntoBattlefieldEffect effect) {
+    private PyxisOfPandemoniumPutOntoBattlefieldEffect(final PyxisOfPandemoniumPutOntoBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/q/Quagmire.java
+++ b/Mage.Sets/src/mage/cards/q/Quagmire.java
@@ -44,7 +44,7 @@ class QuagmireEffect extends AsThoughEffectImpl {
         staticText = "Creatures with swampwalk can be blocked as though they didn't have swampwalk";
     }
 
-    public QuagmireEffect(final QuagmireEffect effect) {
+    private QuagmireEffect(final QuagmireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/q/QuarryColossus.java
+++ b/Mage.Sets/src/mage/cards/q/QuarryColossus.java
@@ -54,7 +54,7 @@ class QuarryColossusReturnLibraryEffect extends OneShotEffect {
                 + "top X cards of that library, where X is the number of Plains you control";
     }
 
-    public QuarryColossusReturnLibraryEffect(final QuarryColossusReturnLibraryEffect effect) {
+    private QuarryColossusReturnLibraryEffect(final QuarryColossusReturnLibraryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/q/QuarryHauler.java
+++ b/Mage.Sets/src/mage/cards/q/QuarryHauler.java
@@ -58,7 +58,7 @@ class QuarryHaulerEffect extends OneShotEffect {
 
     }
 
-    public QuarryHaulerEffect(final QuarryHaulerEffect effect) {
+    private QuarryHaulerEffect(final QuarryHaulerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/q/QuestForTheNihilStone.java
+++ b/Mage.Sets/src/mage/cards/q/QuestForTheNihilStone.java
@@ -51,7 +51,7 @@ class QuestForTheNihilStoneTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new LoseLifeTargetEffect(5), true);
     }
 
-    public QuestForTheNihilStoneTriggeredAbility(final QuestForTheNihilStoneTriggeredAbility ability) {
+    private QuestForTheNihilStoneTriggeredAbility(final QuestForTheNihilStoneTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/q/QuickStudy.java
+++ b/Mage.Sets/src/mage/cards/q/QuickStudy.java
@@ -20,7 +20,7 @@ public final class QuickStudy extends CardImpl {
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(2));
     }
 
-    public QuickStudy(final QuickStudy card) {
+    private QuickStudy(final QuickStudy card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/q/Quicken.java
+++ b/Mage.Sets/src/mage/cards/q/Quicken.java
@@ -56,7 +56,7 @@ class QuickenAsThoughEffect extends AsThoughEffectImpl {
         staticText = "The next sorcery spell you cast this turn can be cast as though it had flash";
     }
 
-    public QuickenAsThoughEffect(final QuickenAsThoughEffect effect) {
+    private QuickenAsThoughEffect(final QuickenAsThoughEffect effect) {
         super(effect);
         this.quickenWatcher = effect.quickenWatcher;
         this.zoneChangeCounter = effect.zoneChangeCounter;

--- a/Mage.Sets/src/mage/cards/q/QuicksilverFountain.java
+++ b/Mage.Sets/src/mage/cards/q/QuicksilverFountain.java
@@ -85,7 +85,7 @@ class QuicksilverFountainEffect extends OneShotEffect {
                 + "long as it has a flood counter on it";
     }
 
-    public QuicksilverFountainEffect(final QuicksilverFountainEffect effect) {
+    private QuicksilverFountainEffect(final QuicksilverFountainEffect effect) {
         super(effect);
     }
 
@@ -123,7 +123,7 @@ class QuicksilverFountainEffect2 extends OneShotEffect {
         staticText = "remove all flood counters from them";
     }
 
-    public QuicksilverFountainEffect2(final QuicksilverFountainEffect2 effect) {
+    private QuicksilverFountainEffect2(final QuicksilverFountainEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/q/QuietSpeculation.java
+++ b/Mage.Sets/src/mage/cards/q/QuietSpeculation.java
@@ -57,7 +57,7 @@ class SearchLibraryPutInGraveEffect extends SearchEffect {
         staticText = "Search target player's library for up to three cards with flashback and put them into that player's graveyard. Then the player shuffles.";
     }
 
-    public SearchLibraryPutInGraveEffect(final SearchLibraryPutInGraveEffect effect) {
+    private SearchLibraryPutInGraveEffect(final SearchLibraryPutInGraveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/q/QuilledSlagwurm.java
+++ b/Mage.Sets/src/mage/cards/q/QuilledSlagwurm.java
@@ -24,7 +24,7 @@ public final class QuilledSlagwurm extends CardImpl {
         this.toughness = new MageInt(8);
     }
 
-    public QuilledSlagwurm (final QuilledSlagwurm card) {
+    private QuilledSlagwurm(final QuilledSlagwurm card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/q/QuirionDruid.java
+++ b/Mage.Sets/src/mage/cards/q/QuirionDruid.java
@@ -61,7 +61,7 @@ class QuirionDruidToken extends TokenImpl {
         this.toughness = new MageInt(2);
     }
 
-    public QuirionDruidToken(final QuirionDruidToken token) {
+    private QuirionDruidToken(final QuirionDruidToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RacecourseFury.java
+++ b/Mage.Sets/src/mage/cards/r/RacecourseFury.java
@@ -50,7 +50,7 @@ public final class RacecourseFury extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(gainedAbility, AttachmentType.AURA, Duration.WhileOnBattlefield, rule)));
     }
 
-    public RacecourseFury (final RacecourseFury card) {
+    private RacecourseFury(final RacecourseFury card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Rackling.java
+++ b/Mage.Sets/src/mage/cards/r/Rackling.java
@@ -46,7 +46,7 @@ class RacklingEffect extends OneShotEffect {
         this.staticText = "{this} deals X damage to that player, where X is 3 minus the number of cards in their hand";
     }
 
-    public RacklingEffect(final RacklingEffect effect) {
+    private RacklingEffect(final RacklingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RaffinesGuidance.java
+++ b/Mage.Sets/src/mage/cards/r/RaffinesGuidance.java
@@ -60,7 +60,7 @@ class RafinnesGuidancePlayEffect extends AsThoughEffectImpl {
         staticText = "You may cast {this} from your graveyard by paying {2}{W} rather than paying its mana cost.";
     }
 
-    public RafinnesGuidancePlayEffect(final RafinnesGuidancePlayEffect effect) {
+    private RafinnesGuidancePlayEffect(final RafinnesGuidancePlayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RagMan.java
+++ b/Mage.Sets/src/mage/cards/r/RagMan.java
@@ -60,7 +60,7 @@ class RagManDiscardEffect extends OneShotEffect {
         this.staticText = "and discards a creature card at random";
     }
 
-    public RagManDiscardEffect(final RagManDiscardEffect effect) {
+    private RagManDiscardEffect(final RagManDiscardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RageForger.java
+++ b/Mage.Sets/src/mage/cards/r/RageForger.java
@@ -71,7 +71,7 @@ class RageForgerDamageEffect extends OneShotEffect {
         this.staticText = "you may have that creature deal 1 damage to target player or planeswalker";
     }
 
-    public RageForgerDamageEffect(final RageForgerDamageEffect effect) {
+    private RageForgerDamageEffect(final RageForgerDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RagingRiver.java
+++ b/Mage.Sets/src/mage/cards/r/RagingRiver.java
@@ -62,7 +62,7 @@ class RagingRiverEffect extends OneShotEffect {
         staticText = "each defending player divides all creatures without flying they control into a \"left\" pile and a \"right\" pile. Then, for each attacking creature you control, choose \"left\" or \"right.\" That creature can't be blocked this combat except by creatures with flying and creatures in a pile with the chosen label";
     }
 
-    public RagingRiverEffect(final RagingRiverEffect effect) {
+    private RagingRiverEffect(final RagingRiverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RagsRiches.java
+++ b/Mage.Sets/src/mage/cards/r/RagsRiches.java
@@ -53,7 +53,7 @@ class RichesEffect extends OneShotEffect {
         this.staticText = "Each opponent chooses a creature they control. You gain control of each of those creatures.";
     }
 
-    public RichesEffect(final RichesEffect effect) {
+    private RichesEffect(final RichesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RaidBombardment.java
+++ b/Mage.Sets/src/mage/cards/r/RaidBombardment.java
@@ -43,7 +43,7 @@ class RaidBombardmentTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(1));
     }
 
-    public RaidBombardmentTriggeredAbility(final RaidBombardmentTriggeredAbility ability) {
+    private RaidBombardmentTriggeredAbility(final RaidBombardmentTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RainOfDaggers.java
+++ b/Mage.Sets/src/mage/cards/r/RainOfDaggers.java
@@ -46,7 +46,7 @@ class RainOfDaggersEffect extends OneShotEffect {
         this.staticText = "Destroy all creatures target opponent controls. You lose 2 life for each creature destroyed this way";
     }
 
-    public RainOfDaggersEffect(final RainOfDaggersEffect effect) {
+    private RainOfDaggersEffect(final RainOfDaggersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RainOfGore.java
+++ b/Mage.Sets/src/mage/cards/r/RainOfGore.java
@@ -49,7 +49,7 @@ class RainOfGoreEffect extends ReplacementEffectImpl {
         staticText = "If a spell or ability would cause its controller to gain life, that player loses that much life instead";
     }
 
-    public RainOfGoreEffect(final RainOfGoreEffect effect) {
+    private RainOfGoreEffect(final RainOfGoreEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RainbowVale.java
+++ b/Mage.Sets/src/mage/cards/r/RainbowVale.java
@@ -47,7 +47,7 @@ public final class RainbowVale extends CardImpl {
             staticText = "an opponent gains control of {this} at the beginning of the next end step";
         }
 
-        public RainbowValeEffect(final RainbowValeEffect effect) {
+        private RainbowValeEffect(final RainbowValeEffect effect) {
             super(effect);
         }
 
@@ -78,7 +78,7 @@ class OpponentGainControlEffect extends ContinuousEffectImpl {
         opponentId = null;
     }
 
-    public OpponentGainControlEffect(final OpponentGainControlEffect effect) {
+    private OpponentGainControlEffect(final OpponentGainControlEffect effect) {
         super(effect);
         this.opponentId = effect.opponentId;
     }

--- a/Mage.Sets/src/mage/cards/r/RaiseTheAlarm.java
+++ b/Mage.Sets/src/mage/cards/r/RaiseTheAlarm.java
@@ -21,7 +21,7 @@ public final class RaiseTheAlarm extends CardImpl {
         this.getSpellAbility().addEffect(new CreateTokenEffect(new SoldierToken(), 2));
     }
 
-    public RaiseTheAlarm (final RaiseTheAlarm card) {
+    private RaiseTheAlarm(final RaiseTheAlarm card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RakdosAugermage.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosAugermage.java
@@ -60,7 +60,7 @@ class RakdosAugermageEffect extends OneShotEffect {
         staticText = "reveal your hand and discard a card of target opponent's choice";
     }
 
-    public RakdosAugermageEffect(final RakdosAugermageEffect effect) {
+    private RakdosAugermageEffect(final RakdosAugermageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RakdosCharm.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosCharm.java
@@ -56,7 +56,7 @@ public final class RakdosCharm extends CardImpl {
             staticText = "each creature deals 1 damage to its controller";
         }
 
-        public RakdosCharmDamageEffect(final RakdosCharmDamageEffect effect) {
+        private RakdosCharmDamageEffect(final RakdosCharmDamageEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/r/RakdosDrake.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosDrake.java
@@ -34,7 +34,7 @@ public final class RakdosDrake extends CardImpl {
 
     }
 
-    public RakdosDrake (final RakdosDrake card) {
+    private RakdosDrake(final RakdosDrake card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RakdosGuildmage.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosGuildmage.java
@@ -63,7 +63,7 @@ class RakdosGuildmageEffect extends OneShotEffect {
         this.staticText = "Create a 2/1 red Goblin creature token with haste. Exile it at the beginning of the next end step";
     }
 
-    public RakdosGuildmageEffect(final RakdosGuildmageEffect effect) {
+    private RakdosGuildmageEffect(final RakdosGuildmageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RakdosKeyrune.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosKeyrune.java
@@ -54,7 +54,7 @@ public final class RakdosKeyrune extends CardImpl {
             toughness = new MageInt(1);
             this.addAbility(FirstStrikeAbility.getInstance());
         }
-        public RakdosKeyruneToken(final RakdosKeyruneToken token) {
+        private RakdosKeyruneToken(final RakdosKeyruneToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/r/RakdosLordOfRiots.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosLordOfRiots.java
@@ -61,7 +61,7 @@ class RakdosLordOfRiotsCantCastEffect extends ContinuousRuleModifyingEffectImpl 
         staticText = "You can't cast this spell unless an opponent lost life this turn";
     }
 
-    public RakdosLordOfRiotsCantCastEffect(final RakdosLordOfRiotsCantCastEffect effect) {
+    private RakdosLordOfRiotsCantCastEffect(final RakdosLordOfRiotsCantCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RakdosPitDragon.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosPitDragon.java
@@ -47,7 +47,7 @@ public final class RakdosPitDragon extends CardImpl {
         )).setAbilityWord(AbilityWord.HELLBENT));
     }
 
-    public RakdosPitDragon(final RakdosPitDragon card) {
+    private RakdosPitDragon(final RakdosPitDragon card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RakingCanopy.java
+++ b/Mage.Sets/src/mage/cards/r/RakingCanopy.java
@@ -43,7 +43,7 @@ class RakingCanopyTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(4));
     }
 
-    public RakingCanopyTriggeredAbility(final RakingCanopyTriggeredAbility ability) {
+    private RakingCanopyTriggeredAbility(final RakingCanopyTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RakishHeir.java
+++ b/Mage.Sets/src/mage/cards/r/RakishHeir.java
@@ -52,7 +52,7 @@ class RakishHeirTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null, false);
     }
 
-    public RakishHeirTriggeredAbility(final RakishHeirTriggeredAbility ability) {
+    private RakishHeirTriggeredAbility(final RakishHeirTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RalZarek.java
+++ b/Mage.Sets/src/mage/cards/r/RalZarek.java
@@ -84,7 +84,7 @@ class RalZarekExtraTurnsEffect extends OneShotEffect {
         this.staticText = "Flip five coins. Take an extra turn after this one for each coin that comes up heads";
     }
 
-    public RalZarekExtraTurnsEffect(final RalZarekExtraTurnsEffect effect) {
+    private RalZarekExtraTurnsEffect(final RalZarekExtraTurnsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RallyTheForces.java
+++ b/Mage.Sets/src/mage/cards/r/RallyTheForces.java
@@ -29,7 +29,7 @@ public final class RallyTheForces extends CardImpl {
         this.getSpellAbility().addEffect(effect);
     }
 
-    public RallyTheForces (final RallyTheForces card) {
+    private RallyTheForces(final RallyTheForces card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RallyTheHorde.java
+++ b/Mage.Sets/src/mage/cards/r/RallyTheHorde.java
@@ -45,7 +45,7 @@ class RallyTheHordeEffect extends OneShotEffect {
         this.staticText = "Exile the top card of your library. Exile the top card of your library. Exile the top card of your library. If the last card exiled isn't a land card, repeat this process. Create a 1/1 red Warrior creature token for each nonland card exiled this way.";
     }
 
-    public RallyTheHordeEffect(final RallyTheHordeEffect effect) {
+    private RallyTheHordeEffect(final RallyTheHordeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RallyTheRighteous.java
+++ b/Mage.Sets/src/mage/cards/r/RallyTheRighteous.java
@@ -50,7 +50,7 @@ class RallyTheRighteousUntapEffect extends OneShotEffect {
         staticText = "<i>Radiance</i> &mdash; Untap target creature and each other creature that shares a color with it";
     }
 
-    public RallyTheRighteousUntapEffect(final RallyTheRighteousUntapEffect effect) {
+    private RallyTheRighteousUntapEffect(final RallyTheRighteousUntapEffect effect) {
         super(effect);
     }
 
@@ -83,7 +83,7 @@ class RallyTheRighteousBoostEffect extends ContinuousEffectImpl {
         staticText = "Those creatures get +2/+0 until end of turn";
     }
 
-    public RallyTheRighteousBoostEffect(final RallyTheRighteousBoostEffect effect) {
+    private RallyTheRighteousBoostEffect(final RallyTheRighteousBoostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RamosDragonEngine.java
+++ b/Mage.Sets/src/mage/cards/r/RamosDragonEngine.java
@@ -69,7 +69,7 @@ class RamosDragonEngineAddCountersEffect extends OneShotEffect {
         staticText = "put a +1/+1 counter on {this} for each of that spell's colors";
     }
 
-    public RamosDragonEngineAddCountersEffect(final RamosDragonEngineAddCountersEffect effect) {
+    private RamosDragonEngineAddCountersEffect(final RamosDragonEngineAddCountersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RampagingHippo.java
+++ b/Mage.Sets/src/mage/cards/r/RampagingHippo.java
@@ -25,7 +25,7 @@ public final class RampagingHippo extends CardImpl {
         addAbility(new CyclingAbility(new ManaCostsImpl<>("{2}")));
     }
 
-    public RampagingHippo(final RampagingHippo rampagingHippo){
+    private RampagingHippo(final RampagingHippo rampagingHippo){
         super(rampagingHippo);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RamunapHydra.java
+++ b/Mage.Sets/src/mage/cards/r/RamunapHydra.java
@@ -84,7 +84,7 @@ class RamunapHydraBoostEffect extends WhileConditionContinuousEffect {
         staticText = "{this} gets +1/+1 as long as there is a Desert card in your graveyard";
     }
 
-    public RamunapHydraBoostEffect(final RamunapHydraBoostEffect effect) {
+    private RamunapHydraBoostEffect(final RamunapHydraBoostEffect effect) {
         super(effect);
         this.power = effect.power;
         this.toughness = effect.toughness;

--- a/Mage.Sets/src/mage/cards/r/RancidEarth.java
+++ b/Mage.Sets/src/mage/cards/r/RancidEarth.java
@@ -52,7 +52,7 @@ class RancidEarthEffect extends OneShotEffect {
         this.staticText = "destroy that land and Rancid Earth deals 1 damage to each creature and each player";
     }
 
-    public RancidEarthEffect(final RancidEarthEffect effect) {
+    private RancidEarthEffect(final RancidEarthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RangeTrooper.java
+++ b/Mage.Sets/src/mage/cards/r/RangeTrooper.java
@@ -64,7 +64,7 @@ class RangeTrooperEffect extends OneShotEffect {
         staticText = "exile target creature. Return that creature to the battlefield at the beginning of the next end step";
     }
 
-    public RangeTrooperEffect(final RangeTrooperEffect effect) {
+    private RangeTrooperEffect(final RangeTrooperEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Ransack.java
+++ b/Mage.Sets/src/mage/cards/r/Ransack.java
@@ -55,7 +55,7 @@ class RansackEffect extends OneShotEffect {
                 + "and the rest on top of the library in any order";
     }
 
-    public RansackEffect(final RansackEffect effect) {
+    private RansackEffect(final RansackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RapaciousOne.java
+++ b/Mage.Sets/src/mage/cards/r/RapaciousOne.java
@@ -51,7 +51,7 @@ class RapaciousOneTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null, false);
     }
 
-    public RapaciousOneTriggeredAbility(final RapaciousOneTriggeredAbility ability) {
+    private RapaciousOneTriggeredAbility(final RapaciousOneTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RapidFire.java
+++ b/Mage.Sets/src/mage/cards/r/RapidFire.java
@@ -57,7 +57,7 @@ class RapidFireEffect extends OneShotEffect {
         this.staticText = "If it doesn't have rampage, that creature gains rampage 2 until end of turn";
     }
 
-    public RapidFireEffect(final RapidFireEffect effect) {
+    private RapidFireEffect(final RapidFireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RapidHybridization.java
+++ b/Mage.Sets/src/mage/cards/r/RapidHybridization.java
@@ -46,7 +46,7 @@ class RapidHybridizationEffect extends OneShotEffect {
         staticText = "That creature's controller creates a 3/3 green Frog Lizard creature token";
     }
 
-    public RapidHybridizationEffect(final RapidHybridizationEffect effect) {
+    private RapidHybridizationEffect(final RapidHybridizationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RashkaTheSlayer.java
+++ b/Mage.Sets/src/mage/cards/r/RashkaTheSlayer.java
@@ -66,7 +66,7 @@ class RashkaTheSlayerTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} blocks a " + filter.getMessage() + ", " );
     }
 
-    public RashkaTheSlayerTriggeredAbility(final RashkaTheSlayerTriggeredAbility ability) {
+    private RashkaTheSlayerTriggeredAbility(final RashkaTheSlayerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RatadrabikOfUrborg.java
+++ b/Mage.Sets/src/mage/cards/r/RatadrabikOfUrborg.java
@@ -82,7 +82,7 @@ class RatadrabikOfUrborgEffect extends OneShotEffect {
                 "except it's not legendary and it's a 2/2 black Zombie in addition to its other colors and types.";
     }
 
-    public RatadrabikOfUrborgEffect(final RatadrabikOfUrborgEffect effect) {
+    private RatadrabikOfUrborgEffect(final RatadrabikOfUrborgEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RatchetBomb.java
+++ b/Mage.Sets/src/mage/cards/r/RatchetBomb.java
@@ -36,7 +36,7 @@ public final class RatchetBomb extends CardImpl {
         this.addAbility(ability);
     }
 
-    public RatchetBomb (final RatchetBomb card) {
+    private RatchetBomb(final RatchetBomb card) {
         super(card);
     }
 
@@ -52,7 +52,7 @@ public final class RatchetBomb extends CardImpl {
             staticText = "Destroy each nonland permanent with mana value equal to the number of charge counters on {this}";
         }
 
-        public RatchetBombEffect(final RatchetBombEffect effect) {
+        private RatchetBombEffect(final RatchetBombEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/r/RavenousRats.java
+++ b/Mage.Sets/src/mage/cards/r/RavenousRats.java
@@ -30,7 +30,7 @@ public final class RavenousRats extends CardImpl {
         this.addAbility(ability);
     }
 
-    public RavenousRats (final RavenousRats card) {
+    private RavenousRats(final RavenousRats card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RavenousSlime.java
+++ b/Mage.Sets/src/mage/cards/r/RavenousSlime.java
@@ -56,7 +56,7 @@ class RavenousSlimeEffect extends ReplacementEffectImpl {
                 + "equal to that creature's power on {this}";
     }
 
-    public RavenousSlimeEffect(final RavenousSlimeEffect effect) {
+    private RavenousSlimeEffect(final RavenousSlimeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RavenousWampa.java
+++ b/Mage.Sets/src/mage/cards/r/RavenousWampa.java
@@ -62,7 +62,7 @@ class RavenousWampaEffect extends OneShotEffect {
         this.staticText = "you gain life equal to the sacrificied creature's toughness";
     }
 
-    public RavenousWampaEffect(final RavenousWampaEffect effect) {
+    private RavenousWampaEffect(final RavenousWampaEffect effect) {
         super(effect);
     }
 
@@ -92,7 +92,7 @@ class RavenousWampaSacrificeTargetCost extends SacrificeTargetCost {
         super(target);
     }
 
-    public RavenousWampaSacrificeTargetCost(RavenousWampaSacrificeTargetCost cost) {
+    private RavenousWampaSacrificeTargetCost(final RavenousWampaSacrificeTargetCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RavingDead.java
+++ b/Mage.Sets/src/mage/cards/r/RavingDead.java
@@ -56,7 +56,7 @@ class RavingDeadDamageEffect extends OneShotEffect {
         this.staticText = "that player loses half their life, rounded down";
     }
 
-    public RavingDeadDamageEffect(final RavingDeadDamageEffect effect) {
+    private RavingDeadDamageEffect(final RavingDeadDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RavingOniSlave.java
+++ b/Mage.Sets/src/mage/cards/r/RavingOniSlave.java
@@ -50,7 +50,7 @@ class RavingOniSlaveEffect extends OneShotEffect {
         this.staticText = "you lose 3 life if you don't control a Demon";
     }
 
-    public RavingOniSlaveEffect(final RavingOniSlaveEffect effect) {
+    private RavingOniSlaveEffect(final RavingOniSlaveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RazakethsRite.java
+++ b/Mage.Sets/src/mage/cards/r/RazakethsRite.java
@@ -24,7 +24,7 @@ public final class RazakethsRite extends CardImpl {
         addAbility(new CyclingAbility(new ManaCostsImpl<>("{B}")));
     }
 
-    public RazakethsRite(final RazakethsRite razakethsRite){
+    private RazakethsRite(final RazakethsRite razakethsRite){
         super(razakethsRite);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RaziaBorosArchangel.java
+++ b/Mage.Sets/src/mage/cards/r/RaziaBorosArchangel.java
@@ -85,7 +85,7 @@ class RaziaBorosArchangelEffect extends RedirectionEffect {
         staticText = "The next " + amount + " damage that would be dealt to target creature you control this turn is dealt to another target creature instead";
     }
 
-    public RaziaBorosArchangelEffect(final RaziaBorosArchangelEffect effect) {
+    private RaziaBorosArchangelEffect(final RaziaBorosArchangelEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RaziasPurification.java
+++ b/Mage.Sets/src/mage/cards/r/RaziasPurification.java
@@ -48,7 +48,7 @@ class RaziasPurificationEffect extends OneShotEffect {
         staticText = "Each player chooses three permanents they control, then sacrifices the rest";
     }
 
-    public RaziasPurificationEffect(RaziasPurificationEffect effect) {
+    private RaziasPurificationEffect(final RaziasPurificationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RazorfieldThresher.java
+++ b/Mage.Sets/src/mage/cards/r/RazorfieldThresher.java
@@ -22,7 +22,7 @@ public final class RazorfieldThresher extends CardImpl {
         this.toughness = new MageInt(4);
     }
 
-    public RazorfieldThresher (final RazorfieldThresher card) {
+    private RazorfieldThresher(final RazorfieldThresher card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReachThroughMists.java
+++ b/Mage.Sets/src/mage/cards/r/ReachThroughMists.java
@@ -23,7 +23,7 @@ public final class ReachThroughMists extends CardImpl {
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1));
     }
 
-    public ReachThroughMists (final ReachThroughMists card) {
+    private ReachThroughMists(final ReachThroughMists card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RealityAcid.java
+++ b/Mage.Sets/src/mage/cards/r/RealityAcid.java
@@ -70,7 +70,7 @@ class RealityAcidTriggeredAbility extends ZoneChangeTriggeredAbility {
         super(Zone.BATTLEFIELD, null, effect, "When {this} leaves the battlefield, ", optional);
     }
 
-    public RealityAcidTriggeredAbility(RealityAcidTriggeredAbility ability) {
+    private RealityAcidTriggeredAbility(final RealityAcidTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RealityScramble.java
+++ b/Mage.Sets/src/mage/cards/r/RealityScramble.java
@@ -69,7 +69,7 @@ class RealityScrambleEffect extends OneShotEffect {
                 + "on the bottom of your library in a random order.";
     }
 
-    public RealityScrambleEffect(final RealityScrambleEffect effect) {
+    private RealityScrambleEffect(final RealityScrambleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RealityShift.java
+++ b/Mage.Sets/src/mage/cards/r/RealityShift.java
@@ -49,7 +49,7 @@ class RealityShiftEffect extends OneShotEffect {
         this.staticText = "Its controller manifests the top card of their library. <i>(That player puts the top card of their library onto the battlefield face down as a 2/2 creature. If it's a creature card, it can be turned face up any time for its mana cost.)</i>";
     }
 
-    public RealityShiftEffect(final RealityShiftEffect effect) {
+    private RealityShiftEffect(final RealityShiftEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RealitySmasher.java
+++ b/Mage.Sets/src/mage/cards/r/RealitySmasher.java
@@ -56,7 +56,7 @@ class RealitySmasherTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CounterUnlessPaysEffect(new DiscardCardCost()), false);
     }
 
-    public RealitySmasherTriggeredAbility(final RealitySmasherTriggeredAbility ability) {
+    private RealitySmasherTriggeredAbility(final RealitySmasherTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RealmRazer.java
+++ b/Mage.Sets/src/mage/cards/r/RealmRazer.java
@@ -56,7 +56,7 @@ class ExileAllEffect extends OneShotEffect {
         staticText = "exile all lands";
     }
 
-    public ExileAllEffect(final ExileAllEffect effect) {
+    private ExileAllEffect(final ExileAllEffect effect) {
         super(effect);
     }
 
@@ -83,7 +83,7 @@ class RealmRazerEffect extends OneShotEffect {
         this.staticText = "return the exiled cards to the battlefield tapped under their owners' control";
     }
 
-    public RealmRazerEffect(final RealmRazerEffect effect) {
+    private RealmRazerEffect(final RealmRazerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RealmsUncharted.java
+++ b/Mage.Sets/src/mage/cards/r/RealmsUncharted.java
@@ -54,7 +54,7 @@ class RealmsUnchartedEffect extends OneShotEffect {
                 "and the rest into your hand. Then shuffle";
     }
 
-    public RealmsUnchartedEffect(final RealmsUnchartedEffect effect) {
+    private RealmsUnchartedEffect(final RealmsUnchartedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Realmwright.java
+++ b/Mage.Sets/src/mage/cards/r/Realmwright.java
@@ -53,7 +53,7 @@ class RealmwrightEffect extends ContinuousEffectImpl {
         staticText = "Lands you control are the chosen type in addition to their other types";
     }
 
-    public RealmwrightEffect(final RealmwrightEffect effect) {
+    private RealmwrightEffect(final RealmwrightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReapIntellect.java
+++ b/Mage.Sets/src/mage/cards/r/ReapIntellect.java
@@ -66,7 +66,7 @@ class ReapIntellectEffect extends OneShotEffect {
                 + "exile them. Then that player shuffles";
     }
 
-    public ReapIntellectEffect(final ReapIntellectEffect effect) {
+    private ReapIntellectEffect(final ReapIntellectEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Rebound.java
+++ b/Mage.Sets/src/mage/cards/r/Rebound.java
@@ -49,7 +49,7 @@ class ReboundEffect extends OneShotEffect {
         this.staticText = "Change the target of target spell that targets only a player. The new target must be a player";
     }
 
-    public ReboundEffect(final ReboundEffect effect) {
+    private ReboundEffect(final ReboundEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Recall.java
+++ b/Mage.Sets/src/mage/cards/r/Recall.java
@@ -49,7 +49,7 @@ class RecallEffect extends OneShotEffect {
         this.staticText = "Discard X cards, then return a card from your graveyard to your hand for each card discarded this way";
     }
 
-    public RecallEffect(final RecallEffect effect) {
+    private RecallEffect(final RecallEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Reciprocate.java
+++ b/Mage.Sets/src/mage/cards/r/Reciprocate.java
@@ -47,7 +47,7 @@ class ReciprocateTarget extends TargetPermanent {
         targetName = "creature that dealt damage to you this turn";
     }
 
-    public ReciprocateTarget(final ReciprocateTarget target) {
+    private ReciprocateTarget(final ReciprocateTarget target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Recoil.java
+++ b/Mage.Sets/src/mage/cards/r/Recoil.java
@@ -46,7 +46,7 @@ class RecoilEffect extends OneShotEffect {
         this.staticText = "return target permanent to its owner's hand. Then that player discards a card";
     }
 
-    public RecoilEffect(final RecoilEffect effect) {
+    private RecoilEffect(final RecoilEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Reconnaissance.java
+++ b/Mage.Sets/src/mage/cards/r/Reconnaissance.java
@@ -56,7 +56,7 @@ class ReconnaissanceRemoveFromCombatEffect extends OneShotEffect {
         this.staticText = "Remove target attacking creature you control from combat and untap it";
     }
 
-    public ReconnaissanceRemoveFromCombatEffect(final ReconnaissanceRemoveFromCombatEffect effect) {
+    private ReconnaissanceRemoveFromCombatEffect(final ReconnaissanceRemoveFromCombatEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Recoup.java
+++ b/Mage.Sets/src/mage/cards/r/Recoup.java
@@ -54,7 +54,7 @@ class RecoupEffect extends ContinuousEffectImpl {
         this.staticText = "Target sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost";
     }
 
-    public RecoupEffect(final RecoupEffect effect) {
+    private RecoupEffect(final RecoupEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RecumbentBliss.java
+++ b/Mage.Sets/src/mage/cards/r/RecumbentBliss.java
@@ -52,7 +52,7 @@ class RecumbentBlissEffect extends RestrictionEffect {
         staticText = "Enchanted creature can't attack or block";
     }
 
-    public RecumbentBlissEffect(final RecumbentBlissEffect effect) {
+    private RecumbentBlissEffect(final RecumbentBlissEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RecurringInsight.java
+++ b/Mage.Sets/src/mage/cards/r/RecurringInsight.java
@@ -47,7 +47,7 @@ class RecurringInsightEffect extends OneShotEffect {
         staticText = "Draw cards equal to the number of cards in target opponent's hand";
     }
 
-    public RecurringInsightEffect(final RecurringInsightEffect effect) {
+    private RecurringInsightEffect(final RecurringInsightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReflectorMage.java
+++ b/Mage.Sets/src/mage/cards/r/ReflectorMage.java
@@ -62,7 +62,7 @@ class ReflectorMageEffect extends OneShotEffect {
         this.staticText = "return target creature an opponent controls to its owner's hand. That creature's owner can't cast spells with the same name as that creature until your next turn";
     }
 
-    public ReflectorMageEffect(final ReflectorMageEffect effect) {
+    private ReflectorMageEffect(final ReflectorMageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RefractionTrap.java
+++ b/Mage.Sets/src/mage/cards/r/RefractionTrap.java
@@ -93,7 +93,7 @@ class RefractionTrapPreventDamageEffect extends PreventionEffectImpl {
         staticText = "The next " + amount + " damage that a source of your choice would deal to you and/or permanents you control this turn. If damage is prevented this way, {this} deals that much damage to any target";
     }
 
-    public RefractionTrapPreventDamageEffect(final RefractionTrapPreventDamageEffect effect) {
+    private RefractionTrapPreventDamageEffect(final RefractionTrapPreventDamageEffect effect) {
         super(effect);
         this.amount = effect.amount;
         this.target = effect.target.copy();

--- a/Mage.Sets/src/mage/cards/r/RefuseCooperate.java
+++ b/Mage.Sets/src/mage/cards/r/RefuseCooperate.java
@@ -55,7 +55,7 @@ class RefuseEffect extends OneShotEffect {
         staticText = "Refuse deals damage to target spell's controller equal to that spell's mana value";
     }
 
-    public RefuseEffect(final RefuseEffect effect) {
+    private RefuseEffect(final RefuseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Regress.java
+++ b/Mage.Sets/src/mage/cards/r/Regress.java
@@ -22,7 +22,7 @@ public final class Regress extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPermanent());
     }
 
-    public Regress (final Regress card) {
+    private Regress(final Regress card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Reincarnation.java
+++ b/Mage.Sets/src/mage/cards/r/Reincarnation.java
@@ -55,7 +55,7 @@ class ReincarnationEffect extends OneShotEffect {
         staticText = "return a creature card from its owner's graveyard to the battlefield under the control of that creature's owner";
     }
 
-    public ReincarnationEffect(final ReincarnationEffect effect) {
+    private ReincarnationEffect(final ReincarnationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReinsOfTheVinesteed.java
+++ b/Mage.Sets/src/mage/cards/r/ReinsOfTheVinesteed.java
@@ -63,7 +63,7 @@ class ReinsOfTheVinesteedEffect extends OneShotEffect {
         staticText = "you may return {this} from your graveyard to the battlefield attached to a creature that shares a creature type with that creature";
     }
 
-    public ReinsOfTheVinesteedEffect(final ReinsOfTheVinesteedEffect effect) {
+    private ReinsOfTheVinesteedEffect(final ReinsOfTheVinesteedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Rejuvenate.java
+++ b/Mage.Sets/src/mage/cards/r/Rejuvenate.java
@@ -23,7 +23,7 @@ public final class Rejuvenate extends CardImpl {
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{2}")));
     }
 
-    public Rejuvenate (final Rejuvenate card) {
+    private Rejuvenate(final Rejuvenate card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReleaseToTheWind.java
+++ b/Mage.Sets/src/mage/cards/r/ReleaseToTheWind.java
@@ -46,7 +46,7 @@ class ReleaseToTheWindEffect extends OneShotEffect {
         this.staticText = "Exile target nonland permanent. For as long as that card remains exiled, its owner may cast it without paying its mana cost";
     }
 
-    public ReleaseToTheWindEffect(final ReleaseToTheWindEffect effect) {
+    private ReleaseToTheWindEffect(final ReleaseToTheWindEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RelentlessDead.java
+++ b/Mage.Sets/src/mage/cards/r/RelentlessDead.java
@@ -60,7 +60,7 @@ class RelentlessDeadEffect extends OneShotEffect {
         this.staticText = "you may pay {X}. If you do, return another target Zombie creature card with mana value X from your graveyard to the battlefield";
     }
 
-    public RelentlessDeadEffect(final RelentlessDeadEffect effect) {
+    private RelentlessDeadEffect(final RelentlessDeadEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RelentlessRats.java
+++ b/Mage.Sets/src/mage/cards/r/RelentlessRats.java
@@ -58,7 +58,7 @@ public final class RelentlessRats extends CardImpl {
             staticText = "{this} gets +1/+1 for each other creature on the battlefield named Relentless Rats";
         }
 
-        public RelentlessRatsEffect(final RelentlessRatsEffect effect) {
+        private RelentlessRatsEffect(final RelentlessRatsEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/r/RelicOfProgenitus.java
+++ b/Mage.Sets/src/mage/cards/r/RelicOfProgenitus.java
@@ -60,7 +60,7 @@ class RelicOfProgenitusEffect extends OneShotEffect {
         this.staticText = "Target player exiles a card from their graveyard";
     }
 
-    public RelicOfProgenitusEffect(final RelicOfProgenitusEffect effect) {
+    private RelicOfProgenitusEffect(final RelicOfProgenitusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RelicPutrescence.java
+++ b/Mage.Sets/src/mage/cards/r/RelicPutrescence.java
@@ -38,7 +38,7 @@ public final class RelicPutrescence extends CardImpl {
         ), "enchanted artifact"));
     }
 
-    public RelicPutrescence(final RelicPutrescence card) {
+    private RelicPutrescence(final RelicPutrescence card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RemorselessPunishment.java
+++ b/Mage.Sets/src/mage/cards/r/RemorselessPunishment.java
@@ -52,7 +52,7 @@ class RemorselessPunishmentEffect extends OneShotEffect {
         this.staticText = "Target opponent loses 5 life unless that player discards two cards or sacrifices a creature or planeswalker. Repeat this process once";
     }
 
-    public RemorselessPunishmentEffect(final RemorselessPunishmentEffect effect) {
+    private RemorselessPunishmentEffect(final RemorselessPunishmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RenderSilent.java
+++ b/Mage.Sets/src/mage/cards/r/RenderSilent.java
@@ -49,7 +49,7 @@ class RenderSilentCounterEffect extends OneShotEffect {
         super(Outcome.Detriment);
     }
 
-    public RenderSilentCounterEffect(final RenderSilentCounterEffect effect) {
+    private RenderSilentCounterEffect(final RenderSilentCounterEffect effect) {
         super(effect);
     }
 
@@ -82,7 +82,7 @@ class RenderSilentEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Its controller can't cast spells this turn";
     }
 
-    public RenderSilentEffect(final RenderSilentEffect effect) {
+    private RenderSilentEffect(final RenderSilentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RendingVines.java
+++ b/Mage.Sets/src/mage/cards/r/RendingVines.java
@@ -52,7 +52,7 @@ class RendingVinesEffect extends OneShotEffect {
         this.staticText = "Destroy target artifact or enchantment if its mana value is less than or equal to the number of cards in your hand";
     }
 
-    public RendingVinesEffect(final RendingVinesEffect effect) {
+    private RendingVinesEffect(final RendingVinesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RenegadeDoppelganger.java
+++ b/Mage.Sets/src/mage/cards/r/RenegadeDoppelganger.java
@@ -93,7 +93,7 @@ class RenegadeDoppelgangerEffect extends OneShotEffect {
         this.staticText = "have {this} become a copy of that creature until end of turn";
     }
 
-    public RenegadeDoppelgangerEffect(final RenegadeDoppelgangerEffect effect) {
+    private RenegadeDoppelgangerEffect(final RenegadeDoppelgangerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RenegadeKrasis.java
+++ b/Mage.Sets/src/mage/cards/r/RenegadeKrasis.java
@@ -50,7 +50,7 @@ class RenegadeKrasisTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersAllEffect(CounterType.P1P1.createInstance(1), StaticFilters.FILTER_OTHER_CONTROLLED_CREATURE_P1P1), false);
     }
 
-    public RenegadeKrasisTriggeredAbility(final RenegadeKrasisTriggeredAbility ability) {
+    private RenegadeKrasisTriggeredAbility(final RenegadeKrasisTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Renounce.java
+++ b/Mage.Sets/src/mage/cards/r/Renounce.java
@@ -44,7 +44,7 @@ class RenounceEffect extends OneShotEffect {
         staticText  = "Sacrifice any number of permanents. You gain 2 life for each permanent sacrificed this way";
     }
 
-    public RenounceEffect(final RenounceEffect effect) {
+    private RenounceEffect(final RenounceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RenownedWeaponsmith.java
+++ b/Mage.Sets/src/mage/cards/r/RenownedWeaponsmith.java
@@ -103,7 +103,7 @@ class RenownedWeaponsmithEffect extends OneShotEffect {
         staticText = "Search your library for a card named Heart-Piercer Bow or Vial of Dragonfire, reveal it, put it into your hand, then shuffle";
     }
 
-    public RenownedWeaponsmithEffect(final RenownedWeaponsmithEffect effect) {
+    private RenownedWeaponsmithEffect(final RenownedWeaponsmithEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Reparations.java
+++ b/Mage.Sets/src/mage/cards/r/Reparations.java
@@ -44,7 +44,7 @@ class ReparationsTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), true);
     }
 
-    public ReparationsTriggeredAbility(final ReparationsTriggeredAbility ability) {
+    private ReparationsTriggeredAbility(final ReparationsTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RepayInKind.java
+++ b/Mage.Sets/src/mage/cards/r/RepayInKind.java
@@ -41,7 +41,7 @@ class RepayInKindEffect extends OneShotEffect {
         staticText = "Each player's life total becomes the lowest life total among all players";
     }
 
-    public RepayInKindEffect(final RepayInKindEffect effect) {
+    private RepayInKindEffect(final RepayInKindEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Repentance.java
+++ b/Mage.Sets/src/mage/cards/r/Repentance.java
@@ -44,7 +44,7 @@ class RepentanceEffect extends OneShotEffect {
         this.staticText = "Target creature deals damage to itself equal to its power";
     }
 
-    public RepentanceEffect(final RepentanceEffect effect) {
+    private RepentanceEffect(final RepentanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Reprocess.java
+++ b/Mage.Sets/src/mage/cards/r/Reprocess.java
@@ -53,7 +53,7 @@ class ReprocessEffect extends OneShotEffect {
         staticText  = "Sacrifice any number of artifacts, creatures, and/or lands. Draw a card for each permanent sacrificed this way.";
     }
 
-    public ReprocessEffect(final ReprocessEffect effect) {
+    private ReprocessEffect(final ReprocessEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RescueFromTheUnderworld.java
+++ b/Mage.Sets/src/mage/cards/r/RescueFromTheUnderworld.java
@@ -84,7 +84,7 @@ class RescueFromTheUnderworldTextEffect extends OneShotEffect {
         this.staticText = "Choose target creature card in your graveyard";
     }
 
-    public RescueFromTheUnderworldTextEffect(final RescueFromTheUnderworldTextEffect effect) {
+    private RescueFromTheUnderworldTextEffect(final RescueFromTheUnderworldTextEffect effect) {
         super(effect);
     }
 
@@ -109,7 +109,7 @@ class RescueFromTheUnderworldCreateDelayedTriggeredAbilityEffect extends OneShot
         this.staticText = "Return that card and the sacrificed card to the battlefield under your control at the beginning of your next upkeep";
     }
 
-    public RescueFromTheUnderworldCreateDelayedTriggeredAbilityEffect(final RescueFromTheUnderworldCreateDelayedTriggeredAbilityEffect effect) {
+    private RescueFromTheUnderworldCreateDelayedTriggeredAbilityEffect(final RescueFromTheUnderworldCreateDelayedTriggeredAbilityEffect effect) {
         super(effect);
         this.ability = effect.ability.copy();
     }
@@ -153,7 +153,7 @@ class RescueFromTheUnderworldDelayedTriggeredAbility extends DelayedTriggeredAbi
         super(effect);
     }
 
-    public RescueFromTheUnderworldDelayedTriggeredAbility(RescueFromTheUnderworldDelayedTriggeredAbility ability) {
+    private RescueFromTheUnderworldDelayedTriggeredAbility(final RescueFromTheUnderworldDelayedTriggeredAbility ability) {
         super(ability);
     }
 
@@ -184,7 +184,7 @@ class RescueFromTheUnderworldReturnEffect extends OneShotEffect {
         super(Outcome.PutCreatureInPlay);
     }
 
-    public RescueFromTheUnderworldReturnEffect(final RescueFromTheUnderworldReturnEffect effect) {
+    private RescueFromTheUnderworldReturnEffect(final RescueFromTheUnderworldReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ResearchDevelopment.java
+++ b/Mage.Sets/src/mage/cards/r/ResearchDevelopment.java
@@ -50,7 +50,7 @@ class ResearchEffect extends OneShotEffect {
         this.staticText = "Shuffle up to four cards you own from outside the game into your library";
     }
 
-    public ResearchEffect(final ResearchEffect effect) {
+    private ResearchEffect(final ResearchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ResoluteArchangel.java
+++ b/Mage.Sets/src/mage/cards/r/ResoluteArchangel.java
@@ -54,7 +54,7 @@ class ResoluteArchangelEffect extends OneShotEffect {
         this.staticText = "if your life total is lower than your starting life total, it becomes equal to your starting life total";
     }
 
-    public ResoluteArchangelEffect(final ResoluteArchangelEffect effect) {
+    private ResoluteArchangelEffect(final ResoluteArchangelEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RestInPeace.java
+++ b/Mage.Sets/src/mage/cards/r/RestInPeace.java
@@ -69,7 +69,7 @@ class RestInPeaceReplacementEffect extends ReplacementEffectImpl {
         staticText = "If a card or token would be put into a graveyard from anywhere, exile it instead";
     }
 
-    public RestInPeaceReplacementEffect(final RestInPeaceReplacementEffect effect) {
+    private RestInPeaceReplacementEffect(final RestInPeaceReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Restore.java
+++ b/Mage.Sets/src/mage/cards/r/Restore.java
@@ -50,7 +50,7 @@ class RestoreEffect extends OneShotEffect {
         this.staticText = "Put target land card from a graveyard onto the battlefield under your control";
     }
 
-    public RestoreEffect(final RestoreEffect effect) {
+    private RestoreEffect(final RestoreEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RetaliatorGriffin.java
+++ b/Mage.Sets/src/mage/cards/r/RetaliatorGriffin.java
@@ -54,7 +54,7 @@ class RetaliatorGriffinTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new RetaliatorGriffinEffect(), true);
     }
 
-    public RetaliatorGriffinTriggeredAbility(final RetaliatorGriffinTriggeredAbility ability) {
+    private RetaliatorGriffinTriggeredAbility(final RetaliatorGriffinTriggeredAbility ability) {
         super(ability);
     }
 
@@ -93,7 +93,7 @@ class RetaliatorGriffinEffect extends OneShotEffect {
         super(Outcome.BoostCreature);
     }
 
-    public RetaliatorGriffinEffect(final RetaliatorGriffinEffect effect) {
+    private RetaliatorGriffinEffect(final RetaliatorGriffinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Retether.java
+++ b/Mage.Sets/src/mage/cards/r/Retether.java
@@ -59,7 +59,7 @@ class RetetherEffect extends OneShotEffect {
         this.staticText = "Return each Aura card from your graveyard to the battlefield. Only creatures can be enchanted this way";
     }
 
-    public RetetherEffect(final RetetherEffect effect) {
+    private RetetherEffect(final RetetherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RetracedImage.java
+++ b/Mage.Sets/src/mage/cards/r/RetracedImage.java
@@ -47,7 +47,7 @@ class RetracedImageEffect extends OneShotEffect {
         this.staticText = "Reveal a card in your hand, then put that card onto the battlefield if it has the same name as a permanent";
     }
 
-    public RetracedImageEffect(final RetracedImageEffect effect) {
+    private RetracedImageEffect(final RetracedImageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Retribution.java
+++ b/Mage.Sets/src/mage/cards/r/Retribution.java
@@ -49,7 +49,7 @@ class RetributionEffect extends OneShotEffect {
         this.staticText = "Choose two target creatures an opponent controls. That player chooses and sacrifices one of those creatures. Put a -1/-1 counter on the other";
     }
 
-    public RetributionEffect(final RetributionEffect effect) {
+    private RetributionEffect(final RetributionEffect effect) {
         super(effect);
     }
 
@@ -92,7 +92,7 @@ class TargetCreaturePermanentOpponentSameController extends TargetCreaturePerman
         super(minNumTargets, maxNumTargets, filter, notTarget);
     }
 
-    public TargetCreaturePermanentOpponentSameController(final TargetCreaturePermanentOpponentSameController target) {
+    private TargetCreaturePermanentOpponentSameController(final TargetCreaturePermanentOpponentSameController target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Retromancer.java
+++ b/Mage.Sets/src/mage/cards/r/Retromancer.java
@@ -50,7 +50,7 @@ class RetromancerTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect);
     }
 
-    public RetromancerTriggeredAbility(final RetromancerTriggeredAbility ability) {
+    private RetromancerTriggeredAbility(final RetromancerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReturnOfTheNightstalkers.java
+++ b/Mage.Sets/src/mage/cards/r/ReturnOfTheNightstalkers.java
@@ -54,7 +54,7 @@ class ReturnOfTheNightstalkersEffect extends OneShotEffect {
         staticText = "Return all Nightstalker permanent cards from your graveyard to the battlefield. Then destroy all Swamps you control";
     }
 
-    public ReturnOfTheNightstalkersEffect(final ReturnOfTheNightstalkersEffect effect) {
+    private ReturnOfTheNightstalkersEffect(final ReturnOfTheNightstalkersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RevealingWind.java
+++ b/Mage.Sets/src/mage/cards/r/RevealingWind.java
@@ -59,7 +59,7 @@ class RevealingWindEffect extends OneShotEffect {
         this.staticText = "You may look at each face-down creature that's attacking or blocking";
     }
 
-    public RevealingWindEffect(final RevealingWindEffect effect) {
+    private RevealingWindEffect(final RevealingWindEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReveilleSquad.java
+++ b/Mage.Sets/src/mage/cards/r/ReveilleSquad.java
@@ -48,7 +48,7 @@ class ReveilleSquadTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new UntapAllControllerEffect(new FilterCreaturePermanent("all creatures you control")), true);
     }
 
-    public ReveilleSquadTriggeredAbility(final ReveilleSquadTriggeredAbility ability) {
+    private ReveilleSquadTriggeredAbility(final ReveilleSquadTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RevengeStarWars.java
+++ b/Mage.Sets/src/mage/cards/r/RevengeStarWars.java
@@ -76,7 +76,7 @@ class RevengeEffect extends OneShotEffect {
         super(Outcome.BoostCreature);
     }
 
-    public RevengeEffect(final RevengeEffect effect) {
+    private RevengeEffect(final RevengeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Reverberation.java
+++ b/Mage.Sets/src/mage/cards/r/Reverberation.java
@@ -53,7 +53,7 @@ class ReverberationEffect extends ReplacementEffectImpl {
         staticText = "All damage that would be dealt this turn by target sorcery spell is dealt to that spell's controller instead";
     }
 
-    public ReverberationEffect(final ReverberationEffect effect) {
+    private ReverberationEffect(final ReverberationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReversalOfFortune.java
+++ b/Mage.Sets/src/mage/cards/r/ReversalOfFortune.java
@@ -52,7 +52,7 @@ class ReversalOfFortuneEffect extends OneShotEffect {
                 + "copy without paying its mana cost";
     }
 
-    public ReversalOfFortuneEffect(final ReversalOfFortuneEffect effect) {
+    private ReversalOfFortuneEffect(final ReversalOfFortuneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReverseDamage.java
+++ b/Mage.Sets/src/mage/cards/r/ReverseDamage.java
@@ -49,7 +49,7 @@ class ReverseDamageEffect extends PreventionEffectImpl {
         this.target = new TargetSource();
     }
 
-    public ReverseDamageEffect(final ReverseDamageEffect effect) {
+    private ReverseDamageEffect(final ReverseDamageEffect effect) {
         super(effect);
         this.target = effect.target.copy();
     }

--- a/Mage.Sets/src/mage/cards/r/ReverseTheSands.java
+++ b/Mage.Sets/src/mage/cards/r/ReverseTheSands.java
@@ -46,7 +46,7 @@ class ReverseTheSandsEffect extends OneShotEffect {
         this.staticText = "Redistribute any number of players' life totals";
     }
 
-    public ReverseTheSandsEffect(final ReverseTheSandsEffect effect) {
+    private ReverseTheSandsEffect(final ReverseTheSandsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RevivingVapors.java
+++ b/Mage.Sets/src/mage/cards/r/RevivingVapors.java
@@ -43,7 +43,7 @@ class RevivingVaporsEffect extends OneShotEffect {
         staticText = "Reveal the top three cards of your library and put one of them into your hand. You gain life equal to that card's mana value. Put all other cards revealed this way into your graveyard";
     }
 
-    public RevivingVaporsEffect(final RevivingVaporsEffect effect) {
+    private RevivingVaporsEffect(final RevivingVaporsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RevokePrivileges.java
+++ b/Mage.Sets/src/mage/cards/r/RevokePrivileges.java
@@ -68,7 +68,7 @@ class RevokePrivilegeCantCrewEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = ", or crew Vehicles";
     }
 
-    public RevokePrivilegeCantCrewEffect(final RevokePrivilegeCantCrewEffect effect) {
+    private RevokePrivilegeCantCrewEffect(final RevokePrivilegeCantCrewEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Reweave.java
+++ b/Mage.Sets/src/mage/cards/r/Reweave.java
@@ -56,7 +56,7 @@ class ReweaveEffect extends OneShotEffect {
         this.staticText = "Target permanent's controller sacrifices it. If the player does, they reveal cards from the top of their library until they reveal a permanent card that shares a card type with the sacrificed permanent, put that card onto the battlefield, then shuffle";
     }
 
-    public ReweaveEffect(final ReweaveEffect effect) {
+    private ReweaveEffect(final ReweaveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Rey.java
+++ b/Mage.Sets/src/mage/cards/r/Rey.java
@@ -63,7 +63,7 @@ class ReyEffect extends OneShotEffect {
         staticText = "reveal the top card of target player's library. You gain life equal to that card's mana value";
     }
 
-    public ReyEffect(final ReyEffect effect) {
+    private ReyEffect(final ReyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReySkywalker.java
+++ b/Mage.Sets/src/mage/cards/r/ReySkywalker.java
@@ -46,7 +46,7 @@ public class ReySkywalker extends CardImpl {
         this.addAbility(loyaltyAbility0);
     }
 
-    public ReySkywalker(final ReySkywalker card) {
+    private ReySkywalker(final ReySkywalker card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReyhanLastOfTheAbzan.java
+++ b/Mage.Sets/src/mage/cards/r/ReyhanLastOfTheAbzan.java
@@ -65,7 +65,7 @@ class ReyhanLastOfTheAbzanTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null, true);
     }
 
-    public ReyhanLastOfTheAbzanTriggeredAbility(final ReyhanLastOfTheAbzanTriggeredAbility ability) {
+    private ReyhanLastOfTheAbzanTriggeredAbility(final ReyhanLastOfTheAbzanTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReysLightsaber.java
+++ b/Mage.Sets/src/mage/cards/r/ReysLightsaber.java
@@ -45,7 +45,7 @@ public class ReysLightsaber extends CardImpl {
         this.addAbility(new EquipAbility(2, false));
     }
 
-    public ReysLightsaber(final ReysLightsaber card) {
+    private ReysLightsaber(final ReysLightsaber card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RhonasTheIndomitable.java
+++ b/Mage.Sets/src/mage/cards/r/RhonasTheIndomitable.java
@@ -76,7 +76,7 @@ class RhonasTheIndomitableRestrictionEffect extends RestrictionEffect {
         staticText = "{this} can't attack or block unless you control another creature with power 4 or greater";
     }
 
-    public RhonasTheIndomitableRestrictionEffect(final RhonasTheIndomitableRestrictionEffect effect) {
+    private RhonasTheIndomitableRestrictionEffect(final RhonasTheIndomitableRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RhoxBrute.java
+++ b/Mage.Sets/src/mage/cards/r/RhoxBrute.java
@@ -25,7 +25,7 @@ public final class RhoxBrute extends CardImpl {
         this.toughness = new MageInt(4);
     }
 
-    public RhoxBrute (final RhoxBrute card) {
+    private RhoxBrute(final RhoxBrute card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RhoxCharger.java
+++ b/Mage.Sets/src/mage/cards/r/RhoxCharger.java
@@ -28,7 +28,7 @@ public final class RhoxCharger extends CardImpl {
         this.addAbility(new ExaltedAbility());
     }
 
-    public RhoxCharger (final RhoxCharger card) {
+    private RhoxCharger(final RhoxCharger card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RhoxFaithmender.java
+++ b/Mage.Sets/src/mage/cards/r/RhoxFaithmender.java
@@ -57,7 +57,7 @@ class RhoxFaithmenderEffect extends ReplacementEffectImpl {
         staticText = "If you would gain life, you gain twice that much life instead";
     }
 
-    public RhoxFaithmenderEffect(final RhoxFaithmenderEffect effect) {
+    private RhoxFaithmenderEffect(final RhoxFaithmenderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RhysTheRedeemed.java
+++ b/Mage.Sets/src/mage/cards/r/RhysTheRedeemed.java
@@ -76,7 +76,7 @@ class RhysTheRedeemedEffect extends OneShotEffect {
         this.staticText = "For each creature token you control, create a token that's a copy of that creature";
     }
 
-    public RhysTheRedeemedEffect(final RhysTheRedeemedEffect effect) {
+    private RhysTheRedeemedEffect(final RhysTheRedeemedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RhysticCave.java
+++ b/Mage.Sets/src/mage/cards/r/RhysticCave.java
@@ -56,7 +56,7 @@ class RhysticCaveManaAbility extends ActivatedManaAbilityImpl {
 
     }
 
-    public RhysticCaveManaAbility(final RhysticCaveManaAbility ability) {
+    private RhysticCaveManaAbility(final RhysticCaveManaAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RhysticScrying.java
+++ b/Mage.Sets/src/mage/cards/r/RhysticScrying.java
@@ -45,7 +45,7 @@ class RhysticScryingEffect extends OneShotEffect {
         this.staticText = "Then if any player pays {2}, discard three cards";
     }
 
-    public RhysticScryingEffect(final RhysticScryingEffect effect) {
+    private RhysticScryingEffect(final RhysticScryingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RhysticStudy.java
+++ b/Mage.Sets/src/mage/cards/r/RhysticStudy.java
@@ -47,7 +47,7 @@ class RhysticStudyDrawEffect extends OneShotEffect {
         this.staticText = "you may draw a card unless that player pays {1}";
     }
 
-    public RhysticStudyDrawEffect(final RhysticStudyDrawEffect effect) {
+    private RhysticStudyDrawEffect(final RhysticStudyDrawEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiaIvorBaneOfBladehold.java
+++ b/Mage.Sets/src/mage/cards/r/RiaIvorBaneOfBladehold.java
@@ -58,7 +58,7 @@ class RiaIvorBaneOfBladeholdEffect extends PreventionEffectImpl {
         this.staticText = "the next time target creature would deal combat damage to one or more players this combat, prevent that damage. If damage is prevented this way, create that many 1/1 colorless Phyrexian Mite artifact creature tokens with toxic 1 and \"This creature can't block.\"";
     }
 
-    public RiaIvorBaneOfBladeholdEffect(final RiaIvorBaneOfBladeholdEffect effect) {
+    private RiaIvorBaneOfBladeholdEffect(final RiaIvorBaneOfBladeholdEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Ricochet.java
+++ b/Mage.Sets/src/mage/cards/r/Ricochet.java
@@ -84,7 +84,7 @@ class RicochetEffect extends OneShotEffect {
         staticText = "each player rolls a six-sided die. Change the target of that spell to the player with the lowest result. Reroll to break ties, if necessary";
     }
 
-    public RicochetEffect(final RicochetEffect effect) {
+    private RicochetEffect(final RicochetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiddleOfLightning.java
+++ b/Mage.Sets/src/mage/cards/r/RiddleOfLightning.java
@@ -50,7 +50,7 @@ class RiddleOfLightningEffect extends OneShotEffect {
         this.staticText = ", then reveal the top card of your library. {this} deals damage equal to that card's mana value to that permanent or player";
     }
 
-    public RiddleOfLightningEffect(final RiddleOfLightningEffect effect) {
+    private RiddleOfLightningEffect(final RiddleOfLightningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Riddleform.java
+++ b/Mage.Sets/src/mage/cards/r/Riddleform.java
@@ -60,7 +60,7 @@ class RiddleformToken extends TokenImpl {
         addAbility(FlyingAbility.getInstance());
     }
 
-    public RiddleformToken(final RiddleformToken token) {
+    private RiddleformToken(final RiddleformToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Riddlesmith.java
+++ b/Mage.Sets/src/mage/cards/r/Riddlesmith.java
@@ -30,7 +30,7 @@ public final class Riddlesmith extends CardImpl {
         ));
     }
 
-    public Riddlesmith(final Riddlesmith card) {
+    private Riddlesmith(final Riddlesmith card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RideDown.java
+++ b/Mage.Sets/src/mage/cards/r/RideDown.java
@@ -58,7 +58,7 @@ class RideDownEffect extends OneShotEffect {
         this.staticText = "Destroy target blocking creature. Creatures that were blocked by that creature this combat gain trample until end of turn";
     }
 
-    public RideDownEffect(final RideDownEffect effect) {
+    private RideDownEffect(final RideDownEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RideTheAvalanche.java
+++ b/Mage.Sets/src/mage/cards/r/RideTheAvalanche.java
@@ -51,7 +51,7 @@ class RideTheAvalancheAsThoughEffect extends AsThoughEffectImpl {
         staticText = "The next spell you cast this turn can be cast as though it had flash";
     }
 
-    public RideTheAvalancheAsThoughEffect(final RideTheAvalancheAsThoughEffect effect) {
+    private RideTheAvalancheAsThoughEffect(final RideTheAvalancheAsThoughEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RidersOfGavony.java
+++ b/Mage.Sets/src/mage/cards/r/RidersOfGavony.java
@@ -65,7 +65,7 @@ class RidersOfGavonyGainAbilityControlledEffect extends ContinuousEffectImpl {
         staticText = "Human creatures you control have protection from creatures of the chosen type";
     }
 
-    public RidersOfGavonyGainAbilityControlledEffect(final RidersOfGavonyGainAbilityControlledEffect effect) {
+    private RidersOfGavonyGainAbilityControlledEffect(final RidersOfGavonyGainAbilityControlledEffect effect) {
         super(effect);
         protectionFilter = effect.protectionFilter;
     }

--- a/Mage.Sets/src/mage/cards/r/RiftmarkedKnight.java
+++ b/Mage.Sets/src/mage/cards/r/RiftmarkedKnight.java
@@ -63,7 +63,7 @@ class RiftmarkedKnightTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When the last time counter is removed from {this} while it's exiled, ");
     }
 
-    public RiftmarkedKnightTriggeredAbility(final RiftmarkedKnightTriggeredAbility ability) {
+    private RiftmarkedKnightTriggeredAbility(final RiftmarkedKnightTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Riftsweeper.java
+++ b/Mage.Sets/src/mage/cards/r/Riftsweeper.java
@@ -61,7 +61,7 @@ class RiftsweeperEffect extends OneShotEffect {
         this.staticText = "choose target face-up exiled card. Its owner shuffles it into their library";
     }
 
-    public RiftsweeperEffect(final RiftsweeperEffect effect) {
+    private RiftsweeperEffect(final RiftsweeperEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RighteousFury.java
+++ b/Mage.Sets/src/mage/cards/r/RighteousFury.java
@@ -45,7 +45,7 @@ class RighteousFuryEffect extends OneShotEffect {
         this.staticText = "Destroy all tapped creatures. You gain 2 life for each creature destroyed this way";
     }
 
-    public RighteousFuryEffect(final RighteousFuryEffect effect) {
+    private RighteousFuryEffect(final RighteousFuryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RighteousIndignation.java
+++ b/Mage.Sets/src/mage/cards/r/RighteousIndignation.java
@@ -44,7 +44,7 @@ class RighteousIndignationTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new BoostTargetEffect(1, 1, Duration.EndOfTurn));
     }
 
-    public RighteousIndignationTriggeredAbility(final RighteousIndignationTriggeredAbility ability) {
+    private RighteousIndignationTriggeredAbility(final RighteousIndignationTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RimefeatherOwl.java
+++ b/Mage.Sets/src/mage/cards/r/RimefeatherOwl.java
@@ -90,7 +90,7 @@ class RimefeatherOwlEffect extends ContinuousEffectImpl {
         this.staticText = "Permanents with ice counters on them are snow.";
     }
 
-    public RimefeatherOwlEffect(final RimefeatherOwlEffect effect) {
+    private RimefeatherOwlEffect(final RimefeatherOwlEffect effect) {
         super(effect);
         this.filter = effect.filter;
     }

--- a/Mage.Sets/src/mage/cards/r/RimehornAurochs.java
+++ b/Mage.Sets/src/mage/cards/r/RimehornAurochs.java
@@ -79,7 +79,7 @@ class RimehornAurochsEffect extends RequirementEffect {
         staticText = "Target creature blocks target creature this turn if able";
     }
 
-    public RimehornAurochsEffect(final RimehornAurochsEffect effect) {
+    private RimehornAurochsEffect(final RimehornAurochsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RingOfMaruf.java
+++ b/Mage.Sets/src/mage/cards/r/RingOfMaruf.java
@@ -54,7 +54,7 @@ class RingOfMarufEffect extends ReplacementEffectImpl {
         staticText = "The next time you would draw a card this turn, instead choose a card you own from outside the game and put it into your hand.";
     }
 
-    public RingOfMarufEffect(final RingOfMarufEffect effect) {
+    private RingOfMarufEffect(final RingOfMarufEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiotPiker.java
+++ b/Mage.Sets/src/mage/cards/r/RiotPiker.java
@@ -35,7 +35,7 @@ public final class RiotPiker extends CardImpl {
 
     }
 
-    public RiotPiker (final RiotPiker card) {
+    private RiotPiker(final RiotPiker card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiptideChronologist.java
+++ b/Mage.Sets/src/mage/cards/r/RiptideChronologist.java
@@ -57,7 +57,7 @@ class RiptideChronologistEffect extends OneShotEffect {
         staticText = "Untap all creatures of the creature type of your choice";
     }
 
-    public RiptideChronologistEffect(final RiptideChronologistEffect effect) {
+    private RiptideChronologistEffect(final RiptideChronologistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiptideEntrancer.java
+++ b/Mage.Sets/src/mage/cards/r/RiptideEntrancer.java
@@ -61,7 +61,7 @@ class RiptideEntrancerTriggeredAbility extends TriggeredAbilityImpl {
         ), false);
     }
 
-    public RiptideEntrancerTriggeredAbility(final RiptideEntrancerTriggeredAbility ability) {
+    private RiptideEntrancerTriggeredAbility(final RiptideEntrancerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiseOfTheDarkRealms.java
+++ b/Mage.Sets/src/mage/cards/r/RiseOfTheDarkRealms.java
@@ -45,7 +45,7 @@ class RiseOfTheDarkRealmsEffect extends OneShotEffect {
         staticText = "Put all creature cards from all graveyards onto the battlefield under your control";
     }
 
-    public RiseOfTheDarkRealmsEffect(final RiseOfTheDarkRealmsEffect effect) {
+    private RiseOfTheDarkRealmsEffect(final RiseOfTheDarkRealmsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiseOfTheHobgoblins.java
+++ b/Mage.Sets/src/mage/cards/r/RiseOfTheHobgoblins.java
@@ -73,7 +73,7 @@ class RiseOfTheHobgoblinsEffect extends OneShotEffect {
         staticText = "you may pay {X}. If you do, create X 1/1 red and white Goblin Soldier creature tokens";
     }
 
-    public RiseOfTheHobgoblinsEffect(final RiseOfTheHobgoblinsEffect effect) {
+    private RiseOfTheHobgoblinsEffect(final RiseOfTheHobgoblinsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RishadanPawnshop.java
+++ b/Mage.Sets/src/mage/cards/r/RishadanPawnshop.java
@@ -62,7 +62,7 @@ class RishadanPawnshopShuffleIntoLibraryEffect extends OneShotEffect {
         this.staticText = "The owner of target nontoken permanent you control shuffles it into their library";
     }
 
-    public RishadanPawnshopShuffleIntoLibraryEffect(final RishadanPawnshopShuffleIntoLibraryEffect effect) {
+    private RishadanPawnshopShuffleIntoLibraryEffect(final RishadanPawnshopShuffleIntoLibraryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RisingWaters.java
+++ b/Mage.Sets/src/mage/cards/r/RisingWaters.java
@@ -53,7 +53,7 @@ class RisingWatersUntapEffect extends OneShotEffect {
         this.staticText = "that player untaps a land they control";
     }
 
-    public RisingWatersUntapEffect(final RisingWatersUntapEffect effect) {
+    private RisingWatersUntapEffect(final RisingWatersUntapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiskFactor.java
+++ b/Mage.Sets/src/mage/cards/r/RiskFactor.java
@@ -48,7 +48,7 @@ class RiskFactorEffect extends OneShotEffect {
                 + "If that player doesn't, you draw three cards.";
     }
 
-    public RiskFactorEffect(final RiskFactorEffect effect) {
+    private RiskFactorEffect(final RiskFactorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiskyMove.java
+++ b/Mage.Sets/src/mage/cards/r/RiskyMove.java
@@ -56,7 +56,7 @@ class RiskyMoveGetControlEffect extends OneShotEffect {
         this.staticText = "that player gains control of {this}";
     }
 
-    public RiskyMoveGetControlEffect(final RiskyMoveGetControlEffect effect) {
+    private RiskyMoveGetControlEffect(final RiskyMoveGetControlEffect effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class RiskyMoveTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When you gain control of {this} from another player, ");
     }
 
-    public RiskyMoveTriggeredAbility(final RiskyMoveTriggeredAbility ability) {
+    private RiskyMoveTriggeredAbility(final RiskyMoveTriggeredAbility ability) {
         super(ability);
     }
 
@@ -132,7 +132,7 @@ class RiskyMoveFlipCoinEffect extends OneShotEffect {
         this.staticText = "choose a creature you control and an opponent. Flip a coin. If you lose the flip, that opponent gains control of that creature";
     }
 
-    public RiskyMoveFlipCoinEffect(final RiskyMoveFlipCoinEffect effect) {
+    private RiskyMoveFlipCoinEffect(final RiskyMoveFlipCoinEffect effect) {
         super(effect);
     }
 
@@ -188,7 +188,7 @@ class RiskyMoveCreatureGainControlEffect extends ContinuousEffectImpl {
         this.staticText = "If you lose the flip, that opponent gains control of that creature";
     }
 
-    public RiskyMoveCreatureGainControlEffect(final RiskyMoveCreatureGainControlEffect effect) {
+    private RiskyMoveCreatureGainControlEffect(final RiskyMoveCreatureGainControlEffect effect) {
         super(effect);
         this.controller = effect.controller;
     }

--- a/Mage.Sets/src/mage/cards/r/RiteOfConsumption.java
+++ b/Mage.Sets/src/mage/cards/r/RiteOfConsumption.java
@@ -50,7 +50,7 @@ class RiteOfConsumptionEffect extends OneShotEffect {
         this.staticText = "{this} deals damage equal to the sacrificed creature's power to target player or planeswalker. You gain life equal to the damage dealt this way";
     }
 
-    public RiteOfConsumptionEffect(final RiteOfConsumptionEffect effect) {
+    private RiteOfConsumptionEffect(final RiteOfConsumptionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiteOfHarmony.java
+++ b/Mage.Sets/src/mage/cards/r/RiteOfHarmony.java
@@ -58,7 +58,7 @@ class RiteOfHarmonyTriggeredAbility extends DelayedTriggeredAbility {
         optional = false;
     }
 
-    public RiteOfHarmonyTriggeredAbility(RiteOfHarmonyTriggeredAbility ability) {
+    private RiteOfHarmonyTriggeredAbility(final RiteOfHarmonyTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiteOfPassage.java
+++ b/Mage.Sets/src/mage/cards/r/RiteOfPassage.java
@@ -50,7 +50,7 @@ class RiteOfPassageTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature you control is dealt damage, ");
     }
 
-    public RiteOfPassageTriggeredAbility(final RiteOfPassageTriggeredAbility ability) {
+    private RiteOfPassageTriggeredAbility(final RiteOfPassageTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiteOfRuin.java
+++ b/Mage.Sets/src/mage/cards/r/RiteOfRuin.java
@@ -44,7 +44,7 @@ class RiteOfRuinEffect extends OneShotEffect {
         this.staticText = "Choose an order for artifacts, creatures, and lands. Each player sacrifices one permanent of the first type, sacrifices two of the second type, then sacrifices three of the third type";
     }
 
-    public RiteOfRuinEffect(final RiteOfRuinEffect effect) {
+    private RiteOfRuinEffect(final RiteOfRuinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiteOfTheSerpent.java
+++ b/Mage.Sets/src/mage/cards/r/RiteOfTheSerpent.java
@@ -49,7 +49,7 @@ class RiteOfTheSerpentEffect extends OneShotEffect {
         this.staticText = "If that creature had a +1/+1 counter on it, create a 1/1 green Snake creature token";
     }
 
-    public RiteOfTheSerpentEffect(final RiteOfTheSerpentEffect effect) {
+    private RiteOfTheSerpentEffect(final RiteOfTheSerpentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RitesOfFlourishing.java
+++ b/Mage.Sets/src/mage/cards/r/RitesOfFlourishing.java
@@ -47,7 +47,7 @@ class RitesOfFlourishingAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardTargetEffect(1));
     }
 
-    public RitesOfFlourishingAbility(final RitesOfFlourishingAbility ability) {
+    private RitesOfFlourishingAbility(final RitesOfFlourishingAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RitesOfReaping.java
+++ b/Mage.Sets/src/mage/cards/r/RitesOfReaping.java
@@ -59,7 +59,7 @@ class RitesOfReapingEffect extends ContinuousEffectImpl {
         this.staticText = "Target creature gets +3/+3 until end of turn. Another target creature gets -3/-3 until end of turn";
     }
 
-    public RitesOfReapingEffect(final RitesOfReapingEffect effect) {
+    private RitesOfReapingEffect(final RitesOfReapingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RithTheAwakener.java
+++ b/Mage.Sets/src/mage/cards/r/RithTheAwakener.java
@@ -61,7 +61,7 @@ class RithTheAwakenerEffect extends OneShotEffect {
         this.staticText = "choose a color, then create a 1/1 green Saproling creature token for each permanent of that color";
     }
 
-    public RithTheAwakenerEffect(final RithTheAwakenerEffect effect) {
+    private RithTheAwakenerEffect(final RithTheAwakenerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RitualOfTheReturned.java
+++ b/Mage.Sets/src/mage/cards/r/RitualOfTheReturned.java
@@ -47,7 +47,7 @@ class RitualOfTheReturnedExileEffect extends OneShotEffect {
         this.staticText = "Exile target creature card from your graveyard. Create a black Zombie creature token. Its power is equal to that card's power and its toughness is equal to that card's toughness.";
     }
 
-    public RitualOfTheReturnedExileEffect(final RitualOfTheReturnedExileEffect effect) {
+    private RitualOfTheReturnedExileEffect(final RitualOfTheReturnedExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Rivalry.java
+++ b/Mage.Sets/src/mage/cards/r/Rivalry.java
@@ -46,7 +46,7 @@ class RivalryTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(2), false);
     }
 
-    public RivalryTriggeredAbility(final RivalryTriggeredAbility ability) {
+    private RivalryTriggeredAbility(final RivalryTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RivalsDuel.java
+++ b/Mage.Sets/src/mage/cards/r/RivalsDuel.java
@@ -45,7 +45,7 @@ class RivalsDuelFightTargetsEffect extends OneShotEffect {
                 "Those creatures fight each other. <i>(Each deals damage equal to its power to the other.)</i>";
     }
 
-    public RivalsDuelFightTargetsEffect(final RivalsDuelFightTargetsEffect effect) {
+    private RivalsDuelFightTargetsEffect(final RivalsDuelFightTargetsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiverKaijin.java
+++ b/Mage.Sets/src/mage/cards/r/RiverKaijin.java
@@ -23,7 +23,7 @@ public final class RiverKaijin extends CardImpl {
         this.toughness = new MageInt(4);
     }
 
-    public RiverKaijin (final RiverKaijin card) {
+    private RiverKaijin(final RiverKaijin card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiverKelpie.java
+++ b/Mage.Sets/src/mage/cards/r/RiverKelpie.java
@@ -55,7 +55,7 @@ class RiverKelpieTriggeredAbility extends TriggeredAbilityImpl {
         return new RiverKelpieTriggeredAbility(this);
     }
 
-    public RiverKelpieTriggeredAbility(final RiverKelpieTriggeredAbility ability) {
+    private RiverKelpieTriggeredAbility(final RiverKelpieTriggeredAbility ability) {
         super(ability);
     }
 
@@ -86,7 +86,7 @@ class RiverKelpieTriggeredAbility2 extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
     }
 
-    public RiverKelpieTriggeredAbility2(final RiverKelpieTriggeredAbility2 ability) {
+    private RiverKelpieTriggeredAbility2(final RiverKelpieTriggeredAbility2 ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiverSerpent.java
+++ b/Mage.Sets/src/mage/cards/r/RiverSerpent.java
@@ -53,7 +53,7 @@ class RiverSerpentEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless there are five or more cards in your graveyard";
     }
 
-    public RiverSerpentEffect(final RiverSerpentEffect effect) {
+    private RiverSerpentEffect(final RiverSerpentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoarOfJukai.java
+++ b/Mage.Sets/src/mage/cards/r/RoarOfJukai.java
@@ -69,7 +69,7 @@ class RoarOfJukaiEffect extends OneShotEffect {
         this.staticText = "If you control a Forest, each blocked creature gets +2/+2 until end of turn";
     }
 
-    public RoarOfJukaiEffect(final RoarOfJukaiEffect effect) {
+    private RoarOfJukaiEffect(final RoarOfJukaiEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoarOfReclamation.java
+++ b/Mage.Sets/src/mage/cards/r/RoarOfReclamation.java
@@ -43,7 +43,7 @@ class RoarOfReclamationEffect extends OneShotEffect {
         staticText = "Each player returns all artifact cards from their graveyard to the battlefield";
     }
 
-    public RoarOfReclamationEffect(final RoarOfReclamationEffect effect) {
+    private RoarOfReclamationEffect(final RoarOfReclamationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoarOfResistance.java
+++ b/Mage.Sets/src/mage/cards/r/RoarOfResistance.java
@@ -82,7 +82,7 @@ class RoarOfResistanceTriggeredAbility extends TriggeredAbilityImpl {
         super(zone, effect, false);
     }
 
-    public RoarOfResistanceTriggeredAbility(final RoarOfResistanceTriggeredAbility ability) {
+    private RoarOfResistanceTriggeredAbility(final RoarOfResistanceTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RobberFly.java
+++ b/Mage.Sets/src/mage/cards/r/RobberFly.java
@@ -53,7 +53,7 @@ class DrawCardsDefendingPlayerEffect extends OneShotEffect {
                 + "then draws that many cards";
     }
 
-    public DrawCardsDefendingPlayerEffect(final DrawCardsDefendingPlayerEffect effect) {
+    private DrawCardsDefendingPlayerEffect(final DrawCardsDefendingPlayerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RockHydra.java
+++ b/Mage.Sets/src/mage/cards/r/RockHydra.java
@@ -65,7 +65,7 @@ public final class RockHydra extends CardImpl {
             staticText = "For each 1 damage that would be dealt to {this}, if it has a +1/+1 counter on it, remove a +1/+1 counter from it and prevent that 1 damage.";
         }
 
-        public RockHydraEffect(final RockHydraEffect effect) {
+        private RockHydraEffect(final RockHydraEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/r/RockJockey.java
+++ b/Mage.Sets/src/mage/cards/r/RockJockey.java
@@ -58,7 +58,7 @@ class RockJockeyEffect extends ContinuousRuleModifyingEffectImpl {
         this.staticText = "You can't play lands if you've cast {this} this turn";
     }
 
-    public RockJockeyEffect(final RockJockeyEffect effect) {
+    private RockJockeyEffect(final RockJockeyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RodOfSpanking.java
+++ b/Mage.Sets/src/mage/cards/r/RodOfSpanking.java
@@ -53,7 +53,7 @@ class RodOfSpankingEffect extends OneShotEffect {
         staticText = "{this} deals 1 damage to target player. Then untap {this} unless that player says \"Thank you, sir. May I have another?\"";
     }
 
-    public RodOfSpankingEffect(final RodOfSpankingEffect effect) {
+    private RodOfSpankingEffect(final RodOfSpankingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RofellossGift.java
+++ b/Mage.Sets/src/mage/cards/r/RofellossGift.java
@@ -54,7 +54,7 @@ class RofellossGiftEffect extends OneShotEffect {
                 "Return an enchantment card from your graveyard to your hand for each card revealed this way.";
     }
 
-    public RofellossGiftEffect(final RofellossGiftEffect effect) {
+    private RofellossGiftEffect(final RofellossGiftEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoilingHorror.java
+++ b/Mage.Sets/src/mage/cards/r/RoilingHorror.java
@@ -71,7 +71,7 @@ class RoilingHorrorTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a time counter is removed from {this} while it's exiled, ");
     }
 
-    public RoilingHorrorTriggeredAbility(final RoilingHorrorTriggeredAbility ability) {
+    private RoilingHorrorTriggeredAbility(final RoilingHorrorTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoilingTerrain.java
+++ b/Mage.Sets/src/mage/cards/r/RoilingTerrain.java
@@ -44,7 +44,7 @@ class RoilingTerrainEffect extends OneShotEffect {
         this.staticText = "Destroy target land, then {this} deals damage to that land's controller equal to the number of land cards in that player's graveyard";
     }
 
-    public RoilingTerrainEffect(final RoilingTerrainEffect effect) {
+    private RoilingTerrainEffect(final RoilingTerrainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RonaDiscipleOfGix.java
+++ b/Mage.Sets/src/mage/cards/r/RonaDiscipleOfGix.java
@@ -81,7 +81,7 @@ class RonaDiscipleOfGixPlayNonLandEffect extends AsThoughEffectImpl {
         staticText = "You may cast nonland cards exiled with {this}";
     }
 
-    public RonaDiscipleOfGixPlayNonLandEffect(final RonaDiscipleOfGixPlayNonLandEffect effect) {
+    private RonaDiscipleOfGixPlayNonLandEffect(final RonaDiscipleOfGixPlayNonLandEffect effect) {
         super(effect);
     }
 
@@ -119,7 +119,7 @@ class RonaDiscipleOfGixExileEffect extends OneShotEffect {
         this.staticText = "Exile the top card of your library";
     }
 
-    public RonaDiscipleOfGixExileEffect(final RonaDiscipleOfGixExileEffect effect) {
+    private RonaDiscipleOfGixExileEffect(final RonaDiscipleOfGixExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoninCliffrider.java
+++ b/Mage.Sets/src/mage/cards/r/RoninCliffrider.java
@@ -54,7 +54,7 @@ class RoninCliffriderEffect extends OneShotEffect {
         this.staticText = "you may have it deal 1 damage to each creature defending player controls";
     }
 
-    public RoninCliffriderEffect(final RoninCliffriderEffect effect) {
+    private RoninCliffriderEffect(final RoninCliffriderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoninHoundmaster.java
+++ b/Mage.Sets/src/mage/cards/r/RoninHoundmaster.java
@@ -28,7 +28,7 @@ public final class RoninHoundmaster extends CardImpl {
         this.addAbility(new BushidoAbility(1));
     }
 
-    public RoninHoundmaster (final RoninHoundmaster card) {
+    private RoninHoundmaster(final RoninHoundmaster card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoofstalkerWight.java
+++ b/Mage.Sets/src/mage/cards/r/RoofstalkerWight.java
@@ -30,7 +30,7 @@ public final class RoofstalkerWight extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.EndOfTurn), new ManaCostsImpl<>("{1}{U}")));
     }
 
-    public RoofstalkerWight (final RoofstalkerWight card) {
+    private RoofstalkerWight(final RoofstalkerWight card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RooftopStorm.java
+++ b/Mage.Sets/src/mage/cards/r/RooftopStorm.java
@@ -56,7 +56,7 @@ class RooftopStormRuleEffect extends ContinuousEffectImpl {
         staticText = "You may pay {0} rather than pay the mana cost for Zombie creature spells you cast";
     }
 
-    public RooftopStormRuleEffect(final RooftopStormRuleEffect effect) {
+    private RooftopStormRuleEffect(final RooftopStormRuleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoonOfTheHiddenRealm.java
+++ b/Mage.Sets/src/mage/cards/r/RoonOfTheHiddenRealm.java
@@ -67,7 +67,7 @@ class RoonOfTheHiddenRealmEffect extends OneShotEffect {
         this.staticText = "Exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step";
     }
 
-    public RoonOfTheHiddenRealmEffect(final RoonOfTheHiddenRealmEffect effect) {
+    private RoonOfTheHiddenRealmEffect(final RoonOfTheHiddenRealmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RootGreevil.java
+++ b/Mage.Sets/src/mage/cards/r/RootGreevil.java
@@ -57,7 +57,7 @@ public final class RootGreevil extends CardImpl {
             this.staticText = "Destroy all enchantments of the color of your choice";
         }
 
-        public RootGreevilEffect(final RootGreevilEffect effect) {
+        private RootGreevilEffect(final RootGreevilEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/r/RootSliver.java
+++ b/Mage.Sets/src/mage/cards/r/RootSliver.java
@@ -56,7 +56,7 @@ class RootSliverEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Sliver spells can't be countered";
     }
 
-    public RootSliverEffect(final RootSliverEffect effect) {
+    private RootSliverEffect(final RootSliverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RootingKavu.java
+++ b/Mage.Sets/src/mage/cards/r/RootingKavu.java
@@ -52,7 +52,7 @@ class RootingKavuEffect extends OneShotEffect {
         this.staticText = "shuffle all creature cards from your graveyard into your library.";
     }
 
-    public RootingKavuEffect(final RootingKavuEffect effect) {
+    private RootingKavuEffect(final RootingKavuEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RotFarmSkeleton.java
+++ b/Mage.Sets/src/mage/cards/r/RotFarmSkeleton.java
@@ -41,7 +41,7 @@ public final class RotFarmSkeleton extends CardImpl {
 
     }
 
-    public RotFarmSkeleton (final RotFarmSkeleton card) {
+    private RotFarmSkeleton(final RotFarmSkeleton card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RotfeasterMaggot.java
+++ b/Mage.Sets/src/mage/cards/r/RotfeasterMaggot.java
@@ -54,7 +54,7 @@ class RotfeasterMaggotExileEffect extends OneShotEffect {
         this.staticText = "exile target creature card from a graveyard. You gain life equal to that card's toughness";
     }
 
-    public RotfeasterMaggotExileEffect(final RotfeasterMaggotExileEffect effect) {
+    private RotfeasterMaggotExileEffect(final RotfeasterMaggotExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RottingRats.java
+++ b/Mage.Sets/src/mage/cards/r/RottingRats.java
@@ -35,7 +35,7 @@ public final class RottingRats extends CardImpl {
 
     }
 
-    public RottingRats (final RottingRats card) {
+    private RottingRats(final RottingRats card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RousingOfSouls.java
+++ b/Mage.Sets/src/mage/cards/r/RousingOfSouls.java
@@ -50,7 +50,7 @@ class RousingOfSoulsEffect extends OneShotEffect {
         this.staticText = "<i>Parley</i> &mdash; Each player reveals the top card of their library. For each nonland card revealed this way, you create a 1/1 white Spirit creature token with flying";
     }
 
-    public RousingOfSoulsEffect(final RousingOfSoulsEffect effect) {
+    private RousingOfSoulsEffect(final RousingOfSoulsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RowanKenrith.java
+++ b/Mage.Sets/src/mage/cards/r/RowanKenrith.java
@@ -75,7 +75,7 @@ class RowanKenrithAttackEffect extends RequirementEffect {
         staticText = "During target player's next turn, each creature that player controls attacks if able";
     }
 
-    public RowanKenrithAttackEffect(final RowanKenrithAttackEffect effect) {
+    private RowanKenrithAttackEffect(final RowanKenrithAttackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RubblebeltMaaka.java
+++ b/Mage.Sets/src/mage/cards/r/RubblebeltMaaka.java
@@ -36,7 +36,7 @@ public final class RubblebeltMaaka extends CardImpl {
 
     }
 
-    public RubblebeltMaaka (final RubblebeltMaaka card) {
+    private RubblebeltMaaka(final RubblebeltMaaka card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RuggedPrairie.java
+++ b/Mage.Sets/src/mage/cards/r/RuggedPrairie.java
@@ -38,7 +38,7 @@ public final class RuggedPrairie extends CardImpl {
         this.addAbility(ability);          
     }
 
-    public RuggedPrairie (final RuggedPrairie card) {
+    private RuggedPrairie(final RuggedPrairie card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RuinInTheirWake.java
+++ b/Mage.Sets/src/mage/cards/r/RuinInTheirWake.java
@@ -56,7 +56,7 @@ class RuinInTheirWakeEffect extends OneShotEffect {
         this.staticText = "Search your library for a basic land card and reveal it. You may put that card onto the battlefield tapped if you control a land named Wastes. Otherwise, put that card into your hand. Then shuffle";
     }
 
-    public RuinInTheirWakeEffect(final RuinInTheirWakeEffect effect) {
+    private RuinInTheirWakeEffect(final RuinInTheirWakeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RumblingAftershocks.java
+++ b/Mage.Sets/src/mage/cards/r/RumblingAftershocks.java
@@ -82,7 +82,7 @@ class RumblingAftershocksDealDamageEffect extends OneShotEffect {
         this.staticText = "you may have {this} deal damage to any target equal to the number of times that spell was kicked";
     }
 
-    public RumblingAftershocksDealDamageEffect(final RumblingAftershocksDealDamageEffect effect) {
+    private RumblingAftershocksDealDamageEffect(final RumblingAftershocksDealDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Rumination.java
+++ b/Mage.Sets/src/mage/cards/r/Rumination.java
@@ -43,7 +43,7 @@ public final class Rumination extends CardImpl {
             staticText = "Draw three cards, then put a card from your hand on top of your library.";
         }
 
-        public RuminationEffect(final RuminationEffect effect) {
+        private RuminationEffect(final RuminationEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/r/RuneScarredDemon.java
+++ b/Mage.Sets/src/mage/cards/r/RuneScarredDemon.java
@@ -33,7 +33,7 @@ public final class RuneScarredDemon extends CardImpl {
         this.addAbility(ability);
     }
 
-    public RuneScarredDemon (final RuneScarredDemon card) {
+    private RuneScarredDemon(final RuneScarredDemon card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RuneTailKitsuneAscendant.java
+++ b/Mage.Sets/src/mage/cards/r/RuneTailKitsuneAscendant.java
@@ -52,7 +52,7 @@ class RuneTailKitsuneAscendantFlipAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new FlipSourceEffect(new RuneTailEssence()));
     }
 
-    public RuneTailKitsuneAscendantFlipAbility(final RuneTailKitsuneAscendantFlipAbility ability) {
+    private RuneTailKitsuneAscendantFlipAbility(final RuneTailKitsuneAscendantFlipAbility ability) {
         super(ability);
     }
 
@@ -91,7 +91,7 @@ class RuneTailEssence extends TokenImpl {
                 new PreventAllDamageToAllEffect(Duration.WhileOnBattlefield, StaticFilters.FILTER_CONTROLLED_CREATURES)));
     }
 
-    public RuneTailEssence(final RuneTailEssence token) {
+    private RuneTailEssence(final RuneTailEssence token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RunedHalo.java
+++ b/Mage.Sets/src/mage/cards/r/RunedHalo.java
@@ -60,7 +60,7 @@ class RunedHaloSetProtectionEffect extends OneShotEffect {
         staticText = "<br/><br/>You have protection from the chosen card name. <i>(You can't be targeted, dealt damage, or enchanted by anything with that name.)</i>";
     }
 
-    public RunedHaloSetProtectionEffect(final RunedHaloSetProtectionEffect effect) {
+    private RunedHaloSetProtectionEffect(final RunedHaloSetProtectionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Runesword.java
+++ b/Mage.Sets/src/mage/cards/r/Runesword.java
@@ -73,7 +73,7 @@ class RuneswordCreateTriggeredAbilityEffect extends OneShotEffect {
         staticText = "When that creature leaves the battlefield this turn, sacrifice {this}";
     }
 
-    public RuneswordCreateTriggeredAbilityEffect(final RuneswordCreateTriggeredAbilityEffect effect) {
+    private RuneswordCreateTriggeredAbilityEffect(final RuneswordCreateTriggeredAbilityEffect effect) {
         super(effect);
     }
 
@@ -109,7 +109,7 @@ class RuneswordCantBeRegeneratedEffect extends ContinuousRuleModifyingEffectImpl
         this.staticText = "If the creature deals damage to a creature this turn, the creature dealt damage can't be regenerated this turn";
     }
 
-    public RuneswordCantBeRegeneratedEffect(final RuneswordCantBeRegeneratedEffect effect) {
+    private RuneswordCantBeRegeneratedEffect(final RuneswordCantBeRegeneratedEffect effect) {
         super(effect);
         targetCreatureId = effect.targetCreatureId;
     }

--- a/Mage.Sets/src/mage/cards/r/Rupture.java
+++ b/Mage.Sets/src/mage/cards/r/Rupture.java
@@ -55,7 +55,7 @@ class RuptureEffect extends OneShotEffect {
         staticText = "Sacrifice a creature. Rupture deals damage equal to that creature's power to each creature without flying and each player";
     }
 
-    public RuptureEffect(final RuptureEffect effect) {
+    private RuptureEffect(final RuptureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RuricTharTheUnbowed.java
+++ b/Mage.Sets/src/mage/cards/r/RuricTharTheUnbowed.java
@@ -64,7 +64,7 @@ class RuricTharTheUnbowedAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(6), false);
     }
 
-    public RuricTharTheUnbowedAbility(final RuricTharTheUnbowedAbility ability) {
+    private RuricTharTheUnbowedAbility(final RuricTharTheUnbowedAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RustElemental.java
+++ b/Mage.Sets/src/mage/cards/r/RustElemental.java
@@ -60,7 +60,7 @@ class RustElementalEffect extends OneShotEffect {
         this.staticText = "Sacrifice an artifact other than {this}. If you can't, tap {this} and you lose 4 life.";
     }
 
-    public RustElementalEffect(final RustElementalEffect effect) {
+    private RustElementalEffect(final RustElementalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RustedRelic.java
+++ b/Mage.Sets/src/mage/cards/r/RustedRelic.java
@@ -52,7 +52,7 @@ class RustedRelicToken extends TokenImpl {
         toughness = new MageInt(5);
     }
 
-    public RustedRelicToken(final RustedRelicToken token) {
+    private RustedRelicToken(final RustedRelicToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RustedSlasher.java
+++ b/Mage.Sets/src/mage/cards/r/RustedSlasher.java
@@ -35,7 +35,7 @@ public final class RustedSlasher extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new SacrificeTargetCost(new TargetControlledPermanent(filter))));
     }
 
-    public RustedSlasher (final RustedSlasher card) {
+    private RustedSlasher(final RustedSlasher card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RuthlessDeathfang.java
+++ b/Mage.Sets/src/mage/cards/r/RuthlessDeathfang.java
@@ -56,7 +56,7 @@ class RuthlessDeathfangTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you sacrifice a creature, ");
     }
 
-    public RuthlessDeathfangTriggeredAbility(final RuthlessDeathfangTriggeredAbility ability) {
+    private RuthlessDeathfangTriggeredAbility(final RuthlessDeathfangTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RysorianBadger.java
+++ b/Mage.Sets/src/mage/cards/r/RysorianBadger.java
@@ -61,7 +61,7 @@ class RysorianBadgerEffect extends OneShotEffect {
                 + "and {this} assigns no combat damage this turn.";
     }
 
-    public RysorianBadgerEffect(final RysorianBadgerEffect effect) {
+    private RysorianBadgerEffect(final RysorianBadgerEffect effect) {
         super(effect);
     }
 


### PR DESCRIPTION
Part of #11054 

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`public ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `private $1(final $1 $3`
