### PR TITLE
Add emblem testing

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/emblems/AddEmblemTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/emblems/AddEmblemTest.java
@@ -1,0 +1,64 @@
+package org.mage.test.cards.emblems;
+
+import mage.abilities.keyword.FlyingAbility;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.game.command.Emblem;
+import mage.game.command.emblems.ChandraTorchOfDefianceEmblem;
+import mage.game.command.emblems.ElspethSunsChampionEmblem;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class AddEmblemTest extends CardTestPlayerBase {
+
+    /**
+     * Emblem
+     * Creatures you control get +2/+2 and have flying.
+     */
+    private static final Emblem elspethSunChampionEmblem = new ElspethSunsChampionEmblem();
+
+    /**
+     * Emblem
+     * Whenever you cast a spell, this emblem deals 5 damage to any target.
+     */
+    private static final Emblem chandraTorchOfDefianceEmblem = new ChandraTorchOfDefianceEmblem();
+
+    @Test
+    public void test_ElpethSunChampionEmblem() {
+        setStrictChooseMode(true);
+
+        addEmblem(playerA, elspethSunChampionEmblem);
+        addCard(Zone.BATTLEFIELD, playerA, "Grizzly Bears"); // 2/2 vanilla
+
+        setStopAt(1, PhaseStep.UPKEEP);
+        execute();
+
+        assertPowerToughness(playerA, "Grizzly Bears", 2 + 2, 2 + 2);
+        assertAbility(playerA, "Grizzly Bears", FlyingAbility.getInstance(), true);
+        assertCommandZoneCount(playerA, elspethSunChampionEmblem.getName(), 1);
+    }
+
+    @Test
+    public void test_ChandraTorchOfDefianceEmblem() {
+        setStrictChooseMode(true);
+
+        addEmblem(playerA, chandraTorchOfDefianceEmblem);
+        addCard(Zone.HAND, playerA, "Memnite", 2); // 1/1 for {0} vanilla
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Memnite");
+        addTarget(playerA, playerB); // emblem trigger
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Memnite");
+        addTarget(playerA, playerB); // emblem trigger
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Memnite", 2);
+        assertLife(playerB, 20 - 5 - 5);
+        assertCommandZoneCount(playerA, chandraTorchOfDefianceEmblem.getName(), 1);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -705,11 +705,15 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     }
 
     public void addEmblem(Player player, Emblem emblem) {
-        currentGame.addEmblem(
-                emblem,
-                emblem, // So this is a little ugly, but addEmblem is expecting a non-null source.
-                player.getId()
-        );
+        Emblem newEmblem = emblem.copy();
+        newEmblem.setControllerId(player.getId());
+        newEmblem.assignNewId();
+        newEmblem.getAbilities().newId();
+        for (Ability ability : newEmblem.getAbilities()) {
+            ability.setSourceId(newEmblem.getId());
+        }
+
+        currentGame.getState().addCommandObject(newEmblem);
     }
 
     /**

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -18,6 +18,7 @@ import mage.filter.FilterCard;
 import mage.filter.predicate.mageobject.NamePredicate;
 import mage.game.*;
 import mage.game.command.CommandObject;
+import mage.game.command.Emblem;
 import mage.game.match.MatchOptions;
 import mage.game.permanent.Permanent;
 import mage.game.permanent.PermanentCard;
@@ -701,6 +702,14 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
 
     public void addPlane(Player player, Planes plane) {
         assertTrue("Can't put plane to game: " + plane.getClassName(), SystemUtil.putPlaneToGame(currentGame, player, plane.getClassName()));
+    }
+
+    public void addEmblem(Player player, Emblem emblem) {
+        currentGame.addEmblem(
+                emblem,
+                emblem, // So this is a little ugly, but addEmblem is expecting a non-null source.
+                player.getId()
+        );
     }
 
     /**


### PR DESCRIPTION
new function `addEmblem` for emblem testing.
The base emblem being the source of the added emblem that is a copy of it is a little weird, but I did not want to allow for a null source if that is not expected in normal gameplay.

Making this to help #10498 happen a little faster, have other changes on the same .form I want to make in the future.