### PR TITLE
Sacellum Godspeaker fix + minor cleanup

### DIFF
--- a/Mage.Sets/src/mage/cards/a/ArsenalThresher.java
+++ b/Mage.Sets/src/mage/cards/a/ArsenalThresher.java
@@ -77,13 +77,11 @@ class ArsenalThresherEffect extends OneShotEffect {
         FilterArtifactCard filter = new FilterArtifactCard();
         filter.add(AnotherPredicate.instance);
         if (controller.chooseUse(Outcome.Benefit, "Reveal other artifacts in your hand?", source, game)) {
-            Cards cards = new CardsImpl();
+
             if (controller.getHand().count(filter, source.getControllerId(), source, game) > 0) {
                 TargetCardInHand target = new TargetCardInHand(0, Integer.MAX_VALUE, filter);
                 if (controller.choose(Outcome.Benefit, target, source, game)) {
-                    for (UUID uuid : target.getTargets()) {
-                        cards.add(controller.getHand().get(uuid, game));
-                    }
+                    Cards cards = new CardsImpl(target.getTargets());
                     if (arsenalThresher != null) {
                         controller.revealCards(arsenalThresher.getIdName(), cards, game);
                         List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects"); // the basic event is the EntersBattlefieldEvent, so use already applied replacement effects from that event

--- a/Mage.Sets/src/mage/cards/a/ArsenalThresher.java
+++ b/Mage.Sets/src/mage/cards/a/ArsenalThresher.java
@@ -77,16 +77,13 @@ class ArsenalThresherEffect extends OneShotEffect {
         FilterArtifactCard filter = new FilterArtifactCard();
         filter.add(AnotherPredicate.instance);
         if (controller.chooseUse(Outcome.Benefit, "Reveal other artifacts in your hand?", source, game)) {
-
-            if (controller.getHand().count(filter, source.getControllerId(), source, game) > 0) {
-                TargetCardInHand target = new TargetCardInHand(0, Integer.MAX_VALUE, filter);
-                if (controller.choose(Outcome.Benefit, target, source, game)) {
-                    Cards cards = new CardsImpl(target.getTargets());
-                    if (arsenalThresher != null) {
-                        controller.revealCards(arsenalThresher.getIdName(), cards, game);
-                        List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects"); // the basic event is the EntersBattlefieldEvent, so use already applied replacement effects from that event
-                        arsenalThresher.addCounters(CounterType.P1P1.createInstance(cards.size()), source.getControllerId(), source, game, appliedEffects);
-                    }
+            TargetCardInHand target = new TargetCardInHand(0, Integer.MAX_VALUE, filter);
+            if (controller.choose(Outcome.Benefit, target, source, game)) {
+                Cards cards = new CardsImpl(target.getTargets());
+                if (arsenalThresher != null) {
+                    controller.revealCards(arsenalThresher.getIdName(), cards, game);
+                    List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects"); // the basic event is the EntersBattlefieldEvent, so use already applied replacement effects from that event
+                    arsenalThresher.addCounters(CounterType.P1P1.createInstance(cards.size()), source.getControllerId(), source, game, appliedEffects);
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/p/PhosphorescentFeast.java
+++ b/Mage.Sets/src/mage/cards/p/PhosphorescentFeast.java
@@ -64,10 +64,7 @@ class PhosphorescentFeastEffect extends OneShotEffect {
             TargetCardInHand target = new TargetCardInHand(0, Integer.MAX_VALUE, new FilterCard());
             if (player.choose(Outcome.Benefit, target, source, game)) {
 
-                Cards cards = new CardsImpl();
-                for (UUID uuid : target.getTargets()) {
-                    cards.add(player.getHand().get(uuid, game));
-                }
+                Cards cards = new CardsImpl(target.getTargets());
                 player.revealCards("cards", cards, game);
                 for (Card card : cards.getCards(game)) {
                     chroma += card.getManaCost().getMana().getGreen();

--- a/Mage.Sets/src/mage/cards/p/PhosphorescentFeast.java
+++ b/Mage.Sets/src/mage/cards/p/PhosphorescentFeast.java
@@ -63,9 +63,8 @@ class PhosphorescentFeastEffect extends OneShotEffect {
         if (player.getHand().count(new FilterCard(), game) > 0) {
             TargetCardInHand target = new TargetCardInHand(0, Integer.MAX_VALUE, new FilterCard());
             if (player.choose(Outcome.Benefit, target, source, game)) {
-
                 Cards cards = new CardsImpl(target.getTargets());
-                player.revealCards("cards", cards, game);
+                player.revealCards(source, cards, game);
                 for (Card card : cards.getCards(game)) {
                     chroma += card.getManaCost().getMana().getGreen();
                 }

--- a/Mage.Sets/src/mage/cards/r/RofellossGift.java
+++ b/Mage.Sets/src/mage/cards/r/RofellossGift.java
@@ -73,27 +73,15 @@ class RofellossGiftEffect extends OneShotEffect {
         if (!player.choose(outcome, player.getHand(), targetCardInHand, source, game)) {
             return false;
         }
-        Cards cards = new CardsImpl();
-        for (UUID cardId : targetCardInHand.getTargets()) {
-            Card card = game.getCard(cardId);
-            if (card != null) {
-                cards.add(card);
-            }
-        }
-        player.revealCards(source, cards, game);
+        Cards revealedCards = new CardsImpl(targetCardInHand.getTargets());
+        player.revealCards(source, revealedCards, game);
         int enchantmentsToReturn = Math.min(player.getGraveyard().count(filter2, game), targetCardInHand.getTargets().size());
         TargetCardInYourGraveyard targetCardInYourGraveyard = new TargetCardInYourGraveyard(enchantmentsToReturn, filter2);
         targetCardInYourGraveyard.setNotTarget(true);
         if (!player.choose(outcome, targetCardInYourGraveyard, source, game)) {
             return false;
         }
-        cards = new CardsImpl();
-        for (UUID cardId : targetCardInYourGraveyard.getTargets()) {
-            Card card = game.getCard(cardId);
-            if (card != null) {
-                cards.add(card);
-            }
-        }
-        return player.moveCards(cards, Zone.HAND, source, game);
+        Cards returnedCards = new CardsImpl(targetCardInYourGraveyard.getTargets());
+        return player.moveCards(returnedCards, Zone.HAND, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SacellumGodspeaker.java
+++ b/Mage.Sets/src/mage/cards/s/SacellumGodspeaker.java
@@ -8,6 +8,7 @@ import mage.abilities.effects.mana.ManaEffect;
 import mage.abilities.mana.SimpleManaAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.cards.CardsImpl;
 import mage.constants.*;
 import mage.filter.common.FilterCreatureCard;
 import mage.filter.predicate.mageobject.PowerPredicate;
@@ -90,6 +91,7 @@ class SacellumGodspeakerEffect extends ManaEffect {
         if (game != null) {
             TargetCardInHand target = new TargetCardInHand(0, Integer.MAX_VALUE, filter);
             if (target.choose(Outcome.Benefit, source.getControllerId(), source.getSourceId(), source, game)) {
+                game.getPlayer(source.getControllerId()).revealCards(source, new CardsImpl(target.getTargets()), game);
                 return Mana.GreenMana(target.getTargets().size());
             }
         }

--- a/Mage.Sets/src/mage/cards/s/SacellumGodspeaker.java
+++ b/Mage.Sets/src/mage/cards/s/SacellumGodspeaker.java
@@ -89,10 +89,13 @@ class SacellumGodspeakerEffect extends ManaEffect {
     @Override
     public Mana produceMana(Game game, Ability source) {
         if (game != null) {
-            TargetCardInHand target = new TargetCardInHand(0, Integer.MAX_VALUE, filter);
-            if (target.choose(Outcome.Benefit, source.getControllerId(), source.getSourceId(), source, game)) {
-                game.getPlayer(source.getControllerId()).revealCards(source, new CardsImpl(target.getTargets()), game);
-                return Mana.GreenMana(target.getTargets().size());
+            Player controller = game.getPlayer(source.getControllerId());
+            if (controller != null) {
+                TargetCardInHand target = new TargetCardInHand(0, Integer.MAX_VALUE, filter);
+                if (target.choose(Outcome.Benefit, source.getControllerId(), source.getSourceId(), source, game)) {
+                    controller.revealCards(source, new CardsImpl(target.getTargets()), game);
+                    return Mana.GreenMana(target.getTargets().size());
+                }
             }
         }
         return new Mana();


### PR DESCRIPTION
Fixes Sacellum Godspeaker to actually reveal the cards chosen.

Also makes a few similar cards use the CardsImpl collection constructor rather than looping through adding each.
Removes the ">0" check from Arsenal Thresher since it's already after the chooseUse anyway so it's basically useless.
Adds a source for Phosphorescent Feast's reveal instead of just saying "cards". I noticed some cards revealed with an ability source (which then gets the name) and others got the name directly, didn't bother trying to unify those since the info was available either way.