### PR TITLE
Clean public copy constructors in cards starting F-G

### DIFF
--- a/Mage.Sets/src/mage/cards/f/FaadiyahSeer.java
+++ b/Mage.Sets/src/mage/cards/f/FaadiyahSeer.java
@@ -57,7 +57,7 @@ class FaadiyahSeerEffect extends OneShotEffect {
         this.staticText = "Draw a card and reveal it. If it isn't a land card, discard it";
     }
 
-    public FaadiyahSeerEffect(final FaadiyahSeerEffect effect) {
+    private FaadiyahSeerEffect(final FaadiyahSeerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FacesOfThePast.java
+++ b/Mage.Sets/src/mage/cards/f/FacesOfThePast.java
@@ -45,7 +45,7 @@ class FacesOfThePastEffect extends OneShotEffect {
         this.staticText = "tap all untapped creatures that share a creature type with it or untap all tapped creatures that share a creature type with it";
     }
 
-    public FacesOfThePastEffect(final FacesOfThePastEffect effect) {
+    private FacesOfThePastEffect(final FacesOfThePastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FaerieArtisans.java
+++ b/Mage.Sets/src/mage/cards/f/FaerieArtisans.java
@@ -67,7 +67,7 @@ class FaerieArtisansEffect extends OneShotEffect {
                 + "Then exile all other tokens created with {this}";
     }
 
-    public FaerieArtisansEffect(final FaerieArtisansEffect effect) {
+    private FaerieArtisansEffect(final FaerieArtisansEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FaerieConclave.java
+++ b/Mage.Sets/src/mage/cards/f/FaerieConclave.java
@@ -50,7 +50,7 @@ class FaerieConclaveToken extends TokenImpl {
         toughness = new MageInt(1);
         this.addAbility(FlyingAbility.getInstance());
     }
-    public FaerieConclaveToken(final FaerieConclaveToken token) {
+    private FaerieConclaveToken(final FaerieConclaveToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FaithfulSquire.java
+++ b/Mage.Sets/src/mage/cards/f/FaithfulSquire.java
@@ -114,7 +114,7 @@ class KaisoMemoryOfLoyaltyToken extends TokenImpl {
         this.addAbility(ability);
     }
 
-    public KaisoMemoryOfLoyaltyToken(final KaisoMemoryOfLoyaltyToken token) {
+    private KaisoMemoryOfLoyaltyToken(final KaisoMemoryOfLoyaltyToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FaithsFetters.java
+++ b/Mage.Sets/src/mage/cards/f/FaithsFetters.java
@@ -64,7 +64,7 @@ class FaithsFettersEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "and its activated abilities can't be activated unless they're mana abilities";
     }
 
-    public FaithsFettersEffect(final FaithsFettersEffect effect) {
+    private FaithsFettersEffect(final FaithsFettersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FaithsShield.java
+++ b/Mage.Sets/src/mage/cards/f/FaithsShield.java
@@ -55,7 +55,7 @@ class FaithsShieldEffect extends OneShotEffect {
                 + "<br/><br/><i>Fateful hour</i> &mdash; If you have 5 or less life, instead you and each permanent you control gain protection from the color of your choice until end of turn";
     }
 
-    public FaithsShieldEffect(final FaithsShieldEffect effect) {
+    private FaithsShieldEffect(final FaithsShieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FalkenrathAristocrat.java
+++ b/Mage.Sets/src/mage/cards/f/FalkenrathAristocrat.java
@@ -62,7 +62,7 @@ class FalkenrathAristocratEffect extends OneShotEffect {
         this.staticText = "If the sacrificed creature was a Human, put a +1/+1 counter on {this}";
     }
 
-    public FalkenrathAristocratEffect(final FalkenrathAristocratEffect effect) {
+    private FalkenrathAristocratEffect(final FalkenrathAristocratEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FalkenrathGorger.java
+++ b/Mage.Sets/src/mage/cards/f/FalkenrathGorger.java
@@ -72,7 +72,7 @@ class FalkenrathGorgerEffect extends ContinuousEffectImpl {
         this.staticText = "Each Vampire creature card you own that isn't on the battlefield has madness. The madness cost is equal to its mana cost";
     }
 
-    public FalkenrathGorgerEffect(final FalkenrathGorgerEffect effect) {
+    private FalkenrathGorgerEffect(final FalkenrathGorgerEffect effect) {
         super(effect);
         this.madnessAbilities.putAll(effect.madnessAbilities);
     }

--- a/Mage.Sets/src/mage/cards/f/FalkenrathNoble.java
+++ b/Mage.Sets/src/mage/cards/f/FalkenrathNoble.java
@@ -53,7 +53,7 @@ class FalkenrathNobleTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetPlayer());
     }
 
-    public FalkenrathNobleTriggeredAbility(final FalkenrathNobleTriggeredAbility ability) {
+    private FalkenrathNobleTriggeredAbility(final FalkenrathNobleTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FalkenrathTorturer.java
+++ b/Mage.Sets/src/mage/cards/f/FalkenrathTorturer.java
@@ -58,7 +58,7 @@ class FalkenrathTorturerEffect extends OneShotEffect {
         this.staticText = "If the sacrificed creature was a Human, put a +1/+1 counter on {this}";
     }
 
-    public FalkenrathTorturerEffect(final FalkenrathTorturerEffect effect) {
+    private FalkenrathTorturerEffect(final FalkenrathTorturerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FallOfTheHammer.java
+++ b/Mage.Sets/src/mage/cards/f/FallOfTheHammer.java
@@ -66,7 +66,7 @@ class FallOfTheHammerDamageEffect extends OneShotEffect {
         this.staticText = "Target creature you control deals damage equal to its power to another target creature";
     }
 
-    public FallOfTheHammerDamageEffect(final FallOfTheHammerDamageEffect effect) {
+    private FallOfTheHammerDamageEffect(final FallOfTheHammerDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FallOfTheThran.java
+++ b/Mage.Sets/src/mage/cards/f/FallOfTheThran.java
@@ -61,7 +61,7 @@ class FallOfTheThranReturnEffect extends OneShotEffect {
         this.staticText = "each player returns two land cards from their graveyard to the battlefield";
     }
 
-    public FallOfTheThranReturnEffect(final FallOfTheThranReturnEffect effect) {
+    private FallOfTheThranReturnEffect(final FallOfTheThranReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FarrelitePriest.java
+++ b/Mage.Sets/src/mage/cards/f/FarrelitePriest.java
@@ -56,7 +56,7 @@ class FarrelitePriestEffect extends OneShotEffect {
         this.staticText = "If this ability has been activated four or more times this turn, sacrifice {this} at the beginning of the next end step";
     }
 
-    public FarrelitePriestEffect(final FarrelitePriestEffect effect) {
+    private FarrelitePriestEffect(final FarrelitePriestEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FarsightMask.java
+++ b/Mage.Sets/src/mage/cards/f/FarsightMask.java
@@ -40,7 +40,7 @@ class FarsightMaskTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), true);
     }
 
-    public FarsightMaskTriggeredAbility(final FarsightMaskTriggeredAbility ability) {
+    private FarsightMaskTriggeredAbility(final FarsightMaskTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Fastbond.java
+++ b/Mage.Sets/src/mage/cards/f/Fastbond.java
@@ -47,7 +47,7 @@ class PlayALandTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageControllerEffect(1), false);
     }
 
-    public PlayALandTriggeredAbility(PlayALandTriggeredAbility ability) {
+    private PlayALandTriggeredAbility(final PlayALandTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Fasting.java
+++ b/Mage.Sets/src/mage/cards/f/Fasting.java
@@ -62,7 +62,7 @@ class FastingReplacementEffect extends ReplacementEffectImpl {
         staticText = "If you would begin your draw step, you may skip that step instead. If you do, you gain 2 life";
     }
 
-    public FastingReplacementEffect(final FastingReplacementEffect effect) {
+    private FastingReplacementEffect(final FastingReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FatalFrenzy.java
+++ b/Mage.Sets/src/mage/cards/f/FatalFrenzy.java
@@ -60,7 +60,7 @@ class FatalFrenzyEffect extends OneShotEffect {
         this.staticText = "Sacrifice it at the beginning of the next end step";
     }
 
-    public FatalFrenzyEffect(final FatalFrenzyEffect effect) {
+    private FatalFrenzyEffect(final FatalFrenzyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FatalMutation.java
+++ b/Mage.Sets/src/mage/cards/f/FatalMutation.java
@@ -57,7 +57,7 @@ class FatalMutationAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever enchanted creature is turned face up, ");
     }
 
-    public FatalMutationAbility(final FatalMutationAbility ability) {
+    private FatalMutationAbility(final FatalMutationAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FateTransfer.java
+++ b/Mage.Sets/src/mage/cards/f/FateTransfer.java
@@ -58,7 +58,7 @@ class FateTransferEffect extends OneShotEffect {
         staticText = "Move all counters from target creature onto another target creature";
     }
 
-    public FateTransferEffect(final FateTransferEffect effect) {
+    private FateTransferEffect(final FateTransferEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Fatespinner.java
+++ b/Mage.Sets/src/mage/cards/f/Fatespinner.java
@@ -61,7 +61,7 @@ class FatespinnerChooseEffect extends OneShotEffect {
         staticText = "that player chooses draw step, main phase, or combat phase. The player skips each instance of the chosen step or phase this turn.";
     }
 
-    public FatespinnerChooseEffect(final FatespinnerChooseEffect effect) {
+    private FatespinnerChooseEffect(final FatespinnerChooseEffect effect) {
         super(effect);
     }
 
@@ -98,7 +98,7 @@ class FatespinnerSkipEffect extends ReplacementEffectImpl {
         this.phase = phase;
     }
 
-    public FatespinnerSkipEffect(final FatespinnerSkipEffect effect) {
+    private FatespinnerSkipEffect(final FatespinnerSkipEffect effect) {
         super(effect);
         this.phase = effect.phase;
     }

--- a/Mage.Sets/src/mage/cards/f/FathomFeeder.java
+++ b/Mage.Sets/src/mage/cards/f/FathomFeeder.java
@@ -67,7 +67,7 @@ class FathomFeederEffect extends OneShotEffect {
         this.staticText = "Each opponent exiles the top card of their library";
     }
 
-    public FathomFeederEffect(final FathomFeederEffect effect) {
+    private FathomFeederEffect(final FathomFeederEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FathomMage.java
+++ b/Mage.Sets/src/mage/cards/f/FathomMage.java
@@ -54,7 +54,7 @@ class FathomMageTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a +1/+1 counter is put on {this}, ");
     }
 
-    public FathomMageTriggeredAbility(FathomMageTriggeredAbility ability) {
+    private FathomMageTriggeredAbility(final FathomMageTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FathomTrawl.java
+++ b/Mage.Sets/src/mage/cards/f/FathomTrawl.java
@@ -41,7 +41,7 @@ public final class FathomTrawl extends CardImpl {
             this.staticText = "Reveal cards from the top of your library until you reveal three nonland cards. Put the nonland cards revealed this way into your hand, then put the rest of the revealed cards on the bottom of your library in any order";
         }
 
-        public FathomTrawlEffect(final FathomTrawlEffect effect) {
+        private FathomTrawlEffect(final FathomTrawlEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/f/FaultLine.java
+++ b/Mage.Sets/src/mage/cards/f/FaultLine.java
@@ -51,7 +51,7 @@ class FaultLineEffect extends OneShotEffect {
         staticText = "{this} deals X damage to each creature without flying and each player";
     }
 
-    public FaultLineEffect(final FaultLineEffect effect) {
+    private FaultLineEffect(final FaultLineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FealtyToTheRealm.java
+++ b/Mage.Sets/src/mage/cards/f/FealtyToTheRealm.java
@@ -66,7 +66,7 @@ class FealtyToTheRealmEffect extends ContinuousEffectImpl {
         staticText = "the monarch controls enchanted creature";
     }
 
-    public FealtyToTheRealmEffect(final FealtyToTheRealmEffect effect) {
+    private FealtyToTheRealmEffect(final FealtyToTheRealmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FearsomeAwakening.java
+++ b/Mage.Sets/src/mage/cards/f/FearsomeAwakening.java
@@ -48,7 +48,7 @@ class FearsomeAwakeningEffect extends OneShotEffect {
         this.staticText = "If it's a Dragon, put two +1/+1 counters on it";
     }
 
-    public FearsomeAwakeningEffect(final FearsomeAwakeningEffect effect) {
+    private FearsomeAwakeningEffect(final FearsomeAwakeningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FeastOfWorms.java
+++ b/Mage.Sets/src/mage/cards/f/FeastOfWorms.java
@@ -38,7 +38,7 @@ public final class FeastOfWorms extends CardImpl {
         this.getSpellAbility().addEffect(new FeastOfWormsEffect());
     }
 
-    public FeastOfWorms (final FeastOfWorms card) {
+    private FeastOfWorms(final FeastOfWorms card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Fecundity.java
+++ b/Mage.Sets/src/mage/cards/f/Fecundity.java
@@ -43,7 +43,7 @@ class FecundityEffect extends OneShotEffect {
         this.staticText = "that creature's controller may draw a card";
     }
 
-    public FecundityEffect(final FecundityEffect effect) {
+    private FecundityEffect(final FecundityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FeedThePack.java
+++ b/Mage.Sets/src/mage/cards/f/FeedThePack.java
@@ -55,7 +55,7 @@ class FeedThePackEffect extends OneShotEffect {
         this.staticText = "sacrifice a nontoken creature. If you do, create X 2/2 green Wolf creature tokens, where X is the sacrificed creature's toughness";
     }
 
-    public FeedThePackEffect(final FeedThePackEffect effect) {
+    private FeedThePackEffect(final FeedThePackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Feint.java
+++ b/Mage.Sets/src/mage/cards/f/Feint.java
@@ -51,7 +51,7 @@ class FeintEffect extends OneShotEffect {
         this.staticText = "tap all creatures blocking target attacking creature";
     }
 
-    public FeintEffect(final FeintEffect effect) {
+    private FeintEffect(final FeintEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FeldonOfTheThirdPath.java
+++ b/Mage.Sets/src/mage/cards/f/FeldonOfTheThirdPath.java
@@ -65,7 +65,7 @@ class FeldonOfTheThirdPathEffect extends OneShotEffect {
         this.staticText = "Create a token that's a copy of target creature card in your graveyard, except it's an artifact in addition to its other types. It gains haste. Sacrifice it at the beginning of the next end step";
     }
 
-    public FeldonOfTheThirdPathEffect(final FeldonOfTheThirdPathEffect effect) {
+    private FeldonOfTheThirdPathEffect(final FeldonOfTheThirdPathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FelhideSpiritbinder.java
+++ b/Mage.Sets/src/mage/cards/f/FelhideSpiritbinder.java
@@ -60,7 +60,7 @@ class FelhideSpiritbinderEffect extends OneShotEffect {
         this.staticText = "create a token that's a copy of another target creature except it's an enchantment in addition to its other types. It gains haste. Exile it at the beginning of the next end step";
     }
 
-    public FelhideSpiritbinderEffect(final FelhideSpiritbinderEffect effect) {
+    private FelhideSpiritbinderEffect(final FelhideSpiritbinderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FelineSovereign.java
+++ b/Mage.Sets/src/mage/cards/f/FelineSovereign.java
@@ -84,7 +84,7 @@ class FelineSovereignTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), false);
     }
 
-    public FelineSovereignTriggeredAbility(final FelineSovereignTriggeredAbility ability) {
+    private FelineSovereignTriggeredAbility(final FelineSovereignTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FellTheMighty.java
+++ b/Mage.Sets/src/mage/cards/f/FellTheMighty.java
@@ -46,7 +46,7 @@ class FellTheMightyEffect extends OneShotEffect {
         this.staticText = "Destroy all creatures with power greater than target creature's power";
     }
 
-    public FellTheMightyEffect(final FellTheMightyEffect effect) {
+    private FellTheMightyEffect(final FellTheMightyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FeralContest.java
+++ b/Mage.Sets/src/mage/cards/f/FeralContest.java
@@ -63,7 +63,7 @@ class FeralContestEffect extends RequirementEffect {
         staticText = "Another target creature blocks it this turn if able";
     }
 
-    public FeralContestEffect(final FeralContestEffect effect) {
+    private FeralContestEffect(final FeralContestEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FeralDeceiver.java
+++ b/Mage.Sets/src/mage/cards/f/FeralDeceiver.java
@@ -64,7 +64,7 @@ class FeralDeceiverEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of your library. If it's a land card, {this} gets +2/+2 and gains trample until end of turn";
     }
 
-    public FeralDeceiverEffect(final FeralDeceiverEffect effect) {
+    private FeralDeceiverEffect(final FeralDeceiverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FeralLightning.java
+++ b/Mage.Sets/src/mage/cards/f/FeralLightning.java
@@ -43,7 +43,7 @@ class FeralLightningEffect extends OneShotEffect {
         this.staticText = "Create three 3/1 red Elemental creature tokens with haste. Exile them at the beginning of the next end step";
     }
 
-    public FeralLightningEffect(final FeralLightningEffect effect) {
+    private FeralLightningEffect(final FeralLightningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FeralProwler.java
+++ b/Mage.Sets/src/mage/cards/f/FeralProwler.java
@@ -21,7 +21,7 @@ public final class FeralProwler extends CardImpl {
         addAbility(new DiesSourceTriggeredAbility(new DrawCardSourceControllerEffect(1), false));
     }
 
-    public FeralProwler(final FeralProwler feralProwler) {
+    private FeralProwler(final FeralProwler feralProwler) {
         super(feralProwler);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Ferrovore.java
+++ b/Mage.Sets/src/mage/cards/f/Ferrovore.java
@@ -40,7 +40,7 @@ public final class Ferrovore extends CardImpl {
         this.addAbility(ability);
     }
 
-    public Ferrovore (final Ferrovore card) {
+    private Ferrovore(final Ferrovore card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FertileImagination.java
+++ b/Mage.Sets/src/mage/cards/f/FertileImagination.java
@@ -65,7 +65,7 @@ class FertileImaginationEffect extends OneShotEffect {
         staticText = "Choose a card type. Target opponent reveals their hand. Create two 1/1 green Saproling creature tokens for each card of the chosen type revealed this way";
     }
 
-    public FertileImaginationEffect(final FertileImaginationEffect effect) {
+    private FertileImaginationEffect(final FertileImaginationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FertileThicket.java
+++ b/Mage.Sets/src/mage/cards/f/FertileThicket.java
@@ -57,7 +57,7 @@ class FertileThicketEffect extends OneShotEffect {
         this.staticText = "you may look at the top five cards of your library. If you do, reveal up to one basic land card from among them, then put that card on top of your library and the rest on the bottom in any order";
     }
 
-    public FertileThicketEffect(final FertileThicketEffect effect) {
+    private FertileThicketEffect(final FertileThicketEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FesteringWound.java
+++ b/Mage.Sets/src/mage/cards/f/FesteringWound.java
@@ -57,7 +57,7 @@ class FesteringWoundEffect extends OneShotEffect {
         this.staticText = "{this} deals X damage to that player, where X is the number of infection counters on {this}";
     }
 
-    public FesteringWoundEffect(final FesteringWoundEffect effect) {
+    private FesteringWoundEffect(final FesteringWoundEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FestivalOfTheAncestors.java
+++ b/Mage.Sets/src/mage/cards/f/FestivalOfTheAncestors.java
@@ -17,7 +17,7 @@ public class FestivalOfTheAncestors extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPlayer());
     }
 
-    public FestivalOfTheAncestors(final FestivalOfTheAncestors card) {
+    private FestivalOfTheAncestors(final FestivalOfTheAncestors card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FetidHeath.java
+++ b/Mage.Sets/src/mage/cards/f/FetidHeath.java
@@ -39,7 +39,7 @@ public final class FetidHeath extends CardImpl {
         this.addAbility(ability);          
     }
 
-    public FetidHeath (final FetidHeath card) {
+    private FetidHeath(final FetidHeath card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Fettergeist.java
+++ b/Mage.Sets/src/mage/cards/f/Fettergeist.java
@@ -64,7 +64,7 @@ class FettergeistUnlessPaysEffect extends OneShotEffect {
         staticText = "sacrifice {this} unless you pay {1} for each other creature you control.";
     }
 
-    public FettergeistUnlessPaysEffect(final FettergeistUnlessPaysEffect effect) {
+    private FettergeistUnlessPaysEffect(final FettergeistUnlessPaysEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FeudkillersVerdict.java
+++ b/Mage.Sets/src/mage/cards/f/FeudkillersVerdict.java
@@ -45,7 +45,7 @@ class FeudkillersVerdictEffect extends OneShotEffect {
         this.staticText = "You gain 10 life. Then if you have more life than an opponent, create a 5/5 white Giant Warrior creature token";
     }
 
-    public FeudkillersVerdictEffect(final FeudkillersVerdictEffect effect) {
+    private FeudkillersVerdictEffect(final FeudkillersVerdictEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FeveredVisions.java
+++ b/Mage.Sets/src/mage/cards/f/FeveredVisions.java
@@ -44,7 +44,7 @@ class FeveredVisionsEffect extends OneShotEffect {
         staticText = "that player draws a card. If the player is your opponent and has four or more cards in hand, {this} deals 2 damage to that player";
     }
 
-    public FeveredVisionsEffect(final FeveredVisionsEffect effect) {
+    private FeveredVisionsEffect(final FeveredVisionsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FeySteed.java
+++ b/Mage.Sets/src/mage/cards/f/FeySteed.java
@@ -74,7 +74,7 @@ class FeySteedTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), true);
     }
 
-    public FeySteedTriggeredAbility(FeySteedTriggeredAbility ability) {
+    private FeySteedTriggeredAbility(final FeySteedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FickleEfreet.java
+++ b/Mage.Sets/src/mage/cards/f/FickleEfreet.java
@@ -55,7 +55,7 @@ class FickleEfreetChangeControlEffect extends OneShotEffect {
         this.staticText = "flip a coin at end of combat. If you lose the flip, choose one of your opponents. That player gains control of {this}";
     }
 
-    public FickleEfreetChangeControlEffect(final FickleEfreetChangeControlEffect effect) {
+    private FickleEfreetChangeControlEffect(final FickleEfreetChangeControlEffect effect) {
         super(effect);
     }
 
@@ -102,7 +102,7 @@ class FickleEfreetGainControlEffect extends ContinuousEffectImpl {
         this.staticText = "That player gains control of {this}";
     }
 
-    public FickleEfreetGainControlEffect(final FickleEfreetGainControlEffect effect) {
+    private FickleEfreetGainControlEffect(final FickleEfreetGainControlEffect effect) {
         super(effect);
         this.controller = effect.controller;
     }

--- a/Mage.Sets/src/mage/cards/f/FieldmistBorderpost.java
+++ b/Mage.Sets/src/mage/cards/f/FieldmistBorderpost.java
@@ -48,7 +48,7 @@ public final class FieldmistBorderpost extends CardImpl {
         this.addAbility(new BlueManaAbility());
     }
 
-    public FieldmistBorderpost (final FieldmistBorderpost card) {
+    private FieldmistBorderpost(final FieldmistBorderpost card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FiendslayerPaladin.java
+++ b/Mage.Sets/src/mage/cards/f/FiendslayerPaladin.java
@@ -63,7 +63,7 @@ class FiendslayerPaladinEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "{this} can't be the target of black or red spells your opponents control";
     }
 
-    public FiendslayerPaladinEffect(final FiendslayerPaladinEffect effect) {
+    private FiendslayerPaladinEffect(final FiendslayerPaladinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FierceInvocation.java
+++ b/Mage.Sets/src/mage/cards/f/FierceInvocation.java
@@ -48,7 +48,7 @@ class FierceInvocationEffect extends OneShotEffect {
         this.staticText = "Manifest the top card of your library, then put two +1/+1 counters on it.<i> (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up any time for its mana cost if it's a creature card.)</i>";
     }
     
-    public FierceInvocationEffect(final FierceInvocationEffect effect) {
+    private FierceInvocationEffect(final FierceInvocationEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/f/FieryBombardment.java
+++ b/Mage.Sets/src/mage/cards/f/FieryBombardment.java
@@ -58,7 +58,7 @@ class FieryBombardmentEffect extends OneShotEffect {
         staticText = "{this} deals damage to any target equal to the number of red mana symbols in the sacrificed creature's mana cost.";
     }
 
-    public FieryBombardmentEffect(final FieryBombardmentEffect effect) {
+    private FieryBombardmentEffect(final FieryBombardmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FieryFall.java
+++ b/Mage.Sets/src/mage/cards/f/FieryFall.java
@@ -29,7 +29,7 @@ public final class FieryFall extends CardImpl {
         this.addAbility(new BasicLandcyclingAbility(new ManaCostsImpl<>("{1}{R}")));
     }
 
-    public FieryFall (final FieryFall card) {
+    private FieryFall(final FieryFall card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FieryGambit.java
+++ b/Mage.Sets/src/mage/cards/f/FieryGambit.java
@@ -47,7 +47,7 @@ class FieryGambitEffect extends OneShotEffect {
         this.staticText = "Flip a coin until you lose a flip or choose to stop flipping. If you lose a flip, Fiery Gambit has no effect. If you win one or more flips, Fiery Gambit deals 3 damage to target creature. If you win two or more flips, Fiery Gambit deals 6 damage to each opponent. If you win three or more flips, draw nine cards and untap all lands you control";
     }
 
-    public FieryGambitEffect(final FieryGambitEffect effect) {
+    private FieryGambitEffect(final FieryGambitEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FightOrFlight.java
+++ b/Mage.Sets/src/mage/cards/f/FightOrFlight.java
@@ -54,7 +54,7 @@ class FightOrFlightEffect extends OneShotEffect {
         this.staticText = "separate all creatures that player controls into two piles. Only creatures in the pile of their choice can attack this turn";
     }
 
-    public FightOrFlightEffect(final FightOrFlightEffect effect) {
+    private FightOrFlightEffect(final FightOrFlightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FighterClass.java
+++ b/Mage.Sets/src/mage/cards/f/FighterClass.java
@@ -122,7 +122,7 @@ class FighterClassRequirementEffect extends RequirementEffect {
         this.mor = mor;
     }
 
-    public FighterClassRequirementEffect(final FighterClassRequirementEffect effect) {
+    private FighterClassRequirementEffect(final FighterClassRequirementEffect effect) {
         super(effect);
         this.mor = effect.mor;
     }

--- a/Mage.Sets/src/mage/cards/f/FiligreeAngel.java
+++ b/Mage.Sets/src/mage/cards/f/FiligreeAngel.java
@@ -52,7 +52,7 @@ class FiligreeAngelEffect extends OneShotEffect {
         staticText = "you gain 3 life for each artifact you control";
     }
 
-    public FiligreeAngelEffect(final FiligreeAngelEffect effect) {
+    private FiligreeAngelEffect(final FiligreeAngelEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FiligreeFracture.java
+++ b/Mage.Sets/src/mage/cards/f/FiligreeFracture.java
@@ -46,7 +46,7 @@ class FiligreeFractureEffect extends OneShotEffect {
         this.staticText = "Destroy target artifact or enchantment. If that permanent was blue or black, draw a card";
     }
 
-    public FiligreeFractureEffect(final FiligreeFractureEffect effect) {
+    private FiligreeFractureEffect(final FiligreeFractureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FiligreeSages.java
+++ b/Mage.Sets/src/mage/cards/f/FiligreeSages.java
@@ -39,7 +39,7 @@ public final class FiligreeSages extends CardImpl {
         this.addAbility(ability);
     }
 
-    public FiligreeSages (final FiligreeSages card) {
+    private FiligreeSages(final FiligreeSages card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FilthyCur.java
+++ b/Mage.Sets/src/mage/cards/f/FilthyCur.java
@@ -49,7 +49,7 @@ class DealtDamageLoseLifeTriggeredAbility extends TriggeredAbilityImpl {
         super(zone, effect, optional);
     }
 
-    public DealtDamageLoseLifeTriggeredAbility(final DealtDamageLoseLifeTriggeredAbility ability) {
+    private DealtDamageLoseLifeTriggeredAbility(final DealtDamageLoseLifeTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FinalParting.java
+++ b/Mage.Sets/src/mage/cards/f/FinalParting.java
@@ -46,7 +46,7 @@ class FinalPartingEffect extends OneShotEffect {
         staticText = "Search your library for two cards. Put one into your hand and the other into your graveyard. Then shuffle";
     }
 
-    public FinalPartingEffect(final FinalPartingEffect effect) {
+    private FinalPartingEffect(final FinalPartingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FinaleOfPromise.java
+++ b/Mage.Sets/src/mage/cards/f/FinaleOfPromise.java
@@ -91,7 +91,7 @@ class FinaleOfPromiseEffect extends OneShotEffect {
                 + "twice. You may choose new targets for the copies.";
     }
 
-    public FinaleOfPromiseEffect(final FinaleOfPromiseEffect effect) {
+    private FinaleOfPromiseEffect(final FinaleOfPromiseEffect effect) {
         super(effect);
     }
 
@@ -170,7 +170,7 @@ class FinaleOfPromiseReplacementEffect extends ReplacementEffectImpl {
         staticText = "If a card cast this way would be put into your graveyard this turn, exile it instead";
     }
 
-    public FinaleOfPromiseReplacementEffect(final FinaleOfPromiseReplacementEffect effect) {
+    private FinaleOfPromiseReplacementEffect(final FinaleOfPromiseReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FindFinality.java
+++ b/Mage.Sets/src/mage/cards/f/FindFinality.java
@@ -66,7 +66,7 @@ class FinalityEffect extends OneShotEffect {
                 + "Then all creatures get -4/-4 until end of turn.";
     }
 
-    public FinalityEffect(final FinalityEffect effect) {
+    private FinalityEffect(final FinalityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FireServant.java
+++ b/Mage.Sets/src/mage/cards/f/FireServant.java
@@ -54,7 +54,7 @@ class FireServantEffect extends ReplacementEffectImpl {
         staticText = "If a red instant or sorcery spell you control would deal damage, it deals double that damage instead";
     }
 
-    public FireServantEffect(final FireServantEffect effect) {
+    private FireServantEffect(final FireServantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Fireball.java
+++ b/Mage.Sets/src/mage/cards/f/Fireball.java
@@ -60,7 +60,7 @@ class FireballEffect extends OneShotEffect {
                 "X damage divided evenly, rounded down, among any number of targets";
     }
 
-    public FireballEffect(final FireballEffect effect) {
+    private FireballEffect(final FireballEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class FireballTargetCreatureOrPlayer extends TargetAnyTarget {
         super(minNumTargets, maxNumTargets);
     }
 
-    public FireballTargetCreatureOrPlayer(final FireballTargetCreatureOrPlayer target) {
+    private FireballTargetCreatureOrPlayer(final FireballTargetCreatureOrPlayer target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FirecatBlitz.java
+++ b/Mage.Sets/src/mage/cards/f/FirecatBlitz.java
@@ -63,7 +63,7 @@ class FirecatBlitzEffect extends OneShotEffect {
         this.staticText = "Create X 1/1 red Elemental Cat creature tokens with haste. Exile them at the beginning of the next end step";
     }
 
-    public FirecatBlitzEffect(final FirecatBlitzEffect effect) {
+    private FirecatBlitzEffect(final FirecatBlitzEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FiresOfMountDoom.java
+++ b/Mage.Sets/src/mage/cards/f/FiresOfMountDoom.java
@@ -72,7 +72,7 @@ class FiresOfMountDoomEffect extends OneShotEffect {
             "When you play a card this way, Fires of Mount Doom deals 2 damage to each player";
     }
 
-    public FiresOfMountDoomEffect(final FiresOfMountDoomEffect effect) {
+    private FiresOfMountDoomEffect(final FiresOfMountDoomEffect effect) {
         super(effect);
     }
 
@@ -120,7 +120,7 @@ class FiresOfMountDoomDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.cardId = cardId;
     }
 
-    public FiresOfMountDoomDelayedTriggeredAbility(FiresOfMountDoomDelayedTriggeredAbility ability) {
+    private FiresOfMountDoomDelayedTriggeredAbility(final FiresOfMountDoomDelayedTriggeredAbility ability) {
         super(ability);
         this.cardId = ability.cardId;
     }

--- a/Mage.Sets/src/mage/cards/f/FiresongAndSunspeaker.java
+++ b/Mage.Sets/src/mage/cards/f/FiresongAndSunspeaker.java
@@ -69,7 +69,7 @@ class FiresongAndSunspeakerTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetCreatureOrPlayer());
     }
 
-    public FiresongAndSunspeakerTriggeredAbility(final FiresongAndSunspeakerTriggeredAbility ability) {
+    private FiresongAndSunspeakerTriggeredAbility(final FiresongAndSunspeakerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Firestorm.java
+++ b/Mage.Sets/src/mage/cards/f/Firestorm.java
@@ -64,7 +64,7 @@ class FirestormEffect extends OneShotEffect {
         staticText = "{this} deals X damage to each of X targets";
     }
 
-    public FirestormEffect(final FirestormEffect effect) {
+    private FirestormEffect(final FirestormEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FirewildBorderpost.java
+++ b/Mage.Sets/src/mage/cards/f/FirewildBorderpost.java
@@ -48,7 +48,7 @@ public final class FirewildBorderpost extends CardImpl {
         this.addAbility(new GreenManaAbility());
     }
 
-    public FirewildBorderpost (final FirewildBorderpost card) {
+    private FirewildBorderpost(final FirewildBorderpost card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FirstDayOfClass.java
+++ b/Mage.Sets/src/mage/cards/f/FirstDayOfClass.java
@@ -53,7 +53,7 @@ class FirstDayOfClassTriggeredAbility extends DelayedTriggeredAbility {
         this.addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn));
     }
 
-    public FirstDayOfClassTriggeredAbility(FirstDayOfClassTriggeredAbility ability) {
+    private FirstDayOfClassTriggeredAbility(final FirstDayOfClassTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FirstOrderJetTrooper.java
+++ b/Mage.Sets/src/mage/cards/f/FirstOrderJetTrooper.java
@@ -39,7 +39,7 @@ public class FirstOrderJetTrooper extends CardImpl {
         this.addAbility(ability);
     }
 
-    public FirstOrderJetTrooper(final FirstOrderJetTrooper card) {
+    private FirstOrderJetTrooper(final FirstOrderJetTrooper card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FistfulOfForce.java
+++ b/Mage.Sets/src/mage/cards/f/FistfulOfForce.java
@@ -52,7 +52,7 @@ class FistfulOfForceEffect extends OneShotEffect {
         this.staticText = "Target creature gets +2/+2 until end of turn. Clash with an opponent. If you win, that creature gets an additional +2/+2 and gains trample until end of turn";
     }
 
-    public FistfulOfForceEffect(final FistfulOfForceEffect effect) {
+    private FistfulOfForceEffect(final FistfulOfForceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FiveAlarmFire.java
+++ b/Mage.Sets/src/mage/cards/f/FiveAlarmFire.java
@@ -66,7 +66,7 @@ class FiveAlarmFireTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature you control deals combat damage, ");
     }
 
-    public FiveAlarmFireTriggeredAbility(final FiveAlarmFireTriggeredAbility ability) {
+    private FiveAlarmFireTriggeredAbility(final FiveAlarmFireTriggeredAbility ability) {
             super(ability);
             triggeringCreatures.addAll(ability.triggeringCreatures);
     }

--- a/Mage.Sets/src/mage/cards/f/FlamebladeAngel.java
+++ b/Mage.Sets/src/mage/cards/f/FlamebladeAngel.java
@@ -52,7 +52,7 @@ class FlamebladeAngelTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(1), true);
     }
 
-    public FlamebladeAngelTriggeredAbility(final FlamebladeAngelTriggeredAbility ability) {
+    private FlamebladeAngelTriggeredAbility(final FlamebladeAngelTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlamebornHellion.java
+++ b/Mage.Sets/src/mage/cards/f/FlamebornHellion.java
@@ -27,7 +27,7 @@ public final class FlamebornHellion extends CardImpl {
         this.addAbility(new AttacksEachCombatStaticAbility());
     }
 
-    public FlamebornHellion (final FlamebornHellion card) {
+    private FlamebornHellion(final FlamebornHellion card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Flamebreak.java
+++ b/Mage.Sets/src/mage/cards/f/Flamebreak.java
@@ -59,7 +59,7 @@ class FlamebreakCantRegenerateEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Creatures dealt damage this way can't be regenerated this turn";
     }
 
-    public FlamebreakCantRegenerateEffect(final FlamebreakCantRegenerateEffect effect) {
+    private FlamebreakCantRegenerateEffect(final FlamebreakCantRegenerateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlamerushRider.java
+++ b/Mage.Sets/src/mage/cards/f/FlamerushRider.java
@@ -72,7 +72,7 @@ class FlamerushRiderEffect extends OneShotEffect {
         this.staticText = "create a token that's a copy of another target attacking creature and that's tapped and attacking. Exile the token at end of combat";
     }
 
-    public FlamerushRiderEffect(final FlamerushRiderEffect effect) {
+    private FlamerushRiderEffect(final FlamerushRiderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlamesOfRemembrance.java
+++ b/Mage.Sets/src/mage/cards/f/FlamesOfRemembrance.java
@@ -61,7 +61,7 @@ class FlamesOfRemembranceExileEffect extends OneShotEffect {
         this.staticText = "Exile top X cards of your library, where X is the number of lore counters on {this}. Until end of turn you play cards exile this way";
     }
 
-    public FlamesOfRemembranceExileEffect(final FlamesOfRemembranceExileEffect effect) {
+    private FlamesOfRemembranceExileEffect(final FlamesOfRemembranceExileEffect effect) {
         super(effect);
         this.amount = effect.amount;
     }
@@ -95,7 +95,7 @@ class FlamesOfRemembranceMayPlayExiledEffect extends AsThoughEffectImpl {
         super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
     }
 
-    public FlamesOfRemembranceMayPlayExiledEffect(final FlamesOfRemembranceMayPlayExiledEffect effect) {
+    private FlamesOfRemembranceMayPlayExiledEffect(final FlamesOfRemembranceMayPlayExiledEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlamesOfTheBloodHand.java
+++ b/Mage.Sets/src/mage/cards/f/FlamesOfTheBloodHand.java
@@ -47,7 +47,7 @@ class FlamesOfTheBloodHandReplacementEffect extends ReplacementEffectImpl {
         staticText = "If that player or that planeswalker's controller would gain life this turn, that player gains no life instead";
     }
 
-    public FlamesOfTheBloodHandReplacementEffect(final FlamesOfTheBloodHandReplacementEffect effect) {
+    private FlamesOfTheBloodHandReplacementEffect(final FlamesOfTheBloodHandReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlameshadowConjuring.java
+++ b/Mage.Sets/src/mage/cards/f/FlameshadowConjuring.java
@@ -60,7 +60,7 @@ class FlameshadowConjuringEffect extends OneShotEffect {
         this.staticText = "create a token that's a copy of that creature. That token gains haste. Exile it at the beginning of the next end step";
     }
 
-    public FlameshadowConjuringEffect(final FlameshadowConjuringEffect effect) {
+    private FlameshadowConjuringEffect(final FlameshadowConjuringEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Flash.java
+++ b/Mage.Sets/src/mage/cards/f/Flash.java
@@ -50,7 +50,7 @@ class FlashEffect extends OneShotEffect {
         this.staticText = "You may put a creature card from your hand onto the battlefield. If you do, sacrifice it unless you pay its mana cost reduced by up to {2}.";
     }
 
-    public FlashEffect(final FlashEffect effect) {
+    private FlashEffect(final FlashEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlashConscription.java
+++ b/Mage.Sets/src/mage/cards/f/FlashConscription.java
@@ -61,7 +61,7 @@ class FlashConscriptionTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null);
     }
 
-    public FlashConscriptionTriggeredAbility(final FlashConscriptionTriggeredAbility ability) {
+    private FlashConscriptionTriggeredAbility(final FlashConscriptionTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlashFoliage.java
+++ b/Mage.Sets/src/mage/cards/f/FlashFoliage.java
@@ -58,7 +58,7 @@ class FlashFoliageEffect extends OneShotEffect {
         this.staticText = "create a 1/1 green Saproling creature token that's blocking target creature attacking you";
     }
 
-    public FlashFoliageEffect(final FlashFoliageEffect effect) {
+    private FlashFoliageEffect(final FlashFoliageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlayerOfTheHatebound.java
+++ b/Mage.Sets/src/mage/cards/f/FlayerOfTheHatebound.java
@@ -57,7 +57,7 @@ class FlayerTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new FlayerEffect(), false);
     }
 
-    public FlayerTriggeredAbility(FlayerTriggeredAbility ability) {
+    private FlayerTriggeredAbility(final FlayerTriggeredAbility ability) {
         super(ability);
     }
 
@@ -98,7 +98,7 @@ class FlayerEffect extends OneShotEffect {
         staticText = "that creature deals damage equal to its power to any target";
     }
 
-    public FlayerEffect(final FlayerEffect effect) {
+    private FlayerEffect(final FlayerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlayingTendrils.java
+++ b/Mage.Sets/src/mage/cards/f/FlayingTendrils.java
@@ -51,7 +51,7 @@ class FlayingTendrilsReplacementEffect extends ReplacementEffectImpl {
         staticText = "If a creature would die this turn, exile it instead";
     }
 
-    public FlayingTendrilsReplacementEffect(final FlayingTendrilsReplacementEffect effect) {
+    private FlayingTendrilsReplacementEffect(final FlayingTendrilsReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FledglingGriffin.java
+++ b/Mage.Sets/src/mage/cards/f/FledglingGriffin.java
@@ -28,7 +28,7 @@ public final class FledglingGriffin extends CardImpl {
         this.addAbility(new LandfallAbility(new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.EndOfTurn), false));
     }
 
-    public FledglingGriffin (final FledglingGriffin card) {
+    private FledglingGriffin(final FledglingGriffin card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FleetingDistraction.java
+++ b/Mage.Sets/src/mage/cards/f/FleetingDistraction.java
@@ -25,7 +25,7 @@ public final class FleetingDistraction extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public FleetingDistraction (final FleetingDistraction card) {
+    private FleetingDistraction(final FleetingDistraction card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FleetingMemories.java
+++ b/Mage.Sets/src/mage/cards/f/FleetingMemories.java
@@ -60,7 +60,7 @@ class FleetingMemoriesTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you sacrifice a Clue, ");
     }
 
-    public FleetingMemoriesTriggeredAbility(final FleetingMemoriesTriggeredAbility ability) {
+    private FleetingMemoriesTriggeredAbility(final FleetingMemoriesTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Flensermite.java
+++ b/Mage.Sets/src/mage/cards/f/Flensermite.java
@@ -28,7 +28,7 @@ public final class Flensermite extends CardImpl {
         this.addAbility(LifelinkAbility.getInstance());
     }
 
-    public Flensermite (final Flensermite card) {
+    private Flensermite(final Flensermite card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FleshBlood.java
+++ b/Mage.Sets/src/mage/cards/f/FleshBlood.java
@@ -58,7 +58,7 @@ class FleshEffect extends OneShotEffect {
         staticText = "Exile target creature card from a graveyard. Put X +1/+1 counters on target creature, where X is the power of the card you exiled";
     }
 
-    public FleshEffect(final FleshEffect effect) {
+    private FleshEffect(final FleshEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FleshCarver.java
+++ b/Mage.Sets/src/mage/cards/f/FleshCarver.java
@@ -70,7 +70,7 @@ class FleshCarverAbility extends DiesSourceTriggeredAbility {
         setTriggerPhrase("When Flesh Carver dies, ");
     }
 
-    public FleshCarverAbility(final FleshCarverAbility ability) {
+    private FleshCarverAbility(final FleshCarverAbility ability) {
         super(ability);
     }
 
@@ -101,7 +101,7 @@ class FleshCarverEffect extends OneShotEffect {
         staticText = "create an X/X black Horror creature token, where X is {this}'s power";
     }
 
-    public FleshCarverEffect(FleshCarverEffect ability) {
+    private FleshCarverEffect(final FleshCarverEffect ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Flickerform.java
+++ b/Mage.Sets/src/mage/cards/f/Flickerform.java
@@ -74,7 +74,7 @@ class FlickerformEffect extends OneShotEffect {
         this.staticText = "Exile enchanted creature and all Auras attached to it. At the beginning of the next end step, return that card to the battlefield under its owner's control. If you do, return the other cards exiled this way to the battlefield under their owners' control attached to that creature";
     }
 
-    public FlickerformEffect(final FlickerformEffect effect) {
+    private FlickerformEffect(final FlickerformEffect effect) {
         super(effect);
     }
 
@@ -135,7 +135,7 @@ class FlickerformReturnEffect extends OneShotEffect {
         this.staticText = "return that card to the battlefield under its owner's control. If you do, return the other cards exiled this way to the battlefield under their owners' control attached to that creature";
     }
 
-    public FlickerformReturnEffect(final FlickerformReturnEffect effect) {
+    private FlickerformReturnEffect(final FlickerformReturnEffect effect) {
         super(effect);
         this.enchantedCardId = effect.enchantedCardId;
         this.exileZoneId = effect.exileZoneId;

--- a/Mage.Sets/src/mage/cards/f/Flickerwisp.java
+++ b/Mage.Sets/src/mage/cards/f/Flickerwisp.java
@@ -68,7 +68,7 @@ class FlickerwispEffect extends OneShotEffect {
         staticText = "exile another target permanent. Return that card to the battlefield under its owner's control at the beginning of the next end step";
     }
 
-    public FlickerwispEffect(final FlickerwispEffect effect) {
+    private FlickerwispEffect(final FlickerwispEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlightSpellbomb.java
+++ b/Mage.Sets/src/mage/cards/f/FlightSpellbomb.java
@@ -35,7 +35,7 @@ public final class FlightSpellbomb extends CardImpl {
         this.addAbility(new DiesSourceTriggeredAbility(new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new ManaCostsImpl<>("{U}")), false));
     }
 
-    public FlightSpellbomb (final FlightSpellbomb card) {
+    private FlightSpellbomb(final FlightSpellbomb card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FloatingShield.java
+++ b/Mage.Sets/src/mage/cards/f/FloatingShield.java
@@ -69,7 +69,7 @@ class FloatingShieldEffect extends OneShotEffect {
         this.staticText = "target creature gains protection from the chosen color until end of turn";
     }
 
-    public FloatingShieldEffect(final FloatingShieldEffect effect) {
+    private FloatingShieldEffect(final FloatingShieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlockOfRabidSheep.java
+++ b/Mage.Sets/src/mage/cards/f/FlockOfRabidSheep.java
@@ -43,7 +43,7 @@ class FlockOfRabidSheepEffect extends OneShotEffect {
         this.staticText = "Flip X coins. For each flip you win, create a 2/2 green Sheep creature token named Rabid Sheep";
     }
 
-    public FlockOfRabidSheepEffect(final FlockOfRabidSheepEffect effect) {
+    private FlockOfRabidSheepEffect(final FlockOfRabidSheepEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FloodedGrove.java
+++ b/Mage.Sets/src/mage/cards/f/FloodedGrove.java
@@ -40,7 +40,7 @@ public final class FloodedGrove extends CardImpl {
         
     }
 
-    public FloodedGrove (final FloodedGrove card) {
+    private FloodedGrove(final FloodedGrove card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Floodgate.java
+++ b/Mage.Sets/src/mage/cards/f/Floodgate.java
@@ -93,7 +93,7 @@ class FloodgateHasFlyingStateTriggeredAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new SacrificeSourceEffect());
     }
 
-    public FloodgateHasFlyingStateTriggeredAbility(final FloodgateHasFlyingStateTriggeredAbility ability) {
+    private FloodgateHasFlyingStateTriggeredAbility(final FloodgateHasFlyingStateTriggeredAbility ability) {
         super(ability);
     }
 
@@ -135,7 +135,7 @@ class FloodgateDamageEffect extends OneShotEffect {
                 + "rounded down, to each nonblue creature without flying";
     }
 
-    public FloodgateDamageEffect(final FloodgateDamageEffect effect) {
+    private FloodgateDamageEffect(final FloodgateDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FloweringLumberknot.java
+++ b/Mage.Sets/src/mage/cards/f/FloweringLumberknot.java
@@ -49,7 +49,7 @@ class FloweringLumberknotEffect extends RestrictionEffect {
         staticText = "{this} can't attack or block unless it's paired with a creature with soulbond";
     }
 
-    public FloweringLumberknotEffect(final FloweringLumberknotEffect effect) {
+    private FloweringLumberknotEffect(final FloweringLumberknotEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlowstoneSculpture.java
+++ b/Mage.Sets/src/mage/cards/f/FlowstoneSculpture.java
@@ -73,7 +73,7 @@ class FlowstoneSculptureEffect extends OneShotEffect {
         staticText = "Put a +1/+1 counter on {this} or {this} gains flying, first strike, or trample.";
     }
 
-    public FlowstoneSculptureEffect(final FlowstoneSculptureEffect effect) {
+    private FlowstoneSculptureEffect(final FlowstoneSculptureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Fluctuator.java
+++ b/Mage.Sets/src/mage/cards/f/Fluctuator.java
@@ -48,7 +48,7 @@ class FluctuatorEffect extends CostModificationEffectImpl {
         staticText = effectText;
     }
 
-    public FluctuatorEffect(final FluctuatorEffect effect) {
+    private FluctuatorEffect(final FluctuatorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FoldIntoAether.java
+++ b/Mage.Sets/src/mage/cards/f/FoldIntoAether.java
@@ -47,7 +47,7 @@ class FoldIntoAetherEffect extends OneShotEffect {
         this.staticText = "Counter target spell. If that spell is countered this way, its controller may put a creature card from their hand onto the battlefield";
     }
 
-    public FoldIntoAetherEffect(final FoldIntoAetherEffect effect) {
+    private FoldIntoAetherEffect(final FoldIntoAetherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FollowedFootsteps.java
+++ b/Mage.Sets/src/mage/cards/f/FollowedFootsteps.java
@@ -60,7 +60,7 @@ class FollowedFootstepsEffect extends OneShotEffect {
         this.staticText = "create a token that's a copy of enchanted creature";
     }
 
-    public FollowedFootstepsEffect(final FollowedFootstepsEffect effect) {
+    private FollowedFootstepsEffect(final FollowedFootstepsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FontOfMythos.java
+++ b/Mage.Sets/src/mage/cards/f/FontOfMythos.java
@@ -41,7 +41,7 @@ class FontOfMythosAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardTargetEffect(2));
     }
 
-    public FontOfMythosAbility(final FontOfMythosAbility ability) {
+    private FontOfMythosAbility(final FontOfMythosAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FootstepsOfTheGoryo.java
+++ b/Mage.Sets/src/mage/cards/f/FootstepsOfTheGoryo.java
@@ -53,7 +53,7 @@ class FootstepsOfTheGoryoEffect extends OneShotEffect {
         this.staticText = "Return target creature card from your graveyard to the battlefield. Sacrifice that creature at the beginning of the next end step";
     }
 
-    public FootstepsOfTheGoryoEffect(final FootstepsOfTheGoryoEffect effect) {
+    private FootstepsOfTheGoryoEffect(final FootstepsOfTheGoryoEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForbiddenCrypt.java
+++ b/Mage.Sets/src/mage/cards/f/ForbiddenCrypt.java
@@ -52,7 +52,7 @@ class ForbiddenCryptDrawCardReplacementEffect extends ReplacementEffectImpl {
         this.staticText = "If you would draw a card, return a card from your graveyard to your hand instead. If you can't, you lose the game";
     }
 
-    public ForbiddenCryptDrawCardReplacementEffect(final ForbiddenCryptDrawCardReplacementEffect effect) {
+    private ForbiddenCryptDrawCardReplacementEffect(final ForbiddenCryptDrawCardReplacementEffect effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class ForbiddenCryptPutIntoYourGraveyardReplacementEffect extends ReplacementEff
         this.staticText = "If a card would be put into your graveyard from anywhere, exile that card instead";
     }
 
-    public ForbiddenCryptPutIntoYourGraveyardReplacementEffect(final ForbiddenCryptPutIntoYourGraveyardReplacementEffect effect) {
+    private ForbiddenCryptPutIntoYourGraveyardReplacementEffect(final ForbiddenCryptPutIntoYourGraveyardReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForbiddingWatchtower.java
+++ b/Mage.Sets/src/mage/cards/f/ForbiddingWatchtower.java
@@ -55,7 +55,7 @@ class ForbiddingWatchtowerToken extends TokenImpl {
         power = new MageInt(1);
         toughness = new MageInt(5);
     }
-    public ForbiddingWatchtowerToken(final ForbiddingWatchtowerToken token) {
+    private ForbiddingWatchtowerToken(final ForbiddingWatchtowerToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForceBubble.java
+++ b/Mage.Sets/src/mage/cards/f/ForceBubble.java
@@ -93,7 +93,7 @@ class ForceBubbleStateTriggeredAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new SacrificeSourceEffect());
     }
 
-    public ForceBubbleStateTriggeredAbility(final ForceBubbleStateTriggeredAbility ability) {
+    private ForceBubbleStateTriggeredAbility(final ForceBubbleStateTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForceChoke.java
+++ b/Mage.Sets/src/mage/cards/f/ForceChoke.java
@@ -53,7 +53,7 @@ class ForceChokeEffect extends OneShotEffect {
                 + "equal to that spell's mana value to return it to its owner's hand";
     }
 
-    public ForceChokeEffect(final ForceChokeEffect effect) {
+    private ForceChokeEffect(final ForceChokeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForceDrain.java
+++ b/Mage.Sets/src/mage/cards/f/ForceDrain.java
@@ -47,7 +47,7 @@ class ForceDrainEffect extends OneShotEffect {
         this.staticText = "ForceDrain deals 2 damage to any target. If player was dealt damage this way, you gain 2 life";
     }
 
-    public ForceDrainEffect(final ForceDrainEffect effect) {
+    private ForceDrainEffect(final ForceDrainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForceLift.java
+++ b/Mage.Sets/src/mage/cards/f/ForceLift.java
@@ -34,7 +34,7 @@ public class ForceLift extends CardImpl {
         this.getSpellAbility().addEffect(new ScryEffect(1));
     }
 
-    public ForceLift(final ForceLift card) {
+    private ForceLift(final ForceLift card) {
         super(card);
     }
 
@@ -95,7 +95,7 @@ class ForceLiftReturnFromExileEffect extends OneShotEffect {
         staticText = "return that card to the battlefield under its owner's control";
     }
 
-    public ForceLiftReturnFromExileEffect(final ForceLiftReturnFromExileEffect effect) {
+    private ForceLiftReturnFromExileEffect(final ForceLiftReturnFromExileEffect effect) {
         super(effect);
         this.objectToReturn = effect.objectToReturn;
     }

--- a/Mage.Sets/src/mage/cards/f/ForceLightning.java
+++ b/Mage.Sets/src/mage/cards/f/ForceLightning.java
@@ -49,7 +49,7 @@ class ForceLightningEffect extends OneShotEffect {
         this.staticText = "Scry X";
     }
 
-    public ForceLightningEffect(final ForceLightningEffect effect) {
+    private ForceLightningEffect(final ForceLightningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForceOfNature.java
+++ b/Mage.Sets/src/mage/cards/f/ForceOfNature.java
@@ -54,7 +54,7 @@ class ForceOfNatureEffect extends OneShotEffect {
         this.staticText = "{this} deals 8 damage to you unless you pay {G}{G}{G}{G}";
     }
 
-    public ForceOfNatureEffect(final ForceOfNatureEffect effect) {
+    private ForceOfNatureEffect(final ForceOfNatureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForceProjection.java
+++ b/Mage.Sets/src/mage/cards/f/ForceProjection.java
@@ -54,7 +54,7 @@ class ForceProjectionEffect extends OneShotEffect {
                 + "in addition to its other types and gains \"When this creature becomes the target of a spell, sacrifice it.\"";
     }
 
-    public ForceProjectionEffect(final ForceProjectionEffect effect) {
+    private ForceProjectionEffect(final ForceProjectionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForcedMarch.java
+++ b/Mage.Sets/src/mage/cards/f/ForcedMarch.java
@@ -40,7 +40,7 @@ class ForcedMarchEffect extends OneShotEffect {
         staticText = "Destroy all creatures with mana value X or less";
     }
 
-    public ForcedMarchEffect(final ForcedMarchEffect effect) {
+    private ForcedMarchEffect(final ForcedMarchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForcedWorship.java
+++ b/Mage.Sets/src/mage/cards/f/ForcedWorship.java
@@ -44,7 +44,7 @@ public final class ForcedWorship extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new ReturnToHandSourceEffect(true), new ManaCostsImpl<>("{2}{W}")));
     }
 
-    public ForcedWorship (final ForcedWorship card) {
+    private ForcedWorship(final ForcedWorship card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForethoughtAmulet.java
+++ b/Mage.Sets/src/mage/cards/f/ForethoughtAmulet.java
@@ -52,7 +52,7 @@ class ForethoughtAmuletEffect extends ReplacementEffectImpl {
         staticText = "If an instant or sorcery source would deal 3 or more damage to you, it deals 2 damage to you instead";
     }
 
-    public ForethoughtAmuletEffect(final ForethoughtAmuletEffect effect) {
+    private ForethoughtAmuletEffect(final ForethoughtAmuletEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForgeOfHeroes.java
+++ b/Mage.Sets/src/mage/cards/f/ForgeOfHeroes.java
@@ -67,7 +67,7 @@ class ForgeOfHeroesEffect extends OneShotEffect {
                 + "and a loyalty counter on it if it's a planeswalker";
     }
 
-    public ForgeOfHeroesEffect(final ForgeOfHeroesEffect effect) {
+    private ForgeOfHeroesEffect(final ForgeOfHeroesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Forget.java
+++ b/Mage.Sets/src/mage/cards/f/Forget.java
@@ -44,7 +44,7 @@ class ForgetEffect extends OneShotEffect {
         this.staticText = "Target player discards two cards, then draws as many cards as they discarded this way";
     }
     
-    public ForgetEffect(final ForgetEffect effect) {
+    private ForgetEffect(final ForgetEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/f/ForgottenAncient.java
+++ b/Mage.Sets/src/mage/cards/f/ForgottenAncient.java
@@ -70,7 +70,7 @@ public final class ForgottenAncient extends CardImpl {
             this.staticText = "you may move any number of +1/+1 counters from {this} onto other creatures.";
         }
 
-        public ForgottenAncientEffect(final ForgottenAncientEffect effect) {
+        private ForgottenAncientEffect(final ForgottenAncientEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/f/ForgottenCreation.java
+++ b/Mage.Sets/src/mage/cards/f/ForgottenCreation.java
@@ -52,7 +52,7 @@ class ForgottenCreationEffect extends OneShotEffect {
         this.staticText = "you may discard all the cards in your hand. If you do, draw that many cards";
     }
 
-    public ForgottenCreationEffect(final ForgottenCreationEffect effect) {
+    private ForgottenCreationEffect(final ForgottenCreationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForgottenLore.java
+++ b/Mage.Sets/src/mage/cards/f/ForgottenLore.java
@@ -49,7 +49,7 @@ class ForgottenLoreEffect extends OneShotEffect {
         staticText = "Target opponent chooses a card in your graveyard. You may pay {G}. If you do, repeat this process except that opponent can't choose a card already chosen for {this}. Then put the last chosen card into your hand.";
     }
 
-    public ForgottenLoreEffect(final ForgottenLoreEffect effect) {
+    private ForgottenLoreEffect(final ForgottenLoreEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForiysianTotem.java
+++ b/Mage.Sets/src/mage/cards/f/ForiysianTotem.java
@@ -65,7 +65,7 @@ class ForiysianTotemToken extends TokenImpl {
         toughness = new MageInt(4);
         this.addAbility(TrampleAbility.getInstance());
     }
-    public ForiysianTotemToken(final ForiysianTotemToken token) {
+    private ForiysianTotemToken(final ForiysianTotemToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForkInTheRoad.java
+++ b/Mage.Sets/src/mage/cards/f/ForkInTheRoad.java
@@ -49,7 +49,7 @@ class ForkInTheRoadEffect extends OneShotEffect {
         staticText = "Search your library for up to two basic land cards and reveal them. Put one into your hand and the other into your graveyard. Then shuffle";
     }
 
-    public ForkInTheRoadEffect(final ForkInTheRoadEffect effect) {
+    private ForkInTheRoadEffect(final ForkInTheRoadEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FormOfTheDinosaur.java
+++ b/Mage.Sets/src/mage/cards/f/FormOfTheDinosaur.java
@@ -51,7 +51,7 @@ class FormOfTheDinosaurEffect extends OneShotEffect {
         this.staticText = "{this} deals 15 damage to target creature an opponent controls and that creature deals damage equal to its power to you";
     }
 
-    public FormOfTheDinosaurEffect(final FormOfTheDinosaurEffect effect) {
+    private FormOfTheDinosaurEffect(final FormOfTheDinosaurEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FormOfTheSquirrel.java
+++ b/Mage.Sets/src/mage/cards/f/FormOfTheSquirrel.java
@@ -64,7 +64,7 @@ class FormOfTheSquirrelCreateTokenEffect extends OneShotEffect {
         staticText = "create a 1/1 green Squirrel creature token. You lose the game when that creature leaves the battlefield";
     }
 
-    public FormOfTheSquirrelCreateTokenEffect(final FormOfTheSquirrelCreateTokenEffect effect) {
+    private FormOfTheSquirrelCreateTokenEffect(final FormOfTheSquirrelCreateTokenEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class FormOfTheSquirrelCantCastEffect extends ContinuousRuleModifyingEffectImpl 
         staticText = "You can't cast spells";
     }
 
-    public FormOfTheSquirrelCantCastEffect(final FormOfTheSquirrelCantCastEffect effect) {
+    private FormOfTheSquirrelCantCastEffect(final FormOfTheSquirrelCantCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FormlessNurturing.java
+++ b/Mage.Sets/src/mage/cards/f/FormlessNurturing.java
@@ -47,7 +47,7 @@ class FormlessNurturingEffect extends OneShotEffect {
         this.staticText = "Manifest the top card of your library, then put a +1/+1 counter on it";
     }
 
-    public FormlessNurturingEffect(final FormlessNurturingEffect effect) {
+    private FormlessNurturingEffect(final FormlessNurturingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForsakenWastes.java
+++ b/Mage.Sets/src/mage/cards/f/ForsakenWastes.java
@@ -56,7 +56,7 @@ class ForsakenWastesTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new LoseLifeTargetEffect(5), false);
     }
 
-    public ForsakenWastesTriggeredAbility(final ForsakenWastesTriggeredAbility ability) {
+    private ForsakenWastesTriggeredAbility(final ForsakenWastesTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForthEorlingas.java
+++ b/Mage.Sets/src/mage/cards/f/ForthEorlingas.java
@@ -54,7 +54,7 @@ class ForthEorlingasTriggeredAbility extends DelayedTriggeredAbility {
         this.setTriggerPhrase("Whenever one or more creatures you control deal combat damage to one or more players this turn, ");
     }
 
-    public ForthEorlingasTriggeredAbility(ForthEorlingasTriggeredAbility ability) {
+    private ForthEorlingasTriggeredAbility(final ForthEorlingasTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FortunateFew.java
+++ b/Mage.Sets/src/mage/cards/f/FortunateFew.java
@@ -50,7 +50,7 @@ class FortunateFewEffect extends OneShotEffect {
         staticText = "Choose a nonland permanent you don't control, then each other player chooses a nonland permanent they don't control that hasn't been chosen this way. Destroy all other nonland permanents";
     }
 
-    public FortunateFewEffect(FortunateFewEffect effect) {
+    private FortunateFewEffect(final FortunateFewEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FortuneThief.java
+++ b/Mage.Sets/src/mage/cards/f/FortuneThief.java
@@ -57,7 +57,7 @@ class FortuneThiefReplacementEffect extends ReplacementEffectImpl {
         staticText = "Damage that would reduce your life total to less than 1 reduces it to 1 instead";
     }
 
-    public FortuneThiefReplacementEffect(final FortuneThiefReplacementEffect effect) {
+    private FortuneThiefReplacementEffect(final FortuneThiefReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FortunesFavor.java
+++ b/Mage.Sets/src/mage/cards/f/FortunesFavor.java
@@ -49,7 +49,7 @@ class FortunesFavorEffect extends OneShotEffect {
         this.staticText = "Target opponent looks at the top four cards of your library and separates them into a face-down pile and a face-up pile. Put one pile into your hand and the other into your graveyard";
     }
 
-    public FortunesFavorEffect(final FortunesFavorEffect effect) {
+    private FortunesFavorEffect(final FortunesFavorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FossilFind.java
+++ b/Mage.Sets/src/mage/cards/f/FossilFind.java
@@ -43,7 +43,7 @@ class FossilFindEffect extends OneShotEffect {
         this.staticText = "Return a card at random from your graveyard to your hand, then reorder your graveyard as you choose";
     }
 
-    public FossilFindEffect(final FossilFindEffect effect) {
+    private FossilFindEffect(final FossilFindEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FoulEmissary.java
+++ b/Mage.Sets/src/mage/cards/f/FoulEmissary.java
@@ -55,7 +55,7 @@ class FoulEmissaryTriggeredAbility extends SacrificeSourceTriggeredAbility {
         setTriggerPhrase("When you sacrifice {this} while casting a spell with emerge, ");
     }
 
-    public FoulEmissaryTriggeredAbility(final FoulEmissaryTriggeredAbility ability) {
+    private FoulEmissaryTriggeredAbility(final FoulEmissaryTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FoulRenewal.java
+++ b/Mage.Sets/src/mage/cards/f/FoulRenewal.java
@@ -52,7 +52,7 @@ class FoulRenewalEffect extends OneShotEffect {
         this.staticText = "Return target creature card from your graveyard to your hand. Target creature gets -X/-X until end of turn, where X is the toughness of the card returned this way";
     }
 
-    public FoulRenewalEffect(final FoulRenewalEffect effect) {
+    private FoulRenewalEffect(final FoulRenewalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FoulTongueShriek.java
+++ b/Mage.Sets/src/mage/cards/f/FoulTongueShriek.java
@@ -45,7 +45,7 @@ class FoulTongueShriekEffect extends OneShotEffect {
         this.staticText = "Target opponent loses 1 life for each attacking creature you control. You gain that much life";
     }
 
-    public FoulTongueShriekEffect(final FoulTongueShriekEffect effect) {
+    private FoulTongueShriekEffect(final FoulTongueShriekEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FracturedLoyalty.java
+++ b/Mage.Sets/src/mage/cards/f/FracturedLoyalty.java
@@ -98,7 +98,7 @@ public final class FracturedLoyalty extends CardImpl {
             super(Zone.BATTLEFIELD, new FracturedLoyaltyEffect(), false);
         }
 
-        public FracturedLoyaltyTriggeredAbility(final FracturedLoyaltyTriggeredAbility ability) {
+        private FracturedLoyaltyTriggeredAbility(final FracturedLoyaltyTriggeredAbility ability) {
             super(ability);
         }
 

--- a/Mage.Sets/src/mage/cards/f/FracturedPowerstone.java
+++ b/Mage.Sets/src/mage/cards/f/FracturedPowerstone.java
@@ -32,7 +32,7 @@ public final class FracturedPowerstone extends CardImpl {
         this.addAbility(ability);
     }
 
-    public FracturedPowerstone(final FracturedPowerstone card) {
+    private FracturedPowerstone(final FracturedPowerstone card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FracturingGust.java
+++ b/Mage.Sets/src/mage/cards/f/FracturingGust.java
@@ -48,7 +48,7 @@ class FracturingGustDestroyEffect extends OneShotEffect {
         this.staticText = "Destroy all artifacts and enchantments. You gain 2 life for each permanent destroyed this way";
     }
 
-    public FracturingGustDestroyEffect(final FracturingGustDestroyEffect effect) {
+    private FracturingGustDestroyEffect(final FracturingGustDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FrayingSanity.java
+++ b/Mage.Sets/src/mage/cards/f/FrayingSanity.java
@@ -59,7 +59,7 @@ class FrayingSanityTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new FrayingSanityEffect());
     }
 
-    public FrayingSanityTriggeredAbility(final FrayingSanityTriggeredAbility ability) {
+    private FrayingSanityTriggeredAbility(final FrayingSanityTriggeredAbility ability) {
         super(ability);
     }
 
@@ -93,7 +93,7 @@ class FrayingSanityEffect extends OneShotEffect {
         this.staticText = "";
     }
 
-    public FrayingSanityEffect(final FrayingSanityEffect effect) {
+    private FrayingSanityEffect(final FrayingSanityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FreeRangeChicken.java
+++ b/Mage.Sets/src/mage/cards/f/FreeRangeChicken.java
@@ -52,7 +52,7 @@ class FreeRangeChickenEffect extends OneShotEffect {
         this.staticText = "Roll two six-sided dice. If both results are the same, Free-Range Chicken gets +X/+X until end of turn, where X is that result. If the total of those results is equal to any other total you have rolled this turn for Free-Range Chicken, sacrifice it";
     }
 
-    public FreeRangeChickenEffect(final FreeRangeChickenEffect effect) {
+    private FreeRangeChickenEffect(final FreeRangeChickenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FreneticEfreet.java
+++ b/Mage.Sets/src/mage/cards/f/FreneticEfreet.java
@@ -58,7 +58,7 @@ class FreneticEfreetEffect extends OneShotEffect {
                 + "{this} phases out. If you lose the flip, sacrifice {this}";
     }
 
-    public FreneticEfreetEffect(FreneticEfreetEffect effect) {
+    private FreneticEfreetEffect(final FreneticEfreetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FreneticSliver.java
+++ b/Mage.Sets/src/mage/cards/f/FreneticSliver.java
@@ -65,7 +65,7 @@ class FreneticSliverEffect extends OneShotEffect {
                 + "at the beginning of the next end step. If you lose the flip, sacrifice it";
     }
 
-    public FreneticSliverEffect(final FreneticSliverEffect effect) {
+    private FreneticSliverEffect(final FreneticSliverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FrenziedFugue.java
+++ b/Mage.Sets/src/mage/cards/f/FrenziedFugue.java
@@ -57,7 +57,7 @@ class FrenziedFugueTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null, false);
     }
 
-    public FrenziedFugueTriggeredAbility(final FrenziedFugueTriggeredAbility ability) {
+    private FrenziedFugueTriggeredAbility(final FrenziedFugueTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FrenzySliver.java
+++ b/Mage.Sets/src/mage/cards/f/FrenzySliver.java
@@ -64,7 +64,7 @@ class FrenzyAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new BoostSourceEffect(1,0, Duration.EndOfTurn));
     }
 
-    public FrenzyAbility(final FrenzyAbility ability) {
+    private FrenzyAbility(final FrenzyAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FriendlyFire.java
+++ b/Mage.Sets/src/mage/cards/f/FriendlyFire.java
@@ -44,7 +44,7 @@ class FriendlyFireEffect extends OneShotEffect {
         this.staticText = "Target creature's controller reveals a card at random from their hand. {this} deals damage to that creature and that player equal to the revealed card's mana value";
     }
 
-    public FriendlyFireEffect(final FriendlyFireEffect effect) {
+    private FriendlyFireEffect(final FriendlyFireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FrightfulDelusion.java
+++ b/Mage.Sets/src/mage/cards/f/FrightfulDelusion.java
@@ -46,7 +46,7 @@ class FrightfulDelusionEffect extends OneShotEffect {
         this.staticText = "Counter target spell unless its controller pays {1}. That player discards a card.";
     }
 
-    public FrightfulDelusionEffect(final FrightfulDelusionEffect effect) {
+    private FrightfulDelusionEffect(final FrightfulDelusionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FromTheAshes.java
+++ b/Mage.Sets/src/mage/cards/f/FromTheAshes.java
@@ -48,7 +48,7 @@ class FromTheAshesEffect extends OneShotEffect {
         this.staticText = "Destroy all nonbasic lands. For each land destroyed this way, its controller may search their library for a basic land card and put it onto the battlefield. Then each player who searched their library this way shuffles";
     }
 
-    public FromTheAshesEffect(final FromTheAshesEffect effect) {
+    private FromTheAshesEffect(final FromTheAshesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FrontlineSage.java
+++ b/Mage.Sets/src/mage/cards/f/FrontlineSage.java
@@ -35,7 +35,7 @@ public final class FrontlineSage extends CardImpl {
         this.addAbility(ability);
     }
 
-    public FrontlineSage (final FrontlineSage card) {
+    private FrontlineSage(final FrontlineSage card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FrostTitan.java
+++ b/Mage.Sets/src/mage/cards/f/FrostTitan.java
@@ -61,7 +61,7 @@ class FrostTitanAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CounterUnlessPaysEffect(new GenericManaCost(2)), false);
     }
 
-    public FrostTitanAbility(final FrostTitanAbility ability) {
+    private FrostTitanAbility(final FrostTitanAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FruitOfTheFirstTree.java
+++ b/Mage.Sets/src/mage/cards/f/FruitOfTheFirstTree.java
@@ -57,7 +57,7 @@ class FruitOfTheFirstTreeEffect extends OneShotEffect {
         this.staticText = "you gain X life and draw X cards, where X is its toughness";
     }
 
-    public FruitOfTheFirstTreeEffect(FruitOfTheFirstTreeEffect copy) {
+    private FruitOfTheFirstTreeEffect(final FruitOfTheFirstTreeEffect copy) {
         super(copy);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FruitcakeElemental.java
+++ b/Mage.Sets/src/mage/cards/f/FruitcakeElemental.java
@@ -69,7 +69,7 @@ class FruitcakeElementalEffect extends OneShotEffect {
         this.staticText = "Target player gains control of {this}.";
     }
 
-    public FruitcakeElementalEffect(final FruitcakeElementalEffect effect) {
+    private FruitcakeElementalEffect(final FruitcakeElementalEffect effect) {
         super(effect);
     }
 
@@ -98,7 +98,7 @@ class FruitcakeElementalControlSourceEffect extends ContinuousEffectImpl {
         super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
     }
 
-    public FruitcakeElementalControlSourceEffect(final FruitcakeElementalControlSourceEffect effect) {
+    private FruitcakeElementalControlSourceEffect(final FruitcakeElementalControlSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FulfillContract.java
+++ b/Mage.Sets/src/mage/cards/f/FulfillContract.java
@@ -60,7 +60,7 @@ class FulfillContractEffect extends OneShotEffect {
         this.staticText = "Destroy target creature with a bounty counter on it. If that creature is destroyed this way, you may put a +1/+1 counter on target Rogue or Hunter you control";
     }
 
-    public FulfillContractEffect(final FulfillContractEffect effect) {
+    private FulfillContractEffect(final FulfillContractEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FulgentDistraction.java
+++ b/Mage.Sets/src/mage/cards/f/FulgentDistraction.java
@@ -30,7 +30,7 @@ public final class FulgentDistraction extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(2));
     }
 
-    public FulgentDistraction (final FulgentDistraction card) {
+    private FulgentDistraction(final FulgentDistraction card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FullMoonsRise.java
+++ b/Mage.Sets/src/mage/cards/f/FullMoonsRise.java
@@ -68,7 +68,7 @@ class FullMoonsRiseEffect extends OneShotEffect {
         staticText = "Regenerate all Werewolf creatures you control";
     }
 
-    public FullMoonsRiseEffect(final FullMoonsRiseEffect effect) {
+    private FullMoonsRiseEffect(final FullMoonsRiseEffect effect) {
         super(effect);
         this.filter = effect.filter.copy();
     }

--- a/Mage.Sets/src/mage/cards/f/FumeSpitter.java
+++ b/Mage.Sets/src/mage/cards/f/FumeSpitter.java
@@ -34,7 +34,7 @@ public final class FumeSpitter extends CardImpl {
         this.addAbility(ability);
     }
 
-    public FumeSpitter (final FumeSpitter card) {
+    private FumeSpitter(final FumeSpitter card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Fumigate.java
+++ b/Mage.Sets/src/mage/cards/f/Fumigate.java
@@ -43,7 +43,7 @@ class FumigateEffect extends OneShotEffect {
         this.staticText = "Destroy all creatures. You gain 1 life for each creature destroyed this way";
     }
 
-    public FumigateEffect(final FumigateEffect effect) {
+    private FumigateEffect(final FumigateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FuneralMarch.java
+++ b/Mage.Sets/src/mage/cards/f/FuneralMarch.java
@@ -59,7 +59,7 @@ class FuneralMarchTriggeredAbility extends ZoneChangeTriggeredAbility {
         super(Zone.BATTLEFIELD, null, new SacrificeEffect(StaticFilters.FILTER_PERMANENT_CREATURE, 1, "its controller"), "When enchanted creature leaves the battlefield, ", false);
     }
 
-    public FuneralMarchTriggeredAbility(final FuneralMarchTriggeredAbility ability) {
+    private FuneralMarchTriggeredAbility(final FuneralMarchTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FungalBehemoth.java
+++ b/Mage.Sets/src/mage/cards/f/FungalBehemoth.java
@@ -65,7 +65,7 @@ class FungalBehemothTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a time counter is removed from {this} while it's exiled, ");
     }
 
-    public FungalBehemothTriggeredAbility(final FungalBehemothTriggeredAbility ability) {
+    private FungalBehemothTriggeredAbility(final FungalBehemothTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FuriousResistance.java
+++ b/Mage.Sets/src/mage/cards/f/FuriousResistance.java
@@ -52,7 +52,7 @@ class FuriousResistanceEffect extends OneShotEffect {
         staticText = "Target blocking creature gets +3/+0 and gains first strike until end of turn";
     }
 
-    public FuriousResistanceEffect(final FuriousResistanceEffect effect) {
+    private FuriousResistanceEffect(final FuriousResistanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FuriousRise.java
+++ b/Mage.Sets/src/mage/cards/f/FuriousRise.java
@@ -53,7 +53,7 @@ class FuriousRiseEffect extends OneShotEffect {
         this.staticText = "exile the top card of your library. You may play that card until you exile another card with Furious Rise";
     }
 
-    public FuriousRiseEffect(final FuriousRiseEffect effect) {
+    private FuriousRiseEffect(final FuriousRiseEffect effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class FuriousRisePlayEffect extends AsThoughEffectImpl {
         super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
     }
 
-    public FuriousRisePlayEffect(final FuriousRisePlayEffect effect) {
+    private FuriousRisePlayEffect(final FuriousRisePlayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FurnaceCelebration.java
+++ b/Mage.Sets/src/mage/cards/f/FurnaceCelebration.java
@@ -46,7 +46,7 @@ class FurnaceCelebrationAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you sacrifice another permanent, ");
     }
 
-    public FurnaceCelebrationAbility(final FurnaceCelebrationAbility ability) {
+    private FurnaceCelebrationAbility(final FurnaceCelebrationAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FurnaceOfRath.java
+++ b/Mage.Sets/src/mage/cards/f/FurnaceOfRath.java
@@ -46,7 +46,7 @@ class FurnaceOfRathEffect extends ReplacementEffectImpl {
         staticText = "If a source would deal damage to a permanent or player, it deals double that damage to that permanent or player instead";
     }
 
-    public FurnaceOfRathEffect(final FurnaceOfRathEffect effect) {
+    private FurnaceOfRathEffect(final FurnaceOfRathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FuryCharm.java
+++ b/Mage.Sets/src/mage/cards/f/FuryCharm.java
@@ -79,7 +79,7 @@ class FuryCharmRemoveCounterEffect extends OneShotEffect {
         this.staticText = "remove two time counters from target permanent or suspended card";
     }
 
-    public FuryCharmRemoveCounterEffect(final FuryCharmRemoveCounterEffect effect) {
+    private FuryCharmRemoveCounterEffect(final FuryCharmRemoveCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GOTOJAIL.java
+++ b/Mage.Sets/src/mage/cards/g/GOTOJAIL.java
@@ -58,7 +58,7 @@ class GoToJailExileEffect extends OneShotEffect {
         this.staticText = "exile target creature an opponent controls until {this} leaves the battlefield.";
     }
 
-    public GoToJailExileEffect(final GoToJailExileEffect effect) {
+    private GoToJailExileEffect(final GoToJailExileEffect effect) {
         super(effect);
     }
 
@@ -96,7 +96,7 @@ class GoToJailTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("At the beginning of the chosen player's upkeep, ");
     }
 
-    public GoToJailTriggeredAbility(final GoToJailTriggeredAbility ability) {
+    private GoToJailTriggeredAbility(final GoToJailTriggeredAbility ability) {
         super(ability);
     }
 
@@ -123,7 +123,7 @@ class GoToJailUpkeepEffect extends OneShotEffect {
         this.staticText = "that player rolls two six-sided dice. If they roll doubles, sacrifice {this}";
     }
 
-    public GoToJailUpkeepEffect(final GoToJailUpkeepEffect effect) {
+    private GoToJailUpkeepEffect(final GoToJailUpkeepEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GabrielAngelfire.java
+++ b/Mage.Sets/src/mage/cards/g/GabrielAngelfire.java
@@ -64,7 +64,7 @@ class GabrielAngelfireGainAbilityEffect extends GainAbilitySourceEffect {
         staticText = "choose flying, first strike, trample, or rampage 3. {this} gains that ability until your next upkeep";
     }
 
-    public GabrielAngelfireGainAbilityEffect(final GabrielAngelfireGainAbilityEffect effect) {
+    private GabrielAngelfireGainAbilityEffect(final GabrielAngelfireGainAbilityEffect effect) {
         super(effect);
         ability.newId();
     }

--- a/Mage.Sets/src/mage/cards/g/GaddockTeeg.java
+++ b/Mage.Sets/src/mage/cards/g/GaddockTeeg.java
@@ -51,7 +51,7 @@ class GaddockTeegReplacementEffect4 extends ContinuousRuleModifyingEffectImpl {
         staticText = "Noncreature spells with mana value 4 or greater can't be cast";
     }
 
-    public GaddockTeegReplacementEffect4(final GaddockTeegReplacementEffect4 effect) {
+    private GaddockTeegReplacementEffect4(final GaddockTeegReplacementEffect4 effect) {
         super(effect);
     }
 
@@ -88,7 +88,7 @@ class GaddockTeegReplacementEffectX extends ContinuousRuleModifyingEffectImpl {
         staticText = "Noncreature spells with {X} in their mana costs can't be cast";
     }
 
-    public GaddockTeegReplacementEffectX(final GaddockTeegReplacementEffectX effect) {
+    private GaddockTeegReplacementEffectX(final GaddockTeegReplacementEffectX effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GaeasHerald.java
+++ b/Mage.Sets/src/mage/cards/g/GaeasHerald.java
@@ -53,7 +53,7 @@ class CantCounterEffect extends ContinuousRuleModifyingEffectImpl {
     }
 
 
-    public CantCounterEffect(final CantCounterEffect effect) {
+    private CantCounterEffect(final CantCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GaeasWill.java
+++ b/Mage.Sets/src/mage/cards/g/GaeasWill.java
@@ -87,7 +87,7 @@ class GaeassWillReplacementEffect extends ReplacementEffectImpl {
         this.staticText = "<br>If a card would be put into your graveyard from anywhere this turn, exile that card instead";
     }
 
-    public GaeassWillReplacementEffect(final GaeassWillReplacementEffect effect) {
+    private GaeassWillReplacementEffect(final GaeassWillReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GahijiHonoredOne.java
+++ b/Mage.Sets/src/mage/cards/g/GahijiHonoredOne.java
@@ -58,7 +58,7 @@ class GahijiHonoredOneTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect, optional);
     }
 
-    public GahijiHonoredOneTriggeredAbility(final GahijiHonoredOneTriggeredAbility ability) {
+    private GahijiHonoredOneTriggeredAbility(final GahijiHonoredOneTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GaleWaterdeepProdigy.java
+++ b/Mage.Sets/src/mage/cards/g/GaleWaterdeepProdigy.java
@@ -75,7 +75,7 @@ class GaleWaterdeepProdigyTriggeredAbility extends SpellCastControllerTriggeredA
         addWatcher(new CastFromHandWatcher());
     }
 
-    public GaleWaterdeepProdigyTriggeredAbility(GaleWaterdeepProdigyTriggeredAbility ability) {
+    private GaleWaterdeepProdigyTriggeredAbility(final GaleWaterdeepProdigyTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GalepowderMage.java
+++ b/Mage.Sets/src/mage/cards/g/GalepowderMage.java
@@ -63,7 +63,7 @@ class GalepowderMageEffect extends OneShotEffect {
         this.staticText = "exile another target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step";
     }
 
-    public GalepowderMageEffect(final GalepowderMageEffect effect) {
+    private GalepowderMageEffect(final GalepowderMageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Galvanoth.java
+++ b/Mage.Sets/src/mage/cards/g/Galvanoth.java
@@ -49,7 +49,7 @@ class GalvanothEffect extends OneShotEffect {
                 + "sorcery card, you may cast it without paying its mana cost";
     }
 
-    public GalvanothEffect(final GalvanothEffect effect) {
+    private GalvanothEffect(final GalvanothEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GameOfChaos.java
+++ b/Mage.Sets/src/mage/cards/g/GameOfChaos.java
@@ -46,7 +46,7 @@ class GameOfChaosEffect extends OneShotEffect {
         this.staticText = "Flip a coin. If you win the flip, you gain 1 life and target opponent loses 1 life, and you decide whether to flip again. If you lose the flip, you lose 1 life and that opponent gains 1 life, and that player decides whether to flip again. Double the life stakes with each flip.";
     }
 
-    public GameOfChaosEffect(final GameOfChaosEffect effect) {
+    private GameOfChaosEffect(final GameOfChaosEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GamePreserve.java
+++ b/Mage.Sets/src/mage/cards/g/GamePreserve.java
@@ -48,7 +48,7 @@ class GamePreserveEffect extends OneShotEffect {
         this.staticText = "each player reveals the top card of their library. If all cards revealed this way are creature cards, put those cards onto the battlefield under their owners' control";
     }
 
-    public GamePreserveEffect(final GamePreserveEffect effect) {
+    private GamePreserveEffect(final GamePreserveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GamorreanPrisonGuard.java
+++ b/Mage.Sets/src/mage/cards/g/GamorreanPrisonGuard.java
@@ -56,7 +56,7 @@ class GamorreanPrisonGuardEffect extends OneShotEffect {
         super(Outcome.Detriment);
     }
 
-    public GamorreanPrisonGuardEffect(final GamorreanPrisonGuardEffect effect) {
+    private GamorreanPrisonGuardEffect(final GamorreanPrisonGuardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GandalfWhiteRider.java
+++ b/Mage.Sets/src/mage/cards/g/GandalfWhiteRider.java
@@ -69,7 +69,7 @@ class GandalfWhiteRiderDyingEffect extends OneShotEffect {
         staticText = "put it into its owner's library fifth from the top";
     }
 
-    public GandalfWhiteRiderDyingEffect(final GandalfWhiteRiderDyingEffect effect) {
+    private GandalfWhiteRiderDyingEffect(final GandalfWhiteRiderDyingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GargantuanGorilla.java
+++ b/Mage.Sets/src/mage/cards/g/GargantuanGorilla.java
@@ -72,7 +72,7 @@ class GargantuanGorillaSacrificeEffect extends OneShotEffect {
         staticText = "you may sacrifice a Forest. If you sacrifice a snow Forest this way, {this} gains trample until end of turn. If you don't sacrifice a Forest, sacrifice {this} and it deals 7 damage to you.";
     }
 
-    public GargantuanGorillaSacrificeEffect(final GargantuanGorillaSacrificeEffect effect) {
+    private GargantuanGorillaSacrificeEffect(final GargantuanGorillaSacrificeEffect effect) {
         super(effect);
     }
 
@@ -114,7 +114,7 @@ class GargantuanGorillaFightEffect extends OneShotEffect {
         this.staticText = "{this} deals damage equal to its power to another target creature. That creature deals damage equal to its power to {this}";
     }
 
-    public GargantuanGorillaFightEffect(final GargantuanGorillaFightEffect effect) {
+    private GargantuanGorillaFightEffect(final GargantuanGorillaFightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GarrukApexPredator.java
+++ b/Mage.Sets/src/mage/cards/g/GarrukApexPredator.java
@@ -84,7 +84,7 @@ class GarrukApexPredatorEffect3 extends OneShotEffect {
         this.staticText = "You gain life equal to its toughness";
     }
 
-    public GarrukApexPredatorEffect3(final GarrukApexPredatorEffect3 effect) {
+    private GarrukApexPredatorEffect3(final GarrukApexPredatorEffect3 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GarrukRelentless.java
+++ b/Mage.Sets/src/mage/cards/g/GarrukRelentless.java
@@ -64,7 +64,7 @@ class GarrukRelentlessStateTrigger extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new TransformSourceEffect());
     }
 
-    public GarrukRelentlessStateTrigger(final GarrukRelentlessStateTrigger ability) {
+    private GarrukRelentlessStateTrigger(final GarrukRelentlessStateTrigger ability) {
         super(ability);
     }
 
@@ -92,7 +92,7 @@ class GarrukRelentlessDamageEffect extends OneShotEffect {
         staticText = "{this} deals 3 damage to target creature. That creature deals damage equal to its power to him";
     }
 
-    public GarrukRelentlessDamageEffect(GarrukRelentlessDamageEffect effect) {
+    private GarrukRelentlessDamageEffect(final GarrukRelentlessDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GateToTheAfterlife.java
+++ b/Mage.Sets/src/mage/cards/g/GateToTheAfterlife.java
@@ -76,7 +76,7 @@ class GateToTheAfterlifeEffect extends OneShotEffect {
                 + " and put it onto the battlefield. If you search your library this way, shuffle";
     }
 
-    public GateToTheAfterlifeEffect(final GateToTheAfterlifeEffect effect) {
+    private GateToTheAfterlifeEffect(final GateToTheAfterlifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GatherSpecimens.java
+++ b/Mage.Sets/src/mage/cards/g/GatherSpecimens.java
@@ -47,7 +47,7 @@ class GatherSpecimensReplacementEffect extends ReplacementEffectImpl {
         staticText = "If a creature would enter the battlefield under an opponent's control this turn, it enters the battlefield under your control instead";
     }
 
-    public GatherSpecimensReplacementEffect(final GatherSpecimensReplacementEffect effect) {
+    private GatherSpecimensReplacementEffect(final GatherSpecimensReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GathererOfGraces.java
+++ b/Mage.Sets/src/mage/cards/g/GathererOfGraces.java
@@ -45,7 +45,7 @@ public final class GathererOfGraces extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new SacrificeTargetCost(new TargetControlledPermanent(filter))));
     }
 
-    public GathererOfGraces(GathererOfGraces gathererOfGraces) {
+    private GathererOfGraces(final GathererOfGraces gathererOfGraces) {
         super(gathererOfGraces);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GauntletsOfChaos.java
+++ b/Mage.Sets/src/mage/cards/g/GauntletsOfChaos.java
@@ -64,7 +64,7 @@ class GauntletsOfChaosFirstTarget extends TargetControlledPermanent {
         setTargetName("artifact, creature, or land you control");
     }
 
-    public GauntletsOfChaosFirstTarget(final GauntletsOfChaosFirstTarget target) {
+    private GauntletsOfChaosFirstTarget(final GauntletsOfChaosFirstTarget target) {
         super(target);
     }
 
@@ -134,7 +134,7 @@ class GauntletsOfChaosSecondTarget extends TargetPermanent {
         setTargetName("permanent an opponent controls that shares one of those types with it");
     }
 
-    public GauntletsOfChaosSecondTarget(final GauntletsOfChaosSecondTarget target) {
+    private GauntletsOfChaosSecondTarget(final GauntletsOfChaosSecondTarget target) {
         super(target);
         this.firstTarget = target.firstTarget;
     }

--- a/Mage.Sets/src/mage/cards/g/GazeOfAdamaro.java
+++ b/Mage.Sets/src/mage/cards/g/GazeOfAdamaro.java
@@ -45,7 +45,7 @@ class GazeOfAdamaroEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to target player equal to the number of cards in that player's hand";
     }
 
-    public GazeOfAdamaroEffect(final GazeOfAdamaroEffect effect) {
+    private GazeOfAdamaroEffect(final GazeOfAdamaroEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GazeOfGranite.java
+++ b/Mage.Sets/src/mage/cards/g/GazeOfGranite.java
@@ -50,7 +50,7 @@ class GazeOfGraniteEffect extends OneShotEffect {
         staticText = "Destroy each nonland permanent with mana value X or less";
     }
 
-    public GazeOfGraniteEffect(final GazeOfGraniteEffect effect) {
+    private GazeOfGraniteEffect(final GazeOfGraniteEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GazeOfTheGorgon.java
+++ b/Mage.Sets/src/mage/cards/g/GazeOfTheGorgon.java
@@ -54,7 +54,7 @@ class GazeOfTheGorgonCreateDelayedTriggeredAbilityEffect extends OneShotEffect {
         this.staticText = "At this turn's next end of combat, destroy all creatures that blocked or were blocked by it this turn";
     }
 
-    public GazeOfTheGorgonCreateDelayedTriggeredAbilityEffect(final GazeOfTheGorgonCreateDelayedTriggeredAbilityEffect effect) {
+    private GazeOfTheGorgonCreateDelayedTriggeredAbilityEffect(final GazeOfTheGorgonCreateDelayedTriggeredAbilityEffect effect) {
         super(effect);
     }
 
@@ -84,7 +84,7 @@ class GazeOfTheGorgonEffect extends OneShotEffect {
         this.targetCreature = targetCreature;
     }
 
-    public GazeOfTheGorgonEffect(final GazeOfTheGorgonEffect effect) {
+    private GazeOfTheGorgonEffect(final GazeOfTheGorgonEffect effect) {
         super(effect);
         targetCreature = effect.targetCreature;
     }

--- a/Mage.Sets/src/mage/cards/g/GeistSnatch.java
+++ b/Mage.Sets/src/mage/cards/g/GeistSnatch.java
@@ -45,7 +45,7 @@ class GeistSnatchCounterTargetEffect extends OneShotEffect {
         staticText = "Counter target creature spell. Create a 1/1 blue Spirit creature token with flying";
     }
 
-    public GeistSnatchCounterTargetEffect(final GeistSnatchCounterTargetEffect effect) {
+    private GeistSnatchCounterTargetEffect(final GeistSnatchCounterTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GelatinousGenesis.java
+++ b/Mage.Sets/src/mage/cards/g/GelatinousGenesis.java
@@ -42,7 +42,7 @@ class GelatinousGenesisEffect extends OneShotEffect {
         staticText = "create X X/X green Ooze creature tokens";
     }
 
-    public GelatinousGenesisEffect(GelatinousGenesisEffect ability) {
+    private GelatinousGenesisEffect(final GelatinousGenesisEffect ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GemstoneCaverns.java
+++ b/Mage.Sets/src/mage/cards/g/GemstoneCaverns.java
@@ -71,7 +71,7 @@ class GemstoneCavernsAbility extends StaticAbility implements OpeningHandAction 
         super(Zone.HAND, new GemstoneCavernsEffect());
     }
 
-    public GemstoneCavernsAbility(final GemstoneCavernsAbility ability) {
+    private GemstoneCavernsAbility(final GemstoneCavernsAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GeneralJarkeld.java
+++ b/Mage.Sets/src/mage/cards/g/GeneralJarkeld.java
@@ -63,7 +63,7 @@ class GeneralJarkeldSwitchBlockersEffect extends OneShotEffect {
         this.staticText = "Switch the blocking creatures of two target attacking creatures";
     }
 
-    public GeneralJarkeldSwitchBlockersEffect(final GeneralJarkeldSwitchBlockersEffect effect) {
+    private GeneralJarkeldSwitchBlockersEffect(final GeneralJarkeldSwitchBlockersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GeneralOrgana.java
+++ b/Mage.Sets/src/mage/cards/g/GeneralOrgana.java
@@ -40,7 +40,7 @@ public class GeneralOrgana extends CardImpl {
         this.addAbility(new LeavesBattlefieldTriggeredAbility(new ScryEffect(2), false));
     }
 
-    public GeneralOrgana(final GeneralOrgana card) {
+    private GeneralOrgana(final GeneralOrgana card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GeneralsRegalia.java
+++ b/Mage.Sets/src/mage/cards/g/GeneralsRegalia.java
@@ -55,7 +55,7 @@ class GeneralsRegaliaEffect extends RedirectionEffect {
         this.damageSource = new TargetSource();
     }
 
-    public GeneralsRegaliaEffect(final GeneralsRegaliaEffect effect) {
+    private GeneralsRegaliaEffect(final GeneralsRegaliaEffect effect) {
         super(effect);
         this.damageSource = effect.damageSource.copy();
     }

--- a/Mage.Sets/src/mage/cards/g/GenesisChamber.java
+++ b/Mage.Sets/src/mage/cards/g/GenesisChamber.java
@@ -74,7 +74,7 @@ class GenesisChamberEffect extends OneShotEffect {
         this.staticText = "that creature's controller creates a 1/1 colorless Myr artifact creature token";
     }
 
-    public GenesisChamberEffect(final GenesisChamberEffect effect) {
+    private GenesisChamberEffect(final GenesisChamberEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GenesisHydra.java
+++ b/Mage.Sets/src/mage/cards/g/GenesisHydra.java
@@ -62,7 +62,7 @@ class GenesisHydraPutOntoBattlefieldEffect extends OneShotEffect {
         staticText = "reveal the top X cards of your library. You may put a nonland permanent card with mana value X or less from among them onto the battlefield. Then shuffle the rest into your library";
     }
 
-    public GenesisHydraPutOntoBattlefieldEffect(final GenesisHydraPutOntoBattlefieldEffect effect) {
+    private GenesisHydraPutOntoBattlefieldEffect(final GenesisHydraPutOntoBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GenesisStorm.java
+++ b/Mage.Sets/src/mage/cards/g/GenesisStorm.java
@@ -53,7 +53,7 @@ class GenesisStormEffect extends OneShotEffect {
                 + "on the bottom of your library in a random order";
     }
 
-    public GenesisStormEffect(GenesisStormEffect effect) {
+    private GenesisStormEffect(final GenesisStormEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GenesisWave.java
+++ b/Mage.Sets/src/mage/cards/g/GenesisWave.java
@@ -49,7 +49,7 @@ class GenesisWaveEffect extends OneShotEffect {
         staticText = "Reveal the top X cards of your library. You may put any number of permanent cards with mana value X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard";
     }
 
-    public GenesisWaveEffect(final GenesisWaveEffect effect) {
+    private GenesisWaveEffect(final GenesisWaveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GenestealerLocus.java
+++ b/Mage.Sets/src/mage/cards/g/GenestealerLocus.java
@@ -49,7 +49,7 @@ class GenestealerLocusTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new BoostTargetEffect(0, 1, Duration.EndOfTurn), false);
     }
 
-    public GenestealerLocusTriggeredAbility(final GenestealerLocusTriggeredAbility ability) {
+    private GenestealerLocusTriggeredAbility(final GenestealerLocusTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GenestealerPatriarch.java
+++ b/Mage.Sets/src/mage/cards/g/GenestealerPatriarch.java
@@ -81,7 +81,7 @@ class GenestealerPatriarchTriggeredAbility extends TriggeredAbilityImpl {
         ;
     }
 
-    public GenestealerPatriarchTriggeredAbility(GenestealerPatriarchTriggeredAbility ability) {
+    private GenestealerPatriarchTriggeredAbility(final GenestealerPatriarchTriggeredAbility ability) {
         super(ability);
     }
 
@@ -119,7 +119,7 @@ class GenestealerPatriarchCloneEffect extends OneShotEffect {
                 "except it's a Tyranid in addition to its other types";
     }
 
-    public GenestealerPatriarchCloneEffect(final GenestealerPatriarchCloneEffect effect) {
+    private GenestealerPatriarchCloneEffect(final GenestealerPatriarchCloneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GenjuOfTheCedars.java
+++ b/Mage.Sets/src/mage/cards/g/GenjuOfTheCedars.java
@@ -70,7 +70,7 @@ public final class GenjuOfTheCedars extends CardImpl {
             toughness = new MageInt(4);
         }
 
-        public SpiritToken(final SpiritToken token) {
+        private SpiritToken(final SpiritToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/g/GenjuOfTheFalls.java
+++ b/Mage.Sets/src/mage/cards/g/GenjuOfTheFalls.java
@@ -72,7 +72,7 @@ public final class GenjuOfTheFalls extends CardImpl {
             addAbility(FlyingAbility.getInstance());
         }
 
-        public SpiritToken(final SpiritToken token) {
+        private SpiritToken(final SpiritToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/g/GenjuOfTheFens.java
+++ b/Mage.Sets/src/mage/cards/g/GenjuOfTheFens.java
@@ -73,7 +73,7 @@ public final class GenjuOfTheFens extends CardImpl {
             addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn), new ManaCostsImpl<>("{B}")));
         }
 
-        public SpiritToken(final SpiritToken token) {
+        private SpiritToken(final SpiritToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/g/GenjuOfTheFields.java
+++ b/Mage.Sets/src/mage/cards/g/GenjuOfTheFields.java
@@ -76,7 +76,7 @@ public final class GenjuOfTheFields extends CardImpl {
             power = new MageInt(2);
             toughness = new MageInt(5);
         }
-        public SpiritToken(final SpiritToken token) {
+        private SpiritToken(final SpiritToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/g/GenjuOfTheRealm.java
+++ b/Mage.Sets/src/mage/cards/g/GenjuOfTheRealm.java
@@ -75,7 +75,7 @@ public final class GenjuOfTheRealm extends CardImpl {
             this.addAbility(TrampleAbility.getInstance());
         }
 
-        public SpiritToken(final SpiritToken token) {
+        private SpiritToken(final SpiritToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/g/GenjuOfTheSpires.java
+++ b/Mage.Sets/src/mage/cards/g/GenjuOfTheSpires.java
@@ -69,7 +69,7 @@ public final class GenjuOfTheSpires extends CardImpl {
             power = new MageInt(6);
             toughness = new MageInt(1);
         }
-        public SpiritToken(final SpiritToken token) {
+        private SpiritToken(final SpiritToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/g/GeodeGolem.java
+++ b/Mage.Sets/src/mage/cards/g/GeodeGolem.java
@@ -57,7 +57,7 @@ class GeodeGolemEffect extends OneShotEffect {
                 + "without paying its mana cost";
     }
 
-    public GeodeGolemEffect(final GeodeGolemEffect effect) {
+    private GeodeGolemEffect(final GeodeGolemEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GerrardCapashen.java
+++ b/Mage.Sets/src/mage/cards/g/GerrardCapashen.java
@@ -62,7 +62,7 @@ class GerrardCapashenEffect extends OneShotEffect {
         staticText = "you gain 1 life for each card in target opponent's hand.";
     }
 
-    public GerrardCapashenEffect(final GerrardCapashenEffect effect) {
+    private GerrardCapashenEffect(final GerrardCapashenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GerrardsHourglassPendant.java
+++ b/Mage.Sets/src/mage/cards/g/GerrardsHourglassPendant.java
@@ -61,7 +61,7 @@ class GerrardsHourglassPendantSkipExtraTurnsEffect extends ReplacementEffectImpl
         staticText = "If a player would begin an extra turn, that player skips that turn instead";
     }
 
-    public GerrardsHourglassPendantSkipExtraTurnsEffect(final GerrardsHourglassPendantSkipExtraTurnsEffect effect) {
+    private GerrardsHourglassPendantSkipExtraTurnsEffect(final GerrardsHourglassPendantSkipExtraTurnsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GerrardsVerdict.java
+++ b/Mage.Sets/src/mage/cards/g/GerrardsVerdict.java
@@ -46,7 +46,7 @@ class GerrardsVerdictEffect extends OneShotEffect {
         this.staticText = "Target player discards two cards. You gain 3 life for each land card discarded this way";
     }
 
-    public GerrardsVerdictEffect(final GerrardsVerdictEffect effect) {
+    private GerrardsVerdictEffect(final GerrardsVerdictEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GethLordOfTheVault.java
+++ b/Mage.Sets/src/mage/cards/g/GethLordOfTheVault.java
@@ -70,7 +70,7 @@ class GethLordOfTheVaultEffect extends OneShotEffect {
         staticText = "Put target artifact or creature card with mana value X from an opponent's graveyard onto the battlefield under your control tapped. Then that player mills X cards";
     }
 
-    public GethLordOfTheVaultEffect(final GethLordOfTheVaultEffect effect) {
+    private GethLordOfTheVaultEffect(final GethLordOfTheVaultEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GethsSummons.java
+++ b/Mage.Sets/src/mage/cards/g/GethsSummons.java
@@ -86,7 +86,7 @@ class GethsSummonsEffect extends OneShotEffect {
                 "the battlefield under your control";
     }
 
-    public GethsSummonsEffect(final GethsSummonsEffect effect) {
+    private GethsSummonsEffect(final GethsSummonsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GhastlordOfFugue.java
+++ b/Mage.Sets/src/mage/cards/g/GhastlordOfFugue.java
@@ -62,7 +62,7 @@ class GhastlordOfFugueEffect extends OneShotEffect {
         staticText = "that player reveals their hand. You choose a card from it. That player exiles that card";
     }
 
-    public GhastlordOfFugueEffect(final GhastlordOfFugueEffect effect) {
+    private GhastlordOfFugueEffect(final GhastlordOfFugueEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GhastlyConscription.java
+++ b/Mage.Sets/src/mage/cards/g/GhastlyConscription.java
@@ -51,7 +51,7 @@ class GhastlyConscriptionEffect extends OneShotEffect {
         this.staticText = "Exile all creature cards from target player's graveyard in a face-down pile, shuffle that pile, then manifest those cards.<i> (To manifest a card, put it onto the battlefield face down as a 2/2 creature. Turn it face up at any time for its mana cost if it's a creature card.)</i>";
     }
 
-    public GhastlyConscriptionEffect(final GhastlyConscriptionEffect effect) {
+    private GhastlyConscriptionEffect(final GhastlyConscriptionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GhastlyDiscovery.java
+++ b/Mage.Sets/src/mage/cards/g/GhastlyDiscovery.java
@@ -45,7 +45,7 @@ class GhastlyDiscoveryEffect extends OneShotEffect {
         this.staticText = "Draw two cards, then discard a card";
     }
 
-    public GhastlyDiscoveryEffect(final GhastlyDiscoveryEffect effect) {
+    private GhastlyDiscoveryEffect(final GhastlyDiscoveryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GhazbanOgre.java
+++ b/Mage.Sets/src/mage/cards/g/GhazbanOgre.java
@@ -55,7 +55,7 @@ class GhazbanOgreEffect extends OneShotEffect {
         this.staticText = "the player with the most life gains control of {this}";
     }
 
-    public GhazbanOgreEffect(final GhazbanOgreEffect effect) {
+    private GhazbanOgreEffect(final GhazbanOgreEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GhituEncampment.java
+++ b/Mage.Sets/src/mage/cards/g/GhituEncampment.java
@@ -56,7 +56,7 @@ class GhituEncampmentToken extends TokenImpl {
 
         this.addAbility(FirstStrikeAbility.getInstance());
     }
-    public GhituEncampmentToken(final GhituEncampmentToken token) {
+    private GhituEncampmentToken(final GhituEncampmentToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GhostlyWings.java
+++ b/Mage.Sets/src/mage/cards/g/GhostlyWings.java
@@ -69,7 +69,7 @@ class GhostlyWingsReturnEffect extends OneShotEffect {
         staticText = "Return enchanted creature to its owner's hand";
     }
 
-    public GhostlyWingsReturnEffect(final GhostlyWingsReturnEffect effect) {
+    private GhostlyWingsReturnEffect(final GhostlyWingsReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GhostsOfTheInnocent.java
+++ b/Mage.Sets/src/mage/cards/g/GhostsOfTheInnocent.java
@@ -50,7 +50,7 @@ class GhostsOfTheInnocentPreventDamageEffect extends ReplacementEffectImpl imple
         staticText = "If a source would deal damage to a permanent or player, it deals half that damage, rounded down, to that permanent or player instead";
     }
 
-    public GhostsOfTheInnocentPreventDamageEffect(final GhostsOfTheInnocentPreventDamageEffect effect) {
+    private GhostsOfTheInnocentPreventDamageEffect(final GhostsOfTheInnocentPreventDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Ghostway.java
+++ b/Mage.Sets/src/mage/cards/g/Ghostway.java
@@ -56,7 +56,7 @@ class GhostwayEffect extends OneShotEffect {
         staticText = "Exile each creature you control. Return those cards to the battlefield under their owner's control at the beginning of the next end step";
     }
 
-    public GhostwayEffect(final GhostwayEffect effect) {
+    private GhostwayEffect(final GhostwayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GiantAlbatross.java
+++ b/Mage.Sets/src/mage/cards/g/GiantAlbatross.java
@@ -60,7 +60,7 @@ class GiantAlbatrossEffect extends OneShotEffect {
         this.staticText = "for each creature that dealt damage to {this} this turn, destroy that creature unless its controller pays 2 life. A creature destroyed this way can't be regenerated";
     }
 
-    public GiantAlbatrossEffect(final GiantAlbatrossEffect effect) {
+    private GiantAlbatrossEffect(final GiantAlbatrossEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GiantOyster.java
+++ b/Mage.Sets/src/mage/cards/g/GiantOyster.java
@@ -74,7 +74,7 @@ class GiantOysterDontUntapAsLongAsSourceTappedEffect extends DontUntapAsLongAsSo
         staticText = "For as long as {this} remains tapped, target tapped creature doesn't untap during its controller's untap step";
     }
 
-    public GiantOysterDontUntapAsLongAsSourceTappedEffect(final GiantOysterDontUntapAsLongAsSourceTappedEffect effect) {
+    private GiantOysterDontUntapAsLongAsSourceTappedEffect(final GiantOysterDontUntapAsLongAsSourceTappedEffect effect) {
         super(effect);
     }
 
@@ -91,7 +91,7 @@ class GiantOysterCreateDelayedTriggerEffects extends OneShotEffect {
         this.staticText = "at the beginning of each of your draw steps, put a -1/-1 counter on that creature. When {this} leaves the battlefield or becomes untapped, remove all -1/-1 counters from the creature.";
     }
 
-    public GiantOysterCreateDelayedTriggerEffects(final GiantOysterCreateDelayedTriggerEffects effect) {
+    private GiantOysterCreateDelayedTriggerEffects(final GiantOysterCreateDelayedTriggerEffects effect) {
         super(effect);
     }
 
@@ -130,7 +130,7 @@ class GiantOysterLeaveUntapDelayedTriggeredAbility extends DelayedTriggeredAbili
         this.addEffect(new RemoveDelayedTriggeredAbilityEffect(abilityToCancel));
     }
 
-    public GiantOysterLeaveUntapDelayedTriggeredAbility(GiantOysterLeaveUntapDelayedTriggeredAbility ability) {
+    private GiantOysterLeaveUntapDelayedTriggeredAbility(final GiantOysterLeaveUntapDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GiantTurtle.java
+++ b/Mage.Sets/src/mage/cards/g/GiantTurtle.java
@@ -51,7 +51,7 @@ class CantAttackIfAttackedLastTurnEffect extends RestrictionEffect {
         staticText = "{this} can't attack if it attacked during your last turn";
     }
 
-    public CantAttackIfAttackedLastTurnEffect(final CantAttackIfAttackedLastTurnEffect effect) {
+    private CantAttackIfAttackedLastTurnEffect(final CantAttackIfAttackedLastTurnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Giantbaiting.java
+++ b/Mage.Sets/src/mage/cards/g/Giantbaiting.java
@@ -47,7 +47,7 @@ class GiantbaitingEffect extends OneShotEffect {
         this.staticText = "Create a 4/4 red and green Giant Warrior creature token with haste. Exile it at the beginning of the next end step";
     }
 
-    public GiantbaitingEffect(final GiantbaitingEffect effect) {
+    private GiantbaitingEffect(final GiantbaitingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GideonAllyOfZendikar.java
+++ b/Mage.Sets/src/mage/cards/g/GideonAllyOfZendikar.java
@@ -70,7 +70,7 @@ class GideonAllyOfZendikarToken extends TokenImpl {
 
         addAbility(IndestructibleAbility.getInstance());
     }
-    public GideonAllyOfZendikarToken(final GideonAllyOfZendikarToken token) {
+    private GideonAllyOfZendikarToken(final GideonAllyOfZendikarToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GideonBattleForged.java
+++ b/Mage.Sets/src/mage/cards/g/GideonBattleForged.java
@@ -90,7 +90,7 @@ class GideonBattleForgedToken extends TokenImpl {
         this.addAbility(IndestructibleAbility.getInstance());
     }
 
-    public GideonBattleForgedToken(final GideonBattleForgedToken token) {
+    private GideonBattleForgedToken(final GideonBattleForgedToken token) {
         super(token);
     }
 
@@ -108,7 +108,7 @@ class GideonBattleForgedAttacksIfAbleTargetEffect extends RequirementEffect {
         staticText = "Up to one target creature an opponent controls attacks {this} during its controller's next turn if able";
     }
 
-    public GideonBattleForgedAttacksIfAbleTargetEffect(final GideonBattleForgedAttacksIfAbleTargetEffect effect) {
+    private GideonBattleForgedAttacksIfAbleTargetEffect(final GideonBattleForgedAttacksIfAbleTargetEffect effect) {
         super(effect);
         this.targetPermanentReference = effect.targetPermanentReference;
     }

--- a/Mage.Sets/src/mage/cards/g/GideonJura.java
+++ b/Mage.Sets/src/mage/cards/g/GideonJura.java
@@ -80,7 +80,7 @@ class GideonJuraToken extends TokenImpl {
         toughness = new MageInt(6);
     }
 
-    public GideonJuraToken(final GideonJuraToken token) {
+    private GideonJuraToken(final GideonJuraToken token) {
         super(token);
     }
 
@@ -99,7 +99,7 @@ class GideonJuraEffect extends RequirementEffect {
         staticText = "During target opponent's next turn, creatures that player controls attack {this} if able";
     }
 
-    public GideonJuraEffect(final GideonJuraEffect effect) {
+    private GideonJuraEffect(final GideonJuraEffect effect) {
         super(effect);
         this.creatingPermanent = effect.creatingPermanent;
     }

--- a/Mage.Sets/src/mage/cards/g/GideonMartialParagon.java
+++ b/Mage.Sets/src/mage/cards/g/GideonMartialParagon.java
@@ -80,7 +80,7 @@ class GideonMartialParagonToken extends TokenImpl {
 
         addAbility(IndestructibleAbility.getInstance());
     }
-    public GideonMartialParagonToken(final GideonMartialParagonToken token) {
+    private GideonMartialParagonToken(final GideonMartialParagonToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GideonOfTheTrials.java
+++ b/Mage.Sets/src/mage/cards/g/GideonOfTheTrials.java
@@ -74,7 +74,7 @@ class GideonOfTheTrialsToken extends TokenImpl {
         toughness = new MageInt(4);
         this.addAbility(IndestructibleAbility.getInstance());
     }
-    public GideonOfTheTrialsToken(final GideonOfTheTrialsToken token) {
+    private GideonOfTheTrialsToken(final GideonOfTheTrialsToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GideonsDefeat.java
+++ b/Mage.Sets/src/mage/cards/g/GideonsDefeat.java
@@ -56,7 +56,7 @@ class GideonsDefeatEffect extends OneShotEffect {
         staticText = "Exile target white creature that's attacking or blocking. If it was a Gideon planeswalker, you gain 5 life";
     }
 
-    public GideonsDefeatEffect(final GideonsDefeatEffect effect) {
+    private GideonsDefeatEffect(final GideonsDefeatEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GideonsIntervention.java
+++ b/Mage.Sets/src/mage/cards/g/GideonsIntervention.java
@@ -62,7 +62,7 @@ class GideonsInterventionCantCastEffect extends ContinuousRuleModifyingEffectImp
         staticText = "Your opponents can't cast spells with the chosen name";
     }
 
-    public GideonsInterventionCantCastEffect(final GideonsInterventionCantCastEffect effect) {
+    private GideonsInterventionCantCastEffect(final GideonsInterventionCantCastEffect effect) {
         super(effect);
     }
 
@@ -104,7 +104,7 @@ class GideonsInterventionPreventAllDamageEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that would be dealt to you and permanents you control by sources with the chosen name.";
     }
 
-    public GideonsInterventionPreventAllDamageEffect(final GideonsInterventionPreventAllDamageEffect effect) {
+    private GideonsInterventionPreventAllDamageEffect(final GideonsInterventionPreventAllDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GiftOfImmortality.java
+++ b/Mage.Sets/src/mage/cards/g/GiftOfImmortality.java
@@ -63,7 +63,7 @@ class GiftOfImmortalityEffect extends OneShotEffect {
         this.staticText = "return that card to the battlefield under its owner's control. Return {this} to the battlefield attached to that creature at the beginning of the next end step";
     }
 
-    public GiftOfImmortalityEffect(final GiftOfImmortalityEffect effect) {
+    private GiftOfImmortalityEffect(final GiftOfImmortalityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GiftOfStrength.java
+++ b/Mage.Sets/src/mage/cards/g/GiftOfStrength.java
@@ -26,7 +26,7 @@ public final class GiftOfStrength extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public GiftOfStrength(final GiftOfStrength giftOfStrength) {
+    private GiftOfStrength(final GiftOfStrength giftOfStrength) {
         super(giftOfStrength);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GiftsUngiven.java
+++ b/Mage.Sets/src/mage/cards/g/GiftsUngiven.java
@@ -54,7 +54,7 @@ class GiftsUngivenEffect extends OneShotEffect {
                 "and the rest into your hand. Then shuffle";
     }
 
-    public GiftsUngivenEffect(final GiftsUngivenEffect effect) {
+    private GiftsUngivenEffect(final GiftsUngivenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Gigantiform.java
+++ b/Mage.Sets/src/mage/cards/g/Gigantiform.java
@@ -76,7 +76,7 @@ class GigantiformAbility extends StaticAbility {
         this.addEffect(new GainAbilityAttachedEffect(ability, AttachmentType.AURA));
     }
 
-    public GigantiformAbility(GigantiformAbility ability) {
+    private GigantiformAbility(final GigantiformAbility ability) {
         super(ability);
     }
 
@@ -103,7 +103,7 @@ class GigantiformEffect extends OneShotEffect {
         super(Outcome.PutCardInPlay);
     }
 
-    public GigantiformEffect(final GigantiformEffect effect) {
+    private GigantiformEffect(final GigantiformEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Gigantomancer.java
+++ b/Mage.Sets/src/mage/cards/g/Gigantomancer.java
@@ -36,7 +36,7 @@ public final class Gigantomancer extends CardImpl {
         this.addAbility(ability);
     }
 
-    public Gigantomancer (final Gigantomancer card) {
+    private Gigantomancer(final Gigantomancer card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GildedDrake.java
+++ b/Mage.Sets/src/mage/cards/g/GildedDrake.java
@@ -61,7 +61,7 @@ class GildedDrakeEffect extends OneShotEffect {
         this.staticText = "exchange control of {this} and up to one target creature an opponent controls. If you don't or can't make an exchange, sacrifice {this}. This ability still resolves if its target becomes illegal";
     }
 
-    public GildedDrakeEffect(final GildedDrakeEffect effect) {
+    private GildedDrakeEffect(final GildedDrakeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GilderBairn.java
+++ b/Mage.Sets/src/mage/cards/g/GilderBairn.java
@@ -57,7 +57,7 @@ class GilderBairnEffect extends OneShotEffect {
         this.staticText = "Double the number of each kind of counter on target permanent";
     }
 
-    public GilderBairnEffect(final GilderBairnEffect effect) {
+    private GilderBairnEffect(final GilderBairnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GiltLeafAmbush.java
+++ b/Mage.Sets/src/mage/cards/g/GiltLeafAmbush.java
@@ -51,7 +51,7 @@ class GiltLeafAmbushCreateTokenEffect extends OneShotEffect {
         this.staticText = "Create two 1/1 green Elf Warrior creature tokens. Clash with an opponent. If you win, those creatures gain deathtouch until end of turn";
     }
 
-    public GiltLeafAmbushCreateTokenEffect(final GiltLeafAmbushCreateTokenEffect effect) {
+    private GiltLeafAmbushCreateTokenEffect(final GiltLeafAmbushCreateTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GiltLeafArchdruid.java
+++ b/Mage.Sets/src/mage/cards/g/GiltLeafArchdruid.java
@@ -81,7 +81,7 @@ class GiltLeafArchdruidEffect extends OneShotEffect {
         this.staticText = "gain control of all lands target player controls";
     }
 
-    public GiltLeafArchdruidEffect(final GiltLeafArchdruidEffect effect) {
+    private GiltLeafArchdruidEffect(final GiltLeafArchdruidEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GiltspireAvenger.java
+++ b/Mage.Sets/src/mage/cards/g/GiltspireAvenger.java
@@ -62,7 +62,7 @@ class GiltspireAvengerTarget extends TargetPermanent {
         targetName = "creature that dealt damage to you this turn";
     }
 
-    public GiltspireAvengerTarget(final GiltspireAvengerTarget target) {
+    private GiltspireAvengerTarget(final GiltspireAvengerTarget target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GitaxianAnatomist.java
+++ b/Mage.Sets/src/mage/cards/g/GitaxianAnatomist.java
@@ -52,7 +52,7 @@ class GitaxianAnatomistCost extends CostImpl {
         this.text = "tap it";
     }
 
-    public GitaxianAnatomistCost(GitaxianAnatomistCost cost) {
+    private GitaxianAnatomistCost(final GitaxianAnatomistCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GiveTake.java
+++ b/Mage.Sets/src/mage/cards/g/GiveTake.java
@@ -54,7 +54,7 @@ class TakeEffect extends OneShotEffect {
         this.staticText = "Remove all +1/+1 counters from target creature you control. Draw that many cards";
     }
 
-    public TakeEffect(final TakeEffect effect) {
+    private TakeEffect(final TakeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlacialCrasher.java
+++ b/Mage.Sets/src/mage/cards/g/GlacialCrasher.java
@@ -59,7 +59,7 @@ class GlacialCrasherEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless there is a Mountain on the battlefield";
     }
 
-    public GlacialCrasherEffect(final GlacialCrasherEffect effect) {
+    private GlacialCrasherEffect(final GlacialCrasherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GladehartCavalry.java
+++ b/Mage.Sets/src/mage/cards/g/GladehartCavalry.java
@@ -54,7 +54,7 @@ class GladehartCavalryTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature you control with a +1/+1 counter on it dies, ");
     }
 
-    public GladehartCavalryTriggeredAbility(final GladehartCavalryTriggeredAbility ability) {
+    private GladehartCavalryTriggeredAbility(final GladehartCavalryTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlamerSpinners.java
+++ b/Mage.Sets/src/mage/cards/g/GlamerSpinners.java
@@ -68,7 +68,7 @@ class GlamerSpinnersEffect extends OneShotEffect {
         staticText = "attach all Auras enchanting target permanent to another permanent with the same controller";
     }
 
-    public GlamerSpinnersEffect(final GlamerSpinnersEffect effect) {
+    private GlamerSpinnersEffect(final GlamerSpinnersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Glarecaster.java
+++ b/Mage.Sets/src/mage/cards/g/Glarecaster.java
@@ -69,7 +69,7 @@ class GlarecasterEffect extends RedirectionEffect {
         staticText = "The next time damage would be dealt to {this} and/or you this turn, that damage is dealt to any target instead";
     }
 
-    public GlarecasterEffect(final GlarecasterEffect effect) {
+    private GlarecasterEffect(final GlarecasterEffect effect) {
         super(effect);
         this.redirectToObject = effect.redirectToObject;
     }

--- a/Mage.Sets/src/mage/cards/g/GlaringSpotlight.java
+++ b/Mage.Sets/src/mage/cards/g/GlaringSpotlight.java
@@ -65,7 +65,7 @@ class GlaringSpotlightEffect extends AsThoughEffectImpl {
         staticText = "Creatures your opponents control with hexproof can be the targets of spells and abilities you control as though they didn't have hexproof";
     }
 
-    public GlaringSpotlightEffect(final GlaringSpotlightEffect effect) {
+    private GlaringSpotlightEffect(final GlaringSpotlightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlassGolem.java
+++ b/Mage.Sets/src/mage/cards/g/GlassGolem.java
@@ -22,7 +22,7 @@ public final class GlassGolem extends CardImpl {
         this.toughness = new MageInt(2);
     }
 
-    public GlassGolem (final GlassGolem card) {
+    private GlassGolem(final GlassGolem card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Glimmerpost.java
+++ b/Mage.Sets/src/mage/cards/g/Glimmerpost.java
@@ -34,7 +34,7 @@ public final class Glimmerpost extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
     }
 
-    public Glimmerpost (final Glimmerpost card) {
+    private Glimmerpost(final Glimmerpost card) {
         super(card);
     }
 
@@ -57,7 +57,7 @@ class GlimmerpostEffect extends OneShotEffect {
         staticText = "you gain 1 life for each Locus on the battlefield";
     }
 
-    public GlimmerpostEffect(final GlimmerpostEffect effect) {
+    private GlimmerpostEffect(final GlimmerpostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlimpseOfNature.java
+++ b/Mage.Sets/src/mage/cards/g/GlimpseOfNature.java
@@ -25,7 +25,7 @@ public final class GlimpseOfNature extends CardImpl {
         this.getSpellAbility().addEffect(new CreateDelayedTriggeredAbilityEffect(new GlimpseOfNatureTriggeredAbility()));
     }
 
-    public GlimpseOfNature (final GlimpseOfNature card) {
+    private GlimpseOfNature(final GlimpseOfNature card) {
         super(card);
     }
 
@@ -42,7 +42,7 @@ class GlimpseOfNatureTriggeredAbility extends DelayedTriggeredAbility {
         super(new DrawCardSourceControllerEffect(1), Duration.EndOfTurn, false);
     }
 
-    public GlimpseOfNatureTriggeredAbility(GlimpseOfNatureTriggeredAbility ability) {
+    private GlimpseOfNatureTriggeredAbility(final GlimpseOfNatureTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlimpseTheCosmos.java
+++ b/Mage.Sets/src/mage/cards/g/GlimpseTheCosmos.java
@@ -64,7 +64,7 @@ class GlimpseTheCosmosPlayEffect extends AsThoughEffectImpl {
         staticText = "As long as you control a Giant, you may cast {this} from your graveyard by paying {U} rather than paying its mana cost";
     }
 
-    public GlimpseTheCosmosPlayEffect(final GlimpseTheCosmosPlayEffect effect) {
+    private GlimpseTheCosmosPlayEffect(final GlimpseTheCosmosPlayEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class GlimpseTheCosmosReplacementEffect extends ReplacementEffectImpl {
         staticText = "As long as you control a Giant, you may cast {this} from your graveyard by paying {U} rather than paying its mana cost. If you cast {this} this way and it would be put into your graveyard, exile it instead";
     }
 
-    public GlimpseTheCosmosReplacementEffect(final GlimpseTheCosmosReplacementEffect effect) {
+    private GlimpseTheCosmosReplacementEffect(final GlimpseTheCosmosReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlintHawkIdol.java
+++ b/Mage.Sets/src/mage/cards/g/GlintHawkIdol.java
@@ -40,7 +40,7 @@ public final class GlintHawkIdol extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BecomesCreatureSourceEffect(new GlintHawkIdolToken(), CardType.ARTIFACT, Duration.EndOfTurn), new ColoredManaCost(ColoredManaSymbol.W)));
     }
 
-    public GlintHawkIdol (final GlintHawkIdol card) {
+    private GlintHawkIdol(final GlintHawkIdol card) {
         super(card);
     }
 
@@ -61,7 +61,7 @@ class GlintHawkIdolToken extends TokenImpl {
         toughness = new MageInt(2);
         addAbility(FlyingAbility.getInstance());
     }
-    public GlintHawkIdolToken(final GlintHawkIdolToken token) {
+    private GlintHawkIdolToken(final GlintHawkIdolToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlissaSunseeker.java
+++ b/Mage.Sets/src/mage/cards/g/GlissaSunseeker.java
@@ -60,7 +60,7 @@ class GlissaSunseekerEffect extends OneShotEffect {
         this.staticText = "Destroy target artifact if its mana value is equal to the amount of unspent mana you have";
     }
 
-    public GlissaSunseekerEffect(final GlissaSunseekerEffect effect) {
+    private GlissaSunseekerEffect(final GlissaSunseekerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlissaSunslayer.java
+++ b/Mage.Sets/src/mage/cards/g/GlissaSunslayer.java
@@ -61,7 +61,7 @@ public final class GlissaSunslayer extends CardImpl {
         this.addAbility(ability);
     }
 
-    public GlissaSunslayer(final GlissaSunslayer card) {
+    private GlissaSunslayer(final GlissaSunslayer card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlissaTheTraitor.java
+++ b/Mage.Sets/src/mage/cards/g/GlissaTheTraitor.java
@@ -53,7 +53,7 @@ public final class GlissaTheTraitor extends CardImpl {
         this.addAbility(ability);
     }
 
-    public GlissaTheTraitor(final GlissaTheTraitor card) {
+    private GlissaTheTraitor(final GlissaTheTraitor card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlissasCourier.java
+++ b/Mage.Sets/src/mage/cards/g/GlissasCourier.java
@@ -26,7 +26,7 @@ public final class GlissasCourier extends CardImpl {
         this.addAbility(new MountainwalkAbility());
     }
 
-    public GlissasCourier (final GlissasCourier card) {
+    private GlissasCourier(final GlissasCourier card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlobalRuin.java
+++ b/Mage.Sets/src/mage/cards/g/GlobalRuin.java
@@ -51,7 +51,7 @@ class GlobalRuinDestroyLandEffect extends OneShotEffect {
         this.staticText = "Each player chooses from the lands they control a land of each basic land type, then sacrifices the rest";
     }
 
-    public GlobalRuinDestroyLandEffect(final GlobalRuinDestroyLandEffect effect) {
+    private GlobalRuinDestroyLandEffect(final GlobalRuinDestroyLandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Gloomhunter.java
+++ b/Mage.Sets/src/mage/cards/g/Gloomhunter.java
@@ -25,7 +25,7 @@ public final class Gloomhunter extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public Gloomhunter (final Gloomhunter card) {
+    private Gloomhunter(final Gloomhunter card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Gloomlance.java
+++ b/Mage.Sets/src/mage/cards/g/Gloomlance.java
@@ -45,7 +45,7 @@ class GloomlanceEffect extends OneShotEffect {
         this.staticText = "Destroy target creature. If that creature was green or white, its controller discards a card";
     }
 
-    public GloomlanceEffect(final GloomlanceEffect effect) {
+    private GloomlanceEffect(final GloomlanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GloomwidowsFeast.java
+++ b/Mage.Sets/src/mage/cards/g/GloomwidowsFeast.java
@@ -57,7 +57,7 @@ class GloomwidowsFeastEffect extends OneShotEffect {
         this.staticText = "Destroy target creature with flying. If that creature was blue or black, create a 1/2 green Spider creature token with reach";
     }
 
-    public GloomwidowsFeastEffect(final GloomwidowsFeastEffect effect) {
+    private GloomwidowsFeastEffect(final GloomwidowsFeastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlorySeeker.java
+++ b/Mage.Sets/src/mage/cards/g/GlorySeeker.java
@@ -24,7 +24,7 @@ public final class GlorySeeker extends CardImpl {
         this.toughness = new MageInt(2);
     }
 
-    public GlorySeeker (final GlorySeeker card) {
+    private GlorySeeker(final GlorySeeker card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlowsporeShaman.java
+++ b/Mage.Sets/src/mage/cards/g/GlowsporeShaman.java
@@ -62,7 +62,7 @@ class GlowsporeShamanEffect extends OneShotEffect {
                 + "on top of your library.";
     }
 
-    public GlowsporeShamanEffect(final GlowsporeShamanEffect effect) {
+    private GlowsporeShamanEffect(final GlowsporeShamanEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlyphKeeper.java
+++ b/Mage.Sets/src/mage/cards/g/GlyphKeeper.java
@@ -60,7 +60,7 @@ class GlyphKeeperAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CounterTargetEffect(), false);
     }
 
-    public GlyphKeeperAbility(final GlyphKeeperAbility ability) {
+    private GlyphKeeperAbility(final GlyphKeeperAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlyphOfDelusion.java
+++ b/Mage.Sets/src/mage/cards/g/GlyphOfDelusion.java
@@ -68,7 +68,7 @@ class GlyphOfDelusionSecondTarget extends TargetPermanent {
         setTargetName("target creature that target Wall blocked this turn");
     }
 
-    public GlyphOfDelusionSecondTarget(final GlyphOfDelusionSecondTarget target) {
+    private GlyphOfDelusionSecondTarget(final GlyphOfDelusionSecondTarget target) {
         super(target);
         this.firstTarget = target.firstTarget;
     }
@@ -113,7 +113,7 @@ class GlyphOfDelusionEffect extends OneShotEffect {
         this.staticText = "Put X glyph counters on target creature that target Wall blocked this turn, where X is the power of that blocked creature. The creature gains \"This creature doesn't untap during your untap step if it has a glyph counter on it\" and \"At the beginning of your upkeep, remove a glyph counter from this creature.\"";
     }
 
-    public GlyphOfDelusionEffect(final GlyphOfDelusionEffect effect) {
+    private GlyphOfDelusionEffect(final GlyphOfDelusionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlyphOfDoom.java
+++ b/Mage.Sets/src/mage/cards/g/GlyphOfDoom.java
@@ -61,7 +61,7 @@ class GlyphOfDoomCreateDelayedTriggeredAbilityEffect extends OneShotEffect {
         this.staticText = "At this turn's next end of combat, destroy all creatures that were blocked by that creature this turn";
     }
 
-    public GlyphOfDoomCreateDelayedTriggeredAbilityEffect(final GlyphOfDoomCreateDelayedTriggeredAbilityEffect effect) {
+    private GlyphOfDoomCreateDelayedTriggeredAbilityEffect(final GlyphOfDoomCreateDelayedTriggeredAbilityEffect effect) {
         super(effect);
     }
 
@@ -91,7 +91,7 @@ class GlyphOfDoomEffect extends OneShotEffect {
         this.targetCreature = targetCreature;
     }
 
-    public GlyphOfDoomEffect(final GlyphOfDoomEffect effect) {
+    private GlyphOfDoomEffect(final GlyphOfDoomEffect effect) {
         super(effect);
         targetCreature = effect.targetCreature;
     }

--- a/Mage.Sets/src/mage/cards/g/GlyphOfLife.java
+++ b/Mage.Sets/src/mage/cards/g/GlyphOfLife.java
@@ -59,7 +59,7 @@ class GlyphOfLifeTriggeredAbility extends DelayedTriggeredAbility {
         setTriggerPhrase("Whenever that creature is dealt damage by an attacking creature this turn, ");
     }
 
-    public GlyphOfLifeTriggeredAbility(final GlyphOfLifeTriggeredAbility effect) {
+    private GlyphOfLifeTriggeredAbility(final GlyphOfLifeTriggeredAbility effect) {
         super(effect);
     }
 
@@ -94,7 +94,7 @@ class GlyphOfLifeGainLifeEffect extends OneShotEffect {
         staticText = "you gain that much life";
     }
 
-    public GlyphOfLifeGainLifeEffect(final GlyphOfLifeGainLifeEffect effect) {
+    private GlyphOfLifeGainLifeEffect(final GlyphOfLifeGainLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlyphOfReincarnation.java
+++ b/Mage.Sets/src/mage/cards/g/GlyphOfReincarnation.java
@@ -68,7 +68,7 @@ class GlyphOfReincarnationEffect extends OneShotEffect {
         this.staticText = "Destroy all creatures that were blocked by target Wall this turn. They can't be regenerated. For each creature that died this way, put a creature card from the graveyard of the player who controlled that creature the last time it became blocked by that Wall onto the battlefield under its owner's control";
     }
 
-    public GlyphOfReincarnationEffect(final GlyphOfReincarnationEffect effect) {
+    private GlyphOfReincarnationEffect(final GlyphOfReincarnationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinArchaeologist.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinArchaeologist.java
@@ -57,7 +57,7 @@ class GoblinArchaeologistEffect extends OneShotEffect {
         this.staticText = "Flip a coin. If you win the flip, destroy target artifact and untap {this}. If you lose the flip, sacrifice {this}";
     }
 
-    public GoblinArchaeologistEffect(final GoblinArchaeologistEffect ability) {
+    private GoblinArchaeologistEffect(final GoblinArchaeologistEffect ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinBangchuckers.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinBangchuckers.java
@@ -54,7 +54,7 @@ class GoblinBangchuckersEffect extends OneShotEffect {
         staticText = "Flip a coin. If you win the flip, {this} deals 2 damage to any target. If you lose the flip, {this} deals 2 damage to itself";
     }
 
-    public GoblinBangchuckersEffect(GoblinBangchuckersEffect effect) {
+    private GoblinBangchuckersEffect(final GoblinBangchuckersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinBomb.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinBomb.java
@@ -63,7 +63,7 @@ class GoblinBombEffect extends OneShotEffect {
         staticText = "flip a coin. If you win the flip, put a fuse counter on {this}. If you lose the flip, remove a fuse counter from {this}";
     }
 
-    public GoblinBombEffect(GoblinBombEffect effect) {
+    private GoblinBombEffect(final GoblinBombEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinBowlingTeam.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinBowlingTeam.java
@@ -54,7 +54,7 @@ class GoblinBowlingTeamEffect extends ReplacementEffectImpl {
         staticText = "If {this} would deal damage to a permanent or player, it deals that much damage plus the result of a six-sided die roll to that permanent or player instead";
     }
 
-    public GoblinBowlingTeamEffect(final GoblinBowlingTeamEffect effect) {
+    private GoblinBowlingTeamEffect(final GoblinBowlingTeamEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinBrawler.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinBrawler.java
@@ -50,7 +50,7 @@ public final class GoblinBrawler extends CardImpl {
 
 class CantBeEquippedSourceEffect extends ContinuousRuleModifyingEffectImpl {
 
-    public CantBeEquippedSourceEffect(CantBeEquippedSourceEffect effect) {
+    private CantBeEquippedSourceEffect(final CantBeEquippedSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinCadets.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinCadets.java
@@ -49,7 +49,7 @@ class GoblinCadetsChangeControlEffect extends ContinuousEffectImpl {
         staticText = "target opponent gains control of it. <i>(This removes {this} from combat.)</i>";
     }
 
-    public GoblinCadetsChangeControlEffect(final GoblinCadetsChangeControlEffect effect) {
+    private GoblinCadetsChangeControlEffect(final GoblinCadetsChangeControlEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinCharbelcher.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinCharbelcher.java
@@ -50,7 +50,7 @@ class GoblinCharbelcherEffect extends OneShotEffect {
         this.staticText = "Reveal cards from the top of your library until you reveal a land card. {this} deals damage equal to the number of nonland cards revealed this way to any target. If the revealed land card was a Mountain, {this} deals double that damage instead. Put the revealed cards on the bottom of your library in any order";
     }
 
-    public GoblinCharbelcherEffect(final GoblinCharbelcherEffect effect) {
+    private GoblinCharbelcherEffect(final GoblinCharbelcherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinClearcutter.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinClearcutter.java
@@ -69,7 +69,7 @@ class GoblinClearCutterManaEffect extends ManaEffect {
         netMana.add(new Mana(0, 0, 0, 3, 0, 0, 0, 0));
     }
 
-    public GoblinClearCutterManaEffect(final GoblinClearCutterManaEffect effect) {
+    private GoblinClearCutterManaEffect(final GoblinClearCutterManaEffect effect) {
         super(effect);
         netMana.addAll(effect.netMana);
     }

--- a/Mage.Sets/src/mage/cards/g/GoblinCohort.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinCohort.java
@@ -51,7 +51,7 @@ class GoblinCohortEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless you've cast a creature spell this turn";
     }
 
-    public GoblinCohortEffect(final GoblinCohortEffect effect) {
+    private GoblinCohortEffect(final GoblinCohortEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinDiplomats.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinDiplomats.java
@@ -51,7 +51,7 @@ class GoblinDiplomatsEffect extends RequirementEffect {
         this.staticText = "Each creature attacks this turn if able";
     }
 
-    public GoblinDiplomatsEffect(final GoblinDiplomatsEffect effect) {
+    private GoblinDiplomatsEffect(final GoblinDiplomatsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinFestival.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinFestival.java
@@ -54,7 +54,7 @@ class GoblinFestivalChangeControlEffect extends OneShotEffect {
         this.staticText = "Flip a coin. If you lose the flip, choose one of your opponents. That player gains control of {this}";
     }
 
-    public GoblinFestivalChangeControlEffect(final GoblinFestivalChangeControlEffect effect) {
+    private GoblinFestivalChangeControlEffect(final GoblinFestivalChangeControlEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class GoblinFestivalGainControlEffect extends ContinuousEffectImpl {
         this.staticText = "That player gains control of {this}";
     }
 
-    public GoblinFestivalGainControlEffect(final GoblinFestivalGainControlEffect effect) {
+    private GoblinFestivalGainControlEffect(final GoblinFestivalGainControlEffect effect) {
         super(effect);
         this.controller = effect.controller;
     }

--- a/Mage.Sets/src/mage/cards/g/GoblinFurrier.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinFurrier.java
@@ -50,7 +50,7 @@ class GoblinFurrierPreventEffectEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that {this} would deal to snow creatures";
     }
 
-    public GoblinFurrierPreventEffectEffect(final GoblinFurrierPreventEffectEffect effect) {
+    private GoblinFurrierPreventEffectEffect(final GoblinFurrierPreventEffectEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinGame.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinGame.java
@@ -45,7 +45,7 @@ class GoblinGameEffect extends OneShotEffect {
                 "If two or more players are tied for fewest, each loses half their life, rounded up.";
     }
 
-    public GoblinGameEffect(final GoblinGameEffect effect) {
+    private GoblinGameEffect(final GoblinGameEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinGoliath.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinGoliath.java
@@ -61,7 +61,7 @@ class GoblinGoliathDamageEffect extends ReplacementEffectImpl {
         staticText = "If a source you control would deal damage to an opponent this turn, it deals double that damage to that player instead.";
     }
 
-    public GoblinGoliathDamageEffect(final GoblinGoliathDamageEffect effect) {
+    private GoblinGoliathDamageEffect(final GoblinGoliathDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinGuide.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinGuide.java
@@ -64,7 +64,7 @@ class GoblinGuideTriggeredAbility extends TriggeredAbilityImpl {
         this.text = text;
     }
 
-    public GoblinGuideTriggeredAbility(final GoblinGuideTriggeredAbility ability) {
+    private GoblinGuideTriggeredAbility(final GoblinGuideTriggeredAbility ability) {
         super(ability);
         this.text = ability.text;
     }
@@ -107,7 +107,7 @@ class GoblinGuideEffect extends OneShotEffect {
         super(Outcome.DrawCard);
     }
 
-    public GoblinGuideEffect(final GoblinGuideEffect effect) {
+    private GoblinGuideEffect(final GoblinGuideEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinKaboomist.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinKaboomist.java
@@ -57,7 +57,7 @@ class GoblinKaboomistFlipCoinEffect extends OneShotEffect {
         staticText = "Then flip a coin. If you lose the flip, {this} deals 2 damage to itself";
     }
 
-    public GoblinKaboomistFlipCoinEffect(final GoblinKaboomistFlipCoinEffect effect) {
+    private GoblinKaboomistFlipCoinEffect(final GoblinKaboomistFlipCoinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinLyre.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinLyre.java
@@ -49,7 +49,7 @@ class GoblinLyreEffect extends OneShotEffect {
                 + "If you lose the flip, Goblin Lyre deals damage to you equal to the number of creatures that opponent or that planeswalker's controller controls";
     }
 
-    public GoblinLyreEffect(final GoblinLyreEffect effect) {
+    private GoblinLyreEffect(final GoblinLyreEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinMachinist.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinMachinist.java
@@ -53,7 +53,7 @@ class GoblinMachinistEffect extends OneShotEffect {
         this.staticText = "Reveal cards from the top of your library until you reveal a nonland card. {this} gets +X/+0 until end of turn, where X is that card's mana value. Put the revealed cards on the bottom of your library in any order";
     }
 
-    public GoblinMachinistEffect(final GoblinMachinistEffect effect) {
+    private GoblinMachinistEffect(final GoblinMachinistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinMountaineer.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinMountaineer.java
@@ -26,7 +26,7 @@ public final class GoblinMountaineer extends CardImpl {
         this.addAbility(new MountainwalkAbility());
     }
 
-    public GoblinMountaineer (final GoblinMountaineer card) {
+    private GoblinMountaineer(final GoblinMountaineer card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinPsychopath.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinPsychopath.java
@@ -53,7 +53,7 @@ class GoblinPsychopathEffect extends ReplacementEffectImpl {
         staticText = "flip a coin. If you lose the flip, the next time it would deal combat damage this turn, it deals that damage to you instead";
     }
 
-    public GoblinPsychopathEffect(final GoblinPsychopathEffect effect) {
+    private GoblinPsychopathEffect(final GoblinPsychopathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinRockSled.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinRockSled.java
@@ -70,7 +70,7 @@ class DontUntapIfAttackedLastTurnSourceEffect extends ContinuousRuleModifyingEff
         staticText = "{this} doesn't untap during your untap step if it attacked during your last turn";
     }
 
-    public DontUntapIfAttackedLastTurnSourceEffect(final DontUntapIfAttackedLastTurnSourceEffect effect) {
+    private DontUntapIfAttackedLastTurnSourceEffect(final DontUntapIfAttackedLastTurnSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinRoughrider.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinRoughrider.java
@@ -24,7 +24,7 @@ public final class GoblinRoughrider extends CardImpl {
         this.toughness = new MageInt(2);
     }
 
-    public GoblinRoughrider (final GoblinRoughrider card) {
+    private GoblinRoughrider(final GoblinRoughrider card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinSecretAgent.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinSecretAgent.java
@@ -55,7 +55,7 @@ class GoblinSecretAgentEffect extends OneShotEffect {
         this.staticText = "reveal a card from your hand at random";
     }
     
-    public GoblinSecretAgentEffect(final GoblinSecretAgentEffect effect) {
+    private GoblinSecretAgentEffect(final GoblinSecretAgentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinSpymaster.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinSpymaster.java
@@ -53,7 +53,7 @@ class SpyMasterGoblinCreateTokenEffect extends OneShotEffect {
         this.staticText = "that player creates a 1/1 red Goblin creature token with \"Creatures you control attack each combat if able.\"";
     }
 
-    public SpyMasterGoblinCreateTokenEffect(final SpyMasterGoblinCreateTokenEffect effect) {
+    private SpyMasterGoblinCreateTokenEffect(final SpyMasterGoblinCreateTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinTinkerer.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinTinkerer.java
@@ -59,7 +59,7 @@ class GoblinTinkererDamageEffect extends OneShotEffect {
         this.staticText = "That artifact deals damage equal to its mana value to {this}";
     }
     
-    public GoblinTinkererDamageEffect(final GoblinTinkererDamageEffect effect) {
+    private GoblinTinkererDamageEffect(final GoblinTinkererDamageEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/g/GoblinTutor.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinTutor.java
@@ -58,7 +58,7 @@ class GoblinTutorEffect extends OneShotEffect {
                 "<br>6 - An instant or sorcery";
     }
 
-    public GoblinTutorEffect(final GoblinTutorEffect effect) {
+    private GoblinTutorEffect(final GoblinTutorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinVandal.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinVandal.java
@@ -66,7 +66,7 @@ class GoblinVandalTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect, false );
     }
 
-    public GoblinVandalTriggeredAbility(final GoblinVandalTriggeredAbility ability) {
+    private GoblinVandalTriggeredAbility(final GoblinVandalTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinWarCry.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinWarCry.java
@@ -90,7 +90,7 @@ class GoblinWarCryRestrictionEffect extends RestrictionEffect {
         this.targetId = targetId;
     }
 
-    public GoblinWarCryRestrictionEffect(final GoblinWarCryRestrictionEffect effect) {
+    private GoblinWarCryRestrictionEffect(final GoblinWarCryRestrictionEffect effect) {
         super(effect);
         targetId = effect.targetId;
     }

--- a/Mage.Sets/src/mage/cards/g/GoblinWardriver.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinWardriver.java
@@ -26,7 +26,7 @@ public final class GoblinWardriver extends CardImpl {
         this.addAbility(new BattleCryAbility());
     }
 
-    public GoblinWardriver (final GoblinWardriver card) {
+    private GoblinWardriver(final GoblinWardriver card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinWelder.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinWelder.java
@@ -63,7 +63,7 @@ public final class GoblinWelder extends CardImpl {
             this.setTargetPointer(new EachTargetPointer());
         }
 
-        public GoblinWelderEffect(final GoblinWelderEffect effect) {
+        private GoblinWelderEffect(final GoblinWelderEffect effect) {
             super(effect);
         }
 
@@ -107,7 +107,7 @@ public final class GoblinWelder extends CardImpl {
             targetName = "target artifact card in that player's graveyard";
         }
 
-        public GoblinWelderTarget(final GoblinWelderTarget target) {
+        private GoblinWelderTarget(final GoblinWelderTarget target) {
             super(target);
         }
 

--- a/Mage.Sets/src/mage/cards/g/GodEternalKefnet.java
+++ b/Mage.Sets/src/mage/cards/g/GodEternalKefnet.java
@@ -63,7 +63,7 @@ class GodEternalKefnetDrawCardReplacementEffect extends ReplacementEffectImpl {
                 + "or sorcery card this way, copy that card and you may cast the copy. That copy costs {2} less to cast";
     }
 
-    public GodEternalKefnetDrawCardReplacementEffect(final GodEternalKefnetDrawCardReplacementEffect effect) {
+    private GodEternalKefnetDrawCardReplacementEffect(final GodEternalKefnetDrawCardReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Godsend.java
+++ b/Mage.Sets/src/mage/cards/g/Godsend.java
@@ -139,7 +139,7 @@ class GodsendExileEffect extends OneShotEffect {
         this.staticText = "you may exile one of those creatures";
     }
 
-    public GodsendExileEffect(final GodsendExileEffect effect) {
+    private GodsendExileEffect(final GodsendExileEffect effect) {
         super(effect);
     }
 
@@ -170,7 +170,7 @@ class GodsendRuleModifyingEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Your opponents can't cast cards with the same name as cards exiled with {this}";
     }
 
-    public GodsendRuleModifyingEffect(final GodsendRuleModifyingEffect effect) {
+    private GodsendRuleModifyingEffect(final GodsendRuleModifyingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoldMyr.java
+++ b/Mage.Sets/src/mage/cards/g/GoldMyr.java
@@ -24,7 +24,7 @@ public final class GoldMyr extends CardImpl {
         this.addAbility(new WhiteManaAbility());
     }
 
-    public GoldMyr (final GoldMyr card) {
+    private GoldMyr(final GoldMyr card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoldenGuardian.java
+++ b/Mage.Sets/src/mage/cards/g/GoldenGuardian.java
@@ -70,7 +70,7 @@ class GoldenGuardianEffect extends OneShotEffect {
         this.staticText = "{this} fights another target creature you control";
     }
 
-    public GoldenGuardianEffect(final GoldenGuardianEffect effect) {
+    private GoldenGuardianEffect(final GoldenGuardianEffect effect) {
         super(effect);
     }
 
@@ -100,7 +100,7 @@ class GoldenGuardianDelayedTriggeredAbility extends DelayedTriggeredAbility {
         setTriggerPhrase("When {this} dies this turn, ");
     }
 
-    public GoldenGuardianDelayedTriggeredAbility(final GoldenGuardianDelayedTriggeredAbility ability) {
+    private GoldenGuardianDelayedTriggeredAbility(final GoldenGuardianDelayedTriggeredAbility ability) {
         super(ability);
     }
 
@@ -127,7 +127,7 @@ class GoldenGuardianReturnTransformedEffect extends OneShotEffect {
         this.staticText = "return it to the battlefield transformed under your control";
     }
 
-    public GoldenGuardianReturnTransformedEffect(final GoldenGuardianReturnTransformedEffect effect) {
+    private GoldenGuardianReturnTransformedEffect(final GoldenGuardianReturnTransformedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoldenUrn.java
+++ b/Mage.Sets/src/mage/cards/g/GoldenUrn.java
@@ -32,7 +32,7 @@ public final class GoldenUrn extends CardImpl {
         this.addAbility(ability);
     }
 
-    public GoldenUrn (final GoldenUrn card) {
+    private GoldenUrn(final GoldenUrn card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoldmeadowHarrier.java
+++ b/Mage.Sets/src/mage/cards/g/GoldmeadowHarrier.java
@@ -35,7 +35,7 @@ public final class GoldmeadowHarrier extends CardImpl {
         this.addAbility(ability);
     }
 
-    public GoldmeadowHarrier (final GoldmeadowHarrier card) {
+    private GoldmeadowHarrier(final GoldmeadowHarrier card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoldnightCastigator.java
+++ b/Mage.Sets/src/mage/cards/g/GoldnightCastigator.java
@@ -61,7 +61,7 @@ class GoldnightCastigatorDoubleDamageEffect extends ReplacementEffectImpl {
             + "<br>If a source would deal damage to {this}, it deals double that damage to {this} instead.";
     }
 
-    public GoldnightCastigatorDoubleDamageEffect(final GoldnightCastigatorDoubleDamageEffect effect) {
+    private GoldnightCastigatorDoubleDamageEffect(final GoldnightCastigatorDoubleDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GolemFoundry.java
+++ b/Mage.Sets/src/mage/cards/g/GolemFoundry.java
@@ -28,7 +28,7 @@ public final class GolemFoundry extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new CreateTokenEffect(new GolemToken()), new RemoveCountersSourceCost(CounterType.CHARGE.createInstance(3))));
     }
 
-    public GolemFoundry (final GolemFoundry card) {
+    private GolemFoundry(final GolemFoundry card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GolemsHeart.java
+++ b/Mage.Sets/src/mage/cards/g/GolemsHeart.java
@@ -42,7 +42,7 @@ class GolemsHeartAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainLifeEffect(1), true);
     }
 
-    public GolemsHeartAbility(final GolemsHeartAbility ability) {
+    private GolemsHeartAbility(final GolemsHeartAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GolgariGraveTroll.java
+++ b/Mage.Sets/src/mage/cards/g/GolgariGraveTroll.java
@@ -62,7 +62,7 @@ class GolgariGraveTrollEffect extends OneShotEffect {
         super(Outcome.BoostCreature);
     }
 
-    public GolgariGraveTrollEffect(final GolgariGraveTrollEffect effect) {
+    private GolgariGraveTrollEffect(final GolgariGraveTrollEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GolgariKeyrune.java
+++ b/Mage.Sets/src/mage/cards/g/GolgariKeyrune.java
@@ -54,7 +54,7 @@ public final class GolgariKeyrune extends CardImpl {
             toughness = new MageInt(2);
             this.addAbility(DeathtouchAbility.getInstance());
         }
-        public GolgariKeyruneToken(final GolgariKeyruneToken token) {
+        private GolgariKeyruneToken(final GolgariKeyruneToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/g/GolgariSignet.java
+++ b/Mage.Sets/src/mage/cards/g/GolgariSignet.java
@@ -26,7 +26,7 @@ public final class GolgariSignet extends CardImpl {
         this.addAbility(ability);
     }
 
-    public GolgariSignet (final GolgariSignet card) {
+    private GolgariSignet(final GolgariSignet card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GolgothianSylex.java
+++ b/Mage.Sets/src/mage/cards/g/GolgothianSylex.java
@@ -60,7 +60,7 @@ class GolgothianSylexEffect extends OneShotEffect {
         this.staticText = "Each nontoken permanent from the Antiquities expansion is sacrificed by its controller.";
     }
 
-    public GolgothianSylexEffect(final GolgothianSylexEffect effect) {
+    private GolgothianSylexEffect(final GolgothianSylexEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoliathSphinx.java
+++ b/Mage.Sets/src/mage/cards/g/GoliathSphinx.java
@@ -25,7 +25,7 @@ public final class GoliathSphinx extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public GoliathSphinx (final GoliathSphinx card) {
+    private GoliathSphinx(final GoliathSphinx card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Gomazoa.java
+++ b/Mage.Sets/src/mage/cards/g/Gomazoa.java
@@ -65,7 +65,7 @@ class GomazoaEffect extends OneShotEffect {
         this.staticText = "Put {this} and each creature it's blocking on top of their owners' libraries, then those players shuffle";
     }
 
-    public GomazoaEffect(final GomazoaEffect effect) {
+    private GomazoaEffect(final GomazoaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GontisMachinations.java
+++ b/Mage.Sets/src/mage/cards/g/GontisMachinations.java
@@ -60,7 +60,7 @@ class GontisMachinationsTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you lose life for the first time each turn, ");
     }
 
-    public GontisMachinationsTriggeredAbility(final GontisMachinationsTriggeredAbility ability) {
+    private GontisMachinationsTriggeredAbility(final GontisMachinationsTriggeredAbility ability) {
         super(ability);
     }
 
@@ -125,7 +125,7 @@ class GontisMachinationsEffect extends OneShotEffect {
         staticText = "Each opponent loses 3 life. You gain life equal to the life lost this way";
     }
 
-    public GontisMachinationsEffect(final GontisMachinationsEffect effect) {
+    private GontisMachinationsEffect(final GontisMachinationsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GorillaWarrior.java
+++ b/Mage.Sets/src/mage/cards/g/GorillaWarrior.java
@@ -24,7 +24,7 @@ public final class GorillaWarrior extends CardImpl {
         this.toughness = new MageInt(2);
     }
 
-    public GorillaWarrior (final GorillaWarrior card) {
+    private GorillaWarrior(final GorillaWarrior card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoroGoroAndSatoru.java
+++ b/Mage.Sets/src/mage/cards/g/GoroGoroAndSatoru.java
@@ -73,7 +73,7 @@ class GoroGoroAndSatoruTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CreateTokenEffect(new DragonSpiritToken()), false);
     }
 
-    public GoroGoroAndSatoruTriggeredAbility(final GoroGoroAndSatoruTriggeredAbility ability) {
+    private GoroGoroAndSatoruTriggeredAbility(final GoroGoroAndSatoruTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GostaDirk.java
+++ b/Mage.Sets/src/mage/cards/g/GostaDirk.java
@@ -50,7 +50,7 @@ class GostaDirkEffect extends AsThoughEffectImpl {
         staticText = "Creatures with islandwalk can be blocked as though they didn't have islandwalk";
     }
 
-    public GostaDirkEffect(final GostaDirkEffect effect) {
+    private GostaDirkEffect(final GostaDirkEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrabTheReins.java
+++ b/Mage.Sets/src/mage/cards/g/GrabTheReins.java
@@ -72,7 +72,7 @@ class GrabTheReinsEffect extends OneShotEffect {
         staticText = "sacrifice a creature. {this} deals damage equal to that creature's power to any target";
     }
 
-    public GrabTheReinsEffect(final GrabTheReinsEffect effect) {
+    private GrabTheReinsEffect(final GrabTheReinsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrafMole.java
+++ b/Mage.Sets/src/mage/cards/g/GrafMole.java
@@ -49,7 +49,7 @@ class GrafMoleTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you sacrifice a Clue, ");
     }
 
-    public GrafMoleTriggeredAbility(final GrafMoleTriggeredAbility ability) {
+    private GrafMoleTriggeredAbility(final GrafMoleTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrafdiggersCage.java
+++ b/Mage.Sets/src/mage/cards/g/GrafdiggersCage.java
@@ -50,7 +50,7 @@ class GrafdiggersCageEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Creature cards in graveyards and libraries can't enter the battlefield";
     }
 
-    public GrafdiggersCageEffect(final GrafdiggersCageEffect effect) {
+    private GrafdiggersCageEffect(final GrafdiggersCageEffect effect) {
         super(effect);
     }
 
@@ -85,7 +85,7 @@ class GrafdiggersCageEffect2 extends ContinuousRuleModifyingEffectImpl {
         staticText = "Players can't cast spells from graveyards or libraries";
     }
 
-    public GrafdiggersCageEffect2(final GrafdiggersCageEffect2 effect) {
+    private GrafdiggersCageEffect2(final GrafdiggersCageEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrandArchitect.java
+++ b/Mage.Sets/src/mage/cards/g/GrandArchitect.java
@@ -80,7 +80,7 @@ class GrandArchitectEffect extends ContinuousEffectImpl {
         staticText = "Target artifact creature becomes blue until end of turn";
     }
 
-    public GrandArchitectEffect(final GrandArchitectEffect effect) {
+    private GrandArchitectEffect(final GrandArchitectEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrandMoffTarkin.java
+++ b/Mage.Sets/src/mage/cards/g/GrandMoffTarkin.java
@@ -53,7 +53,7 @@ class GrandMoffTarkinTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("At the beginning of each opponent's upkeep, ");
     }
 
-    public GrandMoffTarkinTriggeredAbility(final GrandMoffTarkinTriggeredAbility ability) {
+    private GrandMoffTarkinTriggeredAbility(final GrandMoffTarkinTriggeredAbility ability) {
         super(ability);
     }
 
@@ -91,7 +91,7 @@ class GrandMoffTarkinEffect extends OneShotEffect {
         this.staticText = "destroy target creature that that player controls unless that player pays 2 life. If a player pays life this way, draw a card";
     }
 
-    public GrandMoffTarkinEffect(final GrandMoffTarkinEffect effect) {
+    private GrandMoffTarkinEffect(final GrandMoffTarkinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrandWarlordRadha.java
+++ b/Mage.Sets/src/mage/cards/g/GrandWarlordRadha.java
@@ -90,7 +90,7 @@ class GrandWarlordRadhaTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever one or more creatures you control attack, ");
     }
 
-    public GrandWarlordRadhaTriggeredAbility(final GrandWarlordRadhaTriggeredAbility ability) {
+    private GrandWarlordRadhaTriggeredAbility(final GrandWarlordRadhaTriggeredAbility ability) {
         super(ability);
     }
 
@@ -125,7 +125,7 @@ class GrandWarlordRadhaEffect extends OneShotEffect {
         this.staticText = "add that much mana in any combination of {R} and/or {G}. Until end of turn, you don't lose this mana as steps and phases end";
     }
 
-    public GrandWarlordRadhaEffect(final GrandWarlordRadhaEffect effect) {
+    private GrandWarlordRadhaEffect(final GrandWarlordRadhaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraniticTitan.java
+++ b/Mage.Sets/src/mage/cards/g/GraniticTitan.java
@@ -26,7 +26,7 @@ public final class GraniticTitan extends CardImpl {
 
     }
 
-    public GraniticTitan(final GraniticTitan graniticTitan){
+    private GraniticTitan(final GraniticTitan graniticTitan){
         super(graniticTitan);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrappleWithThePast.java
+++ b/Mage.Sets/src/mage/cards/g/GrappleWithThePast.java
@@ -55,7 +55,7 @@ class GrappleWithThePastEffect extends OneShotEffect {
         this.staticText = ", then you may return a creature or land card from your graveyard to your hand";
     }
 
-    public GrappleWithThePastEffect(final GrappleWithThePastEffect effect) {
+    private GrappleWithThePastEffect(final GrappleWithThePastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrapplerSpider.java
+++ b/Mage.Sets/src/mage/cards/g/GrapplerSpider.java
@@ -25,7 +25,7 @@ public final class GrapplerSpider extends CardImpl {
         this.addAbility(ReachAbility.getInstance());
     }
 
-    public GrapplerSpider (final GrapplerSpider card) {
+    private GrapplerSpider(final GrapplerSpider card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrapplingHook.java
+++ b/Mage.Sets/src/mage/cards/g/GrapplingHook.java
@@ -58,7 +58,7 @@ class GrapplingHookEffect extends RequirementEffect {
         staticText = "target creature block it this turn if able";
     }
 
-    public GrapplingHookEffect(final GrapplingHookEffect effect) {
+    private GrapplingHookEffect(final GrapplingHookEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraspOfDarkness.java
+++ b/Mage.Sets/src/mage/cards/g/GraspOfDarkness.java
@@ -23,7 +23,7 @@ public final class GraspOfDarkness extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public GraspOfDarkness (final GraspOfDarkness card) {
+    private GraspOfDarkness(final GraspOfDarkness card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraspOfTheHieromancer.java
+++ b/Mage.Sets/src/mage/cards/g/GraspOfTheHieromancer.java
@@ -72,7 +72,7 @@ class GraspOfTheHieromancerTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect, optional);
     }
 
-    public GraspOfTheHieromancerTriggeredAbility(final GraspOfTheHieromancerTriggeredAbility ability) {
+    private GraspOfTheHieromancerTriggeredAbility(final GraspOfTheHieromancerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraveBetrayal.java
+++ b/Mage.Sets/src/mage/cards/g/GraveBetrayal.java
@@ -55,7 +55,7 @@ class GraveBetrayalTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null);
     }
 
-    public GraveBetrayalTriggeredAbility(final GraveBetrayalTriggeredAbility ability) {
+    private GraveBetrayalTriggeredAbility(final GraveBetrayalTriggeredAbility ability) {
         super(ability);
     }
 
@@ -101,7 +101,7 @@ class GraveBetrayalEffect extends OneShotEffect {
         staticText = " return the creature to the battlefield under your control with an additional +1/+1 counter. That creature is a black Zombie in addition to its other colors and types";
     }
 
-    public GraveBetrayalEffect(final GraveBetrayalEffect effect) {
+    private GraveBetrayalEffect(final GraveBetrayalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraveBirthing.java
+++ b/Mage.Sets/src/mage/cards/g/GraveBirthing.java
@@ -59,7 +59,7 @@ class GraveBirthingEffect extends OneShotEffect {
         this.staticText = "Target opponent exiles a card from their graveyard";
     }
 
-    public GraveBirthingEffect(final GraveBirthingEffect effect) {
+    private GraveBirthingEffect(final GraveBirthingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraveExchange.java
+++ b/Mage.Sets/src/mage/cards/g/GraveExchange.java
@@ -52,7 +52,7 @@ class GraveExchangeEffect extends OneShotEffect {
         this.staticText = "Target player sacrifices a creature";
     }
 
-    public GraveExchangeEffect(final GraveExchangeEffect effect) {
+    private GraveExchangeEffect(final GraveExchangeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GravePact.java
+++ b/Mage.Sets/src/mage/cards/g/GravePact.java
@@ -49,7 +49,7 @@ class GravePactTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature you control dies, ");
     }
 
-    public GravePactTriggeredAbility(final GravePactTriggeredAbility ability) {
+    private GravePactTriggeredAbility(final GravePactTriggeredAbility ability) {
         super(ability);
     }
 
@@ -81,7 +81,7 @@ class GravePactEffect extends OneShotEffect {
         this.staticText = "each other player sacrifices a creature";
     }
 
-    public GravePactEffect(final GravePactEffect effect) {
+    private GravePactEffect(final GravePactEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraveSifter.java
+++ b/Mage.Sets/src/mage/cards/g/GraveSifter.java
@@ -59,7 +59,7 @@ class GraveSifterEffect extends OneShotEffect {
         this.staticText = "each player chooses a creature type and returns any number of cards of that type from their graveyard to their hand";
     }
 
-    public GraveSifterEffect(final GraveSifterEffect effect) {
+    private GraveSifterEffect(final GraveSifterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GravebladeMarauder.java
+++ b/Mage.Sets/src/mage/cards/g/GravebladeMarauder.java
@@ -52,7 +52,7 @@ class GravebladeMarauderEffect extends OneShotEffect {
         this.staticText = "that player loses life equal to the number of creature cards in your graveyard";
     }
 
-    public GravebladeMarauderEffect(final GravebladeMarauderEffect effect) {
+    private GravebladeMarauderEffect(final GravebladeMarauderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Gravecrawler.java
+++ b/Mage.Sets/src/mage/cards/g/Gravecrawler.java
@@ -58,7 +58,7 @@ class GravecrawlerPlayEffect extends AsThoughEffectImpl {
         staticText = "You may cast {this} from your graveyard as long as you control a Zombie";
     }
 
-    public GravecrawlerPlayEffect(final GravecrawlerPlayEffect effect) {
+    private GravecrawlerPlayEffect(final GravecrawlerPlayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Gravestorm.java
+++ b/Mage.Sets/src/mage/cards/g/Gravestorm.java
@@ -51,7 +51,7 @@ class GravestormEffect extends OneShotEffect {
         this.staticText = "At the beginning of your upkeep, target opponent may exile a card from their graveyard. If that player doesn't, you may draw a card.";
     }
 
-    public GravestormEffect(final GravestormEffect effect) {
+    private GravestormEffect(final GravestormEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraviticPunch.java
+++ b/Mage.Sets/src/mage/cards/g/GraviticPunch.java
@@ -51,7 +51,7 @@ class GraviticPunchEffect extends OneShotEffect {
                 + "equal to its power to target player.";
     }
 
-    public GraviticPunchEffect(final GraviticPunchEffect effect) {
+    private GraviticPunchEffect(final GraviticPunchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GravityWell.java
+++ b/Mage.Sets/src/mage/cards/g/GravityWell.java
@@ -46,7 +46,7 @@ class GravityWellTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature with flying attacks, ");
     }
 
-    public GravityWellTriggeredAbility(final GravityWellTriggeredAbility ability) {
+    private GravityWellTriggeredAbility(final GravityWellTriggeredAbility ability) {
         super(ability);
     }
 
@@ -80,7 +80,7 @@ class GravityWellEffect extends ContinuousEffectImpl {
         staticText = "it loses flying until end of turn";
     }
 
-    public GravityWellEffect(final GravityWellEffect effect) {
+    private GravityWellEffect(final GravityWellEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrayscaledGharial.java
+++ b/Mage.Sets/src/mage/cards/g/GrayscaledGharial.java
@@ -25,7 +25,7 @@ public final class GrayscaledGharial extends CardImpl {
         this.addAbility(new IslandwalkAbility());
     }
 
-    public GrayscaledGharial (final GrayscaledGharial card) {
+    private GrayscaledGharial(final GrayscaledGharial card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GreatFurnace.java
+++ b/Mage.Sets/src/mage/cards/g/GreatFurnace.java
@@ -19,7 +19,7 @@ public final class GreatFurnace extends CardImpl {
         this.addAbility(new RedManaAbility());
     }
 
-    public GreatFurnace (final GreatFurnace card) {
+    private GreatFurnace(final GreatFurnace card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GreatOakGuardian.java
+++ b/Mage.Sets/src/mage/cards/g/GreatOakGuardian.java
@@ -63,7 +63,7 @@ class GreatOakGuardianEffect extends ContinuousEffectImpl {
         staticText = "creatures target player controls get +2/+2 until end of turn";
     }
 
-    public GreatOakGuardianEffect(final GreatOakGuardianEffect effect) {
+    private GreatOakGuardianEffect(final GreatOakGuardianEffect effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class GreatOakGuardianUntapEffect extends OneShotEffect {
         this.staticText = "untap them";
     }
 
-    public GreatOakGuardianUntapEffect(final GreatOakGuardianUntapEffect effect) {
+    private GreatOakGuardianUntapEffect(final GreatOakGuardianUntapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GreatWall.java
+++ b/Mage.Sets/src/mage/cards/g/GreatWall.java
@@ -44,7 +44,7 @@ class GreatWallEffect extends AsThoughEffectImpl {
         staticText = "Creatures with plainswalk can be blocked as though they didn't have plainswalk";
     }
 
-    public GreatWallEffect(final GreatWallEffect effect) {
+    private GreatWallEffect(final GreatWallEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GreatbowDoyen.java
+++ b/Mage.Sets/src/mage/cards/g/GreatbowDoyen.java
@@ -61,7 +61,7 @@ class GreatbowDoyenTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever an Archer you control deals damage to a creature, ");
     }
 
-    public GreatbowDoyenTriggeredAbility(final GreatbowDoyenTriggeredAbility ability) {
+    private GreatbowDoyenTriggeredAbility(final GreatbowDoyenTriggeredAbility ability) {
         super(ability);
     }
 
@@ -99,7 +99,7 @@ class GreatbowDoyenEffect extends OneShotEffect {
         this.staticText = "that Archer deals that much damage to that creature's controller";
     }
 
-    public GreatbowDoyenEffect(final GreatbowDoyenEffect effect) {
+    private GreatbowDoyenEffect(final GreatbowDoyenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GreaterGargadon.java
+++ b/Mage.Sets/src/mage/cards/g/GreaterGargadon.java
@@ -61,7 +61,7 @@ class GreaterGargadonAbility extends ActivatedAbilityImpl {
         super(Zone.EXILED, new RemoveCounterSourceEffect(CounterType.TIME.createInstance()), new SacrificeTargetCost(new TargetControlledPermanent(filter)));
     }
 
-    public GreaterGargadonAbility(final GreaterGargadonAbility ability) {
+    private GreaterGargadonAbility(final GreaterGargadonAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GreaterWerewolf.java
+++ b/Mage.Sets/src/mage/cards/g/GreaterWerewolf.java
@@ -55,7 +55,7 @@ class GreaterWerewolfEffect extends OneShotEffect {
         this.staticText = "put a -0/-2 counter on each creature blocking or blocked by {this}";
     }
 
-    public GreaterWerewolfEffect(final GreaterWerewolfEffect effect) {
+    private GreaterWerewolfEffect(final GreaterWerewolfEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GreenhiltTrainee.java
+++ b/Mage.Sets/src/mage/cards/g/GreenhiltTrainee.java
@@ -38,7 +38,7 @@ public final class GreenhiltTrainee extends CardImpl {
         this.addAbility(ability);
     }
 
-    public GreenhiltTrainee(final GreenhiltTrainee card) {
+    private GreenhiltTrainee(final GreenhiltTrainee card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GremlinMine.java
+++ b/Mage.Sets/src/mage/cards/g/GremlinMine.java
@@ -72,7 +72,7 @@ class GremlinMineEffect extends OneShotEffect {
         this.staticText = "Remove up to four charge counters from target noncreature artifact";
     }
 
-    public GremlinMineEffect(GremlinMineEffect effect) {
+    private GremlinMineEffect(final GremlinMineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrenzoHavocRaiser.java
+++ b/Mage.Sets/src/mage/cards/g/GrenzoHavocRaiser.java
@@ -71,7 +71,7 @@ class GrenzoHavocRaiserTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature you control deals combat damage to a player, ");
     }
 
-    public GrenzoHavocRaiserTriggeredAbility(final GrenzoHavocRaiserTriggeredAbility ability) {
+    private GrenzoHavocRaiserTriggeredAbility(final GrenzoHavocRaiserTriggeredAbility ability) {
         super(ability);
         this.damagedPlayerName = ability.damagedPlayerName;
     }
@@ -127,7 +127,7 @@ class GrenzoHavocRaiserEffect extends OneShotEffect {
         this.staticText = "exile the top card of that player's library. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast it";
     }
 
-    public GrenzoHavocRaiserEffect(final GrenzoHavocRaiserEffect effect) {
+    private GrenzoHavocRaiserEffect(final GrenzoHavocRaiserEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrenzosRuffians.java
+++ b/Mage.Sets/src/mage/cards/g/GrenzosRuffians.java
@@ -53,7 +53,7 @@ class GrenzosRuffiansEffect extends OneShotEffect {
         this.staticText = "it deals that much damage to each other opponent";
     }
 
-    public GrenzosRuffiansEffect(final GrenzosRuffiansEffect effect) {
+    private GrenzosRuffiansEffect(final GrenzosRuffiansEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GreyHostReinforcements.java
+++ b/Mage.Sets/src/mage/cards/g/GreyHostReinforcements.java
@@ -64,7 +64,7 @@ class GreyHostReinforcementsEffect extends OneShotEffect {
                 "on {this} equal to the number of creature cards exiled this way";
     }
 
-    public GreyHostReinforcementsEffect(final GreyHostReinforcementsEffect effect) {
+    private GreyHostReinforcementsEffect(final GreyHostReinforcementsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GridMonitor.java
+++ b/Mage.Sets/src/mage/cards/g/GridMonitor.java
@@ -50,7 +50,7 @@ class GridMonitorEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "You can't cast creature spells";
     }
 
-    public GridMonitorEffect(final GridMonitorEffect effect) {
+    private GridMonitorEffect(final GridMonitorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GriefTyrant.java
+++ b/Mage.Sets/src/mage/cards/g/GriefTyrant.java
@@ -57,7 +57,7 @@ class GriefTyrantEffect extends OneShotEffect {
         this.staticText = "put a -1/-1 counter on target creature for each -1/-1 counter on {this}";
     }
     
-    public GriefTyrantEffect(final GriefTyrantEffect effect) {
+    private GriefTyrantEffect(final GriefTyrantEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/g/GriffinCanyon.java
+++ b/Mage.Sets/src/mage/cards/g/GriffinCanyon.java
@@ -53,7 +53,7 @@ class GriffinCanyonEffect extends OneShotEffect {
         this.staticText = "Untap target Griffin. If it's a creature, it gets +1/+1 until end of turn";
     }
 
-    public GriffinCanyonEffect(final GriffinCanyonEffect effect) {
+    private GriffinCanyonEffect(final GriffinCanyonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GriftersBlade.java
+++ b/Mage.Sets/src/mage/cards/g/GriftersBlade.java
@@ -64,7 +64,7 @@ class GriftersBladeChooseCreatureEffect extends OneShotEffect {
         this.staticText = "choose a creature you control it could be attached to. If you do, it enters the battlefield attached to that creature";
     }
 
-    public GriftersBladeChooseCreatureEffect(final GriftersBladeChooseCreatureEffect effect) {
+    private GriftersBladeChooseCreatureEffect(final GriftersBladeChooseCreatureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrimCaptainsCall.java
+++ b/Mage.Sets/src/mage/cards/g/GrimCaptainsCall.java
@@ -46,7 +46,7 @@ class GrimCaptainsCallEffect extends OneShotEffect {
         this.staticText = "Return a Pirate card from your graveyard to your hand, then do the same for Vampire, Dinosaur, and Merfolk";
     }
 
-    public GrimCaptainsCallEffect(final GrimCaptainsCallEffect effect) {
+    private GrimCaptainsCallEffect(final GrimCaptainsCallEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrimContest.java
+++ b/Mage.Sets/src/mage/cards/g/GrimContest.java
@@ -47,7 +47,7 @@ class GrimContestEffect extends OneShotEffect {
         this.staticText = "Choose target creature you control and target creature an opponent controls. Each of those creatures deals damage equal to its toughness to the other";
     }
 
-    public GrimContestEffect(final GrimContestEffect effect) {
+    private GrimContestEffect(final GrimContestEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrimFeast.java
+++ b/Mage.Sets/src/mage/cards/g/GrimFeast.java
@@ -57,7 +57,7 @@ class GrimFeastTriggeredAbility extends PutIntoGraveFromBattlefieldAllTriggeredA
         super(new GrimFeastEffect(), false, filter, true, false);
     }
 
-    public GrimFeastTriggeredAbility(final GrimFeastTriggeredAbility effect) {
+    private GrimFeastTriggeredAbility(final GrimFeastTriggeredAbility effect) {
         super(effect);
     }
 
@@ -79,7 +79,7 @@ class GrimFeastEffect extends OneShotEffect {
         super(Outcome.GainLife);
     }
 
-    public GrimFeastEffect(final GrimFeastEffect effect) {
+    private GrimFeastEffect(final GrimFeastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrimoireOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/g/GrimoireOfTheDead.java
@@ -71,7 +71,7 @@ class GrimoireOfTheDeadEffect extends OneShotEffect {
                 "They're black Zombies in addition to their other colors and types";
     }
 
-    public GrimoireOfTheDeadEffect(final GrimoireOfTheDeadEffect effect) {
+    private GrimoireOfTheDeadEffect(final GrimoireOfTheDeadEffect effect) {
         super(effect);
     }
 
@@ -107,7 +107,7 @@ class GrimoireOfTheDeadEffect2 extends ContinuousEffectImpl {
         super(Duration.Custom, Outcome.Neutral);
     }
 
-    public GrimoireOfTheDeadEffect2(final GrimoireOfTheDeadEffect2 effect) {
+    private GrimoireOfTheDeadEffect2(final GrimoireOfTheDeadEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrimoireThief.java
+++ b/Mage.Sets/src/mage/cards/g/GrimoireThief.java
@@ -75,7 +75,7 @@ class GrimoireThiefExileEffect extends OneShotEffect {
         staticText = "exile the top three cards of target opponent's library face down";
     }
 
-    public GrimoireThiefExileEffect(final GrimoireThiefExileEffect effect) {
+    private GrimoireThiefExileEffect(final GrimoireThiefExileEffect effect) {
         super(effect);
     }
 
@@ -123,7 +123,7 @@ class GrimoireThiefLookEffect extends AsThoughEffectImpl {
         staticText = "You may look at cards exiled with {this}";
     }
 
-    public GrimoireThiefLookEffect(final GrimoireThiefLookEffect effect) {
+    private GrimoireThiefLookEffect(final GrimoireThiefLookEffect effect) {
         super(effect);
     }
 
@@ -175,7 +175,7 @@ class GrimoireThiefCounterspellEffect extends OneShotEffect {
                 + "Counter all spells with those names";
     }
 
-    public GrimoireThiefCounterspellEffect(final GrimoireThiefCounterspellEffect effect) {
+    private GrimoireThiefCounterspellEffect(final GrimoireThiefCounterspellEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Grindclock.java
+++ b/Mage.Sets/src/mage/cards/g/Grindclock.java
@@ -51,7 +51,7 @@ class GrindclockEffect extends OneShotEffect {
         staticText = "Target player mills X cards, where X is the number of charge counters on {this}";
     }
 
-    public GrindclockEffect(final GrindclockEffect effect) {
+    private GrindclockEffect(final GrindclockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrinningTotem.java
+++ b/Mage.Sets/src/mage/cards/g/GrinningTotem.java
@@ -61,7 +61,7 @@ class GrinningTotemSearchAndExileEffect extends OneShotEffect {
                 "At the beginning of your next upkeep, if you haven't played it, put it into its owner's graveyard";
     }
 
-    public GrinningTotemSearchAndExileEffect(final GrinningTotemSearchAndExileEffect effect) {
+    private GrinningTotemSearchAndExileEffect(final GrinningTotemSearchAndExileEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class GrinningTotemDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.exileZoneId = exileZoneId;
     }
 
-    public GrinningTotemDelayedTriggeredAbility(final GrinningTotemDelayedTriggeredAbility ability) {
+    private GrinningTotemDelayedTriggeredAbility(final GrinningTotemDelayedTriggeredAbility ability) {
         super(ability);
         this.exileZoneId = ability.exileZoneId;
     }
@@ -142,7 +142,7 @@ class GrinningTotemPutIntoGraveyardEffect extends OneShotEffect {
         this.exileZoneId = exileZoneId;
     }
 
-    public GrinningTotemPutIntoGraveyardEffect(final GrinningTotemPutIntoGraveyardEffect effect) {
+    private GrinningTotemPutIntoGraveyardEffect(final GrinningTotemPutIntoGraveyardEffect effect) {
         super(effect);
         this.exileZoneId = effect.exileZoneId;
     }

--- a/Mage.Sets/src/mage/cards/g/GrislyAnglerfish.java
+++ b/Mage.Sets/src/mage/cards/g/GrislyAnglerfish.java
@@ -53,7 +53,7 @@ class GrislyAnglerfishMustAttackEffect extends RequirementEffect {
         staticText = "Creatures your opponents control attack this turn if able";
     }
 
-    public GrislyAnglerfishMustAttackEffect(final GrislyAnglerfishMustAttackEffect effect) {
+    private GrislyAnglerfishMustAttackEffect(final GrislyAnglerfishMustAttackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrislySpectacle.java
+++ b/Mage.Sets/src/mage/cards/g/GrislySpectacle.java
@@ -57,7 +57,7 @@ class GrislySpectacleEffect extends OneShotEffect {
         this.staticText = "Its controller mills cards equal to that creature's power";
     }
 
-    public GrislySpectacleEffect(final GrislySpectacleEffect effect) {
+    private GrislySpectacleEffect(final GrislySpectacleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrizzledAngler.java
+++ b/Mage.Sets/src/mage/cards/g/GrizzledAngler.java
@@ -62,7 +62,7 @@ class GrizzledAnglerEffect extends OneShotEffect {
         staticText = "Mill two cards. Then if there is a colorless creature card in your graveyard, transform {this}";
     }
 
-    public GrizzledAnglerEffect(final GrizzledAnglerEffect effect) {
+    private GrizzledAnglerEffect(final GrizzledAnglerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Grollub.java
+++ b/Mage.Sets/src/mage/cards/g/Grollub.java
@@ -48,7 +48,7 @@ class EachOpponentGainsLifeEffect extends OneShotEffect {
         this.staticText = "each opponent gains that much life";
     }
 
-    public EachOpponentGainsLifeEffect(final EachOpponentGainsLifeEffect effect) {
+    private EachOpponentGainsLifeEffect(final EachOpponentGainsLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GroundPounder.java
+++ b/Mage.Sets/src/mage/cards/g/GroundPounder.java
@@ -58,7 +58,7 @@ class GroundPounderEffect extends OneShotEffect {
         this.staticText = "Roll a six-sided die. {this} gets +X/+X until end of turn, where X is the result";
     }
 
-    public GroundPounderEffect(final GroundPounderEffect effect) {
+    private GroundPounderEffect(final GroundPounderEffect effect) {
         super(effect);
     }
 
@@ -86,7 +86,7 @@ class GroundPounderTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainAbilitySourceEffect(TrampleAbility.getInstance(), Duration.EndOfTurn), false);
     }
 
-    public GroundPounderTriggeredAbility(final GroundPounderTriggeredAbility ability) {
+    private GroundPounderTriggeredAbility(final GroundPounderTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GroundlingPouncer.java
+++ b/Mage.Sets/src/mage/cards/g/GroundlingPouncer.java
@@ -79,7 +79,7 @@ class GroundlingPouncerAbility extends LimitedTimesPerTurnActivatedAbility {
         this.ruleText = rule;
     }
 
-    public GroundlingPouncerAbility(GroundlingPouncerAbility ability) {
+    private GroundlingPouncerAbility(final GroundlingPouncerAbility ability) {
         super(ability);
         this.ruleText = ability.ruleText;
     }

--- a/Mage.Sets/src/mage/cards/g/GruesomeMenagerie.java
+++ b/Mage.Sets/src/mage/cards/g/GruesomeMenagerie.java
@@ -66,7 +66,7 @@ class GruesomeMenagerieEffect extends OneShotEffect {
                 + "Return those cards to the battlefield.";
     }
 
-    public GruesomeMenagerieEffect(final GruesomeMenagerieEffect effect) {
+    private GruesomeMenagerieEffect(final GruesomeMenagerieEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GruulKeyrune.java
+++ b/Mage.Sets/src/mage/cards/g/GruulKeyrune.java
@@ -55,7 +55,7 @@ public final class GruulKeyrune extends CardImpl {
             toughness = new MageInt(2);
             this.addAbility(TrampleAbility.getInstance());
         }
-        public GruulKeyruneToken(final GruulKeyruneToken token) {
+        private GruulKeyruneToken(final GruulKeyruneToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/g/GruulWarPlow.java
+++ b/Mage.Sets/src/mage/cards/g/GruulWarPlow.java
@@ -53,7 +53,7 @@ class GruulWarPlowToken extends TokenImpl {
         power = new MageInt(4);
         toughness = new MageInt(4);
     }
-    public GruulWarPlowToken(final GruulWarPlowToken token) {
+    private GruulWarPlowToken(final GruulWarPlowToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GryffsBoon.java
+++ b/Mage.Sets/src/mage/cards/g/GryffsBoon.java
@@ -69,7 +69,7 @@ class GryffsBoonEffect extends OneShotEffect {
         staticText = "Return {this} from your graveyard to the battlefield attached to target creature";
     }
 
-    public GryffsBoonEffect(final GryffsBoonEffect effect) {
+    private GryffsBoonEffect(final GryffsBoonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuardDogs.java
+++ b/Mage.Sets/src/mage/cards/g/GuardDogs.java
@@ -60,7 +60,7 @@ class GuardDogsEffect extends PreventionEffectImpl {
         this.staticText = "Choose a permanent you control. Prevent all combat damage target creature would deal this turn if it shares a color with that permanent";
     }
 
-    public GuardDogsEffect(final GuardDogsEffect effect) {
+    private GuardDogsEffect(final GuardDogsEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/g/GuardDuty.java
+++ b/Mage.Sets/src/mage/cards/g/GuardDuty.java
@@ -39,7 +39,7 @@ public final class GuardDuty extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(DefenderAbility.getInstance(), AttachmentType.AURA)));
     }
 
-    public GuardDuty (final GuardDuty card) {
+    private GuardDuty(final GuardDuty card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuardianAngel.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianAngel.java
@@ -55,7 +55,7 @@ class GuardianAngelEffect extends OneShotEffect {
         this.staticText = "Prevent the next X damage that would be dealt to any target this turn. Until end of turn, you may pay {1} any time you could cast an instant. If you do, prevent the next 1 damage that would be dealt to that permanent or player this turn";
     }
 
-    public GuardianAngelEffect(final GuardianAngelEffect effect) {
+    private GuardianAngelEffect(final GuardianAngelEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuardianBeast.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianBeast.java
@@ -73,7 +73,7 @@ class GuardianBeastConditionalEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = ", and other players can't gain control of them. This effect doesn't remove Auras already attached to those artifacts";
     }
 
-    public GuardianBeastConditionalEffect(final GuardianBeastConditionalEffect effect) {
+    private GuardianBeastConditionalEffect(final GuardianBeastConditionalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuardianIdol.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianIdol.java
@@ -53,7 +53,7 @@ class GuardianIdolGolemToken extends TokenImpl {
         power = new MageInt(2);
         toughness = new MageInt(2);
     }
-    public GuardianIdolGolemToken(final GuardianIdolGolemToken token) {
+    private GuardianIdolGolemToken(final GuardianIdolGolemToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuardianOfTazeem.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianOfTazeem.java
@@ -60,7 +60,7 @@ class GuardianOfTazeemTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("<i>Landfall</i> &mdash; Whenever a land enters the battlefield under your control, " );
     }
 
-    public GuardianOfTazeemTriggeredAbility(final GuardianOfTazeemTriggeredAbility ability) {
+    private GuardianOfTazeemTriggeredAbility(final GuardianOfTazeemTriggeredAbility ability) {
         super(ability);
     }
 
@@ -98,7 +98,7 @@ class GuardianOfTazeemEffect extends OneShotEffect {
         this.staticText = "If that land is an Island, that creature doesn't untap during its controller's next untap step";
     }
 
-    public GuardianOfTazeemEffect(final GuardianOfTazeemEffect effect) {
+    private GuardianOfTazeemEffect(final GuardianOfTazeemEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuardianOfTheAges.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianOfTheAges.java
@@ -56,7 +56,7 @@ class GuardianOfTheAgesTriggerAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainAbilitySourceEffect(TrampleAbility.getInstance()));
         this.addEffect(new LoseAbilitySourceEffect(DefenderAbility.getInstance()));
     }
-    public GuardianOfTheAgesTriggerAbility(final GuardianOfTheAgesTriggerAbility ability){
+    private GuardianOfTheAgesTriggerAbility(final GuardianOfTheAgesTriggerAbility ability){
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuardianSeraph.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianSeraph.java
@@ -52,7 +52,7 @@ class GuardianSeraphEffect extends PreventionEffectImpl {
         this.staticText = "If a source an opponent controls would deal damage to you, prevent 1 of that damage";
     }
 
-    public GuardianSeraphEffect(final GuardianSeraphEffect effect) {
+    private GuardianSeraphEffect(final GuardianSeraphEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuardianZendikon.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianZendikon.java
@@ -72,7 +72,7 @@ class GuardianZendikonWallToken extends TokenImpl {
         toughness = new MageInt(6);
         this.addAbility(DefenderAbility.getInstance());
     }
-    public GuardianZendikonWallToken(final GuardianZendikonWallToken token) {
+    private GuardianZendikonWallToken(final GuardianZendikonWallToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuardiansOfAkrasa.java
+++ b/Mage.Sets/src/mage/cards/g/GuardiansOfAkrasa.java
@@ -28,7 +28,7 @@ public final class GuardiansOfAkrasa extends CardImpl {
         this.addAbility(new ExaltedAbility());
     }
 
-    public GuardiansOfAkrasa (final GuardiansOfAkrasa card) {
+    private GuardiansOfAkrasa(final GuardiansOfAkrasa card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuardiansPledge.java
+++ b/Mage.Sets/src/mage/cards/g/GuardiansPledge.java
@@ -30,7 +30,7 @@ public final class GuardiansPledge extends CardImpl {
         this.getSpellAbility().addEffect(new BoostControlledEffect(2, 2, Duration.EndOfTurn, filter, false));
     }
 
-    public GuardiansPledge (final GuardiansPledge card) {
+    private GuardiansPledge(final GuardiansPledge card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuildFeud.java
+++ b/Mage.Sets/src/mage/cards/g/GuildFeud.java
@@ -54,7 +54,7 @@ class GuildFeudEffect extends OneShotEffect {
         staticText = "target opponent reveals the top three cards of their library, may put a creature card from among them onto the battlefield, then puts the rest into their graveyard. You do the same with the top three cards of your library. If two creatures are put onto the battlefield this way, those creatures fight each other";
     }
 
-    public GuildFeudEffect(final GuildFeudEffect effect) {
+    private GuildFeudEffect(final GuildFeudEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuildSummit.java
+++ b/Mage.Sets/src/mage/cards/g/GuildSummit.java
@@ -72,7 +72,7 @@ class GuildSummitEffect extends OneShotEffect {
                 + "Draw a card for each Gate tapped this way";
     }
 
-    public GuildSummitEffect(GuildSummitEffect effect) {
+    private GuildSummitEffect(final GuildSummitEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuildmagesForum.java
+++ b/Mage.Sets/src/mage/cards/g/GuildmagesForum.java
@@ -89,7 +89,7 @@ class GuildmagesForumEntersBattlefieldEffect extends ReplacementEffectImpl {
         this.mor = mor;
     }
 
-    public GuildmagesForumEntersBattlefieldEffect(GuildmagesForumEntersBattlefieldEffect effect) {
+    private GuildmagesForumEntersBattlefieldEffect(final GuildmagesForumEntersBattlefieldEffect effect) {
         super(effect);
         this.mor = effect.mor;
     }

--- a/Mage.Sets/src/mage/cards/g/GustSkimmer.java
+++ b/Mage.Sets/src/mage/cards/g/GustSkimmer.java
@@ -29,7 +29,7 @@ public final class GustSkimmer extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.EndOfTurn), new ManaCostsImpl<>("{U}")));
     }
 
-    public GustSkimmer (final GustSkimmer card) {
+    private GustSkimmer(final GustSkimmer card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GusthasScepter.java
+++ b/Mage.Sets/src/mage/cards/g/GusthasScepter.java
@@ -59,7 +59,7 @@ class GusthasScepterExileEffect extends OneShotEffect {
         staticText = "exile a card from your hand face down. You may look at it for as long as it remains exiled";
     }
 
-    public GusthasScepterExileEffect(final GusthasScepterExileEffect effect) {
+    private GusthasScepterExileEffect(final GusthasScepterExileEffect effect) {
         super(effect);
     }
 
@@ -136,7 +136,7 @@ class GusthasScepterLookAtCardEffect extends AsThoughEffectImpl {
         staticText = "You may look at it for as long as it remains exiled";
     }
 
-    public GusthasScepterLookAtCardEffect(final GusthasScepterLookAtCardEffect effect) {
+    private GusthasScepterLookAtCardEffect(final GusthasScepterLookAtCardEffect effect) {
         super(effect);
         this.mor = effect.mor;
     }
@@ -172,7 +172,7 @@ class GusthasScepterLoseControlAbility extends DelayedTriggeredAbility {
         super(new GusthasScepterPutExiledCardsInOwnersGraveyard(), Duration.EndOfGame, false);
     }
 
-    public GusthasScepterLoseControlAbility(final GusthasScepterLoseControlAbility ability) {
+    private GusthasScepterLoseControlAbility(final GusthasScepterLoseControlAbility ability) {
         super(ability);
     }
 
@@ -210,7 +210,7 @@ class GusthasScepterPutExiledCardsInOwnersGraveyard extends OneShotEffect {
         super(Outcome.Neutral);
     }
 
-    public GusthasScepterPutExiledCardsInOwnersGraveyard(final GusthasScepterPutExiledCardsInOwnersGraveyard effect) {
+    private GusthasScepterPutExiledCardsInOwnersGraveyard(final GusthasScepterPutExiledCardsInOwnersGraveyard effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GutterGrime.java
+++ b/Mage.Sets/src/mage/cards/g/GutterGrime.java
@@ -50,7 +50,7 @@ class GutterGrimeTriggeredAbility extends TriggeredAbilityImpl {
         this.addEffect(new GutterGrimeEffect());
     }
 
-    public GutterGrimeTriggeredAbility(GutterGrimeTriggeredAbility ability) {
+    private GutterGrimeTriggeredAbility(final GutterGrimeTriggeredAbility ability) {
         super(ability);
     }
 
@@ -91,7 +91,7 @@ class GutterGrimeEffect extends OneShotEffect {
         super(Outcome.PutCreatureInPlay);
     }
 
-    public GutterGrimeEffect(final GutterGrimeEffect effect) {
+    private GutterGrimeEffect(final GutterGrimeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Guttersnipe.java
+++ b/Mage.Sets/src/mage/cards/g/Guttersnipe.java
@@ -40,7 +40,7 @@ public final class Guttersnipe extends CardImpl {
         this.addAbility(new SpellCastControllerTriggeredAbility(new DamagePlayersEffect(2, TargetController.OPPONENT), filter, false));
     }
 
-    public Guttersnipe (final Guttersnipe card) {
+    private Guttersnipe(final Guttersnipe card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuulDrazAssassin.java
+++ b/Mage.Sets/src/mage/cards/g/GuulDrazAssassin.java
@@ -56,7 +56,7 @@ public final class GuulDrazAssassin extends LevelerCard {
         setMaxLevelCounters(4);
     }
 
-    public GuulDrazAssassin (final GuulDrazAssassin card) {
+    private GuulDrazAssassin(final GuulDrazAssassin card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuulDrazOverseer.java
+++ b/Mage.Sets/src/mage/cards/g/GuulDrazOverseer.java
@@ -51,7 +51,7 @@ class GuulDrazOverseerEffect extends OneShotEffect {
         this.staticText = "other creatures you control get +1/+0 until end of turn. If that land is a Swamp, those creatures get +2/+0 until end of turn instead";
     }
 
-    public GuulDrazOverseerEffect(final GuulDrazOverseerEffect effect) {
+    private GuulDrazOverseerEffect(final GuulDrazOverseerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GyrusWakerOfCorpses.java
+++ b/Mage.Sets/src/mage/cards/g/GyrusWakerOfCorpses.java
@@ -75,7 +75,7 @@ class GyrusWakerOfCorpsesEffect extends OneShotEffect {
         this.staticText = "exile target creature card with lesser power from your graveyard. If you do, create a token that's a copy of that card and that's tapped and attacking. Exile the token at the end of combat.";
     }
 
-    public GyrusWakerOfCorpsesEffect(final GyrusWakerOfCorpsesEffect effect) {
+    private GyrusWakerOfCorpsesEffect(final GyrusWakerOfCorpsesEffect effect) {
         super(effect);
     }
 


### PR DESCRIPTION
Part of #11054 

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`public ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `private $1(final $1 $3`
