### PR TITLE
Clean public copy constructors in cards starting A-B

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AAT1.java
+++ b/Mage.Sets/src/mage/cards/a/AAT1.java
@@ -63,7 +63,7 @@ public final class AAT1 extends CardImpl {
             setTriggerPhrase("Whenever a repair counter is removed from a creature card in your graveyard ");
         }
 
-        public AAT1TriggeredAbility(AAT1TriggeredAbility ability) {
+        private AAT1TriggeredAbility(final AAT1TriggeredAbility ability) {
             super(ability);
         }
 

--- a/Mage.Sets/src/mage/cards/a/AJedisFervor.java
+++ b/Mage.Sets/src/mage/cards/a/AJedisFervor.java
@@ -51,7 +51,7 @@ class AJedisFervorEffect extends OneShotEffect {
         staticText = "If an opponent cast a black spell this turn, that player sacrifices a creature or planeswalker.";
     }
 
-    public AJedisFervorEffect(final AJedisFervorEffect effect) {
+    private AJedisFervorEffect(final AJedisFervorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AWing.java
+++ b/Mage.Sets/src/mage/cards/a/AWing.java
@@ -66,7 +66,7 @@ class AWingAttacksNextCombatIfAbleSourceEffect extends RequirementEffect {
         staticText = "It must attack on your next combat if able";
     }
 
-    public AWingAttacksNextCombatIfAbleSourceEffect(final AWingAttacksNextCombatIfAbleSourceEffect effect) {
+    private AWingAttacksNextCombatIfAbleSourceEffect(final AWingAttacksNextCombatIfAbleSourceEffect effect) {
         super(effect);
         this.turnNumber = effect.turnNumber;
         this.phaseCount = effect.phaseCount;

--- a/Mage.Sets/src/mage/cards/a/AbattoirGhoul.java
+++ b/Mage.Sets/src/mage/cards/a/AbattoirGhoul.java
@@ -51,7 +51,7 @@ class AbattoirGhoulEffect extends OneShotEffect {
         staticText = "you gain life equal to that creature's toughness";
     }
 
-    public AbattoirGhoulEffect(final AbattoirGhoulEffect effect) {
+    private AbattoirGhoulEffect(final AbattoirGhoulEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AberrantResearcher.java
+++ b/Mage.Sets/src/mage/cards/a/AberrantResearcher.java
@@ -55,7 +55,7 @@ class AberrantResearcherEffect extends OneShotEffect {
         staticText = "mill a card. If an instant or sorcery card was milled this way, transform {this}";
     }
 
-    public AberrantResearcherEffect(final AberrantResearcherEffect effect) {
+    private AberrantResearcherEffect(final AberrantResearcherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AbsorbIdentity.java
+++ b/Mage.Sets/src/mage/cards/a/AbsorbIdentity.java
@@ -53,7 +53,7 @@ class AbsorbIdentityEffect extends OneShotEffect {
         this.staticText = "You may have Shapeshifters you control become copies of that creature until end of turn.";
     }
 
-    public AbsorbIdentityEffect(final AbsorbIdentityEffect effect) {
+    private AbsorbIdentityEffect(final AbsorbIdentityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AbyssalHorror.java
+++ b/Mage.Sets/src/mage/cards/a/AbyssalHorror.java
@@ -33,7 +33,7 @@ public final class AbyssalHorror extends CardImpl {
         this.addAbility(ability);
     }
 
-    public AbyssalHorror (final AbyssalHorror card) {
+    private AbyssalHorror(final AbyssalHorror card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AcademyDrake.java
+++ b/Mage.Sets/src/mage/cards/a/AcademyDrake.java
@@ -34,7 +34,7 @@ public final class AcademyDrake extends CardImpl {
 
     }
 
-    public AcademyDrake(final AcademyDrake academyDrake) {
+    private AcademyDrake(final AcademyDrake academyDrake) {
         super(academyDrake);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AccorderPaladin.java
+++ b/Mage.Sets/src/mage/cards/a/AccorderPaladin.java
@@ -26,7 +26,7 @@ public final class AccorderPaladin extends CardImpl {
         this.addAbility(new BattleCryAbility());
     }
 
-    public AccorderPaladin (final AccorderPaladin card) {
+    private AccorderPaladin(final AccorderPaladin card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AccordersShield.java
+++ b/Mage.Sets/src/mage/cards/a/AccordersShield.java
@@ -30,7 +30,7 @@ public final class AccordersShield extends CardImpl {
 
     }
 
-    public AccordersShield (final AccordersShield card) {
+    private AccordersShield(final AccordersShield card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AcidWebSpider.java
+++ b/Mage.Sets/src/mage/cards/a/AcidWebSpider.java
@@ -38,7 +38,7 @@ public final class AcidWebSpider extends CardImpl {
         this.addAbility(ability);
     }
 
-    public AcidWebSpider (final AcidWebSpider card) {
+    private AcidWebSpider(final AcidWebSpider card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AcornCatapult.java
+++ b/Mage.Sets/src/mage/cards/a/AcornCatapult.java
@@ -52,7 +52,7 @@ class AcornCatapultEffect extends OneShotEffect {
         staticText = "that creature's controller or that player creates a 1/1 green Squirrel creature token";
     }
 
-    public AcornCatapultEffect(final AcornCatapultEffect effect) {
+    private AcornCatapultEffect(final AcornCatapultEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Acquire.java
+++ b/Mage.Sets/src/mage/cards/a/Acquire.java
@@ -52,7 +52,7 @@ class AcquireEffect extends OneShotEffect {
         staticText = "Search target opponent's library for an artifact card and put that card onto the battlefield under your control. Then that player shuffles";
     }
 
-    public AcquireEffect(final AcquireEffect effect) {
+    private AcquireEffect(final AcquireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Acridian.java
+++ b/Mage.Sets/src/mage/cards/a/Acridian.java
@@ -25,7 +25,7 @@ public final class Acridian extends CardImpl {
         this.addAbility(new EchoAbility("{1}{G}"));
     }
 
-    public Acridian (final Acridian card) {
+    private Acridian(final Acridian card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AdNauseam.java
+++ b/Mage.Sets/src/mage/cards/a/AdNauseam.java
@@ -43,7 +43,7 @@ class AdNauseamEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of your library and put that card into your hand. You lose life equal to its mana value. You may repeat this process any number of times";
     }
 
-    public AdNauseamEffect(final AdNauseamEffect effect) {
+    private AdNauseamEffect(final AdNauseamEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AdmiralAckbar.java
+++ b/Mage.Sets/src/mage/cards/a/AdmiralAckbar.java
@@ -65,7 +65,7 @@ class AdmiralAckbarTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect);
     }
 
-    public AdmiralAckbarTriggeredAbility(final AdmiralAckbarTriggeredAbility ability) {
+    private AdmiralAckbarTriggeredAbility(final AdmiralAckbarTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AegisOfHonor.java
+++ b/Mage.Sets/src/mage/cards/a/AegisOfHonor.java
@@ -57,7 +57,7 @@ class AegisOfHonorEffect extends RedirectionEffect {
         		+ "damage to you this turn, that spell deals that damage to its controller instead";
     }
 
-    public AegisOfHonorEffect(final AegisOfHonorEffect card) {
+    private AegisOfHonorEffect(final AegisOfHonorEffect card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AeonChronicler.java
+++ b/Mage.Sets/src/mage/cards/a/AeonChronicler.java
@@ -60,7 +60,7 @@ class AeonChroniclerTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a time counter is removed from {this} while it's exiled, " );
     }
 
-    public AeonChroniclerTriggeredAbility(final AeonChroniclerTriggeredAbility ability) {
+    private AeonChroniclerTriggeredAbility(final AeonChroniclerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AeonEngine.java
+++ b/Mage.Sets/src/mage/cards/a/AeonEngine.java
@@ -33,7 +33,7 @@ public final class AeonEngine extends CardImpl {
 	this.addAbility(ability);
     }
 
-    public AeonEngine(final AeonEngine card) {
+    private AeonEngine(final AeonEngine card) {
         super(card);
     }
 
@@ -49,7 +49,7 @@ class AeonEngineEffect extends OneShotEffect {
         this.staticText = "Reverse the game turn order.";
     }
 
-    public AeonEngineEffect(final AeonEngineEffect effect) {
+    private AeonEngineEffect(final AeonEngineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AerialExtortionist.java
+++ b/Mage.Sets/src/mage/cards/a/AerialExtortionist.java
@@ -70,7 +70,7 @@ class AerialExtortionistExileEffect extends OneShotEffect {
                 "For as long as that card remains exiled, its owner may cast it";
     }
 
-    public AerialExtortionistExileEffect(final AerialExtortionistExileEffect effect) {
+    private AerialExtortionistExileEffect(final AerialExtortionistExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AetherBurst.java
+++ b/Mage.Sets/src/mage/cards/a/AetherBurst.java
@@ -75,7 +75,7 @@ class DynamicTargetCreaturePermanent extends TargetPermanent {
         super(StaticFilters.FILTER_PERMANENT_CREATURES);
     }
 
-    public DynamicTargetCreaturePermanent(final DynamicTargetCreaturePermanent target) {
+    private DynamicTargetCreaturePermanent(final DynamicTargetCreaturePermanent target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AetherCharge.java
+++ b/Mage.Sets/src/mage/cards/a/AetherCharge.java
@@ -54,7 +54,7 @@ class AetherChargeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AetherChargeEffect(), true); // is optional
     }
 
-    public AetherChargeTriggeredAbility(AetherChargeTriggeredAbility ability) {
+    private AetherChargeTriggeredAbility(final AetherChargeTriggeredAbility ability) {
         super(ability);
     }
 
@@ -93,7 +93,7 @@ class AetherChargeEffect extends OneShotEffect {
         staticText = "you may have it deal 4 damage to target opponent or planeswalker";
     }
 
-    public AetherChargeEffect(final AetherChargeEffect effect) {
+    private AetherChargeEffect(final AetherChargeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AetherRift.java
+++ b/Mage.Sets/src/mage/cards/a/AetherRift.java
@@ -51,7 +51,7 @@ class AetherRiftEffect extends OneShotEffect {
         this.staticText = "discard a card at random. If you discard a creature card this way, return it from your graveyard to the battlefield unless any player pays 5 life";
     }
 
-    public AetherRiftEffect(final AetherRiftEffect effect) {
+    private AetherRiftEffect(final AetherRiftEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AetherSnap.java
+++ b/Mage.Sets/src/mage/cards/a/AetherSnap.java
@@ -47,7 +47,7 @@ class AetherSnapEffect extends OneShotEffect {
         this.staticText = "Remove all counters from all permanents and exile all tokens";
     }
 
-    public AetherSnapEffect(final AetherSnapEffect effect) {
+    private AetherSnapEffect(final AetherSnapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AetherSting.java
+++ b/Mage.Sets/src/mage/cards/a/AetherSting.java
@@ -43,7 +43,7 @@ class AetherStingTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(1), false);
     }
 
-    public AetherStingTriggeredAbility(final AetherStingTriggeredAbility ability) {
+    private AetherStingTriggeredAbility(final AetherStingTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AetherVial.java
+++ b/Mage.Sets/src/mage/cards/a/AetherVial.java
@@ -56,7 +56,7 @@ class AetherVialEffect extends OneShotEffect {
         this.staticText = "You may put a creature card with mana value equal to the number of charge counters on {this} from your hand onto the battlefield";
     }
 
-    public AetherVialEffect(final AetherVialEffect effect) {
+    private AetherVialEffect(final AetherVialEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AetherWeb.java
+++ b/Mage.Sets/src/mage/cards/a/AetherWeb.java
@@ -64,7 +64,7 @@ class AetherWebEffect extends AsThoughEffectImpl {
         staticText = ", and can block creatures with shadow as though they didn't have shadow";
     }
 
-    public AetherWebEffect(final AetherWebEffect effect) {
+    private AetherWebEffect(final AetherWebEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AetherbornMarauder.java
+++ b/Mage.Sets/src/mage/cards/a/AetherbornMarauder.java
@@ -60,7 +60,7 @@ class AetherbornMarauderEffect extends OneShotEffect {
         this.staticText = "move any number of +1/+1 counters from other permanents you control onto {this}";
     }
 
-    public AetherbornMarauderEffect(final AetherbornMarauderEffect effect) {
+    private AetherbornMarauderEffect(final AetherbornMarauderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AethermagesTouch.java
+++ b/Mage.Sets/src/mage/cards/a/AethermagesTouch.java
@@ -48,7 +48,7 @@ class AethermagesTouchEffect extends OneShotEffect {
         this.staticText = "Reveal the top four cards of your library. You may put a creature card from among them onto the battlefield. It gains \"At the beginning of your end step, return this creature to its owner's hand.\" Then put the rest of the cards revealed this way on the bottom of your library in any order";
     }
 
-    public AethermagesTouchEffect(final AethermagesTouchEffect effect) {
+    private AethermagesTouchEffect(final AethermagesTouchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Aetherplasm.java
+++ b/Mage.Sets/src/mage/cards/a/Aetherplasm.java
@@ -58,7 +58,7 @@ class AetherplasmEffect extends OneShotEffect {
         this.staticText = "you may put a creature card from your hand onto the battlefield blocking that creature";
     }
 
-    public AetherplasmEffect(AetherplasmEffect effect) {
+    private AetherplasmEffect(final AetherplasmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AffaGuardHound.java
+++ b/Mage.Sets/src/mage/cards/a/AffaGuardHound.java
@@ -34,7 +34,7 @@ public final class AffaGuardHound extends CardImpl {
         this.addAbility(ability);
     }
 
-    public AffaGuardHound (final AffaGuardHound card) {
+    private AffaGuardHound(final AffaGuardHound card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AfiyaGrove.java
+++ b/Mage.Sets/src/mage/cards/a/AfiyaGrove.java
@@ -60,7 +60,7 @@ class MoveCounterToTargetFromSourceEffect extends OneShotEffect {
         this.staticText = "move a +1/+1 counter from {this} onto target creature";
     }
 
-    public MoveCounterToTargetFromSourceEffect(final MoveCounterToTargetFromSourceEffect effect) {
+    private MoveCounterToTargetFromSourceEffect(final MoveCounterToTargetFromSourceEffect effect) {
         super(effect);
     }
 
@@ -92,7 +92,7 @@ class AfiyaGroveNoCountersAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new SacrificeSourceEffect());
     }
 
-    public AfiyaGroveNoCountersAbility(final AfiyaGroveNoCountersAbility ability) {
+    private AfiyaGroveNoCountersAbility(final AfiyaGroveNoCountersAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AgadeemOccultist.java
+++ b/Mage.Sets/src/mage/cards/a/AgadeemOccultist.java
@@ -58,7 +58,7 @@ class AgadeemOccultistEffect extends OneShotEffect {
         this.staticText = "Put target creature card from an opponent's graveyard onto the battlefield under your control if its mana value is less than or equal to the number of Allies you control";
     }
 
-    public AgadeemOccultistEffect(final AgadeemOccultistEffect effect) {
+    private AgadeemOccultistEffect(final AgadeemOccultistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AgelessEntity.java
+++ b/Mage.Sets/src/mage/cards/a/AgelessEntity.java
@@ -49,7 +49,7 @@ class AgelessEntityEffect extends OneShotEffect {
         this.staticText = "put that many +1/+1 counters on {this}";
     }
 
-    public AgelessEntityEffect(final AgelessEntityEffect effect) {
+    private AgelessEntityEffect(final AgelessEntityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AgentOfMasks.java
+++ b/Mage.Sets/src/mage/cards/a/AgentOfMasks.java
@@ -46,7 +46,7 @@ class AgentOfMasksEffect extends OneShotEffect {
         staticText = "each opponent loses 1 life. You gain life equal to the life lost this way";
     }
 
-    public AgentOfMasksEffect(final AgentOfMasksEffect effect) {
+    private AgentOfMasksEffect(final AgentOfMasksEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Aggravate.java
+++ b/Mage.Sets/src/mage/cards/a/Aggravate.java
@@ -50,7 +50,7 @@ class AggravateRequirementEffect extends RequirementEffect {
         this.staticText = "Each creature dealt damage this way attacks this turn if able";
     }
 
-    public AggravateRequirementEffect(final AggravateRequirementEffect effect) {
+    private AggravateRequirementEffect(final AggravateRequirementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AggressiveMining.java
+++ b/Mage.Sets/src/mage/cards/a/AggressiveMining.java
@@ -56,7 +56,7 @@ class AggressiveMiningEffect extends ContinuousRuleModifyingEffectImpl {
         this.staticText = "You can't play lands";
     }
     
-    public AggressiveMiningEffect(final AggressiveMiningEffect effect) {
+    private AggressiveMiningEffect(final AggressiveMiningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AgonizingMemories.java
+++ b/Mage.Sets/src/mage/cards/a/AgonizingMemories.java
@@ -48,7 +48,7 @@ class AgonizingMemoriesEffect extends OneShotEffect {
         this.staticText = "Look at target player's hand and choose two cards from it. Put them on top of that player's library in any order.";
     }
 
-    public AgonizingMemoriesEffect(final AgonizingMemoriesEffect effect) {
+    private AgonizingMemoriesEffect(final AgonizingMemoriesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AidFromTheCowl.java
+++ b/Mage.Sets/src/mage/cards/a/AidFromTheCowl.java
@@ -53,7 +53,7 @@ class AidFromTheCowlEffect extends OneShotEffect {
         this.staticText = "reveal the top card of your library. If it's a permanent card, you may put it onto the battlefield. Otherwise, you may put that card on the bottom of your library";
     }
 
-    public AidFromTheCowlEffect(final AidFromTheCowlEffect effect) {
+    private AidFromTheCowlEffect(final AidFromTheCowlEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AjanisChosen.java
+++ b/Mage.Sets/src/mage/cards/a/AjanisChosen.java
@@ -54,7 +54,7 @@ class AjanisChosenEffect extends OneShotEffect {
         staticText = "create a 2/2 white Cat creature token. If that enchantment is an Aura, you may attach it to the token";
     }
 
-    public AjanisChosenEffect(final AjanisChosenEffect effect) {
+    private AjanisChosenEffect(final AjanisChosenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AjanisLastStand.java
+++ b/Mage.Sets/src/mage/cards/a/AjanisLastStand.java
@@ -65,7 +65,7 @@ class AjanisLastStandTriggeredAbility extends TriggeredAbilityImpl {
         ), false);
     }
 
-    public AjanisLastStandTriggeredAbility(final AjanisLastStandTriggeredAbility ability) {
+    private AjanisLastStandTriggeredAbility(final AjanisLastStandTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AkkiLavarunner.java
+++ b/Mage.Sets/src/mage/cards/a/AkkiLavarunner.java
@@ -57,7 +57,7 @@ class AkkiLavarunnerAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new FlipSourceEffect(new TokTokVolcanoBorn()));
     }
 
-    public AkkiLavarunnerAbility(final AkkiLavarunnerAbility ability) {
+    private AkkiLavarunnerAbility(final AkkiLavarunnerAbility ability) {
         super(ability);
     }
 
@@ -96,7 +96,7 @@ class TokTokVolcanoBorn extends TokenImpl {
         this.addAbility(ProtectionAbility.from(ObjectColor.RED));
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new TokTokVolcanoBornEffect()));
     }
-    public TokTokVolcanoBorn(final TokTokVolcanoBorn token) {
+    private TokTokVolcanoBorn(final TokTokVolcanoBorn token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AkkiUnderminer.java
+++ b/Mage.Sets/src/mage/cards/a/AkkiUnderminer.java
@@ -29,7 +29,7 @@ public final class AkkiUnderminer extends CardImpl {
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new SacrificeEffect(new FilterPermanent(), 1, "that player"), false, true));
     }
 
-    public AkkiUnderminer (final AkkiUnderminer card) {
+    private AkkiUnderminer(final AkkiUnderminer card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AkoumFirebird.java
+++ b/Mage.Sets/src/mage/cards/a/AkoumFirebird.java
@@ -68,7 +68,7 @@ class AkoumFirebirdLandfallAbility extends TriggeredAbilityImpl {
         super(zone, effect, optional);
     }
 
-    public AkoumFirebirdLandfallAbility(final AkoumFirebirdLandfallAbility ability) {
+    private AkoumFirebirdLandfallAbility(final AkoumFirebirdLandfallAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AkoumFlameseeker.java
+++ b/Mage.Sets/src/mage/cards/a/AkoumFlameseeker.java
@@ -64,7 +64,7 @@ class AkoumFlameseekerEffect extends OneShotEffect {
         this.staticText = "Discard a card. If you do, draw a card";
     }
 
-    public AkoumFlameseekerEffect(final AkoumFlameseekerEffect effect) {
+    private AkoumFlameseekerEffect(final AkoumFlameseekerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AkoumHellkite.java
+++ b/Mage.Sets/src/mage/cards/a/AkoumHellkite.java
@@ -106,7 +106,7 @@ class AkoumHellkiteDamageEffect extends OneShotEffect {
         super(Outcome.Damage);
     }
 
-    public AkoumHellkiteDamageEffect(final AkoumHellkiteDamageEffect effect) {
+    private AkoumHellkiteDamageEffect(final AkoumHellkiteDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AkoumStonewaker.java
+++ b/Mage.Sets/src/mage/cards/a/AkoumStonewaker.java
@@ -53,7 +53,7 @@ class AkoumStonewakerEffect extends OneShotEffect {
         this.staticText = "create a 3/1 red Elemental creature token with trample and haste. Exile that token at the beginning of the next end step";
     }
 
-    public AkoumStonewakerEffect(final AkoumStonewakerEffect effect) {
+    private AkoumStonewakerEffect(final AkoumStonewakerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AkrasanSquire.java
+++ b/Mage.Sets/src/mage/cards/a/AkrasanSquire.java
@@ -26,7 +26,7 @@ public final class AkrasanSquire extends CardImpl {
         this.addAbility(new ExaltedAbility());
     }
 
-    public AkrasanSquire (final AkrasanSquire card) {
+    private AkrasanSquire(final AkrasanSquire card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AkroanHorse.java
+++ b/Mage.Sets/src/mage/cards/a/AkroanHorse.java
@@ -100,7 +100,7 @@ class AkroanHorseGainControlEffect extends ContinuousEffectImpl {
         this.staticText = "Gain control of Akroan Horse";
     }
 
-    public AkroanHorseGainControlEffect(final AkroanHorseGainControlEffect effect) {
+    private AkroanHorseGainControlEffect(final AkroanHorseGainControlEffect effect) {
         super(effect);
         this.controller = effect.controller;
     }

--- a/Mage.Sets/src/mage/cards/a/AladdinsLamp.java
+++ b/Mage.Sets/src/mage/cards/a/AladdinsLamp.java
@@ -57,7 +57,7 @@ class AladdinsLampEffect extends ReplacementEffectImpl {
         staticText = "The next time you would draw a card this turn, instead look at the top X cards of your library, put all but one of them on the bottom of your library in a random order, then draw a card. X can't be 0.";
     }
 
-    public AladdinsLampEffect(final AladdinsLampEffect effect) {
+    private AladdinsLampEffect(final AladdinsLampEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AlchemistsGambit.java
+++ b/Mage.Sets/src/mage/cards/a/AlchemistsGambit.java
@@ -71,7 +71,7 @@ class AlchemistsGambitEffect extends ReplacementEffectImpl {
         this.turnId = turnId;
     }
 
-    public AlchemistsGambitEffect(final AlchemistsGambitEffect effect) {
+    private AlchemistsGambitEffect(final AlchemistsGambitEffect effect) {
         super(effect);
         this.turnId = effect.turnId;
     }

--- a/Mage.Sets/src/mage/cards/a/Aleatory.java
+++ b/Mage.Sets/src/mage/cards/a/Aleatory.java
@@ -58,7 +58,7 @@ class AleatoryEffect extends OneShotEffect {
         staticText = "Flip a coin. If you win the flip, target creature gets +1/+1 until end of turn";
     }
 
-    public AleatoryEffect(AleatoryEffect effect) {
+    private AleatoryEffect(final AleatoryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AlhammarretHighArbiter.java
+++ b/Mage.Sets/src/mage/cards/a/AlhammarretHighArbiter.java
@@ -60,7 +60,7 @@ class AlhammarretHighArbiterEffect extends OneShotEffect {
                 + "<br>Your opponents can't cast spells with the chosen name";
     }
 
-    public AlhammarretHighArbiterEffect(final AlhammarretHighArbiterEffect effect) {
+    private AlhammarretHighArbiterEffect(final AlhammarretHighArbiterEffect effect) {
         super(effect);
     }
 
@@ -114,7 +114,7 @@ class AlhammarretHighArbiterCantCastEffect extends ContinuousRuleModifyingEffect
         staticText = "Your opponents can't cast spells with the chosen name";
     }
 
-    public AlhammarretHighArbiterCantCastEffect(final AlhammarretHighArbiterCantCastEffect effect) {
+    private AlhammarretHighArbiterCantCastEffect(final AlhammarretHighArbiterCantCastEffect effect) {
         super(effect);
         this.cardName = effect.cardName;
         this.zoneChangeCounter = effect.zoneChangeCounter;

--- a/Mage.Sets/src/mage/cards/a/AliFromCairo.java
+++ b/Mage.Sets/src/mage/cards/a/AliFromCairo.java
@@ -48,7 +48,7 @@ class AliFromCairoReplacementEffect extends ReplacementEffectImpl {
         staticText = "Damage that would reduce your life total to less than 1 reduces it to 1 instead";
     }
 
-    public AliFromCairoReplacementEffect(final AliFromCairoReplacementEffect effect) {
+    private AliFromCairoReplacementEffect(final AliFromCairoReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AlignedHedronNetwork.java
+++ b/Mage.Sets/src/mage/cards/a/AlignedHedronNetwork.java
@@ -57,7 +57,7 @@ class AlignedHedronNetworkExileEffect extends OneShotEffect {
         this.staticText = "exile all creatures with power 5 or greater until {this} leaves the battlefield";
     }
 
-    public AlignedHedronNetworkExileEffect(final AlignedHedronNetworkExileEffect effect) {
+    private AlignedHedronNetworkExileEffect(final AlignedHedronNetworkExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AliveWell.java
+++ b/Mage.Sets/src/mage/cards/a/AliveWell.java
@@ -53,7 +53,7 @@ class WellEffect extends OneShotEffect {
         staticText = "You gain 2 life for each creature you control";
     }
 
-    public WellEffect(final WellEffect effect) {
+    private WellEffect(final WellEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AllianceOfArms.java
+++ b/Mage.Sets/src/mage/cards/a/AllianceOfArms.java
@@ -48,7 +48,7 @@ class AllianceOfArmsEffect extends OneShotEffect {
                 "creates X 1/1 white Soldier creature tokens, where X is the total amount of mana paid this way";
     }
 
-    public AllianceOfArmsEffect(final AllianceOfArmsEffect effect) {
+    private AllianceOfArmsEffect(final AllianceOfArmsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AlmsCollector.java
+++ b/Mage.Sets/src/mage/cards/a/AlmsCollector.java
@@ -55,7 +55,7 @@ class AlmsCollectorReplacementEffect extends ReplacementEffectImpl {
         staticText = "If an opponent would draw two or more cards, instead you and that player each draw a card";
     }
 
-    public AlmsCollectorReplacementEffect(final AlmsCollectorReplacementEffect effect) {
+    private AlmsCollectorReplacementEffect(final AlmsCollectorReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AlphaAuthority.java
+++ b/Mage.Sets/src/mage/cards/a/AlphaAuthority.java
@@ -70,7 +70,7 @@ class CantBeBlockedByMoreThanOneAttachedEffect extends ContinuousEffectImpl {
         staticText = attachmentType.verb() + " creature can't be blocked by more than " + CardUtil.numberToText(amount) + " creature" + (amount == 1 ? "" : "s");
     }
 
-    public CantBeBlockedByMoreThanOneAttachedEffect(final CantBeBlockedByMoreThanOneAttachedEffect effect) {
+    private CantBeBlockedByMoreThanOneAttachedEffect(final CantBeBlockedByMoreThanOneAttachedEffect effect) {
         super(effect);
         this.amount = effect.amount;
         this.attachmentType = effect.attachmentType;

--- a/Mage.Sets/src/mage/cards/a/AlphaBrawl.java
+++ b/Mage.Sets/src/mage/cards/a/AlphaBrawl.java
@@ -48,7 +48,7 @@ class AlphaBrawlEffect extends OneShotEffect {
         staticText = "Target creature an opponent controls deals damage equal to its power to each other creature that player controls, then each of those creatures deals damage equal to its power to that creature";
     }
 
-    public AlphaBrawlEffect(final AlphaBrawlEffect effect) {
+    private AlphaBrawlEffect(final AlphaBrawlEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AlpineMoon.java
+++ b/Mage.Sets/src/mage/cards/a/AlpineMoon.java
@@ -59,7 +59,7 @@ class AlpineMoonEffect extends ContinuousEffectImpl {
                 + "and they gain \"{T}: Add one mana of any color.\"";
     }
 
-    public AlpineMoonEffect(final AlpineMoonEffect effect) {
+    private AlpineMoonEffect(final AlpineMoonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AlrundGodOfTheCosmos.java
+++ b/Mage.Sets/src/mage/cards/a/AlrundGodOfTheCosmos.java
@@ -89,7 +89,7 @@ class AlrundGodOfTheCosmosEffect extends OneShotEffect {
         staticText = ", then reveal the top two cards of your library. Put all cards of the chosen type revealed this way into your hand and the rest on the bottom of your library in any order";
     }
 
-    public AlrundGodOfTheCosmosEffect(final AlrundGodOfTheCosmosEffect effect) {
+    private AlrundGodOfTheCosmosEffect(final AlrundGodOfTheCosmosEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AltarOfDementia.java
+++ b/Mage.Sets/src/mage/cards/a/AltarOfDementia.java
@@ -51,7 +51,7 @@ class AltarOfDementiaEffect extends OneShotEffect {
         staticText = "Target player mills cards equal to the sacrificed creature's power";
     }
 
-    public AltarOfDementiaEffect(final AltarOfDementiaEffect effect) {
+    private AltarOfDementiaEffect(final AltarOfDementiaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AltarOfShadows.java
+++ b/Mage.Sets/src/mage/cards/a/AltarOfShadows.java
@@ -60,7 +60,7 @@ class AltarOfShadowsEffect extends OneShotEffect {
         this.staticText = "add {B} for each charge counter on Altar of Shadows";
     }
 
-    public AltarOfShadowsEffect(final AltarOfShadowsEffect effect) {
+    private AltarOfShadowsEffect(final AltarOfShadowsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Aluren.java
+++ b/Mage.Sets/src/mage/cards/a/Aluren.java
@@ -77,7 +77,7 @@ class AlurenRuleEffect extends ContinuousEffectImpl {
         staticText = "Any player may cast creature cards with mana value 3 or less without paying their mana cost";
     }
 
-    public AlurenRuleEffect(final AlurenRuleEffect effect) {
+    private AlurenRuleEffect(final AlurenRuleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AmassTheComponents.java
+++ b/Mage.Sets/src/mage/cards/a/AmassTheComponents.java
@@ -47,7 +47,7 @@ class AmassTheComponentsEffect extends OneShotEffect {
         this.staticText = "Draw three cards, then put a card from your hand on the bottom of your library";
     }
 
-    public AmassTheComponentsEffect(final AmassTheComponentsEffect effect) {
+    private AmassTheComponentsEffect(final AmassTheComponentsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AminatouTheFateshifter.java
+++ b/Mage.Sets/src/mage/cards/a/AminatouTheFateshifter.java
@@ -81,7 +81,7 @@ class AminatouPlusEffect extends OneShotEffect {
         staticText = "draw a card, then put a card from your hand on top of your library";
     }
 
-    public AminatouPlusEffect(final AminatouPlusEffect effect) {
+    private AminatouPlusEffect(final AminatouPlusEffect effect) {
         super(effect);
     }
 
@@ -122,7 +122,7 @@ class AminatouUltimateEffect extends OneShotEffect {
                 + " the Fateshifter controlled by the next player in the chosen direction.";
     }
 
-    public AminatouUltimateEffect(final AminatouUltimateEffect effect) {
+    private AminatouUltimateEffect(final AminatouUltimateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -66,7 +66,7 @@ class AminatousAuguryEffect extends OneShotEffect {
                 + "you may cast a spell of that type from among the exiled cards without paying its mana cost.";
     }
 
-    public AminatousAuguryEffect(final AminatousAuguryEffect effect) {
+    private AminatousAuguryEffect(final AminatousAuguryEffect effect) {
         super(effect);
     }
 
@@ -142,7 +142,7 @@ class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
         staticText = "Cast this card without paying its mana cost";
     }
 
-    public AminatousAuguryCastFromExileEffect(final AminatousAuguryCastFromExileEffect effect) {
+    private AminatousAuguryCastFromExileEffect(final AminatousAuguryCastFromExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AmmitEternal.java
+++ b/Mage.Sets/src/mage/cards/a/AmmitEternal.java
@@ -33,7 +33,7 @@ public final class AmmitEternal extends CardImpl {
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new RemoveAllCountersSourceEffect(CounterType.M1M1), false));
     }
 
-    public AmmitEternal(final AmmitEternal ammitEternal) {
+    private AmmitEternal(final AmmitEternal ammitEternal) {
         super(ammitEternal);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Amnesia.java
+++ b/Mage.Sets/src/mage/cards/a/Amnesia.java
@@ -42,7 +42,7 @@ class AmnesiaEffect extends OneShotEffect {
         this.staticText = "Target player reveals their hand and discards all nonland cards";
     }
 
-    public AmnesiaEffect(final AmnesiaEffect effect) {
+    private AmnesiaEffect(final AmnesiaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnHavvaConstable.java
+++ b/Mage.Sets/src/mage/cards/a/AnHavvaConstable.java
@@ -49,7 +49,7 @@ class AnHavvaConstableEffect extends ContinuousEffectImpl {
         staticText = "{this}'s toughness is equal to 1 plus the number of green creatures on the battlefield";
     }
 
-    public AnHavvaConstableEffect(final AnHavvaConstableEffect effect) {
+    private AnHavvaConstableEffect(final AnHavvaConstableEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnHavvaInn.java
+++ b/Mage.Sets/src/mage/cards/a/AnHavvaInn.java
@@ -44,7 +44,7 @@ class AnHavvaInnEffect extends OneShotEffect {
         staticText = "You gain X plus 1 life, where X is the number of green creatures on the battlefield";
     }
 
-    public AnHavvaInnEffect(final AnHavvaInnEffect effect) {
+    private AnHavvaInnEffect(final AnHavvaInnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnZerrinRuins.java
+++ b/Mage.Sets/src/mage/cards/a/AnZerrinRuins.java
@@ -49,7 +49,7 @@ class AnZerrinRuinsDontUntapEffect extends DontUntapInControllersUntapStepAllEff
         this.staticText = "Creatures of the chosen type don't untap during their controllers' untap steps";
     }
 
-    public AnZerrinRuinsDontUntapEffect(final AnZerrinRuinsDontUntapEffect effect) {
+    private AnZerrinRuinsDontUntapEffect(final AnZerrinRuinsDontUntapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnaBattlemage.java
+++ b/Mage.Sets/src/mage/cards/a/AnaBattlemage.java
@@ -75,7 +75,7 @@ class AnaBattlemageKickerEffect extends OneShotEffect {
         this.staticText = "tap target untapped creature and it deals damage equal to its power to its controller";
     }
 
-    public AnaBattlemageKickerEffect(final AnaBattlemageKickerEffect effect) {
+    private AnaBattlemageKickerEffect(final AnaBattlemageKickerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Anaconda.java
+++ b/Mage.Sets/src/mage/cards/a/Anaconda.java
@@ -25,7 +25,7 @@ public final class Anaconda extends CardImpl {
         this.addAbility(new SwampwalkAbility());
     }
 
-    public Anaconda (final Anaconda card) {
+    private Anaconda(final Anaconda card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnafenzaTheForemost.java
+++ b/Mage.Sets/src/mage/cards/a/AnafenzaTheForemost.java
@@ -72,7 +72,7 @@ class AnafenzaTheForemostEffect extends ReplacementEffectImpl {
         staticText = "If a nontoken creature an opponent owns would die or a creature card not on the battlefield would be put into an opponent's graveyard, exile that card instead";
     }
 
-    public AnafenzaTheForemostEffect(final AnafenzaTheForemostEffect effect) {
+    private AnafenzaTheForemostEffect(final AnafenzaTheForemostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AncestorDragon.java
+++ b/Mage.Sets/src/mage/cards/a/AncestorDragon.java
@@ -53,7 +53,7 @@ class AncestorDragonEffect extends OneShotEffect {
         staticText = "you gain 1 life for each attacking creature";
     }
 
-    public AncestorDragonEffect(final AncestorDragonEffect effect) {
+    private AncestorDragonEffect(final AncestorDragonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AncientDen.java
+++ b/Mage.Sets/src/mage/cards/a/AncientDen.java
@@ -19,7 +19,7 @@ public final class AncientDen extends CardImpl {
         this.addAbility(new WhiteManaAbility());
     }
 
-    public AncientDen (final AncientDen card) {
+    private AncientDen(final AncientDen card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AncientExcavation.java
+++ b/Mage.Sets/src/mage/cards/a/AncientExcavation.java
@@ -48,7 +48,7 @@ class AncientExcavationEffect extends OneShotEffect {
         staticText = "Draw cards equal to the number of cards in your hand, then discard a card for each card drawn this way";
     }
 
-    public AncientExcavationEffect(final AncientExcavationEffect effect) {
+    private AncientExcavationEffect(final AncientExcavationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AncientRunes.java
+++ b/Mage.Sets/src/mage/cards/a/AncientRunes.java
@@ -45,7 +45,7 @@ class AncientRunesDamageTargetEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to that player equal to the number of artifacts they control";
     }
 
-    public AncientRunesDamageTargetEffect(AncientRunesDamageTargetEffect copy) {
+    private AncientRunesDamageTargetEffect(final AncientRunesDamageTargetEffect copy) {
         super(copy);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelOfDeliverance.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfDeliverance.java
@@ -63,7 +63,7 @@ class AngelOfDeliveranceDealsDamageTriggeredAbility extends TriggeredAbilityImpl
         super(Zone.BATTLEFIELD, new ExileTargetEffect(), false);
     }
 
-    public AngelOfDeliveranceDealsDamageTriggeredAbility(final AngelOfDeliveranceDealsDamageTriggeredAbility ability) {
+    private AngelOfDeliveranceDealsDamageTriggeredAbility(final AngelOfDeliveranceDealsDamageTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelOfDespair.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfDespair.java
@@ -33,7 +33,7 @@ public final class AngelOfDespair extends CardImpl {
         this.addAbility(ability);
     }
 
-    public AngelOfDespair (final AngelOfDespair card) {
+    private AngelOfDespair(final AngelOfDespair card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelOfGlorysRise.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfGlorysRise.java
@@ -58,7 +58,7 @@ class AngelOfGlorysRiseEffect extends OneShotEffect {
         staticText = "exile all Zombies, then return all Human creature cards from your graveyard to the battlefield";
     }
 
-    public AngelOfGlorysRiseEffect(final AngelOfGlorysRiseEffect effect) {
+    private AngelOfGlorysRiseEffect(final AngelOfGlorysRiseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelOfJubilation.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfJubilation.java
@@ -62,7 +62,7 @@ class AngelOfJubilationEffect extends ContinuousEffectImpl {
         staticText = "Players can't pay life or sacrifice creatures to cast spells";
     }
 
-    public AngelOfJubilationEffect(final AngelOfJubilationEffect effect) {
+    private AngelOfJubilationEffect(final AngelOfJubilationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelheartVial.java
+++ b/Mage.Sets/src/mage/cards/a/AngelheartVial.java
@@ -57,7 +57,7 @@ class AngelheartVialTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AngelheartVialEffect(), true);
     }
 
-    public AngelheartVialTriggeredAbility(final AngelheartVialTriggeredAbility ability) {
+    private AngelheartVialTriggeredAbility(final AngelheartVialTriggeredAbility ability) {
         super(ability);
     }
 
@@ -92,7 +92,7 @@ class AngelheartVialEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public AngelheartVialEffect(final AngelheartVialEffect effect) {
+    private AngelheartVialEffect(final AngelheartVialEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelicArbiter.java
+++ b/Mage.Sets/src/mage/cards/a/AngelicArbiter.java
@@ -58,7 +58,7 @@ class AngelicArbiterCantAttackTargetEffect extends RestrictionEffect {
         staticText = "Each opponent who cast a spell this turn can't attack with creatures";
     }
 
-    public AngelicArbiterCantAttackTargetEffect(final AngelicArbiterCantAttackTargetEffect effect) {
+    private AngelicArbiterCantAttackTargetEffect(final AngelicArbiterCantAttackTargetEffect effect) {
         super(effect);
     }
 
@@ -89,7 +89,7 @@ class AngelicArbiterEffect2 extends ContinuousRuleModifyingEffectImpl {
         staticText = "Each opponent who attacked with a creature this turn can't cast spells";
     }
 
-    public AngelicArbiterEffect2(final AngelicArbiterEffect2 effect) {
+    private AngelicArbiterEffect2(final AngelicArbiterEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelicChorus.java
+++ b/Mage.Sets/src/mage/cards/a/AngelicChorus.java
@@ -43,7 +43,7 @@ class AngelicChorusTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AngelicChorusEffect(), false);
     }
 
-    public AngelicChorusTriggeredAbility(AngelicChorusTriggeredAbility ability) {
+    private AngelicChorusTriggeredAbility(final AngelicChorusTriggeredAbility ability) {
         super(ability);
     }
 
@@ -82,7 +82,7 @@ class AngelicChorusEffect extends OneShotEffect {
         staticText = "you gain life equal to its toughness";
     }
 
-    public AngelicChorusEffect(final AngelicChorusEffect effect) {
+    private AngelicChorusEffect(final AngelicChorusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelicFavor.java
+++ b/Mage.Sets/src/mage/cards/a/AngelicFavor.java
@@ -70,7 +70,7 @@ class AngelicFavorEffect extends OneShotEffect {
         this.staticText = "Create a 4/4 white Angel creature token with flying. Exile it at the beginning of the next end step";
     }
 
-    public AngelicFavorEffect(final AngelicFavorEffect effect) {
+    private AngelicFavorEffect(final AngelicFavorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelicGuardian.java
+++ b/Mage.Sets/src/mage/cards/a/AngelicGuardian.java
@@ -59,7 +59,7 @@ class AngelicGuardianGainEffect extends OneShotEffect {
         staticText = "they gain indestructible until end of turn";
     }
 
-    public AngelicGuardianGainEffect(final AngelicGuardianGainEffect effect) {
+    private AngelicGuardianGainEffect(final AngelicGuardianGainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelsGrace.java
+++ b/Mage.Sets/src/mage/cards/a/AngelsGrace.java
@@ -53,7 +53,7 @@ class AngelsGraceEffect extends ContinuousRuleModifyingEffectImpl {
                 + "and your opponents can't win the game this turn";
     }
 
-    public AngelsGraceEffect(final AngelsGraceEffect effect) {
+    private AngelsGraceEffect(final AngelsGraceEffect effect) {
         super(effect);
     }
 
@@ -85,7 +85,7 @@ class AngelsGraceReplacementEffect extends ReplacementEffectImpl {
                 + "life total to less than 1 reduces it to 1 instead";
     }
 
-    public AngelsGraceReplacementEffect(final AngelsGraceReplacementEffect effect) {
+    private AngelsGraceReplacementEffect(final AngelsGraceReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngrathMinotaurPirate.java
+++ b/Mage.Sets/src/mage/cards/a/AngrathMinotaurPirate.java
@@ -79,7 +79,7 @@ class AngrathMinotaurPirateThirdAbilityEffect extends OneShotEffect {
         this.staticText = "Destroy all creature target opponent controls. {this} deals damage to that player equal to their total power";
     }
 
-    public AngrathMinotaurPirateThirdAbilityEffect(final AngrathMinotaurPirateThirdAbilityEffect effect) {
+    private AngrathMinotaurPirateThirdAbilityEffect(final AngrathMinotaurPirateThirdAbilityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngrathTheFlameChained.java
+++ b/Mage.Sets/src/mage/cards/a/AngrathTheFlameChained.java
@@ -77,7 +77,7 @@ class AngrathTheFlameUltimateEffect extends OneShotEffect {
         this.staticText = "Each opponent loses life equal to the number of cards in their graveyard";
     }
 
-    public AngrathTheFlameUltimateEffect(final AngrathTheFlameUltimateEffect effect) {
+    private AngrathTheFlameUltimateEffect(final AngrathTheFlameUltimateEffect effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class AngrathTheFlameCreateDelayedTriggerEffect extends OneShotEffect {
         staticText = "Sacrifice it at the beginning of the next end step if it has mana value 3 or less";
     }
 
-    public AngrathTheFlameCreateDelayedTriggerEffect(final AngrathTheFlameCreateDelayedTriggerEffect effect) {
+    private AngrathTheFlameCreateDelayedTriggerEffect(final AngrathTheFlameCreateDelayedTriggerEffect effect) {
         super(effect);
     }
 
@@ -134,7 +134,7 @@ class AngrathTheFlameChainedDelayedTriggeredAbility extends DelayedTriggeredAbil
         super(effect, Duration.Custom);
     }
 
-    public AngrathTheFlameChainedDelayedTriggeredAbility(final AngrathTheFlameChainedDelayedTriggeredAbility ability) {
+    private AngrathTheFlameChainedDelayedTriggeredAbility(final AngrathTheFlameChainedDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngrathsMarauders.java
+++ b/Mage.Sets/src/mage/cards/a/AngrathsMarauders.java
@@ -52,7 +52,7 @@ class AngrathsMaraudersEffect extends ReplacementEffectImpl {
         staticText = "If a source you control would deal damage to a permanent or player, it deals double that damage to that permanent or player instead";
     }
 
-    public AngrathsMaraudersEffect(final AngrathsMaraudersEffect effect) {
+    private AngrathsMaraudersEffect(final AngrathsMaraudersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnimalBoneyard.java
+++ b/Mage.Sets/src/mage/cards/a/AnimalBoneyard.java
@@ -64,7 +64,7 @@ class AnimalBoneyardEffect extends OneShotEffect {
         staticText = "You gain life equal to that creature's toughness";
     }
 
-    public AnimalBoneyardEffect(final AnimalBoneyardEffect effect) {
+    private AnimalBoneyardEffect(final AnimalBoneyardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnimalMagnetism.java
+++ b/Mage.Sets/src/mage/cards/a/AnimalMagnetism.java
@@ -45,7 +45,7 @@ class AnimalMagnetismEffect extends OneShotEffect {
         this.staticText = "Reveal the top five cards of your library. An opponent chooses a creature card from among them. Put that card onto the battlefield and the rest into your graveyard";
     }
 
-    public AnimalMagnetismEffect(final AnimalMagnetismEffect effect) {
+    private AnimalMagnetismEffect(final AnimalMagnetismEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnimateArtifact.java
+++ b/Mage.Sets/src/mage/cards/a/AnimateArtifact.java
@@ -62,7 +62,7 @@ class AnimateArtifactContinuousEffect extends ContinuousEffectImpl {
         staticText = "As long as enchanted artifact isn't a creature, it's an artifact creature with power and toughness each equal to its mana value";
     }
 
-    public AnimateArtifactContinuousEffect(final AnimateArtifactContinuousEffect effect) {
+    private AnimateArtifactContinuousEffect(final AnimateArtifactContinuousEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnimistsAwakening.java
+++ b/Mage.Sets/src/mage/cards/a/AnimistsAwakening.java
@@ -49,7 +49,7 @@ class AnimistsAwakeningEffect extends OneShotEffect {
                 + "<br><i>Spell mastery</i> &mdash; If there are two or more instant and/or sorcery cards in your graveyard, untap those lands";
     }
 
-    public AnimistsAwakeningEffect(final AnimistsAwakeningEffect effect) {
+    private AnimistsAwakeningEffect(final AnimistsAwakeningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnthemOfRakdos.java
+++ b/Mage.Sets/src/mage/cards/a/AnthemOfRakdos.java
@@ -58,7 +58,7 @@ class AnthemOfRakdosHellbentEffect extends ReplacementEffectImpl {
         staticText = "<i>Hellbent</i> &mdash; As long as you have no cards in hand, if a source you control would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.";
     }
 
-    public AnthemOfRakdosHellbentEffect(final AnthemOfRakdosHellbentEffect effect) {
+    private AnthemOfRakdosHellbentEffect(final AnthemOfRakdosHellbentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AntiMagicAura.java
+++ b/Mage.Sets/src/mage/cards/a/AntiMagicAura.java
@@ -61,7 +61,7 @@ class AntiMagicAuraRuleEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "and can't be enchanted by other Auras";
     }
 
-    public AntiMagicAuraRuleEffect(final AntiMagicAuraRuleEffect effect) {
+    private AntiMagicAuraRuleEffect(final AntiMagicAuraRuleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnvilOfBogardan.java
+++ b/Mage.Sets/src/mage/cards/a/AnvilOfBogardan.java
@@ -44,7 +44,7 @@ public final class AnvilOfBogardan extends CardImpl {
 
 class AnvilOfBogardanEffect extends OneShotEffect {
     
-    public AnvilOfBogardanEffect(final AnvilOfBogardanEffect effect) {
+    private AnvilOfBogardanEffect(final AnvilOfBogardanEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/a/ApexOfPower.java
+++ b/Mage.Sets/src/mage/cards/a/ApexOfPower.java
@@ -54,7 +54,7 @@ class ApexOfPowerSpellEffect extends OneShotEffect {
                 "Until end of turn, you may cast spells from among them";
     }
 
-    public ApexOfPowerSpellEffect(final ApexOfPowerSpellEffect effect) {
+    private ApexOfPowerSpellEffect(final ApexOfPowerSpellEffect effect) {
         super(effect);
     }
 
@@ -94,7 +94,7 @@ class ApexOfPowerManaEffect extends OneShotEffect {
         this.staticText = "If this spell was cast from your hand, add ten mana of any one color.";
     }
 
-    public ApexOfPowerManaEffect(final ApexOfPowerManaEffect effect) {
+    private ApexOfPowerManaEffect(final ApexOfPowerManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ApostlesBlessing.java
+++ b/Mage.Sets/src/mage/cards/a/ApostlesBlessing.java
@@ -61,7 +61,7 @@ class ApostlesBlessingEffect extends OneShotEffect {
         this.staticText = "Target artifact or creature you control gains protection from artifacts or from the color of your choice until end of turn";
     }
 
-    public ApostlesBlessingEffect(final ApostlesBlessingEffect effect) {
+    private ApostlesBlessingEffect(final ApostlesBlessingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ApprenticeNecromancer.java
+++ b/Mage.Sets/src/mage/cards/a/ApprenticeNecromancer.java
@@ -65,7 +65,7 @@ class ApprenticeNecromancerEffect extends OneShotEffect {
         this.staticText = "Return target creature card from your graveyard to the battlefield. That creature gains haste. At the beginning of the next end step, sacrifice it";
     }
 
-    public ApprenticeNecromancerEffect(final ApprenticeNecromancerEffect effect) {
+    private ApprenticeNecromancerEffect(final ApprenticeNecromancerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ApproachOfTheSecondSun.java
+++ b/Mage.Sets/src/mage/cards/a/ApproachOfTheSecondSun.java
@@ -52,7 +52,7 @@ class ApproachOfTheSecondSunEffect extends OneShotEffect {
                 + "Otherwise, put {this} into its owner's library seventh from the top and you gain 7 life.";
     }
 
-    public ApproachOfTheSecondSunEffect(final ApproachOfTheSecondSunEffect effect) {
+    private ApproachOfTheSecondSunEffect(final ApproachOfTheSecondSunEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArachnusSpinner.java
+++ b/Mage.Sets/src/mage/cards/a/ArachnusSpinner.java
@@ -76,7 +76,7 @@ class ArachnusSpinnerEffect extends OneShotEffect {
                 + "If you search your library this way, shuffle";
     }
 
-    public ArachnusSpinnerEffect(final ArachnusSpinnerEffect effect) {
+    private ArachnusSpinnerEffect(final ArachnusSpinnerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArahboRoarOfTheWorld.java
+++ b/Mage.Sets/src/mage/cards/a/ArahboRoarOfTheWorld.java
@@ -86,7 +86,7 @@ class ArahboEffect extends OneShotEffect {
         this.staticText = "it gains trample and gets +X/+X until end of turn, where X is its power";
     }
 
-    public ArahboEffect(final ArahboEffect effect) {
+    private ArahboEffect(final ArahboEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArashinSovereign.java
+++ b/Mage.Sets/src/mage/cards/a/ArashinSovereign.java
@@ -53,7 +53,7 @@ class ArashinSovereignEffect extends OneShotEffect {
         this.staticText = "you may put it on the top or bottom of its owner's library";
     }
     
-    public ArashinSovereignEffect(final ArashinSovereignEffect effect) {
+    private ArashinSovereignEffect(final ArashinSovereignEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/a/ArashinWarBeast.java
+++ b/Mage.Sets/src/mage/cards/a/ArashinWarBeast.java
@@ -61,7 +61,7 @@ class ArashinWarBeastTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} deals combat damage to one or more blockers, ");
     }
 
-    public ArashinWarBeastTriggeredAbility(final ArashinWarBeastTriggeredAbility ability) {
+    private ArashinWarBeastTriggeredAbility(final ArashinWarBeastTriggeredAbility ability) {
         super(ability);
         this.usedForCombatDamageStep = ability.usedForCombatDamageStep;
     }

--- a/Mage.Sets/src/mage/cards/a/ArbiterOfTheIdeal.java
+++ b/Mage.Sets/src/mage/cards/a/ArbiterOfTheIdeal.java
@@ -65,7 +65,7 @@ class ArbiterOfTheIdealEffect extends OneShotEffect {
         this.staticText = "reveal the top card of your library. If it's an artifact, creature, or land card, you may put it onto the battlefield with a manifestation counter on it. It's an enchantment in addition to its other types";
     }
 
-    public ArbiterOfTheIdealEffect(final ArbiterOfTheIdealEffect effect) {
+    private ArbiterOfTheIdealEffect(final ArbiterOfTheIdealEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Arboria.java
+++ b/Mage.Sets/src/mage/cards/a/Arboria.java
@@ -48,7 +48,7 @@ class ArboriaEffect extends RestrictionEffect {
         staticText = "Creatures can't attack a player unless that player cast a spell or put a nontoken permanent onto the battlefield during their last turn";
     }
 
-    public ArboriaEffect(final ArboriaEffect effect) {
+    private ArboriaEffect(final ArboriaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArcaneArtisan.java
+++ b/Mage.Sets/src/mage/cards/a/ArcaneArtisan.java
@@ -76,7 +76,7 @@ class ArcaneArtisanCreateTokenEffect extends OneShotEffect {
                 + "If a creature card is exiled this way, that player creates a token that's a copy of that card.";
     }
 
-    public ArcaneArtisanCreateTokenEffect(final ArcaneArtisanCreateTokenEffect effect) {
+    private ArcaneArtisanCreateTokenEffect(final ArcaneArtisanCreateTokenEffect effect) {
         super(effect);
     }
 
@@ -133,7 +133,7 @@ class ArcaneArtisanLeavesBattlefieldTriggeredAbility extends ZoneChangeTriggered
         );
     }
 
-    public ArcaneArtisanLeavesBattlefieldTriggeredAbility(ArcaneArtisanLeavesBattlefieldTriggeredAbility ability) {
+    private ArcaneArtisanLeavesBattlefieldTriggeredAbility(final ArcaneArtisanLeavesBattlefieldTriggeredAbility ability) {
         super(ability);
     }
 
@@ -155,7 +155,7 @@ class ArcaneArtisanExileEffect extends OneShotEffect {
         this.staticText = "exile all tokens created with {this}.";
     }
 
-    public ArcaneArtisanExileEffect(final ArcaneArtisanExileEffect effect) {
+    private ArcaneArtisanExileEffect(final ArcaneArtisanExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArcaneDenial.java
+++ b/Mage.Sets/src/mage/cards/a/ArcaneDenial.java
@@ -59,7 +59,7 @@ class ArcaneDenialEffect extends OneShotEffect {
                 + "at the beginning of the next turn's upkeep";
     }
 
-    public ArcaneDenialEffect(final ArcaneDenialEffect effect) {
+    private ArcaneDenialEffect(final ArcaneDenialEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArcaneSanctum.java
+++ b/Mage.Sets/src/mage/cards/a/ArcaneSanctum.java
@@ -25,7 +25,7 @@ public final class ArcaneSanctum extends CardImpl {
         this.addAbility(new BlackManaAbility());
     }
 
-    public ArcaneSanctum (final ArcaneSanctum card) {
+    private ArcaneSanctum(final ArcaneSanctum card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArcaneSpyglass.java
+++ b/Mage.Sets/src/mage/cards/a/ArcaneSpyglass.java
@@ -42,7 +42,7 @@ public final class ArcaneSpyglass extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), new RemoveCountersSourceCost(CounterType.CHARGE.createInstance(3))));
     }
 
-    public ArcaneSpyglass (final ArcaneSpyglass card) {
+    private ArcaneSpyglass(final ArcaneSpyglass card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Arcbond.java
+++ b/Mage.Sets/src/mage/cards/a/Arcbond.java
@@ -57,7 +57,7 @@ class ArcbondDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new ArcbondEffect(), Duration.EndOfTurn, false);
     }
 
-    public ArcbondDelayedTriggeredAbility(ArcbondDelayedTriggeredAbility ability) {
+    private ArcbondDelayedTriggeredAbility(final ArcbondDelayedTriggeredAbility ability) {
         super(ability);
         this.targetObject = ability.targetObject;
     }
@@ -116,7 +116,7 @@ class ArcbondEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public ArcbondEffect(final ArcbondEffect effect) {
+    private ArcbondEffect(final ArcbondEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArcboundFiend.java
+++ b/Mage.Sets/src/mage/cards/a/ArcboundFiend.java
@@ -63,7 +63,7 @@ class MoveCounterFromTargetToSourceEffect extends OneShotEffect {
         this.staticText = "move a +1/+1 counter from target creature onto {this}";
     }
 
-    public MoveCounterFromTargetToSourceEffect(final MoveCounterFromTargetToSourceEffect effect) {
+    private MoveCounterFromTargetToSourceEffect(final MoveCounterFromTargetToSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArchangelOfStrife.java
+++ b/Mage.Sets/src/mage/cards/a/ArchangelOfStrife.java
@@ -126,7 +126,7 @@ class ArchangelOfStrifeWarEffect extends BoostAllEffect {
         return false;
     }
 
-    public ArchangelOfStrifeWarEffect(ArchangelOfStrifeWarEffect effect) {
+    private ArchangelOfStrifeWarEffect(final ArchangelOfStrifeWarEffect effect) {
         super(effect);
     }
 
@@ -157,7 +157,7 @@ class ArchangelOfStrifePeaceEffect extends BoostAllEffect {
         return false;
     }
 
-    public ArchangelOfStrifePeaceEffect(ArchangelOfStrifePeaceEffect effect) {
+    private ArchangelOfStrifePeaceEffect(final ArchangelOfStrifePeaceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArchangelsLight.java
+++ b/Mage.Sets/src/mage/cards/a/ArchangelsLight.java
@@ -46,7 +46,7 @@ class ArchangelsLightEffect extends OneShotEffect {
         staticText = "You gain 2 life for each card in your graveyard, then shuffle your graveyard into your library";
     }
 
-    public ArchangelsLightEffect(final ArchangelsLightEffect effect) {
+    private ArchangelsLightEffect(final ArchangelsLightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArchdemonOfGreed.java
+++ b/Mage.Sets/src/mage/cards/a/ArchdemonOfGreed.java
@@ -65,7 +65,7 @@ public final class ArchdemonOfGreed extends CardImpl {
             this.staticText = "Sacrifice a Human. If you can't, tap {this} and it deals 9 damage to you.";
         }
 
-        public ArchdemonOfGreedEffect(final ArchdemonOfGreedEffect effect) {
+        private ArchdemonOfGreedEffect(final ArchdemonOfGreedEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/a/ArchfiendOfDepravity.java
+++ b/Mage.Sets/src/mage/cards/a/ArchfiendOfDepravity.java
@@ -57,7 +57,7 @@ class ArchfiendOfDepravityEffect extends OneShotEffect {
         this.staticText = "that player chooses up to two creatures they control, then sacrifices the rest";
     }
 
-    public ArchfiendOfDepravityEffect(final ArchfiendOfDepravityEffect effect) {
+    private ArchfiendOfDepravityEffect(final ArchfiendOfDepravityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArchfiendOfDespair.java
+++ b/Mage.Sets/src/mage/cards/a/ArchfiendOfDespair.java
@@ -67,7 +67,7 @@ class ArchfiendOfDespairEffect extends OneShotEffect {
         this.staticText = "each opponent loses life equal to the life that player lost this turn";
     }
 
-    public ArchfiendOfDespairEffect(final ArchfiendOfDespairEffect effect) {
+    private ArchfiendOfDespairEffect(final ArchfiendOfDespairEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArchitectsOfWill.java
+++ b/Mage.Sets/src/mage/cards/a/ArchitectsOfWill.java
@@ -56,7 +56,7 @@ class ArchitectsOfWillEffect extends OneShotEffect {
         this.staticText = "look at the top three cards of target player's library, then put them back in any order";
     }
 
-    public ArchitectsOfWillEffect(final ArchitectsOfWillEffect effect) {
+    private ArchitectsOfWillEffect(final ArchitectsOfWillEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArchivistOfOghma.java
+++ b/Mage.Sets/src/mage/cards/a/ArchivistOfOghma.java
@@ -52,7 +52,7 @@ class ArchivistOfOghmaTriggeredAbility extends TriggeredAbilityImpl {
         this.addEffect(new DrawCardSourceControllerEffect(1));
     }
 
-    public ArchivistOfOghmaTriggeredAbility(final ArchivistOfOghmaTriggeredAbility ability) {
+    private ArchivistOfOghmaTriggeredAbility(final ArchivistOfOghmaTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArgothianSwine.java
+++ b/Mage.Sets/src/mage/cards/a/ArgothianSwine.java
@@ -25,7 +25,7 @@ public final class ArgothianSwine extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
     }
 
-    public ArgothianSwine (final ArgothianSwine card) {
+    private ArgothianSwine(final ArgothianSwine card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArjunTheShiftingFlame.java
+++ b/Mage.Sets/src/mage/cards/a/ArjunTheShiftingFlame.java
@@ -54,7 +54,7 @@ class ArjunTheShiftingFlameEffect extends OneShotEffect {
         staticText = "put the cards in your hand on the bottom of your library in any order, then draw that many cards";
     }
 
-    public ArjunTheShiftingFlameEffect(final ArjunTheShiftingFlameEffect effect) {
+    private ArjunTheShiftingFlameEffect(final ArjunTheShiftingFlameEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArmWithAether.java
+++ b/Mage.Sets/src/mage/cards/a/ArmWithAether.java
@@ -51,7 +51,7 @@ class ArmWithAetherTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ReturnToHandTargetEffect(), true);
     }
 
-    public ArmWithAetherTriggeredAbility(final ArmWithAetherTriggeredAbility ability) {
+    private ArmWithAetherTriggeredAbility(final ArmWithAetherTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArmamentMaster.java
+++ b/Mage.Sets/src/mage/cards/a/ArmamentMaster.java
@@ -61,7 +61,7 @@ class ArmamentMasterEffect extends ContinuousEffectImpl {
         staticText = "Other Kor creatures you control get +2/+2 for each Equipment attached to {this}";
     }
 
-    public ArmamentMasterEffect(final ArmamentMasterEffect effect) {
+    private ArmamentMasterEffect(final ArmamentMasterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArmoredWolfRider.java
+++ b/Mage.Sets/src/mage/cards/a/ArmoredWolfRider.java
@@ -28,7 +28,7 @@ public final class ArmoredWolfRider extends CardImpl {
 
     }
 
-    public ArmoredWolfRider (final ArmoredWolfRider card) {
+    private ArmoredWolfRider(final ArmoredWolfRider card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArmoryAutomaton.java
+++ b/Mage.Sets/src/mage/cards/a/ArmoryAutomaton.java
@@ -63,7 +63,7 @@ class ArmoryAutomatonEffect extends OneShotEffect {
         this.staticText = "attach any number of target Equipment to it";
     }
 
-    public ArmoryAutomatonEffect(final ArmoryAutomatonEffect effect) {
+    private ArmoryAutomatonEffect(final ArmoryAutomatonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Arrest.java
+++ b/Mage.Sets/src/mage/cards/a/Arrest.java
@@ -39,7 +39,7 @@ public final class Arrest extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new CantBlockAttackActivateAttachedEffect()));
     }
 
-    public Arrest (final Arrest card) {
+    private Arrest(final Arrest card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArsenalThresher.java
+++ b/Mage.Sets/src/mage/cards/a/ArsenalThresher.java
@@ -58,7 +58,7 @@ class ArsenalThresherEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    public ArsenalThresherEffect(final ArsenalThresherEffect effect) {
+    private ArsenalThresherEffect(final ArsenalThresherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArtificersHex.java
+++ b/Mage.Sets/src/mage/cards/a/ArtificersHex.java
@@ -60,7 +60,7 @@ class ArtificersHexEffect extends OneShotEffect {
         this.staticText = "if enchanted Equipment is attached to a creature, destroy that creature";
     }
 
-    public ArtificersHexEffect(final ArtificersHexEffect effect) {
+    private ArtificersHexEffect(final ArtificersHexEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AsForetold.java
+++ b/Mage.Sets/src/mage/cards/a/AsForetold.java
@@ -131,7 +131,7 @@ class AsForetoldAddAltCostEffect extends ContinuousEffectImpl {
         staticText = "Once each turn, you may pay {0} rather than pay the mana cost for a spell you cast with mana value X or less, where X is the number of time counters on {this}.";
     }
 
-    public AsForetoldAddAltCostEffect(final AsForetoldAddAltCostEffect effect) {
+    private AsForetoldAddAltCostEffect(final AsForetoldAddAltCostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AsLuckWouldHaveIt.java
+++ b/Mage.Sets/src/mage/cards/a/AsLuckWouldHaveIt.java
@@ -54,7 +54,7 @@ class AsLuckWouldHaveItTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you roll a die, ");
     }
 
-    public AsLuckWouldHaveItTriggeredAbility(final AsLuckWouldHaveItTriggeredAbility ability) {
+    private AsLuckWouldHaveItTriggeredAbility(final AsLuckWouldHaveItTriggeredAbility ability) {
         super(ability);
     }
 
@@ -90,7 +90,7 @@ class AsLuckWouldHaveItEffect extends OneShotEffect {
         this.staticText = "put a number of luck counters on {this} equal to the result. Then if there are 100 or more luck counters on {this}, you win the game.";
     }
 
-    public AsLuckWouldHaveItEffect(final AsLuckWouldHaveItEffect effect) {
+    private AsLuckWouldHaveItEffect(final AsLuckWouldHaveItEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AscendedLawmage.java
+++ b/Mage.Sets/src/mage/cards/a/AscendedLawmage.java
@@ -36,7 +36,7 @@ public final class AscendedLawmage extends CardImpl {
 
     }
 
-    public AscendedLawmage (final AscendedLawmage card) {
+    private AscendedLawmage(final AscendedLawmage card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AshZealot.java
+++ b/Mage.Sets/src/mage/cards/a/AshZealot.java
@@ -45,7 +45,7 @@ public final class AshZealot extends CardImpl {
 
     }
 
-    public AshZealot (final AshZealot card) {
+    private AshZealot(final AshZealot card) {
         super(card);
     }
 
@@ -61,7 +61,7 @@ class AshZealotTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(3), false);
     }
 
-    public AshZealotTriggeredAbility(final AshZealotTriggeredAbility ability) {
+    private AshZealotTriggeredAbility(final AshZealotTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AshasFavor.java
+++ b/Mage.Sets/src/mage/cards/a/AshasFavor.java
@@ -45,7 +45,7 @@ public final class AshasFavor extends CardImpl {
         this.addAbility(ability);
     }
 
-    public AshasFavor(final AshasFavor card) {
+    private AshasFavor(final AshasFavor card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AshayaSoulOfTheWild.java
+++ b/Mage.Sets/src/mage/cards/a/AshayaSoulOfTheWild.java
@@ -65,7 +65,7 @@ class AshayaSoulOfTheWildEffect extends ContinuousEffectImpl {
         this.dependencyTypes.add(DependencyType.BecomeForest);
     }
 
-    public AshayaSoulOfTheWildEffect(final AshayaSoulOfTheWildEffect effect) {
+    private AshayaSoulOfTheWildEffect(final AshayaSoulOfTheWildEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AshenmoorLiege.java
+++ b/Mage.Sets/src/mage/cards/a/AshenmoorLiege.java
@@ -72,7 +72,7 @@ class AshenmoorLiegeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new LoseLifeTargetEffect(4), false);
     }
 
-    public AshenmoorLiegeTriggeredAbility(final AshenmoorLiegeTriggeredAbility ability) {
+    private AshenmoorLiegeTriggeredAbility(final AshenmoorLiegeTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AshesOfTheAbhorrent.java
+++ b/Mage.Sets/src/mage/cards/a/AshesOfTheAbhorrent.java
@@ -50,7 +50,7 @@ class AshesOfTheAbhorrentEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Players can't cast spells from graveyards or activate abilities of cards in graveyards";
     }
 
-    public AshesOfTheAbhorrentEffect(final AshesOfTheAbhorrentEffect effect) {
+    private AshesOfTheAbhorrentEffect(final AshesOfTheAbhorrentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AshiokNightmareWeaver.java
+++ b/Mage.Sets/src/mage/cards/a/AshiokNightmareWeaver.java
@@ -64,7 +64,7 @@ class AshiokNightmareWeaverExileEffect extends OneShotEffect {
         this.staticText = "Exile the top three cards of target opponent's library";
     }
 
-    public AshiokNightmareWeaverExileEffect(final AshiokNightmareWeaverExileEffect effect) {
+    private AshiokNightmareWeaverExileEffect(final AshiokNightmareWeaverExileEffect effect) {
         super(effect);
     }
 
@@ -95,7 +95,7 @@ class AshiokNightmareWeaverPutIntoPlayEffect extends OneShotEffect {
         this.staticText = "Put a creature card with mana value X exiled with {this} onto the battlefield under your control. That creature is a Nightmare in addition to its other types";
     }
 
-    public AshiokNightmareWeaverPutIntoPlayEffect(final AshiokNightmareWeaverPutIntoPlayEffect effect) {
+    private AshiokNightmareWeaverPutIntoPlayEffect(final AshiokNightmareWeaverPutIntoPlayEffect effect) {
         super(effect);
     }
 
@@ -146,7 +146,7 @@ class AshiokNightmareWeaverExileAllEffect extends OneShotEffect {
         this.staticText = "Exile all cards from all opponents' hands and graveyards";
     }
 
-    public AshiokNightmareWeaverExileAllEffect(final AshiokNightmareWeaverExileAllEffect effect) {
+    private AshiokNightmareWeaverExileAllEffect(final AshiokNightmareWeaverExileAllEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AshlingTheExtinguisher.java
+++ b/Mage.Sets/src/mage/cards/a/AshlingTheExtinguisher.java
@@ -55,7 +55,7 @@ class AshlingTheExtinguisherTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetCreaturePermanent());
     }
 
-    public AshlingTheExtinguisherTriggeredAbility(final AshlingTheExtinguisherTriggeredAbility ability) {
+    private AshlingTheExtinguisherTriggeredAbility(final AshlingTheExtinguisherTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AshlingsPrerogative.java
+++ b/Mage.Sets/src/mage/cards/a/AshlingsPrerogative.java
@@ -61,7 +61,7 @@ class AshlingsPrerogativeIncorrectOddityEffect extends PermanentsEnterBattlefiel
         staticText = "Each creature without mana value of the chosen quality enters the battlefield tapped.";
     }
     
-    public AshlingsPrerogativeIncorrectOddityEffect(final AshlingsPrerogativeIncorrectOddityEffect effect) {
+    private AshlingsPrerogativeIncorrectOddityEffect(final AshlingsPrerogativeIncorrectOddityEffect effect) {
         super(effect);   
     }
 
@@ -95,7 +95,7 @@ class AshlingsPrerogativeCorrectOddityEffect extends GainAbilityAllEffect {
         super(HasteAbility.getInstance(), Duration.WhileOnBattlefield, creaturefilter);
         staticText = "Each creature with mana value of the chosen quality has haste.";
     }
-    public AshlingsPrerogativeCorrectOddityEffect(final AshlingsPrerogativeCorrectOddityEffect effect) {
+    private AshlingsPrerogativeCorrectOddityEffect(final AshlingsPrerogativeCorrectOddityEffect effect) {
         super(effect);   
     }
 

--- a/Mage.Sets/src/mage/cards/a/AssassinsStrike.java
+++ b/Mage.Sets/src/mage/cards/a/AssassinsStrike.java
@@ -48,7 +48,7 @@ class AssassinsStrikeEffect extends OneShotEffect {
         this.staticText = "Its controller discards a card";
     }
 
-    public AssassinsStrikeEffect(final AssassinsStrikeEffect effect) {
+    private AssassinsStrikeEffect(final AssassinsStrikeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AssaultStrobe.java
+++ b/Mage.Sets/src/mage/cards/a/AssaultStrobe.java
@@ -24,7 +24,7 @@ public final class AssaultStrobe extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public AssaultStrobe (final AssaultStrobe card) {
+    private AssaultStrobe(final AssaultStrobe card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AssaultSuit.java
+++ b/Mage.Sets/src/mage/cards/a/AssaultSuit.java
@@ -72,7 +72,7 @@ public final class AssaultSuit extends CardImpl {
         staticText = "and can't be sacrificed";
     }
 
-    public AssaultSuitCantBeSacrificed(final AssaultSuitCantBeSacrificed effect) {
+    private AssaultSuitCantBeSacrificed(final AssaultSuitCantBeSacrificed effect) {
         super(effect);
     }
 
@@ -110,7 +110,7 @@ class AssaultSuitGainControlEffect extends OneShotEffect {
         this.staticText = "you may have that player gain control of equipped creature until end of turn. If you do, untap it";
     }
 
-    public AssaultSuitGainControlEffect(final AssaultSuitGainControlEffect effect) {
+    private AssaultSuitGainControlEffect(final AssaultSuitGainControlEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AssemblyHall.java
+++ b/Mage.Sets/src/mage/cards/a/AssemblyHall.java
@@ -58,7 +58,7 @@ class AssemblyHallEffect extends OneShotEffect {
                 + "reveal it, and put it into your hand. Then shuffle";
     }
 
-    public AssemblyHallEffect(final AssemblyHallEffect effect) {
+    private AssemblyHallEffect(final AssemblyHallEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AstralCornucopia.java
+++ b/Mage.Sets/src/mage/cards/a/AstralCornucopia.java
@@ -54,7 +54,7 @@ class AstralCornucopiaManaEffect extends ManaEffect {
         this.staticText = "Choose a color. Add one mana of that color for each charge counter on {this}";
     }
 
-    public AstralCornucopiaManaEffect(final AstralCornucopiaManaEffect effect) {
+    private AstralCornucopiaManaEffect(final AstralCornucopiaManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AstralSlide.java
+++ b/Mage.Sets/src/mage/cards/a/AstralSlide.java
@@ -50,7 +50,7 @@ class AstralSlideEffect extends OneShotEffect {
         staticText = "exile target creature. If you do, return that card to the battlefield under its owner's control at the beginning of the next end step";
     }
 
-    public AstralSlideEffect(final AstralSlideEffect effect) {
+    private AstralSlideEffect(final AstralSlideEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AtarkaWorldRender.java
+++ b/Mage.Sets/src/mage/cards/a/AtarkaWorldRender.java
@@ -64,7 +64,7 @@ class AtarkaWorldRenderEffect extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainAbilityTargetEffect(DoubleStrikeAbility.getInstance(), Duration.EndOfTurn));
     }
 
-    public AtarkaWorldRenderEffect(final AtarkaWorldRenderEffect ability) {
+    private AtarkaWorldRenderEffect(final AtarkaWorldRenderEffect ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AuntiesSnitch.java
+++ b/Mage.Sets/src/mage/cards/a/AuntiesSnitch.java
@@ -64,7 +64,7 @@ class AuntiesSnitchTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.GRAVEYARD, new ReturnToHandSourceEffect(), true);
     }
 
-    public AuntiesSnitchTriggeredAbility(final AuntiesSnitchTriggeredAbility ability) {
+    private AuntiesSnitchTriggeredAbility(final AuntiesSnitchTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AuraBarbs.java
+++ b/Mage.Sets/src/mage/cards/a/AuraBarbs.java
@@ -44,7 +44,7 @@ public final class AuraBarbs extends CardImpl {
             staticText = "Each enchantment deals 2 damage to its controller, then each Aura attached to a creature deals 2 damage to the creature it's attached to";
         }
 
-        public AuraBarbsEffect(final AuraBarbsEffect effect) {
+        private AuraBarbsEffect(final AuraBarbsEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/a/AuraFinesse.java
+++ b/Mage.Sets/src/mage/cards/a/AuraFinesse.java
@@ -61,7 +61,7 @@ class AuraFinesseEffect extends OneShotEffect {
         this.staticText = "Attach target Aura you control to target creature";
     }
 
-    public AuraFinesseEffect(final AuraFinesseEffect effect) {
+    private AuraFinesseEffect(final AuraFinesseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AuramancersGuise.java
+++ b/Mage.Sets/src/mage/cards/a/AuramancersGuise.java
@@ -63,7 +63,7 @@ class EnchantedCreatureAurasCount implements DynamicValue {
     public EnchantedCreatureAurasCount() {
     }
 
-    public EnchantedCreatureAurasCount(final EnchantedCreatureAurasCount dynamicValue) {
+    private EnchantedCreatureAurasCount(final EnchantedCreatureAurasCount dynamicValue) {
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/a/AuratouchedMage.java
+++ b/Mage.Sets/src/mage/cards/a/AuratouchedMage.java
@@ -54,7 +54,7 @@ class AuratouchedMageEffect extends OneShotEffect {
         staticText = "search your library for an Aura card that could enchant it. If {this} is still on the battlefield, put that Aura card onto the battlefield attached to it. Otherwise, reveal the Aura card and put it into your hand. Then shuffle";
     }
 
-    public AuratouchedMageEffect(final AuratouchedMageEffect effect) {
+    private AuratouchedMageEffect(final AuratouchedMageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AureliaExemplarOfJustice.java
+++ b/Mage.Sets/src/mage/cards/a/AureliaExemplarOfJustice.java
@@ -72,7 +72,7 @@ class AureliaExemplarOfJusticeEffect extends OneShotEffect {
                 + "and gains vigilance if it's white.";
     }
 
-    public AureliaExemplarOfJusticeEffect(final AureliaExemplarOfJusticeEffect effect) {
+    private AureliaExemplarOfJusticeEffect(final AureliaExemplarOfJusticeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Aurification.java
+++ b/Mage.Sets/src/mage/cards/a/Aurification.java
@@ -69,7 +69,7 @@ public final class Aurification extends CardImpl {
             super(Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.GOLD.createInstance()));
         }
 
-        public AddGoldCountersAbility(final AddGoldCountersAbility ability) {
+        private AddGoldCountersAbility(final AddGoldCountersAbility ability) {
             super(ability);
         }
 
@@ -110,7 +110,7 @@ public final class Aurification extends CardImpl {
             this.staticText = "remove all gold counters from all creatures";
         }
 
-        public RemoveAllGoldCountersEffect(final RemoveAllGoldCountersEffect effect) {
+        private RemoveAllGoldCountersEffect(final RemoveAllGoldCountersEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/a/AuriokReplica.java
+++ b/Mage.Sets/src/mage/cards/a/AuriokReplica.java
@@ -52,7 +52,7 @@ class AuriokReplicaEffect extends PreventionEffectImpl {
         this.target = new TargetSource();
     }
 
-    public AuriokReplicaEffect(final AuriokReplicaEffect effect) {
+    private AuriokReplicaEffect(final AuriokReplicaEffect effect) {
         super(effect);
         this.target = effect.target.copy();
     }

--- a/Mage.Sets/src/mage/cards/a/AuriokWindwalker.java
+++ b/Mage.Sets/src/mage/cards/a/AuriokWindwalker.java
@@ -65,7 +65,7 @@ class AttachTargetEquipmentEffect extends OneShotEffect {
         staticText = "Attach target Equipment you control to target creature you control";
     }
 
-    public AttachTargetEquipmentEffect(final AttachTargetEquipmentEffect effect) {
+    private AttachTargetEquipmentEffect(final AttachTargetEquipmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AurraSingBaneOfJedi.java
+++ b/Mage.Sets/src/mage/cards/a/AurraSingBaneOfJedi.java
@@ -74,7 +74,7 @@ class AurraSingBaneOfJediEffect extends OneShotEffect {
         staticText = "You may have {this} deal 2 damage to target creature. If you don't, {this} deals 1 damage to you";
     }
 
-    public AurraSingBaneOfJediEffect(final AurraSingBaneOfJediEffect effect) {
+    private AurraSingBaneOfJediEffect(final AurraSingBaneOfJediEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AutumnWillow.java
+++ b/Mage.Sets/src/mage/cards/a/AutumnWillow.java
@@ -54,7 +54,7 @@ class AutumnWillowEffect extends AsThoughEffectImpl {
         staticText = "Until end of turn, Autumn Willow can be the target of spells and abilities controlled by target player as though it didn't have shroud";
     }
 
-    public AutumnWillowEffect(final AutumnWillowEffect effect) {
+    private AutumnWillowEffect(final AutumnWillowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvacynsCollar.java
+++ b/Mage.Sets/src/mage/cards/a/AvacynsCollar.java
@@ -62,7 +62,7 @@ class AvacynsCollarTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CreateTokenEffect(new SpiritWhiteToken()));
     }
 
-    public AvacynsCollarTriggeredAbility(final AvacynsCollarTriggeredAbility ability) {
+    private AvacynsCollarTriggeredAbility(final AvacynsCollarTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvalancheTusker.java
+++ b/Mage.Sets/src/mage/cards/a/AvalancheTusker.java
@@ -51,7 +51,7 @@ class AvalancheTuskerAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new MustBeBlockedByTargetSourceEffect(Duration.EndOfCombat), false);
     }
 
-    public AvalancheTuskerAbility(final AvalancheTuskerAbility ability) {
+    private AvalancheTuskerAbility(final AvalancheTuskerAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvatarOfGrowth.java
+++ b/Mage.Sets/src/mage/cards/a/AvatarOfGrowth.java
@@ -66,7 +66,7 @@ class AvatarOfGrowthSearchEffect extends OneShotEffect {
         this.staticText = "each player searches their library for up to two basic land cards, puts them onto the battlefield, then shuffles";
     }
 
-    public AvatarOfGrowthSearchEffect(final AvatarOfGrowthSearchEffect effect) {
+    private AvatarOfGrowthSearchEffect(final AvatarOfGrowthSearchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvenMimeomancer.java
+++ b/Mage.Sets/src/mage/cards/a/AvenMimeomancer.java
@@ -59,7 +59,7 @@ class AvenEffect extends ContinuousEffectImpl {
         this.staticText = "If you do, that creature has base power and toughness 3/1 and has flying for as long as it has a feather counter on it";
     }
 
-    public AvenEffect(final AvenEffect effect) {
+    private AvenEffect(final AvenEffect effect) {
         super(effect);
     }
 
@@ -95,7 +95,7 @@ class AvenEffect2 extends ContinuousEffectImpl {
         super(Duration.Custom, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.BoostCreature);
     }
 
-    public AvenEffect2(final AvenEffect2 effect) {
+    private AvenEffect2(final AvenEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvenShrine.java
+++ b/Mage.Sets/src/mage/cards/a/AvenShrine.java
@@ -49,7 +49,7 @@ class AvenShrineTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AvenShrineEffect(), false);
     }
 
-    public AvenShrineTriggeredAbility(final AvenShrineTriggeredAbility ability) {
+    private AvenShrineTriggeredAbility(final AvenShrineTriggeredAbility ability) {
         super(ability);
     }
 
@@ -83,7 +83,7 @@ class AvenShrineEffect extends OneShotEffect {
         staticText = "Whenever a player casts a spell, that player gains X life, where X is the number of cards in all graveyards with the same name as that spell";
     }
 
-    public AvenShrineEffect(final AvenShrineEffect effect) {
+    private AvenShrineEffect(final AvenShrineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvenSoulgazer.java
+++ b/Mage.Sets/src/mage/cards/a/AvenSoulgazer.java
@@ -69,7 +69,7 @@ class AvenSoulgazerLookFaceDownEffect extends OneShotEffect {
         this.staticText = "Look at target face-down creature";
     }
 
-    public AvenSoulgazerLookFaceDownEffect(final AvenSoulgazerLookFaceDownEffect effect) {
+    private AvenSoulgazerLookFaceDownEffect(final AvenSoulgazerLookFaceDownEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvengerEnDal.java
+++ b/Mage.Sets/src/mage/cards/a/AvengerEnDal.java
@@ -59,7 +59,7 @@ class AvengerEnDalEffect extends OneShotEffect {
         staticText = "Its controller gains life equal to its toughness";
     }
 
-    public AvengerEnDalEffect(final AvengerEnDalEffect effect) {
+    private AvengerEnDalEffect(final AvengerEnDalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvengerOfZendikar.java
+++ b/Mage.Sets/src/mage/cards/a/AvengerOfZendikar.java
@@ -46,7 +46,7 @@ public final class AvengerOfZendikar extends CardImpl {
         this.addAbility(new LandfallAbility(new AddCountersAllEffect(CounterType.P1P1.createInstance(), filter), true));
     }
 
-    public AvengerOfZendikar (final AvengerOfZendikar card) {
+    private AvengerOfZendikar(final AvengerOfZendikar card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvengingAngel.java
+++ b/Mage.Sets/src/mage/cards/a/AvengingAngel.java
@@ -53,7 +53,7 @@ class AvengingAngelEffect extends OneShotEffect {
         this.staticText = "you may put it on the top of its owner's library";
     }
     
-    public AvengingAngelEffect(final AvengingAngelEffect effect) {
+    private AvengingAngelEffect(final AvengingAngelEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/a/AwakenTheAncient.java
+++ b/Mage.Sets/src/mage/cards/a/AwakenTheAncient.java
@@ -65,7 +65,7 @@ public final class AwakenTheAncient extends CardImpl {
             this.addAbility(HasteAbility.getInstance());
         }
 
-        public GiantToken(final GiantToken token) {
+        private GiantToken(final GiantToken token) {
             super(token);
         }
 

--- a/Mage.Sets/src/mage/cards/a/AwakenTheErstwhile.java
+++ b/Mage.Sets/src/mage/cards/a/AwakenTheErstwhile.java
@@ -43,7 +43,7 @@ class AwakenTheErstwhileEffect extends OneShotEffect {
         this.staticText = "each player discards all the cards in their hand, then creates that many 2/2 black Zombie creature tokens";
     }
 
-    public AwakenTheErstwhileEffect(final AwakenTheErstwhileEffect effect) {
+    private AwakenTheErstwhileEffect(final AwakenTheErstwhileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AwakenTheSkyTyrant.java
+++ b/Mage.Sets/src/mage/cards/a/AwakenTheSkyTyrant.java
@@ -44,7 +44,7 @@ class AwakenTheSkyTyrantTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When a source an opponent controls deals damage to you, ");
     }
 
-    public AwakenTheSkyTyrantTriggeredAbility(final AwakenTheSkyTyrantTriggeredAbility ability) {
+    private AwakenTheSkyTyrantTriggeredAbility(final AwakenTheSkyTyrantTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AwakenerDruid.java
+++ b/Mage.Sets/src/mage/cards/a/AwakenerDruid.java
@@ -57,7 +57,7 @@ class AwakenerDruidBecomesCreatureEffect extends BecomesCreatureTargetEffect {
         this.staticText = "target Forest becomes a 4/5 green Treefolk creature for as long as {this} remains on the battlefield. It's still a land";
     }
 
-    public AwakenerDruidBecomesCreatureEffect(final AwakenerDruidBecomesCreatureEffect effect) {
+    private AwakenerDruidBecomesCreatureEffect(final AwakenerDruidBecomesCreatureEffect effect) {
         super(effect);
     }
 
@@ -87,7 +87,7 @@ class AwakenerDruidToken extends TokenImpl {
         power = new MageInt(4);
         toughness = new MageInt(5);
     }
-    public AwakenerDruidToken(final AwakenerDruidToken token) {
+    private AwakenerDruidToken(final AwakenerDruidToken token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AweStrike.java
+++ b/Mage.Sets/src/mage/cards/a/AweStrike.java
@@ -46,7 +46,7 @@ class AweStrikeEffect extends PreventionEffectImpl {
         this.staticText = "The next time target creature would deal damage this turn, prevent that damage. You gain life equal to the damage prevented this way";
     }
 
-    public AweStrikeEffect(final AweStrikeEffect effect) {
+    private AweStrikeEffect(final AweStrikeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AwesomePresence.java
+++ b/Mage.Sets/src/mage/cards/a/AwesomePresence.java
@@ -65,7 +65,7 @@ class AwesomePresenceRestrictionEffect extends PayCostToAttackBlockEffectImpl {
                 + " for each creature they control that's blocking it");
     }
 
-    public AwesomePresenceRestrictionEffect(AwesomePresenceRestrictionEffect effect) {
+    private AwesomePresenceRestrictionEffect(final AwesomePresenceRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AzorTheLawbringer.java
+++ b/Mage.Sets/src/mage/cards/a/AzorTheLawbringer.java
@@ -66,7 +66,7 @@ class AzorTheLawbringerEntersBattlefieldEffect extends OneShotEffect {
         this.staticText = "each opponent can't cast instant or sorcery spells during that player's next turn";
     }
 
-    public AzorTheLawbringerEntersBattlefieldEffect(final AzorTheLawbringerEntersBattlefieldEffect effect) {
+    private AzorTheLawbringerEntersBattlefieldEffect(final AzorTheLawbringerEntersBattlefieldEffect effect) {
         super(effect);
     }
 
@@ -96,7 +96,7 @@ class AzorTheLawbringerCantCastEffect extends ContinuousRuleModifyingEffectImpl 
         playersNextTurn = 0;
     }
 
-    public AzorTheLawbringerCantCastEffect(final AzorTheLawbringerCantCastEffect effect) {
+    private AzorTheLawbringerCantCastEffect(final AzorTheLawbringerCantCastEffect effect) {
         super(effect);
         this.playersNextTurn = effect.playersNextTurn;
     }

--- a/Mage.Sets/src/mage/cards/a/AzorsElocutors.java
+++ b/Mage.Sets/src/mage/cards/a/AzorsElocutors.java
@@ -55,7 +55,7 @@ class AzorsElocutorsTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a source deals damage to you, ");
     }
 
-    public AzorsElocutorsTriggeredAbility(final AzorsElocutorsTriggeredAbility ability) {
+    private AzorsElocutorsTriggeredAbility(final AzorsElocutorsTriggeredAbility ability) {
         super(ability);
     }
 
@@ -82,7 +82,7 @@ class AzorsElocutorsEffect extends OneShotEffect {
         staticText = "put a filibuster counter on Azor's Elocutors. Then if Azor's Elocutors has five or more filibuster counters on it, you win the game";
     }
 
-    public AzorsElocutorsEffect(final AzorsElocutorsEffect effect) {
+    private AzorsElocutorsEffect(final AzorsElocutorsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AzorsGateway.java
+++ b/Mage.Sets/src/mage/cards/a/AzorsGateway.java
@@ -66,7 +66,7 @@ class AzorsGatewayEffect extends OneShotEffect {
                 "you gain 5 life, untap Azor's Gateway, and transform it";
     }
 
-    public AzorsGatewayEffect(final AzorsGatewayEffect effect) {
+    private AzorsGatewayEffect(final AzorsGatewayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AzraOddsmaker.java
+++ b/Mage.Sets/src/mage/cards/a/AzraOddsmaker.java
@@ -64,7 +64,7 @@ class AzraOddsmakerEffect extends OneShotEffect {
         this.staticText = "choose a creature. Whenever that creature deals combat damage to a player this turn, you draw two cards";
     }
 
-    public AzraOddsmakerEffect(final AzraOddsmakerEffect effect) {
+    private AzraOddsmakerEffect(final AzraOddsmakerEffect effect) {
         super(effect);
     }
 
@@ -107,7 +107,7 @@ class AzraOddsmakerDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.creatureName = creatureName;
     }
 
-    public AzraOddsmakerDelayedTriggeredAbility(final AzraOddsmakerDelayedTriggeredAbility ability) {
+    private AzraOddsmakerDelayedTriggeredAbility(final AzraOddsmakerDelayedTriggeredAbility ability) {
         super(ability);
         this.mor = ability.mor;
         this.creatureName = ability.creatureName;

--- a/Mage.Sets/src/mage/cards/a/AzusaLostButSeeking.java
+++ b/Mage.Sets/src/mage/cards/a/AzusaLostButSeeking.java
@@ -27,7 +27,7 @@ public final class AzusaLostButSeeking extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PlayAdditionalLandsControllerEffect(2, Duration.WhileOnBattlefield)));
     }
 
-    public AzusaLostButSeeking (final AzusaLostButSeeking card) {
+    private AzusaLostButSeeking(final AzusaLostButSeeking card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BINGO.java
+++ b/Mage.Sets/src/mage/cards/b/BINGO.java
@@ -72,7 +72,7 @@ class BingoEffect extends OneShotEffect {
         staticText = "put a chip counter on its mana value";
     }
 
-    public BingoEffect(final BingoEffect effect) {
+    private BingoEffect(final BingoEffect effect) {
         super(effect);
     }
 
@@ -122,7 +122,7 @@ class BingoCount implements DynamicValue {
     public BingoCount() {
     }
 
-    public BingoCount(final BingoCount countersCount) {
+    private BingoCount(final BingoCount countersCount) {
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/b/BackFromTheBrink.java
+++ b/Mage.Sets/src/mage/cards/b/BackFromTheBrink.java
@@ -56,7 +56,7 @@ class BackFromTheBrinkCost extends CostImpl {
         this.text = "Exile a creature card from your graveyard and pay its mana cost";
     }
 
-    public BackFromTheBrinkCost(final BackFromTheBrinkCost cost) {
+    private BackFromTheBrinkCost(final BackFromTheBrinkCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Backlash.java
+++ b/Mage.Sets/src/mage/cards/b/Backlash.java
@@ -51,7 +51,7 @@ class BacklashEffect extends OneShotEffect {
         this.staticText = "Tap target untapped creature. That creature deals damage equal to its power to its controller.";
     }
 
-    public BacklashEffect(final BacklashEffect effect) {
+    private BacklashEffect(final BacklashEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BakisCurse.java
+++ b/Mage.Sets/src/mage/cards/b/BakisCurse.java
@@ -44,7 +44,7 @@ class BakisCurseEffect extends OneShotEffect {
             staticText = "Baki's Curse deals 2 damage to each creature for each Aura attached to that creature.";
     }
 
-    public BakisCurseEffect(final BakisCurseEffect effect) {
+    private BakisCurseEffect(final BakisCurseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BalanWanderingKnight.java
+++ b/Mage.Sets/src/mage/cards/b/BalanWanderingKnight.java
@@ -61,7 +61,7 @@ public final class BalanWanderingKnight extends CardImpl {
             this.staticText = "Attach all Equipment you control to {this}.";
         }
 
-        public BalanWanderingKnightEffect(final BalanWanderingKnightEffect effect) {
+        private BalanWanderingKnightEffect(final BalanWanderingKnightEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/b/BalanceOfPower.java
+++ b/Mage.Sets/src/mage/cards/b/BalanceOfPower.java
@@ -44,7 +44,7 @@ class BalanceOfPowerEffect extends OneShotEffect {
         this.staticText = "If target opponent has more cards in hand than you, draw cards equal to the difference";
     }
 
-    public BalanceOfPowerEffect(final BalanceOfPowerEffect effect) {
+    private BalanceOfPowerEffect(final BalanceOfPowerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BalduvianDead.java
+++ b/Mage.Sets/src/mage/cards/b/BalduvianDead.java
@@ -60,7 +60,7 @@ class BalduvianDeadEffect extends OneShotEffect {
         this.staticText = "Create a 3/1 black and red Graveborn creature token with haste. Sacrifice it at the beginning of the next end step";
     }
 
-    public BalduvianDeadEffect(final BalduvianDeadEffect effect) {
+    private BalduvianDeadEffect(final BalduvianDeadEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BalefulStare.java
+++ b/Mage.Sets/src/mage/cards/b/BalefulStare.java
@@ -76,7 +76,7 @@ class BalefulStareEffect extends OneShotEffect {
         return false;
     }
 
-    public BalefulStareEffect(final BalefulStareEffect effect) {
+    private BalefulStareEffect(final BalefulStareEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BalthorTheDefiled.java
+++ b/Mage.Sets/src/mage/cards/b/BalthorTheDefiled.java
@@ -72,7 +72,7 @@ class BalthorTheDefiledEffect extends OneShotEffect {
         this.staticText = "Each player returns all black and all red creature cards from their graveyard to the battlefield";
     }
 
-    public BalthorTheDefiledEffect(final BalthorTheDefiledEffect effect) {
+    private BalthorTheDefiledEffect(final BalthorTheDefiledEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BalustradeSpy.java
+++ b/Mage.Sets/src/mage/cards/b/BalustradeSpy.java
@@ -58,7 +58,7 @@ class BalustradeSpyEffect extends OneShotEffect {
         this.staticText = "target player reveals cards from the top of their library until they reveal a land card, then puts those cards into their graveyard";
     }
 
-    public BalustradeSpyEffect(final BalustradeSpyEffect effect) {
+    private BalustradeSpyEffect(final BalustradeSpyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BaneAlleyBlackguard.java
+++ b/Mage.Sets/src/mage/cards/b/BaneAlleyBlackguard.java
@@ -25,7 +25,7 @@ public final class BaneAlleyBlackguard extends CardImpl {
         this.toughness = new MageInt(3);
     }
 
-    public BaneAlleyBlackguard (final BaneAlleyBlackguard card) {
+    private BaneAlleyBlackguard(final BaneAlleyBlackguard card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BaneOfBalaGed.java
+++ b/Mage.Sets/src/mage/cards/b/BaneOfBalaGed.java
@@ -52,7 +52,7 @@ class BaneOfBalaGedEffect extends OneShotEffect {
         this.staticText = "defending player exiles two permanents they control";
     }
 
-    public BaneOfBalaGedEffect(final BaneOfBalaGedEffect effect) {
+    private BaneOfBalaGedEffect(final BaneOfBalaGedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BaneOfProgress.java
+++ b/Mage.Sets/src/mage/cards/b/BaneOfProgress.java
@@ -58,7 +58,7 @@ class BaneOfProgressEffect extends OneShotEffect {
         this.staticText = "destroy all artifacts and enchantments. Put a +1/+1 counter on {this} for each permanent destroyed this way";
     }
 
-    public BaneOfProgressEffect(final BaneOfProgressEffect effect) {
+    private BaneOfProgressEffect(final BaneOfProgressEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Banefire.java
+++ b/Mage.Sets/src/mage/cards/b/Banefire.java
@@ -77,7 +77,7 @@ class BaneFireEffect extends OneShotEffect {
         staticText = "{this} deals X damage to any target";
     }
 
-    public BaneFireEffect(final BaneFireEffect effect) {
+    private BaneFireEffect(final BaneFireEffect effect) {
         super(effect);
     }
 
@@ -113,7 +113,7 @@ class BanefireCantCounterEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "If X is 5 or more, this spell can't be countered and the damage can't be prevented";
     }
 
-    public BanefireCantCounterEffect(final BanefireCantCounterEffect effect) {
+    private BanefireCantCounterEffect(final BanefireCantCounterEffect effect) {
         super(effect);
         this.condition = effect.condition;
     }

--- a/Mage.Sets/src/mage/cards/b/BanewaspAffliction.java
+++ b/Mage.Sets/src/mage/cards/b/BanewaspAffliction.java
@@ -59,7 +59,7 @@ class BanewaspAfflictionLoseLifeEffect extends OneShotEffect {
         this.staticText = "that creature's controller loses life equal to its toughness";
     }
 
-    public BanewaspAfflictionLoseLifeEffect(BanewaspAfflictionLoseLifeEffect copy) {
+    private BanewaspAfflictionLoseLifeEffect(final BanewaspAfflictionLoseLifeEffect copy) {
         super(copy);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BanewhipPunisher.java
+++ b/Mage.Sets/src/mage/cards/b/BanewhipPunisher.java
@@ -46,7 +46,7 @@ public final class BanewhipPunisher extends CardImpl {
         
     }
 
-    public BanewhipPunisher(final BanewhipPunisher banewhipPunisher) {
+    private BanewhipPunisher(final BanewhipPunisher banewhipPunisher) {
         super(banewhipPunisher);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BanishmentDecree.java
+++ b/Mage.Sets/src/mage/cards/b/BanishmentDecree.java
@@ -32,7 +32,7 @@ public final class BanishmentDecree extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPermanent(filter));
     }
 
-    public BanishmentDecree (final BanishmentDecree card) {
+    private BanishmentDecree(final BanishmentDecree card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BantBattlemage.java
+++ b/Mage.Sets/src/mage/cards/b/BantBattlemage.java
@@ -41,7 +41,7 @@ public final class BantBattlemage extends CardImpl {
         this.addAbility(ability);
     }
 
-    public BantBattlemage (final BantBattlemage card) {
+    private BantBattlemage(final BantBattlemage card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BanthaHerd.java
+++ b/Mage.Sets/src/mage/cards/b/BanthaHerd.java
@@ -53,7 +53,7 @@ class BathaHerdEffect extends OneShotEffect {
         this.staticText = "create X 1/1 white Tusken Raider tokens";
     }
 
-    public BathaHerdEffect(final BathaHerdEffect effect) {
+    private BathaHerdEffect(final BathaHerdEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BarbarianBully.java
+++ b/Mage.Sets/src/mage/cards/b/BarbarianBully.java
@@ -50,7 +50,7 @@ class BarbarianBullyEffect extends OneShotEffect {
                 + "unless a player has {this} deal 4 damage to them";
     }
 
-    public BarbarianBullyEffect(final BarbarianBullyEffect effect) {
+    private BarbarianBullyEffect(final BarbarianBullyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BarbedBattlegear.java
+++ b/Mage.Sets/src/mage/cards/b/BarbedBattlegear.java
@@ -32,7 +32,7 @@ public final class BarbedBattlegear extends CardImpl {
         this.addAbility(new EquipAbility(Outcome.Neutral, new GenericManaCost(2), new TargetControlledCreaturePermanent(), false));
     }
 
-    public BarbedBattlegear (final BarbedBattlegear card) {
+    private BarbedBattlegear(final BarbedBattlegear card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BarbedWire.java
+++ b/Mage.Sets/src/mage/cards/b/BarbedWire.java
@@ -60,7 +60,7 @@ class BarbwireDamageEffect extends OneShotEffect {
         this.staticText = "";
     }
 
-    public BarbwireDamageEffect(final BarbwireDamageEffect effect) {
+    private BarbwireDamageEffect(final BarbwireDamageEffect effect) {
         super(effect);
     }
 
@@ -88,7 +88,7 @@ class BarbedWirePreventionEffect extends PreventionEffectImpl {
         staticText = "Prevent the next 1 damage that would be dealt by {this} this turn";
     }
 
-    public BarbedWirePreventionEffect(final BarbedWirePreventionEffect effect) {
+    private BarbedWirePreventionEffect(final BarbedWirePreventionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Barishi.java
+++ b/Mage.Sets/src/mage/cards/b/Barishi.java
@@ -51,7 +51,7 @@ class BarishiEffect extends OneShotEffect {
         this.staticText = "exile {this}, then shuffle all creature cards from your graveyard into your library";
     }
 
-    public BarishiEffect(final BarishiEffect effect) {
+    private BarishiEffect(final BarishiEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BaronVonCount.java
+++ b/Mage.Sets/src/mage/cards/b/BaronVonCount.java
@@ -67,7 +67,7 @@ class BaronVonCountPutCounterEffect extends OneShotEffect {
         staticText = "with a doom counter on \"5.\"";
     }
 
-    public BaronVonCountPutCounterEffect(final BaronVonCountPutCounterEffect effect) {
+    private BaronVonCountPutCounterEffect(final BaronVonCountPutCounterEffect effect) {
         super(effect);
     }
 
@@ -107,7 +107,7 @@ class BaronVonCountTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you cast a spell with the indicated numeral in its mana cost, text box, power, or toughness, ");
     }
 
-    public BaronVonCountTriggeredAbility(final BaronVonCountTriggeredAbility abiltity) {
+    private BaronVonCountTriggeredAbility(final BaronVonCountTriggeredAbility abiltity) {
         super(abiltity);
     }
 
@@ -160,7 +160,7 @@ class BaronVonCountMoveDoomCounterEffect extends OneShotEffect {
         staticText = "move the doom counter one numeral to the left";
     }
 
-    public BaronVonCountMoveDoomCounterEffect(final BaronVonCountMoveDoomCounterEffect effect) {
+    private BaronVonCountMoveDoomCounterEffect(final BaronVonCountMoveDoomCounterEffect effect) {
         super(effect);
     }
 
@@ -202,7 +202,7 @@ class BaronVonCountSecondTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When the doom counter moves from \"1,\" ");
     }
 
-    public BaronVonCountSecondTriggeredAbility(BaronVonCountSecondTriggeredAbility ability) {
+    private BaronVonCountSecondTriggeredAbility(final BaronVonCountSecondTriggeredAbility ability) {
         super(ability);
     }
 
@@ -229,7 +229,7 @@ class BaronVonCountDestroyPlayerEffect extends OneShotEffect {
         staticText = "destroy target player and put that doom counter on \"5.\"";
     }
 
-    public BaronVonCountDestroyPlayerEffect(final BaronVonCountDestroyPlayerEffect effect) {
+    private BaronVonCountDestroyPlayerEffect(final BaronVonCountDestroyPlayerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BarrageOgre.java
+++ b/Mage.Sets/src/mage/cards/b/BarrageOgre.java
@@ -42,7 +42,7 @@ public final class BarrageOgre extends CardImpl {
         this.addAbility(ability);
     }
 
-    public BarrageOgre (final BarrageOgre card) {
+    private BarrageOgre(final BarrageOgre card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BarrinsUnmaking.java
+++ b/Mage.Sets/src/mage/cards/b/BarrinsUnmaking.java
@@ -48,7 +48,7 @@ class BarrinsUnmakingEffect extends OneShotEffect {
         this.staticText = "Return target permanent to its owner's hand if that permanent shares a color with the most common color among all permanents or a color tied for most common.";
     }
 
-    public BarrinsUnmakingEffect(final BarrinsUnmakingEffect effect) {
+    private BarrinsUnmakingEffect(final BarrinsUnmakingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BartelRuneaxe.java
+++ b/Mage.Sets/src/mage/cards/b/BartelRuneaxe.java
@@ -51,7 +51,7 @@ class BartelRuneaxeEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "{this} can't be the target of Aura spells";
     }
 
-    public BartelRuneaxeEffect(final BartelRuneaxeEffect effect) {
+    private BartelRuneaxeEffect(final BartelRuneaxeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BasandraBattleSeraph.java
+++ b/Mage.Sets/src/mage/cards/b/BasandraBattleSeraph.java
@@ -63,7 +63,7 @@ class BasandraBattleSeraphEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Players can't cast spells during combat";
     }
     
-    public BasandraBattleSeraphEffect(final BasandraBattleSeraphEffect effect) {
+    private BasandraBattleSeraphEffect(final BasandraBattleSeraphEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/b/BasriDevotedPaladin.java
+++ b/Mage.Sets/src/mage/cards/b/BasriDevotedPaladin.java
@@ -79,7 +79,7 @@ class BasriDevotedPaladinTriggeredAbility extends DelayedTriggeredAbility {
         super(new AddCountersTargetEffect(CounterType.P1P1.createInstance()), Duration.EndOfTurn, false);
     }
 
-    public BasriDevotedPaladinTriggeredAbility(BasriDevotedPaladinTriggeredAbility ability) {
+    private BasriDevotedPaladinTriggeredAbility(final BasriDevotedPaladinTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BasriKet.java
+++ b/Mage.Sets/src/mage/cards/b/BasriKet.java
@@ -74,7 +74,7 @@ class BasriKetTriggeredAbility extends DelayedTriggeredAbility {
         super(null, Duration.EndOfTurn, false);
     }
 
-    public BasriKetTriggeredAbility(BasriKetTriggeredAbility ability) {
+    private BasriKetTriggeredAbility(final BasriKetTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BatheInLight.java
+++ b/Mage.Sets/src/mage/cards/b/BatheInLight.java
@@ -58,7 +58,7 @@ class BatheInLightEffect extends OneShotEffect {
         this.staticText = "Choose a color. Target creature and each other creature that shares a color with it gain protection from the chosen color until end of turn";
     }
 
-    public BatheInLightEffect(final BatheInLightEffect effect) {
+    private BatheInLightEffect(final BatheInLightEffect effect) {
         super(effect);
     }
 
@@ -108,7 +108,7 @@ class ProtectionChosenColorTargetEffect extends ContinuousEffectImpl {
         super(Duration.EndOfTurn, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
     }
 
-    public ProtectionChosenColorTargetEffect(final ProtectionChosenColorTargetEffect effect) {
+    private ProtectionChosenColorTargetEffect(final ProtectionChosenColorTargetEffect effect) {
         super(effect);
         if (effect.chosenColor != null) {
             this.chosenColor = effect.chosenColor.copy();

--- a/Mage.Sets/src/mage/cards/b/Batterhorn.java
+++ b/Mage.Sets/src/mage/cards/b/Batterhorn.java
@@ -32,7 +32,7 @@ public final class Batterhorn extends CardImpl {
         this.addAbility(ability);
     }
 
-    public Batterhorn (final Batterhorn card) {
+    private Batterhorn(final Batterhorn card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BattleCry.java
+++ b/Mage.Sets/src/mage/cards/b/BattleCry.java
@@ -54,7 +54,7 @@ class BattleCryTriggeredAbility extends DelayedTriggeredAbility {
         super(new BoostTargetEffect(0, 1, Duration.EndOfTurn), Duration.EndOfTurn, false, false);
     }
 
-    public BattleCryTriggeredAbility(final BattleCryTriggeredAbility ability) {
+    private BattleCryTriggeredAbility(final BattleCryTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BattleHurda.java
+++ b/Mage.Sets/src/mage/cards/b/BattleHurda.java
@@ -25,7 +25,7 @@ public final class BattleHurda extends CardImpl {
         this.addAbility(FirstStrikeAbility.getInstance());
     }
 
-    public BattleHurda (final BattleHurda card) {
+    private BattleHurda(final BattleHurda card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BattleStrain.java
+++ b/Mage.Sets/src/mage/cards/b/BattleStrain.java
@@ -43,7 +43,7 @@ class BattleStrainTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(1));
     }
 
-    public BattleStrainTriggeredAbility(final BattleStrainTriggeredAbility ability) {
+    private BattleStrainTriggeredAbility(final BattleStrainTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BattlegraceAngel.java
+++ b/Mage.Sets/src/mage/cards/b/BattlegraceAngel.java
@@ -38,7 +38,7 @@ public final class BattlegraceAngel extends CardImpl {
         ).setText("it gains lifelink until end of turn"), true, false));
     }
 
-    public BattlegraceAngel(final BattlegraceAngel card) {
+    private BattlegraceAngel(final BattlegraceAngel card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BatwingBrume.java
+++ b/Mage.Sets/src/mage/cards/b/BatwingBrume.java
@@ -60,7 +60,7 @@ class BatwingBrumeEffect extends OneShotEffect {
         super(Outcome.LoseLife);
     }
 
-    public BatwingBrumeEffect(final BatwingBrumeEffect effect) {
+    private BatwingBrumeEffect(final BatwingBrumeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BazaarOfWonders.java
+++ b/Mage.Sets/src/mage/cards/b/BazaarOfWonders.java
@@ -59,7 +59,7 @@ class BazaarOfWondersEffect extends OneShotEffect {
                 + "or a nontoken permanent with the same name is on the battlefield";
     }
 
-    public BazaarOfWondersEffect(final BazaarOfWondersEffect effect) {
+    private BazaarOfWondersEffect(final BazaarOfWondersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BazaarTrader.java
+++ b/Mage.Sets/src/mage/cards/b/BazaarTrader.java
@@ -67,7 +67,7 @@ class BazaarTraderEffect extends ContinuousEffectImpl {
         this.staticText = "Target player gains control of target artifact, creature, or land you control";
     }
 
-    public BazaarTraderEffect(final BazaarTraderEffect effect) {
+    private BazaarTraderEffect(final BazaarTraderEffect effect) {
         super(effect);
         this.targetPermanentReference = effect.targetPermanentReference;
     }

--- a/Mage.Sets/src/mage/cards/b/BeaconBehemoth.java
+++ b/Mage.Sets/src/mage/cards/b/BeaconBehemoth.java
@@ -40,7 +40,7 @@ public final class BeaconBehemoth extends CardImpl {
         this.addAbility(ability);
     }
 
-    public BeaconBehemoth (final BeaconBehemoth card) {
+    private BeaconBehemoth(final BeaconBehemoth card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BeaconOfDestiny.java
+++ b/Mage.Sets/src/mage/cards/b/BeaconOfDestiny.java
@@ -59,7 +59,7 @@ class BeaconOfDestinyEffect extends RedirectionEffect {
         this.damageSource = new TargetSource();
     }
 
-    public BeaconOfDestinyEffect(final BeaconOfDestinyEffect effect) {
+    private BeaconOfDestinyEffect(final BeaconOfDestinyEffect effect) {
         super(effect);
         this.damageSource = effect.damageSource.copy();
     }

--- a/Mage.Sets/src/mage/cards/b/BeaconOfImmortality.java
+++ b/Mage.Sets/src/mage/cards/b/BeaconOfImmortality.java
@@ -47,7 +47,7 @@ class BeaconOfImmortalityEffect extends OneShotEffect {
         this.staticText = "Double target player's life total";
     }
 
-    public BeaconOfImmortalityEffect(final BeaconOfImmortalityEffect effect) {
+    private BeaconOfImmortalityEffect(final BeaconOfImmortalityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BeaconOfTomorrows.java
+++ b/Mage.Sets/src/mage/cards/b/BeaconOfTomorrows.java
@@ -47,7 +47,7 @@ class BeaconOfTomorrowsEffect extends OneShotEffect {
         staticText = "Target player takes an extra turn after this one";
     }
 
-    public BeaconOfTomorrowsEffect(final BeaconOfTomorrowsEffect effect) {
+    private BeaconOfTomorrowsEffect(final BeaconOfTomorrowsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BeastmasterAscension.java
+++ b/Mage.Sets/src/mage/cards/b/BeastmasterAscension.java
@@ -49,7 +49,7 @@ class BeastmasterAscensionEffect extends BoostControlledEffect {
         staticText = "As long as {this} has seven or more quest counters on it, creatures you control get +5/+5";
     }
 
-    public BeastmasterAscensionEffect(final BeastmasterAscensionEffect effect) {
+    private BeastmasterAscensionEffect(final BeastmasterAscensionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BeckCall.java
+++ b/Mage.Sets/src/mage/cards/b/BeckCall.java
@@ -51,7 +51,7 @@ class BeckTriggeredAbility extends DelayedTriggeredAbility {
         optional = true;
     }
 
-    public BeckTriggeredAbility(BeckTriggeredAbility ability) {
+    private BeckTriggeredAbility(final BeckTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BeetleformMage.java
+++ b/Mage.Sets/src/mage/cards/b/BeetleformMage.java
@@ -39,7 +39,7 @@ public final class BeetleformMage extends CardImpl {
 
     }
 
-    public BeetleformMage (final BeetleformMage card) {
+    private BeetleformMage(final BeetleformMage card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Befoul.java
+++ b/Mage.Sets/src/mage/cards/b/Befoul.java
@@ -34,7 +34,7 @@ public final class Befoul extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPermanent(filter));
     }
 
-    public Befoul (final Befoul card) {
+    private Befoul(final Befoul card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BeguilerOfWills.java
+++ b/Mage.Sets/src/mage/cards/b/BeguilerOfWills.java
@@ -56,7 +56,7 @@ class BeguilerOfWillsTarget extends TargetPermanent {
         super(new FilterCreaturePermanent("creature with power less than or equal to the number of creatures you control"));
     }
 
-    public BeguilerOfWillsTarget(final BeguilerOfWillsTarget target) {
+    private BeguilerOfWillsTarget(final BeguilerOfWillsTarget target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BellowingFiend.java
+++ b/Mage.Sets/src/mage/cards/b/BellowingFiend.java
@@ -56,7 +56,7 @@ class BellowingFiendEffect extends OneShotEffect {
         this.staticText = "{this} deals 3 damage to that creature's controller";
     }
 
-    public BellowingFiendEffect(final BellowingFiendEffect effect) {
+    private BellowingFiendEffect(final BellowingFiendEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BellowingTanglewurm.java
+++ b/Mage.Sets/src/mage/cards/b/BellowingTanglewurm.java
@@ -39,7 +39,7 @@ public final class BellowingTanglewurm extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityControlledEffect(IntimidateAbility.getInstance(), Duration.WhileOnBattlefield, filter, true)));
     }
 
-    public BellowingTanglewurm (final BellowingTanglewurm card) {
+    private BellowingTanglewurm(final BellowingTanglewurm card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BellowsLizard.java
+++ b/Mage.Sets/src/mage/cards/b/BellowsLizard.java
@@ -31,7 +31,7 @@ public final class BellowsLizard extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 0, Duration.EndOfTurn), new ManaCostsImpl<>("{1}{R}")));
     }
 
-    public BellowsLizard (final BellowsLizard card) {
+    private BellowsLizard(final BellowsLizard card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BenalishCommander.java
+++ b/Mage.Sets/src/mage/cards/b/BenalishCommander.java
@@ -67,7 +67,7 @@ class BenalishCommanderTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a time counter is removed from {this} while it's exiled, ");
     }
 
-    public BenalishCommanderTriggeredAbility(final BenalishCommanderTriggeredAbility ability) {
+    private BenalishCommanderTriggeredAbility(final BenalishCommanderTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BenalishHero.java
+++ b/Mage.Sets/src/mage/cards/b/BenalishHero.java
@@ -28,7 +28,7 @@ public final class BenalishHero extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public BenalishHero (final BenalishHero card) {
+    private BenalishHero(final BenalishHero card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BenalishInfantry.java
+++ b/Mage.Sets/src/mage/cards/b/BenalishInfantry.java
@@ -28,7 +28,7 @@ public final class BenalishInfantry extends CardImpl {
         this.addAbility(BandingAbility.getInstance());
     }
 
-    public BenalishInfantry (final BenalishInfantry card) {
+    private BenalishInfantry(final BenalishInfantry card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BenalishMarshal.java
+++ b/Mage.Sets/src/mage/cards/b/BenalishMarshal.java
@@ -27,7 +27,7 @@ public final class BenalishMarshal extends CardImpl {
     }
 
 
-    public BenalishMarshal(BenalishMarshal benalishMarshall) {
+    private BenalishMarshal(final BenalishMarshal benalishMarshall) {
         super(benalishMarshall);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BendOrBreak.java
+++ b/Mage.Sets/src/mage/cards/b/BendOrBreak.java
@@ -52,7 +52,7 @@ class BendOrBreakEffect extends OneShotEffect {
         this.staticText = "Each player separates all nontoken lands they control into two piles. For each player, one of their piles is chosen by one of their opponents of their choice. Destroy all lands in the chosen piles. Tap all lands in the other piles";
     }
 
-    public BendOrBreakEffect(final BendOrBreakEffect effect) {
+    private BendOrBreakEffect(final BendOrBreakEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BenefactionOfRhonas.java
+++ b/Mage.Sets/src/mage/cards/b/BenefactionOfRhonas.java
@@ -49,7 +49,7 @@ class BenefactionOfRhonasEffect extends OneShotEffect {
         this.staticText = "Reveal the top five cards of your library. You may put a creature card and/or enchantment card from among them into your hand. Put the rest into your graveyard";
     }
 
-    public BenefactionOfRhonasEffect(final BenefactionOfRhonasEffect effect) {
+    private BenefactionOfRhonasEffect(final BenefactionOfRhonasEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BenevolentUnicorn.java
+++ b/Mage.Sets/src/mage/cards/b/BenevolentUnicorn.java
@@ -54,7 +54,7 @@ class BenevolentUnicornEffect extends ReplacementEffectImpl {
         staticText = "If a spell would deal damage to a permanent or player, it deals that much damage minus 1 to that permanent or player instead.";
     }
 
-    public BenevolentUnicornEffect(final BenevolentUnicornEffect effect) {
+    private BenevolentUnicornEffect(final BenevolentUnicornEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Bereavement.java
+++ b/Mage.Sets/src/mage/cards/b/Bereavement.java
@@ -44,7 +44,7 @@ class BereavementTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DiscardTargetEffect(1));
     }
 
-    public BereavementTriggeredAbility(final BereavementTriggeredAbility ability) {
+    private BereavementTriggeredAbility(final BereavementTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Berserk.java
+++ b/Mage.Sets/src/mage/cards/b/Berserk.java
@@ -115,7 +115,7 @@ class BerserkDestroyEffect extends OneShotEffect {
         this.staticText = "At the beginning of the next end step, destroy that creature if it attacked this turn";
     }
 
-    public BerserkDestroyEffect(final BerserkDestroyEffect effect) {
+    private BerserkDestroyEffect(final BerserkDestroyEffect effect) {
         super(effect);
     }
 
@@ -146,7 +146,7 @@ class BerserkDelayedDestroyEffect extends OneShotEffect {
         this.staticText = "destroy that creature if it attacked this turn";
     }
 
-    public BerserkDelayedDestroyEffect(final BerserkDelayedDestroyEffect effect) {
+    private BerserkDelayedDestroyEffect(final BerserkDelayedDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Besmirch.java
+++ b/Mage.Sets/src/mage/cards/b/Besmirch.java
@@ -49,7 +49,7 @@ class BesmirchEffect extends OneShotEffect {
         staticText = "Until end of turn, gain control of target creature and it gains haste. Untap and goad that creature";
     }
 
-    public BesmirchEffect(final BesmirchEffect effect) {
+    private BesmirchEffect(final BesmirchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BidentOfThassa.java
+++ b/Mage.Sets/src/mage/cards/b/BidentOfThassa.java
@@ -56,7 +56,7 @@ class BidentOfThassaTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), true);
     }
 
-    public BidentOfThassaTriggeredAbility(final BidentOfThassaTriggeredAbility ability) {
+    private BidentOfThassaTriggeredAbility(final BidentOfThassaTriggeredAbility ability) {
         super(ability);
     }
 
@@ -94,7 +94,7 @@ class BidentOfThassaMustAttackEffect extends RequirementEffect {
         staticText = "Creatures your opponents control attack this turn if able";
     }
 
-    public BidentOfThassaMustAttackEffect(final BidentOfThassaMustAttackEffect effect) {
+    private BidentOfThassaMustAttackEffect(final BidentOfThassaMustAttackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Bifurcate.java
+++ b/Mage.Sets/src/mage/cards/b/Bifurcate.java
@@ -56,7 +56,7 @@ class BifurcateEffect extends OneShotEffect {
         this.staticText = "search your library for a permanent card with the same name as target nontoken creature, put that card onto the battlefield, then shuffle";
     }
 
-    public BifurcateEffect(final BifurcateEffect effect) {
+    private BifurcateEffect(final BifurcateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BileBlight.java
+++ b/Mage.Sets/src/mage/cards/b/BileBlight.java
@@ -45,7 +45,7 @@ class BileBlightEffect extends BoostAllEffect {
         staticText = "Target creature and all other creatures with the same name as that creature get -3/-3 until end of turn";
     }
 
-    public BileBlightEffect(final BileBlightEffect effect) {
+    private BileBlightEffect(final BileBlightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BiolumeEgg.java
+++ b/Mage.Sets/src/mage/cards/b/BiolumeEgg.java
@@ -66,7 +66,7 @@ class BiolumeEggEffect extends OneShotEffect {
         this.staticText = "return it to the battlefield transformed under your control";
     }
 
-    public BiolumeEggEffect(final BiolumeEggEffect effect) {
+    private BiolumeEggEffect(final BiolumeEggEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BiomanticMastery.java
+++ b/Mage.Sets/src/mage/cards/b/BiomanticMastery.java
@@ -45,7 +45,7 @@ class BiomanticMasteryEffect extends OneShotEffect {
         this.staticText = "Draw a card for each creature target player controls, then draw a card for each creature another target player controls";
     }
 
-    public BiomanticMasteryEffect(final BiomanticMasteryEffect effect) {
+    private BiomanticMasteryEffect(final BiomanticMasteryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Biophagus.java
+++ b/Mage.Sets/src/mage/cards/b/Biophagus.java
@@ -85,7 +85,7 @@ class BiophagusEntersBattlefieldEffect extends ReplacementEffectImpl {
         this.mor = mor;
     }
 
-    public BiophagusEntersBattlefieldEffect(BiophagusEntersBattlefieldEffect effect) {
+    private BiophagusEntersBattlefieldEffect(final BiophagusEntersBattlefieldEffect effect) {
         super(effect);
         this.mor = effect.mor;
     }

--- a/Mage.Sets/src/mage/cards/b/Biorhythm.java
+++ b/Mage.Sets/src/mage/cards/b/Biorhythm.java
@@ -44,7 +44,7 @@ class BiorhythmEffect extends OneShotEffect {
         this.staticText = "Each player's life total becomes the number of creatures they control";
     }
 
-    public BiorhythmEffect(final BiorhythmEffect effect) {
+    private BiorhythmEffect(final BiorhythmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Bioshift.java
+++ b/Mage.Sets/src/mage/cards/b/Bioshift.java
@@ -64,7 +64,7 @@ class MoveCounterFromTargetToTargetEffect extends OneShotEffect {
         this.staticText = "Move any number of +1/+1 counters from target creature onto another target creature with the same controller";
     }
 
-    public MoveCounterFromTargetToTargetEffect(final MoveCounterFromTargetToTargetEffect effect) {
+    private MoveCounterFromTargetToTargetEffect(final MoveCounterFromTargetToTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BirchloreRangers.java
+++ b/Mage.Sets/src/mage/cards/b/BirchloreRangers.java
@@ -67,7 +67,7 @@ class BirchloreRangersManaEffect extends AddManaOfAnyColorEffect {
         this.filter = filter;
     }
 
-    public BirchloreRangersManaEffect(final BirchloreRangersManaEffect effect) {
+    private BirchloreRangersManaEffect(final BirchloreRangersManaEffect effect) {
         super(effect);
         this.filter = effect.filter.copy();
     }

--- a/Mage.Sets/src/mage/cards/b/BishopOfBinding.java
+++ b/Mage.Sets/src/mage/cards/b/BishopOfBinding.java
@@ -68,7 +68,7 @@ class BishopOfBindingExileEffect extends OneShotEffect {
         this.staticText = "exile target creature an opponent controls until {this} leaves the battlefield";
     }
 
-    public BishopOfBindingExileEffect(final BishopOfBindingExileEffect effect) {
+    private BishopOfBindingExileEffect(final BishopOfBindingExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BitterFeud.java
+++ b/Mage.Sets/src/mage/cards/b/BitterFeud.java
@@ -56,7 +56,7 @@ class BitterFeudEntersBattlefieldEffect extends OneShotEffect {
         staticText = "choose two players";
     }
 
-    public BitterFeudEntersBattlefieldEffect(final BitterFeudEntersBattlefieldEffect effect) {
+    private BitterFeudEntersBattlefieldEffect(final BitterFeudEntersBattlefieldEffect effect) {
         super(effect);
     }
 
@@ -103,7 +103,7 @@ class BitterFeudEffect extends ReplacementEffectImpl {
         staticText = "If a source controlled by one of the chosen players would deal damage to the other chosen player or a permanent that player controls, that source deals double that damage to that player or permanent instead";
     }
 
-    public BitterFeudEffect(final BitterFeudEffect effect) {
+    private BitterFeudEffect(final BitterFeudEffect effect) {
         super(effect);
         this.player1 = effect.player1;
         this.player2 = effect.player2;

--- a/Mage.Sets/src/mage/cards/b/BitterheartWitch.java
+++ b/Mage.Sets/src/mage/cards/b/BitterheartWitch.java
@@ -65,7 +65,7 @@ class BitterheartWitchEffect extends OneShotEffect {
         staticText = "you may search your library for a Curse card, put it onto the battlefield attached to target player, then shuffle";
     }
 
-    public BitterheartWitchEffect(final BitterheartWitchEffect effect) {
+    private BitterheartWitchEffect(final BitterheartWitchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlackMarket.java
+++ b/Mage.Sets/src/mage/cards/b/BlackMarket.java
@@ -51,7 +51,7 @@ class BlackMarketEffect extends OneShotEffect {
         this.staticText = "add {B} for each charge counter on Black Market";
     }
 
-    public BlackMarketEffect(final BlackMarketEffect effect) {
+    private BlackMarketEffect(final BlackMarketEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlackSunsZenith.java
+++ b/Mage.Sets/src/mage/cards/b/BlackSunsZenith.java
@@ -28,7 +28,7 @@ public final class BlackSunsZenith extends CardImpl {
         this.getSpellAbility().addEffect(ShuffleSpellEffect.getInstance());
     }
 
-    public BlackSunsZenith (final BlackSunsZenith card) {
+    private BlackSunsZenith(final BlackSunsZenith card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlackVise.java
+++ b/Mage.Sets/src/mage/cards/b/BlackVise.java
@@ -48,7 +48,7 @@ class BlackViseTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("At the beginning of the chosen player's upkeep, ");
     }
 
-    public BlackViseTriggeredAbility(final BlackViseTriggeredAbility ability) {
+    private BlackViseTriggeredAbility(final BlackViseTriggeredAbility ability) {
         super(ability);
     }
 
@@ -75,7 +75,7 @@ class BlackViseEffect extends OneShotEffect {
         this.staticText = "{this} deals X damage to that player, where X is the number of cards in their hand minus 4";
     }
 
-    public BlackViseEffect(final BlackViseEffect effect) {
+    private BlackViseEffect(final BlackViseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlackcleaveGoblin.java
+++ b/Mage.Sets/src/mage/cards/b/BlackcleaveGoblin.java
@@ -27,7 +27,7 @@ public final class BlackcleaveGoblin extends CardImpl {
         this.addAbility(InfectAbility.getInstance());
     }
 
-    public BlackcleaveGoblin (final BlackcleaveGoblin card) {
+    private BlackcleaveGoblin(final BlackcleaveGoblin card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BladeOfTheBloodchief.java
+++ b/Mage.Sets/src/mage/cards/b/BladeOfTheBloodchief.java
@@ -52,7 +52,7 @@ class BladeOfTheBloodchiefEffect extends OneShotEffect {
                 + "put two +1/+1 counters on it instead.";
     }
 
-    public BladeOfTheBloodchiefEffect(final BladeOfTheBloodchiefEffect ability) {
+    private BladeOfTheBloodchiefEffect(final BladeOfTheBloodchiefEffect ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BladedPinions.java
+++ b/Mage.Sets/src/mage/cards/b/BladedPinions.java
@@ -40,7 +40,7 @@ public final class BladedPinions extends CardImpl {
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(2), new TargetControlledCreaturePermanent(), false));
     }
 
-    public BladedPinions(final BladedPinions card) {
+    private BladedPinions(final BladedPinions card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BladedSentinel.java
+++ b/Mage.Sets/src/mage/cards/b/BladedSentinel.java
@@ -29,7 +29,7 @@ public final class BladedSentinel extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainAbilitySourceEffect(VigilanceAbility.getInstance(), Duration.EndOfTurn), new ManaCostsImpl<>("{W}")));
     }
 
-    public BladedSentinel (final BladedSentinel card) {
+    private BladedSentinel(final BladedSentinel card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BladetuskBoar.java
+++ b/Mage.Sets/src/mage/cards/b/BladetuskBoar.java
@@ -25,7 +25,7 @@ public final class BladetuskBoar extends CardImpl {
         this.addAbility(IntimidateAbility.getInstance());
     }
 
-    public BladetuskBoar (final BladetuskBoar card) {
+    private BladetuskBoar(final BladetuskBoar card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlanchwoodTreefolk.java
+++ b/Mage.Sets/src/mage/cards/b/BlanchwoodTreefolk.java
@@ -23,7 +23,7 @@ public final class BlanchwoodTreefolk extends CardImpl {
         this.toughness = new MageInt(5);
     }
 
-    public BlanchwoodTreefolk (final BlanchwoodTreefolk card) {
+    private BlanchwoodTreefolk(final BlanchwoodTreefolk card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlastFromThePast.java
+++ b/Mage.Sets/src/mage/cards/b/BlastFromThePast.java
@@ -44,7 +44,7 @@ public final class BlastFromThePast extends CardImpl {
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(new CreateTokenEffect(new GoblinToken()), KickedCondition.ONCE));
     }
 
-    public BlastFromThePast (final BlastFromThePast card) {
+    private BlastFromThePast(final BlastFromThePast card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlastOfGenius.java
+++ b/Mage.Sets/src/mage/cards/b/BlastOfGenius.java
@@ -45,7 +45,7 @@ class BlastOfGeniusEffect extends OneShotEffect {
         this.staticText = "Choose any target. Draw three cards, then discard a card. {this} deals damage equal to the discard card's mana value to that permanent or player";
     }
 
-    public BlastOfGeniusEffect(final BlastOfGeniusEffect effect) {
+    private BlastOfGeniusEffect(final BlastOfGeniusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlazeCommando.java
+++ b/Mage.Sets/src/mage/cards/b/BlazeCommando.java
@@ -40,7 +40,7 @@ public final class BlazeCommando extends CardImpl {
 
     }
 
-    public BlazeCommando (final BlazeCommando card) {
+    private BlazeCommando(final BlazeCommando card) {
         super(card);
     }
 
@@ -60,7 +60,7 @@ class BlazeCommandoTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever an instant or sorcery spell you control deals damage, ");
     }
 
-    public BlazeCommandoTriggeredAbility(final BlazeCommandoTriggeredAbility ability) {
+    private BlazeCommandoTriggeredAbility(final BlazeCommandoTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlazeOfGlory.java
+++ b/Mage.Sets/src/mage/cards/b/BlazeOfGlory.java
@@ -58,7 +58,7 @@ class BlazeOfGloryRequirementEffect extends RequirementEffect {
         this.staticText = "It blocks each attacking creature this turn if able";
     }
 
-    public BlazeOfGloryRequirementEffect(final BlazeOfGloryRequirementEffect effect) {
+    private BlazeOfGloryRequirementEffect(final BlazeOfGloryRequirementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlazingHope.java
+++ b/Mage.Sets/src/mage/cards/b/BlazingHope.java
@@ -44,7 +44,7 @@ class BlazingHopeTarget extends TargetCreaturePermanent {
         super(new FilterCreaturePermanent("creature with power greater than or equal to your life total"));
     }
 
-    public BlazingHopeTarget(final BlazingHopeTarget target) {
+    private BlazingHopeTarget(final BlazingHopeTarget target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlazingSalvo.java
+++ b/Mage.Sets/src/mage/cards/b/BlazingSalvo.java
@@ -43,7 +43,7 @@ class BlazingSalvoEffect extends OneShotEffect {
         this.staticText = "{this} deals 3 damage to target creature unless that creature's controller has {this} deal 5 damage to them";
     }
 
-    public BlazingSalvoEffect(final BlazingSalvoEffect effect) {
+    private BlazingSalvoEffect(final BlazingSalvoEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlessedReincarnation.java
+++ b/Mage.Sets/src/mage/cards/b/BlessedReincarnation.java
@@ -52,7 +52,7 @@ class BlessedReincarnationEffect extends OneShotEffect {
         this.staticText = "Exile target creature an opponent controls. That player reveals cards from the top of their library until a creature card is revealed. The player puts that card onto the battlefield, then shuffles the rest into their library";
     }
 
-    public BlessedReincarnationEffect(final BlessedReincarnationEffect effect) {
+    private BlessedReincarnationEffect(final BlessedReincarnationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlessingOfTheNephilim.java
+++ b/Mage.Sets/src/mage/cards/b/BlessingOfTheNephilim.java
@@ -55,7 +55,7 @@ class EnchantedCreatureColorsCount implements DynamicValue {
     public EnchantedCreatureColorsCount() {
     }
 
-    public EnchantedCreatureColorsCount(final EnchantedCreatureColorsCount dynamicValue) {
+    private EnchantedCreatureColorsCount(final EnchantedCreatureColorsCount dynamicValue) {
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/b/BlightHerder.java
+++ b/Mage.Sets/src/mage/cards/b/BlightHerder.java
@@ -58,7 +58,7 @@ class BlightHerderEffect extends OneShotEffect {
         this.staticText = "you may put two cards your opponents own from exile into their owners' graveyards. If you do, create three 1/1 colorless Eldrazi Scion creature tokens. They have \"Sacrifice this creature: Add {C}.";
     }
 
-    public BlightHerderEffect(final BlightHerderEffect effect) {
+    private BlightHerderEffect(final BlightHerderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlightMamba.java
+++ b/Mage.Sets/src/mage/cards/b/BlightMamba.java
@@ -31,7 +31,7 @@ public final class BlightMamba extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new ManaCostsImpl<>("{1}{G}")));
     }
 
-    public BlightMamba (final BlightMamba card) {
+    private BlightMamba(final BlightMamba card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Blightwidow.java
+++ b/Mage.Sets/src/mage/cards/b/Blightwidow.java
@@ -28,7 +28,7 @@ public final class Blightwidow extends CardImpl {
         this.addAbility(InfectAbility.getInstance());
     }
 
-    public Blightwidow (final Blightwidow card) {
+    private Blightwidow(final Blightwidow card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlindCreeper.java
+++ b/Mage.Sets/src/mage/cards/b/BlindCreeper.java
@@ -49,7 +49,7 @@ class BlindCreeperAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a player casts a spell, ");
     }
 
-    public BlindCreeperAbility(final BlindCreeperAbility ability) {
+    private BlindCreeperAbility(final BlindCreeperAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlindingBeam.java
+++ b/Mage.Sets/src/mage/cards/b/BlindingBeam.java
@@ -66,7 +66,7 @@ class BlindingBeamEffect extends OneShotEffect {
         staticText = "creatures don't untap during target player's next untap step";
     }
 
-    public BlindingBeamEffect(final BlindingBeamEffect effect) {
+    private BlindingBeamEffect(final BlindingBeamEffect effect) {
         super(effect);
     }
 
@@ -98,7 +98,7 @@ class BlindingBeamEffect2 extends ContinuousRuleModifyingEffectImpl {
         this.targetPlayerId = targetPlayerId;
     }
 
-    public BlindingBeamEffect2(final BlindingBeamEffect2 effect) {
+    private BlindingBeamEffect2(final BlindingBeamEffect2 effect) {
         super(effect);
         this.targetPlayerId = effect.targetPlayerId;
     }

--- a/Mage.Sets/src/mage/cards/b/BlinkmothInfusion.java
+++ b/Mage.Sets/src/mage/cards/b/BlinkmothInfusion.java
@@ -47,7 +47,7 @@ class UntapAllArtifactsEffect extends OneShotEffect {
         staticText = "Untap all artifacts";
     }
 
-    public UntapAllArtifactsEffect(final UntapAllArtifactsEffect effect) {
+    private UntapAllArtifactsEffect(final UntapAllArtifactsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlinkmothUrn.java
+++ b/Mage.Sets/src/mage/cards/b/BlinkmothUrn.java
@@ -49,7 +49,7 @@ class BlinkmothUrnEffect extends OneShotEffect {
         this.staticText = "if Blinkmoth Urn is untapped, that player adds {C} for each artifact they control";
     }
 
-    public BlinkmothUrnEffect(final BlinkmothUrnEffect effect) {
+    private BlinkmothUrnEffect(final BlinkmothUrnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Blistergrub.java
+++ b/Mage.Sets/src/mage/cards/b/Blistergrub.java
@@ -32,7 +32,7 @@ public final class Blistergrub extends CardImpl {
         this.addAbility(new DiesSourceTriggeredAbility(new LoseLifeOpponentsEffect(2), false));
     }
 
-    public Blistergrub (final Blistergrub card) {
+    private Blistergrub(final Blistergrub card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlisterstickShaman.java
+++ b/Mage.Sets/src/mage/cards/b/BlisterstickShaman.java
@@ -30,7 +30,7 @@ public final class BlisterstickShaman extends CardImpl {
         this.addAbility(ability);
     }
 
-    public BlisterstickShaman (final BlisterstickShaman card) {
+    private BlisterstickShaman(final BlisterstickShaman card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlizzardSpecter.java
+++ b/Mage.Sets/src/mage/cards/b/BlizzardSpecter.java
@@ -63,7 +63,7 @@ class ReturnToHandEffect extends OneShotEffect {
         staticText = "That player returns a permanent they control to its owner's hand";
     }
 
-    public ReturnToHandEffect(final ReturnToHandEffect effect) {
+    private ReturnToHandEffect(final ReturnToHandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodOath.java
+++ b/Mage.Sets/src/mage/cards/b/BloodOath.java
@@ -62,7 +62,7 @@ class BloodOathEffect extends OneShotEffect {
         staticText = "Choose a card type. Target opponent reveals their hand. {this} deals 3 damage to that player for each card of the chosen type revealed this way";
     }
 
-    public BloodOathEffect(final BloodOathEffect effect) {
+    private BloodOathEffect(final BloodOathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodOfTheMartyr.java
+++ b/Mage.Sets/src/mage/cards/b/BloodOfTheMartyr.java
@@ -45,7 +45,7 @@ class BloodOfTheMartyrEffect extends ReplacementEffectImpl {
         staticText = "Until end of turn, if damage would be dealt to any creature, you may have that damage dealt to you instead";
     }
 
-    public BloodOfTheMartyrEffect(final BloodOfTheMartyrEffect effect) {
+    private BloodOfTheMartyrEffect(final BloodOfTheMartyrEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodOperative.java
+++ b/Mage.Sets/src/mage/cards/b/BloodOperative.java
@@ -62,7 +62,7 @@ class BloodOperativeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.GRAVEYARD, new DoIfCostPaid(new ReturnSourceFromGraveyardToHandEffect(), new PayLifeCost(3)), false);
     }
 
-    public BloodOperativeTriggeredAbility(final BloodOperativeTriggeredAbility ability) {
+    private BloodOperativeTriggeredAbility(final BloodOperativeTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodScrivener.java
+++ b/Mage.Sets/src/mage/cards/b/BloodScrivener.java
@@ -34,7 +34,7 @@ public final class BloodScrivener  extends CardImpl {
 
     }
 
-    public BloodScrivener (final BloodScrivener card) {
+    private BloodScrivener(final BloodScrivener card) {
         super(card);
     }
 
@@ -52,7 +52,7 @@ class BloodScrivenerReplacementEffect extends ReplacementEffectImpl {
         staticText = "If you would draw a card while you have no cards in hand, instead you draw two cards and you lose 1 life";
     }
 
-    public BloodScrivenerReplacementEffect(final BloodScrivenerReplacementEffect effect) {
+    private BloodScrivenerReplacementEffect(final BloodScrivenerReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodTithe.java
+++ b/Mage.Sets/src/mage/cards/b/BloodTithe.java
@@ -41,7 +41,7 @@ class BloodTitheEffect extends OneShotEffect {
         staticText = "Each opponent loses 3 life. You gain life equal to the life lost this way";
     }
 
-    public BloodTitheEffect(final BloodTitheEffect effect) {
+    private BloodTitheEffect(final BloodTitheEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodTribute.java
+++ b/Mage.Sets/src/mage/cards/b/BloodTribute.java
@@ -68,7 +68,7 @@ class BloodTributeLoseLifeEffect extends OneShotEffect {
         this.staticText = "Target opponent loses half their life, rounded up";
     }
 
-    public BloodTributeLoseLifeEffect(final BloodTributeLoseLifeEffect effect) {
+    private BloodTributeLoseLifeEffect(final BloodTributeLoseLifeEffect effect) {
         super(effect);
     }
 
@@ -99,7 +99,7 @@ class BloodTributeGainLifeEffect extends OneShotEffect {
         this.staticText = "If Blood Tribute was kicked, you gain life equal to the life lost this way";
     }
 
-    public BloodTributeGainLifeEffect(final BloodTributeGainLifeEffect effect) {
+    private BloodTributeGainLifeEffect(final BloodTributeGainLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodTyrant.java
+++ b/Mage.Sets/src/mage/cards/b/BloodTyrant.java
@@ -62,7 +62,7 @@ class PlayerLosesTheGameTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance(5)), false);
     }
 
-    public PlayerLosesTheGameTriggeredAbility(final PlayerLosesTheGameTriggeredAbility ability) {
+    private PlayerLosesTheGameTriggeredAbility(final PlayerLosesTheGameTriggeredAbility ability) {
         super(ability);
     }
 
@@ -94,7 +94,7 @@ class BloodTyrantEffect extends OneShotEffect {
         staticText = "each player loses 1 life. Put a +1/+1 counter on {this} for each 1 life lost this way";
     }
 
-    public BloodTyrantEffect(final BloodTyrantEffect effect) {
+    private BloodTyrantEffect(final BloodTyrantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodcrazedGoblin.java
+++ b/Mage.Sets/src/mage/cards/b/BloodcrazedGoblin.java
@@ -50,7 +50,7 @@ class BloodcrazedGoblinEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless an opponent has been dealt damage this turn";
     }
 
-    public BloodcrazedGoblinEffect(final BloodcrazedGoblinEffect effect) {
+    private BloodcrazedGoblinEffect(final BloodcrazedGoblinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodcrazedHoplite.java
+++ b/Mage.Sets/src/mage/cards/b/BloodcrazedHoplite.java
@@ -57,7 +57,7 @@ class BloodcrazedHopliteTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a +1/+1 counter is put on {this}, ");
     }
 
-    public BloodcrazedHopliteTriggeredAbility(BloodcrazedHopliteTriggeredAbility ability) {
+    private BloodcrazedHopliteTriggeredAbility(final BloodcrazedHopliteTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodforgedBattleAxe.java
+++ b/Mage.Sets/src/mage/cards/b/BloodforgedBattleAxe.java
@@ -58,7 +58,7 @@ class BloodforgedBattleAxeAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CreateTokenCopySourceEffect());
     }
 
-    public BloodforgedBattleAxeAbility(final BloodforgedBattleAxeAbility ability) {
+    private BloodforgedBattleAxeAbility(final BloodforgedBattleAxeAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodhallOoze.java
+++ b/Mage.Sets/src/mage/cards/b/BloodhallOoze.java
@@ -59,7 +59,7 @@ class BloodhallOozeTriggeredAbility1 extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), true);
     }
 
-    public BloodhallOozeTriggeredAbility1(final BloodhallOozeTriggeredAbility1 ability) {
+    private BloodhallOozeTriggeredAbility1(final BloodhallOozeTriggeredAbility1 ability) {
         super(ability);
     }
 
@@ -104,7 +104,7 @@ class BloodhallOozeTriggeredAbility2 extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), true);
     }
 
-    public BloodhallOozeTriggeredAbility2(final BloodhallOozeTriggeredAbility2 ability) {
+    private BloodhallOozeTriggeredAbility2(final BloodhallOozeTriggeredAbility2 ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodhuskRitualist.java
+++ b/Mage.Sets/src/mage/cards/b/BloodhuskRitualist.java
@@ -37,7 +37,7 @@ public final class BloodhuskRitualist extends CardImpl {
         this.addAbility(ability);
     }
 
-    public BloodhuskRitualist (final BloodhuskRitualist card) {
+    private BloodhuskRitualist(final BloodhuskRitualist card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodiedGhost.java
+++ b/Mage.Sets/src/mage/cards/b/BloodiedGhost.java
@@ -33,7 +33,7 @@ public final class BloodiedGhost extends CardImpl {
             "with a -1/-1 counter on it."));
     }
 
-    public BloodiedGhost (final BloodiedGhost card) {
+    private BloodiedGhost(final BloodiedGhost card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Bloodletter.java
+++ b/Mage.Sets/src/mage/cards/b/Bloodletter.java
@@ -53,7 +53,7 @@ class BloodletterStateTriggeredAbility extends StateTriggeredAbility {
         setTriggerPhrase("When the names of three or more nonland permanents begin with the same letter, ");
     }
 
-    public BloodletterStateTriggeredAbility(final BloodletterStateTriggeredAbility ability) {
+    private BloodletterStateTriggeredAbility(final BloodletterStateTriggeredAbility ability) {
         super(ability);
     }
 
@@ -86,7 +86,7 @@ class BloodletterEffect extends OneShotEffect {
         staticText = "sacrifice {this}. If you do, it deals 2 damage to each creature and each player";
     }
 
-    public BloodletterEffect(final BloodletterEffect effect) {
+    private BloodletterEffect(final BloodletterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodlineShaman.java
+++ b/Mage.Sets/src/mage/cards/b/BloodlineShaman.java
@@ -55,7 +55,7 @@ class BloodlineShamanEffect extends OneShotEffect {
                 + "Otherwise, put it into your graveyard";
     }
 
-    public BloodlineShamanEffect(final BloodlineShamanEffect effect) {
+    private BloodlineShamanEffect(final BloodlineShamanEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodriteInvoker.java
+++ b/Mage.Sets/src/mage/cards/b/BloodriteInvoker.java
@@ -34,7 +34,7 @@ public final class BloodriteInvoker extends CardImpl {
         this.addAbility(ability);
     }
 
-    public BloodriteInvoker (final BloodriteInvoker card) {
+    private BloodriteInvoker(final BloodriteInvoker card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodsporeThrinax.java
+++ b/Mage.Sets/src/mage/cards/b/BloodsporeThrinax.java
@@ -53,7 +53,7 @@ class BloodsporeThrinaxEntersBattlefieldEffect extends ReplacementEffectImpl {
         staticText = "Each other creature you control enters the battlefield with an additional X +1/+1 counters on it, where X is the number of +1/+1 counters on {this}";
     }
 
-    public BloodsporeThrinaxEntersBattlefieldEffect(BloodsporeThrinaxEntersBattlefieldEffect effect) {
+    private BloodsporeThrinaxEntersBattlefieldEffect(final BloodsporeThrinaxEntersBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloomTender.java
+++ b/Mage.Sets/src/mage/cards/b/BloomTender.java
@@ -50,7 +50,7 @@ class BloomTenderEffect extends ManaEffect {
         staticText = "For each color among permanents you control, add one mana of that color";
     }
 
-    public BloomTenderEffect(final BloomTenderEffect effect) {
+    private BloomTenderEffect(final BloomTenderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlossomingWreath.java
+++ b/Mage.Sets/src/mage/cards/b/BlossomingWreath.java
@@ -40,7 +40,7 @@ public final class BlossomingWreath extends CardImpl {
             this.staticText = "You gain life equal to the number of creature cards in your graveyard";
         }
 
-        public BlossomingWreathEffect(final BlossomingWreathEffect effect) {
+        private BlossomingWreathEffect(final BlossomingWreathEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/b/BlowflyInfestation.java
+++ b/Mage.Sets/src/mage/cards/b/BlowflyInfestation.java
@@ -76,7 +76,7 @@ class BlowflyInfestationEffect extends OneShotEffect {
         super(Outcome.Detriment);
     }
 
-    public BlowflyInfestationEffect(BlowflyInfestationEffect effect) {
+    private BlowflyInfestationEffect(final BlowflyInfestationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BludgeonBrawl.java
+++ b/Mage.Sets/src/mage/cards/b/BludgeonBrawl.java
@@ -50,7 +50,7 @@ class BludgeonBrawlAbility extends StaticAbility {
         this.addEffect(new BludgeonBrawlGainAbilityEffect());
     }
 
-    public BludgeonBrawlAbility(BludgeonBrawlAbility ability) {
+    private BludgeonBrawlAbility(final BludgeonBrawlAbility ability) {
         super(ability);
     }
 
@@ -71,7 +71,7 @@ class BludgeonBrawlAddSubtypeEffect extends ContinuousEffectImpl {
         super(Duration.WhileOnBattlefield, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.Benefit);
     }
 
-    public BludgeonBrawlAddSubtypeEffect(final BludgeonBrawlAddSubtypeEffect effect) {
+    private BludgeonBrawlAddSubtypeEffect(final BludgeonBrawlAddSubtypeEffect effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class BludgeonBrawlGainAbilityEffect extends ContinuousEffectImpl {
         super(Duration.WhileOnBattlefield, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
     }
 
-    public BludgeonBrawlGainAbilityEffect(final BludgeonBrawlGainAbilityEffect effect) {
+    private BludgeonBrawlGainAbilityEffect(final BludgeonBrawlGainAbilityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlueSunsZenith.java
+++ b/Mage.Sets/src/mage/cards/b/BlueSunsZenith.java
@@ -26,7 +26,7 @@ public final class BlueSunsZenith extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPlayer());
     }
 
-    public BlueSunsZenith (final BlueSunsZenith card) {
+    private BlueSunsZenith(final BlueSunsZenith card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BluntTheAssault.java
+++ b/Mage.Sets/src/mage/cards/b/BluntTheAssault.java
@@ -28,7 +28,7 @@ public final class BluntTheAssault extends CardImpl {
         this.getSpellAbility().addEffect(new PreventAllDamageByAllPermanentsEffect(Duration.EndOfTurn, true));
     }
 
-    public BluntTheAssault (final BluntTheAssault card) {
+    private BluntTheAssault(final BluntTheAssault card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BodyDouble.java
+++ b/Mage.Sets/src/mage/cards/b/BodyDouble.java
@@ -55,7 +55,7 @@ class BodyDoubleCopyEffect extends OneShotEffect {
         this.staticText = "as a copy of any creature card in a graveyard";
     }
 
-    public BodyDoubleCopyEffect(final BodyDoubleCopyEffect effect) {
+    private BodyDoubleCopyEffect(final BodyDoubleCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BogTatters.java
+++ b/Mage.Sets/src/mage/cards/b/BogTatters.java
@@ -25,7 +25,7 @@ public final class BogTatters extends CardImpl {
         this.addAbility(new SwampwalkAbility());
     }
 
-    public BogTatters (final BogTatters card) {
+    private BogTatters(final BogTatters card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BogardanPhoenix.java
+++ b/Mage.Sets/src/mage/cards/b/BogardanPhoenix.java
@@ -58,7 +58,7 @@ class BogardanPhoenixEffect extends OneShotEffect {
                 + "and put a death counter on it.";
     }
 
-    public BogardanPhoenixEffect(final BogardanPhoenixEffect effect) {
+    private BogardanPhoenixEffect(final BogardanPhoenixEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BombSquad.java
+++ b/Mage.Sets/src/mage/cards/b/BombSquad.java
@@ -71,7 +71,7 @@ class BombSquadTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature has four or more fuse counters on it, ");
     }
 
-    public BombSquadTriggeredAbility(final BombSquadTriggeredAbility ability) {
+    private BombSquadTriggeredAbility(final BombSquadTriggeredAbility ability) {
         super(ability);
     }
 
@@ -109,7 +109,7 @@ class BombSquadDamgeEffect extends OneShotEffect {
         this.staticText = "remove all fuse counters from it and destroy it. That creature deals 4 damage to its controller";
     }
 
-    public BombSquadDamgeEffect(final BombSquadDamgeEffect effect) {
+    private BombSquadDamgeEffect(final BombSquadDamgeEffect effect) {
         super(effect);
     }
 
@@ -153,7 +153,7 @@ class BombSquadBeginningEffect extends OneShotEffect {
         this.staticText = "put a fuse counter on each creature with a fuse counter on it";
     }
 
-    public BombSquadBeginningEffect(final BombSquadBeginningEffect effect) {
+    private BombSquadBeginningEffect(final BombSquadBeginningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BondsOfQuicksilver.java
+++ b/Mage.Sets/src/mage/cards/b/BondsOfQuicksilver.java
@@ -44,7 +44,7 @@ public final class BondsOfQuicksilver extends CardImpl {
         
     }
 
-    public BondsOfQuicksilver (final BondsOfQuicksilver card) {
+    private BondsOfQuicksilver(final BondsOfQuicksilver card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoneDancer.java
+++ b/Mage.Sets/src/mage/cards/b/BoneDancer.java
@@ -49,7 +49,7 @@ class BoneDancerEffect extends OneShotEffect {
         this.staticText = "put the top creature card of defending player's graveyard onto the battlefield under your control";
     }
 
-    public BoneDancerEffect(final BoneDancerEffect effect) {
+    private BoneDancerEffect(final BoneDancerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoneMask.java
+++ b/Mage.Sets/src/mage/cards/b/BoneMask.java
@@ -56,7 +56,7 @@ class BoneMaskEffect extends PreventionEffectImpl {
         this.target = new TargetSource();
     }
 
-    public BoneMaskEffect(final BoneMaskEffect effect) {
+    private BoneMaskEffect(final BoneMaskEffect effect) {
         super(effect);
         this.target = effect.target.copy();
     }

--- a/Mage.Sets/src/mage/cards/b/BoneyardScourge.java
+++ b/Mage.Sets/src/mage/cards/b/BoneyardScourge.java
@@ -72,7 +72,7 @@ class DiesWhileInGraveyardTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever " + filter.getMessage() + " dies while {this} is in your graveyard, ");
     }
 
-    public DiesWhileInGraveyardTriggeredAbility(final DiesWhileInGraveyardTriggeredAbility ability) {
+    private DiesWhileInGraveyardTriggeredAbility(final DiesWhileInGraveyardTriggeredAbility ability) {
         super(ability);
         this.filter = ability.filter;
     }

--- a/Mage.Sets/src/mage/cards/b/BontuTheGlorified.java
+++ b/Mage.Sets/src/mage/cards/b/BontuTheGlorified.java
@@ -80,7 +80,7 @@ class BontuTheGlorifiedRestrictionEffect extends RestrictionEffect {
         staticText = "{this} can't attack or block unless a creature died under your control this turn";
     }
 
-    public BontuTheGlorifiedRestrictionEffect(final BontuTheGlorifiedRestrictionEffect effect) {
+    private BontuTheGlorifiedRestrictionEffect(final BontuTheGlorifiedRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BonusRound.java
+++ b/Mage.Sets/src/mage/cards/b/BonusRound.java
@@ -43,7 +43,7 @@ class BonusRoundDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new CopyTargetSpellEffect(true, true), Duration.EndOfTurn, false);
     }
 
-    public BonusRoundDelayedTriggeredAbility(final BonusRoundDelayedTriggeredAbility ability) {
+    private BonusRoundDelayedTriggeredAbility(final BonusRoundDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoobyTrap.java
+++ b/Mage.Sets/src/mage/cards/b/BoobyTrap.java
@@ -55,7 +55,7 @@ class BoobyTrapTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DoIfCostPaid(new DamageTargetEffect(10, true, "that player"), new SacrificeSourceCost(), "", false), false);
     }
 
-    public BoobyTrapTriggeredAbility(BoobyTrapTriggeredAbility ability) {
+    private BoobyTrapTriggeredAbility(final BoobyTrapTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BookBurning.java
+++ b/Mage.Sets/src/mage/cards/b/BookBurning.java
@@ -44,7 +44,7 @@ class BookBurningMillEffect extends OneShotEffect {
         staticText = "Any player may have {this} deal 6 damage to them. If no one does, target player mills six cards";
     }
 
-    public BookBurningMillEffect(final BookBurningMillEffect effect) {
+    private BookBurningMillEffect(final BookBurningMillEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoonReflection.java
+++ b/Mage.Sets/src/mage/cards/b/BoonReflection.java
@@ -44,7 +44,7 @@ class BoonReflectionEffect extends ReplacementEffectImpl {
         staticText = "If you would gain life, you gain twice that much life instead";
     }
 
-    public BoonReflectionEffect(final BoonReflectionEffect effect) {
+    private BoonReflectionEffect(final BoonReflectionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoonweaverGiant.java
+++ b/Mage.Sets/src/mage/cards/b/BoonweaverGiant.java
@@ -59,7 +59,7 @@ class BoonweaverGiantEffect extends OneShotEffect {
                 "If you search your library this way, shuffle.";
     }
 
-    public BoonweaverGiantEffect(final BoonweaverGiantEffect effect) {
+    private BoonweaverGiantEffect(final BoonweaverGiantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoosterTutor.java
+++ b/Mage.Sets/src/mage/cards/b/BoosterTutor.java
@@ -52,7 +52,7 @@ class BoosterTutorEffect extends OneShotEffect {
         this.staticText = "Open a sealed Magic booster pack, reveal the cards, and put one of those cards into your hand";
     }
 
-    public BoosterTutorEffect(final BoosterTutorEffect effect) {
+    private BoosterTutorEffect(final BoosterTutorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BorderlandExplorer.java
+++ b/Mage.Sets/src/mage/cards/b/BorderlandExplorer.java
@@ -57,7 +57,7 @@ class BorderlandExplorerEffect extends OneShotEffect {
                 + "for a basic land card, reveal it, put it into their hand, then shuffle";
     }
 
-    public BorderlandExplorerEffect(final BorderlandExplorerEffect effect) {
+    private BorderlandExplorerEffect(final BorderlandExplorerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoreasCharger.java
+++ b/Mage.Sets/src/mage/cards/b/BoreasCharger.java
@@ -76,7 +76,7 @@ class BoreasChargerEffect extends OneShotEffect {
                 "and the rest into your hand, then shuffle";
     }
 
-    public BoreasChargerEffect(final BoreasChargerEffect effect) {
+    private BoreasChargerEffect(final BoreasChargerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BorosBattleshaper.java
+++ b/Mage.Sets/src/mage/cards/b/BorosBattleshaper.java
@@ -40,7 +40,7 @@ public final class BorosBattleshaper extends CardImpl {
 
     }
 
-    public BorosBattleshaper(final BorosBattleshaper card) {
+    private BorosBattleshaper(final BorosBattleshaper card) {
         super(card);
     }
 
@@ -58,7 +58,7 @@ class BorosBattleshaperEffect extends OneShotEffect {
         this.staticText = "up to one target creature attacks or blocks this combat if able and up to one target creature can't attack or block this combat";
     }
 
-    public BorosBattleshaperEffect(final BorosBattleshaperEffect effect) {
+    private BorosBattleshaperEffect(final BorosBattleshaperEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BorosGuildmage.java
+++ b/Mage.Sets/src/mage/cards/b/BorosGuildmage.java
@@ -39,7 +39,7 @@ public final class BorosGuildmage extends CardImpl {
         this.addAbility(ability);
     }
 
-    public BorosGuildmage (final BorosGuildmage card) {
+    private BorosGuildmage(final BorosGuildmage card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BorosMastiff.java
+++ b/Mage.Sets/src/mage/cards/b/BorosMastiff.java
@@ -33,7 +33,7 @@ public final class BorosMastiff extends CardImpl {
 
     }
 
-    public BorosMastiff (final BorosMastiff card) {
+    private BorosMastiff(final BorosMastiff card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BorosSignet.java
+++ b/Mage.Sets/src/mage/cards/b/BorosSignet.java
@@ -27,7 +27,7 @@ public final class BorosSignet extends CardImpl {
         this.addAbility(ability);
     }
 
-    public BorosSignet (final BorosSignet card) {
+    private BorosSignet(final BorosSignet card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Borrowing100000Arrows.java
+++ b/Mage.Sets/src/mage/cards/b/Borrowing100000Arrows.java
@@ -48,7 +48,7 @@ class Borrowing100000ArrowsEffect extends OneShotEffect {
         this.staticText = "Draw a card for each tapped creature target opponent controls";
     }
 
-    public Borrowing100000ArrowsEffect(final Borrowing100000ArrowsEffect effect) {
+    private Borrowing100000ArrowsEffect(final Borrowing100000ArrowsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoseijuWhoSheltersAll.java
+++ b/Mage.Sets/src/mage/cards/b/BoseijuWhoSheltersAll.java
@@ -96,7 +96,7 @@ class BoseijuWhoSheltersAllCantCounterEffect extends ContinuousRuleModifyingEffe
         staticText = null;
     }
 
-    public BoseijuWhoSheltersAllCantCounterEffect(final BoseijuWhoSheltersAllCantCounterEffect effect) {
+    private BoseijuWhoSheltersAllCantCounterEffect(final BoseijuWhoSheltersAllCantCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BottleOfSuleiman.java
+++ b/Mage.Sets/src/mage/cards/b/BottleOfSuleiman.java
@@ -47,7 +47,7 @@ class BottleOfSuleimanEffect extends OneShotEffect {
         staticText = "Flip a coin. If you lose the flip, {this} deals 5 damage to you. If you win the flip, create a 5/5 colorless Djinn artifact creature token with flying.";
     }
 
-    public BottleOfSuleimanEffect(final BottleOfSuleimanEffect effect) {
+    private BottleOfSuleimanEffect(final BottleOfSuleimanEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoundDetermined.java
+++ b/Mage.Sets/src/mage/cards/b/BoundDetermined.java
@@ -67,7 +67,7 @@ class BoundEffect extends OneShotEffect {
         this.staticText = "Sacrifice a creature. Return up to X cards from your graveyard to your hand, where X is the number of colors that creature was";
     }
 
-    public BoundEffect(final BoundEffect effect) {
+    private BoundEffect(final BoundEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoundlessRealms.java
+++ b/Mage.Sets/src/mage/cards/b/BoundlessRealms.java
@@ -50,7 +50,7 @@ class BoundlessRealmsEffect extends OneShotEffect {
                 "lands you control, put them onto the battlefield tapped, then shuffle";
     }
 
-    public BoundlessRealmsEffect(final BoundlessRealmsEffect effect) {
+    private BoundlessRealmsEffect(final BoundlessRealmsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BounteousKirin.java
+++ b/Mage.Sets/src/mage/cards/b/BounteousKirin.java
@@ -55,7 +55,7 @@ class BounteousKirinEffect extends OneShotEffect {
         this.staticText = "you may gain life equal to that spell's mana value";
     }
 
-    public BounteousKirinEffect(final BounteousKirinEffect effect) {
+    private BounteousKirinEffect(final BounteousKirinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BountyOfTheLuxa.java
+++ b/Mage.Sets/src/mage/cards/b/BountyOfTheLuxa.java
@@ -52,7 +52,7 @@ class BountyOfTheLuxaEffect extends OneShotEffect {
                 "Otherwise, add {C}{G}{U}";
     }
 
-    public BountyOfTheLuxaEffect(final BountyOfTheLuxaEffect effect) {
+    private BountyOfTheLuxaEffect(final BountyOfTheLuxaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoxOfFreerangeGoblins.java
+++ b/Mage.Sets/src/mage/cards/b/BoxOfFreerangeGoblins.java
@@ -43,7 +43,7 @@ class BoxOfFreerangeGoblinsEffect extends OneShotEffect {
         this.staticText = "Roll a six-sided die. Create a number of 1/1 red Goblin creature tokens equal to the result";
     }
 
-    public BoxOfFreerangeGoblinsEffect(final BoxOfFreerangeGoblinsEffect effect) {
+    private BoxOfFreerangeGoblinsEffect(final BoxOfFreerangeGoblinsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BraceForImpact.java
+++ b/Mage.Sets/src/mage/cards/b/BraceForImpact.java
@@ -55,7 +55,7 @@ class BraceForImpactPreventDamageTargetEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that would be dealt to target multicolored creature this turn. For each 1 damage prevented this way, put a +1/+1 counter on that creature";
     }
 
-    public BraceForImpactPreventDamageTargetEffect(final BraceForImpactPreventDamageTargetEffect effect) {
+    private BraceForImpactPreventDamageTargetEffect(final BraceForImpactPreventDamageTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BraidOfFire.java
+++ b/Mage.Sets/src/mage/cards/b/BraidOfFire.java
@@ -42,7 +42,7 @@ class BraidOfFireCost extends CostImpl {
         this.text = "Add {R}";
     }
 
-    public BraidOfFireCost(BraidOfFireCost cost) {
+    private BraidOfFireCost(final BraidOfFireCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrainGorgers.java
+++ b/Mage.Sets/src/mage/cards/b/BrainGorgers.java
@@ -57,7 +57,7 @@ class BrainGorgersCounterSourceEffect extends OneShotEffect {
         staticText = "any player may sacrifice a creature. If a player does, counter {this}";
     }
 
-    public BrainGorgersCounterSourceEffect(final BrainGorgersCounterSourceEffect effect) {
+    private BrainGorgersCounterSourceEffect(final BrainGorgersCounterSourceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrainInAJar.java
+++ b/Mage.Sets/src/mage/cards/b/BrainInAJar.java
@@ -69,7 +69,7 @@ class BrainInAJarCastEffect extends OneShotEffect {
                 + "counters on {this} from your hand without paying its mana cost";
     }
 
-    public BrainInAJarCastEffect(final BrainInAJarCastEffect effect) {
+    private BrainInAJarCastEffect(final BrainInAJarCastEffect effect) {
         super(effect);
     }
 
@@ -99,7 +99,7 @@ class BrainInAJarScryEffect extends OneShotEffect {
         this.staticText = "Scry X";
     }
 
-    public BrainInAJarScryEffect(final BrainInAJarScryEffect effect) {
+    private BrainInAJarScryEffect(final BrainInAJarScryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrainPry.java
+++ b/Mage.Sets/src/mage/cards/b/BrainPry.java
@@ -47,7 +47,7 @@ class BrainPryEffect extends OneShotEffect {
         staticText = "Target player reveals their hand. That player discards a card with that name. If they can't, you draw a card";
     }
 
-    public BrainPryEffect(final BrainPryEffect effect) {
+    private BrainPryEffect(final BrainPryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BranchingBolt.java
+++ b/Mage.Sets/src/mage/cards/b/BranchingBolt.java
@@ -63,7 +63,7 @@ class BranchingBoltEffect extends OneShotEffect {
         this.staticText = "{this} deals 3 damage to target creature with flying and to target creature without flying";
     }
 
-    public BranchingBoltEffect(final BranchingBoltEffect effect) {
+    private BranchingBoltEffect(final BranchingBoltEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrandOfIllOmen.java
+++ b/Mage.Sets/src/mage/cards/b/BrandOfIllOmen.java
@@ -62,7 +62,7 @@ class BrandOfIllOmenEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Enchanted creature's controller can't cast creature spells";
     }
 
-    public BrandOfIllOmenEffect(final BrandOfIllOmenEffect effect) {
+    private BrandOfIllOmenEffect(final BrandOfIllOmenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrandedBrawlers.java
+++ b/Mage.Sets/src/mage/cards/b/BrandedBrawlers.java
@@ -65,7 +65,7 @@ class BrandedBrawlersCantBlockEffect extends RestrictionEffect {
         staticText = "{this} can't block if you control " + filter.getMessage();
     }
 
-    public BrandedBrawlersCantBlockEffect(final BrandedBrawlersCantBlockEffect effect) {
+    private BrandedBrawlersCantBlockEffect(final BrandedBrawlersCantBlockEffect effect) {
         super(effect);
         this.filter = effect.filter;
     }

--- a/Mage.Sets/src/mage/cards/b/BrassHerald.java
+++ b/Mage.Sets/src/mage/cards/b/BrassHerald.java
@@ -57,7 +57,7 @@ class BrassHeraldEntersEffect extends OneShotEffect {
         this.staticText = "reveal the top four cards of your library. Put all creature cards of the chosen type revealed this way into your hand and the rest on the bottom of your library in any order";
     }
 
-    public BrassHeraldEntersEffect(final BrassHeraldEntersEffect effect) {
+    private BrassHeraldEntersEffect(final BrassHeraldEntersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrassSquire.java
+++ b/Mage.Sets/src/mage/cards/b/BrassSquire.java
@@ -62,7 +62,7 @@ class EquipEffect extends OneShotEffect {
         staticText = "Attach target Equipment you control to target creature you control";
     }
 
-    public EquipEffect(final EquipEffect effect) {
+    private EquipEffect(final EquipEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Bravado.java
+++ b/Mage.Sets/src/mage/cards/b/Bravado.java
@@ -56,7 +56,7 @@ class BravadoBoostEnchantedEffect extends ContinuousEffectImpl {
 		staticText = "Enchanted creature gets +1/+1 for each other creature you control";
     }
 
-    public BravadoBoostEnchantedEffect(final BravadoBoostEnchantedEffect effect) {
+    private BravadoBoostEnchantedEffect(final BravadoBoostEnchantedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BreachingLeviathan.java
+++ b/Mage.Sets/src/mage/cards/b/BreachingLeviathan.java
@@ -70,7 +70,7 @@ class BreachingLeviathanEffect extends OneShotEffect {
         this.staticText = "tap all nonblue creatures. Those creatures don't untap during their controllers' next untap steps";
     }
 
-    public BreachingLeviathanEffect(final BreachingLeviathanEffect effect) {
+    private BreachingLeviathanEffect(final BreachingLeviathanEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BreakingEntering.java
+++ b/Mage.Sets/src/mage/cards/b/BreakingEntering.java
@@ -56,7 +56,7 @@ class EnteringReturnFromGraveyardToBattlefieldEffect extends OneShotEffect {
         staticText = "Put a creature card from a graveyard onto the battlefield under your control. It gains haste until end of turn.";
     }
 
-    public EnteringReturnFromGraveyardToBattlefieldEffect(final EnteringReturnFromGraveyardToBattlefieldEffect effect) {
+    private EnteringReturnFromGraveyardToBattlefieldEffect(final EnteringReturnFromGraveyardToBattlefieldEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BreakingOfTheFellowship.java
+++ b/Mage.Sets/src/mage/cards/b/BreakingOfTheFellowship.java
@@ -55,7 +55,7 @@ class BreakingOfTheFellowshipEffect extends OneShotEffect {
         this.staticText = "Target creature an opponent controls deals damage equal to its power to another target creature that player controls";
     }
 
-    public BreakingOfTheFellowshipEffect(final BreakingOfTheFellowshipEffect effect) {
+    private BreakingOfTheFellowshipEffect(final BreakingOfTheFellowshipEffect effect) {
         super(effect);
     }
 
@@ -85,7 +85,7 @@ class BreakingOfTheFellowshipFirstTarget extends TargetCreaturePermanent {
         super(1, 1, filter, false);
     }
 
-    public BreakingOfTheFellowshipFirstTarget(final BreakingOfTheFellowshipFirstTarget target) {
+    private BreakingOfTheFellowshipFirstTarget(final BreakingOfTheFellowshipFirstTarget target) {
         super(target);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BreakingPoint.java
+++ b/Mage.Sets/src/mage/cards/b/BreakingPoint.java
@@ -44,7 +44,7 @@ class BreakingPointDestroyEffect extends OneShotEffect {
         this.staticText = "Any player may have {this} deal 6 damage to them. If no one does, destroy all creatures. Creatures destroyed this way can't be regenerated.";
     }
 
-    public BreakingPointDestroyEffect(final BreakingPointDestroyEffect effect) {
+    private BreakingPointDestroyEffect(final BreakingPointDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BreakingWave.java
+++ b/Mage.Sets/src/mage/cards/b/BreakingWave.java
@@ -52,7 +52,7 @@ class BreakingWaveEffect extends OneShotEffect {
         staticText = "Simultaneously untap all tapped creatures and tap all untapped creatures.";
     }
 
-    public BreakingWaveEffect(BreakingWaveEffect copy) {
+    private BreakingWaveEffect(final BreakingWaveEffect copy) {
         super(copy);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BreathOfFury.java
+++ b/Mage.Sets/src/mage/cards/b/BreathOfFury.java
@@ -60,7 +60,7 @@ class BreathOfFuryAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When enchanted creature deals combat damage to a player, ");
     }
 
-    public BreathOfFuryAbility(final BreathOfFuryAbility ability) {
+    private BreathOfFuryAbility(final BreathOfFuryAbility ability) {
         super(ability);
     }
 
@@ -100,7 +100,7 @@ class BreathOfFuryEffect extends OneShotEffect {
         staticText = "sacrifice it and attach {this} to a creature you control. If you do, untap all creatures you control and after this phase, there is an additional combat phase";
     }
 
-    public BreathOfFuryEffect(final BreathOfFuryEffect effect) {
+    private BreathOfFuryEffect(final BreathOfFuryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BredForTheHunt.java
+++ b/Mage.Sets/src/mage/cards/b/BredForTheHunt.java
@@ -44,7 +44,7 @@ class BredForTheHuntTriggeredAbility extends TriggeredAbilityImpl {
         this.optional = true;
     }
 
-    public BredForTheHuntTriggeredAbility(final BredForTheHuntTriggeredAbility ability) {
+    private BredForTheHuntTriggeredAbility(final BredForTheHuntTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Bribery.java
+++ b/Mage.Sets/src/mage/cards/b/Bribery.java
@@ -47,7 +47,7 @@ class BriberyEffect extends OneShotEffect {
         this.staticText = "Search target opponent's library for a creature card and put that card onto the battlefield under your control. Then that player shuffles";
     }
 
-    public BriberyEffect(final BriberyEffect effect) {
+    private BriberyEffect(final BriberyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BridgeFromBelow.java
+++ b/Mage.Sets/src/mage/cards/b/BridgeFromBelow.java
@@ -65,7 +65,7 @@ class BridgeFromBelowAbility extends TriggeredAbilityImpl {
         setTriggerPhrase(filter.getMessage() + ", if {this} is in your graveyard, ");
     }
 
-    public BridgeFromBelowAbility(BridgeFromBelowAbility ability) {
+    private BridgeFromBelowAbility(final BridgeFromBelowAbility ability) {
         super(ability);
         this.filter = ability.filter;
     }

--- a/Mage.Sets/src/mage/cards/b/BrilliantUltimatum.java
+++ b/Mage.Sets/src/mage/cards/b/BrilliantUltimatum.java
@@ -51,7 +51,7 @@ class BrilliantUltimatumEffect extends OneShotEffect {
                 + "If you cast a spell this way, you cast it without paying its mana cost";
     }
 
-    public BrilliantUltimatumEffect(final BrilliantUltimatumEffect effect) {
+    private BrilliantUltimatumEffect(final BrilliantUltimatumEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrimazKingOfOreskos.java
+++ b/Mage.Sets/src/mage/cards/b/BrimazKingOfOreskos.java
@@ -63,7 +63,7 @@ class BrimazKingOfOreskosEffect extends OneShotEffect {
         this.staticText = "create a 1/1 white Cat Soldier creature token with vigilance blocking that creature";
     }
 
-    public BrimazKingOfOreskosEffect(final BrimazKingOfOreskosEffect effect) {
+    private BrimazKingOfOreskosEffect(final BrimazKingOfOreskosEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrimstoneMage.java
+++ b/Mage.Sets/src/mage/cards/b/BrimstoneMage.java
@@ -51,7 +51,7 @@ public final class BrimstoneMage extends LevelerCard {
         setMaxLevelCounters(3);
     }
 
-    public BrimstoneMage (final BrimstoneMage card) {
+    private BrimstoneMage(final BrimstoneMage card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrineElemental.java
+++ b/Mage.Sets/src/mage/cards/b/BrineElemental.java
@@ -55,7 +55,7 @@ class BrineElementalEffect extends OneShotEffect {
         this.staticText = "each opponent skips their next untap step";
     }
 
-    public BrineElementalEffect(final BrineElementalEffect effect) {
+    private BrineElementalEffect(final BrineElementalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrineHag.java
+++ b/Mage.Sets/src/mage/cards/b/BrineHag.java
@@ -56,7 +56,7 @@ class BrineHagEffect extends OneShotEffect {
         this.staticText = "change the base power and toughness of all creatures that dealt damage to it this turn to 0/2";
     }
 
-    public BrineHagEffect(final BrineHagEffect effect) {
+    private BrineHagEffect(final BrineHagEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrineSeer.java
+++ b/Mage.Sets/src/mage/cards/b/BrineSeer.java
@@ -67,7 +67,7 @@ class BrineSeerEffect extends OneShotEffect {
                 + "Counter target spell unless its controller pays {1} for each card revealed this way";
     }
 
-    public BrineSeerEffect(final BrineSeerEffect effect) {
+    private BrineSeerEffect(final BrineSeerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BringTheEnding.java
+++ b/Mage.Sets/src/mage/cards/b/BringTheEnding.java
@@ -51,7 +51,7 @@ class BringTheEndingCounterEffect extends OneShotEffect {
         staticText = "Counter target spell unless its controller pays {2}.<br>" + AbilityWord.CORRUPTED.formatWord() + "Counter that spell instead if its controller has three or more poison counters.";
     }
 
-    public BringTheEndingCounterEffect(final BringTheEndingCounterEffect effect) {
+    private BringTheEndingCounterEffect(final BringTheEndingCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BringToLight.java
+++ b/Mage.Sets/src/mage/cards/b/BringToLight.java
@@ -51,7 +51,7 @@ class BringToLightEffect extends OneShotEffect {
                 + "then shuffle. You may cast that card without paying its mana cost";
     }
 
-    public BringToLightEffect(final BringToLightEffect effect) {
+    private BringToLightEffect(final BringToLightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BriselaVoiceOfNightmares.java
+++ b/Mage.Sets/src/mage/cards/b/BriselaVoiceOfNightmares.java
@@ -62,7 +62,7 @@ class BriselaVoiceOfNightmaresCantCastEffect extends ContinuousRuleModifyingEffe
         staticText = "Your opponents can't cast spells with mana value 3 or less";
     }
 
-    public BriselaVoiceOfNightmaresCantCastEffect(final BriselaVoiceOfNightmaresCantCastEffect effect) {
+    private BriselaVoiceOfNightmaresCantCastEffect(final BriselaVoiceOfNightmaresCantCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrokenVisage.java
+++ b/Mage.Sets/src/mage/cards/b/BrokenVisage.java
@@ -58,7 +58,7 @@ class BrokenVisageEffect extends OneShotEffect {
         this.staticText = "Destroy target nonartifact attacking creature. It can't be regenerated. Create a black Spirit creature token. Its power is equal to that creature's power and its toughness is equal to that creature's toughness. Sacrifice the token at the beginning of the next end step";
     }
 
-    public BrokenVisageEffect(final BrokenVisageEffect effect) {
+    private BrokenVisageEffect(final BrokenVisageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BronzeBombshell.java
+++ b/Mage.Sets/src/mage/cards/b/BronzeBombshell.java
@@ -52,7 +52,7 @@ class LoseControlTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When a player other than {this}'s owner controls it, ");
     }
 
-    public LoseControlTriggeredAbility(final LoseControlTriggeredAbility ability) {
+    private LoseControlTriggeredAbility(final LoseControlTriggeredAbility ability) {
         super(ability);
     }
 
@@ -86,7 +86,7 @@ class BronzeBombshellEffect extends OneShotEffect {
         this.staticText = "that player sacrifices it. If the player does, {this} deals 7 damage to the player.";
     }
 
-    public BronzeBombshellEffect(final BronzeBombshellEffect effect) {
+    private BronzeBombshellEffect(final BronzeBombshellEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BronzebeakMoa.java
+++ b/Mage.Sets/src/mage/cards/b/BronzebeakMoa.java
@@ -39,7 +39,7 @@ public final class BronzebeakMoa extends CardImpl {
 
     }
 
-    public BronzebeakMoa (final BronzebeakMoa card) {
+    private BronzebeakMoa(final BronzebeakMoa card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BroodBirthing.java
+++ b/Mage.Sets/src/mage/cards/b/BroodBirthing.java
@@ -43,7 +43,7 @@ class BroodBirthingEffect extends OneShotEffect {
         this.staticText = "If you control an Eldrazi Spawn, create three 0/1 colorless Eldrazi Spawn creature tokens. They have \"Sacrifice this creature: Add {C}.\" Otherwise, create one of those tokens";
     }
 
-    public BroodBirthingEffect(final BroodBirthingEffect effect) {
+    private BroodBirthingEffect(final BroodBirthingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BroodSliver.java
+++ b/Mage.Sets/src/mage/cards/b/BroodSliver.java
@@ -52,7 +52,7 @@ class BroodSliverEffect extends OneShotEffect {
         this.staticText = "its controller may create a 1/1 colorless Sliver creature token";
     }
 
-    public BroodSliverEffect(final BroodSliverEffect effect) {
+    private BroodSliverEffect(final BroodSliverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrothersYamazaki.java
+++ b/Mage.Sets/src/mage/cards/b/BrothersYamazaki.java
@@ -79,7 +79,7 @@ class BrothersYamazakiIgnoreLegendRuleEffectEffect extends ContinuousEffectImpl 
         staticText = "If there are exactly two permanents named Brothers Yamazaki on the battlefield, the \"legend rule\" doesn't apply to them";
     }
 
-    public BrothersYamazakiIgnoreLegendRuleEffectEffect(final BrothersYamazakiIgnoreLegendRuleEffectEffect effect) {
+    private BrothersYamazakiIgnoreLegendRuleEffectEffect(final BrothersYamazakiIgnoreLegendRuleEffectEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Browbeat.java
+++ b/Mage.Sets/src/mage/cards/b/Browbeat.java
@@ -44,7 +44,7 @@ class BrowbeatDrawEffect extends OneShotEffect {
         staticText = "Any player may have {this} deal 5 damage to them. If no one does, target player draws three cards.";
     }
 
-    public BrowbeatDrawEffect(final BrowbeatDrawEffect effect) {
+    private BrowbeatDrawEffect(final BrowbeatDrawEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Browse.java
+++ b/Mage.Sets/src/mage/cards/b/Browse.java
@@ -46,7 +46,7 @@ class BrowseEffect extends OneShotEffect {
         this.staticText = "Look at the top five cards of your library, put one of them into your hand, and exile the rest";
     }
 
-    public BrowseEffect(final BrowseEffect effect) {
+    private BrowseEffect(final BrowseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrudicladTelchorEngineer.java
+++ b/Mage.Sets/src/mage/cards/b/BrudicladTelchorEngineer.java
@@ -73,7 +73,7 @@ class BrudicladTelchorEngineerEffect extends OneShotEffect {
         this.staticText = "create a 2/1 blue Phyrexian Myr artifact creature token. Then you may choose a token you control. If you do, each other token you control becomes a copy of that token";
     }
 
-    public BrudicladTelchorEngineerEffect(final BrudicladTelchorEngineerEffect effect) {
+    private BrudicladTelchorEngineerEffect(final BrudicladTelchorEngineerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrunaLightOfAlabaster.java
+++ b/Mage.Sets/src/mage/cards/b/BrunaLightOfAlabaster.java
@@ -64,7 +64,7 @@ class BrunaLightOfAlabasterEffect extends OneShotEffect {
         this.staticText = "attach to it any number of Auras on the battlefield and you may put onto the battlefield attached to it any number of Aura cards that could enchant it from your graveyard and/or hand";
     }
 
-    public BrunaLightOfAlabasterEffect(final BrunaLightOfAlabasterEffect effect) {
+    private BrunaLightOfAlabasterEffect(final BrunaLightOfAlabasterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrutalDeceiver.java
+++ b/Mage.Sets/src/mage/cards/b/BrutalDeceiver.java
@@ -60,7 +60,7 @@ class BrutalDeceiverEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of your library. If it's a land card, {this} gets +1/+0 and gains first strike until end of turn";
     }
 
-    public BrutalDeceiverEffect(final BrutalDeceiverEffect effect) {
+    private BrutalDeceiverEffect(final BrutalDeceiverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrutalHordechief.java
+++ b/Mage.Sets/src/mage/cards/b/BrutalHordechief.java
@@ -62,7 +62,7 @@ class BrutalHordechiefTriggeredAbility extends TriggeredAbilityImpl {
         this.addEffect(new GainLifeEffect(1));
     }
 
-    public BrutalHordechiefTriggeredAbility(final BrutalHordechiefTriggeredAbility ability) {
+    private BrutalHordechiefTriggeredAbility(final BrutalHordechiefTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrutalizerExarch.java
+++ b/Mage.Sets/src/mage/cards/b/BrutalizerExarch.java
@@ -70,7 +70,7 @@ class BrutalizerExarchEffect2 extends OneShotEffect {
         this.staticText = "put target noncreature permanent on the bottom of its owner's library";
     }
 
-    public BrutalizerExarchEffect2(final BrutalizerExarchEffect2 effect) {
+    private BrutalizerExarchEffect2(final BrutalizerExarchEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BubblingCauldron.java
+++ b/Mage.Sets/src/mage/cards/b/BubblingCauldron.java
@@ -64,7 +64,7 @@ class BubblingCauldronEffect extends OneShotEffect {
         staticText = "Each opponent loses 4 life. You gain life equal to the life lost this way";
     }
 
-    public BubblingCauldronEffect(final BubblingCauldronEffect effect) {
+    private BubblingCauldronEffect(final BubblingCauldronEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BudokaGardener.java
+++ b/Mage.Sets/src/mage/cards/b/BudokaGardener.java
@@ -104,7 +104,7 @@ class DokaiWeaverofLife extends TokenImpl {
         this.addAbility(ability);
     }
 
-    public DokaiWeaverofLife(final DokaiWeaverofLife token) {
+    private DokaiWeaverofLife(final DokaiWeaverofLife token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BudokaPupil.java
+++ b/Mage.Sets/src/mage/cards/b/BudokaPupil.java
@@ -81,7 +81,7 @@ class IchigaWhoTopplesOaks extends TokenImpl {
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }
-    public IchigaWhoTopplesOaks(final IchigaWhoTopplesOaks token) {
+    private IchigaWhoTopplesOaks(final IchigaWhoTopplesOaks token) {
         super(token);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BuildersBane.java
+++ b/Mage.Sets/src/mage/cards/b/BuildersBane.java
@@ -59,7 +59,7 @@ class BuildersBaneEffect extends OneShotEffect {
         this.staticText = "Destroy X target artifacts. {this} deals damage to each player equal to the number of artifacts they controlled that were put into a graveyard this way";
     }
 
-    public BuildersBaneEffect(final BuildersBaneEffect effect) {
+    private BuildersBaneEffect(final BuildersBaneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BullCerodon.java
+++ b/Mage.Sets/src/mage/cards/b/BullCerodon.java
@@ -28,7 +28,7 @@ public final class BullCerodon extends CardImpl {
         this.addAbility(HasteAbility.getInstance());
     }
 
-    public BullCerodon (final BullCerodon card) {
+    private BullCerodon(final BullCerodon card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BullElephant.java
+++ b/Mage.Sets/src/mage/cards/b/BullElephant.java
@@ -35,7 +35,7 @@ public final class BullElephant extends CardImpl {
         ))));
     }
 
-    public BullElephant(BullElephant other) {
+    private BullElephant(final BullElephant other) {
         super(other);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BullHippo.java
+++ b/Mage.Sets/src/mage/cards/b/BullHippo.java
@@ -25,7 +25,7 @@ public final class BullHippo extends CardImpl {
         this.addAbility(new IslandwalkAbility());
     }
 
-    public BullHippo (final BullHippo card) {
+    private BullHippo(final BullHippo card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BullRush.java
+++ b/Mage.Sets/src/mage/cards/b/BullRush.java
@@ -23,7 +23,7 @@ public final class BullRush extends CardImpl {
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
-    public BullRush (final BullRush card) {
+    private BullRush(final BullRush card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Bulwark.java
+++ b/Mage.Sets/src/mage/cards/b/Bulwark.java
@@ -47,7 +47,7 @@ class BulwarkDamageEffect extends OneShotEffect {
         staticText = "Bulwark deals X damage to target opponent, where X is the number of cards in your hand minus the number of cards in that player's hand";
     }
 
-    public BulwarkDamageEffect(final BulwarkDamageEffect effect) {
+    private BulwarkDamageEffect(final BulwarkDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BuriedAlive.java
+++ b/Mage.Sets/src/mage/cards/b/BuriedAlive.java
@@ -45,7 +45,7 @@ class BuriedAliveEffect extends OneShotEffect {
         staticText = "search your library for up to three creature cards, put them into your graveyard, then shuffle";
     }
 
-    public BuriedAliveEffect(final BuriedAliveEffect effect) {
+    private BuriedAliveEffect(final BuriedAliveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BurnAtTheStake.java
+++ b/Mage.Sets/src/mage/cards/b/BurnAtTheStake.java
@@ -56,7 +56,7 @@ class BurnAtTheStakeEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to any target equal to three times the number of creatures tapped this way";
     }
 
-    public BurnAtTheStakeEffect(final BurnAtTheStakeEffect effect) {
+    private BurnAtTheStakeEffect(final BurnAtTheStakeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BurnFromWithin.java
+++ b/Mage.Sets/src/mage/cards/b/BurnFromWithin.java
@@ -53,7 +53,7 @@ class BurnFromWithinEffect extends OneShotEffect {
                 "If that creature would die this turn, exile it instead";
     }
 
-    public BurnFromWithinEffect(final BurnFromWithinEffect effect) {
+    private BurnFromWithinEffect(final BurnFromWithinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BurnTheImpure.java
+++ b/Mage.Sets/src/mage/cards/b/BurnTheImpure.java
@@ -45,7 +45,7 @@ class BurnTheImpureEffect extends OneShotEffect {
         staticText = "{this} deals 3 damage to target creature. If that creature has infect, {this} deals 3 damage to that creature's controller.";
     }
 
-    public BurnTheImpureEffect(final BurnTheImpureEffect effect) {
+    private BurnTheImpureEffect(final BurnTheImpureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BurningCinderFuryOfCrimsonChaosFire.java
+++ b/Mage.Sets/src/mage/cards/b/BurningCinderFuryOfCrimsonChaosFire.java
@@ -59,7 +59,7 @@ class BurningCinderFuryOfCrimsonChaosFireAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever any player taps a permanent, ");
     }
 
-    public BurningCinderFuryOfCrimsonChaosFireAbility(BurningCinderFuryOfCrimsonChaosFireAbility ability) {
+    private BurningCinderFuryOfCrimsonChaosFireAbility(final BurningCinderFuryOfCrimsonChaosFireAbility ability) {
         super(ability);
     }
 
@@ -95,7 +95,7 @@ class BurningCinderFuryOfCrimsonChaosFireEffect extends OneShotEffect {
         this.staticText = "that player choose one of their opponents. The chosen player gains control of that permanent at the beginning of the next end step";
     }
 
-    public BurningCinderFuryOfCrimsonChaosFireEffect(final BurningCinderFuryOfCrimsonChaosFireEffect effect) {
+    private BurningCinderFuryOfCrimsonChaosFireEffect(final BurningCinderFuryOfCrimsonChaosFireEffect effect) {
         super(effect);
         this.firstControllerId = effect.firstControllerId;
     }
@@ -149,7 +149,7 @@ class BurningCinderFuryOfCrimsonChaosFireCreatureGainControlEffect extends Conti
         this.staticText = "the chosen player gains control of that permanent";
     }
 
-    public BurningCinderFuryOfCrimsonChaosFireCreatureGainControlEffect(final BurningCinderFuryOfCrimsonChaosFireCreatureGainControlEffect effect) {
+    private BurningCinderFuryOfCrimsonChaosFireCreatureGainControlEffect(final BurningCinderFuryOfCrimsonChaosFireCreatureGainControlEffect effect) {
         super(effect);
         this.controller = effect.controller;
     }

--- a/Mage.Sets/src/mage/cards/b/Burnout.java
+++ b/Mage.Sets/src/mage/cards/b/Burnout.java
@@ -60,7 +60,7 @@ class BurnoutCounterTargetEffect extends OneShotEffect {
         super(Outcome.Detriment);
     }
 
-    public BurnoutCounterTargetEffect(final BurnoutCounterTargetEffect effect) {
+    private BurnoutCounterTargetEffect(final BurnoutCounterTargetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BurrentonBombardier.java
+++ b/Mage.Sets/src/mage/cards/b/BurrentonBombardier.java
@@ -30,7 +30,7 @@ public final class BurrentonBombardier extends CardImpl {
         this.addAbility(new ReinforceAbility(2, new ManaCostsImpl<>("{2}{W}")));
     }
 
-    public BurrentonBombardier (final BurrentonBombardier card) {
+    private BurrentonBombardier(final BurrentonBombardier card) {
         super(card);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BushiTenderfoot.java
+++ b/Mage.Sets/src/mage/cards/b/BushiTenderfoot.java
@@ -68,7 +68,7 @@ class KenzoTheHardhearted extends TokenImpl {
         this.addAbility(DoubleStrikeAbility.getInstance());
         this.addAbility(new BushidoAbility(2));
     }
-    public KenzoTheHardhearted(final KenzoTheHardhearted token) {
+    private KenzoTheHardhearted(final KenzoTheHardhearted token) {
         super(token);
     }
 


### PR DESCRIPTION
Part of #11054 

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`public ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `private $1(final $1 $3`
