### PR TITLE
Clean package-private copy constructors in cards starting A to G

### DIFF
--- a/Mage.Sets/src/mage/cards/a/Abundance.java
+++ b/Mage.Sets/src/mage/cards/a/Abundance.java
@@ -47,7 +47,7 @@ class AbundanceReplacementEffect extends ReplacementEffectImpl {
         staticText = "If you would draw a card, you may instead choose land or nonland and reveal cards from the top of your library until you reveal a card of the chosen kind. Put that card into your hand and put all other cards revealed this way on the bottom of your library in any order";
     }
 
-    AbundanceReplacementEffect(final AbundanceReplacementEffect effect) {
+    private AbundanceReplacementEffect(final AbundanceReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AcademicProbation.java
+++ b/Mage.Sets/src/mage/cards/a/AcademicProbation.java
@@ -59,7 +59,7 @@ class AcademicProbationRestrictionEffect extends RestrictionEffect {
         staticText = "choose target nonland permanent. Until your next turn, it can't attack or block, and its activated abilities can't be activated";
     }
 
-    AcademicProbationRestrictionEffect(final AcademicProbationRestrictionEffect effect) {
+    private AcademicProbationRestrictionEffect(final AcademicProbationRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AcademyResearchers.java
+++ b/Mage.Sets/src/mage/cards/a/AcademyResearchers.java
@@ -55,7 +55,7 @@ class AcademyResearchersEffect extends OneShotEffect {
         this.staticText = "you may put an Aura card from your hand onto the battlefield attached to {this}.";
     }
 
-    AcademyResearchersEffect(final AcademyResearchersEffect effect) {
+    private AcademyResearchersEffect(final AcademyResearchersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AcidicSoil.java
+++ b/Mage.Sets/src/mage/cards/a/AcidicSoil.java
@@ -44,7 +44,7 @@ class AcidicSoilEffect extends OneShotEffect {
         staticText = "{this} deals damage to each player equal to the number of lands they control";
     }
 
-    AcidicSoilEffect(final AcidicSoilEffect effect) {
+    private AcidicSoilEffect(final AcidicSoilEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Addle.java
+++ b/Mage.Sets/src/mage/cards/a/Addle.java
@@ -49,7 +49,7 @@ class AddleEffect extends OneShotEffect {
         staticText = "Choose a color. Target player reveals their hand and you choose a card of that color from it. That player discards that card.";
     }
 
-    AddleEffect(final AddleEffect effect) {
+    private AddleEffect(final AddleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AetherBarrier.java
+++ b/Mage.Sets/src/mage/cards/a/AetherBarrier.java
@@ -47,7 +47,7 @@ class AetherBarrierEffect extends SacrificeEffect {
         this.staticText = "that player sacrifices a permanent unless they pay {1}";
     }
 
-    AetherBarrierEffect(final AetherBarrierEffect effect) {
+    private AetherBarrierEffect(final AetherBarrierEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Aethersnatch.java
+++ b/Mage.Sets/src/mage/cards/a/Aethersnatch.java
@@ -44,7 +44,7 @@ class AethersnatchEffect extends OneShotEffect {
         this.staticText = "Gain control of target spell. You may choose new targets for it";
     }
     
-    AethersnatchEffect(final AethersnatchEffect effect) {
+    private AethersnatchEffect(final AethersnatchEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/a/Aethertow.java
+++ b/Mage.Sets/src/mage/cards/a/Aethertow.java
@@ -51,7 +51,7 @@ class AethertowEffect extends OneShotEffect {
         staticText = "Put target attacking or blocking creature on top of its owner's library";
     }
 
-    AethertowEffect(final AethertowEffect effect) {
+    private AethertowEffect(final AethertowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AetherworksMarvel.java
+++ b/Mage.Sets/src/mage/cards/a/AetherworksMarvel.java
@@ -65,7 +65,7 @@ class AetherworksMarvelEffect extends OneShotEffect {
                 + "library in a random order";
     }
 
-    AetherworksMarvelEffect(final AetherworksMarvelEffect effect) {
+    private AetherworksMarvelEffect(final AetherworksMarvelEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AkkiLavarunner.java
+++ b/Mage.Sets/src/mage/cards/a/AkkiLavarunner.java
@@ -112,7 +112,7 @@ class TokTokVolcanoBornEffect extends ReplacementEffectImpl {
         staticText = "If a red source would deal damage to a player, it deals that much damage plus 1 to that player instead";
     }
 
-    TokTokVolcanoBornEffect(final TokTokVolcanoBornEffect effect) {
+    private TokTokVolcanoBornEffect(final TokTokVolcanoBornEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AlAbarasCarpet.java
+++ b/Mage.Sets/src/mage/cards/a/AlAbarasCarpet.java
@@ -59,7 +59,7 @@ class AlAbarasCarpetEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that would be dealt to you this turn by attacking creatures without flying";
     }
 
-    AlAbarasCarpetEffect(final AlAbarasCarpetEffect effect) {
+    private AlAbarasCarpetEffect(final AlAbarasCarpetEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AllIsDust.java
+++ b/Mage.Sets/src/mage/cards/a/AllIsDust.java
@@ -41,7 +41,7 @@ class AllIsDustEffect extends OneShotEffect {
         staticText = "Each player sacrifices all permanents they control that are one or more colors";
     }
 
-    AllIsDustEffect(final AllIsDustEffect effect) {
+    private AllIsDustEffect(final AllIsDustEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AmuletOfVigor.java
+++ b/Mage.Sets/src/mage/cards/a/AmuletOfVigor.java
@@ -44,7 +44,7 @@ class AmuletOfVigorTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new UntapTargetEffect());
     }
 
-    AmuletOfVigorTriggeredAbility(final AmuletOfVigorTriggeredAbility ability) {
+    private AmuletOfVigorTriggeredAbility(final AmuletOfVigorTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnaSanctuary.java
+++ b/Mage.Sets/src/mage/cards/a/AnaSanctuary.java
@@ -55,7 +55,7 @@ class BoostEffect extends OneShotEffect {
         this.amount = amount;
     }
 
-    BoostEffect(final BoostEffect effect) {
+    private BoostEffect(final BoostEffect effect) {
         super(effect);
         this.amount = effect.amount;
     }

--- a/Mage.Sets/src/mage/cards/a/AnakinSkywalker.java
+++ b/Mage.Sets/src/mage/cards/a/AnakinSkywalker.java
@@ -72,7 +72,7 @@ class AnakinSkywalkerEffect extends ReplacementEffectImpl {
         staticText = "If {this} would die, regenerate and transform him instead";
     }
 
-    AnakinSkywalkerEffect(final AnakinSkywalkerEffect effect) {
+    private AnakinSkywalkerEffect(final AnakinSkywalkerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AncestralKnowledge.java
+++ b/Mage.Sets/src/mage/cards/a/AncestralKnowledge.java
@@ -54,7 +54,7 @@ class AncestralKnowledgeEffect extends OneShotEffect {
         this.staticText = "look at the top ten cards of your library, then exile any number of them and put the rest back on top of your library in any order";
     }
 
-    AncestralKnowledgeEffect(final AncestralKnowledgeEffect effect) {
+    private AncestralKnowledgeEffect(final AncestralKnowledgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelicSkirmisher.java
+++ b/Mage.Sets/src/mage/cards/a/AngelicSkirmisher.java
@@ -60,7 +60,7 @@ class AngelicSkirmisherEffect extends OneShotEffect {
         staticText = "choose first strike, vigilance or lifelink. Creatures you control gain that ability until end of turn";
     }
 
-    AngelicSkirmisherEffect(final AngelicSkirmisherEffect effect) {
+    private AngelicSkirmisherEffect(final AngelicSkirmisherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelsTrumpet.java
+++ b/Mage.Sets/src/mage/cards/a/AngelsTrumpet.java
@@ -51,7 +51,7 @@ class AngelsTrumpetTapEffect extends OneShotEffect {
         this.staticText = "tap all untapped creatures that player controls that didn't attack this turn. Angel's Trumpet deals damage to the player equal to the number of creatures tapped this way";
     }
 
-    AngelsTrumpetTapEffect(final AngelsTrumpetTapEffect effect) {
+    private AngelsTrumpetTapEffect(final AngelsTrumpetTapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnheloThePainter.java
+++ b/Mage.Sets/src/mage/cards/a/AnheloThePainter.java
@@ -65,7 +65,7 @@ class AnheloThePainterGainCausalityEffect extends ContinuousEffectImpl {
                 "When you do, copy the spell and you may choose new targets for the copy.)</i>";
     }
 
-    AnheloThePainterGainCausalityEffect(final AnheloThePainterGainCausalityEffect effect) {
+    private AnheloThePainterGainCausalityEffect(final AnheloThePainterGainCausalityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnimarSoulOfElements.java
+++ b/Mage.Sets/src/mage/cards/a/AnimarSoulOfElements.java
@@ -61,7 +61,7 @@ class AnimarCostReductionEffect extends CostModificationEffectImpl {
         staticText = "Creature spells you cast cost {1} less to cast for each +1/+1 counter on Animar";
     }
 
-    AnimarCostReductionEffect(AnimarCostReductionEffect effect) {
+    private AnimarCostReductionEffect(final AnimarCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnimationModule.java
+++ b/Mage.Sets/src/mage/cards/a/AnimationModule.java
@@ -64,7 +64,7 @@ class AnimationModuleTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DoIfCostPaid(new CreateTokenEffect(new ServoToken()), new GenericManaCost(1)), false);
     }
 
-    AnimationModuleTriggeredAbility(final AnimationModuleTriggeredAbility ability) {
+    private AnimationModuleTriggeredAbility(final AnimationModuleTriggeredAbility ability) {
         super(ability);
     }
 
@@ -103,7 +103,7 @@ class AnimationModuleEffect extends OneShotEffect {
         this.staticText = "Choose a counter on target permanent or player. Give that permanent or player another counter of that kind";
     }
 
-    AnimationModuleEffect(final AnimationModuleEffect effect) {
+    private AnimationModuleEffect(final AnimationModuleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnkhOfMishra.java
+++ b/Mage.Sets/src/mage/cards/a/AnkhOfMishra.java
@@ -46,7 +46,7 @@ class AnkhOfMishraAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(2));
     }
 
-    AnkhOfMishraAbility(final AnkhOfMishraAbility ability) {
+    private AnkhOfMishraAbility(final AnkhOfMishraAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Anthroplasm.java
+++ b/Mage.Sets/src/mage/cards/a/Anthroplasm.java
@@ -59,7 +59,7 @@ class AnthroplasmEffect extends OneShotEffect {
         staticText = "Remove all +1/+1 counters from {this} and put X +1/+1 counters on it";
     }
 
-    AnthroplasmEffect(AnthroplasmEffect effect) {
+    private AnthroplasmEffect(final AnthroplasmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnuridScavenger.java
+++ b/Mage.Sets/src/mage/cards/a/AnuridScavenger.java
@@ -61,7 +61,7 @@ class AnuridScavengerCost extends CostImpl {
     }
 
 
-    AnuridScavengerCost(final AnuridScavengerCost cost) {
+    private AnuridScavengerCost(final AnuridScavengerCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArbiterOfKnollridge.java
+++ b/Mage.Sets/src/mage/cards/a/ArbiterOfKnollridge.java
@@ -52,7 +52,7 @@ class ArbiterOfKnollridgeEffect extends OneShotEffect {
         staticText = "each player's life total becomes the highest life total among all players";
     }
 
-    ArbiterOfKnollridgeEffect(final ArbiterOfKnollridgeEffect effect) {
+    private ArbiterOfKnollridgeEffect(final ArbiterOfKnollridgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArchangelOfTithes.java
+++ b/Mage.Sets/src/mage/cards/a/ArchangelOfTithes.java
@@ -58,7 +58,7 @@ class ArchangelOfTithesPayManaToAttackAllEffect extends CantAttackYouUnlessPayAl
         staticText = "As long as {this} is untapped, creatures can't attack you or planeswalkers you control unless their controller pays {1} for each of those creatures.";
     }
 
-    ArchangelOfTithesPayManaToAttackAllEffect(ArchangelOfTithesPayManaToAttackAllEffect effect) {
+    private ArchangelOfTithesPayManaToAttackAllEffect(final ArchangelOfTithesPayManaToAttackAllEffect effect) {
         super(effect);
     }
 
@@ -85,7 +85,7 @@ class ArchangelOfTithesPayManaToBlockAllEffect extends CantBlockUnlessPayManaAll
         staticText = "As long as {this} is attacking, creatures can't block unless their controller pays {1} for each of those creatures.";
     }
 
-    ArchangelOfTithesPayManaToBlockAllEffect(ArchangelOfTithesPayManaToBlockAllEffect effect) {
+    private ArchangelOfTithesPayManaToBlockAllEffect(final ArchangelOfTithesPayManaToBlockAllEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/Arena.java
+++ b/Mage.Sets/src/mage/cards/a/Arena.java
@@ -53,7 +53,7 @@ class ArenaEffect extends OneShotEffect {
                 "Those creatures fight each other. <i>(Each deals damage equal to its power to the other.)</i>";
     }
 
-    ArenaEffect(final ArenaEffect effect) {
+    private ArenaEffect(final ArenaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArgothianWurm.java
+++ b/Mage.Sets/src/mage/cards/a/ArgothianWurm.java
@@ -55,7 +55,7 @@ class ArgothianWurmEffect extends PutOnLibrarySourceEffect {
         this.staticText = "any player may sacrifice a land. If a player does, put {this} on top of its owner's library";
     }
     
-    ArgothianWurmEffect(final ArgothianWurmEffect effect) {
+    private ArgothianWurmEffect(final ArgothianWurmEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/a/ArtifactPossession.java
+++ b/Mage.Sets/src/mage/cards/a/ArtifactPossession.java
@@ -56,7 +56,7 @@ class AbilityActivatedTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageAttachedControllerEffect(2));
     }
 
-    AbilityActivatedTriggeredAbility(final AbilityActivatedTriggeredAbility ability) {
+    private AbilityActivatedTriggeredAbility(final AbilityActivatedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AshcloudPhoenix.java
+++ b/Mage.Sets/src/mage/cards/a/AshcloudPhoenix.java
@@ -64,7 +64,7 @@ class AshcloudPhoenixEffect extends OneShotEffect {
         this.staticText = "return it to the battlefield face down under your control";
     }
 
-    AshcloudPhoenixEffect(final AshcloudPhoenixEffect effect) {
+    private AshcloudPhoenixEffect(final AshcloudPhoenixEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AshesOfTheFallen.java
+++ b/Mage.Sets/src/mage/cards/a/AshesOfTheFallen.java
@@ -48,7 +48,7 @@ class AshesOfTheFallenEffect extends ContinuousEffectImpl {
         staticText = "Each creature card in your graveyard has the chosen creature type in addition to its other types";
     }
 
-    AshesOfTheFallenEffect(final AshesOfTheFallenEffect effect) {
+    private AshesOfTheFallenEffect(final AshesOfTheFallenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AshnodsCylix.java
+++ b/Mage.Sets/src/mage/cards/a/AshnodsCylix.java
@@ -54,7 +54,7 @@ class AshnodsCylixEffect extends OneShotEffect {
         this.staticText = "Target player looks at the top three cards of their library, puts one of them back on top of their library, then exiles the rest";
     }
 
-    AshnodsCylixEffect(final AshnodsCylixEffect effect) {
+    private AshnodsCylixEffect(final AshnodsCylixEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AugmenterPugilist.java
+++ b/Mage.Sets/src/mage/cards/a/AugmenterPugilist.java
@@ -81,7 +81,7 @@ class EchoingEquationEffect extends OneShotEffect {
         staticText = "choose target creature you control. Each other creature you control becomes a copy of it until end of turn, except those creatures aren't legendary if the chosen creature is legendary";
     }
 
-    EchoingEquationEffect(EchoingEquationEffect effect) {
+    private EchoingEquationEffect(final EchoingEquationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AuriokSurvivors.java
+++ b/Mage.Sets/src/mage/cards/a/AuriokSurvivors.java
@@ -60,7 +60,7 @@ class AuriokSurvivorsEffect extends OneShotEffect {
         staticText = "If you do, you may attach it to {this}";
     }
 
-    AuriokSurvivorsEffect(final AuriokSurvivorsEffect effect) {
+    private AuriokSurvivorsEffect(final AuriokSurvivorsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AurraSingBaneOfJedi.java
+++ b/Mage.Sets/src/mage/cards/a/AurraSingBaneOfJedi.java
@@ -105,7 +105,7 @@ class SacrificeAllEffect extends OneShotEffect {
         staticText = "and sacrificies all creatures they control";
     }
 
-    SacrificeAllEffect(final SacrificeAllEffect effect) {
+    private SacrificeAllEffect(final SacrificeAllEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvariceAmulet.java
+++ b/Mage.Sets/src/mage/cards/a/AvariceAmulet.java
@@ -71,7 +71,7 @@ class AvariceAmuletChangeControlEffect extends ContinuousEffectImpl {
         staticText = "target opponent gains control of {this}";
     }
 
-    AvariceAmuletChangeControlEffect(final AvariceAmuletChangeControlEffect effect) {
+    private AvariceAmuletChangeControlEffect(final AvariceAmuletChangeControlEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvenMindcensor.java
+++ b/Mage.Sets/src/mage/cards/a/AvenMindcensor.java
@@ -54,7 +54,7 @@ class AvenMindcensorEffect extends ReplacementEffectImpl {
         staticText = "If an opponent would search a library, that player searches the top four cards of that library instead";
     }
 
-    AvenMindcensorEffect(final AvenMindcensorEffect effect) {
+    private AvenMindcensorEffect(final AvenMindcensorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvenWarcraft.java
+++ b/Mage.Sets/src/mage/cards/a/AvenWarcraft.java
@@ -49,7 +49,7 @@ class AvenWarcraftEffect extends OneShotEffect {
                 + "choose a color. Creatures you control also gain protection from the chosen color until end of turn";
     }
 
-    AvenWarcraftEffect(final AvenWarcraftEffect effect) {
+    private AvenWarcraftEffect(final AvenWarcraftEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AzorTheLawbringer.java
+++ b/Mage.Sets/src/mage/cards/a/AzorTheLawbringer.java
@@ -153,7 +153,7 @@ class AzorTheLawbringerAttacksEffect extends OneShotEffect {
         staticText = "you may pay {X}{W}{U}{U}. If you do, you gain X life and draw X cards";
     }
 
-    AzorTheLawbringerAttacksEffect(final AzorTheLawbringerAttacksEffect effect) {
+    private AzorTheLawbringerAttacksEffect(final AzorTheLawbringerAttacksEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AzraBladeseeker.java
+++ b/Mage.Sets/src/mage/cards/a/AzraBladeseeker.java
@@ -54,7 +54,7 @@ class AzraBladeseekerEffect extends OneShotEffect {
         this.staticText = "each player on your team may discard a card, then each player who discarded a card this way draws a card";
     }
 
-    AzraBladeseekerEffect(final AzraBladeseekerEffect effect) {
+    private AzraBladeseekerEffect(final AzraBladeseekerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Backslide.java
+++ b/Mage.Sets/src/mage/cards/b/Backslide.java
@@ -62,7 +62,7 @@ class BackslideEffect extends OneShotEffect {
         this.staticText = "Turn target creature with a morph ability face down.";
     }
 
-    BackslideEffect(final BackslideEffect effect) {
+    private BackslideEffect(final BackslideEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Bamboozle.java
+++ b/Mage.Sets/src/mage/cards/b/Bamboozle.java
@@ -51,7 +51,7 @@ class BamboozleEffect extends OneShotEffect {
         staticText = "Target player reveals the top four cards of their library. You choose two of those cards and put them into their graveyard. Put the rest on top of their library in any order";
     }
 
-    BamboozleEffect(final BamboozleEffect effect) {
+    private BamboozleEffect(final BamboozleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BaruFistOfKrosa.java
+++ b/Mage.Sets/src/mage/cards/b/BaruFistOfKrosa.java
@@ -74,7 +74,7 @@ class BaruFistOfKrosaEffect extends OneShotEffect {
         this.staticText = "create an X/X green Wurm creature token, where X is the number of lands you control.";
     }
 
-    BaruFistOfKrosaEffect(final BaruFistOfKrosaEffect effect) {
+    private BaruFistOfKrosaEffect(final BaruFistOfKrosaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BattlefieldScrounger.java
+++ b/Mage.Sets/src/mage/cards/b/BattlefieldScrounger.java
@@ -60,7 +60,7 @@ class BattlefieldScroungerCost extends CostImpl {
     }
 
 
-    BattlefieldScroungerCost(final BattlefieldScroungerCost cost) {
+    private BattlefieldScroungerCost(final BattlefieldScroungerCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BattletideAlchemist.java
+++ b/Mage.Sets/src/mage/cards/b/BattletideAlchemist.java
@@ -51,7 +51,7 @@ class BattletideAlchemistEffect extends PreventionEffectImpl {
         this.staticText = "If a source would deal damage to a player, you may prevent X of that damage, where X is the number of Clerics you control";
     }
 
-    BattletideAlchemistEffect(final BattletideAlchemistEffect effect) {
+    private BattletideAlchemistEffect(final BattletideAlchemistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BenefactorsDraught.java
+++ b/Mage.Sets/src/mage/cards/b/BenefactorsDraught.java
@@ -52,7 +52,7 @@ class BenefactorsDraughtTriggeredAbility extends DelayedTriggeredAbility {
         super(new DrawCardSourceControllerEffect(1), Duration.EndOfTurn, false);
     }
 
-    BenefactorsDraughtTriggeredAbility(final BenefactorsDraughtTriggeredAbility ability) {
+    private BenefactorsDraughtTriggeredAbility(final BenefactorsDraughtTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BenevolentOffering.java
+++ b/Mage.Sets/src/mage/cards/b/BenevolentOffering.java
@@ -51,7 +51,7 @@ class BenevolentOfferingEffect1 extends OneShotEffect {
         this.staticText = "Choose an opponent. You and that player each create three 1/1 white Spirit creature tokens with flying";
     }
 
-    BenevolentOfferingEffect1(final BenevolentOfferingEffect1 effect) {
+    private BenevolentOfferingEffect1(final BenevolentOfferingEffect1 effect) {
         super(effect);
     }
 
@@ -85,7 +85,7 @@ class BenevolentOfferingEffect2 extends OneShotEffect {
         this.staticText = "<br>Choose an opponent. You gain 2 life for each creature you control and that player gains 2 life for each creature they control";
     }
 
-    BenevolentOfferingEffect2(final BenevolentOfferingEffect2 effect) {
+    private BenevolentOfferingEffect2(final BenevolentOfferingEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Berserk.java
+++ b/Mage.Sets/src/mage/cards/b/Berserk.java
@@ -68,7 +68,7 @@ class BerserkReplacementEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Cast this spell only before the combat damage step";
     }
 
-    BerserkReplacementEffect(final BerserkReplacementEffect effect) {
+    private BerserkReplacementEffect(final BerserkReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Bioplasm.java
+++ b/Mage.Sets/src/mage/cards/b/Bioplasm.java
@@ -53,7 +53,7 @@ class BioplasmEffect extends OneShotEffect {
         this.staticText = "exile the top card of your library. If it's a creature card, {this} gets +X/+Y until end of turn, where X is the exiled creature card's power and Y is its toughness";
     }
 
-    BioplasmEffect(final BioplasmEffect effect) {
+    private BioplasmEffect(final BioplasmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlackSunsZenith.java
+++ b/Mage.Sets/src/mage/cards/b/BlackSunsZenith.java
@@ -45,7 +45,7 @@ class BlackSunsZenithEffect extends OneShotEffect {
         staticText = "Put X -1/-1 counters on each creature";
     }
 
-    BlackSunsZenithEffect(final BlackSunsZenithEffect effect) {
+    private BlackSunsZenithEffect(final BlackSunsZenithEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Blightning.java
+++ b/Mage.Sets/src/mage/cards/b/Blightning.java
@@ -47,7 +47,7 @@ class BlightningEffect extends OneShotEffect {
         this.staticText = "That player or that planeswalker's controller discards two cards.";
     }
 
-    BlightningEffect(final BlightningEffect effect) {
+    private BlightningEffect(final BlightningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodFrenzy.java
+++ b/Mage.Sets/src/mage/cards/b/BloodFrenzy.java
@@ -51,7 +51,7 @@ class BloodFrenzyCastRestriction extends ContinuousRuleModifyingEffectImpl {
         staticText = "Cast this spell only before the combat damage step";
     }
 
-    BloodFrenzyCastRestriction(final BloodFrenzyCastRestriction effect) {
+    private BloodFrenzyCastRestriction(final BloodFrenzyCastRestriction effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodMoon.java
+++ b/Mage.Sets/src/mage/cards/b/BloodMoon.java
@@ -50,7 +50,7 @@ public final class BloodMoon extends CardImpl {
             this.dependendToTypes.add(DependencyType.BecomeNonbasicLand);
         }
 
-        BloodMoonEffect(final BloodMoonEffect effect) {
+        private BloodMoonEffect(final BloodMoonEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/b/BloodSeeker.java
+++ b/Mage.Sets/src/mage/cards/b/BloodSeeker.java
@@ -50,7 +50,7 @@ class BloodSeekerTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), true);
     }
 
-    BloodSeekerTriggeredAbility(final BloodSeekerTriggeredAbility ability) {
+    private BloodSeekerTriggeredAbility(final BloodSeekerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodstoneGoblin.java
+++ b/Mage.Sets/src/mage/cards/b/BloodstoneGoblin.java
@@ -61,7 +61,7 @@ class BloodstoneGoblinTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you cast a spell, if that spell was kicked, ");
     }
 
-    BloodstoneGoblinTriggeredAbility(final BloodstoneGoblinTriggeredAbility ability) {
+    private BloodstoneGoblinTriggeredAbility(final BloodstoneGoblinTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoldwyrHeavyweights.java
+++ b/Mage.Sets/src/mage/cards/b/BoldwyrHeavyweights.java
@@ -56,7 +56,7 @@ class BoldwyrHeavyweightsEffect extends OneShotEffect {
         this.staticText = "each opponent may search their library for a creature card and put it onto the battlefield. Then each player who searched their library this way shuffles";
     }
 
-    BoldwyrHeavyweightsEffect(final BoldwyrHeavyweightsEffect effect) {
+    private BoldwyrHeavyweightsEffect(final BoldwyrHeavyweightsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoldwyrIntimidator.java
+++ b/Mage.Sets/src/mage/cards/b/BoldwyrIntimidator.java
@@ -66,7 +66,7 @@ class BoldwyrIntimidatorEffect extends RestrictionEffect {
         staticText = "Cowards can't block Warriors";
     }
 
-    BoldwyrIntimidatorEffect(final BoldwyrIntimidatorEffect effect) {
+    private BoldwyrIntimidatorEffect(final BoldwyrIntimidatorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BomatCourier.java
+++ b/Mage.Sets/src/mage/cards/b/BomatCourier.java
@@ -63,7 +63,7 @@ class BomatCourierExileEffect extends OneShotEffect {
         this.staticText = "exile the top card of your library face down";
     }
 
-    BomatCourierExileEffect(final BomatCourierExileEffect effect) {
+    private BomatCourierExileEffect(final BomatCourierExileEffect effect) {
         super(effect);
     }
 
@@ -97,7 +97,7 @@ class BomatCourierReturnEffect extends OneShotEffect {
         this.staticText = "Put all cards exiled with {this} into their owners' hands";
     }
 
-    BomatCourierReturnEffect(final BomatCourierReturnEffect effect) {
+    private BomatCourierReturnEffect(final BomatCourierReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BonePicker.java
+++ b/Mage.Sets/src/mage/cards/b/BonePicker.java
@@ -62,7 +62,7 @@ class BonePickerAdjustingCostsEffect extends CostModificationEffectImpl {
         staticText = "this spell costs {3} less to cast if a creature died this turn";
     }
 
-    BonePickerAdjustingCostsEffect(BonePickerAdjustingCostsEffect effect) {
+    private BonePickerAdjustingCostsEffect(final BonePickerAdjustingCostsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoneyardParley.java
+++ b/Mage.Sets/src/mage/cards/b/BoneyardParley.java
@@ -58,7 +58,7 @@ class BoneyardParleyEffect extends OneShotEffect {
                 + "and the rest into their owners' graveyards";
     }
 
-    BoneyardParleyEffect(final BoneyardParleyEffect effect) {
+    private BoneyardParleyEffect(final BoneyardParleyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BorosFuryShield.java
+++ b/Mage.Sets/src/mage/cards/b/BorosFuryShield.java
@@ -53,7 +53,7 @@ public final class BorosFuryShield extends CardImpl {
             staticText = "{this} deals damage to that creature's controller equal to the creature's power";
         }
 
-        BorosFuryShieldDamageEffect(final BorosFuryShieldDamageEffect effect) {
+        private BorosFuryShieldDamageEffect(final BorosFuryShieldDamageEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/b/BosiumStrip.java
+++ b/Mage.Sets/src/mage/cards/b/BosiumStrip.java
@@ -57,7 +57,7 @@ class BosiumStripCastFromGraveyardEffect extends AsThoughEffectImpl {
         staticText = "Until end of turn, if the top card of your graveyard is an instant or sorcery card, you may cast that card";
     }
 
-    BosiumStripCastFromGraveyardEffect(final BosiumStripCastFromGraveyardEffect effect) {
+    private BosiumStripCastFromGraveyardEffect(final BosiumStripCastFromGraveyardEffect effect) {
         super(effect);
     }
 
@@ -97,7 +97,7 @@ class BosiumStripReplacementEffect extends ReplacementEffectImpl {
         staticText = "If a card cast this way would be put into a graveyard this turn, exile it instead";
     }
 
-    BosiumStripReplacementEffect(final BosiumStripReplacementEffect effect) {
+    private BosiumStripReplacementEffect(final BosiumStripReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Bossk.java
+++ b/Mage.Sets/src/mage/cards/b/Bossk.java
@@ -64,7 +64,7 @@ class BosskTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetOpponentsCreaturePermanent());
     }
 
-    BosskTriggeredAbility(BosskTriggeredAbility ability) {
+    private BosskTriggeredAbility(final BosskTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BoundDetermined.java
+++ b/Mage.Sets/src/mage/cards/b/BoundDetermined.java
@@ -110,7 +110,7 @@ class DeterminedEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Other spells you control can't be countered this turn";
     }
 
-    DeterminedEffect(final DeterminedEffect effect) {
+    private DeterminedEffect(final DeterminedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BowerPassage.java
+++ b/Mage.Sets/src/mage/cards/b/BowerPassage.java
@@ -44,7 +44,7 @@ class BowerPassageEffect extends RestrictionEffect {
         staticText = "Creatures with flying can't block creatures you control";
     }
 
-    BowerPassageEffect(final BowerPassageEffect effect) {
+    private BowerPassageEffect(final BowerPassageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrambleSovereign.java
+++ b/Mage.Sets/src/mage/cards/b/BrambleSovereign.java
@@ -68,7 +68,7 @@ class BrambleSovereignEffect extends OneShotEffect {
         this.staticText = "its controller creates a token that's a copy of that creature";
     }
 
-    BrambleSovereignEffect(final BrambleSovereignEffect effect) {
+    private BrambleSovereignEffect(final BrambleSovereignEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BramblewoodParagon.java
+++ b/Mage.Sets/src/mage/cards/b/BramblewoodParagon.java
@@ -62,7 +62,7 @@ class BramblewoodParagonReplacementEffect extends ReplacementEffectImpl {
         staticText = "Each other Warrior creature you control enters the battlefield with an additional +1/+1 counter on it";
     }
 
-    BramblewoodParagonReplacementEffect(BramblewoodParagonReplacementEffect effect) {
+    private BramblewoodParagonReplacementEffect(final BramblewoodParagonReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Brightflame.java
+++ b/Mage.Sets/src/mage/cards/b/Brightflame.java
@@ -57,7 +57,7 @@ class BrightflameEffect extends OneShotEffect {
         staticText = "{this} deals X damage to target creature and each other creature that shares a color with it. You gain life equal to the damage dealt this way.";
     }
 
-    BrightflameEffect(final BrightflameEffect effect) {
+    private BrightflameEffect(final BrightflameEffect effect) {
         super(effect);
         this.amount = effect.amount;
     }

--- a/Mage.Sets/src/mage/cards/b/Brightling.java
+++ b/Mage.Sets/src/mage/cards/b/Brightling.java
@@ -89,7 +89,7 @@ class BrightlingEffect extends OneShotEffect {
         this.staticText = "{this} gets +1/-1 or -1/+1 until end of turn";
     }
 
-    BrightlingEffect(final BrightlingEffect effect) {
+    private BrightlingEffect(final BrightlingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BruenorBattlehammer.java
+++ b/Mage.Sets/src/mage/cards/b/BruenorBattlehammer.java
@@ -94,7 +94,7 @@ class BruenorBattlehammerCostEffect extends CostModificationEffectImpl {
                 "of the first equip ability you activate each turn.";
     }
 
-    BruenorBattlehammerCostEffect(final BruenorBattlehammerCostEffect effect) {
+    private BruenorBattlehammerCostEffect(final BruenorBattlehammerCostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrutalSuppression.java
+++ b/Mage.Sets/src/mage/cards/b/BrutalSuppression.java
@@ -63,7 +63,7 @@ class BrutalSuppressionAdditionalCostEffect extends CostModificationEffectImpl {
         this.staticText = "Activated abilities of nontoken Rebels cost an additional \"Sacrifice a land\" to activate";
     }
 
-    BrutalSuppressionAdditionalCostEffect(BrutalSuppressionAdditionalCostEffect effect) {
+    private BrutalSuppressionAdditionalCostEffect(final BrutalSuppressionAdditionalCostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BudokaGardener.java
+++ b/Mage.Sets/src/mage/cards/b/BudokaGardener.java
@@ -65,7 +65,7 @@ class BudokaGardenerEffect extends OneShotEffect {
         staticText = "If you control ten or more lands, flip {this}";
     }
 
-    BudokaGardenerEffect(final BudokaGardenerEffect effect) {
+    private BudokaGardenerEffect(final BudokaGardenerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/Burgeoning.java
+++ b/Mage.Sets/src/mage/cards/b/Burgeoning.java
@@ -42,7 +42,7 @@ class BurgeoningTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new PutCardFromHandOntoBattlefieldEffect(StaticFilters.FILTER_CARD_LAND_A));
     }
 
-    BurgeoningTriggeredAbility(BurgeoningTriggeredAbility ability) {
+    private BurgeoningTriggeredAbility(final BurgeoningTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BurningTreeShaman.java
+++ b/Mage.Sets/src/mage/cards/b/BurningTreeShaman.java
@@ -51,7 +51,7 @@ class BurningTreeShamanTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(StaticValue.get(1), true, "that player", true));
     }
 
-    BurningTreeShamanTriggeredAbility(final BurningTreeShamanTriggeredAbility ability) {
+    private BurningTreeShamanTriggeredAbility(final BurningTreeShamanTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BurningVengeance.java
+++ b/Mage.Sets/src/mage/cards/b/BurningVengeance.java
@@ -46,7 +46,7 @@ class BurningVengeanceOnCastAbility extends TriggeredAbilityImpl {
         this.addTarget(target);
     }
 
-    BurningVengeanceOnCastAbility(BurningVengeanceOnCastAbility ability) {
+    private BurningVengeanceOnCastAbility(final BurningVengeanceOnCastAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/ButcherOfTheHorde.java
+++ b/Mage.Sets/src/mage/cards/b/ButcherOfTheHorde.java
@@ -64,7 +64,7 @@ class ButcherOfTheHordeEffect extends OneShotEffect {
         staticText = "{this} gains your choice of vigilance, lifelink, or haste until end of turn";
     }
 
-    ButcherOfTheHordeEffect(final ButcherOfTheHordeEffect effect) {
+    private ButcherOfTheHordeEffect(final ButcherOfTheHordeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BuzzingWhackADoodle.java
+++ b/Mage.Sets/src/mage/cards/b/BuzzingWhackADoodle.java
@@ -69,7 +69,7 @@ class BuzzingWhackADoodleEffect extends OneShotEffect {
         this.staticText = "You and an opponent each secretly choose Whack or Doodle. Then those choices are revealed. If the choices match, {this} has that ability. Otherwise it has Buzz";
     }
 
-    BuzzingWhackADoodleEffect(final BuzzingWhackADoodleEffect effect) {
+    private BuzzingWhackADoodleEffect(final BuzzingWhackADoodleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Camel.java
+++ b/Mage.Sets/src/mage/cards/c/Camel.java
@@ -62,7 +62,7 @@ class CamelEffect extends PreventionEffectImpl {
         staticText = "As long as {this} is attacking, prevent all damage Deserts would deal to {this} and to creatures banded with {this}";
     }
 
-    CamelEffect(final CamelEffect effect) {
+    private CamelEffect(final CamelEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CarpetOfFlowers.java
+++ b/Mage.Sets/src/mage/cards/c/CarpetOfFlowers.java
@@ -53,7 +53,7 @@ class CarpetOfFlowersTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("At the beginning of each of your main phases, if you haven't added mana with this ability this turn, ");
     }
 
-    CarpetOfFlowersTriggeredAbility(final CarpetOfFlowersTriggeredAbility ability) {
+    private CarpetOfFlowersTriggeredAbility(final CarpetOfFlowersTriggeredAbility ability) {
         super(ability);
     }
 
@@ -115,7 +115,7 @@ class CarpetOfFlowersEffect extends ManaEffect {
         staticText = "you may add X mana of any one color, where X is the number of Islands target opponent controls";
     }
 
-    CarpetOfFlowersEffect(final CarpetOfFlowersEffect effect) {
+    private CarpetOfFlowersEffect(final CarpetOfFlowersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CeaselessSearblades.java
+++ b/Mage.Sets/src/mage/cards/c/CeaselessSearblades.java
@@ -56,7 +56,7 @@ class CeaselessSearbladesTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you activate an ability of an Elemental, ");
     }
 
-    CeaselessSearbladesTriggeredAbility(final CeaselessSearbladesTriggeredAbility ability) {
+    private CeaselessSearbladesTriggeredAbility(final CeaselessSearbladesTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CelestialDawn.java
+++ b/Mage.Sets/src/mage/cards/c/CelestialDawn.java
@@ -65,7 +65,7 @@ class CelestialDawnToPlainsEffect extends ContinuousEffectImpl {
         this.staticText = "Lands you control are Plains";
     }
 
-    CelestialDawnToPlainsEffect(final CelestialDawnToPlainsEffect effect) {
+    private CelestialDawnToPlainsEffect(final CelestialDawnToPlainsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CelestialMantle.java
+++ b/Mage.Sets/src/mage/cards/c/CelestialMantle.java
@@ -99,7 +99,7 @@ class CelestialMantleEffect extends OneShotEffect {
         super(Outcome.GainLife);
     }
 
-    CelestialMantleEffect(final CelestialMantleEffect effect) {
+    private CelestialMantleEffect(final CelestialMantleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CephalidConstable.java
+++ b/Mage.Sets/src/mage/cards/c/CephalidConstable.java
@@ -54,7 +54,7 @@ class CephalidConstableTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ReturnToHandTargetEffect(), false);
     }
 
-    CephalidConstableTriggeredAbility(final CephalidConstableTriggeredAbility ability) {
+    private CephalidConstableTriggeredAbility(final CephalidConstableTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CerebralEruption.java
+++ b/Mage.Sets/src/mage/cards/c/CerebralEruption.java
@@ -46,7 +46,7 @@ class CerebralEruptionEffect extends OneShotEffect {
         staticText = "Target opponent reveals the top card of their library. {this} deals damage equal to the revealed card's mana value to that player and each creature they control. If a land card is revealed this way, return {this} to its owner's hand";
     }
 
-    CerebralEruptionEffect(final CerebralEruptionEffect effect) {
+    private CerebralEruptionEffect(final CerebralEruptionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CerebralVortex.java
+++ b/Mage.Sets/src/mage/cards/c/CerebralVortex.java
@@ -51,7 +51,7 @@ class CerebralVortexEffect extends OneShotEffect {
         this.staticText = ", then Cerebral Vortex deals damage to that player equal to the number of cards they've drawn this turn";
     }
 
-    CerebralVortexEffect(final CerebralVortexEffect effect) {
+    private CerebralVortexEffect(final CerebralVortexEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChainLightning.java
+++ b/Mage.Sets/src/mage/cards/c/ChainLightning.java
@@ -46,7 +46,7 @@ class ChainLightningEffect extends OneShotEffect {
         this.staticText = "{this} deals 3 damage to any target. Then that player or that permanent's controller may pay {R}{R}. If the player does, they may copy this spell and may choose a new target for that copy";
     }
 
-    ChainLightningEffect(final ChainLightningEffect effect) {
+    private ChainLightningEffect(final ChainLightningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChainOfAcid.java
+++ b/Mage.Sets/src/mage/cards/c/ChainOfAcid.java
@@ -56,7 +56,7 @@ class ChainOfAcidEffect extends OneShotEffect {
         this.staticText = "Destroy target noncreature permanent. Then that permanent's controller may copy this spell and may choose a new target for that copy.";
     }
 
-    ChainOfAcidEffect(final ChainOfAcidEffect effect) {
+    private ChainOfAcidEffect(final ChainOfAcidEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChainOfPlasma.java
+++ b/Mage.Sets/src/mage/cards/c/ChainOfPlasma.java
@@ -46,7 +46,7 @@ class ChainOfPlasmaEffect extends OneShotEffect {
         this.staticText = "{this} deals 3 damage to any target. Then that player or that permanent's controller may discard a card. If the player does, they may copy this spell and may choose a new target for that copy.";
     }
 
-    ChainOfPlasmaEffect(final ChainOfPlasmaEffect effect) {
+    private ChainOfPlasmaEffect(final ChainOfPlasmaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChainOfSmog.java
+++ b/Mage.Sets/src/mage/cards/c/ChainOfSmog.java
@@ -47,7 +47,7 @@ class ChainOfSmogEffect extends OneShotEffect {
         this.staticText = "Target player discards two cards. That player may copy this spell and may choose a new target for that copy.";
     }
 
-    ChainOfSmogEffect(final ChainOfSmogEffect effect) {
+    private ChainOfSmogEffect(final ChainOfSmogEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChainerDementiaMaster.java
+++ b/Mage.Sets/src/mage/cards/c/ChainerDementiaMaster.java
@@ -80,7 +80,7 @@ class ChainerDementiaMasterEffect extends OneShotEffect {
         this.staticText = "Put target creature card from a graveyard onto the battlefield under your control. That creature is black and is a Nightmare in addition to its other creature types";
     }
     
-    ChainerDementiaMasterEffect(final ChainerDementiaMasterEffect effect) {
+    private ChainerDementiaMasterEffect(final ChainerDementiaMasterEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/c/ChainersTorment.java
+++ b/Mage.Sets/src/mage/cards/c/ChainersTorment.java
@@ -58,7 +58,7 @@ class ChainersTormentEffect extends OneShotEffect {
         this.staticText = "Create an X/X black Nightmare Horror creature token, where X is half your life total, rounded up. It deals X damage to you";
     }
 
-    ChainersTormentEffect(final ChainersTormentEffect effect) {
+    private ChainersTormentEffect(final ChainersTormentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChampionOfLambholt.java
+++ b/Mage.Sets/src/mage/cards/c/ChampionOfLambholt.java
@@ -62,7 +62,7 @@ class ChampionOfLambholtEffect extends RestrictionEffect {
         staticText = "Creatures with power less than {this}'s power can't block creatures you control";
     }
 
-    ChampionOfLambholtEffect(final ChampionOfLambholtEffect effect) {
+    private ChampionOfLambholtEffect(final ChampionOfLambholtEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChancellorOfTheAnnex.java
+++ b/Mage.Sets/src/mage/cards/c/ChancellorOfTheAnnex.java
@@ -93,7 +93,7 @@ class ChancellorOfTheAnnexDelayedTriggeredAbility extends DelayedTriggeredAbilit
         this.playerId = playerId;
     }
 
-    ChancellorOfTheAnnexDelayedTriggeredAbility(final ChancellorOfTheAnnexDelayedTriggeredAbility ability) {
+    private ChancellorOfTheAnnexDelayedTriggeredAbility(final ChancellorOfTheAnnexDelayedTriggeredAbility ability) {
         super(ability);
         this.playerId = ability.playerId;
     }

--- a/Mage.Sets/src/mage/cards/c/ChancellorOfTheDross.java
+++ b/Mage.Sets/src/mage/cards/c/ChancellorOfTheDross.java
@@ -57,7 +57,7 @@ class ChancellorOfTheDrossDelayedTriggeredAbility extends DelayedTriggeredAbilit
         super(new ChancellorOfTheDrossEffect());
     }
 
-    ChancellorOfTheDrossDelayedTriggeredAbility(ChancellorOfTheDrossDelayedTriggeredAbility ability) {
+    private ChancellorOfTheDrossDelayedTriggeredAbility(final ChancellorOfTheDrossDelayedTriggeredAbility ability) {
         super(ability);
     }
 
@@ -83,7 +83,7 @@ class ChancellorOfTheDrossEffect extends OneShotEffect {
         staticText = "each opponent loses 3 life, then you gain life equal to the life lost this way";
     }
 
-    ChancellorOfTheDrossEffect(ChancellorOfTheDrossEffect effect) {
+    private ChancellorOfTheDrossEffect(final ChancellorOfTheDrossEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChancellorOfTheForge.java
+++ b/Mage.Sets/src/mage/cards/c/ChancellorOfTheForge.java
@@ -56,7 +56,7 @@ class ChancellorOfTheForgeDelayedTriggeredAbility extends DelayedTriggeredAbilit
         super(new CreateTokenEffect(new PhyrexianGoblinHasteToken()));
     }
 
-    ChancellorOfTheForgeDelayedTriggeredAbility(ChancellorOfTheForgeDelayedTriggeredAbility ability) {
+    private ChancellorOfTheForgeDelayedTriggeredAbility(final ChancellorOfTheForgeDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChancellorOfTheTangle.java
+++ b/Mage.Sets/src/mage/cards/c/ChancellorOfTheTangle.java
@@ -57,7 +57,7 @@ class ChancellorOfTheTangleDelayedTriggeredAbility extends DelayedTriggeredAbili
         super(new BasicManaEffect(Mana.GreenMana(1)));
     }
 
-    ChancellorOfTheTangleDelayedTriggeredAbility(ChancellorOfTheTangleDelayedTriggeredAbility ability) {
+    private ChancellorOfTheTangleDelayedTriggeredAbility(final ChancellorOfTheTangleDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandraFlamecaller.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraFlamecaller.java
@@ -90,7 +90,7 @@ class ChandraDrawEffect extends OneShotEffect {
         this.staticText = "Discard all the cards in your hand, then draw that many cards plus one";
     }
 
-    ChandraDrawEffect(final ChandraDrawEffect effect) {
+    private ChandraDrawEffect(final ChandraDrawEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandrasPhoenix.java
+++ b/Mage.Sets/src/mage/cards/c/ChandrasPhoenix.java
@@ -59,7 +59,7 @@ class ChandrasPhoenixTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.GRAVEYARD, new ReturnToHandSourceEffect());
     }
 
-    ChandrasPhoenixTriggeredAbility(final ChandrasPhoenixTriggeredAbility ability) {
+    private ChandrasPhoenixTriggeredAbility(final ChandrasPhoenixTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Channel.java
+++ b/Mage.Sets/src/mage/cards/c/Channel.java
@@ -52,7 +52,7 @@ class ChannelEffect extends OneShotEffect {
         this.staticText = "Until end of turn, any time you could activate a mana ability, you may pay 1 life. If you do, add {C}";
     }
     
-    ChannelEffect(final ChannelEffect effect) {
+    private ChannelEffect(final ChannelEffect effect) {
         super(effect);
     }
     
@@ -81,7 +81,7 @@ class ChannelSpecialAction extends SpecialAction {
         this.addEffect(new BasicManaEffect(Mana.ColorlessMana(1)));
     }
 
-    ChannelSpecialAction(final ChannelSpecialAction ability) {
+    private ChannelSpecialAction(final ChannelSpecialAction ability) {
         super(ability);
     }
 
@@ -99,7 +99,7 @@ class ChannelDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.setRuleVisible(false);
     }
 
-    ChannelDelayedTriggeredAbility(ChannelDelayedTriggeredAbility ability) {
+    private ChannelDelayedTriggeredAbility(final ChannelDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChannelHarm.java
+++ b/Mage.Sets/src/mage/cards/c/ChannelHarm.java
@@ -49,7 +49,7 @@ class ChannelHarmEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that would be dealt to you and permanents you control this turn by sources you don't control. If damage is prevented this way, you may have {this} deal that much damage to target creature";
     }
 
-    ChannelHarmEffect(final ChannelHarmEffect effect) {
+    private ChannelHarmEffect(final ChannelHarmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChaosDragon.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosDragon.java
@@ -96,7 +96,7 @@ class ChaosDragonRestrictionEffect extends RestrictionEffect {
         this.playerSet.addAll(playerSet);
     }
 
-    ChaosDragonRestrictionEffect(final ChaosDragonRestrictionEffect effect) {
+    private ChaosDragonRestrictionEffect(final ChaosDragonRestrictionEffect effect) {
         super(effect);
         this.playerSet.addAll(effect.playerSet);
     }

--- a/Mage.Sets/src/mage/cards/c/CheeringFanatic.java
+++ b/Mage.Sets/src/mage/cards/c/CheeringFanatic.java
@@ -53,7 +53,7 @@ class CheeringFanaticEffect extends OneShotEffect {
         this.staticText = "choose a card name. Spells with the chosen name cost {1} less to cast this turn";
     }
 
-    CheeringFanaticEffect(final CheeringFanaticEffect effect) {
+    private CheeringFanaticEffect(final CheeringFanaticEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChickenEgg.java
+++ b/Mage.Sets/src/mage/cards/c/ChickenEgg.java
@@ -52,7 +52,7 @@ class ChickenEggEffect extends OneShotEffect {
         this.staticText = "roll a six-sided die. If you roll a 6, sacrifice {this} and create a 4/4 red Giant Bird creature token";
     }
 
-    ChickenEggEffect(final ChickenEggEffect effect) {
+    private ChickenEggEffect(final ChickenEggEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChromeMox.java
+++ b/Mage.Sets/src/mage/cards/c/ChromeMox.java
@@ -113,7 +113,7 @@ class ChromeMoxManaEffect extends ManaEffect {
         staticText = "Add one mana of any of the exiled card's colors";
     }
 
-    ChromeMoxManaEffect(ChromeMoxManaEffect effect) {
+    private ChromeMoxManaEffect(final ChromeMoxManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChronicFlooding.java
+++ b/Mage.Sets/src/mage/cards/c/ChronicFlooding.java
@@ -59,7 +59,7 @@ class ChronicFloodingAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new MillCardsTargetEffect(3));
     }
  
-    ChronicFloodingAbility(final ChronicFloodingAbility ability) {
+    private ChronicFloodingAbility(final ChronicFloodingAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CityInABottle.java
+++ b/Mage.Sets/src/mage/cards/c/CityInABottle.java
@@ -147,7 +147,7 @@ class CityInABottleStateTriggeredAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new CityInABottleSacrificeEffect());
     }
 
-    CityInABottleStateTriggeredAbility(final CityInABottleStateTriggeredAbility ability) {
+    private CityInABottleStateTriggeredAbility(final CityInABottleStateTriggeredAbility ability) {
         super(ability);
     }
 
@@ -181,7 +181,7 @@ class CityInABottleSacrificeEffect extends OneShotEffect {
         this.staticText = "its controller sacrifices it";
     }
 
-    CityInABottleSacrificeEffect(final CityInABottleSacrificeEffect effect) {
+    private CityInABottleSacrificeEffect(final CityInABottleSacrificeEffect effect) {
         super(effect);
     }
 
@@ -212,7 +212,7 @@ class CityInABottleCantPlayEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Players can't play cards originally printed in the <i>Arabian Nights</i> expansion";
     }
 
-    CityInABottleCantPlayEffect(final CityInABottleCantPlayEffect effect) {
+    private CityInABottleCantPlayEffect(final CityInABottleCantPlayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CityOfSolitude.java
+++ b/Mage.Sets/src/mage/cards/c/CityOfSolitude.java
@@ -46,7 +46,7 @@ class CityOfSolitudeEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Players can cast spells and activate abilities only during their own turns";
     }
 
-    CityOfSolitudeEffect(final CityOfSolitudeEffect effect) {
+    private CityOfSolitudeEffect(final CityOfSolitudeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CityOfTraitors.java
+++ b/Mage.Sets/src/mage/cards/c/CityOfTraitors.java
@@ -47,7 +47,7 @@ class CityOfTraitorsTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SacrificeSourceEffect());
     }
 
-    CityOfTraitorsTriggeredAbility(CityOfTraitorsTriggeredAbility ability) {
+    private CityOfTraitorsTriggeredAbility(final CityOfTraitorsTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ClamIAm.java
+++ b/Mage.Sets/src/mage/cards/c/ClamIAm.java
@@ -44,7 +44,7 @@ class ClamIAmEffect extends ReplacementEffectImpl {
         staticText = "If you roll a 3 on a six-sided die, you may reroll that die";
     }
 
-    ClamIAmEffect(final ClamIAmEffect effect) {
+    private ClamIAmEffect(final ClamIAmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Cleansing.java
+++ b/Mage.Sets/src/mage/cards/c/Cleansing.java
@@ -44,7 +44,7 @@ class CleansingEffect extends OneShotEffect {
         staticText = "For each land, destroy that land unless any player pays 1 life";
     }
 
-    CleansingEffect(final CleansingEffect effect) {
+    private CleansingEffect(final CleansingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CleansingBeam.java
+++ b/Mage.Sets/src/mage/cards/c/CleansingBeam.java
@@ -52,7 +52,7 @@ class CleansingBeamEffect extends OneShotEffect {
         staticText = "{this} deals 2 damage to target creature and each other creature that shares a color with it";
     }
 
-    CleansingBeamEffect(final CleansingBeamEffect effect) {
+    private CleansingBeamEffect(final CleansingBeamEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ClergyOfTheHolyNimbus.java
+++ b/Mage.Sets/src/mage/cards/c/ClergyOfTheHolyNimbus.java
@@ -52,7 +52,7 @@ class ClergyOfTheHolyNimbusReplacementEffect extends ReplacementEffectImpl {
         staticText = "If {this} would be destroyed, regenerate it";
     }
 
-    ClergyOfTheHolyNimbusReplacementEffect(ClergyOfTheHolyNimbusReplacementEffect effect) {
+    private ClergyOfTheHolyNimbusReplacementEffect(final ClergyOfTheHolyNimbusReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Clockspinning.java
+++ b/Mage.Sets/src/mage/cards/c/Clockspinning.java
@@ -57,7 +57,7 @@ class ClockspinningAddOrRemoveCounterEffect extends OneShotEffect {
         this.staticText = "Choose a counter on target permanent or suspended card. Remove that counter from that permanent or card or put another of those counters on it";
     }
 
-    ClockspinningAddOrRemoveCounterEffect(final ClockspinningAddOrRemoveCounterEffect effect) {
+    private ClockspinningAddOrRemoveCounterEffect(final ClockspinningAddOrRemoveCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ClockworkBeetle.java
+++ b/Mage.Sets/src/mage/cards/c/ClockworkBeetle.java
@@ -57,7 +57,7 @@ class ClockworkBeetleEffect extends OneShotEffect {
         staticText = "remove a +1/+1 counter from {this} at end of combat";
     }
 
-    ClockworkBeetleEffect(final ClockworkBeetleEffect effect) {
+    private ClockworkBeetleEffect(final ClockworkBeetleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ClockworkCondor.java
+++ b/Mage.Sets/src/mage/cards/c/ClockworkCondor.java
@@ -53,7 +53,7 @@ class ClockworkCondorEffect extends OneShotEffect {
         staticText = "remove a +1/+1 counter from {this} at end of combat";
     }
 
-    ClockworkCondorEffect(final ClockworkCondorEffect effect) {
+    private ClockworkCondorEffect(final ClockworkCondorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ClockworkDragon.java
+++ b/Mage.Sets/src/mage/cards/c/ClockworkDragon.java
@@ -57,7 +57,7 @@ class ClockworkDragonEffect extends OneShotEffect {
         staticText = "remove a +1/+1 counter from {this} at end of combat";
     }
 
-    ClockworkDragonEffect(final ClockworkDragonEffect effect) {
+    private ClockworkDragonEffect(final ClockworkDragonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ClockworkVorrac.java
+++ b/Mage.Sets/src/mage/cards/c/ClockworkVorrac.java
@@ -58,7 +58,7 @@ class ClockworkVorracEffect extends OneShotEffect {
         staticText = "remove a +1/+1 counter from {this} at end of combat";
     }
 
-    ClockworkVorracEffect(final ClockworkVorracEffect effect) {
+    private ClockworkVorracEffect(final ClockworkVorracEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Cocoon.java
+++ b/Mage.Sets/src/mage/cards/c/Cocoon.java
@@ -75,7 +75,7 @@ class CocoonEffect extends OneShotEffect {
         staticText = "remove a pupa counter from {this}. If you can't, sacrifice it, put a +1/+1 counter on enchanted creature, and that creature gains flying";
     }
 
-    CocoonEffect(final CocoonEffect effect) {
+    private CocoonEffect(final CocoonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CoffinQueen.java
+++ b/Mage.Sets/src/mage/cards/c/CoffinQueen.java
@@ -96,7 +96,7 @@ class CoffinQueenDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new ExileTargetEffect(), Duration.EndOfGame, true);
     }
 
-    CoffinQueenDelayedTriggeredAbility(CoffinQueenDelayedTriggeredAbility ability) {
+    private CoffinQueenDelayedTriggeredAbility(final CoffinQueenDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CogworkAssembler.java
+++ b/Mage.Sets/src/mage/cards/c/CogworkAssembler.java
@@ -58,7 +58,7 @@ class CogworkAssemblerCreateTokenEffect extends OneShotEffect {
         this.staticText = "Create a token that's a copy of target artifact. That token gains haste. Exile it at the beginning of the next end step";
     }
 
-    CogworkAssemblerCreateTokenEffect(final CogworkAssemblerCreateTokenEffect effect) {
+    private CogworkAssemblerCreateTokenEffect(final CogworkAssemblerCreateTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CollectiveEffort.java
+++ b/Mage.Sets/src/mage/cards/c/CollectiveEffort.java
@@ -94,7 +94,7 @@ class CollectiveEffortEffect extends OneShotEffect {
         staticText = "Put a +1/+1 counter on each creature target player controls";
     }
 
-    CollectiveEffortEffect(final CollectiveEffortEffect effect) {
+    private CollectiveEffortEffect(final CollectiveEffortEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CollectiveRestraint.java
+++ b/Mage.Sets/src/mage/cards/c/CollectiveRestraint.java
@@ -51,7 +51,7 @@ class CollectiveRestraintPayManaToAttackAllEffect extends CantAttackYouUnlessPay
         staticText = "Creatures can't attack you unless their controller pays {X} for each creature they control that's attacking you, where X is the number of basic land types among lands you control.";
     }
 
-    CollectiveRestraintPayManaToAttackAllEffect(CollectiveRestraintPayManaToAttackAllEffect effect) {
+    private CollectiveRestraintPayManaToAttackAllEffect(final CollectiveRestraintPayManaToAttackAllEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ComboAttack.java
+++ b/Mage.Sets/src/mage/cards/c/ComboAttack.java
@@ -44,7 +44,7 @@ class ComboAttackEffect extends OneShotEffect {
         this.staticText = "Two target creatures your team controls each deal damage equal to their power to target creature";
     }
 
-    ComboAttackEffect(final ComboAttackEffect effect) {
+    private ComboAttackEffect(final ComboAttackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CommandBeacon.java
+++ b/Mage.Sets/src/mage/cards/c/CommandBeacon.java
@@ -53,7 +53,7 @@ class CommandBeaconEffect extends OneShotEffect {
         this.staticText = "Put your commander into your hand from the command zone";
     }
 
-    CommandBeaconEffect(final CommandBeaconEffect effect) {
+    private CommandBeaconEffect(final CommandBeaconEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConcertedEffort.java
+++ b/Mage.Sets/src/mage/cards/c/ConcertedEffort.java
@@ -68,7 +68,7 @@ class ConcertedEffortEffect extends OneShotEffect {
         this.staticText = "creatures you control gain flying until end of turn if a creature you control has flying. The same is true for fear, first strike, double strike, landwalk, protection, trample, and vigilance";
     }
 
-    ConcertedEffortEffect(final ConcertedEffortEffect effect) {
+    private ConcertedEffortEffect(final ConcertedEffortEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConsecratedSphinx.java
+++ b/Mage.Sets/src/mage/cards/c/ConsecratedSphinx.java
@@ -52,7 +52,7 @@ class ConsecratedSphinxTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(2), true);
     }
 
-    ConsecratedSphinxTriggeredAbility(final ConsecratedSphinxTriggeredAbility ability) {
+    private ConsecratedSphinxTriggeredAbility(final ConsecratedSphinxTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConspiracyTheorist.java
+++ b/Mage.Sets/src/mage/cards/c/ConspiracyTheorist.java
@@ -66,7 +66,7 @@ class ConspiracyTheoristAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null);
     }
 
-    ConspiracyTheoristAbility(ConspiracyTheoristAbility ability) {
+    private ConspiracyTheoristAbility(final ConspiracyTheoristAbility ability) {
         super(ability);
     }
 
@@ -109,7 +109,7 @@ class ConspiracyTheoristEffect extends OneShotEffect {
         this.discardedCards = discardedCards;
     }
 
-    ConspiracyTheoristEffect(ConspiracyTheoristEffect effect) {
+    private ConspiracyTheoristEffect(final ConspiracyTheoristEffect effect) {
         super(effect);
         this.discardedCards = effect.discardedCards;
     }

--- a/Mage.Sets/src/mage/cards/c/ConsulateCrackdown.java
+++ b/Mage.Sets/src/mage/cards/c/ConsulateCrackdown.java
@@ -56,7 +56,7 @@ class ConsulateCracksownExileEffect extends OneShotEffect {
         this.staticText = "exile all artifacts your opponents control until {this} leaves the battlefield";
     }
 
-    ConsulateCracksownExileEffect(final ConsulateCracksownExileEffect effect) {
+    private ConsulateCracksownExileEffect(final ConsulateCracksownExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConsumingVapors.java
+++ b/Mage.Sets/src/mage/cards/c/ConsumingVapors.java
@@ -50,7 +50,7 @@ class ConsumingVaporsEffect extends OneShotEffect {
         staticText = "Target player sacrifices a creature. You gain life equal to that creature's toughness";
     }
 
-    ConsumingVaporsEffect(ConsumingVaporsEffect effect) {
+    private ConsumingVaporsEffect(final ConsumingVaporsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Contempt.java
+++ b/Mage.Sets/src/mage/cards/c/Contempt.java
@@ -64,7 +64,7 @@ class ContemptEffect extends OneShotEffect {
         this.staticText = "return it and {this} to their owners' hands at end of combat.";
     }
 
-    ContemptEffect(final ContemptEffect effect) {
+    private ContemptEffect(final ContemptEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Conversion.java
+++ b/Mage.Sets/src/mage/cards/c/Conversion.java
@@ -56,7 +56,7 @@ public final class Conversion extends CardImpl {
             this.staticText = "All Mountains are Plains";
         }
 
-        ConversionEffect(final ConversionEffect effect) {
+        private ConversionEffect(final ConversionEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/c/CoordinatedBarrage.java
+++ b/Mage.Sets/src/mage/cards/c/CoordinatedBarrage.java
@@ -47,7 +47,7 @@ class CoordinatedBarrageEffect extends OneShotEffect {
         this.staticText = "Choose a creature type. {this} deals damage to target attacking or blocking creature equal to the number of permanents you control of the chosen type";
     }
 
-    CoordinatedBarrageEffect(final CoordinatedBarrageEffect effect) {
+    private CoordinatedBarrageEffect(final CoordinatedBarrageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CorneredMarket.java
+++ b/Mage.Sets/src/mage/cards/c/CorneredMarket.java
@@ -58,7 +58,7 @@ class CorneredMarketReplacementEffect extends ContinuousRuleModifyingEffectImpl 
                 + "<br> Players can't play nonbasic lands with the same name as a nontoken permanent.";
     }
 
-    CorneredMarketReplacementEffect(final CorneredMarketReplacementEffect effect) {
+    private CorneredMarketReplacementEffect(final CorneredMarketReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CorpsejackMenace.java
+++ b/Mage.Sets/src/mage/cards/c/CorpsejackMenace.java
@@ -58,7 +58,7 @@ class CorpsejackMenaceReplacementEffect extends ReplacementEffectImpl {
         staticText = "If one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on it instead";
     }
 
-    CorpsejackMenaceReplacementEffect(final CorpsejackMenaceReplacementEffect effect) {
+    private CorpsejackMenaceReplacementEffect(final CorpsejackMenaceReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Corrosion.java
+++ b/Mage.Sets/src/mage/cards/c/Corrosion.java
@@ -60,7 +60,7 @@ class CorrosionUpkeepEffect extends OneShotEffect {
         this.staticText = "put a rust counter on each artifact target opponent controls. Then destroy each artifact with mana value less than or equal to the number of rust counters on it. Artifacts destroyed this way can't be regenerated";
     }
     
-    CorrosionUpkeepEffect(final CorrosionUpkeepEffect effect) {
+    private CorrosionUpkeepEffect(final CorrosionUpkeepEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/c/CorruptedResolve.java
+++ b/Mage.Sets/src/mage/cards/c/CorruptedResolve.java
@@ -45,7 +45,7 @@ class CorruptedResolveEffect extends OneShotEffect {
         staticText = "Counter target spell if its controller is poisoned";
     }
 
-    CorruptedResolveEffect(final CorruptedResolveEffect effect) {
+    private CorruptedResolveEffect(final CorruptedResolveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CowedByWisdom.java
+++ b/Mage.Sets/src/mage/cards/c/CowedByWisdom.java
@@ -62,7 +62,7 @@ class CowedByWisdomayCostToAttackBlockEffect extends PayCostToAttackBlockEffectI
         staticText = "Enchanted creature can't attack or block unless its controller pays {1} for each card in your hand";
     }
 
-    CowedByWisdomayCostToAttackBlockEffect(CowedByWisdomayCostToAttackBlockEffect effect) {
+    private CowedByWisdomayCostToAttackBlockEffect(final CowedByWisdomayCostToAttackBlockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrackdownConstruct.java
+++ b/Mage.Sets/src/mage/cards/c/CrackdownConstruct.java
@@ -51,7 +51,7 @@ class CrackdownConstructTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you activate an ability of an artifact or creature that isn't a mana ability, ");
     }
 
-    CrackdownConstructTriggeredAbility(final CrackdownConstructTriggeredAbility ability) {
+    private CrackdownConstructTriggeredAbility(final CrackdownConstructTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CranialExtraction.java
+++ b/Mage.Sets/src/mage/cards/c/CranialExtraction.java
@@ -47,7 +47,7 @@ class CranialExtractionEffect extends SearchTargetGraveyardHandLibraryForCardNam
         this.staticText = "Choose a nonland card name. " + CardUtil.getTextWithFirstCharUpperCase(this.staticText);
     }
 
-    CranialExtractionEffect(final CranialExtractionEffect effect) {
+    private CranialExtractionEffect(final CranialExtractionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrashingBoars.java
+++ b/Mage.Sets/src/mage/cards/c/CrashingBoars.java
@@ -60,7 +60,7 @@ class CrashingBoarsEffect extends OneShotEffect {
         this.staticText = "defending player chooses an untapped creature they control. That creature blocks {this} this turn if able";
     }
     
-    CrashingBoarsEffect(final CrashingBoarsEffect effect) {
+    private CrashingBoarsEffect(final CrashingBoarsEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/c/CreamOfTheCrop.java
+++ b/Mage.Sets/src/mage/cards/c/CreamOfTheCrop.java
@@ -59,7 +59,7 @@ class CreamOfTheCropEffect extends OneShotEffect {
                 + "rest on the bottom of your library in any order";
     }
 
-    CreamOfTheCropEffect(final CreamOfTheCropEffect effect) {
+    private CreamOfTheCropEffect(final CreamOfTheCropEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CreditVoucher.java
+++ b/Mage.Sets/src/mage/cards/c/CreditVoucher.java
@@ -53,7 +53,7 @@ class CreditVoucherEffect extends OneShotEffect {
         this.staticText = "Shuffle any number of cards from your hand into your library, then draw that many cards";
     }
 
-    CreditVoucherEffect(final CreditVoucherEffect effect) {
+    private CreditVoucherEffect(final CreditVoucherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CreepyDoll.java
+++ b/Mage.Sets/src/mage/cards/c/CreepyDoll.java
@@ -55,7 +55,7 @@ class CreepyDollTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CreepyDollEffect());
     }
 
-    CreepyDollTriggeredAbility(final CreepyDollTriggeredAbility ability) {
+    private CreepyDollTriggeredAbility(final CreepyDollTriggeredAbility ability) {
         super(ability);
     }
 
@@ -95,7 +95,7 @@ class CreepyDollEffect extends OneShotEffect {
         staticText = "";
     }
 
-    CreepyDollEffect(final CreepyDollEffect effect) {
+    private CreepyDollEffect(final CreepyDollEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrimePunishment.java
+++ b/Mage.Sets/src/mage/cards/c/CrimePunishment.java
@@ -56,7 +56,7 @@ class PunishmentEffect extends OneShotEffect {
         this.staticText = "Destroy each artifact, creature, and enchantment with mana value X";
     }
 
-    PunishmentEffect(final PunishmentEffect effect) {
+    private PunishmentEffect(final PunishmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrookedScales.java
+++ b/Mage.Sets/src/mage/cards/c/CrookedScales.java
@@ -54,7 +54,7 @@ class CrookedScalesEffect extends OneShotEffect {
         this.staticText = "Flip a coin. If you win the flip, destroy target creature an opponent controls. If you lose the flip, destroy target creature you control unless you pay {3} and repeat this process";
     }
 
-    CrookedScalesEffect(final CrookedScalesEffect effect) {
+    private CrookedScalesEffect(final CrookedScalesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CryptChampion.java
+++ b/Mage.Sets/src/mage/cards/c/CryptChampion.java
@@ -68,7 +68,7 @@ class CryptChampionEffect extends OneShotEffect {
         this.staticText = "each player puts a creature card with mana value 3 or less from their graveyard onto the battlefield";
     }
 
-    CryptChampionEffect(final CryptChampionEffect effect) {
+    private CryptChampionEffect(final CryptChampionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CryptbornHorror.java
+++ b/Mage.Sets/src/mage/cards/c/CryptbornHorror.java
@@ -55,7 +55,7 @@ class CryptbornHorrorEffect extends OneShotEffect {
         super(Outcome.BoostCreature);
     }
 
-    CryptbornHorrorEffect(final CryptbornHorrorEffect effect) {
+    private CryptbornHorrorEffect(final CryptbornHorrorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrystalChimes.java
+++ b/Mage.Sets/src/mage/cards/c/CrystalChimes.java
@@ -50,7 +50,7 @@ class CrystalChimesEffect extends OneShotEffect {
         this.staticText = "Return all enchantment cards from your graveyard to your hand";
     }
 
-    CrystalChimesEffect(final CrystalChimesEffect effect) {
+    private CrystalChimesEffect(final CrystalChimesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CullingDais.java
+++ b/Mage.Sets/src/mage/cards/c/CullingDais.java
@@ -56,7 +56,7 @@ class CullingDaisEffect extends OneShotEffect {
         staticText = "Draw a card for each charge counter on {this}";
     }
 
-    CullingDaisEffect(final CullingDaisEffect effect) {
+    private CullingDaisEffect(final CullingDaisEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CulturalExchange.java
+++ b/Mage.Sets/src/mage/cards/c/CulturalExchange.java
@@ -52,7 +52,7 @@ class CulturalExchangeEffect extends OneShotEffect {
                 + "Those players exchange control of those creatures.";
     }
 
-    CulturalExchangeEffect(final CulturalExchangeEffect effect) {
+    private CulturalExchangeEffect(final CulturalExchangeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfBounty.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfBounty.java
@@ -60,7 +60,7 @@ class CurseOfBountyEffect extends OneShotEffect {
         this.staticText = "untap all nonland permanents you control. Each opponent attacking that player does the same.";
     }
 
-    CurseOfBountyEffect(final CurseOfBountyEffect effect) {
+    private CurseOfBountyEffect(final CurseOfBountyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfDisturbance.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfDisturbance.java
@@ -61,7 +61,7 @@ class CurseOfDisturbanceEffect extends OneShotEffect {
                 + "Each opponent attacking that player does the same.";
     }
 
-    CurseOfDisturbanceEffect(final CurseOfDisturbanceEffect effect) {
+    private CurseOfDisturbanceEffect(final CurseOfDisturbanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfVerbosity.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfVerbosity.java
@@ -59,7 +59,7 @@ class CurseOfVerbosityEffect extends OneShotEffect {
         this.staticText = "you draw a card. Each opponent attacking that player does the same.";
     }
 
-    CurseOfVerbosityEffect(final CurseOfVerbosityEffect effect) {
+    private CurseOfVerbosityEffect(final CurseOfVerbosityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfVitality.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfVitality.java
@@ -59,7 +59,7 @@ class CurseOfVitalityEffect extends OneShotEffect {
         this.staticText = "gain 2 life. Each opponent attacking that player does the same.";
     }
 
-    CurseOfVitalityEffect(final CurseOfVitalityEffect effect) {
+    private CurseOfVitalityEffect(final CurseOfVitalityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CytoplastRootKin.java
+++ b/Mage.Sets/src/mage/cards/c/CytoplastRootKin.java
@@ -64,7 +64,7 @@ class CytoplastRootKinEffect extends OneShotEffect {
         this.staticText = "Move a +1/+1 counter from target creature you control onto Cytoplast Root-Kin";
     }
 
-    CytoplastRootKinEffect(final CytoplastRootKinEffect effect) {
+    private CytoplastRootKinEffect(final CytoplastRootKinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DamiaSageOfStone.java
+++ b/Mage.Sets/src/mage/cards/d/DamiaSageOfStone.java
@@ -62,7 +62,7 @@ class DamiaSageOfStoneTriggeredAbility extends BeginningOfUpkeepTriggeredAbility
         super(new DrawCardSourceControllerEffect(new IntPlusDynamicValue(7, new MultipliedValue(CardsInControllerHandCount.instance, -1))), TargetController.YOU, false);
     }
 
-    DamiaSageOfStoneTriggeredAbility(final DamiaSageOfStoneTriggeredAbility ability) {
+    private DamiaSageOfStoneTriggeredAbility(final DamiaSageOfStoneTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DanithaNewBenaliasLight.java
+++ b/Mage.Sets/src/mage/cards/d/DanithaNewBenaliasLight.java
@@ -67,7 +67,7 @@ class DanithaNewBenaliasLightCastFromGraveyardEffect extends AsThoughEffectImpl 
         staticText = "once during each of your turns, you may cast an Aura or Equipment spell from your graveyard";
     }
 
-    DanithaNewBenaliasLightCastFromGraveyardEffect(final DanithaNewBenaliasLightCastFromGraveyardEffect effect) {
+    private DanithaNewBenaliasLightCastFromGraveyardEffect(final DanithaNewBenaliasLightCastFromGraveyardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarigaazReincarnated.java
+++ b/Mage.Sets/src/mage/cards/d/DarigaazReincarnated.java
@@ -135,7 +135,7 @@ class DarigaazReincarnatedReturnEffect extends OneShotEffect {
         this.staticText = "";
     }
 
-    DarigaazReincarnatedReturnEffect(final DarigaazReincarnatedReturnEffect effect) {
+    private DarigaazReincarnatedReturnEffect(final DarigaazReincarnatedReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkConfidant.java
+++ b/Mage.Sets/src/mage/cards/d/DarkConfidant.java
@@ -51,7 +51,7 @@ class DarkConfidantEffect extends OneShotEffect {
         this.staticText = "reveal the top card of your library and put that card into your hand. You lose life equal to its mana value";
     }
 
-    DarkConfidantEffect(final DarkConfidantEffect effect) {
+    private DarkConfidantEffect(final DarkConfidantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkDeal.java
+++ b/Mage.Sets/src/mage/cards/d/DarkDeal.java
@@ -44,7 +44,7 @@ class DarkDealEffect extends OneShotEffect {
         this.staticText = "Each player discards all the cards in their hand, then draws that many cards minus one";
     }
 
-    DarkDealEffect(final DarkDealEffect effect) {
+    private DarkDealEffect(final DarkDealEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkIntimations.java
+++ b/Mage.Sets/src/mage/cards/d/DarkIntimations.java
@@ -179,7 +179,7 @@ class DarkIntimationsReplacementEffect extends ReplacementEffectImpl {
         staticText = "That planeswalker enters the battlefield with an additional loyalty counter on it";
     }
 
-    DarkIntimationsReplacementEffect(DarkIntimationsReplacementEffect effect) {
+    private DarkIntimationsReplacementEffect(final DarkIntimationsReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkestHour.java
+++ b/Mage.Sets/src/mage/cards/d/DarkestHour.java
@@ -43,7 +43,7 @@ class DarkestHourEffect extends ContinuousEffectImpl {
         staticText = "All creatures are black";
     }
 
-    DarkestHourEffect(final DarkestHourEffect effect) {
+    private DarkestHourEffect(final DarkestHourEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DawningPurist.java
+++ b/Mage.Sets/src/mage/cards/d/DawningPurist.java
@@ -56,7 +56,7 @@ class DawningPuristTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), true);
     }
 
-    DawningPuristTriggeredAbility(final DawningPuristTriggeredAbility ability) {
+    private DawningPuristTriggeredAbility(final DawningPuristTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathOrGlory.java
+++ b/Mage.Sets/src/mage/cards/d/DeathOrGlory.java
@@ -46,7 +46,7 @@ class DeathOrGloryEffect extends OneShotEffect {
         this.staticText = "Separate all creature cards in your graveyard into two piles. Exile the pile of an opponent's choice and return the other to the battlefield";
     }
 
-    DeathOrGloryEffect(final DeathOrGloryEffect effect) {
+    private DeathOrGloryEffect(final DeathOrGloryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeathbringerLiege.java
+++ b/Mage.Sets/src/mage/cards/d/DeathbringerLiege.java
@@ -76,7 +76,7 @@ class DeathbringerLiegeEffect extends OneShotEffect {
         staticText = "destroy target creature if it's tapped";
     }
 
-    DeathbringerLiegeEffect(final DeathbringerLiegeEffect effect) {
+    private DeathbringerLiegeEffect(final DeathbringerLiegeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Deathrender.java
+++ b/Mage.Sets/src/mage/cards/d/Deathrender.java
@@ -56,7 +56,7 @@ class DeathrenderEffect extends OneShotEffect {
         this.staticText = "you may put a creature card from your hand onto the battlefield and attach {this} to it";
     }
 
-    DeathrenderEffect(final DeathrenderEffect effect) {
+    private DeathrenderEffect(final DeathrenderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeepGnomeTerramancer.java
+++ b/Mage.Sets/src/mage/cards/d/DeepGnomeTerramancer.java
@@ -59,7 +59,7 @@ class DeepGnomeTerramancerTriggeredAbility extends TriggeredAbilityImpl {
         addEffect(new SearchLibraryPutInPlayEffect(target, true));
     }
 
-    DeepGnomeTerramancerTriggeredAbility(DeepGnomeTerramancerTriggeredAbility ability) {
+    private DeepGnomeTerramancerTriggeredAbility(final DeepGnomeTerramancerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeepWood.java
+++ b/Mage.Sets/src/mage/cards/d/DeepWood.java
@@ -59,7 +59,7 @@ class DeepWoodEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that would be dealt to you this turn by attacking creatures";
     }
 
-    DeepWoodEffect(final DeepWoodEffect effect) {
+    private DeepWoodEffect(final DeepWoodEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeepwoodElder.java
+++ b/Mage.Sets/src/mage/cards/d/DeepwoodElder.java
@@ -64,7 +64,7 @@ class DeepwoodElderEffect extends OneShotEffect {
         this.staticText = "X target lands become Forests until end of turn";
     }
 
-    DeepwoodElderEffect(final DeepwoodElderEffect effect) {
+    private DeepwoodElderEffect(final DeepwoodElderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DefenseGrid.java
+++ b/Mage.Sets/src/mage/cards/d/DefenseGrid.java
@@ -43,7 +43,7 @@ class DefenseGridCostModificationEffect extends CostModificationEffectImpl {
         staticText = "Each spell costs {3} more to cast except during its controller's turn";
     }
 
-    DefenseGridCostModificationEffect(DefenseGridCostModificationEffect effect) {
+    private DefenseGridCostModificationEffect(final DefenseGridCostModificationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DefensiveManeuvers.java
+++ b/Mage.Sets/src/mage/cards/d/DefensiveManeuvers.java
@@ -47,7 +47,7 @@ class DefensiveManeuversEffect extends OneShotEffect {
         this.staticText = "Creatures of the creature type of your choice get +0/+4 until end of turn.";
     }
 
-    DefensiveManeuversEffect(final DefensiveManeuversEffect effect) {
+    private DefensiveManeuversEffect(final DefensiveManeuversEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DefiantVanguard.java
+++ b/Mage.Sets/src/mage/cards/d/DefiantVanguard.java
@@ -79,7 +79,7 @@ class DefiantVanguardTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect);
     }
 
-    DefiantVanguardTriggeredAbility(final DefiantVanguardTriggeredAbility ability) {
+    private DefiantVanguardTriggeredAbility(final DefiantVanguardTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DefilerOfSouls.java
+++ b/Mage.Sets/src/mage/cards/d/DefilerOfSouls.java
@@ -61,7 +61,7 @@ class DefilerOfSoulsEffect extends OneShotEffect {
         staticText = "that player sacrifices a monocolored creature";
     }
 
-    DefilerOfSoulsEffect(final DefilerOfSoulsEffect effect) {
+    private DefilerOfSoulsEffect(final DefilerOfSoulsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DelayTactic.java
+++ b/Mage.Sets/src/mage/cards/d/DelayTactic.java
@@ -61,7 +61,7 @@ class DelayTacticEffect extends OneShotEffect {
         this.staticText = "Creatures target opponent controls don't untap during their next untap step";
     }
 
-    DelayTacticEffect(final DelayTacticEffect effect) {
+    private DelayTacticEffect(final DelayTacticEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DelayingShield.java
+++ b/Mage.Sets/src/mage/cards/d/DelayingShield.java
@@ -55,7 +55,7 @@ class DelayingShieldReplacementEffect extends ReplacementEffectImpl {
         staticText = "If damage would be dealt to you, put that many delay counters on {this} instead";
     }
 
-    DelayingShieldReplacementEffect(final DelayingShieldReplacementEffect effect) {
+    private DelayingShieldReplacementEffect(final DelayingShieldReplacementEffect effect) {
         super(effect);
     }
 
@@ -89,7 +89,7 @@ class DelayingShieldUpkeepEffect extends OneShotEffect {
         this.staticText = "remove all delay counters from {this}. For each delay counter removed this way, you lose 1 life unless you pay {1}{W}";
     }
 
-    DelayingShieldUpkeepEffect(final DelayingShieldUpkeepEffect effect) {
+    private DelayingShieldUpkeepEffect(final DelayingShieldUpkeepEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DemonicConsultation.java
+++ b/Mage.Sets/src/mage/cards/d/DemonicConsultation.java
@@ -45,7 +45,7 @@ class DemonicConsultationEffect extends OneShotEffect {
                 "Put that card into your hand and exile all other cards revealed this way";
     }
 
-    DemonicConsultationEffect(final DemonicConsultationEffect effect) {
+    private DemonicConsultationEffect(final DemonicConsultationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DepalaPilotExemplar.java
+++ b/Mage.Sets/src/mage/cards/d/DepalaPilotExemplar.java
@@ -72,7 +72,7 @@ class DepalaPilotExemplarEffect extends OneShotEffect {
         this.staticText = "pay {X}. If you do, reveal the top X cards of your library, put all Dwarf and Vehicle cards from among them into your hand, then put the rest on the bottom of your library in a random order";
     }
 
-    DepalaPilotExemplarEffect(final DepalaPilotExemplarEffect effect) {
+    private DepalaPilotExemplarEffect(final DepalaPilotExemplarEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DesecrationDemon.java
+++ b/Mage.Sets/src/mage/cards/d/DesecrationDemon.java
@@ -57,7 +57,7 @@ class DesecrationDemonEffect extends OneShotEffect {
         staticText = "any opponent may sacrifice a creature. If a player does, tap {this} and put a +1/+1 counter on it";
     }
 
-    DesecrationDemonEffect(final DesecrationDemonEffect effect) {
+    private DesecrationDemonEffect(final DesecrationDemonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DesolationTwin.java
+++ b/Mage.Sets/src/mage/cards/d/DesolationTwin.java
@@ -49,7 +49,7 @@ class DesolationTwinOnCastAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When you cast this spell, ");
     }
 
-    DesolationTwinOnCastAbility(DesolationTwinOnCastAbility ability) {
+    private DesolationTwinOnCastAbility(final DesolationTwinOnCastAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DevastatingDreams.java
+++ b/Mage.Sets/src/mage/cards/d/DevastatingDreams.java
@@ -55,7 +55,7 @@ class DevastatingDreamsAdditionalCost extends VariableCostImpl {
         this.text = "as an additional cost to cast this spell, discard X cards at random";
     }
 
-    DevastatingDreamsAdditionalCost(final DevastatingDreamsAdditionalCost cost) {
+    private DevastatingDreamsAdditionalCost(final DevastatingDreamsAdditionalCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DevouringTendrils.java
+++ b/Mage.Sets/src/mage/cards/d/DevouringTendrils.java
@@ -102,7 +102,7 @@ class DevouringTendrilsDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.mor = mor;
     }
 
-    DevouringTendrilsDelayedTriggeredAbility(DevouringTendrilsDelayedTriggeredAbility ability) {
+    private DevouringTendrilsDelayedTriggeredAbility(final DevouringTendrilsDelayedTriggeredAbility ability) {
         super(ability);
         this.mor = ability.mor;
     }

--- a/Mage.Sets/src/mage/cards/d/DiaochanArtfulBeauty.java
+++ b/Mage.Sets/src/mage/cards/d/DiaochanArtfulBeauty.java
@@ -56,7 +56,7 @@ class DiaochanArtfulBeautyDestroyEffect extends OneShotEffect {
         this.staticText = "Destroy target creature of your choice, then destroy target creature of an opponent's choice";
     }
 
-    DiaochanArtfulBeautyDestroyEffect(final DiaochanArtfulBeautyDestroyEffect effect) {
+    private DiaochanArtfulBeautyDestroyEffect(final DiaochanArtfulBeautyDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DimirCutpurse.java
+++ b/Mage.Sets/src/mage/cards/d/DimirCutpurse.java
@@ -47,7 +47,7 @@ class DimirCutpurseEffect extends OneShotEffect {
         staticText = "that player discards a card and you draw a card";
     }
 
-    DimirCutpurseEffect(final DimirCutpurseEffect effect) {
+    private DimirCutpurseEffect(final DimirCutpurseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DimirDoppelganger.java
+++ b/Mage.Sets/src/mage/cards/d/DimirDoppelganger.java
@@ -60,7 +60,7 @@ class DimirDoppelgangerEffect extends OneShotEffect {
         staticText = "Exile target creature card from a graveyard. {this} becomes a copy of that card, except it has this ability";
     }
 
-    DimirDoppelgangerEffect(final DimirDoppelgangerEffect effect) {
+    private DimirDoppelgangerEffect(final DimirDoppelgangerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DimirMachinations.java
+++ b/Mage.Sets/src/mage/cards/d/DimirMachinations.java
@@ -53,7 +53,7 @@ class DimirMachinationsEffect extends OneShotEffect {
         this.staticText = "Look at the top three cards of target player's library. Exile any number of those cards, then put the rest back in any order";
     }
 
-    DimirMachinationsEffect(final DimirMachinationsEffect effect) {
+    private DimirMachinationsEffect(final DimirMachinationsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DinosaurHunter.java
+++ b/Mage.Sets/src/mage/cards/d/DinosaurHunter.java
@@ -48,7 +48,7 @@ class DinosaurHunterAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect());
     }
 
-    DinosaurHunterAbility(final DinosaurHunterAbility ability) {
+    private DinosaurHunterAbility(final DinosaurHunterAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DireFleetRavager.java
+++ b/Mage.Sets/src/mage/cards/d/DireFleetRavager.java
@@ -58,7 +58,7 @@ class DireFleetRavagerEffect extends OneShotEffect {
         this.staticText = "each player loses a third of their life, rounded up";
     }
 
-    DireFleetRavagerEffect(final DireFleetRavagerEffect effect) {
+    private DireFleetRavagerEffect(final DireFleetRavagerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DirtcowlWurm.java
+++ b/Mage.Sets/src/mage/cards/d/DirtcowlWurm.java
@@ -46,7 +46,7 @@ class DirtcowlWurmTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance(1)));
     }
 
-    DirtcowlWurmTriggeredAbility(DirtcowlWurmTriggeredAbility ability) {
+    private DirtcowlWurmTriggeredAbility(final DirtcowlWurmTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DismissIntoDream.java
+++ b/Mage.Sets/src/mage/cards/d/DismissIntoDream.java
@@ -52,7 +52,7 @@ class DismissIntoDreamEffect extends CreaturesBecomeOtherTypeEffect {
         this.staticText = this.staticText + " and has \"When this creature becomes the target of a spell or ability, sacrifice it.\"";
     }
 
-    DismissIntoDreamEffect(final DismissIntoDreamEffect effect) {
+    private DismissIntoDreamEffect(final DismissIntoDreamEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DispenseJustice.java
+++ b/Mage.Sets/src/mage/cards/d/DispenseJustice.java
@@ -54,7 +54,7 @@ class DispenseJusticeEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    DispenseJusticeEffect(DispenseJusticeEffect effect) {
+    private DispenseJusticeEffect(final DispenseJusticeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DistantMelody.java
+++ b/Mage.Sets/src/mage/cards/d/DistantMelody.java
@@ -47,7 +47,7 @@ class DistantMelodyEffect extends OneShotEffect {
         this.staticText = "Choose a creature type. Draw a card for each permanent you control of that type";
     }
 
-    DistantMelodyEffect(final DistantMelodyEffect effect) {
+    private DistantMelodyEffect(final DistantMelodyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DiviningWitch.java
+++ b/Mage.Sets/src/mage/cards/d/DiviningWitch.java
@@ -59,7 +59,7 @@ public final class DiviningWitch extends CardImpl {
                     "Put that card into your hand and exile all other cards revealed this way";
         }
 
-        DiviningWitchEffect(final DiviningWitchEffect effect) {
+        private DiviningWitchEffect(final DiviningWitchEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/d/DosanTheFallingLeaf.java
+++ b/Mage.Sets/src/mage/cards/d/DosanTheFallingLeaf.java
@@ -48,7 +48,7 @@ class DosanTheFallingLeafEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Players can cast spells only during their own turns";
     }
 
-    DosanTheFallingLeafEffect(final DosanTheFallingLeafEffect effect) {
+    private DosanTheFallingLeafEffect(final DosanTheFallingLeafEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DoubleVision.java
+++ b/Mage.Sets/src/mage/cards/d/DoubleVision.java
@@ -44,7 +44,7 @@ class DoubleVisionCopyTriggeredAbility extends SpellCastControllerTriggeredAbili
         super(new CopyTargetSpellEffect(true), new FilterInstantOrSorcerySpell(), false);
     }
 
-    DoubleVisionCopyTriggeredAbility(DoubleVisionCopyTriggeredAbility ability) {
+    private DoubleVisionCopyTriggeredAbility(final DoubleVisionCopyTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DoublingCube.java
+++ b/Mage.Sets/src/mage/cards/d/DoublingCube.java
@@ -51,7 +51,7 @@ class DoublingCubeEffect extends ManaEffect {
         staticText = "Double the amount of each type of unspent mana you have";
     }
 
-    DoublingCubeEffect(final DoublingCubeEffect effect) {
+    private DoublingCubeEffect(final DoublingCubeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Dovescape.java
+++ b/Mage.Sets/src/mage/cards/d/Dovescape.java
@@ -44,7 +44,7 @@ class DovescapeEffect extends OneShotEffect {
         this.staticText = "counter that spell. That player creates X 1/1 white and blue Bird creature tokens with flying, where X is the spell's mana value";
     }
 
-    DovescapeEffect(final DovescapeEffect effect) {
+    private DovescapeEffect(final DovescapeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DovinBaan.java
+++ b/Mage.Sets/src/mage/cards/d/DovinBaan.java
@@ -71,7 +71,7 @@ class DovinBaanCantActivateAbilitiesEffect extends ContinuousRuleModifyingEffect
         staticText = "and its activated abilities can't be activated";
     }
 
-    DovinBaanCantActivateAbilitiesEffect(final DovinBaanCantActivateAbilitiesEffect effect) {
+    private DovinBaanCantActivateAbilitiesEffect(final DovinBaanCantActivateAbilitiesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DrafnasRestoration.java
+++ b/Mage.Sets/src/mage/cards/d/DrafnasRestoration.java
@@ -49,7 +49,7 @@ class DrafnasRestorationTarget extends TargetCardInGraveyard {
         super(0, Integer.MAX_VALUE, new FilterArtifactCard("any number of artifact cards from that player's graveyard"));
     }
 
-    DrafnasRestorationTarget(final DrafnasRestorationTarget target) {
+    private DrafnasRestorationTarget(final DrafnasRestorationTarget target) {
         super(target);
     }
 
@@ -89,7 +89,7 @@ class DrafnasRestorationEffect extends OneShotEffect {
         this.staticText = "Put any number of target artifact cards from target player's graveyard on top of their library in any order.";
     }
 
-    DrafnasRestorationEffect(final DrafnasRestorationEffect effect) {
+    private DrafnasRestorationEffect(final DrafnasRestorationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DragonBreath.java
+++ b/Mage.Sets/src/mage/cards/d/DragonBreath.java
@@ -74,7 +74,7 @@ class DragonBreathEffect extends OneShotEffect {
         this.staticText = "return {this} from your graveyard to the battlefield attached to that creature";
     }
     
-    DragonBreathEffect(final DragonBreathEffect effect) {
+    private DragonBreathEffect(final DragonBreathEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/d/DragonFangs.java
+++ b/Mage.Sets/src/mage/cards/d/DragonFangs.java
@@ -70,7 +70,7 @@ class DragonFangsEffect extends OneShotEffect {
         this.staticText = "return {this} from your graveyard to the battlefield attached to that creature";
     }
     
-    DragonFangsEffect(final DragonFangsEffect effect) {
+    private DragonFangsEffect(final DragonFangsEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/d/DragonScales.java
+++ b/Mage.Sets/src/mage/cards/d/DragonScales.java
@@ -70,7 +70,7 @@ class DragonScalesEffect extends OneShotEffect {
         this.staticText = "return {this} from your graveyard to the battlefield attached to that creature";
     }
     
-    DragonScalesEffect(final DragonScalesEffect effect) {
+    private DragonScalesEffect(final DragonScalesEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/d/DragonShadow.java
+++ b/Mage.Sets/src/mage/cards/d/DragonShadow.java
@@ -70,7 +70,7 @@ class DragonShadowEffect extends OneShotEffect {
         this.staticText = "return {this} from your graveyard to the battlefield attached to that creature";
     }
     
-    DragonShadowEffect(final DragonShadowEffect effect) {
+    private DragonShadowEffect(final DragonShadowEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/d/DragonWings.java
+++ b/Mage.Sets/src/mage/cards/d/DragonWings.java
@@ -72,7 +72,7 @@ class DragonWingsEffect extends OneShotEffect {
         this.staticText = "return {this} from your graveyard to the battlefield attached to that creature";
     }
     
-    DragonWingsEffect(final DragonWingsEffect effect) {
+    private DragonWingsEffect(final DragonWingsEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/d/DrainingWhelk.java
+++ b/Mage.Sets/src/mage/cards/d/DrainingWhelk.java
@@ -60,7 +60,7 @@ class DrainingWhelkEffect extends CounterTargetEffect {
         staticText = "counter target spell. Put X +1/+1 counters on Draining Whelk, where X is that spell's mana value";
     }
     
-    DrainingWhelkEffect(final DrainingWhelkEffect effect) {
+    private DrainingWhelkEffect(final DrainingWhelkEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/d/DralnuLichLord.java
+++ b/Mage.Sets/src/mage/cards/d/DralnuLichLord.java
@@ -71,7 +71,7 @@ class DralnuLichLordReplacementEffect extends ReplacementEffectImpl {
         staticText = "If damage would be dealt to {this}, sacrifice that many permanents instead";
     }
 
-    DralnuLichLordReplacementEffect(final DralnuLichLordReplacementEffect effect) {
+    private DralnuLichLordReplacementEffect(final DralnuLichLordReplacementEffect effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class DralnuLichLordFlashbackEffect extends ContinuousEffectImpl {
         this.staticText = "target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost";
     }
 
-    DralnuLichLordFlashbackEffect(final DralnuLichLordFlashbackEffect effect) {
+    private DralnuLichLordFlashbackEffect(final DralnuLichLordFlashbackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Dread.java
+++ b/Mage.Sets/src/mage/cards/d/Dread.java
@@ -58,7 +58,7 @@ class DreadTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), false);
     }
     
-    DreadTriggeredAbility(final DreadTriggeredAbility ability) {
+    private DreadTriggeredAbility(final DreadTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/d/DreadWight.java
+++ b/Mage.Sets/src/mage/cards/d/DreadWight.java
@@ -70,7 +70,7 @@ class DreadWightTriggeredAbility extends TriggeredAbilityImpl {
         this.usesStack = false;
     }
 
-    DreadWightTriggeredAbility(final DreadWightTriggeredAbility ability) {
+    private DreadWightTriggeredAbility(final DreadWightTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreamTides.java
+++ b/Mage.Sets/src/mage/cards/d/DreamTides.java
@@ -63,7 +63,7 @@ class DreamTidesEffect extends OneShotEffect {
         staticText = "that player may choose any number of tapped nongreen creatures they control and pay {2} for each creature chosen this way. If the player does, untap those creatures";
     }
 
-    DreamTidesEffect(DreamTidesEffect effect) {
+    private DreamTidesEffect(final DreamTidesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DreamsOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/d/DreamsOfTheDead.java
@@ -105,7 +105,7 @@ class DreamsOfTheDeadReplacementEffect extends ReplacementEffectImpl {
         staticText = "If the creature would leave the battlefield, exile it instead of putting it anywhere else";
     }
 
-    DreamsOfTheDeadReplacementEffect(final DreamsOfTheDeadReplacementEffect effect) {
+    private DreamsOfTheDeadReplacementEffect(final DreamsOfTheDeadReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DromarTheBanisher.java
+++ b/Mage.Sets/src/mage/cards/d/DromarTheBanisher.java
@@ -60,7 +60,7 @@ class DromarTheBanisherEffect extends OneShotEffect {
         this.staticText = "choose a color, then return all creatures of that color to their owners' hands.";
     }
 
-    DromarTheBanisherEffect(final DromarTheBanisherEffect effect) {
+    private DromarTheBanisherEffect(final DromarTheBanisherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DroningBureaucrats.java
+++ b/Mage.Sets/src/mage/cards/d/DroningBureaucrats.java
@@ -57,7 +57,7 @@ class DroningBureaucratsEffect extends OneShotEffect {
         this.staticText = "Each creature with mana value X can't attack or block this turn";
     }
 
-    DroningBureaucratsEffect(final DroningBureaucratsEffect effect) {
+    private DroningBureaucratsEffect(final DroningBureaucratsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Drought.java
+++ b/Mage.Sets/src/mage/cards/d/Drought.java
@@ -66,7 +66,7 @@ class DroughtAdditionalCostEffect extends CostModificationEffectImpl {
         this.appliesToSpells = appliesToSpells;
     }
 
-    DroughtAdditionalCostEffect(DroughtAdditionalCostEffect effect) {
+    private DroughtAdditionalCostEffect(final DroughtAdditionalCostEffect effect) {
         super(effect);
         appliesToSpells = effect.appliesToSpells;
     }

--- a/Mage.Sets/src/mage/cards/d/DualNature.java
+++ b/Mage.Sets/src/mage/cards/d/DualNature.java
@@ -74,7 +74,7 @@ class DualNatureCreateTokenEffect extends OneShotEffect {
         this.staticText = "its controller creates a token that's a copy of that creature";
     }
 
-    DualNatureCreateTokenEffect(final DualNatureCreateTokenEffect effect) {
+    private DualNatureCreateTokenEffect(final DualNatureCreateTokenEffect effect) {
         super(effect);
     }
 
@@ -115,7 +115,7 @@ class DualNatureCreatureLeavesEffect extends OneShotEffect {
         this.staticText = "exile all tokens with the same name as that creature";
     }
 
-    DualNatureCreatureLeavesEffect(final DualNatureCreatureLeavesEffect effect) {
+    private DualNatureCreatureLeavesEffect(final DualNatureCreatureLeavesEffect effect) {
         super(effect);
     }
 
@@ -144,7 +144,7 @@ class DualNatureLeavesBattlefieldTriggeredAbility extends ZoneChangeTriggeredAbi
         super(Zone.BATTLEFIELD, null, new DualNatureExileEffect(), "When {this} leaves the battlefield, ", false);
     }
 
-    DualNatureLeavesBattlefieldTriggeredAbility(DualNatureLeavesBattlefieldTriggeredAbility ability) {
+    private DualNatureLeavesBattlefieldTriggeredAbility(final DualNatureLeavesBattlefieldTriggeredAbility ability) {
         super(ability);
     }
 
@@ -176,7 +176,7 @@ class DualNatureExileEffect extends OneShotEffect {
         this.staticText = "exile all tokens created with {this}.";
     }
 
-    DualNatureExileEffect(final DualNatureExileEffect effect) {
+    private DualNatureExileEffect(final DualNatureExileEffect effect) {
         super(effect);
         this.cardZoneString = effect.cardZoneString;
     }

--- a/Mage.Sets/src/mage/cards/d/DurkwoodTracker.java
+++ b/Mage.Sets/src/mage/cards/d/DurkwoodTracker.java
@@ -56,7 +56,7 @@ class DurkwoodTrackerEffect extends OneShotEffect {
                 + "That creature deals damage equal to its power to {this}";
     }
 
-    DurkwoodTrackerEffect(final DurkwoodTrackerEffect effect) {
+    private DurkwoodTrackerEffect(final DurkwoodTrackerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DuskDawn.java
+++ b/Mage.Sets/src/mage/cards/d/DuskDawn.java
@@ -63,7 +63,7 @@ class DawnEffect extends OneShotEffect {
         this.staticText = "Return all creature cards with power 2 or less from your graveyard to your hand.";
     }
 
-    DawnEffect(final DawnEffect effect) {
+    private DawnEffect(final DawnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/d/Dwindle.java
+++ b/Mage.Sets/src/mage/cards/d/Dwindle.java
@@ -59,7 +59,7 @@ class DwindleTriggeredAbility extends BlocksAttachedTriggeredAbility {
         super(new DestroyAttachedToEffect(""), "", false);
     }
 
-    DwindleTriggeredAbility(final DwindleTriggeredAbility ability) {
+    private DwindleTriggeredAbility(final DwindleTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EaterOfVirtue.java
+++ b/Mage.Sets/src/mage/cards/e/EaterOfVirtue.java
@@ -87,7 +87,7 @@ class EaterOfVirtueExileEffect extends OneShotEffect {
         this.staticText = "exile it";
     }
 
-    EaterOfVirtueExileEffect(final EaterOfVirtueExileEffect effect) {
+    private EaterOfVirtueExileEffect(final EaterOfVirtueExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EbonyOwlNetsuke.java
+++ b/Mage.Sets/src/mage/cards/e/EbonyOwlNetsuke.java
@@ -42,7 +42,7 @@ class EbonyOwlNetsukeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(4), false);
     }
 
-    EbonyOwlNetsukeTriggeredAbility(final EbonyOwlNetsukeTriggeredAbility ability) {
+    private EbonyOwlNetsukeTriggeredAbility(final EbonyOwlNetsukeTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EchoChamber.java
+++ b/Mage.Sets/src/mage/cards/e/EchoChamber.java
@@ -56,7 +56,7 @@ class EchoChamberCreateTokenEffect extends OneShotEffect {
         this.staticText = "An opponent chooses target creature they control. Create a token that's a copy of that creature. That token gains haste until end of turn. Exile the token at the beginning of the next end step";
     }
 
-    EchoChamberCreateTokenEffect(final EchoChamberCreateTokenEffect effect) {
+    private EchoChamberCreateTokenEffect(final EchoChamberCreateTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EchoingCalm.java
+++ b/Mage.Sets/src/mage/cards/e/EchoingCalm.java
@@ -44,7 +44,7 @@ class EchoingCalmEffect extends OneShotEffect {
         staticText = "Destroy target enchantment and all other enchantments with the same name as that enchantment";
     }
 
-    EchoingCalmEffect(final EchoingCalmEffect effect) {
+    private EchoingCalmEffect(final EchoingCalmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EchoingRuin.java
+++ b/Mage.Sets/src/mage/cards/e/EchoingRuin.java
@@ -50,7 +50,7 @@ class EchoingRuinEffect extends OneShotEffect {
         staticText = "Destroy target artifact and all other artifacts with the same name as that artifact";
     }
 
-    EchoingRuinEffect(final EchoingRuinEffect effect) {
+    private EchoingRuinEffect(final EchoingRuinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EldritchEvolution.java
+++ b/Mage.Sets/src/mage/cards/e/EldritchEvolution.java
@@ -59,7 +59,7 @@ class EldritchEvolutionEffect extends OneShotEffect {
                 + "onto the battlefield, then shuffle";
     }
 
-    EldritchEvolutionEffect(final EldritchEvolutionEffect effect) {
+    private EldritchEvolutionEffect(final EldritchEvolutionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Electryte.java
+++ b/Mage.Sets/src/mage/cards/e/Electryte.java
@@ -50,7 +50,7 @@ class ElectryteTriggeredAbility extends DealsCombatDamageToAPlayerTriggeredAbili
         super(new ElectryteEffect(), false);
     }
 
-    ElectryteTriggeredAbility(final ElectryteTriggeredAbility effect) {
+    private ElectryteTriggeredAbility(final ElectryteTriggeredAbility effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElementalResonance.java
+++ b/Mage.Sets/src/mage/cards/e/ElementalResonance.java
@@ -63,7 +63,7 @@ class ElementalResonanceEffect extends OneShotEffect {
         this.staticText = "add mana equal to enchanted permanent's mana cost.";
     }
 
-    ElementalResonanceEffect(final ElementalResonanceEffect effect) {
+    private ElementalResonanceEffect(final ElementalResonanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElendaAndAzor.java
+++ b/Mage.Sets/src/mage/cards/e/ElendaAndAzor.java
@@ -70,7 +70,7 @@ class ElendaAndAzorEffect extends OneShotEffect {
         staticText = "you may pay {X}{W}{U}{B}. If you do, draw X cards";
     }
 
-    ElendaAndAzorEffect(final ElendaAndAzorEffect effect) {
+    private ElendaAndAzorEffect(final ElendaAndAzorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EleshNornMotherOfMachines.java
+++ b/Mage.Sets/src/mage/cards/e/EleshNornMotherOfMachines.java
@@ -54,7 +54,7 @@ class EleshNornMotherOfMachinesPreventionEffect extends ContinuousRuleModifyingE
         staticText = "Permanents entering the battlefield don't cause abilities of permanents your opponents control to trigger";
     }
 
-    EleshNornMotherOfMachinesPreventionEffect(final EleshNornMotherOfMachinesPreventionEffect effect) {
+    private EleshNornMotherOfMachinesPreventionEffect(final EleshNornMotherOfMachinesPreventionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElvishBranchbender.java
+++ b/Mage.Sets/src/mage/cards/e/ElvishBranchbender.java
@@ -66,7 +66,7 @@ class ElvishBranchbenderEffect extends OneShotEffect {
         this.staticText = "Until end of turn, target Forest becomes an X/X Treefolk creature in addition to its other types, where X is the number of Elves you control";
     }
     
-    ElvishBranchbenderEffect(final ElvishBranchbenderEffect effect) {
+    private ElvishBranchbenderEffect(final ElvishBranchbenderEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/e/EmbermawHellion.java
+++ b/Mage.Sets/src/mage/cards/e/EmbermawHellion.java
@@ -56,7 +56,7 @@ class EmbermawHellionEffect extends ReplacementEffectImpl {
         staticText = "If another red source you control would deal damage to a permanent or player, it deals that much damage plus 1 to that permanent or player instead.";
     }
 
-    EmbermawHellionEffect(final EmbermawHellionEffect effect) {
+    private EmbermawHellionEffect(final EmbermawHellionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Embersmith.java
+++ b/Mage.Sets/src/mage/cards/e/Embersmith.java
@@ -52,7 +52,7 @@ class EmbersmithEffect extends OneShotEffect {
         staticText = "you may pay {1}. If you do, {this} deals 1 damage to any target";
     }
 
-    EmbersmithEffect(final EmbersmithEffect effect) {
+    private EmbersmithEffect(final EmbersmithEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmberwildeDjinn.java
+++ b/Mage.Sets/src/mage/cards/e/EmberwildeDjinn.java
@@ -62,7 +62,7 @@ class EmberwildeDjinnEffect extends OneShotEffect {
         this.staticText = "that player may pay {R}{R} or 2 life. If they do, the player gains control of {this}";
     }
 
-    EmberwildeDjinnEffect(final EmberwildeDjinnEffect effect) {
+    private EmberwildeDjinnEffect(final EmberwildeDjinnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmissaryOfHope.java
+++ b/Mage.Sets/src/mage/cards/e/EmissaryOfHope.java
@@ -58,7 +58,7 @@ class EmissaryOfHopeEffect extends OneShotEffect {
         staticText = "you gain 1 life for each artifact that player controls";
     }
 
-    EmissaryOfHopeEffect(final EmissaryOfHopeEffect effect) {
+    private EmissaryOfHopeEffect(final EmissaryOfHopeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmpyrialArchangel.java
+++ b/Mage.Sets/src/mage/cards/e/EmpyrialArchangel.java
@@ -55,7 +55,7 @@ class EmpyrialArchangelEffect extends ReplacementEffectImpl {
         staticText = "All damage that would be dealt to you is dealt to {this} instead";
     }
 
-    EmpyrialArchangelEffect(final EmpyrialArchangelEffect effect) {
+    private EmpyrialArchangelEffect(final EmpyrialArchangelEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmrakulsEvangel.java
+++ b/Mage.Sets/src/mage/cards/e/EmrakulsEvangel.java
@@ -118,7 +118,7 @@ class EmrakulsEvangelEffect extends OneShotEffect {
         this.staticText = "Create a 3/2 colorless Eldrazi Horror creature token for each creature sacrificed this way.";
     }
 
-    EmrakulsEvangelEffect(final EmrakulsEvangelEffect effect) {
+    private EmrakulsEvangelEffect(final EmrakulsEvangelEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnduringScalelord.java
+++ b/Mage.Sets/src/mage/cards/e/EnduringScalelord.java
@@ -52,7 +52,7 @@ class EnduringScalelordTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), true);
     }
 
-    EnduringScalelordTriggeredAbility(final EnduringScalelordTriggeredAbility ability) {
+    private EnduringScalelordTriggeredAbility(final EnduringScalelordTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnergyTap.java
+++ b/Mage.Sets/src/mage/cards/e/EnergyTap.java
@@ -52,7 +52,7 @@ class EnergyTapEffect extends OneShotEffect {
         this.staticText = "Tap target untapped creature you control. If you do, add an amount of {C} equal to that creature's mana value";
     }
 
-    EnergyTapEffect(final EnergyTapEffect effect) {
+    private EnergyTapEffect(final EnergyTapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EngulfingSlagwurm.java
+++ b/Mage.Sets/src/mage/cards/e/EngulfingSlagwurm.java
@@ -53,7 +53,7 @@ class EngulfingSlagwurmEffect extends OneShotEffect {
         staticText = "You gain life equal to that creature's toughness";
     }
 
-    EngulfingSlagwurmEffect(final EngulfingSlagwurmEffect effect) {
+    private EngulfingSlagwurmEffect(final EngulfingSlagwurmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnigmaSphinx.java
+++ b/Mage.Sets/src/mage/cards/e/EnigmaSphinx.java
@@ -67,7 +67,7 @@ class EnigmaSphinxTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When {this} is put into your graveyard from the battlefield, ");
     }
 
-    EnigmaSphinxTriggeredAbility(EnigmaSphinxTriggeredAbility ability) {
+    private EnigmaSphinxTriggeredAbility(final EnigmaSphinxTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Enslave.java
+++ b/Mage.Sets/src/mage/cards/e/Enslave.java
@@ -59,7 +59,7 @@ class EnslaveEffect extends OneShotEffect {
         staticText = "enchanted creature deals 1 damage to its owner";
     }
 
-    EnslaveEffect(final EnslaveEffect effect) {
+    private EnslaveEffect(final EnslaveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EssenceFlux.java
+++ b/Mage.Sets/src/mage/cards/e/EssenceFlux.java
@@ -51,7 +51,7 @@ class EssenceFluxEffect extends OneShotEffect {
         staticText = "return that card to the battlefield under its owner's control. If it's a Spirit, put a +1/+1 counter on it";
     }
 
-    EssenceFluxEffect(final EssenceFluxEffect effect) {
+    private EssenceFluxEffect(final EssenceFluxEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EunuchsIntrigues.java
+++ b/Mage.Sets/src/mage/cards/e/EunuchsIntrigues.java
@@ -49,7 +49,7 @@ class EunuchsIntriguesEffect extends OneShotEffect {
         this.staticText = "Target opponent chooses a creature they control. Other creatures they control can't block this turn.";
     }
 
-    EunuchsIntriguesEffect(final EunuchsIntriguesEffect effect) {
+    private EunuchsIntriguesEffect(final EunuchsIntriguesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExaltedDragon.java
+++ b/Mage.Sets/src/mage/cards/e/ExaltedDragon.java
@@ -57,7 +57,7 @@ class ExaltedDragonCostToAttackBlockEffect extends PayCostToAttackBlockEffectImp
         staticText = "{this} can't attack unless you sacrifice a land. <i>(This cost is paid as attackers are declared.)</i>";
     }
 
-    ExaltedDragonCostToAttackBlockEffect(ExaltedDragonCostToAttackBlockEffect effect) {
+    private ExaltedDragonCostToAttackBlockEffect(final ExaltedDragonCostToAttackBlockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExclusionRitual.java
+++ b/Mage.Sets/src/mage/cards/e/ExclusionRitual.java
@@ -59,7 +59,7 @@ class ExclusionRitualImprintEffect extends OneShotEffect {
         staticText = "exile target nonland permanent";
     }
 
-    ExclusionRitualImprintEffect(final ExclusionRitualImprintEffect effect) {
+    private ExclusionRitualImprintEffect(final ExclusionRitualImprintEffect effect) {
         super(effect);
     }
 
@@ -88,7 +88,7 @@ class ExclusionRitualReplacementEffect extends ContinuousRuleModifyingEffectImpl
         staticText = "Players can't cast spells with the same name as the exiled card";
     }
 
-    ExclusionRitualReplacementEffect(final ExclusionRitualReplacementEffect effect) {
+    private ExclusionRitualReplacementEffect(final ExclusionRitualReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EyeOfSingularity.java
+++ b/Mage.Sets/src/mage/cards/e/EyeOfSingularity.java
@@ -64,7 +64,7 @@ class EyeOfSingularityETBEffect extends OneShotEffect {
         this.staticText = "destroy each permanent with the same name as another permanent, except for basic lands. They can't be regenerated";
     }
 
-    EyeOfSingularityETBEffect(final EyeOfSingularityETBEffect effect) {
+    private EyeOfSingularityETBEffect(final EyeOfSingularityETBEffect effect) {
         super(effect);
     }
 
@@ -103,7 +103,7 @@ class EyeOfSingularityTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new EyeOfSingularityTriggeredEffect(), false);
     }
 
-    EyeOfSingularityTriggeredAbility(final EyeOfSingularityTriggeredAbility ability) {
+    private EyeOfSingularityTriggeredAbility(final EyeOfSingularityTriggeredAbility ability) {
         super(ability);
     }
 
@@ -151,7 +151,7 @@ class EyeOfSingularityTriggeredEffect extends OneShotEffect {
         super(Outcome.DestroyPermanent);
     }
 
-    EyeOfSingularityTriggeredEffect(final EyeOfSingularityTriggeredEffect effect) {
+    private EyeOfSingularityTriggeredEffect(final EyeOfSingularityTriggeredEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EyeOfYawgmoth.java
+++ b/Mage.Sets/src/mage/cards/e/EyeOfYawgmoth.java
@@ -57,7 +57,7 @@ class EyeOfYawgmothEffect extends OneShotEffect {
         this.staticText = "Reveal a number of cards from the top of your library equal to the sacrificed creature's power. Put one into your hand and exile the rest";
     }
 
-    EyeOfYawgmothEffect(final EyeOfYawgmothEffect effect) {
+    private EyeOfYawgmothEffect(final EyeOfYawgmothEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FabricationModule.java
+++ b/Mage.Sets/src/mage/cards/f/FabricationModule.java
@@ -55,7 +55,7 @@ class FabricationModuleTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance()), false);
     }
 
-    FabricationModuleTriggeredAbility(final FabricationModuleTriggeredAbility ability) {
+    private FabricationModuleTriggeredAbility(final FabricationModuleTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FalseCure.java
+++ b/Mage.Sets/src/mage/cards/f/FalseCure.java
@@ -45,7 +45,7 @@ class FalseCureTriggeredAbility extends DelayedTriggeredAbility {
         super(new LoseLifeTargetEffect(0), Duration.EndOfTurn, false);
     }
     
-    FalseCureTriggeredAbility(final FalseCureTriggeredAbility ability) {
+    private FalseCureTriggeredAbility(final FalseCureTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/f/FaramirPrinceOfIthilien.java
+++ b/Mage.Sets/src/mage/cards/f/FaramirPrinceOfIthilien.java
@@ -67,7 +67,7 @@ class FaramirPrinceOfIthilienEffect extends OneShotEffect {
             "Otherwise, create three 1/1 white Human Soldier creature tokens.";
     }
 
-    FaramirPrinceOfIthilienEffect(final FaramirPrinceOfIthilienEffect effect) {
+    private FaramirPrinceOfIthilienEffect(final FaramirPrinceOfIthilienEffect effect) {
         super(effect);
     }
 
@@ -111,7 +111,7 @@ class FaramirPrinceOfIthilienDelayedEffect extends OneShotEffect {
             "Otherwise, create three 1/1 white Human Soldier creature tokens.";
     }
 
-    FaramirPrinceOfIthilienDelayedEffect(final FaramirPrinceOfIthilienDelayedEffect effect) {
+    private FaramirPrinceOfIthilienDelayedEffect(final FaramirPrinceOfIthilienDelayedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FatalPush.java
+++ b/Mage.Sets/src/mage/cards/f/FatalPush.java
@@ -48,7 +48,7 @@ class FatalPushEffect extends OneShotEffect {
         this.staticText = "Destroy target creature if it has mana value 2 or less.<br><i>Revolt</i> &mdash; Destroy that creature if it has mana value 4 or less instead if a permanent you controlled left the battlefield this turn";
     }
 
-    FatalPushEffect(final FatalPushEffect effect) {
+    private FatalPushEffect(final FatalPushEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FavorOfTheMighty.java
+++ b/Mage.Sets/src/mage/cards/f/FavorOfTheMighty.java
@@ -63,7 +63,7 @@ class FavorOfTheMightyEffect extends ContinuousEffectImpl {
         this.staticText = "Each creature with the highest mana value has protection from all colors.";
     }
 
-    FavorOfTheMightyEffect(final FavorOfTheMightyEffect effect) {
+    private FavorOfTheMightyEffect(final FavorOfTheMightyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FeastOfWorms.java
+++ b/Mage.Sets/src/mage/cards/f/FeastOfWorms.java
@@ -56,7 +56,7 @@ class FeastOfWormsEffect extends OneShotEffect {
         staticText = "If that land was legendary, its controller sacrifices another land";
     }
 
-    FeastOfWormsEffect(FeastOfWormsEffect effect) {
+    private FeastOfWormsEffect(final FeastOfWormsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FeldonsCane.java
+++ b/Mage.Sets/src/mage/cards/f/FeldonsCane.java
@@ -48,7 +48,7 @@ class FeldonsCaneEffect extends OneShotEffect {
         this.staticText = "Shuffle your graveyard into your library";
     }
     
-    FeldonsCaneEffect(final FeldonsCaneEffect effect) {
+    private FeldonsCaneEffect(final FeldonsCaneEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/f/FieldOfRuin.java
+++ b/Mage.Sets/src/mage/cards/f/FieldOfRuin.java
@@ -71,7 +71,7 @@ class FieldOfRuinEffect extends OneShotEffect {
         this.staticText = "Each player searches their library for a basic land card, puts it onto the battlefield, then shuffles";
     }
 
-    FieldOfRuinEffect(final FieldOfRuinEffect effect) {
+    private FieldOfRuinEffect(final FieldOfRuinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FightingChance.java
+++ b/Mage.Sets/src/mage/cards/f/FightingChance.java
@@ -44,7 +44,7 @@ class FightingChanceEffect extends OneShotEffect {
         staticText = "For each blocking creature, flip a coin. If you win the flip, prevent all combat damage that would be dealt by that creature this turn.";
     }
 
-    FightingChanceEffect(final FightingChanceEffect effect) {
+    private FightingChanceEffect(final FightingChanceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlameKinWarScout.java
+++ b/Mage.Sets/src/mage/cards/f/FlameKinWarScout.java
@@ -55,7 +55,7 @@ class FlameKinWarScourEffect extends OneShotEffect {
         this.staticText = "sacrifice {this}. If you do, {this} deals 4 damage to that creature.";
     }
 
-    FlameKinWarScourEffect(final FlameKinWarScourEffect effect) {
+    private FlameKinWarScourEffect(final FlameKinWarScourEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlameblastDragon.java
+++ b/Mage.Sets/src/mage/cards/f/FlameblastDragon.java
@@ -58,7 +58,7 @@ class FlameblastDragonEffect extends OneShotEffect {
         staticText = "you may pay {X}{R}. If you do, {this} deals X damage to any target";
     }
 
-    FlameblastDragonEffect(final FlameblastDragonEffect effect) {
+    private FlameblastDragonEffect(final FlameblastDragonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Fleshwrither.java
+++ b/Mage.Sets/src/mage/cards/f/Fleshwrither.java
@@ -76,7 +76,7 @@ class FleshwritherEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    FleshwritherEffect(final FleshwritherEffect effect) {
+    private FleshwritherEffect(final FleshwritherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FloodedWoodlands.java
+++ b/Mage.Sets/src/mage/cards/f/FloodedWoodlands.java
@@ -51,7 +51,7 @@ class FloodedWoodlandsCostToAttackBlockEffect extends PayCostToAttackBlockEffect
         staticText = "Green creatures can't attack unless their controller sacrifices a land <i>(This cost is paid as attackers are declared.)</i>";
     }
 
-    FloodedWoodlandsCostToAttackBlockEffect(FloodedWoodlandsCostToAttackBlockEffect effect) {
+    private FloodedWoodlandsCostToAttackBlockEffect(final FloodedWoodlandsCostToAttackBlockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlourishingDefenses.java
+++ b/Mage.Sets/src/mage/cards/f/FlourishingDefenses.java
@@ -44,7 +44,7 @@ class FlourishingDefensesTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CreateTokenEffect(new ElfWarriorToken()), true);
     }
 
-    FlourishingDefensesTriggeredAbility(final FlourishingDefensesTriggeredAbility ability) {
+    private FlourishingDefensesTriggeredAbility(final FlourishingDefensesTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Flux.java
+++ b/Mage.Sets/src/mage/cards/f/Flux.java
@@ -45,7 +45,7 @@ class FluxEffect extends OneShotEffect {
         this.staticText = "Each player discards any number of cards, then draws that many cards";
     }
 
-    FluxEffect(final FluxEffect effect) {
+    private FluxEffect(final FluxEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FoodChain.java
+++ b/Mage.Sets/src/mage/cards/f/FoodChain.java
@@ -71,7 +71,7 @@ class FoodChainManaEffect extends ManaEffect {
         this.staticText = "Add X mana of any one color, where X is 1 plus the exiled creature's mana value. Spend this mana only to cast creature spells";
     }
 
-    FoodChainManaEffect(final FoodChainManaEffect effect) {
+    private FoodChainManaEffect(final FoodChainManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForceBubble.java
+++ b/Mage.Sets/src/mage/cards/f/ForceBubble.java
@@ -60,7 +60,7 @@ class ForceBubbleReplacementEffect extends ReplacementEffectImpl {
         staticText = "If damage would be dealt to you, put that many depletion counters on {this} instead";
     }
 
-    ForceBubbleReplacementEffect(final ForceBubbleReplacementEffect effect) {
+    private ForceBubbleReplacementEffect(final ForceBubbleReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForceLift.java
+++ b/Mage.Sets/src/mage/cards/f/ForceLift.java
@@ -53,7 +53,7 @@ class ForceLiftEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    ForceLiftEffect(ForceLiftEffect effect) {
+    private ForceLiftEffect(final ForceLiftEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForceMastery.java
+++ b/Mage.Sets/src/mage/cards/f/ForceMastery.java
@@ -44,7 +44,7 @@ class ForceMasteryEffect extends OneShotEffect {
         this.staticText = "reveal the top card of your library and put that card into your hand. You gain life equal to its mana value";
     }
 
-    ForceMasteryEffect(final ForceMasteryEffect effect) {
+    private ForceMasteryEffect(final ForceMasteryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Forcefield.java
+++ b/Mage.Sets/src/mage/cards/f/Forcefield.java
@@ -60,7 +60,7 @@ class ForcefieldEffect extends OneShotEffect {
         this.staticText = "The next time an unblocked creature of your choice would deal combat damage to you this turn, prevent all but 1 of that damage";
     }
 
-    ForcefieldEffect(final ForcefieldEffect effect) {
+    private ForcefieldEffect(final ForcefieldEffect effect) {
         super(effect);
     }
 
@@ -97,7 +97,7 @@ class ForcefieldPreventionEffect extends PreventionEffectImpl {
         this.staticText = "Prevent all but 1 of that damage";
     }
 
-    ForcefieldPreventionEffect(ForcefieldPreventionEffect effect) {
+    private ForcefieldPreventionEffect(final ForcefieldPreventionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForgeAnew.java
+++ b/Mage.Sets/src/mage/cards/f/ForgeAnew.java
@@ -70,7 +70,7 @@ class ForgeAnewCostEffect extends CostModificationEffectImpl {
         this.staticText = "you may pay {0} rather than pay the equip cost of the first equip ability you activate during each of your turns.";
     }
 
-    ForgeAnewCostEffect(final ForgeAnewCostEffect effect) {
+    private ForgeAnewCostEffect(final ForgeAnewCostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FrayingOmnipotence.java
+++ b/Mage.Sets/src/mage/cards/f/FrayingOmnipotence.java
@@ -47,7 +47,7 @@ class FrayingOmnipotenceEffect extends OneShotEffect {
                 + "Round up each time.";
     }
 
-    FrayingOmnipotenceEffect(final FrayingOmnipotenceEffect effect) {
+    private FrayingOmnipotenceEffect(final FrayingOmnipotenceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FreyalisesWinds.java
+++ b/Mage.Sets/src/mage/cards/f/FreyalisesWinds.java
@@ -52,7 +52,7 @@ class FreyalisesWindsReplacementEffect extends ReplacementEffectImpl {
         staticText = "If a permanent with a wind counter on it would untap during its controller's untap step, remove all wind counters from it instead";
     }
 
-    FreyalisesWindsReplacementEffect(final FreyalisesWindsReplacementEffect effect) {
+    private FreyalisesWindsReplacementEffect(final FreyalisesWindsReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/f/Fumble.java
+++ b/Mage.Sets/src/mage/cards/f/Fumble.java
@@ -55,7 +55,7 @@ class FumbleEffect extends OneShotEffect {
                 + "then attach them to another creature";
     }
 
-    FumbleEffect(final FumbleEffect effect) {
+    private FumbleEffect(final FumbleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GandalfTheWhite.java
+++ b/Mage.Sets/src/mage/cards/g/GandalfTheWhite.java
@@ -67,7 +67,7 @@ class GandalfTheWhiteDoublingEffect extends ReplacementEffectImpl {
         staticText = "If a legendary permanent or an artifact entering or leaving the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time.";
     }
 
-    GandalfTheWhiteDoublingEffect(final GandalfTheWhiteDoublingEffect effect) {
+    private GandalfTheWhiteDoublingEffect(final GandalfTheWhiteDoublingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GarbageElementalC.java
+++ b/Mage.Sets/src/mage/cards/g/GarbageElementalC.java
@@ -58,7 +58,7 @@ class GarbageElementalCEffect extends OneShotEffect {
         this.staticText = "roll two six-sided dice. Create a number of 1/1 red Goblin creature tokens equal to the difference between those results";
     }
 
-    GarbageElementalCEffect(final GarbageElementalCEffect effect) {
+    private GarbageElementalCEffect(final GarbageElementalCEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GarbageElementalD.java
+++ b/Mage.Sets/src/mage/cards/g/GarbageElementalD.java
@@ -58,7 +58,7 @@ class GarbageElementalDEffect extends OneShotEffect {
         this.staticText = "roll a six-sided die. {this} deals damage equal to the result to target opponent";
     }
 
-    GarbageElementalDEffect(final GarbageElementalDEffect effect) {
+    private GarbageElementalDEffect(final GarbageElementalDEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GarnaTheBloodflame.java
+++ b/Mage.Sets/src/mage/cards/g/GarnaTheBloodflame.java
@@ -72,7 +72,7 @@ class GarnaTheBloodflameEffect extends OneShotEffect {
         staticText = "return to your hand all creature cards in your graveyard that were put there from anywhere this turn";
     }
 
-    GarnaTheBloodflameEffect(final GarnaTheBloodflameEffect effect) {
+    private GarnaTheBloodflameEffect(final GarnaTheBloodflameEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GarrukPrimalHunter.java
+++ b/Mage.Sets/src/mage/cards/g/GarrukPrimalHunter.java
@@ -65,7 +65,7 @@ class GarrukPrimalHunterEffect extends OneShotEffect {
         staticText = "Draw cards equal to the greatest power among creatures you control";
     }
 
-    GarrukPrimalHunterEffect(final GarrukPrimalHunterEffect effect) {
+    private GarrukPrimalHunterEffect(final GarrukPrimalHunterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GarzasAssassin.java
+++ b/Mage.Sets/src/mage/cards/g/GarzasAssassin.java
@@ -60,7 +60,7 @@ class GarzasAssassinCost extends CostImpl {
         this.text = "Pay half your life, rounded up";
     }
 
-    GarzasAssassinCost(GarzasAssassinCost cost) {
+    private GarzasAssassinCost(final GarzasAssassinCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GateToTheAether.java
+++ b/Mage.Sets/src/mage/cards/g/GateToTheAether.java
@@ -46,7 +46,7 @@ class GateToTheAetherEffect extends OneShotEffect {
         this.staticText = "that player reveals the top card of their library. If it's an artifact, creature, enchantment, or land card, the player may put it onto the battlefield";
     }
 
-    GateToTheAetherEffect(final GateToTheAetherEffect effect) {
+    private GateToTheAetherEffect(final GateToTheAetherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GeistOfSaintTraft.java
+++ b/Mage.Sets/src/mage/cards/g/GeistOfSaintTraft.java
@@ -55,7 +55,7 @@ class GeistOfSaintTraftEffect extends OneShotEffect {
         staticText = "create a 4/4 white Angel creature token with flying that's tapped and attacking. Exile that token at end of combat";
     }
 
-    GeistOfSaintTraftEffect(final GeistOfSaintTraftEffect effect) {
+    private GeistOfSaintTraftEffect(final GeistOfSaintTraftEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GeminiEngine.java
+++ b/Mage.Sets/src/mage/cards/g/GeminiEngine.java
@@ -55,7 +55,7 @@ class GeminiEngineCreateTokenEffect extends OneShotEffect {
         this.staticText = "create a colorless Construct artifact creature token named Twin that's attacking. Its power is equal to {this}'s power and its toughness is equal to {this}'s toughness. Sacrifice the token at end of combat.";
     }
 
-    GeminiEngineCreateTokenEffect(final GeminiEngineCreateTokenEffect effect) {
+    private GeminiEngineCreateTokenEffect(final GeminiEngineCreateTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GemstoneCaverns.java
+++ b/Mage.Sets/src/mage/cards/g/GemstoneCaverns.java
@@ -109,7 +109,7 @@ class GemstoneCavernsEffect extends OneShotEffect {
         this.staticText = "you may begin the game with {this} on the battlefield with a luck counter on it. If you do, exile a card from your hand";
     }
 
-    GemstoneCavernsEffect(final GemstoneCavernsEffect effect) {
+    private GemstoneCavernsEffect(final GemstoneCavernsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Gerrymandering.java
+++ b/Mage.Sets/src/mage/cards/g/Gerrymandering.java
@@ -50,7 +50,7 @@ class GerrymanderingEffect extends OneShotEffect {
         this.staticText = "Exile all lands. Give each player a number of those cards chosen at random equal to the number of those cards the player controlled. Each player returns those cards to the battlefield under their control";
     }
 
-    GerrymanderingEffect(final GerrymanderingEffect effect) {
+    private GerrymanderingEffect(final GerrymanderingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GhaltaPrimalHunger.java
+++ b/Mage.Sets/src/mage/cards/g/GhaltaPrimalHunger.java
@@ -69,7 +69,7 @@ class GhaltaPrimalHungerCostReductionEffect extends CostModificationEffectImpl {
         staticText = "this spell costs {X} less to cast, where X is the total power of creatures you control";
     }
 
-    GhaltaPrimalHungerCostReductionEffect(final GhaltaPrimalHungerCostReductionEffect effect) {
+    private GhaltaPrimalHungerCostReductionEffect(final GhaltaPrimalHungerCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GibberingDescent.java
+++ b/Mage.Sets/src/mage/cards/g/GibberingDescent.java
@@ -57,7 +57,7 @@ class GibberingDescentSkipUpkeepEffect extends ContinuousRuleModifyingEffectImpl
         this.staticText = "skip your upkeep step if you have no cards in hand";
     }
 
-    GibberingDescentSkipUpkeepEffect(final GibberingDescentSkipUpkeepEffect effect) {
+    private GibberingDescentSkipUpkeepEffect(final GibberingDescentSkipUpkeepEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GisaAndGeralf.java
+++ b/Mage.Sets/src/mage/cards/g/GisaAndGeralf.java
@@ -61,7 +61,7 @@ class GisaAndGeralfCastFromGraveyardEffect extends AsThoughEffectImpl {
         staticText = "During each of your turns, you may cast a Zombie creature spell from your graveyard";
     }
 
-    GisaAndGeralfCastFromGraveyardEffect(final GisaAndGeralfCastFromGraveyardEffect effect) {
+    private GisaAndGeralfCastFromGraveyardEffect(final GisaAndGeralfCastFromGraveyardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GishathSunsAvatar.java
+++ b/Mage.Sets/src/mage/cards/g/GishathSunsAvatar.java
@@ -68,7 +68,7 @@ class GishathSunsAvatarEffect extends OneShotEffect {
         this.staticText = "reveal that many cards from the top of your library. Put any number of Dinosaur creature cards from among them onto the battlefield and the rest on the bottom of your library in a random order";
     }
 
-    GishathSunsAvatarEffect(final GishathSunsAvatarEffect effect) {
+    private GishathSunsAvatarEffect(final GishathSunsAvatarEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Glaciers.java
+++ b/Mage.Sets/src/mage/cards/g/Glaciers.java
@@ -52,7 +52,7 @@ public final class Glaciers extends CardImpl {
             this.staticText = "All Mountains are Plains";
         }
 
-        GlaciersEffect(final GlaciersEffect effect) {
+        private GlaciersEffect(final GlaciersEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/g/GlimmerpointStag.java
+++ b/Mage.Sets/src/mage/cards/g/GlimmerpointStag.java
@@ -70,7 +70,7 @@ class GlimmerpointStagEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    GlimmerpointStagEffect(GlimmerpointStagEffect effect) {
+    private GlimmerpointStagEffect(final GlimmerpointStagEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlisteningOil.java
+++ b/Mage.Sets/src/mage/cards/g/GlisteningOil.java
@@ -65,7 +65,7 @@ class GlisteningOilEffect extends OneShotEffect {
         staticText = "put a -1/-1 counter on enchanted creature";
     }
 
-    GlisteningOilEffect(final GlisteningOilEffect effect) {
+    private GlisteningOilEffect(final GlisteningOilEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Gloom.java
+++ b/Mage.Sets/src/mage/cards/g/Gloom.java
@@ -54,7 +54,7 @@ class GloomCostIncreaseEffect extends CostModificationEffectImpl {
         staticText = "Activated abilities of white enchantments cost {3} more to activate.";
     }
 
-    GloomCostIncreaseEffect(GloomCostIncreaseEffect effect) {
+    private GloomCostIncreaseEffect(final GloomCostIncreaseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GloomSurgeon.java
+++ b/Mage.Sets/src/mage/cards/g/GloomSurgeon.java
@@ -46,7 +46,7 @@ class GloomSurgeonEffect extends ReplacementEffectImpl {
         staticText = "If combat damage would be dealt to {this}, prevent that damage and exile that many cards from the top of your library";
     }
 
-    GloomSurgeonEffect(final GloomSurgeonEffect effect) {
+    private GloomSurgeonEffect(final GloomSurgeonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinGoon.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinGoon.java
@@ -53,7 +53,7 @@ class GoblinGoonCantAttackEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless you control more creatures than defending player";
     }
 
-    GoblinGoonCantAttackEffect(final GoblinGoonCantAttackEffect effect) {
+    private GoblinGoonCantAttackEffect(final GoblinGoonCantAttackEffect effect) {
         super(effect);
     }
 
@@ -100,7 +100,7 @@ class GoblinGoonCantBlockEffect extends RestrictionEffect {
         staticText = "{this} can't block unless you control more creatures than attacking player";
     }
 
-    GoblinGoonCantBlockEffect(final GoblinGoonCantBlockEffect effect) {
+    private GoblinGoonCantBlockEffect(final GoblinGoonCantBlockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinWarCry.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinWarCry.java
@@ -49,7 +49,7 @@ class GoblinWarCryEffect extends OneShotEffect {
         this.staticText = "Target opponent chooses a creature they control. Other creatures they control can't block this turn.";
     }
 
-    GoblinWarCryEffect(final GoblinWarCryEffect effect) {
+    private GoblinWarCryEffect(final GoblinWarCryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Godsend.java
+++ b/Mage.Sets/src/mage/cards/g/Godsend.java
@@ -67,7 +67,7 @@ class GodsendTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GodsendExileEffect(), true);
     }
 
-    GodsendTriggeredAbility(final GodsendTriggeredAbility ability) {
+    private GodsendTriggeredAbility(final GodsendTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GolemArtisan.java
+++ b/Mage.Sets/src/mage/cards/g/GolemArtisan.java
@@ -71,7 +71,7 @@ class GolemArtisanEffect extends OneShotEffect {
         staticText = "Target artifact creature gains your choice of flying, trample, or haste until end of turn";
     }
 
-    GolemArtisanEffect(final GolemArtisanEffect effect) {
+    private GolemArtisanEffect(final GolemArtisanEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrandArchitect.java
+++ b/Mage.Sets/src/mage/cards/g/GrandArchitect.java
@@ -116,7 +116,7 @@ class GrandArchitectManaAbility extends ActivatedManaAbilityImpl {
         this.filter = filter;
     }
 
-    GrandArchitectManaAbility(GrandArchitectManaAbility ability) {
+    private GrandArchitectManaAbility(final GrandArchitectManaAbility ability) {
         super(ability);
         this.filter = ability.filter.copy();
     }

--- a/Mage.Sets/src/mage/cards/g/GratuitousViolence.java
+++ b/Mage.Sets/src/mage/cards/g/GratuitousViolence.java
@@ -46,7 +46,7 @@ class GratuitousViolenceReplacementEffect extends ReplacementEffectImpl {
         staticText = "If a creature you control would deal damage to a permanent or player, it deals double that damage to that permanent or player instead";
     }
 
-    GratuitousViolenceReplacementEffect(final GratuitousViolenceReplacementEffect effect) {
+    private GratuitousViolenceReplacementEffect(final GratuitousViolenceReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraveBetrayal.java
+++ b/Mage.Sets/src/mage/cards/g/GraveBetrayal.java
@@ -134,7 +134,7 @@ class GraveBetrayalReplacementEffect extends ReplacementEffectImpl {
         super(Duration.EndOfStep, Outcome.BoostCreature);
     }
 
-    GraveBetrayalReplacementEffect(GraveBetrayalReplacementEffect effect) {
+    private GraveBetrayalReplacementEffect(final GraveBetrayalReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GravePeril.java
+++ b/Mage.Sets/src/mage/cards/g/GravePeril.java
@@ -46,7 +46,7 @@ class GravePerilEffect extends OneShotEffect {
         this.staticText = "sacrifice Grave Peril. If you do, destroy that creature";
     }
 
-    GravePerilEffect(final GravePerilEffect effect) {
+    private GravePerilEffect(final GravePerilEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GravebaneZombie.java
+++ b/Mage.Sets/src/mage/cards/g/GravebaneZombie.java
@@ -54,7 +54,7 @@ class GravebaneZombieEffect extends ReplacementEffectImpl {
         staticText = "If {this} would die, put {this} on top of its owner's library instead";
     }
 
-    GravebaneZombieEffect(final GravebaneZombieEffect effect) {
+    private GravebaneZombieEffect(final GravebaneZombieEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GreenbeltRampager.java
+++ b/Mage.Sets/src/mage/cards/g/GreenbeltRampager.java
@@ -50,7 +50,7 @@ public final class GreenbeltRampager extends CardImpl {
             this.staticText = "pay {E}{E}. If you can't, return {this} to its owner's hand and you get {E}";
         }
 
-        GreenbeltRampagerEffect(final GreenbeltRampagerEffect effect) {
+        private GreenbeltRampagerEffect(final GreenbeltRampagerEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/g/GrenzoDungeonWarden.java
+++ b/Mage.Sets/src/mage/cards/g/GrenzoDungeonWarden.java
@@ -61,7 +61,7 @@ class GrenzoDungeonWardenEffect extends OneShotEffect {
         this.staticText = "Put the bottom card of your library into your graveyard. If it's a creature card with power less than or equal to {this}'s power, put it onto the battlefield";
     }
 
-    GrenzoDungeonWardenEffect(final GrenzoDungeonWardenEffect effect) {
+    private GrenzoDungeonWardenEffect(final GrenzoDungeonWardenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrimReminder.java
+++ b/Mage.Sets/src/mage/cards/g/GrimReminder.java
@@ -73,7 +73,7 @@ class GrimReminderEffect extends OneShotEffect {
                 + "Then shuffle.";
     }
 
-    GrimReminderEffect(final GrimReminderEffect effect) {
+    private GrimReminderEffect(final GrimReminderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GripOfPhyresis.java
+++ b/Mage.Sets/src/mage/cards/g/GripOfPhyresis.java
@@ -59,7 +59,7 @@ class GripOfPhyresisEffect extends CreateTokenEffect {
         staticText = ", then " + staticText + " and attach that Equipment to it";
     }
 
-    GripOfPhyresisEffect(final GripOfPhyresisEffect effect) {
+    private GripOfPhyresisEffect(final GripOfPhyresisEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrothamaAllDevouring.java
+++ b/Mage.Sets/src/mage/cards/g/GrothamaAllDevouring.java
@@ -74,7 +74,7 @@ class GrothamaAllDevouringGainAbilityEffect extends GainAbilityAllEffect {
         this.staticText = "Other creatures have \"Whenever this creature attacks, you may have it fight {this}.\"";
     }
 
-    GrothamaAllDevouringGainAbilityEffect(final GrothamaAllDevouringGainAbilityEffect effect) {
+    private GrothamaAllDevouringGainAbilityEffect(final GrothamaAllDevouringGainAbilityEffect effect) {
         super(effect);
     }
 
@@ -104,7 +104,7 @@ class GrothamaAllDevouringFightEffect extends OneShotEffect {
         this.staticText = "you may have it fight " + fightName;
     }
 
-    GrothamaAllDevouringFightEffect(final GrothamaAllDevouringFightEffect effect) {
+    private GrothamaAllDevouringFightEffect(final GrothamaAllDevouringFightEffect effect) {
         super(effect);
         this.fightId = effect.fightId;
     }
@@ -133,7 +133,7 @@ class GrothamaAllDevouringDrawCardsEffect extends OneShotEffect {
                 + "damage dealt to {this} this turn by sources they controlled.";
     }
 
-    GrothamaAllDevouringDrawCardsEffect(final GrothamaAllDevouringDrawCardsEffect effect) {
+    private GrothamaAllDevouringDrawCardsEffect(final GrothamaAllDevouringDrawCardsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GroveOfTheBurnwillows.java
+++ b/Mage.Sets/src/mage/cards/g/GroveOfTheBurnwillows.java
@@ -51,7 +51,7 @@ class GroveOfTheBurnwillowsEffect extends OneShotEffect {
         staticText = "Each opponent gains 1 life";
     }
 
-    GroveOfTheBurnwillowsEffect(GroveOfTheBurnwillowsEffect effect) {
+    private GroveOfTheBurnwillowsEffect(final GroveOfTheBurnwillowsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrowthSpurt.java
+++ b/Mage.Sets/src/mage/cards/g/GrowthSpurt.java
@@ -48,7 +48,7 @@ class GrowthSpurtEffect extends OneShotEffect {
         this.staticText = "Roll a six-sided die. Target creature gets +X/+X until end of turn, where X is the result";
     }
 
-    GrowthSpurtEffect(final GrowthSpurtEffect effect) {
+    private GrowthSpurtEffect(final GrowthSpurtEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuardianAngel.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianAngel.java
@@ -103,7 +103,7 @@ class GuardianAngelAction extends SpecialAction {
         this.addEffect(new PreventDamageToTargetEffect(Duration.EndOfTurn, 1));
     }
 
-    GuardianAngelAction(final GuardianAngelAction ability) {
+    private GuardianAngelAction(final GuardianAngelAction ability) {
         super(ability);
     }
 
@@ -121,7 +121,7 @@ class GuardianAngelDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.setRuleVisible(false);
     }
 
-    GuardianAngelDelayedTriggeredAbility(GuardianAngelDelayedTriggeredAbility ability) {
+    private GuardianAngelDelayedTriggeredAbility(final GuardianAngelDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GuidedPassage.java
+++ b/Mage.Sets/src/mage/cards/g/GuidedPassage.java
@@ -56,7 +56,7 @@ class GuidedPassageEffect extends OneShotEffect {
         this.staticText = "Reveal the cards in your library. An opponent chooses from among them a creature card, a land card, and a noncreature, nonland card. You put the chosen cards into your hand. Then shuffle.";
     }
 
-    GuidedPassageEffect(final GuidedPassageEffect effect) {
+    private GuidedPassageEffect(final GuidedPassageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Guile.java
+++ b/Mage.Sets/src/mage/cards/g/Guile.java
@@ -61,7 +61,7 @@ class GuileReplacementEffect extends ReplacementEffectImpl {
                 + "instead exile that spell and you may play that card without paying its mana cost";
     }
 
-    GuileReplacementEffect(final GuileReplacementEffect effect) {
+    private GuileReplacementEffect(final GuileReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Gurzigost.java
+++ b/Mage.Sets/src/mage/cards/g/Gurzigost.java
@@ -69,7 +69,7 @@ class GurzigostCost extends CostImpl {
     }
 
 
-    GurzigostCost(final GurzigostCost cost) {
+    private GurzigostCost(final GurzigostCost cost) {
         super(cost);
     }
 


### PR DESCRIPTION
Part of #11054, relative to making private copy constructors that were package-private.

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`  ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `  private $1(final $1 $3`
