### PR TITLE
Add a 2s protection timer during draft

### DIFF
--- a/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
+++ b/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
@@ -123,7 +123,6 @@
          );
 
          protectionTimer = new Timer(protectionTime, e -> {
-             protectionPickNo = pickNo;
              protectionTimer.stop();
          });
      }
@@ -340,6 +339,7 @@
 
              if(pickNo != protectionPickNo && !protectionTimer.isRunning()) {
                  // Restart the protection timer.
+                 protectionPickNo = pickNo;
                  protectionTimer.restart();
              }
          }

--- a/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
+++ b/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
@@ -300,9 +300,8 @@
          if (this.pickingCardsListener == null) {
              this.pickingCardsListener = event -> {
                  if (event.getEventType() == ClientEventType.DRAFT_PICK_CARD) {
-                     SimpleCardView source = (SimpleCardView) event.getSource();
-
                      // PICK card
+                     SimpleCardView source = (SimpleCardView) event.getSource();
                      DraftPickView view = SessionHandler.sendCardPick(draftId, source.getId(), cardsHidden);
                      if (view != null) {
                          loadCardsToPickedCardsArea(view.getPicks());

--- a/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
+++ b/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
@@ -19,7 +19,6 @@
  import javax.swing.Timer;
  import javax.swing.*;
  import java.awt.*;
- import java.awt.dnd.DragSourceEvent;
  import java.awt.event.ActionEvent;
  import java.awt.event.ActionListener;
  import java.awt.event.KeyEvent;
@@ -41,6 +40,20 @@
      private UUID draftId;
      private Timer countdown;
      private int timeout;
+
+     /**
+      * ms delay between booster showing up and pick being allowed.
+      */
+     private static final int protectionTime = 2000;
+     /**
+      * Timer starting at booster being displayed, to protect from early pick due to clicking
+      * a little too much on the last pick.
+      */
+     private Timer protectionTimer;
+     /**
+      * Number of the latest card pick for which the protection timer has been set.
+      */
+     private int protectionPickNo = 0;
 
      // popup menu area picked cards
      private final JPopupMenu popupMenuPickedArea;
@@ -108,6 +121,11 @@
                      }
                  }
          );
+
+         protectionTimer = new Timer(protectionTime, e -> {
+             protectionPickNo = pickNo;
+             protectionTimer.stop();
+         });
      }
 
      public void cleanUp() {
@@ -118,6 +136,13 @@
              countdown.stop();
              for (ActionListener al : countdown.getActionListeners()) {
                  countdown.removeActionListener(al);
+             }
+         }
+
+         if (protectionTimer != null) {
+             protectionTimer.stop();
+             for (ActionListener al : protectionTimer.getActionListeners()) {
+                 protectionTimer.removeActionListener(al);
              }
          }
      }
@@ -275,8 +300,9 @@
          if (this.pickingCardsListener == null) {
              this.pickingCardsListener = event -> {
                  if (event.getEventType() == ClientEventType.DRAFT_PICK_CARD) {
-                     // PICK card
                      SimpleCardView source = (SimpleCardView) event.getSource();
+
+                     // PICK card
                      DraftPickView view = SessionHandler.sendCardPick(draftId, source.getId(), cardsHidden);
                      if (view != null) {
                          loadCardsToPickedCardsArea(view.getPicks());
@@ -311,7 +337,12 @@
          }
          
          if (!draftBooster.isEmptyGrid()) {
-            SessionHandler.setBoosterLoaded(draftId); // confirm to the server that the booster has been successfully loaded, otherwise the server will re-send the booster
+             SessionHandler.setBoosterLoaded(draftId); // confirm to the server that the booster has been successfully loaded, otherwise the server will re-send the booster
+
+             if(pickNo != protectionPickNo && !protectionTimer.isRunning()) {
+                 // Restart the protection timer.
+                 protectionTimer.restart();
+             }
          }
      }
 
@@ -343,6 +374,10 @@
          if (s == 6 && !draftBooster.isEmptyGrid()) {
              AudioManager.playOnCountdown1();
          }
+     }
+
+     public boolean isAllowedToPick() {
+         return !protectionTimer.isRunning();
      }
 
      public void hideDraft() {
@@ -525,7 +560,7 @@
          lblPlayer15 = new javax.swing.JLabel();
          lblPlayer16 = new javax.swing.JLabel();
          draftPicks = new mage.client.cards.CardsList();
-         draftBooster = new mage.client.cards.DraftGrid();
+         draftBooster = new mage.client.cards.DraftGrid(this);
 
          draftLeftPane.setBorder(javax.swing.BorderFactory.createBevelBorder(javax.swing.border.BevelBorder.RAISED));
          draftLeftPane.setFocusable(false);


### PR DESCRIPTION
The draft panel can be a little hasty to react to mouse events when boosters just appeared.
This PR adds a 2s grace time for each pick, after booster have been rendered, to prevent mispicking cards. As it happens from time to time, especially with players not that used to the drafting on xmage. That leads to feel bad moments missing picks (and not even knowning what was there unless looking at logs).

User feedback around that protection timer could be improved from there, either with the protection timer being shown somewhere (and replaced with a confirm pick button maybe?), alert (popup?) that the pick was prevented due to it being too fast since booster was drawn first, and/or change the color for the selected card from orange (during protection time), to green (after protection time is over).