### PR TITLE
Add custom options for starting life total and starting hand size

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/CustomOptionsDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/CustomOptionsDialog.form
@@ -52,6 +52,8 @@
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="spnFreeMulligans" max="32767" attributes="0"/>
                   </Group>
+                  <Component id="planechaseDescriptionLabel" alignment="0" max="32767" attributes="0"/>
+                  <Component id="emblemCardsDescriptionLabel" alignment="0" max="32767" attributes="0"/>
                   <Group type="102" attributes="0">
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Component id="lblVariantOptions" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -63,8 +65,15 @@
                       </Group>
                       <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                   </Group>
-                  <Component id="planechaseDescriptionLabel" alignment="0" max="32767" attributes="0"/>
-                  <Component id="emblemCardsDescriptionLabel" alignment="0" max="32767" attributes="0"/>
+                  <Group type="102" alignment="0" attributes="0">
+                      <Component id="checkStartingLife" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="spnCustomLifeTotal" max="32767" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="checkStartingHandSize" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="spnCustomStartingHand" min="-2" pref="46" max="-2" attributes="0"/>
+                  </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
@@ -84,6 +93,17 @@
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="spnFreeMulligans" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="lblFreeMulligans" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Group type="103" alignment="0" groupAlignment="3" attributes="0">
+                      <Component id="spnCustomStartingHand" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="checkStartingHandSize" alignment="3" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <Group type="103" groupAlignment="3" attributes="0">
+                      <Component id="spnCustomLifeTotal" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="checkStartingLife" alignment="3" min="-2" max="-2" attributes="0"/>
+                  </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jSeparator2" min="-2" max="-2" attributes="0"/>
@@ -320,6 +340,48 @@
         <Property name="AccessibleContext.accessibleName" type="java.lang.String" value="Emblem Cards description"/>
         <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" value="Give players emblems with the abilities of cards.&#xa;Note that some abilities may not function correctly from the command zone.&#xa;If anything breaks, please report it on GitHub."/>
       </AccessibilityProperties>
+    </Component>
+    <Component class="javax.swing.JSpinner" name="spnCustomLifeTotal">
+      <Properties>
+        <Property name="toolTipText" type="java.lang.String" value="Custom starting life total"/>
+      </Properties>
+      <AccessibilityProperties>
+        <Property name="AccessibleContext.accessibleName" type="java.lang.String" value="Custom starting life total"/>
+        <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" value="Set a custom starting life total"/>
+      </AccessibilityProperties>
+      <Events>
+        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="spnCustomLifeTotalStateChanged"/>
+      </Events>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="checkStartingLife">
+      <Properties>
+        <Property name="toolTipText" type="java.lang.String" value="Check to use a specific starting life total"/>
+        <Property name="actionCommand" type="java.lang.String" value="checkCustomLife"/>
+        <Property name="horizontalTextPosition" type="int" value="10"/>
+        <Property name="label" type="java.lang.String" value="Custom Starting Life"/>
+      </Properties>
+      <AccessibilityProperties>
+        <Property name="AccessibleContext.accessibleName" type="java.lang.String" value="Custom starting life"/>
+      </AccessibilityProperties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="checkStartingLifeActionPerformed"/>
+      </Events>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="checkStartingHandSize">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Custom Starting Hand"/>
+        <Property name="toolTipText" type="java.lang.String" value="Check to use a specific starting hand size"/>
+        <Property name="actionCommand" type="java.lang.String" value="checkCustomHandSize"/>
+        <Property name="horizontalTextPosition" type="int" value="10"/>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="checkStartingHandSizeActionPerformed"/>
+      </Events>
+    </Component>
+    <Component class="javax.swing.JSpinner" name="spnCustomStartingHand">
+      <Events>
+        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="spnCustomStartingHandStateChanged"/>
+      </Events>
     </Component>
   </SubComponents>
 </Form>

--- a/Mage.Client/src/main/java/mage/client/dialog/CustomOptionsDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/CustomOptionsDialog.java
@@ -4,8 +4,6 @@ import mage.cards.decks.Deck;
 import mage.cards.decks.DeckFileFilter;
 import mage.cards.decks.importer.DeckImporter;
 import mage.client.MageFrame;
-import mage.constants.MultiplayerAttackOption;
-import mage.constants.RangeOfInfluence;
 import mage.game.GameException;
 import mage.game.match.MatchOptions;
 import mage.game.mulligan.MulliganType;
@@ -15,7 +13,6 @@ import javax.swing.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 
 /**
  * App GUI: custom options for match/tournament
@@ -28,6 +25,10 @@ public class CustomOptionsDialog extends MageDialog {
         TABLE(
                 PreferencesDialog.KEY_NEW_TABLE_NUMBER_OF_FREE_MULLIGANS,
                 PreferencesDialog.KEY_NEW_TABLE_MULLIGAN_TYPE,
+                PreferencesDialog.KEY_NEW_TABLE_CUSTOM_STARTING_LIFE,
+                PreferencesDialog.KEY_NEW_TABLE_NUMBER_OF_LIFE_AT_START,
+                PreferencesDialog.KEY_NEW_TABLE_CUSTOM_STARTING_HAND_SIZE,
+                PreferencesDialog.KEY_NEW_TABLE_NUMBER_OF_HAND_SIZE_AT_START,
                 PreferencesDialog.KEY_NEW_TABLE_PLANECHASE,
                 PreferencesDialog.KEY_NEW_TABLE_EMBLEM_CARDS_ENABLED,
                 PreferencesDialog.KEY_NEW_TABLE_EMBLEM_CARDS_PER_PLAYER_FILE,
@@ -37,6 +38,10 @@ public class CustomOptionsDialog extends MageDialog {
         TOURNEY(
                 PreferencesDialog.KEY_NEW_TOURNAMENT_NUMBER_OF_FREE_MULLIGANS,
                 PreferencesDialog.KEY_NEW_TOURNAMENT_MULLIGUN_TYPE,
+                PreferencesDialog.KEY_NEW_TOURNAMENT_CUSTOM_STARTING_LIFE,
+                PreferencesDialog.KEY_NEW_TOURNAMENT_NUMBER_OF_LIFE_AT_START,
+                PreferencesDialog.KEY_NEW_TOURNAMENT_CUSTOM_STARTING_HAND_SIZE,
+                PreferencesDialog.KEY_NEW_TOURNAMENT_NUMBER_OF_HAND_SIZE_AT_START,
                 PreferencesDialog.KEY_NEW_TOURNAMENT_PLANE_CHASE,
                 PreferencesDialog.KEY_NEW_TOURNAMENT_EMBLEM_CARDS_ENABLED,
                 PreferencesDialog.KEY_NEW_TOURNAMENT_EMBLEM_CARDS_PER_PLAYER_FILE,
@@ -44,6 +49,10 @@ public class CustomOptionsDialog extends MageDialog {
         );
         public final String NUMBER_OF_FREE_MULLIGANS;
         public final String MULLIGAN_TYPE;
+        public final String BOOL_CUSTOM_STARTING_LIFE;
+        public final String NUMBER_OF_LIFE_AT_START;
+        public final String BOOL_CUSTOM_STARTING_HAND_SIZE;
+        public final String NUMBER_OF_HAND_SIZE_AT_START;
         public final String PLANECHASE;
         public final String EMBLEM_CARDS_ENABLED;
         public final String EMBLEM_CARDS_PER_PLAYER_FILE;
@@ -52,6 +61,10 @@ public class CustomOptionsDialog extends MageDialog {
         SaveLoadKeys(
                 String numberOfFreeMulligans,
                 String mulliganType,
+                String customStartLife,
+                String valueStartLife,
+                String customStartHandSize,
+                String valueStartHandSize,
                 String planechase,
                 String emblemCardsEnabled,
                 String emblemCardsPerPlayerFile,
@@ -59,6 +72,10 @@ public class CustomOptionsDialog extends MageDialog {
         ) {
             NUMBER_OF_FREE_MULLIGANS = numberOfFreeMulligans;
             MULLIGAN_TYPE = mulliganType;
+            BOOL_CUSTOM_STARTING_LIFE = customStartLife;
+            NUMBER_OF_LIFE_AT_START = valueStartLife;
+            BOOL_CUSTOM_STARTING_HAND_SIZE = customStartHandSize;
+            NUMBER_OF_HAND_SIZE_AT_START = valueStartHandSize;
             PLANECHASE = planechase;
             EMBLEM_CARDS_ENABLED = emblemCardsEnabled;
             EMBLEM_CARDS_PER_PLAYER_FILE = emblemCardsPerPlayerFile;
@@ -81,6 +98,10 @@ public class CustomOptionsDialog extends MageDialog {
         initComponents();
         this.spnFreeMulligans.setModel(new SpinnerNumberModel(0, 0, 5, 1));
         cbMulliganType.setModel(new DefaultComboBoxModel(MulliganType.values()));
+        this.spnCustomLifeTotal.setModel(new SpinnerNumberModel(20, 1, 100, 1));
+        this.spnCustomLifeTotal.setEnabled(false);
+        this.spnCustomStartingHand.setModel(new SpinnerNumberModel(7, 0, 20, 1));
+        this.spnCustomStartingHand.setEnabled(false);
         this.setModal(true);
         fcSelectEmblemCardsPerPlayer = new JFileChooser();
         fcSelectEmblemCardsPerPlayer.setAcceptAllFileFilterUsed(false);
@@ -119,6 +140,10 @@ public class CustomOptionsDialog extends MageDialog {
         txtEmblemCardsStartingPlayer = new javax.swing.JTextField();
         lblEmblemCardsStartingPlayer = new javax.swing.JLabel();
         emblemCardsDescriptionLabel = new javax.swing.JLabel();
+        spnCustomLifeTotal = new javax.swing.JSpinner();
+        checkStartingLife = new javax.swing.JCheckBox();
+        checkStartingHandSize = new javax.swing.JCheckBox();
+        spnCustomStartingHand = new javax.swing.JSpinner();
 
         setTitle("Custom Options");
 
@@ -211,6 +236,39 @@ public class CustomOptionsDialog extends MageDialog {
         emblemCardsDescriptionLabel.setText("<html>Give players emblems with the abilities of cards.<br>Note that some abilities may not function correctly from the command zone.<br>If anything breaks, please report it on GitHub.");
         emblemCardsDescriptionLabel.setVerticalAlignment(javax.swing.SwingConstants.TOP);
 
+        spnCustomLifeTotal.setToolTipText("Custom starting life total");
+        spnCustomLifeTotal.addChangeListener(new javax.swing.event.ChangeListener() {
+            public void stateChanged(javax.swing.event.ChangeEvent evt) {
+                spnCustomLifeTotalStateChanged(evt);
+            }
+        });
+
+        checkStartingLife.setToolTipText("Check to use a specific starting life total");
+        checkStartingLife.setActionCommand("checkCustomLife");
+        checkStartingLife.setHorizontalTextPosition(javax.swing.SwingConstants.LEADING);
+        checkStartingLife.setLabel("Custom Starting Life");
+        checkStartingLife.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                checkStartingLifeActionPerformed(evt);
+            }
+        });
+
+        checkStartingHandSize.setText("Custom Starting Hand");
+        checkStartingHandSize.setToolTipText("Check to use a specific starting hand size");
+        checkStartingHandSize.setActionCommand("checkCustomHandSize");
+        checkStartingHandSize.setHorizontalTextPosition(javax.swing.SwingConstants.LEADING);
+        checkStartingHandSize.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                checkStartingHandSizeActionPerformed(evt);
+            }
+        });
+
+        spnCustomStartingHand.addChangeListener(new javax.swing.event.ChangeListener() {
+            public void stateChanged(javax.swing.event.ChangeEvent evt) {
+                spnCustomStartingHandStateChanged(evt);
+            }
+        });
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
         layout.setHorizontalGroup(
@@ -240,6 +298,8 @@ public class CustomOptionsDialog extends MageDialog {
                         .addComponent(lblFreeMulligans)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(spnFreeMulligans))
+                    .addComponent(planechaseDescriptionLabel)
+                    .addComponent(emblemCardsDescriptionLabel)
                     .addGroup(layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(lblVariantOptions)
@@ -249,8 +309,14 @@ public class CustomOptionsDialog extends MageDialog {
                             .addComponent(lblEmblemCardsStartingPlayer)
                             .addComponent(lblGeneralOptions))
                         .addGap(0, 0, Short.MAX_VALUE))
-                    .addComponent(planechaseDescriptionLabel)
-                    .addComponent(emblemCardsDescriptionLabel))
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(checkStartingLife)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(spnCustomLifeTotal)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(checkStartingHandSize)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(spnCustomStartingHand, javax.swing.GroupLayout.PREFERRED_SIZE, 46, javax.swing.GroupLayout.PREFERRED_SIZE)))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -266,6 +332,14 @@ public class CustomOptionsDialog extends MageDialog {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(spnFreeMulligans, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(lblFreeMulligans))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                        .addComponent(spnCustomStartingHand, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addComponent(checkStartingHandSize))
+                    .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                        .addComponent(spnCustomLifeTotal, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addComponent(checkStartingLife)))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jSeparator2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -317,6 +391,9 @@ public class CustomOptionsDialog extends MageDialog {
         lblEmblemCardsStartingPlayer.getAccessibleContext().setAccessibleParent(chkEmblemCards);
         emblemCardsDescriptionLabel.getAccessibleContext().setAccessibleName("Emblem Cards description");
         emblemCardsDescriptionLabel.getAccessibleContext().setAccessibleDescription("Give players emblems with the abilities of cards.\nNote that some abilities may not function correctly from the command zone.\nIf anything breaks, please report it on GitHub.");
+        spnCustomLifeTotal.getAccessibleContext().setAccessibleName("Custom starting life total");
+        spnCustomLifeTotal.getAccessibleContext().setAccessibleDescription("Set a custom starting life total");
+        checkStartingLife.getAccessibleContext().setAccessibleName("Custom starting life");
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
@@ -360,10 +437,27 @@ public class CustomOptionsDialog extends MageDialog {
 
     }//GEN-LAST:event_txtEmblemCardsStartingPlayerActionPerformed
 
+    private void spnCustomLifeTotalStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_spnCustomLifeTotalStateChanged
+        updateActiveCount();
+    }//GEN-LAST:event_spnCustomLifeTotalStateChanged
+
+    private void spnCustomStartingHandStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_spnCustomStartingHandStateChanged
+        updateActiveCount();
+    }//GEN-LAST:event_spnCustomStartingHandStateChanged
+
+    private void checkStartingLifeActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_checkStartingLifeActionPerformed
+        updateActiveCount();
+    }//GEN-LAST:event_checkStartingLifeActionPerformed
+
+    private void checkStartingHandSizeActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_checkStartingHandSizeActionPerformed
+        updateActiveCount();
+    }//GEN-LAST:event_checkStartingHandSizeActionPerformed
+
     public void showDialog() {
         this.setLocation(150, 100);
         this.setVisible(true);
     }
+
     private void loadEmblemCardFile(boolean isStartingPlayer) {
         JFileChooser fileChooser = isStartingPlayer ? fcSelectEmblemCardsStartingPlayer : fcSelectEmblemCardsPerPlayer;
         JTextField textField = isStartingPlayer ? txtEmblemCardsStartingPlayer : txtEmblemCardsPerPlayer;
@@ -406,6 +500,10 @@ public class CustomOptionsDialog extends MageDialog {
         this.chkPlaneChase.setSelected(PreferencesDialog.getCachedValue(saveLoadKeys.PLANECHASE + versionStr, "No").equals("Yes"));
         this.spnFreeMulligans.setValue(Integer.parseInt(PreferencesDialog.getCachedValue(saveLoadKeys.NUMBER_OF_FREE_MULLIGANS + versionStr, "0")));
         this.cbMulliganType.setSelectedItem(MulliganType.valueByName(PreferencesDialog.getCachedValue(saveLoadKeys.MULLIGAN_TYPE + versionStr, MulliganType.GAME_DEFAULT.toString())));
+        this.checkStartingLife.setSelected(PreferencesDialog.getCachedValue(saveLoadKeys.BOOL_CUSTOM_STARTING_LIFE + versionStr, "No").equals("Yes"));
+        this.spnCustomLifeTotal.setValue(Integer.parseInt(PreferencesDialog.getCachedValue(saveLoadKeys.NUMBER_OF_LIFE_AT_START + versionStr, "20")));
+        this.checkStartingHandSize.setSelected(PreferencesDialog.getCachedValue(saveLoadKeys.BOOL_CUSTOM_STARTING_HAND_SIZE + versionStr, "No").equals("Yes"));
+        this.spnCustomStartingHand.setValue(Integer.parseInt(PreferencesDialog.getCachedValue(saveLoadKeys.NUMBER_OF_HAND_SIZE_AT_START + versionStr, "7")));
         this.chkEmblemCards.setSelected(PreferencesDialog.getCachedValue(saveLoadKeys.EMBLEM_CARDS_ENABLED + versionStr, "No").equals("Yes"));
         this.txtEmblemCardsPerPlayer.setText(PreferencesDialog.getCachedValue(saveLoadKeys.EMBLEM_CARDS_PER_PLAYER_FILE, ""));
         this.txtEmblemCardsStartingPlayer.setText(PreferencesDialog.getCachedValue(saveLoadKeys.EMBLEM_CARDS_STARTING_PLAYER_FILE, ""));
@@ -427,6 +525,10 @@ public class CustomOptionsDialog extends MageDialog {
         }
         PreferencesDialog.saveValue(saveLoadKeys.NUMBER_OF_FREE_MULLIGANS + versionStr, Integer.toString(options.getFreeMulligans()));
         PreferencesDialog.saveValue(saveLoadKeys.MULLIGAN_TYPE + versionStr, options.getMulliganType().toString());
+        PreferencesDialog.saveValue(saveLoadKeys.BOOL_CUSTOM_STARTING_LIFE + versionStr, options.isCustomStartLifeEnabled() ? "Yes" : "No");
+        PreferencesDialog.saveValue(saveLoadKeys.NUMBER_OF_LIFE_AT_START + versionStr, Integer.toString(options.getCustomStartLife()));
+        PreferencesDialog.saveValue(saveLoadKeys.BOOL_CUSTOM_STARTING_HAND_SIZE + versionStr, options.isCustomStartHandSizeEnabled() ? "Yes" : "No");
+        PreferencesDialog.saveValue(saveLoadKeys.NUMBER_OF_HAND_SIZE_AT_START + versionStr, Integer.toString(options.getCustomStartHandSize()));
         PreferencesDialog.saveValue(saveLoadKeys.PLANECHASE + versionStr, options.isPlaneChase() ? "Yes" : "No");
         PreferencesDialog.saveValue(saveLoadKeys.EMBLEM_CARDS_ENABLED + versionStr,
                 !(options.getGlobalEmblemCards().isEmpty() && options.getPerPlayerEmblemCards().isEmpty()) ? "Yes" : "No");
@@ -440,6 +542,10 @@ public class CustomOptionsDialog extends MageDialog {
     public void writeMatchOptionsTo(MatchOptions options) {
         options.setFreeMulligans((Integer) spnFreeMulligans.getValue());
         options.setMullgianType((MulliganType) cbMulliganType.getSelectedItem());
+        options.setCustomStartLifeEnabled(checkStartingLife.isSelected());
+        options.setCustomStartLife((Integer) spnCustomLifeTotal.getValue());
+        options.setCustomStartHandSizeEnabled(checkStartingHandSize.isSelected());
+        options.setCustomStartHandSize((Integer) spnCustomStartingHand.getValue());
         options.setPlaneChase(chkPlaneChase.isSelected());
         if (chkEmblemCards.isSelected()) {
             if (!txtEmblemCardsPerPlayer.getText().isEmpty()) {
@@ -452,8 +558,7 @@ public class CustomOptionsDialog extends MageDialog {
                 if (perPlayerEmblemDeck != null) {
                     perPlayerEmblemDeck.clearLayouts();
                     options.setPerPlayerEmblemCards(perPlayerEmblemDeck.getDeckCardLists().getCards());
-                }
-                else {
+                } else {
                     options.setPerPlayerEmblemCards(Collections.emptySet());
                 }
             }
@@ -467,13 +572,11 @@ public class CustomOptionsDialog extends MageDialog {
                 if (startingPlayerEmblemDeck != null) {
                     startingPlayerEmblemDeck.clearLayouts();
                     options.setGlobalEmblemCards(startingPlayerEmblemDeck.getDeckCardLists().getCards());
-                }
-                else {
+                } else {
                     options.setGlobalEmblemCards(Collections.emptySet());
                 }
             }
-        }
-        else {
+        } else {
             options.setPerPlayerEmblemCards(Collections.emptySet());
             options.setGlobalEmblemCards(Collections.emptySet());
         }
@@ -481,14 +584,17 @@ public class CustomOptionsDialog extends MageDialog {
 
     public void updateActiveCount() {
         int activeCount = 0;
-        if ((Integer)spnFreeMulligans.getValue() > 0) activeCount++;
+        if ((Integer) spnFreeMulligans.getValue() > 0) activeCount++;
+        if (checkStartingLife.isSelected()) activeCount++;
+        spnCustomLifeTotal.setEnabled(checkStartingLife.isSelected());
+        if (checkStartingHandSize.isSelected()) activeCount++;
+        spnCustomStartingHand.setEnabled(checkStartingHandSize.isSelected());
         if (!cbMulliganType.getSelectedItem().toString().equals(MulliganType.GAME_DEFAULT.toString())) activeCount++;
         if (chkPlaneChase.isSelected()) activeCount++;
         if (chkEmblemCards.isSelected()) activeCount++;
         if (activeCount == 0) {
             openButton.setText("Custom Options...");
-        }
-        else {
+        } else {
             openButton.setText("Custom Options (" + activeCount + ")");
         }
     }
@@ -498,6 +604,8 @@ public class CustomOptionsDialog extends MageDialog {
     private javax.swing.JButton btnEmblemCardsStartingPlayer;
     private javax.swing.JButton btnOK;
     private javax.swing.JComboBox<String> cbMulliganType;
+    private javax.swing.JCheckBox checkStartingHandSize;
+    private javax.swing.JCheckBox checkStartingLife;
     private javax.swing.JCheckBox chkEmblemCards;
     private javax.swing.JCheckBox chkPlaneChase;
     private javax.swing.JLabel emblemCardsDescriptionLabel;
@@ -511,6 +619,8 @@ public class CustomOptionsDialog extends MageDialog {
     private javax.swing.JLabel lblMulliganType;
     private javax.swing.JLabel lblVariantOptions;
     private javax.swing.JLabel planechaseDescriptionLabel;
+    private javax.swing.JSpinner spnCustomLifeTotal;
+    private javax.swing.JSpinner spnCustomStartingHand;
     private javax.swing.JSpinner spnFreeMulligans;
     private javax.swing.JTextField txtEmblemCardsPerPlayer;
     private javax.swing.JTextField txtEmblemCardsStartingPlayer;

--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
@@ -203,6 +203,10 @@ public class PreferencesDialog extends javax.swing.JDialog {
     public static final String KEY_NEW_TABLE_PLANECHASE = "newTablePlaneChase";
     public static final String KEY_NEW_TABLE_NUMBER_OF_FREE_MULLIGANS = "newTableNumberOfFreeMulligans";
     public static final String KEY_NEW_TABLE_MULLIGAN_TYPE = "newTableMulliganType";
+    public static final String KEY_NEW_TABLE_CUSTOM_STARTING_LIFE = "newTableUseCustomLife";
+    public static final String KEY_NEW_TABLE_NUMBER_OF_LIFE_AT_START = "newTableNumberOfLifeAtStart";
+    public static final String KEY_NEW_TABLE_CUSTOM_STARTING_HAND_SIZE = "newTableUseCustomHandSize";
+    public static final String KEY_NEW_TABLE_NUMBER_OF_HAND_SIZE_AT_START = "newTableNumberOfHandSizeAtStart";
     public static final String KEY_NEW_TABLE_DECK_FILE = "newTableDeckFile";
     public static final String KEY_NEW_TABLE_RANGE = "newTableRange";
     public static final String KEY_NEW_TABLE_ATTACK_OPTION = "newTableAttackOption";
@@ -226,6 +230,10 @@ public class PreferencesDialog extends javax.swing.JDialog {
     public static final String KEY_NEW_TOURNAMENT_TYPE = "newTournamentType";
     public static final String KEY_NEW_TOURNAMENT_NUMBER_OF_FREE_MULLIGANS = "newTournamentNumberOfFreeMulligans";
     public static final String KEY_NEW_TOURNAMENT_MULLIGUN_TYPE = "newTournamentMulliganType";
+    public static final String KEY_NEW_TOURNAMENT_CUSTOM_STARTING_LIFE = "newTournamentUseCustomLife";
+    public static final String KEY_NEW_TOURNAMENT_NUMBER_OF_LIFE_AT_START = "newTournamentNumberOfLifeAtStart";
+    public static final String KEY_NEW_TOURNAMENT_CUSTOM_STARTING_HAND_SIZE = "newTournamentUseCustomHandSize";
+    public static final String KEY_NEW_TOURNAMENT_NUMBER_OF_HAND_SIZE_AT_START = "newTournamentNumberOfHandSizeAtStart";
     public static final String KEY_NEW_TOURNAMENT_NUMBER_OF_WINS = "newTournamentNumberOfWins";
     public static final String KEY_NEW_TOURNAMENT_PACKS_SEALED = "newTournamentPacksSealed";
     public static final String KEY_NEW_TOURNAMENT_PACKS_DRAFT = "newTournamentPacksDraft";
@@ -332,9 +340,9 @@ public class PreferencesDialog extends javax.swing.JDialog {
     private static int selectedAvatarId;
 
     private static ThemeType currentTheme = null;
-    
+
     private static boolean ignoreGUISizeSliderStateChangedEvent = false;
-    
+
     public static ThemeType getCurrentTheme() {
         if (currentTheme == null) {
             currentTheme = ThemeType.valueByName(getCachedValue(KEY_THEME, "Default"));
@@ -706,30 +714,30 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout main_cardLayout = new org.jdesktop.layout.GroupLayout(main_card);
         main_card.setLayout(main_cardLayout);
         main_cardLayout.setHorizontalGroup(
-            main_cardLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(main_cardLayout.createSequentialGroup()
-                .add(6, 6, 6)
-                .add(tooltipDelayLabel)
-                .addContainerGap(383, Short.MAX_VALUE))
-            .add(main_cardLayout.createSequentialGroup()
-                .add(main_cardLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(main_cardLayout.createSequentialGroup()
-                        .add(showCardName)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(showFullImagePath))
-                    .add(tooltipDelay, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 522, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .add(0, 0, Short.MAX_VALUE))
+                main_cardLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(main_cardLayout.createSequentialGroup()
+                                .add(6, 6, 6)
+                                .add(tooltipDelayLabel)
+                                .addContainerGap(383, Short.MAX_VALUE))
+                        .add(main_cardLayout.createSequentialGroup()
+                                .add(main_cardLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                        .add(main_cardLayout.createSequentialGroup()
+                                                .add(showCardName)
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(showFullImagePath))
+                                        .add(tooltipDelay, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 522, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                .add(0, 0, Short.MAX_VALUE))
         );
         main_cardLayout.setVerticalGroup(
-            main_cardLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(main_cardLayout.createSequentialGroup()
-                .add(main_cardLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(showCardName)
-                    .add(showFullImagePath))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(tooltipDelayLabel)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(tooltipDelay, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                main_cardLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(main_cardLayout.createSequentialGroup()
+                                .add(main_cardLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(showCardName)
+                                        .add(showFullImagePath))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(tooltipDelayLabel)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(tooltipDelay, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         main_game.setBorder(javax.swing.BorderFactory.createTitledBorder(javax.swing.BorderFactory.createEtchedBorder(), "Game"));
@@ -765,51 +773,51 @@ public class PreferencesDialog extends javax.swing.JDialog {
         lblTargetAutoChoose.setText("Auto-choose targets for player:");
         lblTargetAutoChoose.setToolTipText("<html>\nWhen there is only one possible outcome for targeting, the targets can be chosen for you.\n<br>\n<b>None:</b> All targeting must be done by the player.\n<br>\n<b>Most:</b> All targeting other than feel-bad effects (discarding, destroy, sacrifice, exile) that target you, a card you own, or a permanent/spell you control.\n<br>\n<b>All:</b> All targeting that can be automated will be.");
 
-        cbTargetAutoChooseLevel.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Off", "Most", "All" }));
+        cbTargetAutoChooseLevel.setModel(new javax.swing.DefaultComboBoxModel<>(new String[]{"Off", "Most", "All"}));
         cbTargetAutoChooseLevel.setSelectedIndex(1);
         cbTargetAutoChooseLevel.setToolTipText(lblTargetAutoChoose.getToolTipText());
 
         org.jdesktop.layout.GroupLayout main_gameLayout = new org.jdesktop.layout.GroupLayout(main_game);
         main_game.setLayout(main_gameLayout);
         main_gameLayout.setHorizontalGroup(
-            main_gameLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(displayLifeOnAvatar, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-            .add(main_gameLayout.createSequentialGroup()
-                .add(main_gameLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(main_gameLayout.createSequentialGroup()
-                        .addContainerGap()
-                        .add(lblTargetAutoChoose)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(cbTargetAutoChooseLevel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                    .add(cbAskMoveToGraveOrder, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 596, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(main_gameLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING, false)
-                        .add(showPlayerNamesPermanently, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .add(nonLandPermanentsInOnePile, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .add(cbConfirmEmptyManaPool, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .add(cbAllowRequestToShowHandCards, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .add(showAbilityPickerForced)))
-                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                main_gameLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(displayLifeOnAvatar, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .add(main_gameLayout.createSequentialGroup()
+                                .add(main_gameLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                        .add(main_gameLayout.createSequentialGroup()
+                                                .addContainerGap()
+                                                .add(lblTargetAutoChoose)
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                                .add(cbTargetAutoChooseLevel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                        .add(cbAskMoveToGraveOrder, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 596, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                        .add(main_gameLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING, false)
+                                                .add(showPlayerNamesPermanently, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                                .add(nonLandPermanentsInOnePile, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                                .add(cbConfirmEmptyManaPool, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                                .add(cbAllowRequestToShowHandCards, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                                .add(showAbilityPickerForced)))
+                                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         main_gameLayout.setVerticalGroup(
-            main_gameLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(main_gameLayout.createSequentialGroup()
-                .add(nonLandPermanentsInOnePile)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(showPlayerNamesPermanently)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(displayLifeOnAvatar)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(showAbilityPickerForced)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(cbAllowRequestToShowHandCards)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(cbConfirmEmptyManaPool)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(cbAskMoveToGraveOrder)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(main_gameLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(lblTargetAutoChoose)
-                    .add(cbTargetAutoChooseLevel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
+                main_gameLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(main_gameLayout.createSequentialGroup()
+                                .add(nonLandPermanentsInOnePile)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(showPlayerNamesPermanently)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(displayLifeOnAvatar)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(showAbilityPickerForced)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(cbAllowRequestToShowHandCards)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(cbConfirmEmptyManaPool)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(cbAskMoveToGraveOrder)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(main_gameLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(lblTargetAutoChoose)
+                                        .add(cbTargetAutoChooseLevel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
         );
 
         nonLandPermanentsInOnePile.getAccessibleContext().setAccessibleName("nonLandPermanentsInOnePile");
@@ -817,7 +825,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
 
         main_battlefield.setBorder(javax.swing.BorderFactory.createTitledBorder(javax.swing.BorderFactory.createEtchedBorder(), "Battlefield"));
 
-        cbBattlefieldFeedbackColorizingMode.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Disable colorizing", "Enable one color for all phases", "Enable multicolor for different phases" }));
+        cbBattlefieldFeedbackColorizingMode.setModel(new javax.swing.DefaultComboBoxModel(new String[]{"Disable colorizing", "Enable one color for all phases", "Enable multicolor for different phases"}));
         cbBattlefieldFeedbackColorizingMode.setToolTipText("Battlefield feedback panel colorizing on your turn (e.g. use green color if you must select card or answer to request)");
         cbBattlefieldFeedbackColorizingMode.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -831,46 +839,46 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout main_battlefieldLayout = new org.jdesktop.layout.GroupLayout(main_battlefield);
         main_battlefield.setLayout(main_battlefieldLayout);
         main_battlefieldLayout.setHorizontalGroup(
-            main_battlefieldLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(main_battlefieldLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(lblBattlefieldFeedbackColorizingMode)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(cbBattlefieldFeedbackColorizingMode, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 278, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                main_battlefieldLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(main_battlefieldLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(lblBattlefieldFeedbackColorizingMode)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(cbBattlefieldFeedbackColorizingMode, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 278, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         main_battlefieldLayout.setVerticalGroup(
-            main_battlefieldLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(main_battlefieldLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                .add(lblBattlefieldFeedbackColorizingMode)
-                .add(cbBattlefieldFeedbackColorizingMode, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                main_battlefieldLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(main_battlefieldLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                .add(lblBattlefieldFeedbackColorizingMode)
+                                .add(cbBattlefieldFeedbackColorizingMode, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
         );
 
         org.jdesktop.layout.GroupLayout tabMainLayout = new org.jdesktop.layout.GroupLayout(tabMain);
         tabMain.setLayout(tabMainLayout);
         tabMainLayout.setHorizontalGroup(
-            tabMainLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabMainLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(tabMainLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(org.jdesktop.layout.GroupLayout.TRAILING, main_card, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .add(org.jdesktop.layout.GroupLayout.TRAILING, main_gamelog, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .add(main_game, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .add(org.jdesktop.layout.GroupLayout.TRAILING, main_battlefield, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                .addContainerGap())
+                tabMainLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabMainLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(tabMainLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                        .add(org.jdesktop.layout.GroupLayout.TRAILING, main_card, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .add(org.jdesktop.layout.GroupLayout.TRAILING, main_gamelog, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .add(main_game, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .add(org.jdesktop.layout.GroupLayout.TRAILING, main_battlefield, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                                .addContainerGap())
         );
         tabMainLayout.setVerticalGroup(
-            tabMainLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabMainLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(main_card, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(main_game, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(main_gamelog, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(main_battlefield, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .add(20, 20, 20))
+                tabMainLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabMainLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(main_card, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(main_game, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(main_gamelog, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(main_battlefield, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                .add(20, 20, 20))
         );
 
         main_card.getAccessibleContext().setAccessibleName("Game panel");
@@ -880,18 +888,18 @@ public class PreferencesDialog extends javax.swing.JDialog {
         tabGuiSize.setMaximumSize(new java.awt.Dimension(527, 423));
         tabGuiSize.setMinimumSize(new java.awt.Dimension(527, 423));
         java.awt.GridBagLayout tabGuiSizeLayout = new java.awt.GridBagLayout();
-        tabGuiSizeLayout.columnWidths = new int[] {0};
-        tabGuiSizeLayout.rowHeights = new int[] {0, 20, 0};
-        tabGuiSizeLayout.columnWeights = new double[] {1.0};
-        tabGuiSizeLayout.rowWeights = new double[] {1.0, 0.0, 1.0};
+        tabGuiSizeLayout.columnWidths = new int[]{0};
+        tabGuiSizeLayout.rowHeights = new int[]{0, 20, 0};
+        tabGuiSizeLayout.columnWeights = new double[]{1.0};
+        tabGuiSizeLayout.rowWeights = new double[]{1.0, 0.0, 1.0};
         tabGuiSize.setLayout(tabGuiSizeLayout);
 
         guiSizeBasic.setBorder(javax.swing.BorderFactory.createTitledBorder(javax.swing.BorderFactory.createEtchedBorder(), "Size basic elements"));
         guiSizeBasic.setMinimumSize(new java.awt.Dimension(600, 180));
         guiSizeBasic.setPreferredSize(new java.awt.Dimension(600, 180));
         java.awt.GridBagLayout guiSizeBasicLayout = new java.awt.GridBagLayout();
-        guiSizeBasicLayout.columnWeights = new double[] {1.0, 1.0, 1.0};
-        guiSizeBasicLayout.rowWeights = new double[] {1.0, 0.2, 1.0, 0.2};
+        guiSizeBasicLayout.columnWeights = new double[]{1.0, 1.0, 1.0};
+        guiSizeBasicLayout.rowWeights = new double[]{1.0, 0.2, 1.0, 0.2};
         guiSizeBasic.setLayout(guiSizeBasicLayout);
 
         sliderFontSize.setMajorTickSpacing(5);
@@ -1110,8 +1118,8 @@ public class PreferencesDialog extends javax.swing.JDialog {
         guiSizeGame.setMinimumSize(new java.awt.Dimension(600, 180));
         guiSizeGame.setPreferredSize(new java.awt.Dimension(600, 180));
         java.awt.GridBagLayout guiSizeGameLayout = new java.awt.GridBagLayout();
-        guiSizeGameLayout.columnWeights = new double[] {1.0, 1.0, 1.0, 1.0};
-        guiSizeGameLayout.rowWeights = new double[] {1.0, 0.2, 1.0, 0.2};
+        guiSizeGameLayout.columnWeights = new double[]{1.0, 1.0, 1.0, 1.0};
+        guiSizeGameLayout.rowWeights = new double[]{1.0, 0.2, 1.0, 0.2};
         guiSizeGame.setLayout(guiSizeGameLayout);
 
         sliderCardSizeHand.setMajorTickSpacing(5);
@@ -1451,115 +1459,115 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout tabPhasesLayout = new org.jdesktop.layout.GroupLayout(tabPhases);
         tabPhases.setLayout(tabPhasesLayout);
         tabPhasesLayout.setHorizontalGroup(
-            tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabPhasesLayout.createSequentialGroup()
-                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(tabPhasesLayout.createSequentialGroup()
-                        .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                            .add(tabPhasesLayout.createSequentialGroup()
-                                .add(20, 20, 20)
+                tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabPhasesLayout.createSequentialGroup()
                                 .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                                    .add(tabPhasesLayout.createSequentialGroup()
-                                        .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                                            .add(jLabelUpkeep)
-                                            .add(jLabelBeforeCombat)
-                                            .add(jLabelEndofCombat)
-                                            .add(jLabelMain2)
-                                            .add(jLabelEndOfTurn))
-                                        .add(77, 77, 77)
-                                        .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                                            .add(tabPhasesLayout.createSequentialGroup()
-                                                .add(2, 2, 2)
-                                                .add(jLabelYourTurn)
-                                                .add(32, 32, 32)
-                                                .add(jLabelOpponentsTurn))
-                                            .add(tabPhasesLayout.createSequentialGroup()
-                                                .add(13, 13, 13)
-                                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                                                    .add(checkBoxDrawYou)
-                                                    .add(checkBoxUpkeepYou)
-                                                    .add(checkBoxMainYou)
-                                                    .add(checkBoxBeforeCYou)
-                                                    .add(checkBoxEndOfCYou)
-                                                    .add(checkBoxMain2You)
-                                                    .add(checkBoxEndTurnYou))
-                                                .add(78, 78, 78)
-                                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                                                    .add(checkBoxUpkeepOthers)
-                                                    .add(checkBoxBeforeCOthers)
-                                                    .add(checkBoxMainOthers)
-                                                    .add(checkBoxEndOfCOthers)
-                                                    .add(checkBoxDrawOthers)
-                                                    .add(checkBoxMain2Others)
-                                                    .add(checkBoxEndTurnOthers)))))
-                                    .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING, false)
-                                        .add(org.jdesktop.layout.GroupLayout.LEADING, jLabelMain1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                        .add(org.jdesktop.layout.GroupLayout.LEADING, jLabelDraw, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
-                            .add(tabPhasesLayout.createSequentialGroup()
-                                .addContainerGap()
-                                .add(jLabelHeadLine)))
-                        .add(0, 0, Short.MAX_VALUE))
-                    .add(tabPhasesLayout.createSequentialGroup()
-                        .addContainerGap()
-                        .add(phases_stopSettings, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
-                .addContainerGap())
+                                        .add(tabPhasesLayout.createSequentialGroup()
+                                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                                        .add(tabPhasesLayout.createSequentialGroup()
+                                                                .add(20, 20, 20)
+                                                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                                                        .add(tabPhasesLayout.createSequentialGroup()
+                                                                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                                                                        .add(jLabelUpkeep)
+                                                                                        .add(jLabelBeforeCombat)
+                                                                                        .add(jLabelEndofCombat)
+                                                                                        .add(jLabelMain2)
+                                                                                        .add(jLabelEndOfTurn))
+                                                                                .add(77, 77, 77)
+                                                                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                                                                        .add(tabPhasesLayout.createSequentialGroup()
+                                                                                                .add(2, 2, 2)
+                                                                                                .add(jLabelYourTurn)
+                                                                                                .add(32, 32, 32)
+                                                                                                .add(jLabelOpponentsTurn))
+                                                                                        .add(tabPhasesLayout.createSequentialGroup()
+                                                                                                .add(13, 13, 13)
+                                                                                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                                                                                        .add(checkBoxDrawYou)
+                                                                                                        .add(checkBoxUpkeepYou)
+                                                                                                        .add(checkBoxMainYou)
+                                                                                                        .add(checkBoxBeforeCYou)
+                                                                                                        .add(checkBoxEndOfCYou)
+                                                                                                        .add(checkBoxMain2You)
+                                                                                                        .add(checkBoxEndTurnYou))
+                                                                                                .add(78, 78, 78)
+                                                                                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                                                                                        .add(checkBoxUpkeepOthers)
+                                                                                                        .add(checkBoxBeforeCOthers)
+                                                                                                        .add(checkBoxMainOthers)
+                                                                                                        .add(checkBoxEndOfCOthers)
+                                                                                                        .add(checkBoxDrawOthers)
+                                                                                                        .add(checkBoxMain2Others)
+                                                                                                        .add(checkBoxEndTurnOthers)))))
+                                                                        .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING, false)
+                                                                                .add(org.jdesktop.layout.GroupLayout.LEADING, jLabelMain1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                                                                .add(org.jdesktop.layout.GroupLayout.LEADING, jLabelDraw, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
+                                                        .add(tabPhasesLayout.createSequentialGroup()
+                                                                .addContainerGap()
+                                                                .add(jLabelHeadLine)))
+                                                .add(0, 0, Short.MAX_VALUE))
+                                        .add(tabPhasesLayout.createSequentialGroup()
+                                                .addContainerGap()
+                                                .add(phases_stopSettings, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
+                                .addContainerGap())
         );
         tabPhasesLayout.setVerticalGroup(
-            tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabPhasesLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                    .add(tabPhasesLayout.createSequentialGroup()
-                        .add(jLabelOpponentsTurn)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(checkBoxUpkeepOthers))
-                    .add(tabPhasesLayout.createSequentialGroup()
-                        .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                            .add(tabPhasesLayout.createSequentialGroup()
-                                .add(jLabelHeadLine)
-                                .add(20, 20, 20))
-                            .add(jLabelYourTurn))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                            .add(checkBoxUpkeepYou)
-                            .add(jLabelUpkeep))))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                    .add(jLabelDraw)
-                    .add(checkBoxDrawYou)
-                    .add(checkBoxDrawOthers))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                    .add(jLabelMain1)
-                    .add(checkBoxMainYou)
-                    .add(checkBoxMainOthers))
-                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(tabPhasesLayout.createSequentialGroup()
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                            .add(org.jdesktop.layout.GroupLayout.TRAILING, jLabelBeforeCombat)
-                            .add(org.jdesktop.layout.GroupLayout.TRAILING, checkBoxBeforeCYou)))
-                    .add(tabPhasesLayout.createSequentialGroup()
-                        .add(6, 6, 6)
-                        .add(checkBoxBeforeCOthers)))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                    .add(jLabelEndofCombat)
-                    .add(checkBoxEndOfCYou)
-                    .add(checkBoxEndOfCOthers))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                    .add(jLabelMain2)
-                    .add(checkBoxMain2You)
-                    .add(checkBoxMain2Others))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                    .add(checkBoxEndTurnYou)
-                    .add(jLabelEndOfTurn)
-                    .add(checkBoxEndTurnOthers))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                .add(phases_stopSettings, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 321, Short.MAX_VALUE)
-                .addContainerGap())
+                tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabPhasesLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                        .add(tabPhasesLayout.createSequentialGroup()
+                                                .add(jLabelOpponentsTurn)
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(checkBoxUpkeepOthers))
+                                        .add(tabPhasesLayout.createSequentialGroup()
+                                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                                        .add(tabPhasesLayout.createSequentialGroup()
+                                                                .add(jLabelHeadLine)
+                                                                .add(20, 20, 20))
+                                                        .add(jLabelYourTurn))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                                        .add(checkBoxUpkeepYou)
+                                                        .add(jLabelUpkeep))))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                        .add(jLabelDraw)
+                                        .add(checkBoxDrawYou)
+                                        .add(checkBoxDrawOthers))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                        .add(jLabelMain1)
+                                        .add(checkBoxMainYou)
+                                        .add(checkBoxMainOthers))
+                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                        .add(tabPhasesLayout.createSequentialGroup()
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                                        .add(org.jdesktop.layout.GroupLayout.TRAILING, jLabelBeforeCombat)
+                                                        .add(org.jdesktop.layout.GroupLayout.TRAILING, checkBoxBeforeCYou)))
+                                        .add(tabPhasesLayout.createSequentialGroup()
+                                                .add(6, 6, 6)
+                                                .add(checkBoxBeforeCOthers)))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                        .add(jLabelEndofCombat)
+                                        .add(checkBoxEndOfCYou)
+                                        .add(checkBoxEndOfCOthers))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                        .add(jLabelMain2)
+                                        .add(checkBoxMain2You)
+                                        .add(checkBoxMain2Others))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(tabPhasesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                        .add(checkBoxEndTurnYou)
+                                        .add(jLabelEndOfTurn)
+                                        .add(checkBoxEndTurnOthers))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                .add(phases_stopSettings, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 321, Short.MAX_VALUE)
+                                .addContainerGap())
         );
 
         tabsPanel.addTab("Phases & Priority", tabPhases);
@@ -1590,7 +1598,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
         });
 
         cbPreferredImageLanguage.setMaximumRowCount(20);
-        cbPreferredImageLanguage.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
+        cbPreferredImageLanguage.setModel(new javax.swing.DefaultComboBoxModel<>(new String[]{"Item 1", "Item 2", "Item 3", "Item 4"}));
 
         labelPreferredImageLanguage.setText("Default images language:");
         labelPreferredImageLanguage.setFocusable(false);
@@ -1598,57 +1606,57 @@ public class PreferencesDialog extends javax.swing.JDialog {
         labelNumberOfDownloadThreads.setText("Default download threads:");
 
         cbNumberOfDownloadThreads.setMaximumRowCount(20);
-        cbNumberOfDownloadThreads.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
+        cbNumberOfDownloadThreads.setModel(new javax.swing.DefaultComboBoxModel(new String[]{"Item 1", "Item 2", "Item 3", "Item 4"}));
 
         labelHint1.setText("(change it to 1-3 if image source bans your IP for too many connections)");
 
         org.jdesktop.layout.GroupLayout panelCardImagesLayout = new org.jdesktop.layout.GroupLayout(panelCardImages);
         panelCardImages.setLayout(panelCardImagesLayout);
         panelCardImagesLayout.setHorizontalGroup(
-            panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(panelCardImagesLayout.createSequentialGroup()
-                .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(panelCardImagesLayout.createSequentialGroup()
-                        .add(cbUseDefaultImageFolder)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(txtImageFolderPath)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(btnBrowseImageLocation))
-                    .add(panelCardImagesLayout.createSequentialGroup()
-                        .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                            .add(cbSaveToZipFiles)
-                            .add(panelCardImagesLayout.createSequentialGroup()
+                panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(panelCardImagesLayout.createSequentialGroup()
                                 .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                                    .add(labelNumberOfDownloadThreads)
-                                    .add(labelPreferredImageLanguage))
-                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                                .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                                    .add(cbPreferredImageLanguage, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 153, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                                    .add(panelCardImagesLayout.createSequentialGroup()
-                                        .add(cbNumberOfDownloadThreads, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 153, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                                        .add(labelHint1)))))
-                        .add(0, 0, Short.MAX_VALUE)))
-                .addContainerGap())
+                                        .add(panelCardImagesLayout.createSequentialGroup()
+                                                .add(cbUseDefaultImageFolder)
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                                .add(txtImageFolderPath)
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                                .add(btnBrowseImageLocation))
+                                        .add(panelCardImagesLayout.createSequentialGroup()
+                                                .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                                        .add(cbSaveToZipFiles)
+                                                        .add(panelCardImagesLayout.createSequentialGroup()
+                                                                .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                                                        .add(labelNumberOfDownloadThreads)
+                                                                        .add(labelPreferredImageLanguage))
+                                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                                                .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                                                        .add(cbPreferredImageLanguage, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 153, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                                        .add(panelCardImagesLayout.createSequentialGroup()
+                                                                                .add(cbNumberOfDownloadThreads, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 153, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                                                .add(labelHint1)))))
+                                                .add(0, 0, Short.MAX_VALUE)))
+                                .addContainerGap())
         );
         panelCardImagesLayout.setVerticalGroup(
-            panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(panelCardImagesLayout.createSequentialGroup()
-                .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(cbUseDefaultImageFolder)
-                    .add(txtImageFolderPath, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(btnBrowseImageLocation))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                .add(cbSaveToZipFiles)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(labelNumberOfDownloadThreads)
-                    .add(cbNumberOfDownloadThreads, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(labelHint1))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(labelPreferredImageLanguage)
-                    .add(cbPreferredImageLanguage, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
+                panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(panelCardImagesLayout.createSequentialGroup()
+                                .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(cbUseDefaultImageFolder)
+                                        .add(txtImageFolderPath, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                        .add(btnBrowseImageLocation))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                .add(cbSaveToZipFiles)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(labelNumberOfDownloadThreads)
+                                        .add(cbNumberOfDownloadThreads, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                        .add(labelHint1))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(labelPreferredImageLanguage)
+                                        .add(cbPreferredImageLanguage, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
         );
 
         panelCardStyles.setBorder(javax.swing.BorderFactory.createTitledBorder(javax.swing.BorderFactory.createEtchedBorder(), "Card styles (restart xmage to apply new settings)"));
@@ -1713,65 +1721,65 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout panelBackgroundImagesLayout = new org.jdesktop.layout.GroupLayout(panelBackgroundImages);
         panelBackgroundImages.setLayout(panelBackgroundImagesLayout);
         panelBackgroundImagesLayout.setHorizontalGroup(
-            panelBackgroundImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(panelBackgroundImagesLayout.createSequentialGroup()
-                .add(panelBackgroundImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(panelBackgroundImagesLayout.createSequentialGroup()
-                        .add(cbUseDefaultBackground)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(txtBackgroundImagePath)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(btnBrowseBackgroundImage))
-                    .add(panelBackgroundImagesLayout.createSequentialGroup()
-                        .add(cbUseRandomBattleImage)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(txtBattlefieldImagePath)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(btnBrowseBattlefieldImage))
-                    .add(panelBackgroundImagesLayout.createSequentialGroup()
-                        .add(cbUseDefaultBattleImage)
-                        .add(0, 0, Short.MAX_VALUE)))
-                .addContainerGap())
+                panelBackgroundImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(panelBackgroundImagesLayout.createSequentialGroup()
+                                .add(panelBackgroundImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                        .add(panelBackgroundImagesLayout.createSequentialGroup()
+                                                .add(cbUseDefaultBackground)
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(txtBackgroundImagePath)
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                                .add(btnBrowseBackgroundImage))
+                                        .add(panelBackgroundImagesLayout.createSequentialGroup()
+                                                .add(cbUseRandomBattleImage)
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(txtBattlefieldImagePath)
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                                .add(btnBrowseBattlefieldImage))
+                                        .add(panelBackgroundImagesLayout.createSequentialGroup()
+                                                .add(cbUseDefaultBattleImage)
+                                                .add(0, 0, Short.MAX_VALUE)))
+                                .addContainerGap())
         );
         panelBackgroundImagesLayout.setVerticalGroup(
-            panelBackgroundImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(panelBackgroundImagesLayout.createSequentialGroup()
-                .add(cbUseDefaultBattleImage)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(panelBackgroundImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(cbUseDefaultBackground)
-                    .add(txtBackgroundImagePath, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(btnBrowseBackgroundImage))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(panelBackgroundImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(cbUseRandomBattleImage)
-                    .add(txtBattlefieldImagePath, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(btnBrowseBattlefieldImage))
-                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                panelBackgroundImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(panelBackgroundImagesLayout.createSequentialGroup()
+                                .add(cbUseDefaultBattleImage)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(panelBackgroundImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(cbUseDefaultBackground)
+                                        .add(txtBackgroundImagePath, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                        .add(btnBrowseBackgroundImage))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(panelBackgroundImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(cbUseRandomBattleImage)
+                                        .add(txtBattlefieldImagePath, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                        .add(btnBrowseBattlefieldImage))
+                                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         org.jdesktop.layout.GroupLayout tabImagesLayout = new org.jdesktop.layout.GroupLayout(tabImages);
         tabImages.setLayout(tabImagesLayout);
         tabImagesLayout.setHorizontalGroup(
-            tabImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabImagesLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(tabImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(panelCardImages, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .add(panelCardStyles, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .add(panelBackgroundImages, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                .addContainerGap())
+                tabImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabImagesLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(tabImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                        .add(panelCardImages, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .add(panelCardStyles, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .add(panelBackgroundImages, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                                .addContainerGap())
         );
         tabImagesLayout.setVerticalGroup(
-            tabImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabImagesLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(panelCardStyles, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(panelCardImages, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(panelBackgroundImages, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(128, Short.MAX_VALUE))
+                tabImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabImagesLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(panelCardStyles, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(panelCardImages, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(panelBackgroundImages, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addContainerGap(128, Short.MAX_VALUE))
         );
 
         tabsPanel.addTab("Images", tabImages);
@@ -1819,48 +1827,48 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout sounds_backgroundMusicLayout = new org.jdesktop.layout.GroupLayout(sounds_backgroundMusic);
         sounds_backgroundMusic.setLayout(sounds_backgroundMusicLayout);
         sounds_backgroundMusicLayout.setHorizontalGroup(
-            sounds_backgroundMusicLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(sounds_backgroundMusicLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(jLabel16)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(txtBattlefieldIBGMPath)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(btnBattlefieldBGMBrowse))
-            .add(sounds_backgroundMusicLayout.createSequentialGroup()
-                .add(cbEnableBattlefieldBGM)
-                .add(0, 0, Short.MAX_VALUE))
+                sounds_backgroundMusicLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(sounds_backgroundMusicLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(jLabel16)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(txtBattlefieldIBGMPath)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(btnBattlefieldBGMBrowse))
+                        .add(sounds_backgroundMusicLayout.createSequentialGroup()
+                                .add(cbEnableBattlefieldBGM)
+                                .add(0, 0, Short.MAX_VALUE))
         );
         sounds_backgroundMusicLayout.setVerticalGroup(
-            sounds_backgroundMusicLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(sounds_backgroundMusicLayout.createSequentialGroup()
-                .add(cbEnableBattlefieldBGM)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(sounds_backgroundMusicLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(txtBattlefieldIBGMPath, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(btnBattlefieldBGMBrowse)
-                    .add(jLabel16)))
+                sounds_backgroundMusicLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(sounds_backgroundMusicLayout.createSequentialGroup()
+                                .add(cbEnableBattlefieldBGM)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(sounds_backgroundMusicLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(txtBattlefieldIBGMPath, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                        .add(btnBattlefieldBGMBrowse)
+                                        .add(jLabel16)))
         );
 
         org.jdesktop.layout.GroupLayout tabSoundsLayout = new org.jdesktop.layout.GroupLayout(tabSounds);
         tabSounds.setLayout(tabSoundsLayout);
         tabSoundsLayout.setHorizontalGroup(
-            tabSoundsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabSoundsLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(tabSoundsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(sounds_clips, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .add(org.jdesktop.layout.GroupLayout.TRAILING, sounds_backgroundMusic, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                .addContainerGap())
+                tabSoundsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabSoundsLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(tabSoundsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                        .add(sounds_clips, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .add(org.jdesktop.layout.GroupLayout.TRAILING, sounds_backgroundMusic, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                                .addContainerGap())
         );
         tabSoundsLayout.setVerticalGroup(
-            tabSoundsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabSoundsLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(sounds_clips, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(sounds_backgroundMusic, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                tabSoundsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabSoundsLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(sounds_clips, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(sounds_backgroundMusic, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         sounds_clips.getAccessibleContext().setAccessibleDescription("");
@@ -1884,12 +1892,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel10Layout = new org.jdesktop.layout.GroupLayout(jPanel10);
         jPanel10.setLayout(jPanel10Layout);
         jPanel10Layout.setHorizontalGroup(
-            jPanel10Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel10Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel10Layout.setVerticalGroup(
-            jPanel10Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel10Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel10);
@@ -1902,12 +1910,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel11Layout = new org.jdesktop.layout.GroupLayout(jPanel11);
         jPanel11.setLayout(jPanel11Layout);
         jPanel11Layout.setHorizontalGroup(
-            jPanel11Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel11Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel11Layout.setVerticalGroup(
-            jPanel11Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel11Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel11);
@@ -1920,12 +1928,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel12Layout = new org.jdesktop.layout.GroupLayout(jPanel12);
         jPanel12.setLayout(jPanel12Layout);
         jPanel12Layout.setHorizontalGroup(
-            jPanel12Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel12Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel12Layout.setVerticalGroup(
-            jPanel12Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel12Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel12);
@@ -1938,12 +1946,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel13Layout = new org.jdesktop.layout.GroupLayout(jPanel13);
         jPanel13.setLayout(jPanel13Layout);
         jPanel13Layout.setHorizontalGroup(
-            jPanel13Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel13Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel13Layout.setVerticalGroup(
-            jPanel13Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel13Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel13);
@@ -1956,12 +1964,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel14Layout = new org.jdesktop.layout.GroupLayout(jPanel14);
         jPanel14.setLayout(jPanel14Layout);
         jPanel14Layout.setHorizontalGroup(
-            jPanel14Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel14Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel14Layout.setVerticalGroup(
-            jPanel14Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel14Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel14);
@@ -1974,12 +1982,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel15Layout = new org.jdesktop.layout.GroupLayout(jPanel15);
         jPanel15.setLayout(jPanel15Layout);
         jPanel15Layout.setHorizontalGroup(
-            jPanel15Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel15Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel15Layout.setVerticalGroup(
-            jPanel15Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel15Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel15);
@@ -1992,12 +2000,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel16Layout = new org.jdesktop.layout.GroupLayout(jPanel16);
         jPanel16.setLayout(jPanel16Layout);
         jPanel16Layout.setHorizontalGroup(
-            jPanel16Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel16Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel16Layout.setVerticalGroup(
-            jPanel16Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel16Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel16);
@@ -2010,12 +2018,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel17Layout = new org.jdesktop.layout.GroupLayout(jPanel17);
         jPanel17.setLayout(jPanel17Layout);
         jPanel17Layout.setHorizontalGroup(
-            jPanel17Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel17Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel17Layout.setVerticalGroup(
-            jPanel17Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel17Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel17);
@@ -2028,12 +2036,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel18Layout = new org.jdesktop.layout.GroupLayout(jPanel18);
         jPanel18.setLayout(jPanel18Layout);
         jPanel18Layout.setHorizontalGroup(
-            jPanel18Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel18Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel18Layout.setVerticalGroup(
-            jPanel18Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel18Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel18);
@@ -2046,12 +2054,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel19Layout = new org.jdesktop.layout.GroupLayout(jPanel19);
         jPanel19.setLayout(jPanel19Layout);
         jPanel19Layout.setHorizontalGroup(
-            jPanel19Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel19Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel19Layout.setVerticalGroup(
-            jPanel19Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel19Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel19);
@@ -2064,12 +2072,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel20Layout = new org.jdesktop.layout.GroupLayout(jPanel20);
         jPanel20.setLayout(jPanel20Layout);
         jPanel20Layout.setHorizontalGroup(
-            jPanel20Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel20Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel20Layout.setVerticalGroup(
-            jPanel20Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel20Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel20);
@@ -2082,12 +2090,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel21Layout = new org.jdesktop.layout.GroupLayout(jPanel21);
         jPanel21.setLayout(jPanel21Layout);
         jPanel21Layout.setHorizontalGroup(
-            jPanel21Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel21Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel21Layout.setVerticalGroup(
-            jPanel21Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel21Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel21);
@@ -2100,12 +2108,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel22Layout = new org.jdesktop.layout.GroupLayout(jPanel22);
         jPanel22.setLayout(jPanel22Layout);
         jPanel22Layout.setHorizontalGroup(
-            jPanel22Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel22Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel22Layout.setVerticalGroup(
-            jPanel22Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel22Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel22);
@@ -2118,12 +2126,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel23Layout = new org.jdesktop.layout.GroupLayout(jPanel23);
         jPanel23.setLayout(jPanel23Layout);
         jPanel23Layout.setHorizontalGroup(
-            jPanel23Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel23Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel23Layout.setVerticalGroup(
-            jPanel23Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel23Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel23);
@@ -2136,12 +2144,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel24Layout = new org.jdesktop.layout.GroupLayout(jPanel24);
         jPanel24.setLayout(jPanel24Layout);
         jPanel24Layout.setHorizontalGroup(
-            jPanel24Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel24Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel24Layout.setVerticalGroup(
-            jPanel24Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel24Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel24);
@@ -2154,12 +2162,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel25Layout = new org.jdesktop.layout.GroupLayout(jPanel25);
         jPanel25.setLayout(jPanel25Layout);
         jPanel25Layout.setHorizontalGroup(
-            jPanel25Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel25Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel25Layout.setVerticalGroup(
-            jPanel25Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel25Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel25);
@@ -2172,12 +2180,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel26Layout = new org.jdesktop.layout.GroupLayout(jPanel26);
         jPanel26.setLayout(jPanel26Layout);
         jPanel26Layout.setHorizontalGroup(
-            jPanel26Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel26Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel26Layout.setVerticalGroup(
-            jPanel26Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel26Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel26);
@@ -2190,12 +2198,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel27Layout = new org.jdesktop.layout.GroupLayout(jPanel27);
         jPanel27.setLayout(jPanel27Layout);
         jPanel27Layout.setHorizontalGroup(
-            jPanel27Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel27Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel27Layout.setVerticalGroup(
-            jPanel27Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel27Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel27);
@@ -2208,12 +2216,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel28Layout = new org.jdesktop.layout.GroupLayout(jPanel28);
         jPanel28.setLayout(jPanel28Layout);
         jPanel28Layout.setHorizontalGroup(
-            jPanel28Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel28Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel28Layout.setVerticalGroup(
-            jPanel28Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel28Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel28);
@@ -2226,12 +2234,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel29Layout = new org.jdesktop.layout.GroupLayout(jPanel29);
         jPanel29.setLayout(jPanel29Layout);
         jPanel29Layout.setHorizontalGroup(
-            jPanel29Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel29Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel29Layout.setVerticalGroup(
-            jPanel29Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel29Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel29);
@@ -2244,12 +2252,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel30Layout = new org.jdesktop.layout.GroupLayout(jPanel30);
         jPanel30.setLayout(jPanel30Layout);
         jPanel30Layout.setHorizontalGroup(
-            jPanel30Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel30Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel30Layout.setVerticalGroup(
-            jPanel30Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel30Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel30);
@@ -2262,12 +2270,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel31Layout = new org.jdesktop.layout.GroupLayout(jPanel31);
         jPanel31.setLayout(jPanel31Layout);
         jPanel31Layout.setHorizontalGroup(
-            jPanel31Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel31Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel31Layout.setVerticalGroup(
-            jPanel31Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel31Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel31);
@@ -2280,12 +2288,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel32Layout = new org.jdesktop.layout.GroupLayout(jPanel32);
         jPanel32.setLayout(jPanel32Layout);
         jPanel32Layout.setHorizontalGroup(
-            jPanel32Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel32Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel32Layout.setVerticalGroup(
-            jPanel32Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel32Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel32);
@@ -2297,12 +2305,12 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout jPanel33Layout = new org.jdesktop.layout.GroupLayout(jPanel33);
         jPanel33.setLayout(jPanel33Layout);
         jPanel33Layout.setHorizontalGroup(
-            jPanel33Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel33Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
         jPanel33Layout.setVerticalGroup(
-            jPanel33Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 0, Short.MAX_VALUE)
+                jPanel33Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 0, Short.MAX_VALUE)
         );
 
         avatarPanel.add(jPanel33);
@@ -2312,16 +2320,16 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout tabAvatarsLayout = new org.jdesktop.layout.GroupLayout(tabAvatars);
         tabAvatars.setLayout(tabAvatarsLayout);
         tabAvatarsLayout.setHorizontalGroup(
-            tabAvatarsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabAvatarsLayout.createSequentialGroup()
-                .add(avatarPane, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 528, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .add(0, 0, Short.MAX_VALUE))
+                tabAvatarsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabAvatarsLayout.createSequentialGroup()
+                                .add(avatarPane, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 528, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .add(0, 0, Short.MAX_VALUE))
         );
         tabAvatarsLayout.setVerticalGroup(
-            tabAvatarsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabAvatarsLayout.createSequentialGroup()
-                .add(avatarPane, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 504, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .add(0, 52, Short.MAX_VALUE))
+                tabAvatarsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabAvatarsLayout.createSequentialGroup()
+                                .add(avatarPane, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 504, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .add(0, 52, Short.MAX_VALUE))
         );
 
         tabsPanel.addTab("Avatars", tabAvatars);
@@ -2344,27 +2352,27 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout connection_serversLayout = new org.jdesktop.layout.GroupLayout(connection_servers);
         connection_servers.setLayout(connection_serversLayout);
         connection_serversLayout.setHorizontalGroup(
-            connection_serversLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(connection_serversLayout.createSequentialGroup()
-                .add(connection_serversLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(connection_serversLayout.createSequentialGroup()
-                        .addContainerGap()
-                        .add(lblURLServerList, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 96, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(txtURLServerList, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 370, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                    .add(connection_serversLayout.createSequentialGroup()
-                        .add(141, 141, 141)
-                        .add(jLabel17)))
-                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                connection_serversLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(connection_serversLayout.createSequentialGroup()
+                                .add(connection_serversLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                        .add(connection_serversLayout.createSequentialGroup()
+                                                .addContainerGap()
+                                                .add(lblURLServerList, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 96, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                                .add(txtURLServerList, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 370, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                        .add(connection_serversLayout.createSequentialGroup()
+                                                .add(141, 141, 141)
+                                                .add(jLabel17)))
+                                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         connection_serversLayout.setVerticalGroup(
-            connection_serversLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(connection_serversLayout.createSequentialGroup()
-                .add(connection_serversLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING, false)
-                    .add(lblURLServerList, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .add(txtURLServerList, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 26, Short.MAX_VALUE))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(jLabel17))
+                connection_serversLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(connection_serversLayout.createSequentialGroup()
+                                .add(connection_serversLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING, false)
+                                        .add(lblURLServerList, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .add(txtURLServerList, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 26, Short.MAX_VALUE))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(jLabel17))
         );
 
         lblProxyType.setText("Proxy:");
@@ -2393,99 +2401,99 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout pnlProxyLayout = new org.jdesktop.layout.GroupLayout(pnlProxy);
         pnlProxy.setLayout(pnlProxyLayout);
         pnlProxyLayout.setHorizontalGroup(
-            pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(pnlProxyLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(pnlProxyLayout.createSequentialGroup()
-                        .add(rememberPswd)
-                        .add(47, 47, 47)
-                        .add(jLabel11)
-                        .add(34, 34, 34))
-                    .add(pnlProxyLayout.createSequentialGroup()
-                        .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                            .add(lblProxyPort)
-                            .add(lblProxyPassword)
-                            .add(lblProxyServer)
-                            .add(lblProxyUserName))
-                        .add(19, 19, 19)
-                        .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                            .add(txtProxyPort, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 58, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING, false)
-                                .add(org.jdesktop.layout.GroupLayout.LEADING, txtPasswordField)
-                                .add(org.jdesktop.layout.GroupLayout.LEADING, txtProxyUserName, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 148, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                            .add(txtProxyServer))
-                        .addContainerGap())))
+                pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(pnlProxyLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                        .add(pnlProxyLayout.createSequentialGroup()
+                                                .add(rememberPswd)
+                                                .add(47, 47, 47)
+                                                .add(jLabel11)
+                                                .add(34, 34, 34))
+                                        .add(pnlProxyLayout.createSequentialGroup()
+                                                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                                        .add(lblProxyPort)
+                                                        .add(lblProxyPassword)
+                                                        .add(lblProxyServer)
+                                                        .add(lblProxyUserName))
+                                                .add(19, 19, 19)
+                                                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                                        .add(txtProxyPort, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 58, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                        .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING, false)
+                                                                .add(org.jdesktop.layout.GroupLayout.LEADING, txtPasswordField)
+                                                                .add(org.jdesktop.layout.GroupLayout.LEADING, txtProxyUserName, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 148, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                                        .add(txtProxyServer))
+                                                .addContainerGap())))
         );
         pnlProxyLayout.setVerticalGroup(
-            pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(pnlProxyLayout.createSequentialGroup()
-                .add(6, 6, 6)
-                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(txtProxyServer, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(lblProxyServer))
-                .add(8, 8, 8)
-                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(lblProxyPort)
-                    .add(txtProxyPort, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(txtProxyUserName, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(lblProxyUserName))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(txtPasswordField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(lblProxyPassword))
-                .add(18, 18, 18)
-                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(rememberPswd)
-                    .add(jLabel11))
-                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(pnlProxyLayout.createSequentialGroup()
+                                .add(6, 6, 6)
+                                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(txtProxyServer, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                        .add(lblProxyServer))
+                                .add(8, 8, 8)
+                                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(lblProxyPort)
+                                        .add(txtProxyPort, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(txtProxyUserName, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                        .add(lblProxyUserName))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(txtPasswordField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                        .add(lblProxyPassword))
+                                .add(18, 18, 18)
+                                .add(pnlProxyLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(rememberPswd)
+                                        .add(jLabel11))
+                                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         org.jdesktop.layout.GroupLayout pnlProxySettingsLayout = new org.jdesktop.layout.GroupLayout(pnlProxySettings);
         pnlProxySettings.setLayout(pnlProxySettingsLayout);
         pnlProxySettingsLayout.setHorizontalGroup(
-            pnlProxySettingsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(pnlProxySettingsLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(pnlProxy, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addContainerGap())
+                pnlProxySettingsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(pnlProxySettingsLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(pnlProxy, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                .addContainerGap())
         );
         pnlProxySettingsLayout.setVerticalGroup(
-            pnlProxySettingsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(pnlProxySettingsLayout.createSequentialGroup()
-                .add(pnlProxy, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addContainerGap())
+                pnlProxySettingsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(pnlProxySettingsLayout.createSequentialGroup()
+                                .add(pnlProxy, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                .addContainerGap())
         );
 
         org.jdesktop.layout.GroupLayout tabConnectionLayout = new org.jdesktop.layout.GroupLayout(tabConnection);
         tabConnection.setLayout(tabConnectionLayout);
         tabConnectionLayout.setHorizontalGroup(
-            tabConnectionLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(org.jdesktop.layout.GroupLayout.TRAILING, tabConnectionLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(tabConnectionLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                    .add(pnlProxySettings, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .add(org.jdesktop.layout.GroupLayout.LEADING, tabConnectionLayout.createSequentialGroup()
-                        .add(lblProxyType)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(cbProxyType, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 126, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                    .add(connection_servers, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                .addContainerGap())
+                tabConnectionLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(org.jdesktop.layout.GroupLayout.TRAILING, tabConnectionLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(tabConnectionLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                        .add(pnlProxySettings, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .add(org.jdesktop.layout.GroupLayout.LEADING, tabConnectionLayout.createSequentialGroup()
+                                                .add(lblProxyType)
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(cbProxyType, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 126, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                        .add(connection_servers, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                                .addContainerGap())
         );
         tabConnectionLayout.setVerticalGroup(
-            tabConnectionLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabConnectionLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(connection_servers, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(tabConnectionLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(lblProxyType)
-                    .add(cbProxyType, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .add(18, 18, 18)
-                .add(pnlProxySettings, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                tabConnectionLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabConnectionLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(connection_servers, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(tabConnectionLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                        .add(lblProxyType)
+                                        .add(cbProxyType, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                .add(18, 18, 18)
+                                .add(pnlProxySettings, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         pnlProxySettings.getAccessibleContext().setAccessibleDescription("");
@@ -2549,94 +2557,94 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout tabControlsLayout = new org.jdesktop.layout.GroupLayout(tabControls);
         tabControls.setLayout(tabControlsLayout);
         tabControlsLayout.setHorizontalGroup(
-            tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabControlsLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING, false)
-                    .add(bttnResetControls, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .add(tabControlsLayout.createSequentialGroup()
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                            .add(labelCancel)
-                            .add(labelNextTurn)
-                            .add(labelEndStep)
-                            .add(labelMainStep)
-                            .add(labelYourTurn)
-                            .add(lebelSkip)
-                            .add(labelPriorEnd)
-                            .add(labelSkipStep)
-                            .add(labelConfirm)
-                            .add(labelToggleRecordMacro)
-                            .add(labelSwitchChat))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                            .add(keyConfirm, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(keyCancelSkip, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(keyNextTurn, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(keySkipStack, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(keyYourTurn, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(keyMainStep, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(keyPriorEnd, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(keySkipStep, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(keyEndStep, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(keyToggleRecordMacro, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                            .add(keySwitchChat, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                .add(controlsDescriptionLabel)
-                .addContainerGap())
+                tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabControlsLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING, false)
+                                        .add(bttnResetControls, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .add(tabControlsLayout.createSequentialGroup()
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                                        .add(labelCancel)
+                                                        .add(labelNextTurn)
+                                                        .add(labelEndStep)
+                                                        .add(labelMainStep)
+                                                        .add(labelYourTurn)
+                                                        .add(lebelSkip)
+                                                        .add(labelPriorEnd)
+                                                        .add(labelSkipStep)
+                                                        .add(labelConfirm)
+                                                        .add(labelToggleRecordMacro)
+                                                        .add(labelSwitchChat))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                                        .add(keyConfirm, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                        .add(keyCancelSkip, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                        .add(keyNextTurn, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                        .add(keySkipStack, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                        .add(keyYourTurn, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                        .add(keyMainStep, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                        .add(keyPriorEnd, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                        .add(keySkipStep, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                        .add(keyEndStep, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                        .add(keyToggleRecordMacro, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                        .add(keySwitchChat, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                .add(controlsDescriptionLabel)
+                                .addContainerGap())
         );
         tabControlsLayout.setVerticalGroup(
-            tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(tabControlsLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING, false)
-                    .add(tabControlsLayout.createSequentialGroup()
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(labelConfirm)
-                            .add(keyConfirm, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(labelCancel)
-                            .add(keyCancelSkip, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(labelNextTurn)
-                            .add(keyNextTurn, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(labelEndStep)
-                            .add(keyEndStep, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(labelSkipStep)
-                            .add(keySkipStep, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(labelMainStep)
-                            .add(keyMainStep, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(labelYourTurn)
-                            .add(keyYourTurn, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(lebelSkip)
-                            .add(keySkipStack, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(labelPriorEnd)
-                            .add(keyPriorEnd, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(labelToggleRecordMacro)
-                            .add(keyToggleRecordMacro, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                            .add(labelSwitchChat)
-                            .add(keySwitchChat, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(bttnResetControls))
-                    .add(controlsDescriptionLabel))
-                .addContainerGap())
+                tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(tabControlsLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING, false)
+                                        .add(tabControlsLayout.createSequentialGroup()
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                                        .add(labelConfirm)
+                                                        .add(keyConfirm, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                                        .add(labelCancel)
+                                                        .add(keyCancelSkip, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                                        .add(labelNextTurn)
+                                                        .add(keyNextTurn, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                                        .add(labelEndStep)
+                                                        .add(keyEndStep, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                                        .add(labelSkipStep)
+                                                        .add(keySkipStep, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                                        .add(labelMainStep)
+                                                        .add(keyMainStep, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                                        .add(labelYourTurn)
+                                                        .add(keyYourTurn, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                                        .add(lebelSkip)
+                                                        .add(keySkipStack, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                                        .add(labelPriorEnd)
+                                                        .add(keyPriorEnd, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                                        .add(labelToggleRecordMacro)
+                                                        .add(keyToggleRecordMacro, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(tabControlsLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                                        .add(labelSwitchChat)
+                                                        .add(keySwitchChat, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
+                                                .add(bttnResetControls))
+                                        .add(controlsDescriptionLabel))
+                                .addContainerGap())
         );
 
         tabsPanel.addTab("Controls", tabControls);
@@ -2655,46 +2663,46 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout themesCategoryLayout = new org.jdesktop.layout.GroupLayout(themesCategory);
         themesCategory.setLayout(themesCategoryLayout);
         themesCategoryLayout.setHorizontalGroup(
-            themesCategoryLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(themesCategoryLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(lbSelectLabel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 96, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(themesCategoryLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(lbThemeHint)
-                    .add(cbTheme, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 303, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(360, Short.MAX_VALUE))
+                themesCategoryLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(themesCategoryLayout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(lbSelectLabel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 96, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(themesCategoryLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                        .add(lbThemeHint)
+                                        .add(cbTheme, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 303, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                .addContainerGap(360, Short.MAX_VALUE))
         );
         themesCategoryLayout.setVerticalGroup(
-            themesCategoryLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(themesCategoryLayout.createSequentialGroup()
-                .add(themesCategoryLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                    .add(cbTheme, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(lbSelectLabel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 22, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(lbThemeHint)
-                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                themesCategoryLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(themesCategoryLayout.createSequentialGroup()
+                                .add(themesCategoryLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                        .add(cbTheme, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                        .add(lbSelectLabel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 22, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(lbThemeHint)
+                                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         org.jdesktop.layout.GroupLayout tabThemesLayout = new org.jdesktop.layout.GroupLayout(tabThemes);
         tabThemes.setLayout(tabThemesLayout);
         tabThemesLayout.setHorizontalGroup(
-            tabThemesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 807, Short.MAX_VALUE)
-            .add(tabThemesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                .add(tabThemesLayout.createSequentialGroup()
-                    .addContainerGap()
-                    .add(themesCategory, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addContainerGap()))
+                tabThemesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 807, Short.MAX_VALUE)
+                        .add(tabThemesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                .add(tabThemesLayout.createSequentialGroup()
+                                        .addContainerGap()
+                                        .add(themesCategory, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .addContainerGap()))
         );
         tabThemesLayout.setVerticalGroup(
-            tabThemesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(0, 556, Short.MAX_VALUE)
-            .add(tabThemesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                .add(tabThemesLayout.createSequentialGroup()
-                    .add(21, 21, 21)
-                    .add(themesCategory, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .addContainerGap(460, Short.MAX_VALUE)))
+                tabThemesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(0, 556, Short.MAX_VALUE)
+                        .add(tabThemesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                                .add(tabThemesLayout.createSequentialGroup()
+                                        .add(21, 21, 21)
+                                        .add(themesCategory, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                        .addContainerGap(460, Short.MAX_VALUE)))
         );
 
         tabsPanel.addTab("Themes", tabThemes);
@@ -2722,27 +2730,27 @@ public class PreferencesDialog extends javax.swing.JDialog {
         org.jdesktop.layout.GroupLayout layout = new org.jdesktop.layout.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
         layout.setHorizontalGroup(
-            layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(layout.createSequentialGroup()
-                .addContainerGap()
-                .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
-                    .add(org.jdesktop.layout.GroupLayout.LEADING, tabsPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .add(layout.createSequentialGroup()
-                        .add(0, 0, Short.MAX_VALUE)
-                        .add(saveButton, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(exitButton, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
-                .add(6, 6, 6))
+                layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(layout.createSequentialGroup()
+                                .addContainerGap()
+                                .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
+                                        .add(org.jdesktop.layout.GroupLayout.LEADING, tabsPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .add(layout.createSequentialGroup()
+                                                .add(0, 0, Short.MAX_VALUE)
+                                                .add(saveButton, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                                .add(exitButton, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
+                                .add(6, 6, 6))
         );
         layout.setVerticalGroup(
-            layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(layout.createSequentialGroup()
-                .add(tabsPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                    .add(saveButton, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 30, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(exitButton, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 30, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap())
+                layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                        .add(layout.createSequentialGroup()
+                                .add(tabsPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                                .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                                        .add(saveButton, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 30, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                                        .add(exitButton, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 30, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                                .addContainerGap())
         );
 
         pack();
@@ -2895,7 +2903,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
 
     private void saveGUISize() {
         Preferences prefs = MageFrame.getPreferences();
-        
+
         // GUI Size
         save(prefs, dialog.sliderFontSize, KEY_GUI_TABLE_FONT_SIZE, "true", "false", UPDATE_CACHE_POLICY);
         save(prefs, dialog.sliderChatFontSize, KEY_GUI_CHAT_FONT_SIZE, "true", "false", UPDATE_CACHE_POLICY);
@@ -2914,7 +2922,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
         // do as worker job
         GUISizeHelper.changeGUISize();
     }
-    
+
     private void exitButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_exitButtonActionPerformed
         dialog.setVisible(false);
     }//GEN-LAST:event_exitButtonActionPerformed
@@ -3085,8 +3093,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
     private void sliderGUISizeStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_sliderGUISizeStateChanged
         // This prevents this event from firing during the initial
         // setting of the sliders from pref values
-        if (!ignoreGUISizeSliderStateChangedEvent)
-        {
+        if (!ignoreGUISizeSliderStateChangedEvent) {
             saveGUISize();
         }
     }//GEN-LAST:event_sliderGUISizeStateChanged

--- a/Mage.Client/src/main/java/mage/client/dialog/TestCardRenderDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/TestCardRenderDialog.java
@@ -288,7 +288,7 @@ public class TestCardRenderDialog extends MageDialog {
             cardsPanel.addCardEventListener(this.cardListener);
         }
 
-        game = new TestGame(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        game = new TestGame(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         Deck deck = new Deck();
         Player playerYou = new StubPlayer("player1", RangeOfInfluence.ALL);
         game.addPlayer(playerYou, deck);
@@ -750,8 +750,8 @@ class TestGame extends GameImpl {
 
     private int numPlayers;
 
-    public TestGame(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60, 7);
+    public TestGame(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 60, startLife, startHandSize);
     }
 
     public TestGame(final TestGame game) {

--- a/Mage.Common/src/main/java/mage/view/TableView.java
+++ b/Mage.Common/src/main/java/mage/view/TableView.java
@@ -101,11 +101,17 @@ public class TableView implements Serializable {
                 addInfo.append("Wins:").append(table.getMatch().getWinsNeeded());
                 addInfo.append(" Time: ").append(table.getMatch().getOptions().getMatchTimeLimit().toString());
                 addInfo.append(" Buffer: ").append(table.getMatch().getOptions().getMatchBufferTime().toString());
-                if (table.getMatch().getOptions().getMulliganType() != MulliganType.GAME_DEFAULT){
+                if (table.getMatch().getOptions().getMulliganType() != MulliganType.GAME_DEFAULT) {
                     addInfo.append(" Mulligan: \"").append(table.getMatch().getOptions().getMulliganType().toString()).append("\"");
                 }
                 if (table.getMatch().getFreeMulligans() > 0) {
                     addInfo.append(" FM: ").append(table.getMatch().getFreeMulligans());
+                }
+                if (table.getMatch().getOptions().isCustomStartLifeEnabled()) {
+                    addInfo.append(" StartLife: ").append(table.getMatch().getOptions().getCustomStartLife());
+                }
+                if (table.getMatch().getOptions().isCustomStartHandSizeEnabled()) {
+                    addInfo.append(" StartHandSize: ").append(table.getMatch().getOptions().getCustomStartHandSize());
                 }
             } else {
                 addInfo.append("Wins:").append(table.getMatch().getWinsNeeded());
@@ -118,7 +124,7 @@ public class TableView implements Serializable {
                 addInfo.append(" PC");
             }
             if (!(table.getMatch().getOptions().getPerPlayerEmblemCards().isEmpty())
-                || !(table.getMatch().getOptions().getGlobalEmblemCards().isEmpty())) {
+                    || !(table.getMatch().getOptions().getGlobalEmblemCards().isEmpty())) {
                 addInfo.append(" EC");
             }
             if (table.getMatch().getOptions().isSpectatorsAllowed()) {
@@ -162,11 +168,17 @@ public class TableView implements Serializable {
                     MatchOptions tourneyMatchOptions = table.getTournament().getOptions().getMatchOptions();
                     infoText.append(" Time: ").append(tourneyMatchOptions.getMatchTimeLimit().toString());
                     infoText.append(" Buffer: ").append(tourneyMatchOptions.getMatchBufferTime().toString());
-                    if (tourneyMatchOptions.getMulliganType() != MulliganType.GAME_DEFAULT){
+                    if (tourneyMatchOptions.getMulliganType() != MulliganType.GAME_DEFAULT) {
                         infoText.append(" Mulligan: \"").append(tourneyMatchOptions.getMulliganType().toString()).append("\"");
                     }
                     if (tourneyMatchOptions.getFreeMulligans() > 0) {
                         infoText.append(" FM: ").append(tourneyMatchOptions.getFreeMulligans());
+                    }
+                    if (table.getMatch().getOptions().isCustomStartLifeEnabled()) {
+                        infoText.append(" StartLife: ").append(table.getMatch().getOptions().getCustomStartLife());
+                    }
+                    if (table.getMatch().getOptions().isCustomStartHandSizeEnabled()) {
+                        infoText.append(" StartHandSize: ").append(table.getMatch().getOptions().getCustomStartHandSize());
                     }
                     if (table.getTournament().getTournamentType().isLimited()) {
                         infoText.append(" Constr.: ").append(table.getTournament().getOptions().getLimitedOptions().getConstructionTime() / 60).append(" Min.");
@@ -188,7 +200,7 @@ public class TableView implements Serializable {
                     if (table.getTournament().getOptions().isWatchingAllowed()) {
                         infoText.append(" SP");
                     }
-                    
+
                     break;
                 case DUELING:
                     stateText.append(" Round: ").append(table.getTournament().getRounds().size());

--- a/Mage.Server.Plugins/Mage.Game.BrawlDuel/src/mage/game/BrawlDuel.java
+++ b/Mage.Server.Plugins/Mage.Game.BrawlDuel/src/mage/game/BrawlDuel.java
@@ -8,9 +8,9 @@ import mage.game.match.MatchType;
 import mage.game.mulligan.Mulligan;
 
 public class BrawlDuel extends GameCommanderImpl {
-   
-    public BrawlDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60);
+
+    public BrawlDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 60, startLife, startHandSize);
     }
 
     public BrawlDuel(final BrawlDuel game) {

--- a/Mage.Server.Plugins/Mage.Game.BrawlDuel/src/mage/game/BrawlDuelMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.BrawlDuel/src/mage/game/BrawlDuelMatch.java
@@ -17,7 +17,12 @@ public class BrawlDuelMatch extends MatchImpl {
     public void startGame() throws GameException {
         int startLife = 25;
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        BrawlDuel game = new BrawlDuel(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : startLife;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        BrawlDuel game = new BrawlDuel(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setCheckCommanderDamage(false);
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);

--- a/Mage.Server.Plugins/Mage.Game.BrawlFreeForAll/src/mage/game/BrawlFreeForAll.java
+++ b/Mage.Server.Plugins/Mage.Game.BrawlFreeForAll/src/mage/game/BrawlFreeForAll.java
@@ -2,22 +2,22 @@
 
 package mage.game;
 
-import java.util.UUID;
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.RangeOfInfluence;
 import mage.game.match.MatchType;
 import mage.game.mulligan.Mulligan;
 
+import java.util.UUID;
+
 /**
- *
  * @author spjspj
  */
 public class BrawlFreeForAll extends GameCommanderImpl {
 
     private int numPlayers;
 
-    public BrawlFreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60);
+    public BrawlFreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 60, startLife, startHandSize);
     }
 
     public BrawlFreeForAll(final BrawlFreeForAll game) {
@@ -28,7 +28,7 @@ public class BrawlFreeForAll extends GameCommanderImpl {
     @Override
     protected void init(UUID choosingPlayerId) {
         startingPlayerSkipsDraw = false;
-        super.init(choosingPlayerId); 
+        super.init(choosingPlayerId);
     }
 
     @Override

--- a/Mage.Server.Plugins/Mage.Game.BrawlFreeForAll/src/mage/game/BrawlFreeForAllMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.BrawlFreeForAll/src/mage/game/BrawlFreeForAllMatch.java
@@ -17,7 +17,12 @@ public class BrawlFreeForAllMatch extends MatchImpl {
     public void startGame() throws GameException {
         int startLife = 30;
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        BrawlFreeForAll game = new BrawlFreeForAll(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : startLife;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        BrawlFreeForAll game = new BrawlFreeForAll(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setStartMessage(this.createGameStartMessage());
         game.setCheckCommanderDamage(false);
         initGame(game);

--- a/Mage.Server.Plugins/Mage.Game.CanadianHighlanderDuel/src/mage/game/CanadianHighlanderDuel.java
+++ b/Mage.Server.Plugins/Mage.Game.CanadianHighlanderDuel/src/mage/game/CanadianHighlanderDuel.java
@@ -8,9 +8,9 @@ import mage.game.match.MatchType;
 import mage.game.mulligan.Mulligan;
 
 public class CanadianHighlanderDuel extends GameCanadianHighlanderImpl {
-   
-    public CanadianHighlanderDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife);
+
+    public CanadianHighlanderDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, startLife, startHandSize);
     }
 
     public CanadianHighlanderDuel(final CanadianHighlanderDuel game) {

--- a/Mage.Server.Plugins/Mage.Game.CanadianHighlanderDuel/src/mage/game/CanadianHighlanderDuelMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.CanadianHighlanderDuel/src/mage/game/CanadianHighlanderDuelMatch.java
@@ -7,7 +7,6 @@ import mage.game.mulligan.Mulligan;
 import mage.game.mulligan.MulliganType;
 
 /**
- *
  * @author spjspj
  */
 public class CanadianHighlanderDuelMatch extends MatchImpl {
@@ -20,7 +19,12 @@ public class CanadianHighlanderDuelMatch extends MatchImpl {
     public void startGame() throws GameException {
         int startLife = 20;
         Mulligan mulligan = options.getMulliganType().orDefault(MulliganType.CANADIAN_HIGHLANDER).getMulligan(options.getFreeMulligans());
-        CanadianHighlanderDuel game = new CanadianHighlanderDuel(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : startLife;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        CanadianHighlanderDuel game = new CanadianHighlanderDuel(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);
         games.add(game);

--- a/Mage.Server.Plugins/Mage.Game.CommanderDuel/src/mage/game/CommanderDuel.java
+++ b/Mage.Server.Plugins/Mage.Game.CommanderDuel/src/mage/game/CommanderDuel.java
@@ -8,9 +8,9 @@ import mage.game.match.MatchType;
 import mage.game.mulligan.Mulligan;
 
 public class CommanderDuel extends GameCommanderImpl {
-   
-    public CommanderDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 100);
+
+    public CommanderDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 100, startLife, startHandSize);
     }
 
     public CommanderDuel(final CommanderDuel game) {

--- a/Mage.Server.Plugins/Mage.Game.CommanderDuel/src/mage/game/CommanderDuelMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.CommanderDuel/src/mage/game/CommanderDuelMatch.java
@@ -29,7 +29,12 @@ public class CommanderDuelMatch extends MatchImpl {
             startLife = 25;
         }
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        CommanderDuel game = new CommanderDuel(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : startLife;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        CommanderDuel game = new CommanderDuel(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setCheckCommanderDamage(checkCommanderDamage);
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);

--- a/Mage.Server.Plugins/Mage.Game.CommanderFreeForAll/src/mage/game/CommanderFreeForAll.java
+++ b/Mage.Server.Plugins/Mage.Game.CommanderFreeForAll/src/mage/game/CommanderFreeForAll.java
@@ -16,8 +16,8 @@ public class CommanderFreeForAll extends GameCommanderImpl {
 
     private int numPlayers;
 
-    public CommanderFreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 100);
+    public CommanderFreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 100, startLife, startHandSize);
     }
 
     public CommanderFreeForAll(final CommanderFreeForAll game) {

--- a/Mage.Server.Plugins/Mage.Game.CommanderFreeForAll/src/mage/game/CommanderFreeForAllMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.CommanderFreeForAll/src/mage/game/CommanderFreeForAllMatch.java
@@ -20,7 +20,12 @@ public class CommanderFreeForAllMatch extends MatchImpl {
             startLife = 30;
         }
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        CommanderFreeForAll game = new CommanderFreeForAll(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : startLife;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        CommanderFreeForAll game = new CommanderFreeForAll(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);
         games.add(game);

--- a/Mage.Server.Plugins/Mage.Game.CustomPillarOfTheParunsDuel/src/mage/game/CustomPillarOfTheParunsDuel.java
+++ b/Mage.Server.Plugins/Mage.Game.CustomPillarOfTheParunsDuel/src/mage/game/CustomPillarOfTheParunsDuel.java
@@ -49,8 +49,8 @@ import java.util.UUID;
  */
 public class CustomPillarOfTheParunsDuel extends GameImpl {
 
-    public CustomPillarOfTheParunsDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan) {
-        super(attackOption, range, mulligan, 25, 40, 6);
+    public CustomPillarOfTheParunsDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 40, startLife, startHandSize);
     }
 
     @Override
@@ -58,10 +58,10 @@ public class CustomPillarOfTheParunsDuel extends GameImpl {
         super.init(choosingPlayerId);
 
         getPlayers().forEach((playerId, p) -> {
-                addDelayedTriggeredAbility(
-                        new AtTheBeginOfPlayerFirstMainPhase(playerId, "C-Pillar of the Paruns"),
-                        null // TODO: Not sure how to mock something to be displayed instead.
-                );
+            addDelayedTriggeredAbility(
+                    new AtTheBeginOfPlayerFirstMainPhase(playerId, "C-Pillar of the Paruns"),
+                    null // TODO: Not sure how to mock something to be displayed instead.
+            );
         });
 
         state.getTurnMods().add(new TurnMod(startingPlayerId).withSkipStep(PhaseStep.DRAW));

--- a/Mage.Server.Plugins/Mage.Game.CustomPillarOfTheParunsDuel/src/mage/game/CustomPillarOfTheParunsDuelMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.CustomPillarOfTheParunsDuel/src/mage/game/CustomPillarOfTheParunsDuelMatch.java
@@ -16,7 +16,12 @@ public class CustomPillarOfTheParunsDuelMatch extends MatchImpl {
     @Override
     public void startGame() throws GameException {
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        CustomPillarOfTheParunsDuel game = new CustomPillarOfTheParunsDuel(options.getAttackOption(), options.getRange(), mulligan);
+        int startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : 25;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 6;
+        CustomPillarOfTheParunsDuel game = new CustomPillarOfTheParunsDuel(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);
 

--- a/Mage.Server.Plugins/Mage.Game.FreeForAll/src/mage/game/FreeForAll.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeForAll/src/mage/game/FreeForAll.java
@@ -7,15 +7,15 @@ import mage.game.match.MatchType;
 import mage.game.mulligan.Mulligan;
 
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public class FreeForAll extends GameImpl {
 
     private int numPlayers;
 
-    public FreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60, 7);
+    public FreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range,
+                      Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 60, startLife, startHandSize);
     }
 
     public FreeForAll(final FreeForAll game) {

--- a/Mage.Server.Plugins/Mage.Game.FreeForAll/src/mage/game/FreeForAllMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeForAll/src/mage/game/FreeForAllMatch.java
@@ -7,7 +7,6 @@ import mage.game.match.MatchOptions;
 import mage.game.mulligan.Mulligan;
 
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public class FreeForAllMatch extends MatchImpl {
@@ -19,7 +18,12 @@ public class FreeForAllMatch extends MatchImpl {
     @Override
     public void startGame() throws GameException {
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        FreeForAll game = new FreeForAll(options.getAttackOption(), options.getRange(), mulligan, 20);
+        int startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : 20;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        FreeForAll game = new FreeForAll(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);
         games.add(game);

--- a/Mage.Server.Plugins/Mage.Game.FreeformCommanderDuel/src/mage/game/FreeformCommanderDuel.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeformCommanderDuel/src/mage/game/FreeformCommanderDuel.java
@@ -10,8 +10,9 @@ import mage.game.mulligan.Mulligan;
  */
 public class FreeformCommanderDuel extends GameCommanderImpl {
 
-    public FreeformCommanderDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60);
+    public FreeformCommanderDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range,
+                                 Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 60, startLife, startHandSize);
     }
 
     public FreeformCommanderDuel(final FreeformCommanderDuel game) {

--- a/Mage.Server.Plugins/Mage.Game.FreeformCommanderDuel/src/mage/game/FreeformCommanderDuelMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeformCommanderDuel/src/mage/game/FreeformCommanderDuelMatch.java
@@ -18,7 +18,12 @@ public class FreeformCommanderDuelMatch extends MatchImpl {
         int startLife = 40;
 
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        FreeformCommanderDuel game = new FreeformCommanderDuel(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : startLife;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        FreeformCommanderDuel game = new FreeformCommanderDuel(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setCheckCommanderDamage(true);
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);

--- a/Mage.Server.Plugins/Mage.Game.FreeformCommanderFreeForAll/src/mage/game/FreeformCommanderFreeForAll.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeformCommanderFreeForAll/src/mage/game/FreeformCommanderFreeForAll.java
@@ -2,22 +2,23 @@
 
 package mage.game;
 
-import java.util.UUID;
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.RangeOfInfluence;
 import mage.game.match.MatchType;
 import mage.game.mulligan.Mulligan;
 
+import java.util.UUID;
+
 /**
- *
  * @author spjspj
  */
 public class FreeformCommanderFreeForAll extends GameCommanderImpl {
 
     private int numPlayers;
 
-    public FreeformCommanderFreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60);
+    public FreeformCommanderFreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range,
+                                       Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 60, startLife, startHandSize);
     }
 
     public FreeformCommanderFreeForAll(final FreeformCommanderFreeForAll game) {
@@ -28,7 +29,7 @@ public class FreeformCommanderFreeForAll extends GameCommanderImpl {
     @Override
     protected void init(UUID choosingPlayerId) {
         startingPlayerSkipsDraw = false;
-        super.init(choosingPlayerId); 
+        super.init(choosingPlayerId);
     }
 
     @Override

--- a/Mage.Server.Plugins/Mage.Game.FreeformCommanderFreeForAll/src/mage/game/FreeformCommanderFreeForAllMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeformCommanderFreeForAll/src/mage/game/FreeformCommanderFreeForAllMatch.java
@@ -17,7 +17,12 @@ public class FreeformCommanderFreeForAllMatch extends MatchImpl {
     public void startGame() throws GameException {
         int startLife = 40;
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        FreeformCommanderFreeForAll game = new FreeformCommanderFreeForAll(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : startLife;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        FreeformCommanderFreeForAll game = new FreeformCommanderFreeForAll(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);
         games.add(game);

--- a/Mage.Server.Plugins/Mage.Game.FreeformUnlimitedCommander/src/mage/game/FreeformUnlimitedCommander.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeformUnlimitedCommander/src/mage/game/FreeformUnlimitedCommander.java
@@ -1,18 +1,20 @@
 
 package mage.game;
 
-import java.util.UUID;
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.RangeOfInfluence;
 import mage.game.match.MatchType;
 import mage.game.mulligan.Mulligan;
 
+import java.util.UUID;
+
 public class FreeformUnlimitedCommander extends GameCommanderImpl {
 
     private int numPlayers;
 
-    public FreeformUnlimitedCommander(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60);
+    public FreeformUnlimitedCommander(MultiplayerAttackOption attackOption, RangeOfInfluence range,
+                                      Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 60, startLife, startHandSize);
     }
 
     public FreeformUnlimitedCommander(final FreeformUnlimitedCommander game) {
@@ -25,7 +27,7 @@ public class FreeformUnlimitedCommander extends GameCommanderImpl {
         if (state.getPlayerList().size() > 2) {
             startingPlayerSkipsDraw = false;
         }
-        super.init(choosingPlayerId); 
+        super.init(choosingPlayerId);
     }
 
     @Override

--- a/Mage.Server.Plugins/Mage.Game.FreeformUnlimitedCommander/src/mage/game/FreeformUnlimitedCommanderMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.FreeformUnlimitedCommander/src/mage/game/FreeformUnlimitedCommanderMatch.java
@@ -14,7 +14,12 @@ public class FreeformUnlimitedCommanderMatch extends MatchImpl {
     public void startGame() throws GameException {
         int startLife = 40;
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        FreeformUnlimitedCommander game = new FreeformUnlimitedCommander(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : startLife;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        FreeformUnlimitedCommander game = new FreeformUnlimitedCommander(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);
         games.add(game);

--- a/Mage.Server.Plugins/Mage.Game.MomirDuel/src/mage/game/MomirDuel.java
+++ b/Mage.Server.Plugins/Mage.Game.MomirDuel/src/mage/game/MomirDuel.java
@@ -19,13 +19,13 @@ import mage.players.Player;
 import java.util.UUID;
 
 /**
- *
  * @author nigelzor
  */
 public class MomirDuel extends GameImpl {
 
-    public MomirDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60, 7);
+    public MomirDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range,
+                     Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 60, startLife, startHandSize);
     }
 
     public MomirDuel(final MomirDuel game) {

--- a/Mage.Server.Plugins/Mage.Game.MomirDuel/src/mage/game/MomirDuelMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.MomirDuel/src/mage/game/MomirDuelMatch.java
@@ -6,7 +6,6 @@ import mage.game.match.MatchOptions;
 import mage.game.mulligan.Mulligan;
 
 /**
- *
  * @author nigelzor
  */
 public class MomirDuelMatch extends MatchImpl {
@@ -21,7 +20,12 @@ public class MomirDuelMatch extends MatchImpl {
         int startLife = 24;
 
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        MomirDuel game = new MomirDuel(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : startLife;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        MomirDuel game = new MomirDuel(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setStartMessage(this.createGameStartMessage());
 
         this.initGame(game);

--- a/Mage.Server.Plugins/Mage.Game.MomirGame/src/mage/game/MomirFreeForAllMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.MomirGame/src/mage/game/MomirFreeForAllMatch.java
@@ -6,7 +6,6 @@ import mage.game.match.MatchOptions;
 import mage.game.mulligan.Mulligan;
 
 /**
- *
  * @author nigelzor
  */
 public class MomirFreeForAllMatch extends MatchImpl {
@@ -21,7 +20,12 @@ public class MomirFreeForAllMatch extends MatchImpl {
         int startLife = 24;
 
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        MomirGame game = new MomirGame(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : startLife;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        MomirGame game = new MomirGame(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setStartMessage(this.createGameStartMessage());
 
         this.initGame(game);

--- a/Mage.Server.Plugins/Mage.Game.MomirGame/src/mage/game/MomirGame.java
+++ b/Mage.Server.Plugins/Mage.Game.MomirGame/src/mage/game/MomirGame.java
@@ -19,15 +19,15 @@ import mage.players.Player;
 import java.util.UUID;
 
 /**
- *
  * @author nigelzor
  */
 public class MomirGame extends GameImpl {
 
     private int numPlayers;
 
-    public MomirGame(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60, 7);
+    public MomirGame(MultiplayerAttackOption attackOption, RangeOfInfluence range,
+                     Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 60, startLife, startHandSize);
     }
 
     public MomirGame(final MomirGame game) {

--- a/Mage.Server.Plugins/Mage.Game.OathbreakerDuel/src/mage/game/OathbreakerDuel.java
+++ b/Mage.Server.Plugins/Mage.Game.OathbreakerDuel/src/mage/game/OathbreakerDuel.java
@@ -12,8 +12,8 @@ import java.util.UUID;
  */
 public class OathbreakerDuel extends OathbreakerFreeForAll {
 
-    public OathbreakerDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife);
+    public OathbreakerDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, startLife, startHandSize);
         this.startingPlayerSkipsDraw = true;
     }
 

--- a/Mage.Server.Plugins/Mage.Game.OathbreakerDuel/src/mage/game/OathbreakerDuelMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.OathbreakerDuel/src/mage/game/OathbreakerDuelMatch.java
@@ -15,9 +15,13 @@ public class OathbreakerDuelMatch extends MatchImpl {
 
     @Override
     public void startGame() throws GameException {
-        int startLife = 20;
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        OathbreakerDuel game = new OathbreakerDuel(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        int startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : 20;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        OathbreakerDuel game = new OathbreakerDuel(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setCheckCommanderDamage(false);
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);

--- a/Mage.Server.Plugins/Mage.Game.OathbreakerFreeForAll/src/mage/game/OathbreakerFreeForAll.java
+++ b/Mage.Server.Plugins/Mage.Game.OathbreakerFreeForAll/src/mage/game/OathbreakerFreeForAll.java
@@ -31,8 +31,9 @@ public class OathbreakerFreeForAll extends GameCommanderImpl {
     private static final String COMMANDER_NAME_OATHBREAKER = "Oathbreaker";
     private static final String COMMANDER_NAME_SIGNATURE_SPELL = "Signature Spell";
 
-    public OathbreakerFreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 100);
+    public OathbreakerFreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range,
+                                 Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 100, startLife, startHandSize);
         this.startingPlayerSkipsDraw = false;
     }
 

--- a/Mage.Server.Plugins/Mage.Game.OathbreakerFreeForAll/src/mage/game/OathbreakerFreeForAllMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.OathbreakerFreeForAll/src/mage/game/OathbreakerFreeForAllMatch.java
@@ -15,9 +15,13 @@ public class OathbreakerFreeForAllMatch extends MatchImpl {
 
     @Override
     public void startGame() throws GameException {
-        int startLife = 20;
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        OathbreakerFreeForAll game = new OathbreakerFreeForAll(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        int startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : 20;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        OathbreakerFreeForAll game = new OathbreakerFreeForAll(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setCheckCommanderDamage(false);
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);

--- a/Mage.Server.Plugins/Mage.Game.PennyDreadfulCommanderFreeForAll/src/mage/game/PennyDreadfulCommanderFreeForAll.java
+++ b/Mage.Server.Plugins/Mage.Game.PennyDreadfulCommanderFreeForAll/src/mage/game/PennyDreadfulCommanderFreeForAll.java
@@ -2,22 +2,22 @@
 
 package mage.game;
 
-import java.util.UUID;
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.RangeOfInfluence;
 import mage.game.match.MatchType;
 import mage.game.mulligan.Mulligan;
 
+import java.util.UUID;
+
 /**
- *
  * @author spjspj
  */
 public class PennyDreadfulCommanderFreeForAll extends GameCommanderImpl {
 
     private int numPlayers;
 
-    public PennyDreadfulCommanderFreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 60);
+    public PennyDreadfulCommanderFreeForAll(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 60, startLife, startHandSize);
     }
 
     public PennyDreadfulCommanderFreeForAll(final PennyDreadfulCommanderFreeForAll game) {
@@ -28,7 +28,7 @@ public class PennyDreadfulCommanderFreeForAll extends GameCommanderImpl {
     @Override
     protected void init(UUID choosingPlayerId) {
         startingPlayerSkipsDraw = false;
-        super.init(choosingPlayerId); 
+        super.init(choosingPlayerId);
     }
 
     @Override

--- a/Mage.Server.Plugins/Mage.Game.PennyDreadfulCommanderFreeForAll/src/mage/game/PennyDreadfulCommanderFreeForAllMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.PennyDreadfulCommanderFreeForAll/src/mage/game/PennyDreadfulCommanderFreeForAllMatch.java
@@ -20,7 +20,12 @@ public class PennyDreadfulCommanderFreeForAllMatch extends MatchImpl {
             startLife = 30;
         }
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        PennyDreadfulCommanderFreeForAll game = new PennyDreadfulCommanderFreeForAll(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : startLife;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        PennyDreadfulCommanderFreeForAll game = new PennyDreadfulCommanderFreeForAll(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);
         games.add(game);

--- a/Mage.Server.Plugins/Mage.Game.TinyLeadersDuel/src/mage/game/TinyLeadersDuel.java
+++ b/Mage.Server.Plugins/Mage.Game.TinyLeadersDuel/src/mage/game/TinyLeadersDuel.java
@@ -8,13 +8,13 @@ import mage.game.match.MatchType;
 import mage.game.mulligan.Mulligan;
 
 /**
- *
  * @author JRHerlehy
  */
 public class TinyLeadersDuel extends GameTinyLeadersImpl {
 
-    public TinyLeadersDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife);
+    public TinyLeadersDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range,
+                           Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, startLife, startHandSize);
     }
 
     public TinyLeadersDuel(final TinyLeadersDuel game) {

--- a/Mage.Server.Plugins/Mage.Game.TinyLeadersDuel/src/mage/game/TinyLeadersDuelMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.TinyLeadersDuel/src/mage/game/TinyLeadersDuelMatch.java
@@ -7,7 +7,6 @@ import mage.game.match.MatchOptions;
 import mage.game.mulligan.Mulligan;
 
 /**
- *
  * @author JRHerlehy
  */
 public class TinyLeadersDuelMatch extends MatchImpl {
@@ -22,9 +21,14 @@ public class TinyLeadersDuelMatch extends MatchImpl {
         int startLife = 25;
 
         Mulligan mulligan = options.getMulliganType().getMulligan(options.getFreeMulligans());
-        TinyLeadersDuel game = new TinyLeadersDuel(options.getAttackOption(), options.getRange(), mulligan, startLife);
+        startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : startLife;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        TinyLeadersDuel game = new TinyLeadersDuel(
+                options.getAttackOption(), options.getRange(),
+                mulligan, startLife, startHandSize
+        );
         game.setStartMessage(this.createGameStartMessage());
-        
+
         //Tucking a Tiny Leader is legal
         game.setAlsoHand(false);
         game.setAlsoLibrary(false);

--- a/Mage.Server.Plugins/Mage.Game.TwoPlayerDuel/src/mage/game/TwoPlayerDuel.java
+++ b/Mage.Server.Plugins/Mage.Game.TwoPlayerDuel/src/mage/game/TwoPlayerDuel.java
@@ -11,16 +11,9 @@ import java.util.UUID;
 
 public class TwoPlayerDuel extends GameImpl {
 
-    public TwoPlayerDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        this(attackOption, range, mulligan, startLife, 60);
-    }
-
-    public TwoPlayerDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startingLife, int minimumDeckSize) {
-        this(attackOption, range, mulligan, startingLife, minimumDeckSize, 7);
-    }
-
-    public TwoPlayerDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startingLife, int minimumDeckSize, int startingHandSize) {
-        super(attackOption, range, mulligan, startingLife, minimumDeckSize, startingHandSize);
+    public TwoPlayerDuel(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan,
+                         int minimumDeckSize, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, minimumDeckSize, startLife, startHandSize);
     }
 
     public TwoPlayerDuel(final TwoPlayerDuel game) {

--- a/Mage.Server.Plugins/Mage.Game.TwoPlayerDuel/src/mage/game/TwoPlayerMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.TwoPlayerDuel/src/mage/game/TwoPlayerMatch.java
@@ -21,7 +21,12 @@ public class TwoPlayerMatch extends MatchImpl {
         // see comments from https://github.com/magefree/mage/commit/4874ad31c199ea573187ea2790268be3a4d4c95a
         boolean isLimitedDeck = options.isLimited() || "Limited".equals(options.getDeckType());
 
-        TwoPlayerDuel game = new TwoPlayerDuel(options.getAttackOption(), options.getRange(), mulligan, 20, isLimitedDeck ? 40 : 60);
+        int startLife = options.isCustomStartLifeEnabled() ? options.getCustomStartLife() : 20;
+        int startHandSize = options.isCustomStartHandSizeEnabled() ? options.getCustomStartHandSize() : 7;
+        TwoPlayerDuel game = new TwoPlayerDuel(
+                options.getAttackOption(), options.getRange(), mulligan,
+                isLimitedDeck ? 40 : 60, startLife, startHandSize
+        );
         // Sets a start message about the match score
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/GoadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/GoadTest.java
@@ -34,7 +34,7 @@ public class GoadTest extends CardTestMultiPlayerBase {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");
@@ -65,8 +65,8 @@ public class GoadTest extends CardTestMultiPlayerBase {
     /**
      * Checks whether the given attacker is NOT goaded by the provided player(s).
      *
-     * @param attacker  the name of the attacker
-     * @param players   the player(s) that the attacker is supposed to be goaded by.
+     * @param attacker the name of the attacker
+     * @param players  the player(s) that the attacker is supposed to be goaded by.
      */
     private void assertNotGoaded(String attacker, TestPlayer... players) {
         Assert.assertTrue("At least one player should be provided", players.length > 0);
@@ -87,8 +87,8 @@ public class GoadTest extends CardTestMultiPlayerBase {
     /**
      * Checks whether the given attacker is goaded by the provided player(s).
      *
-     * @param attacker  the name of the attacker
-     * @param players   the player(s) that the attacker is supposed to be goaded by.
+     * @param attacker the name of the attacker
+     * @param players  the player(s) that the attacker is supposed to be goaded by.
      */
     private void assertGoaded(String attacker, TestPlayer... players) {
         Assert.assertTrue("At least one player should be provided", players.length > 0);
@@ -220,10 +220,10 @@ public class GoadTest extends CardTestMultiPlayerBase {
     /**
      * Reported bug: https://github.com/magefree/mage/issues/9227
      * Geode Rager (and other goad all effects) goad creatures that enter the battlefield after the effect resolved.
-     *
+     * <p>
      * Ruling:
-     *      Creatures that enter the battlefield or come under the target player’s control after Geode Rager’s ability has resolved won’t be goaded.
-     *      (2020-09-25)
+     * Creatures that enter the battlefield or come under the target player’s control after Geode Rager’s ability has resolved won’t be goaded.
+     * (2020-09-25)
      */
     @Test
     public void goadAllCorrectAffect() {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/other/NaturesWillTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/other/NaturesWillTest.java
@@ -16,7 +16,7 @@ import java.io.FileNotFoundException;
 public class NaturesWillTest extends CardTestPlayerBase {
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");
         playerC = createPlayer(game, "PlayerC");

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/other/StormTheVaultTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/other/StormTheVaultTest.java
@@ -16,7 +16,7 @@ import java.io.FileNotFoundException;
 public class StormTheVaultTest extends CardTestPlayerBase {
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");
         playerC = createPlayer(game, "PlayerC");

--- a/Mage.Tests/src/test/java/org/mage/test/cards/battle/BattleMultiplayerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/battle/BattleMultiplayerTest.java
@@ -23,7 +23,7 @@ public class BattleMultiplayerTest extends BattleBaseTest {
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         Game game = new FreeForAll(
                 MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL,
-                MulliganType.GAME_DEFAULT.getMulligan(0), 20
+                MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7
         );
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");

--- a/Mage.Tests/src/test/java/org/mage/test/cards/designations/MonarchTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/designations/MonarchTest.java
@@ -21,7 +21,7 @@ public class MonarchTest extends CardTestMultiPlayerBase {
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         // reason: must use MultiplayerAttackOption.MULTIPLE
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/akh/RagsRichesTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/akh/RagsRichesTest.java
@@ -19,7 +19,7 @@ import java.io.FileNotFoundException;
 public class RagsRichesTest extends CardTestMultiPlayerBase {
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.LEFT, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new FreeForAll(MultiplayerAttackOption.LEFT, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/c19/AeonEngineTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/c19/AeonEngineTest.java
@@ -1,6 +1,5 @@
 package org.mage.test.cards.single.c19;
 
-import java.io.FileNotFoundException;
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.PhaseStep;
 import mage.constants.RangeOfInfluence;
@@ -12,14 +11,15 @@ import mage.game.mulligan.MulliganType;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestMultiPlayerBase;
 
+import java.io.FileNotFoundException;
+
 /**
- *
  * @author azra1l <algee2005@gmail.com>
  */
 public class AeonEngineTest extends CardTestMultiPlayerBase {
     @Override
     protected Game createNewGameAndPlayers() throws GameException {
-        Game game = new FreeForAll(MultiplayerAttackOption.LEFT, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new FreeForAll(MultiplayerAttackOption.LEFT, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");
@@ -27,7 +27,7 @@ public class AeonEngineTest extends CardTestMultiPlayerBase {
         playerD = createPlayer(game, "PlayerD");
         return game;
     }
-    
+
     @Test
     public void testEnterTappedNormalTurnOrder() {
         // Aeon Engine - Artefact - {5}
@@ -47,7 +47,7 @@ public class AeonEngineTest extends CardTestMultiPlayerBase {
 
         //check if aeon engine is tapped
         assertTapped("Aeon Engine", true);
-    
+
         //check if turn was passed to correct player - should be D
         assertActivePlayer(playerD);
         assertLife(playerA, 17);
@@ -82,7 +82,7 @@ public class AeonEngineTest extends CardTestMultiPlayerBase {
 
         //check if aeon engine has been exiled
         assertExileCount(playerA, "Aeon Engine", 1);
-                
+
         //check if turn was passed to correct player each turn - should be B
         assertActivePlayer(playerB);
         assertLife(playerA, 8);
@@ -93,7 +93,7 @@ public class AeonEngineTest extends CardTestMultiPlayerBase {
         assertGraveyardCount(playerC, "Agonizing Syphon", 1);
         assertGraveyardCount(playerD, "Agonizing Syphon", 1);
     }
-    
+
     @Test
     public void testExileCostReversedTurnOrderDouble() throws GameException, FileNotFoundException {
         // Aeon Engine - Artefact - {5}
@@ -119,7 +119,7 @@ public class AeonEngineTest extends CardTestMultiPlayerBase {
         castSpell(7, PhaseStep.PRECOMBAT_MAIN, playerC, "Agonizing Syphon", playerA);
         activateAbility(8, PhaseStep.PRECOMBAT_MAIN, playerD, "{T}, Exile {this}:");
         castSpell(9, PhaseStep.PRECOMBAT_MAIN, playerC, "Agonizing Syphon", playerA);
-        
+
         setStrictChooseMode(true);
         setStopAt(9, PhaseStep.END_TURN);
         execute();
@@ -127,7 +127,7 @@ public class AeonEngineTest extends CardTestMultiPlayerBase {
         //check if aeon engine's have been exiled
         assertExileCount(playerA, "Aeon Engine", 1);
         assertExileCount(playerD, "Aeon Engine", 1);
-                
+
         //check if turn was passed to correct player each turn - should be C
         assertActivePlayer(playerC);
         assertLife(playerA, 5);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/c19/PramikonSkyRampartTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/c19/PramikonSkyRampartTest.java
@@ -19,7 +19,7 @@ public class PramikonSkyRampartTest extends CardTestMultiPlayerBase {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException {
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/hou/TormentOfHailfireTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/hou/TormentOfHailfireTest.java
@@ -1,7 +1,5 @@
 package org.mage.test.cards.single.hou;
 
-import java.io.FileNotFoundException;
-
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.PhaseStep;
 import mage.constants.RangeOfInfluence;
@@ -14,8 +12,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestMultiPlayerBase;
 
+import java.io.FileNotFoundException;
+
 /**
- *
  * @author LevelX2
  */
 public class TormentOfHailfireTest extends CardTestMultiPlayerBase {
@@ -23,7 +22,7 @@ public class TormentOfHailfireTest extends CardTestMultiPlayerBase {
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         // Start Life = 2
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");
@@ -35,22 +34,22 @@ public class TormentOfHailfireTest extends CardTestMultiPlayerBase {
     @Test
     public void test_Normal() {
         setStrictChooseMode(true);
-        
+
         // Repeat the following process X times. Each opponent loses 3 life unless they sacrifice a nonland permanent or discards a card.        
         addCard(Zone.HAND, playerA, "Torment of Hailfire", 1); // Sorcery {X}{B}{B}        
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 12);
-        
+
         addCard(Zone.BATTLEFIELD, playerB, "Silvercoat Lion", 2);
         addCard(Zone.HAND, playerB, "Plains", 1);
-        
+
         addCard(Zone.BATTLEFIELD, playerC, "Silvercoat Lion", 3);
-        
-        addCard(Zone.BATTLEFIELD, playerD, "Silvercoat Lion", 3);        
+
+        addCard(Zone.BATTLEFIELD, playerD, "Silvercoat Lion", 3);
         addCard(Zone.HAND, playerD, "Plains", 1);
-        
+
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Torment of Hailfire");
         setChoice(playerA, "X=10");
-        
+
         setChoice(playerD, true);// Sacrifices a nonland permanent?
         setChoice(playerD, "Silvercoat Lion");
 
@@ -65,22 +64,22 @@ public class TormentOfHailfireTest extends CardTestMultiPlayerBase {
 
         setChoice(playerD, false);// Sacrifices a nonland permanent?
         setChoice(playerD, true);// Discard a card?
-        
+
         setChoice(playerB, true);// Discard a card?
 
         setChoice(playerD, true);// Sacrifices a nonland permanent?
         setChoice(playerD, "Silvercoat Lion");
-        
+
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
         assertGraveyardCount(playerA, "Torment of Hailfire", 1);
-        
+
         assertLife(playerA, 20);
         assertLife(playerC, 20);
         assertLife(playerD, 2);
         assertLife(playerB, -1);
         Assert.assertFalse("Player B is dead", playerB.isInGame());
-        
+
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/game/FreeformUnlimitedCommander/FreeformUnlimitedCommanderTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/game/FreeformUnlimitedCommander/FreeformUnlimitedCommanderTest.java
@@ -16,13 +16,15 @@ public class FreeformUnlimitedCommanderTest extends MageTestPlayerBase {
         // Arrange
         Mulligan mulligan = new LondonMulligan(1);
         int startLife = 40;
+        int startHandSize = 7;
 
         // Assert
         FreeformUnlimitedCommander game = new FreeformUnlimitedCommander(
                 MultiplayerAttackOption.MULTIPLE,
                 RangeOfInfluence.ALL,
                 mulligan,
-                startLife
+                startLife,
+                startHandSize
         );
 
         // Assert

--- a/Mage.Tests/src/test/java/org/mage/test/mulligan/MulliganTestBase.java
+++ b/Mage.Tests/src/test/java/org/mage/test/mulligan/MulliganTestBase.java
@@ -1,10 +1,18 @@
 package org.mage.test.mulligan;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
 import mage.cards.CardSetInfo;
 import mage.cards.basiclands.Forest;
 import mage.cards.decks.Deck;
 import mage.cards.s.Squire;
+import static mage.constants.MultiplayerAttackOption.LEFT;
 import mage.constants.RangeOfInfluence;
+import static mage.constants.RangeOfInfluence.ONE;
+import static mage.constants.Rarity.LAND;
 import mage.game.Game;
 import mage.game.GameOptions;
 import mage.game.TwoPlayerDuel;
@@ -12,22 +20,13 @@ import mage.game.mulligan.Mulligan;
 import mage.game.mulligan.MulliganType;
 import mage.players.StubPlayer;
 import org.apache.log4j.Logger;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.Iterables.getOnlyElement;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableSet;
-import static mage.constants.MultiplayerAttackOption.LEFT;
-import static mage.constants.RangeOfInfluence.ONE;
-import static mage.constants.Rarity.LAND;
-import static org.junit.Assert.*;
 
 public class MulliganTestBase {
 
@@ -60,7 +59,7 @@ public class MulliganTestBase {
 
         public void run(Runnable callback) {
             Mulligan mulligan = mulliganType.getMulligan(freeMulligans);
-            Game game = new TwoPlayerDuel(LEFT, ONE, mulligan, 20) {
+            Game game = new TwoPlayerDuel(LEFT, ONE, mulligan, 60, 20, 7) {
                 @Override
                 public void fireStatusEvent(String message, boolean withTime, boolean withTurnInfo) {
                     super.fireStatusEvent(message, withTime, withTurnInfo);
@@ -142,10 +141,10 @@ public class MulliganTestBase {
     public static Deck generateDeck(UUID playerId, int count) {
         Deck deck = new Deck();
         Stream.generate(() -> new Forest(playerId, new CardSetInfo("Forest", "TEST", "1", LAND)))
-                .limit(count/2+(count & 1)) //If odd number of cards, add one extra forest
+                .limit(count / 2 + (count & 1)) //If odd number of cards, add one extra forest
                 .forEach(deck.getCards()::add);
         Stream.generate(() -> new Squire(playerId, new CardSetInfo("Squire", "TEST", "2", LAND)))
-                .limit(count/2)
+                .limit(count / 2)
                 .forEach(deck.getCards()::add);
         return deck;
     }

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/AngelOfSerenityTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/AngelOfSerenityTest.java
@@ -18,7 +18,7 @@ public class AngelOfSerenityTest extends CardTestMultiPlayerBase {
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         // Start Life = 2
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 2);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 2, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/BlatantThieveryTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/BlatantThieveryTest.java
@@ -20,7 +20,7 @@ public class BlatantThieveryTest extends CardTestMultiPlayerBase {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/CreepingDreadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/CreepingDreadTest.java
@@ -25,7 +25,7 @@ public class CreepingDreadTest extends CardTestMultiPlayerBase {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/MultiplayerTriggerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/MultiplayerTriggerTest.java
@@ -17,7 +17,7 @@ public class MultiplayerTriggerTest extends CardTestMultiPlayerBase {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/MyriadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/MyriadTest.java
@@ -20,7 +20,7 @@ public class MyriadTest extends CardTestMultiPlayerBase {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerDiedStackTargetHandlingTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerDiedStackTargetHandlingTest.java
@@ -22,7 +22,7 @@ public class PlayerDiedStackTargetHandlingTest extends CardTestMultiPlayerBase {
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         // Start Life = 2
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 3);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 3, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerLeftGameRange1Test.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerLeftGameRange1Test.java
@@ -9,7 +9,6 @@ import mage.game.FreeForAll;
 import mage.game.Game;
 import mage.game.GameException;
 import mage.game.mulligan.MulliganType;
-import mage.game.permanent.Permanent;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestMultiPlayerBase;
@@ -24,7 +23,7 @@ public class PlayerLeftGameRange1Test extends CardTestMultiPlayerBase {
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         // Start Life = 2
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 2);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 2, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerLeftGameRangeAllTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerLeftGameRangeAllTest.java
@@ -1,6 +1,5 @@
 package org.mage.test.multiplayer;
 
-import java.io.FileNotFoundException;
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.PhaseStep;
 import mage.constants.RangeOfInfluence;
@@ -14,6 +13,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestMultiPlayerBase;
 
+import java.io.FileNotFoundException;
+
 /**
  * @author LevelX2
  */
@@ -22,7 +23,7 @@ public class PlayerLeftGameRangeAllTest extends CardTestMultiPlayerBase {
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
         // Start Life = 2
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 2);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 2, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");
@@ -419,14 +420,14 @@ public class PlayerLeftGameRangeAllTest extends CardTestMultiPlayerBase {
 
     /**
      * https://github.com/magefree/mage/issues/6997
-       Some continuous effects should stay in play even after the player that set them leaves the game. 
-       Example: 
-       * Player A: Casts Vorinclex, Voice of Hunger 
-       * Player D: Taps all lands and do stuff (lands shouldn't untap during his next untap step)     
-       * Player C: Kills Player A Player D: Lands untapped normally, though they shouldn't
-       * 
-       * This happened playing commander against 3 AIs. One of the AIs played Vorinclex, I tapped all my lands during my turn to do stuff. 
-       * Next AI killed the one that had Vorinclex. When the game got to my turn, my lands untapped normally.
+     * Some continuous effects should stay in play even after the player that set them leaves the game.
+     * Example:
+     * Player A: Casts Vorinclex, Voice of Hunger
+     * Player D: Taps all lands and do stuff (lands shouldn't untap during his next untap step)
+     * Player C: Kills Player A Player D: Lands untapped normally, though they shouldn't
+     * <p>
+     * This happened playing commander against 3 AIs. One of the AIs played Vorinclex, I tapped all my lands during my turn to do stuff.
+     * Next AI killed the one that had Vorinclex. When the game got to my turn, my lands untapped normally.
      */
     @Test
     public void TestContinuousEffectStaysAfterCreatingPlayerLeft() {
@@ -456,20 +457,20 @@ public class PlayerLeftGameRangeAllTest extends CardTestMultiPlayerBase {
         castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerC, "Lightning Bolt", playerA);
 
         setStopAt(5, PhaseStep.BEGIN_COMBAT);
-        
+
         execute();
 
         assertPermanentCount(playerD, "Silvercoat Lion", 1);
-        
+
         assertGraveyardCount(playerC, "Lightning Bolt", 1);
-        
+
         Assert.assertFalse("Player A is no longer in the game", playerA.isInGame());
 
-        Assert.assertTrue("Player D is the active player",currentGame.getActivePlayerId().equals(playerD.getId()));
-        
+        Assert.assertTrue("Player D is the active player", currentGame.getActivePlayerId().equals(playerD.getId()));
+
         assertTappedCount("Plains", true, 2); // Do not untap because of Vorinclex do not untap effect
 
     }
 
-    
+
 }

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerWinsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/PlayerWinsTest.java
@@ -1,6 +1,5 @@
 package org.mage.test.multiplayer;
 
-import java.io.FileNotFoundException;
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.PhaseStep;
 import mage.constants.RangeOfInfluence;
@@ -13,6 +12,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestMultiPlayerBase;
 
+import java.io.FileNotFoundException;
+
 
 /**
  * @author LevelX2
@@ -21,7 +22,7 @@ public class PlayerWinsTest extends CardTestMultiPlayerBase {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 40, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");
@@ -33,9 +34,9 @@ public class PlayerWinsTest extends CardTestMultiPlayerBase {
     /**
      * Tests multiplayer effects Player order: A -> D -> C -> B
      */
-    
+
     /**
-     * Test that players out of range do not lose the game if effect from Approach of the Seconnd Sun takes effect.     
+     * Test that players out of range do not lose the game if effect from Approach of the Seconnd Sun takes effect.
      */
     @Test
     public void ApproachOfTheSecondSunTest() {
@@ -59,20 +60,20 @@ public class PlayerWinsTest extends CardTestMultiPlayerBase {
         Assert.assertTrue("Player A is in the game", playerA.isInGame());
 
     }
-    
+
     /**
-     * Test that players out of range do not lose the game if effect from Laboratory Maniac takes effect.     
+     * Test that players out of range do not lose the game if effect from Laboratory Maniac takes effect.
      */
     @Test
-    public void LaboratoryManiacWinsTest() {       
+    public void LaboratoryManiacWinsTest() {
         // If you would draw a card while your library has no cards in it, you win the game instead.        
         addCard(Zone.HAND, playerA, "Laboratory Maniac", 1); // Creature {2}{U}
         addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
-        
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Laboratory Maniac");        
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Laboratory Maniac");
         removeAllCardsFromLibrary(playerA);
         addCard(Zone.LIBRARY, playerA, "Mountain");
-        
+
         setStopAt(5, PhaseStep.POSTCOMBAT_MAIN);
         execute();
 
@@ -84,25 +85,25 @@ public class PlayerWinsTest extends CardTestMultiPlayerBase {
         Assert.assertTrue("Player C should be in the game but has lost", playerC.isInGame());
         Assert.assertTrue("Player A should be in the game but has lost", playerA.isInGame());
     }
-    
+
     /**
-     * Test that player can't win while Platinium Angel ist in range.     
+     * Test that player can't win while Platinium Angel ist in range.
      */
     @Test
-    public void LaboratoryManiacAndPlatinumAngelInRangeTest() {       
+    public void LaboratoryManiacAndPlatinumAngelInRangeTest() {
         // If you would draw a card while your library has no cards in it, you win the game instead.        
         addCard(Zone.HAND, playerA, "Laboratory Maniac", 1); // Creature {2}{U}
         addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
         removeAllCardsFromLibrary(playerA);
-        
+
         // You can't lose the game and your opponents can't win the game.
         addCard(Zone.HAND, playerD, "Platinum Angel", 1); // Creature {2}{U}
         addCard(Zone.BATTLEFIELD, playerD, "Island", 7);
-        
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Laboratory Maniac");        
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Laboratory Maniac");
         addCard(Zone.LIBRARY, playerA, "Mountain");
-        
-        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerD, "Platinum Angel");        
+
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerD, "Platinum Angel");
 
         setStopAt(9, PhaseStep.POSTCOMBAT_MAIN);
         execute();
@@ -110,33 +111,33 @@ public class PlayerWinsTest extends CardTestMultiPlayerBase {
         assertPermanentCount(playerA, "Laboratory Maniac", 1);
         assertHandCount(playerA, "Mountain", 1);
         assertLibraryCount(playerA, 0);
-        
+
         assertPermanentCount(playerD, "Platinum Angel", 1);
-        
+
         Assert.assertTrue("Player D should be in the game but has lost", playerD.isInGame());
         Assert.assertTrue("Player B should be in the game but has lost", playerB.isInGame());
         Assert.assertTrue("Player C should be in the game but has lost", playerC.isInGame());
         Assert.assertTrue("Player A should be in the game but has lost", playerA.isInGame());
     }
-    
-        /**
-     * Test that player can't win while Platinium Angel ist in range.     
+
+    /**
+     * Test that player can't win while Platinium Angel ist in range.
      */
     @Test
-    public void LaboratoryManiacAndPlatinumAngelFirstOutOfRangeTest() {       
+    public void LaboratoryManiacAndPlatinumAngelFirstOutOfRangeTest() {
         // If you would draw a card while your library has no cards in it, you win the game instead.        
         addCard(Zone.HAND, playerA, "Laboratory Maniac", 1); // Creature {2}{U}
         addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
         removeAllCardsFromLibrary(playerA);
-        
+
         // You can't lose the game and your opponents can't win the game.
         addCard(Zone.HAND, playerC, "Platinum Angel", 1); // Creature {2}{U}
         addCard(Zone.BATTLEFIELD, playerC, "Island", 7);
-        
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Laboratory Maniac");        
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Laboratory Maniac");
         addCard(Zone.LIBRARY, playerA, "Mountain");
-        
-        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerC, "Platinum Angel");        
+
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerC, "Platinum Angel");
 
         setStopAt(9, PhaseStep.POSTCOMBAT_MAIN);
         execute();
@@ -144,9 +145,9 @@ public class PlayerWinsTest extends CardTestMultiPlayerBase {
         assertPermanentCount(playerA, "Laboratory Maniac", 1);
         assertHandCount(playerA, "Mountain", 1);
         assertLibraryCount(playerA, 0);
-        
+
         assertPermanentCount(playerC, "Platinum Angel", 1);
- 
+
         Assert.assertTrue("Player D still alive but should have lost the gamet", !playerD.isInGame());
         Assert.assertTrue("Player B still alive but should have lost the game", !playerB.isInGame());
         Assert.assertTrue("Player C should be in the game but has lost", playerC.isInGame());

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/PrivilegedPositionTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/PrivilegedPositionTest.java
@@ -22,7 +22,7 @@ public class PrivilegedPositionTest extends CardTestMultiPlayerBase {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/multiplayer/VindictiveLichTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/multiplayer/VindictiveLichTest.java
@@ -20,7 +20,7 @@ public class VindictiveLichTest extends CardTestMultiPlayerBase {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
+        Game game = new FreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 40, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/PlayGameTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/PlayGameTest.java
@@ -36,7 +36,7 @@ public class PlayGameTest extends MageTestBase {
     @Ignore
     @Test
     public void playOneGame() throws GameException, FileNotFoundException, IllegalArgumentException {
-        Game game = new TwoPlayerDuel(MultiplayerAttackOption.LEFT, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new TwoPlayerDuel(MultiplayerAttackOption.LEFT, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 60, 20, 7);
 
         Player computerA = createPlayer("ComputerA", PlayerType.COMPUTER_MINIMAX_HYBRID);
 //        Player playerA = createPlayer("ComputerA", "Computer - mad");

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestCommander3PlayersFFA.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestCommander3PlayersFFA.java
@@ -24,7 +24,7 @@ public abstract class CardTestCommander3PlayersFFA extends CardTestPlayerAPIImpl
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new CommanderFreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
+        Game game = new CommanderFreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 40, 7);
         playerA = createPlayer(game, "PlayerA", deckNameA);
         playerB = createPlayer(game, "PlayerB", deckNameB);
         playerC = createPlayer(game, "PlayerC", deckNameC);

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestCommander4Players.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestCommander4Players.java
@@ -17,7 +17,7 @@ public abstract class CardTestCommander4Players extends CardTestPlayerAPIImpl {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new CommanderFreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new CommanderFreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestCommanderDuelBase.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestCommanderDuelBase.java
@@ -23,7 +23,7 @@ public abstract class CardTestCommanderDuelBase extends CardTestPlayerAPIImpl {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new CommanderDuel(MultiplayerAttackOption.LEFT, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 40);
+        Game game = new CommanderDuel(MultiplayerAttackOption.LEFT, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 40, 7);
 
         playerA = createPlayer(game, "PlayerA", deckNameA);
         playerB = createPlayer(game, "PlayerB", deckNameB);

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestMultiPlayerBase.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestMultiPlayerBase.java
@@ -21,7 +21,7 @@ public abstract class CardTestMultiPlayerBase extends CardTestPlayerAPIImpl {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.LEFT, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new FreeForAll(MultiplayerAttackOption.LEFT, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestMultiPlayerBaseWithRangeAll.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestMultiPlayerBaseWithRangeAll.java
@@ -17,7 +17,7 @@ public abstract class CardTestMultiPlayerBaseWithRangeAll extends CardTestPlayer
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new FreeForAll(MultiplayerAttackOption.LEFT, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new FreeForAll(MultiplayerAttackOption.LEFT, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         // Player order: A -> D -> C -> B
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestOathbreaker3PlayersFFA.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestOathbreaker3PlayersFFA.java
@@ -1,6 +1,5 @@
 package org.mage.test.serverside.base;
 
-import java.io.FileNotFoundException;
 import mage.constants.MultiplayerAttackOption;
 import mage.constants.RangeOfInfluence;
 import mage.game.Game;
@@ -8,6 +7,8 @@ import mage.game.GameException;
 import mage.game.OathbreakerFreeForAll;
 import mage.game.mulligan.MulliganType;
 import org.mage.test.serverside.base.impl.CardTestPlayerAPIImpl;
+
+import java.io.FileNotFoundException;
 
 /**
  * @author LevelX2
@@ -23,7 +24,7 @@ public abstract class CardTestOathbreaker3PlayersFFA extends CardTestPlayerAPIIm
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new OathbreakerFreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new OathbreakerFreeForAll(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20, 7);
         playerA = createPlayer(game, "PlayerA", deckNameA);
         playerB = createPlayer(game, "PlayerB", deckNameB);
         playerC = createPlayer(game, "PlayerC", deckNameC);

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestPlayerBase.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestPlayerBase.java
@@ -24,7 +24,7 @@ public abstract class CardTestPlayerBase extends CardTestPlayerAPIImpl {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new TwoPlayerDuel(MultiplayerAttackOption.LEFT, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new TwoPlayerDuel(MultiplayerAttackOption.LEFT, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 60, 20, 7);
 
         playerA = createPlayer(game, "PlayerA", deckNameA);
         playerB = createPlayer(game, "PlayerB", deckNameB);

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestPlayerBaseAI.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/CardTestPlayerBaseAI.java
@@ -14,7 +14,7 @@ import java.io.FileNotFoundException;
 
 /**
  * PlayerA is full AI player and process all actions as AI logic. You don't need aiXXX commands in that tests.
- *
+ * <p>
  * If you need custom AI tests then use CardTestPlayerBaseWithAIHelps with aiXXX commands
  *
  * @author LevelX2
@@ -25,7 +25,7 @@ public abstract class CardTestPlayerBaseAI extends CardTestPlayerAPIImpl {
 
     @Override
     protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
-        Game game = new TwoPlayerDuel(MultiplayerAttackOption.LEFT, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 20);
+        Game game = new TwoPlayerDuel(MultiplayerAttackOption.LEFT, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 60, 20, 7);
 
         playerA = createPlayer(game, "PlayerA");
         playerB = createPlayer(game, "PlayerB");

--- a/Mage.Tests/src/test/java/org/mage/test/utils/RandomTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/utils/RandomTest.java
@@ -94,7 +94,7 @@ public class RandomTest {
         String dest = "f:/test/xmage/";
         //RandomUtil.setSeed(123);
         Player player = new HumanPlayer("random", RangeOfInfluence.ALL, 1);
-        Game game = new TwoPlayerDuel(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 50);
+        Game game = new TwoPlayerDuel(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 60, 50, 7);
 
         int height = 512;
         int weight = 512;
@@ -117,7 +117,7 @@ public class RandomTest {
         String dest = "f:/test/xmage/";
         //RandomUtil.setSeed(123);
         Player player = new HumanPlayer("random", RangeOfInfluence.ALL, 1);
-        Game game = new TwoPlayerDuel(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 50);
+        Game game = new TwoPlayerDuel(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 60, 50, 7);
 
         int height = 512;
         int weight = 512;
@@ -142,7 +142,7 @@ public class RandomTest {
         String dest = "f:/test/xmage/";
         //RandomUtil.setSeed(123);
         Player player = new HumanPlayer("random", RangeOfInfluence.ALL, 1);
-        Game game = new TwoPlayerDuel(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 50);
+        Game game = new TwoPlayerDuel(MultiplayerAttackOption.MULTIPLE, RangeOfInfluence.ALL, MulliganType.GAME_DEFAULT.getMulligan(0), 60, 50, 7);
         Deck deck = DeckTestUtils.buildRandomDeck("WGUBR", false, "GRN");
         player.getLibrary().addAll(deck.getMaindeckCards(), game);
 

--- a/Mage/src/main/java/mage/game/GameCanadianHighlanderImpl.java
+++ b/Mage/src/main/java/mage/game/GameCanadianHighlanderImpl.java
@@ -11,8 +11,8 @@ import java.util.UUID;
 
 public abstract class GameCanadianHighlanderImpl extends GameImpl {
 
-    public GameCanadianHighlanderImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 100, 7);
+    public GameCanadianHighlanderImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 100, startLife, startHandSize);
     }
 
     protected GameCanadianHighlanderImpl(final GameCanadianHighlanderImpl game) {

--- a/Mage/src/main/java/mage/game/GameCommanderImpl.java
+++ b/Mage/src/main/java/mage/game/GameCommanderImpl.java
@@ -33,8 +33,8 @@ public abstract class GameCommanderImpl extends GameImpl {
     // (see rule 504, "Draw Step") of his or her first turn.
     protected boolean startingPlayerSkipsDraw = true;
 
-    public GameCommanderImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startingLife, int minimumDeckSize) {
-        super(attackOption, range, mulligan, startingLife, minimumDeckSize, 7);
+    public GameCommanderImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int minimumDeckSize, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, minimumDeckSize, startLife, startHandSize);
     }
 
     protected GameCommanderImpl(final GameCommanderImpl game) {

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -157,7 +157,7 @@ public abstract class GameImpl implements Game {
     // temporary store for income concede commands, don't copy
     private final LinkedList<UUID> concedingPlayers = new LinkedList<>();
 
-    public GameImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startingLife, int minimumDeckSize, int startingHandSize) {
+    public GameImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int minimumDeckSize, int startingLife, int startingHandSize) {
         this.id = UUID.randomUUID();
         this.range = range;
         this.mulligan = mulligan;

--- a/Mage/src/main/java/mage/game/GameTinyLeadersImpl.java
+++ b/Mage/src/main/java/mage/game/GameTinyLeadersImpl.java
@@ -34,8 +34,8 @@ public abstract class GameTinyLeadersImpl extends GameImpl {
     // (see rule 504, "Draw Step") of his or her first turn.
     protected boolean startingPlayerSkipsDraw = true;
 
-    public GameTinyLeadersImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife) {
-        super(attackOption, range, mulligan, startLife, 50, 7);
+    public GameTinyLeadersImpl(MultiplayerAttackOption attackOption, RangeOfInfluence range, Mulligan mulligan, int startLife, int startHandSize) {
+        super(attackOption, range, mulligan, 50, startLife, startHandSize);
     }
 
     protected GameTinyLeadersImpl(final GameTinyLeadersImpl game) {

--- a/Mage/src/main/java/mage/game/match/MatchOptions.java
+++ b/Mage/src/main/java/mage/game/match/MatchOptions.java
@@ -15,7 +15,6 @@ import java.io.Serializable;
 import java.util.*;
 
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public class MatchOptions implements Serializable {
@@ -25,6 +24,10 @@ public class MatchOptions implements Serializable {
     protected RangeOfInfluence range;
     protected int winsNeeded;
     protected int freeMulligans;
+    protected boolean customStartLifeEnabled;
+    protected Integer customStartLife; // Only use if customStartLifeEnabled is True
+    protected boolean customStartHandSizeEnabled;
+    protected int customStartHandSize; // Only use if customStartHandSizeEnabled is True
     protected String gameType;
     protected String deckType;
     protected boolean limited;
@@ -53,13 +56,6 @@ public class MatchOptions implements Serializable {
     protected Collection<DeckCardInfo> perPlayerEmblemCards;
     protected Collection<DeckCardInfo> globalEmblemCards;
 
-    /*public MatchOptions(String name, String gameType) {
-        this.name = name;
-        this.gameType = gameType;
-        this.password = "";
-        this.multiPlayer = false;
-        this.numSeats = 2;
-    }*/
     public MatchOptions(String name, String gameType, boolean multiPlayer, int numSeats) {
         this.name = name;
         this.gameType = gameType;
@@ -70,11 +66,11 @@ public class MatchOptions implements Serializable {
         this.globalEmblemCards = Collections.emptySet();
     }
 
-    public void setNumSeats (int numSeats) {
+    public void setNumSeats(int numSeats) {
         this.numSeats = numSeats;
     }
 
-    public int getNumSeats () {
+    public int getNumSeats() {
         return numSeats;
     }
 
@@ -120,6 +116,38 @@ public class MatchOptions implements Serializable {
 
     public void setFreeMulligans(int freeMulligans) {
         this.freeMulligans = freeMulligans;
+    }
+
+    public boolean isCustomStartLifeEnabled() {
+        return customStartLifeEnabled;
+    }
+
+    public void setCustomStartLifeEnabled(boolean value) {
+        this.customStartLifeEnabled = value;
+    }
+
+    public int getCustomStartLife() {
+        return customStartLife;
+    }
+
+    public void setCustomStartLife(int startLife) {
+        this.customStartLife = startLife;
+    }
+
+    public boolean isCustomStartHandSizeEnabled() {
+        return customStartHandSizeEnabled;
+    }
+
+    public void setCustomStartHandSizeEnabled(boolean value) {
+        this.customStartHandSizeEnabled = value;
+    }
+
+    public int getCustomStartHandSize() {
+        return customStartHandSize;
+    }
+
+    public void setCustomStartHandSize(int startHandSize) {
+        this.customStartHandSize = startHandSize;
     }
 
     public String getGameType() {
@@ -211,11 +239,11 @@ public class MatchOptions implements Serializable {
     public void setSpectatorsAllowed(boolean spectatorsAllowed) {
         this.spectatorsAllowed = spectatorsAllowed;
     }
-    
+
     public boolean isPlaneChase() {
         return planeChase;
     }
-    
+
     public void setPlaneChase(boolean planeChase) {
         this.planeChase = planeChase;
     }
@@ -228,9 +256,13 @@ public class MatchOptions implements Serializable {
         this.quitRatio = quitRatio;
     }
 
-    public int getMinimumRating() { return minimumRating; }
+    public int getMinimumRating() {
+        return minimumRating;
+    }
 
-    public void setMinimumRating(int minimumRating) { this.minimumRating = minimumRating; }
+    public void setMinimumRating(int minimumRating) {
+        this.minimumRating = minimumRating;
+    }
 
     public int getEdhPowerLevel() {
         return edhPowerLevel;

--- a/Mage/src/main/java/mage/game/match/MatchOptions.java
+++ b/Mage/src/main/java/mage/game/match/MatchOptions.java
@@ -25,7 +25,7 @@ public class MatchOptions implements Serializable {
     protected int winsNeeded;
     protected int freeMulligans;
     protected boolean customStartLifeEnabled;
-    protected Integer customStartLife; // Only use if customStartLifeEnabled is True
+    protected int customStartLife; // Only use if customStartLifeEnabled is True
     protected boolean customStartHandSizeEnabled;
     protected int customStartHandSize; // Only use if customStartHandSizeEnabled is True
     protected String gameType;


### PR DESCRIPTION
The behavior for each of those is to have a boolean to use the option and a number for the custom value.
If the boolean is at true, we use the custom value, else the mode's default value is used.

The different Class extending GameImpl were modified, to make sure the startHandSize was always controlled by the Game Mode, and to change the order of arguments (it made more sense to have starting life and starting hand size next to each other in the arguments, and I was already looping through each of those constructors anyway)

![image](https://github.com/magefree/mage/assets/34709007/65bb4701-2583-402f-8eea-71c2d1c9687b)
![image](https://github.com/magefree/mage/assets/34709007/cbfdf700-bf92-4278-8eb8-ad39290fb045)
![image](https://github.com/magefree/mage/assets/34709007/895d4bbb-f271-46a0-ad90-baee36f4a36f)

Not using the custom options does not alter anything, as you would expect any of the custom option panel.