### PR TITLE
[WOC] Implement Shadow Puppeteers

### DIFF
--- a/Mage.Sets/src/mage/cards/s/ShadowPuppeteers.java
+++ b/Mage.Sets/src/mage/cards/s/ShadowPuppeteers.java
@@ -1,0 +1,77 @@
+package mage.cards.s;
+
+import mage.MageInt;
+import mage.abilities.common.AttacksCreatureYouControlTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.continuous.BecomesCreatureTargetEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.WardAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.constants.Zone;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.predicate.mageobject.AbilityPredicate;
+import mage.game.permanent.token.FaerieRogueToken;
+import mage.game.permanent.token.custom.CreatureToken;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author Susucr
+ */
+public final class ShadowPuppeteers extends CardImpl {
+
+    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creature you control with flying");
+
+    static {
+        filter.add(new AbilityPredicate(FlyingAbility.class));
+    }
+
+    public ShadowPuppeteers(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{6}{U}");
+        
+        this.subtype.add(SubType.FAERIE);
+        this.subtype.add(SubType.WIZARD);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(4);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Ward {2}
+        this.addAbility(new WardAbility(new ManaCostsImpl<>("{2}")));
+
+        // When Shadow Puppeteers enters the battlefield, create two 1/1 black Faerie Rogue creature tokens with flying.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new CreateTokenEffect(new FaerieRogueToken(), 2)));
+
+        // Whenever a creature you control with flying attacks, you may have it become a red Dragon with base power and toughness 4/4 in addition to its other colors and types until end of turn.
+        Effect effect = new BecomesCreatureTargetEffect(
+                new CreatureToken(4, 4, "red Dragon with base power and toughness 4/4")
+                    .withColor("R")
+                    .withSubType(SubType.DRAGON),
+                false, false,
+                Duration.EndOfTurn, false,
+                true, false,
+                false
+        );
+        this.addAbility(new AttacksCreatureYouControlTriggeredAbility(
+                Zone.BATTLEFIELD, effect, true, filter, true
+        ));
+    }
+
+    private ShadowPuppeteers(final ShadowPuppeteers card) {
+        super(card);
+    }
+
+    @Override
+    public ShadowPuppeteers copy() {
+        return new ShadowPuppeteers(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/WildsOfEldraineCommander.java
+++ b/Mage.Sets/src/mage/sets/WildsOfEldraineCommander.java
@@ -121,6 +121,7 @@ public final class WildsOfEldraineCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Scion of Oona", 109, Rarity.RARE, mage.cards.s.ScionOfOona.class));
         cards.add(new SetCardInfo("Secluded Glen", 166, Rarity.RARE, mage.cards.s.SecludedGlen.class));
         cards.add(new SetCardInfo("Setessan Champion", 132, Rarity.RARE, mage.cards.s.SetessanChampion.class));
+        cards.add(new SetCardInfo("Shadow Puppeteers", 12, Rarity.RARE, mage.cards.s.ShadowPuppeteers.class));
         cards.add(new SetCardInfo("Shalai, Voice of Plenty", 74, Rarity.RARE, mage.cards.s.ShalaiVoiceOfPlenty.class));
         cards.add(new SetCardInfo("Siona, Captain of the Pyleas", 144, Rarity.UNCOMMON, mage.cards.s.SionaCaptainOfThePyleas.class));
         cards.add(new SetCardInfo("Snake Umbra", 133, Rarity.UNCOMMON, mage.cards.s.SnakeUmbra.class));

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java
@@ -22,7 +22,6 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
     protected boolean keepAbilities;
     protected boolean removeSubtypes = false;
     protected boolean loseOtherCardTypes;
-    protected final boolean addCreatureType;
 
     protected boolean durationRuleAtStart = false; // put duration rule to the start of the rules instead end
 
@@ -38,11 +37,6 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
         this(token, loseAllAbilities, stillALand, duration, loseName, keepAbilities, false);
     }
 
-    public BecomesCreatureTargetEffect(Token token, boolean loseAllAbilities, boolean stillALand, Duration duration,
-                                       boolean loseName, boolean keepAbilities, boolean loseOtherCardTypes) {
-        this(token, loseAllAbilities, stillALand, duration, loseName, keepAbilities, loseOtherCardTypes, true);
-    }
-
     /**
      * @param token
      * @param loseAllAbilities   loses all creature subtypes, colors and abilities
@@ -52,10 +46,9 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
      *                           Scale Up)
      * @param duration
      * @param loseOtherCardTypes permanent loses other (original) card types, exclusively obtains card types of token
-     * @param addCreatureType permanent will gain creature type if it's not a creature.
      */
     public BecomesCreatureTargetEffect(Token token, boolean loseAllAbilities, boolean stillALand, Duration duration, boolean loseName,
-                                       boolean keepAbilities, boolean loseOtherCardTypes, boolean addCreatureType) {
+                                       boolean keepAbilities, boolean loseOtherCardTypes) {
         super(duration, Outcome.BecomeCreature);
         this.token = token;
         this.loseAllAbilities = loseAllAbilities;
@@ -63,10 +56,7 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
         this.loseName = loseName;
         this.keepAbilities = keepAbilities;
         this.loseOtherCardTypes = loseOtherCardTypes;
-        this.addCreatureType = addCreatureType;
-        if(!this.addCreatureType) {
-            this.dependencyTypes.add(DependencyType.BecomeCreature);
-        }
+        this.dependencyTypes.add(DependencyType.BecomeCreature);
     }
 
     protected BecomesCreatureTargetEffect(final BecomesCreatureTargetEffect effect) {
@@ -80,7 +70,6 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
         this.dependencyTypes.add(DependencyType.BecomeCreature);
         this.durationRuleAtStart = effect.durationRuleAtStart;
         this.removeSubtypes = effect.removeSubtypes;
-        this.addCreatureType = effect.addCreatureType;
     }
 
     @Override
@@ -110,13 +99,11 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
                     if (loseAllAbilities) {
                         permanent.removeAllCreatureTypes(game);
                     }
-                    if ((addCreatureType && keepAbilities) || removeSubtypes) { // Why keepAbilities there ??? Changeling ability?
+                    if (keepAbilities || removeSubtypes) {
                         permanent.removeAllSubTypes(game);
                     }
                     for (CardType t : token.getCardType(game)) {
-                        if(addCreatureType || !t.equals(CardType.CREATURE)) {
-                            permanent.addCardType(game, t);
-                        }
+                        permanent.addCardType(game, t);
                     }
                     permanent.copySubTypesFrom(game, token);
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java
@@ -22,6 +22,7 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
     protected boolean keepAbilities;
     protected boolean removeSubtypes = false;
     protected boolean loseOtherCardTypes;
+    protected final boolean addCreatureType;
 
     protected boolean durationRuleAtStart = false; // put duration rule to the start of the rules instead end
 
@@ -37,6 +38,11 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
         this(token, loseAllAbilities, stillALand, duration, loseName, keepAbilities, false);
     }
 
+    public BecomesCreatureTargetEffect(Token token, boolean loseAllAbilities, boolean stillALand, Duration duration,
+                                       boolean loseName, boolean keepAbilities, boolean loseOtherCardTypes) {
+        this(token, loseAllAbilities, stillALand, duration, loseName, keepAbilities, loseOtherCardTypes, true);
+    }
+
     /**
      * @param token
      * @param loseAllAbilities   loses all creature subtypes, colors and abilities
@@ -46,9 +52,10 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
      *                           Scale Up)
      * @param duration
      * @param loseOtherCardTypes permanent loses other (original) card types, exclusively obtains card types of token
+     * @param addCreatureType permanent will gain creature type if it's not a creature.
      */
     public BecomesCreatureTargetEffect(Token token, boolean loseAllAbilities, boolean stillALand, Duration duration, boolean loseName,
-                                       boolean keepAbilities, boolean loseOtherCardTypes) {
+                                       boolean keepAbilities, boolean loseOtherCardTypes, boolean addCreatureType) {
         super(duration, Outcome.BecomeCreature);
         this.token = token;
         this.loseAllAbilities = loseAllAbilities;
@@ -56,7 +63,10 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
         this.loseName = loseName;
         this.keepAbilities = keepAbilities;
         this.loseOtherCardTypes = loseOtherCardTypes;
-        this.dependencyTypes.add(DependencyType.BecomeCreature);
+        this.addCreatureType = addCreatureType;
+        if(!this.addCreatureType) {
+            this.dependencyTypes.add(DependencyType.BecomeCreature);
+        }
     }
 
     protected BecomesCreatureTargetEffect(final BecomesCreatureTargetEffect effect) {
@@ -70,6 +80,7 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
         this.dependencyTypes.add(DependencyType.BecomeCreature);
         this.durationRuleAtStart = effect.durationRuleAtStart;
         this.removeSubtypes = effect.removeSubtypes;
+        this.addCreatureType = effect.addCreatureType;
     }
 
     @Override
@@ -99,11 +110,13 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
                     if (loseAllAbilities) {
                         permanent.removeAllCreatureTypes(game);
                     }
-                    if (keepAbilities || removeSubtypes) {
+                    if ((addCreatureType && keepAbilities) || removeSubtypes) { // Why keepAbilities there ??? Changeling ability?
                         permanent.removeAllSubTypes(game);
                     }
                     for (CardType t : token.getCardType(game)) {
-                        permanent.addCardType(game, t);
+                        if(addCreatureType || !t.equals(CardType.CREATURE)) {
+                            permanent.addCardType(game, t);
+                        }
                     }
                     permanent.copySubTypesFrom(game, token);
 


### PR DESCRIPTION
The tweak of `BecomesCreatureTargetEffect` was due to the following ruling:
> If the creature stops being a creature before Shadow Puppeteers's last ability resolves, it will become red until end of turn in addition to its other colors. Since it's not a creature, it won't gain the Dragon subtype, and it won't have base power and toughness 4/4.

So with the trigger on the stack, removing the Creature type does end up with a red non-creature.
![image](https://github.com/magefree/mage/assets/34709007/4f3a5df8-ea4b-4b2b-9e67-544e4974b3a3)
(and back to colorless land when end of turn effect cleared up)