### PR TITLE
Clean public copy constructors in cards starting D-E

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DaggerclawImp.java
+++ b/Mage.Sets/src/mage/cards/d/DaggerclawImp.java
@@ -27,7 +27,7 @@ public final class DaggerclawImp extends CardImpl {
         this.addAbility(new CantBlockAbility());
     }
 
-    public DaggerclawImp (final DaggerclawImp card) {
+    private DaggerclawImp(final DaggerclawImp card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DaghatarTheAdamant.java
+++ b/Mage.Sets/src/mage/cards/d/DaghatarTheAdamant.java
@@ -71,7 +71,7 @@ class MoveCounterFromTargetToTargetEffect extends OneShotEffect {
         this.staticText = "Move a +1/+1 counter from target creature onto a second target creature";
     }
 
-    public MoveCounterFromTargetToTargetEffect(final MoveCounterFromTargetToTargetEffect effect) {
+    private MoveCounterFromTargetToTargetEffect(final MoveCounterFromTargetToTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DakraMystic.java
+++ b/Mage.Sets/src/mage/cards/d/DakraMystic.java
@@ -57,7 +57,7 @@ class DakraMysticEffect extends OneShotEffect {
         this.staticText = "Each player reveals the top card of their library. You may put the revealed cards into their owners' graveyard. If you don't, each player draws a card";
     }
 
-    public DakraMysticEffect(final DakraMysticEffect effect) {
+    private DakraMysticEffect(final DakraMysticEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DamnablePact.java
+++ b/Mage.Sets/src/mage/cards/d/DamnablePact.java
@@ -44,7 +44,7 @@ class DamnablePactEffect extends OneShotEffect {
         staticText = "Target player draws X cards and loses X life";
     }
 
-    public DamnablePactEffect(DamnablePactEffect effect) {
+    private DamnablePactEffect(final DamnablePactEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DampingField.java
+++ b/Mage.Sets/src/mage/cards/d/DampingField.java
@@ -48,7 +48,7 @@ class DampingFieldEffect extends RestrictionUntapNotMoreThanEffect {
         staticText = "Players can't untap more than one artifact during their untap steps";
     }
 
-    public DampingFieldEffect(final DampingFieldEffect effect) {
+    private DampingFieldEffect(final DampingFieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DampingMatrix.java
+++ b/Mage.Sets/src/mage/cards/d/DampingMatrix.java
@@ -58,7 +58,7 @@ class DampingMatrixEffect extends ReplacementEffectImpl {
         staticText = "Activated abilities of artifacts and creatures can't be activated unless they're mana abilities";
     }
 
-    public DampingMatrixEffect(final DampingMatrixEffect effect) {
+    private DampingMatrixEffect(final DampingMatrixEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DanceOfMany.java
+++ b/Mage.Sets/src/mage/cards/d/DanceOfMany.java
@@ -76,7 +76,7 @@ class DanceOfManyCreateTokenCopyEffect extends OneShotEffect {
         staticText = "create a token that's a copy of target nontoken creature";
     }
 
-    public DanceOfManyCreateTokenCopyEffect(final DanceOfManyCreateTokenCopyEffect effect) {
+    private DanceOfManyCreateTokenCopyEffect(final DanceOfManyCreateTokenCopyEffect effect) {
         super(effect);
     }
 
@@ -120,7 +120,7 @@ class DanceOfManyExileTokenEffect extends OneShotEffect {
         staticText = "exile the token";
     }
 
-    public DanceOfManyExileTokenEffect(final DanceOfManyExileTokenEffect effect) {
+    private DanceOfManyExileTokenEffect(final DanceOfManyExileTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DanceOfShadows.java
+++ b/Mage.Sets/src/mage/cards/d/DanceOfShadows.java
@@ -35,7 +35,7 @@ public final class DanceOfShadows extends CardImpl {
         this.getSpellAbility().addEffect(effect);
     }
 
-    public DanceOfShadows (final DanceOfShadows card) {
+    private DanceOfShadows(final DanceOfShadows card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DanceOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/d/DanceOfTheDead.java
@@ -77,7 +77,7 @@ class DanceOfTheDeadDoIfCostPaidEffect extends DoIfCostPaid {
         super(new UntapAttachedEffect(), new ManaCostsImpl<>("{1}{B}"));
     }
 
-    public DanceOfTheDeadDoIfCostPaidEffect(final DanceOfTheDeadDoIfCostPaidEffect effect) {
+    private DanceOfTheDeadDoIfCostPaidEffect(final DanceOfTheDeadDoIfCostPaidEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DanceOfTheSkywise.java
+++ b/Mage.Sets/src/mage/cards/d/DanceOfTheSkywise.java
@@ -53,7 +53,7 @@ public final class DanceOfTheSkywise extends CardImpl {
             toughness = new MageInt(4);
             this.addAbility(FlyingAbility.getInstance());
         }
-        public DragonIllusionToken(final DragonIllusionToken token) {
+        private DragonIllusionToken(final DragonIllusionToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/d/DaredevilDragster.java
+++ b/Mage.Sets/src/mage/cards/d/DaredevilDragster.java
@@ -62,7 +62,7 @@ class DaredevilDragsterEffect extends OneShotEffect {
         this.staticText = "put a velocity counter on it. Then if it has two or more velocity counters on it, sacrifice it and draw two cards";
     }
 
-    public DaredevilDragsterEffect(final DaredevilDragsterEffect effect) {
+    private DaredevilDragsterEffect(final DaredevilDragsterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DargoTheShipwrecker.java
+++ b/Mage.Sets/src/mage/cards/d/DargoTheShipwrecker.java
@@ -70,7 +70,7 @@ class DargoTheShipwreckerEffect extends CostModificationEffectImpl {
         super(Duration.WhileOnStack, Outcome.Benefit, CostModificationType.REDUCE_COST);
     }
 
-    public DargoTheShipwreckerEffect(final DargoTheShipwreckerEffect effect) {
+    private DargoTheShipwreckerEffect(final DargoTheShipwreckerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarienKingOfKjeldor.java
+++ b/Mage.Sets/src/mage/cards/d/DarienKingOfKjeldor.java
@@ -55,7 +55,7 @@ class DarienKingOfKjeldorTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DarienKingOfKjeldorEffect(), true);
     }
 
-    public DarienKingOfKjeldorTriggeredAbility(final DarienKingOfKjeldorTriggeredAbility ability) {
+    private DarienKingOfKjeldorTriggeredAbility(final DarienKingOfKjeldorTriggeredAbility ability) {
         super(ability);
     }
 
@@ -90,7 +90,7 @@ class DarienKingOfKjeldorEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public DarienKingOfKjeldorEffect(final DarienKingOfKjeldorEffect effect) {
+    private DarienKingOfKjeldorEffect(final DarienKingOfKjeldorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarigaazReincarnated.java
+++ b/Mage.Sets/src/mage/cards/d/DarigaazReincarnated.java
@@ -73,7 +73,7 @@ class DarigaazReincarnatedDiesEffect extends ReplacementEffectImpl {
         staticText = "If {this} would die, instead exile it with three egg counters on it";
     }
 
-    public DarigaazReincarnatedDiesEffect(final DarigaazReincarnatedDiesEffect effect) {
+    private DarigaazReincarnatedDiesEffect(final DarigaazReincarnatedDiesEffect effect) {
         super(effect);
     }
 
@@ -118,7 +118,7 @@ class DarigaazReincarnatedInterveningIfTriggeredAbility extends ConditionalInter
                         + "remove an egg counter from it. Then if {this} has no egg counters on it, return it to the battlefield");
     }
 
-    public DarigaazReincarnatedInterveningIfTriggeredAbility(final DarigaazReincarnatedInterveningIfTriggeredAbility effect) {
+    private DarigaazReincarnatedInterveningIfTriggeredAbility(final DarigaazReincarnatedInterveningIfTriggeredAbility effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarigaazTheIgniter.java
+++ b/Mage.Sets/src/mage/cards/d/DarigaazTheIgniter.java
@@ -59,7 +59,7 @@ class DarigaazTheIgniterEffect extends OneShotEffect {
                 + " to the player equal to the number of cards of that color revealed this way";
     }
 
-    public DarigaazTheIgniterEffect(final DarigaazTheIgniterEffect effect) {
+    private DarigaazTheIgniterEffect(final DarigaazTheIgniterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DaringSleuth.java
+++ b/Mage.Sets/src/mage/cards/d/DaringSleuth.java
@@ -51,7 +51,7 @@ class DaringSleuthTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When you sacrifice a Clue, ");
     }
 
-    public DaringSleuthTriggeredAbility(final DaringSleuthTriggeredAbility ability) {
+    private DaringSleuthTriggeredAbility(final DaringSleuthTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DaringThief.java
+++ b/Mage.Sets/src/mage/cards/d/DaringThief.java
@@ -65,7 +65,7 @@ class TargetControlledPermanentSharingOpponentPermanentCardType extends TargetCo
         setTargetName("nonland permanent you control");
     }
 
-    public TargetControlledPermanentSharingOpponentPermanentCardType(final TargetControlledPermanentSharingOpponentPermanentCardType target) {
+    private TargetControlledPermanentSharingOpponentPermanentCardType(final TargetControlledPermanentSharingOpponentPermanentCardType target) {
         super(target);
     }
 
@@ -135,7 +135,7 @@ class DaringThiefSecondTarget extends TargetPermanent {
         setTargetName("permanent an opponent controls that shares a card type with it");
     }
 
-    public DaringThiefSecondTarget(final DaringThiefSecondTarget target) {
+    private DaringThiefSecondTarget(final DaringThiefSecondTarget target) {
         super(target);
         this.firstTarget = target.firstTarget;
     }

--- a/Mage.Sets/src/mage/cards/d/DarkDabbling.java
+++ b/Mage.Sets/src/mage/cards/d/DarkDabbling.java
@@ -51,7 +51,7 @@ class DarkDabblingEffect extends OneShotEffect {
         this.staticText = "<br><i>Spell mastery</i> &mdash; If there are two or more instant and/or sorcery cards in your graveyard, also regenerate each other creature you control";
     }
 
-    public DarkDabblingEffect(final DarkDabblingEffect effect) {
+    private DarkDabblingEffect(final DarkDabblingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkDecision.java
+++ b/Mage.Sets/src/mage/cards/d/DarkDecision.java
@@ -53,7 +53,7 @@ class DarkDecisionEffect extends OneShotEffect {
         this.staticText = "Search the top 10 cards of your library for a nonland card, exile it, then shuffle. Until end of turn, you may cast that card";
     }
 
-    public DarkDecisionEffect(final DarkDecisionEffect effect) {
+    private DarkDecisionEffect(final DarkDecisionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkDepths.java
+++ b/Mage.Sets/src/mage/cards/d/DarkDepths.java
@@ -59,7 +59,7 @@ class DarkDepthsSacrificeEffect extends SacrificeSourceEffect {
         super();
     }
 
-    public DarkDepthsSacrificeEffect(final DarkDepthsSacrificeEffect effect) {
+    private DarkDepthsSacrificeEffect(final DarkDepthsSacrificeEffect effect) {
         super(effect);
         this.sacrificed = effect.sacrificed;
     }
@@ -89,7 +89,7 @@ class DarkDepthsAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new DarkDepthsSacrificeEffect());
     }
 
-    public DarkDepthsAbility(final DarkDepthsAbility ability) {
+    private DarkDepthsAbility(final DarkDepthsAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkHatchling.java
+++ b/Mage.Sets/src/mage/cards/d/DarkHatchling.java
@@ -35,7 +35,7 @@ public final class DarkHatchling extends CardImpl {
         this.addAbility(ability);
     }
 
-    public DarkHatchling (final DarkHatchling card) {
+    private DarkHatchling(final DarkHatchling card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkIntimations.java
+++ b/Mage.Sets/src/mage/cards/d/DarkIntimations.java
@@ -83,7 +83,7 @@ class DarkIntimationsEffect extends OneShotEffect {
         this.staticText = "Each opponent sacrifices a creature or planeswalker, then discards a card. You return a creature or planeswalker card from your graveyard to your hand, then draw a card";
     }
 
-    public DarkIntimationsEffect(final DarkIntimationsEffect effect) {
+    private DarkIntimationsEffect(final DarkIntimationsEffect effect) {
         super(effect);
     }
 
@@ -143,7 +143,7 @@ class DarkIntimationsGraveyardEffect extends OneShotEffect {
         this.staticText = "exile {this} from your graveyard. That planeswalker enters the battlefield with an additional loyalty counter on it";
     }
 
-    public DarkIntimationsGraveyardEffect(final DarkIntimationsGraveyardEffect effect) {
+    private DarkIntimationsGraveyardEffect(final DarkIntimationsGraveyardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkRevenant.java
+++ b/Mage.Sets/src/mage/cards/d/DarkRevenant.java
@@ -54,7 +54,7 @@ class DarkRevenantEffect extends OneShotEffect {
         staticText = "put it on top of its owner's library";
     }
 
-    public DarkRevenantEffect(final DarkRevenantEffect effect) {
+    private DarkRevenantEffect(final DarkRevenantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkSphere.java
+++ b/Mage.Sets/src/mage/cards/d/DarkSphere.java
@@ -58,7 +58,7 @@ class DarkSpherePreventionEffect extends ReplacementEffectImpl {
         this.targetSource = new TargetSource(new FilterObject("source of your choice"));
     }
     
-    public DarkSpherePreventionEffect(final DarkSpherePreventionEffect effect) {
+    private DarkSpherePreventionEffect(final DarkSpherePreventionEffect effect) {
         super(effect);
         this.targetSource = effect.targetSource.copy();
     }

--- a/Mage.Sets/src/mage/cards/d/DarkSupplicant.java
+++ b/Mage.Sets/src/mage/cards/d/DarkSupplicant.java
@@ -64,7 +64,7 @@ class DarkSupplicantEffect extends OneShotEffect {
         this.staticText = "Search your graveyard, hand, and/or library for a card named Scion of Darkness and put it onto the battlefield. If you search your library this way, shuffle";
     }
 
-    public DarkSupplicantEffect(final DarkSupplicantEffect effect) {
+    private DarkSupplicantEffect(final DarkSupplicantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkTemper.java
+++ b/Mage.Sets/src/mage/cards/d/DarkTemper.java
@@ -47,7 +47,7 @@ class DarkTemperEffect extends OneShotEffect {
         this.staticText = "{this} deals 2 damage to target creature. If you control a black permanent, destroy the creature instead";
     }
 
-    public DarkTemperEffect(final DarkTemperEffect effect) {
+    private DarkTemperEffect(final DarkTemperEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkslickDrake.java
+++ b/Mage.Sets/src/mage/cards/d/DarkslickDrake.java
@@ -29,7 +29,7 @@ public final class DarkslickDrake extends CardImpl {
         this.addAbility(new DiesSourceTriggeredAbility(new DrawCardSourceControllerEffect(1), false));
     }
 
-    public DarkslickDrake (final DarkslickDrake card) {
+    private DarkslickDrake(final DarkslickDrake card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarksteelAxe.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelAxe.java
@@ -35,7 +35,7 @@ public final class DarksteelAxe extends CardImpl {
         this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(2), false));
     }
 
-    public DarksteelAxe (final DarksteelAxe card) {
+    private DarksteelAxe(final DarksteelAxe card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarksteelCitadel.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelCitadel.java
@@ -25,7 +25,7 @@ public final class DarksteelCitadel extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
     }
 
-    public DarksteelCitadel (final DarksteelCitadel card) {
+    private DarksteelCitadel(final DarksteelCitadel card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarksteelMonolith.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelMonolith.java
@@ -122,7 +122,7 @@ class DarksteelMonolithAddAltCostEffect extends ContinuousEffectImpl {
         staticText = "Once each turn, you may pay {0} rather than pay the mana cost for a colorless spell you cast from your hand.";
     }
 
-    public DarksteelMonolithAddAltCostEffect(final DarksteelMonolithAddAltCostEffect effect) {
+    private DarksteelMonolithAddAltCostEffect(final DarksteelMonolithAddAltCostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarksteelMutation.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelMutation.java
@@ -67,7 +67,7 @@ class DarksteelMutationInsectToken extends TokenImpl {
 
         this.addAbility(IndestructibleAbility.getInstance());
     }
-    public DarksteelMutationInsectToken(final DarksteelMutationInsectToken token) {
+    private DarksteelMutationInsectToken(final DarksteelMutationInsectToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarksteelMyr.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelMyr.java
@@ -24,7 +24,7 @@ public final class DarksteelMyr extends CardImpl {
         this.addAbility(IndestructibleAbility.getInstance());
     }
 
-    public DarksteelMyr (final DarksteelMyr card) {
+    private DarksteelMyr(final DarksteelMyr card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarksteelPlate.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelPlate.java
@@ -31,7 +31,7 @@ public final class DarksteelPlate extends CardImpl {
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(2), false));
     }
 
-    public DarksteelPlate (final DarksteelPlate card) {
+    private DarksteelPlate(final DarksteelPlate card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarksteelReactor.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelReactor.java
@@ -51,7 +51,7 @@ class DarksteelReactorStateTriggeredAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new WinGameSourceControllerEffect());
     }
 
-    public DarksteelReactorStateTriggeredAbility(final DarksteelReactorStateTriggeredAbility ability) {
+    private DarksteelReactorStateTriggeredAbility(final DarksteelReactorStateTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarksteelSentinel.java
+++ b/Mage.Sets/src/mage/cards/d/DarksteelSentinel.java
@@ -28,7 +28,7 @@ public final class DarksteelSentinel extends CardImpl {
         this.addAbility(IndestructibleAbility.getInstance());
     }
 
-    public DarksteelSentinel (final DarksteelSentinel card) {
+    private DarksteelSentinel(final DarksteelSentinel card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarthTyranusCountOfSerenno.java
+++ b/Mage.Sets/src/mage/cards/d/DarthTyranusCountOfSerenno.java
@@ -73,7 +73,7 @@ class DarthTyranusEffect extends OneShotEffect {
         staticText = "Target player's life total becomes 5. Another target players's life total becomes 30";
     }
 
-    public DarthTyranusEffect(DarthTyranusEffect effect) {
+    private DarthTyranusEffect(final DarthTyranusEffect effect) {
         super(effect);
     }
 
@@ -102,7 +102,7 @@ class TransmuteArtifactEffect extends SearchEffect {
         staticText = "Sacrifice an artifact. If you do, search your library for an artifact card and put that card onto the battlefield. Shuffle your library";
     }
 
-    public TransmuteArtifactEffect(final TransmuteArtifactEffect effect) {
+    private TransmuteArtifactEffect(final TransmuteArtifactEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarthVader.java
+++ b/Mage.Sets/src/mage/cards/d/DarthVader.java
@@ -63,7 +63,7 @@ class UnboostCreaturesDefendingPlayerEffect extends ContinuousEffectImpl {
         staticText = "creatures defending player controls get -1/-1 until end of turn for each +1/+1 counter on Darth Vader";
     }
 
-    public UnboostCreaturesDefendingPlayerEffect(final UnboostCreaturesDefendingPlayerEffect effect) {
+    private UnboostCreaturesDefendingPlayerEffect(final UnboostCreaturesDefendingPlayerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DaruSpiritualist.java
+++ b/Mage.Sets/src/mage/cards/d/DaruSpiritualist.java
@@ -50,7 +50,7 @@ class DaruSpiritualistTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect);
     }
 
-    public DaruSpiritualistTriggeredAbility(final DaruSpiritualistTriggeredAbility ability) {
+    private DaruSpiritualistTriggeredAbility(final DaruSpiritualistTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DashHopes.java
+++ b/Mage.Sets/src/mage/cards/d/DashHopes.java
@@ -51,7 +51,7 @@ class DashHopesCounterSourceEffect extends OneShotEffect {
         staticText = "any player may pay 5 life. If a player does, counter {this}";
     }
 
-    public DashHopesCounterSourceEffect(final DashHopesCounterSourceEffect effect) {
+    private DashHopesCounterSourceEffect(final DashHopesCounterSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DaughterOfAutumn.java
+++ b/Mage.Sets/src/mage/cards/d/DaughterOfAutumn.java
@@ -68,7 +68,7 @@ class DaughterOfAutumnPreventDamageTargetEffect extends RedirectionEffect {
         staticText = "The next " + amount + " damage that would be dealt to target white creature this turn is dealt to {this} instead";
     }
 
-    public DaughterOfAutumnPreventDamageTargetEffect(final DaughterOfAutumnPreventDamageTargetEffect effect) {
+    private DaughterOfAutumnPreventDamageTargetEffect(final DaughterOfAutumnPreventDamageTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DauntingDefender.java
+++ b/Mage.Sets/src/mage/cards/d/DauntingDefender.java
@@ -52,7 +52,7 @@ class DauntingDefenderEffect extends PreventionEffectImpl {
         this.staticText = "If a source would deal damage to a Cleric creature you control, prevent " + amount + " of that damage";
     }
 
-    public DauntingDefenderEffect(DauntingDefenderEffect effect) {
+    private DauntingDefenderEffect(final DauntingDefenderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DauntlessBodyguard.java
+++ b/Mage.Sets/src/mage/cards/d/DauntlessBodyguard.java
@@ -61,7 +61,7 @@ class DauntlessBodyguardGainAbilityEffect extends OneShotEffect {
         this.staticText = "The chosen creature gains indestructible until end of turn";
     }
 
-    public DauntlessBodyguardGainAbilityEffect(final DauntlessBodyguardGainAbilityEffect effect) {
+    private DauntlessBodyguardGainAbilityEffect(final DauntlessBodyguardGainAbilityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DawnOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/d/DawnOfTheDead.java
@@ -59,7 +59,7 @@ class DawnOfTheDeadEffect extends OneShotEffect {
         this.staticText = "return target creature card from your graveyard to the battlefield. That creature gains haste until end of turn. Exile it at the beginning of the next end step";
     }
 
-    public DawnOfTheDeadEffect(final DawnOfTheDeadEffect effect) {
+    private DawnOfTheDeadEffect(final DawnOfTheDeadEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DawnbreakReclaimer.java
+++ b/Mage.Sets/src/mage/cards/d/DawnbreakReclaimer.java
@@ -61,7 +61,7 @@ class DawnbreakReclaimerEffect extends OneShotEffect {
         this.staticText = "choose a creature card in an opponent's graveyard, then that player chooses a creature card in your graveyard. You may return those cards to the battlefield under their owners' control";
     }
 
-    public DawnbreakReclaimerEffect(final DawnbreakReclaimerEffect effect) {
+    private DawnbreakReclaimerEffect(final DawnbreakReclaimerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DaxosOfMeletis.java
+++ b/Mage.Sets/src/mage/cards/d/DaxosOfMeletis.java
@@ -63,7 +63,7 @@ class DaxosOfMeletisEffect extends OneShotEffect {
         this.staticText = "exile the top card of that player's library. You gain life equal to that card's mana value. Until end of turn, you may cast that card and you may spend mana as though it were mana of any color to cast that spell";
     }
 
-    public DaxosOfMeletisEffect(final DaxosOfMeletisEffect effect) {
+    private DaxosOfMeletisEffect(final DaxosOfMeletisEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DayOfTheDragons.java
+++ b/Mage.Sets/src/mage/cards/d/DayOfTheDragons.java
@@ -62,7 +62,7 @@ class DayOfTheDragonsEntersEffect extends OneShotEffect {
         staticText = "exile all creatures you control. Then create that many 5/5 red Dragon creature tokens with flying";
     }
 
-    public DayOfTheDragonsEntersEffect(final DayOfTheDragonsEntersEffect effect) {
+    private DayOfTheDragonsEntersEffect(final DayOfTheDragonsEntersEffect effect) {
         super(effect);
     }
 
@@ -104,7 +104,7 @@ class DayOfTheDragonsLeavesEffect extends OneShotEffect {
         staticText = "sacrifice all Dragons you control. Then return the exiled cards to the battlefield under your control";
     }
 
-    public DayOfTheDragonsLeavesEffect(final DayOfTheDragonsLeavesEffect effect) {
+    private DayOfTheDragonsLeavesEffect(final DayOfTheDragonsLeavesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DazzlingReflection.java
+++ b/Mage.Sets/src/mage/cards/d/DazzlingReflection.java
@@ -48,7 +48,7 @@ class DazzlingReflectionEffect extends OneShotEffect {
         this.staticText = "You gain life equal to target creature's power. The next time that creature would deal damage this turn, prevent that damage";
     }
 
-    public DazzlingReflectionEffect(final DazzlingReflectionEffect effect) {
+    private DazzlingReflectionEffect(final DazzlingReflectionEffect effect) {
         super(effect);
     }
 
@@ -81,7 +81,7 @@ class DazzlingReflectionPreventEffect extends PreventionEffectImpl {
         staticText = "The next time that creature would deal damage this turn, prevent that damage";
     }
 
-    public DazzlingReflectionPreventEffect(final DazzlingReflectionPreventEffect effect) {
+    private DazzlingReflectionPreventEffect(final DazzlingReflectionPreventEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeadIronSledge.java
+++ b/Mage.Sets/src/mage/cards/d/DeadIronSledge.java
@@ -56,7 +56,7 @@ class DeadIronSledgeTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever equipped creature blocks or becomes blocked by a creature, ");
     }
 
-    public DeadIronSledgeTriggeredAbility(final DeadIronSledgeTriggeredAbility ability) {
+    private DeadIronSledgeTriggeredAbility(final DeadIronSledgeTriggeredAbility ability) {
         super(ability);
     }
 
@@ -103,7 +103,7 @@ class DeadIronSledgeDestroyEffect extends OneShotEffect {
         this.staticText = "destroy both creatures";
     }
 
-    public DeadIronSledgeDestroyEffect(final DeadIronSledgeDestroyEffect effect) {
+    private DeadIronSledgeDestroyEffect(final DeadIronSledgeDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeadMansChest.java
+++ b/Mage.Sets/src/mage/cards/d/DeadMansChest.java
@@ -66,7 +66,7 @@ class DeadMansChestEffect extends OneShotEffect {
                 + "and you may spend mana as though it were mana of any type to cast those spells";
     }
 
-    public DeadMansChestEffect(final DeadMansChestEffect effect) {
+    private DeadMansChestEffect(final DeadMansChestEffect effect) {
         super(effect);
     }
 
@@ -112,7 +112,7 @@ class DeadMansChestCastFromExileEffect extends AsThoughEffectImpl {
         staticText = "You may cast nonland cards from among them as long as they remain exiled";
     }
 
-    public DeadMansChestCastFromExileEffect(final DeadMansChestCastFromExileEffect effect) {
+    private DeadMansChestCastFromExileEffect(final DeadMansChestCastFromExileEffect effect) {
         super(effect);
     }
 
@@ -147,7 +147,7 @@ class DeadMansChestSpendManaEffect extends AsThoughEffectImpl implements AsThoug
         staticText = "and you may spend mana as though it were mana of any type to cast those spells";
     }
 
-    public DeadMansChestSpendManaEffect(final DeadMansChestSpendManaEffect effect) {
+    private DeadMansChestSpendManaEffect(final DeadMansChestSpendManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeadReckoning.java
+++ b/Mage.Sets/src/mage/cards/d/DeadReckoning.java
@@ -51,7 +51,7 @@ class DeadReckoningEffect extends OneShotEffect {
         this.setTargetPointer(new EachTargetPointer());
     }
 
-    public DeadReckoningEffect(final DeadReckoningEffect effect) {
+    private DeadReckoningEffect(final DeadReckoningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeadRingers.java
+++ b/Mage.Sets/src/mage/cards/d/DeadRingers.java
@@ -43,7 +43,7 @@ class DeadRingersEffect extends DestroyTargetEffect {
         staticText = "Destroy two target nonblack creatures unless either one is a color the other isn't. They can't be regenerated.";
     }
 
-    public DeadRingersEffect(final DeadRingersEffect effect) {
+    private DeadRingersEffect(final DeadRingersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeadbridgeChant.java
+++ b/Mage.Sets/src/mage/cards/d/DeadbridgeChant.java
@@ -49,7 +49,7 @@ class DeadbridgeChantEffect extends OneShotEffect {
         this.staticText = "choose a card at random in your graveyard. If it's a creature card, put it onto the battlefield. Otherwise, put it into your hand";
     }
 
-    public DeadbridgeChantEffect(final DeadbridgeChantEffect effect) {
+    private DeadbridgeChantEffect(final DeadbridgeChantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Deadfall.java
+++ b/Mage.Sets/src/mage/cards/d/Deadfall.java
@@ -44,7 +44,7 @@ class DeadfallEffect extends AsThoughEffectImpl {
         staticText = "Creatures with forestwalk can be blocked as though they didn't have forestwalk";
     }
 
-    public DeadfallEffect(final DeadfallEffect effect) {
+    private DeadfallEffect(final DeadfallEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeadlockTrap.java
+++ b/Mage.Sets/src/mage/cards/d/DeadlockTrap.java
@@ -59,7 +59,7 @@ class DeadlockTrapCantActivateEffect extends RestrictionEffect {
         staticText = "Its activated abilities can't be activated this turn";
     }
 
-    public DeadlockTrapCantActivateEffect(final DeadlockTrapCantActivateEffect effect) {
+    private DeadlockTrapCantActivateEffect(final DeadlockTrapCantActivateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeadlyDesigns.java
+++ b/Mage.Sets/src/mage/cards/d/DeadlyDesigns.java
@@ -57,7 +57,7 @@ class DeadlyDesignsTriggerAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new DeadlyDesignsEffect());
     }
 
-    public DeadlyDesignsTriggerAbility(final DeadlyDesignsTriggerAbility ability) {
+    private DeadlyDesignsTriggerAbility(final DeadlyDesignsTriggerAbility ability) {
         super(ability);
     }
 
@@ -86,7 +86,7 @@ class DeadlyDesignsEffect extends SacrificeSourceEffect {
         super();
     }
 
-    public DeadlyDesignsEffect(final DeadlyDesignsEffect effect) {
+    private DeadlyDesignsEffect(final DeadlyDesignsEffect effect) {
         super(effect);
         this.sacrificed = effect.sacrificed;
     }

--- a/Mage.Sets/src/mage/cards/d/DeadlyTempest.java
+++ b/Mage.Sets/src/mage/cards/d/DeadlyTempest.java
@@ -46,7 +46,7 @@ class DeadlyTempestEffect extends OneShotEffect {
         this.staticText = "Destroy all creatures. Each player loses life equal to the number of creatures they controlled that were destroyed this way";
     }
 
-    public DeadlyTempestEffect(final DeadlyTempestEffect effect) {
+    private DeadlyTempestEffect(final DeadlyTempestEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DearlyDeparted.java
+++ b/Mage.Sets/src/mage/cards/d/DearlyDeparted.java
@@ -51,7 +51,7 @@ class DearlyDepartedEntersBattlefieldEffect extends ReplacementEffectImpl {
         staticText = "As long as {this} is in your graveyard, each Human creature you control enters the battlefield with an additional +1/+1 counter on it";
     }
 
-    public DearlyDepartedEntersBattlefieldEffect(DearlyDepartedEntersBattlefieldEffect effect) {
+    private DearlyDepartedEntersBattlefieldEffect(final DearlyDepartedEntersBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathByDragons.java
+++ b/Mage.Sets/src/mage/cards/d/DeathByDragons.java
@@ -46,7 +46,7 @@ class DeathByDragonsEffect extends OneShotEffect {
         this.staticText = "Each player other than target player creates a 5/5 red Dragon creature token with flying";
     }
 
-    public DeathByDragonsEffect(final DeathByDragonsEffect effect) {
+    private DeathByDragonsEffect(final DeathByDragonsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathFrenzy.java
+++ b/Mage.Sets/src/mage/cards/d/DeathFrenzy.java
@@ -45,7 +45,7 @@ class DeathFrenzyDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new GainLifeEffect(1), Duration.EndOfTurn, false);
     }
 
-    public DeathFrenzyDelayedTriggeredAbility(DeathFrenzyDelayedTriggeredAbility ability) {
+    private DeathFrenzyDelayedTriggeredAbility(final DeathFrenzyDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathGrasp.java
+++ b/Mage.Sets/src/mage/cards/d/DeathGrasp.java
@@ -26,7 +26,7 @@ public final class DeathGrasp extends CardImpl {
         this.getSpellAbility().addTarget(new TargetAnyTarget());
     }
 
-    public DeathGrasp (final DeathGrasp card) {
+    private DeathGrasp(final DeathGrasp card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathMaskDuplicant.java
+++ b/Mage.Sets/src/mage/cards/d/DeathMaskDuplicant.java
@@ -76,7 +76,7 @@ public final class DeathMaskDuplicant extends CardImpl {
             staticText = "As long as a card exiled with {this} has flying, {this} has flying. The same is true for fear, first strike, double strike, haste, landwalk, protection, and trample";
         }
 
-        public DeathMaskDuplicantEffect(final DeathMaskDuplicantEffect effect) {
+        private DeathMaskDuplicantEffect(final DeathMaskDuplicantEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/d/DeathMatch.java
+++ b/Mage.Sets/src/mage/cards/d/DeathMatch.java
@@ -74,7 +74,7 @@ class DeathMatchEffect extends OneShotEffect {
         return false;
     }
 
-    public DeathMatchEffect(final DeathMatchEffect effect) {
+    private DeathMatchEffect(final DeathMatchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathPitOffering.java
+++ b/Mage.Sets/src/mage/cards/d/DeathPitOffering.java
@@ -46,7 +46,7 @@ class DeathPitOfferingEffect extends OneShotEffect {
         this.staticText = "sacrifice all creatures you control";
     }
 
-    public DeathPitOfferingEffect(final DeathPitOfferingEffect effect) {
+    private DeathPitOfferingEffect(final DeathPitOfferingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathPitsOfRath.java
+++ b/Mage.Sets/src/mage/cards/d/DeathPitsOfRath.java
@@ -42,7 +42,7 @@ class DeathPitsOfRathTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(true));
     }
 
-    public DeathPitsOfRathTriggeredAbility(final DeathPitsOfRathTriggeredAbility effect) {
+    private DeathPitsOfRathTriggeredAbility(final DeathPitsOfRathTriggeredAbility effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathWatch.java
+++ b/Mage.Sets/src/mage/cards/d/DeathWatch.java
@@ -56,7 +56,7 @@ public final class DeathWatch extends CardImpl {
             staticText = "that creature's controller loses life equal to its power and you gain life equal to its toughness.";
         }
 
-        public DeathWatchEffect(DeathWatchEffect copy) {
+        private DeathWatchEffect(final DeathWatchEffect copy) {
             super(copy);
         }
 

--- a/Mage.Sets/src/mage/cards/d/DeathbringerLiege.java
+++ b/Mage.Sets/src/mage/cards/d/DeathbringerLiege.java
@@ -59,7 +59,7 @@ public final class DeathbringerLiege extends CardImpl {
         this.addAbility(ability);
     }
 
-    public DeathbringerLiege (final DeathbringerLiege card) {
+    private DeathbringerLiege(final DeathbringerLiege card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathcurseOgre.java
+++ b/Mage.Sets/src/mage/cards/d/DeathcurseOgre.java
@@ -27,7 +27,7 @@ public final class DeathcurseOgre extends CardImpl {
         this.addAbility(new DiesSourceTriggeredAbility(new LoseLifeAllPlayersEffect(3)));
     }
 
-    public DeathcurseOgre (final DeathcurseOgre card) {
+    private DeathcurseOgre(final DeathcurseOgre card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathforgeShaman.java
+++ b/Mage.Sets/src/mage/cards/d/DeathforgeShaman.java
@@ -56,7 +56,7 @@ class DeathforgeShamanEffect extends OneShotEffect {
         staticText = "it deals damage to target player or planeswalker equal to twice the number of times it was kicked";
     }
 
-    public DeathforgeShamanEffect(final DeathforgeShamanEffect effect) {
+    private DeathforgeShamanEffect(final DeathforgeShamanEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathgorgeScavenger.java
+++ b/Mage.Sets/src/mage/cards/d/DeathgorgeScavenger.java
@@ -55,7 +55,7 @@ class DeathgorgeScavengerEffect extends OneShotEffect {
         this.staticText = "exile target card from a graveyard. If a creature card is exiled this way, you gain 2 life. If a noncreature card is exiled this way, {this} gets +1/+1 until end of turn";
     }
 
-    public DeathgorgeScavengerEffect(final DeathgorgeScavengerEffect effect) {
+    private DeathgorgeScavengerEffect(final DeathgorgeScavengerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathlessAngel.java
+++ b/Mage.Sets/src/mage/cards/d/DeathlessAngel.java
@@ -42,7 +42,7 @@ public final class DeathlessAngel extends CardImpl {
         this.addAbility(ability);
     }
 
-    public DeathlessAngel (final DeathlessAngel card) {
+    private DeathlessAngel(final DeathlessAngel card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathmistRaptor.java
+++ b/Mage.Sets/src/mage/cards/d/DeathmistRaptor.java
@@ -61,7 +61,7 @@ class DeathmistRaptorEffect extends OneShotEffect {
         this.staticText = "you may return {this} from your graveyard to the battlefield face up or face down";
     }
 
-    public DeathmistRaptorEffect(final DeathmistRaptorEffect effect) {
+    private DeathmistRaptorEffect(final DeathmistRaptorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathsCaress.java
+++ b/Mage.Sets/src/mage/cards/d/DeathsCaress.java
@@ -51,7 +51,7 @@ class DeathsCaressEffect extends OneShotEffect {
         this.staticText = "If that creature was a Human, you gain life equal to its toughness";
     }
 
-    public DeathsCaressEffect(final DeathsCaressEffect effect) {
+    private DeathsCaressEffect(final DeathsCaressEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathsPresence.java
+++ b/Mage.Sets/src/mage/cards/d/DeathsPresence.java
@@ -46,7 +46,7 @@ class DeathsPresenceTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null);
     }
 
-    public DeathsPresenceTriggeredAbility(final DeathsPresenceTriggeredAbility ability) {
+    private DeathsPresenceTriggeredAbility(final DeathsPresenceTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DebtOfLoyalty.java
+++ b/Mage.Sets/src/mage/cards/d/DebtOfLoyalty.java
@@ -42,7 +42,7 @@ public final class DebtOfLoyalty extends CardImpl {
             this.staticText = "Regenerate target creature. You gain control of that creature if it regenerates this way.";
         }
 
-        public DebtOfLoyaltyEffect(final DebtOfLoyaltyEffect effect) {
+        private DebtOfLoyaltyEffect(final DebtOfLoyaltyEffect effect) {
             super(effect);
         }
         

--- a/Mage.Sets/src/mage/cards/d/DebtToTheDeathless.java
+++ b/Mage.Sets/src/mage/cards/d/DebtToTheDeathless.java
@@ -41,7 +41,7 @@ class DebtToTheDeathlessEffect extends OneShotEffect {
         this.staticText = "Each opponent loses two times X life. You gain life equal to the life lost this way";
     }
 
-    public DebtToTheDeathlessEffect(final DebtToTheDeathlessEffect effect) {
+    private DebtToTheDeathlessEffect(final DebtToTheDeathlessEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeceiverOfForm.java
+++ b/Mage.Sets/src/mage/cards/d/DeceiverOfForm.java
@@ -50,7 +50,7 @@ class DeceiverOfFormEffect extends OneShotEffect {
         this.staticText = "reveal the top card of your library. If a creature card is revealed this way, you may have creatures you control other than Deceiver of Form becomes copies of that card until end of turn. You may put that card on the bottom of your library";
     }
 
-    public DeceiverOfFormEffect(final DeceiverOfFormEffect effect) {
+    private DeceiverOfFormEffect(final DeceiverOfFormEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DecimatorBeetle.java
+++ b/Mage.Sets/src/mage/cards/d/DecimatorBeetle.java
@@ -72,7 +72,7 @@ class DecimatorBeetleEffect extends OneShotEffect {
         staticText = "remove a -1/-1 counter from target creature you control and put a -1/-1 counter on up to one target creature defending player controls";
     }
 
-    public DecimatorBeetleEffect(DecimatorBeetleEffect effect) {
+    private DecimatorBeetleEffect(final DecimatorBeetleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DecimatorWeb.java
+++ b/Mage.Sets/src/mage/cards/d/DecimatorWeb.java
@@ -33,7 +33,7 @@ public final class DecimatorWeb extends CardImpl {
         this.addAbility(ability);
     }
 
-    public DecimatorWeb (final DecimatorWeb card) {
+    private DecimatorWeb(final DecimatorWeb card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeclarationInStone.java
+++ b/Mage.Sets/src/mage/cards/d/DeclarationInStone.java
@@ -53,7 +53,7 @@ class DeclarationInStoneEffect extends OneShotEffect {
         staticText = "Exile target creature and all other creatures its controller controls with the same name as that creature. That player investigates for each nontoken creature exiled this way.";
     }
 
-    public DeclarationInStoneEffect(final DeclarationInStoneEffect effect) {
+    private DeclarationInStoneEffect(final DeclarationInStoneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DecreeOfPain.java
+++ b/Mage.Sets/src/mage/cards/d/DecreeOfPain.java
@@ -52,7 +52,7 @@ class DecreeOfPainEffect extends OneShotEffect {
         this.staticText = "Destroy all creatures. They can't be regenerated. Draw a card for each creature destroyed this way";
     }
 
-    public DecreeOfPainEffect(final DecreeOfPainEffect effect) {
+    private DecreeOfPainEffect(final DecreeOfPainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeemWorthy.java
+++ b/Mage.Sets/src/mage/cards/d/DeemWorthy.java
@@ -33,7 +33,7 @@ public final class DeemWorthy extends CardImpl {
         this.addAbility(ability);
     }
 
-    public DeemWorthy(final DeemWorthy card) {
+    private DeemWorthy(final DeemWorthy card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeepFreeze.java
+++ b/Mage.Sets/src/mage/cards/d/DeepFreeze.java
@@ -70,7 +70,7 @@ class DeepFreezeToken extends TokenImpl {
         this.addAbility(DefenderAbility.getInstance());
     }
 
-    public DeepFreezeToken(final DeepFreezeToken token) {
+    private DeepFreezeToken(final DeepFreezeToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeepfathomSkulker.java
+++ b/Mage.Sets/src/mage/cards/d/DeepfathomSkulker.java
@@ -62,7 +62,7 @@ class DeepfathomSkulkerTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), true);
     }
 
-    public DeepfathomSkulkerTriggeredAbility(final DeepfathomSkulkerTriggeredAbility ability) {
+    private DeepfathomSkulkerTriggeredAbility(final DeepfathomSkulkerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeepglowSkate.java
+++ b/Mage.Sets/src/mage/cards/d/DeepglowSkate.java
@@ -53,7 +53,7 @@ class DeepglowSkateEffect extends OneShotEffect {
         this.staticText = "double the number of each kind of counter on any number of target permanents";
     }
 
-    public DeepglowSkateEffect(final DeepglowSkateEffect effect) {
+    private DeepglowSkateEffect(final DeepglowSkateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DefiantBloodlord.java
+++ b/Mage.Sets/src/mage/cards/d/DefiantBloodlord.java
@@ -53,7 +53,7 @@ class DefiantBloodlordTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null);
     }
 
-    public DefiantBloodlordTriggeredAbility(final DefiantBloodlordTriggeredAbility ability) {
+    private DefiantBloodlordTriggeredAbility(final DefiantBloodlordTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DefiantVanguard.java
+++ b/Mage.Sets/src/mage/cards/d/DefiantVanguard.java
@@ -121,7 +121,7 @@ class DefiantVanguardEffect extends OneShotEffect {
         staticText = "destroy it and all creatures it blocked this turn";
     }
 
-    public DefiantVanguardEffect(final DefiantVanguardEffect effect) {
+    private DefiantVanguardEffect(final DefiantVanguardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeflectingPalm.java
+++ b/Mage.Sets/src/mage/cards/d/DeflectingPalm.java
@@ -50,7 +50,7 @@ class DeflectingPalmEffect extends PreventionEffectImpl {
         this.target = new TargetSource();
     }
 
-    public DeflectingPalmEffect(final DeflectingPalmEffect effect) {
+    private DeflectingPalmEffect(final DeflectingPalmEffect effect) {
         super(effect);
         this.target = effect.target.copy();
     }

--- a/Mage.Sets/src/mage/cards/d/DefyDeath.java
+++ b/Mage.Sets/src/mage/cards/d/DefyDeath.java
@@ -47,7 +47,7 @@ class DefyDeathEffect extends OneShotEffect {
         this.staticText = "If it's an Angel, put two +1/+1 counters on it";
     }
 
-    public DefyDeathEffect(final DefyDeathEffect effect) {
+    private DefyDeathEffect(final DefyDeathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Delay.java
+++ b/Mage.Sets/src/mage/cards/d/Delay.java
@@ -52,7 +52,7 @@ class DelayEffect extends OneShotEffect {
         this.staticText = "Counter target spell. If the spell is countered this way, exile it with three time counters on it instead of putting it into its owner's graveyard. If it doesn't have suspend, it gains suspend";
     }
 
-    public DelayEffect(final DelayEffect effect) {
+    private DelayEffect(final DelayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DelightedHalfling.java
+++ b/Mage.Sets/src/mage/cards/d/DelightedHalfling.java
@@ -139,7 +139,7 @@ class DelightedHalflingCantCounterEffect extends ContinuousRuleModifyingEffectIm
         staticText = null;
     }
 
-    public DelightedHalflingCantCounterEffect(final DelightedHalflingCantCounterEffect effect) {
+    private DelightedHalflingCantCounterEffect(final DelightedHalflingCantCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Delirium.java
+++ b/Mage.Sets/src/mage/cards/d/Delirium.java
@@ -63,7 +63,7 @@ class DeliriumEffect extends OneShotEffect {
         this.staticText = "that creature deals damage equal to its power to the player";
     }
 
-    public DeliriumEffect(DeliriumEffect effect) {
+    private DeliriumEffect(final DeliriumEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DelverOfSecrets.java
+++ b/Mage.Sets/src/mage/cards/d/DelverOfSecrets.java
@@ -59,7 +59,7 @@ class DelverOfSecretsEffect extends OneShotEffect {
         this.staticText = "look at the top card of your library. You may reveal that card. If an instant or sorcery card is revealed this way, transform {this}";
     }
 
-    public DelverOfSecretsEffect(final DelverOfSecretsEffect effect) {
+    private DelverOfSecretsEffect(final DelverOfSecretsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DementiaSliver.java
+++ b/Mage.Sets/src/mage/cards/d/DementiaSliver.java
@@ -70,7 +70,7 @@ class DementiaSliverEffect extends OneShotEffect {
         staticText = "Target opponent reveals a card at random from their hand. If that card has the chose name, that player discards it";
     }
 
-    public DementiaSliverEffect(final DementiaSliverEffect effect) {
+    private DementiaSliverEffect(final DementiaSliverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DemigodOfRevenge.java
+++ b/Mage.Sets/src/mage/cards/d/DemigodOfRevenge.java
@@ -66,7 +66,7 @@ class DemigodOfRevengeReturnEffect extends OneShotEffect {
         staticText = "return all cards named Demigod of Revenge from your graveyard to the battlefield";
     }
 
-    public DemigodOfRevengeReturnEffect(final DemigodOfRevengeReturnEffect effect) {
+    private DemigodOfRevengeReturnEffect(final DemigodOfRevengeReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DemonicEmbrace.java
+++ b/Mage.Sets/src/mage/cards/d/DemonicEmbrace.java
@@ -75,7 +75,7 @@ class DemonicEmbracePlayEffect extends AsThoughEffectImpl {
         staticText = "You may cast {this} from your graveyard by paying 3 life and discarding a card in addition to paying its other costs";
     }
 
-    public DemonicEmbracePlayEffect(final DemonicEmbracePlayEffect effect) {
+    private DemonicEmbracePlayEffect(final DemonicEmbracePlayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DemonicHordes.java
+++ b/Mage.Sets/src/mage/cards/d/DemonicHordes.java
@@ -70,7 +70,7 @@ class DemonicHordesEffect extends OneShotEffect {
         staticText = "unless you pay {B}{B}{B}, tap {this} and sacrifice a land of an opponent's choice";
     }
 
-    public DemonicHordesEffect(final DemonicHordesEffect effect) {
+    private DemonicHordesEffect(final DemonicHordesEffect effect) {
         super(effect);
         this.cost = effect.cost.copy();
     }

--- a/Mage.Sets/src/mage/cards/d/DemonlordBelzenlok.java
+++ b/Mage.Sets/src/mage/cards/d/DemonlordBelzenlok.java
@@ -59,7 +59,7 @@ class DemonlordBelzenlokEffect extends OneShotEffect {
                 + "{this} deals 1 damage to you for each card put into your hand this way";
     }
 
-    public DemonlordBelzenlokEffect(final DemonlordBelzenlokEffect effect) {
+    private DemonlordBelzenlokEffect(final DemonlordBelzenlokEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Demystify.java
+++ b/Mage.Sets/src/mage/cards/d/Demystify.java
@@ -22,7 +22,7 @@ public final class Demystify extends CardImpl {
         this.getSpellAbility().addTarget(new TargetEnchantmentPermanent());
     }
 
-    public Demystify (final Demystify card) {
+    private Demystify(final Demystify card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Denied.java
+++ b/Mage.Sets/src/mage/cards/d/Denied.java
@@ -47,7 +47,7 @@ class DeniedEffect extends OneShotEffect {
         staticText = "Choose a card name, then target spell's controller reveals their hand. If a card with the chosen name is revealed this way, counter that spell";
     }
 
-    public DeniedEffect(final DeniedEffect effect) {
+    private DeniedEffect(final DeniedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DenseCanopy.java
+++ b/Mage.Sets/src/mage/cards/d/DenseCanopy.java
@@ -52,7 +52,7 @@ class DenseCanopyCantBlockEffect extends RestrictionEffect {
         staticText = "creatures with flying can block only creatures with flying";
     }
 
-    public DenseCanopyCantBlockEffect(final DenseCanopyCantBlockEffect effect) {
+    private DenseCanopyCantBlockEffect(final DenseCanopyCantBlockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DenyReality.java
+++ b/Mage.Sets/src/mage/cards/d/DenyReality.java
@@ -25,7 +25,7 @@ public final class DenyReality extends CardImpl {
         this.addAbility(new CascadeAbility());
     }
 
-    public DenyReality (final DenyReality card) {
+    private DenyReality(final DenyReality card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DereviEmpyrialTactician.java
+++ b/Mage.Sets/src/mage/cards/d/DereviEmpyrialTactician.java
@@ -69,7 +69,7 @@ class DereviEmpyrialTacticianTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect);
     }
 
-    public DereviEmpyrialTacticianTriggeredAbility(DereviEmpyrialTacticianTriggeredAbility ability) {
+    private DereviEmpyrialTacticianTriggeredAbility(final DereviEmpyrialTacticianTriggeredAbility ability) {
         super(ability);
     }
 
@@ -123,7 +123,7 @@ class DereviEmpyrialTacticianAbility extends ActivatedAbilityImpl {
         return super.canActivate(playerId, game);
     }
 
-    public DereviEmpyrialTacticianAbility(DereviEmpyrialTacticianAbility ability) {
+    private DereviEmpyrialTacticianAbility(final DereviEmpyrialTacticianAbility ability) {
         super(ability);
     }
 
@@ -141,7 +141,7 @@ class PutCommanderOnBattlefieldEffect extends OneShotEffect {
         this.staticText = "Put Derevi onto the battlefield from the command zone";
     }
 
-    public PutCommanderOnBattlefieldEffect(final PutCommanderOnBattlefieldEffect effect) {
+    private PutCommanderOnBattlefieldEffect(final PutCommanderOnBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Dermoplasm.java
+++ b/Mage.Sets/src/mage/cards/d/Dermoplasm.java
@@ -62,7 +62,7 @@ class DermoplasmEffect extends OneShotEffect {
         staticText = "you may put a creature card with a morph ability from your hand onto the battlefield face up. If you do, return {this} to its owner's hand";
     }
 
-    public DermoplasmEffect(final DermoplasmEffect effect) {
+    private DermoplasmEffect(final DermoplasmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DescendantOfMasumaro.java
+++ b/Mage.Sets/src/mage/cards/d/DescendantOfMasumaro.java
@@ -56,7 +56,7 @@ class DescendantOfMasumaroEffect extends OneShotEffect {
         this.staticText = "put a +1/+1 counter on {this} for each card in your hand, then remove a +1/+1 counter from {this} for each card in target opponent's hand";
     }
 
-    public DescendantOfMasumaroEffect(final DescendantOfMasumaroEffect effect) {
+    private DescendantOfMasumaroEffect(final DescendantOfMasumaroEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DescendantsPath.java
+++ b/Mage.Sets/src/mage/cards/d/DescendantsPath.java
@@ -52,7 +52,7 @@ class DescendantsPathEffect extends OneShotEffect {
                 "put it on the bottom of your library";
     }
 
-    public DescendantsPathEffect(final DescendantsPathEffect effect) {
+    private DescendantsPathEffect(final DescendantsPathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DescentIntoMadness.java
+++ b/Mage.Sets/src/mage/cards/d/DescentIntoMadness.java
@@ -72,7 +72,7 @@ class DescentIntoMadnessEffect extends OneShotEffect {
         this.staticText = "put a despair counter on {this}, then each player exiles X permanents they control and/or cards from their hand, where X is the number of despair counters on {this}";
     }
 
-    public DescentIntoMadnessEffect(final DescentIntoMadnessEffect effect) {
+    private DescentIntoMadnessEffect(final DescentIntoMadnessEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DescentOfTheDragons.java
+++ b/Mage.Sets/src/mage/cards/d/DescentOfTheDragons.java
@@ -49,7 +49,7 @@ class DescentOfTheDragonsEffect extends OneShotEffect {
         staticText = "Destroy any number of target creatures. For each creature destroyed this way, its controller creates a 4/4 red Dragon creature token with flying";
     }
 
-    public DescentOfTheDragonsEffect(final DescentOfTheDragonsEffect effect) {
+    private DescentOfTheDragonsEffect(final DescentOfTheDragonsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DesecratedEarth.java
+++ b/Mage.Sets/src/mage/cards/d/DesecratedEarth.java
@@ -47,7 +47,7 @@ class DesecratedEarthEffect extends OneShotEffect {
         this.staticText = "Its controller discards a card";
     }
 
-    public DesecratedEarthEffect(final DesecratedEarthEffect effect) {
+    private DesecratedEarthEffect(final DesecratedEarthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DesecratorHag.java
+++ b/Mage.Sets/src/mage/cards/d/DesecratorHag.java
@@ -56,7 +56,7 @@ class DesecratorHagEffect extends OneShotEffect {
         this.staticText = "return to your hand the creature card in your graveyard with the greatest power. If two or more cards are tied for greatest power, you choose one of them";
     }
 
-    public DesecratorHagEffect(final DesecratorHagEffect effect) {
+    private DesecratorHagEffect(final DesecratorHagEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DesperateCastaways.java
+++ b/Mage.Sets/src/mage/cards/d/DesperateCastaways.java
@@ -50,7 +50,7 @@ class DesperateCastawaysEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless you control an artifact";
     }
 
-    public DesperateCastawaysEffect(final DesperateCastawaysEffect effect) {
+    private DesperateCastawaysEffect(final DesperateCastawaysEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DesperateGambit.java
+++ b/Mage.Sets/src/mage/cards/d/DesperateGambit.java
@@ -58,7 +58,7 @@ class DesperateGambitEffect extends PreventionEffectImpl {
         this.target = new TargetControlledSource();
     }
 
-    public DesperateGambitEffect(final DesperateGambitEffect effect) {
+    private DesperateGambitEffect(final DesperateGambitEffect effect) {
         super(effect);
         this.target = effect.target.copy();
     }
@@ -124,7 +124,7 @@ class TargetControlledSource extends TargetSource {
         super(1, 1, new FilterObject("source you control"));
     }
 
-    public TargetControlledSource(final TargetControlledSource target) {
+    private TargetControlledSource(final TargetControlledSource target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DesperateRavings.java
+++ b/Mage.Sets/src/mage/cards/d/DesperateRavings.java
@@ -49,7 +49,7 @@ class DesperateRavingsEffect extends OneShotEffect {
         this.staticText = "Draw two cards, then discard a card at random";
     }
 
-    public DesperateRavingsEffect(final DesperateRavingsEffect effect) {
+    private DesperateRavingsEffect(final DesperateRavingsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DesperateResearch.java
+++ b/Mage.Sets/src/mage/cards/d/DesperateResearch.java
@@ -47,7 +47,7 @@ class DesperateResearchEffect extends OneShotEffect {
         this.staticText = "Reveal the top seven cards of your library and put all of them with that name into your hand. Exile the rest";
     }
 
-    public DesperateResearchEffect(final DesperateResearchEffect effect) {
+    private DesperateResearchEffect(final DesperateResearchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DestroyTheEvidence.java
+++ b/Mage.Sets/src/mage/cards/d/DestroyTheEvidence.java
@@ -48,7 +48,7 @@ class DestroyTheEvidenceEffect extends OneShotEffect {
         this.staticText = "Its controller reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard";
     }
 
-    public DestroyTheEvidenceEffect(final DestroyTheEvidenceEffect effect) {
+    private DestroyTheEvidenceEffect(final DestroyTheEvidenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DestructiveRevelry.java
+++ b/Mage.Sets/src/mage/cards/d/DestructiveRevelry.java
@@ -46,7 +46,7 @@ class DestructiveRevelryEffect extends OneShotEffect {
         this.staticText = "Destroy target artifact or enchantment. {this} deals 2 damage to that permanent's controller";
     }
 
-    public DestructiveRevelryEffect(final DestructiveRevelryEffect effect) {
+    private DestructiveRevelryEffect(final DestructiveRevelryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DetectionTower.java
+++ b/Mage.Sets/src/mage/cards/d/DetectionTower.java
@@ -57,7 +57,7 @@ class DetectionTowerEffect extends AsThoughEffectImpl {
                 + "you control as though they didn't have hexproof";
     }
 
-    public DetectionTowerEffect(final DetectionTowerEffect effect) {
+    private DetectionTowerEffect(final DetectionTowerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DetentionSphere.java
+++ b/Mage.Sets/src/mage/cards/d/DetentionSphere.java
@@ -68,7 +68,7 @@ class DetentionSphereEntersEffect extends OneShotEffect {
         staticText = "you may exile target nonland permanent not named Detention Sphere and all other permanents with the same name as that permanent";
     }
 
-    public DetentionSphereEntersEffect(final DetentionSphereEntersEffect effect) {
+    private DetentionSphereEntersEffect(final DetentionSphereEntersEffect effect) {
         super(effect);
     }
 
@@ -108,7 +108,7 @@ class DetentionSphereLeavesEffect extends OneShotEffect {
         staticText = "return the exiled cards to the battlefield under their owner's control";
     }
 
-    public DetentionSphereLeavesEffect(final DetentionSphereLeavesEffect effect) {
+    private DetentionSphereLeavesEffect(final DetentionSphereLeavesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Detritivore.java
+++ b/Mage.Sets/src/mage/cards/d/Detritivore.java
@@ -68,7 +68,7 @@ class DetritivoreTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a time counter is removed from {this} while it's exiled, ");
     }
 
-    public DetritivoreTriggeredAbility(final DetritivoreTriggeredAbility ability) {
+    private DetritivoreTriggeredAbility(final DetritivoreTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeusOfCalamity.java
+++ b/Mage.Sets/src/mage/cards/d/DeusOfCalamity.java
@@ -55,7 +55,7 @@ class DeusOfCalamityTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), false);
     }
 
-    public DeusOfCalamityTriggeredAbility(final DeusOfCalamityTriggeredAbility ability) {
+    private DeusOfCalamityTriggeredAbility(final DeusOfCalamityTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DevastatingSummons.java
+++ b/Mage.Sets/src/mage/cards/d/DevastatingSummons.java
@@ -47,7 +47,7 @@ class DevastatingSummonsEffect extends OneShotEffect {
         staticText = "Create two X/X red Elemental creature tokens";
     }
 
-    public DevastatingSummonsEffect(final DevastatingSummonsEffect effect) {
+    private DevastatingSummonsEffect(final DevastatingSummonsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeviantGlee.java
+++ b/Mage.Sets/src/mage/cards/d/DeviantGlee.java
@@ -46,7 +46,7 @@ public final class DeviantGlee extends CardImpl {
         this.addAbility(ability2);
     }
 
-    public DeviantGlee (final DeviantGlee card) {
+    private DeviantGlee(final DeviantGlee card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DevotedRetainer.java
+++ b/Mage.Sets/src/mage/cards/d/DevotedRetainer.java
@@ -26,7 +26,7 @@ public final class DevotedRetainer extends CardImpl {
         this.addAbility(new BushidoAbility(1));
     }
 
-    public DevotedRetainer (final DevotedRetainer card) {
+    private DevotedRetainer(final DevotedRetainer card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DevourFlesh.java
+++ b/Mage.Sets/src/mage/cards/d/DevourFlesh.java
@@ -47,7 +47,7 @@ class DevourFleshSacrificeEffect extends OneShotEffect {
         this.staticText = "Target player sacrifices a creature, then gains life equal to that creature's toughness";
     }
 
-    public DevourFleshSacrificeEffect(final DevourFleshSacrificeEffect effect) {
+    private DevourFleshSacrificeEffect(final DevourFleshSacrificeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DevourInShadow.java
+++ b/Mage.Sets/src/mage/cards/d/DevourInShadow.java
@@ -49,7 +49,7 @@ class DevourInShadowEffect extends OneShotEffect {
         staticText = "You lose life equal to that creature's toughness";
     }
 
-    public DevourInShadowEffect(final DevourInShadowEffect effect) {
+    private DevourInShadowEffect(final DevourInShadowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DevouringGreed.java
+++ b/Mage.Sets/src/mage/cards/d/DevouringGreed.java
@@ -60,7 +60,7 @@ class DevouringGreedEffect extends OneShotEffect {
         this.staticText = "Target player loses 2 life plus 2 life for each Spirit sacrificed this way. You gain that much life";
     }
 
-    public DevouringGreedEffect(final DevouringGreedEffect effect) {
+    private DevouringGreedEffect(final DevouringGreedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DevouringRage.java
+++ b/Mage.Sets/src/mage/cards/d/DevouringRage.java
@@ -64,7 +64,7 @@ class DevouringRageEffect extends OneShotEffect {
         this.staticText = "Target creature gets +3/+0 until end of turn. For each Spirit sacrificed this way, that creature gets an additional +3/+0 until end of turn";
     }
 
-    public DevouringRageEffect(final DevouringRageEffect effect) {
+    private DevouringRageEffect(final DevouringRageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DevouringTendrils.java
+++ b/Mage.Sets/src/mage/cards/d/DevouringTendrils.java
@@ -68,7 +68,7 @@ class DevouringTendrilsEffect extends OneShotEffect {
         this.staticText = "when the permanent you don't control dies this turn, you gain 2 life";
     }
 
-    public DevouringTendrilsEffect(final DevouringTendrilsEffect effect) {
+    private DevouringTendrilsEffect(final DevouringTendrilsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DevoutInvocation.java
+++ b/Mage.Sets/src/mage/cards/d/DevoutInvocation.java
@@ -55,7 +55,7 @@ class DevoutInvocationEffect extends OneShotEffect {
         staticText = "Tap any number of untapped creatures you control. Create a 4/4 white Angel creature token with flying for each creature tapped this way";
     }
 
-    public DevoutInvocationEffect(DevoutInvocationEffect effect) {
+    private DevoutInvocationEffect(final DevoutInvocationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DiabolicServitude.java
+++ b/Mage.Sets/src/mage/cards/d/DiabolicServitude.java
@@ -62,7 +62,7 @@ class DiabolicServitudeReturnCreatureEffect extends OneShotEffect {
         this.staticText = "return target creature card from your graveyard to the battlefield";
     }
 
-    public DiabolicServitudeReturnCreatureEffect(final DiabolicServitudeReturnCreatureEffect effect) {
+    private DiabolicServitudeReturnCreatureEffect(final DiabolicServitudeReturnCreatureEffect effect) {
         super(effect);
     }
 
@@ -93,7 +93,7 @@ class DiabolicServitudeCreatureDiesTriggeredAbility extends TriggeredAbilityImpl
         super(Zone.BATTLEFIELD, new DiabolicServitudeExileCreatureEffect(), false);
     }
 
-    public DiabolicServitudeCreatureDiesTriggeredAbility(final DiabolicServitudeCreatureDiesTriggeredAbility ability) {
+    private DiabolicServitudeCreatureDiesTriggeredAbility(final DiabolicServitudeCreatureDiesTriggeredAbility ability) {
         super(ability);
     }
 
@@ -132,7 +132,7 @@ class DiabolicServitudeExileCreatureEffect extends OneShotEffect {
         this.staticText = "exile it and return {this} to its owner's hand";
     }
 
-    public DiabolicServitudeExileCreatureEffect(final DiabolicServitudeExileCreatureEffect effect) {
+    private DiabolicServitudeExileCreatureEffect(final DiabolicServitudeExileCreatureEffect effect) {
         super(effect);
     }
 
@@ -161,7 +161,7 @@ class DiabolicServitudeSourceLeftBattlefieldEffect extends OneShotEffect {
         this.staticText = "exile the creature put onto the battlefield with {this}";
     }
 
-    public DiabolicServitudeSourceLeftBattlefieldEffect(final DiabolicServitudeSourceLeftBattlefieldEffect effect) {
+    private DiabolicServitudeSourceLeftBattlefieldEffect(final DiabolicServitudeSourceLeftBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DiamondLion.java
+++ b/Mage.Sets/src/mage/cards/d/DiamondLion.java
@@ -59,7 +59,7 @@ class DiamondLionAbility extends ActivatedManaAbilityImpl {
 
     }
 
-    public DiamondLionAbility(final DiamondLionAbility ability) {
+    private DiamondLionAbility(final DiamondLionAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DiamondMare.java
+++ b/Mage.Sets/src/mage/cards/d/DiamondMare.java
@@ -53,7 +53,7 @@ class DiamondMareTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainLifeEffect(1), false);
     }
 
-    public DiamondMareTriggeredAbility(final DiamondMareTriggeredAbility ability) {
+    private DiamondMareTriggeredAbility(final DiamondMareTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DictateOfKruphix.java
+++ b/Mage.Sets/src/mage/cards/d/DictateOfKruphix.java
@@ -46,7 +46,7 @@ class DictateOfKruphixAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardTargetEffect(1));
     }
 
-    public DictateOfKruphixAbility(final DictateOfKruphixAbility ability) {
+    private DictateOfKruphixAbility(final DictateOfKruphixAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DictateOfTheTwinGods.java
+++ b/Mage.Sets/src/mage/cards/d/DictateOfTheTwinGods.java
@@ -52,7 +52,7 @@ class DictateOfTheTwinGodsEffect extends ReplacementEffectImpl {
         staticText = "If a source would deal damage to a permanent or player, that source deals double that damage to that permanent or player instead";
     }
 
-    public DictateOfTheTwinGodsEffect(final DictateOfTheTwinGodsEffect effect) {
+    private DictateOfTheTwinGodsEffect(final DictateOfTheTwinGodsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DieYoung.java
+++ b/Mage.Sets/src/mage/cards/d/DieYoung.java
@@ -52,7 +52,7 @@ class DieYoungEffect extends OneShotEffect {
         this.staticText = "Choose target creature. You get {E}{E}, then you may pay any amount of {E}. The creature gets -1/-1 until end of turn for each {E} paid this way";
     }
 
-    public DieYoungEffect(final DieYoungEffect effect) {
+    private DieYoungEffect(final DieYoungEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DiluvianPrimordial.java
+++ b/Mage.Sets/src/mage/cards/d/DiluvianPrimordial.java
@@ -91,7 +91,7 @@ class DiluvianPrimordialEffect extends OneShotEffect {
                 + "into a graveyard, exile it instead";
     }
 
-    public DiluvianPrimordialEffect(final DiluvianPrimordialEffect effect) {
+    private DiluvianPrimordialEffect(final DiluvianPrimordialEffect effect) {
         super(effect);
     }
 
@@ -135,7 +135,7 @@ class DiluvianPrimordialReplacementEffect extends ReplacementEffectImpl {
         staticText = "If a card cast this way would be put into a graveyard this turn, exile it instead";
     }
 
-    public DiluvianPrimordialReplacementEffect(final DiluvianPrimordialReplacementEffect effect) {
+    private DiluvianPrimordialReplacementEffect(final DiluvianPrimordialReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DiminishingReturns.java
+++ b/Mage.Sets/src/mage/cards/d/DiminishingReturns.java
@@ -44,7 +44,7 @@ class DiminishingReturnsEffect extends OneShotEffect {
         staticText = "You exile the top ten cards of your library. Then each player draws up to seven cards.";
     }
 
-    public DiminishingReturnsEffect(final DiminishingReturnsEffect effect) {
+    private DiminishingReturnsEffect(final DiminishingReturnsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DimirCharm.java
+++ b/Mage.Sets/src/mage/cards/d/DimirCharm.java
@@ -72,7 +72,7 @@ class DimirCharmEffect extends OneShotEffect {
         this.staticText = "look at the top three cards of target player's library, then put one back and the rest into that player's graveyard";
     }
 
-    public DimirCharmEffect(final DimirCharmEffect effect) {
+    private DimirCharmEffect(final DimirCharmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DimirSignet.java
+++ b/Mage.Sets/src/mage/cards/d/DimirSignet.java
@@ -26,7 +26,7 @@ public final class DimirSignet extends CardImpl {
         this.addAbility(ability);
     }
 
-    public DimirSignet (final DimirSignet card) {
+    private DimirSignet(final DimirSignet card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DimirSpybug.java
+++ b/Mage.Sets/src/mage/cards/d/DimirSpybug.java
@@ -56,7 +56,7 @@ class DimirSpybugTriggeredAbility extends TriggeredAbilityImpl {
         ), false);
     }
 
-    public DimirSpybugTriggeredAbility(final DimirSpybugTriggeredAbility ability) {
+    private DimirSpybugTriggeredAbility(final DimirSpybugTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DinOfTheFireherd.java
+++ b/Mage.Sets/src/mage/cards/d/DinOfTheFireherd.java
@@ -60,7 +60,7 @@ class DinOfTheFireherdEffect extends OneShotEffect {
         this.staticText = "create a 5/5 black and red Elemental creature token. Target opponent sacrifices a creature for each black creature you control, then sacrifices a land for each red creature you control";
     }
 
-    public DinOfTheFireherdEffect(final DinOfTheFireherdEffect effect) {
+    private DinOfTheFireherdEffect(final DinOfTheFireherdEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DingusEgg.java
+++ b/Mage.Sets/src/mage/cards/d/DingusEgg.java
@@ -42,7 +42,7 @@ class DingusEggTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(2), false);
     }
 
-    public DingusEggTriggeredAbility(final DingusEggTriggeredAbility ability) {
+    private DingusEggTriggeredAbility(final DingusEggTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DingusStaff.java
+++ b/Mage.Sets/src/mage/cards/d/DingusStaff.java
@@ -43,7 +43,7 @@ class DingusStaffEffect extends OneShotEffect {
         this.staticText = "{this} deals 2 damage to that creature's controller";
     }
 
-    public DingusStaffEffect(final DingusStaffEffect effect) {
+    private DingusStaffEffect(final DingusStaffEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DinrovaHorror.java
+++ b/Mage.Sets/src/mage/cards/d/DinrovaHorror.java
@@ -54,7 +54,7 @@ class DinrovaHorrorEffect extends OneShotEffect {
         this.staticText = "return target permanent to its owner's hand, then that player discards a card";
     }
 
-    public DinrovaHorrorEffect(final DinrovaHorrorEffect effect) {
+    private DinrovaHorrorEffect(final DinrovaHorrorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DiregrafCaptain.java
+++ b/Mage.Sets/src/mage/cards/d/DiregrafCaptain.java
@@ -69,7 +69,7 @@ class DiregrafCaptainTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetOpponent());
     }
 
-    public DiregrafCaptainTriggeredAbility(final DiregrafCaptainTriggeredAbility ability) {
+    private DiregrafCaptainTriggeredAbility(final DiregrafCaptainTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DiregrafColossus.java
+++ b/Mage.Sets/src/mage/cards/d/DiregrafColossus.java
@@ -71,7 +71,7 @@ class DiregrafColossusEffect extends OneShotEffect {
         staticText = "{this} enters the battlefield with a +1/+1 counter on it for each Zombie card in your graveyard";
     }
 
-    public DiregrafColossusEffect(final DiregrafColossusEffect effect) {
+    private DiregrafColossusEffect(final DiregrafColossusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Disappear.java
+++ b/Mage.Sets/src/mage/cards/d/Disappear.java
@@ -59,7 +59,7 @@ class DisappearEffect extends OneShotEffect {
         staticText = "Return enchanted creature and {this} to their owners' hands";
     }
 
-    public DisappearEffect(final DisappearEffect effect) {
+    private DisappearEffect(final DisappearEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Disarm.java
+++ b/Mage.Sets/src/mage/cards/d/Disarm.java
@@ -46,7 +46,7 @@ public final class Disarm extends CardImpl {
             this.staticText = "Unattach all Equipment from target creature";
         }
 
-        public DisarmEffect(final DisarmEffect effect) {
+        private DisarmEffect(final DisarmEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/d/DisasterRadius.java
+++ b/Mage.Sets/src/mage/cards/d/DisasterRadius.java
@@ -57,7 +57,7 @@ class DisasterRadiusEffect extends OneShotEffect {
         staticText = "{this} deals X damage to each creature your opponents control, where X is the revealed card's mana value";
     }
 
-    public DisasterRadiusEffect(DisasterRadiusEffect effect) {
+    private DisasterRadiusEffect(final DisasterRadiusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DiscipleOfBolas.java
+++ b/Mage.Sets/src/mage/cards/d/DiscipleOfBolas.java
@@ -53,7 +53,7 @@ class DiscipleOfBolasEffect extends OneShotEffect {
         this.staticText = "sacrifice another creature. You gain X life and draw X cards, where X is that creature's power";
     }
 
-    public DiscipleOfBolasEffect(final DiscipleOfBolasEffect effect) {
+    private DiscipleOfBolasEffect(final DiscipleOfBolasEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DiscipleOfDeceit.java
+++ b/Mage.Sets/src/mage/cards/d/DiscipleOfDeceit.java
@@ -61,7 +61,7 @@ class DiscipleOfDeceitEffect extends OneShotEffect {
         this.staticText = "you may discard a nonland card. If you do, search your library for a card with the same mana value as that card, reveal it, put it into your hand, then shuffle";
     }
     
-    public DiscipleOfDeceitEffect(final DiscipleOfDeceitEffect effect) {
+    private DiscipleOfDeceitEffect(final DiscipleOfDeceitEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/d/DiscipleOfGriselbrand.java
+++ b/Mage.Sets/src/mage/cards/d/DiscipleOfGriselbrand.java
@@ -57,7 +57,7 @@ class DiscipleOfGriselbrandEffect extends OneShotEffect {
         this.staticText = "You gain life equal to the sacrificed creature's toughness";
     }
 
-    public DiscipleOfGriselbrandEffect(final DiscipleOfGriselbrandEffect effect) {
+    private DiscipleOfGriselbrandEffect(final DiscipleOfGriselbrandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DisciplesOfGix.java
+++ b/Mage.Sets/src/mage/cards/d/DisciplesOfGix.java
@@ -54,7 +54,7 @@ class DisciplesOfGixEffect extends OneShotEffect {
         staticText = "search your library for up to three artifact cards, put them into your graveyard, then shuffle";
     }
 
-    public DisciplesOfGixEffect(final DisciplesOfGixEffect effect) {
+    private DisciplesOfGixEffect(final DisciplesOfGixEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DiseasedVermin.java
+++ b/Mage.Sets/src/mage/cards/d/DiseasedVermin.java
@@ -81,7 +81,7 @@ class DiseasedVerminEffect extends OneShotEffect {
         this.staticText = "{this} deals X damage to target opponent previously dealt damage by it, where X is the number of infection counters on it";
     }
 
-    public DiseasedVerminEffect(final DiseasedVerminEffect effect) {
+    private DiseasedVerminEffect(final DiseasedVerminEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DisinformationCampaign.java
+++ b/Mage.Sets/src/mage/cards/d/DisinformationCampaign.java
@@ -52,7 +52,7 @@ class DisinformationCampaignTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ReturnToHandSourceEffect(true), false);
     }
 
-    public DisinformationCampaignTriggeredAbility(final DisinformationCampaignTriggeredAbility ability) {
+    private DisinformationCampaignTriggeredAbility(final DisinformationCampaignTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DismalFailure.java
+++ b/Mage.Sets/src/mage/cards/d/DismalFailure.java
@@ -43,7 +43,7 @@ class DismalFailureEffect extends OneShotEffect {
         this.staticText = "Counter target spell. Its controller discards a card";
     }
 
-    public DismalFailureEffect(final DismalFailureEffect effect) {
+    private DismalFailureEffect(final DismalFailureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Dismantle.java
+++ b/Mage.Sets/src/mage/cards/d/Dismantle.java
@@ -52,7 +52,7 @@ class DismantleEffect extends OneShotEffect {
 
     }
 
-    public DismantleEffect(final DismantleEffect effect) {
+    private DismantleEffect(final DismantleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Dismember.java
+++ b/Mage.Sets/src/mage/cards/d/Dismember.java
@@ -25,7 +25,7 @@ public final class Dismember extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public Dismember (final Dismember card) {
+    private Dismember(final Dismember card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Disorder.java
+++ b/Mage.Sets/src/mage/cards/d/Disorder.java
@@ -61,7 +61,7 @@ class DisorderEffect extends OneShotEffect {
         this.staticText = "and each player who controls a white creature";
     }
 
-    public DisorderEffect(final DisorderEffect effect) {
+    private DisorderEffect(final DisorderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DispellersCapsule.java
+++ b/Mage.Sets/src/mage/cards/d/DispellersCapsule.java
@@ -33,7 +33,7 @@ public final class DispellersCapsule extends CardImpl {
         this.addAbility(ability);
     }
 
-    public DispellersCapsule (final DispellersCapsule card) {
+    private DispellersCapsule(final DispellersCapsule card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Disperse.java
+++ b/Mage.Sets/src/mage/cards/d/Disperse.java
@@ -23,7 +23,7 @@ public final class Disperse extends CardImpl {
         this.getSpellAbility().addEffect(new ReturnToHandTargetEffect());
     }
 
-    public Disperse (final Disperse card) {
+    private Disperse(final Disperse card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DisplayOfDominance.java
+++ b/Mage.Sets/src/mage/cards/d/DisplayOfDominance.java
@@ -71,7 +71,7 @@ class DisplayOfDominanceEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "permanents you control can't be the targets of blue or black spells your opponents control this turn";
     }
 
-    public DisplayOfDominanceEffect(final DisplayOfDominanceEffect effect) {
+    private DisplayOfDominanceEffect(final DisplayOfDominanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Dispossess.java
+++ b/Mage.Sets/src/mage/cards/d/Dispossess.java
@@ -41,7 +41,7 @@ class DispossessEffect extends SearchTargetGraveyardHandLibraryForCardNameAndExi
         super(true, "target opponent's", "any number of cards with the chosen name");
     }
 
-    public DispossessEffect(final DispossessEffect effect) {
+    private DispossessEffect(final DispossessEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DisruptingShoal.java
+++ b/Mage.Sets/src/mage/cards/d/DisruptingShoal.java
@@ -66,7 +66,7 @@ class DisruptingShoalCounterTargetEffect extends OneShotEffect {
         this.staticText = "Counter target spell if its mana value is X";
     }
 
-    public DisruptingShoalCounterTargetEffect(final DisruptingShoalCounterTargetEffect effect) {
+    private DisruptingShoalCounterTargetEffect(final DisruptingShoalCounterTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DisruptionAura.java
+++ b/Mage.Sets/src/mage/cards/d/DisruptionAura.java
@@ -61,7 +61,7 @@ class DisruptionAuraEffect extends OneShotEffect {
         staticText =  "sacrifice this artifact unless you pay its mana cost";
      }
 
-    public DisruptionAuraEffect(final DisruptionAuraEffect effect) {
+    private DisruptionAuraEffect(final DisruptionAuraEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DissipationField.java
+++ b/Mage.Sets/src/mage/cards/d/DissipationField.java
@@ -43,7 +43,7 @@ class DissipationFieldAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ReturnToHandTargetEffect());
     }
 
-    public DissipationFieldAbility(DissipationFieldAbility effect) {
+    private DissipationFieldAbility(final DissipationFieldAbility effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DistantMemories.java
+++ b/Mage.Sets/src/mage/cards/d/DistantMemories.java
@@ -45,7 +45,7 @@ class DistantMemoriesEffect extends OneShotEffect {
                 + "your hand. If no player does, you draw three cards";
     }
 
-    public DistantMemoriesEffect(final DistantMemoriesEffect effect) {
+    private DistantMemoriesEffect(final DistantMemoriesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DistendedMindbender.java
+++ b/Mage.Sets/src/mage/cards/d/DistendedMindbender.java
@@ -75,7 +75,7 @@ class DistendedMindbenderEffect extends OneShotEffect {
                 "That player discards those cards.";
     }
 
-    public DistendedMindbenderEffect(final DistendedMindbenderEffect effect) {
+    private DistendedMindbenderEffect(final DistendedMindbenderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DistortingLens.java
+++ b/Mage.Sets/src/mage/cards/d/DistortingLens.java
@@ -51,7 +51,7 @@ class ChangeColorEffect extends OneShotEffect {
         staticText = "Target permanent becomes the color of your choice until end of turn";
     }
 
-    public ChangeColorEffect(final ChangeColorEffect effect) {
+    private ChangeColorEffect(final ChangeColorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DivergentTransformations.java
+++ b/Mage.Sets/src/mage/cards/d/DivergentTransformations.java
@@ -50,7 +50,7 @@ class DivergentTransformationsEffect extends OneShotEffect {
                 + "until they reveal a creature card, puts that card onto the battlefield, then shuffles the rest into their library";
     }
 
-    public DivergentTransformationsEffect(final DivergentTransformationsEffect effect) {
+    private DivergentTransformationsEffect(final DivergentTransformationsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Divert.java
+++ b/Mage.Sets/src/mage/cards/d/Divert.java
@@ -46,7 +46,7 @@ class DivertEffect extends OneShotEffect {
         this.staticText = "Change the target of target spell with a single target unless that spell's controller pays {2}.";
     }
 
-    public DivertEffect(final DivertEffect effect) {
+    private DivertEffect(final DivertEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Divination.java
+++ b/Mage.Sets/src/mage/cards/d/Divination.java
@@ -20,7 +20,7 @@ public final class Divination extends CardImpl {
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(2));
     }
 
-    public Divination (final Divination card) {
+    private Divination(final Divination card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DivineDeflection.java
+++ b/Mage.Sets/src/mage/cards/d/DivineDeflection.java
@@ -46,7 +46,7 @@ class DivineDeflectionPreventDamageTargetEffect extends PreventionEffectImpl {
         staticText = "Prevent the next X damage that would be dealt to you and/or permanents you control this turn. If damage is prevented this way, {this} deals that much damage to any target";
     }
 
-    public DivineDeflectionPreventDamageTargetEffect(final DivineDeflectionPreventDamageTargetEffect effect) {
+    private DivineDeflectionPreventDamageTargetEffect(final DivineDeflectionPreventDamageTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DivineIntervention.java
+++ b/Mage.Sets/src/mage/cards/d/DivineIntervention.java
@@ -56,7 +56,7 @@ public final class DivineIntervention extends CardImpl {
             super(Zone.BATTLEFIELD, new DivineAbilityEffect2(), false);
         }
 
-        public DivineInterventionAbility(final DivineInterventionAbility ability) {
+        private DivineInterventionAbility(final DivineInterventionAbility ability) {
             super(ability);
         }
 
@@ -91,7 +91,7 @@ public final class DivineIntervention extends CardImpl {
             this.staticText = "you draw the game";
         }
 
-        public DivineAbilityEffect2(final DivineAbilityEffect2 effect) {
+        private DivineAbilityEffect2(final DivineAbilityEffect2 effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/d/DivinePresence.java
+++ b/Mage.Sets/src/mage/cards/d/DivinePresence.java
@@ -44,7 +44,7 @@ class DivinePresenceEffect extends ReplacementEffectImpl {
         staticText = "If a source would deal 4 or more damage to a permanent or player, that source deals 3 damage to that permanent or player instead.";
     }
 
-    public DivinePresenceEffect(final DivinePresenceEffect effect) {
+    private DivinePresenceEffect(final DivinePresenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DivineReckoning.java
+++ b/Mage.Sets/src/mage/cards/d/DivineReckoning.java
@@ -54,7 +54,7 @@ class DivineReckoningEffect extends OneShotEffect {
         staticText = "Each player chooses a creature they control. Destroy the rest";
     }
 
-    public DivineReckoningEffect(DivineReckoningEffect effect) {
+    private DivineReckoningEffect(final DivineReckoningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DivineVisitation.java
+++ b/Mage.Sets/src/mage/cards/d/DivineVisitation.java
@@ -54,7 +54,7 @@ class DivineVisitationEffect extends ReplacementEffectImpl {
                 + "tokens with flying and vigilance are created instead.";
     }
 
-    public DivineVisitationEffect(DivineVisitationEffect effect) {
+    private DivineVisitationEffect(final DivineVisitationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DivinerSpirit.java
+++ b/Mage.Sets/src/mage/cards/d/DivinerSpirit.java
@@ -48,7 +48,7 @@ class DivinerSpiritEffect extends OneShotEffect {
         this.staticText = "you and that player each draw that many cards";
     }
 
-    public DivinerSpiritEffect(final DivinerSpiritEffect effect) {
+    private DivinerSpiritEffect(final DivinerSpiritEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DjeruWithEyesOpen.java
+++ b/Mage.Sets/src/mage/cards/d/DjeruWithEyesOpen.java
@@ -73,7 +73,7 @@ class DjeruWithEyesOpenPreventEffect extends PreventionEffectImpl {
         this.staticText = "If a source would deal damage to a planeswalker you control, prevent 1 of that damage";
     }
 
-    public DjeruWithEyesOpenPreventEffect(DjeruWithEyesOpenPreventEffect effect) {
+    private DjeruWithEyesOpenPreventEffect(final DjeruWithEyesOpenPreventEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DjinnOfWishes.java
+++ b/Mage.Sets/src/mage/cards/d/DjinnOfWishes.java
@@ -63,7 +63,7 @@ class DjinnOfWishesEffect extends OneShotEffect {
         staticText = "Reveal the top card of your library. You may play that card without paying its mana cost. If you don't, exile it";
     }
 
-    public DjinnOfWishesEffect(final DjinnOfWishesEffect effect) {
+    private DjinnOfWishesEffect(final DjinnOfWishesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DoOrDie.java
+++ b/Mage.Sets/src/mage/cards/d/DoOrDie.java
@@ -49,7 +49,7 @@ class DoOrDieEffect extends OneShotEffect {
         this.staticText = "Separate all creatures target player controls into two piles. Destroy all creatures in the pile of that player's choice. They can't be regenerated";
     }
 
-    public DoOrDieEffect(final DoOrDieEffect effect) {
+    private DoOrDieEffect(final DoOrDieEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DocentOfPerfection.java
+++ b/Mage.Sets/src/mage/cards/d/DocentOfPerfection.java
@@ -83,7 +83,7 @@ class DocentOfPerfectionEffect extends OneShotEffect {
         staticText = "Then if you control three or more Wizards, transform {this}";
     }
 
-    public DocentOfPerfectionEffect(final DocentOfPerfectionEffect effect) {
+    private DocentOfPerfectionEffect(final DocentOfPerfectionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Dodecapod.java
+++ b/Mage.Sets/src/mage/cards/d/Dodecapod.java
@@ -51,7 +51,7 @@ class DodecapodEffect extends DiscardOntoBattlefieldEffect {
         staticText = "If a spell or ability an opponent controls causes you to discard {this}, put it onto the battlefield with two +1/+1 counters on it instead of putting it into your graveyard";
     }
 
-    public DodecapodEffect(final DodecapodEffect effect) {
+    private DodecapodEffect(final DodecapodEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DomineeringWill.java
+++ b/Mage.Sets/src/mage/cards/d/DomineeringWill.java
@@ -63,7 +63,7 @@ class DomineeringWillEffect extends OneShotEffect {
         staticText = "Target player gains control of up to three target nonattacking creatures until end of turn. Untap those creatures. They block this turn if able";
     }
 
-    public DomineeringWillEffect(final DomineeringWillEffect effect) {
+    private DomineeringWillEffect(final DomineeringWillEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DomriRade.java
+++ b/Mage.Sets/src/mage/cards/d/DomriRade.java
@@ -67,7 +67,7 @@ class DomriRadeEffect1 extends OneShotEffect {
         this.staticText = "Look at the top card of your library. If it's a creature card, you may reveal it and put it into your hand";
     }
 
-    public DomriRadeEffect1(final DomriRadeEffect1 effect) {
+    private DomriRadeEffect1(final DomriRadeEffect1 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Donate.java
+++ b/Mage.Sets/src/mage/cards/d/Donate.java
@@ -50,7 +50,7 @@ class DonateEffect extends OneShotEffect {
         this.staticText = "Target player gains control of target permanent you control";
     }
     
-    public DonateEffect(final DonateEffect effect) {
+    private DonateEffect(final DonateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DongZhouTheTyrant.java
+++ b/Mage.Sets/src/mage/cards/d/DongZhouTheTyrant.java
@@ -51,7 +51,7 @@ class DongZhouTheTyrantEffect extends OneShotEffect {
         staticText = "target creature an opponent controls deals damage equal to its power to that player";
     }
 
-    public DongZhouTheTyrantEffect(final DongZhouTheTyrantEffect effect) {
+    private DongZhouTheTyrantEffect(final DongZhouTheTyrantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DoomCannon.java
+++ b/Mage.Sets/src/mage/cards/d/DoomCannon.java
@@ -58,7 +58,7 @@ class DoomCannonFilter extends FilterControlledCreaturePermanent {
         super("a creature of the chosen type");
     }
 
-    public DoomCannonFilter(final DoomCannonFilter filter) {
+    private DoomCannonFilter(final DoomCannonFilter filter) {
         super(filter);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Doomfall.java
+++ b/Mage.Sets/src/mage/cards/d/Doomfall.java
@@ -59,7 +59,7 @@ class DoomfallEffect extends OneShotEffect {
         this.staticText = "target player exiles a creature they control";
     }
 
-    public DoomfallEffect(final DoomfallEffect effect) {
+    private DoomfallEffect(final DoomfallEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Doomgape.java
+++ b/Mage.Sets/src/mage/cards/d/Doomgape.java
@@ -59,7 +59,7 @@ class DoomgapeEffect extends OneShotEffect {
         this.staticText = "sacrifice a creature. You gain life equal to that creature's toughness";
     }
 
-    public DoomgapeEffect(final DoomgapeEffect effect) {
+    private DoomgapeEffect(final DoomgapeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Doomsday.java
+++ b/Mage.Sets/src/mage/cards/d/Doomsday.java
@@ -47,7 +47,7 @@ class DoomsdayEffect extends OneShotEffect {
         staticText = "Search your library and graveyard for five cards and exile the rest. Put the chosen cards on top of your library in any order";
     }
 
-    public DoomsdayEffect(final DoomsdayEffect effect) {
+    private DoomsdayEffect(final DoomsdayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DoorOfDestinies.java
+++ b/Mage.Sets/src/mage/cards/d/DoorOfDestinies.java
@@ -55,7 +55,7 @@ class AddCounterAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.CHARGE.createInstance(1)), false);
     }
 
-    public AddCounterAbility(final AddCounterAbility ability) {
+    private AddCounterAbility(final AddCounterAbility ability) {
         super(ability);
     }
 
@@ -96,7 +96,7 @@ class BoostCreatureEffectEffect extends ContinuousEffectImpl {
         staticText = "Creatures you control of the chosen type get +1/+1 for each charge counter on {this}";
     }
 
-    public BoostCreatureEffectEffect(final BoostCreatureEffectEffect effect) {
+    private BoostCreatureEffectEffect(final BoostCreatureEffectEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DoorToNothingness.java
+++ b/Mage.Sets/src/mage/cards/d/DoorToNothingness.java
@@ -55,7 +55,7 @@ class DoorToNothingnessEffect extends OneShotEffect {
         this.staticText = "Target player loses the game";
     }
 
-    public DoorToNothingnessEffect(final DoorToNothingnessEffect effect) {
+    private DoorToNothingnessEffect(final DoorToNothingnessEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DoublingChant.java
+++ b/Mage.Sets/src/mage/cards/d/DoublingChant.java
@@ -52,7 +52,7 @@ class DoublingChantEffect extends OneShotEffect {
                 "Put those cards onto the battlefield, then shuffle";
     }
 
-    public DoublingChantEffect(final DoublingChantEffect effect) {
+    private DoublingChantEffect(final DoublingChantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Draco.java
+++ b/Mage.Sets/src/mage/cards/d/Draco.java
@@ -88,7 +88,7 @@ class DracoSacrificeUnlessPaysEffect extends OneShotEffect {
         staticText = "sacrifice {this} unless you pay {10}. This cost is reduced by {2} for each basic land type among lands you control.";
     }
 
-    public DracoSacrificeUnlessPaysEffect(final DracoSacrificeUnlessPaysEffect effect) {
+    private DracoSacrificeUnlessPaysEffect(final DracoSacrificeUnlessPaysEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Dracoplasm.java
+++ b/Mage.Sets/src/mage/cards/d/Dracoplasm.java
@@ -71,7 +71,7 @@ class DracoplasmEffect extends ReplacementEffectImpl {
         this.staticText = "As {this} enters the battlefield, sacrifice any number of creatures. {this}'s power becomes the total power of those creatures and its toughness becomes their total toughness";
     }
 
-    public DracoplasmEffect(final DracoplasmEffect effect) {
+    private DracoplasmEffect(final DracoplasmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DragonAppeasement.java
+++ b/Mage.Sets/src/mage/cards/d/DragonAppeasement.java
@@ -48,7 +48,7 @@ class DragonAppeasementTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you sacrifice a creature, ");
     }
 
-    public DragonAppeasementTriggeredAbility(final DragonAppeasementTriggeredAbility ability) {
+    private DragonAppeasementTriggeredAbility(final DragonAppeasementTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DragonHunter.java
+++ b/Mage.Sets/src/mage/cards/d/DragonHunter.java
@@ -50,7 +50,7 @@ class CanBlockDragonsAsThoughtIthadReachEffect extends AsThoughEffectImpl {
         staticText = "{this} can block Dragons as though it had reach";
     }
 
-    public CanBlockDragonsAsThoughtIthadReachEffect(final CanBlockDragonsAsThoughtIthadReachEffect effect) {
+    private CanBlockDragonsAsThoughtIthadReachEffect(final CanBlockDragonsAsThoughtIthadReachEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DragonTempest.java
+++ b/Mage.Sets/src/mage/cards/d/DragonTempest.java
@@ -76,7 +76,7 @@ class DragonTempestDamageEffect extends OneShotEffect {
         staticText = "it deals X damage to any target, where X is the number of Dragons you control";
     }
 
-    public DragonTempestDamageEffect(final DragonTempestDamageEffect effect) {
+    private DragonTempestDamageEffect(final DragonTempestDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DragonWhelp.java
+++ b/Mage.Sets/src/mage/cards/d/DragonWhelp.java
@@ -63,7 +63,7 @@ class DragonWhelpEffect extends OneShotEffect {
         this.staticText = "If this ability has been activated four or more times this turn, sacrifice {this} at the beginning of the next end step";
     }
 
-    public DragonWhelpEffect(final DragonWhelpEffect effect) {
+    private DragonWhelpEffect(final DragonWhelpEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DragonlordDromoka.java
+++ b/Mage.Sets/src/mage/cards/d/DragonlordDromoka.java
@@ -57,7 +57,7 @@ class DragonlordDromokaEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Your opponents can't cast spells during your turn";
     }
 
-    public DragonlordDromokaEffect(final DragonlordDromokaEffect effect) {
+    private DragonlordDromokaEffect(final DragonlordDromokaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DragonlordKolaghan.java
+++ b/Mage.Sets/src/mage/cards/d/DragonlordKolaghan.java
@@ -69,7 +69,7 @@ class DragonlordKolaghanTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever an opponent casts a creature or planeswalker spell with the same name as a card in their graveyard, ");
     }
 
-    public DragonlordKolaghanTriggeredAbility(final DragonlordKolaghanTriggeredAbility ability) {
+    private DragonlordKolaghanTriggeredAbility(final DragonlordKolaghanTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DrainPower.java
+++ b/Mage.Sets/src/mage/cards/d/DrainPower.java
@@ -59,7 +59,7 @@ class DrainPowerEffect extends OneShotEffect {
         this.staticText = "Target player activates a mana ability of each land they control. Then that player loses all unspent mana and you add the mana lost this way";
     }
 
-    public DrainPowerEffect(final DrainPowerEffect effect) {
+    private DrainPowerEffect(final DrainPowerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DralnusCrusade.java
+++ b/Mage.Sets/src/mage/cards/d/DralnusCrusade.java
@@ -62,7 +62,7 @@ class DralnusCrusadeEffect extends ContinuousEffectImpl {
         return true;
     }
 
-    public DralnusCrusadeEffect(final DralnusCrusadeEffect effect) {
+    private DralnusCrusadeEffect(final DralnusCrusadeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DralnusPet.java
+++ b/Mage.Sets/src/mage/cards/d/DralnusPet.java
@@ -72,7 +72,7 @@ class DralnusPetEffect extends OneShotEffect {
         this.staticText = "and with X +1/+1 counters on it, where X is the discarded card's mana value";
     }
 
-    public DralnusPetEffect(final DralnusPetEffect effect) {
+    private DralnusPetEffect(final DralnusPetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreadDefiler.java
+++ b/Mage.Sets/src/mage/cards/d/DreadDefiler.java
@@ -62,7 +62,7 @@ class DreadDefilerEffect extends OneShotEffect {
         this.staticText = "Target opponent loses life equal to the exiled card's power";
     }
 
-    public DreadDefilerEffect(final DreadDefilerEffect effect) {
+    private DreadDefilerEffect(final DreadDefilerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreadDrone.java
+++ b/Mage.Sets/src/mage/cards/d/DreadDrone.java
@@ -28,7 +28,7 @@ public final class DreadDrone extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new CreateTokenEffect(new EldraziSpawnToken(), 2)));
     }
 
-    public DreadDrone (final DreadDrone card) {
+    private DreadDrone(final DreadDrone card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreadSlaver.java
+++ b/Mage.Sets/src/mage/cards/d/DreadSlaver.java
@@ -49,7 +49,7 @@ class DreadSlaverEffect extends OneShotEffect {
         staticText = "return it to the battlefield under your control. That creature is a black Zombie in addition to its other colors and types";
     }
 
-    public DreadSlaverEffect(final DreadSlaverEffect effect) {
+    private DreadSlaverEffect(final DreadSlaverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreadStatuary.java
+++ b/Mage.Sets/src/mage/cards/d/DreadStatuary.java
@@ -49,7 +49,7 @@ class DreadStatuaryToken extends TokenImpl {
         power = new MageInt(4);
         toughness = new MageInt(2);
     }
-    public DreadStatuaryToken(final DreadStatuaryToken token) {
+    private DreadStatuaryToken(final DreadStatuaryToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreadWight.java
+++ b/Mage.Sets/src/mage/cards/d/DreadWight.java
@@ -110,7 +110,7 @@ class DreadWightEffect extends OneShotEffect {
                 + "Each of those creatures gains \"{4}: Remove a paralyzation counter from this creature.\"";
     }
 
-    public DreadWightEffect(final DreadWightEffect effect) {
+    private DreadWightEffect(final DreadWightEffect effect) {
         super(effect);
     }
 
@@ -172,7 +172,7 @@ class DreadWightDoNotUntapEffect extends ContinuousRuleModifyingEffectImpl {
         this.permanentId = permanentId;
     }
 
-    public DreadWightDoNotUntapEffect(final DreadWightDoNotUntapEffect effect) {
+    private DreadWightDoNotUntapEffect(final DreadWightDoNotUntapEffect effect) {
         super(effect);
         this.permanentId = effect.permanentId;
     }

--- a/Mage.Sets/src/mage/cards/d/DreamCache.java
+++ b/Mage.Sets/src/mage/cards/d/DreamCache.java
@@ -45,7 +45,7 @@ class DreamCacheEffect extends OneShotEffect {
         this.staticText = "Draw three cards, then put two cards from your hand both on top of your library or both on the bottom of your library.";
     }
 
-    public DreamCacheEffect(final DreamCacheEffect effect) {
+    private DreamCacheEffect(final DreamCacheEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreamCoat.java
+++ b/Mage.Sets/src/mage/cards/d/DreamCoat.java
@@ -64,7 +64,7 @@ class BecomesColorOrColorsEnchantedEffect extends OneShotEffect {
         this.staticText = "Enchanted creature becomes the color or colors of your choice";
     }
 
-    public BecomesColorOrColorsEnchantedEffect(final BecomesColorOrColorsEnchantedEffect effect) {
+    private BecomesColorOrColorsEnchantedEffect(final BecomesColorOrColorsEnchantedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreamFracture.java
+++ b/Mage.Sets/src/mage/cards/d/DreamFracture.java
@@ -48,7 +48,7 @@ class DreamFractureEffect extends OneShotEffect {
         this.staticText = "Counter target spell. Its controller draws a card";
     }
 
-    public DreamFractureEffect(final DreamFractureEffect effect) {
+    private DreamFractureEffect(final DreamFractureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreamHalls.java
+++ b/Mage.Sets/src/mage/cards/d/DreamHalls.java
@@ -56,7 +56,7 @@ class DreamHallsEffect extends ContinuousEffectImpl {
         staticText = "Rather than pay the mana cost for a spell, its controller may discard a card that shares a color with that spell";
     }
 
-    public DreamHallsEffect(final DreamHallsEffect effect) {
+    private DreamHallsEffect(final DreamHallsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreamPillager.java
+++ b/Mage.Sets/src/mage/cards/d/DreamPillager.java
@@ -57,7 +57,7 @@ class DreamPillagerEffect extends OneShotEffect {
         this.staticText = "exile that many cards from the top of your library. Until end of turn, you may cast spells from among those exiled cards";
     }
 
-    public DreamPillagerEffect(final DreamPillagerEffect effect) {
+    private DreamPillagerEffect(final DreamPillagerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreamSalvage.java
+++ b/Mage.Sets/src/mage/cards/d/DreamSalvage.java
@@ -78,7 +78,7 @@ class DreamSalvageEffect extends OneShotEffect {
         staticText = "Draw cards equal to the number of cards target opponent discarded this turn";
     }
 
-    public DreamSalvageEffect(final DreamSalvageEffect effect) {
+    private DreamSalvageEffect(final DreamSalvageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreamsOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/d/DreamsOfTheDead.java
@@ -70,7 +70,7 @@ class DreamsOfTheDeadEffect extends OneShotEffect {
         this.staticText = "Return target white or black creature card from your graveyard to the battlefield. That creature gains \"Cumulative upkeep {2}.\"";
     }
 
-    public DreamsOfTheDeadEffect(final DreamsOfTheDeadEffect effect) {
+    private DreamsOfTheDeadEffect(final DreamsOfTheDeadEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DregReaver.java
+++ b/Mage.Sets/src/mage/cards/d/DregReaver.java
@@ -24,7 +24,7 @@ public final class DregReaver extends CardImpl {
         this.toughness = new MageInt(3);
     }
 
-    public DregReaver (final DregReaver card) {
+    private DregReaver(final DregReaver card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DrippingTongueZubera.java
+++ b/Mage.Sets/src/mage/cards/d/DrippingTongueZubera.java
@@ -30,7 +30,7 @@ public final class DrippingTongueZubera extends CardImpl {
         this.addAbility(new DiesSourceTriggeredAbility(new CreateTokenEffect(new SpiritToken(), ZuberasDiedDynamicValue.instance), false), new ZuberasDiedWatcher());
     }
 
-    public DrippingTongueZubera (final DrippingTongueZubera card) {
+    private DrippingTongueZubera(final DrippingTongueZubera card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DrogskolReaver.java
+++ b/Mage.Sets/src/mage/cards/d/DrogskolReaver.java
@@ -53,7 +53,7 @@ class DrogskolReaverAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
     }
 
-    public DrogskolReaverAbility(final DrogskolReaverAbility ability) {
+    private DrogskolReaverAbility(final DrogskolReaverAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DroidFactory.java
+++ b/Mage.Sets/src/mage/cards/d/DroidFactory.java
@@ -47,7 +47,7 @@ public final class DroidFactory extends CardImpl {
 
     public final class DroidFactoryAbility extends ActivatedAbilityImpl {
 
-        public DroidFactoryAbility(DroidFactoryAbility ability) {
+        private DroidFactoryAbility(final DroidFactoryAbility ability) {
             super(ability);
         }
 

--- a/Mage.Sets/src/mage/cards/d/Droidsmith.java
+++ b/Mage.Sets/src/mage/cards/d/Droidsmith.java
@@ -48,7 +48,7 @@ public class Droidsmith extends CardImpl {
         )));
     }
 
-    public Droidsmith(final Droidsmith card) {
+    private Droidsmith(final Droidsmith card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DromokaMonument.java
+++ b/Mage.Sets/src/mage/cards/d/DromokaMonument.java
@@ -56,7 +56,7 @@ public final class DromokaMonument extends CardImpl {
             toughness = new MageInt(4);
             this.addAbility(FlyingAbility.getInstance());
         }
-        public DromokaMonumentToken(final DromokaMonumentToken token) {
+        private DromokaMonumentToken(final DromokaMonumentToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/d/DroolingOgre.java
+++ b/Mage.Sets/src/mage/cards/d/DroolingOgre.java
@@ -84,7 +84,7 @@ public final class DroolingOgre extends CardImpl {
             super(Zone.BATTLEFIELD, new DroolingOgreEffect(), false);
         }
 
-        public DroolingOgreTriggeredAbility(final DroolingOgreTriggeredAbility ability) {
+        private DroolingOgreTriggeredAbility(final DroolingOgreTriggeredAbility ability) {
             super(ability);
         }
 

--- a/Mage.Sets/src/mage/cards/d/DropOfHoney.java
+++ b/Mage.Sets/src/mage/cards/d/DropOfHoney.java
@@ -56,7 +56,7 @@ class DropOfHoneyEffect extends OneShotEffect {
         this.staticText = "destroy the creature with the least power. It can't be regenerated. If two or more creatures are tied for least power, you choose one of them";
     }
     
-    public DropOfHoneyEffect(final DropOfHoneyEffect effect) {
+    private DropOfHoneyEffect(final DropOfHoneyEffect effect) {
         super(effect);
     }
     
@@ -113,7 +113,7 @@ class DropOfHoneyStateTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("When there are no creatures on the battlefield, ");
     }
 
-    public DropOfHoneyStateTriggeredAbility(final DropOfHoneyStateTriggeredAbility ability) {
+    private DropOfHoneyStateTriggeredAbility(final DropOfHoneyStateTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DrossRipper.java
+++ b/Mage.Sets/src/mage/cards/d/DrossRipper.java
@@ -29,7 +29,7 @@ public final class DrossRipper extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn), new ManaCostsImpl<>("{2}{B}")));
     }
 
-    public DrossRipper (final DrossRipper card) {
+    private DrossRipper(final DrossRipper card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DruidOfHorns.java
+++ b/Mage.Sets/src/mage/cards/d/DruidOfHorns.java
@@ -53,7 +53,7 @@ class DruidOfHornsTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you cast an Aura spell that targets {this}, ");
     }
 
-    public DruidOfHornsTriggeredAbility(final DruidOfHornsTriggeredAbility ability) {
+    private DruidOfHornsTriggeredAbility(final DruidOfHornsTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DruidOfTheAnima.java
+++ b/Mage.Sets/src/mage/cards/d/DruidOfTheAnima.java
@@ -30,7 +30,7 @@ public final class DruidOfTheAnima extends CardImpl {
         this.addAbility(new WhiteManaAbility());
     }
 
-    public DruidOfTheAnima (final DruidOfTheAnima card) {
+    private DruidOfTheAnima(final DruidOfTheAnima card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DruidicSatchel.java
+++ b/Mage.Sets/src/mage/cards/d/DruidicSatchel.java
@@ -49,7 +49,7 @@ class DruidicSatchelEffect extends OneShotEffect {
         staticText = "Reveal the top card of your library. If it's a creature card, create a 1/1 green Saproling creature token. If it's a land card, put that card onto the battlefield under your control. If it's a noncreature, nonland card, you gain 2 life";
     }
 
-    public DruidicSatchelEffect(final DruidicSatchelEffect effect) {
+    private DruidicSatchelEffect(final DruidicSatchelEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Drumhunter.java
+++ b/Mage.Sets/src/mage/cards/d/Drumhunter.java
@@ -61,7 +61,7 @@ class DrumHunterTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), true);
     }
 
-    public DrumHunterTriggeredAbility(final DrumHunterTriggeredAbility ability) {
+    private DrumHunterTriggeredAbility(final DrumHunterTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DryadGreenseeker.java
+++ b/Mage.Sets/src/mage/cards/d/DryadGreenseeker.java
@@ -55,7 +55,7 @@ class DryadGreenseekerEffect extends OneShotEffect {
                 + "If it's a land card, you may reveal it and put it into your hand.";
     }
 
-    public DryadGreenseekerEffect(final DryadGreenseekerEffect effect) {
+    private DryadGreenseekerEffect(final DryadGreenseekerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DryadMilitant.java
+++ b/Mage.Sets/src/mage/cards/d/DryadMilitant.java
@@ -53,7 +53,7 @@ class DryadMilitantReplacementEffect extends ReplacementEffectImpl {
         staticText = "If an instant or sorcery card would be put into a graveyard from anywhere, exile it instead";
     }
 
-    public DryadMilitantReplacementEffect(final DryadMilitantReplacementEffect effect) {
+    private DryadMilitantReplacementEffect(final DryadMilitantReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DubiousChallenge.java
+++ b/Mage.Sets/src/mage/cards/d/DubiousChallenge.java
@@ -47,7 +47,7 @@ class DubiousChallengeEffect extends OneShotEffect {
         this.staticText = "Look at the top ten cards of your library, exile up to two creature cards from among them, then shuffle. Target opponent may choose one of the exiled cards and put it onto the battlefield under their control. Put the rest onto the battlefield under your control.";
     }
 
-    public DubiousChallengeEffect(final DubiousChallengeEffect effect) {
+    private DubiousChallengeEffect(final DubiousChallengeEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class DubiousChallengeMoveToBattlefieldEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public DubiousChallengeMoveToBattlefieldEffect(final DubiousChallengeMoveToBattlefieldEffect effect) {
+    private DubiousChallengeMoveToBattlefieldEffect(final DubiousChallengeMoveToBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DuelistsHeritage.java
+++ b/Mage.Sets/src/mage/cards/d/DuelistsHeritage.java
@@ -54,7 +54,7 @@ class DuelistsHeritageTriggeredAbility extends TriggeredAbilityImpl {
         super(zone, effect, true);
     }
 
-    public DuelistsHeritageTriggeredAbility(final DuelistsHeritageTriggeredAbility ability) {
+    private DuelistsHeritageTriggeredAbility(final DuelistsHeritageTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Duneblast.java
+++ b/Mage.Sets/src/mage/cards/d/Duneblast.java
@@ -49,7 +49,7 @@ class DuneblastEffect extends OneShotEffect {
         this.staticText = "Choose up to one creature. Destroy the rest";
     }
 
-    public DuneblastEffect(final DuneblastEffect effect) {
+    private DuneblastEffect(final DuneblastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DungroveElder.java
+++ b/Mage.Sets/src/mage/cards/d/DungroveElder.java
@@ -41,7 +41,7 @@ public final class DungroveElder extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(new PermanentsOnBattlefieldCount(filterLands))));
     }
 
-    public DungroveElder (final DungroveElder card) {
+    private DungroveElder(final DungroveElder card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Duplicant.java
+++ b/Mage.Sets/src/mage/cards/d/Duplicant.java
@@ -65,7 +65,7 @@ class DuplicantExileTargetEffect extends OneShotEffect {
         this.staticText = "you may exile target nontoken creature";
     }
 
-    public DuplicantExileTargetEffect(final DuplicantExileTargetEffect effect) {
+    private DuplicantExileTargetEffect(final DuplicantExileTargetEffect effect) {
         super(effect);
     }
 
@@ -97,7 +97,7 @@ class DuplicantContinuousEffect extends ContinuousEffectImpl {
         staticText = "As long as a card exiled with {this} is a creature card, {this} has the power, toughness, and creature types of the last creature card exiled with {this}. It's still a Shapeshifter.";
     }
 
-    public DuplicantContinuousEffect(final DuplicantContinuousEffect effect) {
+    private DuplicantContinuousEffect(final DuplicantContinuousEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Duplicity.java
+++ b/Mage.Sets/src/mage/cards/d/Duplicity.java
@@ -68,7 +68,7 @@ class DuplicityEffect extends OneShotEffect {
         staticText = "exile the top five cards of your library face down";
     }
 
-    public DuplicityEffect(final DuplicityEffect effect) {
+    private DuplicityEffect(final DuplicityEffect effect) {
         super(effect);
     }
 
@@ -104,7 +104,7 @@ class DuplicityExileHandEffect extends OneShotEffect {
         staticText = "you may exile all cards from your hand face down. If you do, put all other cards you own exiled with {this} into your hand";
     }
 
-    public DuplicityExileHandEffect(final DuplicityExileHandEffect effect) {
+    private DuplicityExileHandEffect(final DuplicityExileHandEffect effect) {
         super(effect);
     }
 
@@ -147,7 +147,7 @@ class LoseControlDuplicity extends DelayedTriggeredAbility {
         super(new PutExiledCardsInOwnersGraveyard(), Duration.EndOfGame, false);
     }
 
-    public LoseControlDuplicity(final LoseControlDuplicity ability) {
+    private LoseControlDuplicity(final LoseControlDuplicity ability) {
         super(ability);
     }
 
@@ -190,7 +190,7 @@ class PutExiledCardsInOwnersGraveyard extends OneShotEffect {
         staticText = " put all cards exiled with {this} into their owner's graveyard.";
     }
 
-    public PutExiledCardsInOwnersGraveyard(final PutExiledCardsInOwnersGraveyard effect) {
+    private PutExiledCardsInOwnersGraveyard(final PutExiledCardsInOwnersGraveyard effect) {
         super(effect);
     }
 
@@ -220,7 +220,7 @@ class DuplicityEntersBattlefieldAbility extends StaticAbility {
         super(Zone.ALL, new EntersBattlefieldEffect(effect, null, null, true, false));
     }
 
-    public DuplicityEntersBattlefieldAbility(final DuplicityEntersBattlefieldAbility ability) {
+    private DuplicityEntersBattlefieldAbility(final DuplicityEntersBattlefieldAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DuskmantleGuildmage.java
+++ b/Mage.Sets/src/mage/cards/d/DuskmantleGuildmage.java
@@ -63,7 +63,7 @@ class CardPutIntoOpponentGraveThisTurn extends DelayedTriggeredAbility {
         super(new LoseLifeTargetEffect(1), Duration.EndOfTurn, false);
     }
 
-    public CardPutIntoOpponentGraveThisTurn(final CardPutIntoOpponentGraveThisTurn ability) {
+    private CardPutIntoOpponentGraveThisTurn(final CardPutIntoOpponentGraveThisTurn ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DuskmantleSeer.java
+++ b/Mage.Sets/src/mage/cards/d/DuskmantleSeer.java
@@ -55,7 +55,7 @@ class DuskmantleSeerEffect extends OneShotEffect {
                 "loses life equal to that card's mana value, then puts it into their hand";
     }
 
-    public DuskmantleSeerEffect(final DuskmantleSeerEffect effect) {
+    private DuskmantleSeerEffect(final DuskmantleSeerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DwarvenArmorer.java
+++ b/Mage.Sets/src/mage/cards/d/DwarvenArmorer.java
@@ -73,7 +73,7 @@ class DwarvenArmorerEffect extends OneShotEffect {
         staticText = "Put a +0/+1 counter or a +1/+0 counter on target creature.";
     }
 
-    public DwarvenArmorerEffect(final DwarvenArmorerEffect effect) {
+    private DwarvenArmorerEffect(final DwarvenArmorerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DwarvenCatapult.java
+++ b/Mage.Sets/src/mage/cards/d/DwarvenCatapult.java
@@ -46,7 +46,7 @@ class DwarvenCatapultEffect extends OneShotEffect {
         staticText = "{this} deals X damage divided evenly, rounded down, among all creatures target opponent controls.";
     }
 
-    public DwarvenCatapultEffect(final DwarvenCatapultEffect effect) {
+    private DwarvenCatapultEffect(final DwarvenCatapultEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DwarvenDriller.java
+++ b/Mage.Sets/src/mage/cards/d/DwarvenDriller.java
@@ -53,7 +53,7 @@ class DwarvenDrillerEffect extends OneShotEffect {
         this.staticText = "Destroy target land unless its controller has {this} deal 2 damage to them";
     }
 
-    public DwarvenDrillerEffect(final DwarvenDrillerEffect effect) {
+    private DwarvenDrillerEffect(final DwarvenDrillerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DwarvenShrine.java
+++ b/Mage.Sets/src/mage/cards/d/DwarvenShrine.java
@@ -48,7 +48,7 @@ class DwarvenShrineTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DwarvenShrineEffect(), false);
     }
 
-    public DwarvenShrineTriggeredAbility(final DwarvenShrineTriggeredAbility ability) {
+    private DwarvenShrineTriggeredAbility(final DwarvenShrineTriggeredAbility ability) {
         super(ability);
     }
 
@@ -81,7 +81,7 @@ class DwarvenShrineEffect extends OneShotEffect {
         staticText = "Whenever a player casts a spell, {this} deals X damage to that player, where X is twice the number of cards in all graveyards with the same name as that spell.";
     }
 
-    public DwarvenShrineEffect(final DwarvenShrineEffect effect) {
+    private DwarvenShrineEffect(final DwarvenShrineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DyadForceTransfer.java
+++ b/Mage.Sets/src/mage/cards/d/DyadForceTransfer.java
@@ -24,7 +24,7 @@ public class DyadForceTransfer extends CardImpl {
         this.getSpellAbility().addEffect(new ScryEffect(3, true));
     }
 
-    public DyadForceTransfer(final DyadForceTransfer card) {
+    private DyadForceTransfer(final DyadForceTransfer card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EMPBlast.java
+++ b/Mage.Sets/src/mage/cards/e/EMPBlast.java
@@ -48,7 +48,7 @@ class EMPBlastEffect extends OneShotEffect {
         this.staticText = "Tap all other artifacts";
     }
 
-    public EMPBlastEffect(final EMPBlastEffect effect) {
+    private EMPBlastEffect(final EMPBlastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EagerConstruct.java
+++ b/Mage.Sets/src/mage/cards/e/EagerConstruct.java
@@ -47,7 +47,7 @@ class EagerConstructEffect extends OneShotEffect {
         this.staticText = "each player may scry 1";
     }
 
-    public EagerConstructEffect(final EagerConstructEffect effect) {
+    private EagerConstructEffect(final EagerConstructEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EarlyHarvest.java
+++ b/Mage.Sets/src/mage/cards/e/EarlyHarvest.java
@@ -51,7 +51,7 @@ class UntapAllLandsTargetEffect extends OneShotEffect {
         staticText = "Target player untaps all basic lands they control";
     }
 
-    public UntapAllLandsTargetEffect(final UntapAllLandsTargetEffect effect) {
+    private UntapAllLandsTargetEffect(final UntapAllLandsTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EarnestFellowship.java
+++ b/Mage.Sets/src/mage/cards/e/EarnestFellowship.java
@@ -53,7 +53,7 @@ class EarnestFellowshipEffect extends ContinuousEffectImpl {
         this.staticText = "Each creature has protection from its colors";
     }
 
-    public EarnestFellowshipEffect(final EarnestFellowshipEffect effect) {
+    private EarnestFellowshipEffect(final EarnestFellowshipEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EarthElemental.java
+++ b/Mage.Sets/src/mage/cards/e/EarthElemental.java
@@ -23,7 +23,7 @@ public final class EarthElemental extends CardImpl {
         this.toughness = new MageInt(5);
     }
 
-    public EarthElemental (final EarthElemental card) {
+    private EarthElemental(final EarthElemental card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Earthbind.java
+++ b/Mage.Sets/src/mage/cards/e/Earthbind.java
@@ -63,7 +63,7 @@ class EarthbindEffect extends OneShotEffect {
         staticText = "if enchanted creature has flying, {this} deals 2 damage to that creature and Earthbind gains \"Enchanted creature loses flying.\"";
     }
 
-    public EarthbindEffect(final EarthbindEffect effect) {
+    private EarthbindEffect(final EarthbindEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Earthlink.java
+++ b/Mage.Sets/src/mage/cards/e/Earthlink.java
@@ -55,7 +55,7 @@ class EarthlinkEffect extends OneShotEffect {
         this.staticText = "that creature's controller sacrifices a land";
     }
 
-    public EarthlinkEffect(final EarthlinkEffect effect) {
+    private EarthlinkEffect(final EarthlinkEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EatenBySpiders.java
+++ b/Mage.Sets/src/mage/cards/e/EatenBySpiders.java
@@ -55,7 +55,7 @@ class EatenBySpidersEffect extends OneShotEffect {
         this.staticText = "Destroy target creature with flying and all Equipment attached to that creature";
     }
 
-    public EatenBySpidersEffect(final EatenBySpidersEffect effect) {
+    private EatenBySpidersEffect(final EatenBySpidersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EaterOfVirtue.java
+++ b/Mage.Sets/src/mage/cards/e/EaterOfVirtue.java
@@ -119,7 +119,7 @@ class EaterOfVirtueGainAbilityAttachedEffect extends ContinuousEffectImpl {
         staticText = "As long as a card exiled with Eater of Virtue has flying, equipped creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance";
     }
 
-    public EaterOfVirtueGainAbilityAttachedEffect(final EaterOfVirtueGainAbilityAttachedEffect effect) {
+    private EaterOfVirtueGainAbilityAttachedEffect(final EaterOfVirtueGainAbilityAttachedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EbonPraetor.java
+++ b/Mage.Sets/src/mage/cards/e/EbonPraetor.java
@@ -69,7 +69,7 @@ class EbonPraetorEffect extends OneShotEffect {
         this.staticText = "If the sacrificed creature was a Thrull, put a +1/+0 counter on {this}";
     }
 
-    public EbonPraetorEffect(final EbonPraetorEffect effect) {
+    private EbonPraetorEffect(final EbonPraetorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EchoBaseCommando.java
+++ b/Mage.Sets/src/mage/cards/e/EchoBaseCommando.java
@@ -69,7 +69,7 @@ class EchoBaseCommandoEffect extends CostModificationEffectImpl {
         staticText = effectText;
     }
 
-    public EchoBaseCommandoEffect(final EchoBaseCommandoEffect effect) {
+    private EchoBaseCommandoEffect(final EchoBaseCommandoEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EchoCirclet.java
+++ b/Mage.Sets/src/mage/cards/e/EchoCirclet.java
@@ -48,7 +48,7 @@ class EchoCircletEffect extends ContinuousEffectImpl {
         staticText = "Equipped creature can block an additional creature each combat";
     }
 
-    public EchoCircletEffect(final EchoCircletEffect effect) {
+    private EchoCircletEffect(final EchoCircletEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EchoMage.java
+++ b/Mage.Sets/src/mage/cards/e/EchoMage.java
@@ -81,7 +81,7 @@ class EchoMageEffect extends OneShotEffect {
         this.staticText = "Copy target instant or sorcery spell twice. You may choose new targets for the copies";
     }
 
-    public EchoMageEffect(final EchoMageEffect effect) {
+    private EchoMageEffect(final EchoMageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EchoingCourage.java
+++ b/Mage.Sets/src/mage/cards/e/EchoingCourage.java
@@ -50,7 +50,7 @@ class EchoingCourageEffect extends OneShotEffect {
         this.staticText = "Target creature and all other creatures with the same name as that creature get +2/+2 until end of turn";
     }
 
-    public EchoingCourageEffect(final EchoingCourageEffect effect) {
+    private EchoingCourageEffect(final EchoingCourageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EchoingDecay.java
+++ b/Mage.Sets/src/mage/cards/e/EchoingDecay.java
@@ -49,7 +49,7 @@ class EchoingDecayEffect extends OneShotEffect {
         this.staticText = "Target creature and all other creatures with the same name as that creature get -2/-2 until end of turn";
     }
 
-    public EchoingDecayEffect(final EchoingDecayEffect effect) {
+    private EchoingDecayEffect(final EchoingDecayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EchoingTruth.java
+++ b/Mage.Sets/src/mage/cards/e/EchoingTruth.java
@@ -53,7 +53,7 @@ class ReturnToHandAllNamedPermanentsEffect extends OneShotEffect {
         this.staticText = "Return target nonland permanent and all other permanents with the same name as that permanent to their owners' hands";
     }
 
-    public ReturnToHandAllNamedPermanentsEffect(final ReturnToHandAllNamedPermanentsEffect effect) {
+    private ReturnToHandAllNamedPermanentsEffect(final ReturnToHandAllNamedPermanentsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EdificeOfAuthority.java
+++ b/Mage.Sets/src/mage/cards/e/EdificeOfAuthority.java
@@ -69,7 +69,7 @@ class EdificeOfAuthorityEffect extends OneShotEffect {
         staticText = ruleText;
     }
 
-    public EdificeOfAuthorityEffect(final EdificeOfAuthorityEffect effect) {
+    private EdificeOfAuthorityEffect(final EdificeOfAuthorityEffect effect) {
         super(effect);
     }
 
@@ -93,7 +93,7 @@ class EdificeOfAuthorityRestrictionEffect extends RestrictionEffect {
         staticText = "";
     }
 
-    public EdificeOfAuthorityRestrictionEffect(final EdificeOfAuthorityRestrictionEffect effect) {
+    private EdificeOfAuthorityRestrictionEffect(final EdificeOfAuthorityRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EdricSpymasterOfTrest.java
+++ b/Mage.Sets/src/mage/cards/e/EdricSpymasterOfTrest.java
@@ -52,7 +52,7 @@ class EdricSpymasterOfTrestTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardTargetEffect(1, true), false);
     }
 
-    public EdricSpymasterOfTrestTriggeredAbility(final EdricSpymasterOfTrestTriggeredAbility ability) {
+    private EdricSpymasterOfTrestTriggeredAbility(final EdricSpymasterOfTrestTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EerieInterlude.java
+++ b/Mage.Sets/src/mage/cards/e/EerieInterlude.java
@@ -53,7 +53,7 @@ class EerieInterludeEffect extends OneShotEffect {
         staticText = "Exile any number of target creatures you control. Return those cards to the battlefield under their owner's control at the beginning of the next end step";
     }
 
-    public EerieInterludeEffect(final EerieInterludeEffect effect) {
+    private EerieInterludeEffect(final EerieInterludeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EfreetWeaponmaster.java
+++ b/Mage.Sets/src/mage/cards/e/EfreetWeaponmaster.java
@@ -62,7 +62,7 @@ class EfreetWeaponmasterAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When {this} enters the battlefield or is turned face up, ");
     }
 
-    public EfreetWeaponmasterAbility(final EfreetWeaponmasterAbility ability) {
+    private EfreetWeaponmasterAbility(final EfreetWeaponmasterAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EgoErasure.java
+++ b/Mage.Sets/src/mage/cards/e/EgoErasure.java
@@ -49,7 +49,7 @@ class EgoErasureEffect extends ContinuousEffectImpl {
         staticText = "creatures target player controls get -2/-0 and lose all creature types until end of turn";
     }
 
-    public EgoErasureEffect(final EgoErasureEffect effect) {
+    private EgoErasureEffect(final EgoErasureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EidolonOfTheGreatRevel.java
+++ b/Mage.Sets/src/mage/cards/e/EidolonOfTheGreatRevel.java
@@ -53,7 +53,7 @@ class EidolonOfTheGreatRevelTriggeredAbility extends TriggeredAbilityImpl {
     }
 
 
-    public EidolonOfTheGreatRevelTriggeredAbility(final EidolonOfTheGreatRevelTriggeredAbility abiltity) {
+    private EidolonOfTheGreatRevelTriggeredAbility(final EidolonOfTheGreatRevelTriggeredAbility abiltity) {
         super(abiltity);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElbrusTheBindingBlade.java
+++ b/Mage.Sets/src/mage/cards/e/ElbrusTheBindingBlade.java
@@ -58,7 +58,7 @@ class ElbrusTheBindingBladeEffect extends OneShotEffect {
         staticText = "unattach {this}, then transform it";
     }
 
-    public ElbrusTheBindingBladeEffect(final ElbrusTheBindingBladeEffect effect) {
+    private ElbrusTheBindingBladeEffect(final ElbrusTheBindingBladeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElderCathar.java
+++ b/Mage.Sets/src/mage/cards/e/ElderCathar.java
@@ -58,7 +58,7 @@ class ElderCatharAddCountersTargetEffect extends OneShotEffect {
         staticText = "put a +1/+1 counter on target creature you control. If that creature is a Human, put two +1/+1 counters on it instead";
     }
 
-    public ElderCatharAddCountersTargetEffect(final ElderCatharAddCountersTargetEffect effect) {
+    private ElderCatharAddCountersTargetEffect(final ElderCatharAddCountersTargetEffect effect) {
         super(effect);
         this.counter = effect.counter.copy();
         this.counter2 = effect.counter2.copy();

--- a/Mage.Sets/src/mage/cards/e/ElderSpawn.java
+++ b/Mage.Sets/src/mage/cards/e/ElderSpawn.java
@@ -68,7 +68,7 @@ class ElderSpawnEffect extends OneShotEffect {
         staticText = "unless you sacrifice an Island, sacrifice {this} and it deals 6 damage to you";
     }
 
-    public ElderSpawnEffect(final ElderSpawnEffect effect) {
+    private ElderSpawnEffect(final ElderSpawnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElderscaleWurm.java
+++ b/Mage.Sets/src/mage/cards/e/ElderscaleWurm.java
@@ -59,7 +59,7 @@ class ElderscaleWurmSetLifeEffect extends OneShotEffect {
         this.staticText = "if your life total is less than 7, your life total becomes 7";
     }
 
-    public ElderscaleWurmSetLifeEffect(final ElderscaleWurmSetLifeEffect effect) {
+    private ElderscaleWurmSetLifeEffect(final ElderscaleWurmSetLifeEffect effect) {
         super(effect);
     }
 
@@ -88,7 +88,7 @@ class ElderscaleWurmReplacementEffect extends ReplacementEffectImpl {
         staticText = "As long as you have 7 or more life, damage that would reduce your life total to less than 7 reduces it to 7 instead";
     }
 
-    public ElderscaleWurmReplacementEffect(final ElderscaleWurmReplacementEffect effect) {
+    private ElderscaleWurmReplacementEffect(final ElderscaleWurmReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EldraziConscription.java
+++ b/Mage.Sets/src/mage/cards/e/EldraziConscription.java
@@ -47,7 +47,7 @@ public final class EldraziConscription extends CardImpl {
         this.addAbility(ability);
     }
 
-    public EldraziConscription (final EldraziConscription card) {
+    private EldraziConscription(final EldraziConscription card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EldraziMimic.java
+++ b/Mage.Sets/src/mage/cards/e/EldraziMimic.java
@@ -59,7 +59,7 @@ class EldraziMimicEffect extends OneShotEffect {
         staticText = "you may have the base power and toughness of {this} become that creature's power and toughness until end of turn";
     }
 
-    public EldraziMimicEffect(final EldraziMimicEffect effect) {
+    private EldraziMimicEffect(final EldraziMimicEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Electropotence.java
+++ b/Mage.Sets/src/mage/cards/e/Electropotence.java
@@ -49,7 +49,7 @@ class ElectropotenceTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ElectropotenceEffect());
     }
 
-    public ElectropotenceTriggeredAbility(ElectropotenceTriggeredAbility ability) {
+    private ElectropotenceTriggeredAbility(final ElectropotenceTriggeredAbility ability) {
         super(ability);
     }
 
@@ -86,7 +86,7 @@ class ElectropotenceEffect extends OneShotEffect {
         super(Outcome.Damage);
     }
 
-    public ElectropotenceEffect(final ElectropotenceEffect effect) {
+    private ElectropotenceEffect(final ElectropotenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Electryte.java
+++ b/Mage.Sets/src/mage/cards/e/Electryte.java
@@ -83,7 +83,7 @@ class ElectryteEffect extends OneShotEffect {
         staticText = "it deals damage equal to its power to each blocking creature";
     }
 
-    public ElectryteEffect(final ElectryteEffect effect) {
+    private ElectryteEffect(final ElectryteEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElementalAppeal.java
+++ b/Mage.Sets/src/mage/cards/e/ElementalAppeal.java
@@ -57,7 +57,7 @@ class ElementalAppealEffect extends OneShotEffect {
                 + "If this spell was kicked, that creature gets +7/+0 until end of turn";
     }
 
-    public ElementalAppealEffect(final ElementalAppealEffect effect) {
+    private ElementalAppealEffect(final ElementalAppealEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElementalAugury.java
+++ b/Mage.Sets/src/mage/cards/e/ElementalAugury.java
@@ -46,7 +46,7 @@ class ElementalAuguryEffect extends OneShotEffect {
         this.staticText = "look at the top three cards of target player's library, then put them back in any order";
     }
 
-    public ElementalAuguryEffect(final ElementalAuguryEffect effect) {
+    private ElementalAuguryEffect(final ElementalAuguryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElementalMastery.java
+++ b/Mage.Sets/src/mage/cards/e/ElementalMastery.java
@@ -63,7 +63,7 @@ class ElementalMasteryEffect extends OneShotEffect {
         staticText = "create X 1/1 red Elemental creature tokens with haste, where X is this creature's power. Exile them at the beginning of the next end step";
     }
 
-    public ElementalMasteryEffect(final ElementalMasteryEffect effect) {
+    private ElementalMasteryEffect(final ElementalMasteryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElementalUprising.java
+++ b/Mage.Sets/src/mage/cards/e/ElementalUprising.java
@@ -55,7 +55,7 @@ class ElementalUprisingToken extends TokenImpl {
 
         this.addAbility(HasteAbility.getInstance());
     }
-    public ElementalUprisingToken(final ElementalUprisingToken token) {
+    private ElementalUprisingToken(final ElementalUprisingToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EleshNornGrandCenobite.java
+++ b/Mage.Sets/src/mage/cards/e/EleshNornGrandCenobite.java
@@ -41,7 +41,7 @@ public final class EleshNornGrandCenobite extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostOpponentsEffect(-2, -2, Duration.WhileOnBattlefield)));
     }
 
-    public EleshNornGrandCenobite (final EleshNornGrandCenobite card) {
+    private EleshNornGrandCenobite(final EleshNornGrandCenobite card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EliteArcanist.java
+++ b/Mage.Sets/src/mage/cards/e/EliteArcanist.java
@@ -94,7 +94,7 @@ class EliteArcanistImprintEffect extends OneShotEffect {
         staticText = "you may exile an instant card from your hand";
     }
 
-    public EliteArcanistImprintEffect(EliteArcanistImprintEffect effect) {
+    private EliteArcanistImprintEffect(final EliteArcanistImprintEffect effect) {
         super(effect);
     }
 
@@ -135,7 +135,7 @@ class EliteArcanistCopyEffect extends OneShotEffect {
                 + "without paying its mana cost. X is the mana value of the exiled card";
     }
 
-    public EliteArcanistCopyEffect(final EliteArcanistCopyEffect effect) {
+    private EliteArcanistCopyEffect(final EliteArcanistCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElixirOfImmortality.java
+++ b/Mage.Sets/src/mage/cards/e/ElixirOfImmortality.java
@@ -49,7 +49,7 @@ class ElixerOfImmortalityEffect extends OneShotEffect {
         staticText = "You gain 5 life. Shuffle {this} and your graveyard into their owner's library";
     }
 
-    public ElixerOfImmortalityEffect(final ElixerOfImmortalityEffect effect) {
+    private ElixerOfImmortalityEffect(final ElixerOfImmortalityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElkinBottle.java
+++ b/Mage.Sets/src/mage/cards/e/ElkinBottle.java
@@ -50,7 +50,7 @@ class ElkinBottleExileEffect extends OneShotEffect {
         this.staticText = "Exile the top card of your library. Until the beginning of your next upkeep, you may play that card";
     }
 
-    public ElkinBottleExileEffect(final ElkinBottleExileEffect effect) {
+    private ElkinBottleExileEffect(final ElkinBottleExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElkinLair.java
+++ b/Mage.Sets/src/mage/cards/e/ElkinLair.java
@@ -63,7 +63,7 @@ class ElkinLairUpkeepEffect extends OneShotEffect {
                 + "player hasn't played the card, they put it into their graveyard";
     }
 
-    public ElkinLairUpkeepEffect(final ElkinLairUpkeepEffect effect) {
+    private ElkinLairUpkeepEffect(final ElkinLairUpkeepEffect effect) {
         super(effect);
     }
 
@@ -112,7 +112,7 @@ class ElkinLairPutIntoGraveyardEffect extends OneShotEffect {
         staticText = "if the player hasn't played the card, they put it into their graveyard";
     }
 
-    public ElkinLairPutIntoGraveyardEffect(final ElkinLairPutIntoGraveyardEffect effect) {
+    private ElkinLairPutIntoGraveyardEffect(final ElkinLairPutIntoGraveyardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElsewhereFlask.java
+++ b/Mage.Sets/src/mage/cards/e/ElsewhereFlask.java
@@ -54,7 +54,7 @@ class ElsewhereFlaskEffect extends OneShotEffect {
         this.staticText = "Choose a basic land type. Each land you control becomes that type until end of turn";
     }
 
-    public ElsewhereFlaskEffect(final ElsewhereFlaskEffect effect) {
+    private ElsewhereFlaskEffect(final ElsewhereFlaskEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElspethTirel.java
+++ b/Mage.Sets/src/mage/cards/e/ElspethTirel.java
@@ -54,7 +54,7 @@ class ElspethTirelFirstEffect extends OneShotEffect {
         staticText = "You gain 1 life for each creature you control";
     }
 
-    public ElspethTirelFirstEffect(final ElspethTirelFirstEffect effect) {
+    private ElspethTirelFirstEffect(final ElspethTirelFirstEffect effect) {
         super(effect);
     }
 
@@ -82,7 +82,7 @@ class ElspethTirelThirdEffect extends OneShotEffect {
         staticText = "Destroy all other permanents except for lands and tokens";
     }
 
-    public ElspethTirelThirdEffect(final ElspethTirelThirdEffect effect) {
+    private ElspethTirelThirdEffect(final ElspethTirelThirdEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElvishBranchbender.java
+++ b/Mage.Sets/src/mage/cards/e/ElvishBranchbender.java
@@ -97,7 +97,7 @@ class ElvishBranchbenderToken extends TokenImpl {
         power = new MageInt(xValue);
         toughness = new MageInt(xValue);
     }
-    public ElvishBranchbenderToken(final ElvishBranchbenderToken token) {
+    private ElvishBranchbenderToken(final ElvishBranchbenderToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElvishImpersonators.java
+++ b/Mage.Sets/src/mage/cards/e/ElvishImpersonators.java
@@ -47,7 +47,7 @@ class ElvishImpersonatorsEffect extends OneShotEffect {
         staticText = "roll a six-sided die twice. Its base power becomes the first result and its base toughness becomes the second result";
     }
 
-    public ElvishImpersonatorsEffect(final ElvishImpersonatorsEffect effect) {
+    private ElvishImpersonatorsEffect(final ElvishImpersonatorsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElvishSoultiller.java
+++ b/Mage.Sets/src/mage/cards/e/ElvishSoultiller.java
@@ -55,7 +55,7 @@ class ElvishSoultillerEffect extends OneShotEffect {
         this.staticText = "choose a creature type. Shuffle all creature cards of that type from your graveyard into your library";
     }
 
-    public ElvishSoultillerEffect(final ElvishSoultillerEffect effect) {
+    private ElvishSoultillerEffect(final ElvishSoultillerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElvishVisionary.java
+++ b/Mage.Sets/src/mage/cards/e/ElvishVisionary.java
@@ -27,7 +27,7 @@ public final class ElvishVisionary extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DrawCardSourceControllerEffect(1)));
     }
 
-    public ElvishVisionary (final ElvishVisionary card) {
+    private ElvishVisionary(final ElvishVisionary card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmbalmersTools.java
+++ b/Mage.Sets/src/mage/cards/e/EmbalmersTools.java
@@ -70,7 +70,7 @@ class EmbalmersToolsEffect extends CostModificationEffectImpl {
         staticText = effectText;
     }
 
-    public EmbalmersToolsEffect(final EmbalmersToolsEffect effect) {
+    private EmbalmersToolsEffect(final EmbalmersToolsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmberFistZubera.java
+++ b/Mage.Sets/src/mage/cards/e/EmberFistZubera.java
@@ -33,7 +33,7 @@ public final class EmberFistZubera extends CardImpl {
         this.addAbility(ability, new ZuberasDiedWatcher());
     }
 
-    public EmberFistZubera (final EmberFistZubera card) {
+    private EmberFistZubera(final EmberFistZubera card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmberGale.java
+++ b/Mage.Sets/src/mage/cards/e/EmberGale.java
@@ -55,7 +55,7 @@ class EmberGaleEffect extends OneShotEffect {
         staticText = "Creatures target player controls can't block this turn. {this} deals 1 damage to each white and/or blue creature that player controls";
     }
 
-    public EmberGaleEffect(final EmberGaleEffect effect) {
+    private EmberGaleEffect(final EmberGaleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmberwildeCaliph.java
+++ b/Mage.Sets/src/mage/cards/e/EmberwildeCaliph.java
@@ -61,7 +61,7 @@ class EmberwildeCaliphTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new EmberwildeCaliphEffect(), false);
     }
 
-    public EmberwildeCaliphTriggeredAbility(final EmberwildeCaliphTriggeredAbility ability) {
+    private EmberwildeCaliphTriggeredAbility(final EmberwildeCaliphTriggeredAbility ability) {
         super(ability);
     }
 
@@ -99,7 +99,7 @@ class EmberwildeCaliphEffect extends OneShotEffect {
         super(Outcome.LoseLife);
     }
 
-    public EmberwildeCaliphEffect(final EmberwildeCaliphEffect effect) {
+    private EmberwildeCaliphEffect(final EmberwildeCaliphEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmberwildeCaptain.java
+++ b/Mage.Sets/src/mage/cards/e/EmberwildeCaptain.java
@@ -55,7 +55,7 @@ class EmberwildeCaptainTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new EmberwildeCaptainEffect(), false);
     }
 
-    public EmberwildeCaptainTriggeredAbility(final EmberwildeCaptainTriggeredAbility ability) {
+    private EmberwildeCaptainTriggeredAbility(final EmberwildeCaptainTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmbodimentOfFury.java
+++ b/Mage.Sets/src/mage/cards/e/EmbodimentOfFury.java
@@ -74,7 +74,7 @@ class EmbodimentOfFuryToken extends TokenImpl {
         this.toughness = new MageInt(3);
         this.addAbility(HasteAbility.getInstance());
     }
-    public EmbodimentOfFuryToken(final EmbodimentOfFuryToken token) {
+    private EmbodimentOfFuryToken(final EmbodimentOfFuryToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmbodimentOfInsight.java
+++ b/Mage.Sets/src/mage/cards/e/EmbodimentOfInsight.java
@@ -74,7 +74,7 @@ class EmbodimentOfInsightToken extends TokenImpl {
         this.toughness = new MageInt(3);
         this.addAbility(HasteAbility.getInstance());
     }
-    public EmbodimentOfInsightToken(final EmbodimentOfInsightToken token) {
+    private EmbodimentOfInsightToken(final EmbodimentOfInsightToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmeriaShepherd.java
+++ b/Mage.Sets/src/mage/cards/e/EmeriaShepherd.java
@@ -65,7 +65,7 @@ class EmeriaShepherdReturnToHandTargetEffect extends OneShotEffect {
         staticText = "you may return target nonland permanent card from your graveyard to your hand. If that land is a Plains, you may return that nonland permanent card to the battlefield instead";
     }
 
-    public EmeriaShepherdReturnToHandTargetEffect(final EmeriaShepherdReturnToHandTargetEffect effect) {
+    private EmeriaShepherdReturnToHandTargetEffect(final EmeriaShepherdReturnToHandTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmeriaTheSkyRuin.java
+++ b/Mage.Sets/src/mage/cards/e/EmeriaTheSkyRuin.java
@@ -62,7 +62,7 @@ class EmeriaTheSkyRuinTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD));
     }
 
-    public EmeriaTheSkyRuinTriggeredAbility(final EmeriaTheSkyRuinTriggeredAbility ability) {
+    private EmeriaTheSkyRuinTriggeredAbility(final EmeriaTheSkyRuinTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmissaryOfGrudges.java
+++ b/Mage.Sets/src/mage/cards/e/EmissaryOfGrudges.java
@@ -69,7 +69,7 @@ class EmissaryOfGrudgesEffect extends OneShotEffect {
                 + " if it targets you or a permanent you control. Activate only once.";
     }
 
-    public EmissaryOfGrudgesEffect(final EmissaryOfGrudgesEffect effect) {
+    private EmissaryOfGrudgesEffect(final EmissaryOfGrudgesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmperorCrocodile.java
+++ b/Mage.Sets/src/mage/cards/e/EmperorCrocodile.java
@@ -47,7 +47,7 @@ class EmperorCrocodileStateTriggeredAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new SacrificeSourceEffect());
     }
 
-    public EmperorCrocodileStateTriggeredAbility(final EmperorCrocodileStateTriggeredAbility ability) {
+    private EmperorCrocodileStateTriggeredAbility(final EmperorCrocodileStateTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmptyShrineKannushi.java
+++ b/Mage.Sets/src/mage/cards/e/EmptyShrineKannushi.java
@@ -56,7 +56,7 @@ class EmptyShrineKannushiProtectionAbility extends ProtectionAbility {
         super(new FilterCard());
     }
 
-    public EmptyShrineKannushiProtectionAbility(final EmptyShrineKannushiProtectionAbility ability) {
+    private EmptyShrineKannushiProtectionAbility(final EmptyShrineKannushiProtectionAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmptyTheCatacombs.java
+++ b/Mage.Sets/src/mage/cards/e/EmptyTheCatacombs.java
@@ -47,7 +47,7 @@ class EmptyTheCatacombsEffect extends OneShotEffect {
         staticText = "Each player returns all creature cards from their graveyard to their hand";
     }
 
-    public EmptyTheCatacombsEffect(final EmptyTheCatacombsEffect effect) {
+    private EmptyTheCatacombsEffect(final EmptyTheCatacombsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmrakulsEvangel.java
+++ b/Mage.Sets/src/mage/cards/e/EmrakulsEvangel.java
@@ -70,7 +70,7 @@ class EmrakulsEvangelCost extends CostImpl {
         this.text = "Sacrifice {this} and any number of other non-Eldrazi creatures";
     }
 
-    public EmrakulsEvangelCost(EmrakulsEvangelCost cost) {
+    private EmrakulsEvangelCost(final EmrakulsEvangelCost cost) {
         super(cost);
         this.numSacrificed = cost.getNumSacrificed();
     }

--- a/Mage.Sets/src/mage/cards/e/EnchantersBane.java
+++ b/Mage.Sets/src/mage/cards/e/EnchantersBane.java
@@ -50,7 +50,7 @@ class EnchantersBaneEffect extends OneShotEffect {
                 + "unless that player sacrifices it";
     }
 
-    public EnchantersBaneEffect(final EnchantersBaneEffect effect) {
+    private EnchantersBaneEffect(final EnchantersBaneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnchantmentAlteration.java
+++ b/Mage.Sets/src/mage/cards/e/EnchantmentAlteration.java
@@ -108,7 +108,7 @@ class EnchantmentAlterationEffect extends OneShotEffect {
         this.staticText = "Attach target Aura attached to a creature or land to another permanent of that type";
     }
 
-    public EnchantmentAlterationEffect(final EnchantmentAlterationEffect effect) {
+    private EnchantmentAlterationEffect(final EnchantmentAlterationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EncirclingFissure.java
+++ b/Mage.Sets/src/mage/cards/e/EncirclingFissure.java
@@ -49,7 +49,7 @@ class EncirclingFissurePreventEffect extends PreventionEffectImpl {
         staticText = "Prevent all combat damage that would be dealt this turn by creatures target opponent controls";
     }
 
-    public EncirclingFissurePreventEffect(final EncirclingFissurePreventEffect effect) {
+    private EncirclingFissurePreventEffect(final EncirclingFissurePreventEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnclaveCryptologist.java
+++ b/Mage.Sets/src/mage/cards/e/EnclaveCryptologist.java
@@ -49,7 +49,7 @@ public final class EnclaveCryptologist extends LevelerCard {
         setMaxLevelCounters(3);
     }
 
-    public EnclaveCryptologist (final EnclaveCryptologist card) {
+    private EnclaveCryptologist(final EnclaveCryptologist card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EndHostilities.java
+++ b/Mage.Sets/src/mage/cards/e/EndHostilities.java
@@ -46,7 +46,7 @@ class EndHostilitiesEffect extends OneShotEffect {
         this.staticText = "Destroy all creatures and all permanents attached to creatures.";
     }
 
-    public EndHostilitiesEffect(final EndHostilitiesEffect effect) {
+    private EndHostilitiesEffect(final EndHostilitiesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EndlessEvil.java
+++ b/Mage.Sets/src/mage/cards/e/EndlessEvil.java
@@ -70,7 +70,7 @@ class EndlessEvilCloneEffect extends OneShotEffect {
         this.staticText = "create a token that's a copy of enchanted creature, except the token is 1/1";
     }
 
-    public EndlessEvilCloneEffect(final EndlessEvilCloneEffect effect) {
+    private EndlessEvilCloneEffect(final EndlessEvilCloneEffect effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class EndlessEvilBounceAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ReturnToHandSourceEffect(false, true));
     }
 
-    public EndlessEvilBounceAbility(final EndlessEvilBounceAbility effect) {
+    private EndlessEvilBounceAbility(final EndlessEvilBounceAbility effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EndlessWhispers.java
+++ b/Mage.Sets/src/mage/cards/e/EndlessWhispers.java
@@ -62,7 +62,7 @@ class ReturnSourceToBattlefieldEffect extends OneShotEffect {
         staticText = "That player puts this card from its owner's graveyard onto the battlefield under their control";
     }
 
-    public ReturnSourceToBattlefieldEffect(final ReturnSourceToBattlefieldEffect effect) {
+    private ReturnSourceToBattlefieldEffect(final ReturnSourceToBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EndrekSahrMasterBreeder.java
+++ b/Mage.Sets/src/mage/cards/e/EndrekSahrMasterBreeder.java
@@ -62,7 +62,7 @@ class EndrekSahrMasterBreederEffect extends OneShotEffect {
         this.staticText = "create X 1/1 black Thrull creature tokens, where X is that spell's mana value";
     }
 
-    public EndrekSahrMasterBreederEffect(final EndrekSahrMasterBreederEffect effect) {
+    private EndrekSahrMasterBreederEffect(final EndrekSahrMasterBreederEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnduringIdeal.java
+++ b/Mage.Sets/src/mage/cards/e/EnduringIdeal.java
@@ -50,7 +50,7 @@ class EnduringIdealEffect extends OneShotEffect {
         staticText = "Search your library for an enchantment card, put it onto the battlefield, then shuffle";
     }
 
-    public EnduringIdealEffect(final EnduringIdealEffect effect) {
+    private EnduringIdealEffect(final EnduringIdealEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnergyField.java
+++ b/Mage.Sets/src/mage/cards/e/EnergyField.java
@@ -54,7 +54,7 @@ class EnergyFieldEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that would be dealt to you by sources you don't control";
     }
 
-    public EnergyFieldEffect(EnergyFieldEffect effect) {
+    private EnergyFieldEffect(final EnergyFieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnfysNest.java
+++ b/Mage.Sets/src/mage/cards/e/EnfysNest.java
@@ -57,7 +57,7 @@ class EnfysNestEffect extends ExileTargetEffect {
         staticText = "you may exile target creature an opponent controls. If you do, that player gains life equal to that creature's power";
     }
 
-    public EnfysNestEffect(final EnfysNestEffect effect) {
+    private EnfysNestEffect(final EnfysNestEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EngineeredExplosives.java
+++ b/Mage.Sets/src/mage/cards/e/EngineeredExplosives.java
@@ -58,7 +58,7 @@ class EngineeredExplosivesEffect extends OneShotEffect {
     }
 
 
-    public EngineeredExplosivesEffect(final EngineeredExplosivesEffect effect) {
+    private EngineeredExplosivesEffect(final EngineeredExplosivesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EngulfTheShore.java
+++ b/Mage.Sets/src/mage/cards/e/EngulfTheShore.java
@@ -54,7 +54,7 @@ class EngulfTheShoreEffect extends OneShotEffect {
         this.staticText = "Return to their owners' hands all creatures with toughness less than or equal to the number of Islands you control";
     }
 
-    public EngulfTheShoreEffect(final EngulfTheShoreEffect effect) {
+    private EngulfTheShoreEffect(final EngulfTheShoreEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnhancedSurveillance.java
+++ b/Mage.Sets/src/mage/cards/e/EnhancedSurveillance.java
@@ -56,7 +56,7 @@ class EnhancedSurveillanceReplacementEffect extends ReplacementEffectImpl {
                 + "two cards each time you surveil.";
     }
 
-    public EnhancedSurveillanceReplacementEffect(final EnhancedSurveillanceReplacementEffect effect) {
+    private EnhancedSurveillanceReplacementEffect(final EnhancedSurveillanceReplacementEffect effect) {
         super(effect);
     }
 
@@ -89,7 +89,7 @@ class EnhancedSurveillanceShuffleEffect extends OneShotEffect {
         this.staticText = "Shuffle your graveyard into your library";
     }
 
-    public EnhancedSurveillanceShuffleEffect(final EnhancedSurveillanceShuffleEffect effect) {
+    private EnhancedSurveillanceShuffleEffect(final EnhancedSurveillanceShuffleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnigmaSphinx.java
+++ b/Mage.Sets/src/mage/cards/e/EnigmaSphinx.java
@@ -103,7 +103,7 @@ class EnigmaSphinxEffect extends OneShotEffect {
         staticText = "put it into your library third from the top";
     }
 
-    public EnigmaSphinxEffect(final EnigmaSphinxEffect effect) {
+    private EnigmaSphinxEffect(final EnigmaSphinxEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnkiraHostileScavenger.java
+++ b/Mage.Sets/src/mage/cards/e/EnkiraHostileScavenger.java
@@ -63,7 +63,7 @@ class MichonneRuthlessSurvivorAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainAbilitySourceEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn));
     }
 
-    public MichonneRuthlessSurvivorAbility(final MichonneRuthlessSurvivorAbility ability) {
+    private MichonneRuthlessSurvivorAbility(final MichonneRuthlessSurvivorAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnslavedHorror.java
+++ b/Mage.Sets/src/mage/cards/e/EnslavedHorror.java
@@ -54,7 +54,7 @@ class EnslavedHorrorEffect extends OneShotEffect {
         this.staticText = "each other player may put a creature card from their graveyard onto the battlefield";
     }
 
-    public EnslavedHorrorEffect(final EnslavedHorrorEffect effect) {
+    private EnslavedHorrorEffect(final EnslavedHorrorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnsnaringBridge.java
+++ b/Mage.Sets/src/mage/cards/e/EnsnaringBridge.java
@@ -43,7 +43,7 @@ class EnsnaringBridgeRestrictionEffect extends RestrictionEffect {
         this.staticText = "Creatures with power greater than the number of cards in your hand can't attack";
     }
 
-    public EnsnaringBridgeRestrictionEffect(final EnsnaringBridgeRestrictionEffect effect) {
+    private EnsnaringBridgeRestrictionEffect(final EnsnaringBridgeRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnsouledScimitar.java
+++ b/Mage.Sets/src/mage/cards/e/EnsouledScimitar.java
@@ -58,7 +58,7 @@ class EnsouledScimitarToken extends TokenImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public EnsouledScimitarToken(final EnsouledScimitarToken token) {
+    private EnsouledScimitarToken(final EnsouledScimitarToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnterTheInfinite.java
+++ b/Mage.Sets/src/mage/cards/e/EnterTheInfinite.java
@@ -84,7 +84,7 @@ class PutCardOnLibraryEffect extends OneShotEffect {
         staticText = "Then put a card from your hand on top of your library";
     }
 
-    public PutCardOnLibraryEffect(final PutCardOnLibraryEffect effect) {
+    private PutCardOnLibraryEffect(final PutCardOnLibraryEffect effect) {
         super(effect);
     }
 
@@ -116,7 +116,7 @@ class MaximumHandSizeEffect extends MaximumHandSizeControllerEffect {
         staticText = "You have no maximum hand size until your next turn";
     }
 
-    public MaximumHandSizeEffect(final MaximumHandSizeEffect effect) {
+    private MaximumHandSizeEffect(final MaximumHandSizeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EntrailsFeaster.java
+++ b/Mage.Sets/src/mage/cards/e/EntrailsFeaster.java
@@ -54,7 +54,7 @@ class EntrailsFeasterEffect extends OneShotEffect {
         this.staticText = "you may exile a creature card from a graveyard. If you do, put a +1/+1 counter on {this}. If you don't, tap {this}";
     }
 
-    public EntrailsFeasterEffect(final EntrailsFeasterEffect effect) {
+    private EntrailsFeasterEffect(final EntrailsFeasterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EntrapmentManeuver.java
+++ b/Mage.Sets/src/mage/cards/e/EntrapmentManeuver.java
@@ -50,7 +50,7 @@ class EntrapmentManeuverSacrificeEffect extends OneShotEffect {
         this.staticText = "Target player sacrifices an attacking creature. You create X 1/1 white Soldier creature tokens, where X is that creature's toughness";
     }
 
-    public EntrapmentManeuverSacrificeEffect(final EntrapmentManeuverSacrificeEffect effect) {
+    private EntrapmentManeuverSacrificeEffect(final EntrapmentManeuverSacrificeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EntsFury.java
+++ b/Mage.Sets/src/mage/cards/e/EntsFury.java
@@ -55,7 +55,7 @@ class EntsFuryEffect extends OneShotEffect {
                 "Then that creature gets +1/+1 until end of turn and fights target creature you don't control.";
     }
 
-    public EntsFuryEffect(final EntsFuryEffect effect) {
+    private EntsFuryEffect(final EntsFuryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EonHub.java
+++ b/Mage.Sets/src/mage/cards/e/EonHub.java
@@ -46,7 +46,7 @@ class SkipUpkeepStepEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Players skip their upkeep steps";
     }
     
-    public SkipUpkeepStepEffect(final SkipUpkeepStepEffect effect) {
+    private SkipUpkeepStepEffect(final SkipUpkeepStepEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/e/EpicExperiment.java
+++ b/Mage.Sets/src/mage/cards/e/EpicExperiment.java
@@ -54,7 +54,7 @@ class EpicExperimentEffect extends OneShotEffect {
                 + "cards exiled this way that weren't cast into your graveyard";
     }
 
-    public EpicExperimentEffect(final EpicExperimentEffect effect) {
+    private EpicExperimentEffect(final EpicExperimentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Epochrasite.java
+++ b/Mage.Sets/src/mage/cards/e/Epochrasite.java
@@ -65,7 +65,7 @@ class EpochrasiteEffect extends OneShotEffect {
         this.staticText = "exile it with three time counters on it and it gains suspend";
     }
 
-    public EpochrasiteEffect(final EpochrasiteEffect effect) {
+    private EpochrasiteEffect(final EpochrasiteEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EqualTreatment.java
+++ b/Mage.Sets/src/mage/cards/e/EqualTreatment.java
@@ -46,7 +46,7 @@ class EqualTreatmentEffect extends ReplacementEffectImpl {
         staticText = "If any source would deal 1 or more damage to a permanent or player this turn, it deals 2 damage to that permanent or player instead";
     }
 
-    public EqualTreatmentEffect(final EqualTreatmentEffect effect) {
+    private EqualTreatmentEffect(final EqualTreatmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Equipoise.java
+++ b/Mage.Sets/src/mage/cards/e/Equipoise.java
@@ -54,7 +54,7 @@ class EquipoiseEffect extends OneShotEffect {
         this.staticText = "for each land target player controls in excess of the number you control, choose a land they control, then the chosen permanents phase out. Repeat this process for artifacts and creatures";
     }
 
-    public EquipoiseEffect(final EquipoiseEffect effect) {
+    private EquipoiseEffect(final EquipoiseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ErayoSoratamiAscendant.java
+++ b/Mage.Sets/src/mage/cards/e/ErayoSoratamiAscendant.java
@@ -68,7 +68,7 @@ class ErayoSoratamiAscendantTriggeredAbility extends TriggeredAbilityImpl {
         return effect;
     }
 
-    public ErayoSoratamiAscendantTriggeredAbility(final ErayoSoratamiAscendantTriggeredAbility ability) {
+    private ErayoSoratamiAscendantTriggeredAbility(final ErayoSoratamiAscendantTriggeredAbility ability) {
         super(ability);
     }
 
@@ -103,7 +103,7 @@ class ErayosEssenceToken extends TokenImpl {
         effect.setText("counter that spell");
         this.addAbility(new ErayosEssenceTriggeredAbility(effect));
     }
-    public ErayosEssenceToken(final ErayosEssenceToken token) {
+    private ErayosEssenceToken(final ErayosEssenceToken token) {
         super(token);
     }
 
@@ -119,7 +119,7 @@ class ErayosEssenceTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever an opponent casts a spell for the first time each turn, ");
     }
 
-    public ErayosEssenceTriggeredAbility(final ErayosEssenceTriggeredAbility ability) {
+    private ErayosEssenceTriggeredAbility(final ErayosEssenceTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ErdwalIlluminator.java
+++ b/Mage.Sets/src/mage/cards/e/ErdwalIlluminator.java
@@ -55,7 +55,7 @@ class ErdwalIlluminatorTriggeredAbility extends TriggeredAbilityImpl {
         addWatcher(new InvestigatedWatcher());
     }
 
-    public ErdwalIlluminatorTriggeredAbility(final ErdwalIlluminatorTriggeredAbility ability) {
+    private ErdwalIlluminatorTriggeredAbility(final ErdwalIlluminatorTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ErebossTitan.java
+++ b/Mage.Sets/src/mage/cards/e/ErebossTitan.java
@@ -67,7 +67,7 @@ class ErebossTitanTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature card leaves an opponent's graveyard, ");
     }
 
-    public ErebossTitanTriggeredAbility(final ErebossTitanTriggeredAbility ability) {
+    private ErebossTitanTriggeredAbility(final ErebossTitanTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ErrantMinion.java
+++ b/Mage.Sets/src/mage/cards/e/ErrantMinion.java
@@ -63,7 +63,7 @@ class ErrantMinionEffect extends OneShotEffect {
         this.staticText = "that player may pay any amount of mana. Errant Minion deals 2 damage to that player. Prevent X of that damage, where X is the amount of mana that player paid this way";
     }
 
-    public ErrantMinionEffect(final ErrantMinionEffect effect) {
+    private ErrantMinionEffect(final ErrantMinionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ErraticCyclops.java
+++ b/Mage.Sets/src/mage/cards/e/ErraticCyclops.java
@@ -52,7 +52,7 @@ class ErraticCyclopsTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null, false);
     }
 
-    public ErraticCyclopsTriggeredAbility(final ErraticCyclopsTriggeredAbility ability) {
+    private ErraticCyclopsTriggeredAbility(final ErraticCyclopsTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ErraticExplosion.java
+++ b/Mage.Sets/src/mage/cards/e/ErraticExplosion.java
@@ -45,7 +45,7 @@ class ErraticExplosionEffect extends OneShotEffect {
         this.staticText = "Choose any target. Reveal cards from the top of your library until you reveal a nonland card. {this} deals damage equal to that card's mana value to that permanent or player. Put the revealed cards on the bottom of your library in any order";
     }
 
-    public ErraticExplosionEffect(ErraticExplosionEffect effect) {
+    private ErraticExplosionEffect(final ErraticExplosionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ErraticMutation.java
+++ b/Mage.Sets/src/mage/cards/e/ErraticMutation.java
@@ -50,7 +50,7 @@ class ErraticMutationEffect extends OneShotEffect {
         this.staticText = "Choose target creature. Reveal cards from the top of your library until you reveal a nonland card. That creature gets +X/-X until end of turn, where X is that card's mana value. Put all cards revealed this way on the bottom of your library in any order";
     }
 
-    public ErraticMutationEffect(final ErraticMutationEffect effect) {
+    private ErraticMutationEffect(final ErraticMutationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ErraticPortal.java
+++ b/Mage.Sets/src/mage/cards/e/ErraticPortal.java
@@ -55,7 +55,7 @@ class ErraticPortalEffect extends OneShotEffect {
         this.cost = cost;
     }
 
-    public ErraticPortalEffect(final ErraticPortalEffect effect) {
+    private ErraticPortalEffect(final ErraticPortalEffect effect) {
         super(effect);
         this.cost = effect.cost.copy();
     }

--- a/Mage.Sets/src/mage/cards/e/Esperzoa.java
+++ b/Mage.Sets/src/mage/cards/e/Esperzoa.java
@@ -35,7 +35,7 @@ public final class Esperzoa extends CardImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(new ReturnToHandChosenControlledPermanentEffect(new FilterControlledArtifactPermanent()), TargetController.YOU, false));
     }
 
-    public Esperzoa (final Esperzoa card) {
+    private Esperzoa(final Esperzoa card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EssenceBacklash.java
+++ b/Mage.Sets/src/mage/cards/e/EssenceBacklash.java
@@ -44,7 +44,7 @@ class EssenceBacklashEffect extends OneShotEffect {
         staticText = "Counter target creature spell. {this} deals damage equal to that spell's power to its controller";
     }
 
-    public EssenceBacklashEffect(final EssenceBacklashEffect effect) {
+    private EssenceBacklashEffect(final EssenceBacklashEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EssenceBottle.java
+++ b/Mage.Sets/src/mage/cards/e/EssenceBottle.java
@@ -56,7 +56,7 @@ class EssenceBottleEffect extends OneShotEffect {
         this.staticText = "You gain 2 life for each elixir counter removed this way";
     }
 
-    public EssenceBottleEffect(final EssenceBottleEffect effect) {
+    private EssenceBottleEffect(final EssenceBottleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EssenceFeed.java
+++ b/Mage.Sets/src/mage/cards/e/EssenceFeed.java
@@ -27,7 +27,7 @@ public final class EssenceFeed extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPlayer());
     }
 
-    public EssenceFeed (final EssenceFeed card) {
+    private EssenceFeed(final EssenceFeed card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EssenceFilter.java
+++ b/Mage.Sets/src/mage/cards/e/EssenceFilter.java
@@ -52,7 +52,7 @@ class EssenceFilterEffect extends OneShotEffect {
         this.staticText = "Destroy all enchantments or all nonwhite enchantments";
     }
 
-    public EssenceFilterEffect(final EssenceFilterEffect effect) {
+    private EssenceFilterEffect(final EssenceFilterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EssenceHarvest.java
+++ b/Mage.Sets/src/mage/cards/e/EssenceHarvest.java
@@ -45,7 +45,7 @@ class EssenceHarvestEffect extends OneShotEffect {
         this.staticText = "Target player loses X life and you gain X life, where X is the greatest power among creatures you control";
     }
 
-    public EssenceHarvestEffect(final EssenceHarvestEffect effect) {
+    private EssenceHarvestEffect(final EssenceHarvestEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EssenceLeak.java
+++ b/Mage.Sets/src/mage/cards/e/EssenceLeak.java
@@ -68,7 +68,7 @@ class EssenceLeakEffect extends OneShotEffect {
         staticText =  "sacrifice this permanent unless you pay its mana cost";
     }
 
-    public EssenceLeakEffect(final EssenceLeakEffect effect) {
+    private EssenceLeakEffect(final EssenceLeakEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EssenceOfTheWild.java
+++ b/Mage.Sets/src/mage/cards/e/EssenceOfTheWild.java
@@ -46,7 +46,7 @@ class EssenceOfTheWildEffect extends ReplacementEffectImpl {
         staticText = "Creatures you control enter the battlefield as a copy of {this}";
     }
 
-    public EssenceOfTheWildEffect(EssenceOfTheWildEffect effect) {
+    private EssenceOfTheWildEffect(final EssenceOfTheWildEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EssenceSliver.java
+++ b/Mage.Sets/src/mage/cards/e/EssenceSliver.java
@@ -54,7 +54,7 @@ class EssenceSliverTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a Sliver deals damage, ");
     }
 
-    public EssenceSliverTriggeredAbility(final EssenceSliverTriggeredAbility ability) {
+    private EssenceSliverTriggeredAbility(final EssenceSliverTriggeredAbility ability) {
         super(ability);
     }
 
@@ -92,7 +92,7 @@ class EssenceSliverEffect extends OneShotEffect {
         this.staticText = "its controller gains that much life";
     }
 
-    public EssenceSliverEffect(final EssenceSliverEffect effect) {
+    private EssenceSliverEffect(final EssenceSliverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EstridTheMasked.java
+++ b/Mage.Sets/src/mage/cards/e/EstridTheMasked.java
@@ -82,7 +82,7 @@ class EstridTheMaskedTokenEffect extends OneShotEffect {
                 + "The token has enchant permanent and totem armor";
     }
 
-    public EstridTheMaskedTokenEffect(final EstridTheMaskedTokenEffect effect) {
+    private EstridTheMaskedTokenEffect(final EstridTheMaskedTokenEffect effect) {
         super(effect);
     }
 
@@ -121,7 +121,7 @@ class EstridTheMaskedGraveyardEffect extends OneShotEffect {
                 + "then do the same for Aura cards";
     }
 
-    public EstridTheMaskedGraveyardEffect(final EstridTheMaskedGraveyardEffect effect) {
+    private EstridTheMaskedGraveyardEffect(final EstridTheMaskedGraveyardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EtaliPrimalStorm.java
+++ b/Mage.Sets/src/mage/cards/e/EtaliPrimalStorm.java
@@ -54,7 +54,7 @@ class EtaliPrimalStormEffect extends OneShotEffect {
                 + "any number of spells from among those cards without paying their mana costs";
     }
 
-    public EtaliPrimalStormEffect(final EtaliPrimalStormEffect effect) {
+    private EtaliPrimalStormEffect(final EtaliPrimalStormEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EternalDominion.java
+++ b/Mage.Sets/src/mage/cards/e/EternalDominion.java
@@ -65,7 +65,7 @@ class EternalDominionEffect extends OneShotEffect {
         staticText = "Search target opponent's library for an artifact, creature, enchantment, or land card. Put that card onto the battlefield under your control. Then that player shuffles";
     }
 
-    public EternalDominionEffect(final EternalDominionEffect effect) {
+    private EternalDominionEffect(final EternalDominionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EternalScourge.java
+++ b/Mage.Sets/src/mage/cards/e/EternalScourge.java
@@ -53,7 +53,7 @@ class EternalScourgePlayEffect extends AsThoughEffectImpl {
         staticText = "You may cast {this} from exile";
     }
 
-    public EternalScourgePlayEffect(final EternalScourgePlayEffect effect) {
+    private EternalScourgePlayEffect(final EternalScourgePlayEffect effect) {
         super(effect);
     }
 
@@ -85,7 +85,7 @@ class EternalScourgeAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ExileSourceEffect(), false);
     }
 
-    public EternalScourgeAbility(final EternalScourgeAbility ability) {
+    private EternalScourgeAbility(final EternalScourgeAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EternityVessel.java
+++ b/Mage.Sets/src/mage/cards/e/EternityVessel.java
@@ -49,7 +49,7 @@ class EternityVesselEffect extends OneShotEffect {
         staticText = "with X charge counters on it, where X is your life total";
     }
 
-    public EternityVesselEffect(final EternityVesselEffect effect) {
+    private EternityVesselEffect(final EternityVesselEffect effect) {
         super(effect);
     }
 
@@ -81,7 +81,7 @@ class EternityVesselEffect2 extends OneShotEffect {
         staticText = "you may have your life total become the number of charge counters on {this}";
     }
 
-    public EternityVesselEffect2(final EternityVesselEffect2 effect) {
+    private EternityVesselEffect2(final EternityVesselEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EthercasteKnight.java
+++ b/Mage.Sets/src/mage/cards/e/EthercasteKnight.java
@@ -27,7 +27,7 @@ public final class EthercasteKnight extends CardImpl {
         this.addAbility(new ExaltedAbility());
     }
 
-    public EthercasteKnight (final EthercasteKnight card) {
+    private EthercasteKnight(final EthercasteKnight card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EtheriumAbomination.java
+++ b/Mage.Sets/src/mage/cards/e/EtheriumAbomination.java
@@ -27,7 +27,7 @@ public final class EtheriumAbomination extends CardImpl {
         this.addAbility(new UnearthAbility(new ManaCostsImpl<>("{1}{U}{B}")));
     }
 
-    public EtheriumAbomination (final EtheriumAbomination card) {
+    private EtheriumAbomination(final EtheriumAbomination card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EtherswornCanonist.java
+++ b/Mage.Sets/src/mage/cards/e/EtherswornCanonist.java
@@ -87,7 +87,7 @@ class EtherswornCanonistReplacementEffect extends ContinuousRuleModifyingEffectI
         staticText = "Each player who has cast a nonartifact spell this turn can't cast additional nonartifact spells";
     }
 
-    public EtherswornCanonistReplacementEffect(final EtherswornCanonistReplacementEffect effect) {
+    private EtherswornCanonistReplacementEffect(final EtherswornCanonistReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EtrataTheSilencer.java
+++ b/Mage.Sets/src/mage/cards/e/EtrataTheSilencer.java
@@ -64,7 +64,7 @@ class EtrataTheSilencerTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new EtrataTheSilencerEffect());
     }
 
-    public EtrataTheSilencerTriggeredAbility(final EtrataTheSilencerTriggeredAbility ability) {
+    private EtrataTheSilencerTriggeredAbility(final EtrataTheSilencerTriggeredAbility ability) {
         super(ability);
     }
 
@@ -117,7 +117,7 @@ class EtrataTheSilencerEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public EtrataTheSilencerEffect(final EtrataTheSilencerEffect effect) {
+    private EtrataTheSilencerEffect(final EtrataTheSilencerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EunuchsIntrigues.java
+++ b/Mage.Sets/src/mage/cards/e/EunuchsIntrigues.java
@@ -90,7 +90,7 @@ class EunuchsIntriguesRestrictionEffect extends RestrictionEffect {
         this.targetId = targetId;
     }
 
-    public EunuchsIntriguesRestrictionEffect(final EunuchsIntriguesRestrictionEffect effect) {
+    private EunuchsIntriguesRestrictionEffect(final EunuchsIntriguesRestrictionEffect effect) {
         super(effect);
         targetId = effect.targetId;
     }

--- a/Mage.Sets/src/mage/cards/e/Eureka.java
+++ b/Mage.Sets/src/mage/cards/e/Eureka.java
@@ -47,7 +47,7 @@ class EurekaEffect extends OneShotEffect {
         this.staticText = "Starting with you, each player may put a permanent card from their hand onto the battlefield. Repeat this process until no one puts a card onto the battlefield";
     }
 
-    public EurekaEffect(final EurekaEffect effect) {
+    private EurekaEffect(final EurekaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EverWatchingThreshold.java
+++ b/Mage.Sets/src/mage/cards/e/EverWatchingThreshold.java
@@ -39,7 +39,7 @@ class EverWatchingThresholdTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
     }
 
-    public EverWatchingThresholdTriggeredAbility(final EverWatchingThresholdTriggeredAbility ability) {
+    private EverWatchingThresholdTriggeredAbility(final EverWatchingThresholdTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EverflameEidolon.java
+++ b/Mage.Sets/src/mage/cards/e/EverflameEidolon.java
@@ -56,7 +56,7 @@ class EverflameEidolonEffect extends OneShotEffect {
         this.staticText = "{this} gets +1/+0 until end of turn. If it's an Aura, enchanted creature gets +1/+0 until end of turn instead";
     }
 
-    public EverflameEidolonEffect(final EverflameEidolonEffect effect) {
+    private EverflameEidolonEffect(final EverflameEidolonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EverythingamajigC.java
+++ b/Mage.Sets/src/mage/cards/e/EverythingamajigC.java
@@ -67,7 +67,7 @@ class ManaScrewAbility extends ActivatedManaAbilityImpl {
         super(Zone.BATTLEFIELD, new ManaScrewEffect(), new GenericManaCost(1));
     }
 
-    public ManaScrewAbility(final ManaScrewAbility ability) {
+    private ManaScrewAbility(final ManaScrewAbility ability) {
         super(ability);
     }
 
@@ -98,7 +98,7 @@ class ManaScrewEffect extends ManaEffect {
         this.staticText = "Flip a coin. If you win the flip, add {C}{C}";
     }
 
-    public ManaScrewEffect(final ManaScrewEffect effect) {
+    private ManaScrewEffect(final ManaScrewEffect effect) {
         super(effect);
     }
 
@@ -131,7 +131,7 @@ class ChimericStaffEffect extends ContinuousEffectImpl {
         staticText = "{this} becomes an X/X Construct artifact creature until end of turn";
     }
 
-    public ChimericStaffEffect(final ChimericStaffEffect effect) {
+    private ChimericStaffEffect(final ChimericStaffEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EverythingamajigE.java
+++ b/Mage.Sets/src/mage/cards/e/EverythingamajigE.java
@@ -74,7 +74,7 @@ class UrzasHotTubEffect extends OneShotEffect {
         this.staticText = "Search your library for a card that shares a complete word in its name with the discarded card, reveal it, put it into your hand, then shuffle";
     }
 
-    public UrzasHotTubEffect(final UrzasHotTubEffect effect) {
+    private UrzasHotTubEffect(final UrzasHotTubEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EvolutionaryEscalation.java
+++ b/Mage.Sets/src/mage/cards/e/EvolutionaryEscalation.java
@@ -53,7 +53,7 @@ class EvolutionaryEscalationEffect extends OneShotEffect {
         staticText = "put three +1/+1 counters on target creature you control and three +1/+1 counters on target creature an opponent controls";
     }
 
-    public EvolutionaryEscalationEffect(final EvolutionaryEscalationEffect effect) {
+    private EvolutionaryEscalationEffect(final EvolutionaryEscalationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EvolvingAdaptive.java
+++ b/Mage.Sets/src/mage/cards/e/EvolvingAdaptive.java
@@ -66,7 +66,7 @@ class EvolvingAdaptiveTriggeredAbility extends TriggeredAbilityImpl {
                 "control, if that creature has greater power or toughness than {this}, ");
     }
 
-    public EvolvingAdaptiveTriggeredAbility(final EvolvingAdaptiveTriggeredAbility ability) {
+    private EvolvingAdaptiveTriggeredAbility(final EvolvingAdaptiveTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EvraHalcyonWitness.java
+++ b/Mage.Sets/src/mage/cards/e/EvraHalcyonWitness.java
@@ -55,7 +55,7 @@ class EvraHalcyonWitnessEffect extends OneShotEffect {
         staticText = "Exchange your life total with {this}'s power";
     }
 
-    public EvraHalcyonWitnessEffect(final EvraHalcyonWitnessEffect effect) {
+    private EvraHalcyonWitnessEffect(final EvraHalcyonWitnessEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EwokAmbush.java
+++ b/Mage.Sets/src/mage/cards/e/EwokAmbush.java
@@ -49,7 +49,7 @@ class EwokAmbushCreateTokenEffect extends OneShotEffect {
         this.staticText = "Create two 1/1 green Ewok creature tokens. Those tokens gain haste until end of turn";
     }
 
-    public EwokAmbushCreateTokenEffect(final EwokAmbushCreateTokenEffect effect) {
+    private EwokAmbushCreateTokenEffect(final EwokAmbushCreateTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Excavation.java
+++ b/Mage.Sets/src/mage/cards/e/Excavation.java
@@ -53,7 +53,7 @@ class ExcavationEffect extends OneShotEffect {
         this.staticText = "Draw a card. Any player may activate this ability";
     }
 
-    public ExcavationEffect(final ExcavationEffect effect) {
+    private ExcavationEffect(final ExcavationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Excavator.java
+++ b/Mage.Sets/src/mage/cards/e/Excavator.java
@@ -61,7 +61,7 @@ class ExcavatorEffect extends ContinuousEffectImpl {
         setText("Target creature gains landwalk of each of the land types of the sacrificed land until end of turn");
     }
 
-    public ExcavatorEffect(final ExcavatorEffect effect) {
+    private ExcavatorEffect(final ExcavatorEffect effect) {
         super(effect);
         this.abilities = abilities.copy();
     }

--- a/Mage.Sets/src/mage/cards/e/Excruciator.java
+++ b/Mage.Sets/src/mage/cards/e/Excruciator.java
@@ -50,7 +50,7 @@ class ExcruciatorEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Damage that would be dealt by {this} can't be prevented";
     }
 
-    public ExcruciatorEffect(final ExcruciatorEffect effect) {
+    private ExcruciatorEffect(final ExcruciatorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExertInfluence.java
+++ b/Mage.Sets/src/mage/cards/e/ExertInfluence.java
@@ -51,7 +51,7 @@ class ExertInfluenceEffect extends OneShotEffect {
         this.staticText = "Gain control of target creature if its power is less than or equal to the number of colors of mana spent to cast this spell";
     }
 
-    public ExertInfluenceEffect(final ExertInfluenceEffect effect) {
+    private ExertInfluenceEffect(final ExertInfluenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Exhume.java
+++ b/Mage.Sets/src/mage/cards/e/Exhume.java
@@ -47,7 +47,7 @@ class ExhumeEffect extends OneShotEffect {
         this.staticText = "Each player puts a creature card from their graveyard onto the battlefield";
     }
 
-    public ExhumeEffect(final ExhumeEffect effect) {
+    private ExhumeEffect(final ExhumeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Exile.java
+++ b/Mage.Sets/src/mage/cards/e/Exile.java
@@ -60,7 +60,7 @@ class ExileEffect extends OneShotEffect {
         staticText = "You gain life equal to its toughness";
     }
 
-    public ExileEffect(final ExileEffect effect) {
+    private ExileEffect(final ExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Exogorth.java
+++ b/Mage.Sets/src/mage/cards/e/Exogorth.java
@@ -72,7 +72,7 @@ class CanBlockOnlySpaceflightEffect extends RestrictionEffect {
         this.staticText = "{this} can block only creatures with spaceflight";
     }
 
-    public CanBlockOnlySpaceflightEffect(final CanBlockOnlySpaceflightEffect effect) {
+    private CanBlockOnlySpaceflightEffect(final CanBlockOnlySpaceflightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExpelFromOrazca.java
+++ b/Mage.Sets/src/mage/cards/e/ExpelFromOrazca.java
@@ -53,7 +53,7 @@ class ExpelFromOrazcaEffect extends OneShotEffect {
         this.staticText = "Return target nonland permanent to its owner's hand. If you have the city's blessing, you may put that permanent on top of its owner's library instead";
     }
 
-    public ExpelFromOrazcaEffect(final ExpelFromOrazcaEffect effect) {
+    private ExpelFromOrazcaEffect(final ExpelFromOrazcaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExperimentKraj.java
+++ b/Mage.Sets/src/mage/cards/e/ExperimentKraj.java
@@ -68,7 +68,7 @@ class ExperimentKrajEffect extends ContinuousEffectImpl {
         staticText = "{this} has all activated abilities of each other creature with a +1/+1 counter on it";
     }
 
-    public ExperimentKrajEffect(final ExperimentKrajEffect effect) {
+    private ExperimentKrajEffect(final ExperimentKrajEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExplorersScope.java
+++ b/Mage.Sets/src/mage/cards/e/ExplorersScope.java
@@ -50,7 +50,7 @@ class ExplorersScopeEffect extends OneShotEffect {
         this.staticText = "look at the top card of your library. If it's a land card, you may put it onto the battlefield tapped";
     }
 
-    public ExplorersScopeEffect(final ExplorersScopeEffect effect) {
+    private ExplorersScopeEffect(final ExplorersScopeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExplosiveRevelation.java
+++ b/Mage.Sets/src/mage/cards/e/ExplosiveRevelation.java
@@ -48,7 +48,7 @@ class ExplosiveRevelationEffect extends OneShotEffect {
         this.staticText = "Choose any target. Reveal cards from the top of your library until you reveal a nonland card. {this} deals damage equal to that card's mana value to that permanent or player. Put the nonland card into your hand and the rest on the bottom of your library in any order";
     }
 
-    public ExplosiveRevelationEffect(final ExplosiveRevelationEffect effect) {
+    private ExplosiveRevelationEffect(final ExplosiveRevelationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExquisiteArchangel.java
+++ b/Mage.Sets/src/mage/cards/e/ExquisiteArchangel.java
@@ -58,7 +58,7 @@ class ExquisiteArchangelEffect extends ReplacementEffectImpl {
         staticText = "If you would lose the game, instead exile {this} and your life total becomes equal to your starting life total";
     }
 
-    public ExquisiteArchangelEffect(final ExquisiteArchangelEffect effect) {
+    private ExquisiteArchangelEffect(final ExquisiteArchangelEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExquisiteBlood.java
+++ b/Mage.Sets/src/mage/cards/e/ExquisiteBlood.java
@@ -42,7 +42,7 @@ class ExquisiteBloodTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null);
     }
 
-    public ExquisiteBloodTriggeredAbility(final ExquisiteBloodTriggeredAbility ability) {
+    private ExquisiteBloodTriggeredAbility(final ExquisiteBloodTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Exsanguinate.java
+++ b/Mage.Sets/src/mage/cards/e/Exsanguinate.java
@@ -39,7 +39,7 @@ class ExsanguinateEffect extends OneShotEffect {
         staticText = "Each opponent loses X life. You gain life equal to the life lost this way";
     }
 
-    public ExsanguinateEffect(final ExsanguinateEffect effect) {
+    private ExsanguinateEffect(final ExsanguinateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Extinction.java
+++ b/Mage.Sets/src/mage/cards/e/Extinction.java
@@ -46,7 +46,7 @@ class ExtinctionEffect extends OneShotEffect {
         staticText = "Destroy all creatures of the creature type of your choice";
     }
 
-    public ExtinctionEffect(final ExtinctionEffect effect) {
+    private ExtinctionEffect(final ExtinctionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Extirpate.java
+++ b/Mage.Sets/src/mage/cards/e/Extirpate.java
@@ -67,7 +67,7 @@ class ExtirpateEffect extends OneShotEffect {
                 + "as that card and exile them. Then that player shuffles";
     }
 
-    public ExtirpateEffect(final ExtirpateEffect effect) {
+    private ExtirpateEffect(final ExtirpateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExtraplanarLens.java
+++ b/Mage.Sets/src/mage/cards/e/ExtraplanarLens.java
@@ -70,7 +70,7 @@ class ExtraplanarLensImprintEffect extends OneShotEffect {
         staticText = "you may exile target land you control";
     }
 
-    public ExtraplanarLensImprintEffect(ExtraplanarLensImprintEffect effect) {
+    private ExtraplanarLensImprintEffect(final ExtraplanarLensImprintEffect effect) {
         super(effect);
     }
 
@@ -104,7 +104,7 @@ class ExtraplanarLensTriggeredAbility extends TriggeredManaAbility {
         setTriggerPhrase("Whenever a land with the same name as the exiled card is tapped for mana, ");
     }
 
-    public ExtraplanarLensTriggeredAbility(final ExtraplanarLensTriggeredAbility ability) {
+    private ExtraplanarLensTriggeredAbility(final ExtraplanarLensTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExtravagantSpirit.java
+++ b/Mage.Sets/src/mage/cards/e/ExtravagantSpirit.java
@@ -54,7 +54,7 @@ class ExtravagantSpiritEffect extends OneShotEffect {
         this.staticText = "sacrifice {this} unless you pay {1} for each card in your hand";
     }
 
-    public ExtravagantSpiritEffect(final ExtravagantSpiritEffect effect) {
+    private ExtravagantSpiritEffect(final ExtravagantSpiritEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExuberantFirestoker.java
+++ b/Mage.Sets/src/mage/cards/e/ExuberantFirestoker.java
@@ -62,7 +62,7 @@ class ExuberantFirestokerTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetPlayerOrPlaneswalker());
     }
 
-    public ExuberantFirestokerTriggeredAbility(final ExuberantFirestokerTriggeredAbility ability) {
+    private ExuberantFirestokerTriggeredAbility(final ExuberantFirestokerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExultantSkymarcher.java
+++ b/Mage.Sets/src/mage/cards/e/ExultantSkymarcher.java
@@ -27,7 +27,7 @@ public final class ExultantSkymarcher extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
     }
 
-    public ExultantSkymarcher (final ExultantSkymarcher card) {
+    private ExultantSkymarcher(final ExultantSkymarcher card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EyeForAnEye.java
+++ b/Mage.Sets/src/mage/cards/e/EyeForAnEye.java
@@ -47,7 +47,7 @@ class EyeForAnEyeEffect extends ReplacementEffectImpl {
         this.damageSource = new TargetSource();
     }
 
-    public EyeForAnEyeEffect(final EyeForAnEyeEffect effect) {
+    private EyeForAnEyeEffect(final EyeForAnEyeEffect effect) {
         super(effect);
         this.damageSource = effect.damageSource.copy();
     }

--- a/Mage.Sets/src/mage/cards/e/EyeOfDoom.java
+++ b/Mage.Sets/src/mage/cards/e/EyeOfDoom.java
@@ -65,7 +65,7 @@ class EyeOfDoomEffect extends OneShotEffect {
         this.staticText = "each player chooses a nonland permanent and puts a doom counter on it";
     }
 
-    public EyeOfDoomEffect(final EyeOfDoomEffect effect) {
+    private EyeOfDoomEffect(final EyeOfDoomEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EyeOfNowhere.java
+++ b/Mage.Sets/src/mage/cards/e/EyeOfNowhere.java
@@ -27,7 +27,7 @@ public final class EyeOfNowhere extends CardImpl {
 
     }
 
-    public EyeOfNowhere (final EyeOfNowhere card) {
+    private EyeOfNowhere(final EyeOfNowhere card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EyeOfTheStorm.java
+++ b/Mage.Sets/src/mage/cards/e/EyeOfTheStorm.java
@@ -50,7 +50,7 @@ class EyeOfTheStormAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new EyeOfTheStormEffect1(), false);
     }
 
-    public EyeOfTheStormAbility(final EyeOfTheStormAbility ability) {
+    private EyeOfTheStormAbility(final EyeOfTheStormAbility ability) {
         super(ability);
     }
 
@@ -91,7 +91,7 @@ class EyeOfTheStormEffect1 extends OneShotEffect {
                 + "For each copy, the player may cast the copy without paying its mana cost";
     }
 
-    public EyeOfTheStormEffect1(final EyeOfTheStormEffect1 effect) {
+    private EyeOfTheStormEffect1(final EyeOfTheStormEffect1 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EzuriClawOfProgress.java
+++ b/Mage.Sets/src/mage/cards/e/EzuriClawOfProgress.java
@@ -71,7 +71,7 @@ class EzuriClawOfProgressEffect extends OneShotEffect {
         this.staticText = "put X +1/+1 counters on another target creature you control, where X is the number of experience counters you have";
     }
 
-    public EzuriClawOfProgressEffect(final EzuriClawOfProgressEffect effect) {
+    private EzuriClawOfProgressEffect(final EzuriClawOfProgressEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EzurisPredation.java
+++ b/Mage.Sets/src/mage/cards/e/EzurisPredation.java
@@ -51,7 +51,7 @@ class EzurisPredationEffect extends OneShotEffect {
         this.staticText = "For each creature your opponents control, create a 4/4 green Phyrexian Beast creature token. Each of those tokens fights a different one of those creatures";
     }
 
-    public EzurisPredationEffect(final EzurisPredationEffect effect) {
+    private EzurisPredationEffect(final EzurisPredationEffect effect) {
         super(effect);
     }
 


### PR DESCRIPTION
Part of #11054 

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`public ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `private $1(final $1 $3`
