### PR TITLE
Autosave limited decks on submit

### DIFF
--- a/Mage.Client/src/main/java/mage/client/MageFrame.java
+++ b/Mage.Client/src/main/java/mage/client/MageFrame.java
@@ -1197,6 +1197,7 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
                 DeckEditorPane deckEditorPane = (DeckEditorPane) window;
                 if (deckEditorPane.getDeckEditorMode() == DeckEditorMode.LIMITED_BUILDING
                         || deckEditorPane.getDeckEditorMode() == DeckEditorMode.SIDEBOARDING
+                        || deckEditorPane.getDeckEditorMode() == DeckEditorMode.LIMITED_SIDEBOARD_BUILDING
                         || deckEditorPane.getDeckEditorMode() == DeckEditorMode.VIEW_LIMITED_DECK) {
                     deckEditorPane.removeFrame();
                 }
@@ -1207,7 +1208,10 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
 
     public void showDeckEditor(DeckEditorMode mode, Deck deck, UUID tableId, int time) {
         String name;
-        if (mode == DeckEditorMode.SIDEBOARDING || mode == DeckEditorMode.LIMITED_BUILDING || mode == DeckEditorMode.VIEW_LIMITED_DECK) {
+        if (mode == DeckEditorMode.SIDEBOARDING
+                || mode == DeckEditorMode.LIMITED_BUILDING
+                || mode == DeckEditorMode.LIMITED_SIDEBOARD_BUILDING
+                || mode == DeckEditorMode.VIEW_LIMITED_DECK) {
             name = "Deck Editor - " + tableId.toString();
         } else {
             if (deck != null) {

--- a/Mage.Client/src/main/java/mage/client/SessionHandler.java
+++ b/Mage.Client/src/main/java/mage/client/SessionHandler.java
@@ -18,6 +18,7 @@ import mage.remote.SessionImpl;
 import mage.view.*;
 import org.apache.log4j.Logger;
 
+import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -240,7 +241,7 @@ public final class SessionHandler {
             SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");
             String logFilename = sdf.format(new Date()) + "_limited" + ".dck";
             try {
-                XMAGE.getExporter().writeDeck(logFilename, deckList);
+                XMAGE.getExporter().writeDeck(new File("gamelogs"), logFilename, deckList);
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/Mage.Client/src/main/java/mage/client/SessionHandler.java
+++ b/Mage.Client/src/main/java/mage/client/SessionHandler.java
@@ -1,7 +1,9 @@
 package mage.client;
 
 import mage.cards.decks.DeckCardLists;
+import static mage.cards.decks.DeckFormats.XMAGE;
 import mage.client.chat.LocalCommands;
+import mage.client.constants.Constants.DeckEditorMode;
 import mage.client.dialog.PreferencesDialog;
 import mage.constants.ManaType;
 import mage.constants.PlayerAction;
@@ -16,6 +18,8 @@ import mage.remote.SessionImpl;
 import mage.view.*;
 import org.apache.log4j.Logger;
 
+import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 /**
@@ -191,7 +195,6 @@ public final class SessionHandler {
             logger.info(e);
             return null;
         }
-
     }
 
     public static String getUserName() {
@@ -230,8 +233,27 @@ public final class SessionHandler {
         return session.getTournamentTypes();
     }
 
-    public static boolean submitDeck(UUID tableId, DeckCardLists deckCardLists) {
-        return session.submitDeck(tableId, deckCardLists);
+    private static void autoSaveLimitedDeck(DeckCardLists deckList) {
+        String autoSave = PreferencesDialog.getCachedValue(PreferencesDialog.KEY_LIMITED_DECK_AUTO_SAVE, "true");
+        if(autoSave.equals("true")){
+            // Log the submitted deck in the log folder.
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");
+            String logFilename = sdf.format(new Date()) + "_limited_submission" + ".dck";
+            try {
+                XMAGE.getExporter().writeDeck(logFilename, deckList);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public static boolean submitDeck(DeckEditorMode mode, UUID tableId, DeckCardLists deckCardLists) {
+        boolean success = session.submitDeck(tableId, deckCardLists);
+        if(DeckEditorMode.LIMITED_BUILDING.equals(mode)) {
+            // AutoSaving is done after submitting, to not let the server wait.
+            autoSaveLimitedDeck(deckCardLists);
+        }
+        return success;
     }
 
     public static String[] getDeckTypes() {
@@ -273,7 +295,7 @@ public final class SessionHandler {
     public static void sendCardMark(UUID draftId, UUID id) {
         session.sendCardMark(draftId, id);
     }
-    
+
     public static void setBoosterLoaded(UUID draftId) {
         session.setBoosterLoaded(draftId);
     }

--- a/Mage.Client/src/main/java/mage/client/SessionHandler.java
+++ b/Mage.Client/src/main/java/mage/client/SessionHandler.java
@@ -238,7 +238,7 @@ public final class SessionHandler {
         if(autoSave.equals("true")){
             // Log the submitted deck in the log folder.
             SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");
-            String logFilename = sdf.format(new Date()) + "_limited_submission" + ".dck";
+            String logFilename = sdf.format(new Date()) + "_limited" + ".dck";
             try {
                 XMAGE.getExporter().writeDeck(logFilename, deckList);
             } catch (IOException e) {

--- a/Mage.Client/src/main/java/mage/client/constants/Constants.java
+++ b/Mage.Client/src/main/java/mage/client/constants/Constants.java
@@ -104,6 +104,7 @@ public final class Constants {
 
         FREE_BUILDING,
         LIMITED_BUILDING,
+        LIMITED_SIDEBOARD_BUILDING,
         SIDEBOARDING,
         VIEW_LIMITED_DECK
     }

--- a/Mage.Client/src/main/java/mage/client/deckeditor/DeckEditorPane.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/DeckEditorPane.java
@@ -45,7 +45,9 @@ public class DeckEditorPane extends MagePane {
     }
 
     public void show(DeckEditorMode mode, Deck deck, String name, UUID tableId, int time) {
-        if (mode == DeckEditorMode.SIDEBOARDING || mode == DeckEditorMode.LIMITED_BUILDING) {
+        if (mode == DeckEditorMode.SIDEBOARDING
+                || mode == DeckEditorMode.LIMITED_BUILDING
+                || mode == DeckEditorMode.LIMITED_SIDEBOARD_BUILDING) {
             this.setTitle("Deck Editor - " + tableId.toString());
         } else if (mode == DeckEditorMode.VIEW_LIMITED_DECK) {
             this.setTitle("Deck Editor - Current Deck");

--- a/Mage.Client/src/main/java/mage/client/deckeditor/DeckEditorPanel.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/DeckEditorPanel.java
@@ -213,6 +213,7 @@ public class DeckEditorPanel extends javax.swing.JPanel {
         restoreDividerLocationsAndDeckAreaSettings();
         switch (mode) {
             case LIMITED_BUILDING:
+            case LIMITED_SIDEBOARD_BUILDING:
                 this.btnAddLand.setVisible(true);
                 this.txtTimeRemaining.setVisible(true);
                 this.btnLegality.setVisible(false); // legality check available only in free building mode
@@ -1438,7 +1439,9 @@ public class DeckEditorPanel extends javax.swing.JPanel {
     }//GEN-LAST:event_btnLoadActionPerformed
 
     private void btnNewActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnNewActionPerformed
-        if (mode == DeckEditorMode.SIDEBOARDING || mode == DeckEditorMode.LIMITED_BUILDING) {
+        if (mode == DeckEditorMode.SIDEBOARDING
+                || mode == DeckEditorMode.LIMITED_BUILDING
+                || mode == DeckEditorMode.LIMITED_SIDEBOARD_BUILDING) {
             for (Card card : deck.getCards()) {
                 deck.getSideboard().add(card);
             }

--- a/Mage.Client/src/main/java/mage/client/deckeditor/DeckEditorPanel.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/DeckEditorPanel.java
@@ -2,6 +2,8 @@ package mage.client.deckeditor;
 
 import mage.cards.Card;
 import mage.cards.decks.*;
+import static mage.cards.decks.DeckFormats.XMAGE;
+import static mage.cards.decks.DeckFormats.XMAGE_INFO;
 import mage.cards.decks.importer.DeckImporter;
 import mage.cards.repository.CardInfo;
 import mage.cards.repository.CardRepository;
@@ -38,9 +40,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.*;
 import java.util.concurrent.*;
-
-import static mage.cards.decks.DeckFormats.XMAGE;
-import static mage.cards.decks.DeckFormats.XMAGE_INFO;
 
 /**
  * @author BetaSteward_at_googlemail.com, JayDi85, Elandril
@@ -1481,7 +1480,7 @@ public class DeckEditorPanel extends javax.swing.JPanel {
             updateDeckTask.cancel(true);
         }
 
-        if (SessionHandler.submitDeck(tableId, deck.getDeckCardLists())) {
+        if (SessionHandler.submitDeck(mode, tableId, deck.getDeckCardLists())) {
             removeDeckEditor();
         }
     }//GEN-LAST:event_btnSubmitActionPerformed
@@ -1497,7 +1496,7 @@ public class DeckEditorPanel extends javax.swing.JPanel {
                 updateDeckTask.cancel(true);
             }
 
-            if (SessionHandler.submitDeck(tableId, deck.getDeckCardLists())) {
+            if (SessionHandler.submitDeck(mode, tableId, deck.getDeckCardLists())) {
                 removeDeckEditor();
             }
             return null;

--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.form
@@ -4,6 +4,9 @@
   <Properties>
     <Property name="defaultCloseOperation" type="int" value="2"/>
     <Property name="title" type="java.lang.String" value="Preferences"/>
+    <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
+      <Color id="Default Cursor"/>
+    </Property>
   </Properties>
   <SyntheticProperties>
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
@@ -42,7 +45,7 @@
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <Component id="tabsPanel" pref="554" max="32767" attributes="0"/>
+              <Component id="tabsPanel" pref="584" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="saveButton" alignment="3" min="-2" pref="30" max="-2" attributes="0"/>
@@ -97,8 +100,8 @@
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="main_gamelog" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="main_battlefield" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace max="32767" attributes="0"/>
+                      <Component id="main_battlefield" max="32767" attributes="0"/>
+                      <EmptySpace min="-2" pref="20" max="-2" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -140,6 +143,16 @@
                     <Property name="selected" type="boolean" value="true"/>
                     <Property name="text" type="java.lang.String" value="Save draft logs     (to &quot;../Mage.Client/gamelogs/&quot; directory)"/>
                     <Property name="toolTipText" type="java.lang.String" value="The logs of all your games will be saved to the mentioned folder if this option is switched on."/>
+                    <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
+                      <Color id="Default Cursor"/>
+                    </Property>
+                  </Properties>
+                </Component>
+                <Component class="javax.swing.JCheckBox" name="cbLimitedDeckAutoSave">
+                  <Properties>
+                    <Property name="selected" type="boolean" value="true"/>
+                    <Property name="text" type="java.lang.String" value="Save limited decks on submit (to &quot;../Mage.Client/gamelogs/&quot; directory)"/>
+                    <Property name="toolTipText" type="java.lang.String" value="A .dck file for each limited tournament will be saved to the mentioned folder if this option is switched on."/>
                   </Properties>
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="cbGameJsonLogAutoSave">
@@ -4114,7 +4127,7 @@
                           <Component id="checkBoxEndTurnOthers" min="-2" max="-2" attributes="0"/>
                       </Group>
                       <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                      <Component id="phases_stopSettings" pref="354" max="32767" attributes="0"/>
+                      <Component id="phases_stopSettings" pref="321" max="32767" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                   </Group>
               </Group>
@@ -4373,7 +4386,7 @@
                       <Component id="panelCardImages" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="panelBackgroundImages" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace pref="142" max="32767" attributes="0"/>
+                      <EmptySpace pref="128" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -4894,7 +4907,7 @@
               <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" alignment="0" attributes="0">
                       <Component id="avatarPane" min="-2" pref="504" max="-2" attributes="0"/>
-                      <EmptySpace min="0" pref="4" max="32767" attributes="0"/>
+                      <EmptySpace min="0" pref="52" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -6329,12 +6342,12 @@
             </DimensionLayout>
             <DimensionLayout dim="1">
               <Group type="103" groupAlignment="0" attributes="0">
-                  <EmptySpace min="0" pref="623" max="32767" attributes="0"/>
+                  <EmptySpace min="0" pref="556" max="32767" attributes="0"/>
                   <Group type="103" rootIndex="1" groupAlignment="0" attributes="0">
                       <Group type="102" alignment="0" attributes="0">
                           <EmptySpace min="-2" pref="21" max="-2" attributes="0"/>
                           <Component id="themesCategory" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace pref="523" max="32767" attributes="0"/>
+                          <EmptySpace pref="460" max="32767" attributes="0"/>
                       </Group>
                   </Group>
               </Group>

--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
@@ -3,12 +3,15 @@ package mage.client.dialog;
 import mage.client.MageFrame;
 import mage.client.SessionHandler;
 import mage.client.components.KeyBindButton;
+import static mage.client.constants.Constants.AUTO_TARGET_NON_FEEL_BAD;
+import static mage.client.constants.Constants.BATTLEFIELD_FEEDBACK_COLORIZING_MODE_ENABLE_BY_MULTICOLOR;
 import mage.client.themes.ThemeType;
 import mage.client.util.CardLanguage;
 import mage.client.util.ClientDefaultSettings;
 import mage.client.util.GUISizeHelper;
 import mage.client.util.ImageHelper;
 import mage.client.util.gui.BufferedImageBuilder;
+import static mage.constants.Constants.*;
 import mage.players.net.UserData;
 import mage.players.net.UserGroup;
 import mage.players.net.UserSkipPrioritySteps;
@@ -30,10 +33,6 @@ import java.util.List;
 import java.util.*;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
-
-import static mage.client.constants.Constants.AUTO_TARGET_NON_FEEL_BAD;
-import static mage.client.constants.Constants.BATTLEFIELD_FEEDBACK_COLORIZING_MODE_ENABLE_BY_MULTICOLOR;
-import static mage.constants.Constants.*;
 
 /**
  * @author nantuko, JayDi85, leemi
@@ -75,6 +74,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
     public static final String KEY_GAME_LOG_SHOW_TURN_INFO = "gameLogShowTurnInfo";
     public static final String KEY_GAME_LOG_AUTO_SAVE = "gameLogAutoSave";
     public static final String KEY_DRAFT_LOG_AUTO_SAVE = "draftLogAutoSave";
+    public static final String KEY_LIMITED_DECK_AUTO_SAVE = "draftLimitedAutoSave";
     public static final String KEY_JSON_GAME_LOG_AUTO_SAVE = "gameLogJsonAutoSave";
 
     public static final String KEY_CARD_IMAGES_USE_DEFAULT = "cardImagesUseDefault";
@@ -426,6 +426,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
         cbGameLogShowTurnInfo = new javax.swing.JCheckBox();
         cbGameLogAutoSave = new javax.swing.JCheckBox();
         cbDraftLogAutoSave = new javax.swing.JCheckBox();
+        cbLimitedDeckAutoSave = new javax.swing.JCheckBox();
         cbGameJsonLogAutoSave = new javax.swing.JCheckBox();
         main_card = new javax.swing.JPanel();
         showCardName = new javax.swing.JCheckBox();
@@ -630,6 +631,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setTitle("Preferences");
+        setCursor(new java.awt.Cursor(java.awt.Cursor.DEFAULT_CURSOR));
 
         tabsPanel.setMinimumSize(new java.awt.Dimension(532, 451));
 
@@ -649,7 +651,13 @@ public class PreferencesDialog extends javax.swing.JDialog {
         cbDraftLogAutoSave.setSelected(true);
         cbDraftLogAutoSave.setText("Save draft logs     (to \"../Mage.Client/gamelogs/\" directory)");
         cbDraftLogAutoSave.setToolTipText("The logs of all your games will be saved to the mentioned folder if this option is switched on.");
+        cbDraftLogAutoSave.setCursor(new java.awt.Cursor(java.awt.Cursor.DEFAULT_CURSOR));
         main_gamelog.add(cbDraftLogAutoSave);
+
+        cbLimitedDeckAutoSave.setSelected(true);
+        cbLimitedDeckAutoSave.setText("Save limited decks on submit (to \"../Mage.Client/gamelogs/\" directory)");
+        cbLimitedDeckAutoSave.setToolTipText("A .dck file for each limited tournament will be saved to the mentioned folder if this option is switched on.");
+        main_gamelog.add(cbLimitedDeckAutoSave);
 
         cbGameJsonLogAutoSave.setText("Save JSON game logs     (to \"../Mage.Client/gamelogsJson/\" directory)");
         cbGameJsonLogAutoSave.setToolTipText("The JSON logs of all your games will be saved to the mentioned folder if this option is switched on.");
@@ -910,8 +918,8 @@ public class PreferencesDialog extends javax.swing.JDialog {
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                 .add(main_gamelog, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(main_battlefield, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .add(main_battlefield, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .add(20, 20, 20))
         );
 
         main_card.getAccessibleContext().setAccessibleName("Game panel");
@@ -1649,7 +1657,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
                     .add(jLabelEndOfTurn)
                     .add(checkBoxEndTurnOthers))
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                .add(phases_stopSettings, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 354, Short.MAX_VALUE)
+                .add(phases_stopSettings, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 321, Short.MAX_VALUE)
                 .addContainerGap())
         );
 
@@ -1874,7 +1882,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
                 .add(panelCardImages, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                 .add(panelBackgroundImages, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(142, Short.MAX_VALUE))
+                .addContainerGap(128, Short.MAX_VALUE))
         );
 
         tabsPanel.addTab("Images", tabImages);
@@ -2450,7 +2458,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
             tabAvatarsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(tabAvatarsLayout.createSequentialGroup()
                 .add(avatarPane, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 504, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .add(0, 4, Short.MAX_VALUE))
+                .add(0, 52, Short.MAX_VALUE))
         );
 
         tabsPanel.addTab("Avatars", tabAvatars);
@@ -2841,12 +2849,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         );
         tabThemesLayout.setVerticalGroup(
             tabThemesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 623, Short.MAX_VALUE)
+            .add(0, 556, Short.MAX_VALUE)
             .add(tabThemesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
                 .add(tabThemesLayout.createSequentialGroup()
                     .add(21, 21, 21)
                     .add(themesCategory, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .addContainerGap(523, Short.MAX_VALUE)))
+                    .addContainerGap(460, Short.MAX_VALUE)))
         );
 
         tabsPanel.addTab("Themes", tabThemes);
@@ -2889,7 +2897,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
         layout.setVerticalGroup(
             layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(layout.createSequentialGroup()
-                .add(tabsPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 554, Short.MAX_VALUE)
+                .add(tabsPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 584, Short.MAX_VALUE)
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                 .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
                     .add(saveButton, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 30, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
@@ -2918,6 +2926,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
         save(prefs, dialog.cbGameLogShowTurnInfo, KEY_GAME_LOG_SHOW_TURN_INFO, "true", "false", UPDATE_CACHE_POLICY);
         save(prefs, dialog.cbGameLogAutoSave, KEY_GAME_LOG_AUTO_SAVE, "true", "false", UPDATE_CACHE_POLICY);
         save(prefs, dialog.cbDraftLogAutoSave, KEY_DRAFT_LOG_AUTO_SAVE, "true", "false", UPDATE_CACHE_POLICY);
+        save(prefs, dialog.cbLimitedDeckAutoSave, KEY_LIMITED_DECK_AUTO_SAVE, "true", "false", UPDATE_CACHE_POLICY);
         save(prefs, dialog.cbGameJsonLogAutoSave, KEY_JSON_GAME_LOG_AUTO_SAVE, "true", "false", UPDATE_CACHE_POLICY);
 
         String paramName = KEY_BATTLEFIELD_FEEDBACK_COLORIZING_MODE;
@@ -3480,6 +3489,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
         load(prefs, dialog.cbGameLogShowTurnInfo, KEY_GAME_LOG_SHOW_TURN_INFO, "true");
         load(prefs, dialog.cbGameLogAutoSave, KEY_GAME_LOG_AUTO_SAVE, "true");
         load(prefs, dialog.cbDraftLogAutoSave, KEY_DRAFT_LOG_AUTO_SAVE, "true");
+        load(prefs, dialog.cbLimitedDeckAutoSave, KEY_LIMITED_DECK_AUTO_SAVE, "true");
         load(prefs, dialog.cbGameJsonLogAutoSave, KEY_JSON_GAME_LOG_AUTO_SAVE, "true", "false");
 
         String feedbackParam = "";
@@ -4116,6 +4126,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
     private javax.swing.JCheckBox cbGameJsonLogAutoSave;
     private javax.swing.JCheckBox cbGameLogAutoSave;
     private javax.swing.JCheckBox cbGameLogShowTurnInfo;
+    private javax.swing.JCheckBox cbLimitedDeckAutoSave;
     private javax.swing.JComboBox cbNumberOfDownloadThreads;
     private javax.swing.JCheckBox cbPassPriorityActivation;
     private javax.swing.JCheckBox cbPassPriorityCast;

--- a/Mage.Client/src/main/java/mage/client/remote/CallbackClientImpl.java
+++ b/Mage.Client/src/main/java/mage/client/remote/CallbackClientImpl.java
@@ -369,7 +369,7 @@ public class CallbackClientImpl implements CallbackClient {
                         DeckView deckView = message.getDeck();
                         Deck deck = DeckUtil.construct(deckView);
                         if (message.getFlag()) {
-                            construct(deck, message.getTableId(), message.getTime());
+                            construct_sideboard(deck, message.getTableId(), message.getTime());
                         } else {
                             sideboard(deck, message.getTableId(), message.getTime());
                         }
@@ -609,6 +609,10 @@ public class CallbackClientImpl implements CallbackClient {
 
     protected void construct(Deck deck, UUID tableId, int time) {
         frame.showDeckEditor(DeckEditorMode.LIMITED_BUILDING, deck, tableId, time);
+    }
+
+    protected void construct_sideboard(Deck deck, UUID tableId, int time) {
+        frame.showDeckEditor(DeckEditorMode.LIMITED_SIDEBOARD_BUILDING, deck, tableId, time);
     }
 
     protected void viewLimitedDeck(Deck deck, UUID tableId, int time) {

--- a/Mage.Common/src/main/java/mage/view/TournamentView.java
+++ b/Mage.Common/src/main/java/mage/view/TournamentView.java
@@ -2,15 +2,14 @@
 
 package mage.view;
 
-import mage.game.tournament.Round;
-import mage.game.tournament.Tournament;
-import mage.game.tournament.TournamentPlayer;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import mage.game.tournament.Round;
+import mage.game.tournament.Tournament;
+import mage.game.tournament.TournamentPlayer;
 
 /**
  *
@@ -21,7 +20,6 @@ public class TournamentView implements Serializable {
 
     private final String tournamentName;
     private final String tournamentType;
-    private final TournamentTypeView tournamentTypeView;
     private final String tournamentState;
     
     private final Date startTime;
@@ -46,7 +44,6 @@ public class TournamentView implements Serializable {
             typeText.append(' ').append(tournament.getNumberRounds()).append(" rounds");
         } 
         tournamentType = typeText.toString();
-        tournamentTypeView = new TournamentTypeView(tournament.getTournamentType());
         startTime = tournament.getStartTime();
         endTime = tournament.getEndTime();
         stepStartTime = tournament.getStepStartTime();
@@ -75,10 +72,6 @@ public class TournamentView implements Serializable {
 
     public String getTournamentType() {
         return tournamentType;
-    }
-
-    public TournamentTypeView getTournamentTypeView() {
-        return tournamentTypeView;
     }
 
     public Date getStartTime() {

--- a/Mage.Common/src/main/java/mage/view/TournamentView.java
+++ b/Mage.Common/src/main/java/mage/view/TournamentView.java
@@ -2,14 +2,15 @@
 
 package mage.view;
 
+import mage.game.tournament.Round;
+import mage.game.tournament.Tournament;
+import mage.game.tournament.TournamentPlayer;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import mage.game.tournament.Round;
-import mage.game.tournament.Tournament;
-import mage.game.tournament.TournamentPlayer;
 
 /**
  *
@@ -20,6 +21,7 @@ public class TournamentView implements Serializable {
 
     private final String tournamentName;
     private final String tournamentType;
+    private final TournamentTypeView tournamentTypeView;
     private final String tournamentState;
     
     private final Date startTime;
@@ -44,6 +46,7 @@ public class TournamentView implements Serializable {
             typeText.append(' ').append(tournament.getNumberRounds()).append(" rounds");
         } 
         tournamentType = typeText.toString();
+        tournamentTypeView = new TournamentTypeView(tournament.getTournamentType());
         startTime = tournament.getStartTime();
         endTime = tournament.getEndTime();
         stepStartTime = tournament.getStepStartTime();
@@ -72,6 +75,10 @@ public class TournamentView implements Serializable {
 
     public String getTournamentType() {
         return tournamentType;
+    }
+
+    public TournamentTypeView getTournamentTypeView() {
+        return tournamentTypeView;
     }
 
     public Date getStartTime() {

--- a/Mage/src/main/java/mage/cards/decks/exporter/DeckExporter.java
+++ b/Mage/src/main/java/mage/cards/decks/exporter/DeckExporter.java
@@ -15,6 +15,14 @@ public abstract class DeckExporter {
         DeckFormats.writeDeck(file, deck, this);
     }
 
+    public void writeDeck(File directory, String filename, DeckCardLists deck) throws IOException {
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+        String path = new File(directory, filename).getPath();
+        DeckFormats.writeDeck(path, deck, this);
+    }
+
     public void writeDeck(File file, DeckCardLists deck) throws IOException {
         DeckFormats.writeDeck(file, deck, this);
     }


### PR DESCRIPTION
It is really convenient to have a saved .dck version of decks built during limited tournaments, for instance if there is a disconnect/crash.
In order to avoid manual saving every time, I am adding an extra log option (default to true), in order to output some .dck on deck submission of limited tournaments.
Of note, I did have to differentiate the building before the matchs start, and the sideboarding one, in order to not autosave on submitting after sideboarding is done.