### PR TITLE
Update deps for database support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,10 +226,9 @@
         </dependency>
         <dependency>
             <!-- database support - H2 db engine (main db) -->
-            <!-- WARNING, do not update db engine (stable: 1.4.197) cause compatibility issues, see https://github.com/h2database/h2database/issues/2078 -->
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.197</version>
+            <version>2.2.222</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
             <!-- database support - ORM -->
             <groupId>com.j256.ormlite</groupId>
             <artifactId>ormlite-jdbc</artifactId>
-            <version>5.7</version>
+            <version>6.1</version>
         </dependency>
         <dependency>
             <!-- database support - H2 db engine (main db) -->


### PR DESCRIPTION
1. Update H2 to latest version:
   * H2 was previously ignored on stable 1.4.197 due to a bug in 1.4.200 (see 27db1360).
   *  Now latest version is 2.2.222 with 1.4.* officially unsupported (info in <https://github.com/h2database/h2database/issues/2078>). 
   * Databases written by 1.4.* are not ensured to be compatible with 2.* versions.
   * However, the main card database is recreated on new xmage version anyway.
   * I checked and confirmed no errors with card database creation when loading server and client after cleaning databases.
   * Deck editor works and cards function in game.
   * Can anyone else think of a specific issue that could arise?

2. Routine bump of ormlite-jdbc ([changelog](https://github.com/j256/ormlite-core/blob/master/src/main/javadoc/doc-files/changelog.txt))

The bump from #11109 also is database related. While it might make sense to bump it as well, there's an open issue #9350 to add a unit test for the user stats database. Not sure if that's something we could test manually or what the specific concern is. The ormlite-jdbc dependency does seem to be used in (CardRepository, ExpansionRepository, AuthorizedUserRepository, UserStatsRepository, TableRecordRepository) but not sure exactly how H2 and sqlite are used... both are runtime scope.