### PR TITLE
Clean package-private copy constructors in cards starting H to P

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HallarTheFirefletcher.java
+++ b/Mage.Sets/src/mage/cards/h/HallarTheFirefletcher.java
@@ -57,7 +57,7 @@ class HallarTheFirefletcherTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you cast a spell, if that spell was kicked, ");
     }
 
-    HallarTheFirefletcherTriggeredAbility(final HallarTheFirefletcherTriggeredAbility ability) {
+    private HallarTheFirefletcherTriggeredAbility(final HallarTheFirefletcherTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HamletbackGoliath.java
+++ b/Mage.Sets/src/mage/cards/h/HamletbackGoliath.java
@@ -52,7 +52,7 @@ class HamletbackGoliathTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new HamletbackGoliathEffect(), true);
     }
 
-    HamletbackGoliathTriggeredAbility(final HamletbackGoliathTriggeredAbility ability) {
+    private HamletbackGoliathTriggeredAbility(final HamletbackGoliathTriggeredAbility ability) {
         super(ability);
     }
 
@@ -92,7 +92,7 @@ class HamletbackGoliathEffect extends OneShotEffect {
         super(Outcome.BoostCreature);
     }
 
-    HamletbackGoliathEffect(final HamletbackGoliathEffect effect) {
+    private HamletbackGoliathEffect(final HamletbackGoliathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HammerHelper.java
+++ b/Mage.Sets/src/mage/cards/h/HammerHelper.java
@@ -49,7 +49,7 @@ class HammerHelperEffect extends OneShotEffect {
         staticText = "Gain control of target creature until end of turn. Untap that creature and roll a six-sided die. Until end of turn, it gains haste and gets +X/+0, where X is the result";
     }
 
-    HammerHelperEffect(HammerHelperEffect effect) {
+    private HammerHelperEffect(final HammerHelperEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HammerOfRuin.java
+++ b/Mage.Sets/src/mage/cards/h/HammerOfRuin.java
@@ -59,7 +59,7 @@ class HammerOfRuinTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), true);
     }
 
-    HammerOfRuinTriggeredAbility(final HammerOfRuinTriggeredAbility ability) {
+    private HammerOfRuinTriggeredAbility(final HammerOfRuinTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarmonicProdigy.java
+++ b/Mage.Sets/src/mage/cards/h/HarmonicProdigy.java
@@ -56,7 +56,7 @@ class HarmonicProdigyEffect extends ReplacementEffectImpl {
                 "that ability triggers an additional time";
     }
 
-    HarmonicProdigyEffect(final HarmonicProdigyEffect effect) {
+    private HarmonicProdigyEffect(final HarmonicProdigyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarshMentor.java
+++ b/Mage.Sets/src/mage/cards/h/HarshMentor.java
@@ -52,7 +52,7 @@ class HarshMentorTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(StaticValue.get(2), true, "that player", true));
     }
 
-    HarshMentorTriggeredAbility(final HarshMentorTriggeredAbility ability) {
+    private HarshMentorTriggeredAbility(final HarshMentorTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HarvestSeason.java
+++ b/Mage.Sets/src/mage/cards/h/HarvestSeason.java
@@ -58,7 +58,7 @@ class HarvestSeasonEffect extends OneShotEffect {
                 + " put those cards onto the battlefield tapped, then shuffle.";
     }
 
-    HarvestSeasonEffect(final HarvestSeasonEffect effect) {
+    private HarvestSeasonEffect(final HarvestSeasonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HauntingWind.java
+++ b/Mage.Sets/src/mage/cards/h/HauntingWind.java
@@ -44,7 +44,7 @@ class HauntingWindTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(1));
     }
 
-    HauntingWindTriggeredAbility(final HauntingWindTriggeredAbility ability) {
+    private HauntingWindTriggeredAbility(final HauntingWindTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeartOfBogardan.java
+++ b/Mage.Sets/src/mage/cards/h/HeartOfBogardan.java
@@ -53,7 +53,7 @@ class HeartOfBogardanTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetPlayerOrPlaneswalker());
     }
 
-    HeartOfBogardanTriggeredAbility(final HeartOfBogardanTriggeredAbility ability) {
+    private HeartOfBogardanTriggeredAbility(final HeartOfBogardanTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeartwoodStoryteller.java
+++ b/Mage.Sets/src/mage/cards/h/HeartwoodStoryteller.java
@@ -51,7 +51,7 @@ class HeartwoodStorytellerTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new HeartwoodStorytellerEffect(), false);
     }
 
-    HeartwoodStorytellerTriggeredAbility(final HeartwoodStorytellerTriggeredAbility ability) {
+    private HeartwoodStorytellerTriggeredAbility(final HeartwoodStorytellerTriggeredAbility ability) {
         super(ability);
     }
 
@@ -90,7 +90,7 @@ class HeartwoodStorytellerEffect extends OneShotEffect {
         this.staticText = "Each of that player's opponents may draw a card";
     }
 
-    HeartwoodStorytellerEffect(final HeartwoodStorytellerEffect effect) {
+    private HeartwoodStorytellerEffect(final HeartwoodStorytellerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeavyFog.java
+++ b/Mage.Sets/src/mage/cards/h/HeavyFog.java
@@ -59,7 +59,7 @@ class HeavyFogEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that would be dealt to you this turn by attacking creatures";
     }
 
-    HeavyFogEffect(final HeavyFogEffect effect) {
+    private HeavyFogEffect(final HeavyFogEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HedronBlade.java
+++ b/Mage.Sets/src/mage/cards/h/HedronBlade.java
@@ -61,7 +61,7 @@ class HedronBladeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect, false);
     }
 
-    HedronBladeTriggeredAbility(final HedronBladeTriggeredAbility ability) {
+    private HedronBladeTriggeredAbility(final HedronBladeTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HellkiteCharger.java
+++ b/Mage.Sets/src/mage/cards/h/HellkiteCharger.java
@@ -61,7 +61,7 @@ class HellkiteChargerEffect extends OneShotEffect {
         staticText = "you may pay {5}{R}{R}. If you do, untap all attacking creatures and after this phase, there is an additional combat phase";
     }
 
-    HellkiteChargerEffect(final HellkiteChargerEffect effect) {
+    private HellkiteChargerEffect(final HellkiteChargerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeraldOfLeshrac.java
+++ b/Mage.Sets/src/mage/cards/h/HeraldOfLeshrac.java
@@ -82,7 +82,7 @@ class HeraldOfLeshracCumulativeCost extends CostImpl {
         this.text = "Gain control of a land you don't control";
     }
 
-    HeraldOfLeshracCumulativeCost(final HeraldOfLeshracCumulativeCost cost) {
+    private HeraldOfLeshracCumulativeCost(final HeraldOfLeshracCumulativeCost cost) {
         super(cost);
     }
 
@@ -117,7 +117,7 @@ class HeraldOfLeshracLeavesEffect extends OneShotEffect {
         this.staticText = "each player gains control of each land they own that you control";
     }
 
-    HeraldOfLeshracLeavesEffect(final HeraldOfLeshracLeavesEffect effect) {
+    private HeraldOfLeshracLeavesEffect(final HeraldOfLeshracLeavesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeraldOfWar.java
+++ b/Mage.Sets/src/mage/cards/h/HeraldOfWar.java
@@ -56,7 +56,7 @@ class HeraldOfWarCostReductionEffect extends CostModificationEffectImpl {
         staticText = "Angel spells and Human spells you cast cost {1} less to cast for each +1/+1 counter on {this}";
     }
 
-    HeraldOfWarCostReductionEffect(HeraldOfWarCostReductionEffect effect) {
+    private HeraldOfWarCostReductionEffect(final HeraldOfWarCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeroOfBretagard.java
+++ b/Mage.Sets/src/mage/cards/h/HeroOfBretagard.java
@@ -93,7 +93,7 @@ class HeroOfBretagardTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, null, false);
     }
 
-    HeroOfBretagardTriggeredAbility(final HeroOfBretagardTriggeredAbility ability) {
+    private HeroOfBretagardTriggeredAbility(final HeroOfBretagardTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HexParasite.java
+++ b/Mage.Sets/src/mage/cards/h/HexParasite.java
@@ -52,7 +52,7 @@ class HexParasiteEffect extends OneShotEffect {
         staticText = "Remove up to X counters from target permanent. For each counter removed this way, {this} gets +1/+0 until end of turn";
     }
 
-    HexParasiteEffect(HexParasiteEffect effect) {
+    private HexParasiteEffect(final HexParasiteEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HiredGiant.java
+++ b/Mage.Sets/src/mage/cards/h/HiredGiant.java
@@ -53,7 +53,7 @@ class HiredGiantEffect extends OneShotEffect {
         this.staticText = "each other player may search their library for a land card and put that card onto the battlefield. Then each player who searched their library this way shuffles";
     }
 
-    HiredGiantEffect(final HiredGiantEffect effect) {
+    private HiredGiantEffect(final HiredGiantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HisokaMinamoSensei.java
+++ b/Mage.Sets/src/mage/cards/h/HisokaMinamoSensei.java
@@ -56,7 +56,7 @@ class HisokaMinamoSenseiCounterEffect extends OneShotEffect {
         staticText = "Counter target spell if it has the same mana value as the discarded card";
     }
 
-    HisokaMinamoSenseiCounterEffect(final HisokaMinamoSenseiCounterEffect effect) {
+    private HisokaMinamoSenseiCounterEffect(final HisokaMinamoSenseiCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HoardSmelterDragon.java
+++ b/Mage.Sets/src/mage/cards/h/HoardSmelterDragon.java
@@ -61,7 +61,7 @@ class HoardSmelterEffect extends ContinuousEffectImpl {
         staticText = "{this} gets +X/+0 until end of turn, where X is that artifact's mana value";
     }
 
-    HoardSmelterEffect(final HoardSmelterEffect effect) {
+    private HoardSmelterEffect(final HoardSmelterEffect effect) {
         super(effect);
         this.costValue = effect.costValue;
     }

--- a/Mage.Sets/src/mage/cards/h/HollowWarrior.java
+++ b/Mage.Sets/src/mage/cards/h/HollowWarrior.java
@@ -66,7 +66,7 @@ class HollowWarriorCostToAttackBlockEffect extends PayCostToAttackBlockEffectImp
         staticText = "{this} can't attack or block unless you tap an untapped creature you control not declared as an attacking or blocking creature this combat <i>(This cost is paid as attackers are declared.)</i>";
     }
 
-    HollowWarriorCostToAttackBlockEffect(HollowWarriorCostToAttackBlockEffect effect) {
+    private HollowWarriorCostToAttackBlockEffect(final HollowWarriorCostToAttackBlockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HotSoup.java
+++ b/Mage.Sets/src/mage/cards/h/HotSoup.java
@@ -59,7 +59,7 @@ class HotSoupTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever equipped creature is dealt damage, ");
     }
     
-    HotSoupTriggeredAbility(final HotSoupTriggeredAbility ability) {
+    private HotSoupTriggeredAbility(final HotSoupTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/h/HourOfEternity.java
+++ b/Mage.Sets/src/mage/cards/h/HourOfEternity.java
@@ -67,7 +67,7 @@ class HourOfEternityEffect extends OneShotEffect {
                 "except it's a 4/4 black Zombie";
     }
 
-    HourOfEternityEffect(final HourOfEternityEffect effect) {
+    private HourOfEternityEffect(final HourOfEternityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HowlOfTheHorde.java
+++ b/Mage.Sets/src/mage/cards/h/HowlOfTheHorde.java
@@ -60,7 +60,7 @@ class HowlOfTheHordeDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new CopyTargetSpellEffect(true), Duration.EndOfTurn);
     }
 
-    HowlOfTheHordeDelayedTriggeredAbility(final HowlOfTheHordeDelayedTriggeredAbility ability) {
+    private HowlOfTheHordeDelayedTriggeredAbility(final HowlOfTheHordeDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HumOfTheRadix.java
+++ b/Mage.Sets/src/mage/cards/h/HumOfTheRadix.java
@@ -46,7 +46,7 @@ class HumOfTheRadixCostIncreaseEffect extends CostModificationEffectImpl {
         staticText = "each artifact spell costs {1} more to cast for each artifact its controller controls";
     }
 
-    HumOfTheRadixCostIncreaseEffect(final HumOfTheRadixCostIncreaseEffect effect) {
+    private HumOfTheRadixCostIncreaseEffect(final HumOfTheRadixCostIncreaseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HungryFlames.java
+++ b/Mage.Sets/src/mage/cards/h/HungryFlames.java
@@ -44,7 +44,7 @@ public final class HungryFlames extends CardImpl {
             this.staticText = "{this} deals 3 damage to target creature and 2 damage to target player or planeswalker";
         }
 
-        HungryFlamesEffect(final HungryFlamesEffect effect) {
+        private HungryFlamesEffect(final HungryFlamesEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/h/HushwingGryff.java
+++ b/Mage.Sets/src/mage/cards/h/HushwingGryff.java
@@ -61,7 +61,7 @@ class HushwingGryffEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Creatures entering the battlefield don't cause abilities to trigger";
     }
 
-    HushwingGryffEffect(final HushwingGryffEffect effect) {
+    private HushwingGryffEffect(final HushwingGryffEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HydrasGrowth.java
+++ b/Mage.Sets/src/mage/cards/h/HydrasGrowth.java
@@ -64,7 +64,7 @@ class HydrasGrowthDoubleEffect extends OneShotEffect {
         staticText = "double the number of +1/+1 counters on enchanted creature";
     }
 
-    HydrasGrowthDoubleEffect(final HydrasGrowthDoubleEffect effect) {
+    private HydrasGrowthDoubleEffect(final HydrasGrowthDoubleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Hydroblast.java
+++ b/Mage.Sets/src/mage/cards/h/Hydroblast.java
@@ -50,7 +50,7 @@ class HydroblastCounterEffect extends OneShotEffect {
         this.staticText = "Counter target spell if it's red";
     }
 
-    HydroblastCounterEffect(final HydroblastCounterEffect effect) {
+    private HydroblastCounterEffect(final HydroblastCounterEffect effect) {
         super(effect);
     }
 
@@ -75,7 +75,7 @@ class HydroblastDestroyEffect extends OneShotEffect {
         this.staticText = "destroy target permanent if it's red";
     }
 
-    HydroblastDestroyEffect(final HydroblastDestroyEffect effect) {
+    private HydroblastDestroyEffect(final HydroblastDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Hypergenesis.java
+++ b/Mage.Sets/src/mage/cards/h/Hypergenesis.java
@@ -61,7 +61,7 @@ class HypergenesisEffect extends OneShotEffect {
         this.staticText = "Starting with you, each player may put an artifact, creature, enchantment, or land card from their hand onto the battlefield. Repeat this process until no one puts a card onto the battlefield.";
     }
 
-    HypergenesisEffect(final HypergenesisEffect effect) {
+    private HypergenesisEffect(final HypergenesisEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IceCauldron.java
+++ b/Mage.Sets/src/mage/cards/i/IceCauldron.java
@@ -121,7 +121,7 @@ class IceCauldronCastFromExileEffect extends AsThoughEffectImpl {
         staticText = "You may cast that card for as long as it remains exiled";
     }
 
-    IceCauldronCastFromExileEffect(final IceCauldronCastFromExileEffect effect) {
+    private IceCauldronCastFromExileEffect(final IceCauldronCastFromExileEffect effect) {
         super(effect);
     }
 
@@ -191,7 +191,7 @@ class IceCauldronAddManaEffect extends ManaEffect {
         staticText = "Add {this}'s last noted type and amount of mana. Spend this mana only to cast the last card exiled with {this}";
     }
 
-    IceCauldronAddManaEffect(IceCauldronAddManaEffect effect) {
+    private IceCauldronAddManaEffect(final IceCauldronAddManaEffect effect) {
         super(effect);
         storedMana = effect.storedMana == null ? null : effect.storedMana.copy();
         exiledCardMor = effect.exiledCardMor;

--- a/Mage.Sets/src/mage/cards/i/IchormoonGauntlet.java
+++ b/Mage.Sets/src/mage/cards/i/IchormoonGauntlet.java
@@ -71,7 +71,7 @@ class IchormoonGauntletEffect extends OneShotEffect {
         staticText = "choose a counter on target permanent. Put an additional counter of that kind on that permanent";
     }
 
-    IchormoonGauntletEffect(final IchormoonGauntletEffect effect) {
+    private IchormoonGauntletEffect(final IchormoonGauntletEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IllGottenGains.java
+++ b/Mage.Sets/src/mage/cards/i/IllGottenGains.java
@@ -54,7 +54,7 @@ class IllGottenGainsEffect extends OneShotEffect {
         this.staticText = ", then returns up to three cards from their graveyard to their hand.";
     }
 
-    IllGottenGainsEffect(final IllGottenGainsEffect effect) {
+    private IllGottenGainsEffect(final IllGottenGainsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImagesOfThePast.java
+++ b/Mage.Sets/src/mage/cards/i/ImagesOfThePast.java
@@ -48,7 +48,7 @@ class ImagesOfThePastEffect extends OneShotEffect {
         this.staticText = "Return up to two target creature cards from your graveyard to the battlefield, then exile those creatures";
     }
 
-    ImagesOfThePastEffect(final ImagesOfThePastEffect effect) {
+    private ImagesOfThePastEffect(final ImagesOfThePastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImperialEdict.java
+++ b/Mage.Sets/src/mage/cards/i/ImperialEdict.java
@@ -48,7 +48,7 @@ class ImperialEdictEffect extends OneShotEffect {
         this.staticText = "Target opponent chooses a creature they control. Destroy it.";
     }
 
-    ImperialEdictEffect(final ImperialEdictEffect effect) {
+    private ImperialEdictEffect(final ImperialEdictEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImpetuousProtege.java
+++ b/Mage.Sets/src/mage/cards/i/ImpetuousProtege.java
@@ -65,7 +65,7 @@ class ImpetuousProtegeEffect extends OneShotEffect {
         this.staticText = "it gets +X/+0 until end of turn, where X is the greatest power among tapped creatures your opponents control";
     }
 
-    ImpetuousProtegeEffect(final ImpetuousProtegeEffect effect) {
+    private ImpetuousProtegeEffect(final ImpetuousProtegeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Imprison.java
+++ b/Mage.Sets/src/mage/cards/i/Imprison.java
@@ -70,7 +70,7 @@ class ImprisonTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a player activates an ability of enchanted creature with {T} in its activation cost that isn't a mana ability, ");
     }
 
-    ImprisonTriggeredAbility(final ImprisonTriggeredAbility ability) {
+    private ImprisonTriggeredAbility(final ImprisonTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InTheEyeOfChaos.java
+++ b/Mage.Sets/src/mage/cards/i/InTheEyeOfChaos.java
@@ -52,7 +52,7 @@ class InTheEyeOfChaosEffect extends OneShotEffect {
         this.staticText = "counter it unless that player pays {X}, where X is its mana value";
     }
 
-    InTheEyeOfChaosEffect(final InTheEyeOfChaosEffect effect) {
+    private InTheEyeOfChaosEffect(final InTheEyeOfChaosEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IndenturedDjinn.java
+++ b/Mage.Sets/src/mage/cards/i/IndenturedDjinn.java
@@ -55,7 +55,7 @@ class IndenturedDjinnEffect extends OneShotEffect {
         this.staticText = "each other player may draw up to three cards";
     }
 
-    IndenturedDjinnEffect(final IndenturedDjinnEffect effect) {
+    private IndenturedDjinnEffect(final IndenturedDjinnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InduceParanoia.java
+++ b/Mage.Sets/src/mage/cards/i/InduceParanoia.java
@@ -53,7 +53,7 @@ class InduceParanoiaEffect extends OneShotEffect {
         this.staticText = "Counter target spell. If {B} was spent to cast this spell, that spell's controller mills X cards, where X is the spell's mana value.";
     }
 
-    InduceParanoiaEffect(final InduceParanoiaEffect effect) {
+    private InduceParanoiaEffect(final InduceParanoiaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IndulgentTormentor.java
+++ b/Mage.Sets/src/mage/cards/i/IndulgentTormentor.java
@@ -61,7 +61,7 @@ class IndulgentTormentorEffect extends OneShotEffect {
         this.staticText = "draw a card unless target opponent sacrifices a creature or pays 3 life";
     }
 
-    IndulgentTormentorEffect(final IndulgentTormentorEffect effect) {
+    private IndulgentTormentorEffect(final IndulgentTormentorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfectiousHorror.java
+++ b/Mage.Sets/src/mage/cards/i/InfectiousHorror.java
@@ -48,7 +48,7 @@ class InfectiousHorrorEffect extends OneShotEffect {
         staticText = "each opponent loses 2 life";
     }
 
-    InfectiousHorrorEffect(final InfectiousHorrorEffect effect) {
+    private InfectiousHorrorEffect(final InfectiousHorrorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfernalDenizen.java
+++ b/Mage.Sets/src/mage/cards/i/InfernalDenizen.java
@@ -85,7 +85,7 @@ class InfernalDenizenEffect extends OneShotEffect {
                 + "for as long as {this} remains on the battlefield";
     }
 
-    InfernalDenizenEffect(final InfernalDenizenEffect effect) {
+    private InfernalDenizenEffect(final InfernalDenizenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfernalOffering.java
+++ b/Mage.Sets/src/mage/cards/i/InfernalOffering.java
@@ -58,7 +58,7 @@ class InfernalOfferingSacrificeEffect extends OneShotEffect {
         this.staticText = "Choose an opponent. You and that player each sacrifice a creature. Each player who sacrificed a creature this way draws two cards";
     }
 
-    InfernalOfferingSacrificeEffect(final InfernalOfferingSacrificeEffect effect) {
+    private InfernalOfferingSacrificeEffect(final InfernalOfferingSacrificeEffect effect) {
         super(effect);
     }
 
@@ -116,7 +116,7 @@ class InfernalOfferingReturnEffect extends OneShotEffect {
         this.staticText = "Choose an opponent. Return a creature card from your graveyard to the battlefield, then that player returns a creature card from their graveyard to the battlefield";
     }
 
-    InfernalOfferingReturnEffect(final InfernalOfferingReturnEffect effect) {
+    private InfernalOfferingReturnEffect(final InfernalOfferingReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfiniteAuthority.java
+++ b/Mage.Sets/src/mage/cards/i/InfiniteAuthority.java
@@ -65,7 +65,7 @@ class InfiniteAuthorityTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever enchanted creature blocks or becomes blocked by a creature with toughness 3 or less, ");
     }
 
-    InfiniteAuthorityTriggeredAbility(final InfiniteAuthorityTriggeredAbility ability) {
+    private InfiniteAuthorityTriggeredAbility(final InfiniteAuthorityTriggeredAbility ability) {
         super(ability);
     }
 
@@ -113,7 +113,7 @@ class InfiniteAuthorityEffect extends OneShotEffect {
         staticText = "destroy the other creature at end of combat. At the beginning of the next end step, if that creature was destroyed this way, put a +1/+1 counter on the first creature";
     }
 
-    InfiniteAuthorityEffect(final InfiniteAuthorityEffect effect) {
+    private InfiniteAuthorityEffect(final InfiniteAuthorityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InsatiableRakghoul.java
+++ b/Mage.Sets/src/mage/cards/i/InsatiableRakghoul.java
@@ -54,7 +54,7 @@ class InsatiableRakghoulEffect extends OneShotEffect {
         staticText = "with a +1/+1 counter on it if a non-artifact creature died this turn";
     }
 
-    InsatiableRakghoulEffect(final InsatiableRakghoulEffect effect) {
+    private InsatiableRakghoulEffect(final InsatiableRakghoulEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/Insist.java
+++ b/Mage.Sets/src/mage/cards/i/Insist.java
@@ -51,7 +51,7 @@ class InsistEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "The next creature spell you cast this turn can't be countered";
     }
 
-    InsistEffect(final InsistEffect effect) {
+    private InsistEffect(final InsistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InsultInjury.java
+++ b/Mage.Sets/src/mage/cards/i/InsultInjury.java
@@ -100,7 +100,7 @@ class InjuryEffect extends OneShotEffect {
         this.staticText = "{this} deals 2 damage to target creature and 2 damage to target player or planeswalker";
     }
 
-    InjuryEffect(final InjuryEffect effect) {
+    private InjuryEffect(final InjuryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IntellectDevourer.java
+++ b/Mage.Sets/src/mage/cards/i/IntellectDevourer.java
@@ -136,7 +136,7 @@ class IntellectDevourerPlayFromExileEffect extends AsThoughEffectImpl {
         staticText = "You may play lands and cast spells from among cards exiled with {this}";
     }
 
-    IntellectDevourerPlayFromExileEffect(final IntellectDevourerPlayFromExileEffect effect) {super(effect);}
+    private IntellectDevourerPlayFromExileEffect(final IntellectDevourerPlayFromExileEffect effect) {super(effect);}
 
     @Override
     public boolean apply(Game game, Ability source) {return true;}

--- a/Mage.Sets/src/mage/cards/i/IntellectualOffering.java
+++ b/Mage.Sets/src/mage/cards/i/IntellectualOffering.java
@@ -49,7 +49,7 @@ class IntellectualOfferingDrawEffect extends OneShotEffect {
         this.staticText = "Choose an opponent. You and that player each draw three cards";
     }
     
-    IntellectualOfferingDrawEffect(final IntellectualOfferingDrawEffect effect) {
+    private IntellectualOfferingDrawEffect(final IntellectualOfferingDrawEffect effect) {
         super(effect);
     }
     
@@ -82,7 +82,7 @@ class IntellectualOfferingUntapEffect extends OneShotEffect {
         this.staticText = "<br><br>Choose an opponent. Untap all nonland permanents you control and all nonland permanents that player controls";
     }
     
-    IntellectualOfferingUntapEffect(final IntellectualOfferingUntapEffect effect) {
+    private IntellectualOfferingUntapEffect(final IntellectualOfferingUntapEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/i/Interrogation.java
+++ b/Mage.Sets/src/mage/cards/i/Interrogation.java
@@ -47,7 +47,7 @@ class InterrogationEffect extends OneShotEffect {
         this.staticText = "Then that player discards another card unless they pay 3 life";
     }
 
-    InterrogationEffect(final InterrogationEffect effect) {
+    private InterrogationEffect(final InterrogationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InvaderParasite.java
+++ b/Mage.Sets/src/mage/cards/i/InvaderParasite.java
@@ -62,7 +62,7 @@ class InvaderParasiteImprintEffect extends OneShotEffect {
         staticText = "exile target land";
     }
 
-    InvaderParasiteImprintEffect(final InvaderParasiteImprintEffect effect) {
+    private InvaderParasiteImprintEffect(final InvaderParasiteImprintEffect effect) {
         super(effect);
     }
 
@@ -89,7 +89,7 @@ class InvaderParasiteTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(2));
     }
 
-    InvaderParasiteTriggeredAbility(final InvaderParasiteTriggeredAbility ability) {
+    private InvaderParasiteTriggeredAbility(final InvaderParasiteTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InvocationOfSaintTraft.java
+++ b/Mage.Sets/src/mage/cards/i/InvocationOfSaintTraft.java
@@ -63,7 +63,7 @@ class InvocationOfSaintTraftEffect extends OneShotEffect {
         staticText = "create a 4/4 white Angel creature token with flying tapped and attacking. Exile that token at end of combat";
     }
 
-    InvocationOfSaintTraftEffect(final InvocationOfSaintTraftEffect effect) {
+    private InvocationOfSaintTraftEffect(final InvocationOfSaintTraftEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IonaShieldOfEmeria.java
+++ b/Mage.Sets/src/mage/cards/i/IonaShieldOfEmeria.java
@@ -60,7 +60,7 @@ class IonaShieldOfEmeriaReplacementEffect extends ContinuousRuleModifyingEffectI
         staticText = "Your opponents can't cast spells of the chosen color";
     }
 
-    IonaShieldOfEmeriaReplacementEffect(final IonaShieldOfEmeriaReplacementEffect effect) {
+    private IonaShieldOfEmeriaReplacementEffect(final IonaShieldOfEmeriaReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IslandSanctuary.java
+++ b/Mage.Sets/src/mage/cards/i/IslandSanctuary.java
@@ -59,7 +59,7 @@ class IslandSanctuaryEffect extends ReplacementEffectImpl {
         staticText = "If you would draw a card during your draw step, instead you may skip that draw. If you do, until your next turn, you can't be attacked except by creatures with flying and/or islandwalk";
     }
 
-    IslandSanctuaryEffect(final IslandSanctuaryEffect effect) {
+    private IslandSanctuaryEffect(final IslandSanctuaryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IsshinTwoHeavensAsOne.java
+++ b/Mage.Sets/src/mage/cards/i/IsshinTwoHeavensAsOne.java
@@ -50,7 +50,7 @@ class IsshinTwoHeavensAsOneEffect extends ReplacementEffectImpl {
                 "of a permanent you control to trigger, that ability triggers an additional time";
     }
 
-    IsshinTwoHeavensAsOneEffect(final IsshinTwoHeavensAsOneEffect effect) {
+    private IsshinTwoHeavensAsOneEffect(final IsshinTwoHeavensAsOneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IxalansBinding.java
+++ b/Mage.Sets/src/mage/cards/i/IxalansBinding.java
@@ -53,7 +53,7 @@ class IxalansBindingReplacementEffect extends ContinuousRuleModifyingEffectImpl 
         staticText = "Your opponents can't cast spells with the same name as the exiled card";
     }
 
-    IxalansBindingReplacementEffect(final IxalansBindingReplacementEffect effect) {
+    private IxalansBindingReplacementEffect(final IxalansBindingReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JacesArchivist.java
+++ b/Mage.Sets/src/mage/cards/j/JacesArchivist.java
@@ -55,7 +55,7 @@ class JacesArchivistEffect extends OneShotEffect {
         staticText = "Each player discards their hand, then draws cards equal to the greatest number of cards a player discarded this way";
     }
 
-    JacesArchivistEffect(final JacesArchivistEffect effect) {
+    private JacesArchivistEffect(final JacesArchivistEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JackInTheMox.java
+++ b/Mage.Sets/src/mage/cards/j/JackInTheMox.java
@@ -60,7 +60,7 @@ class JackInTheMoxManaEffect extends ManaEffect {
                 + "<br>6 - Add {G}.";
     }
 
-    JackInTheMoxManaEffect(final JackInTheMoxManaEffect effect) {
+    private JackInTheMoxManaEffect(final JackInTheMoxManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JeskaiInfiltrator.java
+++ b/Mage.Sets/src/mage/cards/j/JeskaiInfiltrator.java
@@ -70,7 +70,7 @@ class JeskaiInfiltratorEffect extends OneShotEffect {
         this.staticText = "exile it and the top card of your library in a face-down pile, shuffle that pile, then manifest those cards";
     }
 
-    JeskaiInfiltratorEffect(final JeskaiInfiltratorEffect effect) {
+    private JeskaiInfiltratorEffect(final JeskaiInfiltratorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JestersScepter.java
+++ b/Mage.Sets/src/mage/cards/j/JestersScepter.java
@@ -198,7 +198,7 @@ class JestersScepterCounterEffect extends OneShotEffect {
         staticText = "Counter target spell if it has the same name as that card";
     }
 
-    JestersScepterCounterEffect(final JestersScepterCounterEffect effect) {
+    private JestersScepterCounterEffect(final JestersScepterCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JeweledAmulet.java
+++ b/Mage.Sets/src/mage/cards/j/JeweledAmulet.java
@@ -100,7 +100,7 @@ class JeweledAmuletAddManaEffect extends ManaEffect {
         staticText = "Add one mana of {this}'s last noted type";
     }
 
-    JeweledAmuletAddManaEffect(JeweledAmuletAddManaEffect effect) {
+    private JeweledAmuletAddManaEffect(final JeweledAmuletAddManaEffect effect) {
         super(effect);
         storedMana = effect.storedMana == null ? null : effect.storedMana.copy();
     }

--- a/Mage.Sets/src/mage/cards/j/JhoirasTimebug.java
+++ b/Mage.Sets/src/mage/cards/j/JhoirasTimebug.java
@@ -63,7 +63,7 @@ class JhoirasTimebugEffect extends OneShotEffect {
         this.staticText = "Choose target permanent you control or suspended card you own. If that permanent or card has a time counter on it, you may remove a time counter from it or put another time counter on it";
     }
 
-    JhoirasTimebugEffect(final JhoirasTimebugEffect effect) {
+    private JhoirasTimebugEffect(final JhoirasTimebugEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/j/Jokulmorder.java
+++ b/Mage.Sets/src/mage/cards/j/Jokulmorder.java
@@ -71,7 +71,7 @@ class JokulmorderTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new UntapSourceEffect(), true);
     }
 
-    JokulmorderTriggeredAbility(JokulmorderTriggeredAbility ability) {
+    private JokulmorderTriggeredAbility(final JokulmorderTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JotunGrunt.java
+++ b/Mage.Sets/src/mage/cards/j/JotunGrunt.java
@@ -54,7 +54,7 @@ class JotunGruntCost extends CostImpl {
     }
 
 
-    JotunGruntCost(final JotunGruntCost cost) {
+    private JotunGruntCost(final JotunGruntCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JovialEvil.java
+++ b/Mage.Sets/src/mage/cards/j/JovialEvil.java
@@ -52,7 +52,7 @@ class JovialEvilEffect extends OneShotEffect {
         staticText = "{this} deals X damage to target opponent, where X is twice the number of white creatures that player controls";
     }
 
-    JovialEvilEffect(final JovialEvilEffect effect) {
+    private JovialEvilEffect(final JovialEvilEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KaerveksTorch.java
+++ b/Mage.Sets/src/mage/cards/k/KaerveksTorch.java
@@ -55,7 +55,7 @@ class KaerveksTorchCostIncreaseEffect extends CostModificationEffectImpl {
         staticText = "Spells that target {this} cost {2} more to cast";
     }
 
-    KaerveksTorchCostIncreaseEffect(KaerveksTorchCostIncreaseEffect effect) {
+    private KaerveksTorchCostIncreaseEffect(final KaerveksTorchCostIncreaseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KalamaxTheStormsire.java
+++ b/Mage.Sets/src/mage/cards/k/KalamaxTheStormsire.java
@@ -59,7 +59,7 @@ class KalamaxTheStormsireSpellCastAbility extends SpellCastControllerTriggeredAb
         super(new CopyTargetSpellEffect(true), new FilterInstantSpell(), false);
     }
 
-    KalamaxTheStormsireSpellCastAbility(KalamaxTheStormsireSpellCastAbility ability) {
+    private KalamaxTheStormsireSpellCastAbility(final KalamaxTheStormsireSpellCastAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KalastriaHighborn.java
+++ b/Mage.Sets/src/mage/cards/k/KalastriaHighborn.java
@@ -62,7 +62,7 @@ class LoseGainEffect extends OneShotEffect {
         this.staticText = "target player loses 2 life and you gain 2 life";
     }
 
-    LoseGainEffect(final LoseGainEffect effect) {
+    private LoseGainEffect(final LoseGainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KaradorGhostChieftain.java
+++ b/Mage.Sets/src/mage/cards/k/KaradorGhostChieftain.java
@@ -65,7 +65,7 @@ class KaradorGhostChieftainCostReductionEffect extends CostModificationEffectImp
         staticText = "this spell costs {1} less to cast for each creature card in your graveyard";
     }
 
-    KaradorGhostChieftainCostReductionEffect(KaradorGhostChieftainCostReductionEffect effect) {
+    private KaradorGhostChieftainCostReductionEffect(final KaradorGhostChieftainCostReductionEffect effect) {
         super(effect);
     }
 
@@ -102,7 +102,7 @@ class KaradorGhostChieftainCastFromGraveyardEffect extends AsThoughEffectImpl {
         staticText = "During each of your turns, you may cast a creature spell from your graveyard";
     }
 
-    KaradorGhostChieftainCastFromGraveyardEffect(final KaradorGhostChieftainCastFromGraveyardEffect effect) {
+    private KaradorGhostChieftainCastFromGraveyardEffect(final KaradorGhostChieftainCastFromGraveyardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KarganIntimidator.java
+++ b/Mage.Sets/src/mage/cards/k/KarganIntimidator.java
@@ -87,7 +87,7 @@ class KarganIntimidatorEffect extends RestrictionEffect {
         staticText = "Cowards can't block Warriors";
     }
 
-    KarganIntimidatorEffect(final KarganIntimidatorEffect effect) {
+    private KarganIntimidatorEffect(final KarganIntimidatorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KariZevSkyshipRaider.java
+++ b/Mage.Sets/src/mage/cards/k/KariZevSkyshipRaider.java
@@ -61,7 +61,7 @@ class KariZevSkyshipRaiderEffect extends OneShotEffect {
         staticText = "create Ragavan, a legendary 2/1 red Monkey creature token. Ragavan enters the battlefield tapped and attacking. Exile that token at end of combat";
     }
 
-    KariZevSkyshipRaiderEffect(final KariZevSkyshipRaiderEffect effect) {
+    private KariZevSkyshipRaiderEffect(final KariZevSkyshipRaiderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KarmicJustice.java
+++ b/Mage.Sets/src/mage/cards/k/KarmicJustice.java
@@ -46,7 +46,7 @@ class KarmicJusticeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), true);
     }
     
-    KarmicJusticeTriggeredAbility(final KarmicJusticeTriggeredAbility ability) {
+    private KarmicJusticeTriggeredAbility(final KarmicJusticeTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/k/KarplusanStrider.java
+++ b/Mage.Sets/src/mage/cards/k/KarplusanStrider.java
@@ -51,7 +51,7 @@ class KarplusanStriderEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "{this} can't be the target of blue or black spells";
     }
 
-    KarplusanStriderEffect(final KarplusanStriderEffect effect) {
+    private KarplusanStriderEffect(final KarplusanStriderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KederektParasite.java
+++ b/Mage.Sets/src/mage/cards/k/KederektParasite.java
@@ -59,7 +59,7 @@ class KederektParasiteTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(1, true, "opponent"), true);
     }
 
-    KederektParasiteTriggeredAbility(final KederektParasiteTriggeredAbility ability) {
+    private KederektParasiteTriggeredAbility(final KederektParasiteTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KefnetTheMindful.java
+++ b/Mage.Sets/src/mage/cards/k/KefnetTheMindful.java
@@ -105,7 +105,7 @@ class KefnetTheMindfulEffect extends OneShotEffect {
         staticText = "Draw a card, then you may return a land you control to its owner's hand";
     }
 
-    KefnetTheMindfulEffect(final KefnetTheMindfulEffect effect) {
+    private KefnetTheMindfulEffect(final KefnetTheMindfulEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KessDissidentMage.java
+++ b/Mage.Sets/src/mage/cards/k/KessDissidentMage.java
@@ -64,7 +64,7 @@ class KessDissidentMageCastFromGraveyardEffect extends AsThoughEffectImpl {
         staticText = "During each of your turns, you may cast an instant or sorcery card from your graveyard";
     }
 
-    KessDissidentMageCastFromGraveyardEffect(final KessDissidentMageCastFromGraveyardEffect effect) {
+    private KessDissidentMageCastFromGraveyardEffect(final KessDissidentMageCastFromGraveyardEffect effect) {
         super(effect);
     }
 
@@ -105,7 +105,7 @@ class KessDissidentMageReplacementEffect extends ReplacementEffectImpl {
         staticText = "If a card cast this way would be put into your graveyard, exile it instead";
     }
 
-    KessDissidentMageReplacementEffect(final KessDissidentMageReplacementEffect effect) {
+    private KessDissidentMageReplacementEffect(final KessDissidentMageReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KheruLichLord.java
+++ b/Mage.Sets/src/mage/cards/k/KheruLichLord.java
@@ -127,7 +127,7 @@ class KheruLichLordReplacementEffect extends ReplacementEffectImpl {
         staticText = "If that card would leave the battlefield, exile it instead of putting it anywhere else";
     }
 
-    KheruLichLordReplacementEffect(final KheruLichLordReplacementEffect effect) {
+    private KheruLichLordReplacementEffect(final KheruLichLordReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KheruSpellsnatcher.java
+++ b/Mage.Sets/src/mage/cards/k/KheruSpellsnatcher.java
@@ -59,7 +59,7 @@ class KheruSpellsnatcherEffect extends OneShotEffect {
                 + "You may cast that card without paying its mana cost as long as it remains exiled";
     }
 
-    KheruSpellsnatcherEffect(final KheruSpellsnatcherEffect effect) {
+    private KheruSpellsnatcherEffect(final KheruSpellsnatcherEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KhorvathsFury.java
+++ b/Mage.Sets/src/mage/cards/k/KhorvathsFury.java
@@ -46,7 +46,7 @@ class KhorvathsFuryEffect extends OneShotEffect {
                 + " {this} deals damage to each foe equal to the number of cards in their hand";
     }
 
-    KhorvathsFuryEffect(final KhorvathsFuryEffect effect) {
+    private KhorvathsFuryEffect(final KhorvathsFuryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KillerInstinct.java
+++ b/Mage.Sets/src/mage/cards/k/KillerInstinct.java
@@ -57,7 +57,7 @@ class KillerInstinctEffect extends OneShotEffect {
         this.staticText = "reveal the top card of your library. If it's a creature card, put it onto the battlefield. That creature gains haste until end of turn. Sacrifice it at the beginning of the next end step.";
     }
 
-    KillerInstinctEffect(final KillerInstinctEffect effect) {
+    private KillerInstinctEffect(final KillerInstinctEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KithkinArmor.java
+++ b/Mage.Sets/src/mage/cards/k/KithkinArmor.java
@@ -143,7 +143,7 @@ class KithkinArmorPreventionEffect extends PreventionEffectImpl {
         staticText = "The next time a source of your choice would deal damage to enchanted creature this turn, prevent that damage";
     }
 
-    KithkinArmorPreventionEffect(final KithkinArmorPreventionEffect effect) {
+    private KithkinArmorPreventionEffect(final KithkinArmorPreventionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KjeldoranEliteGuard.java
+++ b/Mage.Sets/src/mage/cards/k/KjeldoranEliteGuard.java
@@ -93,7 +93,7 @@ class KjeldoranEliteGuardDelayedTriggeredAbility extends DelayedTriggeredAbility
         this.creatureId = creatureId;
     }
 
-    KjeldoranEliteGuardDelayedTriggeredAbility(KjeldoranEliteGuardDelayedTriggeredAbility ability) {
+    private KjeldoranEliteGuardDelayedTriggeredAbility(final KjeldoranEliteGuardDelayedTriggeredAbility ability) {
         super(ability);
         this.creatureId = ability.creatureId;
     }

--- a/Mage.Sets/src/mage/cards/k/KjeldoranRoyalGuard.java
+++ b/Mage.Sets/src/mage/cards/k/KjeldoranRoyalGuard.java
@@ -63,7 +63,7 @@ class KjeldoranRoyalGuardEffect extends ReplacementEffectImpl {
         staticText = "All combat damage that would be dealt to you by unblocked creatures this turn is dealt to {this} instead";
     }
 
-    KjeldoranRoyalGuardEffect(final KjeldoranRoyalGuardEffect effect) {
+    private KjeldoranRoyalGuardEffect(final KjeldoranRoyalGuardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnightOfTheHolyNimbus.java
+++ b/Mage.Sets/src/mage/cards/k/KnightOfTheHolyNimbus.java
@@ -58,7 +58,7 @@ class KnightOfTheHolyNimbusReplacementEffect extends ReplacementEffectImpl {
         staticText = "If {this} would be destroyed, regenerate it";
     }
 
-    KnightOfTheHolyNimbusReplacementEffect(KnightOfTheHolyNimbusReplacementEffect effect) {
+    private KnightOfTheHolyNimbusReplacementEffect(final KnightOfTheHolyNimbusReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnowledgeVault.java
+++ b/Mage.Sets/src/mage/cards/k/KnowledgeVault.java
@@ -58,7 +58,7 @@ class KnowledgeVaultExileEffect extends OneShotEffect {
         this.staticText = "exile the top card of your library face down";
     }
 
-    KnowledgeVaultExileEffect(final KnowledgeVaultExileEffect effect) {
+    private KnowledgeVaultExileEffect(final KnowledgeVaultExileEffect effect) {
         super(effect);
     }
 
@@ -92,7 +92,7 @@ class KnowledgeVaultReturnEffect extends OneShotEffect {
         this.staticText = "Sacrifice {this}. If you do, discard your hand, then put all cards exiled with {this} into their owners' hands";
     }
 
-    KnowledgeVaultReturnEffect(final KnowledgeVaultReturnEffect effect) {
+    private KnowledgeVaultReturnEffect(final KnowledgeVaultReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KondasBanner.java
+++ b/Mage.Sets/src/mage/cards/k/KondasBanner.java
@@ -97,7 +97,7 @@ class KondasBannerTypeBoostEffect extends BoostAllEffect {
         staticText = effectText;
     }
 
-    KondasBannerTypeBoostEffect(KondasBannerTypeBoostEffect effect) {
+    private KondasBannerTypeBoostEffect(final KondasBannerTypeBoostEffect effect) {
         super(effect);
     }
 
@@ -137,7 +137,7 @@ class KondasBannerColorBoostEffect extends BoostAllEffect {
         staticText = effectText;
     }
 
-    KondasBannerColorBoostEffect(KondasBannerColorBoostEffect effect) {
+    private KondasBannerColorBoostEffect(final KondasBannerColorBoostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KopalaWardenOfWaves.java
+++ b/Mage.Sets/src/mage/cards/k/KopalaWardenOfWaves.java
@@ -88,7 +88,7 @@ class KopalaWardenOfWavesCostModificationEffect1 extends CostModificationEffectI
         this.staticText = "Spells your opponents cast that target a Merfolk you control cost {2} more to cast";
     }
 
-    KopalaWardenOfWavesCostModificationEffect1(KopalaWardenOfWavesCostModificationEffect1 effect) {
+    private KopalaWardenOfWavesCostModificationEffect1(final KopalaWardenOfWavesCostModificationEffect1 effect) {
         super(effect);
     }
 
@@ -118,7 +118,7 @@ class KopalaWardenOfWavesCostModificationEffect2 extends CostModificationEffectI
         this.staticText = "Abilities your opponents activate that target a Merfolk you control cost {2} more to activate";
     }
 
-    KopalaWardenOfWavesCostModificationEffect2(KopalaWardenOfWavesCostModificationEffect2 effect) {
+    private KopalaWardenOfWavesCostModificationEffect2(final KopalaWardenOfWavesCostModificationEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KorChant.java
+++ b/Mage.Sets/src/mage/cards/k/KorChant.java
@@ -58,7 +58,7 @@ class KorChantEffect extends RedirectionEffect {
         staticText = "All damage that would be dealt this turn to target creature you control by a source of your choice is dealt to another target creature instead";
     }
 
-    KorChantEffect(final KorChantEffect effect) {
+    private KorChantEffect(final KorChantEffect effect) {
         super(effect);
         this.target = effect.target;
     }

--- a/Mage.Sets/src/mage/cards/k/KorDirge.java
+++ b/Mage.Sets/src/mage/cards/k/KorDirge.java
@@ -58,7 +58,7 @@ class KorDirgeEffect extends RedirectionEffect {
         staticText = "All damage that would be dealt this turn to target creature you control by a source of your choice is dealt to another target creature instead";
     }
 
-    KorDirgeEffect(final KorDirgeEffect effect) {
+    private KorDirgeEffect(final KorDirgeEffect effect) {
         super(effect);
         this.target = effect.target;
     }

--- a/Mage.Sets/src/mage/cards/k/KrarksOtherThumb.java
+++ b/Mage.Sets/src/mage/cards/k/KrarksOtherThumb.java
@@ -46,7 +46,7 @@ class KrarksOtherThumbEffect extends ReplacementEffectImpl {
         staticText = "if you would roll a die, instead roll two of those dice and ignore one of those results";
     }
 
-    KrarksOtherThumbEffect(final KrarksOtherThumbEffect effect) {
+    private KrarksOtherThumbEffect(final KrarksOtherThumbEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KravTheUnredeemed.java
+++ b/Mage.Sets/src/mage/cards/k/KravTheUnredeemed.java
@@ -65,7 +65,7 @@ class KravTheUnredeemedEffect extends OneShotEffect {
         this.staticText = "Target player draws X cards and gains X life. Put X +1/+1 counters on {this}";
     }
 
-    KravTheUnredeemedEffect(final KravTheUnredeemedEffect effect) {
+    private KravTheUnredeemedEffect(final KravTheUnredeemedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KrazyKow.java
+++ b/Mage.Sets/src/mage/cards/k/KrazyKow.java
@@ -52,7 +52,7 @@ class KrazyKowEffect extends OneShotEffect {
         this.staticText = "roll a six-sided die. If you roll a 1, sacrifice {this} and it deals 3 damage to each creature and each player";
     }
 
-    KrazyKowEffect(final KrazyKowEffect effect) {
+    private KrazyKowEffect(final KrazyKowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KreshTheBloodbraided.java
+++ b/Mage.Sets/src/mage/cards/k/KreshTheBloodbraided.java
@@ -51,7 +51,7 @@ class KreshTheBloodbraidedEffect extends OneShotEffect {
         staticText = "you may put X +1/+1 counters on {this}, where X is that creature's power";
     }
 
-    KreshTheBloodbraidedEffect(final KreshTheBloodbraidedEffect effect) {
+    private KreshTheBloodbraidedEffect(final KreshTheBloodbraidedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KrovikanVampire.java
+++ b/Mage.Sets/src/mage/cards/k/KrovikanVampire.java
@@ -66,7 +66,7 @@ class KrovikanVampireEffect extends OneShotEffect {
         staticText = "put that card onto the battlefield under your control. Sacrifice it when you lose control of {this}";
     }
 
-    KrovikanVampireEffect(KrovikanVampireEffect effect) {
+    private KrovikanVampireEffect(final KrovikanVampireEffect effect) {
         super(effect);
     }
 
@@ -202,7 +202,7 @@ class KrovikanVampireDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.krovikanVampire = krovikanVampire;
     }
 
-    KrovikanVampireDelayedTriggeredAbility(KrovikanVampireDelayedTriggeredAbility ability) {
+    private KrovikanVampireDelayedTriggeredAbility(final KrovikanVampireDelayedTriggeredAbility ability) {
         super(ability);
         this.krovikanVampire = ability.krovikanVampire;
     }

--- a/Mage.Sets/src/mage/cards/k/KurkeshOnakkeAncient.java
+++ b/Mage.Sets/src/mage/cards/k/KurkeshOnakkeAncient.java
@@ -54,7 +54,7 @@ class KurkeshOnakkeAncientTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you activate an ability of an artifact, if it isn't a mana ability, ");
     }
 
-    KurkeshOnakkeAncientTriggeredAbility(final KurkeshOnakkeAncientTriggeredAbility ability) {
+    private KurkeshOnakkeAncientTriggeredAbility(final KurkeshOnakkeAncientTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KyrenArchive.java
+++ b/Mage.Sets/src/mage/cards/k/KyrenArchive.java
@@ -62,7 +62,7 @@ class KyrenArchiveExileEffect extends OneShotEffect {
         this.staticText = "exile the top card of your library face down";
     }
 
-    KyrenArchiveExileEffect(final KyrenArchiveExileEffect effect) {
+    private KyrenArchiveExileEffect(final KyrenArchiveExileEffect effect) {
         super(effect);
     }
 
@@ -96,7 +96,7 @@ class KyrenArchiveReturnEffect extends OneShotEffect {
         this.staticText = "Put all cards exiled with {this} into their owners' hands";
     }
 
-    KyrenArchiveReturnEffect(final KyrenArchiveReturnEffect effect) {
+    private KyrenArchiveReturnEffect(final KyrenArchiveReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LaeliaTheBladeReforged.java
+++ b/Mage.Sets/src/mage/cards/l/LaeliaTheBladeReforged.java
@@ -61,7 +61,7 @@ class LaeliaTheBladeReforgedAddCountersTriggeredAbility extends TriggeredAbility
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false);
     }
 
-    LaeliaTheBladeReforgedAddCountersTriggeredAbility(final LaeliaTheBladeReforgedAddCountersTriggeredAbility ability) {
+    private LaeliaTheBladeReforgedAddCountersTriggeredAbility(final LaeliaTheBladeReforgedAddCountersTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LaezelVlaakithsChampion.java
+++ b/Mage.Sets/src/mage/cards/l/LaezelVlaakithsChampion.java
@@ -54,7 +54,7 @@ class LaezelVlaakithsChampionEffect extends ReplacementEffectImpl {
                 "put that many plus one of each of those kinds of counters on that permanent or player instead";
     }
 
-    LaezelVlaakithsChampionEffect(final LaezelVlaakithsChampionEffect effect) {
+    private LaezelVlaakithsChampionEffect(final LaezelVlaakithsChampionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LairwatchGiant.java
+++ b/Mage.Sets/src/mage/cards/l/LairwatchGiant.java
@@ -56,7 +56,7 @@ class LairwatchGiantTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainAbilitySourceEffect(FirstStrikeAbility.getInstance()));
     }
 
-    LairwatchGiantTriggeredAbility(final LairwatchGiantTriggeredAbility ability) {
+    private LairwatchGiantTriggeredAbility(final LairwatchGiantTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LastBreath.java
+++ b/Mage.Sets/src/mage/cards/l/LastBreath.java
@@ -55,7 +55,7 @@ class LastBreathEffect extends OneShotEffect {
         staticText = "Its controller gains 4 life";
     }
 
-    LastBreathEffect(final LastBreathEffect effect) {
+    private LastBreathEffect(final LastBreathEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LastDitchEffort.java
+++ b/Mage.Sets/src/mage/cards/l/LastDitchEffort.java
@@ -46,7 +46,7 @@ class LastDitchEffortEffect extends OneShotEffect {
         this.staticText = "Sacrifice any number of creatures. {this} deals that much damage to any target";
     }
 
-    LastDitchEffortEffect(final LastDitchEffortEffect effect) {
+    private LastDitchEffortEffect(final LastDitchEffortEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LastOneStanding.java
+++ b/Mage.Sets/src/mage/cards/l/LastOneStanding.java
@@ -48,7 +48,7 @@ class LastOneStandingEffect extends OneShotEffect {
         this.staticText = "Choose a creature at random, then destroy the rest.";
     }
 
-    LastOneStandingEffect(final LastOneStandingEffect effect) {
+    private LastOneStandingEffect(final LastOneStandingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LaviniaAzoriusRenegade.java
+++ b/Mage.Sets/src/mage/cards/l/LaviniaAzoriusRenegade.java
@@ -62,7 +62,7 @@ class LaviniaAzoriusRenegadeReplacementEffect extends ContinuousRuleModifyingEff
         staticText = "Each opponent can't cast noncreature spells with mana value greater than the number of lands that player controls.";
     }
 
-    LaviniaAzoriusRenegadeReplacementEffect(final LaviniaAzoriusRenegadeReplacementEffect effect) {
+    private LaviniaAzoriusRenegadeReplacementEffect(final LaviniaAzoriusRenegadeReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LazavDimirMastermind.java
+++ b/Mage.Sets/src/mage/cards/l/LazavDimirMastermind.java
@@ -62,7 +62,7 @@ class LazavDimirMastermindEffect extends OneShotEffect {
         staticText = "you may have {this} become a copy of that card, except its name is Lazav, Dimir Mastermind, it's legendary in addition to its other types, and it has hexproof and this ability";
     }
 
-    LazavDimirMastermindEffect(final LazavDimirMastermindEffect effect) {
+    private LazavDimirMastermindEffect(final LazavDimirMastermindEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LazavTheMultifarious.java
+++ b/Mage.Sets/src/mage/cards/l/LazavTheMultifarious.java
@@ -92,7 +92,7 @@ class LazavTheMultifariousEffect extends OneShotEffect {
                 + "and it has this ability";
     }
 
-    LazavTheMultifariousEffect(final LazavTheMultifariousEffect effect) {
+    private LazavTheMultifariousEffect(final LazavTheMultifariousEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LearnFromThePast.java
+++ b/Mage.Sets/src/mage/cards/l/LearnFromThePast.java
@@ -49,7 +49,7 @@ class LearnFromThePastEffect extends OneShotEffect {
         this.staticText = "Target player shuffles their graveyard into their library";
     }
     
-    LearnFromThePastEffect(final LearnFromThePastEffect effect) {
+    private LearnFromThePastEffect(final LearnFromThePastEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/l/LeaveNoTrace.java
+++ b/Mage.Sets/src/mage/cards/l/LeaveNoTrace.java
@@ -56,7 +56,7 @@ class LeaveNoTraceEffect extends OneShotEffect {
         staticText = "Destroy target enchantment and each other enchantment that shares a color with it";
     }
 
-    LeaveNoTraceEffect(final LeaveNoTraceEffect effect) {
+    private LeaveNoTraceEffect(final LeaveNoTraceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeechriddenSwamp.java
+++ b/Mage.Sets/src/mage/cards/l/LeechriddenSwamp.java
@@ -76,7 +76,7 @@ class LeechriddenSwampLoseLifeEffect extends OneShotEffect {
         staticText = "each opponent loses 1 life";
     }
 
-    LeechriddenSwampLoseLifeEffect(LeechriddenSwampLoseLifeEffect effect) {
+    private LeechriddenSwampLoseLifeEffect(final LeechriddenSwampLoseLifeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Leviathan.java
+++ b/Mage.Sets/src/mage/cards/l/Leviathan.java
@@ -93,7 +93,7 @@ class LeviathanCostToAttackBlockEffect extends PayCostToAttackBlockEffectImpl {
         staticText = "{this} can't attack unless you sacrifice two Islands. <i>(This cost is paid as attackers are declared.)</i>";
     }
 
-    LeviathanCostToAttackBlockEffect(LeviathanCostToAttackBlockEffect effect) {
+    private LeviathanCostToAttackBlockEffect(final LeviathanCostToAttackBlockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeylineOfLifeforce.java
+++ b/Mage.Sets/src/mage/cards/l/LeylineOfLifeforce.java
@@ -50,7 +50,7 @@ class LeylineOfLifeforceEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Creature spells can't be countered";
     }
 
-    LeylineOfLifeforceEffect(final LeylineOfLifeforceEffect effect) {
+    private LeylineOfLifeforceEffect(final LeylineOfLifeforceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LeylineOfLightning.java
+++ b/Mage.Sets/src/mage/cards/l/LeylineOfLightning.java
@@ -49,7 +49,7 @@ class LeylineOfLightningEffect extends DamageTargetEffect {
         this.staticText = "you may pay {1}. If you do, {this} deals 1 damage to target player or planeswalker.";
     }
 
-    LeylineOfLightningEffect(final LeylineOfLightningEffect effect) {
+    private LeylineOfLightningEffect(final LeylineOfLightningEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Lich.java
+++ b/Mage.Sets/src/mage/cards/l/Lich.java
@@ -71,7 +71,7 @@ class LichLifeGainReplacementEffect extends ReplacementEffectImpl {
         staticText = "If you would gain life, draw that many cards instead";
     }
 
-    LichLifeGainReplacementEffect(final LichLifeGainReplacementEffect effect) {
+    private LichLifeGainReplacementEffect(final LichLifeGainReplacementEffect effect) {
         super(effect);
     }
 
@@ -106,7 +106,7 @@ class LichDamageTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new LichDamageEffect(), false);
     }
 
-    LichDamageTriggeredAbility(final LichDamageTriggeredAbility ability) {
+    private LichDamageTriggeredAbility(final LichDamageTriggeredAbility ability) {
         super(ability);
     }
 
@@ -153,7 +153,7 @@ class LichDamageEffect extends OneShotEffect {
         this.staticText = "sacrifice that many nontoken permanents. If you can't, you lose the game";
     }
     
-    LichDamageEffect(final LichDamageEffect effect) {
+    private LichDamageEffect(final LichDamageEffect effect) {
         super(effect);
         this.amount = effect.amount;
     }

--- a/Mage.Sets/src/mage/cards/l/Lichenthrope.java
+++ b/Mage.Sets/src/mage/cards/l/Lichenthrope.java
@@ -60,7 +60,7 @@ class LichenthropeEffect extends ReplacementEffectImpl {
         staticText = "If damage would be dealt to {this}, put that many -1/-1 counters on it instead";
     }
 
-    LichenthropeEffect(final LichenthropeEffect effect) {
+    private LichenthropeEffect(final LichenthropeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LichsTomb.java
+++ b/Mage.Sets/src/mage/cards/l/LichsTomb.java
@@ -50,7 +50,7 @@ class LichsTombTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SacrificeControllerEffect(new FilterPermanent(), 0, ""), false);
     }
 
-    LichsTombTriggeredAbility(final LichsTombTriggeredAbility ability) {
+    private LichsTombTriggeredAbility(final LichsTombTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LiciaSanguineTribune.java
+++ b/Mage.Sets/src/mage/cards/l/LiciaSanguineTribune.java
@@ -74,7 +74,7 @@ class LiciaSanguineTribuneCostReductionEffect extends CostModificationEffectImpl
         staticText = "this spell costs {1} less to cast for each 1 life you gained this turn.";
     }
 
-    LiciaSanguineTribuneCostReductionEffect(LiciaSanguineTribuneCostReductionEffect effect) {
+    private LiciaSanguineTribuneCostReductionEffect(final LiciaSanguineTribuneCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LifeAndLimb.java
+++ b/Mage.Sets/src/mage/cards/l/LifeAndLimb.java
@@ -54,7 +54,7 @@ class LifeAndLimbEffect extends ContinuousEffectImpl {
         this.dependendToTypes.add(DependencyType.BecomeCreature);
     }
 
-    LifeAndLimbEffect(final LifeAndLimbEffect effect) {
+    private LifeAndLimbEffect(final LifeAndLimbEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/Lifesmith.java
+++ b/Mage.Sets/src/mage/cards/l/Lifesmith.java
@@ -48,7 +48,7 @@ class LifesmithEffect extends OneShotEffect {
         staticText = "you may pay {1}. If you do, you gain 3 life";
     }
 
-    LifesmithEffect(final LifesmithEffect effect) {
+    private LifesmithEffect(final LifesmithEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LightningCoils.java
+++ b/Mage.Sets/src/mage/cards/l/LightningCoils.java
@@ -57,7 +57,7 @@ class LightningCoilsEffect extends OneShotEffect {
         staticText = "if {this} has five or more charge counters on it, remove all of them from it and create that many 3/1 red Elemental creature tokens with haste. Exile them at the beginning of the next end step.";
     }
 
-    LightningCoilsEffect(final LightningCoilsEffect effect) {
+    private LightningCoilsEffect(final LightningCoilsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LightningRunner.java
+++ b/Mage.Sets/src/mage/cards/l/LightningRunner.java
@@ -66,7 +66,7 @@ class LightningRunnerEffect extends OneShotEffect {
                 + "untap all creatures you control, and after this phase, there is an additional combat phase";
     }
 
-    LightningRunnerEffect(final LightningRunnerEffect effect) {
+    private LightningRunnerEffect(final LightningRunnerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LikenessLooter.java
+++ b/Mage.Sets/src/mage/cards/l/LikenessLooter.java
@@ -87,7 +87,7 @@ class LikenessLooterEffect extends OneShotEffect {
                 + "except it has flying and this ability.";
     }
 
-    LikenessLooterEffect(final LikenessLooterEffect effect) {
+    private LikenessLooterEffect(final LikenessLooterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LinessaZephyrMage.java
+++ b/Mage.Sets/src/mage/cards/l/LinessaZephyrMage.java
@@ -79,7 +79,7 @@ class LinessaZephyrMageEffect extends OneShotEffect {
         this.staticText = "Target player returns a creature they control to its owner's hand, then repeats this process for an artifact, an enchantment, and a land";
     }
 
-    LinessaZephyrMageEffect(final LinessaZephyrMageEffect effect) {
+    private LinessaZephyrMageEffect(final LinessaZephyrMageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LinvalaShieldOfSeaGate.java
+++ b/Mage.Sets/src/mage/cards/l/LinvalaShieldOfSeaGate.java
@@ -83,7 +83,7 @@ class LinvalaShieldOfSeaGateRestrictionEffect extends RestrictionEffect {
         super(Duration.UntilYourNextTurn, Outcome.UnboostCreature);
     }
 
-    LinvalaShieldOfSeaGateRestrictionEffect(final LinvalaShieldOfSeaGateRestrictionEffect effect) {
+    private LinvalaShieldOfSeaGateRestrictionEffect(final LinvalaShieldOfSeaGateRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LocketOfYesterdays.java
+++ b/Mage.Sets/src/mage/cards/l/LocketOfYesterdays.java
@@ -44,7 +44,7 @@ class LocketOfYesterdaysCostReductionEffect extends CostModificationEffectImpl {
         staticText = "Spells you cast cost {1} less to cast for each card with the same name as that spell in your graveyard";
     }
 
-    LocketOfYesterdaysCostReductionEffect(LocketOfYesterdaysCostReductionEffect effect) {
+    private LocketOfYesterdaysCostReductionEffect(final LocketOfYesterdaysCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LodestoneBauble.java
+++ b/Mage.Sets/src/mage/cards/l/LodestoneBauble.java
@@ -93,7 +93,7 @@ class LodestoneBaubleEffect extends OneShotEffect {
         this.staticText = "Put up to four target basic land cards from a player's graveyard on top of their library in any order";
     }
 
-    LodestoneBaubleEffect(final LodestoneBaubleEffect effect) {
+    private LodestoneBaubleEffect(final LodestoneBaubleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LongRoadHome.java
+++ b/Mage.Sets/src/mage/cards/l/LongRoadHome.java
@@ -51,7 +51,7 @@ class LongRoadHomeEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    LongRoadHomeEffect(LongRoadHomeEffect effect) {
+    private LongRoadHomeEffect(final LongRoadHomeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LongTermPlans.java
+++ b/Mage.Sets/src/mage/cards/l/LongTermPlans.java
@@ -42,7 +42,7 @@ class LongTermPlansEffect extends OneShotEffect {
         this.staticText = "Search your library for a card, then shuffle and put that card third from the top";
     }
 
-    LongTermPlansEffect(final LongTermPlansEffect effect) {
+    private LongTermPlansEffect(final LongTermPlansEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LonghornFirebeast.java
+++ b/Mage.Sets/src/mage/cards/l/LonghornFirebeast.java
@@ -50,7 +50,7 @@ class LonghornFirebeastEffect extends OneShotEffect {
         staticText = "any opponent may have it deal 5 damage to them. If a player does, sacrifice {this}";
     }
 
-    LonghornFirebeastEffect(final LonghornFirebeastEffect effect) {
+    private LonghornFirebeastEffect(final LonghornFirebeastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LostLegacy.java
+++ b/Mage.Sets/src/mage/cards/l/LostLegacy.java
@@ -47,7 +47,7 @@ class LostLegacyEffect extends SearchTargetGraveyardHandLibraryForCardNameAndExi
         this.staticText = "Search target player's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way";
     }
 
-    LostLegacyEffect(final LostLegacyEffect effect) {
+    private LostLegacyEffect(final LostLegacyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LoyalCathar.java
+++ b/Mage.Sets/src/mage/cards/l/LoyalCathar.java
@@ -63,7 +63,7 @@ class LoyalCatharEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    LoyalCatharEffect(LoyalCatharEffect effect) {
+    private LoyalCatharEffect(final LoyalCatharEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LudevicsTestSubject.java
+++ b/Mage.Sets/src/mage/cards/l/LudevicsTestSubject.java
@@ -61,7 +61,7 @@ class LudevicsTestSubjectEffect extends OneShotEffect {
         staticText = "Then if there are five or more hatchling counters on it, remove all of them and transform it";
     }
 
-    LudevicsTestSubjectEffect(final LudevicsTestSubjectEffect effect) {
+    private LudevicsTestSubjectEffect(final LudevicsTestSubjectEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LuminescentRain.java
+++ b/Mage.Sets/src/mage/cards/l/LuminescentRain.java
@@ -47,7 +47,7 @@ class LuminescentRainEffect extends OneShotEffect {
         this.staticText = "Choose a creature type. You gain 2 life for each permanent you control of that type.";
     }
 
-    LuminescentRainEffect(final LuminescentRainEffect effect) {
+    private LuminescentRainEffect(final LuminescentRainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LurkingEvil.java
+++ b/Mage.Sets/src/mage/cards/l/LurkingEvil.java
@@ -52,7 +52,7 @@ class LurkingEvilCost extends CostImpl {
         this.text = "Pay half your life, rounded up";
     }
 
-    LurkingEvilCost(LurkingEvilCost cost) {
+    private LurkingEvilCost(final LurkingEvilCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MaddeningImp.java
+++ b/Mage.Sets/src/mage/cards/m/MaddeningImp.java
@@ -136,7 +136,7 @@ class MaddeningImpDelayedDestroyEffect extends OneShotEffect {
         this.staticText = "At the beginning of the next end step, destroy each of those creatures that didn't attack this turn";
     }
 
-    MaddeningImpDelayedDestroyEffect(final MaddeningImpDelayedDestroyEffect effect) {
+    private MaddeningImpDelayedDestroyEffect(final MaddeningImpDelayedDestroyEffect effect) {
         super(effect);
         this.activeCreatures = effect.activeCreatures;
     }

--- a/Mage.Sets/src/mage/cards/m/MagisterSphinx.java
+++ b/Mage.Sets/src/mage/cards/m/MagisterSphinx.java
@@ -56,7 +56,7 @@ class MagisterSphinxEffect extends OneShotEffect {
         staticText = "target player's life total becomes 10";
     }
 
-    MagisterSphinxEffect(final MagisterSphinxEffect effect) {
+    private MagisterSphinxEffect(final MagisterSphinxEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagneticMountain.java
+++ b/Mage.Sets/src/mage/cards/m/MagneticMountain.java
@@ -69,7 +69,7 @@ class MagneticMountainEffect extends OneShotEffect {
         staticText = "that player may choose any number of tapped blue creatures they control and pay {4} for each creature chosen this way. If the player does, untap those creatures.";
     }
 
-    MagneticMountainEffect(MagneticMountainEffect effect) {
+    private MagneticMountainEffect(final MagneticMountainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagusOfTheAbyss.java
+++ b/Mage.Sets/src/mage/cards/m/MagusOfTheAbyss.java
@@ -52,7 +52,7 @@ class MagusOfTheAbyssTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(true), false);
     }
 
-    MagusOfTheAbyssTriggeredAbility(final MagusOfTheAbyssTriggeredAbility ability) {
+    private MagusOfTheAbyssTriggeredAbility(final MagusOfTheAbyssTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagusOfTheArena.java
+++ b/Mage.Sets/src/mage/cards/m/MagusOfTheArena.java
@@ -60,7 +60,7 @@ class MagusOfTheArenaEffect extends OneShotEffect {
                 "Those creatures fight each other. <i>(Each deals damage equal to its power to the other.)</i>";
     }
 
-    MagusOfTheArenaEffect(final MagusOfTheArenaEffect effect) {
+    private MagusOfTheArenaEffect(final MagusOfTheArenaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagusOfTheMind.java
+++ b/Mage.Sets/src/mage/cards/m/MagusOfTheMind.java
@@ -57,7 +57,7 @@ class MagusOfTheMindEffect extends OneShotEffect {
         this.staticText = "Shuffle your library, then exile the top X cards, where X is one plus the number of spells cast this turn. Until end of turn, you may play cards exiled this way without paying their mana costs";
     }
 
-    MagusOfTheMindEffect(final MagusOfTheMindEffect effect) {
+    private MagusOfTheMindEffect(final MagusOfTheMindEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagusOfTheMoon.java
+++ b/Mage.Sets/src/mage/cards/m/MagusOfTheMoon.java
@@ -55,7 +55,7 @@ public final class MagusOfTheMoon extends CardImpl {
             dependencyTypes.add(DependencyType.BecomeMountain);
         }
 
-        MagusOfTheMoonEffect(final MagusOfTheMoonEffect effect) {
+        private MagusOfTheMoonEffect(final MagusOfTheMoonEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/m/MagusOfTheUnseen.java
+++ b/Mage.Sets/src/mage/cards/m/MagusOfTheUnseen.java
@@ -77,7 +77,7 @@ class MagusOfTheUnseenDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new TapTargetEffect(), Duration.EndOfGame, true); // effect can last over turns end, if you still control the target but only one time
     }
 
-    MagusOfTheUnseenDelayedTriggeredAbility(MagusOfTheUnseenDelayedTriggeredAbility ability) {
+    private MagusOfTheUnseenDelayedTriggeredAbility(final MagusOfTheUnseenDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MairsilThePretender.java
+++ b/Mage.Sets/src/mage/cards/m/MairsilThePretender.java
@@ -72,7 +72,7 @@ class MairsilThePretenderExileEffect extends OneShotEffect {
         this.staticText = "you may exile an artifact or creature card from your hand or graveyard and put a cage counter on it.";
     }
 
-    MairsilThePretenderExileEffect(final MairsilThePretenderExileEffect effect) {
+    private MairsilThePretenderExileEffect(final MairsilThePretenderExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MajesticMyriarch.java
+++ b/Mage.Sets/src/mage/cards/m/MajesticMyriarch.java
@@ -90,7 +90,7 @@ class MajesticMyriarchEffect extends OneShotEffect {
                 "The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.";
     }
 
-    MajesticMyriarchEffect(final MajesticMyriarchEffect effect) {
+    private MajesticMyriarchEffect(final MajesticMyriarchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MakeshiftMannequin.java
+++ b/Mage.Sets/src/mage/cards/m/MakeshiftMannequin.java
@@ -64,7 +64,7 @@ class MakeshiftMannequinEffect extends OneShotEffect {
                 + "or ability, sacrifice it.\"";
     }
 
-    MakeshiftMannequinEffect(final MakeshiftMannequinEffect effect) {
+    private MakeshiftMannequinEffect(final MakeshiftMannequinEffect effect) {
         super(effect);
     }
 
@@ -107,7 +107,7 @@ class MakeshiftMannequinGainAbilityEffect extends ContinuousEffectImpl {
         super(Duration.Custom, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
     }
 
-    MakeshiftMannequinGainAbilityEffect(final MakeshiftMannequinGainAbilityEffect effect) {
+    private MakeshiftMannequinGainAbilityEffect(final MakeshiftMannequinGainAbilityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaChargedDragon.java
+++ b/Mage.Sets/src/mage/cards/m/ManaChargedDragon.java
@@ -56,7 +56,7 @@ class ManaChargedDragonEffect extends OneShotEffect {
         this.staticText = "each player starting with you may pay any amount of mana. {this} gets +X/+0 until end of turn, where X is the total amount of mana paid this way";
     }
 
-    ManaChargedDragonEffect(final ManaChargedDragonEffect effect) {
+    private ManaChargedDragonEffect(final ManaChargedDragonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaCrypt.java
+++ b/Mage.Sets/src/mage/cards/m/ManaCrypt.java
@@ -49,7 +49,7 @@ class ManaCryptEffect extends OneShotEffect {
         staticText = "flip a coin. If you lose the flip, {this} deals 3 damage to you";
     }
 
-    ManaCryptEffect(final ManaCryptEffect effect) {
+    private ManaCryptEffect(final ManaCryptEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaMaze.java
+++ b/Mage.Sets/src/mage/cards/m/ManaMaze.java
@@ -50,7 +50,7 @@ class ManaMazeEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Players can't cast spells that share a color with the spell most recently cast this turn";
     }
 
-    ManaMazeEffect(final ManaMazeEffect effect) {
+    private ManaMazeEffect(final ManaMazeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/ManaSkimmer.java
+++ b/Mage.Sets/src/mage/cards/m/ManaSkimmer.java
@@ -54,7 +54,7 @@ class ManaSkimmerTriggeredAbility extends TriggeredAbilityImpl {
         addEffect(new DontUntapInControllersNextUntapStepTargetEffect());
     }
 
-    ManaSkimmerTriggeredAbility(ManaSkimmerTriggeredAbility ability) {
+    private ManaSkimmerTriggeredAbility(final ManaSkimmerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MangarasTome.java
+++ b/Mage.Sets/src/mage/cards/m/MangarasTome.java
@@ -57,7 +57,7 @@ class MangarasTomeSearchEffect extends OneShotEffect {
         this.staticText = "search your library for five cards, exile them in a face-down pile, and shuffle that pile. Then shuffle your library";
     }
 
-    MangarasTomeSearchEffect(final MangarasTomeSearchEffect effect) {
+    private MangarasTomeSearchEffect(final MangarasTomeSearchEffect effect) {
         super(effect);
     }
 
@@ -94,7 +94,7 @@ class MangarasTomeReplacementEffect extends ReplacementEffectImpl {
         staticText = "The next time you would draw a card this turn, instead put the top card of the exiled pile into its owner's hand";
     }
 
-    MangarasTomeReplacementEffect(final MangarasTomeReplacementEffect effect) {
+    private MangarasTomeReplacementEffect(final MangarasTomeReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarangRiverProwler.java
+++ b/Mage.Sets/src/mage/cards/m/MarangRiverProwler.java
@@ -70,7 +70,7 @@ class MarangRiverProwlerCastEffect extends AsThoughEffectImpl {
         staticText = "You may cast {this} from your graveyard as long as you control a black or green permanent";
     }
 
-    MarangRiverProwlerCastEffect(final MarangRiverProwlerCastEffect effect) {
+    private MarangRiverProwlerCastEffect(final MarangRiverProwlerCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MarchesaTheBlackRose.java
+++ b/Mage.Sets/src/mage/cards/m/MarchesaTheBlackRose.java
@@ -109,7 +109,7 @@ class MarchesaTheBlackRoseEffect extends OneShotEffect {
         this.staticText = "return that card to the battlefield under your control at the beginning of the next end step.";
     }
 
-    MarchesaTheBlackRoseEffect(final MarchesaTheBlackRoseEffect effect) {
+    private MarchesaTheBlackRoseEffect(final MarchesaTheBlackRoseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MartyrOfBones.java
+++ b/Mage.Sets/src/mage/cards/m/MartyrOfBones.java
@@ -89,7 +89,7 @@ class RevealVariableBlackCardsFromHandCost extends VariableCostImpl {
         this.text = "Reveal " + xText + " black cards from your hand";
     }
 
-    RevealVariableBlackCardsFromHandCost(final RevealVariableBlackCardsFromHandCost cost) {
+    private RevealVariableBlackCardsFromHandCost(final RevealVariableBlackCardsFromHandCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MaskOfTheMimic.java
+++ b/Mage.Sets/src/mage/cards/m/MaskOfTheMimic.java
@@ -62,7 +62,7 @@ class MaskOfTheMimicEffect extends OneShotEffect {
                 + " put that card onto the battlefield, then shuffle.";
     }
 
-    MaskOfTheMimicEffect(final MaskOfTheMimicEffect effect) {
+    private MaskOfTheMimicEffect(final MaskOfTheMimicEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MassacreWurm.java
+++ b/Mage.Sets/src/mage/cards/m/MassacreWurm.java
@@ -54,7 +54,7 @@ class MassacreWurmTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature an opponent controls dies, ");
     }
 
-    MassacreWurmTriggeredAbility(final MassacreWurmTriggeredAbility ability) {
+    private MassacreWurmTriggeredAbility(final MassacreWurmTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MasterOfTheVeil.java
+++ b/Mage.Sets/src/mage/cards/m/MasterOfTheVeil.java
@@ -69,7 +69,7 @@ class MasterOfTheVeilEffect extends OneShotEffect {
         this.staticText = "turn target creature with a morph ability face down";
     }
 
-    MasterOfTheVeilEffect(final MasterOfTheVeilEffect effect) {
+    private MasterOfTheVeilEffect(final MasterOfTheVeilEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MazzyTrueswordPaladin.java
+++ b/Mage.Sets/src/mage/cards/m/MazzyTrueswordPaladin.java
@@ -78,7 +78,7 @@ class MazzyAttackTriggeredAbility extends AttacksAllTriggeredAbility {
         this.addEffect(new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn));
     }
 
-    MazzyAttackTriggeredAbility(final MazzyAttackTriggeredAbility effect) {
+    private MazzyAttackTriggeredAbility(final MazzyAttackTriggeredAbility effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Meadowboon.java
+++ b/Mage.Sets/src/mage/cards/m/Meadowboon.java
@@ -57,7 +57,7 @@ class MeadowboonEffect extends OneShotEffect {
         staticText = "put a +1/+1 counter on each creature target player controls";
     }
 
-    MeadowboonEffect(final MeadowboonEffect effect) {
+    private MeadowboonEffect(final MeadowboonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Meltdown.java
+++ b/Mage.Sets/src/mage/cards/m/Meltdown.java
@@ -42,7 +42,7 @@ class MeltdownEffect extends OneShotEffect {
         this.staticText = "Destroy each artifact with mana value X or less";
     }
     
-    MeltdownEffect(final MeltdownEffect effect) {
+    private MeltdownEffect(final MeltdownEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/m/Memoricide.java
+++ b/Mage.Sets/src/mage/cards/m/Memoricide.java
@@ -44,7 +44,7 @@ class MemoricideEffect extends SearchTargetGraveyardHandLibraryForCardNameAndExi
         super(true, "target player's", "any number of cards with that name");
     }
 
-    MemoricideEffect(final MemoricideEffect effect) {
+    private MemoricideEffect(final MemoricideEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MephidrossVampire.java
+++ b/Mage.Sets/src/mage/cards/m/MephidrossVampire.java
@@ -57,7 +57,7 @@ class MephidrossVampireEffect extends ContinuousEffectImpl {
         this.addDependedToType(DependencyType.BecomeCreature);
     }
 
-    MephidrossVampireEffect(final MephidrossVampireEffect effect) {
+    private MephidrossVampireEffect(final MephidrossVampireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MeriekeRiBerit.java
+++ b/Mage.Sets/src/mage/cards/m/MeriekeRiBerit.java
@@ -91,7 +91,7 @@ class MeriekeRiBeritDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new DestroyTargetEffect(true), Duration.Custom, true);
     }
 
-    MeriekeRiBeritDelayedTriggeredAbility(MeriekeRiBeritDelayedTriggeredAbility ability) {
+    private MeriekeRiBeritDelayedTriggeredAbility(final MeriekeRiBeritDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MetallicMimic.java
+++ b/Mage.Sets/src/mage/cards/m/MetallicMimic.java
@@ -63,7 +63,7 @@ class MetallicMimicReplacementEffect extends ReplacementEffectImpl {
         setCharacterDefining(true);
     }
 
-    MetallicMimicReplacementEffect(MetallicMimicReplacementEffect effect) {
+    private MetallicMimicReplacementEffect(final MetallicMimicReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MetallurgicSummonings.java
+++ b/Mage.Sets/src/mage/cards/m/MetallurgicSummonings.java
@@ -99,7 +99,7 @@ class MetallurgicSummoningsReturnEffect extends OneShotEffect {
         this.staticText = "Return all instant and sorcery cards from your graveyard to your hand. Activate only if you control six or more artifacts";
     }
 
-    MetallurgicSummoningsReturnEffect(final MetallurgicSummoningsReturnEffect effect) {
+    private MetallurgicSummoningsReturnEffect(final MetallurgicSummoningsReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mimeofacture.java
+++ b/Mage.Sets/src/mage/cards/m/Mimeofacture.java
@@ -56,7 +56,7 @@ class MimeofactureEffect extends OneShotEffect {
                 + "Then that player shuffles.";
     }
 
-    MimeofactureEffect(final MimeofactureEffect effect) {
+    private MimeofactureEffect(final MimeofactureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MimicVat.java
+++ b/Mage.Sets/src/mage/cards/m/MimicVat.java
@@ -62,7 +62,7 @@ class MimicVatTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new MimicVatEffect(), true);
     }
 
-    MimicVatTriggeredAbility(MimicVatTriggeredAbility ability) {
+    private MimicVatTriggeredAbility(final MimicVatTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MindSwords.java
+++ b/Mage.Sets/src/mage/cards/m/MindSwords.java
@@ -68,7 +68,7 @@ class MindSwordsEffect extends OneShotEffect {
         this.staticText = "Each player exiles two cards from their hand.";
     }
 
-    MindSwordsEffect(final MindSwordsEffect effect) {
+    private MindSwordsEffect(final MindSwordsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mindblaze.java
+++ b/Mage.Sets/src/mage/cards/m/Mindblaze.java
@@ -58,7 +58,7 @@ class MindblazeEffect extends OneShotEffect {
                 "{this} deals 8 damage to that player. Then that player shuffles";
     }
 
-    MindblazeEffect(final MindblazeEffect effect) {
+    private MindblazeEffect(final MindblazeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MindsDesire.java
+++ b/Mage.Sets/src/mage/cards/m/MindsDesire.java
@@ -47,7 +47,7 @@ class MindsDesireEffect extends OneShotEffect {
         this.staticText = "Shuffle your library. Then exile the top card of your library. Until end of turn, you may play that card without paying its mana cost";
     }
 
-    MindsDesireEffect(final MindsDesireEffect effect) {
+    private MindsDesireEffect(final MindsDesireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MindsDilation.java
+++ b/Mage.Sets/src/mage/cards/m/MindsDilation.java
@@ -98,7 +98,7 @@ class MindsDilationEffect extends OneShotEffect {
                 + "If it's a nonland card, you may cast it without paying its mana cost";
     }
 
-    MindsDilationEffect(final MindsDilationEffect effect) {
+    private MindsDilationEffect(final MindsDilationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MindspliceApparatus.java
+++ b/Mage.Sets/src/mage/cards/m/MindspliceApparatus.java
@@ -57,7 +57,7 @@ class MindspliceApparatusEffect extends CostModificationEffectImpl {
         staticText = "instant and sorcery spells you cast cost {1} less to cast for each oil counter on {this}";
     }
 
-    MindspliceApparatusEffect(MindspliceApparatusEffect effect) {
+    private MindspliceApparatusEffect(final MindspliceApparatusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MindstormCrown.java
+++ b/Mage.Sets/src/mage/cards/m/MindstormCrown.java
@@ -46,7 +46,7 @@ class MindstormCrownEffect extends OneShotEffect {
         this.staticText = "draw a card if you had no cards in hand at the beginning of this turn. If you had a card in hand, {this} deals 1 damage to you";
     }
 
-    MindstormCrownEffect(final MindstormCrownEffect effect) {
+    private MindstormCrownEffect(final MindstormCrownEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MineMineMine.java
+++ b/Mage.Sets/src/mage/cards/m/MineMineMine.java
@@ -66,7 +66,7 @@ class MineMineMineDrawEffect extends OneShotEffect {
         this.staticText = "each player puts their library into their hand";
     }
 
-    MineMineMineDrawEffect(final MineMineMineDrawEffect effect) {
+    private MineMineMineDrawEffect(final MineMineMineDrawEffect effect) {
         super(effect);
     }
 
@@ -95,7 +95,7 @@ class MineMineMineDontLoseEffect extends ReplacementEffectImpl {
         super(Duration.WhileOnBattlefield, Outcome.Neutral);
     }
 
-    MineMineMineDontLoseEffect(final MineMineMineDontLoseEffect effect) {
+    private MineMineMineDontLoseEffect(final MineMineMineDontLoseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mirari.java
+++ b/Mage.Sets/src/mage/cards/m/Mirari.java
@@ -58,7 +58,7 @@ class MirariTriggeredAbility extends TriggeredAbilityImpl {
                 new GenericManaCost(3)), false);
     }
 
-    MirariTriggeredAbility(final MirariTriggeredAbility ability) {
+    private MirariTriggeredAbility(final MirariTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirriWeatherlightDuelist.java
+++ b/Mage.Sets/src/mage/cards/m/MirriWeatherlightDuelist.java
@@ -64,7 +64,7 @@ class MirriWeatherlightDuelistBlockRestrictionEffect extends RestrictionEffect {
         staticText = "each opponent can't block with more than one creature this combat";
     }
 
-    MirriWeatherlightDuelistBlockRestrictionEffect(final MirriWeatherlightDuelistBlockRestrictionEffect effect) {
+    private MirriWeatherlightDuelistBlockRestrictionEffect(final MirriWeatherlightDuelistBlockRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirrorGolem.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorGolem.java
@@ -60,7 +60,7 @@ class MirrorGolemImprintEffect extends OneShotEffect {
         this.staticText = "you may exile target card from a graveyard";
     }
 
-    MirrorGolemImprintEffect(final MirrorGolemImprintEffect effect) {
+    private MirrorGolemImprintEffect(final MirrorGolemImprintEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MisersCage.java
+++ b/Mage.Sets/src/mage/cards/m/MisersCage.java
@@ -42,7 +42,7 @@ class MisersCageTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(2), false);
     }
 
-    MisersCageTriggeredAbility(final MisersCageTriggeredAbility ability) {
+    private MisersCageTriggeredAbility(final MisersCageTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MishraArtificerProdigy.java
+++ b/Mage.Sets/src/mage/cards/m/MishraArtificerProdigy.java
@@ -58,7 +58,7 @@ class MishraArtificerProdigyTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new MishraArtificerProdigyEffect(), true);
     }
 
-    MishraArtificerProdigyTriggeredAbility(final MishraArtificerProdigyTriggeredAbility ability) {
+    private MishraArtificerProdigyTriggeredAbility(final MishraArtificerProdigyTriggeredAbility ability) {
         super(ability);
     }
 
@@ -99,7 +99,7 @@ class MishraArtificerProdigyEffect extends OneShotEffect {
         this.staticText = "Search your graveyard, hand, and/or library for a card named <i>" + cardName + "</i> and put it onto the battlefield. If you search your library this way, shuffle.";
     }
 
-    MishraArtificerProdigyEffect(final MishraArtificerProdigyEffect effect) {
+    private MishraArtificerProdigyEffect(final MishraArtificerProdigyEffect effect) {
         super(effect);
         this.cardName = effect.cardName;
     }

--- a/Mage.Sets/src/mage/cards/m/Misinformation.java
+++ b/Mage.Sets/src/mage/cards/m/Misinformation.java
@@ -44,7 +44,7 @@ class MisinformationEffect extends OneShotEffect {
         this.staticText = "Put up to three target cards from an opponent's graveyard on top of their library in any order";
     }
     
-    MisinformationEffect(final MisinformationEffect effect) {
+    private MisinformationEffect(final MisinformationEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/m/MistOfStagnation.java
+++ b/Mage.Sets/src/mage/cards/m/MistOfStagnation.java
@@ -53,7 +53,7 @@ class MistOfStagnationEffect extends OneShotEffect {
         this.staticText = "that player chooses a permanent for each card in their graveyard, then untaps those permanents";
     }
 
-    MistOfStagnationEffect(final MistOfStagnationEffect effect) {
+    private MistOfStagnationEffect(final MistOfStagnationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MistbladeShinobi.java
+++ b/Mage.Sets/src/mage/cards/m/MistbladeShinobi.java
@@ -58,7 +58,7 @@ class MistbladeShinobiTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD,  new ReturnToHandTargetEffect(), true);
     }
 
-    MistbladeShinobiTriggeredAbility(final MistbladeShinobiTriggeredAbility ability) {
+    private MistbladeShinobiTriggeredAbility(final MistbladeShinobiTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MizzixOfTheIzmagnus.java
+++ b/Mage.Sets/src/mage/cards/m/MizzixOfTheIzmagnus.java
@@ -90,7 +90,7 @@ class MizzixOfTheIzmagnusCostReductionEffect extends CostModificationEffectImpl 
         staticText = "Instant and sorcery spells you cast cost {1} less to cast for each experience counter you have";
     }
 
-    MizzixOfTheIzmagnusCostReductionEffect(MizzixOfTheIzmagnusCostReductionEffect effect) {
+    private MizzixOfTheIzmagnusCostReductionEffect(final MizzixOfTheIzmagnusCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoggToady.java
+++ b/Mage.Sets/src/mage/cards/m/MoggToady.java
@@ -52,7 +52,7 @@ class MoggToadyCantAttackEffect extends RestrictionEffect {
         staticText = "{this} can't attack unless you control more creatures than defending player";
     }
 
-    MoggToadyCantAttackEffect(final MoggToadyCantAttackEffect effect) {
+    private MoggToadyCantAttackEffect(final MoggToadyCantAttackEffect effect) {
         super(effect);
     }
 
@@ -99,7 +99,7 @@ class MoggToadyCantBlockEffect extends RestrictionEffect {
         staticText = "{this} can't block unless you control more creatures than attacking player";
     }
 
-    MoggToadyCantBlockEffect(final MoggToadyCantBlockEffect effect) {
+    private MoggToadyCantBlockEffect(final MoggToadyCantBlockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenDisaster.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenDisaster.java
@@ -61,7 +61,7 @@ class MoltenDisasterSplitSecondEffect extends ContinuousRuleModifyingEffectImpl 
         staticText = "if this spell was kicked, it has split second. <i>(As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)</i>";
     }
 
-    MoltenDisasterSplitSecondEffect(final MoltenDisasterSplitSecondEffect effect) {
+    private MoltenDisasterSplitSecondEffect(final MoltenDisasterSplitSecondEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MonasterySiege.java
+++ b/Mage.Sets/src/mage/cards/m/MonasterySiege.java
@@ -63,7 +63,7 @@ class MonasterySiegeCostIncreaseEffect extends CostModificationEffectImpl {
         staticText = "&bull; Dragons &mdash; Spells your opponents cast that target you or a permanent you control cost {2} more to cast";
     }
 
-    MonasterySiegeCostIncreaseEffect(MonasterySiegeCostIncreaseEffect effect) {
+    private MonasterySiegeCostIncreaseEffect(final MonasterySiegeCostIncreaseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MonstrousHound.java
+++ b/Mage.Sets/src/mage/cards/m/MonstrousHound.java
@@ -60,7 +60,7 @@ class CantAttackUnlessControllerControlsMoreLandsEffect extends RestrictionEffec
         super(Duration.WhileOnBattlefield);
     }
 
-    CantAttackUnlessControllerControlsMoreLandsEffect(final CantAttackUnlessControllerControlsMoreLandsEffect effect) {
+    private CantAttackUnlessControllerControlsMoreLandsEffect(final CantAttackUnlessControllerControlsMoreLandsEffect effect) {
         super(effect);
     }
 
@@ -108,7 +108,7 @@ class CantBlockUnlessControllerControlsMoreLandsEffect extends RestrictionEffect
         super(Duration.WhileOnBattlefield);
     }
 
-    CantBlockUnlessControllerControlsMoreLandsEffect(final CantBlockUnlessControllerControlsMoreLandsEffect effect) {
+    private CantBlockUnlessControllerControlsMoreLandsEffect(final CantBlockUnlessControllerControlsMoreLandsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoralityShift.java
+++ b/Mage.Sets/src/mage/cards/m/MoralityShift.java
@@ -48,7 +48,7 @@ class MoralityShiftEffect extends OneShotEffect {
         staticText = "Exchange your graveyard and library. Then shuffle your library.";
     }
 
-    MoralityShiftEffect(MoralityShiftEffect effect) {
+    private MoralityShiftEffect(final MoralityShiftEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoratoriumStone.java
+++ b/Mage.Sets/src/mage/cards/m/MoratoriumStone.java
@@ -70,7 +70,7 @@ class MoratoriumStoneEffect extends OneShotEffect {
         this.staticText = "Exile target nonland card from a graveyard, all other cards from graveyards with the same name as that card, and all permanents with that name.";
     }
 
-    MoratoriumStoneEffect(final MoratoriumStoneEffect effect) {
+    private MoratoriumStoneEffect(final MoratoriumStoneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MossPitSkeleton.java
+++ b/Mage.Sets/src/mage/cards/m/MossPitSkeleton.java
@@ -61,7 +61,7 @@ class MossPitSkeletonTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.GRAVEYARD, new PutOnLibrarySourceEffect(true), true);
     }
 
-    MossPitSkeletonTriggeredAbility(final MossPitSkeletonTriggeredAbility ability) {
+    private MossPitSkeletonTriggeredAbility(final MossPitSkeletonTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MossbridgeTroll.java
+++ b/Mage.Sets/src/mage/cards/m/MossbridgeTroll.java
@@ -67,7 +67,7 @@ class MossbridgeTrollReplacementEffect extends ReplacementEffectImpl {
         staticText = "If {this} would be destroyed, regenerate it";
     }
 
-    MossbridgeTrollReplacementEffect(MossbridgeTrollReplacementEffect effect) {
+    private MossbridgeTrollReplacementEffect(final MossbridgeTrollReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MournersShield.java
+++ b/Mage.Sets/src/mage/cards/m/MournersShield.java
@@ -66,7 +66,7 @@ class MournersShieldImprintEffect extends OneShotEffect {
         this.staticText = "you may exile target card from a graveyard";
     }
 
-    MournersShieldImprintEffect(final MournersShieldImprintEffect effect) {
+    private MournersShieldImprintEffect(final MournersShieldImprintEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mudslide.java
+++ b/Mage.Sets/src/mage/cards/m/Mudslide.java
@@ -69,7 +69,7 @@ class MudslideEffect extends OneShotEffect {
         staticText = "that player may choose any number of tapped creatures without flying they control and pay {2} for each creature chosen this way. If the player does, untap those creatures.";
     }
 
-    MudslideEffect(MudslideEffect effect) {
+    private MudslideEffect(final MudslideEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MurderousBetrayal.java
+++ b/Mage.Sets/src/mage/cards/m/MurderousBetrayal.java
@@ -51,7 +51,7 @@ class MurderousBetrayalCost extends CostImpl {
         this.text = "Pay half your life, rounded up";
     }
 
-    MurderousBetrayalCost(MurderousBetrayalCost cost) {
+    private MurderousBetrayalCost(final MurderousBetrayalCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MyrGalvanizer.java
+++ b/Mage.Sets/src/mage/cards/m/MyrGalvanizer.java
@@ -62,7 +62,7 @@ class MyrGalvanizerEffect extends OneShotEffect {
         staticText = "Untap each other Myr you control";
     }
 
-    MyrGalvanizerEffect(final MyrGalvanizerEffect effect) {
+    private MyrGalvanizerEffect(final MyrGalvanizerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MyrIncubator.java
+++ b/Mage.Sets/src/mage/cards/m/MyrIncubator.java
@@ -63,7 +63,7 @@ class MyrIncubatorEffect extends SearchEffect {
         staticText = "Search your library for any number of artifact cards, exile them, then create that many 1/1 colorless Myr artifact creature tokens. Then shuffle";
     }
 
-    MyrIncubatorEffect(final MyrIncubatorEffect effect) {
+    private MyrIncubatorEffect(final MyrIncubatorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MyrPrototype.java
+++ b/Mage.Sets/src/mage/cards/m/MyrPrototype.java
@@ -57,7 +57,7 @@ class MyrPrototypeCantAttackUnlessYouPayEffect extends CantAttackBlockUnlessPays
         staticText = "{this} can't attack or block unless you pay {1} for each +1/+1 counter on it";
     }
 
-    MyrPrototypeCantAttackUnlessYouPayEffect(MyrPrototypeCantAttackUnlessYouPayEffect effect) {
+    private MyrPrototypeCantAttackUnlessYouPayEffect(final MyrPrototypeCantAttackUnlessYouPayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MythUnbound.java
+++ b/Mage.Sets/src/mage/cards/m/MythUnbound.java
@@ -67,7 +67,7 @@ class MythUnboundCostReductionEffect extends CostModificationEffectImpl {
                 + "it's been cast from the command zone this game";
     }
 
-    MythUnboundCostReductionEffect(MythUnboundCostReductionEffect effect) {
+    private MythUnboundCostReductionEffect(final MythUnboundCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MythosOfVadrok.java
+++ b/Mage.Sets/src/mage/cards/m/MythosOfVadrok.java
@@ -81,7 +81,7 @@ class MythosOfVadrokRestrictionEffect extends RestrictionEffect {
         super(Duration.UntilYourNextTurn, Outcome.UnboostCreature);
     }
 
-    MythosOfVadrokRestrictionEffect(final MythosOfVadrokRestrictionEffect effect) {
+    private MythosOfVadrokRestrictionEffect(final MythosOfVadrokRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NabanDeanOfIteration.java
+++ b/Mage.Sets/src/mage/cards/n/NabanDeanOfIteration.java
@@ -55,7 +55,7 @@ class NabanDeanOfIterationEffect extends ReplacementEffectImpl {
         staticText = "If a Wizard entering the battlefield under your control causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time";
     }
 
-    NabanDeanOfIterationEffect(final NabanDeanOfIterationEffect effect) {
+    private NabanDeanOfIterationEffect(final NabanDeanOfIterationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NahiriForgedInFury.java
+++ b/Mage.Sets/src/mage/cards/n/NahiriForgedInFury.java
@@ -72,7 +72,7 @@ class NahiriForgedInFuryEffect extends OneShotEffect {
                 + "You may cast Equipment spells this way without paying their mana costs.";
     }
 
-    NahiriForgedInFuryEffect(final NahiriForgedInFuryEffect effect) {
+    private NahiriForgedInFuryEffect(final NahiriForgedInFuryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NahiriTheHarbinger.java
+++ b/Mage.Sets/src/mage/cards/n/NahiriTheHarbinger.java
@@ -95,7 +95,7 @@ class NahiriTheHarbingerEffect extends SearchEffect {
         this.staticText = "Search your library for an artifact or creature card, put it onto the battlefield, then shuffle. It gains haste. Return it to your hand at the beginning of the next end step";
     }
 
-    NahiriTheHarbingerEffect(final NahiriTheHarbingerEffect effect) {
+    private NahiriTheHarbingerEffect(final NahiriTheHarbingerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NahiriTheLithomancer.java
+++ b/Mage.Sets/src/mage/cards/n/NahiriTheLithomancer.java
@@ -83,7 +83,7 @@ class NahiriTheLithomancerFirstAbilityEffect extends OneShotEffect {
         this.staticText = "Create a 1/1 white Kor Soldier creature token. You may attach an Equipment you control to it";
     }
 
-    NahiriTheLithomancerFirstAbilityEffect(final NahiriTheLithomancerFirstAbilityEffect effect) {
+    private NahiriTheLithomancerFirstAbilityEffect(final NahiriTheLithomancerFirstAbilityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NahiriTheUnforgiving.java
+++ b/Mage.Sets/src/mage/cards/n/NahiriTheUnforgiving.java
@@ -101,7 +101,7 @@ class NahiriTheUnforgivingRestrictionEffect extends RestrictionEffect {
         this.staticText = " a player each combat if able.";
     }
 
-    NahiriTheUnforgivingRestrictionEffect(final NahiriTheUnforgivingRestrictionEffect effect) {
+    private NahiriTheUnforgivingRestrictionEffect(final NahiriTheUnforgivingRestrictionEffect effect) {
         super(effect);
     }
 
@@ -130,7 +130,7 @@ class NahiriTheUnforgivingTokenEffect extends OneShotEffect {
                 "Create a token that's a copy of it. That token gains haste. Exile it at the beginning of the next end step.";
     }
 
-    NahiriTheUnforgivingTokenEffect(final NahiriTheUnforgivingTokenEffect effect) {
+    private NahiriTheUnforgivingTokenEffect(final NahiriTheUnforgivingTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Narcolepsy.java
+++ b/Mage.Sets/src/mage/cards/n/Narcolepsy.java
@@ -57,7 +57,7 @@ class NarcolepsyTriggeredAbility extends BeginningOfUpkeepTriggeredAbility {
         super(new NarcolepsyEffect(), TargetController.ANY, false);
     }
     
-    NarcolepsyTriggeredAbility(final NarcolepsyTriggeredAbility ability) {
+    private NarcolepsyTriggeredAbility(final NarcolepsyTriggeredAbility ability) {
         super(ability);
     }
 
@@ -90,7 +90,7 @@ class NarcolepsyEffect extends OneShotEffect {
         super(Outcome.Tap);
     }
 
-    NarcolepsyEffect(final NarcolepsyEffect effect) {
+    private NarcolepsyEffect(final NarcolepsyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NaturesClaim.java
+++ b/Mage.Sets/src/mage/cards/n/NaturesClaim.java
@@ -48,7 +48,7 @@ class NaturesClaimEffect extends OneShotEffect {
         staticText = "Its controller gains 4 life";
     }
 
-    NaturesClaimEffect(final NaturesClaimEffect effect) {
+    private NaturesClaimEffect(final NaturesClaimEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NazahnReveredBladesmith.java
+++ b/Mage.Sets/src/mage/cards/n/NazahnReveredBladesmith.java
@@ -100,7 +100,7 @@ class NazahnTapEffect extends TapTargetEffect {
         super();
     }
 
-    NazahnTapEffect(final NazahnTapEffect effect) {
+    private NazahnTapEffect(final NazahnTapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NecromanticSummons.java
+++ b/Mage.Sets/src/mage/cards/n/NecromanticSummons.java
@@ -56,7 +56,7 @@ class NecromanticSummoningReplacementEffect extends ReplacementEffectImpl {
         super(Duration.EndOfStep, Outcome.BoostCreature);
     }
 
-    NecromanticSummoningReplacementEffect(NecromanticSummoningReplacementEffect effect) {
+    private NecromanticSummoningReplacementEffect(final NecromanticSummoningReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Necroplasm.java
+++ b/Mage.Sets/src/mage/cards/n/Necroplasm.java
@@ -63,7 +63,7 @@ class NecroplasmEffect extends OneShotEffect {
         this.staticText = "destroy each creature with mana value equal to the number of +1/+1 counters on {this}.";
     }
     
-    NecroplasmEffect(final NecroplasmEffect effect) {
+    private NecroplasmEffect(final NecroplasmEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/n/Necropotence.java
+++ b/Mage.Sets/src/mage/cards/n/Necropotence.java
@@ -64,7 +64,7 @@ class NecropotenceTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you discard a card, ");
     }
 
-    NecropotenceTriggeredAbility(final NecropotenceTriggeredAbility ability) {
+    private NecropotenceTriggeredAbility(final NecropotenceTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NefariousLich.java
+++ b/Mage.Sets/src/mage/cards/n/NefariousLich.java
@@ -61,7 +61,7 @@ class NefariousLichDamageReplacementEffect extends ReplacementEffectImpl {
         staticText = "If damage would be dealt to you, exile that many cards from your graveyard instead. If you can't, you lose the game.";
     }
 
-    NefariousLichDamageReplacementEffect(final NefariousLichDamageReplacementEffect effect) {
+    private NefariousLichDamageReplacementEffect(final NefariousLichDamageReplacementEffect effect) {
         super(effect);
         this.amount = effect.amount;
     }
@@ -116,7 +116,7 @@ class NefariousLichLifeGainReplacementEffect extends ReplacementEffectImpl {
         staticText = "If you would gain life, draw that many cards instead";
     }
 
-    NefariousLichLifeGainReplacementEffect(final NefariousLichLifeGainReplacementEffect effect) {
+    private NefariousLichLifeGainReplacementEffect(final NefariousLichLifeGainReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NetherTraitor.java
+++ b/Mage.Sets/src/mage/cards/n/NetherTraitor.java
@@ -57,7 +57,7 @@ class NetherTraitorTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.GRAVEYARD, new DoIfCostPaid(new ReturnSourceFromGraveyardToBattlefieldEffect(), new ColoredManaCost(ColoredManaSymbol.B)));
     }
     
-    NetherTraitorTriggeredAbility(final NetherTraitorTriggeredAbility ability) {
+    private NetherTraitorTriggeredAbility(final NetherTraitorTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/n/NetherbornPhalanx.java
+++ b/Mage.Sets/src/mage/cards/n/NetherbornPhalanx.java
@@ -53,7 +53,7 @@ class NetherbornPhalanxEffect extends OneShotEffect {
         this.staticText = "each opponent loses 1 life for each creature they control";
     }
 
-    NetherbornPhalanxEffect(final NetherbornPhalanxEffect effect) {
+    private NetherbornPhalanxEffect(final NetherbornPhalanxEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NewPerspectives.java
+++ b/Mage.Sets/src/mage/cards/n/NewPerspectives.java
@@ -51,7 +51,7 @@ class NewPerspectivesCostModificationEffect extends CostModificationEffectImpl {
         this.staticText = "As long as you have seven or more cards in hand, you may pay {0} rather than pay cycling costs";
     }
 
-    NewPerspectivesCostModificationEffect(final NewPerspectivesCostModificationEffect effect) {
+    private NewPerspectivesCostModificationEffect(final NewPerspectivesCostModificationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NezumiGraverobber.java
+++ b/Mage.Sets/src/mage/cards/n/NezumiGraverobber.java
@@ -67,7 +67,7 @@ class NezumiGraverobberFlipEffect extends OneShotEffect {
         staticText = "If no cards are in that graveyard, flip {this}";
     }
 
-    NezumiGraverobberFlipEffect(final NezumiGraverobberFlipEffect effect) {
+    private NezumiGraverobberFlipEffect(final NezumiGraverobberFlipEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NimDeathmantle.java
+++ b/Mage.Sets/src/mage/cards/n/NimDeathmantle.java
@@ -74,7 +74,7 @@ class NimDeathmantleTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new NimDeathmantleEffect(), false);
     }
 
-    NimDeathmantleTriggeredAbility(NimDeathmantleTriggeredAbility ability) {
+    private NimDeathmantleTriggeredAbility(final NimDeathmantleTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NimbusChampion.java
+++ b/Mage.Sets/src/mage/cards/n/NimbusChampion.java
@@ -63,7 +63,7 @@ class NimbusChampionEffect extends OneShotEffect {
                 + "the number of Warriors your team controls";
     }
 
-    NimbusChampionEffect(final NimbusChampionEffect effect) {
+    private NimbusChampionEffect(final NimbusChampionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NinThePainArtist.java
+++ b/Mage.Sets/src/mage/cards/n/NinThePainArtist.java
@@ -59,7 +59,7 @@ class NinThePainArtistEffect extends OneShotEffect {
         this.staticText = "{this} deals X damage to target creature. That creature's controller draws X cards.";
     }
     
-    NinThePainArtistEffect(final NinThePainArtistEffect effect) {
+    private NinThePainArtistEffect(final NinThePainArtistEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/n/NissaSageAnimist.java
+++ b/Mage.Sets/src/mage/cards/n/NissaSageAnimist.java
@@ -68,7 +68,7 @@ class NissaSageAnimistPlusOneEffect extends OneShotEffect {
         this.staticText = "Reveal the top card of your library. If it's a land card, put it onto the battlefield. Otherwise, put it into your hand.";
     }
 
-    NissaSageAnimistPlusOneEffect(final NissaSageAnimistPlusOneEffect effect) {
+    private NissaSageAnimistPlusOneEffect(final NissaSageAnimistPlusOneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NivixAerieOfTheFiremind.java
+++ b/Mage.Sets/src/mage/cards/n/NivixAerieOfTheFiremind.java
@@ -59,7 +59,7 @@ class NivixAerieOfTheFiremindEffect extends OneShotEffect {
         this.staticText = "Exile the top card of your library. Until your next turn, you may cast it if it's an instant or sorcery spell";
     }
 
-    NivixAerieOfTheFiremindEffect(final NivixAerieOfTheFiremindEffect effect) {
+    private NivixAerieOfTheFiremindEffect(final NivixAerieOfTheFiremindEffect effect) {
         super(effect);
     }
 
@@ -96,7 +96,7 @@ class NivixAerieOfTheFiremindCanCastEffect extends AsThoughEffectImpl {
         staticText = "Until your next turn, you may cast that card";
     }
 
-    NivixAerieOfTheFiremindCanCastEffect(final NivixAerieOfTheFiremindCanCastEffect effect) {
+    private NivixAerieOfTheFiremindCanCastEffect(final NivixAerieOfTheFiremindCanCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathOfGideon.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfGideon.java
@@ -51,7 +51,7 @@ class OathOfGideonReplacementEffect extends ReplacementEffectImpl {
         staticText = "Each planeswalker you control enters the battlefield with an additional loyalty counter on it";
     }
 
-    OathOfGideonReplacementEffect(OathOfGideonReplacementEffect effect) {
+    private OathOfGideonReplacementEffect(final OathOfGideonReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathOfTeferi.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfTeferi.java
@@ -58,7 +58,7 @@ class OathOfTeferiBlinkEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    OathOfTeferiBlinkEffect(OathOfTeferiBlinkEffect effect) {
+    private OathOfTeferiBlinkEffect(final OathOfTeferiBlinkEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/ObeliskOfUrd.java
+++ b/Mage.Sets/src/mage/cards/o/ObeliskOfUrd.java
@@ -53,7 +53,7 @@ class ObeliskOfUrdBoostEffect extends ContinuousEffectImpl {
         staticText = "Creatures you control of the chosen type get +2/+2.";
     }
 
-    ObeliskOfUrdBoostEffect(final ObeliskOfUrdBoostEffect effect) {
+    private ObeliskOfUrdBoostEffect(final ObeliskOfUrdBoostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Oblation.java
+++ b/Mage.Sets/src/mage/cards/o/Oblation.java
@@ -45,7 +45,7 @@ class OblationEffect extends OneShotEffect {
         this.staticText = "The owner of target nonland permanent shuffles it into their library, then draws two cards";
     }
 
-    OblationEffect(final OblationEffect effect) {
+    private OblationEffect(final OblationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OblivionStone.java
+++ b/Mage.Sets/src/mage/cards/o/OblivionStone.java
@@ -56,7 +56,7 @@ class OblivionStoneEffect extends OneShotEffect {
         staticText = "Destroy each nonland permanent without a fate counter on it, then remove all fate counters from all permanents";
     }
 
-    OblivionStoneEffect(final OblivionStoneEffect effect) {
+    private OblivionStoneEffect(final OblivionStoneEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Occupation.java
+++ b/Mage.Sets/src/mage/cards/o/Occupation.java
@@ -56,7 +56,7 @@ class OccupationTapEffect extends ReplacementEffectImpl {
         staticText = "Creatures your opponents control enter the battlefield tapped";
     }
 
-    OccupationTapEffect(final OccupationTapEffect effect) {
+    private OccupationTapEffect(final OccupationTapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OdricLunarchMarshal.java
+++ b/Mage.Sets/src/mage/cards/o/OdricLunarchMarshal.java
@@ -80,7 +80,7 @@ class OdricLunarchMarshalEffect extends OneShotEffect {
         this.staticText = "creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance.";
     }
 
-    OdricLunarchMarshalEffect(final OdricLunarchMarshalEffect effect) {
+    private OdricLunarchMarshalEffect(final OdricLunarchMarshalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OgreGeargrabber.java
+++ b/Mage.Sets/src/mage/cards/o/OgreGeargrabber.java
@@ -101,7 +101,7 @@ class OgreGeargrabberDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.equipmentId = equipmentId;
     }
 
-    OgreGeargrabberDelayedTriggeredAbility(OgreGeargrabberDelayedTriggeredAbility ability) {
+    private OgreGeargrabberDelayedTriggeredAbility(final OgreGeargrabberDelayedTriggeredAbility ability) {
         super(ability);
         this.equipmentId = ability.equipmentId;
     }

--- a/Mage.Sets/src/mage/cards/o/OldGrowthDryads.java
+++ b/Mage.Sets/src/mage/cards/o/OldGrowthDryads.java
@@ -55,7 +55,7 @@ class OldGrowthDryadsEffect extends OneShotEffect {
         this.staticText = "each opponent may search their library for a basic land card, put it onto the battlefield tapped, then shuffle";
     }
 
-    OldGrowthDryadsEffect(final OldGrowthDryadsEffect effect) {
+    private OldGrowthDryadsEffect(final OldGrowthDryadsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OonasBlackguard.java
+++ b/Mage.Sets/src/mage/cards/o/OonasBlackguard.java
@@ -61,7 +61,7 @@ class OonasBlackguardReplacementEffect extends ReplacementEffectImpl {
         staticText = "Each other Rogue creature you control enters the battlefield with an additional +1/+1 counter on it";
     }
 
-    OonasBlackguardReplacementEffect(OonasBlackguardReplacementEffect effect) {
+    private OonasBlackguardReplacementEffect(final OonasBlackguardReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpalEyeKondasYojimbo.java
+++ b/Mage.Sets/src/mage/cards/o/OpalEyeKondasYojimbo.java
@@ -70,7 +70,7 @@ class OpalEyeKondasYojimboRedirectionEffect extends ReplacementEffectImpl {
         this.target = new TargetSource();
     }
 
-    OpalEyeKondasYojimboRedirectionEffect(final OpalEyeKondasYojimboRedirectionEffect effect) {
+    private OpalEyeKondasYojimboRedirectionEffect(final OpalEyeKondasYojimboRedirectionEffect effect) {
         super(effect);
         this.target = effect.target.copy();
     }

--- a/Mage.Sets/src/mage/cards/o/OppositionAgent.java
+++ b/Mage.Sets/src/mage/cards/o/OppositionAgent.java
@@ -65,7 +65,7 @@ class OppositionAgentReplacementEffect extends ReplacementEffectImpl {
                 + "of any color to cast them";
     }
 
-    OppositionAgentReplacementEffect(final OppositionAgentReplacementEffect effect) {
+    private OppositionAgentReplacementEffect(final OppositionAgentReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OppressiveRays.java
+++ b/Mage.Sets/src/mage/cards/o/OppressiveRays.java
@@ -67,7 +67,7 @@ class OppressiveRaysCostModificationEffect extends CostModificationEffectImpl {
         staticText = "Activated abilities of enchanted creature cost {3} more to activate";
     }
 
-    OppressiveRaysCostModificationEffect(OppressiveRaysCostModificationEffect effect) {
+    private OppressiveRaysCostModificationEffect(final OppressiveRaysCostModificationEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OracleEnVec.java
+++ b/Mage.Sets/src/mage/cards/o/OracleEnVec.java
@@ -71,7 +71,7 @@ class OracleEnVecEffect extends OneShotEffect {
                 + "destroy each of the chosen creatures that didn't attack this turn";
     }
 
-    OracleEnVecEffect(final OracleEnVecEffect effect) {
+    private OracleEnVecEffect(final OracleEnVecEffect effect) {
         super(effect);
     }
 
@@ -111,7 +111,7 @@ class OracleEnVecMustAttackRequirementEffect extends RequirementEffect {
         super(Duration.UntilEndOfYourNextTurn);
     }
 
-    OracleEnVecMustAttackRequirementEffect(final OracleEnVecMustAttackRequirementEffect effect) {
+    private OracleEnVecMustAttackRequirementEffect(final OracleEnVecMustAttackRequirementEffect effect) {
         super(effect);
     }
 
@@ -166,7 +166,7 @@ class OracleEnVecCantAttackRestrictionEffect extends RestrictionEffect {
         this.staticText = "{this} can't attack.";
     }
 
-    OracleEnVecCantAttackRestrictionEffect(final OracleEnVecCantAttackRestrictionEffect effect) {
+    private OracleEnVecCantAttackRestrictionEffect(final OracleEnVecCantAttackRestrictionEffect effect) {
         super(effect);
     }
 
@@ -213,7 +213,7 @@ class OracleEnVecDelayedTriggeredAbility extends DelayedTriggeredAbility {
         setTriggerPhrase("At the beginning of that turn's end step, ");
     }
 
-    OracleEnVecDelayedTriggeredAbility(final OracleEnVecDelayedTriggeredAbility ability) {
+    private OracleEnVecDelayedTriggeredAbility(final OracleEnVecDelayedTriggeredAbility ability) {
         super(ability);
         this.startingTurn = ability.startingTurn;
     }
@@ -244,7 +244,7 @@ class OracleEnVecDestroyEffect extends OneShotEffect {
         this.staticText = "destroy each of the chosen creatures that didn't attack";
     }
 
-    OracleEnVecDestroyEffect(final OracleEnVecDestroyEffect effect) {
+    private OracleEnVecDestroyEffect(final OracleEnVecDestroyEffect effect) {
         super(effect);
         this.chosenCreatures = effect.chosenCreatures;
     }

--- a/Mage.Sets/src/mage/cards/o/OrimsThunder.java
+++ b/Mage.Sets/src/mage/cards/o/OrimsThunder.java
@@ -70,7 +70,7 @@ class OrimsThunderEffect2 extends OneShotEffect {
         super(Outcome.Damage);
     }
 
-    OrimsThunderEffect2(final OrimsThunderEffect2 effect) {
+    private OrimsThunderEffect2(final OrimsThunderEffect2 effect) {
         super(effect);
     }
 
@@ -103,7 +103,7 @@ class OrimsThunderEffect extends OneShotEffect {
         staticText = "Destroy target artifact or enchantment";
     }
 
-    OrimsThunderEffect(final OrimsThunderEffect effect) {
+    private OrimsThunderEffect(final OrimsThunderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrissSamiteGuardian.java
+++ b/Mage.Sets/src/mage/cards/o/OrissSamiteGuardian.java
@@ -98,7 +98,7 @@ class OrissSamiteGuardianCantCastEffect extends ContinuousRuleModifyingEffectImp
         staticText = "Target player can't cast spells this turn";
     }
 
-    OrissSamiteGuardianCantCastEffect(final OrissSamiteGuardianCantCastEffect effect) {
+    private OrissSamiteGuardianCantCastEffect(final OrissSamiteGuardianCantCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OtherworldlyJourney.java
+++ b/Mage.Sets/src/mage/cards/o/OtherworldlyJourney.java
@@ -54,7 +54,7 @@ class OtherworldlyJourneyEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    OtherworldlyJourneyEffect(OtherworldlyJourneyEffect effect) {
+    private OtherworldlyJourneyEffect(final OtherworldlyJourneyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OverlaidTerrain.java
+++ b/Mage.Sets/src/mage/cards/o/OverlaidTerrain.java
@@ -55,7 +55,7 @@ class SacrificeAllLandEffect extends OneShotEffect {
         staticText = "sacrifice all lands you control";
     }
 
-    SacrificeAllLandEffect(final SacrificeAllLandEffect effect) {
+    private SacrificeAllLandEffect(final SacrificeAllLandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Overload.java
+++ b/Mage.Sets/src/mage/cards/o/Overload.java
@@ -49,7 +49,7 @@ class OverloadEffect extends OneShotEffect {
         this.staticText = "Destroy target artifact if its mana value is 2 or less. If this spell was kicked, destroy that artifact if its mana value is 5 or less instead.";
     }
 
-    OverloadEffect(final OverloadEffect effect) {
+    private OverloadEffect(final OverloadEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/o/Overmaster.java
+++ b/Mage.Sets/src/mage/cards/o/Overmaster.java
@@ -53,7 +53,7 @@ class OvermasterEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "The next instant or sorcery spell you cast this turn can't be countered";
     }
 
-    OvermasterEffect(final OvermasterEffect effect) {
+    private OvermasterEffect(final OvermasterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PacksDisdain.java
+++ b/Mage.Sets/src/mage/cards/p/PacksDisdain.java
@@ -52,7 +52,7 @@ class PacksDisdainEffect extends OneShotEffect {
         this.staticText = "Choose a creature type. Target creature gets -1/-1 until end of turn for each permanent of the chosen type you control";
     }
 
-    PacksDisdainEffect(final PacksDisdainEffect effect) {
+    private PacksDisdainEffect(final PacksDisdainEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PalisadeGiant.java
+++ b/Mage.Sets/src/mage/cards/p/PalisadeGiant.java
@@ -68,7 +68,7 @@ class PalisadeGiantReplacementEffect extends ReplacementEffectImpl {
         staticText = "All damage that would be dealt to you and other permanents you control is dealt to {this} instead";
     }
 
-    PalisadeGiantReplacementEffect(final PalisadeGiantReplacementEffect effect) {
+    private PalisadeGiantReplacementEffect(final PalisadeGiantReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Pangosaur.java
+++ b/Mage.Sets/src/mage/cards/p/Pangosaur.java
@@ -46,7 +46,7 @@ class PangosaurTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ReturnToHandSourceEffect());
     }
 
-    PangosaurTriggeredAbility(PangosaurTriggeredAbility ability) {
+    private PangosaurTriggeredAbility(final PangosaurTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Panharmonicon.java
+++ b/Mage.Sets/src/mage/cards/p/Panharmonicon.java
@@ -46,7 +46,7 @@ class PanharmoniconEffect extends ReplacementEffectImpl {
         staticText = "If an artifact or creature entering the battlefield causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time";
     }
 
-    PanharmoniconEffect(final PanharmoniconEffect effect) {
+    private PanharmoniconEffect(final PanharmoniconEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ParadoxicalOutcome.java
+++ b/Mage.Sets/src/mage/cards/p/ParadoxicalOutcome.java
@@ -63,7 +63,7 @@ class ParadoxicalOutcomeEffect extends OneShotEffect {
         this.staticText = "Return any number of target nonland, nontoken permanents you control to their owners' hands. Draw a card for each card returned to your hand this way";
     }
 
-    ParadoxicalOutcomeEffect(final ParadoxicalOutcomeEffect effect) {
+    private ParadoxicalOutcomeEffect(final ParadoxicalOutcomeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ParallelThoughts.java
+++ b/Mage.Sets/src/mage/cards/p/ParallelThoughts.java
@@ -58,7 +58,7 @@ class ParallelThoughtsSearchEffect extends OneShotEffect {
         this.staticText = "search your library for seven cards, exile them in a face-down pile, and shuffle that pile. Then shuffle your library";
     }
 
-    ParallelThoughtsSearchEffect(final ParallelThoughtsSearchEffect effect) {
+    private ParallelThoughtsSearchEffect(final ParallelThoughtsSearchEffect effect) {
         super(effect);
     }
 
@@ -117,7 +117,7 @@ class ParallelThoughtsReplacementEffect extends ReplacementEffectImpl {
         staticText = "If you would draw a card, you may instead put the top card of the pile you exiled with {this} into your hand";
     }
 
-    ParallelThoughtsReplacementEffect(final ParallelThoughtsReplacementEffect effect) {
+    private ParallelThoughtsReplacementEffect(final ParallelThoughtsReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ParasiticImplant.java
+++ b/Mage.Sets/src/mage/cards/p/ParasiticImplant.java
@@ -55,7 +55,7 @@ class ParasiticImplantEffect extends OneShotEffect {
         staticText = "enchanted creature's controller sacrifices it";
     }
 
-    ParasiticImplantEffect(final ParasiticImplantEffect effect) {
+    private ParasiticImplantEffect(final ParasiticImplantEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Pariah.java
+++ b/Mage.Sets/src/mage/cards/p/Pariah.java
@@ -56,7 +56,7 @@ public final class Pariah extends CardImpl {
             staticText = "All damage that would be dealt to you is dealt to enchanted creature instead";
         }
 
-        PariahEffect(final PariahEffect effect) {
+        private PariahEffect(final PariahEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/p/PariahsShield.java
+++ b/Mage.Sets/src/mage/cards/p/PariahsShield.java
@@ -52,7 +52,7 @@ public final class PariahsShield extends CardImpl {
             staticText = "All damage that would be dealt to you is dealt to equipped creature instead";
         }
 
-        PariahEffect(final PariahEffect effect) {
+        private PariahEffect(final PariahEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/p/Paroxysm.java
+++ b/Mage.Sets/src/mage/cards/p/Paroxysm.java
@@ -72,7 +72,7 @@ class ParoxysmEffect extends OneShotEffect {
                 + "Otherwise, it gets +3/+3 until end of turn.";
     }
 
-    ParoxysmEffect(final ParoxysmEffect effect) {
+    private ParoxysmEffect(final ParoxysmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PatronOfTheMoon.java
+++ b/Mage.Sets/src/mage/cards/p/PatronOfTheMoon.java
@@ -64,7 +64,7 @@ class PatronOfTheMoonEffect extends OneShotEffect {
         staticText = "Put up to two land cards from your hand onto the battlefield tapped";
     }
 
-    PatronOfTheMoonEffect(final PatronOfTheMoonEffect effect) {
+    private PatronOfTheMoonEffect(final PatronOfTheMoonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PeerPressure.java
+++ b/Mage.Sets/src/mage/cards/p/PeerPressure.java
@@ -53,7 +53,7 @@ class PeerPressureEffect extends OneShotEffect {
         this.staticText = "Choose a creature type. If you control more creatures of that type than each other player, you gain control of all creatures of that type";
     }
 
-    PeerPressureEffect(final PeerPressureEffect effect) {
+    private PeerPressureEffect(final PeerPressureEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PestilenceDemon.java
+++ b/Mage.Sets/src/mage/cards/p/PestilenceDemon.java
@@ -56,7 +56,7 @@ class PestilenceDemonEffect extends OneShotEffect {
         staticText = "{this} deals 1 damage to each creature and each player";
     }
 
-    PestilenceDemonEffect(final PestilenceDemonEffect effect) {
+    private PestilenceDemonEffect(final PestilenceDemonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PetalsOfInsight.java
+++ b/Mage.Sets/src/mage/cards/p/PetalsOfInsight.java
@@ -45,7 +45,7 @@ class PetalsOfInsightEffect extends OneShotEffect {
         this.staticText = "Look at the top three cards of your library. You may put those cards on the bottom of your library in any order. If you do, return {this} to its owner's hand. Otherwise, draw three cards";
     }
 
-    PetalsOfInsightEffect(final PetalsOfInsightEffect effect) {
+    private PetalsOfInsightEffect(final PetalsOfInsightEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PetrifiedWoodKin.java
+++ b/Mage.Sets/src/mage/cards/p/PetrifiedWoodKin.java
@@ -75,7 +75,7 @@ class PetrifiedWoodKinEffect extends OneShotEffect {
         staticText = "";
     }
 
-    PetrifiedWoodKinEffect(final PetrifiedWoodKinEffect effect) {
+    private PetrifiedWoodKinEffect(final PetrifiedWoodKinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhantasmalMount.java
+++ b/Mage.Sets/src/mage/cards/p/PhantasmalMount.java
@@ -78,7 +78,7 @@ class PhantasmalMountEffect extends OneShotEffect {
                 + "sacrifice that creature. When the creature leaves the battlefield this turn, sacrifice {this}";
     }
 
-    PhantasmalMountEffect(PhantasmalMountEffect effect) {
+    private PhantasmalMountEffect(final PhantasmalMountEffect effect) {
         super(effect);
     }
 
@@ -124,7 +124,7 @@ class PhantasmalMountDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.creatureId = creatureId;
     }
 
-    PhantasmalMountDelayedTriggeredAbility(PhantasmalMountDelayedTriggeredAbility ability) {
+    private PhantasmalMountDelayedTriggeredAbility(final PhantasmalMountDelayedTriggeredAbility ability) {
         super(ability);
         this.creatureId = ability.creatureId;
     }

--- a/Mage.Sets/src/mage/cards/p/PhyrexianMarauder.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianMarauder.java
@@ -61,7 +61,7 @@ class PhyrexianMarauderCantAttackUnlessYouPayEffect extends CantAttackBlockUnles
         staticText = "{this} can't attack unless you pay {1} for each +1/+1 counter on it";
     }
 
-    PhyrexianMarauderCantAttackUnlessYouPayEffect(PhyrexianMarauderCantAttackUnlessYouPayEffect effect) {
+    private PhyrexianMarauderCantAttackUnlessYouPayEffect(final PhyrexianMarauderCantAttackUnlessYouPayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianNegator.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianNegator.java
@@ -53,7 +53,7 @@ class PhyrexianNegatorTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SacrificeEffect(new FilterPermanent(), 0,""));
     }
 
-    PhyrexianNegatorTriggeredAbility(final PhyrexianNegatorTriggeredAbility ability) {
+    private PhyrexianNegatorTriggeredAbility(final PhyrexianNegatorTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/p/PhyrexianTyranny.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianTyranny.java
@@ -47,7 +47,7 @@ class PhyrexianTyrannyTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new PhyrexianTyrannyEffect(), false);
     }
 
-    PhyrexianTyrannyTriggeredAbility(final PhyrexianTyrannyTriggeredAbility ability) {
+    private PhyrexianTyrannyTriggeredAbility(final PhyrexianTyrannyTriggeredAbility ability) {
         super(ability);
     }
 
@@ -84,7 +84,7 @@ class PhyrexianTyrannyEffect extends OneShotEffect {
         this.staticText = "that player loses 2 life unless they pay {2}";
     }
 
-    PhyrexianTyrannyEffect(final PhyrexianTyrannyEffect effect) {
+    private PhyrexianTyrannyEffect(final PhyrexianTyrannyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Phytohydra.java
+++ b/Mage.Sets/src/mage/cards/p/Phytohydra.java
@@ -49,7 +49,7 @@ class PhytohydraEffect extends ReplacementEffectImpl {
         staticText = "If damage would be dealt to {this}, put that many +1/+1 counters on it instead";
     }
 
-    PhytohydraEffect(final PhytohydraEffect effect) {
+    private PhytohydraEffect(final PhytohydraEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Phytotitan.java
+++ b/Mage.Sets/src/mage/cards/p/Phytotitan.java
@@ -54,7 +54,7 @@ class PhytotitanEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    PhytotitanEffect(PhytotitanEffect effect) {
+    private PhytotitanEffect(final PhytotitanEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PirsWhim.java
+++ b/Mage.Sets/src/mage/cards/p/PirsWhim.java
@@ -51,7 +51,7 @@ class PirsWhimEffect extends OneShotEffect {
                 + "Each foe sacrifices an artifact or enchantment they control.";
     }
 
-    PirsWhimEffect(final PirsWhimEffect effect) {
+    private PirsWhimEffect(final PirsWhimEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlanarBirth.java
+++ b/Mage.Sets/src/mage/cards/p/PlanarBirth.java
@@ -45,7 +45,7 @@ class PlanarBirthEffect extends OneShotEffect {
         this.staticText = "Return all basic land cards from all graveyards to the battlefield tapped under their owners' control";
     }
 
-    PlanarBirthEffect(final PlanarBirthEffect effect) {
+    private PlanarBirthEffect(final PlanarBirthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlanarChaos.java
+++ b/Mage.Sets/src/mage/cards/p/PlanarChaos.java
@@ -54,7 +54,7 @@ class PlanarChaosUpkeepEffect extends OneShotEffect {
         staticText = "flip a coin. If you lose the flip, sacrifice {this}";
     }
 
-    PlanarChaosUpkeepEffect(final PlanarChaosUpkeepEffect effect) {
+    private PlanarChaosUpkeepEffect(final PlanarChaosUpkeepEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlaneswalkersMischief.java
+++ b/Mage.Sets/src/mage/cards/p/PlaneswalkersMischief.java
@@ -99,7 +99,7 @@ class PlaneswalkersMischiefCastFromExileEffect extends AsThoughEffectImpl {
         staticText = "You may cast that card without paying its mana cost as long as it remains exiled";
     }
 
-    PlaneswalkersMischiefCastFromExileEffect(final PlaneswalkersMischiefCastFromExileEffect effect) {
+    private PlaneswalkersMischiefCastFromExileEffect(final PlaneswalkersMischiefCastFromExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlungeIntoDarkness.java
+++ b/Mage.Sets/src/mage/cards/p/PlungeIntoDarkness.java
@@ -64,7 +64,7 @@ class PlungeIntoDarknessLifeEffect extends OneShotEffect {
         this.staticText = "Sacrifice any number of creatures, then you gain 3 life for each sacrificed creature";
     }
 
-    PlungeIntoDarknessLifeEffect(final PlungeIntoDarknessLifeEffect effect) {
+    private PlungeIntoDarknessLifeEffect(final PlungeIntoDarknessLifeEffect effect) {
         super(effect);
     }
 
@@ -104,7 +104,7 @@ class PlungeIntoDarknessSearchEffect extends OneShotEffect {
         this.staticText = "pay X life, then look at the top X cards of your library, put one of those cards into your hand, and exile the rest.";
     }
 
-    PlungeIntoDarknessSearchEffect(final PlungeIntoDarknessSearchEffect effect) {
+    private PlungeIntoDarknessSearchEffect(final PlungeIntoDarknessSearchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PossessedPortal.java
+++ b/Mage.Sets/src/mage/cards/p/PossessedPortal.java
@@ -55,7 +55,7 @@ class PossessedPortalReplacementEffect extends ReplacementEffectImpl {
         this.staticText = "If a player would draw a card, that player skips that draw instead";
     }
 
-    PossessedPortalReplacementEffect(final PossessedPortalReplacementEffect effect) {
+    private PossessedPortalReplacementEffect(final PossessedPortalReplacementEffect effect) {
         super(effect);
     }
 
@@ -87,7 +87,7 @@ class PossessedPortalEffect extends OneShotEffect {
         this.staticText = "each player sacrifices a permanent unless they discard a card";
     }
     
-    PossessedPortalEffect(final PossessedPortalEffect effect) {
+    private PossessedPortalEffect(final PossessedPortalEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/p/Poultrygeist.java
+++ b/Mage.Sets/src/mage/cards/p/Poultrygeist.java
@@ -56,7 +56,7 @@ class PoultrygeistEffect extends OneShotEffect {
         this.staticText = "roll a six-sided die. If you roll a 1, sacrifice {this}. Otherwise, put a +1/+1 counter on {this}";
     }
 
-    PoultrygeistEffect(final PoultrygeistEffect ability) {
+    private PoultrygeistEffect(final PoultrygeistEffect ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Powerleech.java
+++ b/Mage.Sets/src/mage/cards/p/Powerleech.java
@@ -43,7 +43,7 @@ class PowerleechTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new GainLifeEffect(1));
     }
 
-    PowerleechTriggeredAbility(final PowerleechTriggeredAbility ability) {
+    private PowerleechTriggeredAbility(final PowerleechTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Pox.java
+++ b/Mage.Sets/src/mage/cards/p/Pox.java
@@ -50,7 +50,7 @@ class PoxEffect extends OneShotEffect {
                 + "Round up each time.";
     }
 
-    PoxEffect(final PoxEffect effect) {
+    private PoxEffect(final PoxEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PriestOfTheWakeningSun.java
+++ b/Mage.Sets/src/mage/cards/p/PriestOfTheWakeningSun.java
@@ -76,7 +76,7 @@ class PriestOfTheWakeningSunEffect extends OneShotEffect {
         this.staticText = "reveal a Dinosaur card from your hand. If you do, you gain 2 life";
     }
 
-    PriestOfTheWakeningSunEffect(final PriestOfTheWakeningSunEffect effect) {
+    private PriestOfTheWakeningSunEffect(final PriestOfTheWakeningSunEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalAmulet.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalAmulet.java
@@ -68,7 +68,7 @@ class PrimalAmuletEffect extends OneShotEffect {
                 + "you may remove those counters and transform it";
     }
 
-    PrimalAmuletEffect(final PrimalAmuletEffect effect) {
+    private PrimalAmuletEffect(final PrimalAmuletEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimalVigor.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalVigor.java
@@ -91,7 +91,7 @@ class PrimalVigorCounterEffect extends ReplacementEffectImpl {
         staticText = "If one or more +1/+1 counters would be put on a creature, twice that many +1/+1 counters are put on that creature instead";
     }
 
-    PrimalVigorCounterEffect(final PrimalVigorCounterEffect effect) {
+    private PrimalVigorCounterEffect(final PrimalVigorCounterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimevalProtector.java
+++ b/Mage.Sets/src/mage/cards/p/PrimevalProtector.java
@@ -77,7 +77,7 @@ class PrimevalProtectorCostReductionEffect extends CostModificationEffectImpl {
         staticText = "this spell costs {1} less to cast for each creature your opponents control";
     }
 
-    PrimevalProtectorCostReductionEffect(PrimevalProtectorCostReductionEffect effect) {
+    private PrimevalProtectorCostReductionEffect(final PrimevalProtectorCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrimitiveEtchings.java
+++ b/Mage.Sets/src/mage/cards/p/PrimitiveEtchings.java
@@ -47,7 +47,7 @@ class PrimitiveEtchingsAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new InfoEffect(""), false);
     }
 
-    PrimitiveEtchingsAbility(final PrimitiveEtchingsAbility ability) {
+    private PrimitiveEtchingsAbility(final PrimitiveEtchingsAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrinceOfThralls.java
+++ b/Mage.Sets/src/mage/cards/p/PrinceOfThralls.java
@@ -57,7 +57,7 @@ class PrinceOfThrallsTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a permanent an opponent controls is put into a graveyard, ");
     }
 
-    PrinceOfThrallsTriggeredAbility(final PrinceOfThrallsTriggeredAbility ability) {
+    private PrinceOfThrallsTriggeredAbility(final PrinceOfThrallsTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PrismaticStrands.java
+++ b/Mage.Sets/src/mage/cards/p/PrismaticStrands.java
@@ -64,7 +64,7 @@ class PrismaticStrandsEffect extends OneShotEffect {
         this.staticText = "Prevent all damage that sources of the color of your choice would deal this turn";
     }
 
-    PrismaticStrandsEffect(final PrismaticStrandsEffect effect) {
+    private PrismaticStrandsEffect(final PrismaticStrandsEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class PrismaticStrandsPreventionEffect extends PreventionEffectImpl {
         this.color = color;
     }
 
-    PrismaticStrandsPreventionEffect(PrismaticStrandsPreventionEffect effect) {
+    private PrismaticStrandsPreventionEffect(final PrismaticStrandsPreventionEffect effect) {
         super(effect);
         this.color = effect.color;
     }

--- a/Mage.Sets/src/mage/cards/p/Prohibit.java
+++ b/Mage.Sets/src/mage/cards/p/Prohibit.java
@@ -52,7 +52,7 @@ class ProhibitEffect extends OneShotEffect {
                 + "spell if its mana value is 4 or less instead.";
     }
 
-    ProhibitEffect(final ProhibitEffect effect) {
+    private ProhibitEffect(final ProhibitEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ProtectorOfTheCrown.java
+++ b/Mage.Sets/src/mage/cards/p/ProtectorOfTheCrown.java
@@ -58,7 +58,7 @@ class ProtectorOfTheCrownEffect extends ReplacementEffectImpl {
         staticText = "All damage that would be dealt to you is dealt to {this} instead";
     }
 
-    ProtectorOfTheCrownEffect(final ProtectorOfTheCrownEffect effect) {
+    private ProtectorOfTheCrownEffect(final ProtectorOfTheCrownEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ProteusStaff.java
+++ b/Mage.Sets/src/mage/cards/p/ProteusStaff.java
@@ -55,7 +55,7 @@ class ProteusStaffEffect extends OneShotEffect {
         this.staticText = "Put target creature on the bottom of its owner's library. That creature's controller reveals cards from the top of their library until they reveal a creature card. The player puts that card onto the battlefield and the rest on the bottom of their library in any order.";
     }
 
-    ProteusStaffEffect(final ProteusStaffEffect effect) {
+    private ProteusStaffEffect(final ProteusStaffEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Providence.java
+++ b/Mage.Sets/src/mage/cards/p/Providence.java
@@ -49,7 +49,7 @@ class ProvidenceDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new SetPlayerLifeSourceEffect(26));
     }
 
-    ProvidenceDelayedTriggeredAbility(ProvidenceDelayedTriggeredAbility ability) {
+    private ProvidenceDelayedTriggeredAbility(final ProvidenceDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/ProwlingPangolin.java
+++ b/Mage.Sets/src/mage/cards/p/ProwlingPangolin.java
@@ -51,7 +51,7 @@ class ProwlingPangolinEffect extends OneShotEffect {
         this.staticText = "any player may sacrifice two creatures. If a player does, sacrifice {this}";
     }
 
-    ProwlingPangolinEffect(final ProwlingPangolinEffect effect) {
+    private ProwlingPangolinEffect(final ProwlingPangolinEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychicMiasma.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicMiasma.java
@@ -46,7 +46,7 @@ class PsychicMiasmaEffect extends OneShotEffect {
         staticText = "Target player discards a card. If a land card is discarded this way, return {this} to its owner's hand";
     }
 
-    PsychicMiasmaEffect(final PsychicMiasmaEffect effect) {
+    private PsychicMiasmaEffect(final PsychicMiasmaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychogenicProbe.java
+++ b/Mage.Sets/src/mage/cards/p/PsychogenicProbe.java
@@ -43,7 +43,7 @@ class PsychogenicProbeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(2), false);
     }
 
-    PsychogenicProbeTriggeredAbility(final PsychogenicProbeTriggeredAbility ability) {
+    private PsychogenicProbeTriggeredAbility(final PsychogenicProbeTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychoticEpisode.java
+++ b/Mage.Sets/src/mage/cards/p/PsychoticEpisode.java
@@ -55,7 +55,7 @@ class PsychoticEpisodeEffect extends OneShotEffect {
         staticText = "Target player reveals their hand and the top card of their library. You choose a card revealed this way. That player puts the chosen card on the bottom of their library.";
     }
 
-    PsychoticEpisodeEffect(final PsychoticEpisodeEffect effect) {
+    private PsychoticEpisodeEffect(final PsychoticEpisodeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PulseOfTheDross.java
+++ b/Mage.Sets/src/mage/cards/p/PulseOfTheDross.java
@@ -47,7 +47,7 @@ class PulseOfTheDrossReturnToHandEffect extends OneShotEffect {
         this.staticText = "Then if that player has more cards in hand than you, return {this} to its owner's hand";
     }
 
-    PulseOfTheDrossReturnToHandEffect(final PulseOfTheDrossReturnToHandEffect effect) {
+    private PulseOfTheDrossReturnToHandEffect(final PulseOfTheDrossReturnToHandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PulseOfTheFields.java
+++ b/Mage.Sets/src/mage/cards/p/PulseOfTheFields.java
@@ -45,7 +45,7 @@ class PulseOfTheFieldsReturnToHandEffect extends OneShotEffect {
         this.staticText = "Then if an opponent has more life than you, return {this} to its owner's hand";
     }
 
-    PulseOfTheFieldsReturnToHandEffect(final PulseOfTheFieldsReturnToHandEffect effect) {
+    private PulseOfTheFieldsReturnToHandEffect(final PulseOfTheFieldsReturnToHandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PulseOfTheForge.java
+++ b/Mage.Sets/src/mage/cards/p/PulseOfTheForge.java
@@ -47,7 +47,7 @@ class PulseOfTheForgeReturnToHandEffect extends OneShotEffect {
         this.staticText = "Then if that player or that planeswalker's controller has more life than you, return {this} to its owner's hand";
     }
 
-    PulseOfTheForgeReturnToHandEffect(final PulseOfTheForgeReturnToHandEffect effect) {
+    private PulseOfTheForgeReturnToHandEffect(final PulseOfTheForgeReturnToHandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PulseOfTheGrid.java
+++ b/Mage.Sets/src/mage/cards/p/PulseOfTheGrid.java
@@ -45,7 +45,7 @@ class PulseOfTheGridReturnToHandEffect extends OneShotEffect {
         this.staticText = "Then if an opponent has more cards in hand than you, return {this} to its owner's hand";
     }
 
-    PulseOfTheGridReturnToHandEffect(final PulseOfTheGridReturnToHandEffect effect) {
+    private PulseOfTheGridReturnToHandEffect(final PulseOfTheGridReturnToHandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PulseOfTheTangle.java
+++ b/Mage.Sets/src/mage/cards/p/PulseOfTheTangle.java
@@ -50,7 +50,7 @@ class PulseOfTheTangleReturnToHandEffect extends OneShotEffect {
         this.staticText = "Then if an opponent controls more creatures than you, return {this} to its owner's hand";
     }
 
-    PulseOfTheTangleReturnToHandEffect(final PulseOfTheTangleReturnToHandEffect effect) {
+    private PulseOfTheTangleReturnToHandEffect(final PulseOfTheTangleReturnToHandEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PulsemageAdvocate.java
+++ b/Mage.Sets/src/mage/cards/p/PulsemageAdvocate.java
@@ -67,7 +67,7 @@ class PulsemageAdvocateEffect extends OneShotEffect {
         this.staticText = "Return three target cards from an opponent's graveyard to their hand. Return target creature card from your graveyard to the battlefield";
     }
 
-    PulsemageAdvocateEffect(final PulsemageAdvocateEffect effect) {
+    private PulsemageAdvocateEffect(final PulsemageAdvocateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Purgatory.java
+++ b/Mage.Sets/src/mage/cards/p/Purgatory.java
@@ -66,7 +66,7 @@ class PurgatoryTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new PurgatoryExileEffect(), false);
     }
 
-    PurgatoryTriggeredAbility(PurgatoryTriggeredAbility ability) {
+    private PurgatoryTriggeredAbility(final PurgatoryTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/Purity.java
+++ b/Mage.Sets/src/mage/cards/p/Purity.java
@@ -62,7 +62,7 @@ class PurityEffect extends PreventionEffectImpl {
         staticText = "If noncombat damage would be dealt to you, prevent that damage. You gain life equal to the damage prevented this way";
     }
 
-    PurityEffect(final PurityEffect effect) {
+    private PurityEffect(final PurityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PyromancerAscension.java
+++ b/Mage.Sets/src/mage/cards/p/PyromancerAscension.java
@@ -50,7 +50,7 @@ class PyromancerAscensionQuestTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.QUEST.createInstance(), true), true);
     }
 
-    PyromancerAscensionQuestTriggeredAbility(final PyromancerAscensionQuestTriggeredAbility ability) {
+    private PyromancerAscensionQuestTriggeredAbility(final PyromancerAscensionQuestTriggeredAbility ability) {
         super(ability);
     }
 
@@ -103,7 +103,7 @@ class PyromancerAscensionCopyTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CopyTargetSpellEffect(true), true);
     }
 
-    PyromancerAscensionCopyTriggeredAbility(final PyromancerAscensionCopyTriggeredAbility ability) {
+    private PyromancerAscensionCopyTriggeredAbility(final PyromancerAscensionCopyTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PyromancersGauntlet.java
+++ b/Mage.Sets/src/mage/cards/p/PyromancersGauntlet.java
@@ -47,7 +47,7 @@ class PyromancersGauntletReplacementEffect extends ReplacementEffectImpl {
         staticText = "If a red instant or sorcery spell you control or a red planeswalker you control would deal damage to a permanent or player, it deals that much damage plus 2 to that permanent or player instead";
     }
 
-    PyromancersGauntletReplacementEffect(final PyromancersGauntletReplacementEffect effect) {
+    private PyromancersGauntletReplacementEffect(final PyromancersGauntletReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PyromancersSwath.java
+++ b/Mage.Sets/src/mage/cards/p/PyromancersSwath.java
@@ -49,7 +49,7 @@ class PyromancersSwathReplacementEffect extends ReplacementEffectImpl {
         staticText = "If an instant or sorcery source you control would deal damage to a permanent or player, it deals that much damage plus 2 to that permanent or player instead";
     }
 
-    PyromancersSwathReplacementEffect(final PyromancersSwathReplacementEffect effect) {
+    private PyromancersSwathReplacementEffect(final PyromancersSwathReplacementEffect effect) {
         super(effect);
     }
 


### PR DESCRIPTION
Part of #11054, relative to making private copy constructors that were package-private.

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`  ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `  private $1(final $1 $3`
