### PR TITLE
Clean all copy constructors in cards starting M-N-O

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MadcapExperiment.java
+++ b/Mage.Sets/src/mage/cards/m/MadcapExperiment.java
@@ -43,7 +43,7 @@ class MadcapExperimentEffect extends OneShotEffect {
         this.staticText = "Reveal cards from the top of your library until you reveal an artifact card. Put that card onto the battlefield and the rest on the bottom of your library in a random order. {this} deals damage to you equal to the number of cards revealed this way";
     }
 
-    public MadcapExperimentEffect(final MadcapExperimentEffect effect) {
+    private MadcapExperimentEffect(final MadcapExperimentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MaddeningImp.java
+++ b/Mage.Sets/src/mage/cards/m/MaddeningImp.java
@@ -98,7 +98,7 @@ class MaddeningImpCreateDelayedTriggeredAbilityEffect extends OneShotEffect {
         this.staticText = "At the beginning of the next end step, destroy each of those creatures that didn't attack this turn";
     }
 
-    public MaddeningImpCreateDelayedTriggeredAbilityEffect(final MaddeningImpCreateDelayedTriggeredAbilityEffect effect) {
+    private MaddeningImpCreateDelayedTriggeredAbilityEffect(final MaddeningImpCreateDelayedTriggeredAbilityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MadrushCyclops.java
+++ b/Mage.Sets/src/mage/cards/m/MadrushCyclops.java
@@ -32,7 +32,7 @@ public final class MadrushCyclops extends CardImpl {
         )));
     }
 
-    public MadrushCyclops(final MadrushCyclops card) {
+    private MadrushCyclops(final MadrushCyclops card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MaelstromNexus.java
+++ b/Mage.Sets/src/mage/cards/m/MaelstromNexus.java
@@ -52,7 +52,7 @@ class MaelstromNexusGainCascadeFirstSpellEffect extends ContinuousEffectImpl {
         staticText = "The first spell you cast each turn has cascade";
     }
 
-    public MaelstromNexusGainCascadeFirstSpellEffect(final MaelstromNexusGainCascadeFirstSpellEffect effect) {
+    private MaelstromNexusGainCascadeFirstSpellEffect(final MaelstromNexusGainCascadeFirstSpellEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MageRingResponder.java
+++ b/Mage.Sets/src/mage/cards/m/MageRingResponder.java
@@ -60,7 +60,7 @@ class MageRingResponderAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(7));
     }
 
-    public MageRingResponderAbility(final MageRingResponderAbility ability) {
+    private MageRingResponderAbility(final MageRingResponderAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MageSlayer.java
+++ b/Mage.Sets/src/mage/cards/m/MageSlayer.java
@@ -47,7 +47,7 @@ class MageSlayerEffect extends OneShotEffect {
         staticText = "it deals damage equal to its power to the player or planeswalker it's attacking";
     }
 
-    public MageSlayerEffect(final MageSlayerEffect effect) {
+    private MageSlayerEffect(final MageSlayerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagebaneArmor.java
+++ b/Mage.Sets/src/mage/cards/m/MagebaneArmor.java
@@ -55,7 +55,7 @@ class MagebaneArmorAbility extends StaticAbility {
         this.addEffect(new LoseAbilityAttachedEffect(FlyingAbility.getInstance(), AttachmentType.EQUIPMENT));
     }
 
-    public MagebaneArmorAbility(MagebaneArmorAbility ability) {
+    private MagebaneArmorAbility(final MagebaneArmorAbility ability) {
         super(ability);
     }
 
@@ -77,7 +77,7 @@ class MagebaneArmorPreventionEffect extends PreventionEffectImpl {
         this.staticText = "Prevent all noncombat damage that would be dealt to equipped creature";
     }
 
-    public MagebaneArmorPreventionEffect(final MagebaneArmorPreventionEffect effect) {
+    private MagebaneArmorPreventionEffect(final MagebaneArmorPreventionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagefireWings.java
+++ b/Mage.Sets/src/mage/cards/m/MagefireWings.java
@@ -38,7 +38,7 @@ public final class MagefireWings extends CardImpl {
         this.addAbility(ability);
     }
 
-    public MagefireWings(final MagefireWings card) {
+    private MagefireWings(final MagefireWings card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagesContest.java
+++ b/Mage.Sets/src/mage/cards/m/MagesContest.java
@@ -47,7 +47,7 @@ class MagesContestEffect extends OneShotEffect {
         this.staticText = "You and target spell's controller bid life. You start the bidding with a bid of 1. In turn order, each player may top the high bid. The bidding ends if the high bid stands. The high bidder loses life equal to the high bid. If you win the bidding, counter that spell";
     }
 
-    public MagesContestEffect(final MagesContestEffect effect) {
+    private MagesContestEffect(final MagesContestEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Magmaroth.java
+++ b/Mage.Sets/src/mage/cards/m/Magmaroth.java
@@ -31,7 +31,7 @@ public final class Magmaroth extends CardImpl{
 
     }
 
-    public Magmaroth(final Magmaroth magmaroth){
+    private Magmaroth(final Magmaroth magmaroth){
         super(magmaroth);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Magmasaur.java
+++ b/Mage.Sets/src/mage/cards/m/Magmasaur.java
@@ -69,7 +69,7 @@ class MagmasaurEffect extends OneShotEffect {
         this.staticText = "you may remove a +1/+1 counter from {this}. If you don't, sacrifice {this} and it deals damage equal to the number of +1/+1 counters on it to each creature without flying and each player";
     }
 
-    public MagmasaurEffect(final MagmasaurEffect effect) {
+    private MagmasaurEffect(final MagmasaurEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagneticMine.java
+++ b/Mage.Sets/src/mage/cards/m/MagneticMine.java
@@ -45,7 +45,7 @@ class MagneticMineTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect, false);
     }
 
-    public MagneticMineTriggeredAbility(final MagneticMineTriggeredAbility ability) {
+    private MagneticMineTriggeredAbility(final MagneticMineTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagneticTheft.java
+++ b/Mage.Sets/src/mage/cards/m/MagneticTheft.java
@@ -54,7 +54,7 @@ class EquipEffect extends OneShotEffect {
         staticText = "Attach target Equipment to target creature";
     }
 
-    public EquipEffect(final EquipEffect effect) {
+    private EquipEffect(final EquipEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagusOfTheScroll.java
+++ b/Mage.Sets/src/mage/cards/m/MagusOfTheScroll.java
@@ -58,7 +58,7 @@ class MagusOfTheScrollEffect extends OneShotEffect {
         staticText = ", then reveal a card at random from your hand. If that card has the chosen name, {this} deals 2 damage to any target";
     }
 
-    public MagusOfTheScrollEffect(final MagusOfTheScrollEffect effect) {
+    private MagusOfTheScrollEffect(final MagusOfTheScrollEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagusOfTheWill.java
+++ b/Mage.Sets/src/mage/cards/m/MagusOfTheWill.java
@@ -71,7 +71,7 @@ class CanPlayCardsFromGraveyardEffect extends ContinuousEffectImpl {
         staticText = "Until end of turn, you may play cards from your graveyard";
     }
 
-    public CanPlayCardsFromGraveyardEffect(final CanPlayCardsFromGraveyardEffect effect) {
+    private CanPlayCardsFromGraveyardEffect(final CanPlayCardsFromGraveyardEffect effect) {
         super(effect);
     }
 
@@ -99,7 +99,7 @@ class MagusOfTheWillReplacementEffect extends ReplacementEffectImpl {
         this.staticText = "If a card would be put into your graveyard from anywhere else this turn, exile that card instead";
     }
 
-    public MagusOfTheWillReplacementEffect(final MagusOfTheWillReplacementEffect effect) {
+    private MagusOfTheWillReplacementEffect(final MagusOfTheWillReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MaintenanceDroid.java
+++ b/Mage.Sets/src/mage/cards/m/MaintenanceDroid.java
@@ -78,7 +78,7 @@ class MaintenanceDroidEffect extends OneShotEffect {
         staticText = "Choose target card you own with a repair counter on it. You may remove a repair counter from it or put another repair counter on it";
     }
 
-    public MaintenanceDroidEffect(final MaintenanceDroidEffect effect) {
+    private MaintenanceDroidEffect(final MaintenanceDroidEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MaintenanceHangar.java
+++ b/Mage.Sets/src/mage/cards/m/MaintenanceHangar.java
@@ -64,7 +64,7 @@ class RemoveCounterMaintenanceHangarEffect extends OneShotEffect {
         staticText = "remove an additional repair counter from each card in your graveyard";
     }
 
-    public RemoveCounterMaintenanceHangarEffect(final RemoveCounterMaintenanceHangarEffect effect) {
+    private RemoveCounterMaintenanceHangarEffect(final RemoveCounterMaintenanceHangarEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class MaintenanceHangarEffect extends ContinuousEffectImpl {
         this.staticText = "and starship creatures in your graveyard have Repair 6";
     }
 
-    public MaintenanceHangarEffect(final MaintenanceHangarEffect effect) {
+    private MaintenanceHangarEffect(final MaintenanceHangarEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MairsilThePretender.java
+++ b/Mage.Sets/src/mage/cards/m/MairsilThePretender.java
@@ -125,7 +125,7 @@ class MairsilThePretenderGainAbilitiesEffect extends ContinuousEffectImpl {
         staticText = "{this} has all activated abilities of all cards you own in exile with cage counters on them. You may activate each of those abilities only once each turn";
     }
 
-    public MairsilThePretenderGainAbilitiesEffect(final MairsilThePretenderGainAbilitiesEffect effect) {
+    private MairsilThePretenderGainAbilitiesEffect(final MairsilThePretenderGainAbilitiesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MakindiGriffin.java
+++ b/Mage.Sets/src/mage/cards/m/MakindiGriffin.java
@@ -25,7 +25,7 @@ public final class MakindiGriffin extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public MakindiGriffin (final MakindiGriffin card) {
+    private MakindiGriffin(final MakindiGriffin card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MalakirBloodwitch.java
+++ b/Mage.Sets/src/mage/cards/m/MalakirBloodwitch.java
@@ -55,7 +55,7 @@ class MalakirBloodwitchEffect extends OneShotEffect {
         this.staticText = "each opponent loses life equal to the number of Vampires you control. You gain life equal to the life lost this way";
     }
 
-    public MalakirBloodwitchEffect(final MalakirBloodwitchEffect effect) {
+    private MalakirBloodwitchEffect(final MalakirBloodwitchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Malfegor.java
+++ b/Mage.Sets/src/mage/cards/m/Malfegor.java
@@ -58,7 +58,7 @@ class MalfegorEffect extends OneShotEffect {
         staticText = "discard your hand. Each opponent sacrifices a creature for each card discarded this way";
     }
 
-    public MalfegorEffect(final MalfegorEffect effect) {
+    private MalfegorEffect(final MalfegorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Malignus.java
+++ b/Mage.Sets/src/mage/cards/m/Malignus.java
@@ -95,7 +95,7 @@ class MalignusEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Damage that would be dealt by {this} can't be prevented";
     }
 
-    public MalignusEffect(final MalignusEffect effect) {
+    private MalignusEffect(final MalignusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MammothHarness.java
+++ b/Mage.Sets/src/mage/cards/m/MammothHarness.java
@@ -60,7 +60,7 @@ class MammothHarnessTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainAbilityTargetEffect(FirstStrikeAbility.getInstance(), Duration.EndOfTurn), false);
     }
 
-    public MammothHarnessTriggeredAbility(final MammothHarnessTriggeredAbility ability) {
+    private MammothHarnessTriggeredAbility(final MammothHarnessTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaCache.java
+++ b/Mage.Sets/src/mage/cards/m/ManaCache.java
@@ -94,7 +94,7 @@ class ManaCacheManaAbility extends ActivatedManaAbilityImpl {
         this.setMayActivate(TargetController.ANY);
     }
 
-    public ManaCacheManaAbility(final ManaCacheManaAbility ability) {
+    private ManaCacheManaAbility(final ManaCacheManaAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaClash.java
+++ b/Mage.Sets/src/mage/cards/m/ManaClash.java
@@ -42,7 +42,7 @@ class ManaClashEffect extends OneShotEffect {
         this.staticText = "You and target opponent each flip a coin. {this} deals 1 damage to each player whose coin comes up tails. Repeat this process until both players' coins come up heads on the same flip";
     }
 
-    public ManaClashEffect(final ManaClashEffect effect) {
+    private ManaClashEffect(final ManaClashEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaDrain.java
+++ b/Mage.Sets/src/mage/cards/m/ManaDrain.java
@@ -50,7 +50,7 @@ class ManaDrainCounterEffect extends OneShotEffect {
         this.staticText = "Counter target spell. At the beginning of your next main phase, add an amount of {C} equal to that spell's mana value";
     }
 
-    public ManaDrainCounterEffect(final ManaDrainCounterEffect effect) {
+    private ManaDrainCounterEffect(final ManaDrainCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaEchoes.java
+++ b/Mage.Sets/src/mage/cards/m/ManaEchoes.java
@@ -48,7 +48,7 @@ class ManaEchoesEffect extends OneShotEffect {
         this.staticText = "you may add X mana of {C}, where X is the number of creatures you control that share a creature type with it";
     }
 
-    public ManaEchoesEffect(final ManaEchoesEffect effect) {
+    private ManaEchoesEffect(final ManaEchoesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaScrew.java
+++ b/Mage.Sets/src/mage/cards/m/ManaScrew.java
@@ -46,7 +46,7 @@ class ManaScrewAbility extends ActivatedManaAbilityImpl {
         }
     }
 
-    public ManaScrewAbility(final ManaScrewAbility ability) {
+    private ManaScrewAbility(final ManaScrewAbility ability) {
         super(ability);
     }
 
@@ -77,7 +77,7 @@ class ManaScrewEffect extends ManaEffect {
         this.staticText = "Flip a coin. If you win the flip, add {C}{C}";
     }
 
-    public ManaScrewEffect(final ManaScrewEffect effect) {
+    private ManaScrewEffect(final ManaScrewEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaSeism.java
+++ b/Mage.Sets/src/mage/cards/m/ManaSeism.java
@@ -47,7 +47,7 @@ class ManaSeismEffect extends OneShotEffect {
         staticText  = "Sacrifice any number of lands, then add that much {C}";
     }
 
-    public ManaSeismEffect(final ManaSeismEffect effect) {
+    private ManaSeismEffect(final ManaSeismEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaSeverance.java
+++ b/Mage.Sets/src/mage/cards/m/ManaSeverance.java
@@ -47,7 +47,7 @@ class ManaSeveranceEffect extends OneShotEffect {
         this.staticText = "search your library for any number of land cards, exile them, then shuffle";
     }
 
-    public ManaSeveranceEffect(final ManaSeveranceEffect effect) {
+    private ManaSeveranceEffect(final ManaSeveranceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaShort.java
+++ b/Mage.Sets/src/mage/cards/m/ManaShort.java
@@ -42,7 +42,7 @@ class ManaShortEffect extends TapAllTargetPlayerControlsEffect {
         staticText = "Tap all lands target player controls and that player loses all unspent mana";
     }
 
-    public ManaShortEffect(final ManaShortEffect effect) {
+    private ManaShortEffect(final ManaShortEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaVortex.java
+++ b/Mage.Sets/src/mage/cards/m/ManaVortex.java
@@ -63,7 +63,7 @@ class CounterSourceEffect extends OneShotEffect {
         this.staticText = "counter it unless you sacrifice a land";
     }
 
-    public CounterSourceEffect(final CounterSourceEffect effect) {
+    private CounterSourceEffect(final CounterSourceEffect effect) {
         super(effect);
     }
 
@@ -106,7 +106,7 @@ class ManaVortexStateTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("When there are no lands on the battlefield, ");
     }
 
-    public ManaVortexStateTriggeredAbility(final ManaVortexStateTriggeredAbility ability) {
+    private ManaVortexStateTriggeredAbility(final ManaVortexStateTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Manabond.java
+++ b/Mage.Sets/src/mage/cards/m/Manabond.java
@@ -48,7 +48,7 @@ class ManabondEffect extends OneShotEffect {
         staticText = "reveal your hand and put all land cards from it onto the battlefield. If you do, discard your hand";
     }
 
-    public ManabondEffect(final ManabondEffect effect) {
+    private ManabondEffect(final ManabondEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaforgeCinder.java
+++ b/Mage.Sets/src/mage/cards/m/ManaforgeCinder.java
@@ -68,7 +68,7 @@ class ManaforgeCinderManaEffect extends ManaEffect {
         this.staticText = "Add {B} or {R}";
     }
 
-    public ManaforgeCinderManaEffect(final ManaforgeCinderManaEffect effect) {
+    private ManaforgeCinderManaEffect(final ManaforgeCinderManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Manalith.java
+++ b/Mage.Sets/src/mage/cards/m/Manalith.java
@@ -19,7 +19,7 @@ public final class Manalith extends CardImpl {
         this.addAbility(new AnyColorManaAbility());
     }
 
-    public Manalith (final Manalith card) {
+    private Manalith(final Manalith card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManifoldInsights.java
+++ b/Mage.Sets/src/mage/cards/m/ManifoldInsights.java
@@ -48,7 +48,7 @@ class ManifoldInsightsEffect extends OneShotEffect {
         this.staticText = "Reveal the top ten cards of your library. Starting with the next opponent in turn order, each opponent chooses a different nonland card from among them. Put the chosen cards into your hand and the rest on the bottom of your library in a random order";
     }
 
-    public ManifoldInsightsEffect(final ManifoldInsightsEffect effect) {
+    private ManifoldInsightsEffect(final ManifoldInsightsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MantellianSavrip.java
+++ b/Mage.Sets/src/mage/cards/m/MantellianSavrip.java
@@ -53,7 +53,7 @@ class MantellianSavripRestrictionEffect extends RestrictionEffect {
         staticText = "Creatures with power less than {this}'s power can't block it";
     }
 
-    public MantellianSavripRestrictionEffect(final MantellianSavripRestrictionEffect effect) {
+    private MantellianSavripRestrictionEffect(final MantellianSavripRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManticoreEternal.java
+++ b/Mage.Sets/src/mage/cards/m/ManticoreEternal.java
@@ -25,7 +25,7 @@ public final class ManticoreEternal extends CardImpl {
         addAbility(new AttacksEachCombatStaticAbility());
     }
 
-    public ManticoreEternal(final ManticoreEternal manticoreEternal) {
+    private ManticoreEternal(final ManticoreEternal manticoreEternal) {
         super(manticoreEternal);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MaralenOfTheMornsong.java
+++ b/Mage.Sets/src/mage/cards/m/MaralenOfTheMornsong.java
@@ -56,7 +56,7 @@ class MaralenOfTheMornsongEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Players can't draw cards";
     }
 
-    public MaralenOfTheMornsongEffect(final MaralenOfTheMornsongEffect effect) {
+    private MaralenOfTheMornsongEffect(final MaralenOfTheMornsongEffect effect) {
         super(effect);
     }
 
@@ -89,7 +89,7 @@ class MaralenOfTheMornsongEffect2 extends OneShotEffect {
         staticText = "that player loses 3 life, searches their library for a card, puts it into their hand, then shuffles";
     }
 
-    public MaralenOfTheMornsongEffect2(final MaralenOfTheMornsongEffect2 effect) {
+    private MaralenOfTheMornsongEffect2(final MaralenOfTheMornsongEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarbleChalice.java
+++ b/Mage.Sets/src/mage/cards/m/MarbleChalice.java
@@ -23,7 +23,7 @@ public final class MarbleChalice extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(1), new TapSourceCost()));
     }
 
-    public MarbleChalice (final MarbleChalice card) {
+    private MarbleChalice(final MarbleChalice card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarchFromTheTomb.java
+++ b/Mage.Sets/src/mage/cards/m/MarchFromTheTomb.java
@@ -51,7 +51,7 @@ class MarchFromTheTombTarget extends TargetCardInYourGraveyard {
         super(minNumTargets, maxNumTargets, filter);
     }
 
-    public MarchFromTheTombTarget(MarchFromTheTombTarget target) {
+    private MarchFromTheTombTarget(final MarchFromTheTombTarget target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarchOfProgress.java
+++ b/Mage.Sets/src/mage/cards/m/MarchOfProgress.java
@@ -58,7 +58,7 @@ class MarchOfProgressOverloadEffect extends OneShotEffect {
         this.staticText = "Choose each artifact creature you control. For each creature chosen this way, create a token that's a copy of it";
     }
 
-    public MarchOfProgressOverloadEffect(final MarchOfProgressOverloadEffect effect) {
+    private MarchOfProgressOverloadEffect(final MarchOfProgressOverloadEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarchOfRecklessJoy.java
+++ b/Mage.Sets/src/mage/cards/m/MarchOfRecklessJoy.java
@@ -66,7 +66,7 @@ class MarchOfRecklessJoyEffect extends OneShotEffect {
                 "You may play up to two of those cards until the end of your next turn.";
     }
 
-    public MarchOfRecklessJoyEffect(final MarchOfRecklessJoyEffect effect) {
+    private MarchOfRecklessJoyEffect(final MarchOfRecklessJoyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarchOfSouls.java
+++ b/Mage.Sets/src/mage/cards/m/MarchOfSouls.java
@@ -45,7 +45,7 @@ class MarchOfSoulsEffect extends OneShotEffect {
         staticText = "Destroy all creatures. They can't be regenerated. For each creature destroyed this way, its controller creates a 1/1 white Spirit creature token with flying.";
     }
 
-    public MarchOfSoulsEffect(final MarchOfSoulsEffect effect) {
+    private MarchOfSoulsEffect(final MarchOfSoulsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarchOfTheDroids.java
+++ b/Mage.Sets/src/mage/cards/m/MarchOfTheDroids.java
@@ -54,7 +54,7 @@ class MarchOfTheDroidsEffect extends OneShotEffect {
         this.staticText = "Remove all repair counters from all cards in your graveyard. Return each card with a repair counter removed this way from graveyard to the battlefield";
     }
 
-    public MarchOfTheDroidsEffect(final MarchOfTheDroidsEffect effect) {
+    private MarchOfTheDroidsEffect(final MarchOfTheDroidsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarchOfTheMachines.java
+++ b/Mage.Sets/src/mage/cards/m/MarchOfTheMachines.java
@@ -52,7 +52,7 @@ class MarchOfTheMachinesEffect extends ContinuousEffectImpl {
         dependendToTypes.add(DependencyType.ArtifactAddingRemoving);
     }
 
-    public MarchOfTheMachinesEffect(final MarchOfTheMachinesEffect effect) {
+    private MarchOfTheMachinesEffect(final MarchOfTheMachinesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarchesaTheBlackRose.java
+++ b/Mage.Sets/src/mage/cards/m/MarchesaTheBlackRose.java
@@ -69,7 +69,7 @@ class MarchesaTheBlackRoseTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature you control with a +1/+1 counter on it dies, ");
     }
 
-    public MarchesaTheBlackRoseTriggeredAbility(final MarchesaTheBlackRoseTriggeredAbility ability) {
+    private MarchesaTheBlackRoseTriggeredAbility(final MarchesaTheBlackRoseTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarduCharm.java
+++ b/Mage.Sets/src/mage/cards/m/MarduCharm.java
@@ -76,7 +76,7 @@ class MarduCharmCreateTokenEffect extends OneShotEffect {
         this.staticText = "Create two 1/1 white Warrior creature tokens. They gain first strike until end of turn";
     }
 
-    public MarduCharmCreateTokenEffect(final MarduCharmCreateTokenEffect effect) {
+    private MarduCharmCreateTokenEffect(final MarduCharmCreateTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MariTheKillingQuill.java
+++ b/Mage.Sets/src/mage/cards/m/MariTheKillingQuill.java
@@ -165,7 +165,7 @@ class MariTheKillingQuillCreatureDiesAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new MariTheKillingQuillExileCreatureEffect(), false);
     }
 
-    public MariTheKillingQuillCreatureDiesAbility(final MariTheKillingQuillCreatureDiesAbility ability) {
+    private MariTheKillingQuillCreatureDiesAbility(final MariTheKillingQuillCreatureDiesAbility ability) {
         super(ability);
     }
 
@@ -209,7 +209,7 @@ class MariTheKillingQuillExileCreatureEffect extends OneShotEffect {
         this.staticText = "exile it with a hit counter on it";
     }
 
-    public MariTheKillingQuillExileCreatureEffect(final MariTheKillingQuillExileCreatureEffect effect) {
+    private MariTheKillingQuillExileCreatureEffect(final MariTheKillingQuillExileCreatureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarisisTwinclaws.java
+++ b/Mage.Sets/src/mage/cards/m/MarisisTwinclaws.java
@@ -28,7 +28,7 @@ public final class MarisisTwinclaws extends CardImpl {
         this.addAbility(DoubleStrikeAbility.getInstance());
     }
 
-    public MarisisTwinclaws (final MarisisTwinclaws card) {
+    private MarisisTwinclaws(final MarisisTwinclaws card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarkForDeath.java
+++ b/Mage.Sets/src/mage/cards/m/MarkForDeath.java
@@ -52,7 +52,7 @@ class MarkForDeathEffect extends OneShotEffect {
         staticText = "Target creature an opponent controls blocks this turn if able. Untap that creature. Other creatures that player controls can't block this turn";
     }
 
-    public MarkForDeathEffect(final MarkForDeathEffect effect) {
+    private MarkForDeathEffect(final MarkForDeathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarkOfEviction.java
+++ b/Mage.Sets/src/mage/cards/m/MarkOfEviction.java
@@ -62,7 +62,7 @@ class MarkOfEvictionEffect extends OneShotEffect {
         this.staticText = "return enchanted creature and all Auras attached to that creature to their owners' hands";
     }
 
-    public MarkOfEvictionEffect(final MarkOfEvictionEffect effect) {
+    private MarkOfEvictionEffect(final MarkOfEvictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarkOfSakiko.java
+++ b/Mage.Sets/src/mage/cards/m/MarkOfSakiko.java
@@ -66,7 +66,7 @@ class MarkOfSakikoTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null, false);
     }
 
-    public MarkOfSakikoTriggeredAbility(final MarkOfSakikoTriggeredAbility ability) {
+    private MarkOfSakikoTriggeredAbility(final MarkOfSakikoTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarrowGnawer.java
+++ b/Mage.Sets/src/mage/cards/m/MarrowGnawer.java
@@ -50,7 +50,7 @@ public final class MarrowGnawer extends CardImpl {
         this.addAbility(ability);
     }
 
-    public MarrowGnawer (final MarrowGnawer card) {
+    private MarrowGnawer(final MarrowGnawer card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarshCasualties.java
+++ b/Mage.Sets/src/mage/cards/m/MarshCasualties.java
@@ -64,7 +64,7 @@ class MarshCasualtiesEffect extends ContinuousEffectImpl {
         this.toughness = toughness;
     }
 
-    public MarshCasualtiesEffect(final MarshCasualtiesEffect effect) {
+    private MarshCasualtiesEffect(final MarshCasualtiesEffect effect) {
         super(effect);
         this.power = effect.power;
         this.toughness = effect.toughness;

--- a/Mage.Sets/src/mage/cards/m/MarshThreader.java
+++ b/Mage.Sets/src/mage/cards/m/MarshThreader.java
@@ -26,7 +26,7 @@ public final class MarshThreader extends CardImpl {
         this.addAbility(new SwampwalkAbility());
     }
 
-    public MarshThreader (final MarshThreader card) {
+    private MarshThreader(final MarshThreader card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarshalingTheTroops.java
+++ b/Mage.Sets/src/mage/cards/m/MarshalingTheTroops.java
@@ -54,7 +54,7 @@ class MarshalingTheTroopsEffect extends OneShotEffect {
         staticText = "Tap any number of untapped creatures you control. You gain 4 life for each creature tapped this way";
     }
 
-    public MarshalingTheTroopsEffect(MarshalingTheTroopsEffect effect) {
+    private MarshalingTheTroopsEffect(final MarshalingTheTroopsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarshlandBloodcaster.java
+++ b/Mage.Sets/src/mage/cards/m/MarshlandBloodcaster.java
@@ -68,7 +68,7 @@ class MarshlandBloodcasterEffect extends ContinuousEffectImpl {
                 "you may pay life equal to that spell's mana value";
     }
 
-    public MarshlandBloodcasterEffect(final MarshlandBloodcasterEffect effect) {
+    private MarshlandBloodcasterEffect(final MarshlandBloodcasterEffect effect) {
         super(effect);
         this.spellsCast = effect.spellsCast;
     }

--- a/Mage.Sets/src/mage/cards/m/MartialCoup.java
+++ b/Mage.Sets/src/mage/cards/m/MartialCoup.java
@@ -46,7 +46,7 @@ class MartialCoupEffect extends OneShotEffect {
         staticText = "create X 1/1 white Soldier creature tokens. If X is 5 or more, destroy all other creatures";
     }
 
-    public MartialCoupEffect(final MartialCoupEffect effect) {
+    private MartialCoupEffect(final MartialCoupEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Martyrdom.java
+++ b/Mage.Sets/src/mage/cards/m/Martyrdom.java
@@ -48,7 +48,7 @@ class MartyrdomGainAbilityTargetEffect extends ContinuousEffectImpl {
         this.staticText = "Until end of turn, target creature you control gains \"{0}: The next 1 damage that would be dealt to target creature, planeswalker, or player this turn is dealt to this creature instead.\" Only you may activate this ability";
     }
 
-    public MartyrdomGainAbilityTargetEffect(final MartyrdomGainAbilityTargetEffect effect) {
+    private MartyrdomGainAbilityTargetEffect(final MartyrdomGainAbilityTargetEffect effect) {
         super(effect);
     }
 
@@ -117,7 +117,7 @@ class MartyrdomRedirectDamageTargetEffect extends RedirectionEffect {
         staticText = "The next " + amount + " damage that would be dealt to target creature, planeswalker, or player this turn is dealt to {this} instead";
     }
 
-    public MartyrdomRedirectDamageTargetEffect(final MartyrdomRedirectDamageTargetEffect effect) {
+    private MartyrdomRedirectDamageTargetEffect(final MartyrdomRedirectDamageTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MartyrsBond.java
+++ b/Mage.Sets/src/mage/cards/m/MartyrsBond.java
@@ -51,7 +51,7 @@ class MartyrsBondTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new MartyrsBondEffect());
     }
 
-    public MartyrsBondTriggeredAbility(final MartyrsBondTriggeredAbility ability) {
+    private MartyrsBondTriggeredAbility(final MartyrsBondTriggeredAbility ability) {
         super(ability);
     }
 
@@ -96,7 +96,7 @@ class MartyrsBondEffect extends OneShotEffect {
         this.staticText = "each opponent sacrifices a permanent that shares a card type with it";
     }
 
-    public MartyrsBondEffect(final MartyrsBondEffect effect) {
+    private MartyrsBondEffect(final MartyrsBondEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MartyrsOfKorlis.java
+++ b/Mage.Sets/src/mage/cards/m/MartyrsOfKorlis.java
@@ -57,7 +57,7 @@ class RedirectArtifactDamageFromPlayerToSourceEffect extends RedirectionEffect {
         super(duration);
     }
 
-    public RedirectArtifactDamageFromPlayerToSourceEffect(final RedirectArtifactDamageFromPlayerToSourceEffect effect) {
+    private RedirectArtifactDamageFromPlayerToSourceEffect(final RedirectArtifactDamageFromPlayerToSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MasakoTheHumorless.java
+++ b/Mage.Sets/src/mage/cards/m/MasakoTheHumorless.java
@@ -51,7 +51,7 @@ class BlockTappedEffect extends AsThoughEffectImpl {
         staticText ="Tapped creatures you control can block as though they were untapped";
     }
 
-    public BlockTappedEffect(final BlockTappedEffect effect) {
+    private BlockTappedEffect(final BlockTappedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MassMutiny.java
+++ b/Mage.Sets/src/mage/cards/m/MassMutiny.java
@@ -71,7 +71,7 @@ class MassMutinyEffect extends OneShotEffect {
         this.staticText = "For each opponent, gain control of up to one target creature that player controls until end of turn. Untap those creatures. They gain haste until end of turn";
     }
 
-    public MassMutinyEffect(final MassMutinyEffect effect) {
+    private MassMutinyEffect(final MassMutinyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MassPolymorph.java
+++ b/Mage.Sets/src/mage/cards/m/MassPolymorph.java
@@ -50,7 +50,7 @@ class MassPolymorphEffect extends OneShotEffect {
         staticText = "Exile all creatures you control, then reveal cards from the top of your library until you reveal that many creature cards. Put all creature cards revealed this way onto the battlefield, then shuffle the rest of the revealed cards into your library";
     }
 
-    public MassPolymorphEffect(final MassPolymorphEffect effect) {
+    private MassPolymorphEffect(final MassPolymorphEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MasterOfCruelties.java
+++ b/Mage.Sets/src/mage/cards/m/MasterOfCruelties.java
@@ -63,7 +63,7 @@ class MasterOfCrueltiesTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} attacks a player and isn't blocked, ");
     }
 
-    public MasterOfCrueltiesTriggeredAbility(final MasterOfCrueltiesTriggeredAbility ability) {
+    private MasterOfCrueltiesTriggeredAbility(final MasterOfCrueltiesTriggeredAbility ability) {
         super(ability);
     }
 
@@ -105,7 +105,7 @@ class MasterOfCrueltiesEffect extends OneShotEffect {
         this.staticText = "that player's life total becomes 1";
     }
 
-    public MasterOfCrueltiesEffect(final MasterOfCrueltiesEffect effect) {
+    private MasterOfCrueltiesEffect(final MasterOfCrueltiesEffect effect) {
         super(effect);
     }
 
@@ -132,7 +132,7 @@ class MasterOfCrueltiesNoDamageEffect extends ContinuousRuleModifyingEffectImpl 
         staticText = "{this} assigns no combat damage this combat";
     }
 
-    public MasterOfCrueltiesNoDamageEffect(final MasterOfCrueltiesNoDamageEffect effect) {
+    private MasterOfCrueltiesNoDamageEffect(final MasterOfCrueltiesNoDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MasterOfPredicaments.java
+++ b/Mage.Sets/src/mage/cards/m/MasterOfPredicaments.java
@@ -61,7 +61,7 @@ class MasterOfPredicamentsEffect extends OneShotEffect {
                 + "guessed wrong, you may cast the card without paying its mana cost";
     }
 
-    public MasterOfPredicamentsEffect(final MasterOfPredicamentsEffect effect) {
+    private MasterOfPredicamentsEffect(final MasterOfPredicamentsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MasterOfTheWildHunt.java
+++ b/Mage.Sets/src/mage/cards/m/MasterOfTheWildHunt.java
@@ -74,7 +74,7 @@ class MasterOfTheWildHuntEffect extends OneShotEffect {
         staticText = "Tap all untapped Wolf creatures you control. Each Wolf tapped this way deals damage equal to its power to target creature. That creature deals damage equal to its power divided as its controller chooses among any number of those Wolves";
     }
 
-    public MasterOfTheWildHuntEffect(final MasterOfTheWildHuntEffect effect) {
+    private MasterOfTheWildHuntEffect(final MasterOfTheWildHuntEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MastersCall.java
+++ b/Mage.Sets/src/mage/cards/m/MastersCall.java
@@ -21,7 +21,7 @@ public final class MastersCall extends CardImpl {
         this.getSpellAbility().addEffect(new CreateTokenEffect(new MyrToken(), 2));
     }
 
-    public MastersCall (final MastersCall card) {
+    private MastersCall(final MastersCall card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MathasFiendSeeker.java
+++ b/Mage.Sets/src/mage/cards/m/MathasFiendSeeker.java
@@ -72,7 +72,7 @@ class MathasFiendSeekerGainAbilityEffect extends GainAbilityTargetEffect {
         super(ability, duration, rule);
     }
 
-    public MathasFiendSeekerGainAbilityEffect(final MathasFiendSeekerGainAbilityEffect effect) {
+    private MathasFiendSeekerGainAbilityEffect(final MathasFiendSeekerGainAbilityEffect effect) {
         super(effect);
     }
 
@@ -98,7 +98,7 @@ class OpponentsGainLifeEffect extends OneShotEffect {
         staticText = "and gains 2 life.";
     }
 
-    public OpponentsGainLifeEffect(final OpponentsGainLifeEffect effect) {
+    private OpponentsGainLifeEffect(final OpponentsGainLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MatterReshaper.java
+++ b/Mage.Sets/src/mage/cards/m/MatterReshaper.java
@@ -55,7 +55,7 @@ class MatterReshaperEffect extends OneShotEffect {
                 + " with mana value 3 or less. Otherwise, put that card into your hand";
     }
 
-    public MatterReshaperEffect(final MatterReshaperEffect effect) {
+    private MatterReshaperEffect(final MatterReshaperEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MausoleumSecrets.java
+++ b/Mage.Sets/src/mage/cards/m/MausoleumSecrets.java
@@ -51,7 +51,7 @@ class MausoleumSecretsEffect extends OneShotEffect {
                 + "reveal it, put it into your hand, then shuffle.";
     }
 
-    public MausoleumSecretsEffect(final MausoleumSecretsEffect effect) {
+    private MausoleumSecretsEffect(final MausoleumSecretsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MausoleumTurnkey.java
+++ b/Mage.Sets/src/mage/cards/m/MausoleumTurnkey.java
@@ -57,7 +57,7 @@ class MausoleumTurnkeyEffect extends OneShotEffect {
         this.staticText = "return target creature card of an opponent's choice from your graveyard to your hand";
     }
 
-    public MausoleumTurnkeyEffect(final MausoleumTurnkeyEffect effect) {
+    private MausoleumTurnkeyEffect(final MausoleumTurnkeyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MavrenFeinDuskApostle.java
+++ b/Mage.Sets/src/mage/cards/m/MavrenFeinDuskApostle.java
@@ -63,7 +63,7 @@ class MavrenFeinDuskApostleTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever one or more nontoken Vampires you control attack, ");
     }
 
-    public MavrenFeinDuskApostleTriggeredAbility(final MavrenFeinDuskApostleTriggeredAbility ability) {
+    private MavrenFeinDuskApostleTriggeredAbility(final MavrenFeinDuskApostleTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MayaelsAria.java
+++ b/Mage.Sets/src/mage/cards/m/MayaelsAria.java
@@ -52,7 +52,7 @@ class MayaelsAriaEffect extends OneShotEffect {
         this.staticText = "put a +1/+1 counter on each creature you control if you control a creature with power 5 or greater. Then you gain 10 life if you control a creature with power 10 or greater. Then you win the game if you control a creature with power 20 or greater";
     }
 
-    public MayaelsAriaEffect(final MayaelsAriaEffect effect) {
+    private MayaelsAriaEffect(final MayaelsAriaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MazeAbomination.java
+++ b/Mage.Sets/src/mage/cards/m/MazeAbomination.java
@@ -44,7 +44,7 @@ public final class MazeAbomination extends CardImpl {
 
     }
 
-    public MazeAbomination (final MazeAbomination card) {
+    private MazeAbomination(final MazeAbomination card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MazeBehemoth.java
+++ b/Mage.Sets/src/mage/cards/m/MazeBehemoth.java
@@ -44,7 +44,7 @@ public final class MazeBehemoth extends CardImpl {
 
     }
 
-    public MazeBehemoth (final MazeBehemoth card) {
+    private MazeBehemoth(final MazeBehemoth card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MazeGlider.java
+++ b/Mage.Sets/src/mage/cards/m/MazeGlider.java
@@ -44,7 +44,7 @@ public final class MazeGlider extends CardImpl {
 
     }
 
-    public MazeGlider (final MazeGlider card) {
+    private MazeGlider(final MazeGlider card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MazeRusher.java
+++ b/Mage.Sets/src/mage/cards/m/MazeRusher.java
@@ -44,7 +44,7 @@ public final class MazeRusher extends CardImpl {
 
     }
 
-    public MazeRusher (final MazeRusher card) {
+    private MazeRusher(final MazeRusher card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MazeSentinel.java
+++ b/Mage.Sets/src/mage/cards/m/MazeSentinel.java
@@ -44,7 +44,7 @@ public final class MazeSentinel extends CardImpl {
 
     }
 
-    public MazeSentinel (final MazeSentinel card) {
+    private MazeSentinel(final MazeSentinel card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MazesEnd.java
+++ b/Mage.Sets/src/mage/cards/m/MazesEnd.java
@@ -110,7 +110,7 @@ class MazesEndEffect extends OneShotEffect {
         this.staticText = "If you control ten or more Gates with different names, you win the game";
     }
 
-    public MazesEndEffect(final MazesEndEffect effect) {
+    private MazesEndEffect(final MazesEndEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MazirekKraulDeathPriest.java
+++ b/Mage.Sets/src/mage/cards/m/MazirekKraulDeathPriest.java
@@ -58,7 +58,7 @@ class PlayerSacrificesPermanentTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a player sacrifices another permanent, ");
     }
 
-    public PlayerSacrificesPermanentTriggeredAbility(final PlayerSacrificesPermanentTriggeredAbility ability) {
+    private PlayerSacrificesPermanentTriggeredAbility(final PlayerSacrificesPermanentTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MeanderingTowershell.java
+++ b/Mage.Sets/src/mage/cards/m/MeanderingTowershell.java
@@ -75,7 +75,7 @@ class MeanderingTowershellEffect extends OneShotEffect {
         this.staticText = "exile it. Return it to the battlefield under your control tapped and attacking at the beginning of the declare attackers step on your next turn";
     }
 
-    public MeanderingTowershellEffect(final MeanderingTowershellEffect effect) {
+    private MeanderingTowershellEffect(final MeanderingTowershellEffect effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class AtBeginningNextDeclareAttackersStepNextTurnDelayedTriggeredAbility extends
         super(new MeanderingTowershellReturnEffect());
     }
 
-    public AtBeginningNextDeclareAttackersStepNextTurnDelayedTriggeredAbility(final AtBeginningNextDeclareAttackersStepNextTurnDelayedTriggeredAbility ability) {
+    private AtBeginningNextDeclareAttackersStepNextTurnDelayedTriggeredAbility(final AtBeginningNextDeclareAttackersStepNextTurnDelayedTriggeredAbility ability) {
         super(ability);
         this.startingTurn = ability.startingTurn;
     }
@@ -148,7 +148,7 @@ class MeanderingTowershellReturnEffect extends OneShotEffect {
         super(Outcome.PutCreatureInPlay);
     }
 
-    public MeanderingTowershellReturnEffect(final MeanderingTowershellReturnEffect effect) {
+    private MeanderingTowershellReturnEffect(final MeanderingTowershellReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MeasureOfWickedness.java
+++ b/Mage.Sets/src/mage/cards/m/MeasureOfWickedness.java
@@ -73,7 +73,7 @@ class MeasureOfWickednessControlSourceEffect extends ContinuousEffectImpl {
         staticText = "target opponent gains control of {this}";
     }
 
-    public MeasureOfWickednessControlSourceEffect(final MeasureOfWickednessControlSourceEffect effect) {
+    private MeasureOfWickednessControlSourceEffect(final MeasureOfWickednessControlSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MechanizedProduction.java
+++ b/Mage.Sets/src/mage/cards/m/MechanizedProduction.java
@@ -64,7 +64,7 @@ class MechanizedProductionEffect extends OneShotEffect {
         this.staticText = "create a token that's a copy of enchanted artifact. Then if you control eight or more artifacts with the same name as one another, you win the game";
     }
 
-    public MechanizedProductionEffect(final MechanizedProductionEffect effect) {
+    private MechanizedProductionEffect(final MechanizedProductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MeddlingMage.java
+++ b/Mage.Sets/src/mage/cards/m/MeddlingMage.java
@@ -54,7 +54,7 @@ class MeddlingMageReplacementEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Spells with the chosen name can't be cast";
     }
 
-    public MeddlingMageReplacementEffect(final MeddlingMageReplacementEffect effect) {
+    private MeddlingMageReplacementEffect(final MeddlingMageReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Meditate.java
+++ b/Mage.Sets/src/mage/cards/m/Meditate.java
@@ -44,7 +44,7 @@ class SpipTurnEffect extends OneShotEffect {
         staticText = "You skip your next turn";
     }
 
-    public SpipTurnEffect(final SpipTurnEffect effect) {
+    private SpipTurnEffect(final SpipTurnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Megatherium.java
+++ b/Mage.Sets/src/mage/cards/m/Megatherium.java
@@ -54,7 +54,7 @@ class MegatheriumEffect extends OneShotEffect {
         this.staticText = "sacrifice it unless you pay {1} for each card in your hand";
     }
 
-    public MegatheriumEffect(final MegatheriumEffect effect) {
+    private MegatheriumEffect(final MegatheriumEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Meglonoth.java
+++ b/Mage.Sets/src/mage/cards/m/Meglonoth.java
@@ -56,7 +56,7 @@ class MeglonothEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to that creature's controller equal to {this}'s power";
     }
 
-    public MeglonothEffect(final MeglonothEffect effect) {
+    private MeglonothEffect(final MeglonothEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Melee.java
+++ b/Mage.Sets/src/mage/cards/m/Melee.java
@@ -74,7 +74,7 @@ class MeleeTriggeredAbility extends DelayedTriggeredAbility {
         this.addEffect(new RemoveFromCombatTargetEffect());
     }
 
-    public MeleeTriggeredAbility(MeleeTriggeredAbility ability) {
+    private MeleeTriggeredAbility(final MeleeTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MelekIzzetParagon.java
+++ b/Mage.Sets/src/mage/cards/m/MelekIzzetParagon.java
@@ -68,7 +68,7 @@ class MelekIzzetParagonTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CopyTargetSpellEffect(), false);
     }
 
-    public MelekIzzetParagonTriggeredAbility(final MelekIzzetParagonTriggeredAbility ability) {
+    private MelekIzzetParagonTriggeredAbility(final MelekIzzetParagonTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MeletisCharlatan.java
+++ b/Mage.Sets/src/mage/cards/m/MeletisCharlatan.java
@@ -59,7 +59,7 @@ class MeletisCharlatanCopyTargetSpellEffect extends OneShotEffect {
         staticText = "The controller of target instant or sorcery spell copies it. That player may choose new targets for the copy";
     }
 
-    public MeletisCharlatanCopyTargetSpellEffect(final MeletisCharlatanCopyTargetSpellEffect effect) {
+    private MeletisCharlatanCopyTargetSpellEffect(final MeletisCharlatanCopyTargetSpellEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MeliraSylvokOutcast.java
+++ b/Mage.Sets/src/mage/cards/m/MeliraSylvokOutcast.java
@@ -60,7 +60,7 @@ class MeliraSylvokOutcastEffect extends ReplacementEffectImpl {
         staticText = "You can't get poison counters";
     }
 
-    public MeliraSylvokOutcastEffect(final MeliraSylvokOutcastEffect effect) {
+    private MeliraSylvokOutcastEffect(final MeliraSylvokOutcastEffect effect) {
         super(effect);
     }
 
@@ -93,7 +93,7 @@ class MeliraSylvokOutcastEffect2 extends ReplacementEffectImpl {
         staticText = "Creatures you control can't have -1/-1 counters put on them";
     }
 
-    public MeliraSylvokOutcastEffect2(final MeliraSylvokOutcastEffect2 effect) {
+    private MeliraSylvokOutcastEffect2(final MeliraSylvokOutcastEffect2 effect) {
         super(effect);
     }
 
@@ -134,7 +134,7 @@ class MeliraSylvokOutcastEffect3 extends ContinuousEffectImpl {
         staticText = "Creatures your opponents control lose infect";
     }
 
-    public MeliraSylvokOutcastEffect3(final MeliraSylvokOutcastEffect3 effect) {
+    private MeliraSylvokOutcastEffect3(final MeliraSylvokOutcastEffect3 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MeltTerrain.java
+++ b/Mage.Sets/src/mage/cards/m/MeltTerrain.java
@@ -28,7 +28,7 @@ public final class MeltTerrain extends CardImpl {
         this.getSpellAbility().addTarget(new TargetLandPermanent());
     }
 
-    public MeltTerrain (final MeltTerrain card) {
+    private MeltTerrain(final MeltTerrain card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Melting.java
+++ b/Mage.Sets/src/mage/cards/m/Melting.java
@@ -43,7 +43,7 @@ class MeltingEffect extends ContinuousEffectImpl {
         this.staticText = "All lands are no longer snow";
     }
 
-    public MeltingEffect(final MeltingEffect effect) {
+    private MeltingEffect(final MeltingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Memnite.java
+++ b/Mage.Sets/src/mage/cards/m/Memnite.java
@@ -22,7 +22,7 @@ public final class Memnite extends CardImpl {
         this.toughness = new MageInt(1);
     }
 
-    public Memnite (final Memnite card) {
+    private Memnite(final Memnite card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MemoryPlunder.java
+++ b/Mage.Sets/src/mage/cards/m/MemoryPlunder.java
@@ -57,7 +57,7 @@ class MemoryPlunderEffect extends OneShotEffect {
                 + "an opponent's graveyard without paying its mana cost";
     }
 
-    public MemoryPlunderEffect(final MemoryPlunderEffect effect) {
+    private MemoryPlunderEffect(final MemoryPlunderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MenacingOgre.java
+++ b/Mage.Sets/src/mage/cards/m/MenacingOgre.java
@@ -60,7 +60,7 @@ class MenacingOgreEffect extends OneShotEffect {
         this.staticText = "each player secretly chooses a number. Then those numbers are revealed. Each player with the highest number loses that much life. If you are one of those players, put two +1/+1 counters on {this}";
     }
 
-    public MenacingOgreEffect(final MenacingOgreEffect effect) {
+    private MenacingOgreEffect(final MenacingOgreEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MercadianLift.java
+++ b/Mage.Sets/src/mage/cards/m/MercadianLift.java
@@ -61,7 +61,7 @@ class MercadianLiftEffect extends OneShotEffect {
         staticText = "You may put a creature card with mana value X from your hand onto the battlefield";
     }
 
-    public MercadianLiftEffect(final MercadianLiftEffect effect) {
+    private MercadianLiftEffect(final MercadianLiftEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MerchantsDockhand.java
+++ b/Mage.Sets/src/mage/cards/m/MerchantsDockhand.java
@@ -62,7 +62,7 @@ class MerchantsDockhandEffect extends OneShotEffect {
         this.staticText = "Look at the top X cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order";
     }
 
-    public MerchantsDockhandEffect(final MerchantsDockhandEffect effect) {
+    private MerchantsDockhandEffect(final MerchantsDockhandEffect effect) {
         super(effect);
     }
 
@@ -118,7 +118,7 @@ class TapXTargetCost extends VariableCostImpl {
         this.text = "Tap X untapped artifacts you control";
     }
 
-    public TapXTargetCost(final TapXTargetCost cost) {
+    private TapXTargetCost(final TapXTargetCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MercyKilling.java
+++ b/Mage.Sets/src/mage/cards/m/MercyKilling.java
@@ -44,7 +44,7 @@ class MercyKillingTokenEffect extends OneShotEffect {
         staticText = ", then creates X 1/1 green and white Elf Warrior creature tokens, where X is that creature's power";
     }
 
-    public MercyKillingTokenEffect(final MercyKillingTokenEffect effect) {
+    private MercyKillingTokenEffect(final MercyKillingTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MerfolkSpy.java
+++ b/Mage.Sets/src/mage/cards/m/MerfolkSpy.java
@@ -54,7 +54,7 @@ class MerfolkSpyEffect extends OneShotEffect {
         staticText = "that player reveals a card at random from their hand";
     }
 
-    public MerfolkSpyEffect(final MerfolkSpyEffect effect) {
+    private MerfolkSpyEffect(final MerfolkSpyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MerfolkWindrobber.java
+++ b/Mage.Sets/src/mage/cards/m/MerfolkWindrobber.java
@@ -63,7 +63,7 @@ class MerfolkWindrobberTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new MillCardsTargetEffect(1));
     }
 
-    public MerfolkWindrobberTriggeredAbility(final MerfolkWindrobberTriggeredAbility ability) {
+    private MerfolkWindrobberTriggeredAbility(final MerfolkWindrobberTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MeriekeRiBerit.java
+++ b/Mage.Sets/src/mage/cards/m/MeriekeRiBerit.java
@@ -63,7 +63,7 @@ class MeriekeRiBeritCreateDelayedTriggerEffect extends OneShotEffect {
         this.staticText = "When {this} leaves the battlefield or becomes untapped, destroy that creature. It can't be regenerated";
     }
 
-    public MeriekeRiBeritCreateDelayedTriggerEffect(final MeriekeRiBeritCreateDelayedTriggerEffect effect) {
+    private MeriekeRiBeritCreateDelayedTriggerEffect(final MeriekeRiBeritCreateDelayedTriggerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Merseine.java
+++ b/Mage.Sets/src/mage/cards/m/Merseine.java
@@ -105,7 +105,7 @@ class MerseineCost extends CostImpl {
         this.text = "Pay enchanted creature's mana cost";
     }
 
-    public MerseineCost(final MerseineCost cost) {
+    private MerseineCost(final MerseineCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MesaPegasus.java
+++ b/Mage.Sets/src/mage/cards/m/MesaPegasus.java
@@ -31,7 +31,7 @@ public final class MesaPegasus extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public MesaPegasus (final MesaPegasus card) {
+    private MesaPegasus(final MesaPegasus card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MesmericFiend.java
+++ b/Mage.Sets/src/mage/cards/m/MesmericFiend.java
@@ -63,7 +63,7 @@ class MesmericFiendExileEffect extends OneShotEffect {
         this.staticText = "target opponent reveals their hand and you choose a nonland card from it. Exile that card";
     }
     
-    public MesmericFiendExileEffect(final MesmericFiendExileEffect effect) {
+    private MesmericFiendExileEffect(final MesmericFiendExileEffect effect) {
         super(effect);
     }
     
@@ -103,7 +103,7 @@ class MesmericFiendLeaveEffect extends OneShotEffect {
         this.staticText = "return the exiled card to its owner's hand";
     }
     
-    public MesmericFiendLeaveEffect(final MesmericFiendLeaveEffect effect) {
+    private MesmericFiendLeaveEffect(final MesmericFiendLeaveEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/m/MetallurgicSummonings.java
+++ b/Mage.Sets/src/mage/cards/m/MetallurgicSummonings.java
@@ -69,7 +69,7 @@ class MetallurgicSummoningsTokenEffect extends OneShotEffect {
         staticText = "create an X/X colorless Construct artifact creature token, where X is that spell's mana value";
     }
 
-    public MetallurgicSummoningsTokenEffect(MetallurgicSummoningsTokenEffect ability) {
+    private MetallurgicSummoningsTokenEffect(final MetallurgicSummoningsTokenEffect ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Metalworker.java
+++ b/Mage.Sets/src/mage/cards/m/Metalworker.java
@@ -58,7 +58,7 @@ class MetalworkerManaEffect extends ManaEffect {
         staticText = "Reveal any number of artifact cards in your hand. Add {C}{C} for each card revealed this way";
     }
 
-    public MetalworkerManaEffect(final MetalworkerManaEffect effect) {
+    private MetalworkerManaEffect(final MetalworkerManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MetamorphicAlteration.java
+++ b/Mage.Sets/src/mage/cards/m/MetamorphicAlteration.java
@@ -64,7 +64,7 @@ class ChooseACreature extends OneShotEffect {
         staticText = "choose a creature";
     }
 
-    public ChooseACreature(final ChooseACreature effect) {
+    private ChooseACreature(final ChooseACreature effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class MetamorphicAlterationEffect extends ContinuousEffectImpl {
         this.staticText = "Enchanted creature is a copy of the chosen creature.";
     }
 
-    public MetamorphicAlterationEffect(MetamorphicAlterationEffect effect) {
+    private MetamorphicAlterationEffect(final MetamorphicAlterationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Metamorphose.java
+++ b/Mage.Sets/src/mage/cards/m/Metamorphose.java
@@ -70,7 +70,7 @@ class MetamorphoseEffect extends OneShotEffect {
         this.staticText = "That opponent may put an artifact, creature, enchantment, or land card from their hand onto the battlefield.";
     }
 
-    public MetamorphoseEffect (final MetamorphoseEffect effect) { super(effect); }
+    private MetamorphoseEffect(final MetamorphoseEffect effect) { super(effect); }
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/m/Metamorphosis.java
+++ b/Mage.Sets/src/mage/cards/m/Metamorphosis.java
@@ -50,7 +50,7 @@ class MetamorphosisEffect extends OneShotEffect {
         staticText = "Add X mana of any one color, where X is 1 plus the sacrificed creature's mana value. Spend this mana only to cast creature spells.";
     }
 
-    public MetamorphosisEffect(final MetamorphosisEffect effect) {
+    private MetamorphosisEffect(final MetamorphosisEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MetathranAerostat.java
+++ b/Mage.Sets/src/mage/cards/m/MetathranAerostat.java
@@ -59,7 +59,7 @@ class MetathranAerostatEffect extends OneShotEffect {
                 + "If you do, return {this} to its owner's hand";
     }
 
-    public MetathranAerostatEffect(final MetathranAerostatEffect effect) {
+    private MetathranAerostatEffect(final MetathranAerostatEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MeteorCrater.java
+++ b/Mage.Sets/src/mage/cards/m/MeteorCrater.java
@@ -53,7 +53,7 @@ class MeteorCraterEffect extends ManaEffect {
         staticText = "Choose a color of a permanent you control. Add one mana of that color";
     }
 
-    public MeteorCraterEffect(final MeteorCraterEffect effect) {
+    private MeteorCraterEffect(final MeteorCraterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MetzaliTowerOfTriumph.java
+++ b/Mage.Sets/src/mage/cards/m/MetzaliTowerOfTriumph.java
@@ -79,7 +79,7 @@ class MetzaliTowerOfTriumphEffect extends OneShotEffect {
         this.staticText = "Choose a creature at random that attacked this turn. Destroy that creature";
     }
 
-    public MetzaliTowerOfTriumphEffect(final MetzaliTowerOfTriumphEffect effect) {
+    private MetzaliTowerOfTriumphEffect(final MetzaliTowerOfTriumphEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MichikoKondaTruthSeeker.java
+++ b/Mage.Sets/src/mage/cards/m/MichikoKondaTruthSeeker.java
@@ -51,7 +51,7 @@ class MichikoKondaTruthSeekerAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SacrificeEffect(new FilterPermanent(), 1, "that player"), false);
     }
 
-    public MichikoKondaTruthSeekerAbility(final MichikoKondaTruthSeekerAbility ability) {
+    private MichikoKondaTruthSeekerAbility(final MichikoKondaTruthSeekerAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MidnightRitual.java
+++ b/Mage.Sets/src/mage/cards/m/MidnightRitual.java
@@ -61,7 +61,7 @@ class MidnightRitualEffect extends OneShotEffect {
         this.staticText = "Exile X target creature cards from your graveyard. For each creature card exiled this way, create a 2/2 black Zombie creature token";
     }
 
-    public MidnightRitualEffect(final MidnightRitualEffect effect) {
+    private MidnightRitualEffect(final MidnightRitualEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MijaeDjinn.java
+++ b/Mage.Sets/src/mage/cards/m/MijaeDjinn.java
@@ -48,7 +48,7 @@ class MijaeDjinnEffect extends OneShotEffect {
         staticText = "flip a coin. If you lose the flip, remove {this} from combat and tap it";
     }
 
-    public MijaeDjinnEffect(MijaeDjinnEffect effect) {
+    private MijaeDjinnEffect(final MijaeDjinnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MikaeusTheUnhallowed.java
+++ b/Mage.Sets/src/mage/cards/m/MikaeusTheUnhallowed.java
@@ -71,7 +71,7 @@ class MikaeusTheUnhallowedAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect());
     }
 
-    public MikaeusTheUnhallowedAbility(final MikaeusTheUnhallowedAbility ability) {
+    private MikaeusTheUnhallowedAbility(final MikaeusTheUnhallowedAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MilitiasPride.java
+++ b/Mage.Sets/src/mage/cards/m/MilitiasPride.java
@@ -48,7 +48,7 @@ class MilitiasPrideTriggerAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DoIfCostPaid(new CreateTokenEffect(new KithkinSoldierToken(), 1, true, true), new ManaCostsImpl<>("{W}")));
     }
 
-    public MilitiasPrideTriggerAbility(final MilitiasPrideTriggerAbility ability) {
+    private MilitiasPrideTriggerAbility(final MilitiasPrideTriggerAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MimicVat.java
+++ b/Mage.Sets/src/mage/cards/m/MimicVat.java
@@ -114,7 +114,7 @@ class MimicVatEffect extends OneShotEffect {
         staticText = "exile that card";
     }
 
-    public MimicVatEffect(MimicVatEffect effect) {
+    private MimicVatEffect(final MimicVatEffect effect) {
         super(effect);
     }
 
@@ -160,7 +160,7 @@ class MimicVatCreateTokenEffect extends OneShotEffect {
         this.staticText = "Create a token that's a copy of a card exiled with {this}. It gains haste. Exile it at the beginning of the next end step";
     }
 
-    public MimicVatCreateTokenEffect(final MimicVatCreateTokenEffect effect) {
+    private MimicVatCreateTokenEffect(final MimicVatCreateTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MimingSlime.java
+++ b/Mage.Sets/src/mage/cards/m/MimingSlime.java
@@ -45,7 +45,7 @@ class MimingSlimeEffect extends OneShotEffect {
         staticText = "Create an X/X green Ooze creature token, where X is the greatest power among creatures you control";
     }
 
-    public MimingSlimeEffect(final MimingSlimeEffect effect) {
+    private MimingSlimeEffect(final MimingSlimeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MinamoSchoolAtWatersEdge.java
+++ b/Mage.Sets/src/mage/cards/m/MinamoSchoolAtWatersEdge.java
@@ -41,7 +41,7 @@ public final class MinamoSchoolAtWatersEdge extends CardImpl {
         this.addAbility(ability);
     }
 
-    public MinamoSchoolAtWatersEdge (final MinamoSchoolAtWatersEdge card) {
+    private MinamoSchoolAtWatersEdge(final MinamoSchoolAtWatersEdge card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MindFuneral.java
+++ b/Mage.Sets/src/mage/cards/m/MindFuneral.java
@@ -48,7 +48,7 @@ class MindFuneralEffect extends OneShotEffect {
         this.staticText = "Target opponent reveals cards from the top of their library until four land cards are revealed. That player puts all cards revealed this way into their graveyard";
     }
 
-    public MindFuneralEffect(final MindFuneralEffect effect) {
+    private MindFuneralEffect(final MindFuneralEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MindGrind.java
+++ b/Mage.Sets/src/mage/cards/m/MindGrind.java
@@ -53,7 +53,7 @@ class MindGrindEffect extends OneShotEffect {
         this.staticText = "Each opponent reveals cards from the top of their library until they reveal X land cards, then puts all cards revealed this way into their graveyard. X can't be 0";
     }
 
-    public MindGrindEffect(final MindGrindEffect effect) {
+    private MindGrindEffect(final MindGrindEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MindWhip.java
+++ b/Mage.Sets/src/mage/cards/m/MindWhip.java
@@ -69,7 +69,7 @@ class MindWhipEffect extends OneShotEffect {
         staticText = "";
     }
 
-    public MindWhipEffect(final MindWhipEffect effect) {
+    private MindWhipEffect(final MindWhipEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MindbladeRender.java
+++ b/Mage.Sets/src/mage/cards/m/MindbladeRender.java
@@ -54,7 +54,7 @@ class MindbladeRenderTriggeredAbility extends TriggeredAbilityImpl {
         this.usedForCombatDamageStep = false;
     }
 
-    public MindbladeRenderTriggeredAbility(final MindbladeRenderTriggeredAbility effect) {
+    private MindbladeRenderTriggeredAbility(final MindbladeRenderTriggeredAbility effect) {
         super(effect);
         this.usedForCombatDamageStep = effect.usedForCombatDamageStep;
     }

--- a/Mage.Sets/src/mage/cards/m/MindclawShaman.java
+++ b/Mage.Sets/src/mage/cards/m/MindclawShaman.java
@@ -57,7 +57,7 @@ class MindclawShamanEffect extends OneShotEffect {
                 + "an instant or sorcery spell from among those cards without paying its mana cost";
     }
 
-    public MindclawShamanEffect(final MindclawShamanEffect effect) {
+    private MindclawShamanEffect(final MindclawShamanEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mindcrank.java
+++ b/Mage.Sets/src/mage/cards/m/Mindcrank.java
@@ -47,7 +47,7 @@ class MindcrankTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new MindcrankEffect(), false);
     }
 
-    public MindcrankTriggeredAbility(final MindcrankTriggeredAbility ability) {
+    private MindcrankTriggeredAbility(final MindcrankTriggeredAbility ability) {
         super(ability);
     }
 
@@ -86,7 +86,7 @@ class MindcrankEffect extends OneShotEffect {
         super(Outcome.Detriment);
     }
 
-    public MindcrankEffect(final MindcrankEffect effect) {
+    private MindcrankEffect(final MindcrankEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MindleechMass.java
+++ b/Mage.Sets/src/mage/cards/m/MindleechMass.java
@@ -58,7 +58,7 @@ class MindleechMassEffect extends OneShotEffect {
                 "may cast a spell from among those cards without paying its mana cost";
     }
 
-    public MindleechMassEffect(final MindleechMassEffect effect) {
+    private MindleechMassEffect(final MindleechMassEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mindmoil.java
+++ b/Mage.Sets/src/mage/cards/m/Mindmoil.java
@@ -43,7 +43,7 @@ class MindmoilEffect extends OneShotEffect {
         staticText = "put the cards in your hand on the bottom of your library in any order, then draw that many cards";
     }
 
-    public MindmoilEffect(final MindmoilEffect effect) {
+    private MindmoilEffect(final MindmoilEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MindsAglow.java
+++ b/Mage.Sets/src/mage/cards/m/MindsAglow.java
@@ -43,7 +43,7 @@ class MindsAglowEffect extends OneShotEffect {
         this.staticText = "<i>Join forces</i> &mdash; Starting with you, each player may pay any amount of mana. Each player draws X cards, where X is the total amount of mana paid this way";
     }
 
-    public MindsAglowEffect(final MindsAglowEffect effect) {
+    private MindsAglowEffect(final MindsAglowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mindsparker.java
+++ b/Mage.Sets/src/mage/cards/m/Mindsparker.java
@@ -65,7 +65,7 @@ class MindsparkerEffect extends OneShotEffect {
         staticText = "{this} deals 2 damage to that player";
     }
 
-    public MindsparkerEffect(final MindsparkerEffect effect) {
+    private MindsparkerEffect(final MindsparkerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mindswipe.java
+++ b/Mage.Sets/src/mage/cards/m/Mindswipe.java
@@ -52,7 +52,7 @@ class MindswipeEffect extends OneShotEffect {
         this.staticText = "{this} deals X damage to that spell's controller";
     }
 
-    public MindswipeEffect(final MindswipeEffect effect) {
+    private MindswipeEffect(final MindswipeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MineLayer.java
+++ b/Mage.Sets/src/mage/cards/m/MineLayer.java
@@ -72,7 +72,7 @@ class RemoveAllMineCountersEffect extends OneShotEffect {
         this.staticText = "remove all mine counters from all lands";
     }
 
-    public RemoveAllMineCountersEffect(final RemoveAllMineCountersEffect effect) {
+    private RemoveAllMineCountersEffect(final RemoveAllMineCountersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MinionOfLeshrac.java
+++ b/Mage.Sets/src/mage/cards/m/MinionOfLeshrac.java
@@ -64,7 +64,7 @@ class MinionLeshracEffect extends OneShotEffect {
         staticText = "{this} deals 5 damage to you unless you sacrifice a creature other than {this}. If {this} deals damage to you this way, tap it";
     }
 
-    public MinionLeshracEffect(final MinionLeshracEffect effect) {
+    private MinionLeshracEffect(final MinionLeshracEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MinionReflector.java
+++ b/Mage.Sets/src/mage/cards/m/MinionReflector.java
@@ -59,7 +59,7 @@ class MinionReflectorEffect extends OneShotEffect {
         this.staticText = "create a token that's a copy of that creature, except it has haste and \"At the beginning of the end step, sacrifice this permanent.\"";
     }
 
-    public MinionReflectorEffect(final MinionReflectorEffect effect) {
+    private MinionReflectorEffect(final MinionReflectorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MinionsMurmurs.java
+++ b/Mage.Sets/src/mage/cards/m/MinionsMurmurs.java
@@ -42,7 +42,7 @@ public final class MinionsMurmurs extends CardImpl {
             this.staticText = "You draw X cards and you lose X life, where X is the number of creatures you control";
         }
 
-        public MinionsMurmursEffect(final MinionsMurmursEffect effect) {
+        private MinionsMurmursEffect(final MinionsMurmursEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/m/MinotaurAggressor.java
+++ b/Mage.Sets/src/mage/cards/m/MinotaurAggressor.java
@@ -30,7 +30,7 @@ public final class MinotaurAggressor extends CardImpl {
         this.addAbility(HasteAbility.getInstance());
     }
 
-    public MinotaurAggressor (final MinotaurAggressor card) {
+    private MinotaurAggressor(final MinotaurAggressor card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MiraculousRecovery.java
+++ b/Mage.Sets/src/mage/cards/m/MiraculousRecovery.java
@@ -48,7 +48,7 @@ class MiraculousRecoveryEffect extends OneShotEffect {
         this.staticText = "Put a +1/+1 counter on it";
     }
 
-    public MiraculousRecoveryEffect(final MiraculousRecoveryEffect effect) {
+    private MiraculousRecoveryEffect(final MiraculousRecoveryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirageMirror.java
+++ b/Mage.Sets/src/mage/cards/m/MirageMirror.java
@@ -52,7 +52,7 @@ class MirageMirrorCopyEffect extends OneShotEffect {
         this.staticText = "{this} becomes a copy of target artifact, creature, enchantment, or land until end of turn";
     }
 
-    public MirageMirrorCopyEffect(final MirageMirrorCopyEffect effect) {
+    private MirageMirrorCopyEffect(final MirageMirrorCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirenTheMoaningWell.java
+++ b/Mage.Sets/src/mage/cards/m/MirenTheMoaningWell.java
@@ -58,7 +58,7 @@ class MirenTheMoaningWellEffect extends OneShotEffect {
         this.staticText = "You gain life equal to the sacrificed creature's toughness";
     }
 
-    public MirenTheMoaningWellEffect(final MirenTheMoaningWellEffect effect) {
+    private MirenTheMoaningWellEffect(final MirenTheMoaningWellEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirkoVoskMindDrinker.java
+++ b/Mage.Sets/src/mage/cards/m/MirkoVoskMindDrinker.java
@@ -54,7 +54,7 @@ class MirkoVoskMindDrinkerEffect extends OneShotEffect {
         this.staticText = "that player reveals cards from the top of their library until they reveal four land cards, then puts those cards into their graveyard";
     }
 
-    public MirkoVoskMindDrinkerEffect(final MirkoVoskMindDrinkerEffect effect) {
+    private MirkoVoskMindDrinkerEffect(final MirkoVoskMindDrinkerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirkwoodElk.java
+++ b/Mage.Sets/src/mage/cards/m/MirkwoodElk.java
@@ -66,7 +66,7 @@ class MirkwoodElkEffect extends OneShotEffect {
         this.staticText = "return target Elf card from your graveyard to your hand. You gain life equal to that card's power.";
     }
 
-    public MirkwoodElkEffect(final MirkwoodElkEffect effect) { super(effect); }
+    private MirkwoodElkEffect(final MirkwoodElkEffect effect) { super(effect); }
 
     @Override
     public MirkwoodElkEffect copy() { return new MirkwoodElkEffect(this); }

--- a/Mage.Sets/src/mage/cards/m/MirrodinsCore.java
+++ b/Mage.Sets/src/mage/cards/m/MirrodinsCore.java
@@ -31,7 +31,7 @@ public final class MirrodinsCore extends CardImpl {
         this.addAbility(ability);
     }
 
-    public MirrodinsCore (final MirrodinsCore card) {
+    private MirrodinsCore(final MirrodinsCore card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirrorBox.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorBox.java
@@ -63,7 +63,7 @@ class MirrorBoxBoostEffect extends ContinuousEffectImpl {
                 "each other creature you control with the same name as that creature";
     }
 
-    public MirrorBoxBoostEffect(final MirrorBoxBoostEffect effect) {
+    private MirrorBoxBoostEffect(final MirrorBoxBoostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirrorGolem.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorGolem.java
@@ -95,7 +95,7 @@ class MirrorGolemEffect extends ContinuousEffectImpl {
         staticText = "{this} has protection from each of the exiled card's card types.";
     }
 
-    public MirrorGolemEffect(final MirrorGolemEffect effect) {
+    private MirrorGolemEffect(final MirrorGolemEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirrorMadPhantasm.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorMadPhantasm.java
@@ -57,7 +57,7 @@ class MirrorMadPhantasmEffect extends OneShotEffect {
         this.staticText = "{this}'s owner shuffles it into their library. If that player does, they reveal cards from the top of that library until a card named Mirror-Mad Phantasm is revealed. That player puts that card onto the battlefield and all other cards revealed this way into their graveyard";
     }
 
-    public MirrorMadPhantasmEffect(final MirrorMadPhantasmEffect effect) {
+    private MirrorMadPhantasmEffect(final MirrorMadPhantasmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirrorMatch.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorMatch.java
@@ -54,7 +54,7 @@ class MirrorMatchEffect extends OneShotEffect {
         this.staticText = "For each creature attacking you or a planeswalker you control, create a token that's a copy of that creature blocking that creature. Exile those tokens at end of combat";
     }
 
-    public MirrorMatchEffect(final MirrorMatchEffect effect) {
+    private MirrorMatchEffect(final MirrorMatchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirrorMockery.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorMockery.java
@@ -60,7 +60,7 @@ class MirrorMockeryEffect extends OneShotEffect {
         this.staticText = "you may create a token that's a copy of that creature. Exile that token at end of combat";
     }
 
-    public MirrorMockeryEffect(final MirrorMockeryEffect effect) {
+    private MirrorMockeryEffect(final MirrorMockeryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirrorOfFate.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorOfFate.java
@@ -55,7 +55,7 @@ class MirrorOfFateEffect extends OneShotEffect {
         this.staticText = "Choose up to seven face-up exiled cards you own. Exile all the cards from your library, then put the chosen cards on top of your library";
     }
 
-    public MirrorOfFateEffect(final MirrorOfFateEffect effect) {
+    private MirrorOfFateEffect(final MirrorOfFateEffect effect) {
         super(effect);
     }
 
@@ -104,7 +104,7 @@ class MirrorOfFateTarget extends TargetCardInExile {
         this.targetName = "face-up exiled cards you own";
     }
 
-    public MirrorOfFateTarget(final MirrorOfFateTarget target) {
+    private MirrorOfFateTarget(final MirrorOfFateTarget target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirrorStrike.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorStrike.java
@@ -56,7 +56,7 @@ class MirrorStrikeEffect extends ReplacementEffectImpl {
         staticText = "All combat damage that would be dealt to you this turn by target unblocked creature is dealt to its controller instead";
     }
 
-    public MirrorStrikeEffect(final MirrorStrikeEffect effect) {
+    private MirrorStrikeEffect(final MirrorStrikeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mirrorweave.java
+++ b/Mage.Sets/src/mage/cards/m/Mirrorweave.java
@@ -57,7 +57,7 @@ class MirrorWeaveEffect extends OneShotEffect {
         this.staticText = "Each other creature becomes a copy of target nonlegendary creature until end of turn";
     }
 
-    public MirrorWeaveEffect(final MirrorWeaveEffect effect) {
+    private MirrorWeaveEffect(final MirrorWeaveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirrorwoodTreefolk.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorwoodTreefolk.java
@@ -55,7 +55,7 @@ class MirrorwoodTreefolkEffect extends RedirectionEffect {
         staticText = "The next time damage would be dealt to {this} this turn, that damage is dealt to any target instead";
     }
 
-    public MirrorwoodTreefolkEffect(final MirrorwoodTreefolkEffect effect) {
+    private MirrorwoodTreefolkEffect(final MirrorwoodTreefolkEffect effect) {
         super(effect);
         this.redirectToObject = effect.redirectToObject;
     }

--- a/Mage.Sets/src/mage/cards/m/Mise.java
+++ b/Mage.Sets/src/mage/cards/m/Mise.java
@@ -45,7 +45,7 @@ class MiseEffect extends OneShotEffect {
         staticText = "then reveal the top card of your library. If that card has the chosen name, you draw three cards";
     }
 
-    public MiseEffect(final MiseEffect effect) {
+    private MiseEffect(final MiseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MisfortunesGain.java
+++ b/Mage.Sets/src/mage/cards/m/MisfortunesGain.java
@@ -44,7 +44,7 @@ class MisfortunesGainEffect extends OneShotEffect {
         this.staticText = "Destroy target creature. Its owner gains 4 life";
     }
 
-    public MisfortunesGainEffect(final MisfortunesGainEffect effect) {
+    private MisfortunesGainEffect(final MisfortunesGainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MishrasGroundbreaker.java
+++ b/Mage.Sets/src/mage/cards/m/MishrasGroundbreaker.java
@@ -52,7 +52,7 @@ class MishrasGroundbreakerToken extends TokenImpl {
         this.power = new MageInt(3);
         this.toughness = new MageInt(3);
     }
-    public MishrasGroundbreakerToken(final MishrasGroundbreakerToken token) {
+    private MishrasGroundbreakerToken(final MishrasGroundbreakerToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MishrasWarMachine.java
+++ b/Mage.Sets/src/mage/cards/m/MishrasWarMachine.java
@@ -55,7 +55,7 @@ class MishrasWarMachineEffect extends OneShotEffect {
         staticText = "{this} deals 3 damage to you unless you discard a card. If Mishra's War Machine deals damage to you this way, tap it";
     }
 
-    public MishrasWarMachineEffect(final MishrasWarMachineEffect effect) {
+    private MishrasWarMachineEffect(final MishrasWarMachineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MissDemeanor.java
+++ b/Mage.Sets/src/mage/cards/m/MissDemeanor.java
@@ -59,7 +59,7 @@ class MissDemeanorEffect extends OneShotEffect {
         this.staticText = "you may compliment that player on their game play. If you don't, sacrifice {this}";
     }
 
-    public MissDemeanorEffect(final MissDemeanorEffect effect) {
+    private MissDemeanorEffect(final MissDemeanorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MistbindClique.java
+++ b/Mage.Sets/src/mage/cards/m/MistbindClique.java
@@ -62,7 +62,7 @@ class MistbindCliqueAbility extends ZoneChangeTriggeredAbility {
         this.addTarget(new TargetPlayer());
     }
 
-    public MistbindCliqueAbility(MistbindCliqueAbility ability) {
+    private MistbindCliqueAbility(final MistbindCliqueAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mistcaller.java
+++ b/Mage.Sets/src/mage/cards/m/Mistcaller.java
@@ -55,7 +55,7 @@ class ContainmentPriestReplacementEffect extends ReplacementEffectImpl {
         staticText = "until end of turn, if a nontoken creature would enter the battlefield and it wasn't cast, exile it instead";
     }
 
-    public ContainmentPriestReplacementEffect(final ContainmentPriestReplacementEffect effect) {
+    private ContainmentPriestReplacementEffect(final ContainmentPriestReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MistformSliver.java
+++ b/Mage.Sets/src/mage/cards/m/MistformSliver.java
@@ -66,7 +66,7 @@ class MistformSliverEffect extends OneShotEffect {
         staticText = "This permanent becomes the creature type of your choice in addition to its other types until end of turn";
     }
 
-    public MistformSliverEffect(final MistformSliverEffect effect) {
+    private MistformSliverEffect(final MistformSliverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MisthollowGriffin.java
+++ b/Mage.Sets/src/mage/cards/m/MisthollowGriffin.java
@@ -54,7 +54,7 @@ class MisthollowGriffinPlayEffect extends AsThoughEffectImpl {
         staticText = "You may cast {this} from exile";
     }
 
-    public MisthollowGriffinPlayEffect(final MisthollowGriffinPlayEffect effect) {
+    private MisthollowGriffinPlayEffect(final MisthollowGriffinPlayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MistmoonGriffin.java
+++ b/Mage.Sets/src/mage/cards/m/MistmoonGriffin.java
@@ -57,7 +57,7 @@ class MistmoonGriffinEffect extends OneShotEffect {
         this.staticText = ", then return the top creature card of your graveyard to the battlefield";
     }
 
-    public MistmoonGriffinEffect(final MistmoonGriffinEffect effect) {
+    private MistmoonGriffinEffect(final MistmoonGriffinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MistveilPlains.java
+++ b/Mage.Sets/src/mage/cards/m/MistveilPlains.java
@@ -71,7 +71,7 @@ class MistveilPlainsGraveyardToLibraryEffect extends OneShotEffect {
         this.staticText = "Put target card from your graveyard on the bottom of your library";
     }
 
-    public MistveilPlainsGraveyardToLibraryEffect(final MistveilPlainsGraveyardToLibraryEffect effect) {
+    private MistveilPlainsGraveyardToLibraryEffect(final MistveilPlainsGraveyardToLibraryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MistveinBorderpost.java
+++ b/Mage.Sets/src/mage/cards/m/MistveinBorderpost.java
@@ -48,7 +48,7 @@ public final class MistveinBorderpost extends CardImpl {
         this.addAbility(new BlackManaAbility());
     }
 
-    public MistveinBorderpost (final MistveinBorderpost card) {
+    private MistveinBorderpost(final MistveinBorderpost card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MitoticManipulation.java
+++ b/Mage.Sets/src/mage/cards/m/MitoticManipulation.java
@@ -50,7 +50,7 @@ class MitoticManipulationEffect extends OneShotEffect {
         this.staticText = "Look at the top seven cards of your library. You may put one of those cards onto the battlefield if it has the same name as a permanent. Put the rest on the bottom of your library in any order";
     }
 
-    public MitoticManipulationEffect(final MitoticManipulationEffect effect) {
+    private MitoticManipulationEffect(final MitoticManipulationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MizziumTransreliquat.java
+++ b/Mage.Sets/src/mage/cards/m/MizziumTransreliquat.java
@@ -54,7 +54,7 @@ class MizziumTransreliquatCopyEffect extends OneShotEffect {
         this.staticText = "{this} becomes a copy of target artifact until end of turn";
     }
 
-    public MizziumTransreliquatCopyEffect(final MizziumTransreliquatCopyEffect effect) {
+    private MizziumTransreliquatCopyEffect(final MizziumTransreliquatCopyEffect effect) {
         super(effect);
     }
 
@@ -82,7 +82,7 @@ class MizziumTransreliquatCopyAndGainAbilityEffect extends OneShotEffect {
         this.staticText = "{this} becomes a copy of target artifact, except it has this ability";
     }
 
-    public MizziumTransreliquatCopyAndGainAbilityEffect(final MizziumTransreliquatCopyAndGainAbilityEffect effect) {
+    private MizziumTransreliquatCopyAndGainAbilityEffect(final MizziumTransreliquatCopyAndGainAbilityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MizzixsMastery.java
+++ b/Mage.Sets/src/mage/cards/m/MizzixsMastery.java
@@ -64,7 +64,7 @@ class MizzixsMasteryOverloadEffect extends OneShotEffect {
                 + "and you may cast the copy without paying its mana cost. Exile {this}";
     }
 
-    public MizzixsMasteryOverloadEffect(final MizzixsMasteryOverloadEffect effect) {
+    private MizzixsMasteryOverloadEffect(final MizzixsMasteryOverloadEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MnemonicBetrayal.java
+++ b/Mage.Sets/src/mage/cards/m/MnemonicBetrayal.java
@@ -60,7 +60,7 @@ class MnemonicBetrayalExileEffect extends OneShotEffect {
                 "return them to their owners' graveyards";
     }
 
-    public MnemonicBetrayalExileEffect(final MnemonicBetrayalExileEffect effect) {
+    private MnemonicBetrayalExileEffect(final MnemonicBetrayalExileEffect effect) {
         super(effect);
     }
 
@@ -113,7 +113,7 @@ class MnemonicBetrayalDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.morSet.addAll(morSet);
     }
 
-    public MnemonicBetrayalDelayedTriggeredAbility(final MnemonicBetrayalDelayedTriggeredAbility ability) {
+    private MnemonicBetrayalDelayedTriggeredAbility(final MnemonicBetrayalDelayedTriggeredAbility ability) {
         super(ability);
         this.morSet.addAll(ability.morSet);
     }
@@ -155,7 +155,7 @@ class MnemonicBetrayalReturnEffect extends OneShotEffect {
         this.morSet.addAll(morSet);
     }
 
-    public MnemonicBetrayalReturnEffect(final MnemonicBetrayalReturnEffect effect) {
+    private MnemonicBetrayalReturnEffect(final MnemonicBetrayalReturnEffect effect) {
         super(effect);
         this.morSet.addAll(effect.morSet);
     }

--- a/Mage.Sets/src/mage/cards/m/MnemonicNexus.java
+++ b/Mage.Sets/src/mage/cards/m/MnemonicNexus.java
@@ -40,7 +40,7 @@ class MnemonicNexusEffect extends OneShotEffect {
         staticText = "Each player shuffles their graveyard into their library";
     }
 
-    public MnemonicNexusEffect(final MnemonicNexusEffect effect) {
+    private MnemonicNexusEffect(final MnemonicNexusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoaningWall.java
+++ b/Mage.Sets/src/mage/cards/m/MoaningWall.java
@@ -27,7 +27,7 @@ public final class MoaningWall extends CardImpl {
         addAbility(new CyclingAbility(new ManaCostsImpl<>("{2}")));
     }
 
-    public MoaningWall(final MoaningWall moaningWall){
+    private MoaningWall(final MoaningWall moaningWall){
         super(moaningWall);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoggAssassin.java
+++ b/Mage.Sets/src/mage/cards/m/MoggAssassin.java
@@ -93,7 +93,7 @@ class MoggAssassinEffect extends OneShotEffect {
         this.staticText = "You choose target creature an opponent controls, and that opponent chooses target creature. Flip a coin. If you win the flip, destroy the creature you chose. If you lose the flip, destroy the creature your opponent chose";
     }
 
-    public MoggAssassinEffect(final MoggAssassinEffect effect) {
+    private MoggAssassinEffect(final MoggAssassinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoggConscripts.java
+++ b/Mage.Sets/src/mage/cards/m/MoggConscripts.java
@@ -49,7 +49,7 @@ class MoggConscriptsEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless you've cast a creature spell this turn";
     }
 
-    public MoggConscriptsEffect(final MoggConscriptsEffect effect) {
+    private MoggConscriptsEffect(final MoggConscriptsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoggInfestation.java
+++ b/Mage.Sets/src/mage/cards/m/MoggInfestation.java
@@ -52,7 +52,7 @@ class MoggInfestationEffect extends OneShotEffect {
         this.staticText = "Destroy all creatures target player controls. For each creature that died this way, create two 1/1 red Goblin creature tokens under that player's control";
     }
 
-    public MoggInfestationEffect(final MoggInfestationEffect effect) {
+    private MoggInfestationEffect(final MoggInfestationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MolderBeast.java
+++ b/Mage.Sets/src/mage/cards/m/MolderBeast.java
@@ -49,7 +49,7 @@ class MolderBeastTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new BoostSourceEffect(2, 0, Duration.EndOfTurn), false);
     }
 
-    public MolderBeastTriggeredAbility(final MolderBeastTriggeredAbility ability) {
+    private MolderBeastTriggeredAbility(final MolderBeastTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoldgrafMonstrosity.java
+++ b/Mage.Sets/src/mage/cards/m/MoldgrafMonstrosity.java
@@ -61,7 +61,7 @@ class MoldgrafMonstrosityEffect extends OneShotEffect {
         this.staticText = "exile it, then return two creature cards at random from your graveyard to the battlefield";
     }
 
-    public MoldgrafMonstrosityEffect(final MoldgrafMonstrosityEffect effect) {
+    private MoldgrafMonstrosityEffect(final MoldgrafMonstrosityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenDisaster.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenDisaster.java
@@ -115,7 +115,7 @@ class MoltenDisasterEffect extends OneShotEffect {
         staticText = "{this} deals X damage to each creature without flying and each player";
     }
 
-    public MoltenDisasterEffect(final MoltenDisasterEffect effect) {
+    private MoltenDisasterEffect(final MoltenDisasterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenEchoes.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenEchoes.java
@@ -66,7 +66,7 @@ class MoltenEchoesEffect extends OneShotEffect {
         this.staticText = "create a token that's a copy of that creature. That token gains haste. Exile it at the beginning of the next end step";
     }
 
-    public MoltenEchoesEffect(final MoltenEchoesEffect effect) {
+    private MoltenEchoesEffect(final MoltenEchoesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenFrame.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenFrame.java
@@ -32,7 +32,7 @@ public final class MoltenFrame extends CardImpl {
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{2}")));
     }
 
-    public MoltenFrame (final MoltenFrame card) {
+    private MoltenFrame(final MoltenFrame card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenInfluence.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenInfluence.java
@@ -45,7 +45,7 @@ class MoltenInfluenceEffect extends OneShotEffect {
         this.staticText = "Counter target instant or sorcery spell unless its controller has {this} deal 4 damage to them";
     }
 
-    public MoltenInfluenceEffect(final MoltenInfluenceEffect effect) {
+    private MoltenInfluenceEffect(final MoltenInfluenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenPrimordial.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenPrimordial.java
@@ -83,7 +83,7 @@ class MoltenPrimordialEffect extends OneShotEffect {
         this.staticText = "for each opponent, take control of up to one target creature that player controls until end of turn. Untap those creatures. They have haste until end of turn";
     }
 
-    public MoltenPrimordialEffect(final MoltenPrimordialEffect effect) {
+    private MoltenPrimordialEffect(final MoltenPrimordialEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenPsyche.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenPsyche.java
@@ -51,7 +51,7 @@ class MoltenPsycheEffect extends OneShotEffect {
                 + "<i>Metalcraft</i> &mdash; If you control three or more artifacts, {this} deals damage to each opponent equal to the number of cards that player has drawn this turn.";
     }
 
-    public MoltenPsycheEffect(final MoltenPsycheEffect effect) {
+    private MoltenPsycheEffect(final MoltenPsycheEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenRain.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenRain.java
@@ -48,7 +48,7 @@ class MoltenRainEffect extends OneShotEffect {
         this.staticText = "If that land was nonbasic, Molten Rain deals 2 damage to the land's controller";
     }
 
-    public MoltenRainEffect(final MoltenRainEffect effect) {
+    private MoltenRainEffect(final MoltenRainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenSentry.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenSentry.java
@@ -53,7 +53,7 @@ class MoltenSentryEffect extends OneShotEffect {
         super(Outcome.Damage);
     }
 
-    public MoltenSentryEffect(MoltenSentryEffect effect) {
+    private MoltenSentryEffect(final MoltenSentryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenTailMasticore.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenTailMasticore.java
@@ -49,7 +49,7 @@ public final class MoltenTailMasticore extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new GenericManaCost(2)));
     }
 
-    public MoltenTailMasticore (final MoltenTailMasticore card) {
+    private MoltenTailMasticore(final MoltenTailMasticore card) {
         super(card);
     }
 
@@ -65,7 +65,7 @@ class MoltenTailMasticoreAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SacrificeSourceUnlessPaysEffect(new DiscardTargetCost(new TargetCardInHand())));
     }
 
-    public MoltenTailMasticoreAbility(final MoltenTailMasticoreAbility ability) {
+    private MoltenTailMasticoreAbility(final MoltenTailMasticoreAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MomentousFall.java
+++ b/Mage.Sets/src/mage/cards/m/MomentousFall.java
@@ -48,7 +48,7 @@ class MomentousFallEffect extends OneShotEffect {
         staticText = "You draw cards equal to the sacrificed creature's power, then you gain life equal to its toughness";
     }
 
-    public MomentousFallEffect(final MomentousFallEffect effect) {
+    private MomentousFallEffect(final MomentousFallEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MomirVigSimicVisionary.java
+++ b/Mage.Sets/src/mage/cards/m/MomirVigSimicVisionary.java
@@ -76,7 +76,7 @@ class MomirVigSimicVisionaryEffect extends OneShotEffect {
         this.staticText = "reveal the top card of your library. If it's a creature card, put that card into your hand";
     }
 
-    public MomirVigSimicVisionaryEffect(final MomirVigSimicVisionaryEffect effect) {
+    private MomirVigSimicVisionaryEffect(final MomirVigSimicVisionaryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MonkeyCage.java
+++ b/Mage.Sets/src/mage/cards/m/MonkeyCage.java
@@ -51,7 +51,7 @@ class MonkeyCageEffect extends OneShotEffect {
         staticText = "and create X 2/2 green Monkey creature tokens, where X is that creature's mana value";
     }
 
-    public MonkeyCageEffect(final MonkeyCageEffect effect) {
+    private MonkeyCageEffect(final MonkeyCageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MonkeyMonkeyMonkey.java
+++ b/Mage.Sets/src/mage/cards/m/MonkeyMonkeyMonkey.java
@@ -66,7 +66,7 @@ class ChooseLetterEffect extends OneShotEffect {
         staticText = "choose a letter";
     }
 
-    public ChooseLetterEffect(final ChooseLetterEffect effect) {
+    private ChooseLetterEffect(final ChooseLetterEffect effect) {
         super(effect);
     }
 
@@ -110,7 +110,7 @@ class MonkeyMonkeyMonkeyCount implements DynamicValue {
     public MonkeyMonkeyMonkeyCount() {
     }
 
-    public MonkeyMonkeyMonkeyCount(final MonkeyMonkeyMonkeyCount countersCount) {
+    private MonkeyMonkeyMonkeyCount(final MonkeyMonkeyMonkeyCount countersCount) {
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/m/Moonhold.java
+++ b/Mage.Sets/src/mage/cards/m/Moonhold.java
@@ -61,7 +61,7 @@ class MoonholdEffect extends ContinuousRuleModifyingEffectImpl {
         super(Duration.EndOfTurn, Outcome.Detriment);
     }
 
-    public MoonholdEffect(final MoonholdEffect effect) {
+    private MoonholdEffect(final MoonholdEffect effect) {
         super(effect);
     }
 
@@ -104,7 +104,7 @@ class MoonholdEffect2 extends ContinuousRuleModifyingEffectImpl {
         super(Duration.EndOfTurn, Outcome.Detriment);
     }
 
-    public MoonholdEffect2(final MoonholdEffect2 effect) {
+    private MoonholdEffect2(final MoonholdEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoonlightBargain.java
+++ b/Mage.Sets/src/mage/cards/m/MoonlightBargain.java
@@ -48,7 +48,7 @@ class MoonlightBargainEffect extends OneShotEffect {
         this.staticText = "Look at the top five cards of your library. For each card, put that card into your graveyard unless you pay 2 life. Then put the rest into your hand";
     }
 
-    public MoonlightBargainEffect(final MoonlightBargainEffect effect) {
+    private MoonlightBargainEffect(final MoonlightBargainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Moonmist.java
+++ b/Mage.Sets/src/mage/cards/m/Moonmist.java
@@ -60,7 +60,7 @@ class MoonmistEffect extends OneShotEffect {
         staticText = "Transform all Humans";
     }
 
-    public MoonmistEffect(final MoonmistEffect effect) {
+    private MoonmistEffect(final MoonmistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoonringMirror.java
+++ b/Mage.Sets/src/mage/cards/m/MoonringMirror.java
@@ -54,7 +54,7 @@ class MoonringMirrorExileEffect extends OneShotEffect {
         staticText = "exile the top card of your library face down";
     }
 
-    public MoonringMirrorExileEffect(final MoonringMirrorExileEffect effect) {
+    private MoonringMirrorExileEffect(final MoonringMirrorExileEffect effect) {
         super(effect);
     }
 
@@ -94,7 +94,7 @@ class MoonringMirrorEffect extends OneShotEffect {
         this.staticText = "you may exile all cards from your hand face down. If you do, put all other cards you own exiled with {this} into your hand";
     }
 
-    public MoonringMirrorEffect(final MoonringMirrorEffect effect) {
+    private MoonringMirrorEffect(final MoonringMirrorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MordantDragon.java
+++ b/Mage.Sets/src/mage/cards/m/MordantDragon.java
@@ -62,7 +62,7 @@ class MordantDragonTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new MordantDragonEffect(), true);
     }
 
-    public MordantDragonTriggeredAbility(final MordantDragonTriggeredAbility ability) {
+    private MordantDragonTriggeredAbility(final MordantDragonTriggeredAbility ability) {
         super(ability);
     }
 
@@ -110,7 +110,7 @@ class MordantDragonEffect extends OneShotEffect {
         staticText = "it deals that much damage to target creature that player controls";
     }
 
-    public MordantDragonEffect(final MordantDragonEffect effect) {
+    private MordantDragonEffect(final MordantDragonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MorgueBurst.java
+++ b/Mage.Sets/src/mage/cards/m/MorgueBurst.java
@@ -49,7 +49,7 @@ class MorgueBurstEffect extends OneShotEffect {
         this.staticText = "Return target creature card from your graveyard to your hand. Morgue Burst deals damage to any target equal to the power of the card returned this way";
     }
 
-    public MorgueBurstEffect(final MorgueBurstEffect effect) {
+    private MorgueBurstEffect(final MorgueBurstEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoriokReaver.java
+++ b/Mage.Sets/src/mage/cards/m/MoriokReaver.java
@@ -24,7 +24,7 @@ public final class MoriokReaver extends CardImpl {
         this.toughness = new MageInt(2);
     }
 
-    public MoriokReaver (final MoriokReaver card) {
+    private MoriokReaver(final MoriokReaver card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoriokReplica.java
+++ b/Mage.Sets/src/mage/cards/m/MoriokReplica.java
@@ -40,7 +40,7 @@ public final class MoriokReplica extends CardImpl {
         this.addAbility(ability);
     }
 
-    public MoriokReplica (final MoriokReplica card) {
+    private MoriokReplica(final MoriokReplica card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Morselhoarder.java
+++ b/Mage.Sets/src/mage/cards/m/Morselhoarder.java
@@ -58,7 +58,7 @@ class MorselhoarderAbility extends ActivatedManaAbilityImpl {
         this.netMana.add(new Mana(0, 0, 0, 0, 0, 0, 1, 0));
     }
 
-    public MorselhoarderAbility(final MorselhoarderAbility ability) {
+    private MorselhoarderAbility(final MorselhoarderAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MortalObstinacy.java
+++ b/Mage.Sets/src/mage/cards/m/MortalObstinacy.java
@@ -70,7 +70,7 @@ class MortalObstinacyAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever enchanted creature deals combat damage to a player, ");
     }
 
-    public MortalObstinacyAbility(final MortalObstinacyAbility ability) {
+    private MortalObstinacyAbility(final MortalObstinacyAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MorticianBeetle.java
+++ b/Mage.Sets/src/mage/cards/m/MorticianBeetle.java
@@ -50,7 +50,7 @@ class PlayerSacrificesCreatureTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a player sacrifices a creature, ");
     }
 
-    public PlayerSacrificesCreatureTriggeredAbility(final PlayerSacrificesCreatureTriggeredAbility ability) {
+    private PlayerSacrificesCreatureTriggeredAbility(final PlayerSacrificesCreatureTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MosquitoGuard.java
+++ b/Mage.Sets/src/mage/cards/m/MosquitoGuard.java
@@ -29,7 +29,7 @@ public final class MosquitoGuard extends CardImpl {
         this.addAbility(new ReinforceAbility(1, new ManaCostsImpl<>("{1}{W}")));
     }
 
-    public MosquitoGuard (final MosquitoGuard card) {
+    private MosquitoGuard(final MosquitoGuard card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MossKami.java
+++ b/Mage.Sets/src/mage/cards/m/MossKami.java
@@ -25,7 +25,7 @@ public final class MossKami extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
     }
 
-    public MossKami (final MossKami card) {
+    private MossKami(final MossKami card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MossbridgeTroll.java
+++ b/Mage.Sets/src/mage/cards/m/MossbridgeTroll.java
@@ -112,7 +112,7 @@ class MossbridgeTrollCost extends CostImpl {
         this.text = "tap any number of untapped creatures you control other than {this} with total power 10 or greater";
     }
 
-    public MossbridgeTrollCost(final MossbridgeTrollCost cost) {
+    private MossbridgeTrollCost(final MossbridgeTrollCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mossdog.java
+++ b/Mage.Sets/src/mage/cards/m/Mossdog.java
@@ -48,7 +48,7 @@ class MossdogAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false);
     }
 
-    public MossdogAbility(final MossdogAbility ability) {
+    private MossdogAbility(final MossdogAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MothriderSamurai.java
+++ b/Mage.Sets/src/mage/cards/m/MothriderSamurai.java
@@ -28,7 +28,7 @@ public final class MothriderSamurai extends CardImpl {
         this.addAbility(new BushidoAbility(1));
     }
 
-    public MothriderSamurai (final MothriderSamurai card) {
+    private MothriderSamurai(final MothriderSamurai card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MountainTitan.java
+++ b/Mage.Sets/src/mage/cards/m/MountainTitan.java
@@ -55,7 +55,7 @@ class MountainTitanDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), Duration.EndOfTurn, false, false);
     }
 
-    public MountainTitanDelayedTriggeredAbility(final MountainTitanDelayedTriggeredAbility ability) {
+    private MountainTitanDelayedTriggeredAbility(final MountainTitanDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MournersShield.java
+++ b/Mage.Sets/src/mage/cards/m/MournersShield.java
@@ -105,7 +105,7 @@ class MournersShieldEffect extends PreventionEffectImpl {
         this.staticText = "Prevent all damage that would be dealt this turn by a source of your choice that shares a color with the exiled card.";
     }
 
-    public MournersShieldEffect(final MournersShieldEffect effect) {
+    private MournersShieldEffect(final MournersShieldEffect effect) {
         super(effect);
         if (effect.target != null) {
             this.target = effect.target.copy();

--- a/Mage.Sets/src/mage/cards/m/Mournwillow.java
+++ b/Mage.Sets/src/mage/cards/m/Mournwillow.java
@@ -61,7 +61,7 @@ class MournwillowEffect extends RestrictionEffect {
         staticText = "creatures with power 2 or less can't block this turn";
     }
 
-    public MournwillowEffect(final MournwillowEffect effect) {
+    private MournwillowEffect(final MournwillowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoxDiamond.java
+++ b/Mage.Sets/src/mage/cards/m/MoxDiamond.java
@@ -53,7 +53,7 @@ class MoxDiamondReplacementEffect extends ReplacementEffectImpl {
         staticText = "If {this} would enter the battlefield, you may discard a land card instead. If you do, put {this} onto the battlefield. If you don't, put it into its owner's graveyard";
     }
 
-    public MoxDiamondReplacementEffect(final MoxDiamondReplacementEffect effect) {
+    private MoxDiamondReplacementEffect(final MoxDiamondReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MuYanling.java
+++ b/Mage.Sets/src/mage/cards/m/MuYanling.java
@@ -62,7 +62,7 @@ class MuYanlingEffect extends OneShotEffect {
         staticText = "tap all creatures your opponents control. You take an extra turn after this one.";
     }
 
-    public MuYanlingEffect(final MuYanlingEffect effect) {
+    private MuYanlingEffect(final MuYanlingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MuldrothaTheGravetide.java
+++ b/Mage.Sets/src/mage/cards/m/MuldrothaTheGravetide.java
@@ -71,7 +71,7 @@ class MuldrothaTheGravetideCastFromGraveyardEffect extends AsThoughEffectImpl {
                 + "<i>(If a card has multiple permanent types, choose one as you play it.)</i>";
     }
 
-    public MuldrothaTheGravetideCastFromGraveyardEffect(final MuldrothaTheGravetideCastFromGraveyardEffect effect) {
+    private MuldrothaTheGravetideCastFromGraveyardEffect(final MuldrothaTheGravetideCastFromGraveyardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MultanisDecree.java
+++ b/Mage.Sets/src/mage/cards/m/MultanisDecree.java
@@ -44,7 +44,7 @@ class MultanisDecreeDestroyEffect extends OneShotEffect {
         this.staticText = "Destroy all enchantments. You gain 2 life for each enchantment destroyed this way";
     }
 
-    public MultanisDecreeDestroyEffect(final MultanisDecreeDestroyEffect effect) {
+    private MultanisDecreeDestroyEffect(final MultanisDecreeDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MultanisPresence.java
+++ b/Mage.Sets/src/mage/cards/m/MultanisPresence.java
@@ -45,7 +45,7 @@ class MultanisPresenceTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a spell you've cast is countered, ");
     }
 
-    public MultanisPresenceTriggeredAbility(final MultanisPresenceTriggeredAbility ability) {
+    private MultanisPresenceTriggeredAbility(final MultanisPresenceTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MultiformWonder.java
+++ b/Mage.Sets/src/mage/cards/m/MultiformWonder.java
@@ -74,7 +74,7 @@ class MultiformWonderEffect extends OneShotEffect {
         staticText = "{this} gains your choice of flying, vigilance, or lifelink until end of turn";
     }
 
-    public MultiformWonderEffect(final MultiformWonderEffect effect) {
+    private MultiformWonderEffect(final MultiformWonderEffect effect) {
         super(effect);
     }
 
@@ -127,7 +127,7 @@ class MultiformWonder2Effect extends ContinuousEffectImpl {
         this.staticText = "{this} gets +2/-2 or -2/+2 until end of turn";
     }
 
-    public MultiformWonder2Effect(final MultiformWonder2Effect effect) {
+    private MultiformWonder2Effect(final MultiformWonder2Effect effect) {
         super(effect);
         this.power = effect.power;
         this.toughness = effect.toughness;

--- a/Mage.Sets/src/mage/cards/m/MunghaWurm.java
+++ b/Mage.Sets/src/mage/cards/m/MunghaWurm.java
@@ -54,7 +54,7 @@ class MunghaWurmEffect extends RestrictionUntapNotMoreThanEffect {
         staticText = "you can't untap more than one land during your untap step";
     }
 
-    public MunghaWurmEffect(final MunghaWurmEffect effect) {
+    private MunghaWurmEffect(final MunghaWurmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MurderOfCrows.java
+++ b/Mage.Sets/src/mage/cards/m/MurderOfCrows.java
@@ -50,7 +50,7 @@ class MurderOfCrowsEffect extends OneShotEffect {
         this.staticText = "you may draw a card. If you do, discard a card";
     }
 
-    public MurderOfCrowsEffect(final MurderOfCrowsEffect effect) {
+    private MurderOfCrowsEffect(final MurderOfCrowsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MurderousRedcap.java
+++ b/Mage.Sets/src/mage/cards/m/MurderousRedcap.java
@@ -56,7 +56,7 @@ class MurderousRedcapEffect extends OneShotEffect {
         staticText = "it deals damage equal to its power to any target";
     }
 
-    public MurderousRedcapEffect(final MurderousRedcapEffect effect) {
+    private MurderousRedcapEffect(final MurderousRedcapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MurderousSpoils.java
+++ b/Mage.Sets/src/mage/cards/m/MurderousSpoils.java
@@ -51,7 +51,7 @@ class MurderousSpoilsEffect extends OneShotEffect {
         staticText = "Destroy target nonblack creature. It can't be regenerated. You gain control of all Equipment that were attached to it.";
     }
 
-    public MurderousSpoilsEffect(final MurderousSpoilsEffect effect) {
+    private MurderousSpoilsEffect(final MurderousSpoilsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MurmuringPhantasm.java
+++ b/Mage.Sets/src/mage/cards/m/MurmuringPhantasm.java
@@ -30,7 +30,7 @@ public final class MurmuringPhantasm extends CardImpl {
 
     }
 
-    public MurmuringPhantasm (final MurmuringPhantasm card) {
+    private MurmuringPhantasm(final MurmuringPhantasm card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MurmursFromBeyond.java
+++ b/Mage.Sets/src/mage/cards/m/MurmursFromBeyond.java
@@ -50,7 +50,7 @@ class MurmursFromBeyondEffect extends OneShotEffect {
         this.staticText = "Reveal the top three cards of your library. An opponent chooses one of them. Put that card into your graveyard and the rest into your hand";
     }
 
-    public MurmursFromBeyondEffect(final MurmursFromBeyondEffect effect) {
+    private MurmursFromBeyondEffect(final MurmursFromBeyondEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MuseVessel.java
+++ b/Mage.Sets/src/mage/cards/m/MuseVessel.java
@@ -65,7 +65,7 @@ class MuseVesselExileEffect extends OneShotEffect {
         staticText = "target player exiles a card from their hand";
     }
 
-    public MuseVesselExileEffect(final MuseVesselExileEffect effect) {
+    private MuseVesselExileEffect(final MuseVesselExileEffect effect) {
         super(effect);
     }
 
@@ -102,7 +102,7 @@ class MuseVesselMayPlayExiledEffect extends AsThoughEffectImpl {
         this.staticText = "Choose a card exiled with {this}. You may play that card this turn";
     }
 
-    public MuseVesselMayPlayExiledEffect(final MuseVesselMayPlayExiledEffect effect) {
+    private MuseVesselMayPlayExiledEffect(final MuseVesselMayPlayExiledEffect effect) {
         super(effect);
     }
 
@@ -130,7 +130,7 @@ class TargetCardInMuseVesselExile extends TargetCardInExile {
         super(1, 1, new FilterCard("card exiled with Muse Vessel"), null);
     }
 
-    public TargetCardInMuseVesselExile(final TargetCardInMuseVesselExile target) {
+    private TargetCardInMuseVesselExile(final TargetCardInMuseVesselExile target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mutavault.java
+++ b/Mage.Sets/src/mage/cards/m/Mutavault.java
@@ -50,7 +50,7 @@ class MutavaultToken extends TokenImpl {
         power = new MageInt(2);
         toughness = new MageInt(2);
     }
-    public MutavaultToken(final MutavaultToken token) {
+    private MutavaultToken(final MutavaultToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mutiny.java
+++ b/Mage.Sets/src/mage/cards/m/Mutiny.java
@@ -51,7 +51,7 @@ class MutinyEffect extends OneShotEffect {
         this.staticText = "Target creature an opponent controls deals damage equal to its power to another target creature that player controls";
     }
 
-    public MutinyEffect(final MutinyEffect effect) {
+    private MutinyEffect(final MutinyEffect effect) {
         super(effect);
     }
 
@@ -81,7 +81,7 @@ class MutinyFirstTarget extends TargetCreaturePermanent {
         super(1, 1, filter, false);
     }
 
-    public MutinyFirstTarget(final MutinyFirstTarget target) {
+    private MutinyFirstTarget(final MutinyFirstTarget target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MuzzioVisionaryArchitect.java
+++ b/Mage.Sets/src/mage/cards/m/MuzzioVisionaryArchitect.java
@@ -59,7 +59,7 @@ class MuzzioVisionaryArchitectEffect extends OneShotEffect {
         this.staticText = "look at the top X cards of your library, where X is the highest mana value among artifacts you control. You may put an artifact card from among them onto the battlefield. Put the rest on the bottom of your library in any order";
     }
 
-    public MuzzioVisionaryArchitectEffect(final MuzzioVisionaryArchitectEffect effect) {
+    private MuzzioVisionaryArchitectEffect(final MuzzioVisionaryArchitectEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MwonvuliOoze.java
+++ b/Mage.Sets/src/mage/cards/m/MwonvuliOoze.java
@@ -53,7 +53,7 @@ class MwonvuliOozePTValue extends CountersSourceCount {
         super(CounterType.AGE);
     }
 
-    public MwonvuliOozePTValue(final MwonvuliOozePTValue value) {
+    private MwonvuliOozePTValue(final MwonvuliOozePTValue value) {
         super(value);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MycoidShepherd.java
+++ b/Mage.Sets/src/mage/cards/m/MycoidShepherd.java
@@ -53,7 +53,7 @@ class MycoidShepherdTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainLifeEffect(5), true);
     }
 
-    public MycoidShepherdTriggeredAbility(final MycoidShepherdTriggeredAbility ability) {
+    private MycoidShepherdTriggeredAbility(final MycoidShepherdTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MyojinOfLifesWeb.java
+++ b/Mage.Sets/src/mage/cards/m/MyojinOfLifesWeb.java
@@ -71,7 +71,7 @@ class MyojinOfLifesWebPutCreatureOnBattlefieldEffect extends OneShotEffect {
         this.staticText = "Put any number of creature cards from your hand onto the battlefield";
     }
 
-    public MyojinOfLifesWebPutCreatureOnBattlefieldEffect(final MyojinOfLifesWebPutCreatureOnBattlefieldEffect effect) {
+    private MyojinOfLifesWebPutCreatureOnBattlefieldEffect(final MyojinOfLifesWebPutCreatureOnBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MyrBattlesphere.java
+++ b/Mage.Sets/src/mage/cards/m/MyrBattlesphere.java
@@ -62,7 +62,7 @@ class MyrBattlesphereTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new MyrBattlesphereEffect(), true);
     }
 
-    public MyrBattlesphereTriggeredAbility(final MyrBattlesphereTriggeredAbility ability) {
+    private MyrBattlesphereTriggeredAbility(final MyrBattlesphereTriggeredAbility ability) {
         super(ability);
     }
 
@@ -107,7 +107,7 @@ class MyrBattlesphereEffect extends OneShotEffect {
         staticText = "you may tap X untapped Myr you control. If you do, {this} gets +X/+0 until end of turn and deals X damage to the player or planeswalker it's attacking.";
     }
 
-    public MyrBattlesphereEffect(final MyrBattlesphereEffect effect) {
+    private MyrBattlesphereEffect(final MyrBattlesphereEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MyrMatrix.java
+++ b/Mage.Sets/src/mage/cards/m/MyrMatrix.java
@@ -38,7 +38,7 @@ public final class MyrMatrix extends CardImpl {
 
     }
 
-    public MyrMatrix (final MyrMatrix card) {
+    private MyrMatrix(final MyrMatrix card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MyrServitor.java
+++ b/Mage.Sets/src/mage/cards/m/MyrServitor.java
@@ -65,7 +65,7 @@ class MyrServitorReturnEffect extends OneShotEffect {
         this.staticText = "if {this} is on the battlefield, each player returns all cards named Myr Servitor from their graveyard to the battlefield";
     }
 
-    public MyrServitorReturnEffect(final MyrServitorReturnEffect effect) {
+    private MyrServitorReturnEffect(final MyrServitorReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MyrSire.java
+++ b/Mage.Sets/src/mage/cards/m/MyrSire.java
@@ -25,7 +25,7 @@ public final class MyrSire extends CardImpl {
         this.addAbility(new DiesSourceTriggeredAbility(new CreateTokenEffect(new PhyrexianMyrToken())));
     }
 
-    public MyrSire(final MyrSire card) {
+    private MyrSire(final MyrSire card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MyrWelder.java
+++ b/Mage.Sets/src/mage/cards/m/MyrWelder.java
@@ -58,7 +58,7 @@ class MyrWelderEffect extends OneShotEffect {
         staticText = "Exile target artifact card from a graveyard";
     }
 
-    public MyrWelderEffect(MyrWelderEffect effect) {
+    private MyrWelderEffect(final MyrWelderEffect effect) {
         super(effect);
     }
 
@@ -88,7 +88,7 @@ class MyrWelderContinuousEffect extends ContinuousEffectImpl {
         staticText = "{this} has all activated abilities of all cards exiled with it";
     }
 
-    public MyrWelderContinuousEffect(final MyrWelderContinuousEffect effect) {
+    private MyrWelderContinuousEffect(final MyrWelderContinuousEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Myrsmith.java
+++ b/Mage.Sets/src/mage/cards/m/Myrsmith.java
@@ -50,7 +50,7 @@ class MyrsmithEffect extends CreateTokenEffect {
         staticText = "you may pay {1}. If you do, create a 1/1 colorless Myr artifact creature token";
     }
 
-    public MyrsmithEffect(final MyrsmithEffect effect) {
+    private MyrsmithEffect(final MyrsmithEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MysticGenesis.java
+++ b/Mage.Sets/src/mage/cards/m/MysticGenesis.java
@@ -46,7 +46,7 @@ class MysticGenesisEffect extends OneShotEffect {
         staticText = "Counter target spell. Create an X/X green Ooze creature token, where X is that spell's mana value";
     }
 
-    public MysticGenesisEffect(final MysticGenesisEffect effect) {
+    private MysticGenesisEffect(final MysticGenesisEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MysticReflection.java
+++ b/Mage.Sets/src/mage/cards/m/MysticReflection.java
@@ -107,7 +107,7 @@ class MysticReflectionReplacementEffect extends ReplacementEffectImpl {
                 + "enter the battlefield this turn, they enter as copies of {this}";
     }
 
-    public MysticReflectionReplacementEffect(MysticReflectionReplacementEffect effect) {
+    private MysticReflectionReplacementEffect(final MysticReflectionReplacementEffect effect) {
         super(effect);
         this.enteredThisTurn = effect.enteredThisTurn;
         this.identifier = effect.identifier;
@@ -199,7 +199,7 @@ class MysticReflectionGainAbilityEffect extends ContinuousEffectImpl {
         this.ability = ability;
     }
 
-    public MysticReflectionGainAbilityEffect(final MysticReflectionGainAbilityEffect effect) {
+    private MysticReflectionGainAbilityEffect(final MysticReflectionGainAbilityEffect effect) {
         super(effect);
         this.ability = effect.ability;
     }

--- a/Mage.Sets/src/mage/cards/m/MysticRemora.java
+++ b/Mage.Sets/src/mage/cards/m/MysticRemora.java
@@ -56,7 +56,7 @@ class MysticRemoraTriggeredAbility extends TriggeredAbilityImpl {
 
     }
 
-    public MysticRemoraTriggeredAbility(final MysticRemoraTriggeredAbility ability) {
+    private MysticRemoraTriggeredAbility(final MysticRemoraTriggeredAbility ability) {
         super(ability);
     }
 
@@ -101,7 +101,7 @@ class MysticRemoraEffect extends OneShotEffect {
         this.staticText = "you may draw a card unless that player pays {4}";
     }
 
-    public MysticRemoraEffect(final MysticRemoraEffect effect) {
+    private MysticRemoraEffect(final MysticRemoraEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MystifyingMaze.java
+++ b/Mage.Sets/src/mage/cards/m/MystifyingMaze.java
@@ -65,7 +65,7 @@ class MystifyingMazeEffect extends OneShotEffect {
         staticText = "Exile target attacking creature an opponent controls. At the beginning of the next end step, return it to the battlefield tapped under its owner's control";
     }
 
-    public MystifyingMazeEffect(final MystifyingMazeEffect effect) {
+    private MystifyingMazeEffect(final MystifyingMazeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MythRealized.java
+++ b/Mage.Sets/src/mage/cards/m/MythRealized.java
@@ -66,7 +66,7 @@ class MythRealizedToken extends TokenImpl {
         power = new MageInt(0);
         toughness = new MageInt(0);
     }
-    public MythRealizedToken(final MythRealizedToken token) {
+    private MythRealizedToken(final MythRealizedToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NacatlWarPride.java
+++ b/Mage.Sets/src/mage/cards/n/NacatlWarPride.java
@@ -70,7 +70,7 @@ class NacatlWarPrideEffect extends OneShotEffect {
         this.staticText = "create X tokens that are copies of {this} tapped and attacking, where X is the number of creatures defending player controls. Exile the tokens at the beginning of the next end step";
     }
 
-    public NacatlWarPrideEffect(final NacatlWarPrideEffect effect) {
+    private NacatlWarPrideEffect(final NacatlWarPrideEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NahirisSacrifice.java
+++ b/Mage.Sets/src/mage/cards/n/NahirisSacrifice.java
@@ -72,7 +72,7 @@ class SacrificeXManaValueCost extends VariableCostImpl implements SacrificeCost 
         this.filter = filter;
     }
 
-    public SacrificeXManaValueCost(final SacrificeXManaValueCost cost) {
+    private SacrificeXManaValueCost(final SacrificeXManaValueCost cost) {
         super(cost);
         this.filter = cost.filter;
     }
@@ -102,7 +102,7 @@ class SacrificeXCostConvertedMana implements DynamicValue {
         this.type = type;
     }
 
-    public SacrificeXCostConvertedMana(SacrificeXCostConvertedMana value) {
+    private SacrificeXCostConvertedMana(final SacrificeXCostConvertedMana value) {
         this.type = value.type;
     }
 

--- a/Mage.Sets/src/mage/cards/n/NalathniDragon.java
+++ b/Mage.Sets/src/mage/cards/n/NalathniDragon.java
@@ -67,7 +67,7 @@ class NalathniDragonEffect extends OneShotEffect {
         this.staticText = "If this ability has been activated four or more times this turn, sacrifice {this} at the beginning of the next end step";
     }
 
-    public NalathniDragonEffect(final NalathniDragonEffect effect) {
+    private NalathniDragonEffect(final NalathniDragonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NantukoMentor.java
+++ b/Mage.Sets/src/mage/cards/n/NantukoMentor.java
@@ -60,7 +60,7 @@ class NantukoMentorEffect extends OneShotEffect {
         this.staticText = "Target creature gets +X/+X until end of turn, where X is that creature's power";
     }
 
-    public NantukoMentorEffect(final NantukoMentorEffect effect) {
+    private NantukoMentorEffect(final NantukoMentorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NantukoMonastery.java
+++ b/Mage.Sets/src/mage/cards/n/NantukoMonastery.java
@@ -61,7 +61,7 @@ class NantukoMonasteryToken extends TokenImpl {
         toughness = new MageInt(4);
         this.addAbility(FirstStrikeAbility.getInstance());
     }
-    public NantukoMonasteryToken(final NantukoMonasteryToken token) {
+    private NantukoMonasteryToken(final NantukoMonasteryToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NantukoShrine.java
+++ b/Mage.Sets/src/mage/cards/n/NantukoShrine.java
@@ -48,7 +48,7 @@ class NantukoShrineEffect extends OneShotEffect {
         this.staticText = "that player creates X 1/1 green Squirrel creature tokens, where X is the number of cards in all graveyards with the same name as that spell";
     }
 
-    public NantukoShrineEffect(final NantukoShrineEffect effect) {
+    private NantukoShrineEffect(final NantukoShrineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Narcomoeba.java
+++ b/Mage.Sets/src/mage/cards/n/Narcomoeba.java
@@ -47,7 +47,7 @@ class NarcomoebaAbility extends ZoneChangeTriggeredAbility {
         super(Zone.LIBRARY, Zone.GRAVEYARD, new ReturnSourceFromGraveyardToBattlefieldEffect(), "",  true);
     }
 
-    public NarcomoebaAbility(final NarcomoebaAbility ability) {
+    private NarcomoebaAbility(final NarcomoebaAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NarrowEscape.java
+++ b/Mage.Sets/src/mage/cards/n/NarrowEscape.java
@@ -25,7 +25,7 @@ public final class NarrowEscape extends CardImpl {
         this.getSpellAbility().addEffect(new GainLifeEffect(4));
     }
 
-    public NarrowEscape (final NarrowEscape card) {
+    private NarrowEscape(final NarrowEscape card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NarsetEnlightenedMaster.java
+++ b/Mage.Sets/src/mage/cards/n/NarsetEnlightenedMaster.java
@@ -60,7 +60,7 @@ class NarsetEnlightenedMasterExileEffect extends OneShotEffect {
         staticText = "exile the top four cards of your library. Until end of turn, you may cast noncreature spells from among those cards without paying their mana costs";
     }
 
-    public NarsetEnlightenedMasterExileEffect(final NarsetEnlightenedMasterExileEffect effect) {
+    private NarsetEnlightenedMasterExileEffect(final NarsetEnlightenedMasterExileEffect effect) {
         super(effect);
     }
 
@@ -98,7 +98,7 @@ class NarsetEnlightenedMasterCastFromExileEffect extends AsThoughEffectImpl {
         staticText = "Until end of turn, you may cast noncreature cards exiled with {this} this turn without paying their mana costs";
     }
 
-    public NarsetEnlightenedMasterCastFromExileEffect(final NarsetEnlightenedMasterCastFromExileEffect effect) {
+    private NarsetEnlightenedMasterCastFromExileEffect(final NarsetEnlightenedMasterCastFromExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NarsetTranscendent.java
+++ b/Mage.Sets/src/mage/cards/n/NarsetTranscendent.java
@@ -70,7 +70,7 @@ class NarsetTranscendentEffect1 extends OneShotEffect {
         this.staticText = "Look at the top card of your library. If it's a noncreature, nonland card, you may reveal it and put it into your hand";
     }
 
-    public NarsetTranscendentEffect1(final NarsetTranscendentEffect1 effect) {
+    private NarsetTranscendentEffect1(final NarsetTranscendentEffect1 effect) {
         super(effect);
     }
 
@@ -148,7 +148,7 @@ class NarsetTranscendentGainReboundEffect extends ContinuousEffectImpl {
         staticText = "it gains rebound";
     }
 
-    public NarsetTranscendentGainReboundEffect(final NarsetTranscendentGainReboundEffect effect) {
+    private NarsetTranscendentGainReboundEffect(final NarsetTranscendentGainReboundEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NashiMoonSagesScion.java
+++ b/Mage.Sets/src/mage/cards/n/NashiMoonSagesScion.java
@@ -65,7 +65,7 @@ class NashiMoonSagesScionEffect extends OneShotEffect {
                 "pay life equal to its mana value rather than paying its mana cost";
     }
 
-    public NashiMoonSagesScionEffect(final NashiMoonSagesScionEffect effect) {
+    private NashiMoonSagesScionEffect(final NashiMoonSagesScionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NaturalBalance.java
+++ b/Mage.Sets/src/mage/cards/n/NaturalBalance.java
@@ -50,7 +50,7 @@ public final class NaturalBalance extends CardImpl {
             this.staticText = "Each player who controls six or more lands chooses five lands they control and sacrifices the rest. Each player who controls four or fewer lands may search their library for up to X basic land cards and put them onto the battlefield, where X is five minus the number of lands they control. Then each player who searched their library this way shuffles.";
         }
 
-        public NaturalBalanceEffect(final NaturalBalanceEffect effect) {
+        private NaturalBalanceEffect(final NaturalBalanceEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/n/NaturalSelection.java
+++ b/Mage.Sets/src/mage/cards/n/NaturalSelection.java
@@ -46,7 +46,7 @@ class NaturalSelectionEffect extends OneShotEffect {
         this.staticText = "look at the top three cards of target player's library, then put them back in any order. You may have that player shuffle";
     }
 
-    public NaturalSelectionEffect(final NaturalSelectionEffect effect) {
+    private NaturalSelectionEffect(final NaturalSelectionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NaturesBlessing.java
+++ b/Mage.Sets/src/mage/cards/n/NaturesBlessing.java
@@ -70,7 +70,7 @@ class NaturesBlessingEffect extends OneShotEffect {
         this.staticText = "Put a +1/+1 counter on target creature or that creature gains banding, first strike, or trample";
     }
 
-    public NaturesBlessingEffect(final NaturesBlessingEffect effect) {
+    private NaturesBlessingEffect(final NaturesBlessingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NaturesResurgence.java
+++ b/Mage.Sets/src/mage/cards/n/NaturesResurgence.java
@@ -46,7 +46,7 @@ class NaturesResurgenceEffect extends OneShotEffect {
         staticText = "Each player draws a card for each creature card in their graveyard";
     }
 
-    public NaturesResurgenceEffect(final NaturesResurgenceEffect effect) {
+    private NaturesResurgenceEffect(final NaturesResurgenceEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/n/NayaBattlemage.java
+++ b/Mage.Sets/src/mage/cards/n/NayaBattlemage.java
@@ -41,7 +41,7 @@ public final class NayaBattlemage extends CardImpl {
         this.addAbility(ability);
     }
 
-    public NayaBattlemage (final NayaBattlemage card) {
+    private NayaBattlemage(final NayaBattlemage card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NayaSoulbeast.java
+++ b/Mage.Sets/src/mage/cards/n/NayaSoulbeast.java
@@ -63,7 +63,7 @@ class NayaSoulbeastCastEffect extends OneShotEffect {
         this.staticText = "each player reveals the top card of their library";
     }
 
-    public NayaSoulbeastCastEffect(final NayaSoulbeastCastEffect effect) {
+    private NayaSoulbeastCastEffect(final NayaSoulbeastCastEffect effect) {
         super(effect);
     }
 
@@ -106,7 +106,7 @@ class NayaSoulbeastReplacementEffect extends ReplacementEffectImpl {
         staticText = "{this} enters the battlefield with X +1/+1 counters on it, where X is the total mana value of all cards revealed this way";
     }
 
-    public NayaSoulbeastReplacementEffect(final NayaSoulbeastReplacementEffect effect) {
+    private NayaSoulbeastReplacementEffect(final NayaSoulbeastReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Nebuchadnezzar.java
+++ b/Mage.Sets/src/mage/cards/n/Nebuchadnezzar.java
@@ -57,7 +57,7 @@ class NebuchadnezzarEffect extends OneShotEffect {
         staticText = "Target opponent reveals X cards at random from their hand. Then that player discards all cards with that name revealed this way";
     }
 
-    public NebuchadnezzarEffect(final NebuchadnezzarEffect effect) {
+    private NebuchadnezzarEffect(final NebuchadnezzarEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Necrite.java
+++ b/Mage.Sets/src/mage/cards/n/Necrite.java
@@ -57,7 +57,7 @@ class NecriteTriggeredAbility extends AttacksAndIsNotBlockedTriggeredAbility{
         super(effect);
     }
 
-    public NecriteTriggeredAbility(final NecriteTriggeredAbility ability) {
+    private NecriteTriggeredAbility(final NecriteTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NecrogenCenser.java
+++ b/Mage.Sets/src/mage/cards/n/NecrogenCenser.java
@@ -32,7 +32,7 @@ public final class NecrogenCenser extends CardImpl {
         this.addAbility(ability);
     }
 
-    public NecrogenCenser (final NecrogenCenser card) {
+    private NecrogenCenser(final NecrogenCenser card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NecrogenScudder.java
+++ b/Mage.Sets/src/mage/cards/n/NecrogenScudder.java
@@ -29,7 +29,7 @@ public final class NecrogenScudder extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public NecrogenScudder (final NecrogenScudder card) {
+    private NecrogenScudder(final NecrogenScudder card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NecromancersMagemark.java
+++ b/Mage.Sets/src/mage/cards/n/NecromancersMagemark.java
@@ -75,7 +75,7 @@ class NecromancersMagemarkEffect extends ReplacementEffectImpl {
         staticText = "If a creature you control that's enchanted would die, return it to its owner's hand instead";
     }
 
-    public NecromancersMagemarkEffect(final NecromancersMagemarkEffect effect) {
+    private NecromancersMagemarkEffect(final NecromancersMagemarkEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NecromanticSelection.java
+++ b/Mage.Sets/src/mage/cards/n/NecromanticSelection.java
@@ -60,7 +60,7 @@ class NecromanticSelectionEffect extends OneShotEffect {
         this.staticText = "Destroy all creatures, then return a creature card put into a graveyard this way to the battlefield under your control. It's a black Zombie in addition to its other colors and types";
     }
 
-    public NecromanticSelectionEffect(final NecromanticSelectionEffect effect) {
+    private NecromanticSelectionEffect(final NecromanticSelectionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Necropede.java
+++ b/Mage.Sets/src/mage/cards/n/Necropede.java
@@ -33,7 +33,7 @@ public final class Necropede extends CardImpl {
         this.addAbility(ability);
     }
 
-    public Necropede (final Necropede card) {
+    private Necropede(final Necropede card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NecropolisRegent.java
+++ b/Mage.Sets/src/mage/cards/n/NecropolisRegent.java
@@ -55,7 +55,7 @@ class NecropolisRegentTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.QUEST.createInstance()), false);
     }
 
-    public NecropolisRegentTriggeredAbility(final NecropolisRegentTriggeredAbility ability) {
+    private NecropolisRegentTriggeredAbility(final NecropolisRegentTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Necropotence.java
+++ b/Mage.Sets/src/mage/cards/n/Necropotence.java
@@ -95,7 +95,7 @@ class NecropotenceEffect extends OneShotEffect {
         this.staticText = "Exile the top card of your library face down. Put that card into your hand at the beginning of your next end step";
     }
 
-    public NecropotenceEffect(final NecropotenceEffect effect) {
+    private NecropotenceEffect(final NecropotenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Necroskitter.java
+++ b/Mage.Sets/src/mage/cards/n/Necroskitter.java
@@ -57,7 +57,7 @@ class NecroskitterTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ReturnToBattlefieldUnderYourControlTargetEffect(), true);
     }
 
-    public NecroskitterTriggeredAbility(NecroskitterTriggeredAbility ability) {
+    private NecroskitterTriggeredAbility(final NecroskitterTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NecroticPlague.java
+++ b/Mage.Sets/src/mage/cards/n/NecroticPlague.java
@@ -98,7 +98,7 @@ class NecroticPlagueEffect extends OneShotEffect {
                 "Return {this} from its owner's graveyard to the battlefield attached to that creature";
     }
 
-    public NecroticPlagueEffect(final NecroticPlagueEffect effect) {
+    private NecroticPlagueEffect(final NecroticPlagueEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NeedleSpires.java
+++ b/Mage.Sets/src/mage/cards/n/NeedleSpires.java
@@ -63,7 +63,7 @@ class NeedleSpiresToken extends TokenImpl {
         toughness = new MageInt(1);
         addAbility(DoubleStrikeAbility.getInstance());
     }
-    public NeedleSpiresToken(final NeedleSpiresToken token) {
+    private NeedleSpiresToken(final NeedleSpiresToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NeeraWildMage.java
+++ b/Mage.Sets/src/mage/cards/n/NeeraWildMage.java
@@ -56,7 +56,7 @@ class NeeraWildMageEffect extends OneShotEffect {
         staticText = "you may put it on the bottom of its owner's library. If you do, reveal cards from the top of your library until you reveal a nonland card. You may cast that card without paying its mana cost. Then put the rest on the bottom of your library in a random order. This ability triggers only once each turn.";
     }
 
-    public NeeraWildMageEffect(final NeeraWildMageEffect effect) {
+    private NeeraWildMageEffect(final NeeraWildMageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NeglectedHeirloom.java
+++ b/Mage.Sets/src/mage/cards/n/NeglectedHeirloom.java
@@ -59,7 +59,7 @@ class NeglectedHeirloomTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new TransformSourceEffect(), false);
     }
 
-    public NeglectedHeirloomTriggeredAbility(final NeglectedHeirloomTriggeredAbility ability) {
+    private NeglectedHeirloomTriggeredAbility(final NeglectedHeirloomTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NemaSiltlurker.java
+++ b/Mage.Sets/src/mage/cards/n/NemaSiltlurker.java
@@ -23,7 +23,7 @@ public final class NemaSiltlurker extends CardImpl {
         this.toughness = new MageInt(5);
     }
 
-    public NemaSiltlurker (final NemaSiltlurker card) {
+    private NemaSiltlurker(final NemaSiltlurker card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NemesisTrap.java
+++ b/Mage.Sets/src/mage/cards/n/NemesisTrap.java
@@ -68,7 +68,7 @@ class NemesisTrapEffect extends OneShotEffect {
         this.staticText = "Exile target attacking creature. Create a token that's a copy of that creature. Exile it at the beginning of the next end step";
     }
 
-    public NemesisTrapEffect(final NemesisTrapEffect effect) {
+    private NemesisTrapEffect(final NemesisTrapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NephaliaAcademy.java
+++ b/Mage.Sets/src/mage/cards/n/NephaliaAcademy.java
@@ -59,7 +59,7 @@ class NephaliaAcademyEffect extends ReplacementEffectImpl {
         staticText = "If a spell or ability an opponent controls causes you to discard a card, you may reveal that card and put it on top of your library instead of putting it anywhere else.";
     }
 
-    public NephaliaAcademyEffect(final NephaliaAcademyEffect effect) {
+    private NephaliaAcademyEffect(final NephaliaAcademyEffect effect) {
         super(effect);
         this.cardId = effect.cardId;
         this.zoneChangeCounter = effect.zoneChangeCounter;

--- a/Mage.Sets/src/mage/cards/n/NestingGrounds.java
+++ b/Mage.Sets/src/mage/cards/n/NestingGrounds.java
@@ -74,7 +74,7 @@ class NestingGroundsEffect extends OneShotEffect {
         this.staticText = "Move a counter from target permanent you control onto another target permanent";
     }
 
-    public NestingGroundsEffect(final NestingGroundsEffect effect) {
+    private NestingGroundsEffect(final NestingGroundsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NetherShadow.java
+++ b/Mage.Sets/src/mage/cards/n/NetherShadow.java
@@ -53,7 +53,7 @@ class NetherShadowTriggerdAbility extends BeginningOfUpkeepTriggeredAbility{
         super(Zone.GRAVEYARD, new ReturnSourceFromGraveyardToBattlefieldEffect(), TargetController.YOU, true);
     }
 
-    public NetherShadowTriggerdAbility(final NetherShadowTriggerdAbility effect) {
+    private NetherShadowTriggerdAbility(final NetherShadowTriggerdAbility effect) {
         super(effect);
     }    
     

--- a/Mage.Sets/src/mage/cards/n/NettlevineBlight.java
+++ b/Mage.Sets/src/mage/cards/n/NettlevineBlight.java
@@ -64,7 +64,7 @@ class NettlevineBlightEffect extends OneShotEffect {
         this.staticText = "sacrifice this permanent and attach {this} to a creature or land you control";
     }
 
-    public NettlevineBlightEffect(final NettlevineBlightEffect effect) {
+    private NettlevineBlightEffect(final NettlevineBlightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NettlingImp.java
+++ b/Mage.Sets/src/mage/cards/n/NettlingImp.java
@@ -89,7 +89,7 @@ class NettlingImpDelayedDestroyEffect extends OneShotEffect {
         this.staticText = "If it doesn't, destroy it at the beginning of the next end step";
     }
 
-    public NettlingImpDelayedDestroyEffect(final NettlingImpDelayedDestroyEffect effect) {
+    private NettlingImpDelayedDestroyEffect(final NettlingImpDelayedDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NeurokFamiliar.java
+++ b/Mage.Sets/src/mage/cards/n/NeurokFamiliar.java
@@ -56,7 +56,7 @@ class NeurokFamiliarEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of your library. If it's an artifact card, put it into your hand. Otherwise, put it into your graveyard.";
     }
 
-    public NeurokFamiliarEffect(final NeurokFamiliarEffect effect) {
+    private NeurokFamiliarEffect(final NeurokFamiliarEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NeurokInvisimancer.java
+++ b/Mage.Sets/src/mage/cards/n/NeurokInvisimancer.java
@@ -36,7 +36,7 @@ public final class NeurokInvisimancer extends CardImpl {
         this.addAbility(ability);
     }
 
-    public NeurokInvisimancer (final NeurokInvisimancer card) {
+    private NeurokInvisimancer(final NeurokInvisimancer card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NeurokReplica.java
+++ b/Mage.Sets/src/mage/cards/n/NeurokReplica.java
@@ -33,7 +33,7 @@ public final class NeurokReplica extends CardImpl {
         this.addAbility(ability);
     }
 
-    public NeurokReplica (final NeurokReplica card) {
+    private NeurokReplica(final NeurokReplica card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NeverHappened.java
+++ b/Mage.Sets/src/mage/cards/n/NeverHappened.java
@@ -50,7 +50,7 @@ class NeverHappenedEffect extends OneShotEffect {
                 + "or hand and exile it.";
     }
 
-    public NeverHappenedEffect(final NeverHappenedEffect effect) {
+    private NeverHappenedEffect(final NeverHappenedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NeverendingTorment.java
+++ b/Mage.Sets/src/mage/cards/n/NeverendingTorment.java
@@ -53,7 +53,7 @@ class NeverendingTormentEffect extends OneShotEffect {
         staticText = "Search target player's library for X cards, where X is the number of cards in your hand, and exile them. Then that player shuffles";
     }
 
-    public NeverendingTormentEffect(final NeverendingTormentEffect effect) {
+    private NeverendingTormentEffect(final NeverendingTormentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Nevermore.java
+++ b/Mage.Sets/src/mage/cards/n/Nevermore.java
@@ -53,7 +53,7 @@ class NevermoreEffect2 extends ContinuousRuleModifyingEffectImpl {
         staticText = "Spells with the chosen name can't be cast";
     }
 
-    public NevermoreEffect2(final NevermoreEffect2 effect) {
+    private NevermoreEffect2(final NevermoreEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NewBlood.java
+++ b/Mage.Sets/src/mage/cards/n/NewBlood.java
@@ -64,7 +64,7 @@ class NewBloodEffect extends OneShotEffect {
         this.staticText = "Gain control of target creature. Change the text of that creature by replacing all instances of one creature type with Vampire";
     }
 
-    public NewBloodEffect(final NewBloodEffect effect) {
+    private NewBloodEffect(final NewBloodEffect effect) {
         super(effect);
     }
 
@@ -102,7 +102,7 @@ class ChangeCreatureTypeTargetEffect extends ContinuousEffectImpl {
         this.staticText = "Change the text of that creature by replacing all instances of one creature type with Vampire";
     }
 
-    public ChangeCreatureTypeTargetEffect(final ChangeCreatureTypeTargetEffect effect) {
+    private ChangeCreatureTypeTargetEffect(final ChangeCreatureTypeTargetEffect effect) {
         super(effect);
         this.fromSubType = effect.fromSubType;
         this.toSubType = effect.toSubType;

--- a/Mage.Sets/src/mage/cards/n/NewFrontiers.java
+++ b/Mage.Sets/src/mage/cards/n/NewFrontiers.java
@@ -46,7 +46,7 @@ class NewFrontiersEffect extends OneShotEffect {
         this.staticText = "Each player may search their library for up to X basic land cards and put them onto the battlefield tapped. Then each player who searched their library this way shuffles";
     }
 
-    public NewFrontiersEffect(final NewFrontiersEffect effect) {
+    private NewFrontiersEffect(final NewFrontiersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NezumiGraverobber.java
+++ b/Mage.Sets/src/mage/cards/n/NezumiGraverobber.java
@@ -108,7 +108,7 @@ class NighteyesTheDesecratorToken extends TokenImpl {
         ability.addTarget(new TargetCardInGraveyard(new FilterCreatureCard("creature card from a graveyard")));
         this.addAbility(ability);
     }
-    public NighteyesTheDesecratorToken(final NighteyesTheDesecratorToken token) {
+    private NighteyesTheDesecratorToken(final NighteyesTheDesecratorToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NezumiRonin.java
+++ b/Mage.Sets/src/mage/cards/n/NezumiRonin.java
@@ -26,7 +26,7 @@ public final class NezumiRonin extends CardImpl {
         this.addAbility(new BushidoAbility(1));
     }
 
-    public NezumiRonin (final NezumiRonin card) {
+    private NezumiRonin(final NezumiRonin card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NezumiShortfang.java
+++ b/Mage.Sets/src/mage/cards/n/NezumiShortfang.java
@@ -73,7 +73,7 @@ class StabwhiskerTheOdious extends TokenImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
                 Zone.BATTLEFIELD, new StabwhiskerLoseLifeEffect(), TargetController.OPPONENT, false, true));
     }
-    public StabwhiskerTheOdious(final StabwhiskerTheOdious token) {
+    private StabwhiskerTheOdious(final StabwhiskerTheOdious token) {
         super(token);
     }
 
@@ -89,7 +89,7 @@ class StabwhiskerLoseLifeEffect extends OneShotEffect {
         this.staticText = "that player loses 1 life for each card fewer than three in their hand";
     }
 
-    public StabwhiskerLoseLifeEffect(final StabwhiskerLoseLifeEffect effect) {
+    private StabwhiskerLoseLifeEffect(final StabwhiskerLoseLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NicolBolasTheArisen.java
+++ b/Mage.Sets/src/mage/cards/n/NicolBolasTheArisen.java
@@ -86,7 +86,7 @@ class NicolBolasTheArisenEffect extends OneShotEffect {
         this.staticText = "Exile all but the bottom card of target player's library.";
     }
 
-    public NicolBolasTheArisenEffect(final NicolBolasTheArisenEffect effect) {
+    private NicolBolasTheArisenEffect(final NicolBolasTheArisenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NicolBolasTheDeceiver.java
+++ b/Mage.Sets/src/mage/cards/n/NicolBolasTheDeceiver.java
@@ -66,7 +66,7 @@ class NicolBolasTheDeceiverFirstEffect extends OneShotEffect {
         staticText = "Each opponent loses 3 life unless that player sacrifices a nonland permanent or discards a card";
     }
 
-    public NicolBolasTheDeceiverFirstEffect(final NicolBolasTheDeceiverFirstEffect effect) {
+    private NicolBolasTheDeceiverFirstEffect(final NicolBolasTheDeceiverFirstEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NightDay.java
+++ b/Mage.Sets/src/mage/cards/n/NightDay.java
@@ -60,7 +60,7 @@ class DayEffect extends ContinuousEffectImpl {
         staticText = "Creatures target player controls get +1/+1 until end of turn";
     }
 
-    public DayEffect(final DayEffect effect) {
+    private DayEffect(final DayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NightOfSoulsBetrayal.java
+++ b/Mage.Sets/src/mage/cards/n/NightOfSoulsBetrayal.java
@@ -22,7 +22,7 @@ public final class NightOfSoulsBetrayal extends CardImpl {
         this.addAbility(new SimpleStaticAbility(new BoostAllEffect(-1, -1, Duration.WhileOnBattlefield)));
     }
 
-    public NightOfSoulsBetrayal (final NightOfSoulsBetrayal card) {
+    private NightOfSoulsBetrayal(final NightOfSoulsBetrayal card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Nightcreep.java
+++ b/Mage.Sets/src/mage/cards/n/Nightcreep.java
@@ -48,7 +48,7 @@ class NightcreepLandEffect extends BecomesBasicLandTargetEffect {
         this.staticText = "and all lands become Swamps";
     }
 
-    public NightcreepLandEffect(NightcreepLandEffect effect) {
+    private NightcreepLandEffect(final NightcreepLandEffect effect) {
         super(effect);
     }
 
@@ -72,7 +72,7 @@ class NightcreepCreatureEffect extends BecomesColorTargetEffect {
         this.staticText = "Until end of turn, all creatures become black";
     }
 
-    public NightcreepCreatureEffect(NightcreepCreatureEffect effect) {
+    private NightcreepCreatureEffect(final NightcreepCreatureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NightguardPatrol.java
+++ b/Mage.Sets/src/mage/cards/n/NightguardPatrol.java
@@ -28,7 +28,7 @@ public final class NightguardPatrol extends CardImpl {
         this.addAbility(VigilanceAbility.getInstance());
     }
 
-    public NightguardPatrol (final NightguardPatrol card) {
+    private NightguardPatrol(final NightguardPatrol card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Nighthaze.java
+++ b/Mage.Sets/src/mage/cards/n/Nighthaze.java
@@ -26,7 +26,7 @@ public final class Nighthaze extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public Nighthaze (final Nighthaze card) {
+    private Nighthaze(final Nighthaze card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NightmareIncursion.java
+++ b/Mage.Sets/src/mage/cards/n/NightmareIncursion.java
@@ -54,7 +54,7 @@ class NightmareIncursionEffect extends OneShotEffect {
                 "Then that player shuffles";
     }
 
-    public NightmareIncursionEffect(final NightmareIncursionEffect effect) {
+    private NightmareIncursionEffect(final NightmareIncursionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NightshadeAssassin.java
+++ b/Mage.Sets/src/mage/cards/n/NightshadeAssassin.java
@@ -69,7 +69,7 @@ class NightshadeAssassinEffect extends OneShotEffect {
         staticText = "you may reveal X black cards in your hand. If you do, target creature gets -X/-X until end of turn";
     }
 
-    public NightshadeAssassinEffect(final NightshadeAssassinEffect effect) {
+    private NightshadeAssassinEffect(final NightshadeAssassinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NightshadeSeer.java
+++ b/Mage.Sets/src/mage/cards/n/NightshadeSeer.java
@@ -68,7 +68,7 @@ class NightshadeSeerEffect extends OneShotEffect {
                 + "where X is the number of cards revealed this way";
     }
 
-    public NightshadeSeerEffect(final NightshadeSeerEffect effect) {
+    private NightshadeSeerEffect(final NightshadeSeerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Nightsnare.java
+++ b/Mage.Sets/src/mage/cards/n/Nightsnare.java
@@ -44,7 +44,7 @@ class NightsnareDiscardEffect extends OneShotEffect {
         staticText = "Target opponent reveals their hand. You may choose a nonland card from it. If you do, that player discards that card. If you don't, that player discards two cards";
     }
 
-    public NightsnareDiscardEffect(final NightsnareDiscardEffect effect) {
+    private NightsnareDiscardEffect(final NightsnareDiscardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NightveilSpecter.java
+++ b/Mage.Sets/src/mage/cards/n/NightveilSpecter.java
@@ -73,7 +73,7 @@ class NightveilSpecterExileEffect extends OneShotEffect {
         staticText = "that player exiles the top card of their library";
     }
 
-    public NightveilSpecterExileEffect(final NightveilSpecterExileEffect effect) {
+    private NightveilSpecterExileEffect(final NightveilSpecterExileEffect effect) {
         super(effect);
     }
 
@@ -103,7 +103,7 @@ class NightveilSpecterEffect extends AsThoughEffectImpl {
         staticText = "You may play cards exiled with {this}";
     }
 
-    public NightveilSpecterEffect(final NightveilSpecterEffect effect) {
+    private NightveilSpecterEffect(final NightveilSpecterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NimDeathmantle.java
+++ b/Mage.Sets/src/mage/cards/n/NimDeathmantle.java
@@ -119,7 +119,7 @@ class NimDeathmantleEffect extends OneShotEffect {
 
     }
 
-    public NimDeathmantleEffect(NimDeathmantleEffect effect) {
+    private NimDeathmantleEffect(final NimDeathmantleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NimDevourer.java
+++ b/Mage.Sets/src/mage/cards/n/NimDevourer.java
@@ -67,7 +67,7 @@ class NimDevourerEffect extends OneShotEffect {
         this.staticText = ", then sacrifice a creature";
     }
 
-    public NimDevourerEffect(final NimDevourerEffect effect) {
+    private NimDevourerEffect(final NimDevourerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NimbusWings.java
+++ b/Mage.Sets/src/mage/cards/n/NimbusWings.java
@@ -42,7 +42,7 @@ public final class NimbusWings extends CardImpl {
         this.addAbility(ability);
     }
 
-    public NimbusWings (final NimbusWings card) {
+    private NimbusWings(final NimbusWings card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NineLives.java
+++ b/Mage.Sets/src/mage/cards/n/NineLives.java
@@ -63,7 +63,7 @@ class NineLivesPreventionEffect extends PreventionEffectImpl {
         staticText = "If a source would deal damage to you, prevent that damage and put an incarnation counter on {this}";
     }
 
-    public NineLivesPreventionEffect(final NineLivesPreventionEffect effect) {
+    private NineLivesPreventionEffect(final NineLivesPreventionEffect effect) {
         super(effect);
     }
 
@@ -106,7 +106,7 @@ class NineLivesStateTriggeredAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new ExileSourceEffect());
     }
 
-    public NineLivesStateTriggeredAbility(final NineLivesStateTriggeredAbility ability) {
+    private NineLivesStateTriggeredAbility(final NineLivesStateTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NirkanaCutthroat.java
+++ b/Mage.Sets/src/mage/cards/n/NirkanaCutthroat.java
@@ -46,7 +46,7 @@ public final class NirkanaCutthroat extends LevelerCard {
         setMaxLevelCounters(3);
     }
 
-    public NirkanaCutthroat (final NirkanaCutthroat card) {
+    private NirkanaCutthroat(final NirkanaCutthroat card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NissaNaturesArtisan.java
+++ b/Mage.Sets/src/mage/cards/n/NissaNaturesArtisan.java
@@ -65,7 +65,7 @@ class NissaNaturesArtisanEffect extends OneShotEffect {
                 + "from among them onto the battlefield and the rest into your hand";
     }
 
-    public NissaNaturesArtisanEffect(final NissaNaturesArtisanEffect effect) {
+    private NissaNaturesArtisanEffect(final NissaNaturesArtisanEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NissaRevane.java
+++ b/Mage.Sets/src/mage/cards/n/NissaRevane.java
@@ -67,7 +67,7 @@ class NissaRevaneGainLifeEffect extends OneShotEffect {
         staticText = "You gain 2 life for each Elf you control";
     }
 
-    public NissaRevaneGainLifeEffect(final NissaRevaneGainLifeEffect effect) {
+    private NissaRevaneGainLifeEffect(final NissaRevaneGainLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NissaSageAnimist.java
+++ b/Mage.Sets/src/mage/cards/n/NissaSageAnimist.java
@@ -104,7 +104,7 @@ class NissaSageAnimistMinusAnimateEffect extends OneShotEffect {
         this.staticText = "They become 6/6 Elemental creatures. They're still lands";
     }
 
-    public NissaSageAnimistMinusAnimateEffect(final NissaSageAnimistMinusAnimateEffect effect) {
+    private NissaSageAnimistMinusAnimateEffect(final NissaSageAnimistMinusAnimateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NissaStewardOfElements.java
+++ b/Mage.Sets/src/mage/cards/n/NissaStewardOfElements.java
@@ -77,7 +77,7 @@ class NissaStewardOfElementsEffect extends OneShotEffect {
                 + "to the number of loyalty counters on {this}, you may put that card onto the battlefield";
     }
 
-    public NissaStewardOfElementsEffect(final NissaStewardOfElementsEffect effect) {
+    private NissaStewardOfElementsEffect(final NissaStewardOfElementsEffect effect) {
         super(effect);
     }
 
@@ -122,7 +122,7 @@ class NissaStewardOfElementsToken extends TokenImpl {
         this.addAbility(HasteAbility.getInstance());
     }
 
-    public NissaStewardOfElementsToken(final NissaStewardOfElementsToken token) {
+    private NissaStewardOfElementsToken(final NissaStewardOfElementsToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NissaVitalForce.java
+++ b/Mage.Sets/src/mage/cards/n/NissaVitalForce.java
@@ -79,7 +79,7 @@ class NissaVitalForceToken extends TokenImpl {
         this.addAbility(HasteAbility.getInstance());
     }
 
-    public NissaVitalForceToken(final NissaVitalForceToken token) {
+    private NissaVitalForceToken(final NissaVitalForceToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NissaWorldwaker.java
+++ b/Mage.Sets/src/mage/cards/n/NissaWorldwaker.java
@@ -72,7 +72,7 @@ class NissaWorldwakerSearchEffect extends OneShotEffect {
         this.staticText = "Search your library for any number of basic land cards, put them onto the battlefield, then shuffle. Those lands become 4/4 Elemental creatures with trample. They're still lands";
     }
 
-    public NissaWorldwakerSearchEffect(final NissaWorldwakerSearchEffect effect) {
+    private NissaWorldwakerSearchEffect(final NissaWorldwakerSearchEffect effect) {
         super(effect);
     }
 
@@ -122,7 +122,7 @@ class NissaWorldwakerToken extends TokenImpl {
         this.toughness = new MageInt(4);
         this.addAbility(TrampleAbility.getInstance());
     }
-    public NissaWorldwakerToken(final NissaWorldwakerToken token) {
+    private NissaWorldwakerToken(final NissaWorldwakerToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NissasChosen.java
+++ b/Mage.Sets/src/mage/cards/n/NissasChosen.java
@@ -55,7 +55,7 @@ class NissasChosenEffect extends ReplacementEffectImpl {
         staticText = "If {this} would die, put it on the bottom of its owner's library instead";
     }
 
-    public NissasChosenEffect(final NissasChosenEffect effect) {
+    private NissasChosenEffect(final NissasChosenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NissasDefeat.java
+++ b/Mage.Sets/src/mage/cards/n/NissasDefeat.java
@@ -64,7 +64,7 @@ class NissasDefeatEffect extends OneShotEffect {
         this.staticText = "Destroy target Forest, green enchantment, or green planeswalker. If that permanent was a Nissa planeswalker, draw a card.";
     }
 
-    public NissasDefeatEffect(final NissasDefeatEffect effect) {
+    private NissasDefeatEffect(final NissasDefeatEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NissasEncouragement.java
+++ b/Mage.Sets/src/mage/cards/n/NissasEncouragement.java
@@ -55,7 +55,7 @@ class NissasEncouragementEffect extends OneShotEffect {
         this.staticText = "Search your library and graveyard for a card named Forest, a card named Brambleweft Behemoth, and a card named Nissa, Genesis Mage. Reveal those cards, put them into your hand, then shuffle.";
     }
 
-    public NissasEncouragementEffect(final NissasEncouragementEffect effect) {
+    private NissasEncouragementEffect(final NissasEncouragementEffect effect) {
         super(effect);
     }
 
@@ -135,7 +135,7 @@ class NissasEncouragementTarget extends TargetCardInLibrary {
         super(0, 3, filter);
     }
 
-    public NissasEncouragementTarget(final NissasEncouragementTarget target) {
+    private NissasEncouragementTarget(final NissasEncouragementTarget target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NissasJudgment.java
+++ b/Mage.Sets/src/mage/cards/n/NissasJudgment.java
@@ -54,7 +54,7 @@ class NissasJudgmentEffect extends OneShotEffect {
         this.staticText = "Choose up to one target creature an opponent controls. Each creature you control with a +1/+1 counter on it deals damage equal to its power to that creature";
     }
 
-    public NissasJudgmentEffect(final NissasJudgmentEffect effect) {
+    private NissasJudgmentEffect(final NissasJudgmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NissasPilgrimage.java
+++ b/Mage.Sets/src/mage/cards/n/NissasPilgrimage.java
@@ -60,7 +60,7 @@ class NissasPilgrimageEffect extends OneShotEffect {
                 + "<br><i>Spell mastery</i> &mdash; If there are two or more instant and/or sorcery cards in your graveyard, search your library for up to three basic Forest cards instead of two.";
     }
 
-    public NissasPilgrimageEffect(final NissasPilgrimageEffect effect) {
+    private NissasPilgrimageEffect(final NissasPilgrimageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NissasRevelation.java
+++ b/Mage.Sets/src/mage/cards/n/NissasRevelation.java
@@ -48,7 +48,7 @@ class NissasRevelationEffect extends OneShotEffect {
         this.staticText = ", then reveal the top card of your library. If it's a creature card, you draw cards equal to its power and you gain life equal to its toughness";
     }
 
-    public NissasRevelationEffect(final NissasRevelationEffect effect) {
+    private NissasRevelationEffect(final NissasRevelationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NiveousWisps.java
+++ b/Mage.Sets/src/mage/cards/n/NiveousWisps.java
@@ -30,7 +30,7 @@ public final class NiveousWisps extends CardImpl {
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1).concatBy("<br>"));
     }
 
-    public NiveousWisps (final NiveousWisps card) {
+    private NiveousWisps(final NiveousWisps card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NoContest.java
+++ b/Mage.Sets/src/mage/cards/n/NoContest.java
@@ -50,7 +50,7 @@ class TargetCreatureWithLessPowerPermanent extends TargetPermanent {
         super(1, 1, new FilterCreaturePermanent("creature with power less than its power"), false);
     }
 
-    public TargetCreatureWithLessPowerPermanent(final TargetCreatureWithLessPowerPermanent target) {
+    private TargetCreatureWithLessPowerPermanent(final TargetCreatureWithLessPowerPermanent target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NoDachi.java
+++ b/Mage.Sets/src/mage/cards/n/NoDachi.java
@@ -26,7 +26,7 @@ public final class NoDachi extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEquippedEffect(2, 0)));
     }
 
-    public NoDachi (final NoDachi card) {
+    private NoDachi(final NoDachi card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NoMercy.java
+++ b/Mage.Sets/src/mage/cards/n/NoMercy.java
@@ -41,7 +41,7 @@ public final class NoMercy extends CardImpl {
             super(Zone.BATTLEFIELD, new DestroyTargetEffect());
         }
 
-        public NoMercyTriggeredAbility(final NoMercyTriggeredAbility ability) {
+        private NoMercyTriggeredAbility(final NoMercyTriggeredAbility ability) {
             super(ability);
         }
 

--- a/Mage.Sets/src/mage/cards/n/NobleBenefactor.java
+++ b/Mage.Sets/src/mage/cards/n/NobleBenefactor.java
@@ -53,7 +53,7 @@ class NobleBenefactorEffect extends OneShotEffect {
         this.staticText = "each player may search their library for a card and put that card into their hand. Then each player who searched their library this way shuffles";
     }
 
-    public NobleBenefactorEffect(final NobleBenefactorEffect effect) {
+    private NobleBenefactorEffect(final NobleBenefactorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NobleElephant.java
+++ b/Mage.Sets/src/mage/cards/n/NobleElephant.java
@@ -31,7 +31,7 @@ public final class NobleElephant extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public NobleElephant (final NobleElephant card) {
+    private NobleElephant(final NobleElephant card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NobleHeritage.java
+++ b/Mage.Sets/src/mage/cards/n/NobleHeritage.java
@@ -61,7 +61,7 @@ class NobleHeritageTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null, false);
     }
 
-    public NobleHeritageTriggeredAbility(final NobleHeritageTriggeredAbility ability) {
+    private NobleHeritageTriggeredAbility(final NobleHeritageTriggeredAbility ability) {
         super(ability);
     }
 
@@ -110,7 +110,7 @@ class NobleHeritageEffect extends OneShotEffect {
                 + "If a player does, creatures that player controls can't attack you or planeswalkers you control until your next turn";
     }
 
-    public NobleHeritageEffect(final NobleHeritageEffect effect) {
+    private NobleHeritageEffect(final NobleHeritageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NoblePurpose.java
+++ b/Mage.Sets/src/mage/cards/n/NoblePurpose.java
@@ -43,7 +43,7 @@ class NoblePurposeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null);
     }
     
-    public NoblePurposeTriggeredAbility(final NoblePurposeTriggeredAbility ability) {
+    private NoblePurposeTriggeredAbility(final NoblePurposeTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NomadMythmaker.java
+++ b/Mage.Sets/src/mage/cards/n/NomadMythmaker.java
@@ -68,7 +68,7 @@ class NomadMythmakerEffect extends OneShotEffect {
         this.staticText = "Put target Aura card from a graveyard onto the battlefield under your control attached to a creature you control.";
     }
 
-    public NomadMythmakerEffect(final NomadMythmakerEffect effect) {
+    private NomadMythmakerEffect(final NomadMythmakerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NoosegrafMob.java
+++ b/Mage.Sets/src/mage/cards/n/NoosegrafMob.java
@@ -57,7 +57,7 @@ class NoosegrafMobEffect extends OneShotEffect {
         staticText = "remove a +1/+1 counter from Noosegraf Mob. If you do, create a 2/2 black Zombie creature token";
     }
 
-    public NoosegrafMobEffect(final NoosegrafMobEffect effect) {
+    private NoosegrafMobEffect(final NoosegrafMobEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NorinTheWary.java
+++ b/Mage.Sets/src/mage/cards/n/NorinTheWary.java
@@ -51,7 +51,7 @@ class NorinTheWaryTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When a player casts a spell or a creature attacks, ");
     }
 
-    public NorinTheWaryTriggeredAbility(final NorinTheWaryTriggeredAbility ability) {
+    private NorinTheWaryTriggeredAbility(final NorinTheWaryTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NornsInquisitor.java
+++ b/Mage.Sets/src/mage/cards/n/NornsInquisitor.java
@@ -55,7 +55,7 @@ class NornsInquisitorTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance()), false);
     }
 
-    public NornsInquisitorTriggeredAbility(final NornsInquisitorTriggeredAbility ability) {
+    private NornsInquisitorTriggeredAbility(final NornsInquisitorTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Norritt.java
+++ b/Mage.Sets/src/mage/cards/n/Norritt.java
@@ -90,7 +90,7 @@ class NorrittDelayedDestroyEffect extends OneShotEffect {
         this.staticText = "If it doesn't, destroy it at the beginning of the next end step";
     }
 
-    public NorrittDelayedDestroyEffect(final NorrittDelayedDestroyEffect effect) {
+    private NorrittDelayedDestroyEffect(final NorrittDelayedDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NotForgotten.java
+++ b/Mage.Sets/src/mage/cards/n/NotForgotten.java
@@ -48,7 +48,7 @@ class NotForgottenEffect extends OneShotEffect {
         this.staticText = "Put target card from a graveyard on the top or bottom of its owner's library. Create a 1/1 white Spirit creature token with flying.";
     }
     
-    public NotForgottenEffect(final NotForgottenEffect effect) {
+    private NotForgottenEffect(final NotForgottenEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/n/NotionThief.java
+++ b/Mage.Sets/src/mage/cards/n/NotionThief.java
@@ -58,7 +58,7 @@ class NotionThiefReplacementEffect extends ReplacementEffectImpl {
         staticText = "If an opponent would draw a card except the first one they draw in each of their draw steps, instead that player skips that draw and you draw a card";
     }
 
-    public NotionThiefReplacementEffect(final NotionThiefReplacementEffect effect) {
+    private NotionThiefReplacementEffect(final NotionThiefReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NotoriousThrong.java
+++ b/Mage.Sets/src/mage/cards/n/NotoriousThrong.java
@@ -61,7 +61,7 @@ class NotoriousThrongEffect extends OneShotEffect {
         staticText = "create X 1/1 black Faerie Rogue creature tokens with flying, where X is the damage dealt to your opponents this turn";
     }
 
-    public NotoriousThrongEffect(NotoriousThrongEffect effect) {
+    private NotoriousThrongEffect(final NotoriousThrongEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Nourish.java
+++ b/Mage.Sets/src/mage/cards/n/Nourish.java
@@ -20,7 +20,7 @@ public final class Nourish extends CardImpl {
         this.getSpellAbility().addEffect(new GainLifeEffect(6));
     }
 
-    public Nourish (final Nourish card) {
+    private Nourish(final Nourish card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NovaPentacle.java
+++ b/Mage.Sets/src/mage/cards/n/NovaPentacle.java
@@ -57,7 +57,7 @@ class NovaPentacleEffect extends RedirectionEffect {
         this.damageSource = new TargetSource();
     }
 
-    public NovaPentacleEffect(final NovaPentacleEffect effect) {
+    private NovaPentacleEffect(final NovaPentacleEffect effect) {
         super(effect);
         this.damageSource = effect.damageSource.copy();
     }

--- a/Mage.Sets/src/mage/cards/n/NovijenHeartOfProgress.java
+++ b/Mage.Sets/src/mage/cards/n/NovijenHeartOfProgress.java
@@ -55,7 +55,7 @@ class NovijenHeartOfProgressEffect extends OneShotEffect {
         staticText = "put a +1/+1 counter on each creature that entered the battlefield this turn";
     }
 
-    public NovijenHeartOfProgressEffect(final NovijenHeartOfProgressEffect effect) {
+    private NovijenHeartOfProgressEffect(final NovijenHeartOfProgressEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NoxiousGearhulk.java
+++ b/Mage.Sets/src/mage/cards/n/NoxiousGearhulk.java
@@ -56,7 +56,7 @@ class NoxiousGearhulkEffect extends OneShotEffect {
         this.staticText = "you may destroy another target creature. If a creature is destroyed this way, you gain life equal to its toughness";
     }
 
-    public NoxiousGearhulkEffect(final NoxiousGearhulkEffect effect) {
+    private NoxiousGearhulkEffect(final NoxiousGearhulkEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NoyanDarRoilShaper.java
+++ b/Mage.Sets/src/mage/cards/n/NoyanDarRoilShaper.java
@@ -73,7 +73,7 @@ class NoyanDarEffect extends OneShotEffect {
         this.staticText = "put three +1/+1 counters on target land you control. If you do, that land becomes a 0/0 Elemental creature with haste that's still a land.";
     }
 
-    public NoyanDarEffect(final NoyanDarEffect effect) {
+    private NoyanDarEffect(final NoyanDarEffect effect) {
         super(effect);
     }
 
@@ -114,7 +114,7 @@ class AwakenElementalToken extends TokenImpl {
         this.addAbility(HasteAbility.getInstance());
     }
 
-    public AwakenElementalToken(final AwakenElementalToken token) {
+    private AwakenElementalToken(final AwakenElementalToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NullChamber.java
+++ b/Mage.Sets/src/mage/cards/n/NullChamber.java
@@ -56,7 +56,7 @@ class NullChamberChooseEffect extends OneShotEffect {
         staticText = "you and an opponent each choose a card name other than a basic land card name";
     }
 
-    public NullChamberChooseEffect(final NullChamberChooseEffect effect) {
+    private NullChamberChooseEffect(final NullChamberChooseEffect effect) {
         super(effect);
     }
 
@@ -107,7 +107,7 @@ class NullChamberReplacementEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "The named cards can't be played";
     }
 
-    public NullChamberReplacementEffect(final NullChamberReplacementEffect effect) {
+    private NullChamberReplacementEffect(final NullChamberReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NullChampion.java
+++ b/Mage.Sets/src/mage/cards/n/NullChampion.java
@@ -45,7 +45,7 @@ public final class NullChampion extends LevelerCard {
         setMaxLevelCounters(4);
     }
 
-    public NullChampion (final NullChampion card) {
+    private NullChampion(final NullChampion card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NullRod.java
+++ b/Mage.Sets/src/mage/cards/n/NullRod.java
@@ -42,7 +42,7 @@ class NullRodCantActivateEffect extends RestrictionEffect {
         staticText = "Activated abilities of artifacts can't be activated";
     }
 
-    public NullRodCantActivateEffect(final NullRodCantActivateEffect effect) {
+    private NullRodCantActivateEffect(final NullRodCantActivateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NullhideFerox.java
+++ b/Mage.Sets/src/mage/cards/n/NullhideFerox.java
@@ -77,7 +77,7 @@ class NullhideFeroxCantCastEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "You can't cast noncreature spells";
     }
 
-    public NullhideFeroxCantCastEffect(final NullhideFeroxCantCastEffect effect) {
+    private NullhideFeroxCantCastEffect(final NullhideFeroxCantCastEffect effect) {
         super(effect);
     }
 
@@ -109,7 +109,7 @@ class NullhideFeroxLoseAbilitiesEffect extends OneShotEffect {
         this.staticText = "{this} loses all abilities until end of turn. Any player may activate this ability";
     }
 
-    public NullhideFeroxLoseAbilitiesEffect(final NullhideFeroxLoseAbilitiesEffect effect) {
+    private NullhideFeroxLoseAbilitiesEffect(final NullhideFeroxLoseAbilitiesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NullstoneGargoyle.java
+++ b/Mage.Sets/src/mage/cards/n/NullstoneGargoyle.java
@@ -54,7 +54,7 @@ class NullstoneGargoyleTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CounterTargetEffect(), false);
     }
 
-    public NullstoneGargoyleTriggeredAbility(final NullstoneGargoyleTriggeredAbility ability) {
+    private NullstoneGargoyleTriggeredAbility(final NullstoneGargoyleTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NulltreadGargantuan.java
+++ b/Mage.Sets/src/mage/cards/n/NulltreadGargantuan.java
@@ -33,7 +33,7 @@ public final class NulltreadGargantuan extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new NulltreadGargantuanEffect()));
     }
 
-    public NulltreadGargantuan(final NulltreadGargantuan card) {
+    private NulltreadGargantuan(final NulltreadGargantuan card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NumaiOutcast.java
+++ b/Mage.Sets/src/mage/cards/n/NumaiOutcast.java
@@ -36,7 +36,7 @@ public final class NumaiOutcast extends CardImpl {
         this.addAbility(ability);
     }
 
-    public NumaiOutcast (final NumaiOutcast card) {
+    private NumaiOutcast(final NumaiOutcast card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NumbingDose.java
+++ b/Mage.Sets/src/mage/cards/n/NumbingDose.java
@@ -71,7 +71,7 @@ class NumbingDoseTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), false);
     }
 
-    public NumbingDoseTriggeredAbility(final NumbingDoseTriggeredAbility ability) {
+    private NumbingDoseTriggeredAbility(final NumbingDoseTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NyleasColossus.java
+++ b/Mage.Sets/src/mage/cards/n/NyleasColossus.java
@@ -52,7 +52,7 @@ class NyleasColossusEffect extends OneShotEffect {
         this.staticText = "double target creature's power and toughness until end of turn";
     }
 
-    public NyleasColossusEffect(final NyleasColossusEffect effect) {
+    private NyleasColossusEffect(final NyleasColossusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NyleasPresence.java
+++ b/Mage.Sets/src/mage/cards/n/NyleasPresence.java
@@ -63,7 +63,7 @@ class NyleasPresenceLandTypeEffect extends ContinuousEffectImpl {
         dependencyTypes.add(DependencyType.BecomeForest);
     }
 
-    public NyleasPresenceLandTypeEffect(final NyleasPresenceLandTypeEffect effect) {
+    private NyleasPresenceLandTypeEffect(final NyleasPresenceLandTypeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Oakenform.java
+++ b/Mage.Sets/src/mage/cards/o/Oakenform.java
@@ -59,7 +59,7 @@ class OakenformEffect extends ContinuousEffectImpl {
         staticText = "Enchanted creature gets +3/+3";
     }
 
-    public OakenformEffect(final OakenformEffect effect) {
+    private OakenformEffect(final OakenformEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathOfDruids.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfDruids.java
@@ -102,7 +102,7 @@ class OathOfDruidsEffect extends OneShotEffect {
                 + "If they do, that player puts that card onto the battlefield and all other cards revealed this way into their graveyard";
     }
 
-    public OathOfDruidsEffect(OathOfDruidsEffect effect) {
+    private OathOfDruidsEffect(final OathOfDruidsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathOfGhouls.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfGhouls.java
@@ -102,7 +102,7 @@ class OathOfGhoulsEffect extends OneShotEffect {
         staticText = "that player chooses target player whose graveyard has fewer creature cards in it than their graveyard does and is their opponent. The first player may return a creature card from their graveyard to their hand";
     }
 
-    public OathOfGhoulsEffect(OathOfGhoulsEffect effect) {
+    private OathOfGhoulsEffect(final OathOfGhoulsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathOfJace.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfJace.java
@@ -52,7 +52,7 @@ class OathOfJaceEffect extends OneShotEffect {
         this.staticText = "scry X, where X is the number of planeswalkers you control";
     }
 
-    public OathOfJaceEffect(final OathOfJaceEffect effect) {
+    private OathOfJaceEffect(final OathOfJaceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathOfKaya.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfKaya.java
@@ -57,7 +57,7 @@ class OathOfKayaTriggeredAbility extends TriggeredAbilityImpl {
         this.addEffect(new GainLifeEffect(2));
     }
 
-    public OathOfKayaTriggeredAbility(final OathOfKayaTriggeredAbility ability) {
+    private OathOfKayaTriggeredAbility(final OathOfKayaTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathOfLieges.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfLieges.java
@@ -75,7 +75,7 @@ class OathOfLiegesEffect extends OneShotEffect {
                 + "The first player may search their library for a basic land card, put that card onto the battlefield, then shuffle";
     }
 
-    public OathOfLiegesEffect(final OathOfLiegesEffect effect) {
+    private OathOfLiegesEffect(final OathOfLiegesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathOfLimDul.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfLimDul.java
@@ -57,7 +57,7 @@ class OathOfLimDulTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new OathOfLimDulEffect());
     }
 
-    public OathOfLimDulTriggeredAbility(final OathOfLimDulTriggeredAbility ability) {
+    private OathOfLimDulTriggeredAbility(final OathOfLimDulTriggeredAbility ability) {
         super(ability);
     }
 
@@ -98,7 +98,7 @@ class OathOfLimDulEffect extends OneShotEffect {
         super(Outcome.Neutral);
     }
 
-    public OathOfLimDulEffect(final OathOfLimDulEffect effect) {
+    private OathOfLimDulEffect(final OathOfLimDulEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathOfNissa.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfNissa.java
@@ -63,7 +63,7 @@ class OathOfNissaSpendAnyManaEffect extends AsThoughEffectImpl implements AsThou
         staticText = "you may spend mana as though it were mana of any color to cast planeswalker spells";
     }
 
-    public OathOfNissaSpendAnyManaEffect(final OathOfNissaSpendAnyManaEffect effect) {
+    private OathOfNissaSpendAnyManaEffect(final OathOfNissaSpendAnyManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathOfScholars.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfScholars.java
@@ -94,7 +94,7 @@ class OathOfScholarsEffect extends OneShotEffect {
         staticText = "that player chooses target player who has more cards in hand than they do and is their opponent. The first player may discard their hand and draw three cards";
     }
 
-    public OathOfScholarsEffect(OathOfScholarsEffect effect) {
+    private OathOfScholarsEffect(final OathOfScholarsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathOfTeferi.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfTeferi.java
@@ -95,7 +95,7 @@ class OathOfTeferiLoyaltyEffect extends ContinuousEffectImpl {
         staticText = "You may activate the loyalty abilities of planeswalkers you control twice each turn rather than only once";
     }
 
-    public OathOfTeferiLoyaltyEffect(final OathOfTeferiLoyaltyEffect effect) {
+    private OathOfTeferiLoyaltyEffect(final OathOfTeferiLoyaltyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathkeeperTakenosDaisho.java
+++ b/Mage.Sets/src/mage/cards/o/OathkeeperTakenosDaisho.java
@@ -65,7 +65,7 @@ class OathkeeperExileEquippedEffect extends OneShotEffect {
         staticText = "exile equipped creature";
     }
 
-    public OathkeeperExileEquippedEffect(final OathkeeperExileEquippedEffect effect) {
+    private OathkeeperExileEquippedEffect(final OathkeeperExileEquippedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/ObNixilisOfTheBlackOath.java
+++ b/Mage.Sets/src/mage/cards/o/ObNixilisOfTheBlackOath.java
@@ -65,7 +65,7 @@ class ObNixilisOfTheBlackOathEffect1 extends OneShotEffect {
         staticText = "Each opponent loses 1 life. You gain life equal to the life lost this way";
     }
 
-    public ObNixilisOfTheBlackOathEffect1(final ObNixilisOfTheBlackOathEffect1 effect) {
+    private ObNixilisOfTheBlackOathEffect1(final ObNixilisOfTheBlackOathEffect1 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/ObNixilisUnshackled.java
+++ b/Mage.Sets/src/mage/cards/o/ObNixilisUnshackled.java
@@ -68,7 +68,7 @@ class ObNixilisUnshackledTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ObNixilisUnshackledEffect(), false);
     }
 
-    public ObNixilisUnshackledTriggeredAbility(final ObNixilisUnshackledTriggeredAbility ability) {
+    private ObNixilisUnshackledTriggeredAbility(final ObNixilisUnshackledTriggeredAbility ability) {
         super(ability);
     }
 
@@ -108,7 +108,7 @@ class ObNixilisUnshackledEffect extends SacrificeEffect {
         this.staticText = "that player sacrifices a creature and loses 10 life";
     }
 
-    public ObNixilisUnshackledEffect(final ObNixilisUnshackledEffect effect) {
+    private ObNixilisUnshackledEffect(final ObNixilisUnshackledEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/ObeliskOfBant.java
+++ b/Mage.Sets/src/mage/cards/o/ObeliskOfBant.java
@@ -23,7 +23,7 @@ public final class ObeliskOfBant extends CardImpl {
         this.addAbility(new BlueManaAbility());
     }
 
-    public ObeliskOfBant (final ObeliskOfBant card) {
+    private ObeliskOfBant(final ObeliskOfBant card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/ObeliskOfEsper.java
+++ b/Mage.Sets/src/mage/cards/o/ObeliskOfEsper.java
@@ -23,7 +23,7 @@ public final class ObeliskOfEsper extends CardImpl {
         this.addAbility(new BlackManaAbility());
     }
 
-    public ObeliskOfEsper (final ObeliskOfEsper card) {
+    private ObeliskOfEsper(final ObeliskOfEsper card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/ObeliskOfGrixis.java
+++ b/Mage.Sets/src/mage/cards/o/ObeliskOfGrixis.java
@@ -23,7 +23,7 @@ public final class ObeliskOfGrixis extends CardImpl {
         this.addAbility(new RedManaAbility());
     }
 
-    public ObeliskOfGrixis (final ObeliskOfGrixis card) {
+    private ObeliskOfGrixis(final ObeliskOfGrixis card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/ObeliskOfJund.java
+++ b/Mage.Sets/src/mage/cards/o/ObeliskOfJund.java
@@ -23,7 +23,7 @@ public final class ObeliskOfJund extends CardImpl {
         this.addAbility(new GreenManaAbility());
     }
 
-    public ObeliskOfJund (final ObeliskOfJund card) {
+    private ObeliskOfJund(final ObeliskOfJund card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/ObeliskOfNaya.java
+++ b/Mage.Sets/src/mage/cards/o/ObeliskOfNaya.java
@@ -23,7 +23,7 @@ public final class ObeliskOfNaya extends CardImpl {
         this.addAbility(new WhiteManaAbility());
     }
 
-    public ObeliskOfNaya (final ObeliskOfNaya card) {
+    private ObeliskOfNaya(final ObeliskOfNaya card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OblivionSower.java
+++ b/Mage.Sets/src/mage/cards/o/OblivionSower.java
@@ -61,7 +61,7 @@ class OblivionSowerEffect extends OneShotEffect {
         this.staticText = ", then you may put any number of land cards that player owns from exile onto the battlefield under your control";
     }
 
-    public OblivionSowerEffect(final OblivionSowerEffect effect) {
+    private OblivionSowerEffect(final OblivionSowerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/ObsidianFireheart.java
+++ b/Mage.Sets/src/mage/cards/o/ObsidianFireheart.java
@@ -80,7 +80,7 @@ class ObsidianFireheartOneShotEffect extends OneShotEffect {
         super(Outcome.Detriment);
     }
 
-    public ObsidianFireheartOneShotEffect(final ObsidianFireheartOneShotEffect effect) {
+    private ObsidianFireheartOneShotEffect(final ObsidianFireheartOneShotEffect effect) {
         super(effect);
     }
 
@@ -128,7 +128,7 @@ class ObsidianFireheartGainAbilityEffect extends GainAbilityTargetEffect {
         super(ability, duration, rule);
     }
 
-    public ObsidianFireheartGainAbilityEffect(final ObsidianFireheartGainAbilityEffect effect) {
+    private ObsidianFireheartGainAbilityEffect(final ObsidianFireheartGainAbilityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/ObstinateFamiliar.java
+++ b/Mage.Sets/src/mage/cards/o/ObstinateFamiliar.java
@@ -52,7 +52,7 @@ class ObstinateFamiliarReplacementEffect extends ReplacementEffectImpl {
         staticText = "If you would draw a card, you may skip that draw instead";
     }
 
-    public ObstinateFamiliarReplacementEffect(final ObstinateFamiliarReplacementEffect effect) {
+    private ObstinateFamiliarReplacementEffect(final ObstinateFamiliarReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Occupation.java
+++ b/Mage.Sets/src/mage/cards/o/Occupation.java
@@ -100,7 +100,7 @@ class OccupationOneShotEffect extends OneShotEffect {
         staticText = ruleText;
     }
 
-    public OccupationOneShotEffect(final OccupationOneShotEffect effect) {
+    private OccupationOneShotEffect(final OccupationOneShotEffect effect) {
         super(effect);
     }
 
@@ -124,7 +124,7 @@ class OccupationRestrictionEffect extends RestrictionEffect {
         staticText = "";
     }
 
-    public OccupationRestrictionEffect(final OccupationRestrictionEffect effect) {
+    private OccupationRestrictionEffect(final OccupationRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Oculus.java
+++ b/Mage.Sets/src/mage/cards/o/Oculus.java
@@ -27,7 +27,7 @@ public final class Oculus extends CardImpl {
         this.addAbility(new DiesSourceTriggeredAbility(new DrawCardSourceControllerEffect(1), true));
     }
 
-    public Oculus (final Oculus card) {
+    private Oculus(final Oculus card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OddlyUneven.java
+++ b/Mage.Sets/src/mage/cards/o/OddlyUneven.java
@@ -51,7 +51,7 @@ class OddOrEvenEffect extends OneShotEffect {
         this.staticText = "Destroy each creature with an " + (odd ? "odd" : "even") + " number of words in its name. (Hyphenated words are one word.)";
     }
 
-    public OddOrEvenEffect(final OddOrEvenEffect effect) {
+    private OddOrEvenEffect(final OddOrEvenEffect effect) {
         super(effect);
         this.odd = effect.odd;
     }

--- a/Mage.Sets/src/mage/cards/o/OddsEnds.java
+++ b/Mage.Sets/src/mage/cards/o/OddsEnds.java
@@ -52,7 +52,7 @@ class OddsEffect extends OneShotEffect {
         this.staticText = "Flip a coin. If it comes up heads, counter target instant or sorcery spell. If it comes up tails, copy that spell and you may choose new targets for the copy";
     }
 
-    public OddsEffect(final OddsEffect effect) {
+    private OddsEffect(final OddsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OdricMasterTactician.java
+++ b/Mage.Sets/src/mage/cards/o/OdricMasterTactician.java
@@ -52,7 +52,7 @@ class OdricMasterTacticianTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} and at least three other creatures attack, ");
     }
 
-    public OdricMasterTacticianTriggeredAbility(final OdricMasterTacticianTriggeredAbility ability) {
+    private OdricMasterTacticianTriggeredAbility(final OdricMasterTacticianTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OgreGeargrabber.java
+++ b/Mage.Sets/src/mage/cards/o/OgreGeargrabber.java
@@ -63,7 +63,7 @@ class OgreGeargrabberEffect1 extends OneShotEffect {
         staticText = "Attach it to {this}. When you lose control of that Equipment, unattach it.";
     }
 
-    public OgreGeargrabberEffect1(final OgreGeargrabberEffect1 effect) {
+    private OgreGeargrabberEffect1(final OgreGeargrabberEffect1 effect) {
         super(effect);
     }
 
@@ -132,7 +132,7 @@ class OgreGeargrabberEffect2 extends OneShotEffect {
         staticText = "When you lose control of that Equipment, unattach it.";
     }
 
-    public OgreGeargrabberEffect2(final OgreGeargrabberEffect2 effect) {
+    private OgreGeargrabberEffect2(final OgreGeargrabberEffect2 effect) {
         super(effect);
         this.equipmentId = effect.equipmentId;
     }

--- a/Mage.Sets/src/mage/cards/o/OgreMarauder.java
+++ b/Mage.Sets/src/mage/cards/o/OgreMarauder.java
@@ -58,7 +58,7 @@ class OgreMarauderEffect extends OneShotEffect {
         this.staticText = "it gains \"{this} can't be blocked\" until end of turn unless defending player sacrifices a creature";
     }
 
-    public OgreMarauderEffect(final OgreMarauderEffect effect) {
+    private OgreMarauderEffect(final OgreMarauderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OgreResister.java
+++ b/Mage.Sets/src/mage/cards/o/OgreResister.java
@@ -23,7 +23,7 @@ public final class OgreResister extends CardImpl {
         this.toughness = new MageInt(3);
     }
 
-    public OgreResister (final OgreResister card) {
+    private OgreResister(final OgreResister card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OgresCleaver.java
+++ b/Mage.Sets/src/mage/cards/o/OgresCleaver.java
@@ -32,7 +32,7 @@ public final class OgresCleaver extends CardImpl {
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(5), new TargetControlledCreaturePermanent(), false));
     }
 
-    public OgresCleaver (final OgresCleaver card) {
+    private OgresCleaver(final OgresCleaver card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OjutaiMonument.java
+++ b/Mage.Sets/src/mage/cards/o/OjutaiMonument.java
@@ -57,7 +57,7 @@ public final class OjutaiMonument extends CardImpl {
             this.addAbility(FlyingAbility.getInstance());
         }
 
-        public OjutaiMonumentToken(final OjutaiMonumentToken token) {
+        private OjutaiMonumentToken(final OjutaiMonumentToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/o/OketraTheTrue.java
+++ b/Mage.Sets/src/mage/cards/o/OketraTheTrue.java
@@ -64,7 +64,7 @@ class OketraTheTrueRestrictionEffect extends RestrictionEffect {
         staticText = "{this} can't attack or block unless you control at least three other creatures";
     }
 
-    public OketraTheTrueRestrictionEffect(final OketraTheTrueRestrictionEffect effect) {
+    private OketraTheTrueRestrictionEffect(final OketraTheTrueRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OketrasLastMercy.java
+++ b/Mage.Sets/src/mage/cards/o/OketrasLastMercy.java
@@ -48,7 +48,7 @@ class OketrasLastMercyEffect extends OneShotEffect {
         staticText = "Your life total becomes your starting life total";
     }
 
-    public OketrasLastMercyEffect(final OketrasLastMercyEffect effect) {
+    private OketrasLastMercyEffect(final OketrasLastMercyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Okk.java
+++ b/Mage.Sets/src/mage/cards/o/Okk.java
@@ -54,7 +54,7 @@ class OkkAttackEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless a creature with greater power also attacks";
     }
 
-    public OkkAttackEffect(final OkkAttackEffect effect) {
+    private OkkAttackEffect(final OkkAttackEffect effect) {
         super(effect);
     }
 
@@ -92,7 +92,7 @@ class OkkBlockEffect extends RestrictionEffect {
         staticText = "{this} can't block unless a creature with greater power also blocks.";
     }
 
-    public OkkBlockEffect(final OkkBlockEffect effect) {
+    private OkkBlockEffect(final OkkBlockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OldStickfingers.java
+++ b/Mage.Sets/src/mage/cards/o/OldStickfingers.java
@@ -54,7 +54,7 @@ class OldStickfingersEffect extends OneShotEffect {
         this.staticText = "reveal cards from the top of your library until you reveal X creature cards. Put all creature cards revealed this way into your graveyard, then put the rest on the bottom of your library in a random order";
     }
 
-    public OldStickfingersEffect(final OldStickfingersEffect effect) {
+    private OldStickfingersEffect(final OldStickfingersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OliviaCrimsonBride.java
+++ b/Mage.Sets/src/mage/cards/o/OliviaCrimsonBride.java
@@ -114,7 +114,7 @@ class OliviaCrimsonBrideAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new ExileSourceEffect());
     }
 
-    public OliviaCrimsonBrideAbility(final OliviaCrimsonBrideAbility ability) {
+    private OliviaCrimsonBrideAbility(final OliviaCrimsonBrideAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OmenMachine.java
+++ b/Mage.Sets/src/mage/cards/o/OmenMachine.java
@@ -53,7 +53,7 @@ class OmenMachineEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Players can't draw cards";
     }
 
-    public OmenMachineEffect(final OmenMachineEffect effect) {
+    private OmenMachineEffect(final OmenMachineEffect effect) {
         super(effect);
     }
 
@@ -86,7 +86,7 @@ class OmenMachineEffect2 extends OneShotEffect {
         staticText = "that player exiles the top card of their library. If it's a land card, the player puts it onto the battlefield. Otherwise, the player casts it without paying its mana cost if able";
     }
 
-    public OmenMachineEffect2(final OmenMachineEffect2 effect) {
+    private OmenMachineEffect2(final OmenMachineEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OmenOfFire.java
+++ b/Mage.Sets/src/mage/cards/o/OmenOfFire.java
@@ -70,7 +70,7 @@ class OmenOfFireEffect extends OneShotEffect {
         this.staticText = "Each player sacrifices a Plains or a white permanent for each white permanent they control";
     }
 
-    public OmenOfFireEffect(final OmenOfFireEffect effect) {
+    private OmenOfFireEffect(final OmenOfFireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OnceMoreWithFeeling.java
+++ b/Mage.Sets/src/mage/cards/o/OnceMoreWithFeeling.java
@@ -58,7 +58,7 @@ class OnceMoreWithFeelingEffect extends OneShotEffect {
         staticText = "Exile all permanents and all cards from all graveyards. Each player shuffles their hand into their library";
     }
 
-    public OnceMoreWithFeelingEffect(final OnceMoreWithFeelingEffect effect) {
+    private OnceMoreWithFeelingEffect(final OnceMoreWithFeelingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OnduRising.java
+++ b/Mage.Sets/src/mage/cards/o/OnduRising.java
@@ -50,7 +50,7 @@ class OnduRisingTriggeredAbility extends DelayedTriggeredAbility {
         super(new GainAbilityTargetEffect(LifelinkAbility.getInstance(), Duration.EndOfTurn), Duration.EndOfTurn, false);
     }
 
-    public OnduRisingTriggeredAbility(OnduRisingTriggeredAbility ability) {
+    private OnduRisingTriggeredAbility(final OnduRisingTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OnyxGoblet.java
+++ b/Mage.Sets/src/mage/cards/o/OnyxGoblet.java
@@ -28,7 +28,7 @@ public final class OnyxGoblet extends CardImpl {
         this.addAbility(ability);
     }
 
-    public OnyxGoblet (final OnyxGoblet card) {
+    private OnyxGoblet(final OnyxGoblet card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OonaQueenOfTheFae.java
+++ b/Mage.Sets/src/mage/cards/o/OonaQueenOfTheFae.java
@@ -57,7 +57,7 @@ class OonaQueenOfTheFaeEffect extends OneShotEffect {
         this.staticText = "Choose a color. Target opponent exiles the top X cards of their library. For each card of the chosen color exiled this way, create a 1/1 blue and black Faerie Rogue creature token with flying";
     }
 
-    public OonaQueenOfTheFaeEffect(final OonaQueenOfTheFaeEffect effect) {
+    private OonaQueenOfTheFaeEffect(final OonaQueenOfTheFaeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OonasBlackguard.java
+++ b/Mage.Sets/src/mage/cards/o/OonasBlackguard.java
@@ -108,7 +108,7 @@ class OonasBlackguardTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DiscardTargetEffect(1), false);
     }
 
-    public OonasBlackguardTriggeredAbility(final OonasBlackguardTriggeredAbility ability) {
+    private OonasBlackguardTriggeredAbility(final OonasBlackguardTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OozeFlux.java
+++ b/Mage.Sets/src/mage/cards/o/OozeFlux.java
@@ -54,7 +54,7 @@ class OozeFluxCreateTokenEffect extends OneShotEffect {
         staticText = "Create an X/X green Ooze creature token, where X is the number of +1/+1 counters removed this way";
     }
 
-    public OozeFluxCreateTokenEffect(final OozeFluxCreateTokenEffect effect) {
+    private OozeFluxCreateTokenEffect(final OozeFluxCreateTokenEffect effect) {
         super(effect);
         this.token = effect.token.copy();
     }

--- a/Mage.Sets/src/mage/cards/o/OozeGarden.java
+++ b/Mage.Sets/src/mage/cards/o/OozeGarden.java
@@ -61,7 +61,7 @@ class OozeGardenCreateTokenEffect extends OneShotEffect {
         staticText = "Create an X/X green Ooze creature token, where X is the sacrificed creature's power";
     }
 
-    public OozeGardenCreateTokenEffect(final OozeGardenCreateTokenEffect effect) {
+    private OozeGardenCreateTokenEffect(final OozeGardenCreateTokenEffect effect) {
         super(effect);
     }
 
@@ -100,7 +100,7 @@ class OozeToken extends TokenImpl {
         this.power = new MageInt(x);
     }
 
-    public OozeToken(final OozeToken token) {
+    private OozeToken(final OozeToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpalAcrolith.java
+++ b/Mage.Sets/src/mage/cards/o/OpalAcrolith.java
@@ -66,7 +66,7 @@ class OpalAcrolithToken extends TokenImpl {
         toughness = new MageInt(4);
     }
 
-    public OpalAcrolithToken(final OpalAcrolithToken token) {
+    private OpalAcrolithToken(final OpalAcrolithToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpalArchangel.java
+++ b/Mage.Sets/src/mage/cards/o/OpalArchangel.java
@@ -58,7 +58,7 @@ class OpalArchangelToken extends TokenImpl {
         this.addAbility(FlyingAbility.getInstance());
         this.addAbility(VigilanceAbility.getInstance());
     }
-    public OpalArchangelToken(final OpalArchangelToken token) {
+    private OpalArchangelToken(final OpalArchangelToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpalAvenger.java
+++ b/Mage.Sets/src/mage/cards/o/OpalAvenger.java
@@ -45,7 +45,7 @@ class OpalAvengerStateTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("When you have 10 or less life, if {this} is an enchantment, ");
     }
 
-    public OpalAvengerStateTriggeredAbility(final OpalAvengerStateTriggeredAbility ability) {
+    private OpalAvengerStateTriggeredAbility(final OpalAvengerStateTriggeredAbility ability) {
         super(ability);
     }
 
@@ -107,7 +107,7 @@ class OpalAvengerToken extends TokenImpl {
         toughness = new MageInt(5);
     }
 
-    public OpalAvengerToken(final OpalAvengerToken token) {
+    private OpalAvengerToken(final OpalAvengerToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpalCaryatid.java
+++ b/Mage.Sets/src/mage/cards/o/OpalCaryatid.java
@@ -55,7 +55,7 @@ class OpalCaryatidSoldierToken extends TokenImpl {
         toughness = new MageInt(2);
     }
 
-    public OpalCaryatidSoldierToken(final OpalCaryatidSoldierToken token) {
+    private OpalCaryatidSoldierToken(final OpalCaryatidSoldierToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpalChampion.java
+++ b/Mage.Sets/src/mage/cards/o/OpalChampion.java
@@ -56,7 +56,7 @@ class OpalChampionKnight extends TokenImpl {
         toughness = new MageInt(3);
         this.addAbility(FirstStrikeAbility.getInstance());
     }
-    public OpalChampionKnight(final OpalChampionKnight token) {
+    private OpalChampionKnight(final OpalChampionKnight token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpalGargoyle.java
+++ b/Mage.Sets/src/mage/cards/o/OpalGargoyle.java
@@ -56,7 +56,7 @@ class OpalGargoyleToken extends TokenImpl {
         toughness = new MageInt(2);
         this.addAbility(FlyingAbility.getInstance());
     }
-    public OpalGargoyleToken(final OpalGargoyleToken token) {
+    private OpalGargoyleToken(final OpalGargoyleToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpalGuardian.java
+++ b/Mage.Sets/src/mage/cards/o/OpalGuardian.java
@@ -58,7 +58,7 @@ class OpalGuardianGargoyle extends TokenImpl {
         this.addAbility(FlyingAbility.getInstance());
         this.addAbility(ProtectionAbility.from(ObjectColor.RED));
     }
-    public OpalGuardianGargoyle(final OpalGuardianGargoyle token) {
+    private OpalGuardianGargoyle(final OpalGuardianGargoyle token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpalTitan.java
+++ b/Mage.Sets/src/mage/cards/o/OpalTitan.java
@@ -53,7 +53,7 @@ class OpalTitanBecomesCreatureEffect extends ContinuousEffectImpl {
         this.addDependencyType(DependencyType.BecomeCreature);
     }
 
-    public OpalTitanBecomesCreatureEffect(final OpalTitanBecomesCreatureEffect effect) {
+    private OpalTitanBecomesCreatureEffect(final OpalTitanBecomesCreatureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Opalescence.java
+++ b/Mage.Sets/src/mage/cards/o/Opalescence.java
@@ -59,7 +59,7 @@ public final class Opalescence extends CardImpl {
             this.dependencyTypes.add(DependencyType.BecomeCreature);  // Conspiracy
         }
 
-        public OpalescenceEffect(final OpalescenceEffect effect) {
+        private OpalescenceEffect(final OpalescenceEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/o/OpalineSliver.java
+++ b/Mage.Sets/src/mage/cards/o/OpalineSliver.java
@@ -59,7 +59,7 @@ class OpalineSliverTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
     }
 
-    public OpalineSliverTriggeredAbility(final OpalineSliverTriggeredAbility ability) {
+    private OpalineSliverTriggeredAbility(final OpalineSliverTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpenSeason.java
+++ b/Mage.Sets/src/mage/cards/o/OpenSeason.java
@@ -79,7 +79,7 @@ class OpenSeasonRestrictionEffect extends RestrictionEffect {
         staticText = "Creatures your opponent control with bounty counters on them can't activate abilities";
     }
 
-    public OpenSeasonRestrictionEffect(final OpenSeasonRestrictionEffect effect) {
+    private OpenSeasonRestrictionEffect(final OpenSeasonRestrictionEffect effect) {
         super(effect);
     }
 
@@ -109,7 +109,7 @@ class OpenSeasonEffect extends OneShotEffect {
         staticText = "that creature's controller loses 2 life. Each other player gains 2 life";
     }
 
-    public OpenSeasonEffect(final OpenSeasonEffect effect) {
+    private OpenSeasonEffect(final OpenSeasonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpenTheVaults.java
+++ b/Mage.Sets/src/mage/cards/o/OpenTheVaults.java
@@ -45,7 +45,7 @@ class OpenTheVaultsEffect extends OneShotEffect {
         this.staticText = "Return all artifact and enchantment cards from all graveyards to the battlefield under their owners' control";
     }
 
-    public OpenTheVaultsEffect(final OpenTheVaultsEffect effect) {
+    private OpenTheVaultsEffect(final OpenTheVaultsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Oppression.java
+++ b/Mage.Sets/src/mage/cards/o/Oppression.java
@@ -41,7 +41,7 @@ class OppressionTriggeredAbility extends SpellCastAllTriggeredAbility {
         super(new DiscardTargetEffect(1), false);
     }
 
-    public OppressionTriggeredAbility(OppressionTriggeredAbility ability) {
+    private OppressionTriggeredAbility(final OppressionTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OppressiveWill.java
+++ b/Mage.Sets/src/mage/cards/o/OppressiveWill.java
@@ -47,7 +47,7 @@ class SpellSyphonEffect extends OneShotEffect {
         this.staticText = "Counter target spell unless its controller pays {1} for each card in your hand";
     }
 
-    public SpellSyphonEffect(final SpellSyphonEffect effect) {
+    private SpellSyphonEffect(final SpellSyphonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OraclesAttendants.java
+++ b/Mage.Sets/src/mage/cards/o/OraclesAttendants.java
@@ -62,7 +62,7 @@ class OraclesAttendantsReplacementEffect extends ReplacementEffectImpl {
         this.staticText = "All damage that would be dealt to target creature this turn by a source of your choice is dealt to {this} instead";
     }
     
-    public OraclesAttendantsReplacementEffect(final OraclesAttendantsReplacementEffect effect) {
+    private OraclesAttendantsReplacementEffect(final OraclesAttendantsReplacementEffect effect) {
         super(effect);
         this.targetSource = effect.targetSource.copy();
     }

--- a/Mage.Sets/src/mage/cards/o/OraclesVault.java
+++ b/Mage.Sets/src/mage/cards/o/OraclesVault.java
@@ -61,7 +61,7 @@ class OraclesVaultFreeEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public OraclesVaultFreeEffect(final OraclesVaultFreeEffect effect) {
+    private OraclesVaultFreeEffect(final OraclesVaultFreeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OranRiefHydra.java
+++ b/Mage.Sets/src/mage/cards/o/OranRiefHydra.java
@@ -60,7 +60,7 @@ class OranRiefHydraTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new OranRiefHydraEffect());
     }
 
-    public OranRiefHydraTriggeredAbility(final OranRiefHydraTriggeredAbility ability) {
+    private OranRiefHydraTriggeredAbility(final OranRiefHydraTriggeredAbility ability) {
         super(ability);
     }
 
@@ -105,7 +105,7 @@ class OranRiefHydraEffect extends OneShotEffect {
         super(Outcome.BoostCreature);
     }
 
-    public OranRiefHydraEffect(final OranRiefHydraEffect effect) {
+    private OranRiefHydraEffect(final OranRiefHydraEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OranRiefTheVastwood.java
+++ b/Mage.Sets/src/mage/cards/o/OranRiefTheVastwood.java
@@ -52,7 +52,7 @@ class OranRiefTheVastwoodEffect extends OneShotEffect {
         staticText = "Put a +1/+1 counter on each green creature that entered the battlefield this turn";
     }
 
-    public OranRiefTheVastwoodEffect(final OranRiefTheVastwoodEffect effect) {
+    private OranRiefTheVastwoodEffect(final OranRiefTheVastwoodEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Orbak.java
+++ b/Mage.Sets/src/mage/cards/o/Orbak.java
@@ -23,7 +23,7 @@ public class Orbak extends CardImpl {
         this.addAbility(new MonstrosityAbility("{4}{W}", 3));
     }
 
-    public Orbak(final Orbak card) {
+    private Orbak(final Orbak card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrbsOfWarding.java
+++ b/Mage.Sets/src/mage/cards/o/OrbsOfWarding.java
@@ -49,7 +49,7 @@ class OrbsOfWardingEffect extends PreventionEffectImpl {
         this.staticText = "If a creature would deal damage to you, prevent 1 of that damage";
     }
 
-    public OrbsOfWardingEffect(OrbsOfWardingEffect effect) {
+    private OrbsOfWardingEffect(final OrbsOfWardingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrchardWarden.java
+++ b/Mage.Sets/src/mage/cards/o/OrchardWarden.java
@@ -56,7 +56,7 @@ class OrchardWardenffect extends OneShotEffect {
         this.staticText = "you may gain life equal to that creature's toughness";
     }
     
-    public OrchardWardenffect(final OrchardWardenffect effect) {
+    private OrchardWardenffect(final OrchardWardenffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/o/OrcishCaptain.java
+++ b/Mage.Sets/src/mage/cards/o/OrcishCaptain.java
@@ -59,7 +59,7 @@ class OrcishCaptainEffect extends OneShotEffect {
         staticText = "Flip a coin. If you win the flip, target Orc creature gets +2/+0 until end of turn. If you lose the flip, it gets -0/-2 until end of turn";
     }
 
-    public OrcishCaptainEffect(OrcishCaptainEffect effect) {
+    private OrcishCaptainEffect(final OrcishCaptainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrcishLibrarian.java
+++ b/Mage.Sets/src/mage/cards/o/OrcishLibrarian.java
@@ -58,7 +58,7 @@ class OrcishLibrarianEffect extends OneShotEffect {
         this.staticText = "Look at the top eight cards of your library. Exile four of them at random, then put the rest on top of your library in any order";
     }
 
-    public OrcishLibrarianEffect(final OrcishLibrarianEffect effect) {
+    private OrcishLibrarianEffect(final OrcishLibrarianEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrcishLumberjack.java
+++ b/Mage.Sets/src/mage/cards/o/OrcishLumberjack.java
@@ -70,7 +70,7 @@ class OrcishLumberjackManaEffect extends ManaEffect {
         netMana.add(new Mana(0, 0, 0, 3, 0, 0, 0, 0));
     }
 
-    public OrcishLumberjackManaEffect(final OrcishLumberjackManaEffect effect) {
+    private OrcishLumberjackManaEffect(final OrcishLumberjackManaEffect effect) {
         super(effect);
         netMana.addAll(effect.netMana);
     }

--- a/Mage.Sets/src/mage/cards/o/OrcishMine.java
+++ b/Mage.Sets/src/mage/cards/o/OrcishMine.java
@@ -71,7 +71,7 @@ class OrcishMineAbility extends TriggeredAbilityImpl {
         this.addEffect(new DamageAttachedControllerEffect(2));
     }
 
-    public OrcishMineAbility(final OrcishMineAbility ability) {
+    private OrcishMineAbility(final OrcishMineAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrcishSettlers.java
+++ b/Mage.Sets/src/mage/cards/o/OrcishSettlers.java
@@ -59,7 +59,7 @@ class OrcishSettlersEffect extends OneShotEffect {
         this.staticText = "Destroy X target lands";
     }
 
-    public OrcishSettlersEffect(final OrcishSettlersEffect effect) {
+    private OrcishSettlersEffect(final OrcishSettlersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrderOfSuccession.java
+++ b/Mage.Sets/src/mage/cards/o/OrderOfSuccession.java
@@ -54,7 +54,7 @@ class OrderOfSuccessionEffect extends OneShotEffect {
         this.staticText = "Starting with you and proceeding in the chosen direction, each player chooses a creature controlled by the next player in that direction. Each player gains control of the creature they chose";
     }
 
-    public OrderOfSuccessionEffect(final OrderOfSuccessionEffect effect) {
+    private OrderOfSuccessionEffect(final OrderOfSuccessionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrderOfTheSacredBell.java
+++ b/Mage.Sets/src/mage/cards/o/OrderOfTheSacredBell.java
@@ -24,7 +24,7 @@ public final class OrderOfTheSacredBell extends CardImpl {
         this.toughness = new MageInt(3);
     }
 
-    public OrderOfTheSacredBell (final OrderOfTheSacredBell card) {
+    private OrderOfTheSacredBell(final OrderOfTheSacredBell card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OreskosExplorer.java
+++ b/Mage.Sets/src/mage/cards/o/OreskosExplorer.java
@@ -56,7 +56,7 @@ class OreskosExplorerEffect extends OneShotEffect {
         this.staticText = "search your library for up to X Plains cards, where X is the number of players who control more lands than you. Reveal those cards, put them into your hand, then shuffle";
     }
 
-    public OreskosExplorerEffect(final OreskosExplorerEffect effect) {
+    private OreskosExplorerEffect(final OreskosExplorerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OriginSpellbomb.java
+++ b/Mage.Sets/src/mage/cards/o/OriginSpellbomb.java
@@ -34,7 +34,7 @@ public final class OriginSpellbomb extends CardImpl {
         this.addAbility(new DiesSourceTriggeredAbility(new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new ManaCostsImpl<>("{W}")), false));
     }
 
-    public OriginSpellbomb (final OriginSpellbomb card) {
+    private OriginSpellbomb(final OriginSpellbomb card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrimsChant.java
+++ b/Mage.Sets/src/mage/cards/o/OrimsChant.java
@@ -57,7 +57,7 @@ class OrimsChantCantCastEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Target player can't cast spells this turn";
     }
 
-    public OrimsChantCantCastEffect(final OrimsChantCantCastEffect effect) {
+    private OrimsChantCantCastEffect(final OrimsChantCantCastEffect effect) {
         super(effect);
     }
 
@@ -84,7 +84,7 @@ class OrimsChantEffect extends OneShotEffect {
         this.staticText = "if this spell was kicked, creatures can't attack this turn";
     }
 
-    public OrimsChantEffect(final OrimsChantEffect effect) {
+    private OrimsChantEffect(final OrimsChantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrimsPrayer.java
+++ b/Mage.Sets/src/mage/cards/o/OrimsPrayer.java
@@ -42,7 +42,7 @@ class OrimsPrayerTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null);
     }
 
-    public OrimsPrayerTriggeredAbility(final OrimsPrayerTriggeredAbility ability) {
+    private OrimsPrayerTriggeredAbility(final OrimsPrayerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrissSamiteGuardian.java
+++ b/Mage.Sets/src/mage/cards/o/OrissSamiteGuardian.java
@@ -67,7 +67,7 @@ class OrissSamiteGuardianEffect extends OneShotEffect {
         this.staticText = "Target player can't cast spells this turn, and creatures that player controls can't attack this turn";
     }
 
-    public OrissSamiteGuardianEffect(final OrissSamiteGuardianEffect effect) {
+    private OrissSamiteGuardianEffect(final OrissSamiteGuardianEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrnateKanzashi.java
+++ b/Mage.Sets/src/mage/cards/o/OrnateKanzashi.java
@@ -60,7 +60,7 @@ class OrnateKanzashiEffect extends OneShotEffect {
         this.staticText = "Target opponent exiles the top card of their library. You may play that card this turn";
     }
 
-    public OrnateKanzashiEffect(final OrnateKanzashiEffect effect) {
+    private OrnateKanzashiEffect(final OrnateKanzashiEffect effect) {
         super(effect);
     }
 
@@ -97,7 +97,7 @@ class OrnateKanzashiCastFromExileEffect extends AsThoughEffectImpl {
         staticText = "You may play that card from exile this turn";
     }
 
-    public OrnateKanzashiCastFromExileEffect(final OrnateKanzashiCastFromExileEffect effect) {
+    private OrnateKanzashiCastFromExileEffect(final OrnateKanzashiCastFromExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrochiEggwatcher.java
+++ b/Mage.Sets/src/mage/cards/o/OrochiEggwatcher.java
@@ -112,7 +112,7 @@ class ShidakoBroodmistress extends TokenImpl {
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }
-    public ShidakoBroodmistress(final ShidakoBroodmistress token) {
+    private ShidakoBroodmistress(final ShidakoBroodmistress token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrochiLeafcaller.java
+++ b/Mage.Sets/src/mage/cards/o/OrochiLeafcaller.java
@@ -30,7 +30,7 @@ public final class OrochiLeafcaller extends CardImpl {
         this.addAbility(new AnyColorManaAbility(new ColoredManaCost(ColoredManaSymbol.G)));
     }
 
-    public OrochiLeafcaller (final OrochiLeafcaller card) {
+    private OrochiLeafcaller(final OrochiLeafcaller card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrzhovAdvokist.java
+++ b/Mage.Sets/src/mage/cards/o/OrzhovAdvokist.java
@@ -64,7 +64,7 @@ class OrzhovAdvokistEffect extends OneShotEffect {
                 + "If a player does, creatures that player controls can't attack you or planeswalkers you control until your next turn";
     }
 
-    public OrzhovAdvokistEffect(final OrzhovAdvokistEffect effect) {
+    private OrzhovAdvokistEffect(final OrzhovAdvokistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrzhovKeyrune.java
+++ b/Mage.Sets/src/mage/cards/o/OrzhovKeyrune.java
@@ -55,7 +55,7 @@ public final class OrzhovKeyrune extends CardImpl {
             this.addAbility(LifelinkAbility.getInstance());
         }
 
-        public OrzhovKeyruneToken(final OrzhovKeyruneToken token) {
+        private OrzhovKeyruneToken(final OrzhovKeyruneToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/o/OsgirTheReconstructor.java
+++ b/Mage.Sets/src/mage/cards/o/OsgirTheReconstructor.java
@@ -111,7 +111,7 @@ class OsgirTheReconstructorCreateArtifactTokensEffect extends OneShotEffect {
         this.staticText = "Create two tokens that are copies of the exiled card.";
     }
 
-    public OsgirTheReconstructorCreateArtifactTokensEffect(final OsgirTheReconstructorCreateArtifactTokensEffect effect)  {
+    private OsgirTheReconstructorCreateArtifactTokensEffect(final OsgirTheReconstructorCreateArtifactTokensEffect effect)  {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OtherworldAtlas.java
+++ b/Mage.Sets/src/mage/cards/o/OtherworldAtlas.java
@@ -49,7 +49,7 @@ class OtherworldAtlasDrawEffect extends OneShotEffect {
         staticText = "Each player draws a card for each charge counter on {this}";
     }
 
-    public OtherworldAtlasDrawEffect(final OtherworldAtlasDrawEffect effect) {
+    private OtherworldAtlasDrawEffect(final OtherworldAtlasDrawEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OupheVandals.java
+++ b/Mage.Sets/src/mage/cards/o/OupheVandals.java
@@ -65,7 +65,7 @@ class OupheVandalsEffect extends OneShotEffect {
         this.staticText = "Counter target activated ability from an artifact source and destroy that artifact if it's on the battlefield.";
     }
 
-    public OupheVandalsEffect(final OupheVandalsEffect effect) {
+    private OupheVandalsEffect(final OupheVandalsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Oust.java
+++ b/Mage.Sets/src/mage/cards/o/Oust.java
@@ -43,7 +43,7 @@ class OustEffect extends OneShotEffect {
         this.staticText = "Put target creature into its owner's library second from the top. Its controller gains 3 life";
     }
 
-    public OustEffect(final OustEffect effect) {
+    private OustEffect(final OustEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OutOfTheTombs.java
+++ b/Mage.Sets/src/mage/cards/o/OutOfTheTombs.java
@@ -55,7 +55,7 @@ class OutOfTheTombsReplacementEffect extends ReplacementEffectImpl {
                 "from your graveyard to the battlefield. If you can't, you lose the game.";
     }
 
-    public OutOfTheTombsReplacementEffect(final OutOfTheTombsReplacementEffect effect) {
+    private OutOfTheTombsReplacementEffect(final OutOfTheTombsReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Outbreak.java
+++ b/Mage.Sets/src/mage/cards/o/Outbreak.java
@@ -60,7 +60,7 @@ class OutbreakEffect extends OneShotEffect {
         staticText = "Choose a creature type. All creatures of that type get -1/-1 until end of turn";
     }
 
-    public OutbreakEffect(final OutbreakEffect effect) {
+    private OutbreakEffect(final OutbreakEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OutriderOfJhess.java
+++ b/Mage.Sets/src/mage/cards/o/OutriderOfJhess.java
@@ -26,7 +26,7 @@ public final class OutriderOfJhess extends CardImpl {
         this.addAbility(new ExaltedAbility());
     }
 
-    public OutriderOfJhess (final OutriderOfJhess card) {
+    private OutriderOfJhess(final OutriderOfJhess card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Outwit.java
+++ b/Mage.Sets/src/mage/cards/o/Outwit.java
@@ -72,7 +72,7 @@ public final class Outwit extends CardImpl {
             this.targetName = filter.getMessage();
         }
 
-        public CustomTargetSpell(final CustomTargetSpell target) {
+        private CustomTargetSpell(final CustomTargetSpell target) {
             super(target);
             this.filter = target.filter.copy();
         }

--- a/Mage.Sets/src/mage/cards/o/Overblaze.java
+++ b/Mage.Sets/src/mage/cards/o/Overblaze.java
@@ -49,7 +49,7 @@ class OverblazeEffect extends ReplacementEffectImpl {
         staticText = "Each time target permanent would deal damage to a permanent or player this turn, it deals double that damage to that permanent or player instead.";
     }
 
-    public OverblazeEffect(final OverblazeEffect effect) {
+    private OverblazeEffect(final OverblazeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Overcome.java
+++ b/Mage.Sets/src/mage/cards/o/Overcome.java
@@ -25,7 +25,7 @@ public final class Overcome extends CardImpl {
         this.getSpellAbility().addEffect(effect);
     }
 
-    public Overcome(final Overcome overcome){
+    private Overcome(final Overcome overcome){
         super(overcome);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OverrideCard.java
+++ b/Mage.Sets/src/mage/cards/o/OverrideCard.java
@@ -48,7 +48,7 @@ class OverrideEffect extends OneShotEffect {
         this.staticText = "Counter target spell unless its controller pays {1} for each artifact you control";
     }
 
-    public OverrideEffect(final OverrideEffect effect) {
+    private OverrideEffect(final OverrideEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OverwhelmingForces.java
+++ b/Mage.Sets/src/mage/cards/o/OverwhelmingForces.java
@@ -46,7 +46,7 @@ class OverwhelmingForcesEffect extends OneShotEffect {
         this.staticText = "Destroy all creatures target opponent controls. Draw a card for each creature destroyed this way";
     }
 
-    public OverwhelmingForcesEffect(final OverwhelmingForcesEffect effect) {
+    private OverwhelmingForcesEffect(final OverwhelmingForcesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OverwhelmingInstinct.java
+++ b/Mage.Sets/src/mage/cards/o/OverwhelmingInstinct.java
@@ -43,7 +43,7 @@ class OverwhelmingInstinctTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you attack with three or more creatures, ");
     }
 
-    public OverwhelmingInstinctTriggeredAbility(final OverwhelmingInstinctTriggeredAbility ability) {
+    private OverwhelmingInstinctTriggeredAbility(final OverwhelmingInstinctTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OverwhelmingIntellect.java
+++ b/Mage.Sets/src/mage/cards/o/OverwhelmingIntellect.java
@@ -46,7 +46,7 @@ class OverwhelmingIntellectEffect extends OneShotEffect {
         staticText = "Counter target creature spell. Draw cards equal to that spell's mana value";
     }
 
-    public OverwhelmingIntellectEffect(final OverwhelmingIntellectEffect effect) {
+    private OverwhelmingIntellectEffect(final OverwhelmingIntellectEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OverwhelmingSplendor.java
+++ b/Mage.Sets/src/mage/cards/o/OverwhelmingSplendor.java
@@ -65,7 +65,7 @@ class OverwhelmingSplendorLoseAbilitiesEffect extends ContinuousEffectImpl {
         staticText = "Creatures enchanted player controls lose all abilities and have base power and toughness 1/1";
     }
 
-    public OverwhelmingSplendorLoseAbilitiesEffect(final OverwhelmingSplendorLoseAbilitiesEffect effect) {
+    private OverwhelmingSplendorLoseAbilitiesEffect(final OverwhelmingSplendorLoseAbilitiesEffect effect) {
         super(effect);
     }
 
@@ -125,7 +125,7 @@ class OverwhelmingSplendorCantActivateEffect extends ContinuousRuleModifyingEffe
         staticText = "Enchanted player can't activate abilities that aren't mana abilities or loyalty abilities";
     }
 
-    public OverwhelmingSplendorCantActivateEffect(final OverwhelmingSplendorCantActivateEffect effect) {
+    private OverwhelmingSplendorCantActivateEffect(final OverwhelmingSplendorCantActivateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OverwhelmingStampede.java
+++ b/Mage.Sets/src/mage/cards/o/OverwhelmingStampede.java
@@ -48,7 +48,7 @@ class OverwhelmingStampedeInitEffect extends OneShotEffect {
         this.staticText = "Until end of turn, creatures you control gain trample and get +X/+X, where X is the greatest power among creatures you control";
     }
 
-    public OverwhelmingStampedeInitEffect(final OverwhelmingStampedeInitEffect effect) {
+    private OverwhelmingStampedeInitEffect(final OverwhelmingStampedeInitEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Ovinomancer.java
+++ b/Mage.Sets/src/mage/cards/o/Ovinomancer.java
@@ -73,7 +73,7 @@ class OvinomancerEffect extends OneShotEffect {
         this.staticText = "That creature's controller creates a 0/1 green Sheep creature token";
     }
 
-    public OvinomancerEffect(final OvinomancerEffect effect) {
+    private OvinomancerEffect(final OvinomancerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OviyaPashiriSageLifecrafter.java
+++ b/Mage.Sets/src/mage/cards/o/OviyaPashiriSageLifecrafter.java
@@ -60,7 +60,7 @@ class OviyaPashiriSageLifecrafterEffect extends OneShotEffect {
         this.staticText = "Create an X/X colorless Construct artifact creature token, where X is the number of creatures you control";
     }
 
-    public OviyaPashiriSageLifecrafterEffect(final OviyaPashiriSageLifecrafterEffect effect) {
+    private OviyaPashiriSageLifecrafterEffect(final OviyaPashiriSageLifecrafterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OxiddaDaredevil.java
+++ b/Mage.Sets/src/mage/cards/o/OxiddaDaredevil.java
@@ -41,7 +41,7 @@ public final class OxiddaDaredevil extends CardImpl {
                 new SacrificeTargetCost(new TargetControlledPermanent(filter))));
     }
 
-    public OxiddaDaredevil (final OxiddaDaredevil card) {
+    private OxiddaDaredevil(final OxiddaDaredevil card) {
         super(card);
     }
 


### PR DESCRIPTION
Part of #11054 

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`public ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `private $1(final $1 $3`