### PR TITLE
Clean public copy constructors in cards starting H-I

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HaakonStromgaldScourge.java
+++ b/Mage.Sets/src/mage/cards/h/HaakonStromgaldScourge.java
@@ -63,7 +63,7 @@ class HaakonStromgaldScourgePlayEffect extends AsThoughEffectImpl {
         staticText = "You may cast {this} from your graveyard";
     }
 
-    public HaakonStromgaldScourgePlayEffect(final HaakonStromgaldScourgePlayEffect effect) {
+    private HaakonStromgaldScourgePlayEffect(final HaakonStromgaldScourgePlayEffect effect) {
         super(effect);
     }
 
@@ -95,7 +95,7 @@ class HaakonStromgaldScourgePlayEffect2 extends ContinuousRuleModifyingEffectImp
         staticText = ", but not from anywhere else";
     }
 
-    public HaakonStromgaldScourgePlayEffect2 (final HaakonStromgaldScourgePlayEffect2 effect) {
+    private HaakonStromgaldScourgePlayEffect2(final HaakonStromgaldScourgePlayEffect2 effect) {
         super(effect);
     }
 
@@ -132,7 +132,7 @@ class HaakonPlayKnightsFromGraveyardEffect extends AsThoughEffectImpl {
         staticText = "As long as {this} is on the battlefield, you may cast Knight spells from your graveyard";
     }
 
-    public HaakonPlayKnightsFromGraveyardEffect(final HaakonPlayKnightsFromGraveyardEffect effect) {
+    private HaakonPlayKnightsFromGraveyardEffect(final HaakonPlayKnightsFromGraveyardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HaazdaMarshal.java
+++ b/Mage.Sets/src/mage/cards/h/HaazdaMarshal.java
@@ -47,7 +47,7 @@ class HaazdaMarshalTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CreateTokenEffect(new SoldierLifelinkToken()));
     }
 
-    public HaazdaMarshalTriggeredAbility(final HaazdaMarshalTriggeredAbility ability) {
+    private HaazdaMarshalTriggeredAbility(final HaazdaMarshalTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HaazdaSnareSquad.java
+++ b/Mage.Sets/src/mage/cards/h/HaazdaSnareSquad.java
@@ -43,7 +43,7 @@ public final class HaazdaSnareSquad extends CardImpl {
 
     }
 
-    public HaazdaSnareSquad (final HaazdaSnareSquad card) {
+    private HaazdaSnareSquad(final HaazdaSnareSquad card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HairStrungKoto.java
+++ b/Mage.Sets/src/mage/cards/h/HairStrungKoto.java
@@ -38,7 +38,7 @@ public final class HairStrungKoto extends CardImpl {
         this.addAbility(ability);
     }
 
-    public HairStrungKoto (final HairStrungKoto card) {
+    private HairStrungKoto(final HairStrungKoto card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HakimLoreweaver.java
+++ b/Mage.Sets/src/mage/cards/h/HakimLoreweaver.java
@@ -85,7 +85,7 @@ class HakimLoreweaverEffect extends OneShotEffect {
         this.staticText = "Return target Aura card from your graveyard to the battlefield attached to {this}.";
     }
 
-    public HakimLoreweaverEffect(final HakimLoreweaverEffect effect) {
+    private HakimLoreweaverEffect(final HakimLoreweaverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HalcyonGlaze.java
+++ b/Mage.Sets/src/mage/cards/h/HalcyonGlaze.java
@@ -49,7 +49,7 @@ class HalcyonGlazeToken extends TokenImpl {
         toughness = new MageInt(4);
         this.addAbility(FlyingAbility.getInstance());
     }
-    public HalcyonGlazeToken(final HalcyonGlazeToken token) {
+    private HalcyonGlazeToken(final HalcyonGlazeToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Halfdane.java
+++ b/Mage.Sets/src/mage/cards/h/Halfdane.java
@@ -61,7 +61,7 @@ class HalfdaneUpkeepEffect extends OneShotEffect {
         this.staticText = "change {this}'s base power and toughness to the power and toughness of target creature other than Halfdane until the end of your next upkeep";
     }
 
-    public HalfdaneUpkeepEffect(final HalfdaneUpkeepEffect effect) {
+    private HalfdaneUpkeepEffect(final HalfdaneUpkeepEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HallOfTriumph.java
+++ b/Mage.Sets/src/mage/cards/h/HallOfTriumph.java
@@ -50,7 +50,7 @@ class HallOfTriumphBoostControlledEffect extends ContinuousEffectImpl {
         staticText = "Creatures you control of the chosen color get +1/+1";
     }
 
-    public HallOfTriumphBoostControlledEffect(final HallOfTriumphBoostControlledEffect effect) {
+    private HallOfTriumphBoostControlledEffect(final HallOfTriumphBoostControlledEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Hallow.java
+++ b/Mage.Sets/src/mage/cards/h/Hallow.java
@@ -49,7 +49,7 @@ class HallowPreventDamageByTargetEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage target spell would deal this turn. You gain life equal to the damage prevented this way";
     }
 
-    public HallowPreventDamageByTargetEffect(final HallowPreventDamageByTargetEffect effect) {
+    private HallowPreventDamageByTargetEffect(final HallowPreventDamageByTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HallowedBurial.java
+++ b/Mage.Sets/src/mage/cards/h/HallowedBurial.java
@@ -45,7 +45,7 @@ class HallowedBurialEffect extends OneShotEffect {
         this.staticText = "Put all creatures on the bottom of their owners' libraries";
     }
 
-    public HallowedBurialEffect(final HallowedBurialEffect effect) {
+    private HallowedBurialEffect(final HallowedBurialEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HallowedMoonlight.java
+++ b/Mage.Sets/src/mage/cards/h/HallowedMoonlight.java
@@ -51,7 +51,7 @@ class HallowedMoonlightEffect extends ReplacementEffectImpl {
         staticText = "Until end of turn, if a creature would enter the battlefield and it wasn't cast, exile it instead";
     }
 
-    public HallowedMoonlightEffect(final HallowedMoonlightEffect effect) {
+    private HallowedMoonlightEffect(final HallowedMoonlightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HallsOfMist.java
+++ b/Mage.Sets/src/mage/cards/h/HallsOfMist.java
@@ -50,7 +50,7 @@ class CantAttackIfAttackedLastTurnAllEffect extends RestrictionEffect {
         this.staticText = "Creatures that attacked during their controller's last turn can't attack";
     }
 
-    public CantAttackIfAttackedLastTurnAllEffect(final CantAttackIfAttackedLastTurnAllEffect effect) {
+    private CantAttackIfAttackedLastTurnAllEffect(final CantAttackIfAttackedLastTurnAllEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HaltOrder.java
+++ b/Mage.Sets/src/mage/cards/h/HaltOrder.java
@@ -24,7 +24,7 @@ public final class HaltOrder extends CardImpl {
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1).concatBy("<br>"));
     }
 
-    public HaltOrder (final HaltOrder card) {
+    private HaltOrder(final HaltOrder card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HammerJammer.java
+++ b/Mage.Sets/src/mage/cards/h/HammerJammer.java
@@ -91,7 +91,7 @@ class HammerJammerTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you roll a die, ");
     }
 
-    public HammerJammerTriggeredAbility(final HammerJammerTriggeredAbility ability) {
+    private HammerJammerTriggeredAbility(final HammerJammerTriggeredAbility ability) {
         super(ability);
     }
 
@@ -125,7 +125,7 @@ class HammerJammerEffect extends OneShotEffect {
         this.staticText = "remove all +1/+1 counters from {this}, then put a number of +1/+1 counters on it equal to the result";
     }
 
-    public HammerJammerEffect(final HammerJammerEffect effect) {
+    private HammerJammerEffect(final HammerJammerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HammerMage.java
+++ b/Mage.Sets/src/mage/cards/h/HammerMage.java
@@ -58,7 +58,7 @@ class HammerMageEffect extends  OneShotEffect {
         staticText = "Destroy all artifacts with mana value X or less";
     }
 
-    public HammerMageEffect(final HammerMageEffect effect) {
+    private HammerMageEffect(final HammerMageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HammerOfNazahn.java
+++ b/Mage.Sets/src/mage/cards/h/HammerOfNazahn.java
@@ -68,7 +68,7 @@ class HammerOfNazahnEffect extends OneShotEffect {
         this.staticText = "you may attach that Equipment to target creature you control";
     }
 
-    public HammerOfNazahnEffect(final HammerOfNazahnEffect effect) {
+    private HammerOfNazahnEffect(final HammerOfNazahnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HammerOfRuin.java
+++ b/Mage.Sets/src/mage/cards/h/HammerOfRuin.java
@@ -42,7 +42,7 @@ public final class HammerOfRuin extends CardImpl {
         this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(2), false));
     }
 
-    public HammerOfRuin (final HammerOfRuin card) {
+    private HammerOfRuin(final HammerOfRuin card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Hammerheim.java
+++ b/Mage.Sets/src/mage/cards/h/Hammerheim.java
@@ -60,7 +60,7 @@ class HammerheimEffect extends ContinuousEffectImpl {
         this.staticText = "Target creature loses all landwalk abilities until end of turn.";
     }
 
-    public HammerheimEffect(final HammerheimEffect effect) {
+    private HammerheimEffect(final HammerheimEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HanSoloScrumrat.java
+++ b/Mage.Sets/src/mage/cards/h/HanSoloScrumrat.java
@@ -63,7 +63,7 @@ class HanSoloScrumratTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} creature deals damage during your turn, ");
     }
 
-    public HanSoloScrumratTriggeredAbility(final HanSoloScrumratTriggeredAbility ability) {
+    private HanSoloScrumratTriggeredAbility(final HanSoloScrumratTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HanabiBlast.java
+++ b/Mage.Sets/src/mage/cards/h/HanabiBlast.java
@@ -26,7 +26,7 @@ public final class HanabiBlast extends CardImpl {
         this.getSpellAbility().addEffect(new DiscardControllerEffect(1, true).concatBy(", then"));
     }
 
-    public HanabiBlast (final HanabiBlast card) {
+    private HanabiBlast(final HanabiBlast card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HandOfThePraetors.java
+++ b/Mage.Sets/src/mage/cards/h/HandOfThePraetors.java
@@ -50,7 +50,7 @@ public final class HandOfThePraetors extends CardImpl {
         this.addAbility(ability);
     }
 
-    public HandOfThePraetors (final HandOfThePraetors card) {
+    private HandOfThePraetors(final HandOfThePraetors card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HandToHand.java
+++ b/Mage.Sets/src/mage/cards/h/HandToHand.java
@@ -44,7 +44,7 @@ class HandToHandEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "During combat, players can't cast instant spells or activate abilities that aren't mana abilities";
     }
 
-    public HandToHandEffect(final HandToHandEffect effect) {
+    private HandToHandEffect(final HandToHandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HaphazardBombardment.java
+++ b/Mage.Sets/src/mage/cards/h/HaphazardBombardment.java
@@ -63,7 +63,7 @@ class HaphazardBombardmentEffect extends OneShotEffect {
         this.staticText = "choose four nonenchantment permanents you don't control and put an aim counter on each of them";
     }
 
-    public HaphazardBombardmentEffect(final HaphazardBombardmentEffect effect) {
+    private HaphazardBombardmentEffect(final HaphazardBombardmentEffect effect) {
         super(effect);
     }
 
@@ -108,7 +108,7 @@ class HaphazardBombardmentEndOfTurnEffect extends OneShotEffect {
         this.staticText = "destroy one of those permanents at random";
     }
 
-    public HaphazardBombardmentEndOfTurnEffect(final HaphazardBombardmentEndOfTurnEffect effect) {
+    private HaphazardBombardmentEndOfTurnEffect(final HaphazardBombardmentEndOfTurnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarborGuardian.java
+++ b/Mage.Sets/src/mage/cards/h/HarborGuardian.java
@@ -52,7 +52,7 @@ class HarborGuardianEffect extends OneShotEffect {
         staticText = "defending player may draw a card";
     }
 
-    public HarborGuardianEffect(final HarborGuardianEffect effect) {
+    private HarborGuardianEffect(final HarborGuardianEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarborSerpent.java
+++ b/Mage.Sets/src/mage/cards/h/HarborSerpent.java
@@ -56,7 +56,7 @@ class HarborSerpentEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless there are five or more Islands on the battlefield";
     }
 
-    public HarborSerpentEffect(final HarborSerpentEffect effect) {
+    private HarborSerpentEffect(final HarborSerpentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarmlessOffering.java
+++ b/Mage.Sets/src/mage/cards/h/HarmlessOffering.java
@@ -49,7 +49,7 @@ class HarmlessOfferingEffect extends ContinuousEffectImpl {
         this.staticText = "Target opponent gains control of target permanent you control";
     }
 
-    public HarmlessOfferingEffect(final HarmlessOfferingEffect effect) {
+    private HarmlessOfferingEffect(final HarmlessOfferingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarmonicConvergence.java
+++ b/Mage.Sets/src/mage/cards/h/HarmonicConvergence.java
@@ -47,7 +47,7 @@ class HarmonicConvergenceEffect extends OneShotEffect {
         this.staticText = "Put all enchantments on top of their owners' libraries";
     }
 
-    public HarmonicConvergenceEffect(final HarmonicConvergenceEffect effect) {
+    private HarmonicConvergenceEffect(final HarmonicConvergenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarmonyOfNature.java
+++ b/Mage.Sets/src/mage/cards/h/HarmonyOfNature.java
@@ -54,7 +54,7 @@ class HarmonyOfNatureEffect extends OneShotEffect {
         staticText = "Tap any number of untapped creatures you control. You gain 4 life for each creature tapped this way";
     }
 
-    public HarmonyOfNatureEffect(HarmonyOfNatureEffect effect) {
+    private HarmonyOfNatureEffect(final HarmonyOfNatureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarmsWay.java
+++ b/Mage.Sets/src/mage/cards/h/HarmsWay.java
@@ -51,7 +51,7 @@ class HarmsWayPreventDamageTargetEffect extends RedirectionEffect {
         this.damageSource = new TargetSource();
     }
 
-    public HarmsWayPreventDamageTargetEffect(final HarmsWayPreventDamageTargetEffect effect) {
+    private HarmsWayPreventDamageTargetEffect(final HarmsWayPreventDamageTargetEffect effect) {
         super(effect);
         this.damageSource = effect.damageSource.copy();
     }

--- a/Mage.Sets/src/mage/cards/h/HarnessTheStorm.java
+++ b/Mage.Sets/src/mage/cards/h/HarnessTheStorm.java
@@ -55,7 +55,7 @@ class HarnessTheStormTriggeredAbility extends SpellCastControllerTriggeredAbilit
         super(effect, filter, optional);
     }
 
-    public HarnessTheStormTriggeredAbility(HarnessTheStormTriggeredAbility ability) {
+    private HarnessTheStormTriggeredAbility(final HarnessTheStormTriggeredAbility ability) {
         super(ability);
     }
 
@@ -92,7 +92,7 @@ class HarnessTheStormEffect extends OneShotEffect {
                 + "spell from your graveyard. <i>(you still pay its costs.)</i>";
     }
 
-    public HarnessTheStormEffect(final HarnessTheStormEffect effect) {
+    private HarnessTheStormEffect(final HarnessTheStormEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarnessedLightning.java
+++ b/Mage.Sets/src/mage/cards/h/HarnessedLightning.java
@@ -48,7 +48,7 @@ class HarnessedLightningEffect extends OneShotEffect {
         this.staticText = "Choose target creature. You get {E}{E}{E}, then you may pay any amount of {E}. {this} deals that much damage to that creature";
     }
 
-    public HarnessedLightningEffect(final HarnessedLightningEffect effect) {
+    private HarnessedLightningEffect(final HarnessedLightningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarshDeceiver.java
+++ b/Mage.Sets/src/mage/cards/h/HarshDeceiver.java
@@ -63,7 +63,7 @@ class HarshDeceiverEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of your library. If it's a land card, untap {this} and it gets +1/+1 until end of turn";
     }
 
-    public HarshDeceiverEffect(final HarshDeceiverEffect effect) {
+    private HarshDeceiverEffect(final HarshDeceiverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarshJudgment.java
+++ b/Mage.Sets/src/mage/cards/h/HarshJudgment.java
@@ -58,7 +58,7 @@ class HarshJudgmentEffect extends RedirectionEffect {
         staticText = "If an instant or sorcery spell of the chosen color would deal damage to you, it deals that damage to its controller instead";
     }
 
-    public HarshJudgmentEffect(final HarshJudgmentEffect effect) {
+    private HarshJudgmentEffect(final HarshJudgmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarshJustice.java
+++ b/Mage.Sets/src/mage/cards/h/HarshJustice.java
@@ -66,7 +66,7 @@ class HarshJusticeTriggeredAbility extends DelayedTriggeredAbility {
         setTriggerPhrase("This turn, whenever an attacking creature deals combat damage to you, ");
     }
 
-    public HarshJusticeTriggeredAbility(final HarshJusticeTriggeredAbility ability) {
+    private HarshJusticeTriggeredAbility(final HarshJusticeTriggeredAbility ability) {
         super(ability);
     }
 
@@ -105,7 +105,7 @@ class HarshJusticeEffect extends OneShotEffect {
         this.staticText = "it deals that much damage to its controller";
     }
 
-    public HarshJusticeEffect(final HarshJusticeEffect effect) {
+    private HarshJusticeEffect(final HarshJusticeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarshMercy.java
+++ b/Mage.Sets/src/mage/cards/h/HarshMercy.java
@@ -51,7 +51,7 @@ class HarshMercyEffect extends OneShotEffect {
         this.staticText = "Each player chooses a creature type. Destroy all creatures that aren't of a type chosen this way. They can't be regenerated.";
     }
 
-    public HarshMercyEffect(final HarshMercyEffect effect) {
+    private HarshMercyEffect(final HarshMercyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HasranOgress.java
+++ b/Mage.Sets/src/mage/cards/h/HasranOgress.java
@@ -48,7 +48,7 @@ class HasranOgressEffect extends OneShotEffect {
         this.staticText = "{this} deals 3 damage to you unless you pay {2}";
     }
 
-    public HasranOgressEffect(final HasranOgressEffect effect) {
+    private HasranOgressEffect(final HasranOgressEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HatcherySpider.java
+++ b/Mage.Sets/src/mage/cards/h/HatcherySpider.java
@@ -60,7 +60,7 @@ class HatcherySpiderEffect extends OneShotEffect {
                 + "in a random order.";
     }
 
-    public HatcherySpiderEffect(final HatcherySpiderEffect effect) {
+    private HatcherySpiderEffect(final HatcherySpiderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HatchetBully.java
+++ b/Mage.Sets/src/mage/cards/h/HatchetBully.java
@@ -65,7 +65,7 @@ class HatchetBullyCost extends CostImpl {
         this.text = "Put a -1/-1 counter on a creature you control";
     }
 
-    public HatchetBullyCost(HatchetBullyCost cost) {
+    private HatchetBullyCost(final HatchetBullyCost cost) {
         super(cost);
     }
 
@@ -97,7 +97,7 @@ class HatchetBullyEffect extends OneShotEffect {
         staticText = "{this} deals 2 damage to any target";
     }
 
-    public HatchetBullyEffect(final HatchetBullyEffect effect) {
+    private HatchetBullyEffect(final HatchetBullyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HauntedAngel.java
+++ b/Mage.Sets/src/mage/cards/h/HauntedAngel.java
@@ -54,7 +54,7 @@ class HauntedAngelEffect extends OneShotEffect {
         staticText = "and each other player creates a 3/3 black Angel creature token with flying.";
     }
 
-    public HauntedAngelEffect(HauntedAngelEffect copy) {
+    private HauntedAngelEffect(final HauntedAngelEffect copy) {
         super(copy);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HauntedPlateMail.java
+++ b/Mage.Sets/src/mage/cards/h/HauntedPlateMail.java
@@ -66,7 +66,7 @@ class HauntedPlateMailToken extends TokenImpl {
         power = new MageInt(4);
         toughness = new MageInt(4);
     }
-    public HauntedPlateMailToken(final HauntedPlateMailToken token) {
+    private HauntedPlateMailToken(final HauntedPlateMailToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HavengulLich.java
+++ b/Mage.Sets/src/mage/cards/h/HavengulLich.java
@@ -71,7 +71,7 @@ class HavengulLichPlayEffect extends AsThoughEffectImpl {
         staticText = "You may cast target creature card in a graveyard this turn";
     }
 
-    public HavengulLichPlayEffect(final HavengulLichPlayEffect effect) {
+    private HavengulLichPlayEffect(final HavengulLichPlayEffect effect) {
         super(effect);
     }
 
@@ -107,7 +107,7 @@ class HavengulLichPlayedEffect extends OneShotEffect {
         super(Outcome.PutCreatureInPlay);
     }
 
-    public HavengulLichPlayedEffect(final HavengulLichPlayedEffect effect) {
+    private HavengulLichPlayedEffect(final HavengulLichPlayedEffect effect) {
         super(effect);
         staticText = "When you cast that card this turn, {this} gains all activated abilities of that card until end of turn";
     }
@@ -136,7 +136,7 @@ class HavengulLichDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.cardId = cardId;
     }
 
-    public HavengulLichDelayedTriggeredAbility(HavengulLichDelayedTriggeredAbility ability) {
+    private HavengulLichDelayedTriggeredAbility(final HavengulLichDelayedTriggeredAbility ability) {
         super(ability);
         this.cardId = ability.cardId;
     }
@@ -172,7 +172,7 @@ class HavengulLichEffect extends ContinuousEffectImpl {
         this.cardId = cardId;
     }
 
-    public HavengulLichEffect(final HavengulLichEffect effect) {
+    private HavengulLichEffect(final HavengulLichEffect effect) {
         super(effect);
         this.cardId = effect.cardId;
     }

--- a/Mage.Sets/src/mage/cards/h/HavengulMystery.java
+++ b/Mage.Sets/src/mage/cards/h/HavengulMystery.java
@@ -70,7 +70,7 @@ class HavengulMysteryTransformAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD));
     }
 
-    public HavengulMysteryTransformAbility(final HavengulMysteryTransformAbility ability) {
+    private HavengulMysteryTransformAbility(final HavengulMysteryTransformAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HavengulSkaab.java
+++ b/Mage.Sets/src/mage/cards/h/HavengulSkaab.java
@@ -48,7 +48,7 @@ class HavengulSkaabAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ReturnToHandTargetEffect());
     }
 
-    public HavengulSkaabAbility(final HavengulSkaabAbility ability) {
+    private HavengulSkaabAbility(final HavengulSkaabAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HawkeaterMoth.java
+++ b/Mage.Sets/src/mage/cards/h/HawkeaterMoth.java
@@ -27,7 +27,7 @@ public final class HawkeaterMoth extends CardImpl {
         this.addAbility(ShroudAbility.getInstance());
     }
 
-    public HawkeaterMoth (final HawkeaterMoth card) {
+    private HawkeaterMoth(final HawkeaterMoth card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HazduhrTheAbbot.java
+++ b/Mage.Sets/src/mage/cards/h/HazduhrTheAbbot.java
@@ -70,7 +70,7 @@ class HazduhrTheAbbotRedirectDamageEffect extends RedirectionEffect {
         this.staticText = "The next X damage that would be dealt this turn to target white creature you control is dealt to {this} instead";
     }
 
-    public HazduhrTheAbbotRedirectDamageEffect(final HazduhrTheAbbotRedirectDamageEffect effect) {
+    private HazduhrTheAbbotRedirectDamageEffect(final HazduhrTheAbbotRedirectDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HazezonTamar.java
+++ b/Mage.Sets/src/mage/cards/h/HazezonTamar.java
@@ -70,7 +70,7 @@ class HazezonTamarEntersEffect extends OneShotEffect {
         this.staticText = "create X 1/1 Sand Warrior creature tokens that are red, green, and white at the beginning of your next upkeep, where X is the number of lands you control at that time";
     }
 
-    public HazezonTamarEntersEffect(final HazezonTamarEntersEffect effect) {
+    private HazezonTamarEntersEffect(final HazezonTamarEntersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HazoretsFavor.java
+++ b/Mage.Sets/src/mage/cards/h/HazoretsFavor.java
@@ -61,7 +61,7 @@ public final class HazoretsFavor extends CardImpl {
             this.staticText = "If you do, sacrifice it at the beginning of the next end step";
         }
 
-        public HazoretsFavorSacrificeEffect(final HazoretsFavorSacrificeEffect effect) {
+        private HazoretsFavorSacrificeEffect(final HazoretsFavorSacrificeEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/h/HazoretsUndyingFury.java
+++ b/Mage.Sets/src/mage/cards/h/HazoretsUndyingFury.java
@@ -66,7 +66,7 @@ class HazoretsUndyingFuryEffect extends OneShotEffect {
                 "5 or less from among them without paying their mana costs";
     }
 
-    public HazoretsUndyingFuryEffect(final HazoretsUndyingFuryEffect effect) {
+    private HazoretsUndyingFuryEffect(final HazoretsUndyingFuryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HealTheScars.java
+++ b/Mage.Sets/src/mage/cards/h/HealTheScars.java
@@ -47,7 +47,7 @@ class HealTheScarsEffect extends OneShotEffect {
         staticText = "You gain life equal to that creature's toughness";
     }
 
-    public HealTheScarsEffect(final HealTheScarsEffect effect) {
+    private HealTheScarsEffect(final HealTheScarsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HealingGrace.java
+++ b/Mage.Sets/src/mage/cards/h/HealingGrace.java
@@ -50,7 +50,7 @@ class HealingGraceEffect extends PreventionEffectImpl {
         this.staticText = "Prevent the next 3 damage that would be dealt to any target this turn by a source of your choice";
     }
 
-    public HealingGraceEffect(final HealingGraceEffect effect) {
+    private HealingGraceEffect(final HealingGraceEffect effect) {
         super(effect);
         this.targetSource = effect.targetSource.copy();
     }

--- a/Mage.Sets/src/mage/cards/h/HeartOfBogardan.java
+++ b/Mage.Sets/src/mage/cards/h/HeartOfBogardan.java
@@ -90,7 +90,7 @@ class HeartOfBogardanEffect extends OneShotEffect {
                 + "where X is twice the number of age counters on {this} minus 2";
     }
 
-    public HeartOfBogardanEffect(final HeartOfBogardanEffect effect) {
+    private HeartOfBogardanEffect(final HeartOfBogardanEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeartOfLight.java
+++ b/Mage.Sets/src/mage/cards/h/HeartOfLight.java
@@ -57,7 +57,7 @@ class HeartOfLightEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that would be dealt to and dealt by enchanted creature";
     }
 
-    public HeartOfLightEffect(final HeartOfLightEffect effect) {
+    private HeartOfLightEffect(final HeartOfLightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeartWolf.java
+++ b/Mage.Sets/src/mage/cards/h/HeartWolf.java
@@ -69,7 +69,7 @@ class HeartWolfDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new SacrificeSourceEffect(), Duration.EndOfTurn, false);
     }
 
-    public HeartWolfDelayedTriggeredAbility(HeartWolfDelayedTriggeredAbility ability) {
+    private HeartWolfDelayedTriggeredAbility(final HeartWolfDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeartlessHidetsugu.java
+++ b/Mage.Sets/src/mage/cards/h/HeartlessHidetsugu.java
@@ -49,7 +49,7 @@ class HeartlessHidetsuguDamageEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to each player equal to half that player's life total, rounded down";
     }
 
-    public HeartlessHidetsuguDamageEffect(final HeartlessHidetsuguDamageEffect effect) {
+    private HeartlessHidetsuguDamageEffect(final HeartlessHidetsuguDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Heartmender.java
+++ b/Mage.Sets/src/mage/cards/h/Heartmender.java
@@ -59,7 +59,7 @@ class HeartmenderEffect extends OneShotEffect {
         staticText = "remove a -1/-1 counter from each creature you control";
     }
 
-    public HeartmenderEffect(HeartmenderEffect effect) {
+    private HeartmenderEffect(final HeartmenderEffect effect) {
         super(effect);
         this.counter = effect.counter.copy();
     }

--- a/Mage.Sets/src/mage/cards/h/Heartstone.java
+++ b/Mage.Sets/src/mage/cards/h/Heartstone.java
@@ -48,7 +48,7 @@ class HeartstoneEffect extends CostModificationEffectImpl {
         staticText = effectText;
     }
 
-    public HeartstoneEffect(final HeartstoneEffect effect) {
+    private HeartstoneEffect(final HeartstoneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeatOfBattle.java
+++ b/Mage.Sets/src/mage/cards/h/HeatOfBattle.java
@@ -37,7 +37,7 @@ class HeatOfBattleTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(1));
     }
 
-    public HeatOfBattleTriggeredAbility(HeatOfBattleTriggeredAbility ability) {
+    private HeatOfBattleTriggeredAbility(final HeatOfBattleTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeatShimmer.java
+++ b/Mage.Sets/src/mage/cards/h/HeatShimmer.java
@@ -49,7 +49,7 @@ class HeatShimmerEffect extends OneShotEffect {
         this.staticText = "Create a token that's a copy of target creature, except it has haste and \"At the beginning of the end step, exile this permanent.\"";
     }
 
-    public HeatShimmerEffect(final HeatShimmerEffect effect) {
+    private HeatShimmerEffect(final HeatShimmerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeatStroke.java
+++ b/Mage.Sets/src/mage/cards/h/HeatStroke.java
@@ -51,7 +51,7 @@ class HeatStrokeEffect extends OneShotEffect {
         this.staticText = "destroy each creature that blocked or was blocked this turn";
     }
 
-    public HeatStrokeEffect(HeatStrokeEffect effect) {
+    private HeatStrokeEffect(final HeatStrokeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeavenlyBlademaster.java
+++ b/Mage.Sets/src/mage/cards/h/HeavenlyBlademaster.java
@@ -91,7 +91,7 @@ class HeavenlyBlademasterEffect extends OneShotEffect {
         staticText = "you may attach any number of Auras and Equipment you control to it";
     }
 
-    public HeavenlyBlademasterEffect(final HeavenlyBlademasterEffect effect) {
+    private HeavenlyBlademasterEffect(final HeavenlyBlademasterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeavyArbalest.java
+++ b/Mage.Sets/src/mage/cards/h/HeavyArbalest.java
@@ -65,7 +65,7 @@ class HeavyArbalestEffect extends ReplacementEffectImpl {
         staticText = "Equipped creature doesn't untap during its controller's untap step";
     }
 
-    public HeavyArbalestEffect(final HeavyArbalestEffect effect) {
+    private HeavyArbalestEffect(final HeavyArbalestEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HedronAlignment.java
+++ b/Mage.Sets/src/mage/cards/h/HedronAlignment.java
@@ -67,7 +67,7 @@ class HedronAlignmentEffect extends OneShotEffect {
         this.staticText = "you may reveal your hand. If you do, you win the game if you own a card named Hedron Alignment in exile, in your hand, in your graveyard, and on the battlefield";
     }
 
-    public HedronAlignmentEffect(final HedronAlignmentEffect effect) {
+    private HedronAlignmentEffect(final HedronAlignmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HedronFieldPurists.java
+++ b/Mage.Sets/src/mage/cards/h/HedronFieldPurists.java
@@ -72,7 +72,7 @@ class HedronFieldPuristsEffect extends PreventionEffectImpl {
         this.staticText = "If a source would deal damage to you or a creature you control, prevent " + amount + " of that damage";
     }
 
-    public HedronFieldPuristsEffect(HedronFieldPuristsEffect effect) {
+    private HedronFieldPuristsEffect(final HedronFieldPuristsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HedronMatrix.java
+++ b/Mage.Sets/src/mage/cards/h/HedronMatrix.java
@@ -38,7 +38,7 @@ public final class HedronMatrix extends CardImpl {
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(4), new TargetControlledCreaturePermanent(), false));
     }
 
-    public HedronMatrix (final HedronMatrix card) {
+    private HedronMatrix(final HedronMatrix card) {
         super(card);
     }
 
@@ -56,7 +56,7 @@ class HedronMatrixEffect extends ContinuousEffectImpl {
         staticText = "Equipped creature gets +X/+X, where X is its mana value";
     }
 
-    public HedronMatrixEffect(final HedronMatrixEffect effect) {
+    private HedronMatrixEffect(final HedronMatrixEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HedronRover.java
+++ b/Mage.Sets/src/mage/cards/h/HedronRover.java
@@ -26,7 +26,7 @@ public final class HedronRover extends CardImpl {
         this.addAbility(new LandfallAbility(new BoostSourceEffect(2, 2, Duration.EndOfTurn), false));
     }
 
-    public HedronRover (final HedronRover card) {
+    private HedronRover(final HedronRover card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeedTheMists.java
+++ b/Mage.Sets/src/mage/cards/h/HeedTheMists.java
@@ -43,7 +43,7 @@ public final class HeedTheMists extends CardImpl {
             staticText = "Mill a card, then draw cards equal to the milled card's mana value";
         }
 
-        public HeedTheMistsEffect(HeedTheMistsEffect effect) {
+        private HeedTheMistsEffect(final HeedTheMistsEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/h/HeirloomBlade.java
+++ b/Mage.Sets/src/mage/cards/h/HeirloomBlade.java
@@ -62,7 +62,7 @@ class HeirloomBladeEffect extends OneShotEffect {
                 + "Put that card into your hand and the rest on the bottom of your library in a random order";
     }
 
-    public HeirloomBladeEffect(final HeirloomBladeEffect effect) {
+    private HeirloomBladeEffect(final HeirloomBladeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeliodsPunishment.java
+++ b/Mage.Sets/src/mage/cards/h/HeliodsPunishment.java
@@ -65,7 +65,7 @@ class HeliodsPunishmentLoseAllAbilitiesEnchantedEffect extends ContinuousEffectI
         staticText = "It loses all abilities and has \"{T}: Remove a task counter from {this}. Then if it has no task counters on it, destroy {this}.\"";
     }
 
-    public HeliodsPunishmentLoseAllAbilitiesEnchantedEffect(final HeliodsPunishmentLoseAllAbilitiesEnchantedEffect effect) {
+    private HeliodsPunishmentLoseAllAbilitiesEnchantedEffect(final HeliodsPunishmentLoseAllAbilitiesEnchantedEffect effect) {
         super(effect);
     }
 
@@ -102,7 +102,7 @@ class HeliodsPunishmentEffect extends OneShotEffect {
         sourceEnchantmentId = null;
     }
 
-    public HeliodsPunishmentEffect(final HeliodsPunishmentEffect effect) {
+    private HeliodsPunishmentEffect(final HeliodsPunishmentEffect effect) {
         super(effect);
         this.sourceEnchantmentId = effect.sourceEnchantmentId;
     }

--- a/Mage.Sets/src/mage/cards/h/HellcarverDemon.java
+++ b/Mage.Sets/src/mage/cards/h/HellcarverDemon.java
@@ -59,7 +59,7 @@ class HellcarverDemonEffect extends OneShotEffect {
                 + "spells from among cards exiled this way without paying their mana costs";
     }
 
-    public HellcarverDemonEffect(final HellcarverDemonEffect effect) {
+    private HellcarverDemonEffect(final HellcarverDemonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Helldozer.java
+++ b/Mage.Sets/src/mage/cards/h/Helldozer.java
@@ -59,7 +59,7 @@ class HelldozerEffect extends OneShotEffect {
         this.staticText = "Destroy target land. If that land was nonbasic, untap Helldozer";
     }
 
-    public HelldozerEffect(final HelldozerEffect effect) {
+    private HelldozerEffect(final HelldozerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Hellfire.java
+++ b/Mage.Sets/src/mage/cards/h/Hellfire.java
@@ -44,7 +44,7 @@ class HellfireEffect extends OneShotEffect {
         this.staticText = "Destroy all nonblack creatures. {this} deals X plus 3 damage to you, where X is the number of creatures that died this way";
     }
 
-    public HellfireEffect(final HellfireEffect effect) {
+    private HellfireEffect(final HellfireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HellholeRats.java
+++ b/Mage.Sets/src/mage/cards/h/HellholeRats.java
@@ -56,7 +56,7 @@ class HellholeRatsEffect extends OneShotEffect {
         this.staticText = "target player discards a card. {this} deals damage to that player equal to that card's mana value";
     }
 
-    public HellholeRatsEffect(final HellholeRatsEffect effect) {
+    private HellholeRatsEffect(final HellholeRatsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HellionEruption.java
+++ b/Mage.Sets/src/mage/cards/h/HellionEruption.java
@@ -44,7 +44,7 @@ class HellionEruptionEffect extends OneShotEffect {
         this.staticText = "Sacrifice all creatures you control, then create that many 4/4 red Hellion creature tokens";
     }
 
-    public HellionEruptionEffect(final HellionEruptionEffect effect) {
+    private HellionEruptionEffect(final HellionEruptionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HellkiteOverlord.java
+++ b/Mage.Sets/src/mage/cards/h/HellkiteOverlord.java
@@ -38,7 +38,7 @@ public final class HellkiteOverlord extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new ManaCostsImpl<>("{B}{G}")));
     }
 
-    public HellkiteOverlord (final HellkiteOverlord card) {
+    private HellkiteOverlord(final HellkiteOverlord card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HellkiteTyrant.java
+++ b/Mage.Sets/src/mage/cards/h/HellkiteTyrant.java
@@ -83,7 +83,7 @@ class HellkiteTyrantEffect extends OneShotEffect {
         this.staticText = "gain control of all artifacts that player controls";
     }
 
-    public HellkiteTyrantEffect(final HellkiteTyrantEffect effect) {
+    private HellkiteTyrantEffect(final HellkiteTyrantEffect effect) {
         super(effect);
     }
 
@@ -120,7 +120,7 @@ class HellkiteTyrantControlEffect extends ContinuousEffectImpl {
         this.controllerId = controllerId;
     }
 
-    public HellkiteTyrantControlEffect(final HellkiteTyrantControlEffect effect) {
+    private HellkiteTyrantControlEffect(final HellkiteTyrantControlEffect effect) {
         super(effect);
         this.controllerId = effect.controllerId;
     }

--- a/Mage.Sets/src/mage/cards/h/Hellrider.java
+++ b/Mage.Sets/src/mage/cards/h/Hellrider.java
@@ -51,7 +51,7 @@ class HellriderTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(1));
     }
 
-    public HellriderTriggeredAbility(final HellriderTriggeredAbility ability) {
+    private HellriderTriggeredAbility(final HellriderTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HelmOfKaldra.java
+++ b/Mage.Sets/src/mage/cards/h/HelmOfKaldra.java
@@ -98,7 +98,7 @@ class HelmOfKaldraEffect extends OneShotEffect {
         this.staticText = "if you control Equipment named Helm of Kaldra, Sword of Kaldra, and Shield of Kaldra, create Kaldra, a legendary 4/4 colorless Avatar creature token. Attach those Equipment to it";
     }
 
-    public HelmOfKaldraEffect(final HelmOfKaldraEffect effect) {
+    private HelmOfKaldraEffect(final HelmOfKaldraEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HelmOfTheHost.java
+++ b/Mage.Sets/src/mage/cards/h/HelmOfTheHost.java
@@ -60,7 +60,7 @@ class HelmOfTheHostEffect extends OneShotEffect {
         this.staticText = "create a token that's a copy of equipped creature, except the token isn't legendary if equipped creature is legendary. That token gains haste.";
     }
 
-    public HelmOfTheHostEffect(final HelmOfTheHostEffect effect) {
+    private HelmOfTheHostEffect(final HelmOfTheHostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeraldOfAnafenza.java
+++ b/Mage.Sets/src/mage/cards/h/HeraldOfAnafenza.java
@@ -56,7 +56,7 @@ class HeraldOfAnafenzaTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you activate {this}'s outlast ability, ");
     }
 
-    public HeraldOfAnafenzaTriggeredAbility(final HeraldOfAnafenzaTriggeredAbility ability) {
+    private HeraldOfAnafenzaTriggeredAbility(final HeraldOfAnafenzaTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeraldsHorn.java
+++ b/Mage.Sets/src/mage/cards/h/HeraldsHorn.java
@@ -57,7 +57,7 @@ class HeraldsHornEffect extends OneShotEffect {
         this.staticText = "look at the top card of your library. If it's a creature card of the chosen type, you may reveal it and put it into your hand";
     }
 
-    public HeraldsHornEffect(final HeraldsHornEffect effect) {
+    private HeraldsHornEffect(final HeraldsHornEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HereticsPunishment.java
+++ b/Mage.Sets/src/mage/cards/h/HereticsPunishment.java
@@ -48,7 +48,7 @@ class HereticsPunishmentEffect extends OneShotEffect {
         staticText = "Choose any target, then mill three cards. {this} deals damage to that permanent or player equal to the highest mana value among the milled cards";
     }
 
-    public HereticsPunishmentEffect(final HereticsPunishmentEffect effect) {
+    private HereticsPunishmentEffect(final HereticsPunishmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeritageDruid.java
+++ b/Mage.Sets/src/mage/cards/h/HeritageDruid.java
@@ -62,7 +62,7 @@ class HeritageDruidManaEffect extends BasicManaEffect {
         this.filter = filter;
     }
 
-    public HeritageDruidManaEffect(final HeritageDruidManaEffect effect) {
+    private HeritageDruidManaEffect(final HeritageDruidManaEffect effect) {
         super(effect);
         this.filter = effect.filter.copy();
     }

--- a/Mage.Sets/src/mage/cards/h/HeroOfLeinaTower.java
+++ b/Mage.Sets/src/mage/cards/h/HeroOfLeinaTower.java
@@ -56,7 +56,7 @@ class HeroOfLeinaTowerEffect extends OneShotEffect {
         staticText = "you may pay {X}. If you do, put X +1/+1 counters on {this}";
     }
 
-    public HeroOfLeinaTowerEffect(final HeroOfLeinaTowerEffect effect) {
+    private HeroOfLeinaTowerEffect(final HeroOfLeinaTowerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeroOfOxidRidge.java
+++ b/Mage.Sets/src/mage/cards/h/HeroOfOxidRidge.java
@@ -52,7 +52,7 @@ class HeroOfOxidRidgeEffect extends RestrictionEffect {
         staticText = "creatures with power 1 or less can't block this turn";
     }
 
-    public HeroOfOxidRidgeEffect(final HeroOfOxidRidgeEffect effect) {
+    private HeroOfOxidRidgeEffect(final HeroOfOxidRidgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Heroism.java
+++ b/Mage.Sets/src/mage/cards/h/Heroism.java
@@ -70,7 +70,7 @@ class HeroismEffect extends OneShotEffect {
         this.staticText = "For each attacking red creature, prevent all combat damage that would be dealt by that creature this turn unless its controller pays {2}{R}";
     }
 
-    public HeroismEffect(final HeroismEffect effect) {
+    private HeroismEffect(final HeroismEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HexgoldSlash.java
+++ b/Mage.Sets/src/mage/cards/h/HexgoldSlash.java
@@ -43,7 +43,7 @@ class HexgoldSlashEffect extends OneShotEffect {
                 "{this} deals 4 damage to that creature instead";
     }
 
-    public HexgoldSlashEffect(final HexgoldSlashEffect effect) {
+    private HexgoldSlashEffect(final HexgoldSlashEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HibernationsEnd.java
+++ b/Mage.Sets/src/mage/cards/h/HibernationsEnd.java
@@ -55,7 +55,7 @@ class HibernationsEndAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you pay {this}'s cumulative upkeep, ");
     }
 
-    public HibernationsEndAbility(final HibernationsEndAbility ability) {
+    private HibernationsEndAbility(final HibernationsEndAbility ability) {
         super(ability);
     }
 
@@ -82,7 +82,7 @@ class HibernationsEndEffect extends OneShotEffect {
         this.staticText = "search your library for a creature card with mana value equal to the number of age counters on {this}, put it onto the battlefield, then shuffle.";
     }
 
-    public HibernationsEndEffect(final HibernationsEndEffect effect) {
+    private HibernationsEndEffect(final HibernationsEndEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiddenAncients.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenAncients.java
@@ -60,7 +60,7 @@ class HiddenAncientsTreefolkToken extends TokenImpl {
         power = new MageInt(5);
         toughness = new MageInt(5);
     }
-    public HiddenAncientsTreefolkToken(final HiddenAncientsTreefolkToken token) {
+    private HiddenAncientsTreefolkToken(final HiddenAncientsTreefolkToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiddenBase.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenBase.java
@@ -39,7 +39,7 @@ public class HiddenBase extends CardImpl {
         this.addAbility(simpleActivatedAbility);
     }
 
-    public HiddenBase(final HiddenBase card) {
+    private HiddenBase(final HiddenBase card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiddenGibbons.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenGibbons.java
@@ -60,7 +60,7 @@ class HiddenGibbonsApe extends TokenImpl {
         power = new MageInt(4);
         toughness = new MageInt(4);
     }
-    public HiddenGibbonsApe(final HiddenGibbonsApe token) {
+    private HiddenGibbonsApe(final HiddenGibbonsApe token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiddenGuerrillas.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenGuerrillas.java
@@ -56,7 +56,7 @@ class HiddenGuerrillasSoldier extends TokenImpl {
         toughness = new MageInt(3);
         this.addAbility(TrampleAbility.getInstance());
     }
-    public HiddenGuerrillasSoldier(final HiddenGuerrillasSoldier token) {
+    private HiddenGuerrillasSoldier(final HiddenGuerrillasSoldier token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiddenHerd.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenHerd.java
@@ -52,7 +52,7 @@ class HiddenHerdAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new HiddenHerdBeast(), null, Duration.WhileOnBattlefield), false);
     }
 
-    public HiddenHerdAbility(final HiddenHerdAbility ability) {
+    private HiddenHerdAbility(final HiddenHerdAbility ability) {
         super(ability);
     }
 
@@ -87,7 +87,7 @@ class HiddenHerdBeast extends TokenImpl {
         power = new MageInt(3);
         toughness = new MageInt(3);
     }
-    public HiddenHerdBeast(final HiddenHerdBeast token) {
+    private HiddenHerdBeast(final HiddenHerdBeast token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiddenPredators.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenPredators.java
@@ -51,7 +51,7 @@ class HiddenPredatorsStateTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("When an opponent controls a creature with power 4 or greater, if {this} is an enchantment, ");
     }
 
-    public HiddenPredatorsStateTriggeredAbility(final HiddenPredatorsStateTriggeredAbility ability) {
+    private HiddenPredatorsStateTriggeredAbility(final HiddenPredatorsStateTriggeredAbility ability) {
         super(ability);
     }
 
@@ -110,7 +110,7 @@ class HiddenPredatorsToken extends TokenImpl {
         toughness = new MageInt(4);
     }
 
-    public HiddenPredatorsToken(final HiddenPredatorsToken token) {
+    private HiddenPredatorsToken(final HiddenPredatorsToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiddenRetreat.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenRetreat.java
@@ -32,7 +32,7 @@ public class HiddenRetreat extends CardImpl {
 
     }
 
-    public HiddenRetreat(final HiddenRetreat hiddenRetreat) {
+    private HiddenRetreat(final HiddenRetreat hiddenRetreat) {
         super(hiddenRetreat);
     }
 
@@ -49,7 +49,7 @@ class HiddenRetreatEffect extends PreventionEffectImpl {
         this.staticText = "Prevent all damage that would be dealt by target instant or sorcery spell this turn.";
     }
 
-    public HiddenRetreatEffect(final HiddenRetreatEffect effect) {
+    private HiddenRetreatEffect(final HiddenRetreatEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiddenSpider.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenSpider.java
@@ -64,7 +64,7 @@ class HiddenSpiderToken extends TokenImpl {
         toughness = new MageInt(5);
         this.addAbility(ReachAbility.getInstance());
     }
-    public HiddenSpiderToken(final HiddenSpiderToken token) {
+    private HiddenSpiderToken(final HiddenSpiderToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiddenStag.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenStag.java
@@ -63,7 +63,7 @@ class ElkBeastToken extends TokenImpl {
         toughness = new MageInt(2);
     }
 
-    public ElkBeastToken(final ElkBeastToken token) {
+    private ElkBeastToken(final ElkBeastToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiddenStrings.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenStrings.java
@@ -54,7 +54,7 @@ class HiddenStringsEffect extends OneShotEffect {
         this.staticText = "You may tap or untap target permanent, then you may tap or untap another target permanent";
     }
 
-    public HiddenStringsEffect(final HiddenStringsEffect effect) {
+    private HiddenStringsEffect(final HiddenStringsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HideSeek.java
+++ b/Mage.Sets/src/mage/cards/h/HideSeek.java
@@ -55,7 +55,7 @@ class SeekEffect extends OneShotEffect {
         staticText = "Search target opponent's library for a card and exile it. You gain life equal to its mana value. Then that player shuffles";
     }
 
-    public SeekEffect(final SeekEffect effect) {
+    private SeekEffect(final SeekEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HidetsugusSecondRite.java
+++ b/Mage.Sets/src/mage/cards/h/HidetsugusSecondRite.java
@@ -43,7 +43,7 @@ class HidetsugusSecondRiteEffect extends OneShotEffect {
         this.staticText = "If target player has exactly 10 life, Hidetsugu's Second Rite deals 10 damage to that player";
     }
 
-    public HidetsugusSecondRiteEffect(final HidetsugusSecondRiteEffect effect) {
+    private HidetsugusSecondRiteEffect(final HidetsugusSecondRiteEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HighPriestOfPenance.java
+++ b/Mage.Sets/src/mage/cards/h/HighPriestOfPenance.java
@@ -50,7 +50,7 @@ class HighPriestOfPenanceTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} is dealt damage, ");
     }
 
-    public HighPriestOfPenanceTriggeredAbility(final HighPriestOfPenanceTriggeredAbility ability) {
+    private HighPriestOfPenanceTriggeredAbility(final HighPriestOfPenanceTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiredMuscle.java
+++ b/Mage.Sets/src/mage/cards/h/HiredMuscle.java
@@ -82,7 +82,7 @@ class Scarmaker extends TokenImpl {
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }
-    public Scarmaker(final Scarmaker token) {
+    private Scarmaker(final Scarmaker token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiredTorturer.java
+++ b/Mage.Sets/src/mage/cards/h/HiredTorturer.java
@@ -51,7 +51,7 @@ public final class HiredTorturer extends CardImpl {
 
     }
 
-    public HiredTorturer (final HiredTorturer card) {
+    private HiredTorturer(final HiredTorturer card) {
         super(card);
     }
 
@@ -69,7 +69,7 @@ class HiredTorturerEffect extends OneShotEffect {
         staticText = "and reveals a card at random from their hand";
     }
 
-    public HiredTorturerEffect(final HiredTorturerEffect effect) {
+    private HiredTorturerEffect(final HiredTorturerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HisokasGuard.java
+++ b/Mage.Sets/src/mage/cards/h/HisokasGuard.java
@@ -67,7 +67,7 @@ class HisokasGuardGainAbilityTargetEffect extends ContinuousEffectImpl {
         this.ability = ShroudAbility.getInstance();
     }
 
-    public HisokasGuardGainAbilityTargetEffect(final HisokasGuardGainAbilityTargetEffect effect) {
+    private HisokasGuardGainAbilityTargetEffect(final HisokasGuardGainAbilityTargetEffect effect) {
         super(effect);
         this.ability = effect.ability.copy();
     }

--- a/Mage.Sets/src/mage/cards/h/HissingQuagmire.java
+++ b/Mage.Sets/src/mage/cards/h/HissingQuagmire.java
@@ -63,7 +63,7 @@ class HissingQuagmireToken extends TokenImpl {
         toughness = new MageInt(2);
         addAbility(DeathtouchAbility.getInstance());
     }
-    public HissingQuagmireToken(final HissingQuagmireToken token) {
+    private HissingQuagmireToken(final HissingQuagmireToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HitRun.java
+++ b/Mage.Sets/src/mage/cards/h/HitRun.java
@@ -58,7 +58,7 @@ class HitEffect extends OneShotEffect {
         this.staticText = "Target player sacrifices an artifact or creature. Hit deals damage to that player equal to that permanent's mana value";
     }
 
-    public HitEffect(final HitEffect effect) {
+    private HitEffect(final HitEffect effect) {
         super(effect);
     }
 
@@ -100,7 +100,7 @@ class RunEffect extends OneShotEffect {
         this.staticText = "Attacking creatures you control get +1/+0 until end of turn for each other attacking creature";
     }
 
-    public RunEffect(final RunEffect effect) {
+    private RunEffect(final RunEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiveMind.java
+++ b/Mage.Sets/src/mage/cards/h/HiveMind.java
@@ -48,7 +48,7 @@ class HiveMindTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a player casts an instant or sorcery spell, ");
     }
 
-    public HiveMindTriggeredAbility(final HiveMindTriggeredAbility ability) {
+    private HiveMindTriggeredAbility(final HiveMindTriggeredAbility ability) {
         super(ability);
     }
 
@@ -85,7 +85,7 @@ class HiveMindEffect extends OneShotEffect {
         this.staticText = "each other player copies that spell. Each of those players may choose new targets for their copy";
     }
 
-    public HiveMindEffect(final HiveMindEffect effect) {
+    private HiveMindEffect(final HiveMindEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HixusPrisonWarden.java
+++ b/Mage.Sets/src/mage/cards/h/HixusPrisonWarden.java
@@ -56,7 +56,7 @@ class HixusPrisonWardenTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature deals combat damage to you, if {this} entered the battlefield this turn, ");
     }
 
-    public HixusPrisonWardenTriggeredAbility(final HixusPrisonWardenTriggeredAbility ability) {
+    private HixusPrisonWardenTriggeredAbility(final HixusPrisonWardenTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HoardSmelterDragon.java
+++ b/Mage.Sets/src/mage/cards/h/HoardSmelterDragon.java
@@ -43,7 +43,7 @@ public final class HoardSmelterDragon extends CardImpl {
         this.addAbility(ability);
     }
 
-    public HoardSmelterDragon (final HoardSmelterDragon card) {
+    private HoardSmelterDragon(final HoardSmelterDragon card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HoardersGreed.java
+++ b/Mage.Sets/src/mage/cards/h/HoardersGreed.java
@@ -43,7 +43,7 @@ class HoardersGreedEffect extends OneShotEffect {
         this.staticText = "You lose 2 life and draw two cards, then clash with an opponent. If you win, repeat this process";
     }
 
-    public HoardersGreedEffect(final HoardersGreedEffect effect) {
+    private HoardersGreedEffect(final HoardersGreedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HokoriDustDrinker.java
+++ b/Mage.Sets/src/mage/cards/h/HokoriDustDrinker.java
@@ -59,7 +59,7 @@ class HokoriDustDrinkerUntapEffect extends OneShotEffect {
         this.staticText = "that player untaps a land they control";
     }
 
-    public HokoriDustDrinkerUntapEffect(final HokoriDustDrinkerUntapEffect effect) {
+    private HokoriDustDrinkerUntapEffect(final HokoriDustDrinkerUntapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HoldCaptive.java
+++ b/Mage.Sets/src/mage/cards/h/HoldCaptive.java
@@ -32,7 +32,7 @@ public class HoldCaptive extends CardImpl {
         this.addAbility(new SimpleStaticAbility(new CantBlockAttackActivateAttachedEffect()));
     }
 
-    public HoldCaptive(final HoldCaptive card) {
+    private HoldCaptive(final HoldCaptive card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HolisticWisdom.java
+++ b/Mage.Sets/src/mage/cards/h/HolisticWisdom.java
@@ -57,7 +57,7 @@ class HolisticWisdomEffect extends OneShotEffect {
         this.staticText = "Return target card from your graveyard to your hand if it shares a card type with the card exiled this way";
     }
 
-    public HolisticWisdomEffect(final HolisticWisdomEffect effect) {
+    private HolisticWisdomEffect(final HolisticWisdomEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HollowSpecter.java
+++ b/Mage.Sets/src/mage/cards/h/HollowSpecter.java
@@ -53,7 +53,7 @@ class HollowSpecterEffect extends OneShotEffect {
         staticText = "you may pay {X}. If you do, that player reveals X cards from their hand and you choose one of them. That player discards that card";
     }
 
-    public HollowSpecterEffect(final HollowSpecterEffect effect) {
+    private HollowSpecterEffect(final HollowSpecterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HollowbornBarghest.java
+++ b/Mage.Sets/src/mage/cards/h/HollowbornBarghest.java
@@ -73,7 +73,7 @@ class HollowbornBarghestEffect extends OneShotEffect {
         staticText = "Each opponent loses 2 life";
     }
 
-    public HollowbornBarghestEffect(final HollowbornBarghestEffect effect) {
+    private HollowbornBarghestEffect(final HollowbornBarghestEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class HollowbornBarghestTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new LoseLifeTargetEffect(2));
     }
 
-    public HollowbornBarghestTriggeredAbility(final HollowbornBarghestTriggeredAbility ability) {
+    private HollowbornBarghestTriggeredAbility(final HollowbornBarghestTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Holochess.java
+++ b/Mage.Sets/src/mage/cards/h/Holochess.java
@@ -32,7 +32,7 @@ public class Holochess extends CardImpl {
         this.getSpellAbility().addTarget(new TargetOpponent());
     }
 
-    public Holochess(Holochess card) {
+    private Holochess(final Holochess card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Homarid.java
+++ b/Mage.Sets/src/mage/cards/h/Homarid.java
@@ -72,7 +72,7 @@ class HomaridTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("Whenever there are four tide counters on {this}, ");
     }
 
-    public HomaridTriggeredAbility(final HomaridTriggeredAbility ability) {
+    private HomaridTriggeredAbility(final HomaridTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HomaridExplorer.java
+++ b/Mage.Sets/src/mage/cards/h/HomaridExplorer.java
@@ -25,7 +25,7 @@ public final class HomaridExplorer extends CardImpl {
         this.addAbility(ability);
     }
 
-    public HomaridExplorer(final HomaridExplorer homaridExplorer) {
+    private HomaridExplorer(final HomaridExplorer homaridExplorer) {
         super(homaridExplorer);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HomicidalBrute.java
+++ b/Mage.Sets/src/mage/cards/h/HomicidalBrute.java
@@ -55,7 +55,7 @@ class HomicidalBruteTriggeredAbility extends TriggeredAbilityImpl {
         addEffect(new TransformSourceEffect());
     }
 
-    public HomicidalBruteTriggeredAbility(HomicidalBruteTriggeredAbility ability) {
+    private HomicidalBruteTriggeredAbility(final HomicidalBruteTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HomingLightning.java
+++ b/Mage.Sets/src/mage/cards/h/HomingLightning.java
@@ -47,7 +47,7 @@ class HomingLightningEffect extends OneShotEffect {
         staticText = "{this} deals 4 damage to target creature and each other creature with the same name as that creature";
     }
 
-    public HomingLightningEffect(final HomingLightningEffect effect) {
+    private HomingLightningEffect(final HomingLightningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HomingSliver.java
+++ b/Mage.Sets/src/mage/cards/h/HomingSliver.java
@@ -66,7 +66,7 @@ class HomingSliverEffect extends ContinuousEffectImpl {
         this.staticText = "each Sliver card in each player's hand has slivercycling {3}";
     }
 
-    public HomingSliverEffect(final HomingSliverEffect effect) {
+    private HomingSliverEffect(final HomingSliverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HomuraHumanAscendant.java
+++ b/Mage.Sets/src/mage/cards/h/HomuraHumanAscendant.java
@@ -73,7 +73,7 @@ class HomuraReturnFlippedSourceEffect extends OneShotEffect {
         staticText = "return it to the battlefield flipped";
     }
 
-    public HomuraReturnFlippedSourceEffect(final HomuraReturnFlippedSourceEffect effect) {
+    private HomuraReturnFlippedSourceEffect(final HomuraReturnFlippedSourceEffect effect) {
         super(effect);
         this.flipToken = effect.flipToken;
     }
@@ -121,7 +121,7 @@ class HomurasEssence2 extends TokenImpl {
         ability.addEffect(effect);
         this.addAbility(ability);
     }
-    public HomurasEssence2(final HomurasEssence2 token) {
+    private HomurasEssence2(final HomurasEssence2 token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HonorablePassage.java
+++ b/Mage.Sets/src/mage/cards/h/HonorablePassage.java
@@ -46,7 +46,7 @@ class HonorablePassageEffect extends PreventNextDamageFromChosenSourceToTargetEf
         this.staticText = "The next time a source of your choice would deal damage to any target this turn, prevent that damage. If damage from a red source is prevented this way, {this} deals that much damage to the source's controller";
     }
 
-    public HonorablePassageEffect(final HonorablePassageEffect effect) {
+    private HonorablePassageEffect(final HonorablePassageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HoodedHorror.java
+++ b/Mage.Sets/src/mage/cards/h/HoodedHorror.java
@@ -51,7 +51,7 @@ class HoodedHorrorCantBeBlockedEffect extends RestrictionEffect {
         staticText = "{this} can't be blocked as long as defending player controls the most creatures or is tied for the most";
     }
 
-    public HoodedHorrorCantBeBlockedEffect(final HoodedHorrorCantBeBlockedEffect effect) {
+    private HoodedHorrorCantBeBlockedEffect(final HoodedHorrorCantBeBlockedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HopeOfGhirapur.java
+++ b/Mage.Sets/src/mage/cards/h/HopeOfGhirapur.java
@@ -73,7 +73,7 @@ class HopeOfGhirapurCantCastEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Until your next turn, target player who was dealt combat damage by {this} this turn can't cast noncreature spells";
     }
 
-    public HopeOfGhirapurCantCastEffect(final HopeOfGhirapurCantCastEffect effect) {
+    private HopeOfGhirapurCantCastEffect(final HopeOfGhirapurCantCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HordeOfNotions.java
+++ b/Mage.Sets/src/mage/cards/h/HordeOfNotions.java
@@ -69,7 +69,7 @@ class HordeOfNotionsEffect extends OneShotEffect {
         this.staticText = "You may play target Elemental card from your graveyard without paying its mana cost";
     }
 
-    public HordeOfNotionsEffect(final HordeOfNotionsEffect effect) {
+    private HordeOfNotionsEffect(final HordeOfNotionsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HornOfGreed.java
+++ b/Mage.Sets/src/mage/cards/h/HornOfGreed.java
@@ -43,7 +43,7 @@ class HornOfGreedAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a player plays a land, ");
     }
 
-    public HornOfGreedAbility(final HornOfGreedAbility ability) {
+    private HornOfGreedAbility(final HornOfGreedAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HornOfPlenty.java
+++ b/Mage.Sets/src/mage/cards/h/HornOfPlenty.java
@@ -51,7 +51,7 @@ class HornOfPlentyEffect extends OneShotEffect {
         this.staticText = "they may pay {1}. If the player does, they draw a card at the beginning of the next end step";
     }
 
-    public HornOfPlentyEffect(final HornOfPlentyEffect effect) {
+    private HornOfPlentyEffect(final HornOfPlentyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HornetCannon.java
+++ b/Mage.Sets/src/mage/cards/h/HornetCannon.java
@@ -52,7 +52,7 @@ class HornetCannonEffect extends OneShotEffect {
         staticText = "Create a 1/1 colorless Insect artifact creature token with flying and haste named Hornet. Destroy it at the beginning of the next end step.";
     }
 
-    public HornetCannonEffect(final HornetCannonEffect effect) {
+    private HornetCannonEffect(final HornetCannonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HorobiDeathsWail.java
+++ b/Mage.Sets/src/mage/cards/h/HorobiDeathsWail.java
@@ -55,7 +55,7 @@ class HorobiDeathsWailAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect);
     }
 
-    public HorobiDeathsWailAbility(final HorobiDeathsWailAbility ability) {
+    private HorobiDeathsWailAbility(final HorobiDeathsWailAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Hostility.java
+++ b/Mage.Sets/src/mage/cards/h/Hostility.java
@@ -63,7 +63,7 @@ class HostilityEffect extends PreventionEffectImpl {
         staticText = "If a spell you control would deal damage to an opponent, prevent that damage. Create a 3/1 red Elemental Shaman creature token with haste for each 1 damage prevented this way.";
     }
 
-    public HostilityEffect(final HostilityEffect effect) {
+    private HostilityEffect(final HostilityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HourOfGlory.java
+++ b/Mage.Sets/src/mage/cards/h/HourOfGlory.java
@@ -51,7 +51,7 @@ class HourOfGloryEffect extends OneShotEffect {
         this.staticText = "Exile target creature. If that creature was a God, its controller reveals their hand and exiles all cards with the same name as that creature";
     }
 
-    public HourOfGloryEffect(final HourOfGloryEffect effect) {
+    private HourOfGloryEffect(final HourOfGloryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HourOfNeed.java
+++ b/Mage.Sets/src/mage/cards/h/HourOfNeed.java
@@ -50,7 +50,7 @@ class HourOfNeedExileEffect extends OneShotEffect {
         this.staticText = "Exile any number of target creatures. For each creature exiled this way, its controller creates a 4/4 blue Sphinx creature token with flying";
     }
 
-    public HourOfNeedExileEffect(final HourOfNeedExileEffect effect) {
+    private HourOfNeedExileEffect(final HourOfNeedExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Hovermyr.java
+++ b/Mage.Sets/src/mage/cards/h/Hovermyr.java
@@ -28,7 +28,7 @@ public final class Hovermyr extends CardImpl {
         this.addAbility(VigilanceAbility.getInstance());
     }
 
-    public Hovermyr (final Hovermyr card) {
+    private Hovermyr(final Hovermyr card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HowlingMine.java
+++ b/Mage.Sets/src/mage/cards/h/HowlingMine.java
@@ -41,7 +41,7 @@ class HowlingMineAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardTargetEffect(1));
     }
 
-    public HowlingMineAbility(final HowlingMineAbility ability) {
+    private HowlingMineAbility(final HowlingMineAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Hubris.java
+++ b/Mage.Sets/src/mage/cards/h/Hubris.java
@@ -56,7 +56,7 @@ class HubrisReturnEffect extends OneShotEffect {
         this.staticText = "Return target creature and all Auras attached to it to their owners' hands";
     }
 
-    public HubrisReturnEffect(final HubrisReturnEffect effect) {
+    private HubrisReturnEffect(final HubrisReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HumbleBudoka.java
+++ b/Mage.Sets/src/mage/cards/h/HumbleBudoka.java
@@ -26,7 +26,7 @@ public final class HumbleBudoka extends CardImpl {
         this.addAbility(ShroudAbility.getInstance());
     }
 
-    public HumbleBudoka (final HumbleBudoka card) {
+    private HumbleBudoka(final HumbleBudoka card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HumbleDefector.java
+++ b/Mage.Sets/src/mage/cards/h/HumbleDefector.java
@@ -56,7 +56,7 @@ class HumbleDefectorEffect extends OneShotEffect {
         this.staticText = "Draw two cards. Target opponent gains control of {this}.";
     }
 
-    public HumbleDefectorEffect(final HumbleDefectorEffect effect) {
+    private HumbleDefectorEffect(final HumbleDefectorEffect effect) {
         super(effect);
     }
 
@@ -89,7 +89,7 @@ class HumbleDefectorControlSourceEffect extends ContinuousEffectImpl {
         super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
     }
 
-    public HumbleDefectorControlSourceEffect(final HumbleDefectorControlSourceEffect effect) {
+    private HumbleDefectorControlSourceEffect(final HumbleDefectorControlSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Humility.java
+++ b/Mage.Sets/src/mage/cards/h/Humility.java
@@ -49,7 +49,7 @@ public final class Humility extends CardImpl {
             staticText = "All creatures lose all abilities and have base power and toughness 1/1";
         }
 
-        public HumilityEffect(final HumilityEffect effect) {
+        private HumilityEffect(final HumilityEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/h/HundredTalonKami.java
+++ b/Mage.Sets/src/mage/cards/h/HundredTalonKami.java
@@ -27,7 +27,7 @@ public final class HundredTalonKami extends CardImpl {
         this.addAbility(new SoulshiftAbility(4));
     }
 
-    public HundredTalonKami (final HundredTalonKami card) {
+    private HundredTalonKami(final HundredTalonKami card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HungeringHydra.java
+++ b/Mage.Sets/src/mage/cards/h/HungeringHydra.java
@@ -67,7 +67,7 @@ class HungeringHydraEffect extends OneShotEffect {
         this.staticText = "put that many +1/+1 counters on it";
     }
 
-    public HungeringHydraEffect(final HungeringHydraEffect effect) {
+    private HungeringHydraEffect(final HungeringHydraEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HungryHungryHeifer.java
+++ b/Mage.Sets/src/mage/cards/h/HungryHungryHeifer.java
@@ -56,7 +56,7 @@ class HungryHungryHeiferEffect extends OneShotEffect {
         this.staticText = "you may remove a counter from a permanent you control. If you don't, sacrifice {this}";
     }
 
-    public HungryHungryHeiferEffect(final HungryHungryHeiferEffect effect) {
+    private HungryHungryHeiferEffect(final HungryHungryHeiferEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HuntDown.java
+++ b/Mage.Sets/src/mage/cards/h/HuntDown.java
@@ -58,7 +58,7 @@ class HuntDownEffect extends RequirementEffect {
         staticText = "Target creature blocks target creature this turn if able";
     }
 
-    public HuntDownEffect(final HuntDownEffect effect) {
+    private HuntDownEffect(final HuntDownEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HuntedWumpus.java
+++ b/Mage.Sets/src/mage/cards/h/HuntedWumpus.java
@@ -53,7 +53,7 @@ class HuntedWumpusEffect extends OneShotEffect {
         this.staticText = "each other player may put a creature card from their hand onto the battlefield";
     }
 
-    public HuntedWumpusEffect(final HuntedWumpusEffect effect) {
+    private HuntedWumpusEffect(final HuntedWumpusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HuntingWilds.java
+++ b/Mage.Sets/src/mage/cards/h/HuntingWilds.java
@@ -67,7 +67,7 @@ class HuntingWildsEffect extends OneShotEffect {
         this.staticText = "Untap all Forests put onto the battlefield this way. They become 3/3 green creatures with haste that are still lands";
     }
 
-    public HuntingWildsEffect(final HuntingWildsEffect effect) {
+    private HuntingWildsEffect(final HuntingWildsEffect effect) {
         super(effect);
     }
 
@@ -110,7 +110,7 @@ class HuntingWildsToken extends TokenImpl {
 
         this.addAbility(HasteAbility.getInstance());
     }
-    public HuntingWildsToken(final HuntingWildsToken token) {
+    private HuntingWildsToken(final HuntingWildsToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HydraBroodmaster.java
+++ b/Mage.Sets/src/mage/cards/h/HydraBroodmaster.java
@@ -53,7 +53,7 @@ class HydraBroodmasterEffect extends OneShotEffect {
         this.staticText = "create X X/X green Hydra creature tokens";
     }
 
-    public HydraBroodmasterEffect(final HydraBroodmasterEffect effect) {
+    private HydraBroodmasterEffect(final HydraBroodmasterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HydraOmnivore.java
+++ b/Mage.Sets/src/mage/cards/h/HydraOmnivore.java
@@ -49,7 +49,7 @@ class HydraOmnivoreEffect extends OneShotEffect {
         this.staticText = "it deals that much damage to each other opponent";
     }
 
-    public HydraOmnivoreEffect(final HydraOmnivoreEffect effect) {
+    private HydraOmnivoreEffect(final HydraOmnivoreEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Hydroform.java
+++ b/Mage.Sets/src/mage/cards/h/Hydroform.java
@@ -50,7 +50,7 @@ class HydroformToken extends TokenImpl {
 
         this.addAbility(FlyingAbility.getInstance());
     }
-    public HydroformToken(final HydroformToken token) {
+    private HydroformToken(final HydroformToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IbHalfheartGoblinTactician.java
+++ b/Mage.Sets/src/mage/cards/i/IbHalfheartGoblinTactician.java
@@ -76,7 +76,7 @@ class IbHalfheartGoblinTacticianEffect extends OneShotEffect {
         this.staticText = "sacrifice it. If you do, it deals 4 damage to each creature blocking it";
     }
 
-    public IbHalfheartGoblinTacticianEffect(final IbHalfheartGoblinTacticianEffect effect) {
+    private IbHalfheartGoblinTacticianEffect(final IbHalfheartGoblinTacticianEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IcatianPhalanx.java
+++ b/Mage.Sets/src/mage/cards/i/IcatianPhalanx.java
@@ -28,7 +28,7 @@ public final class IcatianPhalanx extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public IcatianPhalanx (final IcatianPhalanx card) {
+    private IcatianPhalanx(final IcatianPhalanx card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IcatianSkirmishers.java
+++ b/Mage.Sets/src/mage/cards/i/IcatianSkirmishers.java
@@ -41,7 +41,7 @@ public final class IcatianSkirmishers extends CardImpl {
         this.addAbility(new AttacksTriggeredAbility(new IcatianSkirmishersEffect(), false));
     }
 
-    public IcatianSkirmishers(final IcatianSkirmishers card) {
+    private IcatianSkirmishers(final IcatianSkirmishers card) {
         super(card);
     }
 
@@ -59,7 +59,7 @@ class IcatianSkirmishersEffect extends OneShotEffect {
         this.staticText = "all creatures banded with it gain first strike until end of turn";
     }
 
-    public IcatianSkirmishersEffect(final IcatianSkirmishersEffect effect) {
+    private IcatianSkirmishersEffect(final IcatianSkirmishersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IceCauldron.java
+++ b/Mage.Sets/src/mage/cards/i/IceCauldron.java
@@ -78,7 +78,7 @@ class IceCauldronExileEffect extends OneShotEffect {
         this.staticText = "and exile a nonland card from your hand. You may cast that card for as long as it remains exiled";
     }
 
-    public IceCauldronExileEffect(final IceCauldronExileEffect effect) {
+    private IceCauldronExileEffect(final IceCauldronExileEffect effect) {
         super(effect);
     }
 
@@ -157,7 +157,7 @@ class IceCauldronNoteManaEffect extends OneShotEffect {
         this.staticText = "Note the type and amount of mana spent to pay this activation cost";
     }
 
-    public IceCauldronNoteManaEffect(final IceCauldronNoteManaEffect effect) {
+    private IceCauldronNoteManaEffect(final IceCauldronNoteManaEffect effect) {
         super(effect);
         manaUsedString = effect.manaUsedString;
     }

--- a/Mage.Sets/src/mage/cards/i/IceCave.java
+++ b/Mage.Sets/src/mage/cards/i/IceCave.java
@@ -49,7 +49,7 @@ class IceCaveEffect extends OneShotEffect {
         this.staticText = "any other player may pay that spell's mana cost. If a player does, counter the spell";
     }
 
-    public IceCaveEffect(final IceCaveEffect effect) {
+    private IceCaveEffect(final IceCaveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Icequake.java
+++ b/Mage.Sets/src/mage/cards/i/Icequake.java
@@ -47,7 +47,7 @@ class IcequakeEffect extends OneShotEffect {
         this.staticText = "Destroy target land.<br>If that land was a snow land, {this} deals 1 damage to that land's controller.";
     }
 
-    public IcequakeEffect(final IcequakeEffect effect) {
+    private IcequakeEffect(final IcequakeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IchneumonDruid.java
+++ b/Mage.Sets/src/mage/cards/i/IchneumonDruid.java
@@ -54,7 +54,7 @@ class IchneumonDruidAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(StaticValue.get(4), false, "that player", true));
     }
 
-    public IchneumonDruidAbility(final IchneumonDruidAbility ability) {
+    private IchneumonDruidAbility(final IchneumonDruidAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IchorplateGolem.java
+++ b/Mage.Sets/src/mage/cards/i/IchorplateGolem.java
@@ -63,7 +63,7 @@ class IchorplateGolemTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.OIL.createInstance()));
     }
 
-    public IchorplateGolemTriggeredAbility(final IchorplateGolemTriggeredAbility ability) {
+    private IchorplateGolemTriggeredAbility(final IchorplateGolemTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IconOfAncestry.java
+++ b/Mage.Sets/src/mage/cards/i/IconOfAncestry.java
@@ -81,7 +81,7 @@ class IconOfAncestryEffect extends OneShotEffect {
         return new LookLibraryAndPickControllerEffect(3, 1, filter, PutCards.HAND, PutCards.BOTTOM_RANDOM).apply(game, source);
     }
 
-    public IconOfAncestryEffect(final IconOfAncestryEffect effect) {
+    private IconOfAncestryEffect(final IconOfAncestryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IdentityThief.java
+++ b/Mage.Sets/src/mage/cards/i/IdentityThief.java
@@ -67,7 +67,7 @@ class IdentityThiefAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} attacks, ");
     }
 
-    public IdentityThiefAbility(final IdentityThiefAbility ability) {
+    private IdentityThiefAbility(final IdentityThiefAbility ability) {
         super(ability);
     }
 
@@ -95,7 +95,7 @@ class IdentityThiefEffect extends OneShotEffect {
                 + "Return the exiled card to the battlefield under its owner's control at the beginning of the next end step";
     }
 
-    public IdentityThiefEffect(final IdentityThiefEffect effect) {
+    private IdentityThiefEffect(final IdentityThiefEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IgniteMemories.java
+++ b/Mage.Sets/src/mage/cards/i/IgniteMemories.java
@@ -45,7 +45,7 @@ class IgniteMemoriesEffect extends OneShotEffect {
         staticText = "Target player reveals a card at random from their hand. {this} deals damage to that player equal to that card's mana value";
     }
 
-    public IgniteMemoriesEffect(final IgniteMemoriesEffect effect) {
+    private IgniteMemoriesEffect(final IgniteMemoriesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IkiralOutrider.java
+++ b/Mage.Sets/src/mage/cards/i/IkiralOutrider.java
@@ -45,7 +45,7 @@ public final class IkiralOutrider extends LevelerCard {
         setMaxLevelCounters(4);
     }
 
-    public IkiralOutrider (final IkiralOutrider card) {
+    private IkiralOutrider(final IkiralOutrider card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IkraShidiqiTheUsurper.java
+++ b/Mage.Sets/src/mage/cards/i/IkraShidiqiTheUsurper.java
@@ -59,7 +59,7 @@ class IkraShidiqiTheUsurperTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null);
     }
 
-    public IkraShidiqiTheUsurperTriggeredAbility(final IkraShidiqiTheUsurperTriggeredAbility ability) {
+    private IkraShidiqiTheUsurperTriggeredAbility(final IkraShidiqiTheUsurperTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IllicitAuction.java
+++ b/Mage.Sets/src/mage/cards/i/IllicitAuction.java
@@ -53,7 +53,7 @@ class IllicitAuctionEffect extends GainControlTargetEffect {
         this.staticText = "Each player may bid life for control of target creature. You start the bidding with a bid of 0. In turn order, each player may top the high bid. The bidding ends if the high bid stands. The high bidder loses life equal to the high bid and gains control of the creature.";
     }
 
-    public IllicitAuctionEffect(final IllicitAuctionEffect effect) {
+    private IllicitAuctionEffect(final IllicitAuctionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Illumination.java
+++ b/Mage.Sets/src/mage/cards/i/Illumination.java
@@ -58,7 +58,7 @@ class IlluminationEffect extends OneShotEffect {
         staticText = "Its controller gains life equal to its mana value";
     }
 
-    public IlluminationEffect(final IlluminationEffect effect) {
+    private IlluminationEffect(final IlluminationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IllusionaryPresence.java
+++ b/Mage.Sets/src/mage/cards/i/IllusionaryPresence.java
@@ -67,7 +67,7 @@ class IllusionaryPresenceEffect extends OneShotEffect {
         this.staticText = "{this} gains landwalk of the chosen type until end of turn";
     }
 
-    public IllusionaryPresenceEffect(final IllusionaryPresenceEffect effect) {
+    private IllusionaryPresenceEffect(final IllusionaryPresenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IllusionaryTerrain.java
+++ b/Mage.Sets/src/mage/cards/i/IllusionaryTerrain.java
@@ -63,7 +63,7 @@ class IllusionaryTerrainEffect extends ContinuousEffectImpl {
         staticText = "Basic lands of the first chosen type are the second chosen type";
     }
 
-    public IllusionaryTerrainEffect(final IllusionaryTerrainEffect effect) {
+    private IllusionaryTerrainEffect(final IllusionaryTerrainEffect effect) {
         super(effect);
     }
 
@@ -141,7 +141,7 @@ class ChooseTwoBasicLandTypesEffect extends OneShotEffect {
         this.staticText = "choose two basic land types";
     }
 
-    public ChooseTwoBasicLandTypesEffect(final ChooseTwoBasicLandTypesEffect effect) {
+    private ChooseTwoBasicLandTypesEffect(final ChooseTwoBasicLandTypesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IllusionistsGambit.java
+++ b/Mage.Sets/src/mage/cards/i/IllusionistsGambit.java
@@ -51,7 +51,7 @@ class IllusionistsGambitRemoveFromCombatEffect extends OneShotEffect {
         this.staticText = "Remove all attacking creatures from combat and untap them. After this phase, there is an additional combat phase. Each of those creatures attacks that combat if able. They can't attack you or planeswalkers you control that combat";
     }
 
-    public IllusionistsGambitRemoveFromCombatEffect(final IllusionistsGambitRemoveFromCombatEffect effect) {
+    private IllusionistsGambitRemoveFromCombatEffect(final IllusionistsGambitRemoveFromCombatEffect effect) {
         super(effect);
     }
 
@@ -95,7 +95,7 @@ class IllusionistsGambitRequirementEffect extends RequirementEffect {
         this.staticText = "Each of those creatures attacks that combat if able";
     }
 
-    public IllusionistsGambitRequirementEffect(final IllusionistsGambitRequirementEffect effect) {
+    private IllusionistsGambitRequirementEffect(final IllusionistsGambitRequirementEffect effect) {
         super(effect);
         this.attackers = effect.attackers;
         this.phase = effect.phase;
@@ -145,7 +145,7 @@ class IllusionistsGambitRestrictionEffect extends RestrictionEffect {
         staticText = "They can't attack you or planeswalkers you control that combat";
     }
 
-    public IllusionistsGambitRestrictionEffect(final IllusionistsGambitRestrictionEffect effect) {
+    private IllusionistsGambitRestrictionEffect(final IllusionistsGambitRestrictionEffect effect) {
         super(effect);
         this.attackers = effect.attackers;
         this.phase = effect.phase;

--- a/Mage.Sets/src/mage/cards/i/IllusoryGains.java
+++ b/Mage.Sets/src/mage/cards/i/IllusoryGains.java
@@ -72,7 +72,7 @@ class IllusoryGainsEffect extends OneShotEffect {
         super(Outcome.Detriment);
     }
 
-    public IllusoryGainsEffect(final IllusoryGainsEffect effect) {
+    private IllusoryGainsEffect(final IllusoryGainsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImaginaryThreats.java
+++ b/Mage.Sets/src/mage/cards/i/ImaginaryThreats.java
@@ -58,7 +58,7 @@ class ImaginaryThreatsEffect extends OneShotEffect {
         staticText = "Creatures target opponent controls attack this turn if able";
     }
 
-    public ImaginaryThreatsEffect(final ImaginaryThreatsEffect effect) {
+    private ImaginaryThreatsEffect(final ImaginaryThreatsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImiStatue.java
+++ b/Mage.Sets/src/mage/cards/i/ImiStatue.java
@@ -48,7 +48,7 @@ class ImiStatueEffect extends RestrictionUntapNotMoreThanEffect {
         staticText = "Players can't untap more than one artifact during their untap steps";
     }
 
-    public ImiStatueEffect(final ImiStatueEffect effect) {
+    private ImiStatueEffect(final ImiStatueEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImmaculateMagistrate.java
+++ b/Mage.Sets/src/mage/cards/i/ImmaculateMagistrate.java
@@ -61,7 +61,7 @@ class ImmaculateMagistrateEffect extends OneShotEffect {
         this.staticText = "Put a +1/+1 counter on target creature for each Elf you control";
     }
 
-    public ImmaculateMagistrateEffect(final ImmaculateMagistrateEffect effect) {
+    private ImmaculateMagistrateEffect(final ImmaculateMagistrateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImminentDoom.java
+++ b/Mage.Sets/src/mage/cards/i/ImminentDoom.java
@@ -58,7 +58,7 @@ class ImminentDoomTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ImminentDoomEffect());
     }
 
-    public ImminentDoomTriggeredAbility(final ImminentDoomTriggeredAbility ability) {
+    private ImminentDoomTriggeredAbility(final ImminentDoomTriggeredAbility ability) {
         super(ability);
     }
 
@@ -99,7 +99,7 @@ class ImminentDoomEffect extends OneShotEffect {
         super(Outcome.Detriment);
     }
 
-    public ImminentDoomEffect(final ImminentDoomEffect effect) {
+    private ImminentDoomEffect(final ImminentDoomEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImmovableRod.java
+++ b/Mage.Sets/src/mage/cards/i/ImmovableRod.java
@@ -94,7 +94,7 @@ class ImmovableRodAttackBlockTargetEffect extends RestrictionEffect {
         staticText = "and can't attack or block";
     }
 
-    public ImmovableRodAttackBlockTargetEffect(final ImmovableRodAttackBlockTargetEffect effect) {
+    private ImmovableRodAttackBlockTargetEffect(final ImmovableRodAttackBlockTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImpelledGiant.java
+++ b/Mage.Sets/src/mage/cards/i/ImpelledGiant.java
@@ -76,7 +76,7 @@ class ImpelledGiantCost extends CostImpl {
         this.text = "Tap an untapped red creature you control other than Impelled Giant";
     }
 
-    public ImpelledGiantCost(final ImpelledGiantCost cost) {
+    private ImpelledGiantCost(final ImpelledGiantCost cost) {
         super(cost);
         this.target = cost.target.copy();
     }
@@ -117,7 +117,7 @@ class ImpelledGiantBoostEffect extends OneShotEffect {
         staticText = "{this} gets +X/+0 until end of turn, where X is the power of the creature tapped this way";
     }
 
-    public ImpelledGiantBoostEffect(ImpelledGiantBoostEffect effect) {
+    private ImpelledGiantBoostEffect(final ImpelledGiantBoostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImperialHovertank.java
+++ b/Mage.Sets/src/mage/cards/i/ImperialHovertank.java
@@ -50,7 +50,7 @@ class ImperialHovertankTriggeredAbility extends TriggeredAbilityImpl {
         this.addEffect(new GainLifeEffect(1));
     }
 
-    public ImperialHovertankTriggeredAbility(final ImperialHovertankTriggeredAbility ability) {
+    private ImperialHovertankTriggeredAbility(final ImperialHovertankTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Imperiosaur.java
+++ b/Mage.Sets/src/mage/cards/i/Imperiosaur.java
@@ -53,7 +53,7 @@ class ImperiosaurStaticAbility extends StaticAbility {
         super(Zone.STACK, null);
     }
 
-    public ImperiosaurStaticAbility(ImperiosaurStaticAbility ability) {
+    private ImperiosaurStaticAbility(final ImperiosaurStaticAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImpetuousDevils.java
+++ b/Mage.Sets/src/mage/cards/i/ImpetuousDevils.java
@@ -61,7 +61,7 @@ class ImpetuousDevilsAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new MustBeBlockedByTargetSourceEffect(Duration.EndOfCombat), false);
     }
 
-    public ImpetuousDevilsAbility(final ImpetuousDevilsAbility ability) {
+    private ImpetuousDevilsAbility(final ImpetuousDevilsAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Imprison.java
+++ b/Mage.Sets/src/mage/cards/i/Imprison.java
@@ -111,7 +111,7 @@ class ImprisonUnblockEffect extends OneShotEffect {
         this.staticText = "tap the creature, remove it from combat, and creatures it was blocking that had become blocked by only that creature this combat become unblocked";
     }
 
-    public ImprisonUnblockEffect(final ImprisonUnblockEffect effect) {
+    private ImprisonUnblockEffect(final ImprisonUnblockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImpromptuRaid.java
+++ b/Mage.Sets/src/mage/cards/i/ImpromptuRaid.java
@@ -66,7 +66,7 @@ class ImpromptuRaidEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of your library. If it isn't a creature card, put it into your graveyard. Otherwise, put that card onto the battlefield. That creature gains haste. Sacrifice it at the beginning of the next end step";
     }
 
-    public ImpromptuRaidEffect(final ImpromptuRaidEffect effect) {
+    private ImpromptuRaidEffect(final ImpromptuRaidEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImpsMischief.java
+++ b/Mage.Sets/src/mage/cards/i/ImpsMischief.java
@@ -57,7 +57,7 @@ class ImpsMischiefLoseLifeEffect extends OneShotEffect {
         staticText = "You lose life equal to that spell's mana value";
     }
 
-    public ImpsMischiefLoseLifeEffect(final ImpsMischiefLoseLifeEffect effect) {
+    private ImpsMischiefLoseLifeEffect(final ImpsMischiefLoseLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImpulsiveManeuvers.java
+++ b/Mage.Sets/src/mage/cards/i/ImpulsiveManeuvers.java
@@ -51,7 +51,7 @@ class ImpulsiveManeuversEffect extends PreventionEffectImpl {
         staticText = "flip a coin. If you win the flip, the next time that creature would deal combat damage this turn, it deals double that damage instead. If you lose the flip, the next time that creature would deal combat damage this turn, prevent that damage";
     }
 
-    public ImpulsiveManeuversEffect(final ImpulsiveManeuversEffect effect) {
+    private ImpulsiveManeuversEffect(final ImpulsiveManeuversEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImpulsiveWager.java
+++ b/Mage.Sets/src/mage/cards/i/ImpulsiveWager.java
@@ -52,7 +52,7 @@ class ImpulsiveWagerEffect extends OneShotEffect {
         staticText = "If the discarded card was a nonland card, draw two cards. Otherwise, put a bounty counter on target creature";
     }
 
-    public ImpulsiveWagerEffect(final ImpulsiveWagerEffect effect) {
+    private ImpulsiveWagerEffect(final ImpulsiveWagerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InallaArchmageRitualist.java
+++ b/Mage.Sets/src/mage/cards/i/InallaArchmageRitualist.java
@@ -98,7 +98,7 @@ class InallaArchmageRitualistEffect extends OneShotEffect {
         this.staticText = "create a token that's a copy of that Wizard. That token gains haste. Exile it at the beginning of the next end step";
     }
 
-    public InallaArchmageRitualistEffect(final InallaArchmageRitualistEffect effect) {
+    private InallaArchmageRitualistEffect(final InallaArchmageRitualistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InameAsOne.java
+++ b/Mage.Sets/src/mage/cards/i/InameAsOne.java
@@ -78,7 +78,7 @@ class InameAsOneEffect extends OneShotEffect {
         this.staticText = "you may exile it. If you do, return target Spirit permanent card from your graveyard to the battlefield";
     }
 
-    public InameAsOneEffect(final InameAsOneEffect effect) {
+    private InameAsOneEffect(final InameAsOneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InameDeathAspect.java
+++ b/Mage.Sets/src/mage/cards/i/InameDeathAspect.java
@@ -54,7 +54,7 @@ class InameDeathAspectEffect extends SearchEffect {
         staticText = "search your library for any number of Spirit cards, put them into your graveyard, then shuffle";
     }
 
-    public InameDeathAspectEffect(final InameDeathAspectEffect effect) {
+    private InameDeathAspectEffect(final InameDeathAspectEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InameLifeAspect.java
+++ b/Mage.Sets/src/mage/cards/i/InameLifeAspect.java
@@ -64,7 +64,7 @@ class InameLifeAspectEffect extends OneShotEffect {
         this.staticText = "you may exile it. If you do, return any number of target Spirit cards from your graveyard to your hand";
     }
 
-    public InameLifeAspectEffect(final InameLifeAspectEffect effect) {
+    private InameLifeAspectEffect(final InameLifeAspectEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IncendiaryCommand.java
+++ b/Mage.Sets/src/mage/cards/i/IncendiaryCommand.java
@@ -65,7 +65,7 @@ class IncendiaryCommandDrawEffect extends OneShotEffect {
         this.staticText = "each player discards all the cards in their hand, then draws that many cards";
     }
 
-    public IncendiaryCommandDrawEffect(final IncendiaryCommandDrawEffect effect) {
+    private IncendiaryCommandDrawEffect(final IncendiaryCommandDrawEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Incinerate.java
+++ b/Mage.Sets/src/mage/cards/i/Incinerate.java
@@ -49,7 +49,7 @@ class IncinerateEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "A creature dealt damage this way can't be regenerated this turn";
     }
 
-    public IncinerateEffect(final IncinerateEffect effect) {
+    private IncinerateEffect(final IncinerateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InciteHysteria.java
+++ b/Mage.Sets/src/mage/cards/i/InciteHysteria.java
@@ -53,7 +53,7 @@ class InciteHysteriaEffect extends OneShotEffect {
         this.staticText = "Until end of turn, target creature and each other creature that shares a color with it gain \"This creature can't block.\"";
     }
 
-    public InciteHysteriaEffect(final InciteHysteriaEffect effect) {
+    private InciteHysteriaEffect(final InciteHysteriaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InciteRebellion.java
+++ b/Mage.Sets/src/mage/cards/i/InciteRebellion.java
@@ -45,7 +45,7 @@ class InciteRebellionEffect extends OneShotEffect {
         this.staticText = "For each player, {this} deals damage to that player and each creature that player controls equal to the number of creatures they control";
     }
 
-    public InciteRebellionEffect(final InciteRebellionEffect effect) {
+    private InciteRebellionEffect(final InciteRebellionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InciteWar.java
+++ b/Mage.Sets/src/mage/cards/i/InciteWar.java
@@ -61,7 +61,7 @@ class InciteWarMustAttackEffect extends OneShotEffect {
         staticText = "Creatures target player controls attack this turn if able";
     }
 
-    public InciteWarMustAttackEffect(final InciteWarMustAttackEffect effect) {
+    private InciteWarMustAttackEffect(final InciteWarMustAttackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Incoming.java
+++ b/Mage.Sets/src/mage/cards/i/Incoming.java
@@ -56,7 +56,7 @@ class IncomingEffect extends OneShotEffect {
         this.staticText = "Each player searches their library for any number of artifact, creature, enchantment, and/or land cards, puts them onto the battlefield, then shuffles";
     }
 
-    public IncomingEffect(final IncomingEffect effect) {
+    private IncomingEffect(final IncomingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IncreasingConfusion.java
+++ b/Mage.Sets/src/mage/cards/i/IncreasingConfusion.java
@@ -49,7 +49,7 @@ class IncreasingConfusionEffect extends OneShotEffect {
         staticText = "Target player mills X cards. If this spell was cast from a graveyard, that player mills twice that many cards";
     }
 
-    public IncreasingConfusionEffect(final IncreasingConfusionEffect effect) {
+    private IncreasingConfusionEffect(final IncreasingConfusionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IncreasingDevotion.java
+++ b/Mage.Sets/src/mage/cards/i/IncreasingDevotion.java
@@ -51,7 +51,7 @@ class IncreasingDevotionEffect extends OneShotEffect {
         staticText = "Create five 1/1 white Human creature tokens. If this spell was cast from a graveyard, create ten of those tokens instead";
     }
 
-    public IncreasingDevotionEffect(final IncreasingDevotionEffect effect) {
+    private IncreasingDevotionEffect(final IncreasingDevotionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IncreasingSavagery.java
+++ b/Mage.Sets/src/mage/cards/i/IncreasingSavagery.java
@@ -50,7 +50,7 @@ class IncreasingSavageryEffect extends OneShotEffect {
         staticText = "Put five +1/+1 counters on target creature. If this spell was cast from a graveyard, put ten +1/+1 counters on that creature instead";
     }
 
-    public IncreasingSavageryEffect(final IncreasingSavageryEffect effect) {
+    private IncreasingSavageryEffect(final IncreasingSavageryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IncreasingVengeance.java
+++ b/Mage.Sets/src/mage/cards/i/IncreasingVengeance.java
@@ -61,7 +61,7 @@ class IncreasingVengeanceEffect extends OneShotEffect {
         staticText = "Copy target instant or sorcery spell you control. If this spell was cast from a graveyard, copy that spell twice instead. You may choose new targets for the copies";
     }
 
-    public IncreasingVengeanceEffect(final IncreasingVengeanceEffect effect) {
+    private IncreasingVengeanceEffect(final IncreasingVengeanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IncrementalBlight.java
+++ b/Mage.Sets/src/mage/cards/i/IncrementalBlight.java
@@ -89,7 +89,7 @@ class IncrementalBlightEffect extends OneShotEffect {
         this.staticText = "Put a -1/-1 counter on target creature, two -1/-1 counters on another target creature, and three -1/-1 counters on a third target creature";
     }
    
-    public IncrementalBlightEffect(final IncrementalBlightEffect effect) {
+    private IncrementalBlightEffect(final IncrementalBlightEffect effect) {
         super(effect);
     }
    

--- a/Mage.Sets/src/mage/cards/i/IncrementalGrowth.java
+++ b/Mage.Sets/src/mage/cards/i/IncrementalGrowth.java
@@ -65,7 +65,7 @@ class IncrementalGrowthEffect extends OneShotEffect {
                 + "and three +1/+1 counters on a third target creature";
     }
 
-    public IncrementalGrowthEffect(final IncrementalGrowthEffect effect) {
+    private IncrementalGrowthEffect(final IncrementalGrowthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IncubationIncongruity.java
+++ b/Mage.Sets/src/mage/cards/i/IncubationIncongruity.java
@@ -56,7 +56,7 @@ class IncongruityEffect extends OneShotEffect {
         staticText = "That creature's controller creates a 3/3 green Frog Lizard creature token";
     }
 
-    public IncongruityEffect(final IncongruityEffect effect) {
+    private IncongruityEffect(final IncongruityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IncurableOgre.java
+++ b/Mage.Sets/src/mage/cards/i/IncurableOgre.java
@@ -24,7 +24,7 @@ public final class IncurableOgre extends CardImpl {
         this.toughness = new MageInt(1);
     }
 
-    public IncurableOgre (final IncurableOgre card) {
+    private IncurableOgre(final IncurableOgre card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IndenturedOaf.java
+++ b/Mage.Sets/src/mage/cards/i/IndenturedOaf.java
@@ -51,7 +51,7 @@ class IndenturedOafPreventEffectEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that {this} would deal to red creatures";
     }
 
-    public IndenturedOafPreventEffectEffect(final IndenturedOafPreventEffectEffect effect) {
+    private IndenturedOafPreventEffectEffect(final IndenturedOafPreventEffectEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IndigoFaerie.java
+++ b/Mage.Sets/src/mage/cards/i/IndigoFaerie.java
@@ -62,7 +62,7 @@ class BecomesBlueTargetEffect extends ContinuousEffectImpl {
         staticText = "Target permanent becomes blue in addition to its other colors until end of turn";
     }
 
-    public BecomesBlueTargetEffect(final BecomesBlueTargetEffect effect) {
+    private BecomesBlueTargetEffect(final BecomesBlueTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IndomitableCreativity.java
+++ b/Mage.Sets/src/mage/cards/i/IndomitableCreativity.java
@@ -74,7 +74,7 @@ class IndomitableCreativityEffect extends OneShotEffect {
                 "Those players put the exiled cards onto the battlefield, then shuffle";
     }
 
-    public IndomitableCreativityEffect(final IndomitableCreativityEffect effect) {
+    private IndomitableCreativityEffect(final IndomitableCreativityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IndomitableWill.java
+++ b/Mage.Sets/src/mage/cards/i/IndomitableWill.java
@@ -35,7 +35,7 @@ public final class IndomitableWill extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(1, 2, Duration.WhileOnBattlefield)));
     }
 
-    public IndomitableWill (final IndomitableWill card) {
+    private IndomitableWill(final IndomitableWill card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InduceDespair.java
+++ b/Mage.Sets/src/mage/cards/i/InduceDespair.java
@@ -54,7 +54,7 @@ class InduceDespairEffect extends OneShotEffect {
         staticText = "Target creature gets -X/-X until end of turn, where X is the revealed card's mana value";
     }
 
-    public InduceDespairEffect(InduceDespairEffect effect) {
+    private InduceDespairEffect(final InduceDespairEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfectiousHorror.java
+++ b/Mage.Sets/src/mage/cards/i/InfectiousHorror.java
@@ -31,7 +31,7 @@ public final class InfectiousHorror extends CardImpl {
         this.addAbility(new AttacksTriggeredAbility(new InfectiousHorrorEffect(), false));
     }
 
-    public InfectiousHorror (final InfectiousHorror card) {
+    private InfectiousHorror(final InfectiousHorror card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfectiousRage.java
+++ b/Mage.Sets/src/mage/cards/i/InfectiousRage.java
@@ -66,7 +66,7 @@ class InfectiousRageReattachEffect extends OneShotEffect {
         this.staticText = "choose a creature at random {this} can enchant. Return {this} to the battlefield attached to that creature.";
     }
 
-    public InfectiousRageReattachEffect(final InfectiousRageReattachEffect effect) {
+    private InfectiousRageReattachEffect(final InfectiousRageReattachEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfernalTutor.java
+++ b/Mage.Sets/src/mage/cards/i/InfernalTutor.java
@@ -61,7 +61,7 @@ class InfernalTutorEffect extends OneShotEffect {
         this.staticText = "Reveal a card from your hand. Search your library for a card with the same name as that card, reveal it, put it into your hand, then shuffle";
     }
 
-    public InfernalTutorEffect(final InfernalTutorEffect effect) {
+    private InfernalTutorEffect(final InfernalTutorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfiltrationLens.java
+++ b/Mage.Sets/src/mage/cards/i/InfiltrationLens.java
@@ -53,7 +53,7 @@ class EquippedBecomesBlockedTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever equipped creature becomes blocked by a creature, ");
     }
 
-    public EquippedBecomesBlockedTriggeredAbility(final EquippedBecomesBlockedTriggeredAbility ability) {
+    private EquippedBecomesBlockedTriggeredAbility(final EquippedBecomesBlockedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfiltratorsMagemark.java
+++ b/Mage.Sets/src/mage/cards/i/InfiltratorsMagemark.java
@@ -71,7 +71,7 @@ class InfiltratorsMagemarkCantBeBlockedAllEffect extends RestrictionEffect {
         this.staticText = "and can't be blocked except by creatures with defender";
     }
 
-    public InfiltratorsMagemarkCantBeBlockedAllEffect(InfiltratorsMagemarkCantBeBlockedAllEffect effect) {
+    private InfiltratorsMagemarkCantBeBlockedAllEffect(final InfiltratorsMagemarkCantBeBlockedAllEffect effect) {
         super(effect);
         this.filter = effect.filter;
     }

--- a/Mage.Sets/src/mage/cards/i/InfiniteObliteration.java
+++ b/Mage.Sets/src/mage/cards/i/InfiniteObliteration.java
@@ -45,7 +45,7 @@ class InfiniteObliterationEffect extends SearchTargetGraveyardHandLibraryForCard
         this.staticText = "Choose a creature card name. " + CardUtil.getTextWithFirstCharUpperCase(this.staticText);
     }
 
-    public InfiniteObliterationEffect(final InfiniteObliterationEffect effect) {
+    private InfiniteObliterationEffect(final InfiniteObliterationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfiniteReflection.java
+++ b/Mage.Sets/src/mage/cards/i/InfiniteReflection.java
@@ -72,7 +72,7 @@ class InfiniteReflectionTriggeredEffect extends OneShotEffect {
         this.staticText = " attached to a creature, each other nontoken creature you control becomes a copy of that creature";
     }
 
-    public InfiniteReflectionTriggeredEffect(final InfiniteReflectionTriggeredEffect effect) {
+    private InfiniteReflectionTriggeredEffect(final InfiniteReflectionTriggeredEffect effect) {
         super(effect);
     }
 
@@ -106,7 +106,7 @@ class InfiniteReflectionEntersBattlefieldEffect extends ReplacementEffectImpl {
         this.staticText = "Nontoken creatures you control enter the battlefield as a copy of enchanted creature";
     }
 
-    public InfiniteReflectionEntersBattlefieldEffect(InfiniteReflectionEntersBattlefieldEffect effect) {
+    private InfiniteReflectionEntersBattlefieldEffect(final InfiniteReflectionEntersBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Inhumaniac.java
+++ b/Mage.Sets/src/mage/cards/i/Inhumaniac.java
@@ -50,7 +50,7 @@ class InhumaniacEffect extends OneShotEffect {
         this.staticText = "roll a six-sided die. On a 3 or 4, put a +1/+1 counter on {this}. On a 5 or higher, put two +1/+1 counters on it. On a 1, remove all +1/+1 counters from {this}";
     }
 
-    public InhumaniacEffect(final InhumaniacEffect effect) {
+    private InhumaniacEffect(final InhumaniacEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InitiateOfBlood.java
+++ b/Mage.Sets/src/mage/cards/i/InitiateOfBlood.java
@@ -110,7 +110,7 @@ class GokaTheUnjust extends TokenImpl {
         ability.addTarget(new TargetCreaturePermanent(filter));
         this.addAbility(ability);
     }
-    public GokaTheUnjust(final GokaTheUnjust token) {
+    private GokaTheUnjust(final GokaTheUnjust token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InitiatesOfTheEbonHand.java
+++ b/Mage.Sets/src/mage/cards/i/InitiatesOfTheEbonHand.java
@@ -55,7 +55,7 @@ class InitiatesOfTheEbonHandEffect extends OneShotEffect {
         this.staticText = "If this ability has been activated four or more times this turn, sacrifice {this} at the beginning of the next end step";
     }
 
-    public InitiatesOfTheEbonHandEffect(final InitiatesOfTheEbonHandEffect effect) {
+    private InitiatesOfTheEbonHandEffect(final InitiatesOfTheEbonHandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InkEyesServantOfOni.java
+++ b/Mage.Sets/src/mage/cards/i/InkEyesServantOfOni.java
@@ -63,7 +63,7 @@ class InkEyesServantOfOniTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ReturnFromGraveyardToBattlefieldTargetEffect(), true);
     }
 
-    public InkEyesServantOfOniTriggeredAbility(final InkEyesServantOfOniTriggeredAbility ability) {
+    private InkEyesServantOfOniTriggeredAbility(final InkEyesServantOfOniTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InkfathomDivers.java
+++ b/Mage.Sets/src/mage/cards/i/InkfathomDivers.java
@@ -34,7 +34,7 @@ public final class InkfathomDivers extends CardImpl {
 
     }
 
-    public InkfathomDivers (final InkfathomDivers card) {
+    private InkfathomDivers(final InkfathomDivers card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InkmothNexus.java
+++ b/Mage.Sets/src/mage/cards/i/InkmothNexus.java
@@ -37,7 +37,7 @@ public final class InkmothNexus extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new GenericManaCost(1)));
     }
 
-    public InkmothNexus (final InkmothNexus card) {
+    private InkmothNexus(final InkmothNexus card) {
         super(card);
     }
 
@@ -59,7 +59,7 @@ class InkmothNexusToken extends TokenImpl {
         this.addAbility(FlyingAbility.getInstance());
         this.addAbility(InfectAbility.getInstance());
     }
-    public InkmothNexusToken(final InkmothNexusToken token) {
+    private InkmothNexusToken(final InkmothNexusToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InnerStruggle.java
+++ b/Mage.Sets/src/mage/cards/i/InnerStruggle.java
@@ -45,7 +45,7 @@ class InnerStruggleEffect extends OneShotEffect {
         this.staticText = "Target creature deals damage to itself equal to its power";
     }
 
-    public InnerStruggleEffect(final InnerStruggleEffect effect) {
+    private InnerStruggleEffect(final InnerStruggleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Inquisition.java
+++ b/Mage.Sets/src/mage/cards/i/Inquisition.java
@@ -53,7 +53,7 @@ class InquisitionEffect extends OneShotEffect {
         staticText = "Target player reveals their hand. Inquisition deals damage to that player equal to the number of white cards in their hand";
     }
 
-    public InquisitionEffect(final InquisitionEffect effect) {
+    private InquisitionEffect(final InquisitionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InquisitorEisenhorn.java
+++ b/Mage.Sets/src/mage/cards/i/InquisitorEisenhorn.java
@@ -63,7 +63,7 @@ class InquisitorEisenhornReplacementEffect extends ReplacementEffectImpl {
                 "sorcery card this way, create Cherubael, a legendary 4/4 black Demon creature token with flying";
     }
 
-    public InquisitorEisenhornReplacementEffect(final InquisitorEisenhornReplacementEffect effect) {
+    private InquisitorEisenhornReplacementEffect(final InquisitorEisenhornReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InquisitorsFlail.java
+++ b/Mage.Sets/src/mage/cards/i/InquisitorsFlail.java
@@ -53,7 +53,7 @@ class InquisitorsFlailEffect extends ReplacementEffectImpl {
                 + "If another creature would deal combat damage to equipped creature, it deals double that damage to equipped creature instead";
     }
 
-    public InquisitorsFlailEffect(final InquisitorsFlailEffect effect) {
+    private InquisitorsFlailEffect(final InquisitorsFlailEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InquisitorsSnare.java
+++ b/Mage.Sets/src/mage/cards/i/InquisitorsSnare.java
@@ -52,7 +52,7 @@ class InquisitorsSnareEffect extends OneShotEffect {
         this.staticText = "Prevent all damage target attacking or blocking creature would deal this turn. If that creature is black or red, destroy it";
     }
 
-    public InquisitorsSnareEffect(final InquisitorsSnareEffect effect) {
+    private InquisitorsSnareEffect(final InquisitorsSnareEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InsidiousDreams.java
+++ b/Mage.Sets/src/mage/cards/i/InsidiousDreams.java
@@ -49,7 +49,7 @@ class InsidiousDreamsEffect extends OneShotEffect {
         this.staticText = "Search your library for up to X cards. Then shuffle and put those cards on top of it in any order";
     }
 
-    public InsidiousDreamsEffect(final InsidiousDreamsEffect effect) {
+    private InsidiousDreamsEffect(final InsidiousDreamsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Instigator.java
+++ b/Mage.Sets/src/mage/cards/i/Instigator.java
@@ -64,7 +64,7 @@ class InstigatorEffect extends OneShotEffect {
         staticText = "Creatures target player controls attack this turn if able";
     }
 
-    public InstigatorEffect(final InstigatorEffect effect) {
+    private InstigatorEffect(final InstigatorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InstillEnergy.java
+++ b/Mage.Sets/src/mage/cards/i/InstillEnergy.java
@@ -63,7 +63,7 @@ class CanAttackAsThoughItHadHasteEnchantedEffect extends AsThoughEffectImpl {
         staticText = "Enchanted creature can attack as though it had haste";
     }
 
-    public CanAttackAsThoughItHadHasteEnchantedEffect(final CanAttackAsThoughItHadHasteEnchantedEffect effect) {
+    private CanAttackAsThoughItHadHasteEnchantedEffect(final CanAttackAsThoughItHadHasteEnchantedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InstillInfection.java
+++ b/Mage.Sets/src/mage/cards/i/InstillInfection.java
@@ -25,7 +25,7 @@ public final class InstillInfection extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public InstillInfection (final InstillInfection card) {
+    private InstillInfection(final InstillInfection card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InsultInjury.java
+++ b/Mage.Sets/src/mage/cards/i/InsultInjury.java
@@ -61,7 +61,7 @@ class InsultDoubleDamageEffect extends ReplacementEffectImpl {
         staticText = "If a source you control would deal damage this turn, it deals double that damage to that permanent or player instead.";
     }
 
-    public InsultDoubleDamageEffect(final InsultDoubleDamageEffect effect) {
+    private InsultDoubleDamageEffect(final InsultDoubleDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Insurrection.java
+++ b/Mage.Sets/src/mage/cards/i/Insurrection.java
@@ -46,7 +46,7 @@ class InsurrectionEffect extends OneShotEffect {
         this.staticText = "Untap all creatures and gain control of them until end of turn. They gain haste until end of turn";
     }
 
-    public InsurrectionEffect(final InsurrectionEffect effect) {
+    private InsurrectionEffect(final InsurrectionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IntellectDevourer.java
+++ b/Mage.Sets/src/mage/cards/i/IntellectDevourer.java
@@ -229,7 +229,7 @@ class IntellectDevourerReturnCardsAbility extends DelayedTriggeredAbility {
         this.setRuleVisible(false);
     }
 
-    public IntellectDevourerReturnCardsAbility(final IntellectDevourerReturnCardsAbility ability) {super(ability);}
+    private IntellectDevourerReturnCardsAbility(final IntellectDevourerReturnCardsAbility ability) {super(ability);}
 
     @Override
     public IntellectDevourerReturnCardsAbility copy() {return new IntellectDevourerReturnCardsAbility(this);}
@@ -258,7 +258,7 @@ class IntellectDevourerReturnExiledCardEffect extends OneShotEffect {
         this.staticText = "Return exiled cards to their owners' hands";
     }
 
-    public IntellectDevourerReturnExiledCardEffect(final IntellectDevourerReturnExiledCardEffect effect) {super(effect);}
+    private IntellectDevourerReturnExiledCardEffect(final IntellectDevourerReturnExiledCardEffect effect) {super(effect);}
 
     @Override
     public IntellectDevourerReturnExiledCardEffect copy() {return new IntellectDevourerReturnExiledCardEffect(this);}

--- a/Mage.Sets/src/mage/cards/i/Interdict.java
+++ b/Mage.Sets/src/mage/cards/i/Interdict.java
@@ -81,7 +81,7 @@ class InterdictCounterEffect extends OneShotEffect {
         staticText = "Counter target activated ability from an artifact, creature, enchantment, or land. That permanent's activated abilities can't be activated this turn.";
     }
 
-    public InterdictCounterEffect(final InterdictCounterEffect effect) {
+    private InterdictCounterEffect(final InterdictCounterEffect effect) {
         super(effect);
     }
 
@@ -114,7 +114,7 @@ class InterdictCantActivateEffect extends RestrictionEffect {
         staticText = "That permanent's activated abilities can't be activated this turn";
     }
 
-    public InterdictCantActivateEffect(final InterdictCantActivateEffect effect) {
+    private InterdictCantActivateEffect(final InterdictCantActivateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InterpretTheSigns.java
+++ b/Mage.Sets/src/mage/cards/i/InterpretTheSigns.java
@@ -42,7 +42,7 @@ class InterpretTheSignsEffect extends OneShotEffect {
         this.staticText = "scry 3, then reveal the top card of your library. Draw cards equal to that card's mana value";
     }
 
-    public InterpretTheSignsEffect(final InterpretTheSignsEffect effect) {
+    private InterpretTheSignsEffect(final InterpretTheSignsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InterventionPact.java
+++ b/Mage.Sets/src/mage/cards/i/InterventionPact.java
@@ -55,7 +55,7 @@ class InterventionPactEffect extends OneShotEffect {
         this.staticText = "The next time a source of your choice would deal damage to you this turn, prevent that damage. You gain life equal to the damage prevented this way";
     }
 
-    public InterventionPactEffect(final InterventionPactEffect effect) {
+    private InterventionPactEffect(final InterventionPactEffect effect) {
         super(effect);
     }
 
@@ -89,7 +89,7 @@ class InterventionPactPreventDamageEffect extends PreventionEffectImpl {
         staticText = "The next time a source of your choice would deal damage to you this turn, prevent that damage. You gain life equal to the damage prevented this way";
     }
 
-    public InterventionPactPreventDamageEffect(final InterventionPactPreventDamageEffect effect) {
+    private InterventionPactPreventDamageEffect(final InterventionPactPreventDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IntetTheDreamer.java
+++ b/Mage.Sets/src/mage/cards/i/IntetTheDreamer.java
@@ -66,7 +66,7 @@ class IntetTheDreamerExileEffect extends OneShotEffect {
         staticText = "exile the top card of your library face down. You may play that card without paying its mana cost for as long as Intet remains on the battlefield";
     }
 
-    public IntetTheDreamerExileEffect(final IntetTheDreamerExileEffect effect) {
+    private IntetTheDreamerExileEffect(final IntetTheDreamerExileEffect effect) {
         super(effect);
     }
 
@@ -165,7 +165,7 @@ class IntetTheDreamerLookEffect extends AsThoughEffectImpl {
         staticText = "You may look at that card for as long as it remains exiled";
     }
 
-    public IntetTheDreamerLookEffect(final IntetTheDreamerLookEffect effect) {
+    private IntetTheDreamerLookEffect(final IntetTheDreamerLookEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IntimidationBolt.java
+++ b/Mage.Sets/src/mage/cards/i/IntimidationBolt.java
@@ -46,7 +46,7 @@ class IntimidationEffect extends RestrictionEffect {
         staticText = "Other creatures can't attack this turn";
     }
 
-    public IntimidationEffect(final IntimidationEffect effect) {
+    private IntimidationEffect(final IntimidationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IntoTheMawOfHell.java
+++ b/Mage.Sets/src/mage/cards/i/IntoTheMawOfHell.java
@@ -48,7 +48,7 @@ class IntoTheMawOfHellEffect extends OneShotEffect {
         this.staticText = "{this} deals 13 damage to target creature";
     }
 
-    public IntoTheMawOfHellEffect(final IntoTheMawOfHellEffect effect) {
+    private IntoTheMawOfHellEffect(final IntoTheMawOfHellEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IntoTheWilds.java
+++ b/Mage.Sets/src/mage/cards/i/IntoTheWilds.java
@@ -47,7 +47,7 @@ class IntoTheWildsEffect extends OneShotEffect {
         this.staticText = "look at the top card of your library. If it's a land card, you may put it onto the battlefield";
     }
 
-    public IntoTheWildsEffect(final IntoTheWildsEffect effect) {
+    private IntoTheWildsEffect(final IntoTheWildsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Intuition.java
+++ b/Mage.Sets/src/mage/cards/i/Intuition.java
@@ -54,7 +54,7 @@ class IntuitionEffect extends SearchEffect {
     }
 
 
-    public IntuitionEffect(final IntuitionEffect effect) {
+    private IntuitionEffect(final IntuitionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InvasionPlans.java
+++ b/Mage.Sets/src/mage/cards/i/InvasionPlans.java
@@ -46,7 +46,7 @@ class InvasionPlansEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "The attacking player chooses how each creature blocks each turn";
     }
 
-    public InvasionPlansEffect(final InvasionPlansEffect effect) {
+    private InvasionPlansEffect(final InvasionPlansEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InvasiveSurgery.java
+++ b/Mage.Sets/src/mage/cards/i/InvasiveSurgery.java
@@ -59,7 +59,7 @@ class InvasiveSurgeryEffect extends SearchTargetGraveyardHandLibraryForCardNameA
                 + "with the same name as that spell, exile those cards, then that player shuffles";
     }
 
-    public InvasiveSurgeryEffect(final InvasiveSurgeryEffect effect) {
+    private InvasiveSurgeryEffect(final InvasiveSurgeryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InventorsFair.java
+++ b/Mage.Sets/src/mage/cards/i/InventorsFair.java
@@ -67,7 +67,7 @@ class InventorsFairAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainLifeEffect(1));
     }
 
-    public InventorsFairAbility(final InventorsFairAbility ability) {
+    private InventorsFairAbility(final InventorsFairAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InvincibleHymn.java
+++ b/Mage.Sets/src/mage/cards/i/InvincibleHymn.java
@@ -42,7 +42,7 @@ class InvincibleHymnEffect extends OneShotEffect {
         this.staticText = "Count the number of cards in your library. Your life total becomes that number";
     }
 
-    public InvincibleHymnEffect(final InvincibleHymnEffect effect) {
+    private InvincibleHymnEffect(final InvincibleHymnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InvokePrejudice.java
+++ b/Mage.Sets/src/mage/cards/i/InvokePrejudice.java
@@ -49,7 +49,7 @@ class InvokePrejudiceTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever an opponent casts a creature spell that doesn't share a color with a creature you control, ");
     }
 
-    public InvokePrejudiceTriggeredAbility(final InvokePrejudiceTriggeredAbility ability) {
+    private InvokePrejudiceTriggeredAbility(final InvokePrejudiceTriggeredAbility ability) {
         super(ability);
     }
 
@@ -95,7 +95,7 @@ class InvokePrejudiceEffect extends CounterUnlessPaysEffect {
         this.staticText = "counter that spell unless that player pays {X}, where X is its mana value";
     }
 
-    public InvokePrejudiceEffect(final InvokePrejudiceEffect effect) {
+    private InvokePrejudiceEffect(final InvokePrejudiceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InvokeTheDivine.java
+++ b/Mage.Sets/src/mage/cards/i/InvokeTheDivine.java
@@ -21,7 +21,7 @@ public final class InvokeTheDivine extends CardImpl {
         this.getSpellAbility().addEffect(new GainLifeEffect(4));
     }
 
-    public InvokeTheDivine(final InvokeTheDivine invokeTheDivine) {
+    private InvokeTheDivine(final InvokeTheDivine invokeTheDivine) {
         super(invokeTheDivine);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IonasBlessing.java
+++ b/Mage.Sets/src/mage/cards/i/IonasBlessing.java
@@ -69,7 +69,7 @@ class IonasBlessingEffect extends ContinuousEffectImpl {
         staticText = ", and can block an additional creature each combat";
     }
 
-    public IonasBlessingEffect(final IonasBlessingEffect effect) {
+    private IonasBlessingEffect(final IonasBlessingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IonasJudgment.java
+++ b/Mage.Sets/src/mage/cards/i/IonasJudgment.java
@@ -32,7 +32,7 @@ public final class IonasJudgment extends CardImpl {
 
     }
 
-    public IonasJudgment (final IonasJudgment card) {
+    private IonasJudgment(final IonasJudgment card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Ionize.java
+++ b/Mage.Sets/src/mage/cards/i/Ionize.java
@@ -44,7 +44,7 @@ class IonizeEffect extends OneShotEffect {
                 + "{this} deals 2 damage to that spell's controller.";
     }
 
-    public IonizeEffect(final IonizeEffect effect) {
+    private IonizeEffect(final IonizeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IridescentDrake.java
+++ b/Mage.Sets/src/mage/cards/i/IridescentDrake.java
@@ -67,7 +67,7 @@ class IridescentDrakeEffect extends OneShotEffect {
         this.staticText = "put target Aura card from a graveyard onto the battlefield under your control attached to {this}";
     }
 
-    public IridescentDrakeEffect(final IridescentDrakeEffect effect) {
+    private IridescentDrakeEffect(final IridescentDrakeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IronMyr.java
+++ b/Mage.Sets/src/mage/cards/i/IronMyr.java
@@ -24,7 +24,7 @@ public final class IronMyr extends CardImpl {
         this.addAbility(new RedManaAbility());
     }
 
-    public IronMyr (final IronMyr card) {
+    private IronMyr(final IronMyr card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IronStar.java
+++ b/Mage.Sets/src/mage/cards/i/IronStar.java
@@ -44,7 +44,7 @@ class IronStarAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DoIfCostPaid(new GainLifeEffect(1), new GenericManaCost(1)), false);
     }
 
-    public IronStarAbility(final IronStarAbility ability) {
+    private IronStarAbility(final IronStarAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IronclawCurse.java
+++ b/Mage.Sets/src/mage/cards/i/IronclawCurse.java
@@ -56,7 +56,7 @@ class IronclawCurseEffect extends CantBlockAttachedEffect {
         this.staticText = "Enchanted creature can't block creatures with power equal to or greater than the enchanted creature's toughness";
     }
 
-    public IronclawCurseEffect(final IronclawCurseEffect effect) {
+    private IronclawCurseEffect(final IronclawCurseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IsochronScepter.java
+++ b/Mage.Sets/src/mage/cards/i/IsochronScepter.java
@@ -69,7 +69,7 @@ class IsochronScepterImprintEffect extends OneShotEffect {
         staticText = "you may exile an instant card with mana value 2 or less from your hand";
     }
 
-    public IsochronScepterImprintEffect(IsochronScepterImprintEffect effect) {
+    private IsochronScepterImprintEffect(final IsochronScepterImprintEffect effect) {
         super(effect);
     }
 
@@ -116,7 +116,7 @@ class IsochronScepterCopyEffect extends OneShotEffect {
                 + "you may cast the copy without paying its mana cost";
     }
 
-    public IsochronScepterCopyEffect(final IsochronScepterCopyEffect effect) {
+    private IsochronScepterCopyEffect(final IsochronScepterCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IsolatedWatchtower.java
+++ b/Mage.Sets/src/mage/cards/i/IsolatedWatchtower.java
@@ -61,7 +61,7 @@ class IsolatedWatchtowerEffect extends OneShotEffect {
                 + "put it onto the battlefield tapped";
     }
 
-    public IsolatedWatchtowerEffect(final IsolatedWatchtowerEffect effect) {
+    private IsolatedWatchtowerEffect(final IsolatedWatchtowerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IsolationCell.java
+++ b/Mage.Sets/src/mage/cards/i/IsolationCell.java
@@ -46,7 +46,7 @@ class IsolationCellTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new IsolationCellEffect(), false);
     }
 
-    public IsolationCellTriggeredAbility(final IsolationCellTriggeredAbility ability) {
+    private IsolationCellTriggeredAbility(final IsolationCellTriggeredAbility ability) {
         super(ability);
     }
 
@@ -86,7 +86,7 @@ class IsolationCellEffect extends OneShotEffect {
         this.staticText = "that player loses 2 life unless they pay {2}";
     }
 
-    public IsolationCellEffect(final IsolationCellEffect effect) {
+    private IsolationCellEffect(final IsolationCellEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IsperiaTheInscrutable.java
+++ b/Mage.Sets/src/mage/cards/i/IsperiaTheInscrutable.java
@@ -71,7 +71,7 @@ class IsperiaTheInscrutableEffect extends OneShotEffect {
         staticText = "That player reveals their hand. If a card with the chosen name is revealed this way, search your library for a creature card with flying, reveal it, put it into your hand, then shuffle";
     }
 
-    public IsperiaTheInscrutableEffect(final IsperiaTheInscrutableEffect effect) {
+    private IsperiaTheInscrutableEffect(final IsperiaTheInscrutableEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IvoryCup.java
+++ b/Mage.Sets/src/mage/cards/i/IvoryCup.java
@@ -44,7 +44,7 @@ class IvoryCupAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DoIfCostPaid(new GainLifeEffect(1), new GenericManaCost(1)), false);
     }
 
-    public IvoryCupAbility(final IvoryCupAbility ability) {
+    private IvoryCupAbility(final IvoryCupAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IvoryTower.java
+++ b/Mage.Sets/src/mage/cards/i/IvoryTower.java
@@ -43,7 +43,7 @@ class IvoryTowerEffect extends OneShotEffect {
         this.staticText = "you gain X life, where X is the number of cards in your hand minus 4.";
     }
 
-    public IvoryTowerEffect(IvoryTowerEffect effect) {
+    private IvoryTowerEffect(final IvoryTowerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IvySeer.java
+++ b/Mage.Sets/src/mage/cards/i/IvySeer.java
@@ -67,7 +67,7 @@ class IvySeerEffect extends OneShotEffect {
                 + "Target creature gets +X/+X until end of turn, where X is the number of cards revealed this way";
     }
 
-    public IvySeerEffect(final IvySeerEffect effect) {
+    private IvySeerEffect(final IvySeerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IwamoriOfTheOpenFist.java
+++ b/Mage.Sets/src/mage/cards/i/IwamoriOfTheOpenFist.java
@@ -64,7 +64,7 @@ class IwamoriOfTheOpenFistEffect extends OneShotEffect {
         this.staticText = "each opponent may put a legendary creature card from their hand onto the battlefield";
     }
 
-    public IwamoriOfTheOpenFistEffect(final IwamoriOfTheOpenFistEffect effect) {
+    private IwamoriOfTheOpenFistEffect(final IwamoriOfTheOpenFistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IzzetChemister.java
+++ b/Mage.Sets/src/mage/cards/i/IzzetChemister.java
@@ -72,7 +72,7 @@ class IzzetChemisterCastFromExileEffect extends OneShotEffect {
         staticText = "cast any number of cards exiled with {this} without paying their mana costs";
     }
 
-    public IzzetChemisterCastFromExileEffect(final IzzetChemisterCastFromExileEffect effect) {
+    private IzzetChemisterCastFromExileEffect(final IzzetChemisterCastFromExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IzzetStaticaster.java
+++ b/Mage.Sets/src/mage/cards/i/IzzetStaticaster.java
@@ -65,7 +65,7 @@ class IzzetStaticasterDamageEffect extends OneShotEffect {
         this.staticText = "{this} deals 1 damage to target creature and each other creature with the same name as that creature";
     }
 
-    public IzzetStaticasterDamageEffect(final IzzetStaticasterDamageEffect effect) {
+    private IzzetStaticasterDamageEffect(final IzzetStaticasterDamageEffect effect) {
         super(effect);
     }
 


### PR DESCRIPTION
Part of #11054 

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`public ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `private $1(final $1 $3`
