### PR TITLE
Fix a Viscera Seer being set without a proper card number (breaks the deck editor)

### DIFF
--- a/Mage.Client/src/main/java/mage/client/deckeditor/table/MageCardComparator.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/table/MageCardComparator.java
@@ -79,22 +79,8 @@ public class MageCardComparator implements CardViewComparator {
                 bCom = b.getExpansionSetCode();
                 break;
             case 8:
-                try {
-                    aCom = Integer.parseInt(a.getCardNumber().replaceAll("[\\D]", ""));
-                }
-                catch (NumberFormatException nfe) {
-                    // If number can not be parsed from cardNumber, we sort the card last.
-                    // https://scryfall.com/card/sld/VS/viscera-seer is the only current case.
-                    aCom = 99999;
-                }
-                try {
-                    bCom = Integer.parseInt(b.getCardNumber().replaceAll("[\\D]", ""));
-                }
-                catch (NumberFormatException nfe) {
-                    // If number can not be parsed from cardNumber, we sort the card last.
-                    // https://scryfall.com/card/sld/VS/viscera-seer is the only current case.
-                    bCom = 99999;
-                }
+                aCom = Integer.parseInt(a.getCardNumber().replaceAll("[\\D]", ""));
+                bCom = Integer.parseInt(b.getCardNumber().replaceAll("[\\D]", ""));
                 break;
             case 9:
                 aCom = RateCard.rateCard(a, null);

--- a/Mage.Client/src/main/java/mage/client/deckeditor/table/MageCardComparator.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/table/MageCardComparator.java
@@ -79,8 +79,22 @@ public class MageCardComparator implements CardViewComparator {
                 bCom = b.getExpansionSetCode();
                 break;
             case 8:
-                aCom = Integer.parseInt(a.getCardNumber().replaceAll("[\\D]", ""));
-                bCom = Integer.parseInt(b.getCardNumber().replaceAll("[\\D]", ""));
+                try {
+                    aCom = Integer.parseInt(a.getCardNumber().replaceAll("[\\D]", ""));
+                }
+                catch (NumberFormatException nfe) {
+                    // If number can not be parsed from cardNumber, we sort the card last.
+                    // https://scryfall.com/card/sld/VS/viscera-seer is the only current case.
+                    aCom = 99999;
+                }
+                try {
+                    bCom = Integer.parseInt(b.getCardNumber().replaceAll("[\\D]", ""));
+                }
+                catch (NumberFormatException nfe) {
+                    // If number can not be parsed from cardNumber, we sort the card last.
+                    // https://scryfall.com/card/sld/VS/viscera-seer is the only current case.
+                    bCom = 99999;
+                }
                 break;
             case 9:
                 aCom = RateCard.rateCard(a, null);

--- a/Mage.Sets/src/mage/sets/SecretLairDrop.java
+++ b/Mage.Sets/src/mage/sets/SecretLairDrop.java
@@ -42,7 +42,7 @@ public class SecretLairDrop extends ExpansionSet {
         cards.add(new SetCardInfo("Shattergang Brothers", "1315*", Rarity.MYTHIC, mage.cards.s.ShattergangBrothers.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Toxin Sliver", "635Ph", Rarity.RARE, mage.cards.t.ToxinSliver.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Virulent Sliver", "659Ph", Rarity.RARE, mage.cards.v.VirulentSliver.class, NON_FULL_USE_VARIOUS));
-        cards.add(new SetCardInfo("Viscera Seer", "VS", Rarity.COMMON, mage.cards.v.VisceraSeer.class));
+        cards.add(new SetCardInfo("Viscera Seer", "99999VS", Rarity.COMMON, mage.cards.v.VisceraSeer.class));
         cards.add(new SetCardInfo("Snow-Covered Plains", 1, Rarity.LAND, mage.cards.s.SnowCoveredPlains.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Snow-Covered Island", 2, Rarity.LAND, mage.cards.s.SnowCoveredIsland.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Snow-Covered Swamp", 3, Rarity.LAND, mage.cards.s.SnowCoveredSwamp.class, NON_FULL_USE_VARIOUS));

--- a/Mage/src/main/java/mage/cards/ExpansionSet.java
+++ b/Mage/src/main/java/mage/cards/ExpansionSet.java
@@ -54,6 +54,18 @@ public abstract class ExpansionSet implements Serializable {
             this.rarity = rarity;
             this.cardClass = cardClass;
             this.graphicInfo = graphicInfo;
+
+            try {
+                // CardNumber must contain an Integer. We check here that it is possible.
+                Integer.parseInt(cardNumber.replaceAll("[\\D]", ""));
+            }
+            catch (NumberFormatException npe) {
+                // How to fix: look to the set infos for that card, and adjust to something that can be parsed to Integer.
+                throw new IllegalStateException(
+                        this.name + " has been set a CardInfo with '" + this.cardNumber
+                                + "' as card number, which can not be parsed as Integer."
+                );
+            }
         }
 
         public String getName() {


### PR DESCRIPTION
The following Viscera Seer from Secret Lair has "VS" has card number.
https://scryfall.com/card/sld/VS/viscera-seer
![image](https://github.com/magefree/mage/assets/34709007/07199ca7-3d6f-4b90-8185-bcbc42fc2c19)

It caused the following error in the deck editor:
![image](https://github.com/magefree/mage/assets/34709007/5105ae41-69a0-4179-b399-aa171c56ac9b)
After that, my deck editor has multiple issues when adding cards / attempting to save, and basically is all kind of broken.

I propose to sort card number that can not be parsed as Integer last, as this is what is broken. Having another info than the Scryfall card number is another possibility, but that probably has consequence to card image download. (And if we decide to go that way, we probably need a check that card numbers can be parsed as Integers in `SetCardInfo` constructors.)
