### PR TITLE
network: reworked client-server events (related to triggers dialog problem from #11173)

### DIFF
--- a/Mage.Client/src/main/java/mage/client/MageFrame.java
+++ b/Mage.Client/src/main/java/mage/client/MageFrame.java
@@ -250,6 +250,11 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
             LOGGER.fatal(null, ex);
         }
 
+        // other settings
+        if (ClientCallback.SIMULATE_BAD_CONNECTION) {
+            LOGGER.info("Network: bad connection mode enabled");
+        }
+
         // DATA PREPARE
         RepositoryUtil.bootstrapLocalDb();
         // re-create database on empty (e.g. after new build cleaned db on startup)

--- a/Mage.Client/src/main/java/mage/client/game/FeedbackPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/FeedbackPanel.java
@@ -38,7 +38,6 @@ public class FeedbackPanel extends javax.swing.JPanel {
     private FeedbackMode mode;
     private MageDialog connectedDialog;
     private ChatPanelBasic connectedChatPanel;
-    private int lastMessageId;
     private Map<String, Serializable> lastOptions = new HashMap<>();
 
     private static final ScheduledExecutorService WORKER = Executors.newSingleThreadScheduledExecutor();
@@ -66,14 +65,8 @@ public class FeedbackPanel extends javax.swing.JPanel {
     }
 
     public void prepareFeedback(FeedbackMode mode, String message, boolean special, Map<String, Serializable> options,
-                                int messageId, boolean gameNeedUserFeedback, TurnPhase gameTurnPhase) {
+                                boolean gameNeedUserFeedback, TurnPhase gameTurnPhase) {
         synchronized (this) {
-            if (messageId < this.lastMessageId) {
-                // if too many warning messages here then look at GAME_REDRAW_GUI event logic
-                LOGGER.warn("catch un-synced message from later source (possible reason: connection or performance problems): " + messageId + ", text=" + message);
-                return;
-            }
-            this.lastMessageId = messageId;
             this.lastOptions = options;
             this.mode = mode;
         }

--- a/Mage.Client/src/main/java/mage/client/game/GamePanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/GamePanel.java
@@ -122,8 +122,8 @@ public final class GamePanel extends javax.swing.JPanel {
     private JPopupMenu popupMenuTriggerOrder;
 
     // keep game data for updates/re-draws
-    // warning, it keeps updates from GAME_UPDATE events only and ignore another events with GameView
     static class LastGameData {
+        int messageId;
         GameView game;
         boolean showPlayable;
         Map<String, Serializable> options;
@@ -571,7 +571,7 @@ public final class GamePanel extends javax.swing.JPanel {
         }
     }
 
-    public synchronized void init(GameView game) {
+    public synchronized void init(int messageId, GameView game) {
         addPlayers(game);
         // default menu states
         setMenuStates(
@@ -581,7 +581,7 @@ public final class GamePanel extends javax.swing.JPanel {
                 holdingPriority
         );
 
-        updateGame(game);
+        updateGame(messageId, game);
     }
 
     private void addPlayers(GameView game) {
@@ -706,12 +706,12 @@ public final class GamePanel extends javax.swing.JPanel {
          */
     }
 
-    public synchronized void updateGame(GameView game) {
-        updateGame(game, false, null, null);
+    public synchronized void updateGame(int messageId, GameView game) {
+        updateGame(messageId, game, false, null, null);
     }
 
-    public synchronized void updateGame(GameView game, boolean showPlayable, Map<String, Serializable> options, Set<UUID> targets) {
-        keepLastGameData(game, showPlayable, options, targets);
+    public synchronized void updateGame(int messageId, GameView game, boolean showPlayable, Map<String, Serializable> options, Set<UUID> targets) {
+        keepLastGameData(messageId, game, showPlayable, options, targets);
         prepareSelectableView();
         updateGame();
     }
@@ -946,6 +946,7 @@ public final class GamePanel extends javax.swing.JPanel {
             }
         }
 
+        //logger.info("game update, message = " + lastGameData.messageId + ", options = " + lastGameData.options + ", priority = " + lastGameData.game.getPriorityPlayerName());
         feedbackPanel.disableUndo();
         feedbackPanel.updateOptions(lastGameData.options);
 
@@ -1361,12 +1362,13 @@ public final class GamePanel extends javax.swing.JPanel {
         windowMap.entrySet().removeIf(entry -> entry.getValue().isClosed());
     }
 
-    public void ask(String question, GameView gameView, int messageId, Map<String, Serializable> options) {
-        updateGame(gameView, false, options, null);
-        this.feedbackPanel.prepareFeedback(FeedbackMode.QUESTION, question, false, options, messageId, true, gameView.getPhase());
+    public void ask(int messageId, GameView gameView, String question, Map<String, Serializable> options) {
+        updateGame(messageId, gameView, false, options, null);
+        this.feedbackPanel.prepareFeedback(FeedbackMode.QUESTION, question, false, options, true, gameView.getPhase());
     }
 
-    private void keepLastGameData(GameView game, boolean showPlayable, Map<String, Serializable> options, Set<UUID> targets) {
+    private void keepLastGameData(int messageId, GameView game, boolean showPlayable, Map<String, Serializable> options, Set<UUID> targets) {
+        lastGameData.messageId = messageId;
         lastGameData.game = game;
         lastGameData.showPlayable = showPlayable;
         lastGameData.options = options;
@@ -1623,8 +1625,8 @@ public final class GamePanel extends javax.swing.JPanel {
      * @param options
      * @param messageId
      */
-    public void pickTarget(GameView gameView, Map<String, Serializable> options, String message, CardsView cardsView, Set<UUID> targets, boolean required, int messageId) {
-        updateGame(gameView, false, options, targets);
+    public void pickTarget(int messageId, GameView gameView, Map<String, Serializable> options, String message, CardsView cardsView, Set<UUID> targets, boolean required) {
+        updateGame(messageId, gameView, false, options, targets);
         hideAll();
         DialogManager.getManager(gameId).fadeOut();
         clearPickTargetDialogs();
@@ -1652,28 +1654,28 @@ public final class GamePanel extends javax.swing.JPanel {
             dialog = prepareCardsDialog(message, cardsView, required, options0, popupMenuType);
             options0.put("dialog", dialog);
         }
-        this.feedbackPanel.prepareFeedback(required ? FeedbackMode.INFORM : FeedbackMode.CANCEL, message, gameView.getSpecial(), options0, messageId, true, gameView.getPhase());
+        this.feedbackPanel.prepareFeedback(required ? FeedbackMode.INFORM : FeedbackMode.CANCEL, message, gameView.getSpecial(), options0, true, gameView.getPhase());
         if (dialog != null) {
             this.pickTarget.add(dialog);
         }
     }
 
-    public void inform(String information, GameView gameView, int messageId) {
-        updateGame(gameView);
-        this.feedbackPanel.prepareFeedback(FeedbackMode.INFORM, information, gameView.getSpecial(), null, messageId, false, gameView.getPhase());
+    public void inform(int messageId, GameView gameView, String information) {
+        updateGame(messageId, gameView);
+        this.feedbackPanel.prepareFeedback(FeedbackMode.INFORM, information, gameView.getSpecial(), null, false, gameView.getPhase());
     }
 
-    public void endMessage(GameView gameView, Map<String, Serializable> options, String message, int messageId) {
-        updateGame(gameView, false, options, null);
+    public void endMessage(int messageId, GameView gameView, Map<String, Serializable> options, String message) {
+        updateGame(messageId, gameView, false, options, null);
         hideAll();
         DialogManager.getManager(gameId).fadeOut();
 
-        this.feedbackPanel.prepareFeedback(FeedbackMode.END, message, false, null, messageId, true, null);
+        this.feedbackPanel.prepareFeedback(FeedbackMode.END, message, false, null, true, null);
         ArrowBuilder.getBuilder().removeAllArrows(gameId);
     }
 
-    public void select(GameView gameView, Map<String, Serializable> options, String message, int messageId) {
-        updateGame(gameView, true, options, null);
+    public void select(int messageId, GameView gameView, Map<String, Serializable> options, String message) {
+        updateGame(messageId, gameView, true, options, null);
         hideAll();
         DialogManager.getManager(gameId).fadeOut();
 
@@ -1716,31 +1718,31 @@ public final class GamePanel extends javax.swing.JPanel {
             priorityPlayerText = " / priority " + gameView.getPriorityPlayerName();
         }
         String messageToDisplay = message + FeedbackPanel.getSmallText(activePlayerText + " / " + gameView.getStep().toString() + priorityPlayerText);
-        this.feedbackPanel.prepareFeedback(FeedbackMode.SELECT, messageToDisplay, gameView.getSpecial(), panelOptions, messageId, true, gameView.getPhase());
+        this.feedbackPanel.prepareFeedback(FeedbackMode.SELECT, messageToDisplay, gameView.getSpecial(), panelOptions, true, gameView.getPhase());
     }
 
-    public void playMana(GameView gameView, Map<String, Serializable> options, String message, int messageId) {
-        updateGame(gameView, true, options, null);
+    public void playMana(int messageId, GameView gameView, Map<String, Serializable> options, String message) {
+        updateGame(messageId, gameView, true, options, null);
         hideAll();
         DialogManager.getManager(gameId).fadeOut();
 
-        this.feedbackPanel.prepareFeedback(FeedbackMode.CANCEL, message, gameView.getSpecial(), options, messageId, true, gameView.getPhase());
+        this.feedbackPanel.prepareFeedback(FeedbackMode.CANCEL, message, gameView.getSpecial(), options, true, gameView.getPhase());
     }
 
-    public void playXMana(GameView gameView, Map<String, Serializable> options, String message, int messageId) {
-        updateGame(gameView, true, options, null);
+    public void playXMana(int messageId, GameView gameView, Map<String, Serializable> options, String message) {
+        updateGame(messageId, gameView, true, options, null);
         hideAll();
         DialogManager.getManager(gameId).fadeOut();
 
-        this.feedbackPanel.prepareFeedback(FeedbackMode.CONFIRM, message, gameView.getSpecial(), null, messageId, true, gameView.getPhase());
+        this.feedbackPanel.prepareFeedback(FeedbackMode.CONFIRM, message, gameView.getSpecial(), null, true, gameView.getPhase());
     }
 
     public void replayMessage(String message) {
         //TODO: implement this
     }
 
-    public void pickAbility(GameView gameView, Map<String, Serializable> options, AbilityPickerView choices) {
-        updateGame(gameView, false, options, null);
+    public void pickAbility(int messageId, GameView gameView, Map<String, Serializable> options, AbilityPickerView choices) {
+        updateGame(messageId, gameView, false, options, null);
         hideAll();
         DialogManager.getManager(gameId).fadeOut();
 
@@ -1764,8 +1766,8 @@ public final class GamePanel extends javax.swing.JPanel {
         return showCards;
     }
 
-    public void getAmount(GameView gameView, Map<String, Serializable> options, int min, int max, String message) {
-        updateGame(gameView, false, options, null);
+    public void getAmount(int messageId, GameView gameView, Map<String, Serializable> options, int min, int max, String message) {
+        updateGame(messageId, gameView, false, options, null);
         hideAll();
         DialogManager.getManager(gameId).fadeOut();
 
@@ -1777,9 +1779,9 @@ public final class GamePanel extends javax.swing.JPanel {
         }
     }
 
-    public void getMultiAmount(List<MultiAmountMessage> messages, GameView gameView, Map<String, Serializable> options,
+    public void getMultiAmount(int messageId, GameView gameView, List<MultiAmountMessage> messages, Map<String, Serializable> options,
             int min, int max) {
-        updateGame(gameView, false, options, null);
+        updateGame(messageId, gameView, false, options, null);
         hideAll();
         DialogManager.getManager(gameId).fadeOut();
 
@@ -1787,8 +1789,8 @@ public final class GamePanel extends javax.swing.JPanel {
         SessionHandler.sendPlayerString(gameId, pickMultiNumber.getMultiAmount());
     }
 
-    public void getChoice(GameView gameView, Map<String, Serializable> options, Choice choice, UUID objectId) {
-        updateGame(gameView, false, options, null);
+    public void getChoice(int messageId, GameView gameView, Map<String, Serializable> options, Choice choice, UUID objectId) {
+        updateGame(messageId, gameView, false, options, null);
         hideAll();
         DialogManager.getManager(gameId).fadeOut();
 
@@ -1813,8 +1815,8 @@ public final class GamePanel extends javax.swing.JPanel {
         pickChoice.removeDialog();
     }
 
-    public void pickPile(GameView gameView, Map<String, Serializable> options, String message, CardsView pile1, CardsView pile2) {
-        updateGame(gameView, false, options, null);
+    public void pickPile(int messageId, GameView gameView, Map<String, Serializable> options, String message, CardsView pile1, CardsView pile2) {
+        updateGame(messageId, gameView, false, options, null);
         hideAll();
         DialogManager.getManager(gameId).fadeOut();
 

--- a/Mage.Client/src/main/java/mage/client/remote/CallbackClientImpl.java
+++ b/Mage.Client/src/main/java/mage/client/remote/CallbackClientImpl.java
@@ -16,6 +16,7 @@ import mage.client.util.audio.AudioManager;
 import mage.client.util.object.SaveObjectUtil;
 import mage.interfaces.callback.CallbackClient;
 import mage.interfaces.callback.ClientCallback;
+import mage.interfaces.callback.ClientCallbackType;
 import mage.remote.ActionData;
 import mage.remote.Session;
 import mage.view.*;
@@ -24,8 +25,7 @@ import org.apache.log4j.Logger;
 
 import javax.swing.*;
 import java.awt.event.KeyEvent;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * @author BetaSteward_at_googlemail.com
@@ -34,38 +34,76 @@ public class CallbackClientImpl implements CallbackClient {
 
     private static final Logger logger = Logger.getLogger(CallbackClientImpl.class);
     private final MageFrame frame;
-    private int messageId = 0;
-    private int gameInformMessageId = 0;
+    private final Map<ClientCallbackType, Integer> lastMessages;
 
     public CallbackClientImpl(MageFrame frame) {
         this.frame = frame;
+        this.lastMessages = new HashMap<>();
+        Arrays.stream(ClientCallbackType.values()).forEach(t -> this.lastMessages.put(t, 0));
     }
 
     @Override
     public synchronized void processCallback(final ClientCallback callback) {
         callback.decompressData();
+
+        // put replay related code here
         SaveObjectUtil.saveObject(callback.getData(), callback.getMethod().toString());
+
+        // all GUI related code must be executed in swing thread
         SwingUtilities.invokeLater(() -> {
             try {
-                logger.debug(callback.getMessageId() + " -- " + callback.getMethod());
+                logger.debug("message " + callback.getMessageId() + " - " + callback.getMethod().getType() + " - " + callback.getMethod());
+
+                // process bad connection (events can income in wrong order, so outdated data must be ignored)
+                // - table/dialog events like game start, game end, choose dialog - must be processed anyway
+                // - messages events like chat, inform, error - must be processed anyway
+                // - update events like opponent priority - can be ignored
+                if (!callback.getMethod().getType().equals(ClientCallbackType.CLIENT_SIDE_EVENT)) {
+                    int lastAnyMessageId = this.lastMessages.values().stream().mapToInt(x -> x).max().orElse(0);
+                    if (lastAnyMessageId > callback.getMessageId()) {
+                        // un-synced message
+                        if (callback.getMethod().getType().mustIgnoreOnOutdated()) {
+                            // ignore
+                            logger.warn(String.format("ignore un-synced message %d - %s - %s, possible reason: slow connection/performance",
+                                    callback.getMessageId(),
+                                    callback.getMethod().getType(),
+                                    callback.getMethod()
+                            ));
+                            return;
+                        } else {
+                            // process it anyway
+                            logger.debug(String.format("processing un-synced message %d - %s - %s, possible reason: slow connection/performance",
+                                    callback.getMessageId(),
+                                    callback.getMethod().getType(),
+                                    callback.getMethod()
+                            ));
+                        }
+                    }
+
+                    // keep track of synced messages only
+                    if (!callback.getMethod().getType().canProcessInAnyOrder()) {
+                        this.lastMessages.put(callback.getMethod().getType(), callback.getMessageId());
+                    }
+                }
+
                 switch (callback.getMethod()) {
 
                     case START_GAME: {
                         TableClientMessage message = (TableClientMessage) callback.getData();
                         GameManager.instance.setCurrentPlayerUUID(message.getPlayerId());
-                        gameStarted(message.getGameId(), message.getPlayerId());
+                        gameStarted(callback.getMessageId(), message.getGameId(), message.getPlayerId());
                         break;
                     }
 
                     case START_TOURNAMENT: {
                         TableClientMessage message = (TableClientMessage) callback.getData();
-                        tournamentStarted(message.getGameId(), message.getPlayerId());
+                        tournamentStarted(callback.getMessageId(), message.getGameId(), message.getPlayerId());
                         break;
                     }
 
                     case START_DRAFT: {
                         TableClientMessage message = (TableClientMessage) callback.getData();
-                        draftStarted(message.getGameId(), message.getPlayerId());
+                        draftStarted(callback.getMessageId(), message.getGameId(), message.getPlayerId());
                         break;
                     }
 
@@ -149,7 +187,7 @@ public class CallbackClientImpl implements CallbackClient {
                     case REPLAY_INIT: {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
-                            panel.init((GameView) callback.getData());
+                            panel.init(callback.getMessageId(), (GameView) callback.getData());
                         }
                         break;
                     }
@@ -157,7 +195,7 @@ public class CallbackClientImpl implements CallbackClient {
                     case REPLAY_DONE: {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
-                            panel.endMessage(null, null, (String) callback.getData(), callback.getMessageId());
+                            panel.endMessage(callback.getMessageId(), null, null, (String) callback.getData());
                         }
                         break;
                     }
@@ -165,7 +203,7 @@ public class CallbackClientImpl implements CallbackClient {
                     case REPLAY_UPDATE: {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
-                            panel.updateGame((GameView) callback.getData());
+                            panel.updateGame(callback.getMessageId(), (GameView) callback.getData());
                         }
                         break;
                     }
@@ -174,7 +212,7 @@ public class CallbackClientImpl implements CallbackClient {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
                             appendJsonEvent("GAME_INIT", callback.getObjectId(), callback.getData());
-                            panel.init((GameView) callback.getData());
+                            panel.init(callback.getMessageId(), (GameView) callback.getData());
                         }
                         break;
                     }
@@ -190,7 +228,7 @@ public class CallbackClientImpl implements CallbackClient {
                                 String logFileName = "game-" + gameId + ".json";
                                 S3Uploader.upload(logFileName, gameId.toString());
                             }
-                            panel.endMessage(message.getGameView(), message.getOptions(), message.getMessage(), callback.getMessageId());
+                            panel.endMessage(callback.getMessageId(), message.getGameView(), message.getOptions(), message.getMessage());
                         }
                         break;
                     }
@@ -205,7 +243,7 @@ public class CallbackClientImpl implements CallbackClient {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
                             appendJsonEvent("GAME_ASK", callback.getObjectId(), message);
-                            panel.ask(message.getMessage(), message.getGameView(), callback.getMessageId(), message.getOptions());
+                            panel.ask(callback.getMessageId(), message.getGameView(), message.getMessage(), message.getOptions());
                         }
                         break;
                     }
@@ -216,8 +254,8 @@ public class CallbackClientImpl implements CallbackClient {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
                             appendJsonEvent("GAME_TARGET", callback.getObjectId(), message);
-                            panel.pickTarget(message.getGameView(), message.getOptions(), message.getMessage(),
-                                    message.getCardsView1(), message.getTargets(), message.isFlag(), callback.getMessageId());
+                            panel.pickTarget(callback.getMessageId(), message.getGameView(), message.getOptions(), message.getMessage(),
+                                    message.getCardsView1(), message.getTargets(), message.isFlag());
                         }
                         break;
                     }
@@ -227,7 +265,7 @@ public class CallbackClientImpl implements CallbackClient {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
                             appendJsonEvent("GAME_SELECT", callback.getObjectId(), message);
-                            panel.select(message.getGameView(), message.getOptions(), message.getMessage(), callback.getMessageId());
+                            panel.select(callback.getMessageId(), message.getGameView(), message.getOptions(), message.getMessage());
                         }
                         break;
                     }
@@ -237,7 +275,7 @@ public class CallbackClientImpl implements CallbackClient {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
                             appendJsonEvent("GAME_CHOOSE_ABILITY", callback.getObjectId(), callback.getData());
-                            panel.pickAbility(abilityPickerView.getGameView(), null, abilityPickerView);
+                            panel.pickAbility(callback.getMessageId(), abilityPickerView.getGameView(), null, abilityPickerView);
                         }
                         break;
                     }
@@ -247,7 +285,7 @@ public class CallbackClientImpl implements CallbackClient {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
                             appendJsonEvent("GAME_CHOOSE_PILE", callback.getObjectId(), message);
-                            panel.pickPile(message.getGameView(), message.getOptions(), message.getMessage(), message.getCardsView1(), message.getCardsView2());
+                            panel.pickPile(callback.getMessageId(), message.getGameView(), message.getOptions(), message.getMessage(), message.getCardsView1(), message.getCardsView2());
                         }
                         break;
                     }
@@ -257,7 +295,7 @@ public class CallbackClientImpl implements CallbackClient {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
                             appendJsonEvent("GAME_CHOOSE_CHOICE", callback.getObjectId(), message);
-                            panel.getChoice(message.getGameView(), message.getOptions(), message.getChoice(), callback.getObjectId());
+                            panel.getChoice(callback.getMessageId(), message.getGameView(), message.getOptions(), message.getChoice(), callback.getObjectId());
                         }
                         break;
                     }
@@ -267,7 +305,7 @@ public class CallbackClientImpl implements CallbackClient {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
                             appendJsonEvent("GAME_PLAY_MANA", callback.getObjectId(), message);
-                            panel.playMana(message.getGameView(), message.getOptions(), message.getMessage(), callback.getMessageId());
+                            panel.playMana(callback.getMessageId(), message.getGameView(), message.getOptions(), message.getMessage());
                         }
                         break;
                     }
@@ -277,7 +315,7 @@ public class CallbackClientImpl implements CallbackClient {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
                             appendJsonEvent("GAME_PLAY_XMANA", callback.getObjectId(), message);
-                            panel.playXMana(message.getGameView(), message.getOptions(), message.getMessage(), callback.getMessageId());
+                            panel.playXMana(callback.getMessageId(), message.getGameView(), message.getOptions(), message.getMessage());
                         }
                         break;
                     }
@@ -287,8 +325,7 @@ public class CallbackClientImpl implements CallbackClient {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
                             appendJsonEvent("GAME_GET_AMOUNT", callback.getObjectId(), message);
-
-                            panel.getAmount(message.getGameView(), message.getOptions(), message.getMin(), message.getMax(), message.getMessage());
+                            panel.getAmount(callback.getMessageId(), message.getGameView(), message.getOptions(), message.getMin(), message.getMax(), message.getMessage());
                         }
                         break;
                     }
@@ -298,8 +335,7 @@ public class CallbackClientImpl implements CallbackClient {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
                             appendJsonEvent("GAME_GET_MULTI_AMOUNT", callback.getObjectId(), message);
-
-                            panel.getMultiAmount(message.getMessages(), message.getGameView(), message.getOptions(), message.getMin(), message.getMax());
+                            panel.getMultiAmount(callback.getMessageId(), message.getGameView(), message.getMessages(), message.getOptions(), message.getMin(), message.getMax());
                         }
                         break;
                     }
@@ -308,7 +344,7 @@ public class CallbackClientImpl implements CallbackClient {
                         GamePanel panel = MageFrame.getGame(callback.getObjectId());
                         if (panel != null) {
                             appendJsonEvent("GAME_UPDATE", callback.getObjectId(), callback.getData());
-                            panel.updateGame((GameView) callback.getData(), true, null, null); // update after undo wtf?!
+                            panel.updateGame(callback.getMessageId(), (GameView) callback.getData(), true, null, null); // update after undo wtf?! // TODO: clean dialogs?!
                         }
                         break;
                     }
@@ -337,20 +373,12 @@ public class CallbackClientImpl implements CallbackClient {
                     }
 
                     case GAME_INFORM: {
-                        if (callback.getMessageId() > gameInformMessageId) {
-                            {
-                                GameClientMessage message = (GameClientMessage) callback.getData();
-                                GamePanel panel = MageFrame.getGame(callback.getObjectId());
-                                if (panel != null) {
-                                    appendJsonEvent("GAME_INFORM", callback.getObjectId(), message);
-                                    panel.inform(message.getMessage(), message.getGameView(), callback.getMessageId());
-                                }
-                            }
-                            // no longer needed because phase skip handling on server side now
-                        } else {
-                            logger.warn(new StringBuilder("message out of sequence - ignoring").append("MessageId = ").append(callback.getMessageId()).append(" method = ").append(callback.getMethod()));
+                        GameClientMessage message = (GameClientMessage) callback.getData();
+                        GamePanel panel = MageFrame.getGame(callback.getObjectId());
+                        if (panel != null) {
+                            appendJsonEvent("GAME_INFORM", callback.getObjectId(), message);
+                            panel.inform(callback.getMessageId(), message.getGameView(), message.getMessage());
                         }
-                        gameInformMessageId = messageId;
                         break;
                     }
 
@@ -432,13 +460,9 @@ public class CallbackClientImpl implements CallbackClient {
                     }
 
                     default: {
+                        // TODO: add exception here and process miss events like TOURNAMENT_UPDATE
                         break;
                     }
-                }
-
-                // sync message for server side events only
-                if (!callback.getMethod().isClientSideMessage()) {
-                    messageId = callback.getMessageId();
                 }
             } catch (Exception ex) {
                 handleException(ex);
@@ -466,50 +490,50 @@ public class CallbackClientImpl implements CallbackClient {
         switch (usedPanel.getChatType()) {
             case GAME:
                 usedPanel.receiveMessage("", new StringBuilder()
-                        .append("HOTKEYS:")
-                        .append("<br/>Turn mousewheel up (ALT-e) - enlarge image of card the mousepointer hovers over")
-                        .append("<br/>Turn mousewheel down (ALT-s) - enlarge original/alternate image of card the mousepointer hovers over")
-                        .append("<br/><b>")
-                        .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_CONFIRM)))
-                        .append("</b> - Confirm \"Ok\", \"Yes\" or \"Done\" button")
-                        .append("<br/><b>")
-                        .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_NEXT_TURN)))
-                        .append("</b> - Skip current turn but stop on declare attackers/blockers and something on the stack")
-                        .append("<br/><b>")
-                        .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_END_STEP)))
-                        .append("</b> - Skip to next end step but stop on declare attackers/blockers and something on the stack")
-                        .append("<br/><b>")
-                        .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_SKIP_STEP)))
-                        .append("</b> - Skip current turn but stop on declare attackers/blockers")
-                        .append("<br/><b>")
-                        .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_MAIN_STEP)))
-                        .append("</b> - Skip to next main phase but stop on declare attackers/blockers and something on the stack")
-                        .append("<br/><b>")
-                        .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_YOUR_TURN)))
-                        .append("</b> - Skip everything until your next turn")
-                        .append("<br/><b>")
-                        .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_PRIOR_END)))
-                        .append("</b> - Skip everything until the end step just prior to your turn")
-                        .append("<br/><b>")
-                        .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_CANCEL_SKIP)))
-                        .append("</b> - Undo F4/F5/F7/F9/F11")
-                        .append("<br/><b>")
-                        .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_SWITCH_CHAT)))
-                        .append("</b> - Switch in/out to chat text field")
-                        /*
+                                .append("HOTKEYS:")
+                                .append("<br/>Turn mousewheel up (ALT-e) - enlarge image of card the mousepointer hovers over")
+                                .append("<br/>Turn mousewheel down (ALT-s) - enlarge original/alternate image of card the mousepointer hovers over")
                                 .append("<br/><b>")
-                                .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_TOGGLE_MACRO)))
-                                .append("</b> - Toggle recording a sequence of actions to repeat. Will not pause if interrupted and can fail if a selected card changes such as when scrying top card to bottom.")
-                                .append("<br/><b>").append(System.getProperty("os.name").contains("Mac OS X") ? "Cmd" : "Ctrl").append(" + click</b> - Hold priority while casting a spell or activating an ability")
-                         */
-                        .append("<br/>")
-                        .append("<br/>")
-                        .append("CHAT COMMANDS:")
-                        .append("<br/>").append("<b>/h username </b> - show player's stats (history)")
-                        .append("<br/>").append("<b>/w username message</b> - send private message to player (whisper)")
-                        .append("<br/>").append("<b>/pings</b> - show players and watchers ping")
-                        .append("<br/>").append("<b>/fix</b> - fix frozen game")
-                        .toString(),
+                                .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_CONFIRM)))
+                                .append("</b> - Confirm \"Ok\", \"Yes\" or \"Done\" button")
+                                .append("<br/><b>")
+                                .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_NEXT_TURN)))
+                                .append("</b> - Skip current turn but stop on declare attackers/blockers and something on the stack")
+                                .append("<br/><b>")
+                                .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_END_STEP)))
+                                .append("</b> - Skip to next end step but stop on declare attackers/blockers and something on the stack")
+                                .append("<br/><b>")
+                                .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_SKIP_STEP)))
+                                .append("</b> - Skip current turn but stop on declare attackers/blockers")
+                                .append("<br/><b>")
+                                .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_MAIN_STEP)))
+                                .append("</b> - Skip to next main phase but stop on declare attackers/blockers and something on the stack")
+                                .append("<br/><b>")
+                                .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_YOUR_TURN)))
+                                .append("</b> - Skip everything until your next turn")
+                                .append("<br/><b>")
+                                .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_PRIOR_END)))
+                                .append("</b> - Skip everything until the end step just prior to your turn")
+                                .append("<br/><b>")
+                                .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_CANCEL_SKIP)))
+                                .append("</b> - Undo F4/F5/F7/F9/F11")
+                                .append("<br/><b>")
+                                .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_SWITCH_CHAT)))
+                                .append("</b> - Switch in/out to chat text field")
+                                /*
+                                        .append("<br/><b>")
+                                        .append(KeyEvent.getKeyText(PreferencesDialog.getCurrentControlKey(PreferencesDialog.KEY_CONTROL_TOGGLE_MACRO)))
+                                        .append("</b> - Toggle recording a sequence of actions to repeat. Will not pause if interrupted and can fail if a selected card changes such as when scrying top card to bottom.")
+                                        .append("<br/><b>").append(System.getProperty("os.name").contains("Mac OS X") ? "Cmd" : "Ctrl").append(" + click</b> - Hold priority while casting a spell or activating an ability")
+                                 */
+                                .append("<br/>")
+                                .append("<br/>")
+                                .append("CHAT COMMANDS:")
+                                .append("<br/>").append("<b>/h username </b> - show player's stats (history)")
+                                .append("<br/>").append("<b>/w username message</b> - send private message to player (whisper)")
+                                .append("<br/>").append("<b>/pings</b> - show players and watchers ping")
+                                .append("<br/>").append("<b>/fix</b> - fix frozen game")
+                                .toString(),
                         null, null, MessageType.USER_INFO, ChatMessage.MessageColor.BLUE);
                 break;
             case TOURNAMENT:
@@ -519,10 +543,10 @@ public class CallbackClientImpl implements CallbackClient {
             case TABLES:
                 String serverAddress = SessionHandler.getSession().getServerHostname().orElse("");
                 usedPanel.receiveMessage("", new StringBuilder("Download card images by using the \"Images\" main menu.")
-                        .append("<br/>Download icons and symbols by using the \"Symbols\" main menu.")
-                        .append("<br/>\\list - show a list of available chat commands.")
-                        .append("<br/>").append(IgnoreList.usage(serverAddress))
-                        .append("<br/>Type <font color=green>\\w yourUserName profanity 0 (or 1 or 2)</font> to turn off/on the profanity filter").toString(),
+                                .append("<br/>Download icons and symbols by using the \"Symbols\" main menu.")
+                                .append("<br/>\\list - show a list of available chat commands.")
+                                .append("<br/>").append(IgnoreList.usage(serverAddress))
+                                .append("<br/>Type <font color=green>\\w yourUserName profanity 0 (or 1 or 2)</font> to turn off/on the profanity filter").toString(),
                         null, null, MessageType.USER_INFO, ChatMessage.MessageColor.BLUE);
                 break;
             default:
@@ -539,7 +563,7 @@ public class CallbackClientImpl implements CallbackClient {
         }
     }
 
-    protected void gameStarted(final UUID gameId, final UUID playerId) {
+    protected void gameStarted(final int messageId, final UUID gameId, final UUID playerId) {
         try {
             frame.showGame(gameId, playerId);
             logger.info("Game " + gameId + " started for player " + playerId);
@@ -552,7 +576,7 @@ public class CallbackClientImpl implements CallbackClient {
         }
     }
 
-    protected void draftStarted(UUID draftId, UUID playerId) {
+    protected void draftStarted(int messageId, UUID draftId, UUID playerId) {
         try {
             frame.showDraft(draftId);
             logger.info("Draft " + draftId + " started for player " + playerId);
@@ -561,7 +585,7 @@ public class CallbackClientImpl implements CallbackClient {
         }
     }
 
-    protected void tournamentStarted(UUID tournamentId, UUID playerId) {
+    protected void tournamentStarted(int messageId, UUID tournamentId, UUID playerId) {
         try {
             frame.showTournament(tournamentId);
             AudioManager.playTournamentStarted();

--- a/Mage.Client/src/main/java/mage/client/util/object/SaveObjectUtil.java
+++ b/Mage.Client/src/main/java/mage/client/util/object/SaveObjectUtil.java
@@ -9,6 +9,8 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
 /**
+ * TODO: part of replay system? Un-used, can be deleted
+ *
  * Utility class to save an object on disk.
  *
  * @author ayrat

--- a/Mage.Common/src/main/java/mage/interfaces/callback/ClientCallback.java
+++ b/Mage.Common/src/main/java/mage/interfaces/callback/ClientCallback.java
@@ -2,6 +2,7 @@ package mage.interfaces.callback;
 
 import mage.remote.traffic.ZippedObject;
 import mage.utils.CompressUtil;
+import mage.utils.ThreadUtils;
 
 import java.io.Serializable;
 import java.util.UUID;
@@ -11,10 +12,22 @@ import java.util.UUID;
  */
 public class ClientCallback implements Serializable {
 
+    // for debug only: simulate bad connection on client side, use launcher's client param like -Dxmage.badconnection
+    private static final String SIMULATE_BAD_CONNECTION_PROP = "xmage.badconnection";
+    public static final boolean SIMULATE_BAD_CONNECTION;
+
+    static {
+        SIMULATE_BAD_CONNECTION = System.getProperty(SIMULATE_BAD_CONNECTION_PROP) != null;
+    }
+
     private UUID objectId;
     private Object data;
     private ClientCallbackMethod method;
     private int messageId;
+
+    public ClientCallback(ClientCallbackMethod method, UUID objectId) {
+        this(method, objectId, null);
+    }
 
     public ClientCallback(ClientCallbackMethod method, UUID objectId, Object data) {
         this(method, objectId, data, true);
@@ -26,8 +39,10 @@ public class ClientCallback implements Serializable {
         this.setData(data, useCompress);
     }
 
-    public ClientCallback(ClientCallbackMethod method, UUID objectId) {
-        this(method, objectId, null);
+    private void simulateBadConnection() {
+        if (SIMULATE_BAD_CONNECTION) {
+            ThreadUtils.sleep(100);
+        }
     }
 
     public void clear() {
@@ -55,12 +70,14 @@ public class ClientCallback implements Serializable {
             this.data = data;
         } else {
             this.data = CompressUtil.compress(data);
+            simulateBadConnection();
         }
     }
 
     public void decompressData() {
         if (this.data instanceof ZippedObject) {
             this.data = CompressUtil.decompress(this.data);
+            simulateBadConnection();
         }
     }
 

--- a/Mage.Common/src/main/java/mage/interfaces/callback/ClientCallbackMethod.java
+++ b/Mage.Common/src/main/java/mage/interfaces/callback/ClientCallbackMethod.java
@@ -1,68 +1,86 @@
 package mage.interfaces.callback;
 
 /**
- * Created by IGOUDT on 4-4-2017.
+ * Server's commands to process on client side. Commands can come in un-synced state due bad/slow network
+ * <p>
+ * Can be:
+ * - critical events (messages, game events, choose dialogs, etc)
+ * - non-critical events (game updates, messages)
  */
 public enum ClientCallbackMethod {
 
-    CHATMESSAGE("chatMessage"),
-    TOURNAMENT_INIT("tournamentInit"),
-    TOURNAMENT_UPDATE("tournamentUpdate"),
-    TOURNAMENT_OVER("tournamentOver"),
-    JOINED_TABLE("joinedTable"),
-    START_DRAFT("startDraft"),
-    START_TOURNAMENT("startTournament"),
-    SIDEBOARD("sideboard"),
-    VIEW_LIMITED_DECK("viewLimitedDeck"),
-    VIEW_SIDEBOARD("viewSideboard"),
-    CONSTRUCT("construct"),
-    SHOW_USERMESSAGE("showUserMessage"),
-    WATCHGAME("watchGame"),
-    REPLAY_GAME("replayGame"),
-    START_GAME("startGame"),
-    SHOW_TOURNAMENT("showTournament"),
-    SHOW_GAME_END_DIALOG("showGameEndDialog"),
-    SERVER_MESSAGE("serverMessage"),
-    GAME_INIT("gameInit"),
-    GAME_OVER("gameOver"),
-    GAME_INFORM("gameInform"),
-    GAME_INFORM_PERSONAL("gameInformPersonal"),
-    GAME_ERROR("gameError"),
-    GAME_UPDATE("gameUpdate"),
-    GAME_REDRAW_GUI("gameRedrawGUI", true),
-    DRAFT_OVER("draftOver"),
-    REPLAY_DONE("replayDone"),
-    USER_REQUEST_DIALOG("userRequestDialog"),
-    REPLAY_UPDATE("replayUpdate"),
-    REPLAY_INIT("replayInit"),
-    END_GAME_INFO("endGameInfo"),
-    GAME_TARGET("gameTarget"),
-    GAME_CHOOSE_ABILITY("gameChooseAbility"),
-    GAME_CHOOSE_PILE("gameChoosePile"),
-    GAME_CHOOSE_CHOICE("gameChooseChoice"),
-    GAME_ASK("gameAsk"),
-    GAME_SELECT("gameSelect"),
-    GAME_PLAY_MANA("gamePlayMana"),
-    GAME_PLAY_XMANA("gamePlayXMana"),
-    GAME_GET_AMOUNT("gameSelectAmount"),
-    GAME_GET_MULTI_AMOUNT("gameSelectMultiAmount"),
-    DRAFT_INIT("draftInit"),
-    DRAFT_PICK("draftPick"),
-    DRAFT_UPDATE("draftUpdate");
+    // TODO: rename events due place/action like GAME_STARTED, GAME_ASK_DIALOG, GAME_TARGET_DIALOG
 
-    String code;
-    boolean isClientSideMessage;
+    // messages
+    CHATMESSAGE(ClientCallbackType.MESSAGE, "chatMessage"),
+    SHOW_USERMESSAGE(ClientCallbackType.MESSAGE, "showUserMessage"),
+    SERVER_MESSAGE(ClientCallbackType.MESSAGE, "serverMessage"),
 
-    ClientCallbackMethod(String code) {
-        this(code, false);
-    }
+    // table
+    JOINED_TABLE(ClientCallbackType.TABLE_CHANGE, "joinedTable"),
 
-    ClientCallbackMethod(String code, boolean isClientSideMessage) {
+    // tournament
+    START_TOURNAMENT(ClientCallbackType.TABLE_CHANGE, "startTournament"),
+    TOURNAMENT_INIT(ClientCallbackType.TABLE_CHANGE, "tournamentInit"), // TODO: unused on client
+    TOURNAMENT_UPDATE(ClientCallbackType.UPDATE, "tournamentUpdate"), // TODO: unused on client
+    TOURNAMENT_OVER(ClientCallbackType.TABLE_CHANGE, "tournamentOver"), // TODO: unused on client
+
+    // draft/sideboard
+    START_DRAFT(ClientCallbackType.TABLE_CHANGE, "startDraft"),
+    SIDEBOARD(ClientCallbackType.TABLE_CHANGE, "sideboard"),
+    CONSTRUCT(ClientCallbackType.TABLE_CHANGE, "construct"),
+    DRAFT_OVER(ClientCallbackType.TABLE_CHANGE, "draftOver"),
+    DRAFT_INIT(ClientCallbackType.TABLE_CHANGE, "draftInit"),
+    DRAFT_PICK(ClientCallbackType.TABLE_CHANGE, "draftPick"),
+    DRAFT_UPDATE(ClientCallbackType.UPDATE, "draftUpdate"),
+
+    // watch
+    SHOW_TOURNAMENT(ClientCallbackType.TABLE_CHANGE, "showTournament"),
+    WATCHGAME(ClientCallbackType.TABLE_CHANGE, "watchGame"),
+
+    // in-game actions
+    VIEW_LIMITED_DECK(ClientCallbackType.MESSAGE, "viewLimitedDeck"),
+    VIEW_SIDEBOARD(ClientCallbackType.MESSAGE, "viewSideboard"),
+
+    // other
+    USER_REQUEST_DIALOG(ClientCallbackType.DIALOG, "userRequestDialog"),
+    GAME_REDRAW_GUI(ClientCallbackType.CLIENT_SIDE_EVENT, "gameRedrawGUI"),
+
+    // game
+    START_GAME(ClientCallbackType.TABLE_CHANGE, "startGame"),
+    GAME_INIT(ClientCallbackType.TABLE_CHANGE, "gameInit"),
+    GAME_INFORM(ClientCallbackType.MESSAGE, "gameInform"),
+    GAME_INFORM_PERSONAL(ClientCallbackType.MESSAGE, "gameInformPersonal"),
+    GAME_ERROR(ClientCallbackType.MESSAGE, "gameError"),
+    GAME_UPDATE(ClientCallbackType.UPDATE, "gameUpdate"),
+    GAME_TARGET(ClientCallbackType.DIALOG, "gameTarget"),
+    GAME_CHOOSE_ABILITY(ClientCallbackType.DIALOG, "gameChooseAbility"),
+    GAME_CHOOSE_PILE(ClientCallbackType.DIALOG, "gameChoosePile"),
+    GAME_CHOOSE_CHOICE(ClientCallbackType.DIALOG, "gameChooseChoice"),
+    GAME_ASK(ClientCallbackType.DIALOG, "gameAsk"),
+    GAME_SELECT(ClientCallbackType.DIALOG, "gameSelect"),
+    GAME_PLAY_MANA(ClientCallbackType.DIALOG, "gamePlayMana"),
+    GAME_PLAY_XMANA(ClientCallbackType.DIALOG, "gamePlayXMana"),
+    GAME_GET_AMOUNT(ClientCallbackType.DIALOG, "gameSelectAmount"),
+    GAME_GET_MULTI_AMOUNT(ClientCallbackType.DIALOG, "gameSelectMultiAmount"),
+    GAME_OVER(ClientCallbackType.TABLE_CHANGE, "gameOver"),
+    END_GAME_INFO(ClientCallbackType.TABLE_CHANGE, "endGameInfo"),
+
+    // replay (unsupported)
+    REPLAY_GAME(ClientCallbackType.TABLE_CHANGE, "replayGame"),
+    REPLAY_INIT(ClientCallbackType.TABLE_CHANGE, "replayInit"),
+    REPLAY_UPDATE(ClientCallbackType.UPDATE, "replayUpdate"),
+    REPLAY_DONE(ClientCallbackType.TABLE_CHANGE, "replayDone");
+
+    final ClientCallbackType type;
+    final String code;
+
+    ClientCallbackMethod(ClientCallbackType type, String code) {
+        this.type = type;
         this.code = code;
-        this.isClientSideMessage = isClientSideMessage;
     }
 
-    public boolean isClientSideMessage() {
-        return this.isClientSideMessage;
+    public ClientCallbackType getType() {
+        return this.type;
     }
 }

--- a/Mage.Common/src/main/java/mage/interfaces/callback/ClientCallbackType.java
+++ b/Mage.Common/src/main/java/mage/interfaces/callback/ClientCallbackType.java
@@ -1,0 +1,35 @@
+package mage.interfaces.callback;
+
+/**
+ * Server event type for processing on the client
+ *
+ * @author JayDi85
+ */
+public enum ClientCallbackType {
+
+    TABLE_CHANGE,
+    UPDATE(true, true),
+    MESSAGE(true, false),
+    DIALOG,
+    CLIENT_SIDE_EVENT(true, true);
+
+    final boolean canProcessInAnyOrder;
+    final boolean mustIgnoreOnOutdated;
+
+    ClientCallbackType() {
+        this(false, false);
+    }
+
+    ClientCallbackType(boolean canProcessInAnyOrder, boolean mustIgnoreOnOutdated) {
+        this.canProcessInAnyOrder = canProcessInAnyOrder;
+        this.mustIgnoreOnOutdated = mustIgnoreOnOutdated;
+    }
+
+    public boolean canProcessInAnyOrder() {
+        return this.canProcessInAnyOrder;
+    }
+
+    public boolean mustIgnoreOnOutdated() {
+        return this.mustIgnoreOnOutdated;
+    }
+}

--- a/Mage.Server/src/main/java/mage/server/User.java
+++ b/Mage.Server/src/main/java/mage/server/User.java
@@ -271,10 +271,6 @@ public class User {
         fireCallback(new ClientCallback(ClientCallbackMethod.SHOW_TOURNAMENT, tournamentId));
     }
 
-    public void ccShowGameEndDialog(final UUID gameId) {
-        fireCallback(new ClientCallback(ClientCallbackMethod.SHOW_GAME_END_DIALOG, gameId));
-    }
-
     public void showUserMessage(final String titel, String message) {
         List<String> messageData = new LinkedList<>();
         messageData.add(titel);

--- a/Mage/src/main/java/mage/game/events/TableEvent.java
+++ b/Mage/src/main/java/mage/game/events/TableEvent.java
@@ -7,6 +7,7 @@ import mage.game.draft.Draft;
 import mage.game.match.MatchOptions;
 import mage.game.tournament.MultiplayerRound;
 import mage.game.tournament.TournamentPairing;
+import org.apache.log4j.Logger;
 
 import java.io.Serializable;
 import java.util.EventObject;
@@ -17,10 +18,14 @@ import java.util.UUID;
  */
 public class TableEvent extends EventObject implements ExternalEvent, Serializable {
 
+    private static final Logger logger = Logger.getLogger(TableEvent.class);
+
     public enum EventType {
         UPDATE, INFO, STATUS, START_DRAFT, START_MATCH, SIDEBOARD, CONSTRUCT, SUBMIT_DECK, END, END_GAME_INFO, ERROR,
         INIT_TIMER, RESUME_TIMER, PAUSE_TIMER, CHECK_STATE_PLAYERS, START_MULTIPLAYER_MATCH
     }
+
+
 
     private Game game;
     private Draft draft;


### PR DESCRIPTION
Original problem:
* xmage sends all game events to the client in synced order, but client get it in non-synced (event with smaller data size will come first);
* example: game update with opponent priority can come after choose dialog data;

So now all game events split in diff types:
* outdated table/tourney events and choose dialogs will be used anyway;
* outdated update events will be ignored;
* outdated messages and logs will be used anyway;

Changes in PR:
* added bad connection mode to test client works on slow network, use -Dxmage.badconnection;
* added bad connection protection in events processing due event type;
* split events to different types (can be ignored, must be synced, etc);
* removed some unused server events.

closes #11173, #8851, #11052, #11086, #11155