### PR TITLE
improve usability of Rebound ability

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HarmlessAssault.java
+++ b/Mage.Sets/src/mage/cards/h/HarmlessAssault.java
@@ -1,4 +1,3 @@
-
 package mage.cards.h;
 
 import java.util.UUID;
@@ -15,13 +14,13 @@ import mage.filter.common.FilterAttackingCreature;
  */
 public final class HarmlessAssault extends CardImpl {
 
+    private static final FilterAttackingCreature filter = new FilterAttackingCreature("attacking creatures");
+
     public HarmlessAssault(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{2}{W}{W}");
 
-
-        // Prevent all combat damage that would be dealt this turn by attacking
-        // creatures.
-        this.getSpellAbility().addEffect(new PreventAllDamageByAllPermanentsEffect(new FilterAttackingCreature(), Duration.EndOfTurn, true));
+        // Prevent all combat damage that would be dealt this turn by attacking creatures.
+        this.getSpellAbility().addEffect(new PreventAllDamageByAllPermanentsEffect(filter, Duration.EndOfTurn, true));
     }
 
     private HarmlessAssault(final HarmlessAssault card) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ReboundTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ReboundTest.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.mage.test.cards.abilities.keywords;
 
 import mage.constants.PhaseStep;
@@ -39,6 +35,7 @@ public class ReboundTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Distortion Strike", "Memnite");
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -63,6 +60,11 @@ public class ReboundTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Distortion Strike", "Memnite");
 
+        // Yes to rebound
+        setChoice(playerA, true);
+        addTarget(playerA, "Memnite");
+
+        setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
         execute();
 
@@ -91,6 +93,7 @@ public class ReboundTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Distortion Strike", "Memnite");
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Counterspell", "Distortion Strike");
 
+        setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
         execute();
 

--- a/Mage/src/main/java/mage/abilities/common/BeginningOfPreCombatMainTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/BeginningOfPreCombatMainTriggeredAbility.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package mage.abilities.common;
 
 import mage.abilities.TriggeredAbilityImpl;

--- a/Mage/src/main/java/mage/abilities/common/DiscardsACardOpponentTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DiscardsACardOpponentTriggeredAbility.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package mage.abilities.common;
 
 import mage.abilities.TriggeredAbilityImpl;

--- a/Mage/src/main/java/mage/abilities/common/delayed/AtTheBeginOfYourNextDrawStepDelayedTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/delayed/AtTheBeginOfYourNextDrawStepDelayedTriggeredAbility.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package mage.abilities.common.delayed;
 
 import mage.abilities.DelayedTriggeredAbility;
@@ -43,4 +39,3 @@ public class AtTheBeginOfYourNextDrawStepDelayedTriggeredAbility extends Delayed
         return event.getPlayerId().equals(this.controllerId);
     }
 }
-

--- a/Mage/src/main/java/mage/abilities/common/delayed/AtTheBeginOfYourNextUpkeepDelayedTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/delayed/AtTheBeginOfYourNextUpkeepDelayedTriggeredAbility.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package mage.abilities.common.delayed;
 
 import mage.abilities.DelayedTriggeredAbility;
@@ -43,4 +39,3 @@ public class AtTheBeginOfYourNextUpkeepDelayedTriggeredAbility extends DelayedTr
         return event.getPlayerId().equals(this.controllerId);
     }
 }
-

--- a/Mage/src/main/java/mage/abilities/decorator/ConditionalActivatedAbility.java
+++ b/Mage/src/main/java/mage/abilities/decorator/ConditionalActivatedAbility.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package mage.abilities.decorator;
 
 import mage.abilities.ActivatedAbilityImpl;

--- a/Mage/src/main/java/mage/abilities/effects/common/PreventNextDamageFromChosenSourceToTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/PreventNextDamageFromChosenSourceToTargetEffect.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package mage.abilities.effects.common;
 
 import mage.MageObject;

--- a/Mage/src/main/java/mage/abilities/effects/common/PreventNextDamageFromChosenSourceToYouEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/PreventNextDamageFromChosenSourceToYouEffect.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package mage.abilities.effects.common;
 
 import mage.abilities.Ability;

--- a/Mage/src/main/java/mage/abilities/keyword/ReboundAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ReboundAbility.java
@@ -127,7 +127,7 @@ class ReboundCastFromHandReplacementEffect extends ReplacementEffectImpl {
 class ReboundEffectCastFromExileDelayedTrigger extends DelayedTriggeredAbility {
 
     ReboundEffectCastFromExileDelayedTrigger(Card card, Game game) {
-        super(new ReboundCastSpellFromExileEffect().setTargetPointer(new FixedTarget(card, game)), Duration.Custom, true, true);
+        super(new ReboundCastSpellFromExileEffect().setTargetPointer(new FixedTarget(card, game)), Duration.Custom, true, false);
     }
 
     private ReboundEffectCastFromExileDelayedTrigger(final ReboundEffectCastFromExileDelayedTrigger ability) {

--- a/Mage/src/main/java/mage/constants/MageObjectType.java
+++ b/Mage/src/main/java/mage/constants/MageObjectType.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package mage.constants;
 
 /**

--- a/Mage/src/main/java/mage/filter/common/FilterControlledCreatureSpell.java
+++ b/Mage/src/main/java/mage/filter/common/FilterControlledCreatureSpell.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package mage.filter.common;
 
 import mage.constants.TargetController;

--- a/Mage/src/main/java/mage/filter/common/FilterCreatureSpell.java
+++ b/Mage/src/main/java/mage/filter/common/FilterCreatureSpell.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package mage.filter.common;
 
 import mage.constants.CardType;

--- a/Mage/src/main/java/mage/filter/common/FilterInstantOrSorceryCard.java
+++ b/Mage/src/main/java/mage/filter/common/FilterInstantOrSorceryCard.java
@@ -1,7 +1,3 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package mage.filter.common;
 
 import mage.constants.CardType;


### PR DESCRIPTION
Previously, Rebound asked the player twice whether they wanted to cast the spell. One choice from the trigger, one choice from the cast. This PR makes the trigger non-optional so that the choice only needs to be selected once. The test for the ability is updated to check this in strict mode.

Also a text fix and removing some boilerplate template code comments.