### PR TITLE
[CMB1] Implement Innocuous Insect

### DIFF
--- a/Mage.Sets/src/mage/cards/i/InnocuousInsect.java
+++ b/Mage.Sets/src/mage/cards/i/InnocuousInsect.java
@@ -1,0 +1,51 @@
+package mage.cards.i;
+
+import mage.MageInt;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.CastSourceTriggeredAbility;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.keyword.BuybackAbility;
+import mage.abilities.keyword.FlashAbility;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+import java.util.UUID;
+
+/**
+ * @author Susucr
+ */
+public final class InnocuousInsect extends CardImpl {
+
+    public InnocuousInsect(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{U}{U}");
+
+        this.subtype.add(SubType.ELDRAZI);
+        this.subtype.add(SubType.INSECT);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(1);
+
+        // Buyback {1}{U}
+        this.addAbility(new BuybackAbility(new ManaCostsImpl<>("{1}{U}")));
+
+        // Flash
+        this.addAbility(FlashAbility.getInstance());
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // When you cast this spell, draw a card.
+        this.addAbility(new CastSourceTriggeredAbility(new DrawCardSourceControllerEffect(1)));
+    }
+
+    private InnocuousInsect(final InnocuousInsect card) {
+        super(card);
+    }
+
+    @Override
+    public InnocuousInsect copy() {
+        return new InnocuousInsect(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/MysteryBoosterPlaytest.java
+++ b/Mage.Sets/src/mage/sets/MysteryBoosterPlaytest.java
@@ -25,6 +25,7 @@ public class MysteryBoosterPlaytest extends ExpansionSet {
 
         cards.add(new SetCardInfo("Banding Sliver", 2, Rarity.RARE, mage.cards.b.BandingSliver.class));
         cards.add(new SetCardInfo("How to Keep an Izzet Mage Busy", 93, Rarity.RARE, mage.cards.h.HowToKeepAnIzzetMageBusy.class));
+        cards.add(new SetCardInfo("Innocuous Insect", 23, Rarity.RARE, mage.cards.i.InnocuousInsect.class));
         cards.add(new SetCardInfo("Recycla-bird", 28, Rarity.RARE, mage.cards.r.RecyclaBird.class));
         cards.add(new SetCardInfo("Slivdrazi Monstrosity", 102, Rarity.RARE, mage.cards.s.SlivdraziMonstrosity.class));
         cards.add(new SetCardInfo("Unicycle", 110, Rarity.RARE, mage.cards.u.Unicycle.class));

--- a/Mage/src/main/java/mage/abilities/keyword/BuybackAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/BuybackAbility.java
@@ -191,7 +191,14 @@ class BuybackEffect extends ReplacementEffectImpl {
         if (event.getTargetId().equals(source.getSourceId())) {
             ZoneChangeEvent zEvent = (ZoneChangeEvent) event;
             // if spell fizzled, the sourceId is null
-            return zEvent.getFromZone() == Zone.STACK && zEvent.getToZone() == Zone.GRAVEYARD
+            return zEvent.getFromZone() == Zone.STACK
+                    && (zEvent.getToZone() == Zone.GRAVEYARD ||
+                            // Innocuous Insect from Mystery Boosters is stretching a little what Buyback can do.
+                            // Although that does not impact normal Buyback usage on instants/sorceries.
+                            //
+                            // (2019-11-12) If you pay the buyback cost for a permanent spell, it doesn't enter
+                            // the battlefield as it resolves. It moves from the stack to its owner's hand.
+                            zEvent.getToZone() == Zone.BATTLEFIELD)
                     && source.getSourceId().equals(event.getSourceId());
         }
         return false;


### PR DESCRIPTION
https://scryfall.com/card/cmb2/23/innocuous-insect from Mystery Booster
Very slight adjustment on Buyback, in order to make a permanent with Buyback work.
Does not impact other existing Buyback effect, as all of them are on instant/sorcery and there is no effect that give Buyback to a card/spell.