### PR TITLE
WIP: Rework cards to use ReselectDefenderAttackedByTarget

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PortalMage.java
+++ b/Mage.Sets/src/mage/cards/p/PortalMage.java
@@ -7,6 +7,7 @@ import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.condition.common.IsStepCondition;
 import mage.abilities.decorator.ConditionalTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.combat.ReselectDefenderAttackedByTargetEffect;
 import mage.abilities.keyword.FlashAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -20,6 +21,7 @@ import mage.game.Game;
 import mage.game.combat.CombatGroup;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
+import mage.target.common.TargetAttackingCreature;
 import mage.target.common.TargetCreaturePermanent;
 import mage.target.common.TargetDefender;
 
@@ -46,11 +48,11 @@ public final class PortalMage extends CardImpl {
 
         // When Portal Mage enters the battlefield during the declare attackers step, you may reselect which player or planeswalker target attacking creature is attacking.
         Ability ability = new ConditionalTriggeredAbility(
-                new EntersBattlefieldTriggeredAbility(new PortalMageEffect(), true),
+                new EntersBattlefieldTriggeredAbility(new ReselectDefenderAttackedByTargetEffect(true), true),
                 new IsStepCondition(PhaseStep.DECLARE_ATTACKERS, false),
                 "When {this} enters the battlefield during the declare attackers step, you may reselect which player or planeswalker target attacking creature is attacking. "
                 + "<i>(It can't attack its controller or its controller's planeswalkers.)</i>");
-        ability.addTarget(new TargetCreaturePermanent(new FilterAttackingCreature()));
+        ability.addTarget(new TargetAttackingCreature());
         this.addAbility(ability);
     }
 
@@ -61,75 +63,5 @@ public final class PortalMage extends CardImpl {
     @Override
     public PortalMage copy() {
         return new PortalMage(this);
-    }
-}
-
-class PortalMageEffect extends OneShotEffect {
-
-    public PortalMageEffect() {
-        super(Outcome.Benefit);
-        this.staticText = "you may reselect which player or planeswalker target attacking creature is attacking";
-    }
-
-    private PortalMageEffect(final PortalMageEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public PortalMageEffect copy() {
-        return new PortalMageEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null) {
-            Permanent attackingCreature = game.getPermanent(getTargetPointer().getFirst(game, source));
-            if (attackingCreature != null) {
-                CombatGroup combatGroupTarget = null;
-                for (CombatGroup combatGroup : game.getCombat().getGroups()) {
-                    if (combatGroup.getAttackers().contains(attackingCreature.getId())) {
-                        combatGroupTarget = combatGroup;
-                        break;
-                    }
-                }
-                if (combatGroupTarget == null) {
-                    return false;
-                }
-                // Reselecting which player or planeswalker a creature is attacking ignores all requirements,
-                // restrictions, and costs associated with attacking.
-
-                // Update possible defender
-                Set<UUID> defenders = new LinkedHashSet<>();
-                for (UUID playerId : game.getCombat().getAttackablePlayers(game)) {
-                    defenders.add(playerId);
-                    for (Permanent permanent : game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_PLANESWALKER, playerId, game)) {
-                        defenders.add(permanent.getId());
-                    }
-                }
-                // Select the new defender
-                TargetDefender target = new TargetDefender(defenders);
-                if (controller.chooseTarget(Outcome.Damage, target, source, game)) {
-                    if (combatGroupTarget.getDefenderId() != null && !combatGroupTarget.getDefenderId().equals(target.getFirstTarget())) {
-                        if (combatGroupTarget.changeDefenderPostDeclaration(target.getFirstTarget(), game)) {
-                            String attacked = "";
-                            Player player = game.getPlayer(target.getFirstTarget());
-                            if (player != null) {
-                                attacked = player.getLogName();
-                            } else {
-                                Permanent permanent = game.getPermanent(target.getFirstTarget());
-                                if (permanent != null) {
-                                    attacked = permanent.getLogName();
-                                }
-                            }
-                            game.informPlayers(attackingCreature.getLogName() + " now attacks " + attacked);
-                            return true;
-                        }
-                    }
-                }
-            }
-            return true;
-        }
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PortalMage.java
+++ b/Mage.Sets/src/mage/cards/p/PortalMage.java
@@ -6,27 +6,14 @@ import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.condition.common.IsStepCondition;
 import mage.abilities.decorator.ConditionalTriggeredAbility;
-import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.combat.ReselectDefenderAttackedByTargetEffect;
 import mage.abilities.keyword.FlashAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.PhaseStep;
 import mage.constants.SubType;
-import mage.filter.StaticFilters;
-import mage.filter.common.FilterAttackingCreature;
-import mage.game.Game;
-import mage.game.combat.CombatGroup;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
 import mage.target.common.TargetAttackingCreature;
-import mage.target.common.TargetCreaturePermanent;
-import mage.target.common.TargetDefender;
-
-import java.util.LinkedHashSet;
-import java.util.Set;
 import java.util.UUID;
 
 /**

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/c20/CapricopianTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/c20/CapricopianTest.java
@@ -1,0 +1,50 @@
+package org.mage.test.cards.single.c20;
+
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestCommander4Players;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+
+/**
+ * @author Xanderhall
+ */
+public class CapricopianTest extends CardTestCommander4Players {
+    
+    /**
+     * Capricopian enters the battlefield with X +1/+1 counters on it.
+     * {2}: Put a +1/+1 counter on Capricopian, then you may reselect which player Capricopian is attacking. 
+     * Only the player Capricopian is attacking may activate this ability and only during the declare attackers step. (It can’t attack its controller.)
+     */
+    private static final String CAPRICOPIAN = "Capricopian";
+    private static final String ANTHEM = "Gaea's Anthem";
+    
+    @Test
+    public void testMultipleActivations() {
+        addCard(Zone.BATTLEFIELD, playerA, ANTHEM);
+        addCard(Zone.BATTLEFIELD, playerA, CAPRICOPIAN);
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain", 2);
+        addCard(Zone.BATTLEFIELD, playerC, "Mountain", 2);
+
+        // Player A attacks Player B
+        attack(1, playerA, CAPRICOPIAN, playerB);
+
+        // Player B activates Capricopian, targetting Player C
+        activateAbility(1, PhaseStep.DECLARE_ATTACKERS, playerB, "{2}");
+        addTarget(playerB, playerC);
+        waitStackResolved(1, PhaseStep.DECLARE_ATTACKERS);
+
+        // Player C activates Capricopian, targetting Player B
+        activateAbility(1, PhaseStep.DECLARE_ATTACKERS, playerC, "{2}");
+        addTarget(playerC, playerB);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, CAPRICOPIAN, 1);
+        assertCounterCount(playerA, CAPRICOPIAN, CounterType.P1P1, 2);
+        assertLife(playerB, 17);
+    }
+}


### PR DESCRIPTION
Capricopian currently fails the test due to not being able to be activated by player C after being redirected by player B