### PR TITLE
Tweak the Pillar of the Paruns format

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -533,6 +533,7 @@ public class ScryfallImageSupportCards {
             add("WOE"); // Wilds of Eldraine
             add("WOT"); // Wilds of Eldraine: Enchanting Tales
             add("WOC"); // Wilds of Eldraine Commander
+            add("CALC"); // Custom Alchemized versions of existing cards. Will download the original in directDownloadLinks
         }
     };
 
@@ -999,6 +1000,8 @@ public class ScryfallImageSupportCards {
             put("PMEI/Jamuraan Lion/10*", "https://api.scryfall.com/cards/pmei/10★/");
             // PRES
             put("PRES/Lathliss, Dragon Queen/149*", "https://api.scryfall.com/cards/pres/149★/");
+            // CALC -- custom alchemy version of cards.
+            put("CALC/C-Pillar of the Paruns", "https://api.scryfall.com/cards/dis/176/");
         }
     };
 

--- a/Mage.Server.Plugins/Mage.Game.CustomPillarOfTheParunsDuel/src/mage/game/CustomPillarOfTheParunsDuel.java
+++ b/Mage.Server.Plugins/Mage.Game.CustomPillarOfTheParunsDuel/src/mage/game/CustomPillarOfTheParunsDuel.java
@@ -32,9 +32,10 @@ import java.util.UUID;
  * To summarize, this uses the default rules for a 1v1 limited match,
  * with two additional custom rules: <p>
  * -> At the beginning of each player's first main phase, that player
- * conjure into play a Pillar of the Paruns. This does count as a
- * land drop for the turn. <p>
- * -> The starting hand size is 6, not 7.
+ * conjure into play a custom version of Pillar of the Paruns. This
+ * does count as a land drop for the turn. The custom Pillar has
+ * hexproof and gain "{T}: add {1}."<p>
+ * -> The starting hand size is 6, and the starting life count is 25.
  * <p> <p>
  * I did took the inspiration for the mode from this cube list (not
  * sure it is the original source for the idea, but i did not found
@@ -49,7 +50,7 @@ import java.util.UUID;
 public class CustomPillarOfTheParunsDuel extends GameImpl {
 
     public CustomPillarOfTheParunsDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan) {
-        super(attackOption, range, mulligan, 20, 40, 6);
+        super(attackOption, range, mulligan, 25, 40, 6);
     }
 
     @Override
@@ -57,7 +58,10 @@ public class CustomPillarOfTheParunsDuel extends GameImpl {
         super.init(choosingPlayerId);
 
         getPlayers().forEach((playerId, p) -> {
-            addDelayedTriggeredAbility(new AtTheBeginOfPlayerFirstMainPhase(playerId, "Pillar of the Paruns"), null);
+                addDelayedTriggeredAbility(
+                        new AtTheBeginOfPlayerFirstMainPhase(playerId, "C-Pillar of the Paruns"),
+                        null // TODO: Not sure how to mock something to be displayed instead.
+                );
         });
 
         state.getTurnMods().add(new TurnMod(startingPlayerId).withSkipStep(PhaseStep.DRAW));
@@ -89,28 +93,28 @@ class InitPillarOfTheParunsEffect extends OneShotEffect {
     private UUID playerId;
     private String cardName;
 
-    InitPillarOfTheParunsEffect(UUID playerId, String cardName){
+    InitPillarOfTheParunsEffect(UUID playerId, String cardName) {
         super(Outcome.PutLandInPlay);
         this.playerId = playerId;
         this.cardName = cardName;
         this.staticText = "conjure " + cardName + " in play. It does count as a land played for the turn.";
     }
 
-    private InitPillarOfTheParunsEffect(final InitPillarOfTheParunsEffect effect){
+    private InitPillarOfTheParunsEffect(final InitPillarOfTheParunsEffect effect) {
         super(effect);
         this.playerId = effect.playerId;
         this.cardName = effect.cardName;
     }
 
     @Override
-    public InitPillarOfTheParunsEffect copy(){
+    public InitPillarOfTheParunsEffect copy() {
         return new InitPillarOfTheParunsEffect(this);
     }
 
     @Override
-    public boolean apply(Game game, Ability source){
+    public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(playerId);
-        if(player == null){
+        if (player == null) {
             return false;
         }
 

--- a/Mage.Sets/src/mage/cards/p/PillarOfTheParunsCustom.java
+++ b/Mage.Sets/src/mage/cards/p/PillarOfTheParunsCustom.java
@@ -1,0 +1,46 @@
+
+package mage.cards.p;
+
+import mage.abilities.keyword.HexproofAbility;
+import mage.abilities.mana.ColorlessManaAbility;
+import mage.abilities.mana.ConditionalAnyColorManaAbility;
+import mage.abilities.mana.conditional.ConditionalSpellManaBuilder;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.StaticFilters;
+
+import java.util.UUID;
+
+/**
+ * Custom version of Pillar of the Paruns.
+ * Tweaked for the needs of the Pillar of the Paruns custom mode.
+ *
+ * Has Hexproof and "{T}: Add {1}"
+ *
+ * @author Susucr
+ */
+public final class PillarOfTheParunsCustom extends CardImpl {
+
+    public PillarOfTheParunsCustom(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.LAND}, "");
+
+        // Custom: Hexproof
+        this.addAbility(HexproofAbility.getInstance());
+
+        // Custom: {T}: Add {1}
+        this.addAbility(new ColorlessManaAbility());
+
+        // {T}: Add one mana of any color. Spend this mana only to cast a multicolored spell.
+        this.addAbility(new ConditionalAnyColorManaAbility(1, new ConditionalSpellManaBuilder(StaticFilters.FILTER_SPELL_A_MULTICOLORED)));
+    }
+
+    private PillarOfTheParunsCustom(final PillarOfTheParunsCustom card) {
+        super(card);
+    }
+
+    @Override
+    public PillarOfTheParunsCustom copy() {
+        return new PillarOfTheParunsCustom(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/CustomAlchemy.java
+++ b/Mage.Sets/src/mage/sets/CustomAlchemy.java
@@ -20,6 +20,9 @@ public final class CustomAlchemy extends ExpansionSet {
 
     private CustomAlchemy() {
         super("Custom Alchemy", "CALC", ExpansionSet.buildDate(2023, 9, 24), SetType.CUSTOM_SET);
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+
         cards.add(new SetCardInfo("C-Pillar of the Paruns", 1, Rarity.SPECIAL, mage.cards.p.PillarOfTheParunsCustom.class));
     }
 

--- a/Mage.Sets/src/mage/sets/CustomAlchemy.java
+++ b/Mage.Sets/src/mage/sets/CustomAlchemy.java
@@ -1,0 +1,26 @@
+
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * Custom version of the official cards.
+ * Similar to Alchemy tweaks of cards.
+ * @author Susucr
+ */
+public final class CustomAlchemy extends ExpansionSet {
+
+    private static final CustomAlchemy instance = new CustomAlchemy();
+
+    public static CustomAlchemy getInstance() {
+        return instance;
+    }
+
+    private CustomAlchemy() {
+        super("Custom Alchemy", "CALC", ExpansionSet.buildDate(2023, 9, 24), SetType.CUSTOM_SET);
+        cards.add(new SetCardInfo("C-Pillar of the Paruns", 1, Rarity.SPECIAL, mage.cards.p.PillarOfTheParunsCustom.class));
+    }
+
+}


### PR DESCRIPTION
Tweaking the custom Pillar of the Paruns format.

After testing a few times, the following was modified:
-> I wanted to add a couple ability to Pillar of the Paruns. This was done here adding a custom version of the card, in an "Custom Alchemy" set. It is more straightforward than adding continuous effect to games in the custom game mode.
-> Starting life set to 25. Ideally this would be a custom option instead in the future, but I delayed working on that due to waiting a PR to be merged first.

![image](https://github.com/magefree/mage/assets/34709007/baec21ad-2161-4fd5-ab77-afc4f87bd808)
