### PR TITLE
Clean package-private copy constructors in cards starting Q to Z

### DIFF
--- a/Mage.Sets/src/mage/cards/q/QuicksilverDragon.java
+++ b/Mage.Sets/src/mage/cards/q/QuicksilverDragon.java
@@ -63,7 +63,7 @@ class QuicksilverDragonEffect extends OneShotEffect {
         this.staticText = "If target spell has only one target and that target is {this}, change that spell's target to another creature";
     }
     
-    QuicksilverDragonEffect(final QuicksilverDragonEffect effect) {
+    private QuicksilverDragonEffect(final QuicksilverDragonEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/r/RaidersSpoils.java
+++ b/Mage.Sets/src/mage/cards/r/RaidersSpoils.java
@@ -52,7 +52,7 @@ class RaidersSpoilsTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new PayLifeCost(1)), false);
     }
     
-    RaidersSpoilsTriggeredAbility(final RaidersSpoilsTriggeredAbility ability) {
+    private RaidersSpoilsTriggeredAbility(final RaidersSpoilsTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/r/RaidingParty.java
+++ b/Mage.Sets/src/mage/cards/r/RaidingParty.java
@@ -81,7 +81,7 @@ class RaidingPartyEffect extends OneShotEffect {
         staticText = "Each player may tap any number of untapped white creatures they control. For each creature tapped this way, that player chooses up to two Plains. Then destroy all Plains that weren't chosen this way by any player";
     }
 
-    RaidingPartyEffect(RaidingPartyEffect effect) {
+    private RaidingPartyEffect(final RaidingPartyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RakdosLordOfRiots.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosLordOfRiots.java
@@ -96,7 +96,7 @@ class RakdosLordOfRiotsCostReductionEffect extends CostModificationEffectImpl {
         staticText = "Creature spells you cast cost {1} less to cast for each 1 life your opponents have lost this turn";
     }
 
-    RakdosLordOfRiotsCostReductionEffect(RakdosLordOfRiotsCostReductionEffect effect) {
+    private RakdosLordOfRiotsCostReductionEffect(final RakdosLordOfRiotsCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RakdossReturn.java
+++ b/Mage.Sets/src/mage/cards/r/RakdossReturn.java
@@ -49,7 +49,7 @@ class RakdossReturnEffect extends OneShotEffect {
         this.staticText = "That player or that planeswalker's controller discards X cards.";
     }
 
-    RakdossReturnEffect(final RakdossReturnEffect effect) {
+    private RakdossReturnEffect(final RakdossReturnEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RallyTheAncestors.java
+++ b/Mage.Sets/src/mage/cards/r/RallyTheAncestors.java
@@ -59,7 +59,7 @@ class RallyTheAncestorsEffect extends OneShotEffect {
         this.staticText = "Return each creature card with mana value X or less from your graveyard to the battlefield. Exile those creatures at the beginning of your next upkeep";
     }
 
-    RallyTheAncestorsEffect(final RallyTheAncestorsEffect effect) {
+    private RallyTheAncestorsEffect(final RallyTheAncestorsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RanarTheEverWatchful.java
+++ b/Mage.Sets/src/mage/cards/r/RanarTheEverWatchful.java
@@ -101,7 +101,7 @@ class RanarTheEverWatchfulTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CreateTokenEffect(new SpiritWhiteToken()), false);
     }
 
-    RanarTheEverWatchfulTriggeredAbility(final RanarTheEverWatchfulTriggeredAbility ability) {
+    private RanarTheEverWatchfulTriggeredAbility(final RanarTheEverWatchfulTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RashmiAndRagavan.java
+++ b/Mage.Sets/src/mage/cards/r/RashmiAndRagavan.java
@@ -72,7 +72,7 @@ class RashmiAndRagavanTriggeredAbility extends SpellCastControllerTriggeredAbili
         this.addEffect(new RashmiAndRagavanEffect());
     }
 
-    RashmiAndRagavanTriggeredAbility(RashmiAndRagavanTriggeredAbility ability) {
+    private RashmiAndRagavanTriggeredAbility(final RashmiAndRagavanTriggeredAbility ability) {
         super(ability);
     }
 
@@ -115,7 +115,7 @@ class RashmiAndRagavanEffect extends OneShotEffect {
                 + "you may cast it this turn";
     }
 
-    RashmiAndRagavanEffect(final RashmiAndRagavanEffect effect) {
+    private RashmiAndRagavanEffect(final RashmiAndRagavanEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RashmiEternitiesCrafter.java
+++ b/Mage.Sets/src/mage/cards/r/RashmiEternitiesCrafter.java
@@ -58,7 +58,7 @@ class RashmiEternitiesCrafterTriggeredAbility extends SpellCastControllerTrigger
         super(new RashmiEternitiesCrafterEffect(), false);
     }
 
-    RashmiEternitiesCrafterTriggeredAbility(RashmiEternitiesCrafterTriggeredAbility ability) {
+    private RashmiEternitiesCrafterTriggeredAbility(final RashmiEternitiesCrafterTriggeredAbility ability) {
         super(ability);
     }
 
@@ -103,7 +103,7 @@ class RashmiEternitiesCrafterEffect extends OneShotEffect {
                 + "revealed card, put it into your hand";
     }
 
-    RashmiEternitiesCrafterEffect(final RashmiEternitiesCrafterEffect effect) {
+    private RashmiEternitiesCrafterEffect(final RashmiEternitiesCrafterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RayOfCommand.java
+++ b/Mage.Sets/src/mage/cards/r/RayOfCommand.java
@@ -51,7 +51,7 @@ class RayOfCommandDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new TapTargetEffect(), Duration.EndOfGame, true); // effect can last over turns end, if you still control the target but only one time
     }
 
-    RayOfCommandDelayedTriggeredAbility(RayOfCommandDelayedTriggeredAbility ability) {
+    private RayOfCommandDelayedTriggeredAbility(final RayOfCommandDelayedTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/r/ReadTheRunes.java
+++ b/Mage.Sets/src/mage/cards/r/ReadTheRunes.java
@@ -46,7 +46,7 @@ class ReadTheRunesEffect extends OneShotEffect {
         this.staticText = "Draw X cards. For each card drawn this way, discard a card unless you sacrifice a permanent.";
     }
     
-    ReadTheRunesEffect(final ReadTheRunesEffect effect) {
+    private ReadTheRunesEffect(final ReadTheRunesEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/r/ReasonBelieve.java
+++ b/Mage.Sets/src/mage/cards/r/ReasonBelieve.java
@@ -54,7 +54,7 @@ class BelieveEffect extends OneShotEffect {
         this.staticText = "Look at the top card of your library. You may put it onto the battlefield if it's a creature card. If you don't, put it into your hand";
     }
 
-    BelieveEffect(final BelieveEffect effect) {
+    private BelieveEffect(final BelieveEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Reclamation.java
+++ b/Mage.Sets/src/mage/cards/r/Reclamation.java
@@ -51,7 +51,7 @@ class ReclamationCostToAttackBlockEffect extends PayCostToAttackBlockEffectImpl 
         staticText = "Black creatures can't attack unless their controller sacrifices a land <i>(This cost is paid as attackers are declared.)</i>";
     }
 
-    ReclamationCostToAttackBlockEffect(ReclamationCostToAttackBlockEffect effect) {
+    private ReclamationCostToAttackBlockEffect(final ReclamationCostToAttackBlockEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReflectorMage.java
+++ b/Mage.Sets/src/mage/cards/r/ReflectorMage.java
@@ -100,7 +100,7 @@ class ExclusionRitualReplacementEffect extends ContinuousRuleModifyingEffectImpl
         this.ownerId = ownerId;
     }
 
-    ExclusionRitualReplacementEffect(final ExclusionRitualReplacementEffect effect) {
+    private ExclusionRitualReplacementEffect(final ExclusionRitualReplacementEffect effect) {
         super(effect);
         this.creatureName = effect.creatureName;
         this.ownerId = effect.ownerId;

--- a/Mage.Sets/src/mage/cards/r/RegnasSanction.java
+++ b/Mage.Sets/src/mage/cards/r/RegnasSanction.java
@@ -62,7 +62,7 @@ class RegnasSanctionEffect extends OneShotEffect {
                 + "Each foe chooses one untapped creature they control, then taps the rest";
     }
 
-    RegnasSanctionEffect(final RegnasSanctionEffect effect) {
+    private RegnasSanctionEffect(final RegnasSanctionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReignOfThePit.java
+++ b/Mage.Sets/src/mage/cards/r/ReignOfThePit.java
@@ -47,7 +47,7 @@ class ReignOfThePitEffect extends OneShotEffect {
         this.staticText = "Each player sacrifices a creature. Create an X/X black Demon creature token with flying, where X is the total power of the creatures sacrificed this way";
     }
 
-    ReignOfThePitEffect(final ReignOfThePitEffect effect) {
+    private ReignOfThePitEffect(final ReignOfThePitEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReinsOfPower.java
+++ b/Mage.Sets/src/mage/cards/r/ReinsOfPower.java
@@ -55,7 +55,7 @@ class ReinsOfPowerEffect extends OneShotEffect {
         this.staticText = "Untap all creatures you control and all creatures target opponent controls. You and that opponent each gain control of all creatures the other controls until end of turn. Those creatures gain haste until end of turn";
     }
 
-    ReinsOfPowerEffect(final ReinsOfPowerEffect effect) {
+    private ReinsOfPowerEffect(final ReinsOfPowerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Reminisce.java
+++ b/Mage.Sets/src/mage/cards/r/Reminisce.java
@@ -42,7 +42,7 @@ class ReminisceEffect extends OneShotEffect {
         this.staticText = "Target player shuffles their graveyard into their library";
     }
 
-    ReminisceEffect(final ReminisceEffect effect) {
+    private ReminisceEffect(final ReminisceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RenegadeDoppelganger.java
+++ b/Mage.Sets/src/mage/cards/r/RenegadeDoppelganger.java
@@ -52,7 +52,7 @@ class RenegadeDoppelgangerTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new RenegadeDoppelgangerEffect(), true);
     }
 
-    RenegadeDoppelgangerTriggeredAbility(final RenegadeDoppelgangerTriggeredAbility ability) {
+    private RenegadeDoppelgangerTriggeredAbility(final RenegadeDoppelgangerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Replenish.java
+++ b/Mage.Sets/src/mage/cards/r/Replenish.java
@@ -43,7 +43,7 @@ class ReplenishEffect extends OneShotEffect {
         this.staticText = "Return all enchantment cards from your graveyard to the battlefield";
     }
 
-    ReplenishEffect(final ReplenishEffect effect) {
+    private ReplenishEffect(final ReplenishEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Repopulate.java
+++ b/Mage.Sets/src/mage/cards/r/Repopulate.java
@@ -48,7 +48,7 @@ class RepopulateEffect extends OneShotEffect {
         staticText = "Shuffle all creature cards from target player's graveyard into that player's library";
     }
 
-    RepopulateEffect(final RepopulateEffect effect) {
+    private RepopulateEffect(final RepopulateEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/ResearchDevelopment.java
+++ b/Mage.Sets/src/mage/cards/r/ResearchDevelopment.java
@@ -89,7 +89,7 @@ class DevelopmentEffect extends OneShotEffect {
         staticText = "Create a 3/1 red Elemental creature token unless any opponent has you draw a card. Repeat this process two more times.";
     }
 
-    DevelopmentEffect(final DevelopmentEffect effect) {
+    private DevelopmentEffect(final DevelopmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Rethink.java
+++ b/Mage.Sets/src/mage/cards/r/Rethink.java
@@ -45,7 +45,7 @@ class RethinkEffect extends OneShotEffect {
         this.staticText = "Counter target spell unless its controller pays {X}, where X is its mana value";
     }
 
-    RethinkEffect(final RethinkEffect effect) {
+    private RethinkEffect(final RethinkEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiftElemental.java
+++ b/Mage.Sets/src/mage/cards/r/RiftElemental.java
@@ -68,7 +68,7 @@ class RiftElementalCost extends CostImpl {
         text = "Remove a time counter from a permanent you control or suspended card you own";
     }
 
-    RiftElementalCost(final RiftElementalCost cost) {
+    private RiftElementalCost(final RiftElementalCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiptideMangler.java
+++ b/Mage.Sets/src/mage/cards/r/RiptideMangler.java
@@ -54,7 +54,7 @@ class RiptideManglerEffect extends OneShotEffect {
         this.staticText = "Change {this}'s base power to target creature's power. <i>(This effect lasts indefinitely.)</i>";
     }
 
-    RiptideManglerEffect(final RiptideManglerEffect effect) {
+    private RiptideManglerEffect(final RiptideManglerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiptideReplicator.java
+++ b/Mage.Sets/src/mage/cards/r/RiptideReplicator.java
@@ -66,7 +66,7 @@ class RiptideReplicatorEffect extends OneShotEffect {
         this.staticText = "Create an X/X creature token of the chosen color and type, where X is the number of charge counters on {this}.";
     }
 
-    RiptideReplicatorEffect(final RiptideReplicatorEffect effect) {
+    private RiptideReplicatorEffect(final RiptideReplicatorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiptideShapeshifter.java
+++ b/Mage.Sets/src/mage/cards/r/RiptideShapeshifter.java
@@ -55,7 +55,7 @@ class RiptideShapeshifterEffect extends OneShotEffect {
         this.staticText = "Choose a creature type. Reveal cards from the top of your library until you reveal a creature card of that type. Put that card onto the battlefield and shuffle the rest into your library";
     }
 
-    RiptideShapeshifterEffect(final RiptideShapeshifterEffect effect) {
+    private RiptideShapeshifterEffect(final RiptideShapeshifterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RisenExecutioner.java
+++ b/Mage.Sets/src/mage/cards/r/RisenExecutioner.java
@@ -71,7 +71,7 @@ class RisenExecutionerCastEffect extends AsThoughEffectImpl {
         staticText = "You may cast {this} from your graveyard if you pay {1} more to cast it for each other creature card in your graveyard";
     }
 
-    RisenExecutionerCastEffect(final RisenExecutionerCastEffect effect) {
+    private RisenExecutionerCastEffect(final RisenExecutionerCastEffect effect) {
         super(effect);
     }
 
@@ -112,7 +112,7 @@ class RisenExecutionerCostIncreasingEffect extends CostModificationEffectImpl {
         staticText = "";
     }
 
-    RisenExecutionerCostIncreasingEffect(final RisenExecutionerCostIncreasingEffect effect) {
+    private RisenExecutionerCostIncreasingEffect(final RisenExecutionerCostIncreasingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RiteOfFlame.java
+++ b/Mage.Sets/src/mage/cards/r/RiteOfFlame.java
@@ -48,7 +48,7 @@ class RiteOfFlameManaEffect extends ManaEffect {
         staticText = "Add {R}{R}, then add {R} for each card named Rite of Flame in each graveyard";
     }
 
-    RiteOfFlameManaEffect(final RiteOfFlameManaEffect effect) {
+    private RiteOfFlameManaEffect(final RiteOfFlameManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RitesOfInitiation.java
+++ b/Mage.Sets/src/mage/cards/r/RitesOfInitiation.java
@@ -43,7 +43,7 @@ class RitesOfInitiationEffect extends OneShotEffect {
         this.staticText = "Discard any number of cards at random. Creatures you control get +1/+0 until end of turn for each card discarded this way";
     }
     
-    RitesOfInitiationEffect(final RitesOfInitiationEffect effect) {
+    private RitesOfInitiationEffect(final RitesOfInitiationEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/r/RoarOfTheCrowd.java
+++ b/Mage.Sets/src/mage/cards/r/RoarOfTheCrowd.java
@@ -49,7 +49,7 @@ class RoarOfTheCrowdEffect extends OneShotEffect {
         this.staticText = "Choose a creature type. {this} deals damage to any target equal to the number of permanents you control of the chosen type.";
     }
 
-    RoarOfTheCrowdEffect(final RoarOfTheCrowdEffect effect) {
+    private RoarOfTheCrowdEffect(final RoarOfTheCrowdEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RohgahhOfKherKeep.java
+++ b/Mage.Sets/src/mage/cards/r/RohgahhOfKherKeep.java
@@ -81,7 +81,7 @@ class RohgahhOfKherKeepEffect extends OneShotEffect {
         this.staticText = "you may pay {R}{R}{R}. If you don't, tap {this} and all creatures named Kobolds of Kher Keep, then an opponent gains control of them.";
     }
 
-    RohgahhOfKherKeepEffect(final RohgahhOfKherKeepEffect effect) {
+    private RohgahhOfKherKeepEffect(final RohgahhOfKherKeepEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RowanKenrith.java
+++ b/Mage.Sets/src/mage/cards/r/RowanKenrith.java
@@ -114,7 +114,7 @@ class RowanKenrithDamageEffect extends OneShotEffect {
         this.staticText = "{this} deals 3 damage to each tapped creature target player controls";
     }
 
-    RowanKenrithDamageEffect(final RowanKenrithDamageEffect effect) {
+    private RowanKenrithDamageEffect(final RowanKenrithDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RowdyCrew.java
+++ b/Mage.Sets/src/mage/cards/r/RowdyCrew.java
@@ -57,7 +57,7 @@ class RowdyCrewEffect extends OneShotEffect {
         this.staticText = "draw three cards, then discard two cards at random. If two cards that share a card type are discarded this way, put two +1/+1 counters on {this}";
     }
 
-    RowdyCrewEffect(final RowdyCrewEffect effect) {
+    private RowdyCrewEffect(final RowdyCrewEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Rowen.java
+++ b/Mage.Sets/src/mage/cards/r/Rowen.java
@@ -47,7 +47,7 @@ class RowenAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new InfoEffect(""), false);
     }
 
-    RowenAbility(final RowenAbility ability) {
+    private RowenAbility(final RowenAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoyalDecree.java
+++ b/Mage.Sets/src/mage/cards/r/RoyalDecree.java
@@ -63,7 +63,7 @@ class RoyalDecreeAbility extends TriggeredAbilityImpl {
             super(Zone.BATTLEFIELD, new DamageTargetEffect(1));
     }
 
-    RoyalDecreeAbility(final RoyalDecreeAbility ability) {
+    private RoyalDecreeAbility(final RoyalDecreeAbility ability) {
             super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RuinRaider.java
+++ b/Mage.Sets/src/mage/cards/r/RuinRaider.java
@@ -57,7 +57,7 @@ class RuinRaiderEffect extends OneShotEffect {
         this.staticText = "reveal the top card of your library and put that card into your hand. You lose life equal to its mana value";
     }
 
-    RuinRaiderEffect(final RuinRaiderEffect effect) {
+    private RuinRaiderEffect(final RuinRaiderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RumblingAftershocks.java
+++ b/Mage.Sets/src/mage/cards/r/RumblingAftershocks.java
@@ -50,7 +50,7 @@ class RumblingAftershocksTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you cast a kicked spell, ");
     }
 
-    RumblingAftershocksTriggeredAbility(final RumblingAftershocksTriggeredAbility ability) {
+    private RumblingAftershocksTriggeredAbility(final RumblingAftershocksTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RunicArmasaur.java
+++ b/Mage.Sets/src/mage/cards/r/RunicArmasaur.java
@@ -48,7 +48,7 @@ class RunicArmasaurTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), true);
     }
 
-    RunicArmasaurTriggeredAbility(final RunicArmasaurTriggeredAbility ability) {
+    private RunicArmasaurTriggeredAbility(final RunicArmasaurTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RustmouthOgre.java
+++ b/Mage.Sets/src/mage/cards/r/RustmouthOgre.java
@@ -51,7 +51,7 @@ class RustmouthOgreTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), true);
     }
 
-    RustmouthOgreTriggeredAbility(final RustmouthOgreTriggeredAbility ability) {
+    private RustmouthOgreTriggeredAbility(final RustmouthOgreTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RuthlessInvasion.java
+++ b/Mage.Sets/src/mage/cards/r/RuthlessInvasion.java
@@ -39,7 +39,7 @@ class RuthlessInvasionEffect extends RestrictionEffect {
         staticText = "Nonartifact creatures can't block this turn";
     }
 
-    RuthlessInvasionEffect(final RuthlessInvasionEffect effect) {
+    private RuthlessInvasionEffect(final RuthlessInvasionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SacredGround.java
+++ b/Mage.Sets/src/mage/cards/s/SacredGround.java
@@ -42,7 +42,7 @@ class SacredGroundTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ReturnFromGraveyardToBattlefieldTargetEffect());
     }
 
-    SacredGroundTriggeredAbility(final SacredGroundTriggeredAbility ability) {
+    private SacredGroundTriggeredAbility(final SacredGroundTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SageOfFables.java
+++ b/Mage.Sets/src/mage/cards/s/SageOfFables.java
@@ -59,7 +59,7 @@ class SageOfFablesReplacementEffect extends ReplacementEffectImpl {
         staticText = "Each other Wizard creature you control enters the battlefield with an additional +1/+1 counter on it";
     }
 
-    SageOfFablesReplacementEffect(SageOfFablesReplacementEffect effect) {
+    private SageOfFablesReplacementEffect(final SageOfFablesReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SaheeliRai.java
+++ b/Mage.Sets/src/mage/cards/s/SaheeliRai.java
@@ -72,7 +72,7 @@ class SaheeliRaiCreateTokenEffect extends OneShotEffect {
         this.staticText = "Create a token that's a copy of target artifact or creature you control, except it's an artifact in addition to its other types. That token gains haste. Exile it at the beginning of the next end step";
     }
 
-    SaheeliRaiCreateTokenEffect(final SaheeliRaiCreateTokenEffect effect) {
+    private SaheeliRaiCreateTokenEffect(final SaheeliRaiCreateTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SandstoneOracle.java
+++ b/Mage.Sets/src/mage/cards/s/SandstoneOracle.java
@@ -53,7 +53,7 @@ class SandstoneOracleEffect extends OneShotEffect {
         this.staticText = "choose an opponent. If that player has more cards in hand than you, draw cards equal to the difference";
     }
 
-    SandstoneOracleEffect(final SandstoneOracleEffect effect) {
+    private SandstoneOracleEffect(final SandstoneOracleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/Sangromancer.java
+++ b/Mage.Sets/src/mage/cards/s/Sangromancer.java
@@ -51,7 +51,7 @@ class SangromancerFirstTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever a creature an opponent controls dies, ");
     }
 
-    SangromancerFirstTriggeredAbility(final SangromancerFirstTriggeredAbility ability) {
+    private SangromancerFirstTriggeredAbility(final SangromancerFirstTriggeredAbility ability) {
         super(ability);
     }
 
@@ -83,7 +83,7 @@ class SangromancerSecondTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever an opponent discards a card, ");
     }
 
-    SangromancerSecondTriggeredAbility(final SangromancerSecondTriggeredAbility ability) {
+    private SangromancerSecondTriggeredAbility(final SangromancerSecondTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SaprolingBurst.java
+++ b/Mage.Sets/src/mage/cards/s/SaprolingBurst.java
@@ -61,7 +61,7 @@ class SaprolingBurstCreateTokenEffect extends OneShotEffect {
         this.staticText = "create a green Saproling creature token. It has \"This creature's power and toughness are each equal to the number of fade counters on {this}.\"";
     }
 
-    SaprolingBurstCreateTokenEffect(final SaprolingBurstCreateTokenEffect effect) {
+    private SaprolingBurstCreateTokenEffect(final SaprolingBurstCreateTokenEffect effect) {
         super(effect);
     }
 
@@ -99,7 +99,7 @@ class SaprolingBurstLeavesBattlefieldTriggeredAbility extends ZoneChangeTriggere
         super(Zone.BATTLEFIELD, null, new SaprolingBurstDestroyEffect(), "When {this} leaves the battlefield, ", false);
     }
 
-    SaprolingBurstLeavesBattlefieldTriggeredAbility(SaprolingBurstLeavesBattlefieldTriggeredAbility ability) {
+    private SaprolingBurstLeavesBattlefieldTriggeredAbility(final SaprolingBurstLeavesBattlefieldTriggeredAbility ability) {
         super(ability);
     }
 
@@ -131,7 +131,7 @@ class SaprolingBurstDestroyEffect extends OneShotEffect {
         this.staticText = "destroy all tokens created with {this}. They can't be regenerated";
     }
 
-    SaprolingBurstDestroyEffect(final SaprolingBurstDestroyEffect effect) {
+    private SaprolingBurstDestroyEffect(final SaprolingBurstDestroyEffect effect) {
         super(effect);
         this.cardZoneString = effect.cardZoneString;
     }

--- a/Mage.Sets/src/mage/cards/s/SarkhanTheDragonspeaker.java
+++ b/Mage.Sets/src/mage/cards/s/SarkhanTheDragonspeaker.java
@@ -67,7 +67,7 @@ class SarkhanTheDragonspeakerEffect extends ContinuousEffectImpl {
         staticText = "Until end of turn, {this} becomes a legendary 4/4 red Dragon creature with flying, indestructible, and haste.";
     }
 
-    SarkhanTheDragonspeakerEffect(final SarkhanTheDragonspeakerEffect effect) {
+    private SarkhanTheDragonspeakerEffect(final SarkhanTheDragonspeakerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SarkhanTheMad.java
+++ b/Mage.Sets/src/mage/cards/s/SarkhanTheMad.java
@@ -69,7 +69,7 @@ class SarkhanTheMadRevealAndDrawEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    SarkhanTheMadRevealAndDrawEffect(SarkhanTheMadRevealAndDrawEffect effect) {
+    private SarkhanTheMadRevealAndDrawEffect(final SarkhanTheMadRevealAndDrawEffect effect) {
         super(effect);
     }
 
@@ -108,7 +108,7 @@ class SarkhanTheMadSacEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    SarkhanTheMadSacEffect(SarkhanTheMadSacEffect effect) {
+    private SarkhanTheMadSacEffect(final SarkhanTheMadSacEffect effect) {
         super(effect);
     }
 
@@ -149,7 +149,7 @@ class SarkhanTheMadDragonDamageEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    SarkhanTheMadDragonDamageEffect(SarkhanTheMadDragonDamageEffect effect) {
+    private SarkhanTheMadDragonDamageEffect(final SarkhanTheMadDragonDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SavingGrace.java
+++ b/Mage.Sets/src/mage/cards/s/SavingGrace.java
@@ -70,7 +70,7 @@ class SavingGraceReplacementEffect extends ReplacementEffectImpl {
         staticText = "all damage that would be dealt this turn to you and permanents you control is dealt to enchanted creature instead.";
     }
 
-    SavingGraceReplacementEffect(final SavingGraceReplacementEffect effect) {
+    private SavingGraceReplacementEffect(final SavingGraceReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/Scarecrow.java
+++ b/Mage.Sets/src/mage/cards/s/Scarecrow.java
@@ -63,7 +63,7 @@ class ScarecrowEffect extends PreventionEffectImpl {
         staticText = "Prevent all damage that would be dealt to you this turn by creatures with flying";
     }
 
-    ScarecrowEffect(final ScarecrowEffect effect) {
+    private ScarecrowEffect(final ScarecrowEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/ScionOfTheUrDragon.java
+++ b/Mage.Sets/src/mage/cards/s/ScionOfTheUrDragon.java
@@ -64,7 +64,7 @@ class ScionOfTheUrDragonEffect extends SearchEffect {
         staticText = "Search your library for a Dragon permanent card and put it into your graveyard. If you do, {this} becomes a copy of that card until end of turn. Then shuffle.";
     }
 
-    ScionOfTheUrDragonEffect(final ScionOfTheUrDragonEffect effect) {
+    private ScionOfTheUrDragonEffect(final ScionOfTheUrDragonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/ScryingSheets.java
+++ b/Mage.Sets/src/mage/cards/s/ScryingSheets.java
@@ -56,7 +56,7 @@ class ScryingSheetsEffect extends OneShotEffect {
         this.staticText = "Look at the top card of your library. If that card is snow, you may reveal it and put it into your hand";
     }
 
-    ScryingSheetsEffect(final ScryingSheetsEffect effect) {
+    private ScryingSheetsEffect(final ScryingSheetsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SealOfTheGuildpact.java
+++ b/Mage.Sets/src/mage/cards/s/SealOfTheGuildpact.java
@@ -58,7 +58,7 @@ class SealOfTheGuildpactChooseColorEffect extends OneShotEffect {
         this.staticText = "choose two colors";
     }
 
-    SealOfTheGuildpactChooseColorEffect(final SealOfTheGuildpactChooseColorEffect effect) {
+    private SealOfTheGuildpactChooseColorEffect(final SealOfTheGuildpactChooseColorEffect effect) {
         super(effect);
     }
 
@@ -115,7 +115,7 @@ class SealOfTheGuildpactCostReductionEffect extends CostModificationEffectImpl {
         staticText = "Each spell you cast costs {1} less to cast for each of the chosen colors it is";
     }
 
-    SealOfTheGuildpactCostReductionEffect(SealOfTheGuildpactCostReductionEffect effect) {
+    private SealOfTheGuildpactCostReductionEffect(final SealOfTheGuildpactCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SeasonOfTheWitch.java
+++ b/Mage.Sets/src/mage/cards/s/SeasonOfTheWitch.java
@@ -65,7 +65,7 @@ class SeasonOfTheWitchEffect extends OneShotEffect {
         this.staticText = "destroy all untapped creatures that didn't attack this turn, except for creatures that couldn't attack";
     }
 
-    SeasonOfTheWitchEffect(final SeasonOfTheWitchEffect effect) {
+    private SeasonOfTheWitchEffect(final SeasonOfTheWitchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SeasonsBeatings.java
+++ b/Mage.Sets/src/mage/cards/s/SeasonsBeatings.java
@@ -49,7 +49,7 @@ class SeasonsBeatingsEffect extends OneShotEffect {
         staticText = "Family gathering <i>Each creature target player controls deals damage equal to its power to another random creature that player controls.</i>";
     }
 
-    SeasonsBeatingsEffect(final SeasonsBeatingsEffect effect) {
+    private SeasonsBeatingsEffect(final SeasonsBeatingsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SedrisTheTraitorKing.java
+++ b/Mage.Sets/src/mage/cards/s/SedrisTheTraitorKing.java
@@ -49,7 +49,7 @@ class SedrisTheTraitorKingEffect extends ContinuousEffectImpl {
         staticText = "Each creature card in your graveyard has unearth {2}{B}";
     }
 
-    SedrisTheTraitorKingEffect(final SedrisTheTraitorKingEffect effect) {
+    private SedrisTheTraitorKingEffect(final SedrisTheTraitorKingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SelfInflictedWound.java
+++ b/Mage.Sets/src/mage/cards/s/SelfInflictedWound.java
@@ -51,7 +51,7 @@ class SelfInflictedWoundEffect extends OneShotEffect {
         staticText = "Target opponent sacrifices a green or white creature. If that player does, they lose 2 life";
     }
 
-    SelfInflictedWoundEffect(SelfInflictedWoundEffect effect) {
+    private SelfInflictedWoundEffect(final SelfInflictedWoundEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SelflessGlyphweaver.java
+++ b/Mage.Sets/src/mage/cards/s/SelflessGlyphweaver.java
@@ -70,7 +70,7 @@ class DeadlyVanityEffect extends OneShotEffect {
         staticText = "choose a creature or planeswalker, then destroy all other creatures and planeswalkers";
     }
 
-    DeadlyVanityEffect(DeadlyVanityEffect effect) {
+    private DeadlyVanityEffect(final DeadlyVanityEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SemblanceAnvil.java
+++ b/Mage.Sets/src/mage/cards/s/SemblanceAnvil.java
@@ -93,7 +93,7 @@ class SemblanceAnvilCostReductionEffect extends CostModificationEffectImpl {
         staticText = effectText;
     }
 
-    SemblanceAnvilCostReductionEffect(SemblanceAnvilCostReductionEffect effect) {
+    private SemblanceAnvilCostReductionEffect(final SemblanceAnvilCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SentinelOfThePearlTrident.java
+++ b/Mage.Sets/src/mage/cards/s/SentinelOfThePearlTrident.java
@@ -73,7 +73,7 @@ class SentinelOfThePearlTridentEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    SentinelOfThePearlTridentEffect(SentinelOfThePearlTridentEffect effect) {
+    private SentinelOfThePearlTridentEffect(final SentinelOfThePearlTridentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SentinelTower.java
+++ b/Mage.Sets/src/mage/cards/s/SentinelTower.java
@@ -56,7 +56,7 @@ class SentinelTowerTriggeredAbility extends SpellCastAllTriggeredAbility {
         this.damageInfo = null;
     }
 
-    SentinelTowerTriggeredAbility(final SentinelTowerTriggeredAbility effect) {
+    private SentinelTowerTriggeredAbility(final SentinelTowerTriggeredAbility effect) {
         super(effect);
         this.damageInfo = effect.damageInfo;
     }

--- a/Mage.Sets/src/mage/cards/s/SepticRats.java
+++ b/Mage.Sets/src/mage/cards/s/SepticRats.java
@@ -51,7 +51,7 @@ class SepticRatsTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn));
     }
 
-    SepticRatsTriggeredAbility(final SepticRatsTriggeredAbility ability) {
+    private SepticRatsTriggeredAbility(final SepticRatsTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/Seraph.java
+++ b/Mage.Sets/src/mage/cards/s/Seraph.java
@@ -67,7 +67,7 @@ class SeraphEffect extends OneShotEffect {
         staticText = "put that card onto the battlefield under your control. Sacrifice it when you lose control of {this}";
     }
 
-    SeraphEffect(SeraphEffect effect) {
+    private SeraphEffect(final SeraphEffect effect) {
         super(effect);
     }
 
@@ -104,7 +104,7 @@ class SeraphDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.seraph = seraph;
     }
 
-    SeraphDelayedTriggeredAbility(SeraphDelayedTriggeredAbility ability) {
+    private SeraphDelayedTriggeredAbility(final SeraphDelayedTriggeredAbility ability) {
         super(ability);
         this.seraph = ability.seraph;
     }

--- a/Mage.Sets/src/mage/cards/s/SerraParagon.java
+++ b/Mage.Sets/src/mage/cards/s/SerraParagon.java
@@ -64,7 +64,7 @@ class SerraParagonPlayEffect extends AsThoughEffectImpl {
                 "\"When this permanent is put into a graveyard from the battlefield, exile it and you gain 2 life.\"";
     }
 
-    SerraParagonPlayEffect(final SerraParagonPlayEffect effect) {
+    private SerraParagonPlayEffect(final SerraParagonPlayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SerumPowder.java
+++ b/Mage.Sets/src/mage/cards/s/SerumPowder.java
@@ -51,7 +51,7 @@ class SerumPowderReplaceEffect extends ReplacementEffectImpl {
         staticText = "Any time you could mulligan and {this} is in your hand, you may exile all the cards from your hand, then draw that many cards";
     }
 
-    SerumPowderReplaceEffect(final SerumPowderReplaceEffect effect) {
+    private SerumPowderReplaceEffect(final SerumPowderReplaceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SettleTheWreckage.java
+++ b/Mage.Sets/src/mage/cards/s/SettleTheWreckage.java
@@ -49,7 +49,7 @@ class SettleTheWreckageEffect extends OneShotEffect {
         this.staticText = "Exile all attacking creatures target player controls. That player may search their library for that many basic land cards, put those cards onto the battlefield tapped, then shuffle";
     }
 
-    SettleTheWreckageEffect(final SettleTheWreckageEffect effect) {
+    private SettleTheWreckageEffect(final SettleTheWreckageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/ShamanEnKor.java
+++ b/Mage.Sets/src/mage/cards/s/ShamanEnKor.java
@@ -76,7 +76,7 @@ class ShamanEnKorRedirectFromTargetEffect extends RedirectionEffect {
         staticText = "The next time a source of your choice would deal damage to target creature this turn, that damage is dealt to {this} instead";
     }
 
-    ShamanEnKorRedirectFromTargetEffect(final ShamanEnKorRedirectFromTargetEffect effect) {
+    private ShamanEnKorRedirectFromTargetEffect(final ShamanEnKorRedirectFromTargetEffect effect) {
         super(effect);
         sourceObject = effect.sourceObject;
     }

--- a/Mage.Sets/src/mage/cards/s/SharedFate.java
+++ b/Mage.Sets/src/mage/cards/s/SharedFate.java
@@ -60,7 +60,7 @@ class SharedFateReplacementEffect extends ReplacementEffectImpl {
         this.staticText = "If a player would draw a card, that player exiles the top card of one of their opponents' libraries face down instead";
     }
 
-    SharedFateReplacementEffect(final SharedFateReplacementEffect effect) {
+    private SharedFateReplacementEffect(final SharedFateReplacementEffect effect) {
         super(effect);
     }
 
@@ -131,7 +131,7 @@ class SharedFatePlayEffect extends AsThoughEffectImpl {
         staticText = "Each player may look at and play cards they exiled with {this}";
     }
 
-    SharedFatePlayEffect(final SharedFatePlayEffect effect) {
+    private SharedFatePlayEffect(final SharedFatePlayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/ShieldOfTheAvatar.java
+++ b/Mage.Sets/src/mage/cards/s/ShieldOfTheAvatar.java
@@ -54,7 +54,7 @@ class ShieldOfTheAvatarPreventionEffect extends PreventionEffectImpl {
         this.staticText = "If a source would deal damage to equipped creature, prevent X of that damage, where X is the number of creatures you control.";
     }
 
-    ShieldOfTheAvatarPreventionEffect(final ShieldOfTheAvatarPreventionEffect effect) {
+    private ShieldOfTheAvatarPreventionEffect(final ShieldOfTheAvatarPreventionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/ShivanWumpus.java
+++ b/Mage.Sets/src/mage/cards/s/ShivanWumpus.java
@@ -55,7 +55,7 @@ class ShivanWumpusEffect extends PutOnLibrarySourceEffect {
         this.staticText = "any player may sacrifice a land. If a player does, put {this} on top of its owner's library";
     }
     
-    ShivanWumpusEffect(final ShivanWumpusEffect effect) {
+    private ShivanWumpusEffect(final ShivanWumpusEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/s/ShrivelingRot.java
+++ b/Mage.Sets/src/mage/cards/s/ShrivelingRot.java
@@ -60,7 +60,7 @@ class ShrivelingRotDestroyTriggeredAbility extends DelayedTriggeredAbility {
         super(new DestroyTargetEffect(), Duration.EndOfTurn, false);
     }
 
-    ShrivelingRotDestroyTriggeredAbility(final ShrivelingRotDestroyTriggeredAbility ability) {
+    private ShrivelingRotDestroyTriggeredAbility(final ShrivelingRotDestroyTriggeredAbility ability) {
         super(ability);
     }
 
@@ -96,7 +96,7 @@ class ShrivelingRotLoseLifeTriggeredAbility extends DelayedTriggeredAbility {
         super(new ShrivelingRotEffect(), Duration.EndOfTurn, false);
     }
 
-    ShrivelingRotLoseLifeTriggeredAbility(final ShrivelingRotLoseLifeTriggeredAbility ability) {
+    private ShrivelingRotLoseLifeTriggeredAbility(final ShrivelingRotLoseLifeTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/Shyft.java
+++ b/Mage.Sets/src/mage/cards/s/Shyft.java
@@ -52,7 +52,7 @@ class ShyftEffect extends OneShotEffect {
         this.staticText = "have {this} become the color or colors of your choice.";
     }
 
-    ShyftEffect(final ShyftEffect effect) {
+    private ShyftEffect(final ShyftEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SilentArbiter.java
+++ b/Mage.Sets/src/mage/cards/s/SilentArbiter.java
@@ -50,7 +50,7 @@ class SilentArbiterAttackRestrictionEffect extends RestrictionEffect {
         staticText = "No more than one creature can attack each combat";
     }
 
-    SilentArbiterAttackRestrictionEffect(final SilentArbiterAttackRestrictionEffect effect) {
+    private SilentArbiterAttackRestrictionEffect(final SilentArbiterAttackRestrictionEffect effect) {
         super(effect);
     }
 
@@ -77,7 +77,7 @@ class SilentArbiterBlockRestrictionEffect extends RestrictionEffect {
         staticText = "No more than one creature can block each combat";
     }
 
-    SilentArbiterBlockRestrictionEffect(final SilentArbiterBlockRestrictionEffect effect) {
+    private SilentArbiterBlockRestrictionEffect(final SilentArbiterBlockRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SirensCall.java
+++ b/Mage.Sets/src/mage/cards/s/SirensCall.java
@@ -62,7 +62,7 @@ class SirensCallMustAttackEffect extends RequirementEffect {
         staticText = "Creatures the active player controls attack this turn if able";
     }
 
-    SirensCallMustAttackEffect(final SirensCallMustAttackEffect effect) {
+    private SirensCallMustAttackEffect(final SirensCallMustAttackEffect effect) {
         super(effect);
     }
 
@@ -95,7 +95,7 @@ class SirensCallDestroyEffect extends OneShotEffect {
         this.staticText = "destroy all non-Wall creatures that player controls that didn't attack this turn. Ignore this effect for each creature the player didn't control continuously since the beginning of the turn";
     }
 
-    SirensCallDestroyEffect(final SirensCallDestroyEffect effect) {
+    private SirensCallDestroyEffect(final SirensCallDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SirensRuse.java
+++ b/Mage.Sets/src/mage/cards/s/SirensRuse.java
@@ -44,7 +44,7 @@ class SirensRuseEffect extends ExileTargetForSourceEffect {
         this.staticText = "Exile target creature you control, then return that card to the battlefield under its owner's control. If a Pirate was exiled this way, draw a card.";
     }
 
-    SirensRuseEffect(final SirensRuseEffect effect) {
+    private SirensRuseEffect(final SirensRuseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SithLord.java
+++ b/Mage.Sets/src/mage/cards/s/SithLord.java
@@ -53,7 +53,7 @@ public final class SithLord extends CardImpl {
             super(Outcome.BoostCreature);
         }
 
-        SithLordEffect(final SithLordEffect effect) {
+        private SithLordEffect(final SithLordEffect effect) {
             super(effect);
         }
 

--- a/Mage.Sets/src/mage/cards/s/SithMagic.java
+++ b/Mage.Sets/src/mage/cards/s/SithMagic.java
@@ -115,7 +115,7 @@ class SithMagicReplacementEffect extends ReplacementEffectImpl {
         staticText = "or if it would leave the battlefield";
     }
 
-    SithMagicReplacementEffect(final SithMagicReplacementEffect effect) {
+    private SithMagicReplacementEffect(final SithMagicReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SkeletonScavengers.java
+++ b/Mage.Sets/src/mage/cards/s/SkeletonScavengers.java
@@ -108,7 +108,7 @@ class SkeletonScavengersEffect extends OneShotEffect {
         this.staticText = "Regenerate {this}. When it regenerates this way, put a +1/+1 counter on it";
     }
 
-    SkeletonScavengersEffect(final SkeletonScavengersEffect effect) {
+    private SkeletonScavengersEffect(final SkeletonScavengersEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/Skullsnatcher.java
+++ b/Mage.Sets/src/mage/cards/s/Skullsnatcher.java
@@ -68,7 +68,7 @@ class SkullsnatcherTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever {this} deals combat damage to a player, ");
     }
 
-    SkullsnatcherTriggeredAbility(final SkullsnatcherTriggeredAbility ability) {
+    private SkullsnatcherTriggeredAbility(final SkullsnatcherTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SkyboonEvangelist.java
+++ b/Mage.Sets/src/mage/cards/s/SkyboonEvangelist.java
@@ -71,7 +71,7 @@ class SkyboonEvangelistTriggeredAbility extends AttacksAllTriggeredAbility {
         ).setText("that creature gains flying until end of turn"), false, filter, SetTargetPointer.PERMANENT, false);
     }
 
-    SkyboonEvangelistTriggeredAbility(final SkyboonEvangelistTriggeredAbility effect) {
+    private SkyboonEvangelistTriggeredAbility(final SkyboonEvangelistTriggeredAbility effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SludgeStrider.java
+++ b/Mage.Sets/src/mage/cards/s/SludgeStrider.java
@@ -112,7 +112,7 @@ class SludgeStriderEffect extends OneShotEffect {
         staticText = "target player loses 1 life and you gain 1 life";
     }
 
-    SludgeStriderEffect(final SludgeStriderEffect effect) {
+    private SludgeStriderEffect(final SludgeStriderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SnickeringSquirrel.java
+++ b/Mage.Sets/src/mage/cards/s/SnickeringSquirrel.java
@@ -48,7 +48,7 @@ class SnickeringSquirrelEffect extends ReplacementEffectImpl {
         staticText = "You may tap {this} to increase the result of a die any player rolled by 1";
     }
 
-    SnickeringSquirrelEffect(final SnickeringSquirrelEffect effect) {
+    private SnickeringSquirrelEffect(final SnickeringSquirrelEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SnowMercy.java
+++ b/Mage.Sets/src/mage/cards/s/SnowMercy.java
@@ -105,7 +105,7 @@ class SnowMercyCost extends CostImpl {
         this.text = "{t}, {q}, {t}, {q}, {t}";
     }
 
-    SnowMercyCost(final SnowMercyCost cost) {
+    private SnowMercyCost(final SnowMercyCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SolphimMayhemDominus.java
+++ b/Mage.Sets/src/mage/cards/s/SolphimMayhemDominus.java
@@ -64,7 +64,7 @@ class SolphimMayhemDominusEffect extends ReplacementEffectImpl {
                 "it deals double that damage to that player or permanent instead";
     }
 
-    SolphimMayhemDominusEffect(final SolphimMayhemDominusEffect effect) {
+    private SolphimMayhemDominusEffect(final SolphimMayhemDominusEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SoltariGuerrillas.java
+++ b/Mage.Sets/src/mage/cards/s/SoltariGuerrillas.java
@@ -61,7 +61,7 @@ class SoltariGuerrillasReplacementEffect extends PreventionEffectImpl {
         staticText = "The next time {this} would deal combat damage to an opponent this turn, it deals that damage to target creature instead";
     }
 
-    SoltariGuerrillasReplacementEffect(final SoltariGuerrillasReplacementEffect effect) {
+    private SoltariGuerrillasReplacementEffect(final SoltariGuerrillasReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SoltariVisionary.java
+++ b/Mage.Sets/src/mage/cards/s/SoltariVisionary.java
@@ -56,7 +56,7 @@ class SoltariVisionaryTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), false);
     }
 
-    SoltariVisionaryTriggeredAbility(final SoltariVisionaryTriggeredAbility ability) {
+    private SoltariVisionaryTriggeredAbility(final SoltariVisionaryTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SosukeSonOfSeshiro.java
+++ b/Mage.Sets/src/mage/cards/s/SosukeSonOfSeshiro.java
@@ -66,7 +66,7 @@ class SosukeSonOfSeshiroTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect);
     }
 
-    SosukeSonOfSeshiroTriggeredAbility(final SosukeSonOfSeshiroTriggeredAbility ability) {
+    private SosukeSonOfSeshiroTriggeredAbility(final SosukeSonOfSeshiroTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SoulBarrier.java
+++ b/Mage.Sets/src/mage/cards/s/SoulBarrier.java
@@ -48,7 +48,7 @@ class SoulBarrierEffect extends OneShotEffect {
         this.staticText = "{this} deals 2 damage to that player unless they pay {2}";
     }
 
-    SoulBarrierEffect(final SoulBarrierEffect effect) {
+    private SoulBarrierEffect(final SoulBarrierEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SoulEcho.java
+++ b/Mage.Sets/src/mage/cards/s/SoulEcho.java
@@ -98,7 +98,7 @@ class SoulEchoReplacementEffect extends ReplacementEffectImpl {
         super(Duration.UntilYourNextUpkeepStep, Outcome.PreventDamage);
     }
 
-    SoulEchoReplacementEffect(final SoulEchoReplacementEffect effect) {
+    private SoulEchoReplacementEffect(final SoulEchoReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SoulRansom.java
+++ b/Mage.Sets/src/mage/cards/s/SoulRansom.java
@@ -71,7 +71,7 @@ class SoulRansomEffect extends OneShotEffect {
         this.staticText = "{this}'s controller sacrifices it, then draws two cards. Only any opponent may activate this ability";
     }
 
-    SoulRansomEffect(final SoulRansomEffect effect) {
+    private SoulRansomEffect(final SoulRansomEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SoulRend.java
+++ b/Mage.Sets/src/mage/cards/s/SoulRend.java
@@ -48,7 +48,7 @@ class SoulRendEffect extends OneShotEffect {
         staticText = "destroy target creature if it's white. A creature destroyed this way can't be regenerated";
     }
 
-    SoulRendEffect(final SoulRendEffect effect) {
+    private SoulRendEffect(final SoulRendEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SoulbladeCorrupter.java
+++ b/Mage.Sets/src/mage/cards/s/SoulbladeCorrupter.java
@@ -64,7 +64,7 @@ class SoulbladeCorrupterTriggeredAbility extends AttacksAllTriggeredAbility {
         ).setText("that creature gains deathtouch until end of turn"), false, StaticFilters.FILTER_CREATURE_P1P1, SetTargetPointer.PERMANENT, false);
     }
 
-    SoulbladeCorrupterTriggeredAbility(final SoulbladeCorrupterTriggeredAbility effect) {
+    private SoulbladeCorrupterTriggeredAbility(final SoulbladeCorrupterTriggeredAbility effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SoulfireGrandMaster.java
+++ b/Mage.Sets/src/mage/cards/s/SoulfireGrandMaster.java
@@ -81,7 +81,7 @@ class SoulfireGrandMasterCastFromHandReplacementEffect extends ReplacementEffect
         this.staticText = "The next time you cast an instant or sorcery spell from your hand this turn, put that card into your hand instead of into your graveyard as it resolves";
     }
 
-    SoulfireGrandMasterCastFromHandReplacementEffect(SoulfireGrandMasterCastFromHandReplacementEffect effect) {
+    private SoulfireGrandMasterCastFromHandReplacementEffect(final SoulfireGrandMasterCastFromHandReplacementEffect effect) {
         super(effect);
         this.spellId = effect.spellId;
     }

--- a/Mage.Sets/src/mage/cards/s/Spellbinder.java
+++ b/Mage.Sets/src/mage/cards/s/Spellbinder.java
@@ -64,7 +64,7 @@ class SpellbinderTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SpellbinderCopyEffect(), true);
     }
 
-    SpellbinderTriggeredAbility(final SpellbinderTriggeredAbility ability) {
+    private SpellbinderTriggeredAbility(final SpellbinderTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/Spelljack.java
+++ b/Mage.Sets/src/mage/cards/s/Spelljack.java
@@ -48,7 +48,7 @@ class SpelljackEffect extends OneShotEffect {
         this.staticText = "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard. You may play it without paying its mana cost for as long as it remains exiled";
     }
 
-    SpelljackEffect(final SpelljackEffect effect) {
+    private SpelljackEffect(final SpelljackEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpelltitheEnforcer.java
+++ b/Mage.Sets/src/mage/cards/s/SpelltitheEnforcer.java
@@ -58,7 +58,7 @@ class SpelltitheEnforcerEffect extends SacrificeEffect {
         this.staticText = "that player sacrifices a permanent unless they pay {1}";
     }
 
-    SpelltitheEnforcerEffect(final SpelltitheEnforcerEffect effect) {
+    private SpelltitheEnforcerEffect(final SpelltitheEnforcerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpellweaverHelix.java
+++ b/Mage.Sets/src/mage/cards/s/SpellweaverHelix.java
@@ -66,7 +66,7 @@ class SpellweaverHelixImprintEffect extends OneShotEffect {
         this.staticText = "you may exile two target sorcery cards from a single graveyard";
     }
 
-    SpellweaverHelixImprintEffect(final SpellweaverHelixImprintEffect effect) {
+    private SpellweaverHelixImprintEffect(final SpellweaverHelixImprintEffect effect) {
         super(effect);
     }
 
@@ -101,7 +101,7 @@ class SpellweaverHelixTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new SpellweaverHelixCastEffect(), false);
     }
 
-    SpellweaverHelixTriggeredAbility(final SpellweaverHelixTriggeredAbility ability) {
+    private SpellweaverHelixTriggeredAbility(final SpellweaverHelixTriggeredAbility ability) {
         super(ability);
     }
 
@@ -161,7 +161,7 @@ class SpellweaverHelixCastEffect extends OneShotEffect {
         this.staticText = "you may copy the other. If you do, you may cast the copy without paying its mana cost";
     }
 
-    SpellweaverHelixCastEffect(final SpellweaverHelixCastEffect effect) {
+    private SpellweaverHelixCastEffect(final SpellweaverHelixCastEffect effect) {
         super(effect);
         this.spellName = effect.spellName;
     }

--- a/Mage.Sets/src/mage/cards/s/SphereOfSafety.java
+++ b/Mage.Sets/src/mage/cards/s/SphereOfSafety.java
@@ -56,7 +56,7 @@ class SphereOfSafetyPayManaToAttackAllEffect extends CantAttackYouUnlessPayAllEf
         staticText = "Creatures can't attack you or planeswalkers you control unless their controller pays {X} for each of those creatures, where X is the number of enchantments you control.";
     }
 
-    SphereOfSafetyPayManaToAttackAllEffect(SphereOfSafetyPayManaToAttackAllEffect effect) {
+    private SphereOfSafetyPayManaToAttackAllEffect(final SphereOfSafetyPayManaToAttackAllEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpikeCannibal.java
+++ b/Mage.Sets/src/mage/cards/s/SpikeCannibal.java
@@ -61,7 +61,7 @@ class SpikeCannibalEffect extends OneShotEffect {
         this.staticText = "move all +1/+1 counters from all creatures onto it";
     }
 
-    SpikeCannibalEffect(final SpikeCannibalEffect effect) {
+    private SpikeCannibalEffect(final SpikeCannibalEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpinningDarkness.java
+++ b/Mage.Sets/src/mage/cards/s/SpinningDarkness.java
@@ -63,7 +63,7 @@ class SpinningDarknessCost extends CostImpl {
         this.text = "exile the top three black cards of your graveyard";      
     }
 
-    SpinningDarknessCost(final SpinningDarknessCost cost) {
+    private SpinningDarknessCost(final SpinningDarknessCost cost) {
         super(cost);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SplendidReclamation.java
+++ b/Mage.Sets/src/mage/cards/s/SplendidReclamation.java
@@ -43,7 +43,7 @@ class ReplenishEffect extends OneShotEffect {
         this.staticText = "Return all land cards from your graveyard to the battlefield tapped";
     }
 
-    ReplenishEffect(final ReplenishEffect effect) {
+    private ReplenishEffect(final ReplenishEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SplinteringWind.java
+++ b/Mage.Sets/src/mage/cards/s/SplinteringWind.java
@@ -94,7 +94,7 @@ class SplinteringWindDelayedTriggeredAbility extends DelayedTriggeredAbility {
         this.tokenId = tokenId;
     }
 
-    SplinteringWindDelayedTriggeredAbility(final SplinteringWindDelayedTriggeredAbility ability) {
+    private SplinteringWindDelayedTriggeredAbility(final SplinteringWindDelayedTriggeredAbility ability) {
         super(ability);
         this.tokenId = ability.tokenId;
     }

--- a/Mage.Sets/src/mage/cards/s/SpreadingPlague.java
+++ b/Mage.Sets/src/mage/cards/s/SpreadingPlague.java
@@ -57,7 +57,7 @@ class SpreadingPlagueEffect extends OneShotEffect {
         staticText = "destroy all other creatures that share a color with it. They can't be regenerated";
     }
 
-    SpreadingPlagueEffect(final SpreadingPlagueEffect effect) {
+    private SpreadingPlagueEffect(final SpreadingPlagueEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SquealingDevil.java
+++ b/Mage.Sets/src/mage/cards/s/SquealingDevil.java
@@ -70,7 +70,7 @@ class SquealingDevilEffect extends OneShotEffect {
         staticText = "you may pay {X}. If you do, target creature gets +X/+0 until end of turn.";
     }
 
-    SquealingDevilEffect(final SquealingDevilEffect effect) {
+    private SquealingDevilEffect(final SquealingDevilEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SquirrelPoweredScheme.java
+++ b/Mage.Sets/src/mage/cards/s/SquirrelPoweredScheme.java
@@ -41,7 +41,7 @@ class SquirrelPoweredSchemeEffect extends ReplacementEffectImpl {
         staticText = "Increase the result of each die you roll by 2";
     }
 
-    SquirrelPoweredSchemeEffect(final SquirrelPoweredSchemeEffect effect) {
+    private SquirrelPoweredSchemeEffect(final SquirrelPoweredSchemeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/StadiumVendors.java
+++ b/Mage.Sets/src/mage/cards/s/StadiumVendors.java
@@ -53,7 +53,7 @@ class StadiumVendorsEffect extends OneShotEffect {
         this.staticText = "choose a player. That player adds two mana of any one color they choose";
     }
 
-    StadiumVendorsEffect(final StadiumVendorsEffect effect) {
+    private StadiumVendorsEffect(final StadiumVendorsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/StalkingYeti.java
+++ b/Mage.Sets/src/mage/cards/s/StalkingYeti.java
@@ -69,7 +69,7 @@ class StalkingYetiEffect extends OneShotEffect {
                 + "and that creature deals damage equal to its power to {this}";
     }
 
-    StalkingYetiEffect(final StalkingYetiEffect effect) {
+    private StalkingYetiEffect(final StalkingYetiEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/Statecraft.java
+++ b/Mage.Sets/src/mage/cards/s/Statecraft.java
@@ -48,7 +48,7 @@ class StatecraftPreventionEffect extends PreventionEffectImpl {
         this.staticText = "Prevent all combat damage that would be dealt to and dealt by creatures you control";
     }
 
-    StatecraftPreventionEffect(final StatecraftPreventionEffect effect) {
+    private StatecraftPreventionEffect(final StatecraftPreventionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SternJudge.java
+++ b/Mage.Sets/src/mage/cards/s/SternJudge.java
@@ -53,7 +53,7 @@ class SternJudgeEffect extends OneShotEffect {
         this.staticText = "Each player loses 1 life for each Swamp they control.";
     }
 
-    SternJudgeEffect(final SternJudgeEffect effect) {
+    private SternJudgeEffect(final SternJudgeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/StompingSlabs.java
+++ b/Mage.Sets/src/mage/cards/s/StompingSlabs.java
@@ -49,7 +49,7 @@ class StompingSlabsEffect extends OneShotEffect {
         this.staticText = "Reveal the top seven cards of your library, then put those cards on the bottom of your library in any order. If a card named Stomping Slabs was revealed this way, {this} deals 7 damage to any target";
     }
     
-    StompingSlabsEffect(final StompingSlabsEffect effect) {
+    private StompingSlabsEffect(final StompingSlabsEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/s/StormHerald.java
+++ b/Mage.Sets/src/mage/cards/s/StormHerald.java
@@ -144,7 +144,7 @@ class StormHeraldReplacementEffect extends ReplacementEffectImpl {
         staticText = "If those Auras would leave the battlefield, exile them instead of putting them anywhere else";
     }
 
-    StormHeraldReplacementEffect(final StormHeraldReplacementEffect effect) {
+    private StormHeraldReplacementEffect(final StormHeraldReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/Storyweave.java
+++ b/Mage.Sets/src/mage/cards/s/Storyweave.java
@@ -75,7 +75,7 @@ class StoryweaveReplacementEffect extends ReplacementEffectImpl {
                 "under your control this turn, each enters with two additional +1/+1 counters on it";
     }
 
-    StoryweaveReplacementEffect(StoryweaveReplacementEffect effect) {
+    private StoryweaveReplacementEffect(final StoryweaveReplacementEffect effect) {
         super(effect);
         this.counter = effect.counter;
     }

--- a/Mage.Sets/src/mage/cards/s/StrataScythe.java
+++ b/Mage.Sets/src/mage/cards/s/StrataScythe.java
@@ -61,7 +61,7 @@ class StrataScytheImprintEffect extends OneShotEffect {
         staticText = "search your library for a land card, exile it, then shuffle";
     }
 
-    StrataScytheImprintEffect(final StrataScytheImprintEffect effect) {
+    private StrataScytheImprintEffect(final StrataScytheImprintEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/StriderRangerOfTheNorth.java
+++ b/Mage.Sets/src/mage/cards/s/StriderRangerOfTheNorth.java
@@ -65,7 +65,7 @@ class StriderRangerOfTheNorthEffect extends OneShotEffect {
                 "or greater, it gains first strike until end of turn.";
     }
 
-    StriderRangerOfTheNorthEffect(final StriderRangerOfTheNorthEffect effect) {
+    private StriderRangerOfTheNorthEffect(final StriderRangerOfTheNorthEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/StrongarmTactics.java
+++ b/Mage.Sets/src/mage/cards/s/StrongarmTactics.java
@@ -49,7 +49,7 @@ class StrongarmTacticsEffect extends OneShotEffect {
         this.staticText = "Each player discards a card. Then each player who didn't discard a creature card this way loses 4 life.";
     }
 
-    StrongarmTacticsEffect(final StrongarmTacticsEffect effect) {
+    private StrongarmTacticsEffect(final StrongarmTacticsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/StrongholdDiscipline.java
+++ b/Mage.Sets/src/mage/cards/s/StrongholdDiscipline.java
@@ -42,7 +42,7 @@ class StrongholdDisciplineEffect extends OneShotEffect {
         this.staticText = "Each player loses 1 life for each creature they control";
     }
 
-    StrongholdDisciplineEffect(final StrongholdDisciplineEffect effect) {
+    private StrongholdDisciplineEffect(final StrongholdDisciplineEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SuppressionField.java
+++ b/Mage.Sets/src/mage/cards/s/SuppressionField.java
@@ -46,7 +46,7 @@ class SuppressionFieldCostReductionEffect extends CostModificationEffectImpl {
         staticText = "Activated abilities cost {2} more to activate unless they're mana abilities";
     }
 
-    SuppressionFieldCostReductionEffect(SuppressionFieldCostReductionEffect effect) {
+    private SuppressionFieldCostReductionEffect(final SuppressionFieldCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SurvivalCache.java
+++ b/Mage.Sets/src/mage/cards/s/SurvivalCache.java
@@ -45,7 +45,7 @@ class SurvivalCacheEffect extends OneShotEffect {
         staticText = "Then if you have more life than an opponent, draw a card";
     }
 
-    SurvivalCacheEffect(final SurvivalCacheEffect effect) {
+    private SurvivalCacheEffect(final SurvivalCacheEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SuturePriest.java
+++ b/Mage.Sets/src/mage/cards/s/SuturePriest.java
@@ -59,7 +59,7 @@ class SuturePriestSecondTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), true);
     }
 
-    SuturePriestSecondTriggeredAbility(final SuturePriestSecondTriggeredAbility ability) {
+    private SuturePriestSecondTriggeredAbility(final SuturePriestSecondTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SwansOfBrynArgoll.java
+++ b/Mage.Sets/src/mage/cards/s/SwansOfBrynArgoll.java
@@ -63,7 +63,7 @@ class SwansOfBrynArgollEffect extends PreventionEffectImpl {
         staticText = "If a source would deal damage to {this}, prevent that damage. The source's controller draws cards equal to the damage prevented this way";
     }
 
-    SwansOfBrynArgollEffect(final SwansOfBrynArgollEffect effect) {
+    private SwansOfBrynArgollEffect(final SwansOfBrynArgollEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SwiftWarkite.java
+++ b/Mage.Sets/src/mage/cards/s/SwiftWarkite.java
@@ -74,7 +74,7 @@ class SwiftWarkiteEffect extends OneShotEffect {
         this.staticText = "that creature gains haste. Return it to your hand at the beginning of the next end step";
     }
 
-    SwiftWarkiteEffect(final SwiftWarkiteEffect effect) {
+    private SwiftWarkiteEffect(final SwiftWarkiteEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SwordOfWarAndPeace.java
+++ b/Mage.Sets/src/mage/cards/s/SwordOfWarAndPeace.java
@@ -103,7 +103,7 @@ class SwordOfWarAndPeaceDamageEffect extends OneShotEffect {
         staticText = "{this} deals damage to that player equal to the number of cards in their hand";
     }
 
-    SwordOfWarAndPeaceDamageEffect(final SwordOfWarAndPeaceDamageEffect effect) {
+    private SwordOfWarAndPeaceDamageEffect(final SwordOfWarAndPeaceDamageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SwordPointDiplomacy.java
+++ b/Mage.Sets/src/mage/cards/s/SwordPointDiplomacy.java
@@ -49,7 +49,7 @@ class SwordPointDiplomacyEffect extends OneShotEffect {
         this.staticText = "Reveal the top three cards of your library. For each of those cards, put that card into your hand unless any opponent pays 3 life. Then exile the rest.";
     }
 
-    SwordPointDiplomacyEffect(final SwordPointDiplomacyEffect effect) {
+    private SwordPointDiplomacyEffect(final SwordPointDiplomacyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SylvanOffering.java
+++ b/Mage.Sets/src/mage/cards/s/SylvanOffering.java
@@ -49,7 +49,7 @@ class SylvanOfferingEffect1 extends OneShotEffect {
         this.staticText = "Choose an opponent. You and that player each create an X/X green Treefolk creature token";
     }
 
-    SylvanOfferingEffect1(final SylvanOfferingEffect1 effect) {
+    private SylvanOfferingEffect1(final SylvanOfferingEffect1 effect) {
         super(effect);
     }
 
@@ -86,7 +86,7 @@ class SylvanOfferingEffect2 extends OneShotEffect {
         this.staticText = "<br>Choose an opponent. You and that player each create X 1/1 green Elf Warrior creature tokens";
     }
 
-    SylvanOfferingEffect2(final SylvanOfferingEffect2 effect) {
+    private SylvanOfferingEffect2(final SylvanOfferingEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SynodSanctum.java
+++ b/Mage.Sets/src/mage/cards/s/SynodSanctum.java
@@ -71,7 +71,7 @@ class SynodSanctumEffect extends OneShotEffect {
         staticText = "Exile target permanent you control";
     }
 
-    SynodSanctumEffect(SynodSanctumEffect effect) {
+    private SynodSanctumEffect(final SynodSanctumEffect effect) {
         super(effect);
     }
 
@@ -107,7 +107,7 @@ class SynodSanctumEffect2 extends OneShotEffect {
         staticText = "Return all cards exiled with {this} to the battlefield under your control";
     }
 
-    SynodSanctumEffect2(SynodSanctumEffect2 effect) {
+    private SynodSanctumEffect2(final SynodSanctumEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SyrixCarrierOfTheFlame.java
+++ b/Mage.Sets/src/mage/cards/s/SyrixCarrierOfTheFlame.java
@@ -97,7 +97,7 @@ class SyrixCarrierOfTheFlameCastEffect extends OneShotEffect {
         this.staticText = "you may cast {this} from your graveyard";
     }
 
-    SyrixCarrierOfTheFlameCastEffect(final SyrixCarrierOfTheFlameCastEffect effect) {
+    private SyrixCarrierOfTheFlameCastEffect(final SyrixCarrierOfTheFlameCastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SzadekLordOfSecrets.java
+++ b/Mage.Sets/src/mage/cards/s/SzadekLordOfSecrets.java
@@ -57,7 +57,7 @@ class SzadekLordOfSecretsEffect extends ReplacementEffectImpl {
         staticText = "If {this} would deal combat damage to a player, instead put that many +1/+1 counters on {this} and that player mills that many cards";
     }
 
-    SzadekLordOfSecretsEffect(final SzadekLordOfSecretsEffect effect) {
+    private SzadekLordOfSecretsEffect(final SzadekLordOfSecretsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TIEInterceptor.java
+++ b/Mage.Sets/src/mage/cards/t/TIEInterceptor.java
@@ -51,7 +51,7 @@ class TIEInterceptorEffect extends OneShotEffect {
         staticText = "each opponent loses 2 life";
     }
 
-    TIEInterceptorEffect(final TIEInterceptorEffect effect) {
+    private TIEInterceptorEffect(final TIEInterceptorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TajNarSwordsmith.java
+++ b/Mage.Sets/src/mage/cards/t/TajNarSwordsmith.java
@@ -53,7 +53,7 @@ class TajNarSwordsmithEffect extends OneShotEffect {
         this.staticText = "you may pay {X}. If you do, search your library for an Equipment card with mana value X or less, put that card onto the battlefield, then shuffle";
     }
 
-    TajNarSwordsmithEffect(final TajNarSwordsmithEffect effect) {
+    private TajNarSwordsmithEffect(final TajNarSwordsmithEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TalusPaladin.java
+++ b/Mage.Sets/src/mage/cards/t/TalusPaladin.java
@@ -61,7 +61,7 @@ class TalusPaladinTriggeredAbility extends TriggeredAbilityImpl {
         this.addEffect(new TalusPaladinEffect());
     }
     
-    TalusPaladinTriggeredAbility(final TalusPaladinTriggeredAbility ability) {
+    private TalusPaladinTriggeredAbility(final TalusPaladinTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/t/TangleWire.java
+++ b/Mage.Sets/src/mage/cards/t/TangleWire.java
@@ -62,7 +62,7 @@ class TangleWireEffect extends OneShotEffect {
         staticText = "that player taps an untapped artifact, creature, or land they control for each fade counter on Tangle Wire";
     }
 
-    TangleWireEffect(final TangleWireEffect effect) {
+    private TangleWireEffect(final TangleWireEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Taunt.java
+++ b/Mage.Sets/src/mage/cards/t/Taunt.java
@@ -43,7 +43,7 @@ class TauntEffect extends RequirementEffect {
         staticText = "During target player's next turn, creatures that player controls attack you if able";
     }
 
-    TauntEffect(final TauntEffect effect) {
+    private TauntEffect(final TauntEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TeferiMageOfZhalfir.java
+++ b/Mage.Sets/src/mage/cards/t/TeferiMageOfZhalfir.java
@@ -117,7 +117,7 @@ class TeferiMageOfZhalfirReplacementEffect extends ContinuousRuleModifyingEffect
         staticText = "Each opponent can cast spells only any time they could cast a sorcery";
     }
 
-    TeferiMageOfZhalfirReplacementEffect(final TeferiMageOfZhalfirReplacementEffect effect) {
+    private TeferiMageOfZhalfirReplacementEffect(final TeferiMageOfZhalfirReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TeferisMoat.java
+++ b/Mage.Sets/src/mage/cards/t/TeferisMoat.java
@@ -50,7 +50,7 @@ class TeferisMoatRestrictionEffect extends RestrictionEffect {
         staticText = "Creatures of the chosen color without flying can't attack you";
     }
 
-    TeferisMoatRestrictionEffect(final TeferisMoatRestrictionEffect effect) {
+    private TeferisMoatRestrictionEffect(final TeferisMoatRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TempOfTheDamned.java
+++ b/Mage.Sets/src/mage/cards/t/TempOfTheDamned.java
@@ -81,7 +81,7 @@ class TempOfTheDamnedUpkeepEffect extends OneShotEffect {
         staticText = "remove a funk counter from {this}. If you can't, sacrifice it";
     }
 
-    TempOfTheDamnedUpkeepEffect(final TempOfTheDamnedUpkeepEffect effect) {
+    private TempOfTheDamnedUpkeepEffect(final TempOfTheDamnedUpkeepEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemporaryTruce.java
+++ b/Mage.Sets/src/mage/cards/t/TemporaryTruce.java
@@ -41,7 +41,7 @@ class TemporaryTruceEffect extends OneShotEffect {
         this.staticText = "Each player may draw up to two cards. For each card less than two a player draws this way, that player gains 2 life";
     }
 
-    TemporaryTruceEffect(final TemporaryTruceEffect effect) {
+    private TemporaryTruceEffect(final TemporaryTruceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TenuousTruce.java
+++ b/Mage.Sets/src/mage/cards/t/TenuousTruce.java
@@ -68,7 +68,7 @@ class TenuousTruceAttackTriggeredAbility extends TriggeredAbilityImpl {
                 "or when they attack you or a planeswalker you control, ");
     }
 
-    TenuousTruceAttackTriggeredAbility(final TenuousTruceAttackTriggeredAbility ability) {
+    private TenuousTruceAttackTriggeredAbility(final TenuousTruceAttackTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TerritorialGorger.java
+++ b/Mage.Sets/src/mage/cards/t/TerritorialGorger.java
@@ -52,7 +52,7 @@ class TerritorialGorgerTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you get one or more {E} <i>(energy counters)</i>, ");
     }
 
-    TerritorialGorgerTriggeredAbility(final TerritorialGorgerTriggeredAbility ability) {
+    private TerritorialGorgerTriggeredAbility(final TerritorialGorgerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThadaAdelAcquisitor.java
+++ b/Mage.Sets/src/mage/cards/t/ThadaAdelAcquisitor.java
@@ -57,7 +57,7 @@ class ThadaAdelAcquisitorEffect extends OneShotEffect {
         staticText = "search that player's library for an artifact card and exile it. Then that player shuffles. Until end of turn, you may play that card";
     }
 
-    ThadaAdelAcquisitorEffect(final ThadaAdelAcquisitorEffect effect) {
+    private ThadaAdelAcquisitorEffect(final ThadaAdelAcquisitorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheAbyss.java
+++ b/Mage.Sets/src/mage/cards/t/TheAbyss.java
@@ -48,7 +48,7 @@ class TheAbyssTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(true), false);
     }
 
-    TheAbyssTriggeredAbility(final TheAbyssTriggeredAbility ability) {
+    private TheAbyssTriggeredAbility(final TheAbyssTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheBattleOfEndor.java
+++ b/Mage.Sets/src/mage/cards/t/TheBattleOfEndor.java
@@ -64,7 +64,7 @@ class TheBattleOfEndorEffect extends OneShotEffect {
         staticText = "Put X +1/+1 counters on each creature you control";
     }
 
-    TheBattleOfEndorEffect(TheBattleOfEndorEffect effect) {
+    private TheBattleOfEndorEffect(final TheBattleOfEndorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheBigIdea.java
+++ b/Mage.Sets/src/mage/cards/t/TheBigIdea.java
@@ -68,7 +68,7 @@ class TheBigIdeaReplacementEffect extends ReplacementEffectImpl {
         staticText = "The next time you would roll a six-sided die, instead roll two six-sided dice and use the total of those results";
     }
 
-    TheBigIdeaReplacementEffect(final TheBigIdeaReplacementEffect effect) {
+    private TheBigIdeaReplacementEffect(final TheBigIdeaReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheEternalWanderer.java
+++ b/Mage.Sets/src/mage/cards/t/TheEternalWanderer.java
@@ -185,7 +185,7 @@ class TheEternalWandererAttackRestrictionEffect extends RestrictionEffect {
                      " The Eternal Wanderer each combat";
     }
 
-    TheEternalWandererAttackRestrictionEffect(final TheEternalWandererAttackRestrictionEffect effect) {
+    private TheEternalWandererAttackRestrictionEffect(final TheEternalWandererAttackRestrictionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheFirstEruption.java
+++ b/Mage.Sets/src/mage/cards/t/TheFirstEruption.java
@@ -80,7 +80,7 @@ class TheFirstEruptionEffect extends OneShotEffect {
         this.staticText = "Sacrifice a Mountain. If you do, {this} deals 3 damage to each creature";
     }
 
-    TheFirstEruptionEffect(final TheFirstEruptionEffect effect) {
+    private TheFirstEruptionEffect(final TheFirstEruptionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheFirstTyrannicWar.java
+++ b/Mage.Sets/src/mage/cards/t/TheFirstTyrannicWar.java
@@ -104,7 +104,7 @@ class TheFirstTyrannicWarReplacementEffect extends ReplacementEffectImpl {
         super(Duration.EndOfStep, Outcome.BoostCreature);
     }
 
-    TheFirstTyrannicWarReplacementEffect(TheFirstTyrannicWarReplacementEffect effect) {
+    private TheFirstTyrannicWarReplacementEffect(final TheFirstTyrannicWarReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheLocustGod.java
+++ b/Mage.Sets/src/mage/cards/t/TheLocustGod.java
@@ -74,7 +74,7 @@ class TheLocustGodEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    TheLocustGodEffect(TheLocustGodEffect effect) {
+    private TheLocustGodEffect(final TheLocustGodEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheMendingOfDominaria.java
+++ b/Mage.Sets/src/mage/cards/t/TheMendingOfDominaria.java
@@ -96,7 +96,7 @@ class TheMendingOfDominariaSecondEffect extends OneShotEffect {
         this.staticText = "Return all land cards from your graveyard to the battlefield, then shuffle your graveyard into your library";
     }
 
-    TheMendingOfDominariaSecondEffect(final TheMendingOfDominariaSecondEffect effect) {
+    private TheMendingOfDominariaSecondEffect(final TheMendingOfDominariaSecondEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheMimeoplasm.java
+++ b/Mage.Sets/src/mage/cards/t/TheMimeoplasm.java
@@ -53,7 +53,7 @@ class TheMimeoplasmEffect extends OneShotEffect {
         super(Outcome.Copy);
     }
 
-    TheMimeoplasmEffect(final TheMimeoplasmEffect effect) {
+    private TheMimeoplasmEffect(final TheMimeoplasmEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheScarabGod.java
+++ b/Mage.Sets/src/mage/cards/t/TheScarabGod.java
@@ -161,7 +161,7 @@ class TheScarabGodEffect3 extends OneShotEffect {
         staticText = effectText;
     }
 
-    TheScarabGodEffect3(TheScarabGodEffect3 effect) {
+    private TheScarabGodEffect3(final TheScarabGodEffect3 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheScorpionGod.java
+++ b/Mage.Sets/src/mage/cards/t/TheScorpionGod.java
@@ -116,7 +116,7 @@ class TheScorpionGodEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    TheScorpionGodEffect(TheScorpionGodEffect effect) {
+    private TheScorpionGodEffect(final TheScorpionGodEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThelonOfHavenwood.java
+++ b/Mage.Sets/src/mage/cards/t/ThelonOfHavenwood.java
@@ -73,7 +73,7 @@ class ThelonOfHavenwoodBoostEffect extends ContinuousEffectImpl {
         staticText = "Each Fungus creature gets +1/+1 for each spore counter on it";
     }
 
-    ThelonOfHavenwoodBoostEffect(final ThelonOfHavenwoodBoostEffect effect) {
+    private ThelonOfHavenwoodBoostEffect(final ThelonOfHavenwoodBoostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThelonsCurse.java
+++ b/Mage.Sets/src/mage/cards/t/ThelonsCurse.java
@@ -73,7 +73,7 @@ class ThelonsCurseEffect extends OneShotEffect {
         staticText = "that player may choose any number of tapped blue creatures they control and pay {U} for each creature chosen this way. If the player does, untap those creatures.";
     }
 
-    ThelonsCurseEffect(ThelonsCurseEffect effect) {
+    private ThelonsCurseEffect(final ThelonsCurseEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThoughtLash.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtLash.java
@@ -57,7 +57,7 @@ class ThoughtLashTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new ThoughtLashExileLibraryEffect(), false);
     }
 
-    ThoughtLashTriggeredAbility(final ThoughtLashTriggeredAbility ability) {
+    private ThoughtLashTriggeredAbility(final ThoughtLashTriggeredAbility ability) {
         super(ability);
     }
 
@@ -89,7 +89,7 @@ class ThoughtLashExileLibraryEffect extends OneShotEffect {
         this.staticText = "that player exiles all cards from their library";
     }
 
-    ThoughtLashExileLibraryEffect(final ThoughtLashExileLibraryEffect effect) {
+    private ThoughtLashExileLibraryEffect(final ThoughtLashExileLibraryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThoughtpickerWitch.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtpickerWitch.java
@@ -64,7 +64,7 @@ class ThoughtpickerWitchEffect extends OneShotEffect {
         this.staticText = "Look at the top two cards of target opponent's library, then exile one of them";
     }
 
-    ThoughtpickerWitchEffect(final ThoughtpickerWitchEffect effect) {
+    private ThoughtpickerWitchEffect(final ThoughtpickerWitchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThranFoundry.java
+++ b/Mage.Sets/src/mage/cards/t/ThranFoundry.java
@@ -52,7 +52,7 @@ class ThranFoundryEffect extends OneShotEffect {
         this.staticText = "Target player shuffles their graveyard into their library";
     }
     
-    ThranFoundryEffect(final ThranFoundryEffect effect) {
+    private ThranFoundryEffect(final ThranFoundryEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/t/ThreeWishes.java
+++ b/Mage.Sets/src/mage/cards/t/ThreeWishes.java
@@ -166,7 +166,7 @@ class ThreeWishesPlayFromExileEffect extends AsThoughEffectImpl {
         staticText = "Until your next turn, you may play those cards";
     }
 
-    ThreeWishesPlayFromExileEffect(final ThreeWishesPlayFromExileEffect effect) {
+    private ThreeWishesPlayFromExileEffect(final ThreeWishesPlayFromExileEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThroatSlitter.java
+++ b/Mage.Sets/src/mage/cards/t/ThroatSlitter.java
@@ -60,7 +60,7 @@ class ThroatSlitterTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DestroyTargetEffect(), false);
     }
 
-    ThroatSlitterTriggeredAbility(final ThroatSlitterTriggeredAbility ability) {
+    private ThroatSlitterTriggeredAbility(final ThroatSlitterTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TianaShipsCaretaker.java
+++ b/Mage.Sets/src/mage/cards/t/TianaShipsCaretaker.java
@@ -67,7 +67,7 @@ class TianaShipsCaretakerTriggeredAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever an Aura or Equipment you control is put into a graveyard from the battlefield, ");
     }
 
-    TianaShipsCaretakerTriggeredAbility(final TianaShipsCaretakerTriggeredAbility ability) {
+    private TianaShipsCaretakerTriggeredAbility(final TianaShipsCaretakerTriggeredAbility ability) {
         super(ability);
     }
 
@@ -107,7 +107,7 @@ class TianaShipsCaretakerEffect extends OneShotEffect {
         this.staticText = "you may return that card to its owner's hand at the beginning of the next end step";
     }
 
-    TianaShipsCaretakerEffect(final TianaShipsCaretakerEffect effect) {
+    private TianaShipsCaretakerEffect(final TianaShipsCaretakerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TimeVault.java
+++ b/Mage.Sets/src/mage/cards/t/TimeVault.java
@@ -62,7 +62,7 @@ class TimeVaultReplacementEffect extends ReplacementEffectImpl {
         staticText = "If you would begin your turn while {this} is tapped, you may skip that turn instead. If you do, untap Time Vault.";        
     }
     
-    TimeVaultReplacementEffect(final TimeVaultReplacementEffect effect) {
+    private TimeVaultReplacementEffect(final TimeVaultReplacementEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/t/Timecrafting.java
+++ b/Mage.Sets/src/mage/cards/t/Timecrafting.java
@@ -58,7 +58,7 @@ class TimecraftingRemoveEffect extends OneShotEffect {
         this.staticText = "Remove X time counters from target permanent or suspended card";
     }
 
-    TimecraftingRemoveEffect(final TimecraftingRemoveEffect effect) {
+    private TimecraftingRemoveEffect(final TimecraftingRemoveEffect effect) {
         super(effect);
     }
 
@@ -95,7 +95,7 @@ class TimecraftingAddEffect extends OneShotEffect {
         this.staticText = "Put X time counters on target permanent with a time counter on it or suspended card";
     }
 
-    TimecraftingAddEffect(final TimecraftingAddEffect effect) {
+    private TimecraftingAddEffect(final TimecraftingAddEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Timesifter.java
+++ b/Mage.Sets/src/mage/cards/t/Timesifter.java
@@ -49,7 +49,7 @@ class TimesifterEffect extends OneShotEffect {
         this.staticText = "each player exiles the top card of their library. The player who exiled the card with the highest mana value takes an extra turn after this one. If two or more players' cards are tied for highest, the tied players repeat this process until the tie is broken";
     }
 
-    TimesifterEffect(final TimesifterEffect effect) {
+    private TimesifterEffect(final TimesifterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Tithe.java
+++ b/Mage.Sets/src/mage/cards/t/Tithe.java
@@ -52,7 +52,7 @@ class TitheEffect extends OneShotEffect {
         this.staticText = "Search your library for a Plains card. If target opponent controls more lands than you, you may search your library for an additional Plains card. Reveal those cards, put them into your hand, then shuffle";
     }
 
-    TitheEffect(final TitheEffect effect) {
+    private TitheEffect(final TitheEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TombstoneStairwell.java
+++ b/Mage.Sets/src/mage/cards/t/TombstoneStairwell.java
@@ -65,7 +65,7 @@ class TombstoneStairwellCreateTokenEffect extends OneShotEffect {
         this.staticText = "if {this} is on the battlefield, each player creates a 2/2 black Zombie creature token with haste named Tombspawn for each creature card in their graveyard";
     }
 
-    TombstoneStairwellCreateTokenEffect(final TombstoneStairwellCreateTokenEffect effect) {
+    private TombstoneStairwellCreateTokenEffect(final TombstoneStairwellCreateTokenEffect effect) {
         super(effect);
     }
 
@@ -110,7 +110,7 @@ class TombstoneStairwellTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new TombstoneStairwellDestroyEffect(), false);
     }
 
-    TombstoneStairwellTriggeredAbility(TombstoneStairwellTriggeredAbility ability) {
+    private TombstoneStairwellTriggeredAbility(final TombstoneStairwellTriggeredAbility ability) {
         super(ability);
     }
 
@@ -170,7 +170,7 @@ class TombstoneStairwellDestroyEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    TombstoneStairwellDestroyEffect(final TombstoneStairwellDestroyEffect effect) {
+    private TombstoneStairwellDestroyEffect(final TombstoneStairwellDestroyEffect effect) {
         super(effect);
         this.cardZoneString = effect.cardZoneString;
     }

--- a/Mage.Sets/src/mage/cards/t/TomorrowAzamisFamiliar.java
+++ b/Mage.Sets/src/mage/cards/t/TomorrowAzamisFamiliar.java
@@ -47,7 +47,7 @@ class TomorrowAzamisFamiliarReplacementEffect extends ReplacementEffectImpl {
         staticText = "If you would draw a card, look at the top three cards of your library instead. Put one of those cards into your hand and the rest on the bottom of your library in any order";
     }
 
-    TomorrowAzamisFamiliarReplacementEffect(final TomorrowAzamisFamiliarReplacementEffect effect) {
+    private TomorrowAzamisFamiliarReplacementEffect(final TomorrowAzamisFamiliarReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TorWaukiTheYounger.java
+++ b/Mage.Sets/src/mage/cards/t/TorWaukiTheYounger.java
@@ -70,7 +70,7 @@ class TorWaukiTheYoungerEffect extends ReplacementEffectImpl {
                 "it deals that much damage plus 1 to that permanent or player instead";
     }
 
-    TorWaukiTheYoungerEffect(final TorWaukiTheYoungerEffect effect) {
+    private TorWaukiTheYoungerEffect(final TorWaukiTheYoungerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TorporOrb.java
+++ b/Mage.Sets/src/mage/cards/t/TorporOrb.java
@@ -49,7 +49,7 @@ class TorporOrbEffect extends ContinuousRuleModifyingEffectImpl {
         staticText = "Creatures entering the battlefield don't cause abilities to trigger";
     }
 
-    TorporOrbEffect(final TorporOrbEffect effect) {
+    private TorporOrbEffect(final TorporOrbEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TotalWar.java
+++ b/Mage.Sets/src/mage/cards/t/TotalWar.java
@@ -75,7 +75,7 @@ class TotalWarDestroyEffect extends OneShotEffect {
         this.staticText = "destroy all untapped non-Wall creatures that player controls that didn't attack, except for creatures the player hasn't controlled continuously since the beginning of the turn";
     }
 
-    TotalWarDestroyEffect(final TotalWarDestroyEffect effect) {
+    private TotalWarDestroyEffect(final TotalWarDestroyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TourachsGate.java
+++ b/Mage.Sets/src/mage/cards/t/TourachsGate.java
@@ -105,7 +105,7 @@ class TourachsGateUpkeepEffect extends OneShotEffect {
         staticText = "remove a time counter from {this}. If there are no time counters on {this}, sacrifice it";
     }
 
-    TourachsGateUpkeepEffect(final TourachsGateUpkeepEffect effect) {
+    private TourachsGateUpkeepEffect(final TourachsGateUpkeepEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ToxicStench.java
+++ b/Mage.Sets/src/mage/cards/t/ToxicStench.java
@@ -60,7 +60,7 @@ class ToxicStenchEffect extends OneShotEffect {
         super(Outcome.UnboostCreature);
     }
 
-    ToxicStenchEffect(final ToxicStenchEffect effect) {
+    private ToxicStenchEffect(final ToxicStenchEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Transcendence.java
+++ b/Mage.Sets/src/mage/cards/t/Transcendence.java
@@ -56,7 +56,7 @@ class TranscendenceStateTriggeredAbility extends StateTriggeredAbility {
         super(Zone.BATTLEFIELD, new LoseGameSourceControllerEffect());
     }
 
-    TranscendenceStateTriggeredAbility(final TranscendenceStateTriggeredAbility ability) {
+    private TranscendenceStateTriggeredAbility(final TranscendenceStateTriggeredAbility ability) {
         super(ability);
     }
 
@@ -86,7 +86,7 @@ class TranscendenceLoseLifeTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new TranscendenceLoseLifeEffect(), false);
     }
 
-    TranscendenceLoseLifeTriggeredAbility(final TranscendenceLoseLifeTriggeredAbility ability) {
+    private TranscendenceLoseLifeTriggeredAbility(final TranscendenceLoseLifeTriggeredAbility ability) {
         super(ability);
     }
 
@@ -128,7 +128,7 @@ class TranscendenceLoseLifeEffect extends OneShotEffect {
         this.staticText = "you gain 2 life for each 1 life you lost";
     }
 
-    TranscendenceLoseLifeEffect(final TranscendenceLoseLifeEffect effect) {
+    private TranscendenceLoseLifeEffect(final TranscendenceLoseLifeEffect effect) {
         super(effect);
         this.amount = effect.amount;
     }

--- a/Mage.Sets/src/mage/cards/t/TreasureMap.java
+++ b/Mage.Sets/src/mage/cards/t/TreasureMap.java
@@ -58,7 +58,7 @@ class TreasureMapEffect extends OneShotEffect {
                 + "three Treasure tokens";
     }
 
-    TreasureMapEffect(final TreasureMapEffect effect) {
+    private TreasureMapEffect(final TreasureMapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TributeToHunger.java
+++ b/Mage.Sets/src/mage/cards/t/TributeToHunger.java
@@ -46,7 +46,7 @@ class TributeToHungerEffect extends OneShotEffect {
         staticText = "Target opponent sacrifices a creature. You gain life equal to that creature's toughness";
     }
 
-    TributeToHungerEffect(TributeToHungerEffect effect) {
+    private TributeToHungerEffect(final TributeToHungerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Truce.java
+++ b/Mage.Sets/src/mage/cards/t/Truce.java
@@ -41,7 +41,7 @@ class TruceEffect extends OneShotEffect {
         this.staticText = "Each player may draw up to two cards. For each card less than two a player draws this way, that player gains 2 life";
     }
 
-    TruceEffect(final TruceEffect effect) {
+    private TruceEffect(final TruceEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TunnelIgnus.java
+++ b/Mage.Sets/src/mage/cards/t/TunnelIgnus.java
@@ -78,7 +78,7 @@ class TunnelIgnusTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DamageTargetEffect(3));
     }
 
-    TunnelIgnusTriggeredAbility(final TunnelIgnusTriggeredAbility ability) {
+    private TunnelIgnusTriggeredAbility(final TunnelIgnusTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TwistedJustice.java
+++ b/Mage.Sets/src/mage/cards/t/TwistedJustice.java
@@ -47,7 +47,7 @@ class TwistedJusticeEffect extends OneShotEffect {
         staticText = "Target player sacrifices a creature. You draw cards equal to that creature's power";
     }
 
-    TwistedJusticeEffect(TwistedJusticeEffect effect) {
+    private TwistedJusticeEffect(final TwistedJusticeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Typhoon.java
+++ b/Mage.Sets/src/mage/cards/t/Typhoon.java
@@ -49,7 +49,7 @@ class TyphoonEffect extends OneShotEffect {
         staticText = "{this} deals damage to each opponent equal to the number of Islands that player controls";
     }
 
-    TyphoonEffect(final TyphoonEffect effect) {
+    private TyphoonEffect(final TyphoonEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Tyrannize.java
+++ b/Mage.Sets/src/mage/cards/t/Tyrannize.java
@@ -47,7 +47,7 @@ class TyrannizeEffect extends OneShotEffect {
         this.staticText = "Target player discards their hand unless they pay 7 life";
     }
     
-    TyrannizeEffect(final TyrannizeEffect effect) {
+    private TyrannizeEffect(final TyrannizeEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/u/UbaMask.java
+++ b/Mage.Sets/src/mage/cards/u/UbaMask.java
@@ -50,7 +50,7 @@ class UbaMaskReplacementEffect extends ReplacementEffectImpl {
         this.staticText = "If a player would draw a card, that player exiles that card face up instead";
     }
 
-    UbaMaskReplacementEffect(final UbaMaskReplacementEffect effect) {
+    private UbaMaskReplacementEffect(final UbaMaskReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UlamogTheCeaselessHunger.java
+++ b/Mage.Sets/src/mage/cards/u/UlamogTheCeaselessHunger.java
@@ -69,7 +69,7 @@ class UlamogExilePermanentsOnCastAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("When you cast this spell, ");
     }
 
-    UlamogExilePermanentsOnCastAbility(UlamogExilePermanentsOnCastAbility ability) {
+    private UlamogExilePermanentsOnCastAbility(final UlamogExilePermanentsOnCastAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UlashtTheHateSeed.java
+++ b/Mage.Sets/src/mage/cards/u/UlashtTheHateSeed.java
@@ -88,7 +88,7 @@ class UlashtTheHateSeedEffect extends OneShotEffect {
         staticText = "{this} enters the battlefield with a +1/+1 counter on it for each other red creature you control and a +1/+1 counter on it for each other green creature you control.";
     }
 
-    UlashtTheHateSeedEffect(final UlashtTheHateSeedEffect effect) {
+    private UlashtTheHateSeedEffect(final UlashtTheHateSeedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnboundFlourishing.java
+++ b/Mage.Sets/src/mage/cards/u/UnboundFlourishing.java
@@ -58,7 +58,7 @@ class UnboundFlourishingDoubleXEffect extends ReplacementEffectImpl {
         staticText = "Whenever you cast a permanent spell with a mana cost that contains {X}, double the value of X";
     }
 
-    UnboundFlourishingDoubleXEffect(final UnboundFlourishingDoubleXEffect effect) {
+    private UnboundFlourishingDoubleXEffect(final UnboundFlourishingDoubleXEffect effect) {
         super(effect);
     }
 
@@ -98,7 +98,7 @@ class UnboundFlourishingCopyAbility extends TriggeredAbilityImpl {
                          "if that spell's mana cost or that ability's activation cost contains {X}" );
     }
 
-    UnboundFlourishingCopyAbility(final UnboundFlourishingCopyAbility ability) {
+    private UnboundFlourishingCopyAbility(final UnboundFlourishingCopyAbility ability) {
         super(ability);
     }
 
@@ -151,7 +151,7 @@ class UnboundFlourishingCopyEffect extends OneShotEffect {
         this.staticText = ", copy that spell or ability. You may choose new targets for the copy";
     }
 
-    UnboundFlourishingCopyEffect(final UnboundFlourishingCopyEffect effect) {
+    private UnboundFlourishingCopyEffect(final UnboundFlourishingCopyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnifiedStrike.java
+++ b/Mage.Sets/src/mage/cards/u/UnifiedStrike.java
@@ -53,7 +53,7 @@ class UnifiedStrikeEffect extends OneShotEffect {
         this.staticText = "Exile target attacking creature if its power is less than or equal to the number of Soldiers on the battlefield";
     }
 
-    UnifiedStrikeEffect(final UnifiedStrikeEffect effect) {
+    private UnifiedStrikeEffect(final UnifiedStrikeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnwillingRecruit.java
+++ b/Mage.Sets/src/mage/cards/u/UnwillingRecruit.java
@@ -49,7 +49,7 @@ class UnwillingRecruitEffect extends OneShotEffect {
         staticText = "Gain control of target creature until end of turn. Untap that creature. It gets +X/+0 and gains haste until end of turn";
     }
 
-    UnwillingRecruitEffect(UnwillingRecruitEffect effect) {
+    private UnwillingRecruitEffect(final UnwillingRecruitEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UphillBattle.java
+++ b/Mage.Sets/src/mage/cards/u/UphillBattle.java
@@ -90,7 +90,7 @@ class UphillBattleTapEffect extends ReplacementEffectImpl {
         staticText = "Creatures played by your opponents enter the battlefield tapped";
     }
 
-    UphillBattleTapEffect(final UphillBattleTapEffect effect) {
+    private UphillBattleTapEffect(final UphillBattleTapEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/u/Urborg.java
+++ b/Mage.Sets/src/mage/cards/u/Urborg.java
@@ -59,7 +59,7 @@ class UrborgEffect extends OneShotEffect {
         this.staticText = "Target creature loses first strike or swampwalk until end of turn.";
     }
 
-    UrborgEffect(final UrborgEffect effect) {
+    private UrborgEffect(final UrborgEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ValakutTheMoltenPinnacle.java
+++ b/Mage.Sets/src/mage/cards/v/ValakutTheMoltenPinnacle.java
@@ -60,7 +60,7 @@ class ValakutTheMoltenPinnacleTriggeredAbility extends TriggeredAbilityImpl {
         this.addTarget(new TargetAnyTarget());
     }
 
-    ValakutTheMoltenPinnacleTriggeredAbility(ValakutTheMoltenPinnacleTriggeredAbility ability) {
+    private ValakutTheMoltenPinnacleTriggeredAbility(final ValakutTheMoltenPinnacleTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VampireHexmage.java
+++ b/Mage.Sets/src/mage/cards/v/VampireHexmage.java
@@ -57,7 +57,7 @@ class VampireHexmageEffect extends OneShotEffect {
         staticText = "Remove all counters from target permanent";
     }
 
-    VampireHexmageEffect(VampireHexmageEffect effect) {
+    private VampireHexmageEffect(final VampireHexmageEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VarolzTheScarStriped.java
+++ b/Mage.Sets/src/mage/cards/v/VarolzTheScarStriped.java
@@ -60,7 +60,7 @@ class VarolzTheScarStripedEffect extends ContinuousEffectImpl {
         staticText = "Each creature card in your graveyard has scavenge. The scavenge cost is equal to its mana cost";
     }
 
-    VarolzTheScarStripedEffect(final VarolzTheScarStripedEffect effect) {
+    private VarolzTheScarStripedEffect(final VarolzTheScarStripedEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VendilionClique.java
+++ b/Mage.Sets/src/mage/cards/v/VendilionClique.java
@@ -66,7 +66,7 @@ class VendilionCliqueEffect extends OneShotEffect {
         staticText = "look at target player's hand. You may choose a nonland card from it. If you do, that player reveals the chosen card, puts it on the bottom of their library, then draws a card";
     }
 
-    VendilionCliqueEffect(final VendilionCliqueEffect effect) {
+    private VendilionCliqueEffect(final VendilionCliqueEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/Venom.java
+++ b/Mage.Sets/src/mage/cards/v/Venom.java
@@ -62,7 +62,7 @@ class VenomTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect);
     }
 
-    VenomTriggeredAbility(final VenomTriggeredAbility ability) {
+    private VenomTriggeredAbility(final VenomTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VenserTheSojourner.java
+++ b/Mage.Sets/src/mage/cards/v/VenserTheSojourner.java
@@ -76,7 +76,7 @@ class VenserTheSojournerEffect extends OneShotEffect {
         staticText = effectText;
     }
 
-    VenserTheSojournerEffect(VenserTheSojournerEffect effect) {
+    private VenserTheSojournerEffect(final VenserTheSojournerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VentifactBottle.java
+++ b/Mage.Sets/src/mage/cards/v/VentifactBottle.java
@@ -65,7 +65,7 @@ class VentifactBottleEffect extends OneShotEffect {
         super(Outcome.Benefit);
     }
 
-    VentifactBottleEffect(final VentifactBottleEffect effect) {
+    private VentifactBottleEffect(final VentifactBottleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VerdantSuccession.java
+++ b/Mage.Sets/src/mage/cards/v/VerdantSuccession.java
@@ -106,7 +106,7 @@ class VerdantSuccessionEffect extends OneShotEffect {
         super(Outcome.PutCardInPlay);
     }
 
-    VerdantSuccessionEffect(final VerdantSuccessionEffect effect) {
+    private VerdantSuccessionEffect(final VerdantSuccessionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeryCrypticCommandD.java
+++ b/Mage.Sets/src/mage/cards/v/VeryCrypticCommandD.java
@@ -90,7 +90,7 @@ class TurnOverEffect extends OneShotEffect {
         this.staticText = "Turn over target nontoken creature";
     }
 
-    TurnOverEffect(final TurnOverEffect effect) {
+    private TurnOverEffect(final TurnOverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeteranBodyguard.java
+++ b/Mage.Sets/src/mage/cards/v/VeteranBodyguard.java
@@ -65,7 +65,7 @@ class VeteranBodyguardEffect extends PreventionEffectImpl {
         staticText = "all combat damage that would be dealt to you by unblocked creatures is dealt to {this} instead";
     }
 
-    VeteranBodyguardEffect(final VeteranBodyguardEffect effect) {
+    private VeteranBodyguardEffect(final VeteranBodyguardEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VeteranWarleader.java
+++ b/Mage.Sets/src/mage/cards/v/VeteranWarleader.java
@@ -79,7 +79,7 @@ class VeteranWarleaderEffect extends OneShotEffect {
         staticText = "{this} gains your choice of first strike, vigilance, or trample until end of turn";
     }
 
-    VeteranWarleaderEffect(final VeteranWarleaderEffect effect) {
+    private VeteranWarleaderEffect(final VeteranWarleaderEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VexingDevil.java
+++ b/Mage.Sets/src/mage/cards/v/VexingDevil.java
@@ -48,7 +48,7 @@ class VexingDevilEffect extends OneShotEffect {
         staticText = "any opponent may have it deal 4 damage to them. If a player does, sacrifice {this}";
     }
 
-    VexingDevilEffect(final VexingDevilEffect effect) {
+    private VexingDevilEffect(final VexingDevilEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VhalCandlekeepResearcher.java
+++ b/Mage.Sets/src/mage/cards/v/VhalCandlekeepResearcher.java
@@ -65,7 +65,7 @@ class VhalCandlekeepResearcherManaEffect extends ManaEffect {
         this.staticText = "Add an amount of {C} equal to {this}'s toughness. This mana can't be spent to cast spells from your hand.";
     }
 
-    VhalCandlekeepResearcherManaEffect(final VhalCandlekeepResearcherManaEffect effect) {
+    private VhalCandlekeepResearcherManaEffect(final VhalCandlekeepResearcherManaEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VialSmasherTheFierce.java
+++ b/Mage.Sets/src/mage/cards/v/VialSmasherTheFierce.java
@@ -65,7 +65,7 @@ class VialSmasherTheFierceTriggeredAbility extends SpellCastControllerTriggeredA
         super(new VialSmasherTheFierceEffect(), false);
     }
 
-    VialSmasherTheFierceTriggeredAbility(VialSmasherTheFierceTriggeredAbility ability) {
+    private VialSmasherTheFierceTriggeredAbility(final VialSmasherTheFierceTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/Victimize.java
+++ b/Mage.Sets/src/mage/cards/v/Victimize.java
@@ -49,7 +49,7 @@ class VictimizeEffect extends OneShotEffect {
         this.staticText = "Choose two target creature cards in your graveyard. Sacrifice a creature. If you do, return the chosen cards to the battlefield tapped";
     }
 
-    VictimizeEffect(final VictimizeEffect effect) {
+    private VictimizeEffect(final VictimizeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VigilForTheLost.java
+++ b/Mage.Sets/src/mage/cards/v/VigilForTheLost.java
@@ -46,7 +46,7 @@ class VigilForTheLostTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new VigilForTheLostEffect());
     }
 
-    VigilForTheLostTriggeredAbility(final VigilForTheLostTriggeredAbility ability) {
+    private VigilForTheLostTriggeredAbility(final VigilForTheLostTriggeredAbility ability) {
         super(ability);
     }
 
@@ -84,7 +84,7 @@ class VigilForTheLostEffect extends OneShotEffect {
         staticText = "you may pay {X}. If you do, you gain X life";
     }
 
-    VigilForTheLostEffect(final VigilForTheLostEffect effect) {
+    private VigilForTheLostEffect(final VigilForTheLostEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/Vigor.java
+++ b/Mage.Sets/src/mage/cards/v/Vigor.java
@@ -60,7 +60,7 @@ class VigorReplacementEffect extends ReplacementEffectImpl {
         staticText = "if damage would be dealt to another creature you control, prevent that damage. Put a +1/+1 counter on that creature for each 1 damage prevented this way";
     }
 
-    VigorReplacementEffect(final VigorReplacementEffect effect) {
+    private VigorReplacementEffect(final VigorReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VigorMortis.java
+++ b/Mage.Sets/src/mage/cards/v/VigorMortis.java
@@ -55,7 +55,7 @@ class VigorMortisReplacementEffect extends ReplacementEffectImpl {
         super(Duration.EndOfStep, Outcome.BoostCreature);
     }
 
-    VigorMortisReplacementEffect(VigorMortisReplacementEffect effect) {
+    private VigorMortisReplacementEffect(final VigorMortisReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/ViridianRevel.java
+++ b/Mage.Sets/src/mage/cards/v/ViridianRevel.java
@@ -44,7 +44,7 @@ class ViridianRevelTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), true);
     }
 
-    ViridianRevelTriggeredAbility(final ViridianRevelTriggeredAbility ability) {
+    private ViridianRevelTriggeredAbility(final ViridianRevelTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VirtussManeuver.java
+++ b/Mage.Sets/src/mage/cards/v/VirtussManeuver.java
@@ -56,7 +56,7 @@ class VirtussManeuverEffect extends OneShotEffect {
                 + "Each foe sacrifices a creature they control";
     }
 
-    VirtussManeuverEffect(final VirtussManeuverEffect effect) {
+    private VirtussManeuverEffect(final VirtussManeuverEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VizierOfTheAnointed.java
+++ b/Mage.Sets/src/mage/cards/v/VizierOfTheAnointed.java
@@ -97,7 +97,7 @@ class VizierOfTheAnointedTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
     }
 
-    VizierOfTheAnointedTriggeredAbility(final VizierOfTheAnointedTriggeredAbility ability) {
+    private VizierOfTheAnointedTriggeredAbility(final VizierOfTheAnointedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VoidStalker.java
+++ b/Mage.Sets/src/mage/cards/v/VoidStalker.java
@@ -57,7 +57,7 @@ class VoidStalkerEffect extends OneShotEffect {
         staticText = "Put {this} and target creature on top of their owners' libraries, then those players shuffle their libraries";
     }
 
-    VoidStalkerEffect(final VoidStalkerEffect effect) {
+    private VoidStalkerEffect(final VoidStalkerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VolatileRig.java
+++ b/Mage.Sets/src/mage/cards/v/VolatileRig.java
@@ -94,7 +94,7 @@ class VolatileRigEffect2 extends OneShotEffect {
         staticText = "flip a coin. If you lose the flip, it deals 4 damage to each creature and each player";
     }
 
-    VolatileRigEffect2(final VolatileRigEffect2 effect) {
+    private VolatileRigEffect2(final VolatileRigEffect2 effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VolrathsLaboratory.java
+++ b/Mage.Sets/src/mage/cards/v/VolrathsLaboratory.java
@@ -59,7 +59,7 @@ class VolrathsLaboratoryEffect extends OneShotEffect {
         this.staticText = "Create a 2/2 creature token of the chosen color and type";
     }
 
-    VolrathsLaboratoryEffect(final VolrathsLaboratoryEffect effect) {
+    private VolrathsLaboratoryEffect(final VolrathsLaboratoryEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VoraciousFellBeast.java
+++ b/Mage.Sets/src/mage/cards/v/VoraciousFellBeast.java
@@ -63,7 +63,7 @@ class VoraciousFellBeastEffect extends OneShotEffect {
             "Create a Food token for each creature sacrificed this way";
     }
 
-    VoraciousFellBeastEffect(final VoraciousFellBeastEffect effect) {
+    private VoraciousFellBeastEffect(final VoraciousFellBeastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WalkerOfSecretWays.java
+++ b/Mage.Sets/src/mage/cards/w/WalkerOfSecretWays.java
@@ -73,7 +73,7 @@ class WalkerOfSecretWaysEffect extends OneShotEffect {
         staticText = "look at that player's hand";
     }
 
-    WalkerOfSecretWaysEffect(final WalkerOfSecretWaysEffect effect) {
+    private WalkerOfSecretWaysEffect(final WalkerOfSecretWaysEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WalkingSponge.java
+++ b/Mage.Sets/src/mage/cards/w/WalkingSponge.java
@@ -62,7 +62,7 @@ class WalkingSpongeEffect extends OneShotEffect {
         this.staticText = "Target creature loses your choice of flying, first strike, or trample until end of turn";
     }
 
-    WalkingSpongeEffect(final WalkingSpongeEffect effect) {
+    private WalkingSpongeEffect(final WalkingSpongeEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WallOfLimbs.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfLimbs.java
@@ -69,7 +69,7 @@ class WallOfLimbsTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false);
     }
     
-    WallOfLimbsTriggeredAbility(final WallOfLimbsTriggeredAbility ability) {
+    private WallOfLimbsTriggeredAbility(final WallOfLimbsTriggeredAbility ability) {
         super(ability);
     }
     

--- a/Mage.Sets/src/mage/cards/w/WallOfReverence.java
+++ b/Mage.Sets/src/mage/cards/w/WallOfReverence.java
@@ -55,7 +55,7 @@ class WallOfReverenceTriggeredEffect extends OneShotEffect {
         staticText = "gain life equal to the power of target creature you control";
     }
 
-    WallOfReverenceTriggeredEffect(WallOfReverenceTriggeredEffect effect) {
+    private WallOfReverenceTriggeredEffect(final WallOfReverenceTriggeredEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarBarge.java
+++ b/Mage.Sets/src/mage/cards/w/WarBarge.java
@@ -54,7 +54,7 @@ class WarBargeDelayedTriggeredAbility extends DelayedTriggeredAbility {
         super(new DestroyTargetEffect(true), Duration.EndOfTurn, false);
     }
 
-    WarBargeDelayedTriggeredAbility(final WarBargeDelayedTriggeredAbility ability) {
+    private WarBargeDelayedTriggeredAbility(final WarBargeDelayedTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarCadence.java
+++ b/Mage.Sets/src/mage/cards/w/WarCadence.java
@@ -51,7 +51,7 @@ class WarCadenceReplacementEffect extends ReplacementEffectImpl {
         staticText = "This turn, creatures can't block unless their controller pays {X} for each blocking creature they control";
     }
 
-    WarCadenceReplacementEffect(WarCadenceReplacementEffect effect) {
+    private WarCadenceReplacementEffect(final WarCadenceReplacementEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarTax.java
+++ b/Mage.Sets/src/mage/cards/w/WarTax.java
@@ -52,7 +52,7 @@ class WarTaxCantAttackUnlessPaysEffect extends PayCostToAttackBlockEffectImpl {
         staticText = "This turn, creatures can't attack unless their controller pays {X} for each attacking creature they control";
     }
 
-    WarTaxCantAttackUnlessPaysEffect(WarTaxCantAttackUnlessPaysEffect effect) {
+    private WarTaxCantAttackUnlessPaysEffect(final WarTaxCantAttackUnlessPaysEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarrenWeirding.java
+++ b/Mage.Sets/src/mage/cards/w/WarrenWeirding.java
@@ -61,7 +61,7 @@ class WarrenWeirdingEffect extends OneShotEffect {
                 "creates two 1/1 black Goblin Rogue creature tokens, and those tokens gain haste until end of turn";
     }
 
-    WarrenWeirdingEffect(WarrenWeirdingEffect effect) {
+    private WarrenWeirdingEffect(final WarrenWeirdingEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WasteNot.java
+++ b/Mage.Sets/src/mage/cards/w/WasteNot.java
@@ -51,7 +51,7 @@ class WasteNotCreatureTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new CreateTokenEffect(new ZombieToken()), false);
     }
 
-    WasteNotCreatureTriggeredAbility(final WasteNotCreatureTriggeredAbility ability) {
+    private WasteNotCreatureTriggeredAbility(final WasteNotCreatureTriggeredAbility ability) {
         super(ability);
     }
 
@@ -88,7 +88,7 @@ class WasteNotLandTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new BasicManaEffect(Mana.BlackMana(2)), false);
     }
 
-    WasteNotLandTriggeredAbility(final WasteNotLandTriggeredAbility ability) {
+    private WasteNotLandTriggeredAbility(final WasteNotLandTriggeredAbility ability) {
         super(ability);
     }
 
@@ -125,7 +125,7 @@ class WasteNotOtherTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
     }
 
-    WasteNotOtherTriggeredAbility(final WasteNotOtherTriggeredAbility ability) {
+    private WasteNotOtherTriggeredAbility(final WasteNotOtherTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WaveOfTerror.java
+++ b/Mage.Sets/src/mage/cards/w/WaveOfTerror.java
@@ -53,7 +53,7 @@ class WaveOfTerrorEffect extends OneShotEffect {
         this.staticText = "destroy each creature with mana value equal to the number of age counters on {this}. They can't be regenerated.";
     }
 
-    WaveOfTerrorEffect(final WaveOfTerrorEffect effect) {
+    private WaveOfTerrorEffect(final WaveOfTerrorEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WeatheredBodyguards.java
+++ b/Mage.Sets/src/mage/cards/w/WeatheredBodyguards.java
@@ -59,7 +59,7 @@ class WeatheredBodyguardsEffect extends ReplacementEffectImpl {
         staticText = "As long as {this} is untapped, all combat damage that would be dealt to you by unblocked creatures is dealt to {this} instead";
     }
 
-    WeatheredBodyguardsEffect(final WeatheredBodyguardsEffect effect) {
+    private WeatheredBodyguardsEffect(final WeatheredBodyguardsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WeaverOfLies.java
+++ b/Mage.Sets/src/mage/cards/w/WeaverOfLies.java
@@ -70,7 +70,7 @@ class WeaverOfLiesEffect extends OneShotEffect {
         this.staticText = "turn any number of target creatures with morph abilities other than {this} face down";
     }
 
-    WeaverOfLiesEffect(final WeaverOfLiesEffect effect) {
+    private WeaverOfLiesEffect(final WeaverOfLiesEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WeiAssassins.java
+++ b/Mage.Sets/src/mage/cards/w/WeiAssassins.java
@@ -58,7 +58,7 @@ class WeiAssassinsEffect extends OneShotEffect {
         this.staticText = "target opponent chooses a creature they control. Destroy it.";
     }
 
-    WeiAssassinsEffect(final WeiAssassinsEffect effect) {
+    private WeiAssassinsEffect(final WeiAssassinsEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WeightOfSpires.java
+++ b/Mage.Sets/src/mage/cards/w/WeightOfSpires.java
@@ -46,7 +46,7 @@ class WeightOfSpiresEffect extends OneShotEffect {
         this.staticText = "{this} deals damage to target creature equal to the number of nonbasic lands that creature's controller controls";
     }
 
-    WeightOfSpiresEffect(final WeightOfSpiresEffect effect) {
+    private WeightOfSpiresEffect(final WeightOfSpiresEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WharfInfiltrator.java
+++ b/Mage.Sets/src/mage/cards/w/WharfInfiltrator.java
@@ -66,7 +66,7 @@ class WharfInfiltratorDiscardAbility extends TriggeredAbilityImpl {
         setTriggerPhrase("Whenever you discard a creature card, " );
     }
 
-    WharfInfiltratorDiscardAbility(final WharfInfiltratorDiscardAbility ability) {
+    private WharfInfiltratorDiscardAbility(final WharfInfiltratorDiscardAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WhiskAway.java
+++ b/Mage.Sets/src/mage/cards/w/WhiskAway.java
@@ -46,7 +46,7 @@ class WhiskAwayEffect extends OneShotEffect {
         staticText = "Put target attacking or blocking creature on top of its owner's library";
     }
 
-    WhiskAwayEffect(final WhiskAwayEffect effect) {
+    private WhiskAwayEffect(final WhiskAwayEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WhisperingSpecter.java
+++ b/Mage.Sets/src/mage/cards/w/WhisperingSpecter.java
@@ -55,7 +55,7 @@ class WhisperingSpecterEffect extends OneShotEffect {
         staticText = "If you do, that player discards a card for each poison counter they have";
     }
 
-    WhisperingSpecterEffect(final WhisperingSpecterEffect effect) {
+    private WhisperingSpecterEffect(final WhisperingSpecterEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WillKenrith.java
+++ b/Mage.Sets/src/mage/cards/w/WillKenrith.java
@@ -91,7 +91,7 @@ class WillKenrithCostReductionEffect extends OneShotEffect {
         this.staticText = "Until your next turn, instant, sorcery, and planeswalker spells that player casts cost {2} less to cast";
     }
 
-    WillKenrithCostReductionEffect(final WillKenrithCostReductionEffect effect) {
+    private WillKenrithCostReductionEffect(final WillKenrithCostReductionEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WindingConstrictor.java
+++ b/Mage.Sets/src/mage/cards/w/WindingConstrictor.java
@@ -57,7 +57,7 @@ class WindingConstrictorPlayerEffect extends ReplacementEffectImpl {
         staticText = "If you would get one or more counters, you get that many plus one of each of those kinds of counters instead";
     }
 
-    WindingConstrictorPlayerEffect(final WindingConstrictorPlayerEffect effect) {
+    private WindingConstrictorPlayerEffect(final WindingConstrictorPlayerEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WinterBlast.java
+++ b/Mage.Sets/src/mage/cards/w/WinterBlast.java
@@ -56,7 +56,7 @@ class WinterBlastEffect extends OneShotEffect {
         this.staticText = "Tap X target creatures. {this} deals 2 damage to each of those creatures with flying.";
     }
 
-    WinterBlastEffect(final WinterBlastEffect effect) {
+    private WinterBlastEffect(final WinterBlastEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/Withdraw.java
+++ b/Mage.Sets/src/mage/cards/w/Withdraw.java
@@ -60,7 +60,7 @@ class WithdrawEffect extends OneShotEffect {
         this.staticText = "Return target creature to its owner's hand. Then return another target creature to its owner's hand unless its controller pays {1}";
     }
 
-    WithdrawEffect(final WithdrawEffect effect) {
+    private WithdrawEffect(final WithdrawEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WordsOfWar.java
+++ b/Mage.Sets/src/mage/cards/w/WordsOfWar.java
@@ -50,7 +50,7 @@ class WordsOfWarEffect extends ReplacementEffectImpl {
         staticText = "The next time you would draw a card this turn, {this} deals 2 damage to any target instead.";
     }
 
-    WordsOfWarEffect(final WordsOfWarEffect effect) {
+    private WordsOfWarEffect(final WordsOfWarEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WordsOfWorship.java
+++ b/Mage.Sets/src/mage/cards/w/WordsOfWorship.java
@@ -47,7 +47,7 @@ class WordsOfWorshipEffect extends ReplacementEffectImpl {
         staticText = "The next time you would draw a card this turn, you gain 5 life instead.";
     }
     
-    WordsOfWorshipEffect(final WordsOfWorshipEffect effect) {
+    private WordsOfWorshipEffect(final WordsOfWorshipEffect effect) {
         super(effect);
     }
     

--- a/Mage.Sets/src/mage/cards/w/Worldslayer.java
+++ b/Mage.Sets/src/mage/cards/w/Worldslayer.java
@@ -54,7 +54,7 @@ class WorldslayerTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, new WorldslayerEffect(), false);
     }
 
-    WorldslayerTriggeredAbility(final WorldslayerTriggeredAbility ability) {
+    private WorldslayerTriggeredAbility(final WorldslayerTriggeredAbility ability) {
         super(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WuSpy.java
+++ b/Mage.Sets/src/mage/cards/w/WuSpy.java
@@ -60,7 +60,7 @@ class WuSpyEffect extends OneShotEffect {
         this.staticText = "look at the top two cards of target player's library. Put one of them into their graveyard";
     }
 
-    WuSpyEffect(final WuSpyEffect effect) {
+    private WuSpyEffect(final WuSpyEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WulfgarOfIcewindDale.java
+++ b/Mage.Sets/src/mage/cards/w/WulfgarOfIcewindDale.java
@@ -56,7 +56,7 @@ class WulfgarOfIcewindDaleEffect extends ReplacementEffectImpl {
                 "of a permanent you control to trigger, that ability triggers an additional time";
     }
 
-    WulfgarOfIcewindDaleEffect(final WulfgarOfIcewindDaleEffect effect) {
+    private WulfgarOfIcewindDaleEffect(final WulfgarOfIcewindDaleEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZabazTheGlimmerwasp.java
+++ b/Mage.Sets/src/mage/cards/z/ZabazTheGlimmerwasp.java
@@ -72,7 +72,7 @@ class ZabazTheGlimmerwaspEffect extends ReplacementEffectImpl {
                 "that many plus one +1/+1 counters are put on it instead";
     }
 
-    ZabazTheGlimmerwaspEffect(final ZabazTheGlimmerwaspEffect effect) {
+    private ZabazTheGlimmerwaspEffect(final ZabazTheGlimmerwaspEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZaxaraTheExemplary.java
+++ b/Mage.Sets/src/mage/cards/z/ZaxaraTheExemplary.java
@@ -100,7 +100,7 @@ class ZaxaraTheExemplaryHydraTokenEffect extends OneShotEffect {
         this.staticText = ", create a 0/0 green Hydra creature token, then put X +1/+1 counters on it.";
     }
 
-    ZaxaraTheExemplaryHydraTokenEffect(final ZaxaraTheExemplaryHydraTokenEffect effect) {
+    private ZaxaraTheExemplaryHydraTokenEffect(final ZaxaraTheExemplaryHydraTokenEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZndrspltsJudgment.java
+++ b/Mage.Sets/src/mage/cards/z/ZndrspltsJudgment.java
@@ -49,7 +49,7 @@ class ZndrspltsJudgmentEffect extends OneShotEffect {
         this.staticText = "For each player, choose friend or foe. Each friend creates a token that's a copy of a creature they control. Each foe returns a creature they control to its owner's hand";
     }
 
-    ZndrspltsJudgmentEffect(final ZndrspltsJudgmentEffect effect) {
+    private ZndrspltsJudgmentEffect(final ZndrspltsJudgmentEffect effect) {
         super(effect);
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZoZuThePunisher.java
+++ b/Mage.Sets/src/mage/cards/z/ZoZuThePunisher.java
@@ -51,7 +51,7 @@ class ZoZuThePunisherAbility extends TriggeredAbilityImpl {
             super(Zone.BATTLEFIELD, new DamageTargetEffect(2));
     }
 
-    ZoZuThePunisherAbility(final ZoZuThePunisherAbility ability) {
+    private ZoZuThePunisherAbility(final ZoZuThePunisherAbility ability) {
             super(ability);
     }
 


### PR DESCRIPTION
Part of #11054, relative to making private copy constructors that were package-private.

Clean copy constructors of cards, setting them private and with their parameter final.
Nothing but the following replacement regex (done with IntelliJ) was applied:
`  ([^ (]*) ?\((final )?\1 ([^,)]*\))` -> `  private $1(final $1 $3`
