### PR TITLE
[dont merge] (Maybe?) Synchronize pickTarget

### DIFF
--- a/Mage.Client/src/main/java/mage/client/game/GamePanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/GamePanel.java
@@ -1623,8 +1623,8 @@ public final class GamePanel extends javax.swing.JPanel {
      * @param options
      * @param messageId
      */
-    public void pickTarget(GameView gameView, Map<String, Serializable> options, String message, CardsView cardsView, Set<UUID> targets, boolean required, int messageId) {
-        updateGame(gameView, false, options, targets);
+    public synchronized void pickTarget(GameView gameView, Map<String, Serializable> options, String message, CardsView cardsView, Set<UUID> targets, boolean required, int messageId) {
+        updateGame(gameView, false, options, targets); // <- this is synchronized
         hideAll();
         DialogManager.getManager(gameId).fadeOut();
         clearPickTargetDialogs();
@@ -1650,9 +1650,9 @@ public final class GamePanel extends javax.swing.JPanel {
         ShowCardsDialog dialog = null;
         if (cardsView != null && !cardsView.isEmpty()) {
             dialog = prepareCardsDialog(message, cardsView, required, options0, popupMenuType);
-            options0.put("dialog", dialog);
+            options0.put("dialog", dialog); // <- this was not synchronized.
         }
-        this.feedbackPanel.prepareFeedback(required ? FeedbackMode.INFORM : FeedbackMode.CANCEL, message, gameView.getSpecial(), options0, messageId, true, gameView.getPhase());
+        this.feedbackPanel.prepareFeedback(required ? FeedbackMode.INFORM : FeedbackMode.CANCEL, message, gameView.getSpecial(), options0, messageId, true, gameView.getPhase()); // <- this starts with synchronized to retrieve options
         if (dialog != null) {
             this.pickTarget.add(dialog);
         }


### PR DESCRIPTION
So I did look at the client part of the target ordering panel.

I do not understand synchronized in Java that well, but I do feel all modification of options should be synchronized? Or else there could be weird asynchronous side effects, sometimes?
I feel that both the "no trigger order panel" and "empty trigger order panel" could both happen if the `lastGameData.options` is not properly set and used in the proper order.

If someone has good recommandation on documentation material of synchronized, what it does and what it does not, I'd very much appreciate it.