### PR TITLE
Add new Set files, as well as add new entries to mtg-cards-data.txt

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/GathererSets.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/GathererSets.java
@@ -6,13 +6,12 @@ import mage.client.constants.Constants;
 import mage.constants.Rarity;
 import org.apache.log4j.Logger;
 import org.mage.plugins.card.dl.DownloadJob;
-
-import java.io.File;
-import java.util.*;
-
 import static org.mage.plugins.card.dl.DownloadJob.fromURL;
 import static org.mage.plugins.card.dl.DownloadJob.toFile;
 import static org.mage.plugins.card.utils.CardImageUtils.getImagesDir;
+
+import java.io.File;
+import java.util.*;
 
 /**
  * WARNING, unsupported images plugin, last updates from 2018
@@ -103,7 +102,8 @@ public class GathererSets implements Iterable<DownloadJob> {
             "C21","MH2","AFR","AFC","J21","MID","MIC","VOW","VOC","YMID",
             "NEC","NEO","SNC","NCC","CLB","2X2","DMU","DMC","40K","GN3",
             "UNF","BRO","BRC","BOT","30A","J22","SCD","DMR","ONE","ONC",
-            "MOM","MOC","MUL","MAT","LTR","CMM","WOE","WHO","RVR","WOT","WOC" 
+            "MOM","MOC","MUL","MAT","LTR","CMM","WOE","WHO","RVR","WOT",
+            "WOC","SPG","LCI","LCC","REX"
             // "HHO", "ANA" -- do not exist on gatherer
     };
 

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -533,6 +533,10 @@ public class ScryfallImageSupportCards {
             add("WOE"); // Wilds of Eldraine
             add("WOT"); // Wilds of Eldraine: Enchanting Tales
             add("WOC"); // Wilds of Eldraine Commander
+            add("LCI"); // Lost Caverns of Ixalan
+            add("LCC"); // Lost Caverns of Ixalan Commander
+            add("REX"); // Jurassic World Collection
+            add("SPG"); // Special Guests
         }
     };
 

--- a/Mage.Sets/src/mage/sets/JurassicWorldCollection.java
+++ b/Mage.Sets/src/mage/sets/JurassicWorldCollection.java
@@ -1,0 +1,23 @@
+
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.SetType;
+
+/**
+ * @author Susucr
+ */
+public final class JurassicWorldCollection extends ExpansionSet {
+
+    private static final JurassicWorldCollection instance = new JurassicWorldCollection();
+
+    public static JurassicWorldCollection getInstance() {
+        return instance;
+    }
+
+    private JurassicWorldCollection() {
+        super("Jurassic World Collection", "REX", ExpansionSet.buildDate(2023, 11, 17), SetType.SUPPLEMENTAL);
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/LostCavernsOfIxalan.java
+++ b/Mage.Sets/src/mage/sets/LostCavernsOfIxalan.java
@@ -1,0 +1,30 @@
+
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * @author Susucr
+ */
+public final class LostCavernsOfIxalan extends ExpansionSet {
+
+    private static final LostCavernsOfIxalan instance = new LostCavernsOfIxalan();
+
+    public static LostCavernsOfIxalan getInstance() {
+        return instance;
+    }
+
+    private LostCavernsOfIxalan() {
+        super("Lost Caverns of Ixalan", "LCI", ExpansionSet.buildDate(2023, 11, 17), SetType.EXPANSION);
+        this.hasBoosters = false; // TODO: enable boosters
+        this.hasBasicLands = true;
+
+        cards.add(new SetCardInfo("Forest", 291, Rarity.LAND, mage.cards.basiclands.Forest.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Island", 288, Rarity.LAND, mage.cards.basiclands.Island.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Mountain", 290, Rarity.LAND, mage.cards.basiclands.Mountain.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Plains", 287, Rarity.LAND, mage.cards.basiclands.Plains.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Swamp", 289, Rarity.LAND, mage.cards.basiclands.Swamp.class, FULL_ART_BFZ_VARIOUS));
+    }
+}

--- a/Mage.Sets/src/mage/sets/LostCavernsOfIxalanCommander.java
+++ b/Mage.Sets/src/mage/sets/LostCavernsOfIxalanCommander.java
@@ -1,0 +1,23 @@
+
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.SetType;
+
+/**
+ * @author Susucr
+ */
+public final class LostCavernsOfIxalanCommander extends ExpansionSet {
+
+    private static final LostCavernsOfIxalanCommander instance = new LostCavernsOfIxalanCommander();
+
+    public static LostCavernsOfIxalanCommander getInstance() {
+        return instance;
+    }
+
+    private LostCavernsOfIxalanCommander() {
+        super("Lost Caverns of Ixalan Commander", "LCC", ExpansionSet.buildDate(2023, 11, 17), SetType.SUPPLEMENTAL);
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/SpecialGuests.java
+++ b/Mage.Sets/src/mage/sets/SpecialGuests.java
@@ -1,0 +1,27 @@
+
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * @author Susucr
+ */
+public final class SpecialGuests extends ExpansionSet {
+
+    private static final SpecialGuests instance = new SpecialGuests();
+
+    public static SpecialGuests getInstance() {
+        return instance;
+    }
+
+    private SpecialGuests() {
+        super("Special Guests", "SPG", ExpansionSet.buildDate(2023, 11, 17), SetType.SUPPLEMENTAL);
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+
+        cards.add(new SetCardInfo("Lord of Atlantis", 1, Rarity.RARE, mage.cards.l.LordOfAtlantis.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Mana Crypt", 17, Rarity.MYTHIC, mage.cards.m.ManaCrypt.class, FULL_ART_BFZ_VARIOUS));
+    }
+}

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -63,7 +63,7 @@ public class VerifyCardDataTest {
 
     private static final Logger logger = Logger.getLogger(VerifyCardDataTest.class);
 
-    private static final String FULL_ABILITIES_CHECK_SET_CODES = "WOE;WOC"; // check ability text due mtgjson, can use multiple sets like MAT;CMD or * for all
+    private static final String FULL_ABILITIES_CHECK_SET_CODES = "LTR;LTC;WOC;LCI;LCC;REX"; // check ability text due mtgjson, can use multiple sets like MAT;CMD or * for all
     private static final boolean CHECK_ONLY_ABILITIES_TEXT = false; // use when checking text locally, suppresses unnecessary checks and output messages
 
     private static final boolean AUTO_FIX_SAMPLE_DECKS = false; // debug only: auto-fix sample decks by test_checkSampleDecks test run

--- a/Utils/known-sets.txt
+++ b/Utils/known-sets.txt
@@ -132,6 +132,7 @@ Judgment|Judgment|
 Jumpstart|Jumpstart|
 Jumpstart: Historic Horizons|JumpstartHistoricHorizons|
 Jumpstart 2022|Jumpstart2022|
+Jurassic World Collection|JurassicWorldCollection|
 Kaladesh|Kaladesh|
 Kaldheim|Kaldheim|
 Kaldheim Commander|KaldheimCommander|
@@ -212,6 +213,7 @@ Seventh Edition|SeventhEdition|
 Shadowmoor|Shadowmoor|
 Shadows over Innistrad|ShadowsOverInnistrad|
 Shards of Alara|ShardsOfAlara|
+Special Guests|SpecialGuests|
 Starter 1999|Starter1999|
 Starter 2000|Starter2000|
 Star Wars|StarWars|

--- a/Utils/known-sets.txt
+++ b/Utils/known-sets.txt
@@ -147,6 +147,8 @@ Limited Edition Beta|LimitedEditionBeta|
 The Lord of the Rings: Tales of Middle-earth|TheLordOfTheRingsTalesOfMiddleEarth|
 Tales of Middle-earth Commander|TalesOfMiddleEarthCommander|
 Lorwyn|Lorwyn|
+Lost Caverns of Ixalan|LostCavernsOfIxalan|
+Lost Caverns of Ixalan Commander|LostCavernsOfIxalanCommander|
 Magic 2010|Magic2010|
 Magic 2011|Magic2011|
 Magic 2012|Magic2012|

--- a/Utils/mtg-sets-data.txt
+++ b/Utils/mtg-sets-data.txt
@@ -121,6 +121,8 @@ Iconic Masters|IMA|
 Ikoria: Lair of Behemoths|IKO|
 Invasion|INV|
 Innistrad|ISD|
+Lost Caverns of Ixalan|LCI|
+Lost Caverns of Ixalan Commander|LCC|
 Innistrad: Midnight Hunt|MID|
 Midnight Hunt Commander|MIC|
 Innistrad: Crimson Vow|VOW|
@@ -202,6 +204,7 @@ Prerelease Events|PPRE|
 Portal Three Kingdoms|PTK|
 Ravnica Allegiance|RNA|
 Ravnica: City of Guilds|RAV|
+Jurassic World Collection|REX|
 Rivals of Ixalan|RIX|
 Rise of the Eldrazi|ROE|
 Return to Ravnica|RTR|
@@ -217,6 +220,7 @@ Scars of Mirrodin|SOM|
 Streets of New Capenna|SNC|
 New Capenna Commander|NCC|
 Stronghold|STH|
+Special Guests|SPG|
 Super Series|SUS|
 Theros|THS|
 Theros Beyond Death|THB|


### PR DESCRIPTION
Adding the 4 new sets SPG, LCI, LCC, REX; as well as updating mtg-cards-data.txt with cards from those new sets and the new cards for LTC/LTR that were just previewed.

I'm working on a scripted way to add new additions in mtg-cards-data from Scryfall bulk data. It is not ready to share yet, but will do in time as I fine tune it.