### PR TITLE
[don't merge yet] Improve text generation of DamageTargetEffect

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AerieOuphes.java
+++ b/Mage.Sets/src/mage/cards/a/AerieOuphes.java
@@ -38,9 +38,11 @@ public final class AerieOuphes extends CardImpl {
         this.power = new MageInt(3);
         this.toughness = new MageInt(3);
 
-        // Sacrifice Aerie Ouphes: Aerie Ouphes deals damage equal to its power to target creature with flying.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(new SourcePermanentPowerCount())
-                .setText("{this} deals damage equal to its power to target creature with flying"), new SacrificeSourceCost());
+        // Sacrifice Aerie Ouphes: It deals damage equal to its power to target creature with flying.
+        Ability ability = new SimpleActivatedAbility(
+                new DamageTargetEffect(new SourcePermanentPowerCount().setSourcePossessiveForm("its"), "it")
+                        .withEqualToBeforeTarget(),
+                new SacrificeSourceCost());
         ability.addTarget(new TargetCreaturePermanent(filter));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/a/AgonizingDemise.java
+++ b/Mage.Sets/src/mage/cards/a/AgonizingDemise.java
@@ -33,7 +33,7 @@ public final class AgonizingDemise extends CardImpl {
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
                 new DamageTargetControllerEffect(TargetPermanentPowerCount.instance),
                 KickedCondition.ONCE,
-                "if this spell was kicked, it deals damage equal to that creature's power to the creature's controller."));
+                "if this spell was kicked, {this} deals damage equal to that creature's power to the creature's controller."));
 
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArmageddonClock.java
+++ b/Mage.Sets/src/mage/cards/a/ArmageddonClock.java
@@ -28,14 +28,23 @@ public final class ArmageddonClock extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{6}");
 
         // At the beginning of your upkeep, put a doom counter on Armageddon Clock.
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.DOOM.createInstance(), StaticValue.get(1), true), TargetController.YOU, false));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(
+                new AddCountersSourceEffect(CounterType.DOOM.createInstance(), StaticValue.get(1), true),
+                TargetController.YOU, false
+        ));
         // At the beginning of your draw step, Armageddon Clock deals damage equal to the number of doom counters on it to each player.
-        this.addAbility(new BeginningOfDrawTriggeredAbility(new DamagePlayersEffect(Outcome.Damage, new CountersSourceCount(CounterType.DOOM))
-                .setText("{this} deals damage equal to the number of doom counters on it to each player"), TargetController.YOU, false));
+        this.addAbility(new BeginningOfDrawTriggeredAbility(
+                new DamagePlayersEffect(Outcome.Damage, new CountersSourceCount(CounterType.DOOM).doPluralizeCounter())
+                        .setText("{this} deals damage equal to the number of doom counters on it to each player"),
+                TargetController.YOU, false
+        ));
         // {4}: Remove a doom counter from Armageddon Clock. Any player may activate this ability but only during any upkeep step.
         ActivatedAbilityImpl ability = new ConditionalActivatedAbility(Zone.BATTLEFIELD,
-                new RemoveCounterSourceEffect(CounterType.DOOM.createInstance()), new ManaCostsImpl<>("{4}"), new IsStepCondition(PhaseStep.UPKEEP, false),
-                "Remove a doom counter from {this}. Any player may activate this ability but only during any upkeep step");
+                new RemoveCounterSourceEffect(CounterType.DOOM.createInstance()),
+                new ManaCostsImpl<>("{4}"),
+                new IsStepCondition(PhaseStep.UPKEEP, false),
+                "Remove a doom counter from {this}. Any player may activate this ability but only during any upkeep step"
+        );
 
         ability.setMayActivate(TargetController.ANY);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/b/BenBenAkkiHermit.java
+++ b/Mage.Sets/src/mage/cards/b/BenBenAkkiHermit.java
@@ -25,7 +25,7 @@ import java.util.UUID;
  */
 public final class BenBenAkkiHermit extends CardImpl {
 
-    private static final FilterLandPermanent filter = new FilterLandPermanent("untapped Mountain you control");
+    private static final FilterLandPermanent filter = new FilterLandPermanent("untapped Mountains you control");
 
     static {
         filter.add(TappedPredicate.UNTAPPED);
@@ -39,7 +39,12 @@ public final class BenBenAkkiHermit extends CardImpl {
 
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter), true), new TapSourceCost());
+
+        // {T}: Ben-Ben, Akki Hermit deals damage to target attacking creature equal to the number of untapped Mountains you control.
+        Ability ability = new SimpleActivatedAbility(
+                new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter), true),
+                new TapSourceCost()
+        );
         ability.addTarget(new TargetAttackingCreature());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BlastOfGenius.java
+++ b/Mage.Sets/src/mage/cards/b/BlastOfGenius.java
@@ -42,7 +42,7 @@ class BlastOfGeniusEffect extends OneShotEffect {
 
     public BlastOfGeniusEffect() {
         super(Outcome.Benefit);
-        this.staticText = "Choose any target. Draw three cards, then discard a card. {this} deals damage equal to the discard card's mana value to that permanent or player";
+        this.staticText = "Choose any target. Draw three cards, then discard a card. {this} deals damage equal to the discarded card's mana value to that permanent or player";
     }
 
     public BlastOfGeniusEffect(final BlastOfGeniusEffect effect) {

--- a/Mage.Sets/src/mage/cards/b/BlazingEffigy.java
+++ b/Mage.Sets/src/mage/cards/b/BlazingEffigy.java
@@ -35,7 +35,11 @@ public final class BlazingEffigy extends CardImpl {
         this.toughness = new MageInt(3);
 
         // When Blazing Effigy dies, it deals X damage to target creature, where X is 3 plus the amount of damage dealt to Blazing Effigy this turn by other sources named Blazing Effigy.
-        Ability ability = new DiesSourceTriggeredAbility(new DamageTargetEffect(BlazingEffigyCount.instance), false);
+        Ability ability = new DiesSourceTriggeredAbility(
+                new DamageTargetEffect(BlazingEffigyCount.instance, "it")
+                        .withWhereXWording(),
+                false
+        );
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability, new BlazingEffigyWatcher());
     }

--- a/Mage.Sets/src/mage/cards/b/BorosFuryShield.java
+++ b/Mage.Sets/src/mage/cards/b/BorosFuryShield.java
@@ -34,7 +34,7 @@ public final class BorosFuryShield extends CardImpl {
         // If {R} was spent to cast Boros Fury-Shield, it deals damage to that creature's controller equal to the creature's power.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
                 new BorosFuryShieldDamageEffect(),
-                ManaWasSpentCondition.RED, "If {R} was spent to cast this spell, it deals damage to that creature's controller equal to the creature's power"));
+                ManaWasSpentCondition.RED, "If {R} was spent to cast this spell, {this} deals damage to that creature's controller equal to the creature's power"));
     }
 
     private BorosFuryShield(final BorosFuryShield card) {

--- a/Mage.Sets/src/mage/cards/b/BouncersBeatdown.java
+++ b/Mage.Sets/src/mage/cards/b/BouncersBeatdown.java
@@ -41,7 +41,7 @@ public final class BouncersBeatdown extends CardImpl {
         ).setRuleAtTheTop(true));
 
         // Bouncer's Beatdown deals X damage to target creature or planeswalker, where X is the greatest power among creatures you control. If that creature or planeswalker would die this turn, exile it instead.
-        this.getSpellAbility().addEffect(new DamageTargetEffect(GreatestPowerAmongControlledCreaturesValue.instance));
+        this.getSpellAbility().addEffect(new DamageTargetEffect(GreatestPowerAmongControlledCreaturesValue.instance).withWhereXWording());
         this.getSpellAbility().addTarget(new TargetCreatureOrPlaneswalker());
         this.getSpellAbility().addEffect(new ExileTargetIfDiesEffect("creature or planeswalker"));
         this.getSpellAbility().addHint(GreatestPowerAmongControlledCreaturesValue.getHint());

--- a/Mage.Sets/src/mage/cards/c/ChandraLegacyOfFire.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraLegacyOfFire.java
@@ -45,7 +45,7 @@ public final class ChandraLegacyOfFire extends CardImpl {
         this.addAbility(new BeginningOfEndStepTriggeredAbility(
                 new DamagePlayersEffect(
                         Outcome.Benefit, xValue, TargetController.OPPONENT
-                ), TargetController.YOU, false
+                ).setText("{this} deals X damage to each opponent, where X is the number of planeswalkers you control."), TargetController.YOU, false
         ).addHint(hint));
 
         // +1: Add {R} for each planeswalker you control.

--- a/Mage.Sets/src/mage/cards/c/CinderShade.java
+++ b/Mage.Sets/src/mage/cards/c/CinderShade.java
@@ -31,10 +31,14 @@ public final class CinderShade extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {B}: Cinder Shade gets +1/+1 until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn), new ManaCostsImpl<>("{B}")));
+        this.addAbility(new SimpleActivatedAbility(new BoostSourceEffect(1, 1, Duration.EndOfTurn), new ManaCostsImpl<>("{B}")));
         
-        // {R}, Sacrifice Cinder Shade: Cinder Shade deals damage equal to its power to target creature.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(new SourcePermanentPowerCount()), new ManaCostsImpl<>("{R}"));
+        // {R}, Sacrifice Cinder Shade: It deals damage equal to its power to target creature.
+        Ability ability = new SimpleActivatedAbility(
+                new DamageTargetEffect(new SourcePermanentPowerCount().setSourcePossessiveForm("its"), "it")
+                        .withEqualToBeforeTarget(),
+                new ManaCostsImpl<>("{R}")
+        );
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/c/CommodoreGuff.java
+++ b/Mage.Sets/src/mage/cards/c/CommodoreGuff.java
@@ -61,7 +61,7 @@ public final class CommodoreGuff extends CardImpl {
         ability = new LoyaltyAbility(new DrawCardSourceControllerEffect(xValue).setText("you draw X cards"), -3);
         ability.addEffect(new DamagePlayersEffect(
                 Outcome.Damage, xValue, TargetController.OPPONENT
-        ).concatBy("and"));
+        ).setText("and {this} deals X damage to each opponent, where X is the number of planeswalkers you control"));
         this.addAbility(ability.addHint(hint));
 
         // Commodore Guff can be your commander.

--- a/Mage.Sets/src/mage/cards/c/Cyclone.java
+++ b/Mage.Sets/src/mage/cards/c/Cyclone.java
@@ -49,7 +49,8 @@ class CycloneEffect extends OneShotEffect {
 
     public CycloneEffect() {
         super(Outcome.Damage);
-        this.staticText = "Pay Green Mana for each counter to damage everything or sacrifice Cyclone.";
+        this.staticText = ", then sacrifice {this} unless you pay {G} for each wind counter on it. "
+                + "If you pay, {this} deals damage equal to the number of wind counters on it to each creature and each player.";
     }
 
     public CycloneEffect(final CycloneEffect effect) {

--- a/Mage.Sets/src/mage/cards/e/Electryte.java
+++ b/Mage.Sets/src/mage/cards/e/Electryte.java
@@ -48,6 +48,7 @@ class ElectryteTriggeredAbility extends DealsCombatDamageToAPlayerTriggeredAbili
 
     ElectryteTriggeredAbility() {
         super(new ElectryteEffect(), false);
+        this.setTriggerPhrase("Whenever {this} deals combat damage to defending player, ");
     }
 
     ElectryteTriggeredAbility(final ElectryteTriggeredAbility effect) {
@@ -65,12 +66,6 @@ class ElectryteTriggeredAbility extends DealsCombatDamageToAPlayerTriggeredAbili
             return game.getCombat().getDefenderId(getSourceId()).equals(event.getPlayerId());
         }
         return false;
-    }
-
-    @Override
-    public String getRule() {
-        return "Whenever {this} deals combat damage to defending player, "
-                + "it deals damage equal to its power to each blocking creature";
     }
 }
 

--- a/Mage.Sets/src/mage/cards/e/EomerKingOfRohan.java
+++ b/Mage.Sets/src/mage/cards/e/EomerKingOfRohan.java
@@ -83,7 +83,7 @@ class EomerKingOfRohanEffect extends OneShotEffect {
 
     EomerKingOfRohanEffect() {
         super(Outcome.Benefit);
-        staticText = "target player becomes the monarch. {this} deals equal to its power to any target.";
+        staticText = "target player becomes the monarch. {this} deals damage equal to its power to any target.";
     }
 
     private EomerKingOfRohanEffect(final EomerKingOfRohanEffect effect) {

--- a/Mage.Sets/src/mage/cards/e/EternalFlame.java
+++ b/Mage.Sets/src/mage/cards/e/EternalFlame.java
@@ -29,8 +29,13 @@ public final class EternalFlame extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{R}{R}");
 
         // Eternal Flame deals X damage to target opponent, where X is the number of Mountains you control. It deals half X damage, rounded up, to you.);
-        this.getSpellAbility().addEffect(new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter)).setText("{this} deals X damage to target opponent, where X is the number of Mountains you control"));
-        this.getSpellAbility().addEffect(new DamageControllerEffect(new HalfValue(new PermanentsOnBattlefieldCount(filter), true)).setText("It deals half X damage, rounded up, to you"));
+        this.getSpellAbility().addEffect(
+                new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter))
+                        .setText("{this} deals X damage to target opponent or planeswalker")
+        );
+        this.getSpellAbility().addEffect(
+                new DamageControllerEffect(new HalfValue(new PermanentsOnBattlefieldCount(filter), true))
+                        .setText(" and half X damage, rounded up, to you, where X is the number of Mountains you control"));
         this.getSpellAbility().addTarget(new TargetOpponentOrPlaneswalker());
     }
 

--- a/Mage.Sets/src/mage/cards/f/FalkenrathExterminator.java
+++ b/Mage.Sets/src/mage/cards/f/FalkenrathExterminator.java
@@ -35,7 +35,10 @@ public final class FalkenrathExterminator extends CardImpl {
         // Whenever Falkenrath Exterminator deals combat damage to a player, put a +1/+1 counter on it.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false));
         // {2}{R}: Falkenrath Exterminator deals damage to target creature equal to the number of +1/+1 counters on Falkenrath Exterminator.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(new CountersSourceCount(CounterType.P1P1)), new ManaCostsImpl<>("{2}{R}"));
+        Ability ability = new SimpleActivatedAbility(
+                new DamageTargetEffect(new CountersSourceCount(CounterType.P1P1).doPluralizeCounter()),
+                new ManaCostsImpl<>("{2}{R}")
+        );
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/f/FireDragon.java
+++ b/Mage.Sets/src/mage/cards/f/FireDragon.java
@@ -22,7 +22,8 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class FireDragon extends CardImpl {
     
-    private static final FilterControlledPermanent filter = new FilterControlledPermanent("for each Mountain you control");
+    private static final FilterControlledPermanent filter =
+            new FilterControlledPermanent("Mountains you control");
 
     static {
         filter.add(SubType.MOUNTAIN.getPredicate());
@@ -38,8 +39,7 @@ public final class FireDragon extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         
         // When Fire Dragon enters the battlefield, it deals damage equal to the number of Mountains you control to target creature.
-        Effect effect = new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter));
-        effect.setText("it deals damage equal to the number of Mountains you control to target creature");
+        Effect effect = new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter), "it");
         Ability ability = new EntersBattlefieldTriggeredAbility(effect, false);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/f/FlameElemental.java
+++ b/Mage.Sets/src/mage/cards/f/FlameElemental.java
@@ -29,8 +29,12 @@ public final class FlameElemental extends CardImpl {
         this.power = new MageInt(3);
         this.toughness = new MageInt(2);
 
-        // {R}, {tap}, Sacrifice Flame Elemental: Flame Elemental deals damage equal to its power to target creature.
-        Ability ability = new SimpleActivatedAbility(new DamageTargetEffect(new SourcePermanentPowerCount(false)), new ManaCostsImpl<>("{R}"));
+        // {R}, {tap}, Sacrifice Flame Elemental: It deals damage equal to its power to target creature.
+        Ability ability = new SimpleActivatedAbility(
+                new DamageTargetEffect(new SourcePermanentPowerCount(false).setSourcePossessiveForm("its"), "it")
+                        .withEqualToBeforeTarget(),
+                new ManaCostsImpl<>("{R}")
+        );
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/g/GempalmIncinerator.java
+++ b/Mage.Sets/src/mage/cards/g/GempalmIncinerator.java
@@ -37,7 +37,10 @@ public final class GempalmIncinerator extends CardImpl {
         // Cycling {1}{R}
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{1}{R}")));
         // When you cycle Gempalm Incinerator, you may have it deal X damage to target creature, where X is the number of Goblins on the battlefield.
-        Ability ability = new CycleTriggeredAbility(new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter)),true);
+        Ability ability = new CycleTriggeredAbility(
+                new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter)).withWhereXWording(),
+                true
+        );
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/g/GhituFireEater.java
+++ b/Mage.Sets/src/mage/cards/g/GhituFireEater.java
@@ -31,7 +31,11 @@ public final class GhituFireEater extends CardImpl {
         this.toughness = new MageInt(2);
 
         // {T}, Sacrifice Ghitu Fire-Eater: Ghitu Fire-Eater deals damage equal to its power to any target.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(new SourcePermanentPowerCount()), new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(
+                new DamageTargetEffect(new SourcePermanentPowerCount().setSourcePossessiveForm("its"), "it")
+                        .withEqualToBeforeTarget(),
+                new TapSourceCost()
+        );
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/h/HallarTheFirefletcher.java
+++ b/Mage.Sets/src/mage/cards/h/HallarTheFirefletcher.java
@@ -50,9 +50,9 @@ public final class HallarTheFirefletcher extends CardImpl {
 class HallarTheFirefletcherTriggeredAbility extends TriggeredAbilityImpl {
 
     HallarTheFirefletcherTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()).setText("put a +1/+1 counter on {this}"), true);
+        super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()).setText("put a +1/+1 counter on {this}"), false);
         this.addEffect(new DamagePlayersEffect(Outcome.Benefit, new CountersSourceCount(CounterType.P1P1), TargetController.OPPONENT)
-                .setText("then {this} deals damage equal to the number of +1/+1 counters on it to each opponent")
+                .setText(", then {this} deals damage equal to the number of +1/+1 counters on it to each opponent")
         );
         setTriggerPhrase("Whenever you cast a spell, if that spell was kicked, ");
     }

--- a/Mage.Sets/src/mage/cards/h/Heliophial.java
+++ b/Mage.Sets/src/mage/cards/h/Heliophial.java
@@ -28,9 +28,13 @@ public final class Heliophial extends CardImpl {
 
         // Sunburst
         this.addAbility(new SunburstAbility(this));
-        // {2}, Sacrifice Heliophial: Heliophial deals damage equal to the number of charge counters on it to any target.
-        Effect effect = new DamageTargetEffect(new CountersSourceCount(CounterType.CHARGE));
-        effect.setText("{this} deals damage equal to the number of charge counters on it to any target");
+        // {2}, Sacrifice Heliophial: It deals damage equal to the number of charge counters on it to any target.
+        Effect effect = new DamageTargetEffect(
+                new CountersSourceCount(CounterType.CHARGE)
+                        .setSourceName("it")
+                        .doPluralizeCounter(),
+                "it"
+        ).withEqualToBeforeTarget();
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{2}"));
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetAnyTarget());

--- a/Mage.Sets/src/mage/cards/h/HondenOfInfiniteRage.java
+++ b/Mage.Sets/src/mage/cards/h/HondenOfInfiniteRage.java
@@ -24,7 +24,7 @@ import mage.target.common.TargetAnyTarget;
 public final class HondenOfInfiniteRage extends CardImpl {
 
     private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(
-            new FilterControlledPermanent(SubType.SHRINE)
+            new FilterControlledPermanent(SubType.SHRINE, "Shrines you control")
     );
     private static final Hint hint = new ValueHint("Shrines you control", xValue);
 

--- a/Mage.Sets/src/mage/cards/i/IreOfKaminari.java
+++ b/Mage.Sets/src/mage/cards/i/IreOfKaminari.java
@@ -18,7 +18,7 @@ import java.util.UUID;
  */
 public final class IreOfKaminari extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("Arcane");
+    private static final FilterCard filter = new FilterCard("Arcane cards");
 
     static {
         filter.add(SubType.ARCANE.getPredicate());

--- a/Mage.Sets/src/mage/cards/i/IronMaiden.java
+++ b/Mage.Sets/src/mage/cards/i/IronMaiden.java
@@ -40,13 +40,13 @@ public final class IronMaiden extends CardImpl {
 
 class IronMaidenEffect extends OneShotEffect {
 
-    private IronMaidenEffect(final IronMaidenEffect effect) {
-        super(effect);
-        this.staticText = "Iron Maiden deals X damage to that player, where X is the number of cards in their hand minus 4";
+    IronMaidenEffect() {
+        super(Outcome.Damage);
+        this.staticText = "{this} deals X damage to that player, where X is the number of cards in their hand minus 4";
     }
 
-    public IronMaidenEffect() {
-        super(Outcome.Damage);
+    private IronMaidenEffect(final IronMaidenEffect effect) {
+        super(effect);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/j/JuriMasterOfTheRevue.java
+++ b/Mage.Sets/src/mage/cards/j/JuriMasterOfTheRevue.java
@@ -5,6 +5,7 @@ import mage.abilities.Ability;
 import mage.abilities.common.DiesSourceTriggeredAbility;
 import mage.abilities.common.SacrificePermanentTriggeredAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.SourcePermanentPowerCount;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
@@ -40,8 +41,10 @@ public final class JuriMasterOfTheRevue extends CardImpl {
         ));
 
         // When Juri dies, it deals damage equal its power to any target.
-        Ability ability = new DiesSourceTriggeredAbility(new DamageTargetEffect(JuriMasterOfTheRevueValue.instance)
-                .setText("it deals damage equal its power to any target"));
+        Ability ability = new DiesSourceTriggeredAbility(
+                new DamageTargetEffect(new SourcePermanentPowerCount().setSourcePossessiveForm("its"), "it")
+                        .withEqualToBeforeTarget()
+        );
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }
@@ -53,25 +56,5 @@ public final class JuriMasterOfTheRevue extends CardImpl {
     @Override
     public JuriMasterOfTheRevue copy() {
         return new JuriMasterOfTheRevue(this);
-    }
-}
-
-enum JuriMasterOfTheRevueValue implements DynamicValue {
-    instance;
-
-    @Override
-    public int calculate(Game game, Ability sourceAbility, Effect effect) {
-        Permanent permanent = (Permanent) effect.getValue("permanentLeftBattlefield");
-        return permanent == null ? 0 : permanent.getPower().getValue();
-    }
-
-    @Override
-    public JuriMasterOfTheRevueValue copy() {
-        return instance;
-    }
-
-    @Override
-    public String getMessage() {
-        return "";
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LightningStorm.java
+++ b/Mage.Sets/src/mage/cards/l/LightningStorm.java
@@ -32,9 +32,9 @@ public final class LightningStorm extends CardImpl {
     public LightningStorm(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{R}{R}");
 
-        // Lightning Storm deals X damage to any target, where X is 3 plus the number of charge counters on it.
+        // Lightning Storm deals X damage to any target, where X is 3 plus the number of charge counters on Lightning Storm.
         Effect effect = new DamageTargetEffect(new LightningStormCountCondition(CounterType.CHARGE));
-        effect.setText("{this} deals X damage to any target, where X is 3 plus the number of charge counters on it");
+        effect.setText("{this} deals X damage to any target, where X is 3 plus the number of charge counters on {this}");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetAnyTarget());
 

--- a/Mage.Sets/src/mage/cards/l/LotlethGiant.java
+++ b/Mage.Sets/src/mage/cards/l/LotlethGiant.java
@@ -32,7 +32,7 @@ public final class LotlethGiant extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(
                 new DamageTargetEffect(new CardsInControllerGraveyardCount(
                         StaticFilters.FILTER_CARD_CREATURE
-                ), "it"), false);
+                ), "it").with1DamageForEachWording(), false);
         ability.addTarget(new TargetOpponent());
         ability.setAbilityWord(AbilityWord.UNDERGROWTH);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/l/LozhanDragonsLegacy.java
+++ b/Mage.Sets/src/mage/cards/l/LozhanDragonsLegacy.java
@@ -29,7 +29,7 @@ import java.util.UUID;
  */
 public final class LozhanDragonsLegacy extends CardImpl {
 
-    private static final FilterSpell filter = new FilterSpell("an Adventure spell or Dragon spell");
+    private static final FilterSpell filter = new FilterSpell("an Adventure or Dragon spell");
     private static final FilterPermanentOrPlayer filter2
             = new FilterAnyTarget("any target that isn't a commander");
 

--- a/Mage.Sets/src/mage/cards/m/MagmaMine.java
+++ b/Mage.Sets/src/mage/cards/m/MagmaMine.java
@@ -31,8 +31,16 @@ public final class MagmaMine extends CardImpl {
                 new AddCountersSourceEffect(CounterType.PRESSURE.createInstance(), true), 
                 new GenericManaCost(4)));
         
-        // {tap}, Sacrifice Magma Mine: Magma Mine deals damage equal to the number of pressure counters on it to any target.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(new CountersSourceCount(CounterType.PRESSURE)), new TapSourceCost());
+        // {tap}, Sacrifice Magma Mine: It deals damage equal to the number of pressure counters on it to any target.
+        Ability ability = new SimpleActivatedAbility(
+                new DamageTargetEffect(
+                        new CountersSourceCount(CounterType.PRESSURE)
+                                .setSourceName("it")
+                                .doPluralizeCounter(),
+                        "it"
+                ).withEqualToBeforeTarget(),
+                new TapSourceCost()
+        );
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/m/MercurialChemister.java
+++ b/Mage.Sets/src/mage/cards/m/MercurialChemister.java
@@ -39,7 +39,7 @@ public final class MercurialChemister extends CardImpl {
         this.addAbility(ability);
 
         // {R}, {T}, Discard a card: Mercurial Chemister deals damage to target creature equal to the discarded card's converted mana cost.
-        ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(DiscardCostCardManaValue.instance), new ManaCostsImpl<>("{R}"));
+        ability = new SimpleActivatedAbility(new DamageTargetEffect(DiscardCostCardManaValue.instance), new ManaCostsImpl<>("{R}"));
         ability.addTarget(new TargetCreaturePermanent());
         ability.addCost(new TapSourceCost());
         ability.addCost(new DiscardCardCost());

--- a/Mage.Sets/src/mage/cards/m/MinotaurIllusionist.java
+++ b/Mage.Sets/src/mage/cards/m/MinotaurIllusionist.java
@@ -37,9 +37,9 @@ public final class MinotaurIllusionist extends CardImpl {
         // {1}{U}: Minotaur Illusionist gains shroud until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilitySourceEffect(ShroudAbility.getInstance(),
             Duration.EndOfTurn), new ManaCostsImpl<>("{1}{U}")));
-        // {R}, Sacrifice Minotaur Illusionist: Minotaur Illusionist deals damage equal to its power to target creature.
-        Effect effect = new DamageTargetEffect(new SourcePermanentPowerCount());
-        effect.setText("{this} deals damage equal to its power to target creature.");
+        // {R}, Sacrifice Minotaur Illusionist: It deals damage equal to its power to target creature.
+        Effect effect = new DamageTargetEffect(new SourcePermanentPowerCount().setSourcePossessiveForm("its"), "it")
+                .withEqualToBeforeTarget();
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{R}"));
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/m/MoltenHydra.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenHydra.java
@@ -38,9 +38,10 @@ public final class MoltenHydra extends CardImpl {
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance(1)), new ManaCostsImpl<>("{1}{R}{R}")
         ));
 
-        // {tap}, Remove all +1/+1 counters from Molten Hydra: Molten Hydra deals damage to any target equal to the number of +1/+1 counters removed this way.
+        // {tap}, Remove all +1/+1 counters from Molten Hydra: It deals damage to any target equal to the number of +1/+1 counters removed this way.
         Ability ability = new SimpleActivatedAbility(
-                new DamageTargetEffect(MoltenHydraDynamicValue.instance), new TapSourceCost()
+                new DamageTargetEffect(MoltenHydraDynamicValue.instance, "it"),
+                new TapSourceCost()
         );
         ability.addCost(new RemoveAllCountersSourceCost(CounterType.P1P1));
         ability.addTarget(new TargetAnyTarget());

--- a/Mage.Sets/src/mage/cards/m/MurasaPyromancer.java
+++ b/Mage.Sets/src/mage/cards/m/MurasaPyromancer.java
@@ -21,7 +21,8 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class MurasaPyromancer extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("Ally you control");
+    private static final FilterControlledCreaturePermanent filter =
+            new FilterControlledCreaturePermanent("Allies you control");
 
     static {
         filter.add(SubType.ALLY.getPredicate());
@@ -37,7 +38,10 @@ public final class MurasaPyromancer extends CardImpl {
         this.power = new MageInt(3);
         this.toughness = new MageInt(2);
 
-        Ability ability = new AllyEntersBattlefieldTriggeredAbility(new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter)), true);
+        Ability ability = new AllyEntersBattlefieldTriggeredAbility(
+                new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter)),
+                true
+        );
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability.setAbilityWord(null));
 

--- a/Mage.Sets/src/mage/cards/n/NissasJudgment.java
+++ b/Mage.Sets/src/mage/cards/n/NissasJudgment.java
@@ -34,7 +34,7 @@ public final class NissasJudgment extends CardImpl {
         effect = new NissasJudgmentEffect();
         effect.setTargetPointer(new SecondTargetPointer()); // First target is used by Support
         getSpellAbility().addTarget(new TargetCreaturePermanent(0, 1, StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE, false));
-        getSpellAbility().addEffect(effect);
+        getSpellAbility().addEffect(effect.concatBy("<br>"));
     }
 
     private NissasJudgment(final NissasJudgment card) {

--- a/Mage.Sets/src/mage/cards/n/NoiseMarine.java
+++ b/Mage.Sets/src/mage/cards/n/NoiseMarine.java
@@ -36,6 +36,7 @@ public final class NoiseMarine extends CardImpl {
         // Sonic Blaster -- When Noise Marine enters the battlefield, it deals damage equal to the number of spells you've cast this turn to any target.
         Ability ability = new EntersBattlefieldTriggeredAbility(
                 new DamageTargetEffect(NoiseMarineValue.instance, "it")
+                        .withEqualToBeforeTarget()
         );
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability.withFlavorWord("Sonic Blaster"));

--- a/Mage.Sets/src/mage/cards/o/OssuaryRats.java
+++ b/Mage.Sets/src/mage/cards/o/OssuaryRats.java
@@ -43,7 +43,10 @@ public final class OssuaryRats extends CardImpl {
         this.toughness = new MageInt(2);
 
         // When Ossuary Rats enters the battlefield, it deals X damage to target creature or planeswalker an opponent controls, where X is the number of creature cards in your graveyard.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new DamageTargetEffect(xValue, "it"));
+        Ability ability = new EntersBattlefieldTriggeredAbility(
+                new DamageTargetEffect(xValue, "it")
+                        .withWhereXWording()
+        );
         ability.addTarget(new TargetPermanent(filter));
         this.addAbility(ability.addHint(hint));
     }

--- a/Mage.Sets/src/mage/cards/p/Pandemonium.java
+++ b/Mage.Sets/src/mage/cards/p/Pandemonium.java
@@ -29,7 +29,7 @@ public final class Pandemonium extends CardImpl {
         // Whenever a creature enters the battlefield, that creature's controller may have it deal damage equal to its power to any target of their choice.
         Ability ability = new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new PandemoniumEffect(),
-                StaticFilters.FILTER_PERMANENT_CREATURE,
+                StaticFilters.FILTER_PERMANENT_A_CREATURE,
                 false, SetTargetPointer.PERMANENT, ""
         );
         ability.addTarget(new TargetAnyTarget());

--- a/Mage.Sets/src/mage/cards/p/PassionateArchaeologist.java
+++ b/Mage.Sets/src/mage/cards/p/PassionateArchaeologist.java
@@ -38,9 +38,11 @@ public final class PassionateArchaeologist extends CardImpl {
         this.subtype.add(SubType.BACKGROUND);
 
         // Commander creatures you own have "Whenever you cast a spell from exile, this creature deals damage equal to that spell's mana value to target opponent."
-        Ability ability = new SpellCastControllerTriggeredAbility(new DamageTargetEffect(
-                PassionateArchaeologistValue.instance, "this creature"
-        ), filter, false);
+        Ability ability = new SpellCastControllerTriggeredAbility(
+                new DamageTargetEffect(PassionateArchaeologistValue.instance, "this creature")
+                        .withEqualToBeforeTarget(),
+                filter, false
+        );
         ability.addTarget(new TargetOpponent());
         this.addAbility(new SimpleStaticAbility(new GainAbilityAllEffect(
                 ability, Duration.WhileOnBattlefield,

--- a/Mage.Sets/src/mage/cards/p/PowerSurge.java
+++ b/Mage.Sets/src/mage/cards/p/PowerSurge.java
@@ -43,7 +43,7 @@ class PowerSurgeDamageEffect extends OneShotEffect {
 
     public PowerSurgeDamageEffect() {
         super(Outcome.Damage);
-        this.staticText = "{this} deals X damage to that player where X is the number of untapped lands they controlled at the beginning of this turn";
+        this.staticText = "{this} deals X damage to that player, where X is the number of untapped lands they controlled at the beginning of this turn";
     }
 
     private PowerSurgeDamageEffect(final PowerSurgeDamageEffect copy) {

--- a/Mage.Sets/src/mage/cards/p/PressIntoService.java
+++ b/Mage.Sets/src/mage/cards/p/PressIntoService.java
@@ -32,6 +32,7 @@ public final class PressIntoService extends CardImpl {
 
         this.getSpellAbility().addEffect(new GainControlTargetEffect(Duration.EndOfTurn)
                 .setText("Gain control of target creature until end of turn")
+                .concatBy("<br>")
                 .setTargetPointer(new SecondTargetPointer())
         );
         this.getSpellAbility().addEffect(new UntapTargetEffect()

--- a/Mage.Sets/src/mage/cards/p/PreyseizerDragon.java
+++ b/Mage.Sets/src/mage/cards/p/PreyseizerDragon.java
@@ -37,7 +37,10 @@ public final class PreyseizerDragon extends CardImpl {
         this.addAbility(new DevourAbility(2));
 
         // Whenever Preyseizer Dragon attacks, it deals damage to any target equal to the number of +1/+1 counters on Preyseizer Dragon.
-        Ability ability = new AttacksTriggeredAbility(new DamageTargetEffect(new CountersSourceCount(CounterType.P1P1)), false);
+        Ability ability = new AttacksTriggeredAbility(
+                new DamageTargetEffect(new CountersSourceCount(CounterType.P1P1).doPluralizeCounter()),
+                false
+        );
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/p/ProfanePrayers.java
+++ b/Mage.Sets/src/mage/cards/p/ProfanePrayers.java
@@ -2,6 +2,8 @@
 package mage.cards.p;
 
 import java.util.UUID;
+
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.GainLifeEffect;
@@ -23,14 +25,18 @@ public final class ProfanePrayers extends CardImpl {
     static {
         filter.add(SubType.CLERIC.getPredicate());
     }
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(filter);
     
     public ProfanePrayers(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{B}{B}");
 
         // Profane Prayers deals X damage to any target and you gain X life, where X is the number of Clerics on the battlefield.
-        this.getSpellAbility().addEffect(new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter)));
+        this.getSpellAbility().addEffect(new DamageTargetEffect(xValue)
+                .setText("{this} deals X damage to any target"));
         this.getSpellAbility().addTarget(new TargetAnyTarget());
-        this.getSpellAbility().addEffect(new GainLifeEffect(new PermanentsOnBattlefieldCount(filter)));
+        this.getSpellAbility().addEffect(new GainLifeEffect(xValue)
+                .setText("and you gain X life, where X is the number of " + xValue.getMessage()));
     }
 
     private ProfanePrayers(final ProfanePrayers card) {

--- a/Mage.Sets/src/mage/cards/p/PyreSledgeArsonist.java
+++ b/Mage.Sets/src/mage/cards/p/PyreSledgeArsonist.java
@@ -44,7 +44,9 @@ public final class PyreSledgeArsonist extends CardImpl {
 
         // {1}, {T}: Pyre-Sledge Arsonist deals X damage to any target, where X is the number of permanents you sacrificed this turn.
         Ability ability = new SimpleActivatedAbility(
-                new DamageTargetEffect(PyreSledgeArsonistValue.instance), new GenericManaCost(1)
+                new DamageTargetEffect(PyreSledgeArsonistValue.instance)
+                        .withWhereXWording(),
+                new GenericManaCost(1)
         );
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetAnyTarget());

--- a/Mage.Sets/src/mage/cards/r/RockslideAmbush.java
+++ b/Mage.Sets/src/mage/cards/r/RockslideAmbush.java
@@ -17,7 +17,7 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class RockslideAmbush extends CardImpl {
 
-    private static final FilterControlledPermanent filter = new FilterControlledPermanent("Mountain you control");
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent("Mountains you control");
 
     static {
         filter.add(SubType.MOUNTAIN.getPredicate());

--- a/Mage.Sets/src/mage/cards/r/RuneflareTrap.java
+++ b/Mage.Sets/src/mage/cards/r/RuneflareTrap.java
@@ -72,7 +72,7 @@ class TargetPlayerCardsInHandCount implements DynamicValue {
 
     @Override
     public String getMessage() {
-        return "target player's cards in hand";
+        return "the number of cards in that player's hand";
     }
 }
 

--- a/Mage.Sets/src/mage/cards/s/SavageSmash.java
+++ b/Mage.Sets/src/mage/cards/s/SavageSmash.java
@@ -24,7 +24,7 @@ public final class SavageSmash extends CardImpl {
         this.getSpellAbility().addEffect(new BoostTargetEffect(2, 2, Duration.EndOfTurn));
         this.getSpellAbility().addEffect(
                 new FightTargetsEffect().setText("It fights target creature you don't control." +
-                        "<i>(Each deals damage equal to its power to the other.)</i>")
+                        " <i>(Each deals damage equal to its power to the other.)</i>")
         );
         this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent());
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_CREATURE_YOU_DONT_CONTROL));

--- a/Mage.Sets/src/mage/cards/s/ScrapyardSalvo.java
+++ b/Mage.Sets/src/mage/cards/s/ScrapyardSalvo.java
@@ -7,6 +7,7 @@ import mage.abilities.effects.common.DamageTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterArtifactCard;
 import mage.target.common.TargetPlayerOrPlaneswalker;
 
@@ -20,7 +21,9 @@ public final class ScrapyardSalvo extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{R}{R}");
 
         this.getSpellAbility().addTarget(new TargetPlayerOrPlaneswalker());
-        this.getSpellAbility().addEffect(new DamageTargetEffect(new CardsInControllerGraveyardCount(new FilterArtifactCard())));
+        this.getSpellAbility().addEffect(new DamageTargetEffect(
+                new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_ARTIFACTS)
+        ));
     }
 
     private ScrapyardSalvo(final ScrapyardSalvo card) {

--- a/Mage.Sets/src/mage/cards/s/SeasonsBeatings.java
+++ b/Mage.Sets/src/mage/cards/s/SeasonsBeatings.java
@@ -29,6 +29,7 @@ public final class SeasonsBeatings extends CardImpl {
         // Family gathering - Each creature target player controls deals damage equal to its power to another random creature that player controls.
         this.getSpellAbility().addEffect(new SeasonsBeatingsEffect());
         this.getSpellAbility().addTarget(new TargetPlayer());
+        this.getSpellAbility().withFlavorWord("Family gathering");
 
     }
 
@@ -46,7 +47,7 @@ class SeasonsBeatingsEffect extends OneShotEffect {
 
     SeasonsBeatingsEffect() {
         super(Outcome.Damage);
-        staticText = "Family gathering <i>Each creature target player controls deals damage equal to its power to another random creature that player controls.</i>";
+        staticText = "Each creature target player controls deals damage equal to its power to another random creature that player controls.</i>";
     }
 
     SeasonsBeatingsEffect(final SeasonsBeatingsEffect effect) {

--- a/Mage.Sets/src/mage/cards/s/SharpshooterElf.java
+++ b/Mage.Sets/src/mage/cards/s/SharpshooterElf.java
@@ -35,7 +35,8 @@ public final class SharpshooterElf extends CardImpl {
         filter.add(new AbilityPredicate(FlyingAbility.class));
     }
 
-    private static final DynamicValue xValue = new SourcePermanentPowerCount(false);
+    private static final DynamicValue xValue = new SourcePermanentPowerCount(false)
+            .setSourcePossessiveForm("its");
 
     public SharpshooterElf(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}");
@@ -55,7 +56,9 @@ public final class SharpshooterElf extends CardImpl {
 
         // When Sharpshooter Elf enters the battlefield, it deals damage equal to its power to target creature with flying an opponent controls.
         Ability ability = new EntersBattlefieldTriggeredAbility(
-                new DamageTargetEffect(xValue, "it"), true
+                new DamageTargetEffect(xValue, "it")
+                        .withEqualToBeforeTarget(),
+                false
         );
         ability.addTarget(new TargetPermanent(filter));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/ShrineOfBurningRage.java
+++ b/Mage.Sets/src/mage/cards/s/ShrineOfBurningRage.java
@@ -45,7 +45,14 @@ public final class ShrineOfBurningRage extends CardImpl {
                 new SpellCastControllerTriggeredAbility(null, filter, false)));
 
         //{3}, {T}, Sacrifice Shrine of Burning Rage: It deals damage equal to the number of charge counters on it to any target.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(new CountersSourceCount(CounterType.CHARGE)), new GenericManaCost(3));
+        Ability ability = new SimpleActivatedAbility(
+                new DamageTargetEffect(
+                        new CountersSourceCount(CounterType.CHARGE)
+                                .setSourceName("it")
+                                .doPluralizeCounter(),
+                        "it"
+                ).withEqualToBeforeTarget(),
+                new GenericManaCost(3));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetAnyTarget());

--- a/Mage.Sets/src/mage/cards/s/SkarrganSkybreaker.java
+++ b/Mage.Sets/src/mage/cards/s/SkarrganSkybreaker.java
@@ -33,8 +33,12 @@ public final class SkarrganSkybreaker extends CardImpl {
 
         // Bloodthirst 3
         this.addAbility(new BloodthirstAbility(3));
-        // {1}, Sacrifice Skarrgan Skybreaker: Skarrgan Skybreaker deals damage equal to its power to any target.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(new SourcePermanentPowerCount()), new GenericManaCost(1));
+        // {1}, Sacrifice Skarrgan Skybreaker: It deals damage equal to its power to any target.
+        Ability ability = new SimpleActivatedAbility(
+                new DamageTargetEffect(new SourcePermanentPowerCount().setSourcePossessiveForm("its"), "it")
+                        .withEqualToBeforeTarget(),
+                new GenericManaCost(1)
+        );
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/SlightMalfunction.java
+++ b/Mage.Sets/src/mage/cards/s/SlightMalfunction.java
@@ -48,7 +48,7 @@ class SlightMalfunctionEffect extends OneShotEffect {
 
     SlightMalfunctionEffect() {
         super(Outcome.Benefit);
-        staticText = "roll a six-side die. When you do, {this} deals 1 damage " +
+        staticText = "roll a six-sided die. When you do, {this} deals 1 damage " +
                 "to each of up to X target creatures, where X is the result";
     }
 

--- a/Mage.Sets/src/mage/cards/s/Sparksmith.java
+++ b/Mage.Sets/src/mage/cards/s/Sparksmith.java
@@ -6,6 +6,7 @@ import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DamageControllerEffect;
 import mage.abilities.effects.common.DamageTargetEffect;
@@ -27,6 +28,8 @@ public final class Sparksmith extends CardImpl {
     static {
         filter.add(SubType.GOBLIN.getPredicate());
     }
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(filter);
     
     public Sparksmith(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{R}");
@@ -36,9 +39,13 @@ public final class Sparksmith extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {tap}: Sparksmith deals X damage to target creature and X damage to you, where X is the number of Goblins on the battlefield.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter)), new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(
+                new DamageTargetEffect(xValue).setText("{this} deals X damage to target creature"),
+                new TapSourceCost()
+        );
         ability.addTarget(new TargetCreaturePermanent());
-        ability.addEffect(new DamageControllerEffect(new PermanentsOnBattlefieldCount(filter)));
+        ability.addEffect(new DamageControllerEffect(xValue)
+                .setText("and X damage to you, where X is the number of " + xValue.getMessage()));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpireBarrage.java
+++ b/Mage.Sets/src/mage/cards/s/SpireBarrage.java
@@ -18,7 +18,7 @@ import mage.target.common.TargetAnyTarget;
  */
 public final class SpireBarrage extends CardImpl {
 
-    private static final FilterLandPermanent filter = new FilterLandPermanent("Mountain you control");
+    private static final FilterLandPermanent filter = new FilterLandPermanent("Mountains you control");
 
     static {
         filter.add(SubType.MOUNTAIN.getPredicate());

--- a/Mage.Sets/src/mage/cards/t/TorchSong.java
+++ b/Mage.Sets/src/mage/cards/t/TorchSong.java
@@ -31,10 +31,10 @@ public final class TorchSong extends CardImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD,
                 new AddCountersSourceEffect(CounterType.VERSE.createInstance(), true), TargetController.YOU, true));
 
-        // {2}{R}, Sacrifice Torch Song: Torch Song deals X damage to any target, where X is the number of verse counters on Torch Song.
+        // {2}{R}, Sacrifice Torch Song: It deals X damage to any target, where X is the number of verse counters on Torch Song.
         Ability ability = new SimpleActivatedAbility(
-                Zone.BATTLEFIELD,
-                new DamageTargetEffect(new CountersSourceCount(CounterType.VERSE)),
+                new DamageTargetEffect(new CountersSourceCount(CounterType.VERSE).doPluralizeCounter(), "it")
+                        .withWhereXWording(),
                 new ManaCostsImpl<>("{2}{R}")
         );
         ability.addCost(new SacrificeSourceCost());

--- a/Mage.Sets/src/mage/cards/t/TortureChamber.java
+++ b/Mage.Sets/src/mage/cards/t/TortureChamber.java
@@ -92,7 +92,7 @@ class TortureChamberEffect2 extends OneShotEffect {
 
     public TortureChamberEffect2() {
         super(Outcome.Damage);
-        this.staticText = "{this} deals damage to target creature equal to the number of pain counters removed this way";
+        this.staticText = "it deals damage to target creature equal to the number of pain counters removed this way";
     }
 
     private TortureChamberEffect2(final TortureChamberEffect2 effect) {

--- a/Mage.Sets/src/mage/cards/t/TribalFlames.java
+++ b/Mage.Sets/src/mage/cards/t/TribalFlames.java
@@ -22,7 +22,7 @@ public final class TribalFlames extends CardImpl {
 
 
         // Domain - Tribal Flames deals X damage to any target, where X is the number of basic land types among lands you control.
-        this.getSpellAbility().addEffect(new DamageTargetEffect(DomainValue.REGULAR));
+        this.getSpellAbility().addEffect(new DamageTargetEffect(DomainValue.REGULAR).withWhereXWording());
         this.getSpellAbility().addTarget(new TargetAnyTarget());
         this.getSpellAbility().addHint(DomainHint.instance);
         this.getSpellAbility().setAbilityWord(AbilityWord.DOMAIN);

--- a/Mage.Sets/src/mage/cards/t/TuktukScrapper.java
+++ b/Mage.Sets/src/mage/cards/t/TuktukScrapper.java
@@ -86,7 +86,7 @@ class TuktukScrapperTriggeredAbility extends TriggeredAbilityImpl {
 
         // originally returned fullText, user reported that because the trigger text is so lengthy, they cannot click Yes/No buttons
         //String fullText = "Whenever {this} or another Ally enters the battlefield under your control, you may destroy target artifact. If that artifact is put into a graveyard this way, {this} deals damage to that artifact's controller equal to the number of Allies you control.";
-        String condensedText = "Whenever {this} or another Ally you enters the battlefield under your control, you may destroy target artifact. If you do, {this} deals damage to that controller equal to the number of Allies you control.";
+        String condensedText = "Whenever {this} or another Ally enters the battlefield under your control, you may destroy target artifact. If you do, {this} deals damage to that controller equal to the number of Allies you control.";
 
         return condensedText;
     }

--- a/Mage.Sets/src/mage/cards/u/UnnaturalHunger.java
+++ b/Mage.Sets/src/mage/cards/u/UnnaturalHunger.java
@@ -42,7 +42,7 @@ public final class UnnaturalHunger extends CardImpl {
         Ability ability = new EnchantAbility(auraTarget);
         this.addAbility(ability);
 
-        // At the beginning of the upkeep of enchanted creature's controller, Unnatural Hunger deals damage to that player equal to that creature's power unless they sacrifice another creature.
+        // At the beginning of the upkeep of enchanted creature's controller, Unnatural Hunger deals damage equal to that creature's power to that player unless they sacrifice another creature.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(new UnnaturalHungerEffect(),
                 TargetController.CONTROLLER_ATTACHED_TO, false));
     }
@@ -61,7 +61,7 @@ class UnnaturalHungerEffect extends OneShotEffect {
 
     public UnnaturalHungerEffect() {
         super(Outcome.Detriment);
-        this.staticText = "{this} deals damage to that player equal to that creature's power unless they sacrifice another creature";
+        this.staticText = "{this} deals damage equal to that creature's power to that player unless they sacrifice another creature";
     }
 
     private UnnaturalHungerEffect(UnnaturalHungerEffect effect) {

--- a/Mage.Sets/src/mage/cards/u/UrabrasksAnointer.java
+++ b/Mage.Sets/src/mage/cards/u/UrabrasksAnointer.java
@@ -43,7 +43,10 @@ public final class UrabrasksAnointer extends CardImpl {
         this.toughness = new MageInt(2);
 
         // When Urabrask's Anointer enters the battlefield, it deals X damage to any target, where X is the number of permanents you control with oil counters on them.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new DamageTargetEffect(xValue, "it"));
+        Ability ability = new EntersBattlefieldTriggeredAbility(
+                new DamageTargetEffect(xValue, "it")
+                        .withWhereXWording()
+        );
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability.addHint(hint));
     }

--- a/Mage.Sets/src/mage/cards/v/VentSentinel.java
+++ b/Mage.Sets/src/mage/cards/v/VentSentinel.java
@@ -24,7 +24,8 @@ import mage.target.common.TargetPlayerOrPlaneswalker;
  */
 public final class VentSentinel extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creatures with defender you control");
+    private static final FilterControlledCreaturePermanent filter =
+            new FilterControlledCreaturePermanent("creatures you control with defender");
 
     static {
         filter.add(new AbilityPredicate(DefenderAbility.class));
@@ -38,7 +39,10 @@ public final class VentSentinel extends CardImpl {
         this.toughness = new MageInt(4);
 
         this.addAbility(DefenderAbility.getInstance());
-        SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter)), new ManaCostsImpl<>("{1}{R}"));
+        SimpleActivatedAbility ability = new SimpleActivatedAbility(
+                new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter)),
+                new ManaCostsImpl<>("{1}{R}")
+        );
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetPlayerOrPlaneswalker());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/v/VoodooDoll.java
+++ b/Mage.Sets/src/mage/cards/v/VoodooDoll.java
@@ -51,7 +51,10 @@ public final class VoodooDoll extends CardImpl {
 
         // {X}{X}, {T}: Voodoo Doll deals damage equal to the number of pin counters on it to any target. X is the number of pin counters on Voodoo Doll.
         ability = new SimpleActivatedAbility(
-                new DamageTargetEffect(new CountersSourceCount(CounterType.PIN)), new ManaCostsImpl<>("{X}{X}")
+                new DamageTargetEffect(new CountersSourceCount(CounterType.PIN))
+                        .setText("{this} deals damage equal to the number of pin counters on it to any target. "
+                                + "X is the number of pin counters on {this}."),
+                new ManaCostsImpl<>("{X}{X}")
         );
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetAnyTarget());

--- a/Mage.Sets/src/mage/cards/w/WheelOfTorture.java
+++ b/Mage.Sets/src/mage/cards/w/WheelOfTorture.java
@@ -39,13 +39,13 @@ public final class WheelOfTorture extends CardImpl {
 
 class WheelOfTortureEffect extends OneShotEffect {
 
-    private WheelOfTortureEffect(final WheelOfTortureEffect effect) {
-        super(effect);
-        this.staticText = "Wheel of Torture deals X damage to that player, where X is 3 minus the number of cards in their hand";
+    WheelOfTortureEffect() {
+        super(Outcome.Damage);
+        this.staticText = "{this} deals X damage to that player, where X is 3 minus the number of cards in their hand";
     }
 
-    public WheelOfTortureEffect() {
-        super(Outcome.Damage);
+    private WheelOfTortureEffect(final WheelOfTortureEffect effect) {
+        super(effect);
     }
 
     @Override

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/KickerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/KickerTest.java
@@ -291,7 +291,6 @@ public class KickerTest extends CardTestPlayerBase {
         setChoice(playerA, true);  // use kicker {R} - 2 damage to any target
         setChoice(playerA, false); // not use kicker {W} - destroy target
         addTarget(playerA, playerB); // target for 2 damage
-        setChoice(playerA, true); // put counter on hallar
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/CountersSourceCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/CountersSourceCount.java
@@ -11,6 +11,8 @@ import mage.game.permanent.Permanent;
 public class CountersSourceCount implements DynamicValue {
 
     private final CounterType counterType;
+    private String sourceName = "{this}"; // for text generation
+    private boolean pluralizeCounter = false; // for text generation
 
     public CountersSourceCount(CounterType counterType) {
         this.counterType = counterType;
@@ -18,6 +20,8 @@ public class CountersSourceCount implements DynamicValue {
 
     protected CountersSourceCount(final CountersSourceCount countersCount) {
         this.counterType = countersCount.counterType;
+        this.sourceName = countersCount.sourceName;
+        this.pluralizeCounter = countersCount.pluralizeCounter;
     }
 
     @Override
@@ -47,8 +51,20 @@ public class CountersSourceCount implements DynamicValue {
         return "1";
     }
 
+    public CountersSourceCount setSourceName(String sourceName) {
+        this.sourceName = sourceName;
+        return this;
+    }
+
+    public CountersSourceCount doPluralizeCounter() {
+        this.pluralizeCounter = true;
+        return this;
+    }
+
     @Override
     public String getMessage() {
-        return (counterType != null ? counterType.toString() + ' ' : "") + "counter on {this}";
+        return (counterType != null ? counterType.toString() + ' ' : "")
+                + "counter" + (pluralizeCounter ? "s" : "")
+                + " on " + sourceName;
     }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/SourcePermanentPowerCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/SourcePermanentPowerCount.java
@@ -13,6 +13,7 @@ import mage.game.permanent.Permanent;
 public class SourcePermanentPowerCount implements DynamicValue {
 
     private final boolean allowNegativeValues;
+    private String sourcePossessiveForm = "{this}'s"; // for text generation
 
     public SourcePermanentPowerCount() {
         this(true);
@@ -26,6 +27,7 @@ public class SourcePermanentPowerCount implements DynamicValue {
     protected SourcePermanentPowerCount(final SourcePermanentPowerCount dynamicValue) {
         super();
         this.allowNegativeValues = dynamicValue.allowNegativeValues;
+        this.sourcePossessiveForm = dynamicValue.sourcePossessiveForm;
     }
 
     @Override
@@ -53,8 +55,13 @@ public class SourcePermanentPowerCount implements DynamicValue {
         return "X";
     }
 
+    public SourcePermanentPowerCount setSourcePossessiveForm(String possessiveForm) {
+        this.sourcePossessiveForm = possessiveForm;
+        return this;
+    }
+
     @Override
     public String getMessage() {
-        return "{this}'s power";
+        return sourcePossessiveForm + " power";
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilityAttachedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilityAttachedEffect.java
@@ -151,7 +151,7 @@ public class GainAbilityAttachedEffect extends ContinuousEffectImpl {
         if (quotes) {
             sb.append('"');
         }
-        sb.append(CardUtil.stripReminderText(ability.getRule("This " + targetObjectName)));
+        sb.append(CardUtil.stripReminderText(ability.getRule("this " + targetObjectName)));
         if (quotes) {
             sb.append('"');
         }


### PR DESCRIPTION
Added support for various distinct wording of DamageTargetEffect, when a DynamicValue is involved.

Fixed rule generation for a bunch of cards using that effect.