### PR TITLE
Clean all copy constructors in cards starting J-K-L

### DIFF
--- a/Mage.Sets/src/mage/cards/j/JabbaTheHutt.java
+++ b/Mage.Sets/src/mage/cards/j/JabbaTheHutt.java
@@ -83,7 +83,7 @@ class JabbaTheHuttEffect extends OneShotEffect {
         this.staticText = "Create a tapped 4/4 red Hunter creature token. It fights another target creature an opponent control with a bounty counter on it";
     }
 
-    public JabbaTheHuttEffect(final JabbaTheHuttEffect effect) {
+    private JabbaTheHuttEffect(final JabbaTheHuttEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JaceArchitectOfThought.java
+++ b/Mage.Sets/src/mage/cards/j/JaceArchitectOfThought.java
@@ -62,7 +62,7 @@ class JaceArchitectOfThoughtStartEffect1 extends OneShotEffect {
                 + "controls attacks, it gets -1/-0 until end of turn";
     }
 
-    public JaceArchitectOfThoughtStartEffect1(final JaceArchitectOfThoughtStartEffect1 effect) {
+    private JaceArchitectOfThoughtStartEffect1(final JaceArchitectOfThoughtStartEffect1 effect) {
         super(effect);
     }
 
@@ -88,7 +88,7 @@ class JaceArchitectOfThoughtDelayedTriggeredAbility extends DelayedTriggeredAbil
         this.startingTurn = startingTurn;
     }
 
-    public JaceArchitectOfThoughtDelayedTriggeredAbility(final JaceArchitectOfThoughtDelayedTriggeredAbility ability) {
+    private JaceArchitectOfThoughtDelayedTriggeredAbility(final JaceArchitectOfThoughtDelayedTriggeredAbility ability) {
         super(ability);
         this.startingTurn = ability.startingTurn;
     }
@@ -134,7 +134,7 @@ class JaceArchitectOfThoughtEffect3 extends OneShotEffect {
                 + "then that player shuffles. You may cast those cards without paying their mana costs";
     }
 
-    public JaceArchitectOfThoughtEffect3(final JaceArchitectOfThoughtEffect3 effect) {
+    private JaceArchitectOfThoughtEffect3(final JaceArchitectOfThoughtEffect3 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JaceTheMindSculptor.java
+++ b/Mage.Sets/src/mage/cards/j/JaceTheMindSculptor.java
@@ -73,7 +73,7 @@ class JaceTheMindSculptorEffect1 extends OneShotEffect {
         staticText = "Look at the top card of target player's library. You may put that card on the bottom of that player's library";
     }
 
-    public JaceTheMindSculptorEffect1(final JaceTheMindSculptorEffect1 effect) {
+    private JaceTheMindSculptorEffect1(final JaceTheMindSculptorEffect1 effect) {
         super(effect);
     }
 
@@ -111,7 +111,7 @@ class JaceTheMindSculptorEffect2 extends OneShotEffect {
         staticText = "Exile all cards from target player's library, then that player shuffles their hand into their library";
     }
 
-    public JaceTheMindSculptorEffect2(final JaceTheMindSculptorEffect2 effect) {
+    private JaceTheMindSculptorEffect2(final JaceTheMindSculptorEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JaceThePerfectedMind.java
+++ b/Mage.Sets/src/mage/cards/j/JaceThePerfectedMind.java
@@ -69,7 +69,7 @@ class JaceThePerfectedMindEffect extends OneShotEffect{
                 "three cards. Otherwise, you draw a card.";
     }
 
-    public JaceThePerfectedMindEffect(JaceThePerfectedMindEffect effect){
+    private JaceThePerfectedMindEffect(final JaceThePerfectedMindEffect effect){
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JacesDefeat.java
+++ b/Mage.Sets/src/mage/cards/j/JacesDefeat.java
@@ -62,7 +62,7 @@ class JacesDefeatEffect extends OneShotEffect {
         this.staticText = "Counter target blue spell. If it was a Jace planeswalker spell, scry 2.";
     }
 
-    public JacesDefeatEffect(final JacesDefeatEffect effect) {
+    private JacesDefeatEffect(final JacesDefeatEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JacesMindseeker.java
+++ b/Mage.Sets/src/mage/cards/j/JacesMindseeker.java
@@ -63,7 +63,7 @@ class JaceMindseekerEffect extends OneShotEffect {
                 "from among them without paying its mana cost.";
     }
 
-    public JaceMindseekerEffect(final JaceMindseekerEffect effect) {
+    private JaceMindseekerEffect(final JaceMindseekerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JaddiLifestrider.java
+++ b/Mage.Sets/src/mage/cards/j/JaddiLifestrider.java
@@ -59,7 +59,7 @@ class JaddiLifestriderEffect extends OneShotEffect {
         staticText = "you may tap any number of untapped creatures you control. You gain 2 life for each creature tapped this way";
     }
 
-    public JaddiLifestriderEffect(JaddiLifestriderEffect effect) {
+    private JaddiLifestriderEffect(final JaddiLifestriderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JadeIdol.java
+++ b/Mage.Sets/src/mage/cards/j/JadeIdol.java
@@ -44,7 +44,7 @@ class JadeIdolToken extends TokenImpl {
         power = new MageInt(4);
         toughness = new MageInt(4);
     }
-    public JadeIdolToken(final JadeIdolToken token) {
+    private JadeIdolToken(final JadeIdolToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JadeMonolith.java
+++ b/Mage.Sets/src/mage/cards/j/JadeMonolith.java
@@ -58,7 +58,7 @@ class JadeMonolithRedirectionEffect extends ReplacementEffectImpl {
         this.targetSource = new TargetSource(new FilterObject("source of your choice"));
     }
     
-    public JadeMonolithRedirectionEffect(final JadeMonolithRedirectionEffect effect) {
+    private JadeMonolithRedirectionEffect(final JadeMonolithRedirectionEffect effect) {
         super(effect);
         this.targetSource = effect.targetSource.copy();
     }

--- a/Mage.Sets/src/mage/cards/j/JadeStatue.java
+++ b/Mage.Sets/src/mage/cards/j/JadeStatue.java
@@ -48,7 +48,7 @@ public final class JadeStatue extends CardImpl {
             power = new MageInt(3);
             toughness = new MageInt(6);
 	    }
-        public JadeStatueToken(final JadeStatueToken token) {
+        private JadeStatueToken(final JadeStatueToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/j/JagwaspSwarm.java
+++ b/Mage.Sets/src/mage/cards/j/JagwaspSwarm.java
@@ -25,7 +25,7 @@ public final class JagwaspSwarm extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public JagwaspSwarm (final JagwaspSwarm card) {
+    private JagwaspSwarm(final JagwaspSwarm card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JalumGrifter.java
+++ b/Mage.Sets/src/mage/cards/j/JalumGrifter.java
@@ -69,7 +69,7 @@ class JalumGrifterEffect extends OneShotEffect {
         this.staticText = "Shuffle {this} and two lands you control face down. Target opponent chooses one of those cards. Turn the cards face up. If they chose {this}, sacrifice it. Otherwise, destroy target permanent";
     }
 
-    public JalumGrifterEffect(final JalumGrifterEffect effect) {
+    private JalumGrifterEffect(final JalumGrifterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JandorsRing.java
+++ b/Mage.Sets/src/mage/cards/j/JandorsRing.java
@@ -58,7 +58,7 @@ class JandorsRingEffect extends OneShotEffect {
         staticText = "Draw a card";
     }
 
-    public JandorsRingEffect(final JandorsRingEffect effect) {
+    private JandorsRingEffect(final JandorsRingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JanglingAutomaton.java
+++ b/Mage.Sets/src/mage/cards/j/JanglingAutomaton.java
@@ -47,7 +47,7 @@ class JanglingAutomatonEffect extends OneShotEffect {
         this.staticText = "untap all creatures defending player controls";
     }
 
-    public JanglingAutomatonEffect(final JanglingAutomatonEffect effect) {
+    private JanglingAutomatonEffect(final JanglingAutomatonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JangoFett.java
+++ b/Mage.Sets/src/mage/cards/j/JangoFett.java
@@ -67,7 +67,7 @@ class JangoFettEffect extends OneShotEffect {
         this.staticText = "it gets +X/+0, where X is the number of creatures defending player controls with a bounty counter on them";
     }
 
-    public JangoFettEffect(final JangoFettEffect ability) {
+    private JangoFettEffect(final JangoFettEffect ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JarJarBinks.java
+++ b/Mage.Sets/src/mage/cards/j/JarJarBinks.java
@@ -64,7 +64,7 @@ class JarJarBinksEffect extends OneShotEffect {
         this.staticText = "target opponent gains control of it";
     }
 
-    public JarJarBinksEffect(final JarJarBinksEffect effect) {
+    private JarJarBinksEffect(final JarJarBinksEffect effect) {
         super(effect);
     }
 
@@ -95,7 +95,7 @@ class JarJarBinksGainControlSourceEffect extends ContinuousEffectImpl {
         super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
     }
 
-    public JarJarBinksGainControlSourceEffect(final JarJarBinksGainControlSourceEffect effect) {
+    private JarJarBinksGainControlSourceEffect(final JarJarBinksGainControlSourceEffect effect) {
         super(effect);
     }
 
@@ -125,7 +125,7 @@ class JarJarBinksTapEffect extends OneShotEffect {
         this.staticText = "tap the creature you control with the highest power. If two or more creatures are tied for the greatest power, you choose one of them";
     }
 
-    public JarJarBinksTapEffect(final JarJarBinksTapEffect effect) {
+    private JarJarBinksTapEffect(final JarJarBinksTapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JaradsOrders.java
+++ b/Mage.Sets/src/mage/cards/j/JaradsOrders.java
@@ -47,7 +47,7 @@ class JaradsOrdersEffect extends OneShotEffect {
         staticText = "Search your library for up to two creature cards and reveal them. Put one into your hand and the other into your graveyard. Then shuffle";
     }
 
-    public JaradsOrdersEffect(final JaradsOrdersEffect effect) {
+    private JaradsOrdersEffect(final JaradsOrdersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JaredCarthalion.java
+++ b/Mage.Sets/src/mage/cards/j/JaredCarthalion.java
@@ -76,7 +76,7 @@ class JaredCarthalionBoostEffect extends OneShotEffect {
                 "a number of +1/+1 counters on it equal to the number of colors it is.";
     }
 
-    public JaredCarthalionBoostEffect(final JaredCarthalionBoostEffect effect) {
+    private JaredCarthalionBoostEffect(final JaredCarthalionBoostEffect effect) {
         super(effect);
     }
 
@@ -106,7 +106,7 @@ class JaredCarthalionUltimateEffect extends OneShotEffect {
                 "If that card was all colors, draw a card and create two Treasure tokens.";
     }
 
-    public JaredCarthalionUltimateEffect(final JaredCarthalionUltimateEffect effect) {
+    private JaredCarthalionUltimateEffect(final JaredCarthalionUltimateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JasmineSeer.java
+++ b/Mage.Sets/src/mage/cards/j/JasmineSeer.java
@@ -64,7 +64,7 @@ class JasmineSeerEffect extends OneShotEffect {
                 + "You gain 2 life for each card revealed this way";
     }
 
-    public JasmineSeerEffect(final JasmineSeerEffect effect) {
+    private JasmineSeerEffect(final JasmineSeerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JayaBallardTaskMage.java
+++ b/Mage.Sets/src/mage/cards/j/JayaBallardTaskMage.java
@@ -86,7 +86,7 @@ class CantRegenerateEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "A creature dealt damage this way can't be regenerated this turn";
     }
 
-    public CantRegenerateEffect(final CantRegenerateEffect effect) {
+    private CantRegenerateEffect(final CantRegenerateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JayasPhoenix.java
+++ b/Mage.Sets/src/mage/cards/j/JayasPhoenix.java
@@ -76,7 +76,7 @@ class JayasPhoenixTriggeredAbility extends DelayedTriggeredAbility {
         super(new CopyTargetStackAbilityEffect(), Duration.EndOfTurn);
     }
 
-    public JayasPhoenixTriggeredAbility(final JayasPhoenixTriggeredAbility ability) {
+    private JayasPhoenixTriggeredAbility(final JayasPhoenixTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JediEnclave.java
+++ b/Mage.Sets/src/mage/cards/j/JediEnclave.java
@@ -47,7 +47,7 @@ public final class JediEnclave extends CardImpl {
 
     public static class JediEnclaveAbility extends ActivatedAbilityImpl {
 
-        public JediEnclaveAbility(JediEnclaveAbility ability) {
+        private JediEnclaveAbility(final JediEnclaveAbility ability) {
             super(ability);
         }
 

--- a/Mage.Sets/src/mage/cards/j/JediTraining.java
+++ b/Mage.Sets/src/mage/cards/j/JediTraining.java
@@ -56,7 +56,7 @@ class JediTrainingTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ScryEffect(1));
     }
 
-    public JediTrainingTriggeredAbility(final JediTrainingTriggeredAbility ability) {
+    private JediTrainingTriggeredAbility(final JediTrainingTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JelevaNephaliasScourge.java
+++ b/Mage.Sets/src/mage/cards/j/JelevaNephaliasScourge.java
@@ -71,7 +71,7 @@ class JelevaNephaliasScourgeEffect extends OneShotEffect {
                 + "where X is the amount of mana spent to cast this spell";
     }
 
-    public JelevaNephaliasScourgeEffect(final JelevaNephaliasScourgeEffect effect) {
+    private JelevaNephaliasScourgeEffect(final JelevaNephaliasScourgeEffect effect) {
         super(effect);
     }
 
@@ -114,7 +114,7 @@ class JelevaNephaliasCastEffect extends OneShotEffect {
                 "from among cards exiled with {this} without paying its mana cost";
     }
 
-    public JelevaNephaliasCastEffect(final JelevaNephaliasCastEffect effect) {
+    private JelevaNephaliasCastEffect(final JelevaNephaliasCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JenaraAsuraOfWar.java
+++ b/Mage.Sets/src/mage/cards/j/JenaraAsuraOfWar.java
@@ -35,7 +35,7 @@ public final class JenaraAsuraOfWar extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), new ManaCostsImpl<>("{1}{W}")));
     }
 
-    public JenaraAsuraOfWar (final JenaraAsuraOfWar card) {
+    private JenaraAsuraOfWar(final JenaraAsuraOfWar card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JestersScepter.java
+++ b/Mage.Sets/src/mage/cards/j/JestersScepter.java
@@ -68,7 +68,7 @@ class JestersScepterEffect extends OneShotEffect {
         staticText = "exile the top five cards of target player's library face down";
     }
 
-    public JestersScepterEffect(final JestersScepterEffect effect) {
+    private JestersScepterEffect(final JestersScepterEffect effect) {
         super(effect);
     }
 
@@ -106,7 +106,7 @@ class JestersScepterLookAtCardEffect extends AsThoughEffectImpl {
         staticText = "You may look at cards exiled with {this}";
     }
 
-    public JestersScepterLookAtCardEffect(final JestersScepterLookAtCardEffect effect) {
+    private JestersScepterLookAtCardEffect(final JestersScepterLookAtCardEffect effect) {
         super(effect);
     }
 
@@ -145,7 +145,7 @@ class JestersScepterCost extends CostImpl {
         this.text = "Put a card exiled with {this} into its owner's graveyard";
     }
 
-    public JestersScepterCost(JestersScepterCost cost) {
+    private JestersScepterCost(final JestersScepterCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JettingGlasskite.java
+++ b/Mage.Sets/src/mage/cards/j/JettingGlasskite.java
@@ -56,7 +56,7 @@ class JettingGlasskiteAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CounterTargetEffect(), false);
     }
 
-    public JettingGlasskiteAbility(final JettingGlasskiteAbility ability) {
+    private JettingGlasskiteAbility(final JettingGlasskiteAbility ability) {
         super(ability);
         turnUsed = ability.turnUsed;
     }

--- a/Mage.Sets/src/mage/cards/j/JeweledAmulet.java
+++ b/Mage.Sets/src/mage/cards/j/JeweledAmulet.java
@@ -66,7 +66,7 @@ class JeweledAmuletAddCounterEffect extends OneShotEffect {
         this.staticText = "Note the type of mana spent to pay this activation cost. Activate only if there are no charge counters on {this}";
     }
 
-    public JeweledAmuletAddCounterEffect(final JeweledAmuletAddCounterEffect effect) {
+    private JeweledAmuletAddCounterEffect(final JeweledAmuletAddCounterEffect effect) {
         super(effect);
         manaUsedString = effect.manaUsedString;
     }

--- a/Mage.Sets/src/mage/cards/j/JeweledSpirit.java
+++ b/Mage.Sets/src/mage/cards/j/JeweledSpirit.java
@@ -63,7 +63,7 @@ class JeweledSpiritEffect extends OneShotEffect {
         this.staticText = "{this} gains protection from artifacts or from the color of your choice until end of turn";
     }
 
-    public JeweledSpiritEffect(final JeweledSpiritEffect effect) {
+    private JeweledSpiritEffect(final JeweledSpiritEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JhessianInfiltrator.java
+++ b/Mage.Sets/src/mage/cards/j/JhessianInfiltrator.java
@@ -27,7 +27,7 @@ public final class JhessianInfiltrator extends CardImpl {
         this.addAbility(new CantBeBlockedSourceAbility());
     }
 
-    public JhessianInfiltrator (final JhessianInfiltrator card) {
+    private JhessianInfiltrator(final JhessianInfiltrator card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JhessianLookout.java
+++ b/Mage.Sets/src/mage/cards/j/JhessianLookout.java
@@ -24,7 +24,7 @@ public final class JhessianLookout extends CardImpl {
         this.toughness = new MageInt(1);
     }
 
-    public JhessianLookout (final JhessianLookout card) {
+    private JhessianLookout(final JhessianLookout card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JhoiraOfTheGhitu.java
+++ b/Mage.Sets/src/mage/cards/j/JhoiraOfTheGhitu.java
@@ -61,7 +61,7 @@ class JhoiraOfTheGhituSuspendEffect extends OneShotEffect {
         this.staticText = "Put four time counters on the exiled card. If it doesn't have suspend, it gains suspend. <i>(At the beginning of your upkeep, remove a time counter from that card. When the last is removed, cast it without paying its mana cost. If it's a creature, it has haste.)</i>";
     }
 
-    public JhoiraOfTheGhituSuspendEffect(final JhoiraOfTheGhituSuspendEffect effect) {
+    private JhoiraOfTheGhituSuspendEffect(final JhoiraOfTheGhituSuspendEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JhoiraWeatherlightCaptain.java
+++ b/Mage.Sets/src/mage/cards/j/JhoiraWeatherlightCaptain.java
@@ -33,7 +33,7 @@ public final class JhoiraWeatherlightCaptain extends CardImpl {
 
     }
 
-    public JhoiraWeatherlightCaptain(final JhoiraWeatherlightCaptain jhoiraWeatherlightCaptain) {
+    private JhoiraWeatherlightCaptain(final JhoiraWeatherlightCaptain jhoiraWeatherlightCaptain) {
         super(jhoiraWeatherlightCaptain);
     }
 

--- a/Mage.Sets/src/mage/cards/j/Jihad.java
+++ b/Mage.Sets/src/mage/cards/j/Jihad.java
@@ -70,7 +70,7 @@ class JihadTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("When the chosen player controls no nontoken permanents of the chosen color, ");
     }
 
-    public JihadTriggeredAbility(final JihadTriggeredAbility ability) {
+    private JihadTriggeredAbility(final JihadTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JinxedChoker.java
+++ b/Mage.Sets/src/mage/cards/j/JinxedChoker.java
@@ -65,7 +65,7 @@ class JinxedChokerChangeControllerEffect extends ContinuousEffectImpl {
         staticText = "target opponent gains control of {this}";
     }
 
-    public JinxedChokerChangeControllerEffect(final JinxedChokerChangeControllerEffect effect) {
+    private JinxedChokerChangeControllerEffect(final JinxedChokerChangeControllerEffect effect) {
         super(effect);
     }
 
@@ -149,7 +149,7 @@ class JinxedChokerCounterEffect extends OneShotEffect {
         this.staticText = "Put a charge counter on {this} or remove one from it";
     }
 
-    public JinxedChokerCounterEffect(final JinxedChokerCounterEffect effect) {
+    private JinxedChokerCounterEffect(final JinxedChokerCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JinxedIdol.java
+++ b/Mage.Sets/src/mage/cards/j/JinxedIdol.java
@@ -55,7 +55,7 @@ class JinxedIdolEffect extends ContinuousEffectImpl {
         staticText = "Target opponent gains control of {this}";
     }
 
-    public JinxedIdolEffect(final JinxedIdolEffect effect) {
+    private JinxedIdolEffect(final JinxedIdolEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JinxedRing.java
+++ b/Mage.Sets/src/mage/cards/j/JinxedRing.java
@@ -67,7 +67,7 @@ class JinxedRingEffect extends ContinuousEffectImpl {
         staticText = "Target opponent gains control of {this}";
     }
 
-    public JinxedRingEffect(final JinxedRingEffect effect) {
+    private JinxedRingEffect(final JinxedRingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JodahsAvenger.java
+++ b/Mage.Sets/src/mage/cards/j/JodahsAvenger.java
@@ -69,7 +69,7 @@ class JodahsAvengerEffect extends ContinuousEffectImpl {
         this.staticText = "Until end of turn, {this} gets -1/-1 and gains your choice of double strike, protection from red, vigilance, or shadow";
     }
 
-    public JodahsAvengerEffect(final JodahsAvengerEffect effect) {
+    private JodahsAvengerEffect(final JodahsAvengerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JointAssault.java
+++ b/Mage.Sets/src/mage/cards/j/JointAssault.java
@@ -52,7 +52,7 @@ class JointAssaultBoostTargetEffect extends ContinuousEffectImpl {
         staticText = "Target creature gets +2/+2 until end of turn. If it's paired with a creature, that creature also gets +2/+2 until end of turn";
     }
 
-    public JointAssaultBoostTargetEffect(final JointAssaultBoostTargetEffect effect) {
+    private JointAssaultBoostTargetEffect(final JointAssaultBoostTargetEffect effect) {
         super(effect);
         this.power = effect.power;
         this.toughness = effect.toughness;

--- a/Mage.Sets/src/mage/cards/j/JolraelEmpressOfBeasts.java
+++ b/Mage.Sets/src/mage/cards/j/JolraelEmpressOfBeasts.java
@@ -63,7 +63,7 @@ class JolraelEmpressOfBeastsEffect extends OneShotEffect {
         this.staticText = "All lands target player controls become 3/3 creatures until end of turn. They're still lands.";
     }
 
-    public JolraelEmpressOfBeastsEffect(final JolraelEmpressOfBeastsEffect effect) {
+    private JolraelEmpressOfBeastsEffect(final JolraelEmpressOfBeastsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JoragaInvocation.java
+++ b/Mage.Sets/src/mage/cards/j/JoragaInvocation.java
@@ -50,7 +50,7 @@ class JoragaInvocationEffect extends OneShotEffect {
         this.staticText = "and must be blocked this turn if able";
     }
 
-    public JoragaInvocationEffect(final JoragaInvocationEffect effect) {
+    private JoragaInvocationEffect(final JoragaInvocationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JourneyToEternity.java
+++ b/Mage.Sets/src/mage/cards/j/JourneyToEternity.java
@@ -68,7 +68,7 @@ class JourneyToEternityReturnTransformedSourceEffect extends OneShotEffect {
         this.staticText = ", then return {this} to the battlefield transformed under your control.";
     }
 
-    public JourneyToEternityReturnTransformedSourceEffect(final JourneyToEternityReturnTransformedSourceEffect effect) {
+    private JourneyToEternityReturnTransformedSourceEffect(final JourneyToEternityReturnTransformedSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JourneyersKite.java
+++ b/Mage.Sets/src/mage/cards/j/JourneyersKite.java
@@ -34,7 +34,7 @@ public final class JourneyersKite extends CardImpl {
         this.addAbility(ability);
     }
 
-    public JourneyersKite (final JourneyersKite card) {
+    private JourneyersKite(final JourneyersKite card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JovensFerrets.java
+++ b/Mage.Sets/src/mage/cards/j/JovensFerrets.java
@@ -66,7 +66,7 @@ class JovensFerretsEffect extends OneShotEffect {
         this.staticText = "tap all creatures that blocked {this} this turn. They don't untap during their controller's next untap step.";
     }
 
-    public JovensFerretsEffect(final JovensFerretsEffect effect) {
+    private JovensFerretsEffect(final JovensFerretsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JoyousRespite.java
+++ b/Mage.Sets/src/mage/cards/j/JoyousRespite.java
@@ -30,7 +30,7 @@ public final class JoyousRespite extends CardImpl {
         this.getSpellAbility().addEffect(new GainLifeEffect(new PermanentsOnBattlefieldCount(filter)));
     }
 
-    public JoyousRespite (final JoyousRespite card) {
+    private JoyousRespite(final JoyousRespite card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JudgeUnworthy.java
+++ b/Mage.Sets/src/mage/cards/j/JudgeUnworthy.java
@@ -51,7 +51,7 @@ class JudgeUnworthyEffect extends OneShotEffect {
         this.staticText = ", then reveal the top card of your library. {this} deals damage equal to that card's mana value to that creature";
     }
     
-    public JudgeUnworthyEffect(final JudgeUnworthyEffect effect) {
+    private JudgeUnworthyEffect(final JudgeUnworthyEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/j/JukaiMessenger.java
+++ b/Mage.Sets/src/mage/cards/j/JukaiMessenger.java
@@ -26,7 +26,7 @@ public final class JukaiMessenger extends CardImpl {
         this.addAbility(new ForestwalkAbility());
     }
 
-    public JukaiMessenger (final JukaiMessenger card) {
+    private JukaiMessenger(final JukaiMessenger card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JumboImp.java
+++ b/Mage.Sets/src/mage/cards/j/JumboImp.java
@@ -97,7 +97,7 @@ class JumboImpAddCountersEffect extends OneShotEffect {
         this.staticText = "roll a six-sided die and put a number of +1/+1 counters on {this} equal to the result";
     }
 
-    public JumboImpAddCountersEffect(final JumboImpAddCountersEffect effect) {
+    private JumboImpAddCountersEffect(final JumboImpAddCountersEffect effect) {
         super(effect);
     }
 
@@ -126,7 +126,7 @@ class JumboImpRemoveCountersEffect extends OneShotEffect {
         this.staticText = "roll a six-sided die and remove a number of +1/+1 counters on {this} equal to the result";
     }
 
-    public JumboImpRemoveCountersEffect(final JumboImpRemoveCountersEffect effect) {
+    private JumboImpRemoveCountersEffect(final JumboImpRemoveCountersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JumpTrooper.java
+++ b/Mage.Sets/src/mage/cards/j/JumpTrooper.java
@@ -65,7 +65,7 @@ class JumpTrooperTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect);
     }
 
-    public JumpTrooperTriggeredAbility(final JumpTrooperTriggeredAbility ability) {
+    private JumpTrooperTriggeredAbility(final JumpTrooperTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JundBattlemage.java
+++ b/Mage.Sets/src/mage/cards/j/JundBattlemage.java
@@ -40,7 +40,7 @@ public final class JundBattlemage extends CardImpl {
         this.addAbility(ability);
     }
 
-    public JundBattlemage (final JundBattlemage card) {
+    private JundBattlemage(final JundBattlemage card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JungleShrine.java
+++ b/Mage.Sets/src/mage/cards/j/JungleShrine.java
@@ -25,7 +25,7 @@ public final class JungleShrine extends CardImpl {
         this.addAbility(new WhiteManaAbility());
     }
 
-    public JungleShrine (final JungleShrine card) {
+    private JungleShrine(final JungleShrine card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JungleVillage.java
+++ b/Mage.Sets/src/mage/cards/j/JungleVillage.java
@@ -47,7 +47,7 @@ public final class JungleVillage extends CardImpl {
 
     public final class JungleVillageAbility extends ActivatedAbilityImpl {
 
-        public JungleVillageAbility(JungleVillageAbility ability) {
+        private JungleVillageAbility(final JungleVillageAbility ability) {
             super(ability);
         }
 

--- a/Mage.Sets/src/mage/cards/j/JungleWayfinder.java
+++ b/Mage.Sets/src/mage/cards/j/JungleWayfinder.java
@@ -54,7 +54,7 @@ class JungleWayfinderEffect extends OneShotEffect {
         this.staticText = "each player may search their library for a basic land card, reveal it, put it into their hand, then shuffle";
     }
 
-    public JungleWayfinderEffect(final JungleWayfinderEffect effect) {
+    private JungleWayfinderEffect(final JungleWayfinderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JungleWeaver.java
+++ b/Mage.Sets/src/mage/cards/j/JungleWeaver.java
@@ -28,7 +28,7 @@ public final class JungleWeaver extends CardImpl {
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{2}")));
     }
 
-    public JungleWeaver (final JungleWeaver card) {
+    private JungleWeaver(final JungleWeaver card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JunkyoBell.java
+++ b/Mage.Sets/src/mage/cards/j/JunkyoBell.java
@@ -58,7 +58,7 @@ public final class JunkyoBell extends CardImpl {
             this.staticText = "If you do, sacrifice that creature at the beginning of the next end step";
         }
 
-        public JunkyoBellSacrificeEffect(final JunkyoBellSacrificeEffect effect) {
+        private JunkyoBellSacrificeEffect(final JunkyoBellSacrificeEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/j/JushiApprentice.java
+++ b/Mage.Sets/src/mage/cards/j/JushiApprentice.java
@@ -75,7 +75,7 @@ class TomoyaTheRevealer extends TokenImpl {
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }
-    public TomoyaTheRevealer(final TomoyaTheRevealer token) {
+    private TomoyaTheRevealer(final TomoyaTheRevealer token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/j/Justice.java
+++ b/Mage.Sets/src/mage/cards/j/Justice.java
@@ -55,7 +55,7 @@ class JusticeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect);
     }
 
-    public JusticeTriggeredAbility(final JusticeTriggeredAbility ability) {
+    private JusticeTriggeredAbility(final JusticeTriggeredAbility ability) {
         super(ability);
     }
 
@@ -96,7 +96,7 @@ class JusticeEffect extends OneShotEffect {
         super(Outcome.Damage);
     }
 
-    public JusticeEffect(final JusticeEffect effect) {
+    private JusticeEffect(final JusticeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JusticeStrike.java
+++ b/Mage.Sets/src/mage/cards/j/JusticeStrike.java
@@ -42,7 +42,7 @@ class JusticeStrikeEffect extends OneShotEffect {
         this.staticText = "Target creature deals damage to itself equal to its power.";
     }
 
-    public JusticeStrikeEffect(final JusticeStrikeEffect effect) {
+    private JusticeStrikeEffect(final JusticeStrikeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/Juxtapose.java
+++ b/Mage.Sets/src/mage/cards/j/Juxtapose.java
@@ -61,7 +61,7 @@ class JuxtaposeEffect extends ContinuousEffectImpl {
         this.lockedControllers = new HashMap<>();
     }
 
-    public JuxtaposeEffect(final JuxtaposeEffect effect) {
+    private JuxtaposeEffect(final JuxtaposeEffect effect) {
         super(effect);
         this.filter = effect.filter.copy();
         this.zoneChangeCounter = new HashMap<>(effect.zoneChangeCounter);

--- a/Mage.Sets/src/mage/cards/j/JwariScuttler.java
+++ b/Mage.Sets/src/mage/cards/j/JwariScuttler.java
@@ -23,7 +23,7 @@ public final class JwariScuttler extends CardImpl {
         this.toughness = new MageInt(3);
     }
 
-    public JwariScuttler (final JwariScuttler card) {
+    private JwariScuttler(final JwariScuttler card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KaaliaOfTheVast.java
+++ b/Mage.Sets/src/mage/cards/k/KaaliaOfTheVast.java
@@ -58,7 +58,7 @@ class KaaliaOfTheVastAttacksAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new KaaliaOfTheVastEffect(), false);
     }
 
-    public KaaliaOfTheVastAttacksAbility(final KaaliaOfTheVastAttacksAbility ability) {
+    private KaaliaOfTheVastAttacksAbility(final KaaliaOfTheVastAttacksAbility ability) {
         super(ability);
     }
 
@@ -103,7 +103,7 @@ class KaaliaOfTheVastEffect extends OneShotEffect {
         this.staticText = "put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.";
     }
 
-    public KaaliaOfTheVastEffect(final KaaliaOfTheVastEffect effect) {
+    private KaaliaOfTheVastEffect(final KaaliaOfTheVastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KaervekTheMerciless.java
+++ b/Mage.Sets/src/mage/cards/k/KaervekTheMerciless.java
@@ -54,7 +54,7 @@ class KaervekTheMercilessEffect extends OneShotEffect {
         this.staticText = "{this} deals damage equal to that spell's mana value to any target";
     }
 
-    public KaervekTheMercilessEffect(final KaervekTheMercilessEffect effect) {
+    private KaervekTheMercilessEffect(final KaervekTheMercilessEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KaerveksPurge.java
+++ b/Mage.Sets/src/mage/cards/k/KaerveksPurge.java
@@ -64,7 +64,7 @@ class KaerveksPurgeEffect extends OneShotEffect {
                 " to the creature's controller";
     }
 
-    public KaerveksPurgeEffect(final KaerveksPurgeEffect effect) {
+    private KaerveksPurgeEffect(final KaerveksPurgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KahoMinamoHistorian.java
+++ b/Mage.Sets/src/mage/cards/k/KahoMinamoHistorian.java
@@ -72,7 +72,7 @@ class KahoMinamoHistorianEffect extends SearchEffect {
         this.staticText = "search your library for up to three instant cards, exile them, then shuffle";
     }
 
-    public KahoMinamoHistorianEffect(final KahoMinamoHistorianEffect effect) {
+    private KahoMinamoHistorianEffect(final KahoMinamoHistorianEffect effect) {
         super(effect);
     }
 
@@ -109,7 +109,7 @@ class KahoMinamoHistorianCastEffect extends OneShotEffect {
                 "from among cards exiled with {this} without paying its mana cost";
     }
 
-    public KahoMinamoHistorianCastEffect(final KahoMinamoHistorianCastEffect effect) {
+    private KahoMinamoHistorianCastEffect(final KahoMinamoHistorianCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KaitoDancingShadow.java
+++ b/Mage.Sets/src/mage/cards/k/KaitoDancingShadow.java
@@ -118,7 +118,7 @@ class KaitoDancingShadowIncreaseLoyaltyUseEffect extends ContinuousEffectImpl {
         super(Duration.EndOfTurn, Layer.RulesEffects, SubLayer.NA, Outcome.Benefit);
     }
 
-    public KaitoDancingShadowIncreaseLoyaltyUseEffect(final KaitoDancingShadowIncreaseLoyaltyUseEffect effect) {
+    private KaitoDancingShadowIncreaseLoyaltyUseEffect(final KaitoDancingShadowIncreaseLoyaltyUseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KalitasBloodchiefOfGhet.java
+++ b/Mage.Sets/src/mage/cards/k/KalitasBloodchiefOfGhet.java
@@ -60,7 +60,7 @@ class KalitasDestroyEffect extends OneShotEffect {
         this.staticText = "Destroy target creature. If that creature dies this way, create a black Vampire creature token. Its power is equal to that creature's power and its toughness is equal to that creature's toughness";
     }
 
-    public KalitasDestroyEffect(final KalitasDestroyEffect effect) {
+    private KalitasDestroyEffect(final KalitasDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KalitasTraitorOfGhet.java
+++ b/Mage.Sets/src/mage/cards/k/KalitasTraitorOfGhet.java
@@ -78,7 +78,7 @@ class KalitasTraitorOfGhetEffect extends ReplacementEffectImpl {
         staticText = "If a nontoken creature an opponent controls would die, instead exile that card and create a 2/2 black Zombie creature token";
     }
 
-    public KalitasTraitorOfGhetEffect(final KalitasTraitorOfGhetEffect effect) {
+    private KalitasTraitorOfGhetEffect(final KalitasTraitorOfGhetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KalonianHydra.java
+++ b/Mage.Sets/src/mage/cards/k/KalonianHydra.java
@@ -62,7 +62,7 @@ class KalonianHydraEffect extends OneShotEffect {
         this.staticText = "double the number of +1/+1 counters on each creature you control";
     }
 
-    public KalonianHydraEffect(final KalonianHydraEffect effect) {
+    private KalonianHydraEffect(final KalonianHydraEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KamahlsDruidicVow.java
+++ b/Mage.Sets/src/mage/cards/k/KamahlsDruidicVow.java
@@ -57,7 +57,7 @@ class KamahlsDruidicVowEffect extends OneShotEffect {
         this.staticText = "Look at the top X cards of your library. You may put any number of land and/or legendary permanent cards with mana value X or less from among them onto the battlefield. Put the rest into your graveyard";
     }
 
-    public KamahlsDruidicVowEffect(final KamahlsDruidicVowEffect effect) {
+    private KamahlsDruidicVowEffect(final KamahlsDruidicVowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KamahlsSummons.java
+++ b/Mage.Sets/src/mage/cards/k/KamahlsSummons.java
@@ -49,7 +49,7 @@ class KamahlsSummonsEffect extends OneShotEffect {
         this.staticText = "Each player may reveal any number of creature cards from their hand. Then each player creates a 2/2 green Bear creature token for each card they revealed this way";
     }
 
-    public KamahlsSummonsEffect(final KamahlsSummonsEffect effect) {
+    private KamahlsSummonsEffect(final KamahlsSummonsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KamiOfAncientLaw.java
+++ b/Mage.Sets/src/mage/cards/k/KamiOfAncientLaw.java
@@ -32,7 +32,7 @@ public final class KamiOfAncientLaw extends CardImpl {
         this.addAbility(ability);
     }
 
-    public KamiOfAncientLaw (final KamiOfAncientLaw card) {
+    private KamiOfAncientLaw(final KamiOfAncientLaw card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KamiOfOldStone.java
+++ b/Mage.Sets/src/mage/cards/k/KamiOfOldStone.java
@@ -23,7 +23,7 @@ public final class KamiOfOldStone extends CardImpl {
         this.toughness = new MageInt(7);
     }
 
-    public KamiOfOldStone (final KamiOfOldStone card) {
+    private KamiOfOldStone(final KamiOfOldStone card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KamiOfTheHonoredDead.java
+++ b/Mage.Sets/src/mage/cards/k/KamiOfTheHonoredDead.java
@@ -58,7 +58,7 @@ class KamiOfTheHonoredDeadTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} is dealt damage, ");
     }
 
-    public KamiOfTheHonoredDeadTriggeredAbility(final KamiOfTheHonoredDeadTriggeredAbility effect) {
+    private KamiOfTheHonoredDeadTriggeredAbility(final KamiOfTheHonoredDeadTriggeredAbility effect) {
         super(effect);
     }
 
@@ -90,7 +90,7 @@ class KamiOfTheHonoredDeadGainLifeEffect extends OneShotEffect {
             staticText = "you gain that much life";
         }
 
-    public KamiOfTheHonoredDeadGainLifeEffect(final KamiOfTheHonoredDeadGainLifeEffect effect) {
+    private KamiOfTheHonoredDeadGainLifeEffect(final KamiOfTheHonoredDeadGainLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/Karma.java
+++ b/Mage.Sets/src/mage/cards/k/Karma.java
@@ -54,7 +54,7 @@ class KarmaDamageTargetEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to that player equal to the number of Swamps they control";
     }
 
-    public KarmaDamageTargetEffect(KarmaDamageTargetEffect copy) {
+    private KarmaDamageTargetEffect(final KarmaDamageTargetEffect copy) {
         super(copy);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KarnLiberated.java
+++ b/Mage.Sets/src/mage/cards/k/KarnLiberated.java
@@ -69,7 +69,7 @@ class KarnLiberatedEffect extends OneShotEffect {
         this.staticText = "Restart the game, leaving in exile all non-Aura permanent cards exiled with {this}. Then put those cards onto the battlefield under your control";
     }
 
-    public KarnLiberatedEffect(final KarnLiberatedEffect effect) {
+    private KarnLiberatedEffect(final KarnLiberatedEffect effect) {
         super(effect);
     }
 
@@ -147,7 +147,7 @@ class KarnLiberatedDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new KarnLiberatedDelayedEffect(exileId));
     }
 
-    public KarnLiberatedDelayedTriggeredAbility(final KarnLiberatedDelayedTriggeredAbility ability) {
+    private KarnLiberatedDelayedTriggeredAbility(final KarnLiberatedDelayedTriggeredAbility ability) {
         super(ability);
     }
 
@@ -178,7 +178,7 @@ class KarnLiberatedDelayedEffect extends OneShotEffect {
         this.staticText = "Put those cards onto the battlefield under your control";
     }
 
-    public KarnLiberatedDelayedEffect(final KarnLiberatedDelayedEffect effect) {
+    private KarnLiberatedDelayedEffect(final KarnLiberatedDelayedEffect effect) {
         super(effect);
         this.exileId = effect.exileId;
     }
@@ -225,7 +225,7 @@ class KarnPlayerExileEffect extends OneShotEffect {
         staticText = "target player exiles a card from their hand.";
     }
 
-    public KarnPlayerExileEffect(final KarnPlayerExileEffect effect) {
+    private KarnPlayerExileEffect(final KarnPlayerExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KarnSilverGolem.java
+++ b/Mage.Sets/src/mage/cards/k/KarnSilverGolem.java
@@ -62,7 +62,7 @@ class KarnSilverGolemEffect extends ContinuousEffectImpl {
         staticText = "Target noncreature artifact becomes an artifact creature with power and toughness each equal to its mana value until end of turn";
     }
 
-    public KarnSilverGolemEffect(final KarnSilverGolemEffect effect) {
+    private KarnSilverGolemEffect(final KarnSilverGolemEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KarnsSylex.java
+++ b/Mage.Sets/src/mage/cards/k/KarnsSylex.java
@@ -60,7 +60,7 @@ class KarnsSylexEffect extends ContinuousEffectImpl {
         staticText = "Players can't pay life to cast spells or to activate abilities that aren't mana abilities";
     }
 
-    public KarnsSylexEffect(final KarnsSylexEffect effect) {
+    private KarnsSylexEffect(final KarnsSylexEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KarnsTemporalSundering.java
+++ b/Mage.Sets/src/mage/cards/k/KarnsTemporalSundering.java
@@ -55,7 +55,7 @@ class KarnsTemporalSunderingEffect extends OneShotEffect {
         this.staticText = "Target player takes an extra turn after this one. Return up to one target nonland permanent to its owner's hand";
     }
 
-    public KarnsTemporalSunderingEffect(final KarnsTemporalSunderingEffect effect) {
+    private KarnsTemporalSunderingEffect(final KarnsTemporalSunderingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KarnsTouch.java
+++ b/Mage.Sets/src/mage/cards/k/KarnsTouch.java
@@ -54,7 +54,7 @@ class KarnsTouchEffect extends ContinuousEffectImpl {
         staticText = "Target noncreature artifact becomes an artifact creature with power and toughness each equal to its mana value until end of turn";
     }
 
-    public KarnsTouchEffect(final KarnsTouchEffect effect) {
+    private KarnsTouchEffect(final KarnsTouchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KaronaFalseGod.java
+++ b/Mage.Sets/src/mage/cards/k/KaronaFalseGod.java
@@ -63,7 +63,7 @@ class KaronaFalseGodUntapGetControlEffect extends OneShotEffect {
         this.staticText = "that player untaps {this} and gains control of it";
     }
 
-    public KaronaFalseGodUntapGetControlEffect(final KaronaFalseGodUntapGetControlEffect effect) {
+    private KaronaFalseGodUntapGetControlEffect(final KaronaFalseGodUntapGetControlEffect effect) {
         super(effect);
     }
 
@@ -110,7 +110,7 @@ class KaronaFalseGodEffect extends OneShotEffect {
         this.staticText = "creatures of the creature type of your choice get +3/+3 until end of turn";
     }
 
-    public KaronaFalseGodEffect(final KaronaFalseGodEffect effect) {
+    private KaronaFalseGodEffect(final KaronaFalseGodEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KarplusanMinotaur.java
+++ b/Mage.Sets/src/mage/cards/k/KarplusanMinotaur.java
@@ -64,7 +64,7 @@ class KarplusanMinotaurFlipWinTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetAnyTarget());
     }
 
-    public KarplusanMinotaurFlipWinTriggeredAbility(final KarplusanMinotaurFlipWinTriggeredAbility ability) {
+    private KarplusanMinotaurFlipWinTriggeredAbility(final KarplusanMinotaurFlipWinTriggeredAbility ability) {
         super(ability);
     }
 
@@ -100,7 +100,7 @@ class KarplusanMinotaurFlipLoseTriggeredAbility extends TriggeredAbilityImpl {
         targetAdjuster = KarplusanMinotaurAdjuster.instance;
     }
 
-    public KarplusanMinotaurFlipLoseTriggeredAbility(final KarplusanMinotaurFlipLoseTriggeredAbility ability) {
+    private KarplusanMinotaurFlipLoseTriggeredAbility(final KarplusanMinotaurFlipLoseTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KasetoOrochiArchmage.java
+++ b/Mage.Sets/src/mage/cards/k/KasetoOrochiArchmage.java
@@ -53,7 +53,7 @@ class KasetoEffect extends OneShotEffect {
         staticText = "Target creature can't be blocked this turn. If that creature is a Snake, it gets +2/+2 until end of turn";
     }
 
-    public KasetoEffect(final KasetoEffect effect) {
+    private KasetoEffect(final KasetoEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KatabaticWinds.java
+++ b/Mage.Sets/src/mage/cards/k/KatabaticWinds.java
@@ -63,7 +63,7 @@ class KatabaticWindsRestrictionEffect extends RestrictionEffect {
         staticText = "Creatures with flying can't attack or block";
     }
 
-    public KatabaticWindsRestrictionEffect(final KatabaticWindsRestrictionEffect effect) {
+    private KatabaticWindsRestrictionEffect(final KatabaticWindsRestrictionEffect effect) {
         super(effect);
     }
 
@@ -95,7 +95,7 @@ class KatabaticWindsRuleModifyingEffect extends ContinuousRuleModifyingEffectImp
         staticText = ", and their activated abilities with {T} in their costs can't be activated";
     }
 
-    public KatabaticWindsRuleModifyingEffect(final KatabaticWindsRuleModifyingEffect effect) {
+    private KatabaticWindsRuleModifyingEffect(final KatabaticWindsRuleModifyingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KathariRemnant.java
+++ b/Mage.Sets/src/mage/cards/k/KathariRemnant.java
@@ -34,7 +34,7 @@ public final class KathariRemnant extends CardImpl {
         this.addAbility(new CascadeAbility());
     }
 
-    public KathariRemnant (final KathariRemnant card) {
+    private KathariRemnant(final KathariRemnant card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KathariScreecher.java
+++ b/Mage.Sets/src/mage/cards/k/KathariScreecher.java
@@ -33,7 +33,7 @@ public final class KathariScreecher extends CardImpl {
         this.addAbility(new UnearthAbility(new ManaCostsImpl<>("{2}{U}")));
     }
 
-    public KathariScreecher (final KathariScreecher card) {
+    private KathariScreecher(final KathariScreecher card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KatildaAndLier.java
+++ b/Mage.Sets/src/mage/cards/k/KatildaAndLier.java
@@ -64,7 +64,7 @@ class KatildaAndLierEffect extends ContinuousEffectImpl {
         this.staticText = "target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost";
     }
 
-    public KatildaAndLierEffect(final KatildaAndLierEffect effect) {
+    private KatildaAndLierEffect(final KatildaAndLierEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KavuPredator.java
+++ b/Mage.Sets/src/mage/cards/k/KavuPredator.java
@@ -55,7 +55,7 @@ class KavuPredatorTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever an opponent gains life, ");
     }
 
-    public KavuPredatorTriggeredAbility(final KavuPredatorTriggeredAbility ability) {
+    private KavuPredatorTriggeredAbility(final KavuPredatorTriggeredAbility ability) {
         super(ability);
     }
 
@@ -86,7 +86,7 @@ class KavuPredatorEffect extends OneShotEffect {
         this.staticText = "put that many +1/+1 counters on {this}";
     }
 
-    public KavuPredatorEffect(final KavuPredatorEffect effect) {
+    private KavuPredatorEffect(final KavuPredatorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KayaGhostAssassin.java
+++ b/Mage.Sets/src/mage/cards/k/KayaGhostAssassin.java
@@ -75,7 +75,7 @@ class KayaGhostAssassinEffect extends OneShotEffect {
                 + "You lose 2 life";
     }
 
-    public KayaGhostAssassinEffect(final KayaGhostAssassinEffect effect) {
+    private KayaGhostAssassinEffect(final KayaGhostAssassinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KazarovSengirPureblood.java
+++ b/Mage.Sets/src/mage/cards/k/KazarovSengirPureblood.java
@@ -64,7 +64,7 @@ class KazarovSengirPurebloodTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()));
     }
 
-    public KazarovSengirPurebloodTriggeredAbility(final KazarovSengirPurebloodTriggeredAbility effect) {
+    private KazarovSengirPurebloodTriggeredAbility(final KazarovSengirPurebloodTriggeredAbility effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KazuulsTollCollector.java
+++ b/Mage.Sets/src/mage/cards/k/KazuulsTollCollector.java
@@ -56,7 +56,7 @@ class KazuulsTollCollectorEffect extends OneShotEffect {
         staticText = "attach target Equipment you control to {this}";
     }
 
-    public KazuulsTollCollectorEffect(final KazuulsTollCollectorEffect effect) {
+    private KazuulsTollCollectorEffect(final KazuulsTollCollectorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KeeningStone.java
+++ b/Mage.Sets/src/mage/cards/k/KeeningStone.java
@@ -48,7 +48,7 @@ class KeeningStoneEffect extends OneShotEffect {
         this.staticText = "Target player mills X cards, where X is the number of cards in that player's graveyard";
     }
 
-    public KeeningStoneEffect(final KeeningStoneEffect effect) {
+    private KeeningStoneEffect(final KeeningStoneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KeeperOfTheBeasts.java
+++ b/Mage.Sets/src/mage/cards/k/KeeperOfTheBeasts.java
@@ -59,7 +59,7 @@ class KeeperOfTheBeastsTarget extends TargetPlayer {
         super(1, 1, false, new FilterOpponent("opponent that controls more creatures than you"));
     }
 
-    public KeeperOfTheBeastsTarget(final KeeperOfTheBeastsTarget target) {
+    private KeeperOfTheBeastsTarget(final KeeperOfTheBeastsTarget target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KeeperOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/k/KeeperOfTheDead.java
@@ -99,7 +99,7 @@ class KeeperOfTheDeadCreatureTarget extends TargetPermanent {
         super(1, 1, new FilterCreaturePermanent("nonblack creature that player controls"), false);
     }
 
-    public KeeperOfTheDeadCreatureTarget(final KeeperOfTheDeadCreatureTarget target) {
+    private KeeperOfTheDeadCreatureTarget(final KeeperOfTheDeadCreatureTarget target) {
         super(target);
     }
 
@@ -153,7 +153,7 @@ class KeeperOfTheDeadEffect extends OneShotEffect {
         this.staticText = "Destroy target nonblack creature contolled by target opponent who had at least two fewer creature cards in their graveyard than you did as you activated this ability";
     }
 
-    public KeeperOfTheDeadEffect(final KeeperOfTheDeadEffect effect) {
+    private KeeperOfTheDeadEffect(final KeeperOfTheDeadEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KeeperOfTheLens.java
+++ b/Mage.Sets/src/mage/cards/k/KeeperOfTheLens.java
@@ -62,7 +62,7 @@ class KeeperOfTheLensLookFaceDownAbility extends ActivatedAbilityImpl {
         this.addTarget(new TargetCreaturePermanent(filter));
     }
 
-    public KeeperOfTheLensLookFaceDownAbility(KeeperOfTheLensLookFaceDownAbility ability) {
+    private KeeperOfTheLensLookFaceDownAbility(final KeeperOfTheLensLookFaceDownAbility ability) {
         super(ability);
     }
 
@@ -80,7 +80,7 @@ class KeeperOfTheLensLookFaceDownEffect extends OneShotEffect {
         this.staticText = "You may look at face-down creatures you don't control any time";
     }
 
-    public KeeperOfTheLensLookFaceDownEffect(final KeeperOfTheLensLookFaceDownEffect effect) {
+    private KeeperOfTheLensLookFaceDownEffect(final KeeperOfTheLensLookFaceDownEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KeeperOfTheLight.java
+++ b/Mage.Sets/src/mage/cards/k/KeeperOfTheLight.java
@@ -61,7 +61,7 @@ class KeeperOfTheLightTarget extends TargetPlayer {
         super(1, 1, false, new FilterOpponent("opponent that has more life than you"));
     }
 
-    public KeeperOfTheLightTarget(final KeeperOfTheLightTarget target) {
+    private KeeperOfTheLightTarget(final KeeperOfTheLightTarget target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KefnetTheMindful.java
+++ b/Mage.Sets/src/mage/cards/k/KefnetTheMindful.java
@@ -66,7 +66,7 @@ class KefnetTheMindfulRestrictionEffect extends RestrictionEffect {
         staticText = "{this} can't attack or block unless you have seven or more cards in your hand";
     }
 
-    public KefnetTheMindfulRestrictionEffect(final KefnetTheMindfulRestrictionEffect effect) {
+    private KefnetTheMindfulRestrictionEffect(final KefnetTheMindfulRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KeldonBattlewagon.java
+++ b/Mage.Sets/src/mage/cards/k/KeldonBattlewagon.java
@@ -80,7 +80,7 @@ class KeldonBattlewagonCost extends CostImpl {
         this.text = "Tap an untapped creature you control";
     }
 
-    public KeldonBattlewagonCost(final KeldonBattlewagonCost cost) {
+    private KeldonBattlewagonCost(final KeldonBattlewagonCost cost) {
         super(cost);
         this.target = cost.target.copy();
     }
@@ -120,7 +120,7 @@ class KeldonBattlewagonBoostEffect extends OneShotEffect {
         staticText = "{this} gets +X/+0 until end of turn, where X is the power of the creature tapped this way";
     }
 
-    public KeldonBattlewagonBoostEffect(KeldonBattlewagonBoostEffect effect) {
+    private KeldonBattlewagonBoostEffect(final KeldonBattlewagonBoostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KeldonFirebombers.java
+++ b/Mage.Sets/src/mage/cards/k/KeldonFirebombers.java
@@ -59,7 +59,7 @@ class KeldonFirebombersEffect extends OneShotEffect {
         this.staticText = "each player sacrifices all lands they control except for three";
     }
 
-    public KeldonFirebombersEffect(final KeldonFirebombersEffect effect) {
+    private KeldonFirebombersEffect(final KeldonFirebombersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KembasLegion.java
+++ b/Mage.Sets/src/mage/cards/k/KembasLegion.java
@@ -51,7 +51,7 @@ class KembasLegionEffect extends ContinuousEffectImpl {
         staticText = "{this} can block an additional creature for each Equipment attached to Kemba's Legion";
     }
 
-    public KembasLegionEffect(final KembasLegionEffect effect) {
+    private KembasLegionEffect(final KembasLegionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KenessosPriestOfThassa.java
+++ b/Mage.Sets/src/mage/cards/k/KenessosPriestOfThassa.java
@@ -108,7 +108,7 @@ class KenessosPriestOfThassaActivatedEffect extends OneShotEffect {
                 "you may put it on the bottom of your library.";
     }
 
-    public KenessosPriestOfThassaActivatedEffect(final KenessosPriestOfThassaActivatedEffect effect) {
+    private KenessosPriestOfThassaActivatedEffect(final KenessosPriestOfThassaActivatedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KentaroTheSmilingCat.java
+++ b/Mage.Sets/src/mage/cards/k/KentaroTheSmilingCat.java
@@ -68,7 +68,7 @@ class KentaroTheSmilingCatCastingEffect extends ContinuousEffectImpl {
         staticText = "You may pay {X} rather than pay the mana cost for Samurai spells you cast, where X is that spell's mana value";
     }
     
-    public KentaroTheSmilingCatCastingEffect(final KentaroTheSmilingCatCastingEffect effect) {
+    private KentaroTheSmilingCatCastingEffect(final KentaroTheSmilingCatCastingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KessigCagebreakers.java
+++ b/Mage.Sets/src/mage/cards/k/KessigCagebreakers.java
@@ -50,7 +50,7 @@ class KessigCagebreakersEffect extends OneShotEffect {
         this.staticText = "create a 2/2 green Wolf creature token that's tapped and attacking for each creature card in your graveyard";
     }
 
-    public KessigCagebreakersEffect(final KessigCagebreakersEffect effect) {
+    private KessigCagebreakersEffect(final KessigCagebreakersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KhenraEternal.java
+++ b/Mage.Sets/src/mage/cards/k/KhenraEternal.java
@@ -23,7 +23,7 @@ public final class KhenraEternal extends CardImpl {
 
     }
 
-    public KhenraEternal(final KhenraEternal khenraEternal) {
+    private KhenraEternal(final KhenraEternal khenraEternal) {
         super(khenraEternal);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KheruLichLord.java
+++ b/Mage.Sets/src/mage/cards/k/KheruLichLord.java
@@ -71,7 +71,7 @@ class KheruLichLordEffect extends OneShotEffect {
         this.staticText = "return a creature card at random from your graveyard to the battlefield. It gains flying, trample, and haste. Exile that card at the beginning of the next end step. If that card would leave the battlefield, exile it instead of putting it anywhere else";
     }
 
-    public KheruLichLordEffect(final KheruLichLordEffect effect) {
+    private KheruLichLordEffect(final KheruLichLordEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KheruMindEater.java
+++ b/Mage.Sets/src/mage/cards/k/KheruMindEater.java
@@ -68,7 +68,7 @@ class KheruMindEaterExileEffect extends OneShotEffect {
         staticText = "that player exiles a card of their hand face down";
     }
 
-    public KheruMindEaterExileEffect(final KheruMindEaterExileEffect effect) {
+    private KheruMindEaterExileEffect(final KheruMindEaterExileEffect effect) {
         super(effect);
     }
 
@@ -103,7 +103,7 @@ class KheruMindEaterEffect extends AsThoughEffectImpl {
         staticText = "You may play cards exiled with {this}";
     }
 
-    public KheruMindEaterEffect(final KheruMindEaterEffect effect) {
+    private KheruMindEaterEffect(final KheruMindEaterEffect effect) {
         super(effect);
     }
 
@@ -135,7 +135,7 @@ class KheruMindEaterLookAtCardEffect extends AsThoughEffectImpl {
         staticText = "You may look at cards exiled with {this}";
     }
 
-    public KheruMindEaterLookAtCardEffect(final KheruMindEaterLookAtCardEffect effect) {
+    private KheruMindEaterLookAtCardEffect(final KheruMindEaterLookAtCardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KikiJikiMirrorBreaker.java
+++ b/Mage.Sets/src/mage/cards/k/KikiJikiMirrorBreaker.java
@@ -72,7 +72,7 @@ class KikiJikiMirrorBreakerEffect extends OneShotEffect {
         this.staticText = "Create a token that's a copy of target nonlegendary creature you control, except it has haste. Sacrifice it at the beginning of the next end step";
     }
 
-    public KikiJikiMirrorBreakerEffect(final KikiJikiMirrorBreakerEffect effect) {
+    private KikiJikiMirrorBreakerEffect(final KikiJikiMirrorBreakerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KikuNightsFlower.java
+++ b/Mage.Sets/src/mage/cards/k/KikuNightsFlower.java
@@ -47,7 +47,7 @@ public final class KikuNightsFlower extends CardImpl {
         this.addAbility(ability);
     }
 
-    public KikuNightsFlower (final KikuNightsFlower card) {
+    private KikuNightsFlower(final KikuNightsFlower card) {
         super(card);
     }
 
@@ -64,7 +64,7 @@ class KikuNightsFlowerEffect extends OneShotEffect {
             this.staticText = "Target creature deals damage to itself equal to its power";        
         }
 
-    public KikuNightsFlowerEffect(final KikuNightsFlowerEffect effect) {
+    private KikuNightsFlowerEffect(final KikuNightsFlowerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KikusShadow.java
+++ b/Mage.Sets/src/mage/cards/k/KikusShadow.java
@@ -45,7 +45,7 @@ class KikusShadowEffect extends OneShotEffect {
         this.staticText = "Target creature deals damage to itself equal to its power";
     }
 
-    public KikusShadowEffect(final KikusShadowEffect effect) {
+    private KikusShadowEffect(final KikusShadowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KillSuitCultist.java
+++ b/Mage.Sets/src/mage/cards/k/KillSuitCultist.java
@@ -61,7 +61,7 @@ class KillSuitCultistEffect extends ReplacementEffectImpl {
         staticText = "The next time damage would be dealt to target creature this turn, destroy that creature instead";
     }
 
-    public KillSuitCultistEffect(final KillSuitCultistEffect effect) {
+    private KillSuitCultistEffect(final KillSuitCultistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KillingWave.java
+++ b/Mage.Sets/src/mage/cards/k/KillingWave.java
@@ -45,7 +45,7 @@ class KillingWaveEffect extends OneShotEffect {
         this.staticText = "For each creature, its controller sacrifices it unless they pay X life";
     }
 
-    public KillingWaveEffect(final KillingWaveEffect effect) {
+    private KillingWaveEffect(final KillingWaveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KinTreeInvocation.java
+++ b/Mage.Sets/src/mage/cards/k/KinTreeInvocation.java
@@ -48,7 +48,7 @@ class KinTreeInvocationCreateTokenEffect extends OneShotEffect {
         staticText = "Create an X/X black and green Spirit Warrior creature token, where X is the greatest toughness among creatures you control";
     }
 
-    public KinTreeInvocationCreateTokenEffect(final KinTreeInvocationCreateTokenEffect effect) {
+    private KinTreeInvocationCreateTokenEffect(final KinTreeInvocationCreateTokenEffect effect) {
         super(effect);
     }
 
@@ -90,7 +90,7 @@ class SpiritWarriorToken extends TokenImpl {
         this.toughness = new MageInt(x);
     }
 
-    public SpiritWarriorToken(final SpiritWarriorToken token) {
+    private SpiritWarriorToken(final SpiritWarriorToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KindleTheCarnage.java
+++ b/Mage.Sets/src/mage/cards/k/KindleTheCarnage.java
@@ -45,7 +45,7 @@ class KindleTheCarnageEffect extends OneShotEffect {
         this.staticText = "Discard a card at random. If you do, {this} deals damage equal to that card's mana value to each creature. You may repeat this process any number of times";
     }
 
-    public KindleTheCarnageEffect(final KindleTheCarnageEffect effect) {
+    private KindleTheCarnageEffect(final KindleTheCarnageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KindredCharge.java
+++ b/Mage.Sets/src/mage/cards/k/KindredCharge.java
@@ -54,7 +54,7 @@ class KindredChargeEffect extends OneShotEffect {
                 + "Those tokens gain haste. Exile them at the beginning of the next end step";
     }
 
-    public KindredChargeEffect(final KindredChargeEffect effect) {
+    private KindredChargeEffect(final KindredChargeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KindredDominance.java
+++ b/Mage.Sets/src/mage/cards/k/KindredDominance.java
@@ -47,7 +47,7 @@ class KindredDominanceEffect extends OneShotEffect {
         this.staticText = "Choose a creature type. Destroy all creatures that aren't of the chosen type.";
     }
 
-    public KindredDominanceEffect(final KindredDominanceEffect effect) {
+    private KindredDominanceEffect(final KindredDominanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KindredSummons.java
+++ b/Mage.Sets/src/mage/cards/k/KindredSummons.java
@@ -55,7 +55,7 @@ class KindredSummonsEffect extends OneShotEffect {
                 + "then shuffle the rest of the revealed cards into your library";
     }
 
-    public KindredSummonsEffect(final KindredSummonsEffect effect) {
+    private KindredSummonsEffect(final KindredSummonsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KingNarfisBetrayal.java
+++ b/Mage.Sets/src/mage/cards/k/KingNarfisBetrayal.java
@@ -132,7 +132,7 @@ class KingNarfisBetrayalSecondEffect extends OneShotEffect {
                 " and you may spend mana as though it were mana of any color to cast those spells";
     }
 
-    public KingNarfisBetrayalSecondEffect(final KingNarfisBetrayalSecondEffect effect) {
+    private KingNarfisBetrayalSecondEffect(final KingNarfisBetrayalSecondEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KioraTheCrashingWave.java
+++ b/Mage.Sets/src/mage/cards/k/KioraTheCrashingWave.java
@@ -75,7 +75,7 @@ class KioraPreventionEffect extends PreventionEffectImpl {
         staticText = "Until your next turn, prevent all damage that would be dealt to and dealt by target permanent an opponent controls";
     }
 
-    public KioraPreventionEffect(final KioraPreventionEffect effect) {
+    private KioraPreventionEffect(final KioraPreventionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KiraGreatGlassSpinner.java
+++ b/Mage.Sets/src/mage/cards/k/KiraGreatGlassSpinner.java
@@ -61,7 +61,7 @@ class KiraGreatGlassSpinnerAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect, false);
     }
 
-    public KiraGreatGlassSpinnerAbility(final KiraGreatGlassSpinnerAbility ability) {
+    private KiraGreatGlassSpinnerAbility(final KiraGreatGlassSpinnerAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KirtarsWrath.java
+++ b/Mage.Sets/src/mage/cards/k/KirtarsWrath.java
@@ -50,7 +50,7 @@ class KirtarsWrathEffect extends OneShotEffect {
         this.staticText = "destroy all creatures, then create two 1/1 white Spirit creature tokens with flying. Creatures destroyed this way can't be regenerated";
     }
 
-    public KirtarsWrathEffect(final KirtarsWrathEffect effect) {
+    private KirtarsWrathEffect(final KirtarsWrathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KiteShield.java
+++ b/Mage.Sets/src/mage/cards/k/KiteShield.java
@@ -28,7 +28,7 @@ public final class KiteShield extends CardImpl {
 
     }
 
-    public KiteShield (final KiteShield card) {
+    private KiteShield(final KiteShield card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KitesailFreebooter.java
+++ b/Mage.Sets/src/mage/cards/k/KitesailFreebooter.java
@@ -66,7 +66,7 @@ class KitesailFreebooterExileEffect extends OneShotEffect {
         this.staticText = "target opponent reveals their hand. You choose a noncreature, nonland card from it. Exile that card until {this} leaves the battlefield";
     }
 
-    public KitesailFreebooterExileEffect(final KitesailFreebooterExileEffect effect) {
+    private KitesailFreebooterExileEffect(final KitesailFreebooterExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KithkinArmor.java
+++ b/Mage.Sets/src/mage/cards/k/KithkinArmor.java
@@ -72,7 +72,7 @@ class KithkinArmorCost extends CostImpl {
         this.text = "sacrifice {this}";
     }
 
-    public KithkinArmorCost(KithkinArmorCost cost) {
+    private KithkinArmorCost(final KithkinArmorCost cost) {
         super(cost);
     }
 
@@ -109,7 +109,7 @@ class KithkinArmorRestrictionEffect extends RestrictionEffect {
         staticText = "Enchanted creature can't be blocked by creatures with power 3 or greater";
     }
 
-    public KithkinArmorRestrictionEffect(final KithkinArmorRestrictionEffect effect) {
+    private KithkinArmorRestrictionEffect(final KithkinArmorRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KithkinZealot.java
+++ b/Mage.Sets/src/mage/cards/k/KithkinZealot.java
@@ -63,7 +63,7 @@ class KithkinZealotEffect extends OneShotEffect {
         this.staticText = "you gain 1 life for each black and/or red permanent target opponent controls";
     }
 
-    public KithkinZealotEffect(final KithkinZealotEffect effect) {
+    private KithkinZealotEffect(final KithkinZealotEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KitsuneBlademaster.java
+++ b/Mage.Sets/src/mage/cards/k/KitsuneBlademaster.java
@@ -28,7 +28,7 @@ public final class KitsuneBlademaster extends CardImpl {
         this.addAbility(new BushidoAbility(1));
     }
 
-    public KitsuneBlademaster (final KitsuneBlademaster card) {
+    private KitsuneBlademaster(final KitsuneBlademaster card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KitsuneDiviner.java
+++ b/Mage.Sets/src/mage/cards/k/KitsuneDiviner.java
@@ -41,7 +41,7 @@ public final class KitsuneDiviner extends CardImpl {
         this.addAbility(ability);
     }
 
-    public KitsuneDiviner (final KitsuneDiviner card) {
+    private KitsuneDiviner(final KitsuneDiviner card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KitsuneMystic.java
+++ b/Mage.Sets/src/mage/cards/k/KitsuneMystic.java
@@ -80,7 +80,7 @@ class AutumnTailKitsuneSage extends TokenImpl {
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }
-    public AutumnTailKitsuneSage(final AutumnTailKitsuneSage token) {
+    private AutumnTailKitsuneSage(final AutumnTailKitsuneSage token) {
         super(token);
     }
 
@@ -96,7 +96,7 @@ class AutumnTailEffect extends OneShotEffect {
         this.staticText = "Attach target Aura attached to a creature to another creature";
     }
 
-    public AutumnTailEffect(final AutumnTailEffect effect) {
+    private AutumnTailEffect(final AutumnTailEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KitsunePalliator.java
+++ b/Mage.Sets/src/mage/cards/k/KitsunePalliator.java
@@ -53,7 +53,7 @@ class KitsunePalliatorEffect extends OneShotEffect {
         this.staticText = "Prevent the next 1 damage that would be dealt to each creature and each player this turn";
     }
 
-    public KitsunePalliatorEffect(final KitsunePalliatorEffect effect) {
+    private KitsunePalliatorEffect(final KitsunePalliatorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KiyomaroFirstToStand.java
+++ b/Mage.Sets/src/mage/cards/k/KiyomaroFirstToStand.java
@@ -76,7 +76,7 @@ class KiyomaroFirstToStandDealsDamageTriggeredAbility extends TriggeredAbilityIm
         super(Zone.BATTLEFIELD, new GainLifeEffect(7), false);
     }
 
-    public KiyomaroFirstToStandDealsDamageTriggeredAbility(final KiyomaroFirstToStandDealsDamageTriggeredAbility ability) {
+    private KiyomaroFirstToStandDealsDamageTriggeredAbility(final KiyomaroFirstToStandDealsDamageTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KjeldoranEscort.java
+++ b/Mage.Sets/src/mage/cards/k/KjeldoranEscort.java
@@ -28,7 +28,7 @@ public final class KjeldoranEscort extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public KjeldoranEscort (final KjeldoranEscort card) {
+    private KjeldoranEscort(final KjeldoranEscort card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KjeldoranPhalanx.java
+++ b/Mage.Sets/src/mage/cards/k/KjeldoranPhalanx.java
@@ -32,7 +32,7 @@ public final class KjeldoranPhalanx extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public KjeldoranPhalanx (final KjeldoranPhalanx card) {
+    private KjeldoranPhalanx(final KjeldoranPhalanx card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KjeldoranSkycaptain.java
+++ b/Mage.Sets/src/mage/cards/k/KjeldoranSkycaptain.java
@@ -36,7 +36,7 @@ public final class KjeldoranSkycaptain extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public KjeldoranSkycaptain (final KjeldoranSkycaptain card) {
+    private KjeldoranSkycaptain(final KjeldoranSkycaptain card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KjeldoranSkyknight.java
+++ b/Mage.Sets/src/mage/cards/k/KjeldoranSkyknight.java
@@ -36,7 +36,7 @@ public final class KjeldoranSkyknight extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public KjeldoranSkyknight (final KjeldoranSkyknight card) {
+    private KjeldoranSkyknight(final KjeldoranSkyknight card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KjeldoranWarrior.java
+++ b/Mage.Sets/src/mage/cards/k/KjeldoranWarrior.java
@@ -28,7 +28,7 @@ public final class KjeldoranWarrior extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public KjeldoranWarrior (final KjeldoranWarrior card) {
+    private KjeldoranWarrior(final KjeldoranWarrior card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnacksawClique.java
+++ b/Mage.Sets/src/mage/cards/k/KnacksawClique.java
@@ -68,7 +68,7 @@ class KnacksawCliqueEffect extends OneShotEffect {
         this.staticText = "Target opponent exiles the top card of their library. Until end of turn, you may play that card";
     }
 
-    public KnacksawCliqueEffect(final KnacksawCliqueEffect effect) {
+    private KnacksawCliqueEffect(final KnacksawCliqueEffect effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class KnacksawCliqueCastFromExileEffect extends AsThoughEffectImpl {
         staticText = "Until end of turn, you may play that card";
     }
 
-    public KnacksawCliqueCastFromExileEffect(final KnacksawCliqueCastFromExileEffect effect) {
+    private KnacksawCliqueCastFromExileEffect(final KnacksawCliqueCastFromExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnickknackOuphe.java
+++ b/Mage.Sets/src/mage/cards/k/KnickknackOuphe.java
@@ -68,7 +68,7 @@ class KnickknackOuphePutOntoBattlefieldEffect extends OneShotEffect {
         "Then put all cards revealed this way that weren't put onto the battlefield on the bottom of your library in a random order";
     }
 
-    public KnickknackOuphePutOntoBattlefieldEffect(final KnickknackOuphePutOntoBattlefieldEffect effect) {
+    private KnickknackOuphePutOntoBattlefieldEffect(final KnickknackOuphePutOntoBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnightOfGrace.java
+++ b/Mage.Sets/src/mage/cards/k/KnightOfGrace.java
@@ -45,7 +45,7 @@ public final class KnightOfGrace extends CardImpl {
 
     }
 
-    public KnightOfGrace(final KnightOfGrace knightOfGrace){
+    private KnightOfGrace(final KnightOfGrace knightOfGrace){
         super(knightOfGrace);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnightOfMalice.java
+++ b/Mage.Sets/src/mage/cards/k/KnightOfMalice.java
@@ -43,7 +43,7 @@ public final class KnightOfMalice extends CardImpl {
 
     }
 
-    public KnightOfMalice(final KnightOfMalice knightOfGrace) {
+    private KnightOfMalice(final KnightOfMalice knightOfGrace) {
         super(knightOfGrace);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnightOfNewAlara.java
+++ b/Mage.Sets/src/mage/cards/k/KnightOfNewAlara.java
@@ -63,7 +63,7 @@ class KnightOfNewAlaraEffect extends ContinuousEffectImpl {
         staticText = "Each other multicolored creature you control gets +1/+1 for each of its colors";
     }
 
-    public KnightOfNewAlaraEffect(final KnightOfNewAlaraEffect effect) {
+    private KnightOfNewAlaraEffect(final KnightOfNewAlaraEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnightlyValor.java
+++ b/Mage.Sets/src/mage/cards/k/KnightlyValor.java
@@ -57,7 +57,7 @@ public final class KnightlyValor extends CardImpl {
 
     }
 
-    public KnightlyValor (final KnightlyValor card) {
+    private KnightlyValor(final KnightlyValor card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnightsOfRen.java
+++ b/Mage.Sets/src/mage/cards/k/KnightsOfRen.java
@@ -49,7 +49,7 @@ public class KnightsOfRen extends CardImpl {
         this.addAbility(abilityAttacks, new LifeLossOtherFromCombatWatcher());
     }
 
-    public KnightsOfRen(final KnightsOfRen card) {
+    private KnightsOfRen(final KnightsOfRen card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnightsOfTheBlackRose.java
+++ b/Mage.Sets/src/mage/cards/k/KnightsOfTheBlackRose.java
@@ -60,7 +60,7 @@ class KnightsOfTheBlackRoseTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever an opponent becomes the monarch, if you were the monarch as the turn began, ");
     }
 
-    public KnightsOfTheBlackRoseTriggeredAbility(final KnightsOfTheBlackRoseTriggeredAbility ability) {
+    private KnightsOfTheBlackRoseTriggeredAbility(final KnightsOfTheBlackRoseTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnightsOfThorn.java
+++ b/Mage.Sets/src/mage/cards/k/KnightsOfThorn.java
@@ -33,7 +33,7 @@ public final class KnightsOfThorn extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public KnightsOfThorn (final KnightsOfThorn card) {
+    private KnightsOfThorn(final KnightsOfThorn card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnollspineDragon.java
+++ b/Mage.Sets/src/mage/cards/k/KnollspineDragon.java
@@ -57,7 +57,7 @@ class KnollspineDragonEffect extends OneShotEffect {
         staticText = "you may discard your hand and draw cards equal to the damage dealt to target opponent this turn";
     }
 
-    public KnollspineDragonEffect(KnollspineDragonEffect effect) {
+    private KnollspineDragonEffect(final KnollspineDragonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnowledgePool.java
+++ b/Mage.Sets/src/mage/cards/k/KnowledgePool.java
@@ -61,7 +61,7 @@ class KnowledgePoolExileThreeCardsEffect extends OneShotEffect {
         staticText = "each player exiles the top three cards of their library";
     }
 
-    public KnowledgePoolExileThreeCardsEffect(final KnowledgePoolExileThreeCardsEffect effect) {
+    private KnowledgePoolExileThreeCardsEffect(final KnowledgePoolExileThreeCardsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KodamaOfTheNorthTree.java
+++ b/Mage.Sets/src/mage/cards/k/KodamaOfTheNorthTree.java
@@ -29,7 +29,7 @@ public final class KodamaOfTheNorthTree extends CardImpl {
         this.addAbility(ShroudAbility.getInstance());
     }
 
-    public KodamaOfTheNorthTree (final KodamaOfTheNorthTree card) {
+    private KodamaOfTheNorthTree(final KodamaOfTheNorthTree card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KodamasReach.java
+++ b/Mage.Sets/src/mage/cards/k/KodamasReach.java
@@ -51,7 +51,7 @@ class KodamasReachEffect extends OneShotEffect {
                 "put one onto the battlefield tapped and the other into your hand, then shuffle";
     }
 
-    public KodamasReachEffect(final KodamasReachEffect effect) {
+    private KodamasReachEffect(final KodamasReachEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KokushoTheEveningStar.java
+++ b/Mage.Sets/src/mage/cards/k/KokushoTheEveningStar.java
@@ -50,7 +50,7 @@ class KokushoTheEveningStarEffect extends OneShotEffect {
         staticText = "each opponent loses 5 life. You gain life equal to the life lost this way";
     }
 
-    public KokushoTheEveningStarEffect(final KokushoTheEveningStarEffect effect) {
+    private KokushoTheEveningStarEffect(final KokushoTheEveningStarEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KolaghanMonument.java
+++ b/Mage.Sets/src/mage/cards/k/KolaghanMonument.java
@@ -56,7 +56,7 @@ public final class KolaghanMonument extends CardImpl {
             toughness = new MageInt(4);
             this.addAbility(FlyingAbility.getInstance());
         }
-        public KolaghanMonumentToken(final KolaghanMonumentToken token) {
+        private KolaghanMonumentToken(final KolaghanMonumentToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/k/KondasHatamoto.java
+++ b/Mage.Sets/src/mage/cards/k/KondasHatamoto.java
@@ -46,7 +46,7 @@ public final class KondasHatamoto extends CardImpl {
 
     }
 
-    public KondasHatamoto (final KondasHatamoto card) {
+    private KondasHatamoto(final KondasHatamoto card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KorFirewalker.java
+++ b/Mage.Sets/src/mage/cards/k/KorFirewalker.java
@@ -38,7 +38,7 @@ public final class KorFirewalker extends CardImpl {
 
     }
 
-    public KorFirewalker (final KorFirewalker card) {
+    private KorFirewalker(final KorFirewalker card) {
         super(card);
     }
 
@@ -55,7 +55,7 @@ class KorFirewalkerAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainLifeEffect(1), true);
     }
 
-    public KorFirewalkerAbility(final KorFirewalkerAbility ability) {
+    private KorFirewalkerAbility(final KorFirewalkerAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KorOutfitter.java
+++ b/Mage.Sets/src/mage/cards/k/KorOutfitter.java
@@ -61,7 +61,7 @@ class EquipEffect extends OneShotEffect {
         staticText = "attach target Equipment you control to target creature you control";
     }
 
-    public EquipEffect(final EquipEffect effect) {
+    private EquipEffect(final EquipEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KorSanctifiers.java
+++ b/Mage.Sets/src/mage/cards/k/KorSanctifiers.java
@@ -39,7 +39,7 @@ public final class KorSanctifiers extends CardImpl {
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, KickedCondition.ONCE, "When {this} enters the battlefield, if it was kicked, destroy target artifact or enchantment."));
     }
 
-    public KorSanctifiers (final KorSanctifiers card) {
+    private KorSanctifiers(final KorSanctifiers card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KorSkyfisher.java
+++ b/Mage.Sets/src/mage/cards/k/KorSkyfisher.java
@@ -34,7 +34,7 @@ public final class KorSkyfisher extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new ReturnToHandChosenControlledPermanentEffect(new FilterControlledPermanent()), false));
     }
 
-    public KorSkyfisher (final KorSkyfisher card) {
+    private KorSkyfisher(final KorSkyfisher card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KothOfTheHammer.java
+++ b/Mage.Sets/src/mage/cards/k/KothOfTheHammer.java
@@ -78,7 +78,7 @@ class KothOfTheHammerToken extends TokenImpl {
         this.power = new MageInt(4);
         this.toughness = new MageInt(4);
     }
-    public KothOfTheHammerToken(final KothOfTheHammerToken token) {
+    private KothOfTheHammerToken(final KothOfTheHammerToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KothophedSoulHoarder.java
+++ b/Mage.Sets/src/mage/cards/k/KothophedSoulHoarder.java
@@ -74,7 +74,7 @@ class KothophedSoulHoarderTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature leaves an opponent's graveyard, ");
     }
 
-    public KothophedSoulHoarderTriggeredAbility(final KothophedSoulHoarderTriggeredAbility ability) {
+    private KothophedSoulHoarderTriggeredAbility(final KothophedSoulHoarderTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KothsCourier.java
+++ b/Mage.Sets/src/mage/cards/k/KothsCourier.java
@@ -26,7 +26,7 @@ public final class KothsCourier extends CardImpl {
         this.addAbility(new ForestwalkAbility());
     }
 
-    public KothsCourier (final KothsCourier card) {
+    private KothsCourier(final KothsCourier card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KotoseTheSilentSpider.java
+++ b/Mage.Sets/src/mage/cards/k/KotoseTheSilentSpider.java
@@ -75,7 +75,7 @@ class KotoseTheSilentSpiderEffect extends OneShotEffect {
                 "play one of the exiled cards, and you may spend mana as though it were mana of any color to cast it";
     }
 
-    public KotoseTheSilentSpiderEffect(final KotoseTheSilentSpiderEffect effect) {
+    private KotoseTheSilentSpiderEffect(final KotoseTheSilentSpiderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KozilekTheGreatDistortion.java
+++ b/Mage.Sets/src/mage/cards/k/KozilekTheGreatDistortion.java
@@ -78,7 +78,7 @@ class KozilekDrawEffect extends OneShotEffect {
         this.staticText = "if you have fewer than seven cards in hand, draw cards equal to the difference";
     }
 
-    public KozilekDrawEffect(final KozilekDrawEffect effect) {
+    private KozilekDrawEffect(final KozilekDrawEffect effect) {
         super(effect);
     }
 
@@ -104,7 +104,7 @@ class KozilekDiscardCost extends CostImpl {
         this.text = "discard a card with mana value X";
     }
 
-    public KozilekDiscardCost(final KozilekDiscardCost cost) {
+    private KozilekDiscardCost(final KozilekDiscardCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KrakenOfTheStraits.java
+++ b/Mage.Sets/src/mage/cards/k/KrakenOfTheStraits.java
@@ -59,7 +59,7 @@ class CantBeBlockedByCreaturesWithLessPowerEffect extends RestrictionEffect {
         staticText = "Creatures with power less than the number of Islands you control can't block {this}";
     }
 
-    public CantBeBlockedByCreaturesWithLessPowerEffect(final CantBeBlockedByCreaturesWithLessPowerEffect effect) {
+    private CantBeBlockedByCreaturesWithLessPowerEffect(final CantBeBlockedByCreaturesWithLessPowerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KrakensEye.java
+++ b/Mage.Sets/src/mage/cards/k/KrakensEye.java
@@ -42,7 +42,7 @@ class KrakensEyeAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainLifeEffect(1), true);
     }
 
-    public KrakensEyeAbility(final KrakensEyeAbility ability) {
+    private KrakensEyeAbility(final KrakensEyeAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/Kranioceros.java
+++ b/Mage.Sets/src/mage/cards/k/Kranioceros.java
@@ -30,7 +30,7 @@ public final class Kranioceros extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(0, 3, Duration.EndOfTurn), new ManaCostsImpl<>("{1}{W}")));
     }
 
-    public Kranioceros (final Kranioceros card) {
+    private Kranioceros(final Kranioceros card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KraulHarpooner.java
+++ b/Mage.Sets/src/mage/cards/k/KraulHarpooner.java
@@ -73,7 +73,7 @@ class KraulHarpoonerEffect extends OneShotEffect {
                 + "then you may have {this} fight that creature.";
     }
 
-    public KraulHarpoonerEffect(final KraulHarpoonerEffect effect) {
+    private KraulHarpoonerEffect(final KraulHarpoonerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KraulWarrior.java
+++ b/Mage.Sets/src/mage/cards/k/KraulWarrior.java
@@ -35,7 +35,7 @@ public final class KraulWarrior extends CardImpl {
 
     }
 
-    public KraulWarrior (final KraulWarrior card) {
+    private KraulWarrior(final KraulWarrior card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KrovikanElementalist.java
+++ b/Mage.Sets/src/mage/cards/k/KrovikanElementalist.java
@@ -71,7 +71,7 @@ class KrovikanElementalistEffect extends OneShotEffect {
         this.staticText = "Sacrifice it at the beginning of the next end step";
     }
 
-    public KrovikanElementalistEffect(final KrovikanElementalistEffect effect) {
+    private KrovikanElementalistEffect(final KrovikanElementalistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KrrikSonOfYawgmoth.java
+++ b/Mage.Sets/src/mage/cards/k/KrrikSonOfYawgmoth.java
@@ -78,7 +78,7 @@ class KrrikSonOfYawgmothPhyrexianEffect extends ContinuousEffectImpl {
         this.staticText = "for each {B} in a cost, you may pay 2 life rather than pay that mana";
     }
 
-    public KrrikSonOfYawgmothPhyrexianEffect(final KrrikSonOfYawgmothPhyrexianEffect effect) {
+    private KrrikSonOfYawgmothPhyrexianEffect(final KrrikSonOfYawgmothPhyrexianEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/Kudzu.java
+++ b/Mage.Sets/src/mage/cards/k/Kudzu.java
@@ -60,7 +60,7 @@ class KudzuEffect extends OneShotEffect {
         staticText = "destroy it. That land's controller attaches {this} to a land of their choice";
     }
 
-    public KudzuEffect(final KudzuEffect effect) {
+    private KudzuEffect(final KudzuEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KuldothaRingleader.java
+++ b/Mage.Sets/src/mage/cards/k/KuldothaRingleader.java
@@ -28,7 +28,7 @@ public final class KuldothaRingleader extends CardImpl {
         this.addAbility(new AttacksEachCombatStaticAbility());
     }
 
-    public KuldothaRingleader (final KuldothaRingleader card) {
+    private KuldothaRingleader(final KuldothaRingleader card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KulrathKnight.java
+++ b/Mage.Sets/src/mage/cards/k/KulrathKnight.java
@@ -63,7 +63,7 @@ class KulrathKnightRestrictionEffect extends RestrictionEffect {
         staticText = "Creatures your opponents control with counters on them can't attack or block.";
     }
 
-    public KulrathKnightRestrictionEffect(final KulrathKnightRestrictionEffect effect) {
+    private KulrathKnightRestrictionEffect(final KulrathKnightRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KumanosBlessing.java
+++ b/Mage.Sets/src/mage/cards/k/KumanosBlessing.java
@@ -64,7 +64,7 @@ class KumanosBlessingEffect extends ReplacementEffectImpl {
         staticText = "If a creature dealt damage by enchanted creature this turn would die, exile it instead";
     }
 
-    public KumanosBlessingEffect(final KumanosBlessingEffect effect) {
+    private KumanosBlessingEffect(final KumanosBlessingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KuonOgreAscendant.java
+++ b/Mage.Sets/src/mage/cards/k/KuonOgreAscendant.java
@@ -72,7 +72,7 @@ class KuonsEssenceToken extends TokenImpl {
                 new SacrificeEffect(StaticFilters.FILTER_PERMANENT_CREATURE, 1, "that player"),
                 TargetController.ANY, false, true));
     }
-    public KuonsEssenceToken(final KuonsEssenceToken token) {
+    private KuonsEssenceToken(final KuonsEssenceToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KusariGama.java
+++ b/Mage.Sets/src/mage/cards/k/KusariGama.java
@@ -68,7 +68,7 @@ class KusariGamaAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new KusariGamaDamageEffect());
     }
 
-    public KusariGamaAbility(final KusariGamaAbility ability) {
+    private KusariGamaAbility(final KusariGamaAbility ability) {
         super(ability);
     }
 
@@ -107,7 +107,7 @@ class KusariGamaDamageEffect extends OneShotEffect {
         this.staticText = "{this} deals that much damage to each other creature defending player controls";
     }
 
-    public KusariGamaDamageEffect(final KusariGamaDamageEffect effect) {
+    private KusariGamaDamageEffect(final KusariGamaDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KyloRen.java
+++ b/Mage.Sets/src/mage/cards/k/KyloRen.java
@@ -83,7 +83,7 @@ class KyloRenTapTargetEffect extends TapTargetEffect {
         this.staticText = "and you may tap target creature defending player controls";
     }
 
-    public KyloRenTapTargetEffect(final KyloRenTapTargetEffect effect) {
+    private KyloRenTapTargetEffect(final KyloRenTapTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KynaiosAndTiroOfMeletis.java
+++ b/Mage.Sets/src/mage/cards/k/KynaiosAndTiroOfMeletis.java
@@ -62,7 +62,7 @@ class KynaiosAndTirosEffect extends OneShotEffect {
         staticText = "draw a card. Each player may put a land card from their hand onto the battlefield, then each opponent who didn't draws a card";
     }
 
-    public KynaiosAndTirosEffect(final KynaiosAndTirosEffect effect) {
+    private KynaiosAndTirosEffect(final KynaiosAndTirosEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LaboratoryManiac.java
+++ b/Mage.Sets/src/mage/cards/l/LaboratoryManiac.java
@@ -54,7 +54,7 @@ class LaboratoryManiacEffect extends ReplacementEffectImpl {
         staticText = "If you would draw a card while your library has no cards in it, you win the game instead";
     }
 
-    public LaboratoryManiacEffect(final LaboratoryManiacEffect effect) {
+    private LaboratoryManiacEffect(final LaboratoryManiacEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LabyrinthGuardian.java
+++ b/Mage.Sets/src/mage/cards/l/LabyrinthGuardian.java
@@ -57,7 +57,7 @@ class LabyrinthGuardianTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SacrificeSourceEffect(), false);
     }
 
-    public LabyrinthGuardianTriggeredAbility(final LabyrinthGuardianTriggeredAbility ability) {
+    private LabyrinthGuardianTriggeredAbility(final LabyrinthGuardianTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LaccolithRig.java
+++ b/Mage.Sets/src/mage/cards/l/LaccolithRig.java
@@ -57,7 +57,7 @@ class LaccolithRigEffect extends OneShotEffect {
         this.staticText = "it deal damage equal to its power to target creature";
     }
 
-    public LaccolithRigEffect(final LaccolithRigEffect effect) {
+    private LaccolithRigEffect(final LaccolithRigEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LagacLizard.java
+++ b/Mage.Sets/src/mage/cards/l/LagacLizard.java
@@ -23,7 +23,7 @@ public final class LagacLizard extends CardImpl {
         this.toughness = new MageInt(3);
     }
 
-    public LagacLizard (final LagacLizard card) {
+    private LagacLizard(final LagacLizard card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LambholtPacifist.java
+++ b/Mage.Sets/src/mage/cards/l/LambholtPacifist.java
@@ -62,7 +62,7 @@ class LambholtPacifistEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless you control a creature with power 4 or greater";
     }
 
-    public LambholtPacifistEffect(final LambholtPacifistEffect effect) {
+    private LambholtPacifistEffect(final LambholtPacifistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LandEquilibrium.java
+++ b/Mage.Sets/src/mage/cards/l/LandEquilibrium.java
@@ -43,7 +43,7 @@ class LandEquilibriumAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SacrificeEffect(StaticFilters.FILTER_LAND, 1, ""), false);
     }
 
-    public LandEquilibriumAbility(final LandEquilibriumAbility ability) {
+    private LandEquilibriumAbility(final LandEquilibriumAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LandGrant.java
+++ b/Mage.Sets/src/mage/cards/l/LandGrant.java
@@ -74,7 +74,7 @@ class LandGrantReavealCost extends CostImpl {
         this.text = "reveal your hand";
     }
 
-    public LandGrantReavealCost(LandGrantReavealCost cost) {
+    private LandGrantReavealCost(final LandGrantReavealCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LandsEdge.java
+++ b/Mage.Sets/src/mage/cards/l/LandsEdge.java
@@ -57,7 +57,7 @@ class LandsEdgeEffect extends OneShotEffect {
         staticText = "If the discarded card was a land card, {this} deals 2 damage to target player";
     }
 
-    public LandsEdgeEffect(final LandsEdgeEffect effect) {
+    private LandsEdgeEffect(final LandsEdgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Landslide.java
+++ b/Mage.Sets/src/mage/cards/l/Landslide.java
@@ -55,7 +55,7 @@ class LandslideEffect extends OneShotEffect {
         staticText = "Sacrifice any number of Mountains. {this} deals that much damage to target player or planeswalker";
     }
 
-    public LandslideEffect(final LandslideEffect effect) {
+    private LandslideEffect(final LandslideEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LanternKami.java
+++ b/Mage.Sets/src/mage/cards/l/LanternKami.java
@@ -25,7 +25,7 @@ public final class LanternKami extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public LanternKami (final LanternKami card) {
+    private LanternKami(final LanternKami card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LaquatussChampion.java
+++ b/Mage.Sets/src/mage/cards/l/LaquatussChampion.java
@@ -63,7 +63,7 @@ class LaquatussChampionEntersBattlefieldTriggeredAbility extends EntersBattlefie
         super(effect, false);
     }
 
-    public LaquatussChampionEntersBattlefieldTriggeredAbility(final LaquatussChampionEntersBattlefieldTriggeredAbility ability) {
+    private LaquatussChampionEntersBattlefieldTriggeredAbility(final LaquatussChampionEntersBattlefieldTriggeredAbility ability) {
         super(ability);
     }
 
@@ -92,7 +92,7 @@ class LaquatussChampionLeavesBattlefieldTriggeredAbility extends LeavesBattlefie
         super(new GainLifeTargetEffect(6), false);
     }
 
-    public LaquatussChampionLeavesBattlefieldTriggeredAbility(LaquatussChampionLeavesBattlefieldTriggeredAbility ability) {
+    private LaquatussChampionLeavesBattlefieldTriggeredAbility(final LaquatussChampionLeavesBattlefieldTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LaquatussCreativity.java
+++ b/Mage.Sets/src/mage/cards/l/LaquatussCreativity.java
@@ -45,7 +45,7 @@ class LaquatussCreativityEffect extends OneShotEffect {
         this.staticText = "Target player draws cards equal to the number of cards in their hand, then discards that many cards.";
     }
     
-    public LaquatussCreativityEffect(final LaquatussCreativityEffect effect) {
+    private LaquatussCreativityEffect(final LaquatussCreativityEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/l/Larceny.java
+++ b/Mage.Sets/src/mage/cards/l/Larceny.java
@@ -46,7 +46,7 @@ class LarcenyTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DiscardTargetEffect(1), false);
     }
 
-    public LarcenyTriggeredAbility(final LarcenyTriggeredAbility ability) {
+    private LarcenyTriggeredAbility(final LarcenyTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LashOut.java
+++ b/Mage.Sets/src/mage/cards/l/LashOut.java
@@ -45,7 +45,7 @@ class LashOutEffect extends OneShotEffect {
         this.staticText = "Lash Out deals 3 damage to target creature. Clash with an opponent. If you win, Lash Out deals 3 damage to that creature's controller";
     }
 
-    public LashOutEffect(final LashOutEffect effect) {
+    private LashOutEffect(final LashOutEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LashknifeBarrier.java
+++ b/Mage.Sets/src/mage/cards/l/LashknifeBarrier.java
@@ -49,7 +49,7 @@ class LashknifeBarrierEffect extends ReplacementEffectImpl {
         staticText = "If a source would deal damage to a creature you control, it deals that much damage minus 1 to that creature instead.";
     }
 
-    public LashknifeBarrierEffect(final LashknifeBarrierEffect effect) {
+    private LashknifeBarrierEffect(final LashknifeBarrierEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LastKiss.java
+++ b/Mage.Sets/src/mage/cards/l/LastKiss.java
@@ -24,7 +24,7 @@ public final class LastKiss extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public LastKiss (final LastKiss card) {
+    private LastKiss(final LastKiss card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LastLaugh.java
+++ b/Mage.Sets/src/mage/cards/l/LastLaugh.java
@@ -55,7 +55,7 @@ class LastLaughStateTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("When no creatures are on the battlefield, ");
     }
 
-    public LastLaughStateTriggeredAbility(final LastLaughStateTriggeredAbility ability) {
+    private LastLaughStateTriggeredAbility(final LastLaughStateTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LastStand.java
+++ b/Mage.Sets/src/mage/cards/l/LastStand.java
@@ -63,7 +63,7 @@ class LastStandEffect extends OneShotEffect {
         this.staticText = "Target opponent loses 2 life for each Swamp you control. Last Stand deals damage to target creature equal to the number of Mountains you control. Create a 1/1 green Saproling creature token for each Forest you control. You gain 2 life for each Plains you control. Draw a card for each Island you control, then discard that many cards";
     }
 
-    public LastStandEffect(final LastStandEffect effect) {
+    private LastStandEffect(final LastStandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LastWord.java
+++ b/Mage.Sets/src/mage/cards/l/LastWord.java
@@ -24,7 +24,7 @@ public final class LastWord extends CardImpl {
         this.getSpellAbility().addTarget(new TargetSpell());
     }
 
-    public LastWord (final LastWord card) {
+    private LastWord(final LastWord card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LatNamsLegacy.java
+++ b/Mage.Sets/src/mage/cards/l/LatNamsLegacy.java
@@ -48,7 +48,7 @@ class LatNamsLegacyEffect extends OneShotEffect {
         staticText = "Shuffle a card from your hand into your library. If you do, draw two cards at the beginning of the next turn's upkeep";
     }
 
-    public LatNamsLegacyEffect(LatNamsLegacyEffect effect) {
+    private LatNamsLegacyEffect(final LatNamsLegacyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LatullasOrders.java
+++ b/Mage.Sets/src/mage/cards/l/LatullasOrders.java
@@ -63,7 +63,7 @@ class LatullasOrdersTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), true);
     }
 
-    public LatullasOrdersTriggeredAbility(final LatullasOrdersTriggeredAbility ability) {
+    private LatullasOrdersTriggeredAbility(final LatullasOrdersTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LavaBlister.java
+++ b/Mage.Sets/src/mage/cards/l/LavaBlister.java
@@ -43,7 +43,7 @@ class LavaBlisterEffect extends OneShotEffect {
         this.staticText = "Destroy target nonbasic land unless its controller has {this} deal 6 damage to them";
     }
 
-    public LavaBlisterEffect(final LavaBlisterEffect effect) {
+    private LavaBlisterEffect(final LavaBlisterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LavaRunner.java
+++ b/Mage.Sets/src/mage/cards/l/LavaRunner.java
@@ -52,7 +52,7 @@ class LavaRunnerAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SacrificeEffect(new FilterLandPermanent(), 1, ""), false);
     }
 
-    public LavaRunnerAbility(final LavaRunnerAbility ability) {
+    private LavaRunnerAbility(final LavaRunnerAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LavaclawReaches.java
+++ b/Mage.Sets/src/mage/cards/l/LavaclawReaches.java
@@ -62,7 +62,7 @@ class LavaclawReachesToken extends TokenImpl {
         toughness = new MageInt(2);
         addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(ManacostVariableValue.REGULAR, StaticValue.get(0), Duration.EndOfTurn), new ManaCostsImpl<>("{X}")));
     }
-    public LavaclawReachesToken(final LavaclawReachesToken token) {
+    private LavaclawReachesToken(final LavaclawReachesToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Lavalanche.java
+++ b/Mage.Sets/src/mage/cards/l/Lavalanche.java
@@ -52,7 +52,7 @@ class LavalancheEffect extends OneShotEffect {
         staticText = "{this} deals X damage to target player or planeswalker and each creature that player or that planeswalker's controller controls";
     }
 
-    public LavalancheEffect(final LavalancheEffect effect) {
+    private LavalancheEffect(final LavalancheEffect effect) {
         super(effect);
         this.amount = effect.amount;
     }

--- a/Mage.Sets/src/mage/cards/l/LaviniaOfTheTenth.java
+++ b/Mage.Sets/src/mage/cards/l/LaviniaOfTheTenth.java
@@ -49,7 +49,7 @@ public final class LaviniaOfTheTenth  extends CardImpl {
 
     }
 
-    public LaviniaOfTheTenth (final LaviniaOfTheTenth card) {
+    private LaviniaOfTheTenth(final LaviniaOfTheTenth card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LayBare.java
+++ b/Mage.Sets/src/mage/cards/l/LayBare.java
@@ -48,7 +48,7 @@ class LayBareEffect extends OneShotEffect {
         staticText = "Look at its controller's hand";
     }
 
-    public LayBareEffect(final LayBareEffect effect) {
+    private LayBareEffect(final LayBareEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LazotepConvert.java
+++ b/Mage.Sets/src/mage/cards/l/LazotepConvert.java
@@ -76,7 +76,7 @@ class LazotepConvertCopyEffect extends OneShotEffect {
                 "except it's a 4/4 black Zombie in addition to its other types";
     }
 
-    public LazotepConvertCopyEffect(final LazotepConvertCopyEffect effect) {
+    private LazotepConvertCopyEffect(final LazotepConvertCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeadenMyr.java
+++ b/Mage.Sets/src/mage/cards/l/LeadenMyr.java
@@ -24,7 +24,7 @@ public final class LeadenMyr extends CardImpl {
         this.addAbility(new BlackManaAbility());
     }
 
-    public LeadenMyr (final LeadenMyr card) {
+    private LeadenMyr(final LeadenMyr card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeafCrownedElder.java
+++ b/Mage.Sets/src/mage/cards/l/LeafCrownedElder.java
@@ -53,7 +53,7 @@ class LeafCrownedElderPlayEffect extends OneShotEffect {
         staticText = "you may play that card without paying its mana cost";
     }
 
-    public LeafCrownedElderPlayEffect(final LeafCrownedElderPlayEffect effect) {
+    private LeafCrownedElderPlayEffect(final LeafCrownedElderPlayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeatherbackBaloth.java
+++ b/Mage.Sets/src/mage/cards/l/LeatherbackBaloth.java
@@ -23,7 +23,7 @@ public final class LeatherbackBaloth extends CardImpl {
         this.toughness = new MageInt(5);
     }
 
-    public LeatherbackBaloth (final LeatherbackBaloth card) {
+    private LeatherbackBaloth(final LeatherbackBaloth card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LedevChampion.java
+++ b/Mage.Sets/src/mage/cards/l/LedevChampion.java
@@ -71,7 +71,7 @@ class LedevChampionEffect extends OneShotEffect {
                 + "{this} gets +1/+1 until end of turn for each creature tapped this way.";
     }
 
-    public LedevChampionEffect(LedevChampionEffect effect) {
+    private LedevChampionEffect(final LedevChampionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeechBonder.java
+++ b/Mage.Sets/src/mage/cards/l/LeechBonder.java
@@ -81,7 +81,7 @@ class LeechBonderEffect extends OneShotEffect {
         this.staticText = "Move a counter from target creature onto a second target creature";
     }
 
-    public LeechBonderEffect(final LeechBonderEffect effect) {
+    private LeechBonderEffect(final LeechBonderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Leeches.java
+++ b/Mage.Sets/src/mage/cards/l/Leeches.java
@@ -43,7 +43,7 @@ class LeechesEffect extends OneShotEffect {
         this.staticText = "Target player loses all poison counters. Leeches deals that much damage to that player";
     }
 
-    public LeechesEffect(final LeechesEffect effect) {
+    private LeechesEffect(final LeechesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeechingBite.java
+++ b/Mage.Sets/src/mage/cards/l/LeechingBite.java
@@ -59,7 +59,7 @@ class LeechingBiteEffect extends ContinuousEffectImpl {
         this.staticText = "Target creature gets +1/+1 until end of turn. Another target creature gets -1/-1 until end of turn";
     }
     
-    public LeechingBiteEffect(final LeechingBiteEffect effect) {
+    private LeechingBiteEffect(final LeechingBiteEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/l/LegacyOfTheBeloved.java
+++ b/Mage.Sets/src/mage/cards/l/LegacyOfTheBeloved.java
@@ -58,7 +58,7 @@ class LegacyOfTheBelovedEffect extends OneShotEffect {
         this.staticText = "Search you library for up to two creatures cards that each have a lower mana value that sacrificied creature's mana value, reveal them and put them onto the battlefield, then shuffle you library";
     }
 
-    public LegacyOfTheBelovedEffect(final LegacyOfTheBelovedEffect effect) {
+    private LegacyOfTheBelovedEffect(final LegacyOfTheBelovedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LegionLoyalist.java
+++ b/Mage.Sets/src/mage/cards/l/LegionLoyalist.java
@@ -61,7 +61,7 @@ class CantBeBlockedByTokenEffect extends RestrictionEffect {
         staticText = "Creatures you control can't be blocked by tokens this turn";
     }
 
-    public CantBeBlockedByTokenEffect(final CantBeBlockedByTokenEffect effect) {
+    private CantBeBlockedByTokenEffect(final CantBeBlockedByTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LegionWarboss.java
+++ b/Mage.Sets/src/mage/cards/l/LegionWarboss.java
@@ -67,7 +67,7 @@ class LegionWarbossEffect extends OneShotEffect {
                 + "and attacks this combat if able";
     }
 
-    public LegionWarbossEffect(final LegionWarbossEffect effect) {
+    private LegionWarbossEffect(final LegionWarbossEffect effect) {
         super(effect);
     }
 
@@ -110,7 +110,7 @@ class LegionWarbossAbility extends StaticAbility {
         ).setText("this creature attacks this combat if able"));
     }
 
-    public LegionWarbossAbility(LegionWarbossAbility ability) {
+    private LegionWarbossAbility(final LegionWarbossAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LegionsLanding.java
+++ b/Mage.Sets/src/mage/cards/l/LegionsLanding.java
@@ -55,7 +55,7 @@ class LegionsLandingTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When you attack with three or more creatures, " );
     }
 
-    public LegionsLandingTriggeredAbility(final LegionsLandingTriggeredAbility ability) {
+    private LegionsLandingTriggeredAbility(final LegionsLandingTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LenaSelflessChampion.java
+++ b/Mage.Sets/src/mage/cards/l/LenaSelflessChampion.java
@@ -77,7 +77,7 @@ class LenaSelflessChampionEffect extends OneShotEffect {
                 + "{this}'s power gain indestructible until end of turn";
     }
 
-    public LenaSelflessChampionEffect(final LenaSelflessChampionEffect effect) {
+    private LenaSelflessChampionEffect(final LenaSelflessChampionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LensOfClarity.java
+++ b/Mage.Sets/src/mage/cards/l/LensOfClarity.java
@@ -55,7 +55,7 @@ class LensOfClarityLookLibraryAbility extends ActivatedAbilityImpl {
         this.usesStack = false;
     }
 
-    public LensOfClarityLookLibraryAbility(LensOfClarityLookLibraryAbility ability) {
+    private LensOfClarityLookLibraryAbility(final LensOfClarityLookLibraryAbility ability) {
         super(ability);
     }
 
@@ -73,7 +73,7 @@ class LensOfClarityLookLibraryEffect extends OneShotEffect {
         this.staticText = "You may look at the top card of your library";
     }
 
-    public LensOfClarityLookLibraryEffect(final LensOfClarityLookLibraryEffect effect) {
+    private LensOfClarityLookLibraryEffect(final LensOfClarityLookLibraryEffect effect) {
         super(effect);
     }
 
@@ -118,7 +118,7 @@ class LensOfClarityLookFaceDownAbility extends ActivatedAbilityImpl {
         this.addTarget(new TargetCreaturePermanent(filter));
     }
 
-    public LensOfClarityLookFaceDownAbility(LensOfClarityLookFaceDownAbility ability) {
+    private LensOfClarityLookFaceDownAbility(final LensOfClarityLookFaceDownAbility ability) {
         super(ability);
     }
 
@@ -136,7 +136,7 @@ class LensOfClarityLookFaceDownEffect extends OneShotEffect {
         this.staticText = "You may look at face-down creatures you don't control";
     }
 
-    public LensOfClarityLookFaceDownEffect(final LensOfClarityLookFaceDownEffect effect) {
+    private LensOfClarityLookFaceDownEffect(final LensOfClarityLookFaceDownEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeoninArbiter.java
+++ b/Mage.Sets/src/mage/cards/l/LeoninArbiter.java
@@ -59,7 +59,7 @@ class LeoninArbiterSpecialAction extends SpecialAction {
         this.setMayActivate(TargetController.ANY);
     }
 
-    public LeoninArbiterSpecialAction(final LeoninArbiterSpecialAction ability) {
+    private LeoninArbiterSpecialAction(final LeoninArbiterSpecialAction ability) {
         super(ability);
     }
 
@@ -79,7 +79,7 @@ class LeoninArbiterIgnoreEffect extends OneShotEffect {
         this.staticText = "Any player may pay {2} for that player to ignore this effect until end of turn";
     }
 
-    public LeoninArbiterIgnoreEffect(final LeoninArbiterIgnoreEffect effect) {
+    private LeoninArbiterIgnoreEffect(final LeoninArbiterIgnoreEffect effect) {
         super(effect);
         this.keyString = effect.keyString;
     }
@@ -120,7 +120,7 @@ class LeoninArbiterCantSearchEffect extends ContinuousRuleModifyingEffectImpl {
         this.keyString = keyString;
     }
 
-    public LeoninArbiterCantSearchEffect(LeoninArbiterCantSearchEffect effect) {
+    private LeoninArbiterCantSearchEffect(final LeoninArbiterCantSearchEffect effect) {
         super(effect);
         this.keyString = effect.keyString;
     }

--- a/Mage.Sets/src/mage/cards/l/LeoninRelicWarder.java
+++ b/Mage.Sets/src/mage/cards/l/LeoninRelicWarder.java
@@ -40,7 +40,7 @@ public final class LeoninRelicWarder extends CardImpl {
         this.addAbility(ability2);
     }
 
-    public LeoninRelicWarder (final LeoninRelicWarder card) {
+    private LeoninRelicWarder(final LeoninRelicWarder card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeoninSkyhunter.java
+++ b/Mage.Sets/src/mage/cards/l/LeoninSkyhunter.java
@@ -26,7 +26,7 @@ public final class LeoninSkyhunter extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public LeoninSkyhunter (final LeoninSkyhunter card) {
+    private LeoninSkyhunter(final LeoninSkyhunter card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeovoldEmissaryOfTrest.java
+++ b/Mage.Sets/src/mage/cards/l/LeovoldEmissaryOfTrest.java
@@ -55,7 +55,7 @@ class LeovoldEmissaryOfTrestEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Each opponent can't draw more than one card each turn";
     }
 
-    public LeovoldEmissaryOfTrestEffect(final LeovoldEmissaryOfTrestEffect effect) {
+    private LeovoldEmissaryOfTrestEffect(final LeovoldEmissaryOfTrestEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LesserWerewolf.java
+++ b/Mage.Sets/src/mage/cards/l/LesserWerewolf.java
@@ -66,7 +66,7 @@ class LesserWerewolfEffect extends OneShotEffect {
         this.staticText = "If {this}'s power is 1 or more, it gets -1/-0 until end of turn and put a -0/-1 counter on target creature blocking or blocked by {this}";
     }
 
-    public LesserWerewolfEffect(final LesserWerewolfEffect effect) {
+    private LesserWerewolfEffect(final LesserWerewolfEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LethalScheme.java
+++ b/Mage.Sets/src/mage/cards/l/LethalScheme.java
@@ -60,7 +60,7 @@ class LethalSchemeEffect extends OneShotEffect {
         this.staticText = "Each creature that convoked {this} connives.";
     }
 
-    public LethalSchemeEffect(final LethalSchemeEffect effect) {
+    private LethalSchemeEffect(final LethalSchemeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LethalSting.java
+++ b/Mage.Sets/src/mage/cards/l/LethalSting.java
@@ -52,7 +52,7 @@ class LethalStingCost extends CostImpl {
         this.text = "put a -1/-1 counter on a creature you control";
     }
 
-    public LethalStingCost(LethalStingCost cost) {
+    private LethalStingCost(final LethalStingCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Levitation.java
+++ b/Mage.Sets/src/mage/cards/l/Levitation.java
@@ -25,7 +25,7 @@ public final class Levitation extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityControlledEffect(FlyingAbility.getInstance(), Duration.WhileOnBattlefield, StaticFilters.FILTER_PERMANENT_CREATURES, false)));
     }
 
-    public Levitation (final Levitation card) {
+    private Levitation(final Levitation card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeyLine.java
+++ b/Mage.Sets/src/mage/cards/l/LeyLine.java
@@ -61,7 +61,7 @@ class LeyLineEffect extends OneShotEffect {
         staticText = "that player may put a +1/+1 counter on target creature of their choice";
     }
 
-    public LeyLineEffect(LeyLineEffect effect) {
+    private LeyLineEffect(final LeyLineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeylineOfPunishment.java
+++ b/Mage.Sets/src/mage/cards/l/LeylineOfPunishment.java
@@ -53,7 +53,7 @@ class LeylineOfPunishmentEffect2 extends ContinuousRuleModifyingEffectImpl {
         staticText = "Damage can't be prevented";
     }
 
-    public LeylineOfPunishmentEffect2(final LeylineOfPunishmentEffect2 effect) {
+    private LeylineOfPunishmentEffect2(final LeylineOfPunishmentEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeylineOfSingularity.java
+++ b/Mage.Sets/src/mage/cards/l/LeylineOfSingularity.java
@@ -49,7 +49,7 @@ class SetSupertypeAllEffect extends ContinuousEffectImpl {
         this.staticText = "All nonland permanents are legendary";
     }
 
-    public SetSupertypeAllEffect(final SetSupertypeAllEffect effect) {
+    private SetSupertypeAllEffect(final SetSupertypeAllEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeylineOfTheVoid.java
+++ b/Mage.Sets/src/mage/cards/l/LeylineOfTheVoid.java
@@ -53,7 +53,7 @@ class LeylineOfTheVoidEffect extends ReplacementEffectImpl {
         staticText = "If a card would be put into an opponent's graveyard from anywhere, exile it instead";
     }
 
-    public LeylineOfTheVoidEffect(final LeylineOfTheVoidEffect effect) {
+    private LeylineOfTheVoidEffect(final LeylineOfTheVoidEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeylinePhantom.java
+++ b/Mage.Sets/src/mage/cards/l/LeylinePhantom.java
@@ -48,7 +48,7 @@ class LeylinePhantomTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} deals combat damage, ");
     }
 
-    public LeylinePhantomTriggeredAbility(final LeylinePhantomTriggeredAbility ability) {
+    private LeylinePhantomTriggeredAbility(final LeylinePhantomTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Liability.java
+++ b/Mage.Sets/src/mage/cards/l/Liability.java
@@ -51,7 +51,7 @@ class LiabilityEffect extends OneShotEffect {
         this.staticText = "that player loses 1 life.";
     }
 
-    public LiabilityEffect(final LiabilityEffect effect) {
+    private LiabilityEffect(final LiabilityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LiarsPendulum.java
+++ b/Mage.Sets/src/mage/cards/l/LiarsPendulum.java
@@ -51,7 +51,7 @@ class LiarsPendulumEffect extends OneShotEffect {
         this.staticText = "Choose a card name. Target opponent guesses whether a card with that name is in your hand. You may reveal your hand. If you do and your opponent guessed wrong, draw a card";
     }
 
-    public LiarsPendulumEffect(final LiarsPendulumEffect effect) {
+    private LiarsPendulumEffect(final LiarsPendulumEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LibraryOfLeng.java
+++ b/Mage.Sets/src/mage/cards/l/LibraryOfLeng.java
@@ -55,7 +55,7 @@ class LibraryOfLengEffect extends ReplacementEffectImpl {
         staticText = "If an effect causes you to discard a card, discard it, but you may put it on top of your library instead of into your graveyard";
     }
 
-    public LibraryOfLengEffect(final LibraryOfLengEffect effect) {
+    private LibraryOfLengEffect(final LibraryOfLengEffect effect) {
         super(effect);
         this.cardId = effect.cardId;
         this.zoneChangeCounter = effect.zoneChangeCounter;

--- a/Mage.Sets/src/mage/cards/l/LichsMastery.java
+++ b/Mage.Sets/src/mage/cards/l/LichsMastery.java
@@ -79,7 +79,7 @@ class LichsMasteryCantLoseEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "You can't lose the game";
     }
 
-    public LichsMasteryCantLoseEffect(final LichsMasteryCantLoseEffect effect) {
+    private LichsMasteryCantLoseEffect(final LichsMasteryCantLoseEffect effect) {
         super(effect);
     }
 
@@ -106,7 +106,7 @@ class LichsMasteryDrawCardsEffect extends OneShotEffect {
         this.staticText = "draw that many cards";
     }
 
-    public LichsMasteryDrawCardsEffect(final LichsMasteryDrawCardsEffect effect) {
+    private LichsMasteryDrawCardsEffect(final LichsMasteryDrawCardsEffect effect) {
         super(effect);
     }
 
@@ -131,7 +131,7 @@ class LichsMasteryLoseLifeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new LichsMasteryLoseLifeEffect(), false);
     }
 
-    public LichsMasteryLoseLifeTriggeredAbility(final LichsMasteryLoseLifeTriggeredAbility ability) {
+    private LichsMasteryLoseLifeTriggeredAbility(final LichsMasteryLoseLifeTriggeredAbility ability) {
         super(ability);
     }
 
@@ -173,7 +173,7 @@ class LichsMasteryLoseLifeEffect extends OneShotEffect {
         this.staticText = "for each 1 life you lost, exile a permanent you control or a card from your hand or graveyard.";
     }
 
-    public LichsMasteryLoseLifeEffect(final LichsMasteryLoseLifeEffect effect) {
+    private LichsMasteryLoseLifeEffect(final LichsMasteryLoseLifeEffect effect) {
         super(effect);
         this.amount = effect.amount;
     }

--- a/Mage.Sets/src/mage/cards/l/LichsMirror.java
+++ b/Mage.Sets/src/mage/cards/l/LichsMirror.java
@@ -47,7 +47,7 @@ class LichsMirrorEffect extends ReplacementEffectImpl {
         staticText = "If you would lose the game, instead shuffle your hand, your graveyard, and all permanents you own into your library, then draw seven cards and your life total becomes 20";
     }
 
-    public LichsMirrorEffect(final LichsMirrorEffect effect) {
+    private LichsMirrorEffect(final LichsMirrorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LiegeOfTheHollows.java
+++ b/Mage.Sets/src/mage/cards/l/LiegeOfTheHollows.java
@@ -54,7 +54,7 @@ class LiegeOfTheHollowsEffect extends OneShotEffect {
                 + "of 1/1 green Squirrel creature tokens equal to the amount of mana they paid this way";
     }
 
-    public LiegeOfTheHollowsEffect(final LiegeOfTheHollowsEffect effect) {
+    private LiegeOfTheHollowsEffect(final LiegeOfTheHollowsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LiegeOfThePit.java
+++ b/Mage.Sets/src/mage/cards/l/LiegeOfThePit.java
@@ -60,7 +60,7 @@ class LiegeOfThePitEffect extends OneShotEffect {
         this.staticText = "sacrifice a creature other than {this}. If you can't, {this} deals 7 damage to you.";
     }
 
-    public LiegeOfThePitEffect(final LiegeOfThePitEffect effect) {
+    private LiegeOfThePitEffect(final LiegeOfThePitEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LiegeOfTheTangle.java
+++ b/Mage.Sets/src/mage/cards/l/LiegeOfTheTangle.java
@@ -64,7 +64,7 @@ class LiegeOfTheTangleEffect extends ContinuousEffectImpl {
         staticText = "each of those lands is an 8/8 green Elemental creature for as long as it has an awakening counter on it. They're still lands";
     }
 
-    public LiegeOfTheTangleEffect(final LiegeOfTheTangleEffect effect) {
+    private LiegeOfTheTangleEffect(final LiegeOfTheTangleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LierDiscipleOfTheDrowned.java
+++ b/Mage.Sets/src/mage/cards/l/LierDiscipleOfTheDrowned.java
@@ -88,7 +88,7 @@ class LierDiscipleOfTheDrownedFlashbackEffect extends ContinuousEffectImpl {
                 "The flashback cost is equal to that card's mana cost";
     }
 
-    public LierDiscipleOfTheDrownedFlashbackEffect(final LierDiscipleOfTheDrownedFlashbackEffect effect) {
+    private LierDiscipleOfTheDrownedFlashbackEffect(final LierDiscipleOfTheDrownedFlashbackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LifeChisel.java
+++ b/Mage.Sets/src/mage/cards/l/LifeChisel.java
@@ -56,7 +56,7 @@ class LifeChiselEffect extends OneShotEffect {
         this.staticText = "You gain life equal to the sacrificed creature's toughness";
     }
 
-    public LifeChiselEffect(final LifeChiselEffect effect) {
+    private LifeChiselEffect(final LifeChiselEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LifeDeath.java
+++ b/Mage.Sets/src/mage/cards/l/LifeDeath.java
@@ -61,7 +61,7 @@ class DeathEffect extends OneShotEffect {
         this.staticText = "return target creature card from your graveyard to the battlefield. You lose life equal to its mana value";
     }
 
-    public DeathEffect(final DeathEffect effect) {
+    private DeathEffect(final DeathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LifebloodHydra.java
+++ b/Mage.Sets/src/mage/cards/l/LifebloodHydra.java
@@ -59,7 +59,7 @@ class LifebloodHydraEffect extends OneShotEffect {
         this.staticText = "you gain life and draw cards equal to its power";
     }
 
-    public LifebloodHydraEffect(final LifebloodHydraEffect effect) {
+    private LifebloodHydraEffect(final LifebloodHydraEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LifecraftAwakening.java
+++ b/Mage.Sets/src/mage/cards/l/LifecraftAwakening.java
@@ -61,7 +61,7 @@ class LifecraftAwakeningEffect extends OneShotEffect {
         this.staticText = "If it isn't a creature or Vehicle, it becomes a 0/0 Construct artifact creature";
     }
 
-    public LifecraftAwakeningEffect(final LifecraftAwakeningEffect effect) {
+    private LifecraftAwakeningEffect(final LifecraftAwakeningEffect effect) {
         super(effect);
     }
 
@@ -94,7 +94,7 @@ class LifecraftAwakeningToken extends TokenImpl {
         this.power = new MageInt(0);
         this.toughness = new MageInt(0);
     }
-    public LifecraftAwakeningToken(final LifecraftAwakeningToken token) {
+    private LifecraftAwakeningToken(final LifecraftAwakeningToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Lifeline.java
+++ b/Mage.Sets/src/mage/cards/l/Lifeline.java
@@ -53,7 +53,7 @@ class LifelineEffect extends OneShotEffect {
         this.staticText = "";
     }
 
-    public LifelineEffect(final LifelineEffect effect) {
+    private LifelineEffect(final LifelineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Lifelink.java
+++ b/Mage.Sets/src/mage/cards/l/Lifelink.java
@@ -33,7 +33,7 @@ public final class Lifelink extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(LifelinkAbility.getInstance(), AttachmentType.AURA)));
     }
 
-    public Lifelink (final Lifelink card) {
+    private Lifelink(final Lifelink card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LifesFinale.java
+++ b/Mage.Sets/src/mage/cards/l/LifesFinale.java
@@ -50,7 +50,7 @@ class LifesFinaleEffect extends OneShotEffect {
         staticText = "Destroy all creatures, then search target opponent's library for up to three creature cards and put them into their graveyard. Then that player shuffles";
     }
 
-    public LifesFinaleEffect(final LifesFinaleEffect effect) {
+    private LifesFinaleEffect(final LifesFinaleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LifesLegacy.java
+++ b/Mage.Sets/src/mage/cards/l/LifesLegacy.java
@@ -48,7 +48,7 @@ class LifesLegacyEffect extends OneShotEffect {
         staticText = "Draw cards equal to the sacrificed creature's power";
     }
 
-    public LifesLegacyEffect(final LifesLegacyEffect effect) {
+    private LifesLegacyEffect(final LifesLegacyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LightFromWithin.java
+++ b/Mage.Sets/src/mage/cards/l/LightFromWithin.java
@@ -42,7 +42,7 @@ class LightFromWithinEffect extends ContinuousEffectImpl {
         staticText = "Each creature you control gets +1/+1 for each white mana symbol in its mana cost";
     }
 
-    public LightFromWithinEffect(final LightFromWithinEffect effect) {
+    private LightFromWithinEffect(final LightFromWithinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LightOfSanction.java
+++ b/Mage.Sets/src/mage/cards/l/LightOfSanction.java
@@ -48,7 +48,7 @@ class LightOfSanctionEffect extends PreventionEffectImpl {
         consumable = false;
     }
 
-    public LightOfSanctionEffect(LightOfSanctionEffect effect) {
+    private LightOfSanctionEffect(final LightOfSanctionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LightmineField.java
+++ b/Mage.Sets/src/mage/cards/l/LightmineField.java
@@ -49,7 +49,7 @@ class LightmineFieldTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever one or more creatures attack, ");
     }
 
-    public LightmineFieldTriggeredAbility(final LightmineFieldTriggeredAbility ability) {
+    private LightmineFieldTriggeredAbility(final LightmineFieldTriggeredAbility ability) {
         super(ability);
     }
 
@@ -86,7 +86,7 @@ class LightmineFieldEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to each of those creatures equal to the number of attacking creatures";
     }
 
-    public LightmineFieldEffect(final LightmineFieldEffect effect) {
+    private LightmineFieldEffect(final LightmineFieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LightningDart.java
+++ b/Mage.Sets/src/mage/cards/l/LightningDart.java
@@ -43,7 +43,7 @@ public final class LightningDart extends CardImpl {
             this.staticText = "Lightning Dart deals 1 damage to target creature. If that creature is white or blue, Lightning Dart deals 4 damage to it instead";
         }
 
-        public LightningDartEffect(final LightningDartEffect effect) {
+        private LightningDartEffect(final LightningDartEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/l/LightningElemental.java
+++ b/Mage.Sets/src/mage/cards/l/LightningElemental.java
@@ -25,7 +25,7 @@ public final class LightningElemental extends CardImpl {
         this.addAbility(HasteAbility.getInstance());
     }
 
-    public LightningElemental (final LightningElemental card) {
+    private LightningElemental(final LightningElemental card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LightningStorm.java
+++ b/Mage.Sets/src/mage/cards/l/LightningStorm.java
@@ -101,7 +101,7 @@ class LightningStormAddCounterEffect extends OneShotEffect {
         this.staticText = "Put two charge counters on {this}. You may choose a new target for it.";
     }
 
-    public LightningStormAddCounterEffect(final LightningStormAddCounterEffect effect) {
+    private LightningStormAddCounterEffect(final LightningStormAddCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LightspeedSkipping.java
+++ b/Mage.Sets/src/mage/cards/l/LightspeedSkipping.java
@@ -31,7 +31,7 @@ public class LightspeedSkipping extends CardImpl {
         this.getSpellAbility().addMode(mode);
     }
 
-    public LightspeedSkipping(final LightspeedSkipping card) {
+    private LightspeedSkipping(final LightspeedSkipping card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LightwielderPaladin.java
+++ b/Mage.Sets/src/mage/cards/l/LightwielderPaladin.java
@@ -57,7 +57,7 @@ class LightwielderPaladinTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ExileTargetEffect(), true);
     }
 
-    public LightwielderPaladinTriggeredAbility(final LightwielderPaladinTriggeredAbility ability) {
+    private LightwielderPaladinTriggeredAbility(final LightwielderPaladinTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LilianaDeathWielder.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaDeathWielder.java
@@ -71,7 +71,7 @@ class LilianaDeathWielderEffect extends OneShotEffect {
         this.staticText = "Return all creature cards from your graveyard to the battlefield";
     }
 
-    public LilianaDeathWielderEffect(final LilianaDeathWielderEffect effect) {
+    private LilianaDeathWielderEffect(final LilianaDeathWielderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LilianaOfTheVeil.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaOfTheVeil.java
@@ -67,7 +67,7 @@ class LilianaOfTheVeilEffect extends OneShotEffect {
         this.staticText = "Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice";
     }
     
-    public LilianaOfTheVeilEffect(final LilianaOfTheVeilEffect effect) {
+    private LilianaOfTheVeilEffect(final LilianaOfTheVeilEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/l/LilianaTheLastHope.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaTheLastHope.java
@@ -72,7 +72,7 @@ class LilianaTheLastHopeEffect extends OneShotEffect {
         this.staticText = ", then you may return a creature card from your graveyard to your hand";
     }
 
-    public LilianaTheLastHopeEffect(final LilianaTheLastHopeEffect effect) {
+    private LilianaTheLastHopeEffect(final LilianaTheLastHopeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LilianaTheNecromancer.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaTheNecromancer.java
@@ -68,7 +68,7 @@ class LilianaTheNecromancerEffect extends OneShotEffect {
         this.staticText = "Put up to two creature cards from graveyards onto the battlefield under your control";
     }
 
-    public LilianaTheNecromancerEffect(final LilianaTheNecromancerEffect effect) {
+    private LilianaTheNecromancerEffect(final LilianaTheNecromancerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LilianaUntouchedByDeath.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaUntouchedByDeath.java
@@ -65,7 +65,7 @@ class LilianaUntouchedByDeathEffect extends OneShotEffect {
         this.staticText = "mill three cards. If at least one of them is a Zombie card, each opponent loses 2 life and you gain 2 life";
     }
 
-    public LilianaUntouchedByDeathEffect(final LilianaUntouchedByDeathEffect effect) {
+    private LilianaUntouchedByDeathEffect(final LilianaUntouchedByDeathEffect effect) {
         super(effect);
     }
 
@@ -99,7 +99,7 @@ class LilianaUntouchedByDeathGraveyardEffect extends AsThoughEffectImpl {
         staticText = "You may cast Zombie cards from your graveyard this turn";
     }
 
-    public LilianaUntouchedByDeathGraveyardEffect(final LilianaUntouchedByDeathGraveyardEffect effect) {
+    private LilianaUntouchedByDeathGraveyardEffect(final LilianaUntouchedByDeathGraveyardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LilianaVess.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaVess.java
@@ -65,7 +65,7 @@ class LilianaVessEffect extends OneShotEffect {
         staticText = "Put all creature cards from all graveyards onto the battlefield under your control";
     }
 
-    public LilianaVessEffect(final LilianaVessEffect effect) {
+    private LilianaVessEffect(final LilianaVessEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LilianasDefeat.java
+++ b/Mage.Sets/src/mage/cards/l/LilianasDefeat.java
@@ -52,7 +52,7 @@ class LilianasDefeatEffect extends OneShotEffect {
         this.staticText = "Destroy target black creature or black planeswalker. If that permanent was a Liliana planeswalker, her controller loses 3 life";
     }
 
-    public LilianasDefeatEffect(final LilianasDefeatEffect effect) {
+    private LilianasDefeatEffect(final LilianasDefeatEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LilianasIndignation.java
+++ b/Mage.Sets/src/mage/cards/l/LilianasIndignation.java
@@ -44,7 +44,7 @@ class LilianasIndignationEffect extends OneShotEffect {
         this.staticText = "Mill X cards. Target player loses 2 life for each creature card put into your graveyard this way";
     }
 
-    public LilianasIndignationEffect(final LilianasIndignationEffect effect) {
+    private LilianasIndignationEffect(final LilianasIndignationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LimDulTheNecromancer.java
+++ b/Mage.Sets/src/mage/cards/l/LimDulTheNecromancer.java
@@ -71,7 +71,7 @@ class LimDulTheNecromancerEffect extends OneShotEffect {
         staticText = "return that card to the battlefield under your control. If it's a creature, it's a Zombie in addition to its other creature types";
     }
 
-    public LimDulTheNecromancerEffect(final LimDulTheNecromancerEffect effect) {
+    private LimDulTheNecromancerEffect(final LimDulTheNecromancerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LimDulsHex.java
+++ b/Mage.Sets/src/mage/cards/l/LimDulsHex.java
@@ -45,7 +45,7 @@ class LimDulsHexEffect extends OneShotEffect {
         this.staticText = "for each player, {this} deals 1 damage to that player unless they pay {B} or {3}";
     }
 
-    public LimDulsHexEffect(final LimDulsHexEffect effect) {
+    private LimDulsHexEffect(final LimDulsHexEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LimDulsPaladin.java
+++ b/Mage.Sets/src/mage/cards/l/LimDulsPaladin.java
@@ -72,7 +72,7 @@ class LimDulsPaladinEffect extends SacrificeSourceUnlessPaysEffect {
         staticText = "you may discard a card. If you don't, sacrifice {this} and draw a card.";
     }
 
-    public LimDulsPaladinEffect(final LimDulsPaladinEffect effect) {
+    private LimDulsPaladinEffect(final LimDulsPaladinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LimDulsVault.java
+++ b/Mage.Sets/src/mage/cards/l/LimDulsVault.java
@@ -44,7 +44,7 @@ class LimDulsVaultEffect extends OneShotEffect {
                 + "Then shuffle and put the last cards you looked at this way on top of it in any order";
     }
 
-    public LimDulsVaultEffect(final LimDulsVaultEffect effect) {
+    private LimDulsVaultEffect(final LimDulsVaultEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LimitedResources.java
+++ b/Mage.Sets/src/mage/cards/l/LimitedResources.java
@@ -62,7 +62,7 @@ class LimitedResourcesEffect extends OneShotEffect {
         this.staticText = "each player chooses five lands they control and sacrifices the rest";
     }
 
-    public LimitedResourcesEffect(final LimitedResourcesEffect effect) {
+    private LimitedResourcesEffect(final LimitedResourcesEffect effect) {
         super(effect);
     }
 
@@ -97,7 +97,7 @@ class CantPlayLandEffect extends ContinuousRuleModifyingEffectImpl {
         this.staticText = "Players can't play lands as long as ten or more lands are on the battlefield";
     }
 
-    public CantPlayLandEffect(final CantPlayLandEffect effect) {
+    private CantPlayLandEffect(final CantPlayLandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LinSivviDefiantHero.java
+++ b/Mage.Sets/src/mage/cards/l/LinSivviDefiantHero.java
@@ -75,7 +75,7 @@ class LinSivviDefiantHeroEffect extends OneShotEffect {
         this.staticText = "Search your library for a Rebel permanent card with mana value X or less, put it onto the battlefield, then shuffle";
     }
 
-    public LinSivviDefiantHeroEffect(final LinSivviDefiantHeroEffect effect) {
+    private LinSivviDefiantHeroEffect(final LinSivviDefiantHeroEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LingeringDeath.java
+++ b/Mage.Sets/src/mage/cards/l/LingeringDeath.java
@@ -56,7 +56,7 @@ class LingeringDeathAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SacrificeTargetEffect());
     }
 
-    public LingeringDeathAbility(final LingeringDeathAbility ability) {
+    private LingeringDeathAbility(final LingeringDeathAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LinvalaKeeperOfSilence.java
+++ b/Mage.Sets/src/mage/cards/l/LinvalaKeeperOfSilence.java
@@ -50,7 +50,7 @@ class LinvalaKeeperOfSilenceCantActivateEffect extends RestrictionEffect {
         staticText = "Activated abilities of creatures your opponents control can't be activated";
     }
 
-    public LinvalaKeeperOfSilenceCantActivateEffect(final LinvalaKeeperOfSilenceCantActivateEffect effect) {
+    private LinvalaKeeperOfSilenceCantActivateEffect(final LinvalaKeeperOfSilenceCantActivateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LionsEyeDiamond.java
+++ b/Mage.Sets/src/mage/cards/l/LionsEyeDiamond.java
@@ -52,7 +52,7 @@ class LionsEyeDiamondAbility extends ActivatedManaAbilityImpl {
 
     }
 
-    public LionsEyeDiamondAbility(final LionsEyeDiamondAbility ability) {
+    private LionsEyeDiamondAbility(final LionsEyeDiamondAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LiquimetalCoating.java
+++ b/Mage.Sets/src/mage/cards/l/LiquimetalCoating.java
@@ -29,7 +29,7 @@ public final class LiquimetalCoating extends CardImpl {
         this.addAbility(ability);
     }
 
-    public LiquimetalCoating (final LiquimetalCoating card) {
+    private LiquimetalCoating(final LiquimetalCoating card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LithomancersFocus.java
+++ b/Mage.Sets/src/mage/cards/l/LithomancersFocus.java
@@ -48,7 +48,7 @@ class LithomancersFocusPreventDamageToTargetEffect extends PreventionEffectImpl 
         staticText = "Prevent all damage that would be dealt to that creature this turn by colorless sources";
     }
 
-    public LithomancersFocusPreventDamageToTargetEffect(final LithomancersFocusPreventDamageToTargetEffect effect) {
+    private LithomancersFocusPreventDamageToTargetEffect(final LithomancersFocusPreventDamageToTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LivingArmor.java
+++ b/Mage.Sets/src/mage/cards/l/LivingArmor.java
@@ -49,7 +49,7 @@ public final class LivingArmor extends CardImpl {
             this.staticText = "Put X +0/+1 counters on target creature, where X is that creature's mana value";
         }
 
-        public LivingArmorEffect(final LivingArmorEffect effect) {
+        private LivingArmorEffect(final LivingArmorEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/l/LivingArtifact.java
+++ b/Mage.Sets/src/mage/cards/l/LivingArtifact.java
@@ -69,7 +69,7 @@ class LivingArtifactTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new LivingArtifactEffect(), false);
     }
 
-    public LivingArtifactTriggeredAbility(final LivingArtifactTriggeredAbility ability) {
+    private LivingArtifactTriggeredAbility(final LivingArtifactTriggeredAbility ability) {
         super(ability);
     }
 
@@ -104,7 +104,7 @@ class LivingArtifactEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public LivingArtifactEffect(final LivingArtifactEffect effect) {
+    private LivingArtifactEffect(final LivingArtifactEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LivingDestiny.java
+++ b/Mage.Sets/src/mage/cards/l/LivingDestiny.java
@@ -50,7 +50,7 @@ class LivingDestinyEffect extends OneShotEffect {
         staticText = "You gain life equal to the revealed card's mana value";
     }
 
-    public LivingDestinyEffect(LivingDestinyEffect effect) {
+    private LivingDestinyEffect(final LivingDestinyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LivingInferno.java
+++ b/Mage.Sets/src/mage/cards/l/LivingInferno.java
@@ -71,7 +71,7 @@ class LivingInfernoEffect extends OneShotEffect {
                 "Each of those creatures deals damage equal to its power to {this}";
     }
 
-    public LivingInfernoEffect(final LivingInfernoEffect effect) {
+    private LivingInfernoEffect(final LivingInfernoEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LivingLore.java
+++ b/Mage.Sets/src/mage/cards/l/LivingLore.java
@@ -73,7 +73,7 @@ class LivingLoreExileEffect extends OneShotEffect {
         staticText = "exile an instant or sorcery card from your graveyard";
     }
 
-    public LivingLoreExileEffect(final LivingLoreExileEffect effect) {
+    private LivingLoreExileEffect(final LivingLoreExileEffect effect) {
         super(effect);
     }
 
@@ -143,7 +143,7 @@ class LivingLoreCastEffect extends OneShotEffect {
         this.staticText = "you may cast the exiled card without paying its mana cost";
     }
 
-    public LivingLoreCastEffect(final LivingLoreCastEffect effect) {
+    private LivingLoreCastEffect(final LivingLoreCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LivingTerrain.java
+++ b/Mage.Sets/src/mage/cards/l/LivingTerrain.java
@@ -57,7 +57,7 @@ class TreefolkToken extends TokenImpl {
             power = new MageInt(5);
             toughness = new MageInt(6);
         }
-    public TreefolkToken(final TreefolkToken token) {
+    private TreefolkToken(final TreefolkToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LlanowarDruid.java
+++ b/Mage.Sets/src/mage/cards/l/LlanowarDruid.java
@@ -64,7 +64,7 @@ class LlanowarDruidEffect extends OneShotEffect {
         staticText = "Untap all Forests";
     }
 
-    public LlanowarDruidEffect(final LlanowarDruidEffect effect) {
+    private LlanowarDruidEffect(final LlanowarDruidEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LlanowarEmpath.java
+++ b/Mage.Sets/src/mage/cards/l/LlanowarEmpath.java
@@ -57,7 +57,7 @@ class LlanowarEmpathEffect extends OneShotEffect {
         this.staticText = ", then reveal the top card of your library. If it's a creature card, put it into your hand.";
     }
 
-    public LlanowarEmpathEffect(final LlanowarEmpathEffect effect) {
+    private LlanowarEmpathEffect(final LlanowarEmpathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LlawanCephalidEmpress.java
+++ b/Mage.Sets/src/mage/cards/l/LlawanCephalidEmpress.java
@@ -75,7 +75,7 @@ class LlawanCephalidRuleModifyingEffect extends ContinuousRuleModifyingEffectImp
         staticText = "Your opponents can't cast blue creature spells";
     }
 
-    public LlawanCephalidRuleModifyingEffect(final LlawanCephalidRuleModifyingEffect effect) {
+    private LlawanCephalidRuleModifyingEffect(final LlawanCephalidRuleModifyingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LoafingGiant.java
+++ b/Mage.Sets/src/mage/cards/l/LoafingGiant.java
@@ -50,7 +50,7 @@ class LoafingGiantEffect extends OneShotEffect {
         this.staticText = "Mill a card. If a land card was milled this way, prevent all combat damage {this} would deal this turn.";
     }
 
-    public LoafingGiantEffect(final LoafingGiantEffect effect) {
+    private LoafingGiantEffect(final LoafingGiantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LobeLobber.java
+++ b/Mage.Sets/src/mage/cards/l/LobeLobber.java
@@ -56,7 +56,7 @@ class LobeLobberEffect extends OneShotEffect {
         this.staticText = "This creature deals 1 damage to target player. Roll a six-sided die. On a 5 or higher, untap it";
     }
 
-    public LobeLobberEffect(final LobeLobberEffect effect) {
+    private LobeLobberEffect(final LobeLobberEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Lobotomy.java
+++ b/Mage.Sets/src/mage/cards/l/Lobotomy.java
@@ -56,7 +56,7 @@ class LobotomyEffect extends OneShotEffect {
         staticText = "Target player reveals their hand, then you choose a card other than a basic land card from it. Search that player's graveyard, hand, and library for all cards with the same name as the chosen card and exile them. Then that player shuffles";
     }
 
-    public LobotomyEffect(final LobotomyEffect effect) {
+    private LobotomyEffect(final LobotomyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LockjawSnapper.java
+++ b/Mage.Sets/src/mage/cards/l/LockjawSnapper.java
@@ -54,7 +54,7 @@ class LockjawSnapperEffect extends OneShotEffect {
         this.staticText = "put a -1/-1 counter on each creature with a -1/-1 counter on it";
     }
 
-    public LockjawSnapperEffect(final LockjawSnapperEffect effect) {
+    private LockjawSnapperEffect(final LockjawSnapperEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LodestoneBauble.java
+++ b/Mage.Sets/src/mage/cards/l/LodestoneBauble.java
@@ -64,7 +64,7 @@ class LodestoneBaubleTarget extends TargetCardInGraveyard {
         super(0, 4, new FilterBasicLandCard("basic land cards from a player's graveyard"));
     }
 
-    public LodestoneBaubleTarget(final LodestoneBaubleTarget target) {
+    private LodestoneBaubleTarget(final LodestoneBaubleTarget target) {
         super(target);
     }
 
@@ -124,7 +124,7 @@ class LodestoneBaubleDrawEffect extends OneShotEffect {
         staticText = "That player draws a card at the beginning of the next turn's upkeep";
     }
 
-    public LodestoneBaubleDrawEffect(final LodestoneBaubleDrawEffect effect) {
+    private LodestoneBaubleDrawEffect(final LodestoneBaubleDrawEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LordMagnus.java
+++ b/Mage.Sets/src/mage/cards/l/LordMagnus.java
@@ -53,7 +53,7 @@ class LordMagnusFirstEffect extends AsThoughEffectImpl {
         staticText = "Creatures with plainswalk can be blocked as though they didn't have plainswalk";
     }
 
-    public LordMagnusFirstEffect(final LordMagnusFirstEffect effect) {
+    private LordMagnusFirstEffect(final LordMagnusFirstEffect effect) {
         super(effect);
     }
 
@@ -80,7 +80,7 @@ class LordMagnusSecondEffect extends AsThoughEffectImpl {
         staticText = "Creatures with forestwalk can be blocked as though they didn't have forestwalk";
     }
 
-    public LordMagnusSecondEffect(final LordMagnusSecondEffect effect) {
+    private LordMagnusSecondEffect(final LordMagnusSecondEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LordOfShatterskullPass.java
+++ b/Mage.Sets/src/mage/cards/l/LordOfShatterskullPass.java
@@ -71,7 +71,7 @@ class LordOfShatterskullPassEffect extends OneShotEffect {
         this.staticText = "it deals 6 damage to each creature defending player controls";
     }
 
-    public LordOfShatterskullPassEffect(final LordOfShatterskullPassEffect effect) {
+    private LordOfShatterskullPassEffect(final LordOfShatterskullPassEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LordOfThePit.java
+++ b/Mage.Sets/src/mage/cards/l/LordOfThePit.java
@@ -56,7 +56,7 @@ class LordOfThePitEffect extends OneShotEffect {
         this.staticText = "sacrifice a creature other than {this}. If you can't, {this} deals 7 damage to you.";
     }
 
-    public LordOfThePitEffect(final LordOfThePitEffect effect) {
+    private LordOfThePitEffect(final LordOfThePitEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LordOfTheVoid.java
+++ b/Mage.Sets/src/mage/cards/l/LordOfTheVoid.java
@@ -57,7 +57,7 @@ class LordOfTheVoidEffect extends OneShotEffect {
         this.staticText = "exile the top seven cards of that player's library, then put a creature card from among them onto the battlefield under your control";
     }
 
-    public LordOfTheVoidEffect(final LordOfTheVoidEffect effect) {
+    private LordOfTheVoidEffect(final LordOfTheVoidEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LordWindgrace.java
+++ b/Mage.Sets/src/mage/cards/l/LordWindgrace.java
@@ -85,7 +85,7 @@ class LordWindgraceEffect extends OneShotEffect {
                 + "If a land card is discarded this way, draw an additional card";
     }
 
-    public LordWindgraceEffect(final LordWindgraceEffect effect) {
+    private LordWindgraceEffect(final LordWindgraceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LostAuramancers.java
+++ b/Mage.Sets/src/mage/cards/l/LostAuramancers.java
@@ -64,7 +64,7 @@ class LostAuramancersAbility extends PutIntoGraveFromBattlefieldSourceTriggeredA
         super(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterEnchantmentCard())));
     }
 
-    public LostAuramancersAbility(final LostAuramancersAbility ability) {
+    private LostAuramancersAbility(final LostAuramancersAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LostHours.java
+++ b/Mage.Sets/src/mage/cards/l/LostHours.java
@@ -48,7 +48,7 @@ class LostHoursEffect extends OneShotEffect {
         this.staticText = "Target player reveals their hand. You choose a nonland card from it. That player puts that card into their library third from the top";
     }
 
-    public LostHoursEffect(final LostHoursEffect effect) {
+    private LostHoursEffect(final LostHoursEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LostInTheWoods.java
+++ b/Mage.Sets/src/mage/cards/l/LostInTheWoods.java
@@ -44,7 +44,7 @@ class LostInTheWoodsEffect extends OneShotEffect {
         staticText = "reveal the top card of your library. If it's a Forest card, remove that creature from combat. Then put the revealed card on the bottom of your library";
     }
 
-    public LostInTheWoodsEffect(final LostInTheWoodsEffect effect) {
+    private LostInTheWoodsEffect(final LostInTheWoodsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LostInThought.java
+++ b/Mage.Sets/src/mage/cards/l/LostInThought.java
@@ -52,7 +52,7 @@ public final class LostInThought extends CardImpl {
         this.addAbility(new LostInThoughtSpecialAction());
     }
 
-    public LostInThought (final LostInThought card) {
+    private LostInThought(final LostInThought card) {
         super(card);
     }
 
@@ -70,7 +70,7 @@ class LostInThoughtRestrictionEffect extends RestrictionEffect {
         this.staticText = "Enchanted creature can't attack or block";
     }
 
-    public LostInThoughtRestrictionEffect(final LostInThoughtRestrictionEffect effect) {
+    private LostInThoughtRestrictionEffect(final LostInThoughtRestrictionEffect effect) {
         super(effect);
     }
 
@@ -108,7 +108,7 @@ class LostInThoughtCantActivateAbilitiesEffect extends ContinuousRuleModifyingEf
         staticText = ", and its activated abilities can't be activated";
     }
 
-    public LostInThoughtCantActivateAbilitiesEffect(final LostInThoughtCantActivateAbilitiesEffect effect) {
+    private LostInThoughtCantActivateAbilitiesEffect(final LostInThoughtCantActivateAbilitiesEffect effect) {
         super(effect);
     }
 
@@ -152,7 +152,7 @@ class LostInThoughtSpecialAction extends SpecialAction {
         this.setMayActivate(TargetController.CONTROLLER_ATTACHED_TO);
     }
 
-    public LostInThoughtSpecialAction(final LostInThoughtSpecialAction ability) {
+    private LostInThoughtSpecialAction(final LostInThoughtSpecialAction ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LostLeonin.java
+++ b/Mage.Sets/src/mage/cards/l/LostLeonin.java
@@ -27,7 +27,7 @@ public final class LostLeonin extends CardImpl {
         this.addAbility(InfectAbility.getInstance());
     }
 
-    public LostLeonin (final LostLeonin card) {
+    private LostLeonin(final LostLeonin card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LowlandOaf.java
+++ b/Mage.Sets/src/mage/cards/l/LowlandOaf.java
@@ -73,7 +73,7 @@ class LowlandOafEffect extends OneShotEffect {
         this.staticText = "Sacrifice that creature at the beginning of the next end step";
     }
 
-    public LowlandOafEffect(final LowlandOafEffect effect) {
+    private LowlandOafEffect(final LowlandOafEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LoxodonPartisan.java
+++ b/Mage.Sets/src/mage/cards/l/LoxodonPartisan.java
@@ -26,7 +26,7 @@ public final class LoxodonPartisan extends CardImpl {
         this.addAbility(new BattleCryAbility());
     }
 
-    public LoxodonPartisan (final LoxodonPartisan card) {
+    private LoxodonPartisan(final LoxodonPartisan card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LoxodonPeacekeeper.java
+++ b/Mage.Sets/src/mage/cards/l/LoxodonPeacekeeper.java
@@ -61,7 +61,7 @@ class LoxodonPeacekeeperEffect extends OneShotEffect {
         this.staticText = "the player with the lowest life total gains control of {this}. If two or more players are tied for lowest life total, you choose one of them, and that player gains control of {this}";
     }
 
-    public LoxodonPeacekeeperEffect(final LoxodonPeacekeeperEffect effect) {
+    private LoxodonPeacekeeperEffect(final LoxodonPeacekeeperEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LoxodonWayfarer.java
+++ b/Mage.Sets/src/mage/cards/l/LoxodonWayfarer.java
@@ -24,7 +24,7 @@ public final class LoxodonWayfarer extends CardImpl {
         this.toughness = new MageInt(5);
     }
 
-    public LoxodonWayfarer (final LoxodonWayfarer card) {
+    private LoxodonWayfarer(final LoxodonWayfarer card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LoyalApprentice.java
+++ b/Mage.Sets/src/mage/cards/l/LoyalApprentice.java
@@ -63,7 +63,7 @@ class LoyalApprenticeEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public LoyalApprenticeEffect(final LoyalApprenticeEffect effect) {
+    private LoyalApprenticeEffect(final LoyalApprenticeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LoyalCathar.java
+++ b/Mage.Sets/src/mage/cards/l/LoyalCathar.java
@@ -92,7 +92,7 @@ class ReturnLoyalCatharEffect extends OneShotEffect {
         this.staticText = "return it to the battlefield transformed under your control";
     }
 
-    public ReturnLoyalCatharEffect(final ReturnLoyalCatharEffect effect) {
+    private ReturnLoyalCatharEffect(final ReturnLoyalCatharEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LudevicNecroAlchemist.java
+++ b/Mage.Sets/src/mage/cards/l/LudevicNecroAlchemist.java
@@ -82,7 +82,7 @@ class LudevicNecroAlchemistEffect extends OneShotEffect {
         staticText = "that player may draw a card if a player other than you lost life this turn";
     }
 
-    public LudevicNecroAlchemistEffect(final LudevicNecroAlchemistEffect effect) {
+    private LudevicNecroAlchemistEffect(final LudevicNecroAlchemistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LukeSkywalker.java
+++ b/Mage.Sets/src/mage/cards/l/LukeSkywalker.java
@@ -66,7 +66,7 @@ class LukeSkywalkerCost extends CostImpl {
         this.text = "Remove all +1/+1 counters from {this}";
     }
 
-    public LukeSkywalkerCost(LukeSkywalkerCost cost) {
+    private LukeSkywalkerCost(final LukeSkywalkerCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LukesLightsaber.java
+++ b/Mage.Sets/src/mage/cards/l/LukesLightsaber.java
@@ -46,7 +46,7 @@ public class LukesLightsaber extends CardImpl {
         this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(2), false));
     }
 
-    public LukesLightsaber(final LukesLightsaber card) {
+    private LukesLightsaber(final LukesLightsaber card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LumberingFalls.java
+++ b/Mage.Sets/src/mage/cards/l/LumberingFalls.java
@@ -60,7 +60,7 @@ class LumberingFallsToken extends TokenImpl {
         toughness = new MageInt(3);
         addAbility(HexproofAbility.getInstance());
     }
-    public LumberingFallsToken(final LumberingFallsToken token) {
+    private LumberingFallsToken(final LumberingFallsToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LumengridAugur.java
+++ b/Mage.Sets/src/mage/cards/l/LumengridAugur.java
@@ -57,7 +57,7 @@ class LumengridAugurEffect extends OneShotEffect {
         staticText = "Target player draws a card, then discards a card. If that player discards an artifact card this way, untap {this}";
     }
 
-    public LumengridAugurEffect(final LumengridAugurEffect effect) {
+    private LumengridAugurEffect(final LumengridAugurEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LumengridGargoyle.java
+++ b/Mage.Sets/src/mage/cards/l/LumengridGargoyle.java
@@ -24,7 +24,7 @@ public final class LumengridGargoyle extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public LumengridGargoyle (final LumengridGargoyle card) {
+    private LumengridGargoyle(final LumengridGargoyle card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Luminesce.java
+++ b/Mage.Sets/src/mage/cards/l/Luminesce.java
@@ -43,7 +43,7 @@ class LuminescePreventionEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that black sources and red sources would deal this turn";
     }
 
-    public LuminescePreventionEffect(LuminescePreventionEffect effect) {
+    private LuminescePreventionEffect(final LuminescePreventionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LunarAvenger.java
+++ b/Mage.Sets/src/mage/cards/l/LunarAvenger.java
@@ -72,7 +72,7 @@ class LunarAvengerEffect extends OneShotEffect {
         staticText = "{this} gains your choice of flying, first strike, or haste until end of turn";
     }
 
-    public LunarAvengerEffect(final LunarAvengerEffect effect) {
+    private LunarAvengerEffect(final LunarAvengerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Lure.java
+++ b/Mage.Sets/src/mage/cards/l/Lure.java
@@ -40,7 +40,7 @@ public final class Lure extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new MustBeBlockedByAllAttachedEffect(AttachmentType.AURA)));
     }
 
-    public Lure (final Lure card) {
+    private Lure(final Lure card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LureOfPrey.java
+++ b/Mage.Sets/src/mage/cards/l/LureOfPrey.java
@@ -57,7 +57,7 @@ class LureOfPreyRestrictionEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Cast this spell only if an opponent cast a creature spell this turn";
     }
 
-    public LureOfPreyRestrictionEffect(final LureOfPreyRestrictionEffect effect) {
+    private LureOfPreyRestrictionEffect(final LureOfPreyRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LureboundScarecrow.java
+++ b/Mage.Sets/src/mage/cards/l/LureboundScarecrow.java
@@ -56,7 +56,7 @@ class LureboundScarecrowTriggeredAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new SacrificeSourceEffect());
     }
 
-    public LureboundScarecrowTriggeredAbility(LureboundScarecrowTriggeredAbility ability) {
+    private LureboundScarecrowTriggeredAbility(final LureboundScarecrowTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LurkingEvil.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingEvil.java
@@ -96,7 +96,7 @@ class LurkingEvilToken extends TokenImpl {
         cardType.add(CardType.CREATURE);
         this.addAbility(FlyingAbility.getInstance());
     }
-    public LurkingEvilToken(final LurkingEvilToken token) {
+    private LurkingEvilToken(final LurkingEvilToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LurkingJackals.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingJackals.java
@@ -44,7 +44,7 @@ class LurkingJackalsStateTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("When an opponent has 10 or less life, if {this} is an enchantment, ");
     }
 
-    public LurkingJackalsStateTriggeredAbility(final LurkingJackalsStateTriggeredAbility ability) {
+    private LurkingJackalsStateTriggeredAbility(final LurkingJackalsStateTriggeredAbility ability) {
         super(ability);
     }
 
@@ -110,7 +110,7 @@ class LurkingJackalsToken extends TokenImpl {
         toughness = new MageInt(2);
     }
 
-    public LurkingJackalsToken(final LurkingJackalsToken token) {
+    private LurkingJackalsToken(final LurkingJackalsToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LurkingPredators.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingPredators.java
@@ -47,7 +47,7 @@ class LurkingPredatorsEffect extends OneShotEffect {
         this.staticText = "reveal the top card of your library. If it's a creature card, put it onto the battlefield. Otherwise, you may put that card on the bottom of your library";
     }
 
-    public LurkingPredatorsEffect(final LurkingPredatorsEffect effect) {
+    private LurkingPredatorsEffect(final LurkingPredatorsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LurkingSkirge.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingSkirge.java
@@ -61,7 +61,7 @@ class LurkingSkirgeToken extends TokenImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public LurkingSkirgeToken(final LurkingSkirgeToken token) {
+    private LurkingSkirgeToken(final LurkingSkirgeToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LuxCannon.java
+++ b/Mage.Sets/src/mage/cards/l/LuxCannon.java
@@ -31,7 +31,7 @@ public final class LuxCannon extends CardImpl {
         this.addAbility(ability);
     }
 
-    public LuxCannon (final LuxCannon card) {
+    private LuxCannon(final LuxCannon card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LymphSliver.java
+++ b/Mage.Sets/src/mage/cards/l/LymphSliver.java
@@ -54,7 +54,7 @@ class SliverAbsorbEffect extends PreventionEffectImpl {
         this.staticText = "Absorb 1 <i>(If a source would deal damage to this creature, prevent 1 of that damage.</i>)";
     }
 
-    public SliverAbsorbEffect(SliverAbsorbEffect effect) {
+    private SliverAbsorbEffect(final SliverAbsorbEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LyraDawnbringer.java
+++ b/Mage.Sets/src/mage/cards/l/LyraDawnbringer.java
@@ -44,7 +44,7 @@ public final class LyraDawnbringer extends CardImpl {
         this.addAbility(ability);
     }
 
-    public LyraDawnbringer(final LyraDawnbringer lyraDawnbringer) {
+    private LyraDawnbringer(final LyraDawnbringer lyraDawnbringer) {
         super(lyraDawnbringer);
     }
 


### PR DESCRIPTION
Part of #11054 

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`public ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `private $1(final $1 $3`
