### PR TITLE
Clean public copy constructors in cards starting C

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CabalShrine.java
+++ b/Mage.Sets/src/mage/cards/c/CabalShrine.java
@@ -49,7 +49,7 @@ class CabalShrineTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CabalShrineEffect(), false);
     }
 
-    public CabalShrineTriggeredAbility(final CabalShrineTriggeredAbility ability) {
+    private CabalShrineTriggeredAbility(final CabalShrineTriggeredAbility ability) {
         super(ability);
     }
 
@@ -83,7 +83,7 @@ class CabalShrineEffect extends OneShotEffect {
         staticText = "Whenever a player casts a spell, that player discards X cards, where X is the number of cards in all graveyards with the same name as that spell";
     }
 
-    public CabalShrineEffect(final CabalShrineEffect effect) {
+    private CabalShrineEffect(final CabalShrineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CabalTherapy.java
+++ b/Mage.Sets/src/mage/cards/c/CabalTherapy.java
@@ -57,7 +57,7 @@ class CabalTherapyEffect extends OneShotEffect {
         staticText = "Target player reveals their hand and discards all cards with that name";
     }
 
-    public CabalTherapyEffect(final CabalTherapyEffect effect) {
+    private CabalTherapyEffect(final CabalTherapyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CadaverousBloom.java
+++ b/Mage.Sets/src/mage/cards/c/CadaverousBloom.java
@@ -51,7 +51,7 @@ class CadaverousBloomManaEffect extends BasicManaEffect {
         super(mana);
     }
 
-    public CadaverousBloomManaEffect(final CadaverousBloomManaEffect effect) {
+    private CadaverousBloomManaEffect(final CadaverousBloomManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CageOfHands.java
+++ b/Mage.Sets/src/mage/cards/c/CageOfHands.java
@@ -59,7 +59,7 @@ class CageOfHandsEffect extends RestrictionEffect {
         staticText = "Enchanted creature can't attack or block";
     }
 
-    public CageOfHandsEffect(final CageOfHandsEffect effect) {
+    private CageOfHandsEffect(final CageOfHandsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CagedSun.java
+++ b/Mage.Sets/src/mage/cards/c/CagedSun.java
@@ -57,7 +57,7 @@ class CagedSunEffect2 extends ContinuousEffectImpl {
         staticText = "Creatures you control of the chosen color get +1/+1";
     }
 
-    public CagedSunEffect2(final CagedSunEffect2 effect) {
+    private CagedSunEffect2(final CagedSunEffect2 effect) {
         super(effect);
     }
 
@@ -93,7 +93,7 @@ class CagedSunTriggeredAbility extends TriggeredManaAbility {
         super(Zone.BATTLEFIELD, new CagedSunEffect());
     }
 
-    public CagedSunTriggeredAbility(CagedSunTriggeredAbility ability) {
+    private CagedSunTriggeredAbility(final CagedSunTriggeredAbility ability) {
         super(ability);
     }
 
@@ -131,7 +131,7 @@ class CagedSunEffect extends ManaEffect {
         super();
     }
 
-    public CagedSunEffect(final CagedSunEffect effect) {
+    private CagedSunEffect(final CagedSunEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CairnWanderer.java
+++ b/Mage.Sets/src/mage/cards/c/CairnWanderer.java
@@ -53,7 +53,7 @@ public final class CairnWanderer extends CardImpl {
             staticText = "As long as a creature card with flying is in a graveyard, {this} has flying. The same is true for fear, first strike, double strike, deathtouch, haste, landwalk, lifelink, protection, reach, trample, shroud, and vigilance.";
         }
 
-        public CairnWandererEffect(final CairnWandererEffect effect) {
+        private CairnWandererEffect(final CairnWandererEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/c/CallOfTheWild.java
+++ b/Mage.Sets/src/mage/cards/c/CallOfTheWild.java
@@ -44,7 +44,7 @@ class CallOfTheWildEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of your library. If it's a creature card, put it onto the battlefield. Otherwise, put it into your graveyard";
     }
 
-    public CallOfTheWildEffect(final CallOfTheWildEffect effect) {
+    private CallOfTheWildEffect(final CallOfTheWildEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CallToArms.java
+++ b/Mage.Sets/src/mage/cards/c/CallToArms.java
@@ -83,7 +83,7 @@ class CallToArmsEffect extends ContinuousEffectImpl {
                 + "the chosen player controls but isn't tied for most common.";
     }
 
-    public CallToArmsEffect(final CallToArmsEffect effect) {
+    private CallToArmsEffect(final CallToArmsEffect effect) {
         super(effect);
     }
 
@@ -117,7 +117,7 @@ class CallToArmsStateTriggeredAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new SacrificeSourceEffect());
     }
 
-    public CallToArmsStateTriggeredAbility(final CallToArmsStateTriggeredAbility ability) {
+    private CallToArmsStateTriggeredAbility(final CallToArmsStateTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CallToHeel.java
+++ b/Mage.Sets/src/mage/cards/c/CallToHeel.java
@@ -48,7 +48,7 @@ class CallToHeelEffect extends OneShotEffect {
         this.staticText = "Its controller draws a card";
     }
 
-    public CallToHeelEffect(final CallToHeelEffect effect) {
+    private CallToHeelEffect(final CallToHeelEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CallerOfGales.java
+++ b/Mage.Sets/src/mage/cards/c/CallerOfGales.java
@@ -39,7 +39,7 @@ public final class CallerOfGales extends CardImpl {
         this.addAbility(ability);
     }
 
-    public CallerOfGales (final CallerOfGales card) {
+    private CallerOfGales(final CallerOfGales card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CallerOfTheHunt.java
+++ b/Mage.Sets/src/mage/cards/c/CallerOfTheHunt.java
@@ -131,7 +131,7 @@ class ChooseCreatureTypeEffect extends OneShotEffect {
         staticText = "choose a creature type";
     }
 
-    public ChooseCreatureTypeEffect(final ChooseCreatureTypeEffect effect) {
+    private ChooseCreatureTypeEffect(final ChooseCreatureTypeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CallousDeceiver.java
+++ b/Mage.Sets/src/mage/cards/c/CallousDeceiver.java
@@ -60,7 +60,7 @@ class CallousDeceiverEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of your library. If it's a land card, {this} gets +1/+0 and gains flying until end of turn";
     }
 
-    public CallousDeceiverEffect(final CallousDeceiverEffect effect) {
+    private CallousDeceiverEffect(final CallousDeceiverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CallousGiant.java
+++ b/Mage.Sets/src/mage/cards/c/CallousGiant.java
@@ -49,7 +49,7 @@ class CallousGiantEffect extends PreventionEffectImpl {
         staticText = "If a source would deal 3 or less damage to {this}, prevent that damage.";
     }
 
-    public CallousGiantEffect(final CallousGiantEffect effect) {
+    private CallousGiantEffect(final CallousGiantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CallousOppressor.java
+++ b/Mage.Sets/src/mage/cards/c/CallousOppressor.java
@@ -74,7 +74,7 @@ class CallousOppressorFilter extends FilterCreaturePermanent {
         super("creature that isn't of the chosen type");
     }
 
-    public CallousOppressorFilter(final CallousOppressorFilter filter) {
+    private CallousOppressorFilter(final CallousOppressorFilter filter) {
         super(filter);
     }
 
@@ -104,7 +104,7 @@ class CallousOppressorChooseCreatureTypeEffect extends OneShotEffect {
         staticText = "an opponent chooses a creature type";
     }
 
-    public CallousOppressorChooseCreatureTypeEffect(final CallousOppressorChooseCreatureTypeEffect effect) {
+    private CallousOppressorChooseCreatureTypeEffect(final CallousOppressorChooseCreatureTypeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CallowJushi.java
+++ b/Mage.Sets/src/mage/cards/c/CallowJushi.java
@@ -81,7 +81,7 @@ class JarakuTheInterloper extends TokenImpl {
         ability.addTarget(new TargetSpell());
         this.addAbility(ability);
     }
-    public JarakuTheInterloper(final JarakuTheInterloper token) {
+    private JarakuTheInterloper(final JarakuTheInterloper token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CalmingVerse.java
+++ b/Mage.Sets/src/mage/cards/c/CalmingVerse.java
@@ -63,7 +63,7 @@ class CalmingVerseEffect extends OneShotEffect {
         this.staticText = "Destroy all enchantments you don't control. Then if you control an untapped land, destroy all enchantments you control";
     }
 
-    public CalmingVerseEffect(final CalmingVerseEffect effect) {
+    private CalmingVerseEffect(final CalmingVerseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Camaraderie.java
+++ b/Mage.Sets/src/mage/cards/c/Camaraderie.java
@@ -47,7 +47,7 @@ class CamaraderieEffect extends OneShotEffect {
                 + "Creatures you control get +1/+1 until end of turn.";
     }
 
-    public CamaraderieEffect(final CamaraderieEffect effect) {
+    private CamaraderieEffect(final CamaraderieEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Camouflage.java
+++ b/Mage.Sets/src/mage/cards/c/Camouflage.java
@@ -65,7 +65,7 @@ class CamouflageEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "This turn, instead of declaring blockers, each defending player chooses any number of creatures they control and divides them into a number of piles equal to the number of attacking creatures for whom that player is the defending player. Creatures they control that can block additional creatures may likewise be put into additional piles. Assign each pile to a different one of those attacking creatures at random. Each creature in a pile that can block the creature that pile is assigned to does so";
     }
 
-    public CamouflageEffect(final CamouflageEffect effect) {
+    private CamouflageEffect(final CamouflageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CampaignOfVengeance.java
+++ b/Mage.Sets/src/mage/cards/c/CampaignOfVengeance.java
@@ -44,7 +44,7 @@ class CampaignOfVengeanceTriggeredAbility extends TriggeredAbilityImpl {
         this.addEffect(new GainLifeEffect(1));
     }
 
-    public CampaignOfVengeanceTriggeredAbility(final CampaignOfVengeanceTriggeredAbility ability) {
+    private CampaignOfVengeanceTriggeredAbility(final CampaignOfVengeanceTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CanalCourier.java
+++ b/Mage.Sets/src/mage/cards/c/CanalCourier.java
@@ -61,7 +61,7 @@ class CanalCourierTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} and another creature attack different players, ");
     }
 
-    public CanalCourierTriggeredAbility(final CanalCourierTriggeredAbility ability) {
+    private CanalCourierTriggeredAbility(final CanalCourierTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CandlesGlow.java
+++ b/Mage.Sets/src/mage/cards/c/CandlesGlow.java
@@ -54,7 +54,7 @@ class CandlesGlowPreventDamageTargetEffect extends PreventionEffectImpl {
         staticText = "Prevent the next 3 damage that would be dealt to any target this turn. You gain life equal to the damage prevented this way";
     }
 
-    public CandlesGlowPreventDamageTargetEffect(final CandlesGlowPreventDamageTargetEffect effect) {
+    private CandlesGlowPreventDamageTargetEffect(final CandlesGlowPreventDamageTargetEffect effect) {
         super(effect);
         this.amount = effect.amount;
     }

--- a/Mage.Sets/src/mage/cards/c/CandlesOfLeng.java
+++ b/Mage.Sets/src/mage/cards/c/CandlesOfLeng.java
@@ -50,7 +50,7 @@ class CandlesOfLengEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of your library. If it has the same name as a card in your graveyard, put it into your graveyard. Otherwise, draw a card";
     }
 
-    public CandlesOfLengEffect(final CandlesOfLengEffect effect) {
+    private CandlesOfLengEffect(final CandlesOfLengEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CankerAbomination.java
+++ b/Mage.Sets/src/mage/cards/c/CankerAbomination.java
@@ -56,7 +56,7 @@ class CankerAbominationEffect extends OneShotEffect {
         this.staticText = "choose an opponent. {this} enters the battlefield with a -1/-1 counter on it for each creature that player controls";
     }
 
-    public CankerAbominationEffect(final CankerAbominationEffect effect) {
+    private CankerAbominationEffect(final CankerAbominationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CankerousThirst.java
+++ b/Mage.Sets/src/mage/cards/c/CankerousThirst.java
@@ -63,7 +63,7 @@ class CankerousThirstEffect extends OneShotEffect {
         this.staticText = "If {B} was spent to cast this spell, you may have target creature get -3/-3 until end of turn. If {G} was spent to cast this spell, you may have target creature get +3/+3 until end of turn";
     }
 
-    public CankerousThirstEffect(final CankerousThirstEffect effect) {
+    private CankerousThirstEffect(final CankerousThirstEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Cannibalize.java
+++ b/Mage.Sets/src/mage/cards/c/Cannibalize.java
@@ -49,7 +49,7 @@ class CannibalizeEffect extends OneShotEffect {
                 "Exile one of the creatures and put two +1/+1 counters on the other";
     }
 
-    public CannibalizeEffect(final CannibalizeEffect effect) {
+    private CannibalizeEffect(final CannibalizeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CapriciousEfreet.java
+++ b/Mage.Sets/src/mage/cards/c/CapriciousEfreet.java
@@ -66,7 +66,7 @@ class CapriciousEfreetEffect extends OneShotEffect {
         this.staticText = "choose target nonland permanent you control and up to two target nonland permanents you don't control. Destroy one of them at random";
     }
 
-    public CapriciousEfreetEffect(final CapriciousEfreetEffect effect) {
+    private CapriciousEfreetEffect(final CapriciousEfreetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CaptivatingGlance.java
+++ b/Mage.Sets/src/mage/cards/c/CaptivatingGlance.java
@@ -63,7 +63,7 @@ class CaptivatingGlanceEffect extends OneShotEffect {
         this.staticText = "clash with an opponent. If you win, gain control of enchanted creature. Otherwise, that player gains control of enchanted creature";
     }
 
-    public CaptivatingGlanceEffect(final CaptivatingGlanceEffect effect) {
+    private CaptivatingGlanceEffect(final CaptivatingGlanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CaptivatingVampire.java
+++ b/Mage.Sets/src/mage/cards/c/CaptivatingVampire.java
@@ -69,7 +69,7 @@ class CaptivatingVampireEffect extends ContinuousEffectImpl {
         staticText = "Gain control of target creature. It becomes a Vampire in addition to its other types";
     }
 
-    public CaptivatingVampireEffect(final CaptivatingVampireEffect effect) {
+    private CaptivatingVampireEffect(final CaptivatingVampireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CapturedSunlight.java
+++ b/Mage.Sets/src/mage/cards/c/CapturedSunlight.java
@@ -23,7 +23,7 @@ public final class CapturedSunlight extends CardImpl {
         this.addAbility(new CascadeAbility());
     }
 
-    public CapturedSunlight (final CapturedSunlight card) {
+    private CapturedSunlight(final CapturedSunlight card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CaravanHurda.java
+++ b/Mage.Sets/src/mage/cards/c/CaravanHurda.java
@@ -25,7 +25,7 @@ public final class CaravanHurda extends CardImpl {
         this.addAbility(LifelinkAbility.getInstance());
     }
 
-    public CaravanHurda (final CaravanHurda card) {
+    private CaravanHurda(final CaravanHurda card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CaravanVigil.java
+++ b/Mage.Sets/src/mage/cards/c/CaravanVigil.java
@@ -49,7 +49,7 @@ class CaravanVigilEffect extends OneShotEffect {
                 + "<i>Morbid</i> &mdash; You may put that card onto the battlefield instead of putting it into your hand if a creature died this turn";
     }
 
-    public CaravanVigilEffect(final CaravanVigilEffect effect) {
+    private CaravanVigilEffect(final CaravanVigilEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CarnageGladiator.java
+++ b/Mage.Sets/src/mage/cards/c/CarnageGladiator.java
@@ -38,7 +38,7 @@ public final class CarnageGladiator extends CardImpl {
 
     }
 
-    public CarnageGladiator (final CarnageGladiator card) {
+    private CarnageGladiator(final CarnageGladiator card) {
         super(card);
     }
 
@@ -55,7 +55,7 @@ class CarnageGladiatorTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1));
     }
 
-    public CarnageGladiatorTriggeredAbility(final CarnageGladiatorTriggeredAbility ability) {
+    private CarnageGladiatorTriggeredAbility(final CarnageGladiatorTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Carom.java
+++ b/Mage.Sets/src/mage/cards/c/Carom.java
@@ -61,7 +61,7 @@ class CaromEffect extends RedirectionEffect {
         staticText = "The next " + amount + " damage that would be dealt to target creature this turn is dealt to another target creature instead";
     }
 
-    public CaromEffect(final CaromEffect effect) {
+    private CaromEffect(final CaromEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CarrionCall.java
+++ b/Mage.Sets/src/mage/cards/c/CarrionCall.java
@@ -22,7 +22,7 @@ public final class CarrionCall extends CardImpl {
         this.getSpellAbility().addEffect(new CreateTokenEffect(new InsectInfectToken(), 2));
     }
 
-    public CarrionCall (final CarrionCall card) {
+    private CarrionCall(final CarrionCall card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CarrionRats.java
+++ b/Mage.Sets/src/mage/cards/c/CarrionRats.java
@@ -54,7 +54,7 @@ class CarrionRatsEffect extends OneShotEffect {
         this.staticText = "any player may exile a card from their graveyard. If a player does, {this} assigns no combat damage this turn";
     }
 
-    public CarrionRatsEffect(final CarrionRatsEffect effect) {
+    private CarrionRatsEffect(final CarrionRatsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CarrionWurm.java
+++ b/Mage.Sets/src/mage/cards/c/CarrionWurm.java
@@ -54,7 +54,7 @@ class CarrionWurmEffect extends OneShotEffect {
         this.staticText = "any player may exile three cards from their graveyard. If a player does, {this} assigns no combat damage this turn";
     }
 
-    public CarrionWurmEffect(final CarrionWurmEffect effect) {
+    private CarrionWurmEffect(final CarrionWurmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CarryAway.java
+++ b/Mage.Sets/src/mage/cards/c/CarryAway.java
@@ -62,7 +62,7 @@ class CarryAwayEffect extends OneShotEffect {
         this.staticText = "unattach enchanted Equipment.";
     }
 
-    public CarryAwayEffect(final CarryAwayEffect effect) {
+    private CarryAwayEffect(final CarryAwayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CartoucheOfStrength.java
+++ b/Mage.Sets/src/mage/cards/c/CartoucheOfStrength.java
@@ -76,7 +76,7 @@ class FightEnchantedTargetEffect extends OneShotEffect {
                 "<i>(Each deals damage equal to its power to the other.)</i>";
     }
 
-    public FightEnchantedTargetEffect(final FightEnchantedTargetEffect effect) {
+    private FightEnchantedTargetEffect(final FightEnchantedTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Cataclysm.java
+++ b/Mage.Sets/src/mage/cards/c/Cataclysm.java
@@ -51,7 +51,7 @@ class CataclysmEffect extends OneShotEffect {
         staticText = "Each player chooses from among the permanents they control an artifact, a creature, an enchantment, and a land, then sacrifices the rest";
     }
 
-    public CataclysmEffect(CataclysmEffect effect) {
+    private CataclysmEffect(final CataclysmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CataclysmicGearhulk.java
+++ b/Mage.Sets/src/mage/cards/c/CataclysmicGearhulk.java
@@ -84,7 +84,7 @@ class CataclysmicGearhulkEffect extends OneShotEffect {
                 "from among the nonland permanents they control, then sacrifices the rest";
     }
 
-    public CataclysmicGearhulkEffect(CataclysmicGearhulkEffect effect) {
+    private CataclysmicGearhulkEffect(final CataclysmicGearhulkEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Catastrophe.java
+++ b/Mage.Sets/src/mage/cards/c/Catastrophe.java
@@ -44,7 +44,7 @@ class CatastropheEffect extends OneShotEffect {
         this.staticText = "Destroy all lands or all creatures. Creatures destroyed this way can't be regenerated";
     }
 
-    public CatastropheEffect(final CatastropheEffect effect) {
+    private CatastropheEffect(final CatastropheEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CatchRelease.java
+++ b/Mage.Sets/src/mage/cards/c/CatchRelease.java
@@ -66,7 +66,7 @@ class ReleaseSacrificeEffect extends OneShotEffect {
         staticText = "Each player sacrifices an artifact, a creature, an enchantment, a land, and a planeswalker";
     }
 
-    public ReleaseSacrificeEffect(ReleaseSacrificeEffect effect) {
+    private ReleaseSacrificeEffect(final ReleaseSacrificeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CauldronDance.java
+++ b/Mage.Sets/src/mage/cards/c/CauldronDance.java
@@ -59,7 +59,7 @@ class CauldronDanceReturnFromGraveyardToBattlefieldTargetEffect extends OneShotE
         this.staticText = "Return target creature card from your graveyard to the battlefield. That creature gains haste. Return it to your hand at the beginning of the next end step";
     }
 
-    public CauldronDanceReturnFromGraveyardToBattlefieldTargetEffect(final CauldronDanceReturnFromGraveyardToBattlefieldTargetEffect effect) {
+    private CauldronDanceReturnFromGraveyardToBattlefieldTargetEffect(final CauldronDanceReturnFromGraveyardToBattlefieldTargetEffect effect) {
         super(effect);
     }
 
@@ -104,7 +104,7 @@ class CauldronDancePutCreatureFromHandOntoBattlefieldEffect extends OneShotEffec
         this.staticText = "You may put a creature card from your hand onto the battlefield. That creature gains haste. Its controller sacrifices it at the beginning of the next end step";
     }
 
-    public CauldronDancePutCreatureFromHandOntoBattlefieldEffect(final CauldronDancePutCreatureFromHandOntoBattlefieldEffect effect) {
+    private CauldronDancePutCreatureFromHandOntoBattlefieldEffect(final CauldronDancePutCreatureFromHandOntoBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CausticHound.java
+++ b/Mage.Sets/src/mage/cards/c/CausticHound.java
@@ -27,7 +27,7 @@ public final class CausticHound extends CardImpl {
         this.addAbility(new DiesSourceTriggeredAbility(new LoseLifeAllPlayersEffect(4)));
     }
 
-    public CausticHound (final CausticHound card) {
+    private CausticHound(final CausticHound card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CausticWasps.java
+++ b/Mage.Sets/src/mage/cards/c/CausticWasps.java
@@ -55,7 +55,7 @@ class CausticWaspsTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), true);
     }
 
-    public CausticWaspsTriggeredAbility(final CausticWaspsTriggeredAbility ability) {
+    private CausticWaspsTriggeredAbility(final CausticWaspsTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CavernOfSouls.java
+++ b/Mage.Sets/src/mage/cards/c/CavernOfSouls.java
@@ -168,7 +168,7 @@ class CavernOfSoulsCantCounterEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = null;
     }
 
-    public CavernOfSoulsCantCounterEffect(final CavernOfSoulsCantCounterEffect effect) {
+    private CavernOfSoulsCantCounterEffect(final CavernOfSoulsCantCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CavernThoctar.java
+++ b/Mage.Sets/src/mage/cards/c/CavernThoctar.java
@@ -29,7 +29,7 @@ public final class CavernThoctar extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 0, Duration.EndOfTurn), new ManaCostsImpl<>("{1}{R}")));
     }
 
-    public CavernThoctar (final CavernThoctar card) {
+    private CavernThoctar(final CavernThoctar card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CavernsOfDespair.java
+++ b/Mage.Sets/src/mage/cards/c/CavernsOfDespair.java
@@ -48,7 +48,7 @@ class CavernsOfDespairAttackRestrictionEffect extends RestrictionEffect {
         staticText = "No more than two creatures can attack each combat";
     }
 
-    public CavernsOfDespairAttackRestrictionEffect(final CavernsOfDespairAttackRestrictionEffect effect) {
+    private CavernsOfDespairAttackRestrictionEffect(final CavernsOfDespairAttackRestrictionEffect effect) {
         super(effect);
     }
 
@@ -75,7 +75,7 @@ class CavernsOfDespairBlockRestrictionEffect extends RestrictionEffect {
         staticText = "No more than two creatures can block each combat";
     }
 
-    public CavernsOfDespairBlockRestrictionEffect(final CavernsOfDespairBlockRestrictionEffect effect) {
+    private CavernsOfDespairBlockRestrictionEffect(final CavernsOfDespairBlockRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CeaseFire.java
+++ b/Mage.Sets/src/mage/cards/c/CeaseFire.java
@@ -53,7 +53,7 @@ class CeaseFireEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Target player can't cast creature spells this turn";
     }
 
-    public CeaseFireEffect(final CeaseFireEffect effect) {
+    private CeaseFireEffect(final CeaseFireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CelestialConvergence.java
+++ b/Mage.Sets/src/mage/cards/c/CelestialConvergence.java
@@ -56,7 +56,7 @@ class CelestialConvergenceEffect extends OneShotEffect {
         this.staticText = "If there are no omen counters on {this}, the player with the highest life total wins the game. If two or more players are tied for highest life total, the game is a draw";
     }
 
-    public CelestialConvergenceEffect(final CelestialConvergenceEffect effect) {
+    private CelestialConvergenceEffect(final CelestialConvergenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CelestialDawn.java
+++ b/Mage.Sets/src/mage/cards/c/CelestialDawn.java
@@ -183,7 +183,7 @@ class CelestialDawnSpendAnyManaEffect extends AsThoughEffectImpl implements AsTh
         staticText = "You may spend white mana as though it were mana of any color";
     }
 
-    public CelestialDawnSpendAnyManaEffect(final CelestialDawnSpendAnyManaEffect effect) {
+    private CelestialDawnSpendAnyManaEffect(final CelestialDawnSpendAnyManaEffect effect) {
         super(effect);
     }
 
@@ -218,7 +218,7 @@ class CelestialDawnSpendColorlessManaEffect extends AsThoughEffectImpl implement
         staticText = "You may spend other mana only as though it were colorless mana";
     }
 
-    public CelestialDawnSpendColorlessManaEffect(final CelestialDawnSpendColorlessManaEffect effect) {
+    private CelestialDawnSpendColorlessManaEffect(final CelestialDawnSpendColorlessManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CelestialKirin.java
+++ b/Mage.Sets/src/mage/cards/c/CelestialKirin.java
@@ -58,7 +58,7 @@ class CelestialKirinEffect extends OneShotEffect {
         this.staticText = "destroy all permanents with that spell's mana value";
     }
 
-    public CelestialKirinEffect(final CelestialKirinEffect effect) {
+    private CelestialKirinEffect(final CelestialKirinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CelestialMantle.java
+++ b/Mage.Sets/src/mage/cards/c/CelestialMantle.java
@@ -66,7 +66,7 @@ class CelestialMantleAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CelestialMantleEffect());
     }
 
-    public CelestialMantleAbility(final CelestialMantleAbility ability) {
+    private CelestialMantleAbility(final CelestialMantleAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CellarDoor.java
+++ b/Mage.Sets/src/mage/cards/c/CellarDoor.java
@@ -51,7 +51,7 @@ class CellarDoorEffect extends OneShotEffect {
         this.staticText = "Target player puts the bottom card of their library into their graveyard. If it's a creature card, you create a 2/2 black Zombie creature token";
     }
 
-    public CellarDoorEffect(final CellarDoorEffect effect) {
+    private CellarDoorEffect(final CellarDoorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CemeteryPuca.java
+++ b/Mage.Sets/src/mage/cards/c/CemeteryPuca.java
@@ -60,7 +60,7 @@ class CemeteryPucaEffect extends OneShotEffect {
         staticText = "{this} becomes a copy of that creature, except it has this ability";
     }
 
-    public CemeteryPucaEffect(final CemeteryPucaEffect effect) {
+    private CemeteryPucaEffect(final CemeteryPucaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CemeteryRecruitment.java
+++ b/Mage.Sets/src/mage/cards/c/CemeteryRecruitment.java
@@ -47,7 +47,7 @@ class CemeteryRecruitmentEffect extends OneShotEffect {
         staticText = "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card";
     }
 
-    public CemeteryRecruitmentEffect(final CemeteryRecruitmentEffect effect) {
+    private CemeteryRecruitmentEffect(final CemeteryRecruitmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CentaurPeacemaker.java
+++ b/Mage.Sets/src/mage/cards/c/CentaurPeacemaker.java
@@ -50,7 +50,7 @@ class CentaurMediatorEffect extends OneShotEffect {
         staticText = "each player gains 4 life.";
     }
 
-    public CentaurMediatorEffect(final CentaurMediatorEffect effect) {
+    private CentaurMediatorEffect(final CentaurMediatorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CephalidShrine.java
+++ b/Mage.Sets/src/mage/cards/c/CephalidShrine.java
@@ -50,7 +50,7 @@ class CephalidShrineTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CephalidShrineEffect(), false);
     }
 
-    public CephalidShrineTriggeredAbility(final CephalidShrineTriggeredAbility ability) {
+    private CephalidShrineTriggeredAbility(final CephalidShrineTriggeredAbility ability) {
         super(ability);
     }
 
@@ -88,7 +88,7 @@ class CephalidShrineEffect extends OneShotEffect {
                 + "as the spell";
     }
 
-    public CephalidShrineEffect(final CephalidShrineEffect effect) {
+    private CephalidShrineEffect(final CephalidShrineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CephalidSnitch.java
+++ b/Mage.Sets/src/mage/cards/c/CephalidSnitch.java
@@ -55,7 +55,7 @@ class CephalidSnitchEffect extends LoseAbilityTargetEffect{
         staticText = "Target creature loses protection from black until end of turn.";
     }
 
-    public CephalidSnitchEffect(final CephalidSnitchEffect effect) {
+    private CephalidSnitchEffect(final CephalidSnitchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CephalidVandal.java
+++ b/Mage.Sets/src/mage/cards/c/CephalidVandal.java
@@ -56,7 +56,7 @@ class CephalidVandalEffect extends OneShotEffect {
         staticText = "Then mill a card for each shred counter on {this}";
     }
 
-    public CephalidVandalEffect(final CephalidVandalEffect effect) {
+    private CephalidVandalEffect(final CephalidVandalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CertainDeath.java
+++ b/Mage.Sets/src/mage/cards/c/CertainDeath.java
@@ -44,7 +44,7 @@ class CertainDeathEffect extends OneShotEffect {
         this.staticText = "Destroy target creature. Its controller loses 2 life and you gain 2 life";
     }
 
-    public CertainDeathEffect(final CertainDeathEffect effect) {
+    private CertainDeathEffect(final CertainDeathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CeruleanWisps.java
+++ b/Mage.Sets/src/mage/cards/c/CeruleanWisps.java
@@ -31,7 +31,7 @@ public final class CeruleanWisps extends CardImpl {
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1).concatBy("<br>"));
     }
 
-    public CeruleanWisps (final CeruleanWisps card) {
+    private CeruleanWisps(final CeruleanWisps card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChainOfSilence.java
+++ b/Mage.Sets/src/mage/cards/c/ChainOfSilence.java
@@ -53,7 +53,7 @@ class ChainOfSilenceEffect extends OneShotEffect {
         this.staticText = "Prevent all damage target creature would deal this turn. That creature's controller may sacrifice a land. If the player does, they may copy this spell and may choose a new target for that copy";
     }
 
-    public ChainOfSilenceEffect(final ChainOfSilenceEffect effect) {
+    private ChainOfSilenceEffect(final ChainOfSilenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChainOfVapor.java
+++ b/Mage.Sets/src/mage/cards/c/ChainOfVapor.java
@@ -50,7 +50,7 @@ class ChainOfVaporEffect extends OneShotEffect {
         this.staticText = "Return target nonland permanent to its owner's hand. Then that permanent's controller may sacrifice a land. If the player does, they may copy this spell and may choose a new target for that copy";
     }
 
-    public ChainOfVaporEffect(final ChainOfVaporEffect effect) {
+    private ChainOfVaporEffect(final ChainOfVaporEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChainStasis.java
+++ b/Mage.Sets/src/mage/cards/c/ChainStasis.java
@@ -52,7 +52,7 @@ class ChainStasisEffect extends OneShotEffect {
         this.staticText = "You may tap or untap target creature. Then that creature's controller may pay {2}{U}. If the player does, they may copy this spell and may choose a new target for that copy";
     }
 
-    public ChainStasisEffect(final ChainStasisEffect effect) {
+    private ChainStasisEffect(final ChainStasisEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChainsOfMephistopheles.java
+++ b/Mage.Sets/src/mage/cards/c/ChainsOfMephistopheles.java
@@ -46,7 +46,7 @@ class ChainsOfMephistophelesReplacementEffect extends ReplacementEffectImpl {
         staticText = "If a player would draw a card except the first one they draw in each of their draw steps, that player discards a card instead. If the player discards a card this way, they draw a card. If the player doesn't discard a card this way, they mill a card";
     }
 
-    public ChainsOfMephistophelesReplacementEffect(final ChainsOfMephistophelesReplacementEffect effect) {
+    private ChainsOfMephistophelesReplacementEffect(final ChainsOfMephistophelesReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChaliceOfLife.java
+++ b/Mage.Sets/src/mage/cards/c/ChaliceOfLife.java
@@ -50,7 +50,7 @@ class ChaliceOfLifeEffect extends OneShotEffect {
         staticText = "You gain 1 life. Then if you have at least 10 life more than your starting life total, transform Chalice of Life";
     }
 
-    public ChaliceOfLifeEffect(final ChaliceOfLifeEffect effect) {
+    private ChaliceOfLifeEffect(final ChaliceOfLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChaliceOfTheVoid.java
+++ b/Mage.Sets/src/mage/cards/c/ChaliceOfTheVoid.java
@@ -50,7 +50,7 @@ class ChaliceOfTheVoidTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CounterTargetEffect());
     }
 
-    public ChaliceOfTheVoidTriggeredAbility(final ChaliceOfTheVoidTriggeredAbility abiltity) {
+    private ChaliceOfTheVoidTriggeredAbility(final ChaliceOfTheVoidTriggeredAbility abiltity) {
         super(abiltity);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChamberSentry.java
+++ b/Mage.Sets/src/mage/cards/c/ChamberSentry.java
@@ -95,7 +95,7 @@ class ChamberSentryRemoveVariableCountersSourceCost extends VariableCostImpl {
         }
     }
 
-    public ChamberSentryRemoveVariableCountersSourceCost(final ChamberSentryRemoveVariableCountersSourceCost cost) {
+    private ChamberSentryRemoveVariableCountersSourceCost(final ChamberSentryRemoveVariableCountersSourceCost cost) {
         super(cost);
         this.minimalCountersToPay = cost.minimalCountersToPay;
         this.counterName = cost.counterName;

--- a/Mage.Sets/src/mage/cards/c/ChameleonBlur.java
+++ b/Mage.Sets/src/mage/cards/c/ChameleonBlur.java
@@ -42,7 +42,7 @@ class ChameleonBlurEffect extends PreventionEffectImpl {
         staticText = "prevent all damage that creatures would deal to players this turn";
     }
 
-    public ChameleonBlurEffect(final ChameleonBlurEffect effect) {
+    private ChameleonBlurEffect(final ChameleonBlurEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChancellorOfTheAnnex.java
+++ b/Mage.Sets/src/mage/cards/c/ChancellorOfTheAnnex.java
@@ -64,7 +64,7 @@ class ChancellorOfTheAnnexEffect extends OneShotEffect {
         staticText = "when each opponent casts their first spell of the game, counter that spell unless that player pays {1}";
     }
 
-    public ChancellorOfTheAnnexEffect(ChancellorOfTheAnnexEffect effect) {
+    private ChancellorOfTheAnnexEffect(final ChancellorOfTheAnnexEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandraAblaze.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraAblaze.java
@@ -73,7 +73,7 @@ class ChandraAblazeEffect1 extends OneShotEffect {
         this.staticText = "Discard a card";
     }
 
-    public ChandraAblazeEffect1(final ChandraAblazeEffect1 effect) {
+    private ChandraAblazeEffect1(final ChandraAblazeEffect1 effect) {
         super(effect);
     }
 
@@ -107,7 +107,7 @@ class ChandraAblazeEffect2 extends OneShotEffect {
         this.staticText = "If a red card is discarded this way, {this} deals 4 damage to any target";
     }
 
-    public ChandraAblazeEffect2(final ChandraAblazeEffect2 effect) {
+    private ChandraAblazeEffect2(final ChandraAblazeEffect2 effect) {
         super(effect);
     }
 
@@ -149,7 +149,7 @@ class ChandraAblazeEffect5 extends OneShotEffect {
         this.staticText = "Cast any number of red instant and/or sorcery cards from your graveyard without paying their mana costs";
     }
 
-    public ChandraAblazeEffect5(final ChandraAblazeEffect5 effect) {
+    private ChandraAblazeEffect5(final ChandraAblazeEffect5 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandraFlamecaller.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraFlamecaller.java
@@ -60,7 +60,7 @@ class ChandraElementalEffect extends OneShotEffect {
         this.staticText = "Create two 3/1 red Elemental creature tokens with haste. Exile them at the beginning of the next end step";
     }
 
-    public ChandraElementalEffect(final ChandraElementalEffect effect) {
+    private ChandraElementalEffect(final ChandraElementalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandraPyromaster.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraPyromaster.java
@@ -76,7 +76,7 @@ class ChandraPyromasterEffect1 extends OneShotEffect {
                 + "planeswalker's controller controls. That creature can't block this turn.";
     }
 
-    public ChandraPyromasterEffect1(final ChandraPyromasterEffect1 effect) {
+    private ChandraPyromasterEffect1(final ChandraPyromasterEffect1 effect) {
         super(effect);
     }
 
@@ -107,7 +107,7 @@ class ChandraPyromasterTarget extends TargetPermanent {
                 + "or planeswalker's controller controls"), false);
     }
 
-    public ChandraPyromasterTarget(final ChandraPyromasterTarget target) {
+    private ChandraPyromasterTarget(final ChandraPyromasterTarget target) {
         super(target);
     }
 
@@ -168,7 +168,7 @@ class ChandraPyromasterEffect2 extends OneShotEffect {
         this.staticText = "Exile the top card of your library. You may play it this turn";
     }
 
-    public ChandraPyromasterEffect2(final ChandraPyromasterEffect2 effect) {
+    private ChandraPyromasterEffect2(final ChandraPyromasterEffect2 effect) {
         super(effect);
     }
 
@@ -205,7 +205,7 @@ class ChandraPyromasterEffect3 extends OneShotEffect {
                 + "You may cast the copies without paying their mana costs";
     }
 
-    public ChandraPyromasterEffect3(final ChandraPyromasterEffect3 effect) {
+    private ChandraPyromasterEffect3(final ChandraPyromasterEffect3 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandraRoaringFlame.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraRoaringFlame.java
@@ -67,7 +67,7 @@ class ChandraRoaringFlameEmblemEffect extends OneShotEffect {
         this.staticText = "{this} deals 6 damage to each opponent. Each player dealt damage this way gets an emblem with \"At the beginning of your upkeep, this emblem deals 3 damage to you.\"";
     }
 
-    public ChandraRoaringFlameEmblemEffect(final ChandraRoaringFlameEmblemEffect effect) {
+    private ChandraRoaringFlameEmblemEffect(final ChandraRoaringFlameEmblemEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandraTorchOfDefiance.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraTorchOfDefiance.java
@@ -72,7 +72,7 @@ class ChandraTorchOfDefianceEffect extends OneShotEffect {
         this.staticText = "Exile the top card of your library. You may cast that card. If you don't, {this} deals 2 damage to each opponent";
     }
 
-    public ChandraTorchOfDefianceEffect(final ChandraTorchOfDefianceEffect effect) {
+    private ChandraTorchOfDefianceEffect(final ChandraTorchOfDefianceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandrasDefeat.java
+++ b/Mage.Sets/src/mage/cards/c/ChandrasDefeat.java
@@ -63,7 +63,7 @@ class ChandrasDefeatEffect extends OneShotEffect {
         this.staticText = "{this} deals 5 damage to target red creature or red planeswalker. If it was a Chandra planeswalker, you may discard a card. If you do, draw a card.";
     }
 
-    public ChandrasDefeatEffect(final ChandrasDefeatEffect effect) {
+    private ChandrasDefeatEffect(final ChandrasDefeatEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandrasIgnition.java
+++ b/Mage.Sets/src/mage/cards/c/ChandrasIgnition.java
@@ -44,7 +44,7 @@ class ChandrasIgnitionEffect extends OneShotEffect {
         this.staticText = "Target creature you control deals damage equal to its power to each other creature and each opponent";
     }
 
-    public ChandrasIgnitionEffect(final ChandrasIgnitionEffect effect) {
+    private ChandrasIgnitionEffect(final ChandrasIgnitionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandrasRevolution.java
+++ b/Mage.Sets/src/mage/cards/c/ChandrasRevolution.java
@@ -48,7 +48,7 @@ class ChandrasRevolutionEffect extends OneShotEffect {
         this.staticText = "{this} deals 4 damage to target creature. Tap target land. That land doesn't untap during its controller's next untap step";
     }
 
-    public ChandrasRevolutionEffect(final ChandrasRevolutionEffect effect) {
+    private ChandrasRevolutionEffect(final ChandrasRevolutionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandrasSpitfire.java
+++ b/Mage.Sets/src/mage/cards/c/ChandrasSpitfire.java
@@ -52,7 +52,7 @@ class ChandrasSpitfireAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new BoostSourceEffect(3, 0, Duration.EndOfTurn), false);
     }
 
-    public ChandrasSpitfireAbility(final ChandrasSpitfireAbility ability) {
+    private ChandrasSpitfireAbility(final ChandrasSpitfireAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChantOfVituGhazi.java
+++ b/Mage.Sets/src/mage/cards/c/ChantOfVituGhazi.java
@@ -49,7 +49,7 @@ class ChantOfVituGhaziPreventEffect extends PreventAllDamageByAllPermanentsEffec
         staticText = "Prevent all damage that would be dealt by creatures this turn. You gain life equal to the damage prevented this way";
     }
 
-    public ChantOfVituGhaziPreventEffect(final ChantOfVituGhaziPreventEffect effect) {
+    private ChantOfVituGhaziPreventEffect(final ChantOfVituGhaziPreventEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChaosHarlequin.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosHarlequin.java
@@ -48,7 +48,7 @@ class ChaosHarlequinEffect extends OneShotEffect {
                 "{this} gets -4/-0 until end of turn. Otherwise, {this} gets +2/+0 until end of turn";
     }
 
-    public ChaosHarlequinEffect(final ChaosHarlequinEffect effect) {
+    private ChaosHarlequinEffect(final ChaosHarlequinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChaosLord.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosLord.java
@@ -103,7 +103,7 @@ class GainControlSourceEffect extends ContinuousEffectImpl {
         staticText = "target opponent gains control of {this}";
     }
 
-    public GainControlSourceEffect(final GainControlSourceEffect effect) {
+    private GainControlSourceEffect(final GainControlSourceEffect effect) {
         super(effect);
     }
 
@@ -131,7 +131,7 @@ class ChaosLordEffect extends AsThoughEffectImpl {
         staticText = "Chaos Lord can attack as though it had haste unless it entered the battlefield this turn";
     }
 
-    public ChaosLordEffect(final ChaosLordEffect effect) {
+    private ChaosLordEffect(final ChaosLordEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChaosMaw.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosMaw.java
@@ -26,7 +26,7 @@ public final class ChaosMaw extends CardImpl {
         addAbility(new EntersBattlefieldTriggeredAbility(new DamageAllEffect(3, "it", filter)));
     }
 
-    public ChaosMaw(final ChaosMaw chaosMaw){
+    private ChaosMaw(final ChaosMaw chaosMaw){
         super(chaosMaw);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChaosWand.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosWand.java
@@ -55,7 +55,7 @@ class ChaosWandEffect extends OneShotEffect {
                 + "bottom of that library in a random order.";
     }
 
-    public ChaosWandEffect(final ChaosWandEffect effect) {
+    private ChaosWandEffect(final ChaosWandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChaosWarp.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosWarp.java
@@ -51,7 +51,7 @@ class ChaosWarpShuffleIntoLibraryEffect extends OneShotEffect {
         this.staticText = "The owner of target permanent shuffles it into their library";
     }
 
-    public ChaosWarpShuffleIntoLibraryEffect(final ChaosWarpShuffleIntoLibraryEffect effect) {
+    private ChaosWarpShuffleIntoLibraryEffect(final ChaosWarpShuffleIntoLibraryEffect effect) {
         super(effect);
     }
 
@@ -82,7 +82,7 @@ class ChaosWarpRevealEffect extends OneShotEffect {
         this.staticText = ", then reveals the top card of their library. If it's a permanent card, they put it onto the battlefield";
     }
 
-    public ChaosWarpRevealEffect(final ChaosWarpRevealEffect effect) {
+    private ChaosWarpRevealEffect(final ChaosWarpRevealEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Chaosphere.java
+++ b/Mage.Sets/src/mage/cards/c/Chaosphere.java
@@ -68,7 +68,7 @@ class ChaosphereEffect extends RestrictionEffect {
         staticText = "creatures with flying can block only creatures with flying";
     }
 
-    public ChaosphereEffect(final ChaosphereEffect effect) {
+    private ChaosphereEffect(final ChaosphereEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChaoticBacklash.java
+++ b/Mage.Sets/src/mage/cards/c/ChaoticBacklash.java
@@ -56,7 +56,7 @@ class ChaoticBacklashEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to target player equal to twice the number of white and/or blue permanents they control";
     }
 
-    public ChaoticBacklashEffect(final ChaoticBacklashEffect effect) {
+    private ChaoticBacklashEffect(final ChaoticBacklashEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChaoticGoo.java
+++ b/Mage.Sets/src/mage/cards/c/ChaoticGoo.java
@@ -58,7 +58,7 @@ class ChaoticGooEffect extends OneShotEffect {
         staticText = "flip a coin. If you win the flip, put a +1/+1 counter on {this}. If you lose the flip, remove a +1/+1 counter from {this}";
     }
 
-    public ChaoticGooEffect(ChaoticGooEffect effect) {
+    private ChaoticGooEffect(final ChaoticGooEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChaoticStrike.java
+++ b/Mage.Sets/src/mage/cards/c/ChaoticStrike.java
@@ -56,7 +56,7 @@ class ChaoticStrikeEffect extends OneShotEffect {
         staticText = "Flip a coin. If you win the flip, target creature gets +1/+1 until end of turn";
     }
 
-    public ChaoticStrikeEffect(ChaoticStrikeEffect effect) {
+    private ChaoticStrikeEffect(final ChaoticStrikeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Charge.java
+++ b/Mage.Sets/src/mage/cards/c/Charge.java
@@ -19,7 +19,7 @@ public final class Charge extends CardImpl {
     }
 
 
-    public Charge(final Charge charge){
+    private Charge(final Charge charge){
         super(charge);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChargingCinderhorn.java
+++ b/Mage.Sets/src/mage/cards/c/ChargingCinderhorn.java
@@ -77,7 +77,7 @@ class ChargingCinderhornDamageTargetEffect extends OneShotEffect {
         super(Outcome.Damage);
     }
 
-    public ChargingCinderhornDamageTargetEffect(ChargingCinderhornDamageTargetEffect copy) {
+    private ChargingCinderhornDamageTargetEffect(final ChargingCinderhornDamageTargetEffect copy) {
         super(copy);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChargingTuskodon.java
+++ b/Mage.Sets/src/mage/cards/c/ChargingTuskodon.java
@@ -56,7 +56,7 @@ class ChargingTuskodonEffect extends ReplacementEffectImpl {
         staticText = "If {this} would deal combat damage to a player, it deals double that damage to that player instead";
     }
 
-    public ChargingTuskodonEffect(final ChargingTuskodonEffect effect) {
+    private ChargingTuskodonEffect(final ChargingTuskodonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChariotOfTheSun.java
+++ b/Mage.Sets/src/mage/cards/c/ChariotOfTheSun.java
@@ -60,7 +60,7 @@ class ChariotOfTheSunEffect extends ContinuousEffectImpl {
         staticText = "and has base toughness 1";
     }
 
-    public ChariotOfTheSunEffect(final ChariotOfTheSunEffect effect) {
+    private ChariotOfTheSunEffect(final ChariotOfTheSunEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CharmedGriffin.java
+++ b/Mage.Sets/src/mage/cards/c/CharmedGriffin.java
@@ -57,7 +57,7 @@ class CharmedGriffinEffect extends OneShotEffect {
         this.staticText = "each other player may put an artifact or enchantment card onto the battlefield from their hand";
     }
 
-    public CharmedGriffinEffect(final CharmedGriffinEffect effect) {
+    private CharmedGriffinEffect(final CharmedGriffinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CharmedPendant.java
+++ b/Mage.Sets/src/mage/cards/c/CharmedPendant.java
@@ -60,7 +60,7 @@ class CharmedPendantAbility extends ActivatedManaAbilityImpl {
 
     }
 
-    public CharmedPendantAbility(final CharmedPendantAbility ability) {
+    private CharmedPendantAbility(final CharmedPendantAbility ability) {
         super(ability);
     }
 
@@ -91,7 +91,7 @@ class CharmedPendantManaEffect extends ManaEffect {
         staticText = "For each colored mana symbol in the milled card's mana cost, add one mana of that color";
     }
 
-    public CharmedPendantManaEffect(final CharmedPendantManaEffect effect) {
+    private CharmedPendantManaEffect(final CharmedPendantManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChasmSkulker.java
+++ b/Mage.Sets/src/mage/cards/c/ChasmSkulker.java
@@ -59,7 +59,7 @@ class ChasmSkulkerEffect extends OneShotEffect {
         this.staticText = "create X 1/1 blue Squid creature tokens with islandwalk, where X is the number of +1/+1 counters on Chasm Skulker";
     }
 
-    public ChasmSkulkerEffect(final ChasmSkulkerEffect effect) {
+    private ChasmSkulkerEffect(final ChasmSkulkerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Chastise.java
+++ b/Mage.Sets/src/mage/cards/c/Chastise.java
@@ -48,7 +48,7 @@ class ChastiseEffect extends OneShotEffect {
         this.staticText = "You gain life equal to its power";
     }
 
-    public ChastiseEffect(final ChastiseEffect effect) {
+    private ChastiseEffect(final ChastiseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChecksAndBalances.java
+++ b/Mage.Sets/src/mage/cards/c/ChecksAndBalances.java
@@ -65,7 +65,7 @@ class ChecksAndBalancesEffect extends OneShotEffect {
         staticText = "each of that player's opponents may discard a card. If they do, counter that spell";
     }
 
-    public ChecksAndBalancesEffect(final ChecksAndBalancesEffect effect) {
+    private ChecksAndBalancesEffect(final ChecksAndBalancesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChickenALaKing.java
+++ b/Mage.Sets/src/mage/cards/c/ChickenALaKing.java
@@ -72,7 +72,7 @@ class ChickenALaKingTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersAllEffect(CounterType.P1P1.createInstance(), filter));
     }
 
-    public ChickenALaKingTriggeredAbility(final ChickenALaKingTriggeredAbility ability) {
+    private ChickenALaKingTriggeredAbility(final ChickenALaKingTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChimericCoils.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericCoils.java
@@ -46,7 +46,7 @@ class ChimericCoilsEffect extends ContinuousEffectImpl {
         staticText = "{this} becomes an X/X Construct artifact creature";
     }
 
-    public ChimericCoilsEffect(final ChimericCoilsEffect effect) {
+    private ChimericCoilsEffect(final ChimericCoilsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChimericStaff.java
+++ b/Mage.Sets/src/mage/cards/c/ChimericStaff.java
@@ -41,7 +41,7 @@ class ChimericStaffEffect extends ContinuousEffectImpl {
         staticText = "{this} becomes an X/X Construct artifact creature until end of turn";
     }
 
-    public ChimericStaffEffect(final ChimericStaffEffect effect) {
+    private ChimericStaffEffect(final ChimericStaffEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChimneyImp.java
+++ b/Mage.Sets/src/mage/cards/c/ChimneyImp.java
@@ -58,7 +58,7 @@ class ChimneyImpEffect extends OneShotEffect {
         this.staticText = "target opponent puts a card from their hand on top of their library.";
     }
 
-    public ChimneyImpEffect(final ChimneyImpEffect effect) {
+    private ChimneyImpEffect(final ChimneyImpEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChirrutImwe.java
+++ b/Mage.Sets/src/mage/cards/c/ChirrutImwe.java
@@ -63,7 +63,7 @@ class ChirrutImweEffect extends ContinuousEffectImpl {
         staticText = "{this} can block up to two additional creatures";
     }
     
-    public ChirrutImweEffect(final ChirrutImweEffect effect) {
+    private ChirrutImweEffect(final ChirrutImweEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/c/ChitteringDoom.java
+++ b/Mage.Sets/src/mage/cards/c/ChitteringDoom.java
@@ -42,7 +42,7 @@ class ChitteringDoomTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CreateTokenEffect(new SquirrelToken()), false);
     }
 
-    public ChitteringDoomTriggeredAbility(final ChitteringDoomTriggeredAbility ability) {
+    private ChitteringDoomTriggeredAbility(final ChitteringDoomTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChitteringRats.java
+++ b/Mage.Sets/src/mage/cards/c/ChitteringRats.java
@@ -55,7 +55,7 @@ class ChitteringRatsEffect extends OneShotEffect {
         this.staticText = "target opponent puts a card from their hand on top of their library";
     }
 
-    public ChitteringRatsEffect(final ChitteringRatsEffect effect) {
+    private ChitteringRatsEffect(final ChitteringRatsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChoArrimAlchemist.java
+++ b/Mage.Sets/src/mage/cards/c/ChoArrimAlchemist.java
@@ -62,7 +62,7 @@ class ChoArrimAlchemistEffect extends PreventionEffectImpl {
         this.target = new TargetSource();
     }
 
-    public ChoArrimAlchemistEffect(final ChoArrimAlchemistEffect effect) {
+    private ChoArrimAlchemistEffect(final ChoArrimAlchemistEffect effect) {
         super(effect);
         this.target = effect.target.copy();
     }

--- a/Mage.Sets/src/mage/cards/c/ChoiceOfDamnations.java
+++ b/Mage.Sets/src/mage/cards/c/ChoiceOfDamnations.java
@@ -49,7 +49,7 @@ class ChoiceOfDamnationsEffect extends OneShotEffect {
         this.staticText = "Target opponent chooses a number. You may have that player lose that much life. If you don't, that player sacrifices all but that many permanents";
     }
 
-    public ChoiceOfDamnationsEffect(final ChoiceOfDamnationsEffect effect) {
+    private ChoiceOfDamnationsEffect(final ChoiceOfDamnationsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChokingSands.java
+++ b/Mage.Sets/src/mage/cards/c/ChokingSands.java
@@ -57,7 +57,7 @@ class ChokingSandsEffect extends OneShotEffect {
         this.staticText = "If that land was nonbasic, Choking Sands deals 2 damage to the land's controller";
     }
 
-    public ChokingSandsEffect(final ChokingSandsEffect effect) {
+    private ChokingSandsEffect(final ChokingSandsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChorusOfTheConclave.java
+++ b/Mage.Sets/src/mage/cards/c/ChorusOfTheConclave.java
@@ -60,7 +60,7 @@ class ChorusOfTheConclaveReplacementEffect extends ReplacementEffectImpl {
         staticText = "As an additional cost to cast creature spells, you may pay any amount of mana";
     }
 
-    public ChorusOfTheConclaveReplacementEffect(final ChorusOfTheConclaveReplacementEffect effect) {
+    private ChorusOfTheConclaveReplacementEffect(final ChorusOfTheConclaveReplacementEffect effect) {
         super(effect);
     }
 
@@ -115,7 +115,7 @@ class ChorusOfTheConclaveReplacementEffect2 extends ReplacementEffectImpl {
         staticText = "If you do, that creature enters the battlefield with that many additional +1/+1 counters on it";
     }
 
-    public ChorusOfTheConclaveReplacementEffect2(final ChorusOfTheConclaveReplacementEffect2 effect) {
+    private ChorusOfTheConclaveReplacementEffect2(final ChorusOfTheConclaveReplacementEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChromeMox.java
+++ b/Mage.Sets/src/mage/cards/c/ChromeMox.java
@@ -68,7 +68,7 @@ class ChromeMoxEffect extends OneShotEffect {
         staticText = "exile a nonartifact, nonland card from your hand";
     }
 
-    public ChromeMoxEffect(ChromeMoxEffect effect) {
+    private ChromeMoxEffect(final ChromeMoxEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
+++ b/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
@@ -79,7 +79,7 @@ class ChromiumTheMutableToken extends TokenImpl {
         addAbility(HexproofAbility.getInstance());
     }
 
-    public ChromiumTheMutableToken(final ChromiumTheMutableToken token) {
+    private ChromiumTheMutableToken(final ChromiumTheMutableToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CinderCloud.java
+++ b/Mage.Sets/src/mage/cards/c/CinderCloud.java
@@ -46,7 +46,7 @@ class CinderCloudEffect extends OneShotEffect {
                 "{this} deals damage to that creature's controller equal to the creature's power";
     }
 
-    public CinderCloudEffect(final CinderCloudEffect effect) {
+    private CinderCloudEffect(final CinderCloudEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CinderSeer.java
+++ b/Mage.Sets/src/mage/cards/c/CinderSeer.java
@@ -66,7 +66,7 @@ class CinderSeerEffect extends OneShotEffect {
                 + "{this} deals X damage to any target, where X is the number of cards revealed this way";
     }
 
-    public CinderSeerEffect(final CinderSeerEffect effect) {
+    private CinderSeerEffect(final CinderSeerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CircleOfAffliction.java
+++ b/Mage.Sets/src/mage/cards/c/CircleOfAffliction.java
@@ -56,7 +56,7 @@ class CircleOfAfflictionTriggeredAbility extends TriggeredAbilityImpl {
         ((DoIfCostPaid) getEffects().get(0)).addEffect(new GainLifeEffect(1));
     }
 
-    public CircleOfAfflictionTriggeredAbility(final CircleOfAfflictionTriggeredAbility ability) {
+    private CircleOfAfflictionTriggeredAbility(final CircleOfAfflictionTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CircleOfFlame.java
+++ b/Mage.Sets/src/mage/cards/c/CircleOfFlame.java
@@ -45,7 +45,7 @@ class CircleOfFlameTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(1));
     }
 
-    public CircleOfFlameTriggeredAbility(final CircleOfFlameTriggeredAbility ability) {
+    private CircleOfFlameTriggeredAbility(final CircleOfFlameTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CirclingVultures.java
+++ b/Mage.Sets/src/mage/cards/c/CirclingVultures.java
@@ -57,7 +57,7 @@ class CirclingVulturesSpecialAction extends SpecialAction {
         this.addEffect(new CirclingVulturesDiscardEffect());
     }
 
-    public CirclingVulturesSpecialAction(final CirclingVulturesSpecialAction ability) {
+    private CirclingVulturesSpecialAction(final CirclingVulturesSpecialAction ability) {
         super(ability);
     }
 
@@ -78,7 +78,7 @@ class CirclingVulturesDiscardEffect extends OneShotEffect {
         this.staticText = "discard {this}";
     }
 
-    public CirclingVulturesDiscardEffect(final CirclingVulturesDiscardEffect effect) {
+    private CirclingVulturesDiscardEffect(final CirclingVulturesDiscardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CircuDimirLobotomist.java
+++ b/Mage.Sets/src/mage/cards/c/CircuDimirLobotomist.java
@@ -75,7 +75,7 @@ class CircuDimirLobotomistEffect extends OneShotEffect {
         this.staticText = "exile the top card of target player's library";
     }
 
-    public CircuDimirLobotomistEffect(final CircuDimirLobotomistEffect effect) {
+    private CircuDimirLobotomistEffect(final CircuDimirLobotomistEffect effect) {
         super(effect);
     }
 
@@ -106,7 +106,7 @@ class CircuDimirLobotomistRuleModifyingEffect extends ContinuousRuleModifyingEff
         staticText = "Your opponents can't cast spells with the same name as a card exiled with {this}";
     }
 
-    public CircuDimirLobotomistRuleModifyingEffect(final CircuDimirLobotomistRuleModifyingEffect effect) {
+    private CircuDimirLobotomistRuleModifyingEffect(final CircuDimirLobotomistRuleModifyingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Clamavus.java
+++ b/Mage.Sets/src/mage/cards/c/Clamavus.java
@@ -50,7 +50,7 @@ class ClamavusEffect extends ContinuousEffectImpl {
         this.staticText = "each creature you control gets +1/+1 for each +1/+1 counter on it";
     }
 
-    public ClamavusEffect(final ClamavusEffect effect) {
+    private ClamavusEffect(final ClamavusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Clambassadors.java
+++ b/Mage.Sets/src/mage/cards/c/Clambassadors.java
@@ -67,7 +67,7 @@ class ClambassadorsEffect extends OneShotEffect {
         this.staticText = "choose an artifact, creature, or land you control. That player gains control of that permanent";
     }
 
-    public ClambassadorsEffect(final ClambassadorsEffect effect) {
+    private ClambassadorsEffect(final ClambassadorsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ClanGuildmage.java
+++ b/Mage.Sets/src/mage/cards/c/ClanGuildmage.java
@@ -75,7 +75,7 @@ class ClanGuildmageToken extends TokenImpl {
         this.addAbility(HasteAbility.getInstance());
     }
 
-    public ClanGuildmageToken(final ClanGuildmageToken token) {
+    private ClanGuildmageToken(final ClanGuildmageToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ClarionUltimatum.java
+++ b/Mage.Sets/src/mage/cards/c/ClarionUltimatum.java
@@ -52,7 +52,7 @@ class ClarionUltimatumEffect extends OneShotEffect {
                 "Put those cards onto the battlefield tapped, then shuffle";
     }
 
-    public ClarionUltimatumEffect(final ClarionUltimatumEffect effect) {
+    private ClarionUltimatumEffect(final ClarionUltimatumEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ClashOfRealities.java
+++ b/Mage.Sets/src/mage/cards/c/ClashOfRealities.java
@@ -62,7 +62,7 @@ public final class ClashOfRealities extends CardImpl {
             super(Zone.BATTLEFIELD, effect, rule, true);
         }
 
-        public ClashOfRealitiesTriggeredAbility(ClashOfRealitiesTriggeredAbility ability) {
+        private ClashOfRealitiesTriggeredAbility(final ClashOfRealitiesTriggeredAbility ability) {
             super(ability);
         }
 

--- a/Mage.Sets/src/mage/cards/c/ClawsOfValakut.java
+++ b/Mage.Sets/src/mage/cards/c/ClawsOfValakut.java
@@ -46,7 +46,7 @@ public final class ClawsOfValakut extends CardImpl {
         this.addAbility(ability);
     }
 
-    public ClawsOfValakut (final ClawsOfValakut card) {
+    private ClawsOfValakut(final ClawsOfValakut card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CleansingMeditation.java
+++ b/Mage.Sets/src/mage/cards/c/CleansingMeditation.java
@@ -50,7 +50,7 @@ class CleansingMeditationEffect extends OneShotEffect {
         this.staticText = "Destroy all enchantments.<br>" + AbilityWord.THRESHOLD.formatWord() + "If seven or more cards are in your graveyard, instead destroy all enchantments, then return all cards in your graveyard destroyed this way to the battlefield.";
     }
 
-    public CleansingMeditationEffect(final CleansingMeditationEffect effect) {
+    private CleansingMeditationEffect(final CleansingMeditationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ClearTheLand.java
+++ b/Mage.Sets/src/mage/cards/c/ClearTheLand.java
@@ -46,7 +46,7 @@ class ClearTheLandEffect extends OneShotEffect {
         this.staticText = "Each player reveals the top five cards of their library, puts all land cards revealed this way onto the battlefield tapped, and exiles the rest.";
     }
     
-    public ClearTheLandEffect(final ClearTheLandEffect effect) {
+    private ClearTheLandEffect(final ClearTheLandEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/c/CliffThreader.java
+++ b/Mage.Sets/src/mage/cards/c/CliffThreader.java
@@ -26,7 +26,7 @@ public final class CliffThreader extends CardImpl {
         this.addAbility(new MountainwalkAbility());
     }
 
-    public CliffThreader (final CliffThreader card) {
+    private CliffThreader(final CliffThreader card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ClingingMists.java
+++ b/Mage.Sets/src/mage/cards/c/ClingingMists.java
@@ -56,7 +56,7 @@ class ClingingMistsEffect extends OneShotEffect {
         staticText = "tap all attacking creatures. Those creatures don't untap during their controller's next untap step";
     }
 
-    public ClingingMistsEffect(final ClingingMistsEffect effect) {
+    private ClingingMistsEffect(final ClingingMistsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CloneLegion.java
+++ b/Mage.Sets/src/mage/cards/c/CloneLegion.java
@@ -48,7 +48,7 @@ class CloneLegionEffect extends OneShotEffect {
         this.staticText = "For each creature target player controls, create a token that's a copy of that creature";
     }
 
-    public CloneLegionEffect(final CloneLegionEffect effect) {
+    private CloneLegionEffect(final CloneLegionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CloneShell.java
+++ b/Mage.Sets/src/mage/cards/c/CloneShell.java
@@ -56,7 +56,7 @@ class CloneShellEffect extends OneShotEffect {
         staticText = "look at the top four cards of your library, exile one face down, then put the rest on the bottom of your library in any order";
     }
 
-    public CloneShellEffect(CloneShellEffect effect) {
+    private CloneShellEffect(final CloneShellEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class CloneShellDiesEffect extends OneShotEffect {
         staticText = "turn the exiled card face up. If it's a creature card, put it onto the battlefield under your control";
     }
 
-    public CloneShellDiesEffect(CloneShellDiesEffect effect) {
+    private CloneShellDiesEffect(final CloneShellDiesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CloudCover.java
+++ b/Mage.Sets/src/mage/cards/c/CloudCover.java
@@ -44,7 +44,7 @@ class CloudCoverAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ReturnToHandTargetEffect(), true);
     }
 
-    public CloudCoverAbility(final CloudCoverAbility ability) {
+    private CloudCoverAbility(final CloudCoverAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CloudheathDrake.java
+++ b/Mage.Sets/src/mage/cards/c/CloudheathDrake.java
@@ -32,7 +32,7 @@ public final class CloudheathDrake extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilitySourceEffect(VigilanceAbility.getInstance(), Duration.EndOfTurn), new ManaCostsImpl<>("{1}{W}")));
     }
 
-    public CloudheathDrake (final CloudheathDrake card) {
+    private CloudheathDrake(final CloudheathDrake card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CloudstoneCurio.java
+++ b/Mage.Sets/src/mage/cards/c/CloudstoneCurio.java
@@ -54,7 +54,7 @@ class CloudstoneCurioEffect extends OneShotEffect {
         this.staticText = "you may return another permanent you control that shares a permanent type with it to its owner's hand";
     }
 
-    public CloudstoneCurioEffect(final CloudstoneCurioEffect effect) {
+    private CloudstoneCurioEffect(final CloudstoneCurioEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CoalitionRelic.java
+++ b/Mage.Sets/src/mage/cards/c/CoalitionRelic.java
@@ -56,7 +56,7 @@ class CoalitionRelicEffect extends OneShotEffect {
         this.staticText = "remove all charge counters from Coalition Relic. Add one mana of any color for each charge counter removed this way";
     }
 
-    public CoalitionRelicEffect(final CoalitionRelicEffect effect) {
+    private CoalitionRelicEffect(final CoalitionRelicEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CoatOfArms.java
+++ b/Mage.Sets/src/mage/cards/c/CoatOfArms.java
@@ -43,7 +43,7 @@ class CoatOfArmsEffect extends ContinuousEffectImpl {
         this.staticText = "Each creature gets +1/+1 for each other creature on the battlefield that shares at least one creature type with it";
     }
 
-    public CoatOfArmsEffect(final CoatOfArmsEffect effect) {
+    private CoatOfArmsEffect(final CoatOfArmsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Cobblebrute.java
+++ b/Mage.Sets/src/mage/cards/c/Cobblebrute.java
@@ -23,7 +23,7 @@ public final class Cobblebrute extends CardImpl {
         this.toughness = new MageInt(2);
     }
 
-    public Cobblebrute (final Cobblebrute card) {
+    private Cobblebrute(final Cobblebrute card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CoffinQueen.java
+++ b/Mage.Sets/src/mage/cards/c/CoffinQueen.java
@@ -68,7 +68,7 @@ class CoffinQueenCreateDelayedTriggerEffect extends OneShotEffect {
         this.staticText = "When {this} becomes untapped or you lose control of {this}, exile that creature.";
     }
 
-    public CoffinQueenCreateDelayedTriggerEffect(final CoffinQueenCreateDelayedTriggerEffect effect) {
+    private CoffinQueenCreateDelayedTriggerEffect(final CoffinQueenCreateDelayedTriggerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CoilsOfTheMedusa.java
+++ b/Mage.Sets/src/mage/cards/c/CoilsOfTheMedusa.java
@@ -64,7 +64,7 @@ class CoilsOfTheMedusaDestroyEffect extends OneShotEffect {
         this.staticText = "Destroy all non-Wall creatures blocking enchanted creature.";
     }
 
-    public CoilsOfTheMedusaDestroyEffect(final CoilsOfTheMedusaDestroyEffect effect) {
+    private CoilsOfTheMedusaDestroyEffect(final CoilsOfTheMedusaDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ColdSnap.java
+++ b/Mage.Sets/src/mage/cards/c/ColdSnap.java
@@ -53,7 +53,7 @@ class ColdSnapDamageTargetEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to that player equal to the number of snow lands they control";
     }
 
-    public ColdSnapDamageTargetEffect(ColdSnapDamageTargetEffect copy) {
+    private ColdSnapDamageTargetEffect(final ColdSnapDamageTargetEffect copy) {
         super(copy);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ColfenorsPlans.java
+++ b/Mage.Sets/src/mage/cards/c/ColfenorsPlans.java
@@ -62,7 +62,7 @@ class ColfenorsPlansExileEffect extends OneShotEffect {
         staticText = "exile the top seven cards of your library face down";
     }
 
-    public ColfenorsPlansExileEffect(final ColfenorsPlansExileEffect effect) {
+    private ColfenorsPlansExileEffect(final ColfenorsPlansExileEffect effect) {
         super(effect);
     }
 
@@ -100,7 +100,7 @@ class ColfenorsPlansPlayCardEffect extends AsThoughEffectImpl {
         staticText = "You may play cards exiled with {this}";
     }
 
-    public ColfenorsPlansPlayCardEffect(final ColfenorsPlansPlayCardEffect effect) {
+    private ColfenorsPlansPlayCardEffect(final ColfenorsPlansPlayCardEffect effect) {
         super(effect);
     }
 
@@ -131,7 +131,7 @@ class ColfenorsPlansLookAtCardEffect extends AsThoughEffectImpl {
         staticText = "You may look at cards exiled with {this}";
     }
 
-    public ColfenorsPlansLookAtCardEffect(final ColfenorsPlansLookAtCardEffect effect) {
+    private ColfenorsPlansLookAtCardEffect(final ColfenorsPlansLookAtCardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ColfenorsUrn.java
+++ b/Mage.Sets/src/mage/cards/c/ColfenorsUrn.java
@@ -64,7 +64,7 @@ class ColfenorsUrnEffect extends OneShotEffect {
         this.staticText = "If you do, return those cards to the battlefield under their owner's control";
     }
 
-    public ColfenorsUrnEffect(final ColfenorsUrnEffect effect) {
+    private ColfenorsUrnEffect(final ColfenorsUrnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CollectiveDefiance.java
+++ b/Mage.Sets/src/mage/cards/c/CollectiveDefiance.java
@@ -75,7 +75,7 @@ class CollectiveDefianceEffect extends OneShotEffect {
         this.staticText = "Target player discards all the cards in their hand, then draws that many cards";
     }
 
-    public CollectiveDefianceEffect(final CollectiveDefianceEffect effect) {
+    private CollectiveDefianceEffect(final CollectiveDefianceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CollectiveVoyage.java
+++ b/Mage.Sets/src/mage/cards/c/CollectiveVoyage.java
@@ -49,7 +49,7 @@ class CollectiveVoyageEffect extends OneShotEffect {
         this.staticText = "<i>Join forces</i> &mdash; Starting with you, each player may pay any amount of mana. Each player searches their library for up to X basic land cards, where X is the total amount of mana paid this way, puts them onto the battlefield tapped, then shuffles";
     }
 
-    public CollectiveVoyageEffect(final CollectiveVoyageEffect effect) {
+    private CollectiveVoyageEffect(final CollectiveVoyageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ColossalMight.java
+++ b/Mage.Sets/src/mage/cards/c/ColossalMight.java
@@ -28,7 +28,7 @@ public final class ColossalMight extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public ColossalMight(final ColossalMight card) {
+    private ColossalMight(final ColossalMight card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CombatCalligrapher.java
+++ b/Mage.Sets/src/mage/cards/c/CombatCalligrapher.java
@@ -112,7 +112,7 @@ class CombatCalligrapherEffect extends RestrictionEffect {
         this.staticText = "Inklings can't attack you or planeswalkers you control";
     }
 
-    public CombatCalligrapherEffect(final CombatCalligrapherEffect effect) {
+    private CombatCalligrapherEffect(final CombatCalligrapherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CombustibleGearhulk.java
+++ b/Mage.Sets/src/mage/cards/c/CombustibleGearhulk.java
@@ -57,7 +57,7 @@ class CombustibleGearhulkEffect extends OneShotEffect {
         staticText = "target opponent may have you draw three cards. If the player doesn't, you mill three cards, then {this} deals damage to that player equal to the total mana value of those cards";
     }
 
-    public CombustibleGearhulkEffect(final CombustibleGearhulkEffect effect) {
+    private CombustibleGearhulkEffect(final CombustibleGearhulkEffect effect) {
         super(effect);
     }
 
@@ -97,7 +97,7 @@ class CombustibleGearhulkMillAndDamageEffect extends OneShotEffect {
         super(Outcome.Damage);
     }
 
-    public CombustibleGearhulkMillAndDamageEffect(final CombustibleGearhulkMillAndDamageEffect effect) {
+    private CombustibleGearhulkMillAndDamageEffect(final CombustibleGearhulkMillAndDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CometStorm.java
+++ b/Mage.Sets/src/mage/cards/c/CometStorm.java
@@ -61,7 +61,7 @@ class CometStormEffect extends OneShotEffect {
         staticText = "Choose any target, then choose another target for each time this spell was kicked. {this} deals X damage to each of them";
     }
 
-    public CometStormEffect(final CometStormEffect effect) {
+    private CometStormEffect(final CometStormEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Comeuppance.java
+++ b/Mage.Sets/src/mage/cards/c/Comeuppance.java
@@ -50,7 +50,7 @@ class ComeuppanceEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that would be dealt to you and planeswalkers you control this turn by sources you don't control. If damage from a creature source is prevented this way, {this} deals that much damage to that creature. If damage from a noncreature source is prevented this way, {this} deals that much damage to the source's controller";
     }
 
-    public ComeuppanceEffect(final ComeuppanceEffect effect) {
+    private ComeuppanceEffect(final ComeuppanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Commandeer.java
+++ b/Mage.Sets/src/mage/cards/c/Commandeer.java
@@ -64,7 +64,7 @@ class CommandeerEffect extends OneShotEffect {
                 "the permanent enters the battlefield under your control.)</i>";
     }
 
-    public CommandeerEffect(final CommandeerEffect effect) {
+    private CommandeerEffect(final CommandeerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CommandoRaid.java
+++ b/Mage.Sets/src/mage/cards/c/CommandoRaid.java
@@ -59,7 +59,7 @@ class CommandoRaidTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CommandoRaidEffect(), true);
     }
 
-    public CommandoRaidTriggeredAbility(final CommandoRaidTriggeredAbility ability) {
+    private CommandoRaidTriggeredAbility(final CommandoRaidTriggeredAbility ability) {
         super(ability);
     }
 
@@ -107,7 +107,7 @@ class CommandoRaidEffect extends OneShotEffect {
         staticText = "it deals that much damage to target creature that player controls";
     }
 
-    public CommandoRaidEffect(final CommandoRaidEffect effect) {
+    private CommandoRaidEffect(final CommandoRaidEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CommitMemory.java
+++ b/Mage.Sets/src/mage/cards/c/CommitMemory.java
@@ -68,7 +68,7 @@ class CommitEffect extends OneShotEffect {
         this.staticText = "Put target spell or nonland permanent into its owner's library second from the top";
     }
 
-    public CommitEffect(final CommitEffect effect) {
+    private CommitEffect(final CommitEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CommuneWithLava.java
+++ b/Mage.Sets/src/mage/cards/c/CommuneWithLava.java
@@ -46,7 +46,7 @@ class CommuneWithLavaEffect extends OneShotEffect {
         this.staticText = "Exile the top X cards of your library. Until the end of your next turn, you may play those cards";
     }
 
-    public CommuneWithLavaEffect(final CommuneWithLavaEffect effect) {
+    private CommuneWithLavaEffect(final CommuneWithLavaEffect effect) {
         super(effect);
     }
 
@@ -85,7 +85,7 @@ class CommuneWithLavaMayPlayEffect extends AsThoughEffectImpl {
         this.staticText = "Until the end of your next turn, you may play that card.";
     }
 
-    public CommuneWithLavaMayPlayEffect(final CommuneWithLavaMayPlayEffect effect) {
+    private CommuneWithLavaMayPlayEffect(final CommuneWithLavaMayPlayEffect effect) {
         super(effect);
         castOnTurn = effect.castOnTurn;
     }

--- a/Mage.Sets/src/mage/cards/c/CompellingDeterrence.java
+++ b/Mage.Sets/src/mage/cards/c/CompellingDeterrence.java
@@ -47,7 +47,7 @@ class CompellingDeterrenceEffect extends OneShotEffect {
         this.staticText = "return target nonland permanent to its owner's hand. Then that player discards a card if you control a Zombie";
     }
 
-    public CompellingDeterrenceEffect(final CompellingDeterrenceEffect effect) {
+    private CompellingDeterrenceEffect(final CompellingDeterrenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CompleatDevotion.java
+++ b/Mage.Sets/src/mage/cards/c/CompleatDevotion.java
@@ -44,7 +44,7 @@ class CompleatDevotionEffect extends OneShotEffect {
         staticText = "";
     }
 
-    public CompleatDevotionEffect(final CompleatDevotionEffect effect) {
+    private CompleatDevotionEffect(final CompleatDevotionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConchHorn.java
+++ b/Mage.Sets/src/mage/cards/c/ConchHorn.java
@@ -51,7 +51,7 @@ class ConchHornEffect extends OneShotEffect {
         staticText = "Draw two cards, then put a card from your hand on top of your library";
     }
 
-    public ConchHornEffect(final ConchHornEffect effect) {
+    private ConchHornEffect(final ConchHornEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConcussiveBolt.java
+++ b/Mage.Sets/src/mage/cards/c/ConcussiveBolt.java
@@ -54,7 +54,7 @@ class ConcussiveBoltEffect extends OneShotEffect {
         this.staticText = "<br><i>Metalcraft</i> &mdash; If you control three or more artifacts, creatures controlled by that player or by that planeswalker's controller can't block this turn.";
     }
 
-    public ConcussiveBoltEffect(final ConcussiveBoltEffect effect) {
+    private ConcussiveBoltEffect(final ConcussiveBoltEffect effect) {
         super(effect);
     }
 
@@ -76,7 +76,7 @@ class ConcussiveBoltRestrictionEffect extends RestrictionEffect {
         super(Duration.EndOfTurn);
     }
 
-    public ConcussiveBoltRestrictionEffect(final ConcussiveBoltRestrictionEffect effect) {
+    private ConcussiveBoltRestrictionEffect(final ConcussiveBoltRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Condemn.java
+++ b/Mage.Sets/src/mage/cards/c/Condemn.java
@@ -48,7 +48,7 @@ class CondemnEffect extends OneShotEffect {
         staticText = "Its controller gains life equal to its toughness";
     }
 
-    public CondemnEffect(final CondemnEffect effect) {
+    private CondemnEffect(final CondemnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConduitOfWorlds.java
+++ b/Mage.Sets/src/mage/cards/c/ConduitOfWorlds.java
@@ -111,7 +111,7 @@ class ConduitOfWorldsCantCastEffect extends ContinuousRuleModifyingEffectImpl {
         super(Duration.EndOfTurn, Outcome.Detriment);
     }
 
-    public ConduitOfWorldsCantCastEffect(final ConduitOfWorldsCantCastEffect effect) {
+    private ConduitOfWorldsCantCastEffect(final ConduitOfWorldsCantCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConeOfFlame.java
+++ b/Mage.Sets/src/mage/cards/c/ConeOfFlame.java
@@ -62,7 +62,7 @@ class ConeOfFlameEffect extends OneShotEffect {
                 + "and 3 damage to a third target";
     }
 
-    public ConeOfFlameEffect(final ConeOfFlameEffect effect) {
+    private ConeOfFlameEffect(final ConeOfFlameEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConfiscationCoup.java
+++ b/Mage.Sets/src/mage/cards/c/ConfiscationCoup.java
@@ -59,7 +59,7 @@ class ConfiscationCoupEffect extends OneShotEffect {
         this.staticText = "Choose target artifact or creature. You get {E}{E}{E}{E}, then you may pay an amount of {E} equal to that permanent's mana value. If you do, gain control of it";
     }
 
-    public ConfiscationCoupEffect(final ConfiscationCoupEffect effect) {
+    private ConfiscationCoupEffect(final ConfiscationCoupEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConfrontThePast.java
+++ b/Mage.Sets/src/mage/cards/c/ConfrontThePast.java
@@ -82,7 +82,7 @@ class ConfrontThePastLoyaltyEffect extends OneShotEffect {
         staticText = "remove twice X loyalty counters from target planeswalker an opponent controls";
     }
 
-    public ConfrontThePastLoyaltyEffect(ConfrontThePastLoyaltyEffect effect) {
+    private ConfrontThePastLoyaltyEffect(final ConfrontThePastLoyaltyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CongregationAtDawn.java
+++ b/Mage.Sets/src/mage/cards/c/CongregationAtDawn.java
@@ -49,7 +49,7 @@ class CongregationAtDawnEffect extends OneShotEffect {
                 "then shuffle and put those cards on top in any order";
     }
 
-    public CongregationAtDawnEffect(final CongregationAtDawnEffect effect) {
+    private CongregationAtDawnEffect(final CongregationAtDawnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConniveConcoct.java
+++ b/Mage.Sets/src/mage/cards/c/ConniveConcoct.java
@@ -75,7 +75,7 @@ class ConcoctEffect extends OneShotEffect {
                 + "from your graveyard to the battlefield.";
     }
 
-    public ConcoctEffect(final ConcoctEffect effect) {
+    private ConcoctEffect(final ConcoctEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConquerorsFlail.java
+++ b/Mage.Sets/src/mage/cards/c/ConquerorsFlail.java
@@ -92,7 +92,7 @@ class ConquerorsFlailEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "as long as {this} is attached to a creature, your opponents can't cast spells during your turn";
     }
 
-    public ConquerorsFlailEffect(final ConquerorsFlailEffect effect) {
+    private ConquerorsFlailEffect(final ConquerorsFlailEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConsecrateLand.java
+++ b/Mage.Sets/src/mage/cards/c/ConsecrateLand.java
@@ -61,7 +61,7 @@ class ConsecrateLandRuleEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "and can't be enchanted by other Auras";
     }
 
-    public ConsecrateLandRuleEffect(final ConsecrateLandRuleEffect effect) {
+    private ConsecrateLandRuleEffect(final ConsecrateLandRuleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConsignToDream.java
+++ b/Mage.Sets/src/mage/cards/c/ConsignToDream.java
@@ -48,7 +48,7 @@ class ConsignToDreamEffect extends OneShotEffect {
         this.staticText = "Return target permanent to its owner's hand. If that permanent is red or green, put it on top of its owner's library instead";
     }
 
-    public ConsignToDreamEffect(final ConsignToDreamEffect effect) {
+    private ConsignToDreamEffect(final ConsignToDreamEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConsumeStrength.java
+++ b/Mage.Sets/src/mage/cards/c/ConsumeStrength.java
@@ -57,7 +57,7 @@ class ConsumeStrengthEffect extends OneShotEffect {
         this.staticText = "Target creature gets +2/+2 until end of turn. Another target creature gets -2/-2 until end of turn";
     }
 
-    public ConsumeStrengthEffect(final ConsumeStrengthEffect effect) {
+    private ConsumeStrengthEffect(final ConsumeStrengthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConsumingAberration.java
+++ b/Mage.Sets/src/mage/cards/c/ConsumingAberration.java
@@ -55,7 +55,7 @@ class ConsumingAberrationEffect extends OneShotEffect {
         this.staticText = "each opponent reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard";
     }
 
-    public ConsumingAberrationEffect(final ConsumingAberrationEffect effect) {
+    private ConsumingAberrationEffect(final ConsumingAberrationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConsumingFerocity.java
+++ b/Mage.Sets/src/mage/cards/c/ConsumingFerocity.java
@@ -73,7 +73,7 @@ class ConsumingFerocityEffect extends OneShotEffect {
         staticText = "If that creature has three or more +1/+0 counters on it, it deals damage equal to its power to its controller, then destroy that creature and it can't be regenerated";
     }
 
-    public ConsumingFerocityEffect(final ConsumingFerocityEffect effect) {
+    private ConsumingFerocityEffect(final ConsumingFerocityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ContagionClasp.java
+++ b/Mage.Sets/src/mage/cards/c/ContagionClasp.java
@@ -40,7 +40,7 @@ public final class ContagionClasp extends CardImpl {
         this.addAbility(ability);
     }
 
-    public ContagionClasp (final ContagionClasp card) {
+    private ContagionClasp(final ContagionClasp card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ContagiousNim.java
+++ b/Mage.Sets/src/mage/cards/c/ContagiousNim.java
@@ -26,7 +26,7 @@ public final class ContagiousNim extends CardImpl {
         this.addAbility(InfectAbility.getInstance());
     }
 
-    public ContagiousNim (final ContagiousNim card) {
+    private ContagiousNim(final ContagiousNim card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ContainmentConstruct.java
+++ b/Mage.Sets/src/mage/cards/c/ContainmentConstruct.java
@@ -55,7 +55,7 @@ class ContainmentConstructTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you discard a card, ");
     }
 
-    public ContainmentConstructTriggeredAbility(final ContainmentConstructTriggeredAbility ability) {
+    private ContainmentConstructTriggeredAbility(final ContainmentConstructTriggeredAbility ability) {
         super(ability);
     }
 
@@ -87,7 +87,7 @@ class ContainmentConstructEffect extends OneShotEffect {
         this.staticText = "you may exile that card from your graveyard. If you do, you may play that card this turn";
     }
 
-    public ContainmentConstructEffect(final ContainmentConstructEffect effect) {
+    private ContainmentConstructEffect(final ContainmentConstructEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ContainmentPriest.java
+++ b/Mage.Sets/src/mage/cards/c/ContainmentPriest.java
@@ -55,7 +55,7 @@ class ContainmentPriestReplacementEffect extends ReplacementEffectImpl {
         staticText = "If a nontoken creature would enter the battlefield and it wasn't cast, exile it instead";
     }
 
-    public ContainmentPriestReplacementEffect(final ContainmentPriestReplacementEffect effect) {
+    private ContainmentPriestReplacementEffect(final ContainmentPriestReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ContestedWarZone.java
+++ b/Mage.Sets/src/mage/cards/c/ContestedWarZone.java
@@ -57,7 +57,7 @@ class ContestedWarZoneAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ContestedWarZoneEffect());
     }
 
-    public ContestedWarZoneAbility(final ContestedWarZoneAbility ability) {
+    private ContestedWarZoneAbility(final ContestedWarZoneAbility ability) {
         super(ability);
     }
 
@@ -98,7 +98,7 @@ class ContestedWarZoneEffect extends ContinuousEffectImpl {
         this.staticText = "Gain control of {this}";
     }
 
-    public ContestedWarZoneEffect(final ContestedWarZoneEffect effect) {
+    private ContestedWarZoneEffect(final ContestedWarZoneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConundrumSphinx.java
+++ b/Mage.Sets/src/mage/cards/c/ConundrumSphinx.java
@@ -58,7 +58,7 @@ class ConundrumSphinxEffect extends OneShotEffect {
                 "If it doesn't, that player puts it on the bottom of their library";
     }
 
-    public ConundrumSphinxEffect(final ConundrumSphinxEffect effect) {
+    private ConundrumSphinxEffect(final ConundrumSphinxEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Convalescence.java
+++ b/Mage.Sets/src/mage/cards/c/Convalescence.java
@@ -44,7 +44,7 @@ class ConvalescenceEffect extends OneShotEffect {
         staticText = "if you have 10 or less life, you gain 1 life";
     }
 
-    public ConvalescenceEffect(final ConvalescenceEffect effect) {
+    private ConvalescenceEffect(final ConvalescenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConvincingMirage.java
+++ b/Mage.Sets/src/mage/cards/c/ConvincingMirage.java
@@ -58,7 +58,7 @@ class ConvincingMirageContinousEffect extends ContinuousEffectImpl {
         staticText = "Enchanted land is the chosen type";
     }
 
-    public ConvincingMirageContinousEffect(final ConvincingMirageContinousEffect effect) {
+    private ConvincingMirageContinousEffect(final ConvincingMirageContinousEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CopperMyr.java
+++ b/Mage.Sets/src/mage/cards/c/CopperMyr.java
@@ -24,7 +24,7 @@ public final class CopperMyr extends CardImpl {
         this.addAbility(new GreenManaAbility());
     }
 
-    public CopperMyr (final CopperMyr card) {
+    private CopperMyr(final CopperMyr card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CopperhornScout.java
+++ b/Mage.Sets/src/mage/cards/c/CopperhornScout.java
@@ -51,7 +51,7 @@ class CopperhornScoutTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CopperhornScoutUntapEffect(), false);
     }
 
-    public CopperhornScoutTriggeredAbility(final CopperhornScoutTriggeredAbility ability) {
+    private CopperhornScoutTriggeredAbility(final CopperhornScoutTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CoralFighters.java
+++ b/Mage.Sets/src/mage/cards/c/CoralFighters.java
@@ -48,7 +48,7 @@ class CoralFightersEffect extends OneShotEffect {
         staticText = "look at the top card of defending player's library. You may put that card on the bottom of that player's library";
     }
 
-    public CoralFightersEffect(final CoralFightersEffect effect) {
+    private CoralFightersEffect(final CoralFightersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CorpseChurn.java
+++ b/Mage.Sets/src/mage/cards/c/CorpseChurn.java
@@ -47,7 +47,7 @@ class CorpseChurnEffect extends OneShotEffect {
         this.staticText = ", then you may return a creature card from your graveyard to your hand";
     }
 
-    public CorpseChurnEffect(final CorpseChurnEffect effect) {
+    private CorpseChurnEffect(final CorpseChurnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CorpseConnoisseur.java
+++ b/Mage.Sets/src/mage/cards/c/CorpseConnoisseur.java
@@ -56,7 +56,7 @@ class SearchLibraryPutInGraveyard extends SearchEffect {
         staticText = "search your library for a creature card, put that card into your graveyard, then shuffle";
     }
 
-    public SearchLibraryPutInGraveyard(final SearchLibraryPutInGraveyard effect) {
+    private SearchLibraryPutInGraveyard(final SearchLibraryPutInGraveyard effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CorpseCur.java
+++ b/Mage.Sets/src/mage/cards/c/CorpseCur.java
@@ -39,7 +39,7 @@ public final class CorpseCur extends CardImpl {
         this.addAbility(ability);
     }
 
-    public CorpseCur(final CorpseCur card) {
+    private CorpseCur(final CorpseCur card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CorpseDance.java
+++ b/Mage.Sets/src/mage/cards/c/CorpseDance.java
@@ -56,7 +56,7 @@ class CorpseDanceEffect extends OneShotEffect {
         this.staticText = "Return the top creature card of your graveyard to the battlefield. That creature gains haste until end of turn. Exile it at the beginning of the next end step";
     }
 
-    public CorpseDanceEffect(final CorpseDanceEffect effect) {
+    private CorpseDanceEffect(final CorpseDanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CorpseLunge.java
+++ b/Mage.Sets/src/mage/cards/c/CorpseLunge.java
@@ -51,7 +51,7 @@ class CorpseLungeEffect extends OneShotEffect {
         this.staticText = "{this} deals damage equal to the exiled card's power to target creature";
     }
 
-    public CorpseLungeEffect(final CorpseLungeEffect effect) {
+    private CorpseLungeEffect(final CorpseLungeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Corpseweft.java
+++ b/Mage.Sets/src/mage/cards/c/Corpseweft.java
@@ -51,7 +51,7 @@ class CorpseweftEffect extends OneShotEffect {
         this.staticText = "create a tapped X/X black Zombie Horror creature token, where X is twice the number of cards exiled this way";
     }
 
-    public CorpseweftEffect(final CorpseweftEffect effect) {
+    private CorpseweftEffect(final CorpseweftEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Corrosion.java
+++ b/Mage.Sets/src/mage/cards/c/Corrosion.java
@@ -100,7 +100,7 @@ class CorrosionRemoveCountersEffect extends OneShotEffect {
         staticText = "remove all rust counters from all permanents";
     }
 
-    public CorrosionRemoveCountersEffect(final CorrosionRemoveCountersEffect effect) {
+    private CorrosionRemoveCountersEffect(final CorrosionRemoveCountersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CorrosiveOoze.java
+++ b/Mage.Sets/src/mage/cards/c/CorrosiveOoze.java
@@ -64,7 +64,7 @@ class CorrosiveOozeEffect extends OneShotEffect {
         this.staticText = "destroy all Equipment attached to that creature at end of combat";
     }
 
-    public CorrosiveOozeEffect(final CorrosiveOozeEffect effect) {
+    private CorrosiveOozeEffect(final CorrosiveOozeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Corrupt.java
+++ b/Mage.Sets/src/mage/cards/c/Corrupt.java
@@ -54,7 +54,7 @@ class CorruptEffect extends OneShotEffect {
         staticText = "{this} deals damage to any target equal to the number of Swamps you control. You gain life equal to the damage dealt this way";
     }
 
-    public CorruptEffect(final CorruptEffect effect) {
+    private CorruptEffect(final CorruptEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CorruptedGrafstone.java
+++ b/Mage.Sets/src/mage/cards/c/CorruptedGrafstone.java
@@ -53,7 +53,7 @@ class CorruptedGrafstoneManaAbility extends ActivatedManaAbilityImpl {
         super(Zone.BATTLEFIELD, new CorruptedGrafstoneManaEffect(), new TapSourceCost());
     }
 
-    public CorruptedGrafstoneManaAbility(final CorruptedGrafstoneManaAbility ability) {
+    private CorruptedGrafstoneManaAbility(final CorruptedGrafstoneManaAbility ability) {
         super(ability);
     }
 
@@ -82,7 +82,7 @@ class CorruptedGrafstoneManaEffect extends ManaEffect {
         this.staticText = "Choose a color of a card in your graveyard. Add one mana of that color";
     }
 
-    public CorruptedGrafstoneManaEffect(final CorruptedGrafstoneManaEffect effect) {
+    private CorruptedGrafstoneManaEffect(final CorruptedGrafstoneManaEffect effect) {
         super(effect);
         this.computedMana = effect.computedMana.copy();
     }

--- a/Mage.Sets/src/mage/cards/c/CorruptedZendikon.java
+++ b/Mage.Sets/src/mage/cards/c/CorruptedZendikon.java
@@ -69,7 +69,7 @@ class CorruptedZendikonOozeToken extends TokenImpl {
         this.power = new MageInt(3);
         this.toughness = new MageInt(3);
     }
-    public CorruptedZendikonOozeToken(final CorruptedZendikonOozeToken token) {
+    private CorruptedZendikonOozeToken(final CorruptedZendikonOozeToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CosisTrickster.java
+++ b/Mage.Sets/src/mage/cards/c/CosisTrickster.java
@@ -48,7 +48,7 @@ class CosisTricksterTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), true);
     }
 
-    public CosisTricksterTriggeredAbility(final CosisTricksterTriggeredAbility ability) {
+    private CosisTricksterTriggeredAbility(final CosisTricksterTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CosmicHorror.java
+++ b/Mage.Sets/src/mage/cards/c/CosmicHorror.java
@@ -58,7 +58,7 @@ class CosmicHorrorEffect extends OneShotEffect {
         staticText = "destroy {this} unless you pay {3}{B}{B}{B}. If {this} is destroyed this way it deals 7 damage to you";
     }
 
-    public CosmicHorrorEffect(final CosmicHorrorEffect effect) {
+    private CosmicHorrorEffect(final CosmicHorrorEffect effect) {
         super(effect);
         this.cost = effect.cost.copy();
     }

--- a/Mage.Sets/src/mage/cards/c/CouncilOfTheAbsolute.java
+++ b/Mage.Sets/src/mage/cards/c/CouncilOfTheAbsolute.java
@@ -60,7 +60,7 @@ class CouncilOfTheAbsoluteReplacementEffect extends ContinuousRuleModifyingEffec
         staticText = "Your opponents can't cast spells with the chosen name";
     }
 
-    public CouncilOfTheAbsoluteReplacementEffect(final CouncilOfTheAbsoluteReplacementEffect effect) {
+    private CouncilOfTheAbsoluteReplacementEffect(final CouncilOfTheAbsoluteReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CounselOfTheSoratami.java
+++ b/Mage.Sets/src/mage/cards/c/CounselOfTheSoratami.java
@@ -20,7 +20,7 @@ public final class CounselOfTheSoratami extends CardImpl {
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(2));
     }
 
-    public CounselOfTheSoratami (final CounselOfTheSoratami card) {
+    private CounselOfTheSoratami(final CounselOfTheSoratami card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Counterbalance.java
+++ b/Mage.Sets/src/mage/cards/c/Counterbalance.java
@@ -50,7 +50,7 @@ class CounterbalanceEffect extends OneShotEffect {
         this.staticText = "you may reveal the top card of your library. If you do, counter that spell if it has the same mana value as the revealed card";
     }
 
-    public CounterbalanceEffect(final CounterbalanceEffect effect) {
+    private CounterbalanceEffect(final CounterbalanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Counterflux.java
+++ b/Mage.Sets/src/mage/cards/c/Counterflux.java
@@ -74,7 +74,7 @@ class CounterfluxEffect extends OneShotEffect {
 
     }
 
-    public CounterfluxEffect(final CounterfluxEffect effect) {
+    private CounterfluxEffect(final CounterfluxEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Counterlash.java
+++ b/Mage.Sets/src/mage/cards/c/Counterlash.java
@@ -50,7 +50,7 @@ class CounterlashEffect extends OneShotEffect {
                 + "without paying its mana cost";
     }
 
-    public CounterlashEffect(final CounterlashEffect effect) {
+    private CounterlashEffect(final CounterlashEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Countermand.java
+++ b/Mage.Sets/src/mage/cards/c/Countermand.java
@@ -46,7 +46,7 @@ class CountermandEffect extends OneShotEffect {
         staticText = "Counter target spell. Its controller mills four cards.";
     }
 
-    public CountermandEffect(final CountermandEffect effect) {
+    private CountermandEffect(final CountermandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CouriersCapsule.java
+++ b/Mage.Sets/src/mage/cards/c/CouriersCapsule.java
@@ -30,7 +30,7 @@ public final class CouriersCapsule extends CardImpl {
         this.addAbility(ability);
     }
 
-    public CouriersCapsule (final CouriersCapsule card) {
+    private CouriersCapsule(final CouriersCapsule card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CourtArchers.java
+++ b/Mage.Sets/src/mage/cards/c/CourtArchers.java
@@ -28,7 +28,7 @@ public final class CourtArchers extends CardImpl {
         this.addAbility(new ExaltedAbility());
     }
 
-    public CourtArchers (final CourtArchers card) {
+    private CourtArchers(final CourtArchers card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CovenantOfMinds.java
+++ b/Mage.Sets/src/mage/cards/c/CovenantOfMinds.java
@@ -46,7 +46,7 @@ class CovenantOfMindsEffect extends OneShotEffect {
         this.staticText = "Reveal the top three cards of your library. Target opponent may choose to put those cards into your hand. If they don't, put those cards into your graveyard and draw five cards";
     }
 
-    public CovenantOfMindsEffect(final CovenantOfMindsEffect effect) {
+    private CovenantOfMindsEffect(final CovenantOfMindsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CoverOfDarkness.java
+++ b/Mage.Sets/src/mage/cards/c/CoverOfDarkness.java
@@ -48,7 +48,7 @@ class FilterCoverOfDarkness extends FilterCreaturePermanent {
         super("creatures of the chosen type");
     }
 
-    public FilterCoverOfDarkness(final FilterCoverOfDarkness filter) {
+    private FilterCoverOfDarkness(final FilterCoverOfDarkness filter) {
         super(filter);
         this.subType = filter.subType;
     }

--- a/Mage.Sets/src/mage/cards/c/CoverOfWinter.java
+++ b/Mage.Sets/src/mage/cards/c/CoverOfWinter.java
@@ -59,7 +59,7 @@ class CoverOfWinterEffect extends PreventionEffectImpl {
         this.staticText = "If a creature would deal combat damage to you and/or one or more creatures you control, prevent X of that damage, where X is the number of age counters on {this}";
     }
 
-    public CoverOfWinterEffect(CoverOfWinterEffect effect) {
+    private CoverOfWinterEffect(final CoverOfWinterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CovetedJewel.java
+++ b/Mage.Sets/src/mage/cards/c/CovetedJewel.java
@@ -63,7 +63,7 @@ class CovetedJewelTriggeredAbility extends TriggeredAbilityImpl {
         this.addEffect(new UntapSourceEffect());
     }
 
-    public CovetedJewelTriggeredAbility(final CovetedJewelTriggeredAbility ability) {
+    private CovetedJewelTriggeredAbility(final CovetedJewelTriggeredAbility ability) {
         super(ability);
     }
 
@@ -110,7 +110,7 @@ class CovetedJewelControlEffect extends ContinuousEffectImpl {
         super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
     }
 
-    public CovetedJewelControlEffect(final CovetedJewelControlEffect effect) {
+    private CovetedJewelControlEffect(final CovetedJewelControlEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Cowardice.java
+++ b/Mage.Sets/src/mage/cards/c/Cowardice.java
@@ -42,7 +42,7 @@ class CowardiceTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ReturnToHandTargetEffect(), false);
     }
 
-    public CowardiceTriggeredAbility(CowardiceTriggeredAbility ability) {
+    private CowardiceTriggeredAbility(final CowardiceTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CracklingDoom.java
+++ b/Mage.Sets/src/mage/cards/c/CracklingDoom.java
@@ -55,7 +55,7 @@ class CracklingDoomEffect extends OneShotEffect {
         this.staticText = "Each opponent sacrifices a creature with the greatest power among creatures that player controls";
     }
 
-    public CracklingDoomEffect(final CracklingDoomEffect effect) {
+    private CracklingDoomEffect(final CracklingDoomEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CraftyCutpurse.java
+++ b/Mage.Sets/src/mage/cards/c/CraftyCutpurse.java
@@ -56,7 +56,7 @@ class CraftyCutpurseReplacementEffect extends ReplacementEffectImpl {
         staticText = "each token that would be created under an opponent's control this turn is created under your control instead";
     }
 
-    public CraftyCutpurseReplacementEffect(final CraftyCutpurseReplacementEffect effect) {
+    private CraftyCutpurseReplacementEffect(final CraftyCutpurseReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CragganwickCremator.java
+++ b/Mage.Sets/src/mage/cards/c/CragganwickCremator.java
@@ -55,7 +55,7 @@ class CragganwickCrematorEffect extends OneShotEffect {
         this.staticText = "discard a card at random. If you discard a creature card this way, {this} deals damage equal to that card's power to target player or planeswalker";
     }
 
-    public CragganwickCrematorEffect(final CragganwickCrematorEffect effect) {
+    private CragganwickCrematorEffect(final CragganwickCrematorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CranialArchive.java
+++ b/Mage.Sets/src/mage/cards/c/CranialArchive.java
@@ -51,7 +51,7 @@ class CranialArchiveEffect extends OneShotEffect {
         this.staticText = "Target player shuffles their graveyard into their library. Draw a card";
     }
 
-    public CranialArchiveEffect(final CranialArchiveEffect effect) {
+    private CranialArchiveEffect(final CranialArchiveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CraterHellion.java
+++ b/Mage.Sets/src/mage/cards/c/CraterHellion.java
@@ -56,7 +56,7 @@ class CraterHellionEffect extends OneShotEffect {
         staticText = "it deals 4 damage to each other creature";
     }
 
-    public CraterHellionEffect(final CraterHellionEffect effect) {
+    private CraterHellionEffect(final CraterHellionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrawlingSensation.java
+++ b/Mage.Sets/src/mage/cards/c/CrawlingSensation.java
@@ -47,7 +47,7 @@ class CrawlingSensationTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CreateTokenEffect(new InsectToken()), false);
     }
 
-    public CrawlingSensationTriggeredAbility(final CrawlingSensationTriggeredAbility ability) {
+    private CrawlingSensationTriggeredAbility(final CrawlingSensationTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrazedArmodon.java
+++ b/Mage.Sets/src/mage/cards/c/CrazedArmodon.java
@@ -61,7 +61,7 @@ public final class CrazedArmodon extends CardImpl {
             super(new DestroySourceEffect());
         }
 
-        public CrazedArmodonDelayedTriggeredAbility(final CrazedArmodonDelayedTriggeredAbility ability) {
+        private CrazedArmodonDelayedTriggeredAbility(final CrazedArmodonDelayedTriggeredAbility ability) {
             super(ability);
         }
 

--- a/Mage.Sets/src/mage/cards/c/CrazedSkirge.java
+++ b/Mage.Sets/src/mage/cards/c/CrazedSkirge.java
@@ -28,7 +28,7 @@ public final class CrazedSkirge extends CardImpl {
         this.addAbility(HasteAbility.getInstance());
     }
 
-    public CrazedSkirge (final CrazedSkirge card) {
+    private CrazedSkirge(final CrazedSkirge card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CreepingBloodsucker.java
+++ b/Mage.Sets/src/mage/cards/c/CreepingBloodsucker.java
@@ -49,7 +49,7 @@ class CreepingBloodsuckerEffect extends OneShotEffect {
         staticText = "{this} deals 1 damage to each opponent. You gain life equal to the damage dealt this way";
     }
 
-    public CreepingBloodsuckerEffect(final CreepingBloodsuckerEffect effect) {
+    private CreepingBloodsuckerEffect(final CreepingBloodsuckerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CreepingChill.java
+++ b/Mage.Sets/src/mage/cards/c/CreepingChill.java
@@ -56,7 +56,7 @@ class CreepingChillAbility extends ZoneChangeTriggeredAbility {
         );
     }
 
-    public CreepingChillAbility(final CreepingChillAbility ability) {
+    private CreepingChillAbility(final CreepingChillAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CreepingDread.java
+++ b/Mage.Sets/src/mage/cards/c/CreepingDread.java
@@ -47,7 +47,7 @@ class CreepingDreadEffect extends OneShotEffect {
         this.staticText = "each player discards a card. Each opponent who discarded a card that shares a card type with the card you discarded loses 3 life.";
     }
 
-    public CreepingDreadEffect(final CreepingDreadEffect effect) {
+    private CreepingDreadEffect(final CreepingDreadEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CreepingInn.java
+++ b/Mage.Sets/src/mage/cards/c/CreepingInn.java
@@ -67,7 +67,7 @@ class CreepingInnEffect extends OneShotEffect {
                 "where X is the number of creature cards exiled with Creeping Inn.";
     }
 
-    public CreepingInnEffect(final CreepingInnEffect effect) {
+    private CreepingInnEffect(final CreepingInnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CreepingRenaissance.java
+++ b/Mage.Sets/src/mage/cards/c/CreepingRenaissance.java
@@ -52,7 +52,7 @@ class CreepingRenaissanceEffect extends OneShotEffect {
         staticText = "Choose a permanent type. Return all cards of the chosen type from your graveyard to your hand";
     }
 
-    public CreepingRenaissanceEffect(final CreepingRenaissanceEffect effect) {
+    private CreepingRenaissanceEffect(final CreepingRenaissanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Crevasse.java
+++ b/Mage.Sets/src/mage/cards/c/Crevasse.java
@@ -44,7 +44,7 @@ class CrevasseEffect extends AsThoughEffectImpl {
         staticText = "Creatures with mountainwalk can be blocked as though they didn't have mountainwalk";
     }
 
-    public CrevasseEffect(final CrevasseEffect effect) {
+    private CrevasseEffect(final CrevasseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrimsonWisps.java
+++ b/Mage.Sets/src/mage/cards/c/CrimsonWisps.java
@@ -34,7 +34,7 @@ public final class CrimsonWisps extends CardImpl {
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1).concatBy("<br>"));
     }
 
-    public CrimsonWisps(final CrimsonWisps card) {
+    private CrimsonWisps(final CrimsonWisps card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrovaxTheCursed.java
+++ b/Mage.Sets/src/mage/cards/c/CrovaxTheCursed.java
@@ -64,7 +64,7 @@ class CrovaxTheCursedEffect extends OneShotEffect {
         this.staticText = "you may sacrifice a creature. If you do, put a +1/+1 counter on {this}. If you don't, remove a +1/+1 counter from {this}";
     }
 
-    public CrovaxTheCursedEffect(final CrovaxTheCursedEffect effect) {
+    private CrovaxTheCursedEffect(final CrovaxTheCursedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrownHunterHireling.java
+++ b/Mage.Sets/src/mage/cards/c/CrownHunterHireling.java
@@ -54,7 +54,7 @@ class CrownHunterHirelingCantAttackEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless defending player is the monarch";
     }
 
-    public CrownHunterHirelingCantAttackEffect(final CrownHunterHirelingCantAttackEffect effect) {
+    private CrownHunterHirelingCantAttackEffect(final CrownHunterHirelingCantAttackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrownOfDoom.java
+++ b/Mage.Sets/src/mage/cards/c/CrownOfDoom.java
@@ -98,7 +98,7 @@ class CrownOfDoomEffect extends OneShotEffect {
         this.staticText = "Target player other than {this}'s owner gains control of it";
     }
 
-    public CrownOfDoomEffect(final CrownOfDoomEffect effect) {
+    private CrownOfDoomEffect(final CrownOfDoomEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrownOfEmpires.java
+++ b/Mage.Sets/src/mage/cards/c/CrownOfEmpires.java
@@ -51,7 +51,7 @@ class CrownOfEmpiresEffect extends OneShotEffect {
         staticText = "Tap target creature. Gain control of that creature instead if you control artifacts named Scepter of Empires and Throne of Empires";
     }
 
-    public CrownOfEmpiresEffect(CrownOfEmpiresEffect effect) {
+    private CrownOfEmpiresEffect(final CrownOfEmpiresEffect effect) {
         super(effect);
     }
 
@@ -92,7 +92,7 @@ class CrownOfEmpiresControlEffect extends ContinuousEffectImpl {
         this.staticText = "Gain control of {this}";
     }
 
-    public CrownOfEmpiresControlEffect(final CrownOfEmpiresControlEffect effect) {
+    private CrownOfEmpiresControlEffect(final CrownOfEmpiresControlEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrownOfTheAges.java
+++ b/Mage.Sets/src/mage/cards/c/CrownOfTheAges.java
@@ -64,7 +64,7 @@ class CrownOfTheAgesEffect extends OneShotEffect {
         this.staticText = "Attach target Aura attached to a creature to another creature";
     }
 
-    public CrownOfTheAgesEffect(final CrownOfTheAgesEffect effect) {
+    private CrownOfTheAgesEffect(final CrownOfTheAgesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CruelDeceiver.java
+++ b/Mage.Sets/src/mage/cards/c/CruelDeceiver.java
@@ -60,7 +60,7 @@ class CruelDeceiverEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of your library. If it's a land card, {this} gains \"Whenever Cruel Deceiver deals damage to a creature, destroy that creature\" until end of turn";
     }
 
-    public CruelDeceiverEffect(final CruelDeceiverEffect effect) {
+    private CruelDeceiverEffect(final CruelDeceiverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CruelEntertainment.java
+++ b/Mage.Sets/src/mage/cards/c/CruelEntertainment.java
@@ -46,7 +46,7 @@ class CruelEntertainmentEffect extends OneShotEffect {
                 + " during the second player's next turn, and the second player controls the first player during the first player's next turn";
     }
 
-    public CruelEntertainmentEffect(final CruelEntertainmentEffect effect) {
+    private CruelEntertainmentEffect(final CruelEntertainmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CruelUltimatum.java
+++ b/Mage.Sets/src/mage/cards/c/CruelUltimatum.java
@@ -57,7 +57,7 @@ class CruelUltimatumEffect extends OneShotEffect {
                 + "to your hand, draw three cards, then gain 5 life";
     }
 
-    public CruelUltimatumEffect(final CruelUltimatumEffect effect) {
+    private CruelUltimatumEffect(final CruelUltimatumEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Crumble.java
+++ b/Mage.Sets/src/mage/cards/c/Crumble.java
@@ -46,7 +46,7 @@ class CrumbleEffect extends OneShotEffect {
         staticText = "That artifact's controller gains life equal to its mana value";
     }
 
-    public CrumbleEffect(final CrumbleEffect effect) {
+    private CrumbleEffect(final CrumbleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrumblingSanctuary.java
+++ b/Mage.Sets/src/mage/cards/c/CrumblingSanctuary.java
@@ -45,7 +45,7 @@ class CrumblingSanctuaryEffect extends PreventionEffectImpl {
         staticText = "If damage would be dealt to a player, that player exiles that many cards from the top of their library instead.";
     }
 
-    public CrumblingSanctuaryEffect(final CrumblingSanctuaryEffect effect) {
+    private CrumblingSanctuaryEffect(final CrumblingSanctuaryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrushUnderfoot.java
+++ b/Mage.Sets/src/mage/cards/c/CrushUnderfoot.java
@@ -57,7 +57,7 @@ class CrushUnderfootEffect extends OneShotEffect {
         this.staticText = "Choose a Giant creature you control. It deals damage equal to its power to target creature";
     }
 
-    public CrushUnderfootEffect(final CrushUnderfootEffect effect) {
+    private CrushUnderfootEffect(final CrushUnderfootEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrusherZendikon.java
+++ b/Mage.Sets/src/mage/cards/c/CrusherZendikon.java
@@ -69,7 +69,7 @@ class CrusherZendikonToken extends TokenImpl {
         toughness = new MageInt(2);
         this.addAbility(TrampleAbility.getInstance());
     }
-    public CrusherZendikonToken(final CrusherZendikonToken token) {
+    private CrusherZendikonToken(final CrusherZendikonToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrushingPain.java
+++ b/Mage.Sets/src/mage/cards/c/CrushingPain.java
@@ -60,7 +60,7 @@ public final class CrushingPain extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter));
     }
 
-    public CrushingPain (final CrushingPain card) {
+    private CrushingPain(final CrushingPain card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrypticGateway.java
+++ b/Mage.Sets/src/mage/cards/c/CrypticGateway.java
@@ -53,7 +53,7 @@ class CrypticGatewayEffect extends OneShotEffect {
         this.staticText = "you may put a creature card from your hand that shares a creature type with each creature tapped this way onto the battlefield";
     }
 
-    public CrypticGatewayEffect(final CrypticGatewayEffect effect) {
+    private CrypticGatewayEffect(final CrypticGatewayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrystalRod.java
+++ b/Mage.Sets/src/mage/cards/c/CrystalRod.java
@@ -45,7 +45,7 @@ class CrystalRodAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DoIfCostPaid(new GainLifeEffect(1), new GenericManaCost(1)), false);
     }
 
-    public CrystalRodAbility(final CrystalRodAbility ability) {
+    private CrystalRodAbility(final CrystalRodAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrystalSeer.java
+++ b/Mage.Sets/src/mage/cards/c/CrystalSeer.java
@@ -37,7 +37,7 @@ public final class CrystalSeer extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new ReturnToHandSourceEffect(true), new ManaCostsImpl<>("{4}{U}")));
     }
 
-    public CrystalSeer (final CrystalSeer card) {
+    private CrystalSeer(final CrystalSeer card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CultOfTheWaxingMoon.java
+++ b/Mage.Sets/src/mage/cards/c/CultOfTheWaxingMoon.java
@@ -57,7 +57,7 @@ class CultOfTheWaxingMoonAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a permanent you control transforms into a non-Human creature, ");
     }
 
-    public CultOfTheWaxingMoonAbility(final CultOfTheWaxingMoonAbility ability) {
+    private CultOfTheWaxingMoonAbility(final CultOfTheWaxingMoonAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Cunning.java
+++ b/Mage.Sets/src/mage/cards/c/Cunning.java
@@ -64,7 +64,7 @@ class SacrificeSourceBeginningCleanupStepEffect extends OneShotEffect {
         this.staticText = "sacrifice {this} at the beginning of the next cleanup step";
     }
 
-    public SacrificeSourceBeginningCleanupStepEffect(final SacrificeSourceBeginningCleanupStepEffect effect) {
+    private SacrificeSourceBeginningCleanupStepEffect(final SacrificeSourceBeginningCleanupStepEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CunningAbduction.java
+++ b/Mage.Sets/src/mage/cards/c/CunningAbduction.java
@@ -54,7 +54,7 @@ class CunningAbductionExileEffect extends OneShotEffect {
         this.staticText = "Target opponent reveals their hand. You choose a nonland card from that player's hand and exile it. You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell";
     }
 
-    public CunningAbductionExileEffect(final CunningAbductionExileEffect effect) {
+    private CunningAbductionExileEffect(final CunningAbductionExileEffect effect) {
         super(effect);
     }
 
@@ -106,7 +106,7 @@ class CunningAbductionSpendAnyManaEffect extends AsThoughEffectImpl implements A
         staticText = "you may spend mana as though it were mana of any color to cast it";
     }
 
-    public CunningAbductionSpendAnyManaEffect(final CunningAbductionSpendAnyManaEffect effect) {
+    private CunningAbductionSpendAnyManaEffect(final CunningAbductionSpendAnyManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CunningBandit.java
+++ b/Mage.Sets/src/mage/cards/c/CunningBandit.java
@@ -81,7 +81,7 @@ class AzamukiTreacheryIncarnate extends TokenImpl {
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }
-    public AzamukiTreacheryIncarnate(final AzamukiTreacheryIncarnate token) {
+    private AzamukiTreacheryIncarnate(final AzamukiTreacheryIncarnate token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CunningRhetoric.java
+++ b/Mage.Sets/src/mage/cards/c/CunningRhetoric.java
@@ -46,7 +46,7 @@ class CunningRhetoricTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CunningRhetoricEffect(), false);
     }
 
-    public CunningRhetoricTriggeredAbility(final CunningRhetoricTriggeredAbility ability) {
+    private CunningRhetoricTriggeredAbility(final CunningRhetoricTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CunningSparkmage.java
+++ b/Mage.Sets/src/mage/cards/c/CunningSparkmage.java
@@ -35,7 +35,7 @@ public final class CunningSparkmage extends CardImpl {
         this.addAbility(ability);
     }
 
-    public CunningSparkmage (final CunningSparkmage card) {
+    private CunningSparkmage(final CunningSparkmage card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CuratorsWard.java
+++ b/Mage.Sets/src/mage/cards/c/CuratorsWard.java
@@ -66,7 +66,7 @@ class CuratorsWardTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(2), false);
     }
 
-    public CuratorsWardTriggeredAbility(CuratorsWardTriggeredAbility ability) {
+    private CuratorsWardTriggeredAbility(final CuratorsWardTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Curiosity.java
+++ b/Mage.Sets/src/mage/cards/c/Curiosity.java
@@ -59,7 +59,7 @@ class CuriosityAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), true);
     }
 
-    public CuriosityAbility(final CuriosityAbility ability) {
+    private CuriosityAbility(final CuriosityAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfBloodletting.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfBloodletting.java
@@ -54,7 +54,7 @@ class CurseOfBloodlettingEffect extends ReplacementEffectImpl {
         staticText = "If a source would deal damage to enchanted player, it deals double that damage to that player instead";
     }
 
-    public CurseOfBloodlettingEffect(final CurseOfBloodlettingEffect effect) {
+    private CurseOfBloodlettingEffect(final CurseOfBloodlettingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfBounty.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfBounty.java
@@ -109,7 +109,7 @@ class UntapAllNonlandsTargetEffect extends OneShotEffect {
         super(Outcome.Untap);
     }
 
-    public UntapAllNonlandsTargetEffect(final UntapAllNonlandsTargetEffect effect) {
+    private UntapAllNonlandsTargetEffect(final UntapAllNonlandsTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfChaos.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfChaos.java
@@ -59,7 +59,7 @@ class CurseOfChaosTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a player attacks enchanted player with one or more creatures, ");
     }
 
-    public CurseOfChaosTriggeredAbility(final CurseOfChaosTriggeredAbility ability) {
+    private CurseOfChaosTriggeredAbility(final CurseOfChaosTriggeredAbility ability) {
         super(ability);
     }
 
@@ -96,7 +96,7 @@ class CurseOfChaosEffect extends OneShotEffect {
         this.staticText = "that attacking player may discard a card. If the player does, they draw a card";
     }
 
-    public CurseOfChaosEffect(final CurseOfChaosEffect effect) {
+    private CurseOfChaosEffect(final CurseOfChaosEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfEchoes.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfEchoes.java
@@ -68,7 +68,7 @@ class CurseOfEchoesCopyTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CurseOfEchoesEffect(), false);
     }
 
-    public CurseOfEchoesCopyTriggeredAbility(final CurseOfEchoesCopyTriggeredAbility ability) {
+    private CurseOfEchoesCopyTriggeredAbility(final CurseOfEchoesCopyTriggeredAbility ability) {
         super(ability);
     }
 
@@ -110,7 +110,7 @@ class CurseOfEchoesEffect extends OneShotEffect {
         super(Outcome.Copy);
     }
 
-    public CurseOfEchoesEffect(final CurseOfEchoesEffect effect) {
+    private CurseOfEchoesEffect(final CurseOfEchoesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfExhaustion.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfExhaustion.java
@@ -56,7 +56,7 @@ class CurseOfExhaustionEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Enchanted player can't cast more than one spell each turn";
     }
 
-    public CurseOfExhaustionEffect(final CurseOfExhaustionEffect effect) {
+    private CurseOfExhaustionEffect(final CurseOfExhaustionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfInertia.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfInertia.java
@@ -58,7 +58,7 @@ class CurseOfInertiaTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CurseOfInertiaTapOrUntapTargetEffect(), false);
     }
 
-    public CurseOfInertiaTriggeredAbility(final CurseOfInertiaTriggeredAbility ability) {
+    private CurseOfInertiaTriggeredAbility(final CurseOfInertiaTriggeredAbility ability) {
         super(ability);
     }
 
@@ -99,7 +99,7 @@ class CurseOfInertiaTapOrUntapTargetEffect extends OneShotEffect {
         staticText = "tap or untap target permanent of their choice";
     }
 
-    public CurseOfInertiaTapOrUntapTargetEffect(final CurseOfInertiaTapOrUntapTargetEffect effect) {
+    private CurseOfInertiaTapOrUntapTargetEffect(final CurseOfInertiaTapOrUntapTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfMisfortunes.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfMisfortunes.java
@@ -64,7 +64,7 @@ class CurseOfMisfortunesEffect extends OneShotEffect {
         staticText = "you may search your library for a Curse card that doesn't have the same name as a Curse attached to enchanted player, put it onto the battlefield attached to that player, then shuffle";
     }
 
-    public CurseOfMisfortunesEffect(final CurseOfMisfortunesEffect effect) {
+    private CurseOfMisfortunesEffect(final CurseOfMisfortunesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfPredation.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfPredation.java
@@ -61,7 +61,7 @@ class CurseOfPredationTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect, optional);
     }
 
-    public CurseOfPredationTriggeredAbility(final CurseOfPredationTriggeredAbility ability) {
+    private CurseOfPredationTriggeredAbility(final CurseOfPredationTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfShallowGraves.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfShallowGraves.java
@@ -64,7 +64,7 @@ class CurseOfShallowTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect, optional);
     }
 
-    public CurseOfShallowTriggeredAbility(final CurseOfShallowTriggeredAbility ability) {
+    private CurseOfShallowTriggeredAbility(final CurseOfShallowTriggeredAbility ability) {
         super(ability);
     }
 
@@ -106,7 +106,7 @@ class CurseOfShallowEffect extends OneShotEffect {
         this.staticText = "that attacking player may create a tapped 2/2 black Zombie creature token";
     }
 
-    public CurseOfShallowEffect(final CurseOfShallowEffect effect) {
+    private CurseOfShallowEffect(final CurseOfShallowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfStalkedPrey.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfStalkedPrey.java
@@ -62,7 +62,7 @@ class CurseOfStalkedPreyTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance()));
     }
 
-    public CurseOfStalkedPreyTriggeredAbility(final CurseOfStalkedPreyTriggeredAbility ability) {
+    private CurseOfStalkedPreyTriggeredAbility(final CurseOfStalkedPreyTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfTheCabal.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfTheCabal.java
@@ -67,7 +67,7 @@ class CurseOfTheCabalSacrificeEffect extends OneShotEffect {
         this.staticText = "Target player sacrifices half the permanents they control, rounded down.";
     }
 
-    public CurseOfTheCabalSacrificeEffect(final CurseOfTheCabalSacrificeEffect effect) {
+    private CurseOfTheCabalSacrificeEffect(final CurseOfTheCabalSacrificeEffect effect) {
         super(effect);
     }
 
@@ -118,7 +118,7 @@ class CurseOfTheCabalInterveningIfTriggeredAbility extends ConditionalIntervenin
         // counters aren't placed
     }
 
-    public CurseOfTheCabalInterveningIfTriggeredAbility(final CurseOfTheCabalInterveningIfTriggeredAbility effect) {
+    private CurseOfTheCabalInterveningIfTriggeredAbility(final CurseOfTheCabalInterveningIfTriggeredAbility effect) {
         super(effect);
     }
 
@@ -150,7 +150,7 @@ class CurseOfTheCabalTriggeredAbilityConditionalDelay extends AddCountersSourceE
         return true;
     }
 
-    public CurseOfTheCabalTriggeredAbilityConditionalDelay(final CurseOfTheCabalTriggeredAbilityConditionalDelay effect) {
+    private CurseOfTheCabalTriggeredAbilityConditionalDelay(final CurseOfTheCabalTriggeredAbilityConditionalDelay effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfTheForsaken.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfTheForsaken.java
@@ -62,7 +62,7 @@ class CurseOfTheForsakenTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect, optional);
     }
 
-    public CurseOfTheForsakenTriggeredAbility(final CurseOfTheForsakenTriggeredAbility ability) {
+    private CurseOfTheForsakenTriggeredAbility(final CurseOfTheForsakenTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfTheNightlyHunt.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfTheNightlyHunt.java
@@ -54,7 +54,7 @@ class CurseOfTheNightlyHuntEffect extends RequirementEffect {
         staticText = "Creatures enchanted player controls attack each turn if able";
     }
 
-    public CurseOfTheNightlyHuntEffect(final CurseOfTheNightlyHuntEffect effect) {
+    private CurseOfTheNightlyHuntEffect(final CurseOfTheNightlyHuntEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfTheSwine.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfTheSwine.java
@@ -66,7 +66,7 @@ class CurseOfTheSwineEffect extends OneShotEffect {
                 + "its controller creates a 2/2 green Boar creature token";
     }
 
-    public CurseOfTheSwineEffect(final CurseOfTheSwineEffect effect) {
+    private CurseOfTheSwineEffect(final CurseOfTheSwineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfVengeance.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfVengeance.java
@@ -67,7 +67,7 @@ class CurseOfVengeanceTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect, optional);
     }
 
-    public CurseOfVengeanceTriggeredAbility(final CurseOfVengeanceTriggeredAbility ability) {
+    private CurseOfVengeanceTriggeredAbility(final CurseOfVengeanceTriggeredAbility ability) {
         super(ability);
     }
 
@@ -107,7 +107,7 @@ class CurseOfVengeancePlayerLosesTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CurseOfVengeanceDrawLifeEffect(), false);
     }
 
-    public CurseOfVengeancePlayerLosesTriggeredAbility(final CurseOfVengeancePlayerLosesTriggeredAbility ability) {
+    private CurseOfVengeancePlayerLosesTriggeredAbility(final CurseOfVengeancePlayerLosesTriggeredAbility ability) {
         super(ability);
     }
 
@@ -142,7 +142,7 @@ class CurseOfVengeanceDrawLifeEffect extends OneShotEffect {
                 + "number of spite counters on {this}";
     }
 
-    public CurseOfVengeanceDrawLifeEffect(final CurseOfVengeanceDrawLifeEffect effect) {
+    private CurseOfVengeanceDrawLifeEffect(final CurseOfVengeanceDrawLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfWizardry.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfWizardry.java
@@ -51,7 +51,7 @@ class CurseOfWizardryPlayerCastsSpellChosenColorTriggeredAbility extends Trigger
         super(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), false);
     }
 
-    public CurseOfWizardryPlayerCastsSpellChosenColorTriggeredAbility(final CurseOfWizardryPlayerCastsSpellChosenColorTriggeredAbility ability) {
+    private CurseOfWizardryPlayerCastsSpellChosenColorTriggeredAbility(final CurseOfWizardryPlayerCastsSpellChosenColorTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CursedRack.java
+++ b/Mage.Sets/src/mage/cards/c/CursedRack.java
@@ -46,7 +46,7 @@ class CursedRackHandSizeEffect extends ContinuousEffectImpl {
         staticText = "The chosen player's maximum hand size is four";
     }
 
-    public CursedRackHandSizeEffect(final CursedRackHandSizeEffect effect) {
+    private CursedRackHandSizeEffect(final CursedRackHandSizeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CursedRonin.java
+++ b/Mage.Sets/src/mage/cards/c/CursedRonin.java
@@ -33,7 +33,7 @@ public final class CursedRonin extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn), new ColoredManaCost(ColoredManaSymbol.B)));
     }
 
-    public CursedRonin (final CursedRonin card) {
+    private CursedRonin(final CursedRonin card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CursedScroll.java
+++ b/Mage.Sets/src/mage/cards/c/CursedScroll.java
@@ -52,7 +52,7 @@ class CursedScrollEffect extends OneShotEffect {
         staticText = ", then reveal a card at random from your hand. If that card has the chosen name, {this} deals 2 damage to any target";
     }
 
-    public CursedScrollEffect(final CursedScrollEffect effect) {
+    private CursedScrollEffect(final CursedScrollEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CursedTotem.java
+++ b/Mage.Sets/src/mage/cards/c/CursedTotem.java
@@ -42,7 +42,7 @@ class CursedTotemCantActivateEffect extends RestrictionEffect {
         staticText = "Activated abilities of creatures can't be activated";
     }
 
-    public CursedTotemCantActivateEffect(final CursedTotemCantActivateEffect effect) {
+    private CursedTotemCantActivateEffect(final CursedTotemCantActivateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CustodyBattle.java
+++ b/Mage.Sets/src/mage/cards/c/CustodyBattle.java
@@ -81,7 +81,7 @@ class GiveControlEffect extends ContinuousEffectImpl {
         staticText = "Target opponent gains control of {this}";
     }
 
-    public GiveControlEffect(final GiveControlEffect effect) {
+    private GiveControlEffect(final GiveControlEffect effect) {
         super(effect);
     }
 
@@ -114,7 +114,7 @@ class CustodyBattleUnlessPaysEffect extends OneShotEffect {
         this.cost = cost;
     }
 
-    public CustodyBattleUnlessPaysEffect(final CustodyBattleUnlessPaysEffect effect) {
+    private CustodyBattleUnlessPaysEffect(final CustodyBattleUnlessPaysEffect effect) {
         super(effect);
         this.cost = effect.cost.copy();
     }

--- a/Mage.Sets/src/mage/cards/c/Cyclone.java
+++ b/Mage.Sets/src/mage/cards/c/Cyclone.java
@@ -52,7 +52,7 @@ class CycloneEffect extends OneShotEffect {
         this.staticText = "Pay Green Mana for each counter to damage everything or sacrifice Cyclone.";
     }
 
-    public CycloneEffect(final CycloneEffect effect) {
+    private CycloneEffect(final CycloneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CyclopsGladiator.java
+++ b/Mage.Sets/src/mage/cards/c/CyclopsGladiator.java
@@ -57,7 +57,7 @@ class CyclopsGladiatorEffect extends OneShotEffect {
         staticText = "you may have it deal damage equal to its power to target creature defending player controls. If you do, that creature deals damage equal to its power to {this}";
     }
 
-    public CyclopsGladiatorEffect(final CyclopsGladiatorEffect effect) {
+    private CyclopsGladiatorEffect(final CyclopsGladiatorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CylianElf.java
+++ b/Mage.Sets/src/mage/cards/c/CylianElf.java
@@ -24,7 +24,7 @@ public final class CylianElf extends CardImpl {
         this.toughness = new MageInt(2);
     }
 
-    public CylianElf (final CylianElf card) {
+    private CylianElf(final CylianElf card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Cytoshape.java
+++ b/Mage.Sets/src/mage/cards/c/Cytoshape.java
@@ -63,7 +63,7 @@ class CytoshapeEffect extends OneShotEffect {
         this.staticText = "Choose a nonlegendary creature on the battlefield. Target creature becomes a copy of that creature until end of turn.";
     }
 
-    public CytoshapeEffect(final CytoshapeEffect effect) {
+    private CytoshapeEffect(final CytoshapeEffect effect) {
         super(effect);
     }
 


### PR DESCRIPTION
Part of #11054 

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`public ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `private $1(final $1 $3`
