### PR TITLE
refactor: remove unnecessary "lockedIn" parameter

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AkroanHoplite.java
+++ b/Mage.Sets/src/mage/cards/a/AkroanHoplite.java
@@ -38,7 +38,7 @@ public final class AkroanHoplite extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever Akroan Hoplite attacks, it gets +X/+0 until end of turn, where X is the number of attacking creatures you control.
-        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, "it"), false));
     }
 
     private AkroanHoplite(final AkroanHoplite card) {

--- a/Mage.Sets/src/mage/cards/a/AlandraSkyDreamer.java
+++ b/Mage.Sets/src/mage/cards/a/AlandraSkyDreamer.java
@@ -49,8 +49,7 @@ public final class AlandraSkyDreamer extends CardImpl {
                 new BoostSourceEffect(
                         CardsInControllerHandCount.instance,
                         CardsInControllerHandCount.instance,
-                        Duration.EndOfTurn,
-                        true
+                        Duration.EndOfTurn
                 ).setText("{this}"),
                 false,
                 5

--- a/Mage.Sets/src/mage/cards/a/AlandraSkyDreamer.java
+++ b/Mage.Sets/src/mage/cards/a/AlandraSkyDreamer.java
@@ -61,8 +61,7 @@ public final class AlandraSkyDreamer extends CardImpl {
                         CardsInControllerHandCount.instance,
                         Duration.EndOfTurn,
                         filter,
-                        false,
-                        true
+                        false
                 ).setText("and Drakes you control each get +X/+X until end of turn, where X is the number of cards in your hand")
         );
         this.addAbility(

--- a/Mage.Sets/src/mage/cards/a/AllosaurusShepherd.java
+++ b/Mage.Sets/src/mage/cards/a/AllosaurusShepherd.java
@@ -48,7 +48,7 @@ public class AllosaurusShepherd extends CardImpl {
         //4GG: Until end of turn, each Elf creature you control has base power and toughness 5/5 
         // and becomes a Dinosaur in addition to its other creature types.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new SetBasePowerToughnessAllEffect(5, 5, Duration.EndOfTurn, elvesFilter, true)
+                new SetBasePowerToughnessAllEffect(5, 5, Duration.EndOfTurn, elvesFilter)
                         .setText("Until end of turn, each Elf creature you control has base power and toughness 5/5"),
                 new ManaCostsImpl<>("{4}{G}{G}"));
         ability.addEffect(new CreaturesBecomeOtherTypeEffect(elvesFilter, SubType.DINOSAUR, Duration.EndOfTurn)

--- a/Mage.Sets/src/mage/cards/a/AlpineHoundmaster.java
+++ b/Mage.Sets/src/mage/cards/a/AlpineHoundmaster.java
@@ -56,7 +56,7 @@ public final class AlpineHoundmaster extends CardImpl {
 
         // Whenever Alpine Houndmaster attacks, it gets +X/+0 until end of turn, where X is the number of other attacking creatures.
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
-                xValue, StaticValue.get(0), Duration.EndOfTurn, true, "it"
+                xValue, StaticValue.get(0), Duration.EndOfTurn, "it"
         ), false));
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelicCaptain.java
+++ b/Mage.Sets/src/mage/cards/a/AngelicCaptain.java
@@ -41,7 +41,7 @@ public final class AngelicCaptain extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Whenever Angelic Captain attacks, it gets +1/+1 until end of turn for each other attacking Ally.
-        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, "it"), false));
     }
 
     private AngelicCaptain(final AngelicCaptain card) {

--- a/Mage.Sets/src/mage/cards/a/AnimusOfNightsReach.java
+++ b/Mage.Sets/src/mage/cards/a/AnimusOfNightsReach.java
@@ -52,7 +52,7 @@ public final class AnimusOfNightsReach extends CardImpl {
 
         // Whenever Animus of Night's Reach attacks, it gets +X/+0 until end of turn, where X is the number of creature cards in defending player's graveyard.
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
-                xValue, StaticValue.get(0), Duration.EndOfTurn, true
+                xValue, StaticValue.get(0), Duration.EndOfTurn
         ).setText("it gets +X/+0 until end of turn, where X is the number of creature cards in defending player's graveyard")).addHint(AnimusOfNightsReachHint.instance));
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArchonOfTheWildRose.java
+++ b/Mage.Sets/src/mage/cards/a/ArchonOfTheWildRose.java
@@ -43,7 +43,7 @@ public final class ArchonOfTheWildRose extends CardImpl {
 
         // Other creatures you control that are enchanted by Auras you control have base power and toughness 4/4 and have flying.
         Ability ability = new SimpleStaticAbility(
-                new SetBasePowerToughnessAllEffect(4, 4, Duration.WhileOnBattlefield, filter, true)
+                new SetBasePowerToughnessAllEffect(4, 4, Duration.WhileOnBattlefield, filter)
         );
         ability.addEffect(new GainAbilityAllEffect(FlyingAbility.getInstance(), Duration.WhileOnBattlefield, filter)
                 .setText("and have flying"));

--- a/Mage.Sets/src/mage/cards/a/AsajjVentress.java
+++ b/Mage.Sets/src/mage/cards/a/AsajjVentress.java
@@ -38,7 +38,7 @@ public final class AsajjVentress extends CardImpl {
         this.addAbility(DoubleStrikeAbility.getInstance());
 
         // When Asajj Ventress becomes blocked, she gets +1/+1 until end of turn for each creature blocking her.
-        Effect effect = new BoostSourceEffect(BlockingCreatureCount.SOURCE, BlockingCreatureCount.SOURCE, Duration.EndOfTurn, true);
+        Effect effect = new BoostSourceEffect(BlockingCreatureCount.SOURCE, BlockingCreatureCount.SOURCE, Duration.EndOfTurn);
         effect.setText("she gets +1/+1 until end of turn for each creature blocking her");
         this.addAbility(new BecomesBlockedSourceTriggeredAbility(effect, false));
 

--- a/Mage.Sets/src/mage/cards/a/Aurochs.java
+++ b/Mage.Sets/src/mage/cards/a/Aurochs.java
@@ -40,7 +40,7 @@ public final class Aurochs extends CardImpl {
         // Trample
         this.addAbility(TrampleAbility.getInstance());
         // Whenever Aurochs attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.
-        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, "it"), false));
     }
 
     private Aurochs(final Aurochs card) {

--- a/Mage.Sets/src/mage/cards/a/AurochsHerd.java
+++ b/Mage.Sets/src/mage/cards/a/AurochsHerd.java
@@ -49,7 +49,7 @@ public final class AurochsHerd extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
             new TargetCardInLibrary(filter1), true), true));
         // Whenever Aurochs Herd attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.
-        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, "it"), false));
     }
 
     private AurochsHerd(final AurochsHerd card) {

--- a/Mage.Sets/src/mage/cards/b/BessSoulNourisher.java
+++ b/Mage.Sets/src/mage/cards/b/BessSoulNourisher.java
@@ -53,7 +53,7 @@ public class BessSoulNourisher extends CardImpl {
         DynamicValue xValue = new CountersSourceCount(CounterType.P1P1);
         this.addAbility(new AttacksTriggeredAbility(new BoostControlledEffect(
                 xValue, xValue, Duration.EndOfTurn,
-                StaticFilters.FILTER_PERMANENT_CREATURE, true, true
+                StaticFilters.FILTER_PERMANENT_CREATURE, true
         ).setText("each other creature you control with base power and toughness 1/1 " +
                 "gets +X/+X until end of turn, where X is the number of +1/+1 counters on {this}"),
                 false));

--- a/Mage.Sets/src/mage/cards/b/BiomassMutation.java
+++ b/Mage.Sets/src/mage/cards/b/BiomassMutation.java
@@ -23,7 +23,7 @@ public final class BiomassMutation extends CardImpl {
 
         // Creatures you control have base power and toughness X/X until end of turn.
         DynamicValue variableMana = ManacostVariableValue.REGULAR;
-        this.getSpellAbility().addEffect(new SetBasePowerToughnessAllEffect(variableMana, variableMana, Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES, true));
+        this.getSpellAbility().addEffect(new SetBasePowerToughnessAllEffect(variableMana, variableMana, Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES));
     }
 
     private BiomassMutation(final BiomassMutation card) {

--- a/Mage.Sets/src/mage/cards/b/BloodvialPurveyor.java
+++ b/Mage.Sets/src/mage/cards/b/BloodvialPurveyor.java
@@ -53,7 +53,7 @@ public final class BloodvialPurveyor extends CardImpl {
 
         // Whenever Bloodvial Purveyor attacks, it gets +1/+0 until end of turn for each Blood token defending player controls.
         this.addAbility(new AttacksTriggeredAbility(
-                new BoostSourceEffect(new PermanentsTargetOpponentControlsCount(filter), StaticValue.get(0), Duration.EndOfTurn, true)
+                new BoostSourceEffect(new PermanentsTargetOpponentControlsCount(filter), StaticValue.get(0), Duration.EndOfTurn)
                         .setText("it gets +1/+0 until end of turn for each Blood token defending player controls"),
                 false, null, SetTargetPointer.PLAYER
         ));

--- a/Mage.Sets/src/mage/cards/b/BlossomingBogbeast.java
+++ b/Mage.Sets/src/mage/cards/b/BlossomingBogbeast.java
@@ -38,7 +38,7 @@ public final class BlossomingBogbeast extends CardImpl {
         ).setText("Then creatures you control gain trample"));
         ability.addEffect(new BoostControlledEffect(
                 ControllerGainedLifeCount.instance, ControllerGainedLifeCount.instance, Duration.EndOfTurn,
-                StaticFilters.FILTER_PERMANENT_CREATURES, false, true
+                StaticFilters.FILTER_PERMANENT_CREATURES, false
         ).setText("and get +X/+X until end of turn, where X is the amount of life you gained this turn"));
         this.addAbility(ability.addHint(ControllerGainedLifeCount.getHint()), new PlayerGainedLifeWatcher());
     }

--- a/Mage.Sets/src/mage/cards/b/BorderlandBehemoth.java
+++ b/Mage.Sets/src/mage/cards/b/BorderlandBehemoth.java
@@ -41,7 +41,7 @@ public final class BorderlandBehemoth extends CardImpl {
 
         // Borderland Behemoth gets +4/+4 for each other Giant you control.
         this.addAbility(new SimpleStaticAbility(new BoostSourceEffect(
-                xValue, xValue, Duration.WhileOnBattlefield, false
+                xValue, xValue, Duration.WhileOnBattlefield
         ).setText("{this} gets +4/+4 for each other Giant you control")));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrineHag.java
+++ b/Mage.Sets/src/mage/cards/b/BrineHag.java
@@ -81,7 +81,7 @@ class BrineHagEffect extends OneShotEffect {
         if (!set.isEmpty()) {
             FilterCreaturePermanent filter = new FilterCreaturePermanent();
             filter.add(new PermanentReferenceInCollectionPredicate(set));
-            game.addEffect(new SetBasePowerToughnessAllEffect(0, 2, Duration.Custom, filter, true), source);
+            game.addEffect(new SetBasePowerToughnessAllEffect(0, 2, Duration.Custom, filter), source);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/b/BullAurochs.java
+++ b/Mage.Sets/src/mage/cards/b/BullAurochs.java
@@ -41,7 +41,7 @@ public final class BullAurochs extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Whenever Bull Aurochs attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.
-        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, "it"), false));
     }
 
     private BullAurochs(final BullAurochs card) {

--- a/Mage.Sets/src/mage/cards/c/CandlekeepInspiration.java
+++ b/Mage.Sets/src/mage/cards/c/CandlekeepInspiration.java
@@ -34,7 +34,7 @@ public final class CandlekeepInspiration extends CardImpl {
         // Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards you own in exile and in your graveyard that are instant cards, are sorcery cards, and/or have an Adventure.
         this.getSpellAbility().addEffect(new SetBasePowerToughnessAllEffect(
                 CandlekeepInspirationValue.instance, CandlekeepInspirationValue.instance,
-                Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURE, true
+                Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURE
         ).setText("until end of turn, creatures you control have base power and toughness X/X, " +
                 "where X is the number of cards you own in exile and in your graveyard " +
                 "that are instant cards, are sorcery cards, and/or have an Adventure"));

--- a/Mage.Sets/src/mage/cards/c/CaptainVargusWrath.java
+++ b/Mage.Sets/src/mage/cards/c/CaptainVargusWrath.java
@@ -37,7 +37,7 @@ public final class CaptainVargusWrath extends CardImpl {
         // Whenever Captain Vargus Wrath attacks, Pirates you control get +1/+1 until end of turn for each time you've cast a commander from the command zone this game.
         this.addAbility(new AttacksTriggeredAbility(new BoostControlledEffect(
                 CaptainVargusWrathValue.instance, CaptainVargusWrathValue.instance,
-                Duration.EndOfTurn, filter, false, true
+                Duration.EndOfTurn, filter, false
         ), false, "Whenever {this} attacks, Pirates you control get +1/+1 until end of turn " +
                 "for each time you've cast a commander from the command zone this game."
         ).addHint(CaptainVargusWrathValue.getHint()));

--- a/Mage.Sets/src/mage/cards/c/CennsHeir.java
+++ b/Mage.Sets/src/mage/cards/c/CennsHeir.java
@@ -37,7 +37,7 @@ public final class CennsHeir extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Whenever Cenn's Heir attacks, it gets +1/+1 until end of turn for each other attacking Kithkin.
-        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, "it"), false));
     }
 
     private CennsHeir(final CennsHeir card) {

--- a/Mage.Sets/src/mage/cards/c/ChameleonColossus.java
+++ b/Mage.Sets/src/mage/cards/c/ChameleonColossus.java
@@ -38,7 +38,7 @@ public final class ChameleonColossus extends CardImpl {
 
         // {2}{G}{G}: Chameleon Colossus gets +X/+X until end of turn, where X is its power.
         this.addAbility(new SimpleActivatedAbility(
-                new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, true)
+                new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn)
                         .setText("{this} gets +X/+X until end of turn, where X is its power"),
                 new ManaCostsImpl<>("{2}{G}{G}")
         ));

--- a/Mage.Sets/src/mage/cards/c/ChargeAcrossTheAraba.java
+++ b/Mage.Sets/src/mage/cards/c/ChargeAcrossTheAraba.java
@@ -22,7 +22,7 @@ public final class ChargeAcrossTheAraba extends CardImpl {
 
         // Sweep - Return any number of Plains you control to their owner's hand. Creatures you control get +1/+1 until end of turn for each Plains returned this way.
         this.getSpellAbility().addEffect(new SweepEffect(SubType.PLAINS));
-        this.getSpellAbility().addEffect(new BoostControlledEffect(SweepNumber.PLAINS, SweepNumber.PLAINS, Duration.EndOfTurn, null, false, true));
+        this.getSpellAbility().addEffect(new BoostControlledEffect(SweepNumber.PLAINS, SweepNumber.PLAINS, Duration.EndOfTurn, null, false));
     }
 
     private ChargeAcrossTheAraba(final ChargeAcrossTheAraba card) {

--- a/Mage.Sets/src/mage/cards/c/ChargingHooligan.java
+++ b/Mage.Sets/src/mage/cards/c/ChargingHooligan.java
@@ -55,7 +55,7 @@ public final class ChargingHooligan extends CardImpl {
 
         // Whenever Charging Hooligan attacks, it gets +1/+0 until end of turn for each attacking creature. If a Rat is attacking, Charging Hooligan gains trample until end of turn.
         Ability ability = new AttacksTriggeredAbility(
-                new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, true, "it")
+                new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, "it")
         );
         ability.addEffect(new ConditionalOneShotEffect(
                 new AddContinuousEffectToGame(

--- a/Mage.Sets/src/mage/cards/c/CharixTheRagingIsle.java
+++ b/Mage.Sets/src/mage/cards/c/CharixTheRagingIsle.java
@@ -44,7 +44,7 @@ public final class CharixTheRagingIsle extends CardImpl {
 
         // {3}: Charix gets +X/-X until end of turn, where X is the number of Islands you control.
         this.addAbility(new SimpleActivatedAbility(new BoostSourceEffect(
-                xValue, xValue2, Duration.EndOfTurn, true
+                xValue, xValue2, Duration.EndOfTurn
         ).setText("{this} gets +X/-X until end of turn, where X is the number of Islands you control"), new GenericManaCost(3)));
     }
 

--- a/Mage.Sets/src/mage/cards/c/CoastlineMarauders.java
+++ b/Mage.Sets/src/mage/cards/c/CoastlineMarauders.java
@@ -46,7 +46,7 @@ public final class CoastlineMarauders extends CardImpl {
 
         // Whenever Coastline Marauders attacks, it gets +1/+0 until end of turn for each land defending player controls.
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
-                xValue, StaticValue.get(0), Duration.EndOfTurn, true
+                xValue, StaticValue.get(0), Duration.EndOfTurn
         ).setText("it gets +1/+0 until end of turn for each land defending player controls"), false));
 
         // Encore {4}{R}{R}

--- a/Mage.Sets/src/mage/cards/c/CraterhoofBehemoth.java
+++ b/Mage.Sets/src/mage/cards/c/CraterhoofBehemoth.java
@@ -45,7 +45,7 @@ public final class CraterhoofBehemoth extends CardImpl {
         ).setText("creatures you control gain trample"));
         ability.addEffect(new BoostControlledEffect(
                 CreaturesYouControlCount.instance, CreaturesYouControlCount.instance,
-                Duration.EndOfTurn, filter, false, true
+                Duration.EndOfTurn, filter, false
         ).setText("and get +X/+X until end of turn, where X is the number of creatures you control"));
         ability.addHint(CreaturesYouControlHint.instance);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/c/CreepingTrailblazer.java
+++ b/Mage.Sets/src/mage/cards/c/CreepingTrailblazer.java
@@ -44,7 +44,7 @@ public final class CreepingTrailblazer extends CardImpl {
 
         // {2}{R}{G}: Creeping Trailblazer gets +1/+1 until end of turn for each Elemental you control.
         this.addAbility(new SimpleActivatedAbility(
-                new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, true)
+                new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn)
                         .setText("{this} gets +1/+1 until end of turn for each Elemental you control."),
                 new ManaCostsImpl<>("{2}{R}{G}")
         ));

--- a/Mage.Sets/src/mage/cards/c/CriminalPast.java
+++ b/Mage.Sets/src/mage/cards/c/CriminalPast.java
@@ -38,7 +38,7 @@ public final class CriminalPast extends CardImpl {
         ));
         ability.addEffect(new GainAbilityAllEffect(
                 new SimpleStaticAbility(new BoostSourceEffect(
-                        xValue, StaticValue.get(0), Duration.WhileOnBattlefield, false, "this creature"
+                        xValue, StaticValue.get(0), Duration.WhileOnBattlefield, "this creature"
                 )), Duration.WhileOnBattlefield, StaticFilters.FILTER_CREATURES_OWNED_COMMANDER
         ).setText("and \"This creature gets +X/+0, where X is the number of creature cards in your graveyard.\" " +
                 "<i>(A creature with menace can't be blocked except by two or more creatures.)</i>"));

--- a/Mage.Sets/src/mage/cards/c/CultivatorOfBlades.java
+++ b/Mage.Sets/src/mage/cards/c/CultivatorOfBlades.java
@@ -32,7 +32,7 @@ public final class CultivatorOfBlades extends CardImpl {
         this.addAbility(new FabricateAbility(2));
 
         // Whenever Cultivator of Blades attacks, you may have other attacking creatures get +X/+X until end of turn, where X is Cultivator of Blades's power.
-        this.addAbility(new AttacksTriggeredAbility(new BoostControlledEffect(new SourcePermanentPowerCount(), new SourcePermanentPowerCount(), Duration.EndOfTurn, StaticFilters.FILTER_ATTACKING_CREATURES, true, true),
+        this.addAbility(new AttacksTriggeredAbility(new BoostControlledEffect(new SourcePermanentPowerCount(), new SourcePermanentPowerCount(), Duration.EndOfTurn, StaticFilters.FILTER_ATTACKING_CREATURES, true),
                 true, "Whenever Cultivator of Blades attacks, you may have other attacking creatures get +X/+X until end of turn, where X is Cultivator of Blades's power."));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DireFleetCaptain.java
+++ b/Mage.Sets/src/mage/cards/d/DireFleetCaptain.java
@@ -38,7 +38,7 @@ public final class DireFleetCaptain extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever Dire Fleet Captain attacks, it gets +1/+1 until end of turn for each other attacking Pirate.
-        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, "it"), false));
     }
 
     private DireFleetCaptain(final DireFleetCaptain card) {

--- a/Mage.Sets/src/mage/cards/d/DollhouseOfHorrors.java
+++ b/Mage.Sets/src/mage/cards/d/DollhouseOfHorrors.java
@@ -95,7 +95,6 @@ class DollhouseOfHorrorsEffect extends OneShotEffect {
                 xValue,
                 xValue,
                 Duration.WhileOnBattlefield,
-                false,
                 "this creature"
         )));
         effect.apply(game, source);

--- a/Mage.Sets/src/mage/cards/d/DragonThroneOfTarkir.java
+++ b/Mage.Sets/src/mage/cards/d/DragonThroneOfTarkir.java
@@ -38,7 +38,7 @@ public final class DragonThroneOfTarkir extends CardImpl {
         effect.setText("Other creatures you control gain trample");
         Ability gainedAbility = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new GenericManaCost(2));
         DynamicValue xValue = new SourcePermanentPowerCount();
-        effect = new BoostControlledEffect(xValue, xValue, Duration.EndOfTurn, StaticFilters.FILTER_PERMANENT_CREATURE, true, true);
+        effect = new BoostControlledEffect(xValue, xValue, Duration.EndOfTurn, StaticFilters.FILTER_PERMANENT_CREATURE, true);
         effect.setText("and get +X/+X until end of turn, where X is this creature's power");
         gainedAbility.addEffect(effect);
         gainedAbility.addCost(new TapSourceCost());

--- a/Mage.Sets/src/mage/cards/e/ElectrostaticPummeler.java
+++ b/Mage.Sets/src/mage/cards/e/ElectrostaticPummeler.java
@@ -35,7 +35,7 @@ public final class ElectrostaticPummeler extends CardImpl {
 
         // Pay {E}{E}{E}: Electrostatic Pummeler gets +X/+X until end of turn, where X is its power.
         this.addAbility(new SimpleActivatedAbility(new BoostSourceEffect(
-                xValue, xValue, Duration.EndOfTurn, true
+                xValue, xValue, Duration.EndOfTurn
         ).setText("{this} gets +X/+X until end of turn, where X is its power"), new PayEnergyCost(3)));
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElvishBerserker.java
+++ b/Mage.Sets/src/mage/cards/e/ElvishBerserker.java
@@ -25,7 +25,7 @@ public final class ElvishBerserker extends CardImpl {
 
         // Whenever Elvish Berserker becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.
         this.addAbility(new BecomesBlockedSourceTriggeredAbility(
-                new BoostSourceEffect(BlockingCreatureCount.SOURCE, BlockingCreatureCount.SOURCE, Duration.EndOfTurn, true, "it"),
+                new BoostSourceEffect(BlockingCreatureCount.SOURCE, BlockingCreatureCount.SOURCE, Duration.EndOfTurn, "it"),
                 false
         ));
     }

--- a/Mage.Sets/src/mage/cards/e/EmberethSkyblazer.java
+++ b/Mage.Sets/src/mage/cards/e/EmberethSkyblazer.java
@@ -45,7 +45,7 @@ public final class EmberethSkyblazer extends CardImpl {
         this.addAbility(new AttacksTriggeredAbility(new DoIfCostPaid(
                 new BoostControlledEffect(
                         OpponentsCount.instance, StaticValue.get(0), Duration.EndOfTurn,
-                        StaticFilters.FILTER_PERMANENT_CREATURE, false, true
+                        StaticFilters.FILTER_PERMANENT_CREATURE, false
                 ).setText("creatures you control get +X/+0 until end of turn, where X is the number of opponents you have"),
                 new ManaCostsImpl<>("{2}{R}")
         ), false));

--- a/Mage.Sets/src/mage/cards/f/FaeburrowElder.java
+++ b/Mage.Sets/src/mage/cards/f/FaeburrowElder.java
@@ -41,7 +41,7 @@ public final class FaeburrowElder extends CardImpl {
 
         // Faeburrow Elder gets +1/+1 for each color among permanents you control.
         this.addAbility(new SimpleStaticAbility(new BoostSourceEffect(
-                FaeburrowElderValue.instance, FaeburrowElderValue.instance, Duration.WhileOnBattlefield, false
+                FaeburrowElderValue.instance, FaeburrowElderValue.instance, Duration.WhileOnBattlefield
         )));
 
         // {T}: For each color among permanents you control, add one mana of that color.

--- a/Mage.Sets/src/mage/cards/f/FeralAnimist.java
+++ b/Mage.Sets/src/mage/cards/f/FeralAnimist.java
@@ -31,7 +31,7 @@ public final class FeralAnimist extends CardImpl {
 
         // {3}: Feral Animist gets +X/+0 until end of turn, where X is its power.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new BoostSourceEffect(new SourcePermanentPowerCount(), StaticValue.get(0), Duration.EndOfTurn, true),
+                new BoostSourceEffect(new SourcePermanentPowerCount(), StaticValue.get(0), Duration.EndOfTurn),
                 new GenericManaCost(3)));
     }
 

--- a/Mage.Sets/src/mage/cards/f/FreelanceMuscle.java
+++ b/Mage.Sets/src/mage/cards/f/FreelanceMuscle.java
@@ -38,7 +38,7 @@ public final class FreelanceMuscle extends CardImpl {
         // Whenever Freelance Muscle attacks or blocks, it gets +X/+X until end of turn, where X is the greatest power and/or toughness among other creatures you control.
         this.addAbility(new AttacksOrBlocksTriggeredAbility(new BoostSourceEffect(
                 FreelanceMuscleValue.instance, FreelanceMuscleValue.instance,
-                Duration.EndOfTurn, true, "it"
+                Duration.EndOfTurn, "it"
         ), false).addHint(hint));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GangOfElk.java
+++ b/Mage.Sets/src/mage/cards/g/GangOfElk.java
@@ -29,7 +29,7 @@ public final class GangOfElk extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Whenever Gang of Elk becomes blocked, it gets +2/+2 until end of turn for each creature blocking it.
-        this.addAbility(new BecomesBlockedSourceTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new BecomesBlockedSourceTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, "it"), false));
     }
 
     private GangOfElk(final GangOfElk card) {

--- a/Mage.Sets/src/mage/cards/g/GeneralTazri.java
+++ b/Mage.Sets/src/mage/cards/g/GeneralTazri.java
@@ -47,7 +47,6 @@ public final class GeneralTazri extends CardImpl {
         // {W}{U}{B}{R}{G}: Ally creatures you control get +X/+X until end of turn, where X is the number of colors among those creatures.
         DynamicValue xValue = new GeneralTazriColorCount();
         BoostControlledEffect effect = new BoostControlledEffect(xValue, xValue, Duration.EndOfTurn, new FilterCreaturePermanent(SubType.ALLY, "Ally creatures"), false);
-        effect.setLockedIn(true);
         this.addAbility(new SimpleActivatedAbility(
                 Zone.BATTLEFIELD,
                 effect,

--- a/Mage.Sets/src/mage/cards/g/GoblinPiledriver.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinPiledriver.java
@@ -44,7 +44,7 @@ public final class GoblinPiledriver extends CardImpl {
         // Protection from blue
         this.addAbility(ProtectionAbility.from(ObjectColor.BLUE));
         // Whenever Goblin Piledriver attacks, it gets +2/+0 until end of turn for each other attacking Goblin.
-        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, "it"), false));
     }
 
     private GoblinPiledriver(final GoblinPiledriver card) {

--- a/Mage.Sets/src/mage/cards/g/GoblinRabblemaster.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinRabblemaster.java
@@ -53,7 +53,7 @@ public final class GoblinRabblemaster extends CardImpl {
         this.addAbility(new BeginningOfCombatTriggeredAbility(new CreateTokenEffect(new GoblinToken(true)), TargetController.YOU, false));
 
         // When Goblin Rabblemaster attacks, it gets +1/+0 until end of turn for each other attacking Goblin.
-        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(new PermanentsOnBattlefieldCount(attackingFilter), StaticValue.get(0), Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(new PermanentsOnBattlefieldCount(attackingFilter), StaticValue.get(0), Duration.EndOfTurn, "it"), false));
     }
 
     private GoblinRabblemaster(final GoblinRabblemaster card) {

--- a/Mage.Sets/src/mage/cards/g/GodheadOfAwe.java
+++ b/Mage.Sets/src/mage/cards/g/GodheadOfAwe.java
@@ -41,7 +41,7 @@ public final class GodheadOfAwe extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Other creatures have base power and toughness 1/1.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessAllEffect(1, 1, Duration.WhileOnBattlefield, filter, true)));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessAllEffect(1, 1, Duration.WhileOnBattlefield, filter)));
     }
 
     private GodheadOfAwe(final GodheadOfAwe card) {

--- a/Mage.Sets/src/mage/cards/g/GraazUnstoppableJuggernaut.java
+++ b/Mage.Sets/src/mage/cards/g/GraazUnstoppableJuggernaut.java
@@ -52,7 +52,7 @@ public final class GraazUnstoppableJuggernaut extends CardImpl {
 
         // Other creatures you control have base power and toughness 5/3 and are Juggernauts in addition to their other creature types.
         Ability ability = new SimpleStaticAbility(new SetBasePowerToughnessAllEffect(
-                5, 3, Duration.WhileOnBattlefield, filter3, true
+                5, 3, Duration.WhileOnBattlefield, filter3
         ));
         ability.addEffect(new AddCardSubtypeAllEffect(
                 filter3, SubType.JUGGERNAUT, null

--- a/Mage.Sets/src/mage/cards/g/GravenDominator.java
+++ b/Mage.Sets/src/mage/cards/g/GravenDominator.java
@@ -37,7 +37,7 @@ public final class GravenDominator extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // Haunt
         // When Graven Dominator enters the battlefield or the creature it haunts dies, each other creature has base power and toughness 1/1 until end of turn.
-        Ability ability = new HauntAbility(this, new SetBasePowerToughnessAllEffect(1,1, Duration.EndOfTurn, filter, true));
+        Ability ability = new HauntAbility(this, new SetBasePowerToughnessAllEffect(1,1, Duration.EndOfTurn, filter));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraverobberSpider.java
+++ b/Mage.Sets/src/mage/cards/g/GraverobberSpider.java
@@ -35,7 +35,7 @@ public final class GraverobberSpider extends CardImpl {
         this.addAbility(ReachAbility.getInstance());
         // {3}{B}: Graverobber Spider gets +X/+X until end of turn, where X is the number of creature cards in your graveyard. Activate this ability only once each turn.
         DynamicValue xValue = new CardsInControllerGraveyardCount(new FilterCreatureCard("creature cards"));
-        Ability ability = new LimitedTimesPerTurnActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, true), new ManaCostsImpl<>("{3}{B}"));
+        Ability ability = new LimitedTimesPerTurnActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn), new ManaCostsImpl<>("{3}{B}"));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrotagBugCatcher.java
+++ b/Mage.Sets/src/mage/cards/g/GrotagBugCatcher.java
@@ -33,7 +33,7 @@ public final class GrotagBugCatcher extends CardImpl {
 
         // Whenever Grotag Bug-Catcher attacks, it gets +1/+0 until end of turn for each creature in your party.
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
-                PartyCount.instance, StaticValue.get(0), Duration.EndOfTurn, true
+                PartyCount.instance, StaticValue.get(0), Duration.EndOfTurn
         ).setText("it gets +1/+0 until end of turn for each creature in your party. " + PartyCount.getReminder()), false).addHint(PartyCountHint.instance));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrunnTheLonelyKing.java
+++ b/Mage.Sets/src/mage/cards/g/GrunnTheLonelyKing.java
@@ -40,7 +40,7 @@ public final class GrunnTheLonelyKing extends CardImpl {
 
         //Whenever Grunn attacks alone, double its power and toughness until end of turn.
         SourcePermanentPowerCount power = new SourcePermanentPowerCount();
-        Effect effect = new BoostSourceEffect(power, SourcePermanentToughnessValue.getInstance(), Duration.EndOfTurn, true);
+        Effect effect = new BoostSourceEffect(power, SourcePermanentToughnessValue.getInstance(), Duration.EndOfTurn);
         effect.setText("double its power and toughness until end of turn");
         this.addAbility(new AttacksAloneSourceTriggeredAbility(effect));
     }

--- a/Mage.Sets/src/mage/cards/g/GuardianOfTheGateless.java
+++ b/Mage.Sets/src/mage/cards/g/GuardianOfTheGateless.java
@@ -47,7 +47,7 @@ public final class GuardianOfTheGateless extends CardImpl {
 
         // Whenever Guardian of the Gateless blocks, it gets +1/+1 until end of turn for each creature it's blocking.
         this.addAbility(new BlocksSourceTriggeredAbility(
-                new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, true, "it")));
+                new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, "it")));
     }
 
     private GuardianOfTheGateless(final GuardianOfTheGateless card) {

--- a/Mage.Sets/src/mage/cards/h/HaldirLorienLieutenant.java
+++ b/Mage.Sets/src/mage/cards/h/HaldirLorienLieutenant.java
@@ -54,7 +54,7 @@ public final class HaldirLorienLieutenant extends CardImpl {
                 VigilanceAbility.getInstance(), Duration.EndOfTurn, filter, true
         ).setText("until end of turn, other Elves you control gain vigilance"), new ManaCostsImpl<>("{5}{G}"));
         ability.addEffect(new BoostControlledEffect(
-                xValue, xValue, Duration.EndOfTurn, filter2, true, true
+                xValue, xValue, Duration.EndOfTurn, filter2, true
         ).setText("and get +1/+1 for each +1/+1 counter on {this}"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/h/HarmoniousArchon.java
+++ b/Mage.Sets/src/mage/cards/h/HarmoniousArchon.java
@@ -40,7 +40,7 @@ public final class HarmoniousArchon extends CardImpl {
 
         // Non-Archon creatures have base power and toughness 3/3.
         this.addAbility(new SimpleStaticAbility(new SetBasePowerToughnessAllEffect(
-                3, 3, Duration.WhileOnBattlefield, filter, true
+                3, 3, Duration.WhileOnBattlefield, filter
         )));
 
         // When Harmonious Archon enters the battlefield, create two 1/1 white Human creature tokens.

--- a/Mage.Sets/src/mage/cards/h/HeartlashCinder.java
+++ b/Mage.Sets/src/mage/cards/h/HeartlashCinder.java
@@ -33,7 +33,7 @@ public final class HeartlashCinder extends CardImpl {
 
         // Chroma - When Heartlash Cinder enters the battlefield, it gets +X/+0 until end of turn, where X is the number of red mana symbols in the mana costs of permanents you control.
         DynamicValue xValue = new ChromaCount(ManaType.RED);
-        ContinuousEffect effect = new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, true);
+        ContinuousEffect effect = new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn);
         effect.setText("it gets +X/+0 until end of turn, where X is the number of red mana symbols in the mana costs of permanents you control");
         this.addAbility(new EntersBattlefieldTriggeredAbility(
                 effect, false)

--- a/Mage.Sets/src/mage/cards/h/HellkiteIgniter.java
+++ b/Mage.Sets/src/mage/cards/h/HellkiteIgniter.java
@@ -46,8 +46,8 @@ public final class HellkiteIgniter extends CardImpl {
                 new BoostSourceEffect(
                         new PermanentsOnBattlefieldCount(filter),
                         StaticValue.get(0),
-                        Duration.EndOfTurn,
-                        true),
+                        Duration.EndOfTurn
+                ),
                 new ManaCostsImpl<>("{1}{R}")));
     }
 

--- a/Mage.Sets/src/mage/cards/h/HuntmasterLiger.java
+++ b/Mage.Sets/src/mage/cards/h/HuntmasterLiger.java
@@ -32,7 +32,7 @@ public final class HuntmasterLiger extends CardImpl {
         // Whenever this creature mutates, other creatures you control get +X/+X until end of turn, where X is the number of times this creature has mutated.
         this.addAbility(new MutatesSourceTriggeredAbility(new BoostControlledEffect(
                 SourceMutatedCount.instance, SourceMutatedCount.instance, Duration.EndOfTurn,
-                StaticFilters.FILTER_PERMANENT_CREATURES, true, true
+                StaticFilters.FILTER_PERMANENT_CREATURES, true
         )));
     }
 

--- a/Mage.Sets/src/mage/cards/i/InkfathomWitch.java
+++ b/Mage.Sets/src/mage/cards/i/InkfathomWitch.java
@@ -38,7 +38,7 @@ public final class InkfathomWitch extends CardImpl {
         // Fear
         this.addAbility(FearAbility.getInstance());
         // {2}{U}{B}: Each unblocked creature has base power and toughness 4/1 until end of turn.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessAllEffect(4, 1, Duration.EndOfTurn, filter, true), new ManaCostsImpl<>("{2}{U}{B}")));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessAllEffect(4, 1, Duration.EndOfTurn, filter), new ManaCostsImpl<>("{2}{U}{B}")));
     }
 
     private InkfathomWitch(final InkfathomWitch card) {

--- a/Mage.Sets/src/mage/cards/j/JazalGoldmane.java
+++ b/Mage.Sets/src/mage/cards/j/JazalGoldmane.java
@@ -36,7 +36,7 @@ public final class JazalGoldmane extends CardImpl {
         // {3}{W}{W}: Attacking creatures you control get +X/+X until end of turn, where X is the number of attacking creatures.
         DynamicValue xValue = new AttackingCreatureCount("the number of attacking creatures");
         this.addAbility(new SimpleActivatedAbility(
-                new BoostControlledEffect(xValue, xValue, Duration.EndOfTurn, StaticFilters.FILTER_ATTACKING_CREATURES, false, true),
+                new BoostControlledEffect(xValue, xValue, Duration.EndOfTurn, StaticFilters.FILTER_ATTACKING_CREATURES, false),
                 new ManaCostsImpl<>("{3}{W}{W}")));
     }
 

--- a/Mage.Sets/src/mage/cards/j/JohtullWurm.java
+++ b/Mage.Sets/src/mage/cards/j/JohtullWurm.java
@@ -29,7 +29,7 @@ public final class JohtullWurm extends CardImpl {
         this.toughness = new MageInt(6);
 
         // Whenever Johtull Wurm becomes blocked, it gets -2/-1 until end of turn for each creature blocking it beyond the first.
-        this.addAbility(new BecomesBlockedSourceTriggeredAbility(new BoostSourceEffect(xValue2, xValue1, Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new BecomesBlockedSourceTriggeredAbility(new BoostSourceEffect(xValue2, xValue1, Duration.EndOfTurn, "it"), false));
     }
 
     private JohtullWurm(final JohtullWurm card) {

--- a/Mage.Sets/src/mage/cards/j/JolraelMwonvuliRecluse.java
+++ b/Mage.Sets/src/mage/cards/j/JolraelMwonvuliRecluse.java
@@ -38,7 +38,7 @@ public final class JolraelMwonvuliRecluse extends CardImpl {
         // {4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.
         this.addAbility(new SimpleActivatedAbility(new SetBasePowerToughnessAllEffect(
                 CardsInControllerHandCount.instance, CardsInControllerHandCount.instance,
-                Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES, true
+                Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES
         ).setText("until end of turn, creatures you control have base power and toughness X/X, " +
                 "where X is the number of cards in your hand"), new ManaCostsImpl<>("{4}{G}{G}")));
     }

--- a/Mage.Sets/src/mage/cards/j/JorKadeenFirstGoldwarden.java
+++ b/Mage.Sets/src/mage/cards/j/JorKadeenFirstGoldwarden.java
@@ -54,7 +54,7 @@ public final class JorKadeenFirstGoldwarden extends CardImpl {
 
         // Whenever Jor Kadeen, First Goldwarden attacks, it gets +X/+X until end of turn, where X is the number of equipped creatures you control. Then if Jor Kadeen's power is 4 or greater, draw a card.
         Ability ability = new AttacksTriggeredAbility(new BoostSourceEffect(
-                xValue, xValue, Duration.EndOfTurn, true, "it"
+                xValue, xValue, Duration.EndOfTurn, "it"
         ));
         ability.addEffect(new ConditionalOneShotEffect(
                 new DrawCardSourceControllerEffect(1),

--- a/Mage.Sets/src/mage/cards/j/JungleWurm.java
+++ b/Mage.Sets/src/mage/cards/j/JungleWurm.java
@@ -28,7 +28,7 @@ public final class JungleWurm extends CardImpl {
         this.toughness = new MageInt(5);
 
         // Whenever Jungle Wurm becomes blocked, it gets -1/-1 until end of turn for each creature blocking it beyond the first.
-        this.addAbility(new BecomesBlockedSourceTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new BecomesBlockedSourceTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, "it"), false));
     }
 
     private JungleWurm(final JungleWurm card) {

--- a/Mage.Sets/src/mage/cards/k/KavuMauler.java
+++ b/Mage.Sets/src/mage/cards/k/KavuMauler.java
@@ -39,7 +39,7 @@ public final class KavuMauler extends CardImpl {
         // Trample
         this.addAbility(TrampleAbility.getInstance());
         // Whenever Kavu Mauler attacks, it gets +1/+1 until end of turn for each other attacking Kavu.
-        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, "it"), false));
     }
 
     private KavuMauler(final KavuMauler card) {

--- a/Mage.Sets/src/mage/cards/k/KelsienThePlague.java
+++ b/Mage.Sets/src/mage/cards/k/KelsienThePlague.java
@@ -47,7 +47,7 @@ public final class KelsienThePlague extends CardImpl {
         // Kelsien, the Plague gets +1/+1 for each experience counter you have.
         this.addAbility(new SimpleStaticAbility(new BoostSourceEffect(
                 KelsienThePlagueCount.instance, KelsienThePlagueCount.instance,
-                Duration.WhileOnBattlefield, false
+                Duration.WhileOnBattlefield
         )));
 
         // {T}: Kelsien deals 1 damage to target creature you don't control. When that creature dies this turn, you get an experience counter.

--- a/Mage.Sets/src/mage/cards/k/KitsuneLoreweaver.java
+++ b/Mage.Sets/src/mage/cards/k/KitsuneLoreweaver.java
@@ -30,7 +30,7 @@ public final class KitsuneLoreweaver extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {1}{W}: Kitsune Loreweaver gets +0/+X until end of turn, where X is the number of cards in your hand.
-        Effect effect = new BoostSourceEffect(StaticValue.get(0), CardsInControllerHandCount.instance, Duration.EndOfTurn, true);
+        Effect effect = new BoostSourceEffect(StaticValue.get(0), CardsInControllerHandCount.instance, Duration.EndOfTurn);
         effect.setText("{this} gets +0/+X until end of turn, where X is the number of cards in your hand");
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{1}{W}")));
     }

--- a/Mage.Sets/src/mage/cards/k/KjeldoranWarCry.java
+++ b/Mage.Sets/src/mage/cards/k/KjeldoranWarCry.java
@@ -31,7 +31,7 @@ public final class KjeldoranWarCry extends CardImpl {
 
         // Creatures you control get +X/+X until end of turn, where X is 1 plus the number of cards named Kjeldoran War Cry in all graveyards.
         IntPlusDynamicValue value = new IntPlusDynamicValue(1, new CardsInAllGraveyardsCount(filter));
-        Effect effect = new BoostControlledEffect(value, value, Duration.EndOfTurn, new FilterCreaturePermanent("creatures"), false, true);
+        Effect effect = new BoostControlledEffect(value, value, Duration.EndOfTurn, new FilterCreaturePermanent("creatures"), false);
         effect.setText("Creatures you control get +X/+X until end of turn, where X is 1 plus the number of cards named {this} in all graveyards");
         this.getSpellAbility().addEffect(effect);
     }

--- a/Mage.Sets/src/mage/cards/k/KlothyssDesign.java
+++ b/Mage.Sets/src/mage/cards/k/KlothyssDesign.java
@@ -21,7 +21,7 @@ public final class KlothyssDesign extends CardImpl {
         // Creatures you control get +X/+X until end of turn, where X is your devotion to green.
         this.getSpellAbility().addEffect(new BoostControlledEffect(
                 DevotionCount.G, DevotionCount.G, Duration.EndOfTurn,
-                StaticFilters.FILTER_PERMANENT_CREATURES, false, true
+                StaticFilters.FILTER_PERMANENT_CREATURES, false
         ));
         this.getSpellAbility().addHint(DevotionCount.G.getHint());
     }

--- a/Mage.Sets/src/mage/cards/k/KnotvinePaladin.java
+++ b/Mage.Sets/src/mage/cards/k/KnotvinePaladin.java
@@ -41,7 +41,7 @@ public final class KnotvinePaladin extends CardImpl {
         this.toughness = new MageInt(2);
 
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
-                xValue, xValue, Duration.EndOfTurn, true, "it"
+                xValue, xValue, Duration.EndOfTurn, "it"
         ), false).addHint(hint));
     }
 

--- a/Mage.Sets/src/mage/cards/k/KuldothaCackler.java
+++ b/Mage.Sets/src/mage/cards/k/KuldothaCackler.java
@@ -48,7 +48,7 @@ public final class KuldothaCackler extends CardImpl {
 
         // Whenever Kuldotha Cackler attacks, it gets +X/+0 until end of turn, where X is the number of permanents you control with oil counters on them.
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
-                xValue, StaticValue.get(0), Duration.EndOfTurn, true, "it"
+                xValue, StaticValue.get(0), Duration.EndOfTurn, "it"
         )).addHint(hint));
     }
 

--- a/Mage.Sets/src/mage/cards/l/LavakinBrawler.java
+++ b/Mage.Sets/src/mage/cards/l/LavakinBrawler.java
@@ -34,7 +34,7 @@ public final class LavakinBrawler extends CardImpl {
 
         // Whenever Lavakin Brawler attacks, it gets +1/+0 until end of turn for each Elemental you control.
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
-                xValue, StaticValue.get(0), Duration.EndOfTurn, true
+                xValue, StaticValue.get(0), Duration.EndOfTurn
         ).setText("it gets +1/+0 until end of turn for each Elemental you control"), false));
     }
 

--- a/Mage.Sets/src/mage/cards/l/LifeOfTheParty.java
+++ b/Mage.Sets/src/mage/cards/l/LifeOfTheParty.java
@@ -53,7 +53,7 @@ public final class LifeOfTheParty extends CardImpl {
         // Whenever Life of the Party attacks, it gets +X/+0 until end of turn, where X is the number of creatures you control.
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
                 CreaturesYouControlCount.instance, StaticValue.get(0),
-                Duration.EndOfTurn, true, "it"
+                Duration.EndOfTurn, "it"
         )));
 
         // When Life of the Party enters the battlefield, if it's not a token, each opponent creates a token that's a copy of it. The tokens are goaded for the rest of the game.

--- a/Mage.Sets/src/mage/cards/l/LordOfTheNazgul.java
+++ b/Mage.Sets/src/mage/cards/l/LordOfTheNazgul.java
@@ -64,7 +64,7 @@ public final class LordOfTheNazgul extends CardImpl {
                 StaticFilters.FILTER_SPELL_AN_INSTANT_OR_SORCERY, false
         );
         ability.addEffect(new ConditionalContinuousEffect(
-                new SetBasePowerToughnessAllEffect(9, 9, Duration.EndOfTurn, filterWraith, true),
+                new SetBasePowerToughnessAllEffect(9, 9, Duration.EndOfTurn, filterWraith),
                 condition, "Then if you control nine or more Wraiths, Wraiths you control have base power and toughness 9/9 until end of turn"
         ));
         this.addAbility(ability.addHint(hint));

--- a/Mage.Sets/src/mage/cards/l/LoxodonLifechanter.java
+++ b/Mage.Sets/src/mage/cards/l/LoxodonLifechanter.java
@@ -42,7 +42,7 @@ public final class LoxodonLifechanter extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(new BoostSourceEffect(
                 LoxodonLifechanterValue2.instance,
                 LoxodonLifechanterValue2.instance,
-                Duration.EndOfTurn, true
+                Duration.EndOfTurn
         ), new ManaCostsImpl<>("{5}{W}")));
     }
 

--- a/Mage.Sets/src/mage/cards/m/Manaplasm.java
+++ b/Mage.Sets/src/mage/cards/m/Manaplasm.java
@@ -32,7 +32,7 @@ public final class Manaplasm extends CardImpl {
         // Whenever you cast a spell, Manaplasm gets +X/+X until end of turn, where X is that spell's converted mana cost.
         this.addAbility(new SpellCastControllerTriggeredAbility(new BoostSourceEffect(
                 ManaplasmValue.instance, ManaplasmValue.instance,
-                Duration.EndOfTurn, true
+                Duration.EndOfTurn
         ), false));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MassDiminish.java
+++ b/Mage.Sets/src/mage/cards/m/MassDiminish.java
@@ -64,7 +64,7 @@ class MassDiminishEffect extends OneShotEffect {
         FilterCreaturePermanent filter = new FilterCreaturePermanent();
         filter.add(new ControllerIdPredicate(source.getFirstTarget()));
         game.addEffect(new SetBasePowerToughnessAllEffect(
-                1, 1, Duration.UntilYourNextTurn, filter, true
+                1, 1, Duration.UntilYourNextTurn, filter
         ), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/m/MirrorEntity.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorEntity.java
@@ -38,7 +38,7 @@ public final class MirrorEntity extends CardImpl {
         // {X}: Until end of turn, creatures you control have base power and toughness X/X and gain all creature types.
         Ability ability = new SimpleActivatedAbility(new SetBasePowerToughnessAllEffect(
                 ManacostVariableValue.REGULAR, ManacostVariableValue.REGULAR,
-                Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES, true
+                Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES
         ).setText("Until end of turn, creatures you control have base power and toughness X/X"), new VariableManaCost(VariableCostType.NORMAL));
         ability.addEffect(new MirrorEntityEffect());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/n/NightOfTheSweetsRevenge.java
+++ b/Mage.Sets/src/mage/cards/n/NightOfTheSweetsRevenge.java
@@ -52,7 +52,7 @@ public final class NightOfTheSweetsRevenge extends CardImpl {
         Ability ability = new ActivateAsSorceryActivatedAbility(
                 new BoostControlledEffect(
                         xValue, xValue, Duration.EndOfTurn,
-                        StaticFilters.FILTER_PERMANENT_CREATURES, false, true
+                        StaticFilters.FILTER_PERMANENT_CREATURES, false
                 ).setText("creatures you control get +X/+X until end of turn, where X is the number of Foods you control"),
                 new ManaCostsImpl<>("{5}{G}{G}")
         ).addHint(hint);

--- a/Mage.Sets/src/mage/cards/n/NissaAscendedAnimist.java
+++ b/Mage.Sets/src/mage/cards/n/NissaAscendedAnimist.java
@@ -24,7 +24,6 @@ import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
 import mage.game.permanent.token.PhyrexianHorrorGreenToken;
-import mage.game.permanent.token.PhyrexianHorrorRedToken;
 import mage.target.TargetPermanent;
 
 /**
@@ -58,7 +57,7 @@ public final class NissaAscendedAnimist extends CardImpl {
         ability = new LoyaltyAbility(new BoostControlledEffect(
                 xValue, xValue, Duration.EndOfTurn,
                 StaticFilters.FILTER_PERMANENT_CREATURE,
-                false, true
+                false
         ).setText("until end of turn, creatures you control get +1/+1 for each Forest you control"), -7);
         ability.addEffect(new GainAbilityControlledEffect(
                 TrampleAbility.getInstance(), Duration.EndOfTurn,

--- a/Mage.Sets/src/mage/cards/o/OkaunEyeOfChaos.java
+++ b/Mage.Sets/src/mage/cards/o/OkaunEyeOfChaos.java
@@ -43,8 +43,7 @@ public final class OkaunEyeOfChaos extends CardImpl {
                 new BoostSourceEffect(
                         sourcePower,
                         SourcePermanentToughnessValue.getInstance(),
-                        Duration.EndOfTurn,
-                        true
+                        Duration.EndOfTurn
                 ).setText("double {this}'s power and toughness until end of turn")
         ));
     }

--- a/Mage.Sets/src/mage/cards/o/OkoTheTrickster.java
+++ b/Mage.Sets/src/mage/cards/o/OkoTheTrickster.java
@@ -48,7 +48,7 @@ public final class OkoTheTrickster extends CardImpl {
 
         // −7: Until end of turn, each creature you control has base power and toughness 10/10 and gains trample.
         ability = new LoyaltyAbility(new SetBasePowerToughnessAllEffect(
-                10, 10, Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURE, true
+                10, 10, Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURE
         ).setText("Until end of turn, each creature you control has base power and toughness 10/10"), -7);
         ability.addEffect(new GainAbilityAllEffect(
                 TrampleAbility.getInstance(), Duration.EndOfTurn,

--- a/Mage.Sets/src/mage/cards/o/OkosHospitality.java
+++ b/Mage.Sets/src/mage/cards/o/OkosHospitality.java
@@ -28,7 +28,7 @@ public final class OkosHospitality extends CardImpl {
 
         // Creatures you control have base power and toughness 3/3 until end of turn. You may search your library and/or graveyard for a card named Oko, the Trickster, reveal it, and put it into your hand. If you search your library this way, shuffle it.
         this.getSpellAbility().addEffect(new SetBasePowerToughnessAllEffect(
-                3, 3, Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES, true
+                3, 3, Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES
         ));
         this.getSpellAbility().addEffect(
                 new SearchLibraryGraveyardPutInHandEffect(filter, false, true)

--- a/Mage.Sets/src/mage/cards/o/OrcishSiegemaster.java
+++ b/Mage.Sets/src/mage/cards/o/OrcishSiegemaster.java
@@ -24,7 +24,7 @@ import java.util.UUID;
  */
 public final class OrcishSiegemaster extends CardImpl {
 
-    private final static FilterControlledCreaturePermanent filterOrcAndGoblins =
+    private static final FilterControlledCreaturePermanent filterOrcAndGoblins =
             new FilterControlledCreaturePermanent("Orcs and Goblins");
 
     static {
@@ -62,7 +62,7 @@ public final class OrcishSiegemaster extends CardImpl {
         this.addAbility(new AttacksTriggeredAbility(
                 new BoostSourceEffect(
                         GreatestPowerAmongControlledCreaturesValue.instance,
-                        StaticValue.get(0), Duration.EndOfTurn, true, "it"
+                        StaticValue.get(0), Duration.EndOfTurn, "it"
                 )
         ));
     }

--- a/Mage.Sets/src/mage/cards/r/RabidElephant.java
+++ b/Mage.Sets/src/mage/cards/r/RabidElephant.java
@@ -29,7 +29,7 @@ public final class RabidElephant extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Whenever Rabid Elephant becomes blocked, it gets +2/+2 until end of turn for each creature blocking it.
-        this.addAbility(new BecomesBlockedSourceTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new BecomesBlockedSourceTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, "it"), false));
     }
 
     private RabidElephant(final RabidElephant card) {

--- a/Mage.Sets/src/mage/cards/r/RadhaHeartOfKeld.java
+++ b/Mage.Sets/src/mage/cards/r/RadhaHeartOfKeld.java
@@ -57,7 +57,7 @@ public final class RadhaHeartOfKeld extends CardImpl {
 
         // 4RG: Radha gets +X/+X until end of turn, where X is the number of lands you control.
         DynamicValue controlledLands = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_PERMANENT_LANDS);
-        BoostSourceEffect bse = new BoostSourceEffect(controlledLands, controlledLands, Duration.EndOfTurn, true);
+        BoostSourceEffect bse = new BoostSourceEffect(controlledLands, controlledLands, Duration.EndOfTurn);
         bse.setText("Radha gets +X/+X until end of turn, where X is the number of lands you control");
         this.addAbility(new SimpleActivatedAbility(bse, new ManaCostsImpl<>("{4}{R}{G}")));
     }

--- a/Mage.Sets/src/mage/cards/r/RaisedByGiants.java
+++ b/Mage.Sets/src/mage/cards/r/RaisedByGiants.java
@@ -28,7 +28,7 @@ public final class RaisedByGiants extends CardImpl {
         // Commander creatures you own have base power and toughness 10/10 and are Giants in addition to their other types.
         Ability ability = new SimpleStaticAbility(new SetBasePowerToughnessAllEffect(
                 10, 10, Duration.WhileOnBattlefield,
-                StaticFilters.FILTER_CREATURES_OWNED_COMMANDER, true
+                StaticFilters.FILTER_CREATURES_OWNED_COMMANDER
         ));
         ability.addEffect(new AddCardSubtypeAllEffect(
                 StaticFilters.FILTER_CREATURES_OWNED_COMMANDER,

--- a/Mage.Sets/src/mage/cards/r/RalsStaticaster.java
+++ b/Mage.Sets/src/mage/cards/r/RalsStaticaster.java
@@ -46,7 +46,7 @@ public final class RalsStaticaster extends CardImpl {
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(
                 new AttacksTriggeredAbility(new BoostSourceEffect(
                         CardsInControllerHandCount.instance, StaticValue.get(0),
-                        Duration.EndOfTurn, true), false),
+                        Duration.EndOfTurn), false),
                 new PermanentsOnTheBattlefieldCondition(filter),
                 "Whenever {this} attacks, if you control a Ral planeswalker, "
                 + "{this} gets +1/+0 for each card in your hand until end of turn."

--- a/Mage.Sets/src/mage/cards/r/RatColony.java
+++ b/Mage.Sets/src/mage/cards/r/RatColony.java
@@ -40,7 +40,7 @@ public final class RatColony extends CardImpl {
         // Rat Colony gets +1/+0 for each other Rat you control.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD,
                 new BoostSourceEffect(new PermanentsOnBattlefieldCount(filter),
-                        StaticValue.get(0), Duration.WhileOnBattlefield, false)));
+                        StaticValue.get(0), Duration.WhileOnBattlefield)));
 
         // A deck can have any number of cards named Rat Colony.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new InfoEffect("A deck can have any number of cards named Rat Colony.")));

--- a/Mage.Sets/src/mage/cards/r/RecklessAmplimancer.java
+++ b/Mage.Sets/src/mage/cards/r/RecklessAmplimancer.java
@@ -32,7 +32,7 @@ public final class RecklessAmplimancer extends CardImpl {
 
         // {4}{G}: Double Reckless Amplimancer's power and toughness until end of turn.
         this.addAbility(new SimpleActivatedAbility(new BoostSourceEffect(
-                sourcePower, SourcePermanentToughnessValue.getInstance(), Duration.EndOfTurn, true
+                sourcePower, SourcePermanentToughnessValue.getInstance(), Duration.EndOfTurn
         ).setText("double {this}'s power and toughness until end of turn"), new ManaCostsImpl<>("{4}{G}")));
     }
 

--- a/Mage.Sets/src/mage/cards/r/RimehornAurochs.java
+++ b/Mage.Sets/src/mage/cards/r/RimehornAurochs.java
@@ -49,7 +49,7 @@ public final class RimehornAurochs extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Whenever Rimehorn Aurochs attacks, it gets +1/+0 until end of turn for each other attacking Aurochs.
-        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, "it"), false));
 
         // {2}{S}: Target creature blocks target creature this turn if able.
         Ability ability = new SimpleActivatedAbility(new RimehornAurochsEffect(), new ManaCostsImpl<>("{2}{S}"));

--- a/Mage.Sets/src/mage/cards/r/RubblebeltRioters.java
+++ b/Mage.Sets/src/mage/cards/r/RubblebeltRioters.java
@@ -33,7 +33,7 @@ public final class RubblebeltRioters extends CardImpl {
         // Whenever Rubblebelt Rioters attacks, it gets +X/+0 until end of turn, where X is the greatest power among creatures you control.
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
                 GreatestPowerAmongControlledCreaturesValue.instance, StaticValue.get(0),
-                Duration.EndOfTurn, true
+                Duration.EndOfTurn
         ), false));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SardianAvenger.java
+++ b/Mage.Sets/src/mage/cards/s/SardianAvenger.java
@@ -53,7 +53,7 @@ public final class SardianAvenger extends CardImpl {
 
         // Whenever Sardian Avenger attacks, it gets +X/+0 until end of turn, where X is the number of artifacts your opponents control.
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
-                xValue, StaticValue.get(0), Duration.EndOfTurn, true, "it"
+                xValue, StaticValue.get(0), Duration.EndOfTurn, "it"
         )));
 
         // Whenever an artifact an opponent controls is put into a graveyard from the battlefield, Sardian Avenger deals 1 damage to that player.

--- a/Mage.Sets/src/mage/cards/s/ShaleskinBruiser.java
+++ b/Mage.Sets/src/mage/cards/s/ShaleskinBruiser.java
@@ -41,7 +41,7 @@ public final class ShaleskinBruiser extends CardImpl {
         // Trample
         this.addAbility(TrampleAbility.getInstance());
         // Whenever Shaleskin Bruiser attacks, it gets +3/+0 until end of turn for each other attacking Beast.
-        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, true, "it"), false));
+        this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(xValue, StaticValue.get(0), Duration.EndOfTurn, "it"), false));
     }
 
     private ShaleskinBruiser(final ShaleskinBruiser card) {

--- a/Mage.Sets/src/mage/cards/s/SkanosDragonheart.java
+++ b/Mage.Sets/src/mage/cards/s/SkanosDragonheart.java
@@ -47,7 +47,7 @@ public final class SkanosDragonheart extends CardImpl {
         // Whenever Skanos Dragonheart attacks, it gets +X/+X until end of turn, where X is the greatest power among Dragon cards in your graveyard or other Dragons you control.
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
                 SkanosDragonheartValue.instance, SkanosDragonheartValue.instance,
-                Duration.EndOfTurn, true, "it"
+                Duration.EndOfTurn, "it"
         )).addHint(hint));
 
         // Choose a Background

--- a/Mage.Sets/src/mage/cards/s/SlumberingKeepguard.java
+++ b/Mage.Sets/src/mage/cards/s/SlumberingKeepguard.java
@@ -38,7 +38,7 @@ public final class SlumberingKeepguard extends CardImpl {
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new ScryEffect(1, false), new FilterEnchantmentPermanent("an enchantment")));
         // {2}{W}: Slumbering Keepguard gets +1/+1 until end of turn for each enchantment you control.
         this.addAbility(new SimpleActivatedAbility(
-            new BoostSourceEffect(value, value, Duration.EndOfTurn, true), new ManaCostsImpl<>("{2}{W}"))
+            new BoostSourceEffect(value, value, Duration.EndOfTurn), new ManaCostsImpl<>("{2}{W}"))
             .addHint(new ValueHint("Enchantments you control", value))
         );
     }

--- a/Mage.Sets/src/mage/cards/s/SokenzanSpellblade.java
+++ b/Mage.Sets/src/mage/cards/s/SokenzanSpellblade.java
@@ -35,7 +35,7 @@ public final class SokenzanSpellblade extends CardImpl {
         // Bushido 1
         this.addAbility(new BushidoAbility(1));
         // {1}{R}: Sokenzan Spellblade gets +X/+0 until end of turn, where X is the number of cards in your hand.
-        Effect effect = new BoostSourceEffect(CardsInControllerHandCount.instance, StaticValue.get(0), Duration.EndOfTurn, true);
+        Effect effect = new BoostSourceEffect(CardsInControllerHandCount.instance, StaticValue.get(0), Duration.EndOfTurn);
         effect.setText("{this} gets +X/+0 until end of turn, where X is the number of cards in your hand");
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 effect, new ManaCostsImpl<>("{1}{R}")

--- a/Mage.Sets/src/mage/cards/s/SparringGolem.java
+++ b/Mage.Sets/src/mage/cards/s/SparringGolem.java
@@ -25,7 +25,7 @@ public final class SparringGolem extends CardImpl {
 
         // Whenever Sparring Golem becomes blocked, it gets +1/+1 until end of turn for each creature blocking it.
         this.addAbility(new BecomesBlockedSourceTriggeredAbility(
-                new BoostSourceEffect(BlockingCreatureCount.SOURCE, BlockingCreatureCount.SOURCE, Duration.EndOfTurn, true, "it"),
+                new BoostSourceEffect(BlockingCreatureCount.SOURCE, BlockingCreatureCount.SOURCE, Duration.EndOfTurn, "it"),
                 false
         ));
     }

--- a/Mage.Sets/src/mage/cards/s/SquirrelMob.java
+++ b/Mage.Sets/src/mage/cards/s/SquirrelMob.java
@@ -37,7 +37,7 @@ public final class SquirrelMob extends CardImpl {
 
         // Squirrel Mob gets +1/+1 for each other Squirrel on the battlefield.
         this.addAbility(new SimpleStaticAbility(new BoostSourceEffect(
-                xValue, xValue, Duration.WhileOnBattlefield, false
+                xValue, xValue, Duration.WhileOnBattlefield
         ).setText("{this} gets +1/+1 for each other Squirrel on the battlefield")));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SunbathingRootwalla.java
+++ b/Mage.Sets/src/mage/cards/s/SunbathingRootwalla.java
@@ -28,7 +28,7 @@ public final class SunbathingRootwalla extends CardImpl {
         // Domain -- {3}{G}: Until end of turn, Sunbathing Rootwalla gets +1/+1 for each basic land type among lands you control. Activate only once each turn.
         Ability ability = new LimitedTimesPerTurnActivatedAbility(
                 Zone.BATTLEFIELD,
-                new BoostSourceEffect(DomainValue.REGULAR, DomainValue.REGULAR, Duration.EndOfTurn, true),
+                new BoostSourceEffect(DomainValue.REGULAR, DomainValue.REGULAR, Duration.EndOfTurn),
                 new ManaCostsImpl<>("{3}{G}")
         );
         ability.setAbilityWord(AbilityWord.DOMAIN);

--- a/Mage.Sets/src/mage/cards/t/TanazirQuandrix.java
+++ b/Mage.Sets/src/mage/cards/t/TanazirQuandrix.java
@@ -52,7 +52,7 @@ public final class TanazirQuandrix extends CardImpl {
         // Whenever Tanazir Quandrix attacks, you may have the base power and toughness of other creatures you control become equal to Tanazir Quandrix's power and toughness until end of turn.
         this.addAbility(new AttacksTriggeredAbility(new SetBasePowerToughnessAllEffect(
                 xValue, SourcePermanentToughnessValue.getInstance(), Duration.EndOfTurn,
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, true
+                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE
         ).setText("have the base power and toughness of other creatures you control " +
                 "become equal to {this}'s power and toughness until end of turn"), true));
     }

--- a/Mage.Sets/src/mage/cards/t/TaroxBladewing.java
+++ b/Mage.Sets/src/mage/cards/t/TaroxBladewing.java
@@ -37,7 +37,7 @@ public final class TaroxBladewing extends CardImpl {
         
         // Grandeur - Discard another card named Tarox Bladewing: Tarox Bladewing gets +X/+X until end of turn, where X is its power.
         SourcePermanentPowerCount x = new SourcePermanentPowerCount();
-        this.addAbility(new GrandeurAbility(new BoostSourceEffect(x, x, Duration.EndOfTurn, true), "Tarox Bladewing"));
+        this.addAbility(new GrandeurAbility(new BoostSourceEffect(x, x, Duration.EndOfTurn), "Tarox Bladewing"));
     }
 
     private TaroxBladewing(final TaroxBladewing card) {

--- a/Mage.Sets/src/mage/cards/t/TearsOfRage.java
+++ b/Mage.Sets/src/mage/cards/t/TearsOfRage.java
@@ -36,7 +36,7 @@ public final class TearsOfRage extends CardImpl {
 
         // Attacking creatures you control get +X/+0 until end of turn, where X is the number of attacking creatures. Sacrifice those creatures at the beginning of the next end step.
         BoostControlledEffect effect = new BoostControlledEffect(new AttackingCreatureCount("the number of attacking creatures"), StaticValue.get(0),
-                Duration.EndOfTurn, StaticFilters.FILTER_ATTACKING_CREATURES, false, true);
+                Duration.EndOfTurn, StaticFilters.FILTER_ATTACKING_CREATURES, false);
         getSpellAbility().addEffect(effect);
         getSpellAbility().addEffect(new TearsOfRageEffect());
     }

--- a/Mage.Sets/src/mage/cards/t/TerraRavager.java
+++ b/Mage.Sets/src/mage/cards/t/TerraRavager.java
@@ -41,7 +41,7 @@ public final class TerraRavager extends CardImpl {
 
         // Whenever Terra Ravager attacks, it gets +X/+0 until end of turn, where X is the number of lands defending player controls.
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
-                xValue, StaticValue.get(0), Duration.EndOfTurn, true, "it"
+                xValue, StaticValue.get(0), Duration.EndOfTurn, "it"
         ), false));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheArchimandrite.java
+++ b/Mage.Sets/src/mage/cards/t/TheArchimandrite.java
@@ -78,7 +78,7 @@ public final class TheArchimandrite extends CardImpl {
         ).setText("each Advisor, Artificer, and Monk you control gains vigilance"));
         ability.addEffect(new BoostControlledEffect(
                 TheArchimandriteValue.instance, StaticValue.get(0), Duration.EndOfTurn,
-                filter2, false, true
+                filter2, false
         ).setText("and gets +X/+0 until end of turn, where X is the amount of life you gained"));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/t/ThunderousMight.java
+++ b/Mage.Sets/src/mage/cards/t/ThunderousMight.java
@@ -34,7 +34,6 @@ public final class ThunderousMight extends CardImpl {
         // Whenever enchanted creature attacks, it gets +X/+0 until end of turn, where X is your devotion to red.
         BoostEnchantedEffect effect = new BoostEnchantedEffect(DevotionCount.R, StaticValue.get(0), Duration.EndOfTurn);
         effect.setText("it gets +X/+0 until end of turn, where X is your devotion to red");
-        effect.setLockedIn(true);
         this.addAbility(new AttacksAttachedTriggeredAbility(effect, AttachmentType.AURA, false)
                 .addHint(DevotionCount.R.getHint()));
     }

--- a/Mage.Sets/src/mage/cards/t/TimbermawLarva.java
+++ b/Mage.Sets/src/mage/cards/t/TimbermawLarva.java
@@ -38,7 +38,7 @@ public final class TimbermawLarva extends CardImpl {
         this.toughness = new MageInt(2);
 
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
-                xValue, xValue, Duration.EndOfTurn, true, "it"
+                xValue, xValue, Duration.EndOfTurn, "it"
         ), false));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TuyaBearclaw.java
+++ b/Mage.Sets/src/mage/cards/t/TuyaBearclaw.java
@@ -37,7 +37,7 @@ public final class TuyaBearclaw extends CardImpl {
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
                 TuyaBearclawValue.instance,
                 TuyaBearclawValue.instance,
-                Duration.EndOfTurn, true
+                Duration.EndOfTurn
         ), false));
     }
 

--- a/Mage.Sets/src/mage/cards/v/VedalkenHumiliator.java
+++ b/Mage.Sets/src/mage/cards/v/VedalkenHumiliator.java
@@ -35,8 +35,7 @@ public final class VedalkenHumiliator extends CardImpl {
         TriggeredAbility ability = new AttacksTriggeredAbility(
                 new SetBasePowerToughnessAllEffect(
                         1, 1, Duration.EndOfTurn,
-                        StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE,
-                        true
+                        StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE
                 ), false
         );
         ability.addEffect(new LoseAllAbilitiesAllEffect(

--- a/Mage.Sets/src/mage/cards/v/VeteransArmaments.java
+++ b/Mage.Sets/src/mage/cards/v/VeteransArmaments.java
@@ -35,7 +35,7 @@ public final class VeteransArmaments extends CardImpl {
         this.subtype.add(SubType.EQUIPMENT);
 
         // Equipped creature has "Whenever this creature attacks or blocks, it gets +1/+1 until end of turn for each attacking creature."
-        Ability gainedAbility = new AttacksOrBlocksTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn, true), false);
+        Ability gainedAbility = new AttacksOrBlocksTriggeredAbility(new BoostSourceEffect(xValue, xValue, Duration.EndOfTurn), false);
         Effect effect = new GainAbilityAttachedEffect(gainedAbility, AttachmentType.EQUIPMENT);
         effect.setText("Equipped creature has \"Whenever this creature attacks or blocks, it gets +1/+1 until end of turn for each attacking creature.\"");
         Ability ability = new SimpleStaticAbility(Zone.BATTLEFIELD, effect);

--- a/Mage.Sets/src/mage/cards/v/VileDeacon.java
+++ b/Mage.Sets/src/mage/cards/v/VileDeacon.java
@@ -35,7 +35,7 @@ public final class VileDeacon extends CardImpl {
 
         // Whenever Vile Deacon attacks, it gets +X/+X until end of turn, where X is the number of Clerics on the battlefield.
         PermanentsOnBattlefieldCount amount = new PermanentsOnBattlefieldCount(filter);
-        Effect effect = new BoostSourceEffect(amount, amount, Duration.EndOfTurn, true);
+        Effect effect = new BoostSourceEffect(amount, amount, Duration.EndOfTurn);
         effect.setText("it gets +X/+X until end of turn, where X is the number of Clerics on the battlefield");
         this.addAbility(new AttacksTriggeredAbility(effect, false));
     }

--- a/Mage.Sets/src/mage/cards/w/WanderingGoblins.java
+++ b/Mage.Sets/src/mage/cards/w/WanderingGoblins.java
@@ -31,7 +31,7 @@ public final class WanderingGoblins extends CardImpl {
 
         // Domain - {3}: Wandering Goblins gets +1/+0 until end of turn for each basic land type among lands you control.
         this.addAbility(new SimpleActivatedAbility(new BoostSourceEffect(
-                DomainValue.REGULAR, StaticValue.get(0), Duration.EndOfTurn, true
+                DomainValue.REGULAR, StaticValue.get(0), Duration.EndOfTurn
         ), new GenericManaCost(3)).addHint(DomainHint.instance).setAbilityWord(AbilityWord.DOMAIN));
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildBeastmaster.java
+++ b/Mage.Sets/src/mage/cards/w/WildBeastmaster.java
@@ -31,7 +31,7 @@ public final class WildBeastmaster extends CardImpl {
 
         // Whenever Wild Beastmaster attacks, each other creature you control gets +X/+X until end of turn, where X is Wild Beastmaster's power.
         SourcePermanentPowerCount creaturePower = new SourcePermanentPowerCount();
-        BoostControlledEffect effect = new BoostControlledEffect(creaturePower, creaturePower, Duration.EndOfTurn, StaticFilters.FILTER_PERMANENT_CREATURE, true, true);
+        BoostControlledEffect effect = new BoostControlledEffect(creaturePower, creaturePower, Duration.EndOfTurn, StaticFilters.FILTER_PERMANENT_CREATURE, true);
         effect.setText(EFFECT_TEXT);
         this.addAbility(new AttacksTriggeredAbility(effect, false));
     }

--- a/Mage.Sets/src/mage/cards/w/WildBeastmaster.java
+++ b/Mage.Sets/src/mage/cards/w/WildBeastmaster.java
@@ -33,7 +33,6 @@ public final class WildBeastmaster extends CardImpl {
         SourcePermanentPowerCount creaturePower = new SourcePermanentPowerCount();
         BoostControlledEffect effect = new BoostControlledEffect(creaturePower, creaturePower, Duration.EndOfTurn, StaticFilters.FILTER_PERMANENT_CREATURE, true, true);
         effect.setText(EFFECT_TEXT);
-        effect.setLockedIn(true);
         this.addAbility(new AttacksTriggeredAbility(effect, false));
     }
 

--- a/Mage.Sets/src/mage/cards/y/YewSpirit.java
+++ b/Mage.Sets/src/mage/cards/y/YewSpirit.java
@@ -31,7 +31,7 @@ public final class YewSpirit extends CardImpl {
         // {2}{G}{G}: Yew Spirit gets +X/+X until end of turn, where X is its power.
         SourcePermanentPowerCount x = new SourcePermanentPowerCount();
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD,
-                new BoostSourceEffect(x, x, Duration.EndOfTurn, true),
+                new BoostSourceEffect(x, x, Duration.EndOfTurn),
                 new ManaCostsImpl<>("{2}{G}{G}")));
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/bng/ThunderousMightTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/bng/ThunderousMightTest.java
@@ -1,0 +1,38 @@
+package org.mage.test.cards.single.bng;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class ThunderousMightTest extends CardTestPlayerBase {
+
+    // See bug #3777
+    private static final String aura = "Thunderous Might"; // {1}{R} Aura
+    // Whenever enchanted creature attacks, it gets +X/+0 until end of turn, where X is your devotion to red.
+
+    @Test
+    public void testLockedIn() {
+        String bear = "Runeclaw Bear"; // 2/2 {1}{G}
+        addCard(Zone.BATTLEFIELD, playerA, bear);
+        addCard(Zone.BATTLEFIELD, playerA, "Duergar Assailant"); // 1/1 {R/W} Sac: 1 dmg to target attacking/blocking
+        addCard(Zone.HAND, playerA, aura);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, aura, bear);
+        attack(1, playerA, bear, playerB);
+        waitStackResolved(1, PhaseStep.DECLARE_ATTACKERS);
+        checkPT("2 devotion", 1, PhaseStep.DECLARE_ATTACKERS, playerA, bear, 4, 2);
+        activateAbility(1, PhaseStep.DECLARE_BLOCKERS, playerA, "Sacrifice", bear);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPowerToughness(playerA, bear, 4, 2);
+        assertDamageReceived(playerA, bear, 1);
+        assertLife(playerB, 16);
+        assertGraveyardCount(playerA, 1);
+
+    }
+}

--- a/Mage/src/main/java/mage/abilities/decorator/ConditionalRequirementEffect.java
+++ b/Mage/src/main/java/mage/abilities/decorator/ConditionalRequirementEffect.java
@@ -30,13 +30,13 @@ public class ConditionalRequirementEffect extends RequirementEffect {
     }
 
     public ConditionalRequirementEffect(RequirementEffect effect, Condition condition, String text) {
-        this(effect.getDuration(), effect, condition, null, false);
+        this(effect.getDuration(), effect, condition, null);
         if (text != null) {
             setText(text);
         }
     }
 
-    public ConditionalRequirementEffect(Duration duration, RequirementEffect effect, Condition condition, RequirementEffect otherwiseEffect, boolean lockedInCondition) {
+    public ConditionalRequirementEffect(Duration duration, RequirementEffect effect, Condition condition, RequirementEffect otherwiseEffect) {
         super(duration);
         this.effectType = EffectType.REQUIREMENT;
         this.effect = effect;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostControlledEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostControlledEffect.java
@@ -27,7 +27,6 @@ public class BoostControlledEffect extends ContinuousEffectImpl {
     private DynamicValue toughness;
     protected FilterCreaturePermanent filter;
     protected boolean excludeSource;
-    protected boolean lockedIn = false;
 
     public BoostControlledEffect(int power, int toughness, Duration duration) {
         this(power, toughness, duration, StaticFilters.FILTER_PERMANENT_CREATURES, false);
@@ -69,7 +68,6 @@ public class BoostControlledEffect extends ContinuousEffectImpl {
         this.toughness = toughness;
         this.filter = (filter == null ? StaticFilters.FILTER_PERMANENT_CREATURES : filter);
         this.excludeSource = excludeSource;
-        this.lockedIn = lockedIn;
         setText();
     }
 
@@ -79,7 +77,6 @@ public class BoostControlledEffect extends ContinuousEffectImpl {
         this.toughness = effect.toughness;
         this.filter = effect.filter.copy();
         this.excludeSource = effect.excludeSource;
-        this.lockedIn = effect.lockedIn;
     }
 
     @Override
@@ -139,11 +136,4 @@ public class BoostControlledEffect extends ContinuousEffectImpl {
         staticText = sb.toString();
     }
 
-    public void setRule(String rule) {
-        staticText = rule;
-    }
-
-    public void setLockedIn(boolean lockedIn) {
-        this.lockedIn = lockedIn;
-    }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostControlledEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostControlledEffect.java
@@ -97,8 +97,6 @@ public class BoostControlledEffect extends ContinuousEffectImpl {
                     affectedObjectList.add(new MageObjectReference(perm, game));
                 }
             }
-        }
-        if (this.lockedIn) {
             power = StaticValue.get(power.calculate(game, source, this));
             toughness = StaticValue.get(toughness.calculate(game, source, this));
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostControlledEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostControlledEffect.java
@@ -45,24 +45,13 @@ public class BoostControlledEffect extends ContinuousEffectImpl {
     }
 
     public BoostControlledEffect(int power, int toughness, Duration duration, FilterCreaturePermanent filter, boolean excludeSource) {
-        this(StaticValue.get(power), StaticValue.get(toughness), duration, filter, excludeSource, true);
-    }
-
-    public BoostControlledEffect(DynamicValue power, DynamicValue toughness, Duration duration, FilterCreaturePermanent filter, boolean excludeSource) {
-        this(power, toughness, duration, filter, excludeSource, false);
+        this(StaticValue.get(power), StaticValue.get(toughness), duration, filter, excludeSource);
     }
 
     /**
-     * @param power
-     * @param toughness
-     * @param duration
-     * @param filter        AnotherPredicate is not working, you need to use the
-     *                      excludeSource option
-     * @param lockedIn      if true, power and toughness will be calculated only
-     *                      once, when the ability resolves
-     * @param excludeSource
+     * Note: use excludeSource rather than AnotherPredicate
      */
-    public BoostControlledEffect(DynamicValue power, DynamicValue toughness, Duration duration, FilterCreaturePermanent filter, boolean excludeSource, boolean lockedIn) {
+    public BoostControlledEffect(DynamicValue power, DynamicValue toughness, Duration duration, FilterCreaturePermanent filter, boolean excludeSource) {
         super(duration, Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, Outcome.BoostCreature);
         this.power = power;
         this.toughness = toughness;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostEnchantedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostEnchantedEffect.java
@@ -1,4 +1,3 @@
-
 package mage.abilities.effects.common.continuous;
 
 import mage.abilities.Ability;
@@ -7,7 +6,6 @@ import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.constants.Duration;
 import mage.constants.Layer;
-import mage.constants.Outcome;
 import mage.constants.SubLayer;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -21,7 +19,6 @@ public class BoostEnchantedEffect extends ContinuousEffectImpl {
 
     private DynamicValue power;
     private DynamicValue toughness;
-    private boolean lockedIn = false;
 
     public BoostEnchantedEffect(int power, int toughness) {
         this(power, toughness, Duration.WhileOnBattlefield);
@@ -46,7 +43,6 @@ public class BoostEnchantedEffect extends ContinuousEffectImpl {
         super(effect);
         this.power = effect.power.copy();
         this.toughness = effect.toughness.copy();
-        this.lockedIn = effect.lockedIn;
     }
 
     @Override
@@ -57,10 +53,6 @@ public class BoostEnchantedEffect extends ContinuousEffectImpl {
     @Override
     public void init(Ability source, Game game) {
         super.init(source, game);
-        if (lockedIn) {
-            power = StaticValue.get(power.calculate(game, source, this));
-            toughness = StaticValue.get(toughness.calculate(game, source, this));
-        }
         if (affectedObjectsSet) {
             // Added boosts of activated or triggered abilities exist independent from the source they are created by
             // so a continuous effect for the permanent itself with the attachment is created
@@ -68,6 +60,8 @@ public class BoostEnchantedEffect extends ContinuousEffectImpl {
             if (equipment != null && equipment.getAttachedTo() != null) {
                 this.setTargetPointer(new FixedTarget(equipment.getAttachedTo(), game.getState().getZoneChangeCounter(equipment.getAttachedTo())));
             }
+            power = StaticValue.get(power.calculate(game, source, this));
+            toughness = StaticValue.get(toughness.calculate(game, source, this));
         }
     }
 
@@ -93,7 +87,4 @@ public class BoostEnchantedEffect extends ContinuousEffectImpl {
         return true;
     }
 
-    public void setLockedIn(boolean lockedIn) {
-        this.lockedIn = lockedIn;
-    }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BoostSourceEffect.java
@@ -20,36 +20,23 @@ import org.apache.log4j.Logger;
 public class BoostSourceEffect extends ContinuousEffectImpl {
     private DynamicValue power;
     private DynamicValue toughness;
-    private final boolean lockedIn;
 
     public BoostSourceEffect(int power, int toughness, Duration duration) {
         this(power, toughness, duration, "{this}");
     }
 
     public BoostSourceEffect(int power, int toughness, Duration duration, String description) {
-        this(StaticValue.get(power), StaticValue.get(toughness), duration, false, description);
+        this(StaticValue.get(power), StaticValue.get(toughness), duration, description);
     }
 
     public BoostSourceEffect(DynamicValue power, DynamicValue toughness, Duration duration) {
-        this(power, toughness, duration, false);
+        this(power, toughness, duration, "{this}");
     }
 
-    public BoostSourceEffect(DynamicValue power, DynamicValue toughness, Duration duration, boolean lockedIn) {
-        this(power, toughness, duration, lockedIn, "{this}");
-    }
-
-    /**
-     * @param power
-     * @param toughness
-     * @param duration
-     * @param lockedIn    if true, power and toughness will be calculated only once, when the ability resolves
-     * @param description
-     */
-    public BoostSourceEffect(DynamicValue power, DynamicValue toughness, Duration duration, boolean lockedIn, String description) {
+    public BoostSourceEffect(DynamicValue power, DynamicValue toughness, Duration duration, String description) {
         super(duration, Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, Outcome.BoostCreature);
         this.power = power;
         this.toughness = toughness;
-        this.lockedIn = lockedIn;
         this.staticText = description + " gets " + CardUtil.getBoostText(power, toughness, duration);
     }
 
@@ -57,7 +44,6 @@ public class BoostSourceEffect extends ContinuousEffectImpl {
         super(effect);
         this.power = effect.power.copy();
         this.toughness = effect.toughness.copy();
-        this.lockedIn = effect.lockedIn;
     }
 
     @Override
@@ -74,8 +60,6 @@ public class BoostSourceEffect extends ContinuousEffectImpl {
             } catch (IllegalArgumentException ex) {
                 Logger.getLogger(BoostSourceEffect.class).error("Could not get sourceId reference: " + source.getRule());
             }
-        }
-        if (lockedIn) {
             power = StaticValue.get(power.calculate(game, source, this));
             toughness = StaticValue.get(toughness.calculate(game, source, this));
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessAllEffect.java
@@ -26,22 +26,20 @@ public class SetBasePowerToughnessAllEffect extends ContinuousEffectImpl {
     private final FilterPermanent filter;
     private DynamicValue power;
     private DynamicValue toughness;
-    private final boolean lockedInPT;
 
     public SetBasePowerToughnessAllEffect(int power, int toughness, Duration duration) {
-        this(StaticValue.get(power), StaticValue.get(toughness), duration, new FilterCreaturePermanent("Creatures"), true);
+        this(StaticValue.get(power), StaticValue.get(toughness), duration, new FilterCreaturePermanent("Creatures"));
     }
 
-    public SetBasePowerToughnessAllEffect(int power, int toughness, Duration duration, FilterPermanent filter, boolean lockedInPT) {
-        this(StaticValue.get(power), StaticValue.get(toughness), duration, filter, lockedInPT);
+    public SetBasePowerToughnessAllEffect(int power, int toughness, Duration duration, FilterPermanent filter) {
+        this(StaticValue.get(power), StaticValue.get(toughness), duration, filter);
     }
 
-    public SetBasePowerToughnessAllEffect(DynamicValue power, DynamicValue toughness, Duration duration, FilterPermanent filter, boolean lockedInPT) {
+    public SetBasePowerToughnessAllEffect(DynamicValue power, DynamicValue toughness, Duration duration, FilterPermanent filter) {
         super(duration, Layer.PTChangingEffects_7, SubLayer.SetPT_7b, Outcome.BoostCreature);
         this.power = power;
         this.toughness = toughness;
         this.filter = filter;
-        this.lockedInPT = lockedInPT;
     }
 
     protected SetBasePowerToughnessAllEffect(final SetBasePowerToughnessAllEffect effect) {
@@ -49,7 +47,6 @@ public class SetBasePowerToughnessAllEffect extends ContinuousEffectImpl {
         this.power = effect.power;
         this.toughness = effect.toughness;
         this.filter = effect.filter;
-        this.lockedInPT = effect.lockedInPT;
     }
 
     @Override
@@ -64,8 +61,6 @@ public class SetBasePowerToughnessAllEffect extends ContinuousEffectImpl {
             for (Permanent perm : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)) {
                 affectedObjectList.add(new MageObjectReference(perm, game));
             }
-        }
-        if (lockedInPT) {
             power = StaticValue.get(power.calculate(game, source, this));
             toughness = StaticValue.get(toughness.calculate(game, source, this));
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/SetBasePowerToughnessAllEffect.java
@@ -2,7 +2,6 @@ package mage.abilities.effects.common.continuous;
 
 import mage.MageObjectReference;
 import mage.abilities.Ability;
-import mage.abilities.Mode;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.ContinuousEffectImpl;
@@ -11,7 +10,7 @@ import mage.constants.Layer;
 import mage.constants.Outcome;
 import mage.constants.SubLayer;
 import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 
@@ -28,7 +27,7 @@ public class SetBasePowerToughnessAllEffect extends ContinuousEffectImpl {
     private DynamicValue toughness;
 
     public SetBasePowerToughnessAllEffect(int power, int toughness, Duration duration) {
-        this(StaticValue.get(power), StaticValue.get(toughness), duration, new FilterCreaturePermanent("Creatures"));
+        this(power, toughness, duration, StaticFilters.FILTER_PERMANENT_CREATURES);
     }
 
     public SetBasePowerToughnessAllEffect(int power, int toughness, Duration duration, FilterPermanent filter) {
@@ -40,6 +39,10 @@ public class SetBasePowerToughnessAllEffect extends ContinuousEffectImpl {
         this.power = power;
         this.toughness = toughness;
         this.filter = filter;
+        this.staticText = filter.getMessage()
+                + (filter.getMessage().toLowerCase(Locale.ENGLISH).startsWith("each ") ? " has " : " have ")
+                + "base power and toughness " + power + '/' + toughness
+                + (duration.toString().isEmpty() ? "" : ' ' + duration.toString());
     }
 
     protected SetBasePowerToughnessAllEffect(final SetBasePowerToughnessAllEffect effect) {
@@ -89,23 +92,4 @@ public class SetBasePowerToughnessAllEffect extends ContinuousEffectImpl {
         return true;
     }
 
-    @Override
-    public String getText(Mode mode) {
-        if (staticText != null && !staticText.isEmpty()) {
-            return staticText;
-        }
-
-        StringBuilder sb = new StringBuilder();
-        sb.append(filter.getMessage());
-        if (filter.getMessage().toLowerCase(Locale.ENGLISH).startsWith("each ")) {
-            sb.append(" has base power and toughness ");
-        } else {
-            sb.append(" have base power and toughness ");
-        }
-        sb.append(power).append('/').append(toughness);
-        if (!duration.toString().isEmpty()) {
-            sb.append(' ').append(duration.toString());
-        }
-        return sb.toString();
-    }
 }

--- a/Mage/src/main/java/mage/abilities/keyword/BushidoAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/BushidoAbility.java
@@ -7,7 +7,6 @@ import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.constants.Duration;
-import mage.constants.Zone;
 import mage.game.Game;
 
 /**
@@ -23,7 +22,7 @@ public class BushidoAbility extends BlocksOrBlockedSourceTriggeredAbility {
     }
 
     public BushidoAbility(DynamicValue value) {
-        super(new BoostSourceEffect(value, value, Duration.EndOfTurn, true));
+        super(new BoostSourceEffect(value, value, Duration.EndOfTurn));
         this.value = value;
         rule = (
                 value instanceof StaticValue ?

--- a/Mage/src/main/java/mage/abilities/keyword/MeleeAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/MeleeAbility.java
@@ -19,7 +19,7 @@ import java.util.*;
 public class MeleeAbility extends AttacksTriggeredAbility {
 
     public MeleeAbility() {
-        super(new BoostSourceEffect(MeleeDynamicValue.instance, MeleeDynamicValue.instance, Duration.EndOfTurn, true), false);
+        super(new BoostSourceEffect(MeleeDynamicValue.instance, MeleeDynamicValue.instance, Duration.EndOfTurn), false);
         this.addWatcher(new MeleeWatcher());
     }
 

--- a/Mage/src/main/java/mage/abilities/keyword/RampageAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/RampageAbility.java
@@ -1,6 +1,5 @@
 package mage.abilities.keyword;
 
-import mage.abilities.Ability;
 import mage.abilities.common.BecomesBlockedSourceTriggeredAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.MultipliedValue;
@@ -26,7 +25,7 @@ public class RampageAbility extends BecomesBlockedSourceTriggeredAbility {
                 : " <i>(Whenever this creature becomes blocked, it gets +"
                 + amount + "/+" + amount + " until end of turn for each creature blocking it beyond the first.)</i>");
         DynamicValue rv = (amount == 1 ? BlockingCreatureCount.BEYOND_FIRST : new MultipliedValue(BlockingCreatureCount.BEYOND_FIRST, amount));
-        this.addEffect(new BoostSourceEffect(rv, rv, Duration.EndOfTurn, true));
+        this.addEffect(new BoostSourceEffect(rv, rv, Duration.EndOfTurn));
     }
 
     protected RampageAbility(final RampageAbility ability) {


### PR DESCRIPTION
See history from ecbfc4e and #9334, applying the same cleanup to the remaining classes that affect power/toughness. Instead of manually specifying, can infer from the type of ability/effect using `affectedObjectsSet`. This will alleviate bugs like #3777 and #11027. The underlying logic is used many places, though I did add a test for Thunderous Might to double check.